### PR TITLE
feat(deploy): fast prebuilt-binary image path (P1-E)

### DIFF
--- a/deploy/docker/Dockerfile.prebuilt
+++ b/deploy/docker/Dockerfile.prebuilt
@@ -1,0 +1,60 @@
+# ProximaDB OSS image — PREBUILT binary path (fast bake, no in-Docker compile).
+# ----------------------------------------------------------------------------
+# Decouples "compile the binary" (done once on the host / a CI build job, with
+# sccache) from "bake the image" (seconds: just a COPY). Same hardened,
+# non-root, Python-free debian-slim runtime as `deploy/docker/Dockerfile` target
+# `runtime`, so images are interchangeable — only the build path differs.
+#
+# The binary MUST be a Linux binary for the target arch/glibc (it is COPY'd, not
+# compiled): build it on a Linux runner (or extract it from the in-Docker build).
+# A macOS host binary will NOT run here — use the multi-stage Dockerfile locally
+# on Mac, and this fast path in CI / on Linux.
+#
+#   # Linux host / CI:
+#   cargo build --release --features cloud-full -p proximadb-server
+#   docker build -f deploy/docker/Dockerfile.prebuilt \
+#     --build-arg BIN=target/release/proximadb-server -t proximadb:preview .
+#
+# For multi-arch CI, build each arch's binary natively and pass its path via BIN,
+# then merge per-arch images into one manifest (as publish-image.yml does).
+# ----------------------------------------------------------------------------
+ARG RUNTIME_BASE=debian:bookworm-slim
+FROM ${RUNTIME_BASE} AS runtime
+
+# Path to the pre-built Linux proximadb-server binary, relative to the build
+# context. Override with --build-arg BIN=target/<triple>/release/proximadb-server.
+ARG BIN=target/release/proximadb-server
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN groupadd -r proximadb && useradd -r -g proximadb proximadb
+# /log and /var/lib/proximadb are default writable paths the server needs.
+RUN mkdir -p /data/proximadb /config /log /var/lib/proximadb && \
+    chown -R proximadb:proximadb /data /config /log /var/lib/proximadb
+
+COPY ${BIN} /usr/local/bin/proximadb-server
+COPY config/config.toml /config/config.toml
+RUN chmod 0755 /usr/local/bin/proximadb-server && \
+    chown proximadb:proximadb /usr/local/bin/proximadb-server
+
+USER proximadb
+ENV RUST_LOG=info \
+    PROXIMADB_DATA_DIR=/data/proximadb \
+    PROXIMADB_BIND_ADDRESS=0.0.0.0 \
+    PROXIMADB_REST_PORT=5678 \
+    PROXIMADB_GRPC_PORT=5679 \
+    PROXIMADB_ARROW_IPC_PORT=5680 \
+    PROXIMADB_METRICS_PORT=9090
+EXPOSE 5678 5679 5680 5433
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:5678/health || exit 1
+VOLUME ["/data/proximadb"]
+WORKDIR /data/proximadb
+COPY --chmod=0755 deploy/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["--config", "/config/config.toml"]

--- a/deploy/docker/IMAGE_PUBLISH.md
+++ b/deploy/docker/IMAGE_PUBLISH.md
@@ -75,3 +75,25 @@ docker build -f deploy/docker/Dockerfile --target runtime -t proximadb:local .
 # full image with ONNX + baked bge-small-en-v1.5
 docker build -f deploy/docker/Dockerfile --target runtime-full -t proximadb:local-full .
 ```
+
+## Fast prebuilt image (decoupled compile vs. bake)
+
+`deploy/docker/Dockerfile.prebuilt` bakes an **already-built** cloud-full server
+binary into the same hardened, non-root, Python-free runtime — **no in-Docker
+Rust compile**. Compile once (host/CI, with sccache), then bake in seconds:
+
+```bash
+# Linux host / CI — the binary is COPY'd, so it must be a Linux binary for the
+# target arch (a macOS host binary will NOT run; use the multi-stage Dockerfile
+# locally on Mac).
+cargo build --release --features cloud-full -p proximadb-server
+docker build -f deploy/docker/Dockerfile.prebuilt \
+  --build-arg BIN=target/release/proximadb-server -t proximadb:preview .
+```
+
+Measured ~13s to bake vs. minutes for the in-Docker compile. This is the
+foundation for cheap **per-PR preview images** (build the binary once in CI,
+reuse it across the bake + smoke deploy). Wiring per-PR `pr-<n>-<sha>` tags
+with auto-prune-on-merge into `publish-image.yml` is a tracked follow-up —
+deliberately on-demand rather than auto-building every PR push (4 native Rust
+builds per push is too costly, and fork PRs can't access the registry secrets).


### PR DESCRIPTION
**P1-E of the build/workspace/isolation plan** — decoupled, nimble deploy.

## What
`deploy/docker/Dockerfile.prebuilt`: bake an **already-built cloud-full binary** into the same hardened, non-root, Python-free runtime as the multi-stage Dockerfile's `runtime` target — **no in-Docker Rust compile**. Compile once (host/CI + sccache), bake in seconds.

## Verified end-to-end
Extracted the cloud-full arm64 binary from the prior image, baked via `Dockerfile.prebuilt` in **12.9s** (vs minutes for the in-Docker compile), ran it with `PROXIMADB_QUEUE_ROOT=adls://` → **no `Unsupported filesystem scheme`** (cloud backends linked + registering). So it's a real, working, fast cloud-full image.

Caveat documented: the binary is COPY'd, so it must be a Linux binary for the target arch — use this in CI/Linux; use the multi-stage Dockerfile locally on Mac.

## Notes / follow-ups
- The **root `Dockerfile.prebuilt` is stale** (`FROM python:3.11-slim`, demo config) and superseded by this one — removal in a follow-up.
- **Per-PR `pr-<n>-<sha>` preview tags + prune-on-merge**: tracked follow-up, built on this prebuilt path. Deliberately on-demand, not auto-building every PR push (4 native Rust builds/push is too costly; fork PRs can't access registry secrets) — and it touches the freshly-fixed publish workflow, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)