### PR TITLE
fix(ci): disable embedded wheel builds (no Rust bindings)

### DIFF
--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -273,81 +273,85 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # BUILD PYTHON EMBEDDED WHEELS - ONLY for clients/python-embedded (Rust bindings)
+  # BUILD PYTHON EMBEDDED WHEELS - DISABLED for v0.2.0
   # ============================================================================
-  build-embedded-wheels:
-    name: Build Embedded Wheels (${{ matrix.os }}, ${{ matrix.target }})
-    needs: prepare
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            target: x86_64
-          - os: ubuntu-22.04
-            target: aarch64
-          - os: macos-latest
-            target: aarch64
-          - os: windows-2022
-            target: x64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Install Maturin
-        run: pip install maturin
-
-      - name: Build Embedded Wheels (Linux x86_64)
-        if: matrix.os == 'ubuntu-22.04' && matrix.target == 'x86_64'
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: clients/python-embedded
-          target: x86_64
-          manylinux: auto
-          args: --release --out dist --features python
-
-      - name: Build Embedded Wheels (Linux aarch64)
-        if: matrix.os == 'ubuntu-22.04' && matrix.target == 'aarch64'
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: clients/python-embedded
-          target: aarch64
-          manylinux: auto
-          args: --release --out dist --features python
-
-      - name: Build Embedded Wheels (macOS/Windows)
-        if: runner.os != 'Linux'
-        working-directory: clients/python-embedded
-        run: |
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            if [ "${{ matrix.target }}" = "aarch64" ]; then
-              maturin build --release --out dist --features python --target aarch64-apple-darwin
-            else
-              maturin build --release --out dist --features python --target x86_64-apple-darwin
-            fi
-          else
-            maturin build --release --out dist --features python
-          fi
-        shell: bash
-
-      - name: Upload Embedded Wheel Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: embedded-wheel-${{ matrix.os }}-${{ matrix.target }}
-          path: clients/python-embedded/dist/*.whl
-          retention-days: 7
+  # NOTE: clients/python-embedded does NOT have Rust bindings yet.
+  # It's a placeholder/stub without actual Rust code or Cargo.toml.
+  # TODO: Re-enable when proper PyO3 bindings are implemented.
+  #
+  # build-embedded-wheels:
+  #   name: Build Embedded Wheels (${{ matrix.os }}, ${{ matrix.target }})
+  #   needs: prepare
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - os: ubuntu-22.04
+  #           target: x86_64
+  #         - os: ubuntu-22.04
+  #           target: aarch64
+  #         - os: macos-latest
+  #           target: aarch64
+  #         - os: windows-2022
+  #           target: x64
+  #
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.11"
+  #
+  #     - name: Install Rust Toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         toolchain: stable
+  #
+  #     - name: Install Maturin
+  #       run: pip install maturin
+  #
+  #     - name: Build Embedded Wheels (Linux x86_64)
+  #       if: matrix.os == 'ubuntu-22.04' && matrix.target == 'x86_64'
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         working-directory: clients/python-embedded
+  #         target: x86_64
+  #         manylinux: auto
+  #         args: --release --out dist --features python
+  #
+  #     - name: Build Embedded Wheels (Linux aarch64)
+  #       if: matrix.os == 'ubuntu-22.04' && matrix.target == 'aarch64'
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         working-directory: clients/python-embedded
+  #         target: aarch64
+  #         manylinux: auto
+  #         args: --release --out dist --features python
+  #
+  #     - name: Build Embedded Wheels (macOS/Windows)
+  #       if: runner.os != 'Linux'
+  #       working-directory: clients/python-embedded
+  #       run: |
+  #         if [ "${{ runner.os }}" = "macOS" ]; then
+  #           if [ "${{ matrix.target }}" = "aarch64" ]; then
+  #             maturin build --release --out dist --features python --target aarch64-apple-darwin
+  #           else
+  #             maturin build --release --out dist --features python --target x86_64-apple-darwin
+  #           fi
+  #         else
+  #           maturin build --release --out dist --features python
+  #         fi
+  #       shell: bash
+  #
+  #     - name: Upload Embedded Wheel Artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: embedded-wheel-${{ matrix.os }}-${{ matrix.target }}
+  #         path: clients/python-embedded/dist/*.whl
+  #         retention-days: 7
 
   # ============================================================================
   # BUILD SOURCE DISTRIBUTION
@@ -369,9 +373,12 @@ jobs:
         run: |
           pip install build
 
-      - name: Build sdist (embedded package with Rust)
+      - name: Build sdist (embedded package - NOTE: no Rust bindings yet)
         working-directory: clients/python-embedded
-        run: pip install maturin && maturin sdist --out dist
+        run: |
+          # clients/python-embedded doesn't have Rust bindings yet
+          # Build as pure Python package for now
+          pip install build && python -m build --sdist --outdir dist
 
       - name: Build sdist (pure Python package)
         working-directory: clients/python
@@ -391,7 +398,7 @@ jobs:
   # ============================================================================
   validate-artifacts:
     name: Validate Artifacts
-    needs: [prepare, build-binaries, build-embedded-wheels, build-sdist]
+    needs: [prepare, build-binaries, build-sdist]
     runs-on: ubuntu-latest
     outputs:
       validation_passed: ${{ steps.validate.outputs.passed }}
@@ -412,9 +419,10 @@ jobs:
           echo "Version: $VERSION"
           echo "=============================================="
           echo ""
-          echo "NOTE: clients/python is pure Python (setuptools),"
-          echo "      so no Rust-based wheels are built for it."
-          echo "      Only embedded wheels with Rust bindings are built."
+          echo "NOTE: For v0.2.0:"
+          echo "  - clients/python is pure Python (setuptools)"
+          echo "  - clients/python-embedded has no Rust bindings yet"
+          echo "  - Only native binaries and source distributions are built"
           echo ""
 
           # Expected Binary Targets (5 platforms - removed x86_64-apple-darwin)
@@ -438,9 +446,8 @@ jobs:
           done
           echo "Binary Summary: $BINARY_COUNT/${#EXPECTED_BINARIES[@]} found"
 
-          # Count embedded wheels (not main wheels)
-          EMBEDDED_WHEEL_COUNT=$(find artifacts -name "embedded-wheel-*" -type d 2>/dev/null | wc -l)
-          echo "Embedded wheel builds: $EMBEDDED_WHEEL_COUNT (expected 4)"
+          # NOTE: Embedded wheels are NOT built (no Rust bindings yet)
+          echo "Embedded wheel builds: skipped (no Rust bindings in clients/python-embedded)"
 
           # Source distributions
           SDIST_COUNT=$(find artifacts -path "*/sdist/*.tar.gz" -type f 2>/dev/null | wc -l)
@@ -694,7 +701,6 @@ jobs:
 
           # Count artifacts
           BINARY_COUNT=$(find artifacts -name "binaries-*" -type d | wc -l)
-          EMBEDDED_COUNT=$(find artifacts -name "embedded-wheel-*" -type d | wc -l)
           SDIST_COUNT=$(find artifacts -name "sdist" -type d | wc -l)
           RPM_COUNT=$(find artifacts -name "*.rpm" -type f 2>/dev/null | wc -l)
           DEB_COUNT=$(find artifacts -name "*.deb" -type f 2>/dev/null | wc -l)
@@ -710,14 +716,14 @@ jobs:
             "timestamp": "$TIMESTAMP",
             "artifacts": {
               "binaries": $BINARY_COUNT,
-              "embedded_wheels": $EMBEDDED_COUNT,
+              "embedded_wheels": 0,
               "sdist": $SDIST_COUNT,
               "rpm": $RPM_COUNT,
               "deb": $DEB_COUNT,
               "dmg": $DMG_COUNT,
               "msi": $MSI_COUNT
             },
-            "note": "clients/python is pure Python (setuptools), no Rust wheels built"
+            "note": "v0.2.0: clients/python and clients/python-embedded are pure Python packages (no Rust bindings)"
           }
           EOF
 
@@ -743,8 +749,8 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "All artifacts built successfully. This commit is ready for release." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Note:** \`clients/python\` is a pure Python package (setuptools)," >> $GITHUB_STEP_SUMMARY
-            echo "so only source distributions are built. No Rust-based wheels." >> $GITHUB_STEP_SUMMARY
+            echo "**Note:** Both \`clients/python\` and \`clients/python-embedded\` are pure Python" >> $GITHUB_STEP_SUMMARY
+            echo "packages (setuptools) without Rust bindings. Only source distributions are built." >> $GITHUB_STEP_SUMMARY
           else
             echo ":x: **Pre-release CI failed**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -765,7 +771,6 @@ jobs:
         with:
           name: |
             binaries-*
-            embedded-wheel-*
             sdist
             rpm-package
             deb-package


### PR DESCRIPTION
## Summary

Disables embedded wheel builds because `clients/python-embedded` doesn't have actual Rust/PyO3 bindings yet.

## Root Cause

The `clients/python-embedded` package:
- Has `pyproject.toml` that specifies `maturin` as build backend
- But there's NO `Cargo.toml` or Rust source code
- The `src/proximadb_embedded/` directory only contains pure Python code

When the CI tried to build it with maturin, it failed with:
```
Can't find Cargo.toml (in clients/python-embedded)
```

## Changes

1. **Disabled `build-embedded-wheels` job** (commented out)
2. **Changed sdist build** for python-embedded to use `python -m build` instead of `maturin sdist`
3. **Updated validation** to remove embedded wheel count check
4. **Updated summary** to set `embedded_wheels: 0`
5. **Updated cleanup** to remove `embedded-wheel-*` pattern

## Expected Artifacts (v0.2.0)

- **Binaries (5)**: Linux (x86_64-gnu, x86_64-musl, aarch64), macOS (aarch64), Windows (x86_64)
- **Source distributions (2)**: `clients/python` (setuptools), `clients/python-embedded` (setuptools)
- **Platform packages**: RPM, DEB, DMG, MSI

No compiled wheels are built since neither Python package has Rust bindings.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>