### PR TITLE
fix(ci): fix YAML syntax error in prerelease-ci.yml

### DIFF
--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -373,14 +373,14 @@ jobs:
         run: |
           pip install build
 
-      - name: Build sdist (embedded package - NOTE: no Rust bindings yet)
+      - name: Build sdist for embedded package
         working-directory: clients/python-embedded
         run: |
           # clients/python-embedded doesn't have Rust bindings yet
           # Build as pure Python package for now
           pip install build && python -m build --sdist --outdir dist
 
-      - name: Build sdist (pure Python package)
+      - name: Build sdist for pure Python package
         working-directory: clients/python
         run: python -m build --sdist --outdir dist
 


### PR DESCRIPTION
## Summary

Fixes the YAML syntax error in `prerelease-ci.yml` that has been preventing the workflow from running.

## Root Cause

The step names contained colons inside parentheses, which caused PyYAML to fail parsing:
```yaml
- name: Build sdist (embedded package - NOTE: no Rust bindings yet)
```

Error:
```
mapping values are not allowed here at line 376, column 51
```

The colon after `NOTE` was being interpreted as a YAML mapping indicator.

## Fix

Simplified step names to avoid special characters:
- `Build sdist (embedded package - NOTE: no Rust bindings yet)` 
  → `Build sdist for embedded package`
- `Build sdist (pure Python package)` 
  → `Build sdist for pure Python package`

The detailed notes are preserved in the step comments instead of the name.

## Testing

- ✅ PyYAML validation passes
- ✅ Workflow should now run without "workflow file issue" error

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>