### PR TITLE
fix(docker): cloud-capable OSS images (cloud-full) — fixes AnvaiOps ADLS CrashLoop

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -46,10 +46,9 @@ on:
         options: [runtime, runtime-full]
         default: runtime
 
-concurrency:
-  # One publish per ref at a time; never cancel an in-flight push.
-  group: publish-image-${{ github.ref }}
-  cancel-in-progress: false
+# NOTE: concurrency is set per-job (build/merge) so it can include the matrix
+# `target` — runtime and runtime-full publish independently and must not
+# serialize against each other. A workflow-level group can't see the matrix.
 
 permissions:
   contents: read
@@ -61,9 +60,19 @@ jobs:
     if: ${{ github.repository == 'vjsingh1984/proximadb' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    # Per (target,platform) cell: never cancel an in-flight push; a new run's
+    # same cell queues behind the old one. target is in the group so the two
+    # targets publish in parallel.
+    concurrency:
+      group: publish-image-${{ github.ref }}-${{ matrix.target }}-${{ matrix.platform }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: {runtime,runtime-full} × {amd64,arm64} = 4 native builds.
+        # `include` attaches the right runner to each platform.
+        target: [runtime, runtime-full]
+        platform: [linux/amd64, linux/arm64]
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
@@ -71,7 +80,7 @@ jobs:
             runner: ubuntu-24.04-arm
     env:
       IMAGE_REPO: ${{ vars.DOCKERHUB_IMAGE || 'vjsingh1984/proximadb' }}
-      TARGET: ${{ github.event.inputs.target || 'runtime' }}
+      TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4
 
@@ -116,22 +125,28 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ steps.prep.outputs.pair }}
+          name: digests-${{ matrix.target }}-${{ steps.prep.outputs.pair }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
   merge:
-    name: Merge multi-arch manifest
+    name: Merge ${{ matrix.target }} manifest
     needs: build
     if: ${{ github.repository == 'vjsingh1984/proximadb' }}
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.tags.outputs.version }}
-      primary: ${{ steps.tags.outputs.primary }}
+    # One merge per target → two manifest lists (runtime, runtime-full), each
+    # carrying its own tag set (the -full suffix is applied in "Derive tags").
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [runtime, runtime-full]
+    concurrency:
+      group: publish-image-merge-${{ github.ref }}-${{ matrix.target }}
+      cancel-in-progress: false
     env:
       IMAGE_REPO: ${{ vars.DOCKERHUB_IMAGE || 'vjsingh1984/proximadb' }}
-      TARGET: ${{ github.event.inputs.target || 'runtime' }}
+      TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4
 
@@ -139,7 +154,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          # Only this target's per-arch digests (digests-<target>-linux-<arch>).
+          pattern: digests-${{ matrix.target }}-*
           merge-multiple: true
 
       - name: Log in to Docker Hub

--- a/apps/proximadb-server/Cargo.toml
+++ b/apps/proximadb-server/Cargo.toml
@@ -25,6 +25,16 @@ onnx = ["proximadb-embedding/onnx"]
 # set `PROXIMADB_EMBED_PROVIDER=coreml` to route BGE inference through the
 # Apple Neural Engine + GPU instead of CPU.
 coreml = ["onnx", "proximadb-embedding/coreml"]
+# Cloud object_store backends. Forward to the root `proximadb` crate's gated
+# features so the server binary links the S3 / ADLS / GCS object_store
+# implementations. WITHOUT these the server fails at boot with
+# "Unsupported filesystem scheme: adls" (resp. s3/gcs) when storage points at
+# a cloud URL — the default build only has the local `file://` backend.
+aws = ["proximadb/aws"]
+azure = ["proximadb/azure"]
+gcp = ["proximadb/gcp"]
+# Convenience: all three cloud backends (mirrors the root crate's cloud-full).
+cloud-full = ["aws", "azure", "gcp"]
 
 [dependencies]
 anyhow.workspace = true

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p src/bin && \
     echo "pub fn lib() {}" > src/lib.rs
 
 # Build dependencies only (cached layer)
-RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --bin proximadb-server 2>/dev/null || true
+RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --features cloud-full --bin proximadb-server 2>/dev/null || true
 
 # Copy actual source code. Workspace members (apps/, clients/, crates/)
 # are required for cargo to resolve the workspace — Cargo.toml at /build
@@ -39,8 +39,8 @@ COPY apps/ apps/
 COPY clients/ clients/
 COPY crates/ crates/
 
-# Build the actual binary
-RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --bin proximadb-server
+# Build the actual binary (with cloud object_store backends: S3/ADLS/GCS).
+RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --features cloud-full --bin proximadb-server
 
 # Strip debug symbols for smaller binary
 RUN strip /build/target/release/proximadb-server
@@ -76,7 +76,7 @@ COPY config/ config/
 COPY apps/ apps/
 COPY clients/ clients/
 COPY crates/ crates/
-RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --features onnx --bin proximadb-server \
+RUN RUSTFLAGS="-A unsafe_op_in_unsafe_fn" cargo build -p proximadb-server --release --features cloud-full,onnx --bin proximadb-server \
  && strip /build/target/release/proximadb-server
 
 # ============================================================================

--- a/src/storage/persistence/filesystem/aws_s3.rs
+++ b/src/storage/persistence/filesystem/aws_s3.rs
@@ -17,6 +17,10 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::StreamExt;
 use object_store::ObjectStore;
+// Extension trait providing get/get_range/put/delete/head on the object_store
+// handle. Required in scope here or the bridge calls below fail to resolve
+// (E0599) — this file is feature-gated (`aws`) and not built by default CI.
+use object_store::ObjectStoreExt;
 use object_store::PutPayload;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjPath;

--- a/src/storage/persistence/filesystem/azure_blob.rs
+++ b/src/storage/persistence/filesystem/azure_blob.rs
@@ -19,6 +19,10 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::StreamExt;
 use object_store::ObjectStore;
+// Extension trait providing get/get_range/put/delete/head on the object_store
+// handle. Required in scope here or the bridge calls below fail to resolve
+// (E0599) — this file is feature-gated (`azure`) and not built by default CI.
+use object_store::ObjectStoreExt;
 use object_store::PutPayload;
 use object_store::azure::MicrosoftAzureBuilder;
 use object_store::path::Path as ObjPath;


### PR DESCRIPTION
## Problem
AnvaiOps' AKS deploy CrashLoopBackOff'd: `Failed to get filesystem: Unsupported filesystem scheme: adls`. The OSS image was built with default features, which omit the object_store cloud backends (`aws`/`azure`/`gcp` are gated).

## Two real blockers (the handoff assumed only the first half of #1)
1. **`proximadb-server` didn't expose `cloud-full`** — it only forwarded `onnx`; the cloud features live on the root `proximadb` crate. Added `aws`/`azure`/`gcp`/`cloud-full` forwarding features to `apps/proximadb-server/Cargo.toml`.
2. **Compile-rot in the cloud backends** — enabling `aws`/`azure` surfaced **12 `E0599`** errors: `aws_s3.rs`/`azure_blob.rs` call `get/put/head/delete/get_range` but never imported `object_store::ObjectStoreExt`. Feature-gated → never built in default CI → rot unnoticed. Imported the trait (as `nova_ranged_reader.rs` already does). `gcs_store.rs` is unaffected (native client).

## Changes
- `apps/proximadb-server/Cargo.toml`: `aws`/`azure`/`gcp`/`cloud-full` forwarding features.
- `deploy/docker/Dockerfile`: runtime builder (+ dep-cache) → `--features cloud-full`; builder-full → `--features cloud-full,onnx`. Server stays Python-free.
- `src/storage/persistence/filesystem/{aws_s3,azure_blob}.rs`: import `ObjectStoreExt`.
- `.github/workflows/publish-image.yml`: matrix `target [runtime, runtime-full] × platform [amd64, arm64]`; per-target manifest merge; concurrency widened with `-<target>`. develop push → `:sha-<sha>` (cloud-full) + `:sha-<sha>-full` (cloud-full,onnx), multi-arch.

## Verification (local, arm64)
Built `--target runtime` (cloud-full) → 396MB, **zero E0599**. Ran it with `PROXIMADB_QUEUE_ROOT=adls://…`: **no `Unsupported filesystem scheme`** — queue init clean, cloud backends register (fail only on missing creds). The `-full` image's onnx + baked bge-small are already proven (semantic-cosine test on develop) and built by the same Dockerfile path.

## Multi-arch digests
The amd64+arm64 manifest-list digests (ADR-0016 pinning) come from the `publish-image.yml` run on merge — local amd64 via QEMU is unreliable for the Rust build, and push needs the Docker Hub secrets. Will report both manifest digests (`:sha-<sha>` and `:sha-<sha>-full`) + resolved tags from that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)