### PR TITLE
fix(datafusion): schema-size ProximaScanExec stats (DF54 aggregate panic)

### DIFF
--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -346,7 +346,18 @@ impl ExecutionPlan for ProximaScanExec {
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
-        Ok(Arc::new(self.statistics.clone().unwrap_or_default()))
+        // DataFusion 54 indexes `column_statistics[col.index()]` when a parent
+        // (e.g. AggregateExec) derives its own statistics. A bare
+        // `Statistics::default()` carries an EMPTY `column_statistics`, so any
+        // aggregate planned over this scan panics with "index out of bounds".
+        // Always hand back a schema-sized Statistics: use the provided stats only
+        // when their column count matches the schema, else an unknown-but-sized one.
+        let schema = self.schema();
+        let stats = match &self.statistics {
+            Some(s) if s.column_statistics.len() == schema.fields().len() => s.clone(),
+            _ => Statistics::new_unknown(&schema),
+        };
+        Ok(Arc::new(stats))
     }
 }
 


### PR DESCRIPTION
## P0 — regression from the arrow58/DataFusion54 migration

DataFusion 54's `AggregateExec` derives its statistics by indexing the child plan's `column_statistics` (`datafusion-physical-plan-54` `aggregates/mod.rs:1145`). The arrow58 migration left `ProximaScanExec::partition_statistics` returning `self.statistics.unwrap_or_default()`, and `Statistics::default()` carries an **empty** `column_statistics`. So **any aggregate SQL** planned over a parquet scan panicked:

```
thread '…' panicked at datafusion-physical-plan-54.0.0/src/aggregates/mod.rs:1145:
index out of bounds: the len is 0 but the index is 0
```

This was **red on develop** (CI run `27796367500`, `Rust Tests (unit): failure`), so the published OSS image (built from that commit) could panic on aggregate queries, and it also blocked PR #69.

## Fix
Return a **schema-sized** `Statistics`: use the provided stats only when their column count matches the schema, else `Statistics::new_unknown(&schema)`.

## Verification
`cargo test -p proximadb --lib query::execution::datafusion_engine::tests` → **8 passed / 0 failed** (the 7 previously-panicking tests now pass).

Root cause was missed originally because the migration was verified with `cargo check`/clippy/fmt but not the test suite (a *runtime* panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)