### PR TITLE
feat(dev): affected-only check/test + fast pre-push hook (P1-D)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fast pre-push gate. Activated repo-wide by `scripts/worktree.sh new` (or
+# manually: `git config core.hooksPath .githooks`). Kept deliberately cheap —
+# it enforces the worktree mandate and catches the two most common CI failures
+# (wrong tree, formatting) WITHOUT a compile, so it doesn't slow down pushes.
+# Heavier checks (affected build/test) are `scripts/worktree.sh check|test`.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+# 1) Worktree mandate: refuse to push from the shared main checkout.
+if ! "$root/scripts/worktree.sh" guard >/dev/null 2>&1; then
+  echo "pre-push: BLOCKED — you are in the main checkout. Work in a worktree:" >&2
+  echo "          eval \"\$(scripts/worktree.sh new <type/topic>)\"" >&2
+  echo "          (bypass once with: git push --no-verify)" >&2
+  exit 1
+fi
+
+# 2) Formatting (fast, no compile) — the most frequent avoidable CI red.
+if command -v cargo >/dev/null 2>&1; then
+  if ! cargo fmt --all -- --check >/dev/null 2>&1; then
+    echo "pre-push: BLOCKED — rustfmt drift. Run: cargo fmt --all   (bypass: git push --no-verify)" >&2
+    exit 1
+  fi
+fi
+
+echo "pre-push: OK (worktree + fmt)"

--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -47,6 +47,8 @@ eval "$(scripts/worktree.sh new feat/my-thing)"
 
 scripts/worktree.sh list                 # all worktrees + which are dirty
 scripts/worktree.sh guard                # exits non-zero if run in the main checkout
+scripts/worktree.sh check                # cargo check ONLY the crates changed vs develop
+scripts/worktree.sh test                 # cargo nextest ONLY the crates changed vs develop
 scripts/worktree.sh rm feat/my-thing     # remove after the PR merges (guards dirty)
 scripts/worktree.sh clean                # drop every worktree already merged to develop
 ```
@@ -54,6 +56,17 @@ scripts/worktree.sh clean                # drop every worktree already merged to
 `new` refuses to clobber an existing branch/path; `rm` refuses to delete a
 dirty worktree (pass `--force` to discard) and only deletes the branch if it's
 merged; `clean` is the periodic housekeeping pass.
+
+**Affected-only feedback.** `check`/`test` map your diff vs `develop` to the
+owning crates (via `scripts/affected_crates.py` + `cargo metadata`) and build/
+test only those — so editing one crate doesn't compile the 66-crate workspace.
+It's direct crates only; for a change to a low-level/foundation crate, also run
+the full `make test` (a dependent in another crate won't be picked up).
+
+**Pre-push hook.** `new` activates a fast `.githooks/pre-push` (repo-wide, via
+`core.hooksPath`) that blocks pushing from the main checkout and on rustfmt
+drift — no compile, so it stays quick. Activate manually in an existing clone
+with `git config core.hooksPath .githooks`; bypass once with `git push --no-verify`.
 
 ## Lifecycle
 

--- a/scripts/affected_crates.py
+++ b/scripts/affected_crates.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Print the workspace crates whose source changed vs a base ref.
+
+Maps each changed file to the package whose manifest directory is the file's
+longest path prefix, counting only source-ish files (src/, tests/, benches/,
+build.rs, Cargo.toml) — so doc/CI/script edits map to no crate. Files under the
+repo root's src/ map to the root `proximadb` crate.
+
+This is DIRECT crates only — reverse-dependents are not expanded. For a change
+to a low-level foundation crate, also run the full suite (`make test`); a
+v2 can walk `cargo metadata`'s resolve graph for dependents.
+
+Usage: affected_crates.py [base-ref]   (default: origin/develop)
+Prints space-separated crate names to stdout (empty if no crate source changed).
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def git(args, cwd):
+    return subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd).stdout
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else "origin/develop"
+    root = git(["rev-parse", "--show-toplevel"], cwd=".").strip()
+    if not root:
+        sys.exit(0)
+    # Committed changes vs base + any uncommitted working-tree changes.
+    diff = git(["diff", "--name-only", f"{base}...HEAD"], root)
+    diff += git(["diff", "--name-only", "HEAD"], root)
+    changed = sorted({ln.strip() for ln in diff.splitlines() if ln.strip()})
+    if not changed:
+        return
+
+    meta = json.loads(
+        subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            capture_output=True, text=True, cwd=root,
+        ).stdout
+    )
+    # (manifest-dir-relative-with-trailing-slash, crate-name), longest dir first
+    # so a nested crate wins over the root crate.
+    pkgs = []
+    for p in meta["packages"]:
+        d = os.path.relpath(os.path.dirname(p["manifest_path"]), root)
+        pkgs.append(("" if d == "." else d + "/", p["name"]))
+    pkgs.sort(key=lambda x: -len(x[0]))
+
+    def crate_for(f):
+        for d, name in pkgs:
+            if d == "":
+                rest = f
+            elif f.startswith(d):
+                rest = f[len(d):]
+            else:
+                continue
+            if rest in ("Cargo.toml", "build.rs") or rest.startswith(("src/", "tests/", "benches/")):
+                return name
+        return None
+
+    seen = []
+    for f in changed:
+        c = crate_for(f)
+        if c and c not in seen:
+            seen.append(c)
+    if seen:
+        print(" ".join(seen))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -70,6 +70,9 @@ cmd_new() {
   git -C "$(repo_main)" fetch --quiet "$REMOTE" "$base" || die "cannot fetch $REMOTE/$base"
   mkdir -p "$(worktree_root)"
   git -C "$(repo_main)" worktree add -b "$branch" "$dir" "$REMOTE/$base" >&2
+  # Activate the repo's fast pre-push hook (idempotent + repo-wide; each
+  # worktree resolves .githooks/ from its own checkout).
+  git -C "$(repo_main)" config core.hooksPath .githooks 2>/dev/null || true
   # Emit a `cd` + the shared-cache env so `eval "$(... new ...)"` lands in the
   # worktree AND wires up sccache for fast, dedup'd compilation across worktrees.
   printf 'cd %q\n' "$dir"
@@ -147,6 +150,29 @@ cmd_guard() {
   printf 'worktree: OK — isolated workspace %s (branch %s)\n' "$here" "$(git rev-parse --abbrev-ref HEAD)"
 }
 
+# Affected-only feedback: build/test ONLY the crates whose source changed vs
+# develop (mirrors CI change-detection locally), so an agent touching one crate
+# doesn't compile the whole 66-crate workspace. Direct crates only — for a
+# low-level/foundation change, run the full `make test` too.
+_affected() { python3 "$(repo_main)/scripts/affected_crates.py" "$REMOTE/$BASE_DEFAULT"; }
+_pkg_args() { local a=""; for p in $1; do a="$a -p $p"; done; printf '%s' "$a"; }
+
+cmd_check() {
+  local pkgs; pkgs="$(_affected)"
+  [ -n "$pkgs" ] || { printf 'worktree: no crate source changed vs %s — nothing to check\n' "$BASE_DEFAULT" >&2; return 0; }
+  printf 'worktree: cargo check%s\n' "$(_pkg_args "$pkgs")" >&2
+  # shellcheck disable=SC2046
+  cargo check $(_pkg_args "$pkgs")
+}
+
+cmd_test() {
+  local pkgs; pkgs="$(_affected)"
+  [ -n "$pkgs" ] || { printf 'worktree: no crate source changed vs %s — nothing to test\n' "$BASE_DEFAULT" >&2; return 0; }
+  printf 'worktree: cargo nextest run%s (affected crates)\n' "$(_pkg_args "$pkgs")" >&2
+  # shellcheck disable=SC2046
+  cargo nextest run $(_pkg_args "$pkgs") || cargo test $(_pkg_args "$pkgs")
+}
+
 case "${1:-}" in
   new)   shift; cmd_new "$@" ;;
   list)  shift; cmd_list "$@" ;;
@@ -154,6 +180,8 @@ case "${1:-}" in
   clean) shift; cmd_clean "$@" ;;
   guard) shift; cmd_guard "$@" ;;
   cache-env) shift; emit_cache_env ;;
+  check) shift; cmd_check "$@" ;;
+  test)  shift; cmd_test "$@" ;;
   *) cat >&2 <<'USAGE'
 worktree: one task = one worktree = one branch (isolated by construction)
   scripts/worktree.sh new   <type/topic> [base]   create + print `cd` + cache env (eval it)
@@ -162,6 +190,8 @@ worktree: one task = one worktree = one branch (isolated by construction)
   scripts/worktree.sh clean                         drop worktrees merged to develop
   scripts/worktree.sh guard                         fail if run in the main checkout
   scripts/worktree.sh cache-env                     print sccache env for an existing worktree (eval it)
+  scripts/worktree.sh check                         cargo check ONLY the crates changed vs develop
+  scripts/worktree.sh test                          cargo nextest ONLY the crates changed vs develop
 USAGE
      exit 2 ;;
 esac


### PR DESCRIPTION
**P1-D of the build/workspace/isolation plan** — fast, scoped feedback for worktree-agents + enforcement of the mandate.

## What
- **`scripts/affected_crates.py`** — maps `git diff` vs develop → owning crates (longest manifest-dir prefix; only `src/`/`tests/`/`benches/`/`build.rs`/`Cargo.toml` count, so doc/CI/script edits map to nothing).
- **`worktree.sh check` / `test`** — `cargo check` / `cargo nextest run -p <affected>`: an agent editing one crate no longer compiles the whole 66-crate workspace. Direct crates only (documented limitation — run full `make test` for low-level/foundation changes).
- **`.githooks/pre-push`** — fast gate (no compile): blocks pushing from the main checkout (enforces the worktree mandate) and on rustfmt drift — the two most common avoidable CI reds. `worktree.sh new` sets `core.hooksPath` repo-wide; bypass once with `git push --no-verify`.

## Verified
`bash -n` clean; scripts-only diff → no crate (empty); touching `proximadb-kernel/src/*` → reports `proximadb-kernel`; exec bits committed (100755).

🤖 Generated with [Claude Code](https://claude.com/claude-code)