### PR TITLE
fix(ci): runtime image manifest contaminated with runtime-full (prefix-glob)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -154,8 +154,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          # Only this target's per-arch digests (digests-<target>-linux-<arch>).
-          pattern: digests-${{ matrix.target }}-*
+          # Only THIS target's per-arch digests. The `-linux-` anchor is load-
+          # bearing: a bare `digests-${{ matrix.target }}-*` for target=runtime
+          # also matches `digests-runtime-full-*` (prefix collision), which
+          # merged the runtime-full images into the runtime manifest. Platform
+          # pairs are always linux-<arch>, so anchoring on `-linux-` disambiguates
+          # `digests-runtime-linux-*` from `digests-runtime-full-linux-*`.
+          pattern: digests-${{ matrix.target }}-linux-*
           merge-multiple: true
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
## Bug (introduced in PR #78, found while extracting the cloud-full digests)
The per-target merge job downloads digests with `pattern: digests-${{ matrix.target }}-*`. For `target=runtime` that glob **also matches `digests-runtime-full-*`** — so the runtime manifest list was assembled from all 4 digests (runtime + runtime-full).

**Verified on the live `vjsingh1984/proximadb:sha-75deaa384020`:** the runtime manifest has **4 entries** (2× amd64, 2× arm64); two of them (`sha256:15b4…`, `sha256:e0a5…`, size 2271) are byte-identical to the `-full` manifest. So a `linux/amd64` pull of the runtime tag nondeterministically gets either the cloud-full *or* the cloud-full+onnx image. (The ADLS fix is present in both, so the crash is fixed regardless — but the tag is ambiguous/bloated and unsafe to digest-pin.) The `-full` manifest was already correct (2 entries).

## Fix
Anchor the download pattern on `-linux-` (platform pairs are always `linux-<arch>`):
`digests-${{ matrix.target }}-linux-*` → `digests-runtime-linux-*` no longer matches `digests-runtime-full-linux-*`. Confirmed by a glob simulation: runtime resolves to exactly its 2 digests; runtime-full to its 2.

## After merge
The publish re-runs on the merge commit and produces **clean, unambiguous** manifests; I'll report the corrected `:sha-<sha>` / `:sha-<sha>-full` manifest-list digests for AnvaiOps ADR-0016 pinning then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)