### PR TITLE
chore(deps): rebase onto arrow 58 / parquet 58 / DataFusion 54 / object_store 0.13 / pyo3 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrow"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -275,7 +275,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7950df881e69c9c05b7d1775e770393c71925f871625debd3e3ed92c7f2ba94"
+checksum = "28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -383,21 +383,22 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex 0.12.2",
+ "lz4_flex 0.13.1",
  "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -413,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -426,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699e04d51e2ac87efc52faa0a1bb9742b11b7f75c2abd2842de50c41cc630a47"
+checksum = "d29abdf672a81c1aeb57fd2661457f9918964d49aed0e9f18932535f2a9e49ce"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -438,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -451,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.11.1",
  "serde_core",
@@ -462,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -476,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1306,7 +1307,7 @@ dependencies = [
  "hyper 0.14.32",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -2250,14 +2251,13 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datafusion"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
+checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -2284,14 +2284,12 @@ dependencies = [
  "datafusion-session",
  "datafusion-sql",
  "futures",
+ "indexmap",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.4",
- "regex",
- "rstest",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tempfile",
  "tokio",
  "url",
@@ -2300,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
+checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2325,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
+checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2344,36 +2342,37 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
+checksum = "121c9ded5d87d9172319e006f2afdb9928d72dbacd6a90a458d8acb1e3b43a65"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "indexmap",
+ "itertools 0.14.0",
  "libc",
  "log",
  "object_store",
- "paste",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
+checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
 dependencies = [
  "futures",
  "log",
@@ -2382,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
+checksum = "ffd7d295b2ec7c00d8a56562f41ed41062cf0af75549ed891c12a0a09eddfefe"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2404,6 +2403,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.4",
  "tokio",
  "url",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
+checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
+checksum = "68850aa426b897e879c8b87e512ea8124f1d0a2869a4e51808ddaaddf1bc0ada"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
+checksum = "402f93242ae08ef99139ee2c528a49d087efe88d5c7b2c3ff5480855a40ce54f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2476,25 +2476,28 @@ dependencies = [
  "futures",
  "object_store",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-doc"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
+checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-execution"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
+checksum = "37a8643ab852eb68864e1b72ae789e8066282dce48eea6347ffb0aee33d1ccc0"
 dependencies = [
  "arrow",
+ "arrow-buffer",
  "async-trait",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
  "object_store",
@@ -2506,11 +2509,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
+checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2521,57 +2525,56 @@ dependencies = [
  "datafusion-physical-expr-common",
  "indexmap",
  "itertools 0.14.0",
- "paste",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
 name = "datafusion-expr-common"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
+checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
 dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
  "itertools 0.14.0",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
+checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "base64 0.22.1",
  "chrono",
+ "chrono-tz",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools 0.14.0",
  "log",
+ "memchr",
  "num-traits",
  "rand 0.9.4",
  "regex",
- "unicode-segmentation",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
+checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2581,18 +2584,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
- "paste",
+ "num-traits",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
+checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2601,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
+checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2617,32 +2620,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
+ "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
+checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
+checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2653,14 +2658,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
+checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2668,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
+checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2679,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
+checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
 dependencies = [
  "arrow",
  "chrono",
@@ -2698,11 +2702,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
+checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2710,19 +2713,19 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools 0.14.0",
  "parking_lot",
- "paste",
  "petgraph 0.8.3",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
+checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2735,23 +2738,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
+checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
 dependencies = [
- "ahash",
  "arrow",
+ "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
+ "indexmap",
  "itertools 0.14.0",
+ "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
+checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2767,30 +2773,32 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
+checksum = "776ee54d47d15bdb126452f9ca17b03761e3b004682914beaedd3f86eb507fbc"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools 0.14.0",
  "log",
+ "num-traits",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -2798,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
+checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2809,15 +2817,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
+checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2829,19 +2836,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
+checksum = "6094ad36a3ed6d7ac87b20b479b2d0b118250f66cf997603829fdc65b44a7099"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-nested",
  "indexmap",
  "log",
  "regex",
- "sqlparser",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
@@ -3502,12 +3510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +3890,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -4414,15 +4421,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -4955,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash 2.1.2",
 ]
@@ -5106,15 +5104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -5430,21 +5419,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -5605,12 +5579,12 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
 dependencies = [
  "libc",
- "ndarray 0.16.1",
+ "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -5667,16 +5641,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body-util",
  "httparse",
@@ -5687,10 +5663,10 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5833,7 +5809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "half",
- "ndarray 0.17.2",
+ "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
@@ -5898,14 +5874,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.1"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -5917,8 +5892,8 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "lz4_flex 0.12.2",
+ "hashbrown 0.17.1",
+ "lz4_flex 0.13.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -6336,15 +6311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6608,13 +6574,13 @@ dependencies = [
  "rmp-serde",
  "rocksdb",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "snap",
- "sqlparser",
+ "sqlparser 0.59.0",
  "sqlx",
  "sysinfo",
  "tantivy",
@@ -6854,7 +6820,7 @@ dependencies = [
  "crossbeam-queue",
  "dashmap",
  "half",
- "ndarray 0.17.2",
+ "ndarray",
  "once_cell",
  "ort",
  "prometheus",
@@ -7237,7 +7203,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "dashmap",
- "ndarray 0.17.2",
+ "ndarray",
  "ort",
  "proximadb-kernel",
  "proximadb-rank-core",
@@ -7348,7 +7314,7 @@ dependencies = [
  "proximadb-relational-algebra",
  "proximadb-relational-types",
  "serde",
- "sqlparser",
+ "sqlparser 0.59.0",
  "thiserror 1.0.69",
 ]
 
@@ -7634,35 +7600,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -7670,9 +7633,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -7682,9 +7645,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7707,9 +7670,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -8041,12 +8004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8073,7 +8030,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8226,35 +8183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.117",
- "unicode-ident",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8377,15 +8305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8865,14 +8784,23 @@ checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
  "recursive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
  "sqlparser_derive",
 ]
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9780,7 +9708,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_edit",
 ]
 
 [[package]]
@@ -9826,18 +9754,6 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -10271,12 +10187,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,13 +121,13 @@ anyhow = "1.0"
 # dep at the workspace level. Same pin as the root `[dependencies]`
 # entry.
 sqlparser = "0.59"
-arrow = { version = "57.1", features = ["prettyprint"] }
-arrow-array = { version = "57.1", default-features = false }
+arrow = { version = "58", features = ["prettyprint"] }
+arrow-array = { version = "58", default-features = false }
 bincode = "1.3"
-arrow-flight = { version = "57.1", features = ["flight-sql-experimental"] }
-arrow-schema = { version = "57.1", default-features = false }
-parquet = { version = "57.1", default-features = false, features = ["arrow", "object_store", "zstd", "lz4", "snap", "brotli", "flate2", "flate2-rust_backened"] }
-object_store = "0.12"
+arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
+arrow-schema = { version = "58", default-features = false }
+parquet = { version = "58", default-features = false, features = ["arrow", "object_store", "zstd", "lz4", "snap", "brotli", "flate2", "flate2-rust_backened"] }
+object_store = "0.13"
 async-trait = "0.1"
 axum = { version = "0.6", features = ["json", "ws"] }
 chrono = { version = "0.4.31", features = ["serde"] }
@@ -202,8 +202,8 @@ xz2 = "0.1"
 zstd = "0.13"
 
 # Language bindings
-pyo3 = { version = "0.26", features = ["extension-module"] }
-numpy = { version = "0.26" }
+pyo3 = { version = "0.28", features = ["extension-module"] }
+numpy = { version = "0.28" }
 
 # TurboQuant numerics (ADR-021, gated by `experimental-turboquant`).
 # Kept here so future modality + benchmark consumers share a single version.
@@ -341,22 +341,22 @@ sqlx = { version = "0.7", features = ["runtime-tokio-native-tls", "json", "chron
 tempfile = "3.0"
 rayon = "1.10"  # Parallel processing for search optimization
 # Parquet and Arrow dependencies - using v57+ for improved performance and tonic 0.14 compatibility
-parquet = { version = "57.1", default-features = false, features = ["arrow", "zstd", "lz4", "snap", "brotli", "flate2", "flate2-rust_backened"] }
+parquet = { version = "58", default-features = false, features = ["arrow", "zstd", "lz4", "snap", "brotli", "flate2", "flate2-rust_backened"] }
 # Arrow dependencies matching parquet v57
-arrow = { version = "57.1", features = ["prettyprint"] }
-arrow-array = { version = "57.1", default-features = false }
-arrow-buffer = { version = "57.1", default-features = false }
-arrow-schema = { version = "57.1", default-features = false }
-arrow-data = { version = "57.1", default-features = false }
-arrow-ipc = { version = "57.1", default-features = false, features = ["lz4", "zstd"] }
-arrow-select = { version = "57.1", default-features = false }
-arrow-ord = { version = "57.1", default-features = false }
-arrow-flight = { version = "57.1", features = ["flight-sql-experimental"] }
-arrow-cast = { version = "57.1", default-features = false }
+arrow = { version = "58", features = ["prettyprint"] }
+arrow-array = { version = "58", default-features = false }
+arrow-buffer = { version = "58", default-features = false }
+arrow-schema = { version = "58", default-features = false }
+arrow-data = { version = "58", default-features = false }
+arrow-ipc = { version = "58", default-features = false, features = ["lz4", "zstd"] }
+arrow-select = { version = "58", default-features = false }
+arrow-ord = { version = "58", default-features = false }
+arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
+arrow-cast = { version = "58", default-features = false }
 
 # DataFusion for SQL and compute engine compatibility (Arrow 57 compatible)
-datafusion = { version = "51.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions"], optional = true }
-datafusion-common = { version = "51.0", optional = true }
+datafusion = { version = "54.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions"], optional = true }
+datafusion-common = { version = "54.0", optional = true }
 
 # Advanced compression for recovery-optimized WAL
 lz4_flex = "0.11"        # Faster LZ4 implementation

--- a/benches/hmgi_benchmark.rs
+++ b/benches/hmgi_benchmark.rs
@@ -75,6 +75,7 @@ fn modality_query(modality: &str) -> HybridQuery {
         ann_filtering_mode: Default::default(),
         ann_filtering_policy: None,
         estimated_selectivity: None,
+        search_effort: None,
     }
 }
 

--- a/crates/query/proximadb-graph-arrow/Cargo.toml
+++ b/crates/query/proximadb-graph-arrow/Cargo.toml
@@ -14,7 +14,7 @@ name = "proximadb_graph_arrow"
 path = "src/lib.rs"
 
 [dependencies]
-arrow = { version = "57.1", features = ["prettyprint"] }
+arrow = { version = "58", features = ["prettyprint"] }
 async-trait.workspace = true
 futures = "0.3"
 proximadb-graph-query = { path = "../proximadb-graph-query" }

--- a/crates/storage/proximadb-object-store/src/lib.rs
+++ b/crates/storage/proximadb-object-store/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::StreamExt;
 use object_store::path::Path;
-use object_store::{ObjectMeta, ObjectStore, PutMode, PutOptions};
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions};
 use proximadb_kernel::error::StorageError;
 use url::Url;
 

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -107,10 +107,6 @@ impl std::fmt::Debug for VectorSearchTableProvider {
 
 #[async_trait]
 impl TableProvider for VectorSearchTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         vector_matches_schema()
     }

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -21,7 +21,6 @@
 //! `logical_lowering`) into the shared logical plane so the join is reachable from
 //! pgwire SQL. Both reuse [`vector_matches_to_batch`] below.
 
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow_array::{Float32Array, RecordBatch, StringArray};

--- a/src/datafusion/engine_adapters/filesystem_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/filesystem_parquet_reader.rs
@@ -12,7 +12,6 @@
 //! reference-counted [`Bytes`]; per-row-group ranged reads are a future optimization the
 //! blueprint already tracks.
 
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow_schema::{Schema, SchemaRef};

--- a/src/datafusion/engine_adapters/filesystem_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/filesystem_parquet_reader.rs
@@ -190,10 +190,6 @@ impl FilesystemParquetTable {
 
 #[async_trait]
 impl TableProvider for FilesystemParquetTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/engine_adapters/helix_adapter.rs
+++ b/src/datafusion/engine_adapters/helix_adapter.rs
@@ -53,7 +53,6 @@
 
 #![allow(dead_code)] // forward-scaffolding fields pending wiring
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/datafusion/engine_adapters/helix_adapter.rs
+++ b/src/datafusion/engine_adapters/helix_adapter.rs
@@ -358,10 +358,6 @@ impl HelixTableProvider {
 
 #[async_trait]
 impl TableProvider for HelixTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -4,7 +4,6 @@
 //! `IcebergObjectStoreBridge` for base-prefix discovery and Parquet's
 //! `ParquetObjectReader` for range-based footer and row-group reads.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -560,7 +559,7 @@ mod tests {
         )
         .unwrap();
         let props = WriterProperties::builder()
-            .set_max_row_group_size(2)
+            .set_max_row_group_row_count(Some(2))
             .build();
         let file = std::fs::File::create(path).unwrap();
         let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -21,6 +21,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::path::Path;
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use parquet::file::metadata::ParquetMetaData;
@@ -295,10 +296,6 @@ impl ObjectStoreParquetTable {
 
 #[async_trait]
 impl TableProvider for ObjectStoreParquetTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/engine_adapters/sst_adapter.rs
+++ b/src/datafusion/engine_adapters/sst_adapter.rs
@@ -279,10 +279,6 @@ impl SstTableProvider {
 
 #[async_trait]
 impl TableProvider for SstTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/engine_adapters/sst_adapter.rs
+++ b/src/datafusion/engine_adapters/sst_adapter.rs
@@ -45,7 +45,6 @@
 
 #![allow(dead_code)] // forward-scaffolding fields pending wiring
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/datafusion/engine_adapters/viper_adapter.rs
+++ b/src/datafusion/engine_adapters/viper_adapter.rs
@@ -324,10 +324,6 @@ impl ViperTableProvider {
 
 #[async_trait]
 impl TableProvider for ViperTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/engine_adapters/viper_adapter.rs
+++ b/src/datafusion/engine_adapters/viper_adapter.rs
@@ -52,7 +52,6 @@
 
 #![allow(dead_code)] // forward-scaffolding fields pending wiring
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -138,7 +138,7 @@ pub struct ProximaScanExec {
     /// Collection name for logging
     collection_name: String,
     /// Plan properties
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     /// Cached statistics
     statistics: Option<Statistics>,
 }
@@ -257,11 +257,7 @@ impl ExecutionPlan for ProximaScanExec {
         "ProximaScanExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -350,8 +346,8 @@ impl ExecutionPlan for ProximaScanExec {
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, limited)))
     }
 
-    fn statistics(&self) -> DFResult<Statistics> {
-        Ok(self.statistics.clone().unwrap_or_default())
+    fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
+        Ok(Arc::new(self.statistics.clone().unwrap_or_default()))
     }
 }
 
@@ -483,7 +479,7 @@ impl ProximaScanExecBuilder {
             reader,
             batch_size,
             collection_name: self.collection_name,
-            properties,
+            properties: Arc::new(properties),
             statistics: self.statistics,
         })
     }

--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -45,7 +45,6 @@
 //! let stream = scan_exec.execute(0, context)?;
 //! ```
 
-use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/datafusion/proxima_table_provider.rs
+++ b/src/datafusion/proxima_table_provider.rs
@@ -33,7 +33,6 @@
 //! - **I (Interface Segregation)**: Separate traits for table metadata and split reading
 //! - **D (Dependency Inversion)**: ExecutionPlan depends on abstract SplitReader trait
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/src/datafusion/proxima_table_provider.rs
+++ b/src/datafusion/proxima_table_provider.rs
@@ -418,10 +418,6 @@ impl NullProximaTableProvider {
 
 #[async_trait]
 impl TableProvider for NullProximaTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/datafusion/scan_executor.rs
+++ b/src/datafusion/scan_executor.rs
@@ -57,7 +57,7 @@ pub struct ProximaDBScanExec {
     /// Batch size for reading
     batch_size: usize,
     /// Plan properties
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl ProximaDBScanExec {
@@ -111,7 +111,7 @@ impl ProximaDBScanExec {
             limit,
             partitions,
             batch_size,
-            properties,
+            properties: Arc::new(properties),
         })
     }
 
@@ -163,11 +163,7 @@ impl ExecutionPlan for ProximaDBScanExec {
         "ProximaDBScanExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/src/datafusion/scan_executor.rs
+++ b/src/datafusion/scan_executor.rs
@@ -3,7 +3,6 @@
 //! Implements DataFusion's ExecutionPlan for scanning ProximaDB collections.
 //! Supports parallel partition scanning with filter and projection pushdown.
 
-use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/datafusion/table_provider.rs
+++ b/src/datafusion/table_provider.rs
@@ -18,7 +18,6 @@
 //! let provider = ProximaDataFusionTable::new(collection, schema, reader);
 //! ```
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/src/datafusion/table_provider.rs
+++ b/src/datafusion/table_provider.rs
@@ -164,10 +164,6 @@ impl std::fmt::Debug for ProximaDBTableProvider {
 
 #[async_trait]
 impl TableProvider for ProximaDBTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
@@ -457,10 +453,6 @@ impl Debug for ProximaDataFusionTable {
 
 #[async_trait]
 impl TableProvider for ProximaDataFusionTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/src/embedded/python.rs
+++ b/src/embedded/python.rs
@@ -116,7 +116,7 @@ pub struct PySearchResult {
 impl PySearchResult {
     /// Get metadata as a Python dictionary
     #[getter]
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (k, v) in &self.metadata_map {
             dict.set_item(k, v)?;
@@ -364,7 +364,7 @@ impl PyGraphNode {
 
     /// Get properties as a dictionary
     #[getter]
-    fn properties(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn properties(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (k, v) in &self.properties_map {
             dict.set_item(k, v)?;
@@ -477,7 +477,7 @@ impl PyGraphEdge {
 
     /// Get properties as a dictionary
     #[getter]
-    fn properties(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn properties(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (k, v) in &self.properties_map {
             dict.set_item(k, v)?;
@@ -792,7 +792,7 @@ pub struct PyStreamingSearchResult {
 impl PyStreamingSearchResult {
     /// Get metadata as a Python dictionary
     #[getter]
-    fn metadata(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         for (k, v) in &self.metadata_map {
             dict.set_item(k, v)?;
@@ -1266,7 +1266,7 @@ impl PyProximaDB {
         py: Python<'_>,
         collection: &str,
         requested_partitions: u32,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         let requested = requested_partitions.max(1);
         let partitions = self
             .db()?
@@ -1371,7 +1371,7 @@ impl PyProximaDB {
             };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.insert(collection, ids, rust_vectors, rust_metadata))
+        py.detach(move || inner.insert(collection, ids, rust_vectors, rust_metadata))
             .map_err(|e| PyRuntimeError::new_err(format!("Insert failed: {}", e)))
     }
 
@@ -1424,20 +1424,18 @@ impl PyProximaDB {
         };
 
         let inner = self.db()?;
-        py.allow_threads(move || {
-            inner.search_with_mode(collection, query_vec, top_k, filter, search_mode)
-        })
-        .map(|results| {
-            results
-                .into_iter()
-                .map(|r| PySearchResult {
-                    id: r.id,
-                    score: r.score,
-                    metadata_map: r.metadata,
-                })
-                .collect()
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("Search failed: {}", e)))
+        py.detach(move || inner.search_with_mode(collection, query_vec, top_k, filter, search_mode))
+            .map(|results| {
+                results
+                    .into_iter()
+                    .map(|r| PySearchResult {
+                        id: r.id,
+                        score: r.score,
+                        metadata_map: r.metadata,
+                    })
+                    .collect()
+            })
+            .map_err(|e| PyRuntimeError::new_err(format!("Search failed: {}", e)))
     }
 
     /// Insert vectors from a NumPy array with ZERO-COPY transfer
@@ -1519,7 +1517,7 @@ impl PyProximaDB {
             };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.insert(collection, ids, rust_vectors, rust_metadata))
+        py.detach(move || inner.insert(collection, ids, rust_vectors, rust_metadata))
             .map_err(|e| PyRuntimeError::new_err(format!("Insert failed: {}", e)))
     }
 
@@ -1540,7 +1538,7 @@ impl PyProximaDB {
             .collect::<PyResult<Vec<_>>>()?;
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.insert_proxima_records(collection, rust_records))
+        py.detach(move || inner.insert_proxima_records(collection, rust_records))
             .map_err(|e| PyRuntimeError::new_err(format!("Record insert failed: {}", e)))
     }
 
@@ -1603,7 +1601,7 @@ impl PyProximaDB {
         }
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.insert_proxima_records(collection, records))
+        py.detach(move || inner.insert_proxima_records(collection, records))
             .map_err(|e| PyRuntimeError::new_err(format!("Record insert failed: {}", e)))
     }
 
@@ -1617,7 +1615,7 @@ impl PyProximaDB {
         ids: Vec<String>,
         vectors: PyReadonlyArray2<f32>,
         props: Option<&Bound<'_, PyList>>,
-    ) -> PyResult<(usize, PyObject)> {
+    ) -> PyResult<(usize, Py<PyAny>)> {
         let total_started = std::time::Instant::now();
         let array = vectors.as_array();
         let shape = array.shape();
@@ -1690,7 +1688,7 @@ impl PyProximaDB {
         let inner = self.db()?;
         let insert_started = std::time::Instant::now();
         let result = py
-            .allow_threads(move || inner.insert_proxima_records(collection, records))
+            .detach(move || inner.insert_proxima_records(collection, records))
             .map_err(|e| PyRuntimeError::new_err(format!("Record insert failed: {}", e)))?;
         let insert_elapsed = insert_started.elapsed();
         let total_elapsed = total_started.elapsed();
@@ -1746,20 +1744,18 @@ impl PyProximaDB {
             .unwrap_or_else(|_| query.as_array().to_vec());
 
         let inner = self.db()?;
-        py.allow_threads(move || {
-            inner.search_with_mode(collection, query_vec, top_k, filter, search_mode)
-        })
-        .map(|results| {
-            results
-                .into_iter()
-                .map(|r| PySearchResult {
-                    id: r.id,
-                    score: r.score,
-                    metadata_map: r.metadata,
-                })
-                .collect()
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("Search failed: {}", e)))
+        py.detach(move || inner.search_with_mode(collection, query_vec, top_k, filter, search_mode))
+            .map(|results| {
+                results
+                    .into_iter()
+                    .map(|r| PySearchResult {
+                        id: r.id,
+                        score: r.score,
+                        metadata_map: r.metadata,
+                    })
+                    .collect()
+            })
+            .map_err(|e| PyRuntimeError::new_err(format!("Search failed: {}", e)))
     }
 
     /// Profiled variant of `search_numpy` used by the benchmark harness to
@@ -1773,7 +1769,7 @@ impl PyProximaDB {
         top_k: usize,
         filter: Option<&str>,
         search_mode: Option<&str>,
-    ) -> PyResult<(Vec<PySearchResult>, PyObject)> {
+    ) -> PyResult<(Vec<PySearchResult>, Py<PyAny>)> {
         let total_started = std::time::Instant::now();
         let copy_started = std::time::Instant::now();
         let query_vec: Vec<f32> = query
@@ -1785,7 +1781,7 @@ impl PyProximaDB {
         let inner = self.db()?;
         let search_started = std::time::Instant::now();
         let results = py
-            .allow_threads(move || {
+            .detach(move || {
                 inner.search_with_mode(collection, query_vec, top_k, filter, search_mode)
             })
             .map_err(|e| PyRuntimeError::new_err(format!("Search failed: {}", e)))?;
@@ -2010,7 +2006,7 @@ impl PyProximaDB {
         py: Python<'_>,
         collection: &str,
         vector_id: &str,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         match self.db()?.get_vector(collection, vector_id) {
             Ok(Some(record)) => {
                 let dict = PyDict::new(py);
@@ -2181,7 +2177,7 @@ impl PyProximaDB {
             };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.upsert(collection, ids, rust_vectors, rust_metadata))
+        py.detach(move || inner.upsert(collection, ids, rust_vectors, rust_metadata))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to upsert vectors: {}", e)))
     }
 
@@ -2246,7 +2242,7 @@ impl PyProximaDB {
             };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.upsert(collection, ids, rust_vectors, rust_metadata))
+        py.detach(move || inner.upsert(collection, ids, rust_vectors, rust_metadata))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to upsert vectors: {}", e)))
     }
 
@@ -2826,7 +2822,7 @@ impl PyProximaDB {
         max_depth: u32,
         edge_types: Option<Vec<String>>,
         limit: Option<u32>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         let result = self
             .db()?
             .traverse_graph(graph_id, start_node_id, max_depth, edge_types, limit)
@@ -2862,7 +2858,7 @@ impl PyProximaDB {
         py: Python<'_>,
         cypher: &str,
         graph_id: Option<&str>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         let cypher = inject_graph_target_into_cypher(graph_id, cypher);
         let sql = format!(
             "SELECT * FROM GRAPH_QUERY('{}')",
@@ -2963,7 +2959,7 @@ impl PyProximaDB {
         py: Python<'_>,
         collection: &str,
         doc_id: &str,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         match self.db()?.get_document(collection, doc_id) {
             Ok(Some(doc)) => json_to_python(py, &doc).map(Some),
             Ok(None) => Ok(None),
@@ -2997,7 +2993,7 @@ impl PyProximaDB {
         collection: &str,
         filter: Option<&str>,
         limit: u32,
-    ) -> PyResult<Vec<(String, PyObject)>> {
+    ) -> PyResult<Vec<(String, Py<PyAny>)>> {
         self.db()?
             .query_documents(collection, filter, limit)
             .map(|results| {
@@ -3160,7 +3156,7 @@ impl PyProximaDB {
         }
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.ingest_logs(namespace, rust_logs))
+        py.detach(move || inner.ingest_logs(namespace, rust_logs))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to ingest logs: {}", e)))
     }
 
@@ -3192,44 +3188,42 @@ impl PyProximaDB {
         end_time_ns: i64,
         query: Option<&str>,
         limit: u32,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = self.db()?;
-        py.allow_threads(move || {
-            inner.query_logs(namespace, start_time_ns, end_time_ns, query, limit)
-        })
-        .map(|logs| {
-            logs.into_iter()
-                .map(|log| {
-                    let dict = PyDict::new(py);
-                    dict.set_item("timestamp_ns", log.timestamp_ns).ok();
-                    dict.set_item("severity", &log.severity).ok();
-                    dict.set_item("message", &log.message).ok();
-                    // Handle Option<String> for source and service
-                    if let Some(ref source) = log.source {
-                        dict.set_item("source", source).ok();
-                    } else {
-                        dict.set_item("source", py.None()).ok();
-                    }
-                    if let Some(ref service) = log.service {
-                        dict.set_item("service", service).ok();
-                    } else {
-                        dict.set_item("service", py.None()).ok();
-                    }
-
-                    let fields_dict = PyDict::new(py);
-                    for (k, v) in &log.fields {
-                        // Convert serde_json::Value to Python
-                        if let Ok(py_val) = json_to_python(py, v) {
-                            fields_dict.set_item(k, py_val).ok();
+        py.detach(move || inner.query_logs(namespace, start_time_ns, end_time_ns, query, limit))
+            .map(|logs| {
+                logs.into_iter()
+                    .map(|log| {
+                        let dict = PyDict::new(py);
+                        dict.set_item("timestamp_ns", log.timestamp_ns).ok();
+                        dict.set_item("severity", &log.severity).ok();
+                        dict.set_item("message", &log.message).ok();
+                        // Handle Option<String> for source and service
+                        if let Some(ref source) = log.source {
+                            dict.set_item("source", source).ok();
+                        } else {
+                            dict.set_item("source", py.None()).ok();
                         }
-                    }
-                    dict.set_item("fields", fields_dict).ok();
+                        if let Some(ref service) = log.service {
+                            dict.set_item("service", service).ok();
+                        } else {
+                            dict.set_item("service", py.None()).ok();
+                        }
 
-                    dict.into()
-                })
-                .collect()
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to query logs: {}", e)))
+                        let fields_dict = PyDict::new(py);
+                        for (k, v) in &log.fields {
+                            // Convert serde_json::Value to Python
+                            if let Ok(py_val) = json_to_python(py, v) {
+                                fields_dict.set_item(k, py_val).ok();
+                            }
+                        }
+                        dict.set_item("fields", fields_dict).ok();
+
+                        dict.into()
+                    })
+                    .collect()
+            })
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to query logs: {}", e)))
     }
 
     /// Ingest metric samples
@@ -3296,7 +3290,7 @@ impl PyProximaDB {
         }
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.ingest_metrics(namespace, rust_samples))
+        py.detach(move || inner.ingest_metrics(namespace, rust_samples))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to ingest metrics: {}", e)))
     }
 
@@ -3310,9 +3304,9 @@ impl PyProximaDB {
         start_time: Option<&str>,
         end_time: Option<&str>,
         step_seconds: u32,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = self.db()?;
-        py.allow_threads(move || {
+        py.detach(move || {
             inner.aggregate_metrics(
                 namespace,
                 metric_name,
@@ -3411,7 +3405,7 @@ impl PyProximaDB {
         }
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.ingest_traces(namespace, rust_traces))
+        py.detach(move || inner.ingest_traces(namespace, rust_traces))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to ingest traces: {}", e)))
     }
 
@@ -3428,9 +3422,9 @@ impl PyProximaDB {
         min_duration_ns: Option<i64>,
         status: Option<&str>,
         limit: u32,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = self.db()?;
-        py.allow_threads(move || {
+        py.detach(move || {
             inner.query_traces(
                 namespace,
                 start_time_ns,
@@ -3452,12 +3446,12 @@ impl PyProximaDB {
         })
     }
 
-    fn get_trace(&self, py: Python<'_>, namespace: &str, trace_id: &str) -> PyResult<PyObject> {
+    fn get_trace(&self, py: Python<'_>, namespace: &str, trace_id: &str) -> PyResult<Py<PyAny>> {
         let inner = self.db()?;
-        py.allow_threads(move || inner.get_trace(namespace, trace_id))
+        py.detach(move || inner.get_trace(namespace, trace_id))
             .and_then(|trace| {
                 let dict = PyDict::new(py);
-                let spans: Vec<PyObject> = trace
+                let spans: Vec<Py<PyAny>> = trace
                     .spans
                     .into_iter()
                     .map(|span| trace_span_to_python(py, span))
@@ -3480,7 +3474,7 @@ impl PyProximaDB {
         query: &str,
         parameters: Option<&Bound<'_, PyAny>>,
         collection: Option<&str>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         let rust_params = if let Some(params) = parameters {
             let json_value = python_to_json(params)?;
             Some(match json_value {
@@ -3492,7 +3486,7 @@ impl PyProximaDB {
         };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.execute_sql(query, rust_params, collection))
+        py.detach(move || inner.execute_sql(query, rust_params, collection))
             .and_then(|result| {
                 let dict = PyDict::new(py);
                 let rows = PyList::empty(py);
@@ -3529,12 +3523,16 @@ impl PyProximaDB {
         };
 
         let inner = self.db()?;
-        py.allow_threads(move || inner.execute_sql(query, rust_params, collection))
+        py.detach(move || inner.execute_sql(query, rust_params, collection))
             .and_then(|result| sql_result_to_arrow_ipc(&result))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to execute SQL as Arrow: {}", e)))
     }
 
-    fn explain_notebook_plan(&self, py: Python<'_>, plan: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+    fn explain_notebook_plan(
+        &self,
+        py: Python<'_>,
+        plan: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<PyAny>> {
         let plan_json = python_to_json(plan)?;
         let explanation = notebook_plan_explain(self.db()?.as_ref(), &plan_json)
             .map_err(|e| PyValueError::new_err(format!("Invalid notebook plan: {}", e)))?;
@@ -3550,7 +3548,7 @@ impl PyProximaDB {
         let sql = compile_notebook_plan_sql(&plan_json)
             .map_err(|e| PyValueError::new_err(format!("Invalid notebook plan: {}", e)))?;
         let inner = self.db()?;
-        py.allow_threads(move || inner.execute_sql(&sql, None, None))
+        py.detach(move || inner.execute_sql(&sql, None, None))
             .and_then(|result| sql_result_to_arrow_ipc(&result))
             .map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to execute notebook plan as Arrow: {}", e))
@@ -3596,10 +3594,8 @@ impl PyProximaDB {
         };
 
         let inner = self.db()?;
-        py.allow_threads(move || {
-            inner.insert_arrow_ipc(collection, &ipc_stream, insert_only, tenant_id)
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to insert Arrow batch: {}", e)))
+        py.detach(move || inner.insert_arrow_ipc(collection, &ipc_stream, insert_only, tenant_id))
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to insert Arrow batch: {}", e)))
     }
 
     #[pyo3(signature = (collection, ipc_stream, tenant_id=None))]
@@ -3611,7 +3607,7 @@ impl PyProximaDB {
         tenant_id: Option<&str>,
     ) -> PyResult<u64> {
         let inner = self.db()?;
-        py.allow_threads(move || inner.insert_arrow_ipc(collection, &ipc_stream, false, tenant_id))
+        py.detach(move || inner.insert_arrow_ipc(collection, &ipc_stream, false, tenant_id))
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to upsert Arrow batch: {}", e)))
     }
 
@@ -3646,9 +3642,9 @@ impl PyProximaDB {
         query: &str,
         query_vector: Option<Vec<f32>>,
         fusion_strategy: Option<&str>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner = self.db()?;
-        py.allow_threads(move || inner.execute_unified_query(query, query_vector, fusion_strategy))
+        py.detach(move || inner.execute_unified_query(query, query_vector, fusion_strategy))
             .map(|records| {
                 records
                     .into_iter()
@@ -3702,7 +3698,7 @@ impl PyProximaDB {
     ///     for comp in plan['components']:
     ///         print(f"  {comp['model']}: cost={comp['estimated_cost']}")
     ///     ```
-    fn explain_unified_query(&self, py: Python<'_>, query: &str) -> PyResult<PyObject> {
+    fn explain_unified_query(&self, py: Python<'_>, query: &str) -> PyResult<Py<PyAny>> {
         self.db()?
             .explain_unified_query(query)
             .map(|plan| {
@@ -4076,7 +4072,7 @@ fn proxima_tree_node_to_json(node: &proximadb_records::ProximaTreeNode) -> serde
     }
 }
 
-fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> PyResult<PyObject> {
+fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> PyResult<Py<PyAny>> {
     match value {
         serde_json::Value::Null => Ok(py.None()),
         serde_json::Value::Bool(b) => Ok((*b).into_pyobject(py)?.to_owned().into_any().unbind()),
@@ -4568,7 +4564,7 @@ fn json_f64_value(value: &serde_json::Value) -> Option<f64> {
     }
 }
 
-fn trace_span_to_python(py: Python<'_>, span: super::EmbeddedTraceSpan) -> PyResult<PyObject> {
+fn trace_span_to_python(py: Python<'_>, span: super::EmbeddedTraceSpan) -> PyResult<Py<PyAny>> {
     let dict = PyDict::new(py);
     dict.set_item("trace_id", span.trace_id)?;
     dict.set_item("span_id", span.span_id)?;

--- a/src/embedded/python.rs
+++ b/src/embedded/python.rs
@@ -49,7 +49,7 @@ use super::{
 use crate::core::config::{AdvancedPruneConfig, PruneModeConfig};
 
 /// Python wrapper for disk configuration
-#[pyclass(name = "DiskConfig")]
+#[pyclass(name = "DiskConfig", from_py_object)]
 #[derive(Clone)]
 pub struct PyDiskConfig {
     /// Path to storage directory
@@ -188,7 +188,7 @@ pub struct PyStorageStats {
 // ============================================================================
 
 /// Python wrapper for checkpoint information
-#[pyclass(name = "CheckpointInfo")]
+#[pyclass(name = "CheckpointInfo", from_py_object)]
 #[derive(Clone)]
 pub struct PyCheckpointInfo {
     /// Name of the checkpoint
@@ -231,7 +231,7 @@ impl From<super::CheckpointInfo> for PyCheckpointInfo {
 }
 
 /// Python wrapper for delta save information
-#[pyclass(name = "DeltaInfo")]
+#[pyclass(name = "DeltaInfo", from_py_object)]
 #[derive(Clone)]
 pub struct PyDeltaInfo {
     /// Path where delta was saved
@@ -304,7 +304,7 @@ impl From<super::DeltaInfo> for PyDeltaInfo {
 ///
 ///     # For a social network:
 ///     node = GraphNode("user_123", labels=["Person"], properties={"name": "Alice"})
-#[pyclass(name = "GraphNode")]
+#[pyclass(name = "GraphNode", from_py_object)]
 #[derive(Clone)]
 pub struct PyGraphNode {
     /// Unique node ID
@@ -410,7 +410,7 @@ impl From<PyGraphNode> for super::GraphNode {
 }
 
 /// Generic graph edge with flexible property storage
-#[pyclass(name = "GraphEdge")]
+#[pyclass(name = "GraphEdge", from_py_object)]
 #[derive(Clone)]
 pub struct PyGraphEdge {
     /// Optional edge ID
@@ -535,7 +535,7 @@ pub struct PyGraphStats {
 // ============================================================================
 
 /// Latency statistics for an operation type
-#[pyclass(name = "LatencyStats")]
+#[pyclass(name = "LatencyStats", from_py_object)]
 #[derive(Clone)]
 pub struct PyLatencyStats {
     /// Number of operations recorded
@@ -597,7 +597,7 @@ impl From<super::LatencyStats> for PyLatencyStats {
 ///     print(f"Cache hit rate: {metrics.cache_hit_rate * 100}%")
 ///     print(f"Total searches: {metrics.total_searches}")
 ///     ```
-#[pyclass(name = "EmbeddedMetrics")]
+#[pyclass(name = "EmbeddedMetrics", from_py_object)]
 #[derive(Clone)]
 pub struct PyEmbeddedMetrics {
     // Latency histograms
@@ -775,7 +775,7 @@ impl From<super::GraphStats> for PyGraphStats {
 }
 
 /// Python wrapper for streaming search results
-#[pyclass(name = "StreamingSearchResult")]
+#[pyclass(name = "StreamingSearchResult", from_py_object)]
 #[derive(Clone)]
 pub struct PyStreamingSearchResult {
     /// Vector ID
@@ -1066,7 +1066,7 @@ impl PyProximaDB {
                         1,
                     )?;
                 }
-            } else if let Ok(dict) = mode_arg.downcast::<PyDict>() {
+            } else if let Ok(dict) = mode_arg.cast::<PyDict>() {
                 let prune_type = dict
                     .get_item("type")?
                     .and_then(|t| t.extract::<String>().ok())
@@ -1356,7 +1356,7 @@ impl PyProximaDB {
             if let Some(meta_list) = metadata {
                 let mut result = Vec::with_capacity(meta_list.len());
                 for item in meta_list.iter() {
-                    let dict = item.downcast::<PyDict>()?;
+                    let dict = item.cast::<PyDict>()?;
                     let mut map = HashMap::new();
                     for (k, v) in dict.iter() {
                         let key: String = k.extract()?;
@@ -1502,7 +1502,7 @@ impl PyProximaDB {
             if let Some(meta_list) = metadata {
                 let mut result = Vec::with_capacity(meta_list.len());
                 for item in meta_list.iter() {
-                    let dict = item.downcast::<PyDict>()?;
+                    let dict = item.cast::<PyDict>()?;
                     let mut map = HashMap::new();
                     for (k, v) in dict.iter() {
                         let key: String = k.extract()?;
@@ -1530,7 +1530,7 @@ impl PyProximaDB {
         collection: &str,
         records: &Bound<'_, PyAny>,
     ) -> PyResult<usize> {
-        let record_list = records.downcast::<PyList>()?;
+        let record_list = records.cast::<PyList>()?;
         let now_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
         let rust_records = record_list
             .iter()
@@ -2162,7 +2162,7 @@ impl PyProximaDB {
             if let Some(meta_list) = metadata {
                 let mut result = Vec::with_capacity(meta_list.len());
                 for item in meta_list.iter() {
-                    let dict = item.downcast::<PyDict>()?;
+                    let dict = item.cast::<PyDict>()?;
                     let mut map = HashMap::new();
                     for (k, v) in dict.iter() {
                         let key: String = k.extract()?;
@@ -2227,7 +2227,7 @@ impl PyProximaDB {
             if let Some(meta_list) = metadata {
                 let mut result = Vec::with_capacity(meta_list.len());
                 for item in meta_list.iter() {
-                    let dict = item.downcast::<PyDict>()?;
+                    let dict = item.cast::<PyDict>()?;
                     let mut map = HashMap::new();
                     for (k, v) in dict.iter() {
                         let key: String = k.extract()?;
@@ -3111,7 +3111,7 @@ impl PyProximaDB {
 
         let mut rust_logs = Vec::with_capacity(logs.len());
         for item in logs.iter() {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
 
             let timestamp_ns: i64 = dict
                 .get_item("timestamp_ns")?
@@ -3136,7 +3136,7 @@ impl PyProximaDB {
 
             let mut fields = std::collections::HashMap::new();
             if let Some(fields_dict) = dict.get_item("fields")? {
-                if let Ok(d) = fields_dict.downcast::<PyDict>() {
+                if let Ok(d) = fields_dict.cast::<PyDict>() {
                     for (k, v) in d.iter() {
                         let key: String = k.extract()?;
                         let value = python_to_json(&v)?;
@@ -3253,7 +3253,7 @@ impl PyProximaDB {
 
         let mut rust_samples = Vec::with_capacity(samples.len());
         for item in samples.iter() {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
 
             let metric_name: String = dict
                 .get_item("metric_name")?
@@ -3270,7 +3270,7 @@ impl PyProximaDB {
 
             let mut labels = HashMap::new();
             if let Some(labels_dict) = dict.get_item("labels")? {
-                if let Ok(d) = labels_dict.downcast::<PyDict>() {
+                if let Ok(d) = labels_dict.cast::<PyDict>() {
                     for (k, v) in d.iter() {
                         let key: String = k.extract()?;
                         let val: String = v
@@ -3340,7 +3340,7 @@ impl PyProximaDB {
 
         let mut rust_traces = Vec::with_capacity(traces.len());
         for item in traces.iter() {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
             let trace_id: String = dict
                 .get_item("trace_id")?
                 .ok_or_else(|| PyValueError::new_err("Trace span missing 'trace_id'"))?
@@ -3381,7 +3381,7 @@ impl PyProximaDB {
 
             let mut attributes = HashMap::new();
             if let Some(attr_dict) = dict.get_item("attributes")?
-                && let Ok(py_dict) = attr_dict.downcast::<PyDict>()
+                && let Ok(py_dict) = attr_dict.cast::<PyDict>()
             {
                 for (k, v) in py_dict.iter() {
                     let key: String = k.extract()?;
@@ -3832,13 +3832,13 @@ fn python_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
         Ok(serde_json::json!(f))
     } else if let Ok(s) = value.extract::<String>() {
         Ok(serde_json::Value::String(s))
-    } else if let Ok(list) = value.downcast::<PyList>() {
+    } else if let Ok(list) = value.cast::<PyList>() {
         let arr: Vec<serde_json::Value> = list
             .iter()
             .map(|item| python_to_json(&item))
             .collect::<PyResult<_>>()?;
         Ok(serde_json::Value::Array(arr))
-    } else if let Ok(dict) = value.downcast::<PyDict>() {
+    } else if let Ok(dict) = value.cast::<PyDict>() {
         let mut map = serde_json::Map::new();
         for (k, v) in dict.iter() {
             let key: String = k.extract()?;
@@ -3862,19 +3862,19 @@ fn python_to_json_record_value(value: &Bound<'_, PyAny>) -> PyResult<serde_json:
         Ok(serde_json::json!(f))
     } else if let Ok(s) = value.extract::<String>() {
         Ok(serde_json::Value::String(s))
-    } else if let Ok(list) = value.downcast::<PyList>() {
+    } else if let Ok(list) = value.cast::<PyList>() {
         let arr: Vec<serde_json::Value> = list
             .iter()
             .map(|item| python_to_json_record_value(&item))
             .collect::<PyResult<_>>()?;
         Ok(serde_json::Value::Array(arr))
-    } else if let Ok(tuple) = value.downcast::<PyTuple>() {
+    } else if let Ok(tuple) = value.cast::<PyTuple>() {
         let arr: Vec<serde_json::Value> = tuple
             .iter()
             .map(|item| python_to_json_record_value(&item))
             .collect::<PyResult<_>>()?;
         Ok(serde_json::Value::Array(arr))
-    } else if let Ok(dict) = value.downcast::<PyDict>() {
+    } else if let Ok(dict) = value.cast::<PyDict>() {
         let mut map = serde_json::Map::new();
         for (k, v) in dict.iter() {
             let key: String = k.extract()?;
@@ -3893,7 +3893,7 @@ fn python_record_field<'py>(
     record: &Bound<'py, PyAny>,
     name: &str,
 ) -> PyResult<Option<Bound<'py, PyAny>>> {
-    if let Ok(dict) = record.downcast::<PyDict>() {
+    if let Ok(dict) = record.cast::<PyDict>() {
         dict.get_item(name)
     } else if record.hasattr(name)? {
         Ok(Some(record.getattr(name)?))
@@ -3923,7 +3923,7 @@ fn python_record_props(record: &Bound<'_, PyAny>) -> PyResult<proximadb_records:
     if let Some(props_value) = python_record_field(record, "props")?
         && !props_value.is_none()
     {
-        let props_dict = props_value.downcast::<PyDict>()?;
+        let props_dict = props_value.cast::<PyDict>()?;
         for (key, value) in props_dict.iter() {
             let key: String = key.extract()?;
             props.insert(
@@ -3977,7 +3977,7 @@ fn python_props_list_item(
 ) -> PyResult<proximadb_records::ProximaTree> {
     if let Some(prop_list) = props {
         let item = prop_list.get_item(index)?;
-        let dict = item.downcast::<PyDict>()?;
+        let dict = item.cast::<PyDict>()?;
         python_dict_to_proxima_tree(dict)
     } else {
         Ok(proximadb_records::ProximaTree::new())

--- a/src/embedded/python_dataframe.rs
+++ b/src/embedded/python_dataframe.rs
@@ -23,7 +23,7 @@ fn require_non_blank(label: &str, value: &str) -> PyResult<()> {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyExpr {
     pub expr: Expr,
@@ -686,7 +686,7 @@ impl PyDataFrame {
         for batch in batches {
             let py_batch = batch.to_pyarrow(py)?;
             let pylist = py_batch.call_method0("to_pylist")?;
-            for item in pylist.downcast::<PyList>()?.iter() {
+            for item in pylist.cast::<PyList>()?.iter() {
                 list.append(item)?;
             }
         }

--- a/src/embedded/python_dataframe.rs
+++ b/src/embedded/python_dataframe.rs
@@ -649,7 +649,7 @@ impl PyDataFrame {
     }
 
     /// Convert results to a PyArrow Table (Zero-Copy)
-    fn to_arrow(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_arrow(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let batches = self
             .db
             .runtime()
@@ -675,7 +675,7 @@ impl PyDataFrame {
     }
 
     /// Collect results as a list of dictionaries
-    fn collect(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn collect(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let batches = self
             .db
             .runtime()

--- a/src/storage/engines/core/formats/columnar/columnar_io.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_io.rs
@@ -597,7 +597,7 @@ impl UnifiedColumnarWriter {
             } else {
                 parquet::file::properties::EnabledStatistics::None
             })
-            .set_max_row_group_size(self.config.row_group_size)
+            .set_max_row_group_row_count(Some(self.config.row_group_size))
             .set_data_page_size_limit(self.config.page_size);
 
         // Configure bloom filters for specific columns

--- a/src/storage/engines/core/formats/columnar/parquet_write_engine/schema_builder.rs
+++ b/src/storage/engines/core/formats/columnar/parquet_write_engine/schema_builder.rs
@@ -167,7 +167,7 @@ impl ParquetSchemaBuilder {
 /// Create writer properties with comprehensive optimizations
 pub fn create_writer_properties(config: &ParquetWriterConfig) -> Result<WriterProperties> {
     let mut builder = WriterProperties::builder()
-        .set_max_row_group_size(config.row_group_size)
+        .set_max_row_group_row_count(Some(config.row_group_size))
         .set_data_page_size_limit(config.page_size)
         .set_write_batch_size(config.write_batch_size);
 

--- a/src/storage/engines/nova/nova_ranged_reader.rs
+++ b/src/storage/engines/nova/nova_ranged_reader.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures::StreamExt;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use proximadb_records::ProximaRecord;
 use url::Url;

--- a/src/storage/engines/viper/pipeline.rs
+++ b/src/storage/engines/viper/pipeline.rs
@@ -2165,7 +2165,7 @@ impl ParquetFlusher {
             .set_compression(compression)
             .set_encoding(Encoding::DELTA_BINARY_PACKED)
             .set_dictionary_enabled(self.config.enable_dictionary_encoding)
-            .set_max_row_group_size(self.config.row_group_size)
+            .set_max_row_group_row_count(Some(self.config.row_group_size))
             .set_write_batch_size(self.config.write_batch_size)
             .build();
 


### PR DESCRIPTION
## Summary
Rebases the workspace onto the current Arrow ecosystem so we are on **arrow 58** end-to-end. This unblocks `arrow/pyarrow` (which requires pyo3 ≥ 0.28) and keeps DataFusion aligned (DF 54 is built on arrow 58).

| Dependency | From | To |
|---|---|---|
| arrow / arrow-* / parquet | 57.1 | **58** |
| datafusion / datafusion-common | 51.0 | **54.0** |
| object_store | 0.12 | **0.13** |
| pyo3 / numpy | 0.26 | **0.28** |

## API migrations
- **DataFusion 54**: `ExecutionPlan`/`TableProvider` dropped `as_any` (now `Any` supertrait) → removed 12 `as_any` impls; `properties()` returns `&Arc<PlanProperties>`; `statistics()` → `partition_statistics(Option<usize>) -> Result<Arc<Statistics>>`.
- **object_store 0.13**: `put/get/get_range/head/delete` moved to the `ObjectStoreExt` extension trait → added imports where used.
- **parquet 58**: deprecated `set_max_row_group_size(usize)` → `set_max_row_group_row_count(Option<usize>)` (4 sites).
- **pyo3 0.28**: `PyObject` → `Py<PyAny>`; `Python::allow_threads` → `Python::detach`; `PyAnyMethods::downcast` → `Bound::cast` (21 sites); `#[pyclass(from_py_object)]` on the 9 Clone-deriving pyclasses to retain the auto-derived `FromPyObject` (now opt-in in 0.28).

## Why arrow 58 and not 59
arrow 59 released ~1 day ago and there is **no DataFusion release built on arrow 59** yet; DF 54 is on arrow 58. arrow 58 is the current viable ceiling.

## Verification (all green)
- `cargo clippy --lib --bins -- -D warnings` — 0 warnings
- `cargo check --workspace --lib` and `--all-targets`
- `cargo check -p proximadb --features python` — 0 warnings (pyo3 0.28 surface)
- `cargo fmt --all -- --check` — clean
- No new `.unwrap()/.expect()/panic!` on production paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)