### PR TITLE
chore(dev): isolated-workspace system (one task = one worktree = one branch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,9 @@ You must also strictly enforce SaaS Operational constraints:
 ====
 
 ### Core Directives
-1.  **Architecture Source Of Truth:** Use `docs/12-design/README.adoc` as the architecture index. Pay special attention to the `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` document.
-2.  **Safety First:** NO `.unwrap()`, `.expect()`, or `panic!()` in production code. Use `Result` and `?`.
-3.  **Token Efficiency:** When running long-output commands, use `grep` with context flags.
+1.  **Workspace Isolation (MANDATORY — this repo is worked on by multiple concurrent sessions):** NEVER edit, commit, `checkout`, `reset`, `stash`, or `branch -f` in the main checkout, and NEVER touch another worktree's branch or uncommitted WIP. Every task gets its own git worktree + branch off `origin/develop`: run `eval "$(scripts/worktree.sh new <type/topic>)"` to create one and `cd` into it. Run `scripts/worktree.sh guard` before editing — if it fails, you are in the shared checkout; stop and make a worktree. Clean up with `scripts/worktree.sh rm <type/topic>` once your PR merges. Full rationale + commands: `docs/10-quality/WORKSPACE_ISOLATION.md`.
+2.  **Architecture Source Of Truth:** Use `docs/12-design/README.adoc` as the architecture index. Pay special attention to the `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` document.
+3.  **Safety First:** NO `.unwrap()`, `.expect()`, or `panic!()` in production code. Use `Result` and `?`.
+4.  **Token Efficiency:** When running long-output commands, use `grep` with context flags.
 
 *See `GEMINI.md` for the comprehensive list of engineering mandates.*

--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -1,0 +1,83 @@
+# Workspace Isolation — one task = one worktree = one branch
+
+> **Mandate:** Never edit or commit in the main checkout
+> (`/…/proximaDB`). Every unit of work gets its own isolated git **worktree**.
+> Use `scripts/worktree.sh`. This is enforced for AI agents (see `CLAUDE.md`)
+> and strongly recommended for humans running concurrent sessions.
+
+## Why this exists
+
+ProximaDB is frequently worked on by **several sessions at once** — multiple AI
+agents and/or a human, in parallel. When they all share a single git checkout
+they also share one **HEAD, index, and working tree** — a single piece of
+mutable state that they fight over. Observed failure modes (all real):
+
+| Symptom | Cause |
+|---|---|
+| A commit lands on the **wrong branch** | Another session ran `git checkout` and moved the shared HEAD between your `checkout -b` and your `commit`. |
+| Edits silently clobber someone's work | The shared tree held another session's **uncommitted WIP**. |
+| `git stash`/`checkout` destroys WIP | Same shared tree; defensive `git commit -o <file>` was the only safe write. |
+| CI head-of-line stalls | Everyone pushes the same shared branches; superseded runs pile up. |
+
+The fix is to **eliminate the shared mutable state**: give every task its own
+worktree (its own directory + branch + HEAD + index), branched from a
+known-good base. Isolation is then structural, not a matter of discipline.
+
+## The model
+
+- **One task = one worktree = one branch = one PR.** A session may own several.
+- Worktrees live in a **sibling** directory next to the repo, so they're
+  outside it (no `.gitignore`, no tooling scans them):
+  ```
+  /…/code/proximaDB/                      ← main checkout (read/run only; never edit)
+  /…/code/proximaDB.worktrees/
+      feat-cloud-full/                    ← branch feat/cloud-full
+      fix-adls-scheme/                    ← branch fix/adls-scheme
+  ```
+  Override the root with `PROXIMADB_WORKTREE_ROOT`.
+- Every branch is cut from **`origin/develop`** (freshly fetched), the
+  integration base.
+
+## Commands (`scripts/worktree.sh`)
+
+```bash
+# Start a task — creates the worktree + branch off origin/develop and
+# prints a `cd`. eval it to land inside:
+eval "$(scripts/worktree.sh new feat/my-thing)"
+
+scripts/worktree.sh list                 # all worktrees + which are dirty
+scripts/worktree.sh guard                # exits non-zero if run in the main checkout
+scripts/worktree.sh rm feat/my-thing     # remove after the PR merges (guards dirty)
+scripts/worktree.sh clean                # drop every worktree already merged to develop
+```
+
+`new` refuses to clobber an existing branch/path; `rm` refuses to delete a
+dirty worktree (pass `--force` to discard) and only deletes the branch if it's
+merged; `clean` is the periodic housekeeping pass.
+
+## Lifecycle
+
+```
+new feat/x  ──▶  edit · commit · push · open PR  ──▶  PR merges  ──▶  rm feat/x
+                 (inside the worktree only)                          (or: clean)
+```
+
+## Agent mandate (also in `CLAUDE.md`)
+
+1. **Before editing anything, run `scripts/worktree.sh guard`.** If it fails,
+   you are in the main checkout — stop and create a worktree.
+2. **Never** `checkout`, `reset`, `stash`, or `branch -f` in a tree you don't
+   own; never touch another worktree's branch or WIP.
+3. Commit only files you created/changed (the worktree makes this natural; if
+   ever in a shared tree, fall back to `git commit -o <file>`).
+4. Clean up (`rm`) once your PR merges.
+
+## FAQ
+
+- **Disk cost?** Worktrees share the one `.git` object store; only the checked-
+  out files are duplicated. Cheap relative to the safety.
+- **Builds?** Each worktree has its own `target/` (no cross-contamination of
+  feature flags). That's a feature — a `--features cloud-full` build can't
+  poison a default build.
+- **`/tmp` worktrees?** Fine for throwaway/CI, but prefer the sibling root so
+  work survives reboots and is discoverable via `worktree.sh list`.

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ProximaDB isolated-workspace helper.
+# ----------------------------------------------------------------------------
+# One task = one git worktree = one branch. Each unit of work gets its OWN
+# working directory, branch, HEAD and index, branched from a known-good base
+# (origin/develop). Concurrent sessions (humans or AI agents) therefore never
+# share a checkout, so they cannot churn each other's HEAD, strand commits on
+# the wrong branch, or clobber uncommitted WIP.
+#
+# Worktrees live in a SIBLING directory next to the repo (outside it — no
+# .gitignore needed, no tooling scans them):
+#   <repo-parent>/proximaDB.worktrees/<sanitized-branch>/
+# Override with PROXIMADB_WORKTREE_ROOT.
+#
+# Usage:
+#   scripts/worktree.sh new   <type/topic> [base]   # create + print path
+#   scripts/worktree.sh list                         # list worktrees + state
+#   scripts/worktree.sh rm    <type/topic> [--force] # remove (guards dirty)
+#   scripts/worktree.sh clean                        # drop merged worktrees
+#   scripts/worktree.sh guard                        # fail if in main checkout
+#
+# Typical flow (also the agent mandate — see CLAUDE.md):
+#   eval "$(scripts/worktree.sh new feat/my-thing)"  # cd's you into it
+#   ...edit, commit, push, open PR...
+#   scripts/worktree.sh rm feat/my-thing             # after the PR merges
+# ----------------------------------------------------------------------------
+set -euo pipefail
+
+BASE_DEFAULT="develop"
+REMOTE="origin"
+
+die() { printf 'worktree: %s\n' "$*" >&2; exit 1; }
+
+# Resolve the MAIN repository checkout (the common dir's parent), regardless of
+# which worktree we're invoked from.
+repo_main() { git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's#/\.git/*$##'; }
+
+worktree_root() {
+  if [ -n "${PROXIMADB_WORKTREE_ROOT:-}" ]; then printf '%s' "$PROXIMADB_WORKTREE_ROOT"; return; fi
+  printf '%s/proximaDB.worktrees' "$(dirname "$(repo_main)")"
+}
+
+sanitize() { printf '%s' "$1" | tr '/' '-' | tr -cs 'A-Za-z0-9._-' '-'; }
+
+cmd_new() {
+  local branch="${1:-}" base="${2:-$BASE_DEFAULT}"
+  [ -n "$branch" ] || die "usage: new <type/topic> [base]   (e.g. feat/cloud-full)"
+  case "$branch" in */*) : ;; *) die "branch must be <type>/<topic> (e.g. feat/$branch)";; esac
+  local dir; dir="$(worktree_root)/$(sanitize "$branch")"
+  [ -e "$dir" ] && die "worktree path already exists: $dir"
+  git show-ref --verify --quiet "refs/heads/$branch" && die "branch already exists: $branch (use 'rm' first, or pick another)"
+
+  git -C "$(repo_main)" fetch --quiet "$REMOTE" "$base" || die "cannot fetch $REMOTE/$base"
+  mkdir -p "$(worktree_root)"
+  git -C "$(repo_main)" worktree add -b "$branch" "$dir" "$REMOTE/$base" >&2
+  # Emit a `cd` so callers can `eval "$(... new ...)"` to land in the worktree.
+  printf 'cd %q\n' "$dir"
+  printf 'worktree: %s  (branch %s off %s/%s)\n' "$dir" "$branch" "$REMOTE" "$base" >&2
+}
+
+cmd_list() {
+  git -C "$(repo_main)" worktree list --porcelain | awk -v RS='' '
+    { wt=""; br="(detached)";
+      for (i=1;i<=split($0,L,"\n");i++) {
+        if (L[i] ~ /^worktree /) { sub(/^worktree /,"",L[i]); wt=L[i] }
+        if (L[i] ~ /^branch /)   { sub(/^branch refs\/heads\//,"",L[i]); br=L[i] }
+      }
+      printf "%-60s %s\n", wt, br
+    }'
+  echo "--- dirty? ---"
+  while read -r wt; do
+    [ -d "$wt" ] || continue
+    local n; n="$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+    [ "$n" != "0" ] && printf '  %s: %s uncommitted file(s)\n' "$wt" "$n"
+  done < <(git -C "$(repo_main)" worktree list --porcelain | sed -n 's/^worktree //p')
+  echo "(clean worktrees omitted)"
+}
+
+# Map a branch name -> its worktree path (empty if none).
+wt_for_branch() {
+  git -C "$(repo_main)" worktree list --porcelain | awk -v b="refs/heads/$1" '
+    /^worktree /{p=$2} /^branch /{ if ($2==b) print p }'
+}
+
+cmd_rm() {
+  local branch="${1:-}" force=""
+  [ -n "$branch" ] || die "usage: rm <type/topic> [--force]"
+  [ "${2:-}" = "--force" ] && force="--force"
+  local dir; dir="$(wt_for_branch "$branch")"
+  [ -n "$dir" ] || die "no worktree for branch: $branch"
+  if [ -z "$force" ] && [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]; then
+    die "worktree is dirty: $dir  (commit/stash, or pass --force to discard)"
+  fi
+  git -C "$(repo_main)" worktree remove ${force:+--force} "$dir"
+  if git -C "$(repo_main)" branch --merged "$REMOTE/$BASE_DEFAULT" --format='%(refname:short)' | grep -qx "$branch"; then
+    git -C "$(repo_main)" branch -d "$branch" && printf 'worktree: deleted merged branch %s\n' "$branch" >&2
+  else
+    printf 'worktree: removed %s (branch %s kept — not merged into %s)\n' "$dir" "$branch" "$BASE_DEFAULT" >&2
+  fi
+}
+
+cmd_clean() {
+  git -C "$(repo_main)" fetch --quiet "$REMOTE" "$BASE_DEFAULT" || true
+  local removed=0
+  while read -r dir; do
+    [ "$dir" = "$(repo_main)" ] && continue
+    local br; br="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo)"
+    [ -n "$br" ] || continue
+    if git -C "$(repo_main)" merge-base --is-ancestor "$br" "$REMOTE/$BASE_DEFAULT" 2>/dev/null; then
+      [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ] && { printf 'skip (dirty): %s\n' "$dir" >&2; continue; }
+      git -C "$(repo_main)" worktree remove "$dir" && git -C "$(repo_main)" branch -D "$br" >/dev/null 2>&1 || true
+      printf 'cleaned merged worktree: %s (%s)\n' "$dir" "$br" >&2
+      removed=$((removed+1))
+    fi
+  done < <(git -C "$(repo_main)" worktree list --porcelain | sed -n 's/^worktree //p')
+  git -C "$(repo_main)" worktree prune
+  printf 'worktree: cleaned %d merged worktree(s)\n' "$removed" >&2
+}
+
+# Guardrail: refuse if the CWD is the MAIN checkout (agents call this before
+# editing). A worktree's toplevel != the main checkout's toplevel.
+cmd_guard() {
+  local here; here="$(git rev-parse --show-toplevel 2>/dev/null || echo)"
+  [ -n "$here" ] || die "not in a git repo"
+  if [ "$here" = "$(repo_main)" ]; then
+    die "you are in the MAIN checkout ($here). Do NOT edit here — run: scripts/worktree.sh new <type/topic>"
+  fi
+  printf 'worktree: OK — isolated workspace %s (branch %s)\n' "$here" "$(git rev-parse --abbrev-ref HEAD)"
+}
+
+case "${1:-}" in
+  new)   shift; cmd_new "$@" ;;
+  list)  shift; cmd_list "$@" ;;
+  rm)    shift; cmd_rm "$@" ;;
+  clean) shift; cmd_clean "$@" ;;
+  guard) shift; cmd_guard "$@" ;;
+  *) cat >&2 <<'USAGE'
+worktree: one task = one worktree = one branch (isolated by construction)
+  scripts/worktree.sh new   <type/topic> [base]   create + print `cd` (eval it)
+  scripts/worktree.sh list                          list worktrees + dirty state
+  scripts/worktree.sh rm    <type/topic> [--force]  remove (guards dirty)
+  scripts/worktree.sh clean                         drop worktrees merged to develop
+  scripts/worktree.sh guard                         fail if run in the main checkout
+USAGE
+     exit 2 ;;
+esac


### PR DESCRIPTION
## Problem
ProximaDB is worked on by **multiple concurrent sessions** (AI agents + human) in one git checkout — so they share one HEAD/index/working-tree. That single shared mutable state caused, this week alone: a commit landing on the **wrong branch** (HEAD moved mid-task), edits at risk of clobbering another session's uncommitted WIP, and constant defensive `git commit -o` / ad-hoc `/tmp` worktrees.

## Fix — make isolation structural
**One task = one worktree = one branch = one PR.** Each unit of work gets its own directory + branch + HEAD + index, cut from `origin/develop`, in a sibling `proximaDB.worktrees/` root.

- **`scripts/worktree.sh`** — `new` (create + print `cd` to eval) · `list` (worktrees + dirty state) · `guard` (fails in the main checkout) · `rm` (dirty-safe, deletes only merged branches) · `clean` (drop merged worktrees). Smoke-tested: `guard` passes in a worktree, exits 1 in the main checkout; `list` enumerates all live worktrees.
- **`docs/10-quality/WORKSPACE_ISOLATION.md`** — rationale (the real failure modes), model, commands, lifecycle, agent mandate, FAQ.
- **`CLAUDE.md`** — Workspace Isolation is now **Core Directive #1**.

## Follow-up
Mirror the directive into `GEMINI.md` (the doc references it as the comprehensive mandate list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)