### PR TITLE
ci(feature-matrix): compile feature-gated code so it can't rot (P0-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,45 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
         run: cargo clippy --lib --bins -- -D warnings
 
+  # Feature-gated code paths that DEFAULT CI never compiles. This is the job
+  # that would have caught the cloud-full `ObjectStoreExt` compile-rot (the
+  # AnvaiOps ADLS CrashLoopBackOff) at PR time instead of in production:
+  # aws/azure/gcp/onnx/cluster/catalog code is gated, so the default build
+  # skips it and rot accumulates invisibly. `cargo check` (no link/test) keeps
+  # this cheap while still surfacing E0599-class errors. Each combo runs on its
+  # own runner (fail-fast: false) so one feature's break doesn't mask others.
+  feature-matrix:
+    name: Feature Matrix (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The two combos the published images actually ship (PR #78):
+          - { label: "cloud-full",          pkg: proximadb-server, feats: "cloud-full" }
+          - { label: "cloud-full,onnx",     pkg: proximadb-server, feats: "cloud-full,onnx" }
+          # Other gated surfaces invisible to default CI:
+          - { label: "cluster",             pkg: proximadb,        feats: "cluster" }
+          - { label: "enterprise-catalogs", pkg: proximadb,        feats: "enterprise-catalogs" }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install System Dependencies
+        # g++ provides libstdc++ for the onnxruntime (ort) build script.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler g++
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-feature-matrix"
+          shared-key: ${{ matrix.label }}
+      - name: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
+        run: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+
   rust-security:
     name: Security Audit
     runs-on: ubuntu-latest
@@ -1290,6 +1329,7 @@ jobs:
       - panic-policy-no-regression
       - panic-policy-module-guard
       - rust-clippy
+      - feature-matrix
       - rust-security
       - rust-build
       - rust-test


### PR DESCRIPTION
**P0-B of the build/workspace/isolation plan.** Closes the gap that let the AnvaiOps ADLS CrashLoop ship.

## Problem
Default CI never compiles feature-gated code — `--features` appears only in commented-out workflow lines. So `aws`/`azure`/`gcp`/`onnx`/`cluster`/catalog code rots invisibly. The cloud backends had 12×`E0599` (`ObjectStoreExt` unimported); it only surfaced when I built `--features cloud-full` by hand for the ADLS fix.

## Change
New `feature-matrix` job (gated on `changes.outputs.rust`, `fail-fast: false`), one runner per combo:
| pkg | features | covers |
|---|---|---|
| proximadb-server | `cloud-full` | what `:sha-*` ships (the ADLS fix) |
| proximadb-server | `cloud-full,onnx` | what `:sha-*-full` ships |
| proximadb | `cluster` | distributed surface |
| proximadb | `enterprise-catalogs` | unity/polaris/delta |

`cargo check` (no link/test) keeps it cheap while catching E0599-class rot. Wired into the `ci-success` gate so a feature break **blocks merge**. Verified: YAML valid, all four features exist in the manifests, and `cloud-full` already compiles clean (proven by the cloud-full image build in PR #78).

## Follow-ups (same plan)
P0-A sccache/mold (kill the worktree `target/` tax), P0-C ephemeral test ports (parallel-agent integration tests). A nightly schedule trigger for fuller `cargo hack --feature-powerset` can layer on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)