### PR TITLE
docs(isolation): runtime isolation for parallel agents (P0-C)

### DIFF
--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -72,6 +72,32 @@ new feat/x  ──▶  edit · commit · push · open PR  ──▶  PR merges  
    ever in a shared tree, fall back to `git commit -o <file>`).
 4. Clean up (`rm`) once your PR merges.
 
+## Runtime isolation (beyond git)
+
+Git worktrees isolate *source*, but two agents running servers/tests in parallel
+also share **runtime** state — TCP ports, data dirs, the Docker daemon,
+registries. Isolate those too:
+
+- **Server ports.** The default server binds 5678 (REST) / 5679 (gRPC) / 5680
+  (Flight) / 5433 (pgwire); two servers on the same port collide. Give each
+  agent's server its own ports via `PROXIMADB_REST_PORT` / `PROXIMADB_GRPC_PORT`
+  / `PROXIMADB_ARROW_IPC_PORT` (or `0` for an OS-assigned ephemeral port).
+- **Point tests at your server.** Integration tests honor `REST_API_URL`
+  (default `http://127.0.0.1:5678`) — set it to your agent's server so suites in
+  different worktrees don't hit one shared instance. (A few legacy tests still
+  hardcode the URL; standardizing them onto `REST_API_URL` is a tracked follow-up.)
+- **Data dirs.** Use a per-agent `PROXIMADB_DATA_DIR` (tests already use
+  `tempfile::TempDir`); never share `/data/proximadb`.
+- **Docker.** Use a unique Compose **project name** (`docker compose -p
+  pdb-<branch>`) and don't publish fixed host ports — let Docker assign them or
+  map to the agent's ephemeral ports, so containers/networks/volumes don't
+  collide across agents.
+- **Registries / tags.** Use per-PR image tags (`pr-<n>-<sha>`) so concurrent
+  publishes don't clobber each other.
+
+Rule of thumb: anything with a *fixed* global name (port, path, container, tag)
+needs a per-agent value before two agents can use it at once.
+
 ## FAQ
 
 - **Disk cost?** Worktrees share the one `.git` object store; only the checked-


### PR DESCRIPTION
**P0-C of the build/workspace/isolation plan** — lets multiple worktree-agents run servers/tests in parallel without colliding.

## Scope correction (transparency)
The plan assumed `tests/common/server.rs` bound fixed ports that we'd switch to ephemeral. **There's no such fixture** — integration tests *connect* to an externally-started server, and most already honor `REST_API_URL`. So the real gap is **runtime-isolation guidance** + standardizing a few hardcoded URLs.

## This PR
Adds a **Runtime Isolation (beyond git)** section to `WORKSPACE_ISOLATION.md`: per-agent server ports (`PROXIMADB_*_PORT` or `:0`), `REST_API_URL` pointed at the agent's own server, per-agent `PROXIMADB_DATA_DIR` (TempDir), unique `docker compose -p` project, per-PR image tags. Rule of thumb: anything with a fixed global name needs a per-agent value.

## Tracked follow-up
Standardize the remaining hardcoded connect-URLs onto `REST_API_URL` (`api_v2_integration_test.rs` 17 sites — runs in CI; `document_observability_integration_test.rs` 29 sites — `#[ignore]`'d). Mechanical const→accessor refactor; deferred because it's a 46-site change across files that need a full integration-build to compile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)