### PR TITLE
ci: cancel superseded develop runs (cancel-in-progress on develop)

### DIFF
--- a/.github/workflows/capability-contract-tests.yml
+++ b/.github/workflows/capability-contract-tests.yml
@@ -25,7 +25,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   capability-contract-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded runs
   # on feature/PR branches, but let protected-branch validation finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -63,7 +63,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   # ============================================================================

--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -10,7 +10,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   layering-validation:

--- a/.github/workflows/prerelease-ci-v0.2.1-macos.yml
+++ b/.github/workflows/prerelease-ci-v0.2.1-macos.yml
@@ -7,7 +7,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   notes:

--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -68,7 +68,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   # ============================================================================

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -16,7 +16,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   # ========================================

--- a/.github/workflows/tier-config-fingerprint.yml
+++ b/.github/workflows/tier-config-fingerprint.yml
@@ -29,7 +29,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
 jobs:
   fingerprint-check:


### PR DESCRIPTION
Fixes the develop CI head-of-line stalls (superseded runs blocking the latest commit, observed as ci.yml stuck pending with 0 jobs). develop is unprotected + fast-churning, so flip it into cancel-in-progress so only the latest push is tested and superseded runs auto-cancel.

**Scope/safety:** main and `development` stay `cancel-in-progress: false` (release-line/prerelease/deploy commits fully validated, never cancelled mid-flight). Only ci.yml, layering-check, tier-config-fingerprint trigger on develop push (all tests/checks); deploy/publish/prerelease are main/development-gated → no in-flight deploy cancelled. Trade-off: intermediate develop commits no longer each get a CI result (re-run manually if a specific commit needs validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)