### PR TITLE
feat: qa-gate (TPC-H/DS + 4 modalities) + Iceberg v3 interop, CDC core, cross-surface convergence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
+      # Three-tier CI (feat -> develop -> qa -> main):
+      #   * feat -> develop = LIGHT: compile + fmt/clippy + layering + proto +
+      #     panic-policy + capability + security-audit + lints + docs. Fast inner
+      #     loop so development merges quickly and stays unblocked.
+      #   * develop -> qa = MEDIUM (`test_tier`): LIGHT + the core correctness
+      #     suites — rust-test, the 4 rust-integration-test-* engines, feature-matrix.
+      #   * qa -> main = FULL (`extensive`): MEDIUM + docker-build, coverage,
+      #     python multi-version, cross integration-test, benchmarks. The heaviest,
+      #     pre-promotion gate.
+      # `test_tier` is true for base qa or main (and pushes to those); `extensive`
+      # is true only for base main (and pushes to main).
+      test_tier: ${{ github.base_ref == 'qa' || github.base_ref == 'main' || github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/main' }}
+      extensive: ${{ github.base_ref == 'main' || github.ref == 'refs/heads/main' }}
       rust: ${{ steps.filter.outputs.rust }}
       python: ${{ steps.filter.outputs.python }}
       docker: ${{ steps.filter.outputs.docker }}
@@ -352,7 +365,7 @@ jobs:
     name: Feature Matrix (${{ matrix.label }})
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.test_tier == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -804,7 +817,7 @@ jobs:
     name: Rust Tests (${{ matrix.test-type }})
     runs-on: ubuntu-latest
     needs: [changes, rust-build]
-    if: needs.changes.outputs.rust == 'true' && !inputs.skip_tests
+    if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.test_tier == 'true' && !inputs.skip_tests
     strategy:
       fail-fast: false
       matrix:
@@ -860,6 +873,7 @@ jobs:
     needs: [changes, rust-build]
     if: |
       !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
       needs.changes.outputs.rust == 'true' &&
       (needs.changes.outputs.storage_changes == 'true' ||
        needs.changes.outputs.core_changes == 'true')
@@ -892,6 +906,7 @@ jobs:
     needs: [changes, rust-build]
     if: |
       !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
       needs.changes.outputs.rust == 'true' &&
       (needs.changes.outputs.query_changes == 'true' ||
        needs.changes.outputs.core_changes == 'true')
@@ -923,6 +938,7 @@ jobs:
     needs: [changes, rust-build]
     if: |
       !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
       needs.changes.outputs.rust == 'true' &&
       (needs.changes.outputs.graph_changes == 'true' ||
        needs.changes.outputs.core_changes == 'true')
@@ -954,6 +970,7 @@ jobs:
     needs: [changes, rust-build]
     if: |
       !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
       needs.changes.outputs.rust == 'true' &&
       (needs.changes.outputs.network_changes == 'true' ||
        needs.changes.outputs.core_changes == 'true')
@@ -981,7 +998,10 @@ jobs:
   rust-coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    needs: [rust-test]
+    # FULL tier only (qa -> main). rust-test runs at the MEDIUM tier (qa), but
+    # coverage is expensive, so gate it to the main-promotion gate explicitly.
+    needs: [changes, rust-test]
+    if: needs.changes.outputs.extensive == 'true'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -1038,7 +1058,7 @@ jobs:
       matrix:
         # 3.9 dropped: the package declares requires-python ">=3.10".
         python-version: ["3.10", "3.11", "3.12"]
-    if: "!inputs.skip_tests"
+    if: ${{ !inputs.skip_tests && needs.changes.outputs.extensive == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -1115,7 +1135,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes, rust-build, python-test]
-    if: "!inputs.skip_tests"
+    if: ${{ !inputs.skip_tests && needs.changes.outputs.extensive == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -1237,7 +1257,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: changes
-    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.rust == 'true'
+    if: (needs.changes.outputs.docker == 'true' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.extensive == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development, develop]
+    branches: [main, development, develop, qa]
   pull_request:
-    branches: [main, development, develop]
+    branches: [main, development, develop, qa]
   workflow_dispatch:
     inputs:
       skip_tests:

--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -2,9 +2,9 @@ name: Workspace Layering Check
 
 on:
   push:
-    branches: [ main, develop, 'feature/**' ]
+    branches: [ main, develop, qa, 'feature/**' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, qa ]
 
 concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -1,0 +1,155 @@
+name: QA Gate
+
+# The qa branch is the promotion gate between develop and main:
+#   develop --(PR)--> qa --(PR)--> main
+# This workflow runs the heavier integration + coverage gates that the qa branch
+# is responsible for. Its job names are wired as REQUIRED status checks on `qa`
+# (and `main`) via branch protection.
+
+on:
+  pull_request:
+    branches: [qa, main]
+  push:
+    branches: [qa]
+  workflow_dispatch:
+
+concurrency:
+  group: qa-gate-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Enforce the promotion path: main may only be promoted FROM qa.
+  promotion-source-guard:
+    name: Promotion Source Guard (main <- qa only)
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: main PRs must originate from qa
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "qa" ]; then
+            echo "::error::main can only be promoted from 'qa' (got '$HEAD_REF'). Flow is develop -> qa -> main."
+            exit 1
+          fi
+          echo "ok: main PR originates from qa"
+
+  tpch-pgwire:
+    name: TPC-H pgwire integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-qa-tpch"
+      - name: Run TPC-H over pgwire
+        run: CARGO_BUILD_JOBS=2 cargo test --test tpch_pgwire_e2e -- --nocapture
+
+  tpcds-pgwire:
+    name: TPC-DS pgwire integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-qa-tpcds"
+      - name: Run TPC-DS over pgwire
+        run: CARGO_BUILD_JOBS=2 cargo test --test tpcds_pgwire_e2e -- --nocapture
+
+  sdk-coverage-ratchet:
+    name: SDK Coverage Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: clients/python/pyproject.toml
+      - name: Install SDK + coverage deps
+        working-directory: clients/python
+        run: pip install -e ".[dev]" pytest-cov pyarrow pandas jsonschema psutil
+      - name: Run SDK tests with coverage
+        working-directory: clients/python
+        env:
+          PROXIMADB_EMBEDDED: "0"
+          HF_HUB_DOWNLOAD_TIMEOUT: "30"
+          PROXIMADB_TEST_FORCE_FALLBACK_EMBEDDINGS: "1"
+        run: |
+          # Coverage needs a single aggregating process; tolerate the known
+          # _cov sys.modules-leak failures (the ratchet measures coverage, not
+          # pass/fail — the per-file isolation gate in ci.yml owns correctness).
+          pytest tests/unit/ -q -p no:cacheprovider --timeout=120 \
+            --cov=proximadb_sdk --cov-report=json:/tmp/sdk-cov.json \
+            --ignore=tests/unit/test_integrations_victor_cov.py \
+            --ignore=tests/unit/test_chunking_code_cov.py \
+            --continue-on-collection-errors || true
+          test -f /tmp/sdk-cov.json
+      - name: Ratchet check
+        run: |
+          python3 scripts/coverage_ratchet.py normalize --sdk /tmp/sdk-cov.json -o /tmp/sdk-current.json
+          python3 scripts/coverage_ratchet.py check \
+            --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json \
+            --current /tmp/sdk-current.json
+
+  rust-coverage-ratchet:
+    name: Rust Coverage Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # FIRST CUT: cargo-llvm-cov over the full workspace is heavy and has OOM'd
+    # CI before; kept non-blocking until the baseline is seeded from a clean run
+    # and memory is tamed. Flip to required (remove this line) once stable.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install system deps + cargo-llvm-cov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+          cargo install cargo-llvm-cov --locked
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-qa-llvmcov"
+      - name: Coverage (lib) + ratchet
+        env:
+          CARGO_BUILD_JOBS: "1"
+        run: |
+          cargo llvm-cov --lib --no-report --workspace
+          cargo llvm-cov report --json --output-path /tmp/llvm-cov.json
+          python3 scripts/coverage_ratchet.py normalize --rust /tmp/llvm-cov.json -o /tmp/rust-current.json
+          # Seed the baseline if absent (first run), else ratchet-check.
+          if python3 -c "import json,sys; d=json.load(open('docs/_internal/roadmap/COVERAGE_BASELINE.json')); sys.exit(0 if any(k.startswith('rust:') for k in d) else 1)"; then
+            python3 scripts/coverage_ratchet.py check \
+              --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json \
+              --current /tmp/rust-current.json
+          else
+            echo "::warning::no rust baseline yet — emitting current as artifact to seed it"
+            cp /tmp/rust-current.json rust-coverage-seed.json
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rust-coverage
+          path: |
+            /tmp/llvm-cov.json
+            rust-coverage-seed.json
+          if-no-files-found: ignore

--- a/.github/workflows/tier-config-fingerprint.yml
+++ b/.github/workflows/tier-config-fingerprint.yml
@@ -20,9 +20,9 @@ name: Tier Config Fingerprint
 
 on:
   push:
-    branches: [main, develop, 'feature/**', 'proximadb-**']
+    branches: [main, develop, qa, 'feature/**', 'proximadb-**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, qa]
   workflow_dispatch:
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,30 @@ When changing a storage format, reader, codec, cache, or engine you MUST:
 5.  **Token Efficiency:** When running long-output commands, use `grep` with context flags.
 6.  **Measure, Don't Assert:** Gate performance claims on the evidence ledger (`BENCHMARK_EVIDENCE.toml`); reject "indicative" kernel benchmarks masquerading as end-to-end metrics.
 
+### Mandate: Full ANSI SQL over pgwire
+ProximaDB is driving toward **full ANSI/standard SQL support over the PostgreSQL
+wire protocol (pgwire)**. Treat **TPC-H and TPC-DS over pgwire as the conformance
+driver** (first cuts live in the qa-gate integration suites). As you implement or
+touch query paths:
+
+- **Submit queries to ProximaDB and let it route** — the engine owns engine
+  selection. The pgwire SELECT path lowers SQL and calls
+  `ComputeScheduler::route_select` → **DataFusion (OLAP) for parquet-backed
+  tables, Volcano/native otherwise** (`src/network/postgres/relational_pipeline.rs`,
+  `src/query/compute_scheduler.rs`). Never bypass pgwire/the router in product
+  code or end-to-end tests to call an engine directly.
+- A table reaches the DataFusion OLAP engine when it is **parquet-backed** — via
+  `ALTER TABLE … MATERIALIZE` (warehouse materializer, auto-wired from `data_dir`)
+  or a federated/external Parquet storage layout.
+- **Fix SQL wiring/lowering gaps incrementally as you find them** — relax
+  vector-collection-era constraints that leak into relational DDL (e.g. the former
+  8-char collection-name minimum blocked `part`/`orders`/`region`), extend the
+  relational frontend/planner/executor and DataFusion lowering, and prefer real
+  ANSI semantics over ad-hoc shortcuts. Each TPC-H/TPC-DS query that starts passing
+  is the ratchet of progress.
+- **Diagnostics:** the pgwire client surfaces failures as a generic `db error`;
+  the real cause is in the server `DbError` (code/message) — inspect via
+  `e.as_db_error()` and run with `RUST_LOG=proximadb=debug`. Keep server-side error
+  messages specific and actionable.
+
 *See `GEMINI.md` for the comprehensive list of engineering mandates.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6898,6 +6898,7 @@ dependencies = [
 name = "proximadb-iceberg-engine"
 version = "0.2.0"
 dependencies = [
+ "apache-avro",
  "arrow-array",
  "arrow-schema",
  "async-trait",
@@ -6910,7 +6911,10 @@ dependencies = [
  "proximadb-object-store",
  "proximadb-records",
  "proximadb-storage-common",
+ "serde",
+ "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,7 +355,7 @@ arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
 arrow-cast = { version = "58", default-features = false }
 
 # DataFusion for SQL and compute engine compatibility (Arrow 57 compatible)
-datafusion = { version = "54.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions"], optional = true }
+datafusion = { version = "54.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions", "datetime_expressions", "math_expressions"], optional = true }
 datafusion-common = { version = "54.0", optional = true }
 
 # Advanced compression for recovery-optimized WAL

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+ProximaDB is a high-performance vector + graph database. Because it stores and
+serves tenant data, we treat security and tenant isolation as first-class
+correctness properties, not add-ons.
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Please report privately via GitHub's [private vulnerability
+reporting](https://github.com/vjsingh1984/proximaDB/security/advisories/new)
+(Security tab → "Report a vulnerability"). This routes the report to the
+maintainers confidentially.
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept where possible).
+- Affected version / commit, and configuration (transport, auth mode, storage
+  backend) if relevant.
+- Any suggested remediation.
+
+### Response targets
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement | within 3 business days |
+| Triage + severity assessment | within 7 business days |
+| Fix or mitigation plan | depends on severity; criticals prioritized |
+
+We will keep you informed through the advisory thread and credit you in the
+release notes unless you ask us not to.
+
+## Scope
+
+In scope:
+
+- The server (`proximadb-server`) and all crates in this workspace.
+- Tenant isolation boundaries (path isolation under `DrPathBuilder`,
+  `TenantContext` enforcement at I/O boundaries).
+- Authentication / authorization, transport security (REST, gRPC, pgwire,
+  Arrow Flight), and the embedded/SDK clients.
+- Data-at-rest handling (object store paths, WAL, segment formats).
+
+Out of scope:
+
+- Issues that require a privileged local account on the host running the server.
+- Denial of service from unbounded but documented configuration (e.g. operator
+  setting limits too high).
+- Vulnerabilities in third-party dependencies already tracked by an upstream
+  advisory — please still tell us so we can bump.
+
+## Supported Versions
+
+ProximaDB is pre-1.0. Security fixes land on `main` and the active `develop`
+line. Older tags are not separately patched; please track `main`.
+
+## Our Defensive Posture
+
+The codebase enforces several security invariants automatically in CI:
+
+- **No panics in production paths** — `unwrap()` / `expect()` / `panic!()` are
+  gated by the panic-policy checks; errors propagate via `Result`.
+- **Structural tenant isolation** — isolation is enforced at the boundary, never
+  as a per-query predicate; a tenant-path guard runs in CI.
+- **Secret scanning + push protection** are enabled on this repository.
+- **Dependency and code scanning** run against pushes and pull requests.
+- **Tiered merge gates** — feature branches run lint/build/security checks;
+  promotion to `qa` and `main` adds progressively heavier test and audit gates.
+
+Thank you for helping keep ProximaDB and its users safe.

--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -249,19 +249,27 @@ fn lower_select(
     select: &SqlSelect,
     catalog: &dyn CatalogLookup,
 ) -> Result<LogicalNode, FrontendError> {
-    // 1) FROM (single or with joins). Empty FROM is unsupported.
+    // 1) FROM (single, with explicit joins, or comma-separated). Empty FROM is
+    //    unsupported.
     if select.from.is_empty() {
         return Err(FrontendError::Unsupported("SELECT without FROM".into()));
     }
-    if select.from.len() > 1 {
-        return Err(FrontendError::Unsupported(
-            "comma-separated FROM (use explicit JOIN)".into(),
-        ));
+    // Comma-separated FROM is an implicit cross join: `FROM a, b, c` becomes
+    // a left-deep chain of CROSS joins, with the equality predicates in WHERE
+    // acting as the join conditions (the optimizer rewrites Cross+Filter into
+    // hash joins). This is the classic ANSI/TPC-H join spelling.
+    let (mut plan, mut scope) = lower_table_with_joins(&select.from[0], catalog)?;
+    for twj in &select.from[1..] {
+        let (right, right_scope) = lower_table_with_joins(twj, catalog)?;
+        scope = scope.concat(&right_scope);
+        plan = LogicalNode::Join {
+            left: Box::new(plan),
+            right: Box::new(right),
+            kind: JoinKind::Cross,
+            on: None,
+            strategy: JoinStrategy::Auto,
+        };
     }
-    let twj = &select.from[0];
-    let (scan, scope) = lower_table_with_joins(twj, catalog)?;
-    let mut plan = scan;
-    let mut scope = scope;
 
     // 2) WHERE — lift uncorrelated IN / EXISTS / NOT EXISTS subqueries that appear
     //    as top-level AND-conjuncts into Semi/Anti joins; the remaining conjuncts

--- a/crates/storage/proximadb-iceberg-engine/Cargo.toml
+++ b/crates/storage/proximadb-iceberg-engine/Cargo.toml
@@ -29,6 +29,11 @@ arrow-array.workspace = true
 arrow-schema.workspace = true
 async-trait.workspace = true
 futures.workspace = true
+# Spec-compliant Iceberg manifest / manifest-list (Avro) + TableMetadata (JSON).
+apache-avro = "0.16"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }

--- a/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
@@ -1,0 +1,490 @@
+//! # iceberg — spec-shaped Iceberg v2 manifests, manifest lists, and table metadata
+//!
+//! [`crate::manifest::ManifestCommitter`] / [`crate::metadata::MetadataCommitter`] own the
+//! *atomicity* of publishing a snapshot (versioned create-only CAS + generation fence) but
+//! treat the published bytes as opaque. Historically the bytes were a newline-delimited list
+//! of data-file keys — readable only by ProximaDB.
+//!
+//! This module supplies the **content**: the Apache Iceberg v2 on-disk artifacts so that
+//! external engines (Spark, Trino, DuckDB, PyIceberg) can read ProximaDB-published tables:
+//!
+//! - **manifest** (Avro): one `manifest_entry` per data file (status + `data_file` struct).
+//! - **manifest list** (Avro): one `manifest_file` per manifest in a snapshot.
+//! - **table metadata** (JSON): format-version 2 `TableMetadata` — schema, partition spec
+//!   (unpartitioned here), snapshots (each pointing at its manifest list), `current-snapshot-id`,
+//!   and the `main` ref.
+//!
+//! The Avro schemas carry Iceberg `field-id`s on every field (the spec's identity contract).
+//! Tables are written **unpartitioned** for the first cut (partition spec id 0, empty struct);
+//! partitioned layout is a follow-up. The committers still own atomicity — this module only
+//! shapes bytes and is fully round-trip tested.
+
+use apache_avro::{Reader, Schema, Writer};
+use proximadb_kernel::error::StorageError;
+use serde::{Deserialize, Serialize};
+
+fn ser_err(context: &str, e: impl std::fmt::Display) -> StorageError {
+    StorageError::Serialization(format!("iceberg: {context}: {e}"))
+}
+
+// --- Iceberg v2 manifest Avro schema (unpartitioned) -----------------------
+// field-ids per the Iceberg spec (data_file: 134/100/101/102/103/104; entry: 0/1/3/4/2).
+const MANIFEST_SCHEMA_JSON: &str = r#"
+{
+  "type": "record",
+  "name": "manifest_entry",
+  "fields": [
+    {"name": "status", "type": "int", "field-id": 0},
+    {"name": "snapshot_id", "type": ["null", "long"], "default": null, "field-id": 1},
+    {"name": "sequence_number", "type": ["null", "long"], "default": null, "field-id": 3},
+    {"name": "file_sequence_number", "type": ["null", "long"], "default": null, "field-id": 4},
+    {"name": "data_file", "field-id": 2, "type": {
+      "type": "record",
+      "name": "r2",
+      "fields": [
+        {"name": "content", "type": "int", "field-id": 134},
+        {"name": "file_path", "type": "string", "field-id": 100},
+        {"name": "file_format", "type": "string", "field-id": 101},
+        {"name": "partition", "field-id": 102, "type": {
+          "type": "record", "name": "r102", "fields": []
+        }},
+        {"name": "record_count", "type": "long", "field-id": 103},
+        {"name": "file_size_in_bytes", "type": "long", "field-id": 104}
+      ]
+    }}
+  ]
+}
+"#;
+
+// --- Iceberg v2 manifest-list Avro schema ----------------------------------
+const MANIFEST_LIST_SCHEMA_JSON: &str = r#"
+{
+  "type": "record",
+  "name": "manifest_file",
+  "fields": [
+    {"name": "manifest_path", "type": "string", "field-id": 500},
+    {"name": "manifest_length", "type": "long", "field-id": 501},
+    {"name": "partition_spec_id", "type": "int", "field-id": 502},
+    {"name": "content", "type": "int", "field-id": 517},
+    {"name": "sequence_number", "type": "long", "field-id": 515},
+    {"name": "min_sequence_number", "type": "long", "field-id": 516},
+    {"name": "added_snapshot_id", "type": "long", "field-id": 503},
+    {"name": "added_files_count", "type": "int", "field-id": 504},
+    {"name": "existing_files_count", "type": "int", "field-id": 505},
+    {"name": "deleted_files_count", "type": "int", "field-id": 506},
+    {"name": "added_rows_count", "type": "long", "field-id": 512},
+    {"name": "existing_rows_count", "type": "long", "field-id": 513},
+    {"name": "deleted_rows_count", "type": "long", "field-id": 514}
+  ]
+}
+"#;
+
+/// Public description of one data file in a snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DataFileMeta {
+    pub file_path: String,
+    pub record_count: i64,
+    pub file_size_in_bytes: i64,
+}
+
+/// Public description of one manifest in a manifest list.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ManifestFileMeta {
+    pub manifest_path: String,
+    pub manifest_length: i64,
+    pub added_files_count: i32,
+    pub added_rows_count: i64,
+    pub added_snapshot_id: i64,
+}
+
+// --- Avro serde mirrors (field order MUST match the schemas above) ----------
+#[derive(Serialize, Deserialize)]
+struct AvroPartition {}
+
+#[derive(Serialize, Deserialize)]
+struct AvroDataFile {
+    content: i32,
+    file_path: String,
+    file_format: String,
+    partition: AvroPartition,
+    record_count: i64,
+    file_size_in_bytes: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct AvroManifestEntry {
+    status: i32,
+    snapshot_id: Option<i64>,
+    sequence_number: Option<i64>,
+    file_sequence_number: Option<i64>,
+    data_file: AvroDataFile,
+}
+
+#[derive(Serialize, Deserialize)]
+struct AvroManifestFile {
+    manifest_path: String,
+    manifest_length: i64,
+    partition_spec_id: i32,
+    content: i32,
+    sequence_number: i64,
+    min_sequence_number: i64,
+    added_snapshot_id: i64,
+    added_files_count: i32,
+    existing_files_count: i32,
+    deleted_files_count: i32,
+    added_rows_count: i64,
+    existing_rows_count: i64,
+    deleted_rows_count: i64,
+}
+
+/// Serialize a manifest (one `manifest_entry` per data file) as Iceberg v2 Avro.
+/// `status` is ADDED (1), `content` is DATA (0), format is PARQUET, unpartitioned.
+pub fn write_manifest(files: &[DataFileMeta], snapshot_id: i64) -> Result<Vec<u8>, StorageError> {
+    let schema = Schema::parse_str(MANIFEST_SCHEMA_JSON)
+        .map_err(|e| ser_err("parse manifest schema", e))?;
+    let mut writer = Writer::new(&schema, Vec::new());
+    for f in files {
+        let entry = AvroManifestEntry {
+            status: 1, // ADDED
+            snapshot_id: Some(snapshot_id),
+            sequence_number: None,
+            file_sequence_number: None,
+            data_file: AvroDataFile {
+                content: 0, // DATA
+                file_path: f.file_path.clone(),
+                file_format: "PARQUET".to_string(),
+                partition: AvroPartition {},
+                record_count: f.record_count,
+                file_size_in_bytes: f.file_size_in_bytes,
+            },
+        };
+        writer
+            .append_ser(&entry)
+            .map_err(|e| ser_err("append manifest entry", e))?;
+    }
+    writer.into_inner().map_err(|e| ser_err("finish manifest", e))
+}
+
+/// Read an Iceberg v2 manifest Avro back into the data-file list.
+pub fn read_manifest(bytes: &[u8]) -> Result<Vec<DataFileMeta>, StorageError> {
+    let schema = Schema::parse_str(MANIFEST_SCHEMA_JSON)
+        .map_err(|e| ser_err("parse manifest schema", e))?;
+    let reader =
+        Reader::with_schema(&schema, bytes).map_err(|e| ser_err("open manifest reader", e))?;
+    let mut out = Vec::new();
+    for value in reader {
+        let value = value.map_err(|e| ser_err("read manifest value", e))?;
+        let entry: AvroManifestEntry =
+            apache_avro::from_value(&value).map_err(|e| ser_err("decode manifest entry", e))?;
+        // status 2 == DELETED; skip deleted entries when surfacing live data files.
+        if entry.status == 2 {
+            continue;
+        }
+        out.push(DataFileMeta {
+            file_path: entry.data_file.file_path,
+            record_count: entry.data_file.record_count,
+            file_size_in_bytes: entry.data_file.file_size_in_bytes,
+        });
+    }
+    Ok(out)
+}
+
+/// Serialize a manifest list (one `manifest_file` per manifest) as Iceberg v2 Avro.
+pub fn write_manifest_list(manifests: &[ManifestFileMeta]) -> Result<Vec<u8>, StorageError> {
+    let schema = Schema::parse_str(MANIFEST_LIST_SCHEMA_JSON)
+        .map_err(|e| ser_err("parse manifest-list schema", e))?;
+    let mut writer = Writer::new(&schema, Vec::new());
+    for m in manifests {
+        let mf = AvroManifestFile {
+            manifest_path: m.manifest_path.clone(),
+            manifest_length: m.manifest_length,
+            partition_spec_id: 0,
+            content: 0, // DATA
+            sequence_number: 0,
+            min_sequence_number: 0,
+            added_snapshot_id: m.added_snapshot_id,
+            added_files_count: m.added_files_count,
+            existing_files_count: 0,
+            deleted_files_count: 0,
+            added_rows_count: m.added_rows_count,
+            existing_rows_count: 0,
+            deleted_rows_count: 0,
+        };
+        writer
+            .append_ser(&mf)
+            .map_err(|e| ser_err("append manifest_file", e))?;
+    }
+    writer
+        .into_inner()
+        .map_err(|e| ser_err("finish manifest list", e))
+}
+
+/// Read an Iceberg v2 manifest list back into its entries.
+pub fn read_manifest_list(bytes: &[u8]) -> Result<Vec<ManifestFileMeta>, StorageError> {
+    let schema = Schema::parse_str(MANIFEST_LIST_SCHEMA_JSON)
+        .map_err(|e| ser_err("parse manifest-list schema", e))?;
+    let reader =
+        Reader::with_schema(&schema, bytes).map_err(|e| ser_err("open manifest-list reader", e))?;
+    let mut out = Vec::new();
+    for value in reader {
+        let value = value.map_err(|e| ser_err("read manifest-list value", e))?;
+        let mf: AvroManifestFile =
+            apache_avro::from_value(&value).map_err(|e| ser_err("decode manifest_file", e))?;
+        out.push(ManifestFileMeta {
+            manifest_path: mf.manifest_path,
+            manifest_length: mf.manifest_length,
+            added_files_count: mf.added_files_count,
+            added_rows_count: mf.added_rows_count,
+            added_snapshot_id: mf.added_snapshot_id,
+        });
+    }
+    Ok(out)
+}
+
+/// One Iceberg schema field (subset of the spec needed to publish flat relational tables).
+#[derive(Debug, Clone)]
+pub struct IcebergField {
+    pub id: i32,
+    pub name: String,
+    /// Iceberg primitive type name, e.g. "long", "string", "double", "boolean", "date".
+    pub type_name: String,
+    pub required: bool,
+}
+
+/// Iceberg table format version. v2 is the interop default (broadest external-reader
+/// support); v3 is opt-in and aligns with ProximaDB's differentiators (row lineage ↔ CDC,
+/// deletion vectors, `variant` ↔ documents, nanosecond timestamps). Callers negotiate the
+/// version; v3-only data-file features (DVs, row-lineage columns) are layered separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormatVersion {
+    /// format-version 2 — the interop default.
+    V2,
+    /// format-version 3 — opt-in; standardizes lineage / DV / variant / ns-timestamps.
+    V3,
+}
+
+impl FormatVersion {
+    fn as_i32(self) -> i32 {
+        match self {
+            FormatVersion::V2 => 2,
+            FormatVersion::V3 => 3,
+        }
+    }
+    /// The interop default.
+    pub fn default_for_interop() -> Self {
+        FormatVersion::V2
+    }
+}
+
+/// Build a `TableMetadata` JSON document for a single snapshot at the given format version.
+///
+/// `snapshot_id` identifies the snapshot; `manifest_list_location` is the object key of the
+/// snapshot's manifest list; `timestamp_ms` is the commit time (passed in — this crate avoids
+/// wall-clock for determinism/testability). The table is unpartitioned (spec id 0). Pass
+/// [`FormatVersion::V2`] for maximum external-reader compatibility, [`FormatVersion::V3`] to
+/// opt into the lineage/DV/variant-aligned format.
+#[allow(clippy::too_many_arguments)]
+pub fn build_table_metadata(
+    format_version: FormatVersion,
+    table_uuid: &str,
+    location: &str,
+    fields: &[IcebergField],
+    snapshot_id: i64,
+    sequence_number: i64,
+    manifest_list_location: &str,
+    timestamp_ms: i64,
+    added_files: i64,
+    added_records: i64,
+) -> Result<String, StorageError> {
+    let last_column_id = fields.iter().map(|f| f.id).max().unwrap_or(0);
+    let schema_fields: Vec<serde_json::Value> = fields
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "id": f.id,
+                "name": f.name,
+                "required": f.required,
+                "type": f.type_name,
+            })
+        })
+        .collect();
+    let metadata = serde_json::json!({
+        "format-version": format_version.as_i32(),
+        "table-uuid": table_uuid,
+        "location": location,
+        "last-sequence-number": sequence_number,
+        "last-updated-ms": timestamp_ms,
+        "last-column-id": last_column_id,
+        "current-schema-id": 0,
+        "schemas": [{
+            "type": "struct",
+            "schema-id": 0,
+            "fields": schema_fields,
+        }],
+        "default-spec-id": 0,
+        "partition-specs": [{"spec-id": 0, "fields": []}],
+        "last-partition-id": 999,
+        "default-sort-order-id": 0,
+        "sort-orders": [{"order-id": 0, "fields": []}],
+        "properties": {},
+        "current-snapshot-id": snapshot_id,
+        "snapshots": [{
+            "snapshot-id": snapshot_id,
+            "sequence-number": sequence_number,
+            "timestamp-ms": timestamp_ms,
+            "summary": {
+                "operation": "append",
+                "added-data-files": added_files.to_string(),
+                "added-records": added_records.to_string(),
+            },
+            "manifest-list": manifest_list_location,
+            "schema-id": 0,
+        }],
+        "snapshot-log": [{"snapshot-id": snapshot_id, "timestamp-ms": timestamp_ms}],
+        "metadata-log": [],
+        "refs": {"main": {"snapshot-id": snapshot_id, "type": "branch"}},
+    });
+    serde_json::to_string_pretty(&metadata).map_err(|e| ser_err("serialize table metadata", e))
+}
+
+/// Extract the current snapshot's manifest-list location from a `TableMetadata` JSON.
+pub fn current_manifest_list(metadata_json: &str) -> Result<Option<String>, StorageError> {
+    let v: serde_json::Value =
+        serde_json::from_str(metadata_json).map_err(|e| ser_err("parse table metadata", e))?;
+    let current = v.get("current-snapshot-id").and_then(|x| x.as_i64());
+    let Some(current) = current else {
+        return Ok(None);
+    };
+    let snapshots = v.get("snapshots").and_then(|x| x.as_array());
+    let Some(snapshots) = snapshots else {
+        return Ok(None);
+    };
+    Ok(snapshots
+        .iter()
+        .find(|s| s.get("snapshot-id").and_then(|x| x.as_i64()) == Some(current))
+        .and_then(|s| s.get("manifest-list").and_then(|x| x.as_str()))
+        .map(String::from))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files() -> Vec<DataFileMeta> {
+        vec![
+            DataFileMeta {
+                file_path: "data/t/ns/tbl/data/part-0.parquet".into(),
+                record_count: 100,
+                file_size_in_bytes: 4096,
+            },
+            DataFileMeta {
+                file_path: "data/t/ns/tbl/data/part-1.parquet".into(),
+                record_count: 50,
+                file_size_in_bytes: 2048,
+            },
+        ]
+    }
+
+    #[test]
+    fn manifest_round_trips() {
+        let bytes = write_manifest(&files(), 12345).unwrap();
+        let back = read_manifest(&bytes).unwrap();
+        assert_eq!(back, files());
+    }
+
+    #[test]
+    fn manifest_list_round_trips() {
+        let manifests = vec![ManifestFileMeta {
+            manifest_path: "data/t/ns/tbl/metadata/abc-m0.avro".into(),
+            manifest_length: 1234,
+            added_files_count: 2,
+            added_rows_count: 150,
+            added_snapshot_id: 12345,
+        }];
+        let bytes = write_manifest_list(&manifests).unwrap();
+        let back = read_manifest_list(&bytes).unwrap();
+        assert_eq!(back, manifests);
+    }
+
+    #[test]
+    fn table_metadata_points_at_manifest_list() {
+        let fields = vec![
+            IcebergField { id: 1, name: "id".into(), type_name: "long".into(), required: true },
+            IcebergField { id: 2, name: "name".into(), type_name: "string".into(), required: false },
+        ];
+        let json = build_table_metadata(
+            FormatVersion::V2,
+            "uuid-1",
+            "data/t/ns/tbl",
+            &fields,
+            777,
+            1,
+            "data/t/ns/tbl/metadata/snap-777-list.avro",
+            1_700_000_000_000,
+            2,
+            150,
+        )
+        .unwrap();
+        // Valid JSON, format v2, and resolvable current manifest list.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["format-version"], 2);
+        assert_eq!(v["last-column-id"], 2);
+        assert_eq!(
+            current_manifest_list(&json).unwrap().as_deref(),
+            Some("data/t/ns/tbl/metadata/snap-777-list.avro")
+        );
+
+        // v3 is reachable (opt-in) — same structure, format-version flips to 3.
+        let v3 = build_table_metadata(
+            FormatVersion::V3,
+            "uuid-1",
+            "data/t/ns/tbl",
+            &fields,
+            778,
+            2,
+            "data/t/ns/tbl/metadata/snap-778-list.avro",
+            1_700_000_000_001,
+            1,
+            10,
+        )
+        .unwrap();
+        let v3v: serde_json::Value = serde_json::from_str(&v3).unwrap();
+        assert_eq!(v3v["format-version"], 3);
+        assert!(current_manifest_list(&v3).unwrap().is_some());
+    }
+
+    /// End-to-end content round-trip: metadata → manifest-list → manifest → data files.
+    #[test]
+    fn snapshot_content_round_trips_end_to_end() {
+        let data = files();
+        let manifest_bytes = write_manifest(&data, 777).unwrap();
+        let manifests = vec![ManifestFileMeta {
+            manifest_path: "m0.avro".into(),
+            manifest_length: manifest_bytes.len() as i64,
+            added_files_count: data.len() as i32,
+            added_rows_count: data.iter().map(|f| f.record_count).sum(),
+            added_snapshot_id: 777,
+        }];
+        let list_bytes = write_manifest_list(&manifests).unwrap();
+        let json = build_table_metadata(
+            FormatVersion::V2,
+            "uuid-1",
+            "loc",
+            &[IcebergField { id: 1, name: "id".into(), type_name: "long".into(), required: true }],
+            777,
+            1,
+            "snap-777-list.avro",
+            1,
+            data.len() as i64,
+            data.iter().map(|f| f.record_count).sum(),
+        )
+        .unwrap();
+
+        // Resolve back down the chain.
+        assert!(current_manifest_list(&json).unwrap().is_some());
+        let list = read_manifest_list(&list_bytes).unwrap();
+        assert_eq!(list.len(), 1);
+        let recovered = read_manifest(&manifest_bytes).unwrap();
+        assert_eq!(recovered, data);
+    }
+}

--- a/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
@@ -140,8 +140,8 @@ struct AvroManifestFile {
 /// Serialize a manifest (one `manifest_entry` per data file) as Iceberg v2 Avro.
 /// `status` is ADDED (1), `content` is DATA (0), format is PARQUET, unpartitioned.
 pub fn write_manifest(files: &[DataFileMeta], snapshot_id: i64) -> Result<Vec<u8>, StorageError> {
-    let schema = Schema::parse_str(MANIFEST_SCHEMA_JSON)
-        .map_err(|e| ser_err("parse manifest schema", e))?;
+    let schema =
+        Schema::parse_str(MANIFEST_SCHEMA_JSON).map_err(|e| ser_err("parse manifest schema", e))?;
     let mut writer = Writer::new(&schema, Vec::new());
     for f in files {
         let entry = AvroManifestEntry {
@@ -162,13 +162,15 @@ pub fn write_manifest(files: &[DataFileMeta], snapshot_id: i64) -> Result<Vec<u8
             .append_ser(&entry)
             .map_err(|e| ser_err("append manifest entry", e))?;
     }
-    writer.into_inner().map_err(|e| ser_err("finish manifest", e))
+    writer
+        .into_inner()
+        .map_err(|e| ser_err("finish manifest", e))
 }
 
 /// Read an Iceberg v2 manifest Avro back into the data-file list.
 pub fn read_manifest(bytes: &[u8]) -> Result<Vec<DataFileMeta>, StorageError> {
-    let schema = Schema::parse_str(MANIFEST_SCHEMA_JSON)
-        .map_err(|e| ser_err("parse manifest schema", e))?;
+    let schema =
+        Schema::parse_str(MANIFEST_SCHEMA_JSON).map_err(|e| ser_err("parse manifest schema", e))?;
     let reader =
         Reader::with_schema(&schema, bytes).map_err(|e| ser_err("open manifest reader", e))?;
     let mut out = Vec::new();
@@ -410,8 +412,18 @@ mod tests {
     #[test]
     fn table_metadata_points_at_manifest_list() {
         let fields = vec![
-            IcebergField { id: 1, name: "id".into(), type_name: "long".into(), required: true },
-            IcebergField { id: 2, name: "name".into(), type_name: "string".into(), required: false },
+            IcebergField {
+                id: 1,
+                name: "id".into(),
+                type_name: "long".into(),
+                required: true,
+            },
+            IcebergField {
+                id: 2,
+                name: "name".into(),
+                type_name: "string".into(),
+                required: false,
+            },
         ];
         let json = build_table_metadata(
             FormatVersion::V2,
@@ -471,7 +483,12 @@ mod tests {
             FormatVersion::V2,
             "uuid-1",
             "loc",
-            &[IcebergField { id: 1, name: "id".into(), type_name: "long".into(), required: true }],
+            &[IcebergField {
+                id: 1,
+                name: "id".into(),
+                type_name: "long".into(),
+                required: true,
+            }],
             777,
             1,
             "snap-777-list.avro",

--- a/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/iceberg.rs
@@ -251,15 +251,20 @@ pub struct IcebergField {
     pub required: bool,
 }
 
-/// Iceberg table format version. v2 is the interop default (broadest external-reader
-/// support); v3 is opt-in and aligns with ProximaDB's differentiators (row lineage ↔ CDC,
-/// deletion vectors, `variant` ↔ documents, nanosecond timestamps). Callers negotiate the
-/// version; v3-only data-file features (DVs, row-lineage columns) are layered separately.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Iceberg table format version.
+///
+/// **v3 is ProximaDB's target and default** — its headline features map onto ProximaDB's
+/// differentiators (row lineage ↔ CDC, deletion vectors ↔ dedup, `variant` ↔ documents,
+/// `timestamp_ns` ↔ our nanosecond-native format), so building toward v3 directly avoids
+/// double-spending on v2-only mechanisms (positional/equality deletes, microsecond-only
+/// timestamps) that v3 supersedes. v2 stays reachable for the subset of external readers
+/// that are still v2-only (capability negotiation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FormatVersion {
-    /// format-version 2 — the interop default.
+    /// format-version 2 — reachable for legacy external readers.
     V2,
-    /// format-version 3 — opt-in; standardizes lineage / DV / variant / ns-timestamps.
+    /// format-version 3 — ProximaDB's target (lineage / DV / variant / ns-timestamps).
+    #[default]
     V3,
 }
 
@@ -269,10 +274,6 @@ impl FormatVersion {
             FormatVersion::V2 => 2,
             FormatVersion::V3 => 3,
         }
-    }
-    /// The interop default.
-    pub fn default_for_interop() -> Self {
-        FormatVersion::V2
     }
 }
 

--- a/crates/storage/proximadb-iceberg-engine/src/lib.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/lib.rs
@@ -56,11 +56,11 @@ use proximadb_storage_common::proxima_arrow::infer_proxima_schema;
 use proximadb_storage_common::proxima_parquet::proxima_records_to_parquet_bytes;
 use proximadb_storage_common::proxima_schema::ProximaSchema;
 
+/// Spec-shaped Iceberg v2 manifest / manifest-list (Avro) + TableMetadata (JSON) content.
+pub mod iceberg;
 /// Iceberg-style atomic manifest commits (optimistic concurrency via `put_if_absent`).
 pub mod manifest;
 pub mod metadata;
-/// Spec-shaped Iceberg v2 manifest / manifest-list (Avro) + TableMetadata (JSON) content.
-pub mod iceberg;
 
 /// Map a Parquet read/decode failure into a [`StorageError`] with operation context.
 fn read_err(context: &str, e: impl std::fmt::Display) -> StorageError {
@@ -180,9 +180,7 @@ impl IcebergObjectStoreBridge {
         }];
         let list_bytes = iceberg::write_manifest_list(&manifest_list)?;
         let list_path = Path::from(format!("{metadata_prefix}/snap-{snapshot_id}-list.avro"));
-        self.store
-            .put(&list_path, Bytes::from(list_bytes))
-            .await?;
+        self.store.put(&list_path, Bytes::from(list_bytes)).await?;
 
         // 3. Build + atomically commit the TableMetadata.
         let committer = metadata::MetadataCommitter::new(self.store.clone(), metadata_prefix);

--- a/crates/storage/proximadb-iceberg-engine/src/lib.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/lib.rs
@@ -439,6 +439,54 @@ impl ObjectStoreBridge for IcebergObjectStoreBridge {
         let committer = metadata::MetadataCommitter::new(self.store.clone(), metadata_prefix);
         committer.commit(parent, Bytes::from(metadata)).await
     }
+
+    /// Map the storage-common field descriptors to Iceberg fields and delegate to the
+    /// inherent [`publish_iceberg_snapshot`](IcebergObjectStoreBridge::publish_iceberg_snapshot).
+    async fn publish_iceberg_table(
+        &self,
+        data_prefix: &Path,
+        metadata_prefix: &str,
+        table_uuid: &str,
+        table_location: &str,
+        fields: &[proximadb_storage_common::object_store_bridge::IcebergSnapshotField],
+        snapshot_id: i64,
+        timestamp_ms: i64,
+        v3: bool,
+    ) -> Result<CommitOutcome, StorageError> {
+        let mapped: Vec<iceberg::IcebergField> = fields
+            .iter()
+            .map(|f| iceberg::IcebergField {
+                id: f.id,
+                name: f.name.clone(),
+                type_name: f.type_name.clone(),
+                required: f.required,
+            })
+            .collect();
+        let format_version = if v3 {
+            iceberg::FormatVersion::V3
+        } else {
+            iceberg::FormatVersion::V2
+        };
+        self.publish_iceberg_snapshot(
+            data_prefix,
+            metadata_prefix,
+            table_uuid,
+            table_location,
+            &mapped,
+            snapshot_id,
+            timestamp_ms,
+            format_version,
+        )
+        .await
+    }
+
+    async fn read_iceberg_table(
+        &self,
+        metadata_prefix: &str,
+        version: u64,
+    ) -> Result<Vec<Path>, StorageError> {
+        self.read_iceberg_snapshot(metadata_prefix, version).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/proximadb-iceberg-engine/src/lib.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/lib.rs
@@ -118,6 +118,117 @@ impl IcebergObjectStoreBridge {
             .map(Path::from)
             .collect())
     }
+
+    /// Row count of a Parquet object, read from the footer metadata only (no row data).
+    async fn parquet_num_rows(&self, path: &Path) -> Result<i64, StorageError> {
+        let reader = ParquetObjectReader::new(self.store.store(), self.full_object_path(path));
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .map_err(|e| read_err("open parquet footer", e))?;
+        Ok(builder.metadata().file_metadata().num_rows())
+    }
+
+    /// Publish a snapshot as **spec-shaped Iceberg** (v3 by default): write an Avro manifest
+    /// for the `*.parquet` data files under `data_prefix`, an Avro manifest list, and a
+    /// `TableMetadata` JSON referencing it, committed atomically through the metadata log at
+    /// `metadata_prefix`. External Iceberg engines can then read the table. `snapshot_id` and
+    /// `timestamp_ms` are caller-supplied (no wall-clock here, for determinism). Returns the
+    /// committed metadata version (or a `Conflict` to rebase onto).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn publish_iceberg_snapshot(
+        &self,
+        data_prefix: &Path,
+        metadata_prefix: &str,
+        table_uuid: &str,
+        table_location: &str,
+        fields: &[iceberg::IcebergField],
+        snapshot_id: i64,
+        timestamp_ms: i64,
+        format_version: iceberg::FormatVersion,
+    ) -> Result<CommitOutcome, StorageError> {
+        // 1. Enumerate data files with size (HEAD) + record count (footer).
+        let mut keys: Vec<Path> = self.list_objects(data_prefix).await?;
+        keys.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+        let mut data_files = Vec::new();
+        for key in &keys {
+            if !key.as_ref().ends_with(".parquet") {
+                continue;
+            }
+            let size = self.store.object_size(key).await?;
+            let record_count = self.parquet_num_rows(key).await.unwrap_or(0);
+            data_files.push(iceberg::DataFileMeta {
+                file_path: key.as_ref().to_string(),
+                record_count,
+                file_size_in_bytes: size as i64,
+            });
+        }
+        let added_records: i64 = data_files.iter().map(|f| f.record_count).sum();
+        let added_files = data_files.len() as i64;
+
+        // 2. Write the Avro manifest + manifest list.
+        let manifest_bytes = iceberg::write_manifest(&data_files, snapshot_id)?;
+        let manifest_path = Path::from(format!("{metadata_prefix}/{snapshot_id}-m0.avro"));
+        self.store
+            .put(&manifest_path, Bytes::from(manifest_bytes.clone()))
+            .await?;
+        let manifest_list = vec![iceberg::ManifestFileMeta {
+            manifest_path: manifest_path.as_ref().to_string(),
+            manifest_length: manifest_bytes.len() as i64,
+            added_files_count: added_files as i32,
+            added_rows_count: added_records,
+            added_snapshot_id: snapshot_id,
+        }];
+        let list_bytes = iceberg::write_manifest_list(&manifest_list)?;
+        let list_path = Path::from(format!("{metadata_prefix}/snap-{snapshot_id}-list.avro"));
+        self.store
+            .put(&list_path, Bytes::from(list_bytes))
+            .await?;
+
+        // 3. Build + atomically commit the TableMetadata.
+        let committer = metadata::MetadataCommitter::new(self.store.clone(), metadata_prefix);
+        let parent = committer.latest_version().await?;
+        let sequence_number = parent.map(|p| p as i64 + 1).unwrap_or(1);
+        let json = iceberg::build_table_metadata(
+            format_version,
+            table_uuid,
+            table_location,
+            fields,
+            snapshot_id,
+            sequence_number,
+            list_path.as_ref(),
+            timestamp_ms,
+            added_files,
+            added_records,
+        )?;
+        committer.commit(parent, Bytes::from(json)).await
+    }
+
+    /// Resolve the data-file keys of the current snapshot in the Iceberg metadata log at
+    /// `metadata_prefix` (decodes `TableMetadata` → manifest list → manifests). Each returned
+    /// path is consumable by [`read_parquet_batches`](ObjectStoreBridge::read_parquet_batches).
+    pub async fn read_iceberg_snapshot(
+        &self,
+        metadata_prefix: &str,
+        version: u64,
+    ) -> Result<Vec<Path>, StorageError> {
+        let committer = metadata::MetadataCommitter::new(self.store.clone(), metadata_prefix);
+        let meta_bytes = committer.read_metadata(version).await?;
+        let meta_json =
+            std::str::from_utf8(&meta_bytes).map_err(|e| read_err("metadata utf8", e))?;
+        let Some(list_loc) = iceberg::current_manifest_list(meta_json)? else {
+            return Ok(Vec::new());
+        };
+        let list_bytes = self.store.get(&Path::from(list_loc)).await?;
+        let manifests = iceberg::read_manifest_list(&list_bytes)?;
+        let mut out = Vec::new();
+        for m in manifests {
+            let mbytes = self.store.get(&Path::from(m.manifest_path)).await?;
+            for df in iceberg::read_manifest(&mbytes)? {
+                out.push(Path::from(df.file_path));
+            }
+        }
+        Ok(out)
+    }
 }
 
 #[async_trait]
@@ -413,6 +524,85 @@ mod tests {
         assert_eq!(ages.value(1), 41);
         // The inferred dense-vector column round-tripped as a column too.
         assert!(batch.column_by_name("vector").is_some());
+    }
+
+    /// End-to-end Iceberg publish: write a Parquet data file, publish a v3 snapshot
+    /// (manifest + manifest list + TableMetadata), then resolve the snapshot back to its
+    /// data files and read their rows. Proves ProximaDB emits a readable Iceberg table.
+    #[tokio::test]
+    async fn iceberg_snapshot_publishes_and_reads_back_v3() {
+        let b = bridge();
+        let data_prefix = Path::from("wh/t/ns/tbl/data");
+        let metadata_prefix = "wh/t/ns/tbl/metadata";
+
+        let r0 = record(
+            "r0",
+            vec![
+                ("name", ProximaValue::String("alice".into())),
+                ("age", ProximaValue::Int64(30)),
+            ],
+        );
+        let r1 = record(
+            "r1",
+            vec![
+                ("name", ProximaValue::String("bob".into())),
+                ("age", ProximaValue::Int64(41)),
+            ],
+        );
+        b.write_records_to_parquet(
+            &Path::from("wh/t/ns/tbl/data/part-0.parquet"),
+            &[r0, r1],
+            None,
+        )
+        .await
+        .unwrap();
+
+        let fields = vec![
+            iceberg::IcebergField {
+                id: 1,
+                name: "name".into(),
+                type_name: "string".into(),
+                required: false,
+            },
+            iceberg::IcebergField {
+                id: 2,
+                name: "age".into(),
+                type_name: "long".into(),
+                required: false,
+            },
+        ];
+        let out = b
+            .publish_iceberg_snapshot(
+                &data_prefix,
+                metadata_prefix,
+                "uuid-1",
+                "wh/t/ns/tbl",
+                &fields,
+                1001,
+                1_700_000_000_000,
+                iceberg::FormatVersion::V3,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CommitOutcome::Committed(0));
+
+        // The committed metadata is Iceberg format-version 3.
+        let meta = b.read_table_metadata(metadata_prefix, 0).await.unwrap();
+        let mj: serde_json::Value = serde_json::from_slice(&meta).unwrap();
+        assert_eq!(mj["format-version"], 3);
+
+        // Resolve the snapshot back to its data file(s) and read the rows.
+        let files = b.read_iceberg_snapshot(metadata_prefix, 0).await.unwrap();
+        assert_eq!(files.len(), 1, "one data file in the snapshot");
+        let mut stream = b
+            .read_parquet_batches(&files[0], Arc::new(ArrowSchema::empty()), 1024, None)
+            .await
+            .unwrap();
+        let mut total = 0;
+        while let Some(batch) = stream.next().await {
+            total += batch.unwrap().num_rows();
+        }
+        assert_eq!(total, 2, "snapshot data files carry all rows");
     }
 
     /// A non-empty `schema` arg projects the read to only the named columns (by name),

--- a/crates/storage/proximadb-iceberg-engine/src/lib.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/lib.rs
@@ -59,6 +59,8 @@ use proximadb_storage_common::proxima_schema::ProximaSchema;
 /// Iceberg-style atomic manifest commits (optimistic concurrency via `put_if_absent`).
 pub mod manifest;
 pub mod metadata;
+/// Spec-shaped Iceberg v2 manifest / manifest-list (Avro) + TableMetadata (JSON) content.
+pub mod iceberg;
 
 /// Map a Parquet read/decode failure into a [`StorageError`] with operation context.
 fn read_err(context: &str, e: impl std::fmt::Display) -> StorageError {

--- a/crates/storage/proximadb-storage-common/src/object_store_bridge.rs
+++ b/crates/storage/proximadb-storage-common/src/object_store_bridge.rs
@@ -223,4 +223,59 @@ pub trait ObjectStoreBridge: Send + Sync {
             "commit_table_metadata not supported".into(),
         ))
     }
+
+    /// Publish the `*.parquet` data files under `data_prefix` as a **spec-shaped Iceberg
+    /// snapshot** (Avro manifest + manifest list + `TableMetadata`) committed atomically
+    /// through the metadata log at `metadata_prefix`, so external Iceberg engines can read
+    /// the table. `v3` selects Iceberg format-version 3 (ProximaDB's default) vs v2. The
+    /// field descriptors are storage-common-local (this trait can't depend on the Iceberg
+    /// engine crate); the Iceberg bridge maps them to its own types. Default: unsupported.
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_iceberg_table(
+        &self,
+        data_prefix: &Path,
+        metadata_prefix: &str,
+        table_uuid: &str,
+        table_location: &str,
+        fields: &[IcebergSnapshotField],
+        snapshot_id: i64,
+        timestamp_ms: i64,
+        v3: bool,
+    ) -> Result<CommitOutcome, StorageError> {
+        let _ = (
+            data_prefix,
+            metadata_prefix,
+            table_uuid,
+            table_location,
+            fields,
+            snapshot_id,
+            timestamp_ms,
+            v3,
+        );
+        Err(StorageError::Serialization(
+            "publish_iceberg_table not supported".into(),
+        ))
+    }
+
+    /// Resolve the current snapshot's data-file paths from the Iceberg metadata log at
+    /// `metadata_prefix` (decodes `TableMetadata` → manifest list → manifests). Default: empty.
+    async fn read_iceberg_table(
+        &self,
+        metadata_prefix: &str,
+        version: u64,
+    ) -> Result<Vec<Path>, StorageError> {
+        let _ = (metadata_prefix, version);
+        Ok(Vec::new())
+    }
+}
+
+/// Storage-common-local descriptor of one Iceberg schema field (the trait can't reference
+/// the Iceberg engine's own type). The Iceberg bridge maps `type_name` to an Iceberg
+/// primitive type ("long", "int", "string", "double", "boolean", "date", "timestamp", …).
+#[derive(Debug, Clone)]
+pub struct IcebergSnapshotField {
+    pub id: i32,
+    pub name: String,
+    pub type_name: String,
+    pub required: bool,
 }

--- a/crates/storage/proximadb-storage-common/src/proxima_arrow.rs
+++ b/crates/storage/proximadb-storage-common/src/proxima_arrow.rs
@@ -51,14 +51,15 @@ use std::collections::HashMap;
 use arrow_array::{
     Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, FixedSizeBinaryArray, Float32Array,
     Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, LargeStringArray, RecordBatch,
-    StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    StringArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use proximadb_kernel::error::StorageError;
 use proximadb_records::{
     EmbeddingCell, EmbeddingValues, ProximaRecord, ProximaTreeNode, ProximaValue, tree_get,
 };
 
-use proximadb_data_model::{ProximaType, VectorElement as DmVectorElement};
+use proximadb_data_model::{ProximaType, TimeUnit as DmTimeUnit, VectorElement as DmVectorElement};
 
 use crate::proxima_schema::{ProximaColumn, ProximaSchema};
 
@@ -117,6 +118,11 @@ fn build_column(records: &[ProximaRecord], col: &ProximaColumn) -> Result<ArrayR
         ProximaType::Float32 => scalar_col!(Float32Builder, |v| pv_as_f64(v).map(|x| x as f32)),
         ProximaType::Float64 => scalar_col!(Float64Builder, pv_as_f64),
         ProximaType::Date => scalar_col!(Date32Builder, pv_as_date32),
+        // Temporal: build in the column's DECLARED unit, converting each stored
+        // value from its own unit (INSERT lowers DATE/TIMESTAMP literals to ms).
+        // TimestampTz carries a "UTC" zone so the Arrow type matches `to_arrow_type`.
+        ProximaType::Timestamp(unit) => build_timestamp_column(records, col, *unit, false),
+        ProximaType::TimestampTz(unit) => build_timestamp_column(records, col, *unit, true),
         // Utf8-backed types per `to_arrow_type` (String, Json).
         ProximaType::String | ProximaType::Json => {
             let mut b = StringBuilder::new();
@@ -188,6 +194,57 @@ fn build_vector_column(
         }
     }
     Ok(Arc::new(b.finish()) as ArrayRef)
+}
+
+/// Nanoseconds per one tick of a [`DmTimeUnit`].
+fn time_unit_nanos(u: DmTimeUnit) -> i64 {
+    match u {
+        DmTimeUnit::Second => 1_000_000_000,
+        DmTimeUnit::Millisecond => 1_000_000,
+        DmTimeUnit::Microsecond => 1_000,
+        DmTimeUnit::Nanosecond => 1,
+    }
+}
+
+/// Convert a tick count from `from` unit to `to` unit (via nanoseconds).
+fn convert_ticks(val: i64, from: DmTimeUnit, to: DmTimeUnit) -> i64 {
+    val.saturating_mul(time_unit_nanos(from)) / time_unit_nanos(to)
+}
+
+/// Build a Timestamp(unit[, UTC]) column, converting each stored value into the
+/// column's declared `unit`. A bare `Int64` is assumed already in `unit`.
+fn build_timestamp_column(
+    records: &[ProximaRecord],
+    col: &ProximaColumn,
+    unit: DmTimeUnit,
+    tz: bool,
+) -> Result<ArrayRef, StorageError> {
+    let vals: Vec<Option<i64>> = records
+        .iter()
+        .map(|r| {
+            tree_get(&r.props, &col.name).and_then(|v| match v {
+                ProximaValue::Timestamp(t, u) | ProximaValue::TimestampTz(t, u) => {
+                    Some(convert_ticks(*t, *u, unit))
+                }
+                ProximaValue::Int64(t) => Some(*t),
+                _ => None,
+            })
+        })
+        .collect();
+    let tzopt: Option<String> = if tz { Some("UTC".to_string()) } else { None };
+    let arr: ArrayRef = match unit {
+        DmTimeUnit::Second => Arc::new(TimestampSecondArray::from(vals).with_timezone_opt(tzopt)),
+        DmTimeUnit::Millisecond => {
+            Arc::new(TimestampMillisecondArray::from(vals).with_timezone_opt(tzopt))
+        }
+        DmTimeUnit::Microsecond => {
+            Arc::new(TimestampMicrosecondArray::from(vals).with_timezone_opt(tzopt))
+        }
+        DmTimeUnit::Nanosecond => {
+            Arc::new(TimestampNanosecondArray::from(vals).with_timezone_opt(tzopt))
+        }
+    };
+    Ok(arr)
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
+++ b/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
@@ -97,13 +97,32 @@ the manifest, so TPC-H 22/22 stays green.
 REMAINING: serve the current `TableMetadata` via the native Iceberg REST catalog
 (`load_table` discovery); partitioned layout; column statistics in manifests.
 
-=== P2 — CDC change-feed (`since_lsn` + `table_changes`)  [PLANNED]
+=== P2 — CDC change-feed (`since_lsn` + surfaces)  [CORE SHIPPED; surfaces pending]
 
-Outbound CDC already exists (`src/cdc/outbound`: `WalSubscriber`, `PositionTracker`,
-exactly-once; `GlobalLsnAllocator`). Add `load_entries_since(lsn)` incremental read and a
-pgwire `table_changes('<table>', <since_lsn>)` table-valued function returning
-`(op, lsn, <row cols>)`. v3 alignment: model the feed on *row lineage* and later emit the
-Iceberg `_row_id`/`_last_updated_sequence_number` columns so external engines do the same
+*Core (shipped):* the change-feed read primitive over the canonical WAL —
+`TableWalAppender::read_all_entries` (framed appender), `TableRecordStore::read_changes_since`
+(WAL-backed store: filter by `collection_id` == table + `sequence_number > since_lsn`,
+map RecordUpsert→`upsert` / RecordDelete→`delete` with oid + after-image JSON, lsn-ordered),
+and `DmlService::changes_since(table, since_lsn) -> Vec<ChangeRow>`. Verified: a service test
+(INSERT→UPDATE→DELETE → 3 lsn-ordered changes; `since_lsn` tail; table isolation).
+
+*Surface wiring (the remaining work, and why it's deliberate):* the REST/gRPC
+`UnifiedHandlers` holds `DmlService::new(catalog, vector_ops)` (shared_services.rs:1589),
+a *different* instance than the pgwire direct-write path's WAL-backed `DmlService`
+(`build_direct_pgwire_write_services`, multi_server.rs). So a change-feed surfaced through
+`UnifiedHandlers` returns empty for pgwire-written tables. Both surfaces therefore require
+threading the WAL-backed record store (or a dedicated change-feed reader handle) into the
+serving layer at boot:
+
+* *REST* `GET /collections/:id/changes?since_lsn=N` — add a change-feed reader to `AppState`
+  wired from the same WAL-backed store; handler calls `changes_since`.
+* *pgwire* `table_changes('<table>', <since_lsn>)` TVF — register like `vector_search`, and
+  teach the router to route TVF-only `SELECT`s (today a standalone TVF select has no
+  parquet-backed table, so it doesn't reach the DataFusion engine).
+* *north star* Postgres logical replication (`pgoutput`) — Debezium-compatible streaming.
+
+v3 alignment: model the feed on *row lineage* and later emit the Iceberg
+`_row_id`/`_last_updated_sequence_number` columns so external engines do the same
 incremental read.
 
 === P3 — Wire RaBitQ into ANN search + f32 rerank  [PLANNED]

--- a/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
+++ b/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
@@ -106,13 +106,17 @@ map RecordUpsert→`upsert` / RecordDelete→`delete` with oid + after-image JSO
 and `DmlService::changes_since(table, since_lsn) -> Vec<ChangeRow>`. Verified: a service test
 (INSERT→UPDATE→DELETE → 3 lsn-ordered changes; `since_lsn` tail; table isolation).
 
-*Surface wiring (the remaining work, and why it's deliberate):* the REST/gRPC
-`UnifiedHandlers` holds `DmlService::new(catalog, vector_ops)` (shared_services.rs:1589),
-a *different* instance than the pgwire direct-write path's WAL-backed `DmlService`
-(`build_direct_pgwire_write_services`, multi_server.rs). So a change-feed surfaced through
-`UnifiedHandlers` returns empty for pgwire-written tables. Both surfaces therefore require
-threading the WAL-backed record store (or a dedicated change-feed reader handle) into the
-serving layer at boot:
+*Cross-surface convergence (DONE — prerequisite, shipped):* REST/gRPC and pgwire
+previously ran on *divergent* record stores (REST/gRPC `DmlService::new` →
+`with_vector_compatibility` stub; pgwire → WAL-backed `DirectWalTableRecordStore`), so a
+change-feed surfaced through `UnifiedHandlers` returned empty for pgwire writes.
+`SharedServices::new` now builds the canonical WAL-backed store ONCE and shares the single
+instance across both the REST/gRPC `DmlService` (`with_direct_record_storage`) and the
+pgwire path (reuse short-circuit). Proven by `tests/cross_surface_unification_e2e.rs`
+(pgwire INSERT visible on the shared store) with full modality regression green. This
+unblocks the surfaces below — they now read the same state any protocol wrote.
+
+*Surface wiring (remaining):* with the store unified, the surfaces are thin adapters:
 
 * *REST* `GET /collections/:id/changes?since_lsn=N` — add a change-feed reader to `AppState`
   wired from the same WAL-backed store; handler calls `changes_since`.

--- a/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
+++ b/docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc
@@ -1,0 +1,149 @@
+= Format Strategy: Iceberg / Delta / Lance — Gap Closure & v3 Alignment
+:toc: macro
+:icons: font
+2026-06-19
+
+toc::[]
+
+== Why this document
+
+ProximaDB is a multi-modal database (relational + vector + document + graph + events)
+over one router and the PostgreSQL wire protocol. The lakehouse/AI format landscape it
+must coexist with has three reference points — Apache Iceberg, Delta Lake, and Lance.
+This document records the strategy for where ProximaDB invests vs. interoperates, the
+concrete gaps a codebase audit found against that strategy, and the program closing them.
+
+NOTE: This is a living design artifact. Implementation status is tracked inline; the
+executable spec lives in the qa-gate harnesses and the `proximadb-iceberg-engine` crate.
+
+== Strategic north star
+
+Two camps, not three competitors:
+
+* *Iceberg & Delta* — warehouse table formats. Broad engine ecosystem, governance,
+  time-travel; *index-blind* for vector/full-text. Converging (Delta UniForm, Apache
+  XTable, REST Catalog).
+* *Lance* — AI-native format. Vector + full-text + random access; ecosystem-thin, weak
+  on relational/governance/multi-engine.
+* *ProximaDB* — the only one attempting unified multi-modal over one router + pgwire.
+
+[.lead]
+*Interoperate with Iceberg/Delta on the warehouse boundary, out-engineer Lance on the
+vector format, and win on the layers all three ignore — the unified router, pgwire
+protocol, multi-modal breadth, and multi-tenant economics.*
+
+=== Feature matrix
+
+[cols="2,1,1,1,2",options="header"]
+|===
+| Capability | Iceberg | Delta | Lance | ProximaDB (PAX + router)
+| Primary role | Warehouse fmt | Warehouse fmt | AI/vector fmt | *Multi-modal DB*
+| Native vector/ANN index | ✗ | ✗ | ✓ | ✓ (SQ8/RaBitQ + engines)
+| Full-text / secondary index | Puffin (nascent) | ✗ | ✓ | bloom; BM25 = gap
+| In-file zone-map pruning | manifest-layer | clustering-layer | index-layer | *block+row-group (edge)*
+| Random row access | ✗ | ✗ | ✓ | adopt (mini-block)
+| Native CDC / change feed | coarse | ✓ CDF | ✗ | gap → P2
+| Adaptive clustering | hidden partition | ✓ liquid | — | gap → P4
+| Constraints (PK/FK/CHECK) | ✗ | partial | ✗ | *✓ (ahead)*
+| Cross-cloud atomic commit | catalog CAS | log + coordinator | light manifest | *✓ commit_fenced + BranchRef*
+| Multi-tenant isolation/billing | ✗ | ✗ | ✗ | *✓ DrPathBuilder + TenantCache*
+| Universal client protocol | engine-specific | engine-specific | Python/Rust API | *✓ pgwire (ANSI SQL)*
+| Multi-modal (graph/events/doc) | ✗ | ✗ | ✗ | ✓ (proven)
+|===
+
+== Iceberg v3 alignment (V3-FIRST)
+
+v3 is *ProximaDB's target and default*. Its headline features map onto ProximaDB's
+differentiators, so building toward v3 directly avoids double-spending on v2-only
+mechanisms:
+
+[cols="2,3",options="header"]
+|===
+| Iceberg v3 feature | Maps onto
+| Row lineage (`_row_id`, `_last_updated_sequence_number`) | CDC change-feed (P2) + `GlobalLsnAllocator`
+| Deletion vectors (Puffin) | dedup / delete handling (P4, Lance-parity)
+| `variant` type | document/JSON modality
+| `timestamp_ns` / `timestamptz_ns` | ProximaDB's nanosecond-native format
+| Default values | constraints (TD-110)
+|===
+
+Decision: the v2/v3 metadata+manifest *core is shared* (build-once;
+`FormatVersion {V2,V3}`, default `V3`). Divergent features are built *in their v3 form
+only*. v2 stays reachable via the enum for v2-only external readers (capability
+negotiation). Caveat: v3-default means v2-only external engines can't read our tables
+until their v3 support lands — accepted, since v3 is where our differentiators live.
+
+== Workstreams
+
+=== P1 — Real Iceberg manifests + versioned snapshots  [SHIPPED]
+
+The `proximadb-iceberg-engine` manifest was a custom newline-delimited key list,
+readable only by ProximaDB. Replaced with spec-shaped content:
+
+* `iceberg` module: Avro manifest (one `manifest_entry`/data file, Iceberg field-ids) +
+  Avro manifest list + `TableMetadata` JSON; `FormatVersion::{V2,V3}` (V3 default).
+* Bridge `publish_iceberg_snapshot` / `read_iceberg_snapshot` (atomic CAS commit; record
+  counts from the Parquet footer).
+* `ObjectStoreBridge::publish_iceberg_table` / `read_iceberg_table` (storage-common-typed
+  `IcebergSnapshotField`) so the warehouse materializer can call it through `dyn`.
+* `MATERIALIZE` (dml) emits a v3 Iceberg table best-effort under `{prefix}/metadata`
+  (field types lock-step with the Parquet physical types; deterministic table-uuid).
+
+Verified: 24 leaf-crate tests + an e2e (`tests/iceberg_interop_e2e.rs`) asserting a
+`v*.metadata.json` (format-version 3 → manifest list) + Avro manifest/list + Parquet on
+disk after pgwire `MATERIALIZE`. Additive: SELECTs read the catalog storage layout, not
+the manifest, so TPC-H 22/22 stays green.
+
+REMAINING: serve the current `TableMetadata` via the native Iceberg REST catalog
+(`load_table` discovery); partitioned layout; column statistics in manifests.
+
+=== P2 — CDC change-feed (`since_lsn` + `table_changes`)  [PLANNED]
+
+Outbound CDC already exists (`src/cdc/outbound`: `WalSubscriber`, `PositionTracker`,
+exactly-once; `GlobalLsnAllocator`). Add `load_entries_since(lsn)` incremental read and a
+pgwire `table_changes('<table>', <since_lsn>)` table-valued function returning
+`(op, lsn, <row cols>)`. v3 alignment: model the feed on *row lineage* and later emit the
+Iceberg `_row_id`/`_last_updated_sequence_number` columns so external engines do the same
+incremental read.
+
+=== P3 — Wire RaBitQ into ANN search + f32 rerank  [PLANNED]
+
+RaBitQ (~30×) kernel + length-renorm are built/tested but UNWIRED (reserved
+`quant_kind=2`). Populate codes on write; decode + length-renorm in the ANN scan; add a
+f32 cold-rerank tier for top-k; per-collection opt-in. Gate: the `vector_ann_recall_e2e`
+recall ratchet must hold with ~30× smaller payload.
+
+=== P4 — Adaptive clustering + relational streaming freshness  [PLANNED]
+
+`cluster_by` / `allow_zorder_pruning` are catalog-only stubs. Thread `cluster_by` into
+the flush sort + optional Z-order in the PAX writer (tighter zone-map skip). Union the
+memtable delta into relational streaming reads (gated by `VectorFreshnessMode`) so OLAP
+reads aren't stale. v3 alignment: deletes via *deletion vectors* (Puffin), not v2
+positional/equality deletes.
+
+=== Phase 2 — spec-only (sequenced)
+
+* *Delta read + UniForm exposure*: parse `_delta_log/*.json`; expose Iceberg metadata
+  alongside Delta. (`proximadb-catalog/src/delta.rs` is a stub today.)
+* *Remaining Lance-parity*: FSST strings, mini-block metadata random-access, AIMD/byte-
+  backpressure I/O scheduler, explicit deletion-vector bitmap, quantized hot-tier cache
+  (R3) + zero-copy `Bytes` read path (R1).
+* *Full-text / BM25 inverted index*: segment-level term dictionary + posting lists +
+  query-time term→block routing (today: bloom membership + external AXIS only).
+* *Router signal enrichment + billing completion*: `QueryShape` cardinality / point-lookup
+  / cdc-time-travel / hybrid-vector signals; compute-time + cardinality billing emit
+  points; RL feedback.
+
+== What NOT to do
+
+* Don't build a third warehouse format — interoperate (Iceberg now, Delta/UniForm next).
+* Don't out-warehouse Snowflake/Databricks on pure relational.
+* Don't build a proprietary catalog ecosystem — adopt the REST Catalog protocol.
+* Don't let PAX diverge so far it can't export to Iceberg/Delta.
+
+== Verification ledger
+
+* P1: `cargo test -p proximadb-iceberg-engine` (24), `--test iceberg_interop_e2e`,
+  `--test tpch_pgwire_e2e` (regression).
+* P2/P3/P4: per-workstream TDD + the existing modality/SQL suites as regression gates
+  (TPC-H 22, TPC-DS 16, document 11, events 10, vector recall, graph 10).

--- a/docs/_internal/roadmap/COVERAGE_BASELINE.json
+++ b/docs/_internal/roadmap/COVERAGE_BASELINE.json
@@ -1,0 +1,3 @@
+{
+  "sdk:proximadb-python": 80.0
+}

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Coverage ratchet gate for the qa branch.
+
+Enforces a NO-REGRESSION policy with an 80% target across components (Rust crates
+and the Python SDK):
+
+  - FAIL if any component's line coverage drops more than TOLERANCE below its
+    committed baseline (a regression).
+  - FAIL if a NEW component lands below the 80% target.
+  - WARN (non-fatal) for existing components still under 80% — they ratchet up
+    over time; regressions are what block.
+
+Usage:
+  # compute a normalized {component: pct} map from raw tool output:
+  coverage_ratchet.py normalize --rust llvm-cov.json --sdk sdk-cov.json -o current.json
+
+  # check current against the committed baseline:
+  coverage_ratchet.py check --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json \
+      --current current.json
+
+  # (re)write the baseline from current (after an intentional change):
+  coverage_ratchet.py write --current current.json \
+      --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+TARGET = 80.0  # coverage goal (%)
+TOLERANCE = 0.5  # allowed downward drift before it's a regression (%)
+
+
+def _pct(covered: int, total: int) -> float:
+    return 100.0 * covered / total if total else 100.0
+
+
+def normalize_rust(path: Path) -> dict[str, float]:
+    """Parse `cargo llvm-cov report --json` into {crate: line_pct}.
+
+    llvm-cov json: {"data":[{"files":[{"filename":..., "summary":{"lines":{"count","covered"}}}]}]}
+    We group files by workspace crate (the path segment after `crates/<tier>/<crate>/`
+    or the root crate `src/`).
+    """
+    doc = json.loads(path.read_text())
+    agg: dict[str, list[int]] = {}  # crate -> [covered, total]
+    for block in doc.get("data", []):
+        for f in block.get("files", []):
+            name = f.get("filename", "")
+            lines = f.get("summary", {}).get("lines", {})
+            covered = int(lines.get("covered", 0))
+            total = int(lines.get("count", 0))
+            crate = _crate_of(name)
+            if crate is None:
+                continue
+            slot = agg.setdefault(crate, [0, 0])
+            slot[0] += covered
+            slot[1] += total
+    return {f"rust:{k}": round(_pct(v[0], v[1]), 2) for k, v in agg.items() if v[1]}
+
+
+def _crate_of(path: str) -> str | None:
+    parts = path.replace("\\", "/").split("/")
+    if "crates" in parts:
+        i = parts.index("crates")
+        # crates/<tier>/<crate>/src/...
+        if len(parts) > i + 2:
+            return parts[i + 2]
+    # root crate: .../<repo>/src/...  -> "proximadb"
+    if "src" in parts:
+        return "proximadb"
+    return None
+
+
+def normalize_sdk(path: Path) -> dict[str, float]:
+    """Parse `coverage json` (pytest-cov) into {sdk: line_pct}."""
+    doc = json.loads(path.read_text())
+    totals = doc.get("totals", {})
+    pct = totals.get("percent_covered")
+    if pct is None:
+        covered = totals.get("covered_lines", 0)
+        total = covered + totals.get("missing_lines", 0)
+        pct = _pct(covered, total)
+    return {"sdk:proximadb-python": round(float(pct), 2)}
+
+
+def cmd_normalize(args) -> int:
+    current: dict[str, float] = {}
+    if args.rust:
+        current.update(normalize_rust(Path(args.rust)))
+    if args.sdk:
+        current.update(normalize_sdk(Path(args.sdk)))
+    Path(args.out).write_text(json.dumps(dict(sorted(current.items())), indent=2) + "\n")
+    print(f"wrote {len(current)} components -> {args.out}")
+    return 0
+
+
+def cmd_write(args) -> int:
+    current = json.loads(Path(args.current).read_text())
+    Path(args.baseline).write_text(json.dumps(dict(sorted(current.items())), indent=2) + "\n")
+    print(f"baseline written: {len(current)} components -> {args.baseline}")
+    return 0
+
+
+def cmd_check(args) -> int:
+    baseline = json.loads(Path(args.baseline).read_text())
+    current = json.loads(Path(args.current).read_text())
+    regressions, new_below, warnings = [], [], []
+
+    for comp, cur in sorted(current.items()):
+        base = baseline.get(comp)
+        if base is None:
+            if cur + 1e-9 < TARGET:
+                new_below.append((comp, cur))
+            continue
+        if cur + TOLERANCE < base:
+            regressions.append((comp, base, cur))
+        elif cur + 1e-9 < TARGET:
+            warnings.append((comp, cur))
+
+    missing = sorted(set(baseline) - set(current))
+
+    print(f"=== Coverage ratchet (target {TARGET}%, tolerance {TOLERANCE}%) ===")
+    print(f"  components: {len(current)} current / {len(baseline)} baseline")
+    if warnings:
+        print(f"  below-target (warn, {len(warnings)}):")
+        for c, p in warnings[:40]:
+            print(f"    - {c}: {p}%")
+    if missing:
+        print(f"  WARNING: {len(missing)} baseline component(s) absent from current: {missing[:10]}")
+    if new_below:
+        print(f"  NEW component(s) below {TARGET}% (FAIL):")
+        for c, p in new_below:
+            print(f"    - {c}: {p}% (< {TARGET}%)")
+    if regressions:
+        print(f"  REGRESSIONS (FAIL):")
+        for c, b, cur in regressions:
+            print(f"    - {c}: {b}% -> {cur}% (drop {round(b - cur, 2)}%)")
+
+    if regressions or new_below:
+        print("\nqa coverage gate: FAIL")
+        return 1
+    print("\nqa coverage gate: PASS")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    n = sub.add_parser("normalize", help="normalize raw tool output -> {component: pct}")
+    n.add_argument("--rust", help="cargo llvm-cov report --json output")
+    n.add_argument("--sdk", help="pytest coverage json output")
+    n.add_argument("-o", "--out", required=True)
+    n.set_defaults(func=cmd_normalize)
+
+    c = sub.add_parser("check", help="check current vs baseline (ratchet)")
+    c.add_argument("--baseline", required=True)
+    c.add_argument("--current", required=True)
+    c.set_defaults(func=cmd_check)
+
+    w = sub.add_parser("write", help="write baseline from current")
+    w.add_argument("--current", required=True)
+    w.add_argument("--baseline", required=True)
+    w.set_defaults(func=cmd_write)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/database.rs
+++ b/src/database.rs
@@ -467,6 +467,19 @@ impl ProximaDB {
         self.queue_client.clone()
     }
 
+    /// The shared canonical WAL-backed record store unified across ALL surfaces (REST/gRPC
+    /// `DmlService` + pgwire direct writes both route relational tables through this single
+    /// instance). `None` when direct record writes aren't configured. Exposed so embedded
+    /// and integration consumers can observe the converged relational state — and the CDC
+    /// change-feed — regardless of which protocol wrote the data.
+    pub fn canonical_record_store(
+        &self,
+    ) -> Option<Arc<crate::services::record_store::DirectWalTableRecordStore>> {
+        self.multi_server
+            .as_ref()
+            .and_then(|ms| ms.shared_services.canonical_record_store.clone())
+    }
+
     /// Start all database services (network listeners, background tasks, WAL recovery).
     pub async fn start(&mut self) -> anyhow::Result<()> {
         tracing::info!("🚀 ProximaDB::start - Starting database services...");

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -182,6 +182,12 @@ fn build_session_context(
     // Deferred: cosine_distance, euclidean_distance, etc.
     ctx.register_udf(udf::mc_price_udf());
 
+    // JSON extraction UDFs — the analytical (DataFusion) counterpart of the pgwire
+    // JSON operator translation, so GROUP BY / aggregate queries over JSON document
+    // columns (`doc->'a'->>'b'`) work on the OLAP route, not just the legacy path.
+    ctx.register_udf(udf::json_extract_udf());
+    ctx.register_udf(udf::json_extract_text_udf());
+
     // F2: bind every NON-native registry scalar as a DataFusion ScalarUDF (the consolidated
     // engine-neutral functions defined once in proximadb-functions). DataFusion's own
     // vectorized builtins (UPPER/ABS/…) stay the fast path; this covers registry/custom

--- a/src/datafusion/udf.rs
+++ b/src/datafusion/udf.rs
@@ -14,12 +14,105 @@
 
 use std::sync::Arc;
 
-use arrow_array::{ArrayRef, BooleanArray, Float64Array, Int64Array};
+use arrow_array::{Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
 use arrow_schema::DataType;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility, create_udf};
 
 use crate::compute::montecarlo::mc_price_batch_seq;
+
+// =========================================================================
+// JSON extraction UDFs
+//
+// The pgwire translator rewrites PostgreSQL JSON operators to portable function
+// calls — `col -> 'k'` → `JSON_EXTRACT(col, 'k')` and `col ->> 'k'` →
+// `JSON_EXTRACT_TEXT(col, 'k')`. A query that is BOTH relational (GROUP BY /
+// aggregate) AND JSON-extracting routes to the DataFusion OLAP engine, so these
+// functions must be registered there too (the document modality over the
+// analytical route). JSON columns materialize to Parquet as Utf8 text; both UDFs
+// take (Utf8 json, Utf8 key) → Utf8.
+//   * json_extract       — returns the sub-value as compact JSON text (chainable:
+//                          `doc->'a'->>'b'` = JSON_EXTRACT_TEXT(JSON_EXTRACT(...))).
+//   * json_extract_text  — returns the sub-value as plain text (strings unquoted).
+// A missing key, NULL input, non-object container, or unparseable JSON yields NULL.
+// =========================================================================
+
+/// `JSON_EXTRACT(json_text, key)` → sub-value as compact JSON text.
+pub fn json_extract_udf() -> ScalarUDF {
+    create_udf(
+        "json_extract",
+        vec![DataType::Utf8, DataType::Utf8],
+        DataType::Utf8,
+        Volatility::Immutable,
+        Arc::new(|args| json_extract_impl(args, false)),
+    )
+}
+
+/// `JSON_EXTRACT_TEXT(json_text, key)` → sub-value as plain text.
+pub fn json_extract_text_udf() -> ScalarUDF {
+    create_udf(
+        "json_extract_text",
+        vec![DataType::Utf8, DataType::Utf8],
+        DataType::Utf8,
+        Volatility::Immutable,
+        Arc::new(|args| json_extract_impl(args, true)),
+    )
+}
+
+fn json_extract_impl(args: &[ColumnarValue], as_text: bool) -> DFResult<ColumnarValue> {
+    if args.len() != 2 {
+        return Err(DataFusionError::Execution(format!(
+            "json_extract expects 2 arguments (json, key), got {}",
+            args.len()
+        )));
+    }
+    let num_rows = args
+        .iter()
+        .find_map(|a| match a {
+            ColumnarValue::Array(arr) => Some(arr.len()),
+            ColumnarValue::Scalar(_) => None,
+        })
+        .unwrap_or(1);
+    let docs = args[0].clone().into_array(num_rows)?;
+    let keys = args[1].clone().into_array(num_rows)?;
+    let docs = docs
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| DataFusionError::Execution("json_extract: arg0 must be Utf8".into()))?;
+    let keys = keys
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| DataFusionError::Execution("json_extract: arg1 must be Utf8".into()))?;
+
+    let mut out: Vec<Option<String>> = Vec::with_capacity(num_rows);
+    for i in 0..num_rows {
+        if docs.is_null(i) || keys.is_null(i) {
+            out.push(None);
+            continue;
+        }
+        out.push(extract_one(docs.value(i), keys.value(i), as_text));
+    }
+    Ok(ColumnarValue::Array(Arc::new(StringArray::from(out))))
+}
+
+fn extract_one(doc: &str, key: &str, as_text: bool) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(doc).ok()?;
+    // Object key, or numeric index into an array.
+    let child = match &parsed {
+        serde_json::Value::Object(map) => map.get(key)?,
+        serde_json::Value::Array(arr) => arr.get(key.parse::<usize>().ok()?)?,
+        _ => return None,
+    };
+    if as_text {
+        match child {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Null => None,
+            other => Some(other.to_string()),
+        }
+    } else {
+        Some(child.to_string())
+    }
+}
 
 /// Fixed base seed so the UDF is deterministic (same inputs → same prices), which keeps
 /// query results reproducible and benchmark comparisons fair.

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -222,15 +222,15 @@ impl MultiServer {
         // pgwire and the REST/gRPC `DmlService` then operate on ONE instance — a write on
         // any protocol is visible to reads + the CDC change-feed on every protocol — and the
         // WAL is replayed exactly once. A custom WAL path opts out (builds its own below).
-        if wal_path == default_wal_path {
-            if let Some(store) = self.shared_services.canonical_record_store.clone() {
-                info!(
-                    "🐘 pgwire reusing shared canonical record store (unified cross-surface relational state)"
-                );
-                return Ok(Some(
-                    crate::network::postgres::DirectPgwireWriteServices::new(store),
-                ));
-            }
+        if wal_path == default_wal_path
+            && let Some(store) = self.shared_services.canonical_record_store.clone()
+        {
+            info!(
+                "🐘 pgwire reusing shared canonical record store (unified cross-surface relational state)"
+            );
+            return Ok(Some(
+                crate::network::postgres::DirectPgwireWriteServices::new(store),
+            ));
         }
 
         // T2.3 / TD-066 production wiring: prefer the shared canonical WAL

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -217,6 +217,22 @@ impl MultiServer {
             .clone()
             .unwrap_or_else(|| default_wal_path.clone());
 
+        // Cross-surface unification: when the pgwire WAL path is the default, reuse the
+        // SHARED canonical record store that `SharedServices` already built + WAL-recovered.
+        // pgwire and the REST/gRPC `DmlService` then operate on ONE instance — a write on
+        // any protocol is visible to reads + the CDC change-feed on every protocol — and the
+        // WAL is replayed exactly once. A custom WAL path opts out (builds its own below).
+        if wal_path == default_wal_path {
+            if let Some(store) = self.shared_services.canonical_record_store.clone() {
+                info!(
+                    "🐘 pgwire reusing shared canonical record store (unified cross-surface relational state)"
+                );
+                return Ok(Some(
+                    crate::network::postgres::DirectPgwireWriteServices::new(store),
+                ));
+            }
+        }
+
         // T2.3 / TD-066 production wiring: prefer the shared canonical WAL
         // appender held on `SharedServices` so graph checkpoint emission
         // and pgwire direct writes share the same `next_sequence` counter

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -1174,12 +1174,18 @@ fn set_expr_engages(body: &SetExpr) -> bool {
             // JOIN; the legacy single-table path can't serve it. Same safety as the
             // WHERE case — an unliftable shape declines back to legacy.
             let has_projection_subquery = select.projection.iter().any(select_item_has_subquery);
+            // A derived table (subquery in FROM, e.g. `FROM (SELECT … row_number()
+            // OVER …) t WHERE rn = 1`, the TSBS last-point shape) is not something
+            // the legacy single-table path can serve — engage the relational/OLAP
+            // route so it reaches DataFusion.
+            let has_derived = select.from.iter().any(table_with_joins_has_derived);
             has_join
                 || has_group_by
                 || select.having.is_some()
                 || has_aggregate
                 || has_where_subquery
                 || has_projection_subquery
+                || has_derived
         }
         _ => false,
     }
@@ -1294,6 +1300,17 @@ fn collect_subquery_tables_in_expr(expr: &SqlExpr, out: &mut Vec<String>) {
         }
         _ => {}
     }
+}
+
+/// True if the FROM item (or any of its joins) is a derived table — a subquery in
+/// FROM. Such a shape must engage the relational/OLAP route (the legacy single-table
+/// path can't serve it).
+fn table_with_joins_has_derived(twj: &TableWithJoins) -> bool {
+    matches!(twj.relation, TableFactor::Derived { .. })
+        || twj
+            .joins
+            .iter()
+            .any(|j| matches!(j.relation, TableFactor::Derived { .. }))
 }
 
 fn collect_from_table_with_joins(twj: &TableWithJoins, out: &mut Vec<String>) {

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -256,7 +256,13 @@ pub async fn try_run_select(
             parquet_tables,
             vector_ops,
             tenant_id: tenant.map(str::to_string),
-            allow_engine_sql_fallback: false,
+            // Full ANSI SQL over pgwire: when the shared relational frontend can't
+            // yet lower a query (e.g. typed DATE literals, certain subquery/window
+            // shapes), execute it through DataFusion's own ANSI SQL planner over the
+            // same registered Parquet tables. The query still routes through pgwire →
+            // ComputeScheduler → the DataFusion engine; only the lowering frontend
+            // differs. The shared logical plane stays the fast path where it works.
+            allow_engine_sql_fallback: true,
             controls: controls.clone(),
         };
         return Some(

--- a/src/network/postgres/translator.rs
+++ b/src/network/postgres/translator.rs
@@ -151,15 +151,26 @@ impl QueryTranslator {
     fn translate_jsonb(&self, query: &str) -> Result<String> {
         let mut result = query.to_string();
 
-        let re_text_extract = regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_\.]*)\s*->>\s*'([^']+)'"#)?;
-        result = re_text_extract
-            .replace_all(&result, "JSON_EXTRACT_TEXT($1, '$2')")
-            .to_string();
-
-        let re_json_extract = regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_\.]*)\s*->\s*'([^']+)'"#)?;
-        result = re_json_extract
-            .replace_all(&result, "JSON_EXTRACT($1, '$2')")
-            .to_string();
+        // The left operand of -> / ->> is either a bare column identifier OR an
+        // already-rewritten JSON_EXTRACT(...) call — the latter so CHAINED paths
+        // like `doc->'a'->>'b'` translate fully. Apply ->> (text) then -> (json)
+        // repeatedly to a fixed point so each nesting level is peeled in turn.
+        let left = r#"(?:[A-Za-z_][A-Za-z0-9_\.]*|JSON_EXTRACT(?:_TEXT)?\([^()]*\))"#;
+        let re_text_extract = regex::Regex::new(&format!(r#"({left})\s*->>\s*'([^']+)'"#))?;
+        let re_json_extract = regex::Regex::new(&format!(r#"({left})\s*->\s*'([^']+)'"#))?;
+        // Bounded fixed-point loop (guards against pathological input).
+        for _ in 0..16 {
+            let before = result.clone();
+            result = re_text_extract
+                .replace_all(&result, "JSON_EXTRACT_TEXT($1, '$2')")
+                .to_string();
+            result = re_json_extract
+                .replace_all(&result, "JSON_EXTRACT($1, '$2')")
+                .to_string();
+            if result == before {
+                break;
+            }
+        }
 
         let re_contains =
             regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_\.]*)\s*@>\s*('[^']+'(?:::jsonb)?)"#)?;

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -227,6 +227,16 @@ pub struct SharedServices {
     /// (graph: tracing-only; pgwire: opens its own appender locally).
     pub canonical_wal_appender: Option<Arc<crate::services::FramedTableWalAppender>>,
 
+    /// The single canonical WAL-backed record store, built + WAL-recovered ONCE here and
+    /// shared across ALL surfaces — the REST/gRPC `DmlService` and the pgwire direct-write
+    /// path both route relational tables through this instance — so a write on any protocol
+    /// is visible to reads + the CDC change-feed on every protocol. Previously the REST/gRPC
+    /// `DmlService` used the vector-compatibility stub for relational tables while pgwire used
+    /// the real WAL store, leaving the cross-surface APIs unconverged. `None` on test paths
+    /// without `opt_config` (each consumer falls back to its own store).
+    pub canonical_record_store:
+        Option<Arc<crate::services::record_store::DirectWalTableRecordStore>>,
+
     /// Process-wide recall-probe gate (TD-064 / LLD §5). The gate enables
     /// the quantized candidate route only after the recall-probe set passes
     /// the tenant's target for three consecutive builds; a single failure
@@ -1224,6 +1234,36 @@ impl SharedServices {
                 None
             };
 
+        // Cross-surface unification: build the canonical WAL-backed record store ONCE and
+        // WAL-recover it here, then share it across every surface (REST/gRPC DmlService below
+        // + pgwire direct-write path). One store ⇒ one authoritative relational state and one
+        // CDC change-feed, regardless of which protocol wrote the data.
+        let canonical_record_store: Option<
+            Arc<crate::services::record_store::DirectWalTableRecordStore>,
+        > = if let Some(appender) = canonical_wal_appender.clone() {
+            let store = Arc::new(
+                crate::services::record_store::DirectWalTableRecordStore::new_partitioned(
+                    appender.clone(),
+                ),
+            );
+            match appender.read_entries().await {
+                Ok(entries) => {
+                    if let Err(e) = store.replay_wal_entries(entries).await {
+                        warn!("SharedServices: canonical record-store WAL replay failed: {e}");
+                    }
+                }
+                Err(e) => {
+                    warn!("SharedServices: reading canonical WAL for shared store failed: {e}")
+                }
+            }
+            info!(
+                "✅ SharedServices: shared canonical record store built + recovered (unifies REST/gRPC + pgwire relational state)"
+            );
+            Some(store)
+        } else {
+            None
+        };
+
         // Create GraphOperationsService for native graph database operations
         // IMPORTANT: Pass the shared GraphCollectionService instance
         debug!(
@@ -1586,10 +1626,17 @@ impl SharedServices {
         // routing). EXPLAIN INSERT … SELECT queries arriving on the ExecuteSql RPC
         // are detected in execute_sql_v1 / the adapter and dispatched here instead
         // of the legacy SQL frontend.
-        let dml_service_for_grpc = Arc::new(DmlService::new(
-            catalog_manager.clone(),
-            vector_operations_service.clone(),
-        ));
+        // Use the SHARED canonical store so REST/gRPC relational DML/reads/EXPLAIN and the
+        // CDC change-feed operate on the SAME state pgwire writes to. Fall back to the
+        // vector-compatibility store only when no canonical store exists (test paths).
+        let dml_service_for_grpc = Arc::new(match canonical_record_store.clone() {
+            Some(store) => DmlService::with_direct_record_storage(
+                catalog_manager.clone(),
+                vector_operations_service.clone(),
+                store,
+            ),
+            None => DmlService::new(catalog_manager.clone(), vector_operations_service.clone()),
+        });
 
         // Wire QueryFacadeAdapter to UnifiedHandlers for unified SQL routing.
         // This enables SQL queries to flow through the facade when the
@@ -1884,6 +1931,7 @@ impl SharedServices {
                 // for pgwire direct writes — guaranteeing both consumers
                 // share the same next_sequence counter.
                 canonical_wal_appender,
+                canonical_record_store,
                 // TD-064 / LLD §5: per-collection recall-probe gate. Empty
                 // at startup; populated as the stats refresher / search path
                 // observe probe outcomes. Route-health surfaces per-scope

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -126,11 +126,26 @@ impl DataFusionLocalEngine {
 
         // P4 lowering
         let lowered_plan = match lower_sql(sql, &catalog) {
-            Ok(node) => Some(
-                crate::datafusion::logical_lowering::lower_logical_node(&ctx, &node)
-                    .await
-                    .map_err(|e| ExecutionError::Planning(format!("lower logical node: {e}")))?,
-            ),
+            Ok(node) => {
+                match crate::datafusion::logical_lowering::lower_logical_node(&ctx, &node).await {
+                    Ok(plan) => Some(plan),
+                    // The shared frontend accepted the SQL but the DataFusion
+                    // logical-node lowering can't yet express it. Rather than hard
+                    // failing, fall back to DataFusion's own ANSI SQL planner over
+                    // the same registered Parquet tables (full ANSI coverage).
+                    Err(e) if context.allow_engine_sql_fallback => {
+                        tracing::debug!(
+                            target: "proximadb::compute_route",
+                            error = %e,
+                            "shared frontend lowered but DataFusion logical-node lowering declined; using DataFusion SQL fallback"
+                        );
+                        None
+                    }
+                    Err(e) => {
+                        return Err(ExecutionError::Planning(format!("lower logical node: {e}")));
+                    }
+                }
+            }
             Err(e) if context.allow_engine_sql_fallback => {
                 tracing::debug!(
                     target: "proximadb::compute_route",

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -398,7 +398,7 @@ impl RouteCostModel {
             return None; // all candidates warm — exploit, don't explore
         }
         let tick = self.explore_tick.fetch_add(1, Ordering::Relaxed);
-        if tick % self.exploration_interval == 0 {
+        if tick.is_multiple_of(self.exploration_interval) {
             Some(cand)
         } else {
             None

--- a/src/query/sql_frontend/parser.rs
+++ b/src/query/sql_frontend/parser.rs
@@ -1319,6 +1319,13 @@ impl SqlFrontendParser {
                 Ok(SqlValueLiteral::Function { name, args })
             }
             SqlExpr::Cast { expr, .. } => self.convert_expr_to_dml_literal(expr),
+            SqlExpr::TypedString(typed) => {
+                // Typed string literals: DATE '1995-02-15', TIMESTAMP '...',
+                // TIME '...'. Carry the inner string; the target column's declared
+                // type drives coercion, and ISO-8601 values sort chronologically as
+                // strings. (TPC-H is dense with DATE literals in INSERT ... VALUES.)
+                self.convert_value_to_dml_literal(&typed.value.value)
+            }
             SqlExpr::Identifier(ident) => {
                 // Could be DEFAULT or a column reference
                 if ident.value.eq_ignore_ascii_case("DEFAULT") {

--- a/src/services/canonical_wal.rs
+++ b/src/services/canonical_wal.rs
@@ -77,6 +77,10 @@ impl FramedTableWalAppender {
 
 #[async_trait]
 impl TableWalAppender for FramedTableWalAppender {
+    async fn read_all_entries(&self) -> Result<Vec<CanonicalWalEntry>> {
+        self.read_entries().await
+    }
+
     async fn append_operations(
         &self,
         operations: Vec<CanonicalOperation>,

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -835,14 +835,11 @@ impl CollectionService {
             ));
         }
 
-        // Validate collection name length to prevent collision with IDs
-        if config.name.len() < 8 {
-            return Ok(CollectionServiceResponse::error(
-                "INVALID_NAME_LENGTH: Collection name must be at least 8 characters long"
-                    .to_string(),
-                start_time.elapsed().as_micros() as i64,
-            ));
-        }
+        // No artificial minimum name length. SQL/ANSI identifiers — and hence
+        // relational tables created over pgwire (e.g. TPC-H `part`, `orders`,
+        // `region`) — are routinely short. Name shape is validated elsewhere
+        // (CollectionNameValidator: non-empty, valid pattern, not reserved); a
+        // length floor here only blocked legitimate short table names.
 
         if config.dimension == 0 || config.dimension > 1_000_000 {
             return Ok(CollectionServiceResponse::error(
@@ -1028,10 +1025,12 @@ impl CollectionService {
     pub async fn resolve_collection_id(&self, identifier: &str) -> Result<Option<String>> {
         tracing::debug!("🔍 Resolving collection identifier: '{}'", identifier);
 
-        // Check if this looks like a base62 collection ID (short alphanumeric)
-        let _is_likely_id =
-            identifier.len() <= 12 && identifier.chars().all(|c| c.is_alphanumeric());
-
+        // Resolution is NAME-AUTHORITATIVE and shape-independent: `collection()`
+        // looks up the catalog asset (by name) first, then the metadata backend
+        // (by id). The historical base62-id "looks like an id" length heuristic is
+        // gone — IDs are now opaque UUIDs (no overlap with user names), so name
+        // length carries no meaning here. This is why short SQL/ANSI table names
+        // are safe (TPC-H `part`/`orders`/`region`) and the 8-char floor was dropped.
         if let Some(collection) = self.collection(identifier).await? {
             let collection_id = collection.id;
             tracing::debug!(
@@ -2880,10 +2879,12 @@ mod tests {
 
         // Test cases for collection name length
         let test_cases = vec![
-            ("", false, "INVALID_NAME"),                  // Empty name
-            ("a", false, "INVALID_NAME_LENGTH"),          // 1 char
-            ("abc", false, "INVALID_NAME_LENGTH"),        // 3 chars
-            ("seven77", false, "INVALID_NAME_LENGTH"),    // 7 chars
+            ("", false, "INVALID_NAME"), // Empty name
+            // Short names are valid SQL/ANSI identifiers (no artificial 8-char floor);
+            // required for relational tables over pgwire (TPC-H `part`, `orders`, ...).
+            ("a", true, ""),                              // 1 char
+            ("abc", true, ""),                            // 3 chars
+            ("seven77", true, ""),                        // 7 chars
             ("exactly8", true, ""),                       // 8 chars (valid)
             ("ninechars", true, ""),                      // 9 chars (valid)
             ("this_is_a_long_collection_name", true, ""), // Long name (valid)
@@ -2938,6 +2939,95 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    /// TDD: short SQL/ANSI table names (e.g. TPC-H `part`) create successfully,
+    /// resolve to a DISTINCT opaque UUID id (not the name), and round-trip
+    /// name<->id. Proves the redesign: name and id are separate, unambiguous
+    /// namespaces with NO length dependence (the old 8-char floor is gone), and
+    /// resolution is name-authoritative.
+    #[tokio::test]
+    async fn test_short_name_resolves_name_authoritative() -> Result<()> {
+        use crate::storage::metadata::backends::universal_backend::{
+            UniversalMetadataBackend, UniversalMetadataConfig,
+        };
+        use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let filestore_config = UniversalMetadataConfig {
+            storage_url: temp_path,
+            compression: false,
+            enable_snapshots: false,
+            snapshot_threshold: 1000,
+            keep_snapshots: 3,
+            backup_url: None,
+            temp_dir: None,
+        };
+        let filesystem_factory = Arc::new(
+            FilesystemFactory::create(FilesystemConfig::default())
+                .await
+                .context("fs factory")?,
+        );
+        let backend = Arc::new(
+            UniversalMetadataBackend::new(filestore_config, filesystem_factory)
+                .await
+                .context("metadata backend")?,
+        );
+        let service = CollectionService::new(backend, StorageConfig::default())
+            .await
+            .context("collection service")?;
+
+        // A short, standard SQL identifier (4 chars) — would have been rejected by
+        // the old 8-char floor.
+        let name = "part";
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension: 16,
+            distance_metric: Some(1),
+            storage_engine: Some(1),
+            filterable_columns: vec![],
+            index_configs: vec![],
+            quantization: None,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            description: None,
+            tags: vec![],
+            owner: None,
+            embedding_models: vec![],
+            storage_config: None,
+            record_schema: None,
+            enable_proxima_record: None,
+            text_columns: vec![],
+            text_storage_configs: vec![],
+            enable_dual_use_embeddings: None,
+            canonical_embedding_precision: None,
+        };
+        let created = service.create_collection(&config).await.context("create")?;
+        assert!(
+            created.success,
+            "short name should create: {:?}",
+            created.error_code
+        );
+
+        // Resolve name -> id: must yield an opaque id DISTINCT from the name.
+        let id = service
+            .resolve_collection_id(name)
+            .await
+            .context("resolve id")?
+            .ok_or_else(|| anyhow::anyhow!("name did not resolve to an id"))?;
+        assert_ne!(id, name, "id must be opaque, not the name");
+
+        // Round-trip id -> name.
+        let back = service
+            .resolve_collection_name(&id)
+            .await
+            .context("resolve name")?
+            .ok_or_else(|| anyhow::anyhow!("id did not resolve back to a name"))?;
+        assert_eq!(back, name, "id must round-trip to the original name");
 
         Ok(())
     }

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2782,7 +2782,8 @@ mod tests {
             result.error_code
         );
 
-        // Test short name (less than 8 characters)
+        // Short names are valid SQL/ANSI identifiers — the vestigial 8-char floor was
+        // removed (TPC-H `part`/`orders` etc. need short table names). "short" now succeeds.
         let short_name = CollectionConfig {
             name: "short".to_string(),
             ..valid_config.clone()
@@ -2791,14 +2792,9 @@ mod tests {
             .create_collection(&short_name)
             .await
             .context("Failed to create collection with short name")?;
-        assert!(!result.success);
         assert!(
-            result
-                .error_code
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("Error code missing"))?
-                .contains("INVALID_NAME_LENGTH"),
-            "Error code should contain INVALID_NAME_LENGTH, got: {:?}",
+            result.success,
+            "short names are now valid; got error: {:?}",
             result.error_code
         );
 

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -877,6 +877,20 @@ impl DmlService {
             .await
     }
 
+    /// CDC change-feed (P2): row-level changes for `table_name` with WAL sequence number
+    /// strictly greater than `since_lsn`, oldest first. Backed by the canonical WAL via the
+    /// record store; returns empty for stores without a readable change log. The REST
+    /// change-feed surface and (later) the pgwire `table_changes()` TVF call this.
+    pub async fn changes_since(
+        &self,
+        table_name: &str,
+        since_lsn: u64,
+    ) -> Result<Vec<crate::services::record_store::ChangeRow>> {
+        self.record_store
+            .read_changes_since(table_name, since_lsn)
+            .await
+    }
+
     /// Select current visible records and resolve projection columns inside the
     /// DML/catalog boundary.
     pub async fn select_table_records_with_projection(
@@ -5417,6 +5431,84 @@ mod tests {
             1,
             "replayed memtable must hold the record"
         );
+    }
+
+    /// CDC change-feed (P2): INSERT → UPDATE → DELETE produce ordered change rows over the
+    /// canonical WAL; `changes_since` filters by table + lsn and reports correct op tags.
+    #[tokio::test]
+    async fn cdc_change_feed_reports_ops_since_lsn() {
+        use crate::services::record_store::DirectWalTableRecordStore;
+        use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let wal_path = temp_dir.path().join("cdc.wal");
+        let manager = Arc::new(CatalogManager::new());
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+        let ddl = DdlService::new(manager.clone());
+        ddl.execute(DdlStatement::CreateNamespace {
+            namespace: vec!["default".to_string()],
+            if_not_exists: true,
+            properties: HashMap::new(),
+        })
+        .await
+        .expect("create namespace");
+
+        let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+        let ddl_stmt = parser
+            .parse_ddl("CREATE TABLE acct (id TEXT NOT NULL, bal INT, PRIMARY KEY (id));")
+            .expect("parse create")
+            .expect("ddl");
+        ddl.execute(ddl_stmt).await.expect("create table");
+
+        let wal_appender =
+            Arc::new(FramedTableWalAppender::open(&wal_path).await.expect("open WAL"));
+        let record_store = Arc::new(DirectWalTableRecordStore::new(
+            Arc::new(MemtableRecordStorage::new()),
+            wal_appender,
+        ));
+        let dml = DmlService::with_record_store_and_table_write_executor(
+            manager.clone(),
+            record_store,
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        );
+
+        let run = |sql: &str| {
+            let parser = &parser;
+            let dml = &dml;
+            let sql = sql.to_string();
+            async move {
+                let stmt = parser.parse_dml(&sql).expect("parse dml").expect("dml");
+                dml.execute(stmt).await.expect("execute dml")
+            }
+        };
+        run("INSERT INTO acct (id, bal) VALUES ('a', 100);").await;
+        run("UPDATE acct SET bal = 150 WHERE id = 'a';").await;
+        run("DELETE FROM acct WHERE id = 'a';").await;
+
+        // Full feed from the beginning: upsert, upsert (update), delete — lsn-ordered.
+        let changes = dml.changes_since("acct", 0).await.expect("changes");
+        assert_eq!(changes.len(), 3, "three changes: insert, update, delete");
+        assert_eq!(changes[0].op, "upsert");
+        assert_eq!(changes[1].op, "upsert");
+        assert_eq!(changes[2].op, "delete");
+        assert!(
+            changes[0].lsn < changes[1].lsn && changes[1].lsn < changes[2].lsn,
+            "changes are lsn-ordered"
+        );
+        assert_eq!(changes[2].key, "a", "delete carries the key");
+
+        // Incremental: only changes after the first lsn (the two later ops).
+        let tail = dml
+            .changes_since("acct", changes[0].lsn)
+            .await
+            .expect("tail");
+        assert_eq!(tail.len(), 2, "since first lsn → update + delete only");
+
+        // A different table sees nothing.
+        assert!(dml.changes_since("other", 0).await.expect("other").is_empty());
     }
 
     #[tokio::test]

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -4077,8 +4077,7 @@ impl DmlService {
                 if matches!(val, SqlValueLiteral::Null) && column.nullable {
                     return Ok(ProximaValue::Null);
                 }
-                self.literal_to_i64(val)
-                    .map(|value| ProximaValue::Date(value as i32))
+                self.literal_to_date_days(val).map(ProximaValue::Date)
             }
             ProximaType::Time(_) => {
                 if matches!(val, SqlValueLiteral::Null) && column.nullable {
@@ -4172,6 +4171,29 @@ impl DmlService {
                 .map_err(|e| anyhow!("Invalid integer literal '{}': {}", value, e)),
             SqlValueLiteral::Null => Err(anyhow!("Cannot convert NULL to integer")),
             _ => Err(anyhow!("Expected integer literal")),
+        }
+    }
+
+    /// Coerce a DML literal to a DATE stored as days since the Unix epoch.
+    /// Accepts an integer (already a day count) or an ISO-8601 `YYYY-MM-DD`
+    /// string (the form `DATE '1995-02-15'` literals lower to). Parsing to a
+    /// real day count — rather than stuffing the string in — keeps the column a
+    /// true Date32 through materialization, so DataFusion compares it correctly
+    /// against `DATE '...'` predicates.
+    fn literal_to_date_days(&self, val: &SqlValueLiteral) -> Result<i32> {
+        match val {
+            SqlValueLiteral::Integer(value) => Ok(*value as i32),
+            SqlValueLiteral::String(value) => {
+                let date = chrono::NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d")
+                    .map_err(|e| anyhow!("Invalid DATE literal '{}': {}", value, e))?;
+                let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+                    .ok_or_else(|| anyhow!("internal: bad epoch date"))?;
+                Ok(date.signed_duration_since(epoch).num_days() as i32)
+            }
+            SqlValueLiteral::Null => Err(anyhow!("Cannot convert NULL to date")),
+            _ => Err(anyhow!(
+                "Expected date literal (integer days or 'YYYY-MM-DD')"
+            )),
         }
     }
 

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -3967,11 +3967,34 @@ impl DmlService {
             SqlValueLiteral::Null => Ok(None),
             SqlValueLiteral::Integer(i) => Ok(Some(*i)),
             SqlValueLiteral::String(s) => {
-                // Parse ISO 8601 timestamp
-                use chrono::DateTime;
-                let dt = DateTime::parse_from_rfc3339(s)
-                    .map_err(|e| anyhow!("Invalid timestamp format: {e}"))?;
-                Ok(Some(dt.timestamp_millis()))
+                // Accept RFC3339 (with TZ) first, then standard SQL naive timestamp
+                // spellings (`YYYY-MM-DD HH:MM:SS[.fff]` or with a `T` separator,
+                // treated as UTC) and a bare date. `TIMESTAMP '2016-01-01 00:00:00'`
+                // literals (no TZ) are standard SQL and dense in time-series data.
+                use chrono::{DateTime, NaiveDate, NaiveDateTime};
+                let s = s.trim();
+                if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+                    return Ok(Some(dt.timestamp_millis()));
+                }
+                for fmt in [
+                    "%Y-%m-%d %H:%M:%S%.f",
+                    "%Y-%m-%d %H:%M:%S",
+                    "%Y-%m-%dT%H:%M:%S%.f",
+                    "%Y-%m-%dT%H:%M:%S",
+                ] {
+                    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, fmt) {
+                        return Ok(Some(ndt.and_utc().timestamp_millis()));
+                    }
+                }
+                if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                    return Ok(Some(
+                        d.and_hms_opt(0, 0, 0)
+                            .ok_or_else(|| anyhow!("internal: bad midnight"))?
+                            .and_utc()
+                            .timestamp_millis(),
+                    ));
+                }
+                Err(anyhow!("Invalid timestamp format: {s}"))
             }
             SqlValueLiteral::Function { name, .. } if name.eq_ignore_ascii_case("NOW") => {
                 Ok(Some(chrono::Utc::now().timestamp_millis()))

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -200,6 +200,49 @@ impl RelationalPredicateTree {
     }
 }
 
+/// Map an Arrow column type (the materialized Parquet's physical type) to the Iceberg
+/// primitive type name for the published `TableMetadata` schema. Kept in lock-step with
+/// the Parquet physical types so an external Iceberg reader's schema matches the file.
+/// Timestamps map to the v3 nanosecond types (ProximaDB is nanosecond-native).
+fn iceberg_type_for(arrow: &arrow_schema::DataType) -> &'static str {
+    use arrow_schema::DataType as D;
+    match arrow {
+        D::Boolean => "boolean",
+        D::Int8 | D::Int16 | D::Int32 => "int",
+        D::Int64 | D::UInt8 | D::UInt16 | D::UInt32 | D::UInt64 => "long",
+        D::Float16 | D::Float32 => "float",
+        D::Float64 => "double",
+        D::Date32 | D::Date64 => "date",
+        D::Timestamp(_, Some(_)) => "timestamptz_ns",
+        D::Timestamp(_, None) => "timestamp_ns",
+        D::Utf8 | D::LargeUtf8 => "string",
+        D::Binary | D::LargeBinary | D::FixedSizeBinary(_) => "binary",
+        // JSON columns materialize as Utf8 today; v3 `variant` is a follow-up.
+        _ => "string",
+    }
+}
+
+/// A stable, well-formed UUID string derived deterministically from the table's object
+/// prefix, so an Iceberg table keeps the same `table-uuid` across re-materializations
+/// (no `uuid` v5 dependency; two seeded hashes fill the 16 bytes).
+fn deterministic_table_uuid(prefix: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h1 = std::collections::hash_map::DefaultHasher::new();
+    prefix.hash(&mut h1);
+    let a = h1.finish();
+    let mut h2 = std::collections::hash_map::DefaultHasher::new();
+    (prefix, 0x50524f58_4944425fu64).hash(&mut h2); // "PROX_IDB_" salt
+    let b = h2.finish();
+    format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        (a >> 32) as u32,
+        (a >> 16) as u16,
+        a as u16,
+        (b >> 48) as u16,
+        b & 0x0000_ffff_ffff_ffff
+    )
+}
+
 /// Parse a SQL literal into a JSON value for the pushdown filter: integers and
 /// floats become JSON numbers (so i64/f64 zone-map pruning fires); everything
 /// else stays a string (string-equality hash pruning).
@@ -1173,6 +1216,54 @@ impl DmlService {
         };
         catalog.set_storage_layouts(&table_id, vec![layout]).await?;
 
+        // 6. Best-effort: also publish a spec-shaped Iceberg snapshot (v3) — Avro manifest
+        //    + manifest list + TableMetadata under `{prefix}/metadata` — so EXTERNAL Iceberg
+        //    engines (Spark/Trino/DuckDB/PyIceberg) can read the table. This is purely
+        //    additive interop: ProximaDB's own SELECT path reads via the catalog storage
+        //    layout above, not the manifest, so a failure here never breaks materialize.
+        let iceberg_fields: Vec<
+            proximadb_storage_common::object_store_bridge::IcebergSnapshotField,
+        > = schema
+            .to_arrow_schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                proximadb_storage_common::object_store_bridge::IcebergSnapshotField {
+                    id: (i + 1) as i32,
+                    name: f.name().clone(),
+                    type_name: iceberg_type_for(f.data_type()).to_string(),
+                    required: !f.is_nullable(),
+                }
+            })
+            .collect();
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let table_uuid = deterministic_table_uuid(&prefix);
+        let data_prefix = object_store::path::Path::from(format!("{prefix}/data"));
+        let metadata_prefix = format!("{prefix}/metadata");
+        if let Err(e) = bridge
+            .publish_iceberg_table(
+                &data_prefix,
+                &metadata_prefix,
+                &table_uuid,
+                &location,
+                &iceberg_fields,
+                now_ms, // snapshot id (unique per materialize)
+                now_ms, // timestamp ms
+                true,   // v3 (ProximaDB default)
+            )
+            .await
+        {
+            tracing::warn!(
+                target: "proximadb::warehouse::iceberg",
+                table = %table_name,
+                "Iceberg snapshot publish failed (non-fatal, interop only): {e}"
+            );
+        }
+
         Ok(location)
     }
 
@@ -1774,6 +1865,13 @@ impl DmlService {
         );
     }
 
+    /// Strip a leading table qualifier (`t.col` / alias `k.col` → `col`). On a
+    /// single-table SELECT the qualifier is unambiguous, so the unqualified suffix
+    /// is the column name to resolve against the schema.
+    fn unqualified_column(name: &str) -> &str {
+        name.rsplit('.').next().unwrap_or(name)
+    }
+
     fn resolve_select_predicates(
         table_schema: &CatalogTableSchema,
         predicates: &[RelationalSelectPredicateInput],
@@ -1781,10 +1879,11 @@ impl DmlService {
         predicates
             .iter()
             .map(|predicate| {
+                let bare = Self::unqualified_column(&predicate.column_name);
                 let column = table_schema
                     .columns
                     .iter()
-                    .find(|column| column.name.eq_ignore_ascii_case(&predicate.column_name))
+                    .find(|column| column.name.eq_ignore_ascii_case(bare))
                     .cloned()
                     .ok_or_else(|| {
                         anyhow!(
@@ -1812,10 +1911,11 @@ impl DmlService {
         projection_column_names
             .iter()
             .map(|column_name| {
+                let bare = Self::unqualified_column(column_name);
                 table_schema
                     .columns
                     .iter()
-                    .find(|column| column.name.eq_ignore_ascii_case(column_name))
+                    .find(|column| column.name.eq_ignore_ascii_case(bare))
                     .cloned()
                     .ok_or_else(|| {
                         anyhow!(

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1242,14 +1242,14 @@ impl DmlService {
             .fields()
             .iter()
             .enumerate()
-            .map(|(i, f)| {
-                proximadb_storage_common::object_store_bridge::IcebergSnapshotField {
+            .map(
+                |(i, f)| proximadb_storage_common::object_store_bridge::IcebergSnapshotField {
                     id: (i + 1) as i32,
                     name: f.name().clone(),
                     type_name: iceberg_type_for(f.data_type()).to_string(),
                     required: !f.is_nullable(),
-                }
-            })
+                },
+            )
             .collect();
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -5463,8 +5463,11 @@ mod tests {
             .expect("ddl");
         ddl.execute(ddl_stmt).await.expect("create table");
 
-        let wal_appender =
-            Arc::new(FramedTableWalAppender::open(&wal_path).await.expect("open WAL"));
+        let wal_appender = Arc::new(
+            FramedTableWalAppender::open(&wal_path)
+                .await
+                .expect("open WAL"),
+        );
         let record_store = Arc::new(DirectWalTableRecordStore::new(
             Arc::new(MemtableRecordStorage::new()),
             wal_appender,
@@ -5508,7 +5511,12 @@ mod tests {
         assert_eq!(tail.len(), 2, "since first lsn → update + delete only");
 
         // A different table sees nothing.
-        assert!(dml.changes_since("other", 0).await.expect("other").is_empty());
+        assert!(
+            dml.changes_since("other", 0)
+                .await
+                .expect("other")
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -134,6 +134,13 @@ pub trait TableWalAppender: Send + Sync {
         operations: Vec<CanonicalOperation>,
         tenant_id: Option<String>,
     ) -> Result<Vec<CanonicalWalEntry>>;
+
+    /// Read every canonical WAL entry this appender has durably recorded, oldest first.
+    /// The default returns nothing (appenders without a readable log opt out); the framed
+    /// appender overrides it. Used by the CDC change-feed to surface row-level changes.
+    async fn read_all_entries(&self) -> Result<Vec<CanonicalWalEntry>> {
+        Ok(Vec::new())
+    }
 }
 
 /// Physical writer route selected from xCatalog table metadata.
@@ -422,6 +429,18 @@ async fn list_objects_with_suffix(
 }
 
 /// Canonical table-record store API.
+/// One row-level change surfaced by the CDC change-feed (P2). `lsn` is the WAL sequence
+/// number (monotonic), `op` is `"upsert"` or `"delete"`, `key` is the canonical OID, and
+/// `props` carries the after-image (JSON) for upserts. Serializable for the REST surface.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChangeRow {
+    pub lsn: u64,
+    pub op: String,
+    pub collection: String,
+    pub key: String,
+    pub props: Option<serde_json::Value>,
+}
+
 #[async_trait]
 pub trait TableRecordStore: Send + Sync {
     /// Write catalog-validated record mutations.
@@ -547,6 +566,18 @@ pub trait TableRecordStore: Send + Sync {
             }
         }
         Ok(None)
+    }
+
+    /// CDC change-feed: return row-level changes for `collection_id` with WAL sequence
+    /// number strictly greater than `since_lsn`, oldest first. The default returns nothing
+    /// (stores without a readable change log opt out); the WAL-backed store overrides it.
+    async fn read_changes_since(
+        &self,
+        collection_id: &str,
+        since_lsn: u64,
+    ) -> Result<Vec<ChangeRow>> {
+        let _ = (collection_id, since_lsn);
+        Ok(Vec::new())
     }
 }
 
@@ -1300,6 +1331,53 @@ impl DirectWalTableRecordStore {
 
 #[async_trait]
 impl TableRecordStore for DirectWalTableRecordStore {
+    /// CDC change-feed over the canonical WAL: surface every RecordUpsert/RecordDelete for
+    /// `collection_id` (the table name) with sequence number > `since_lsn`, oldest first.
+    async fn read_changes_since(
+        &self,
+        collection_id: &str,
+        since_lsn: u64,
+    ) -> Result<Vec<ChangeRow>> {
+        let entries = self.wal_appender.read_all_entries().await?;
+        let mut out = Vec::new();
+        for e in entries {
+            if e.sequence_number <= since_lsn {
+                continue;
+            }
+            match e.operation {
+                CanonicalOperation::RecordUpsert {
+                    collection_id: c,
+                    record,
+                    ..
+                } if c == collection_id => {
+                    out.push(ChangeRow {
+                        lsn: e.sequence_number,
+                        op: "upsert".to_string(),
+                        collection: c,
+                        key: record.oid.clone(),
+                        props: serde_json::to_value(&record.props).ok(),
+                    });
+                }
+                CanonicalOperation::RecordDelete {
+                    collection_id: c,
+                    oid,
+                    ..
+                } if c == collection_id => {
+                    out.push(ChangeRow {
+                        lsn: e.sequence_number,
+                        op: "delete".to_string(),
+                        collection: c,
+                        key: oid,
+                        props: None,
+                    });
+                }
+                _ => {}
+            }
+        }
+        out.sort_by_key(|r| r.lsn);
+        Ok(out)
+    }
+
     async fn write_mutations(
         &self,
         table_schema: &CatalogTableSchema,

--- a/tests/cross_surface_unification_e2e.rs
+++ b/tests/cross_surface_unification_e2e.rs
@@ -133,7 +133,11 @@ async fn pgwire_write_is_visible_on_the_shared_canonical_store() {
         "pgwire INSERT of 2 rows must be visible on the shared store the REST/gRPC \
          DmlService reads from; got {changes:?}"
     );
-    assert!(changes.iter().all(|c| c.op == "upsert" && c.collection == "uacct"));
+    assert!(
+        changes
+            .iter()
+            .all(|c| c.op == "upsert" && c.collection == "uacct")
+    );
     let keys: Vec<&str> = changes.iter().map(|c| c.key.as_str()).collect();
     assert!(keys.contains(&"1") && keys.contains(&"2"), "keys: {keys:?}");
     eprintln!("✓ cross-surface unified: pgwire write visible on the shared REST/gRPC store");

--- a/tests/cross_surface_unification_e2e.rs
+++ b/tests/cross_surface_unification_e2e.rs
@@ -1,0 +1,140 @@
+//! Cross-surface unification: a write on ONE protocol must be visible to every surface.
+//!
+//! Proves the convergence fix — REST/gRPC `DmlService` and the pgwire direct-write path now
+//! share ONE `DirectWalTableRecordStore` (`SharedServices.canonical_record_store`) instead of
+//! divergent instances (the old vector-compatibility stub on REST/gRPC vs the WAL store on
+//! pgwire). Here we INSERT over pgwire, then read the change-feed off the SHARED store the
+//! REST/gRPC `DmlService` is built on, and see the row.
+//!
+//!   cargo test --test cross_surface_unification_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::services::record_store::TableRecordStore;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pgwire_write_is_visible_on_the_shared_canonical_store() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Write over pgwire.
+    let _ = client.simple_query("DROP TABLE IF EXISTS uacct").await;
+    client
+        .simple_query("CREATE TABLE uacct (id INT PRIMARY KEY, bal INT)")
+        .await
+        .expect("create");
+    client
+        .simple_query("INSERT INTO uacct (id, bal) VALUES (1, 100), (2, 200)")
+        .await
+        .expect("insert");
+    sleep(Duration::from_millis(200)).await;
+
+    // Read the change-feed off the SHARED canonical store — the SAME instance the REST/gRPC
+    // DmlService is built on (SharedServices.canonical_record_store). If the surfaces were
+    // still divergent (pgwire WAL store vs REST/gRPC vector-compat stub), this would be empty.
+    let store = server
+        .db
+        .as_ref()
+        .expect("db")
+        .canonical_record_store()
+        .expect("shared canonical record store must exist when config is provided");
+
+    let changes = store
+        .read_changes_since("uacct", 0)
+        .await
+        .expect("read changes");
+
+    assert_eq!(
+        changes.len(),
+        2,
+        "pgwire INSERT of 2 rows must be visible on the shared store the REST/gRPC \
+         DmlService reads from; got {changes:?}"
+    );
+    assert!(changes.iter().all(|c| c.op == "upsert" && c.collection == "uacct"));
+    let keys: Vec<&str> = changes.iter().map(|c| c.key.as_str()).collect();
+    assert!(keys.contains(&"1") && keys.contains(&"2"), "keys: {keys:?}");
+    eprintln!("✓ cross-surface unified: pgwire write visible on the shared REST/gRPC store");
+}

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -1,0 +1,251 @@
+//! Document (SQL/JSON) over pgwire — conformance harness (first cut).
+//!
+//! Documents are modeled as a relational table with a JSON column, queried over
+//! the PostgreSQL wire protocol — the open, standard way to store + query
+//! semi-structured documents in a SQL database. Same model as the TPC-H/TPC-DS
+//! harnesses: CREATE → INSERT → MATERIALIZE → query one by one, routed by
+//! ProximaDB. Each query that executes cleanly counts toward `DOC_RATCHET`.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test document_json_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+/// Document/JSON queries expected to execute cleanly over pgwire (the ratchet).
+const DOC_RATCHET: usize = 11;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+const SCHEMA: &[(&str, &str)] = &[(
+    "docs",
+    "CREATE TABLE docs (doc_id INT PRIMARY KEY, kind VARCHAR, doc JSON)",
+)];
+
+const DATA: &[&str] = &[
+    "INSERT INTO docs (doc_id, kind, doc) VALUES (1, 'product', '{\"title\":\"alpha\",\"price\":10,\"in_stock\":true,\"tags\":[\"x\",\"y\"],\"author\":{\"name\":\"Ann\",\"country\":\"CA\"}}')",
+    "INSERT INTO docs (doc_id, kind, doc) VALUES (2, 'product', '{\"title\":\"beta\",\"price\":25,\"in_stock\":false,\"tags\":[\"y\",\"z\"],\"author\":{\"name\":\"Bob\",\"country\":\"US\"}}')",
+    "INSERT INTO docs (doc_id, kind, doc) VALUES (3, 'article', '{\"title\":\"gamma\",\"price\":5,\"in_stock\":true,\"tags\":[\"x\"],\"author\":{\"name\":\"Ann\",\"country\":\"CA\"}}')",
+];
+
+/// Document/JSON queries probing increasing capability. Numbered for reporting.
+fn doc_queries() -> Vec<(&'static str, String)> {
+    vec![
+        // Baseline: store + retrieve the whole JSON document.
+        ("d01_select_all", "select doc_id, kind, doc from docs order by doc_id".to_string()),
+        // Filter on a normal relational column alongside the JSON blob.
+        ("d02_filter_col", "select doc_id, doc from docs where kind = 'product' order by doc_id".to_string()),
+        ("d03_count_by_kind", "select kind, count(*) as n from docs group by kind order by kind".to_string()),
+        // JSON scalar field extraction (-> as json, ->> as text).
+        ("d04_arrow_text", "select doc_id, doc->>'title' as title from docs order by doc_id".to_string()),
+        ("d05_arrow_json", "select doc_id, doc->'price' as price from docs order by doc_id".to_string()),
+        // Filter on an extracted JSON scalar.
+        ("d06_filter_json_scalar", "select doc_id from docs where (doc->>'price')::int > 8 order by doc_id".to_string()),
+        ("d07_filter_json_text", "select doc_id from docs where doc->>'title' = 'alpha'".to_string()),
+        // Nested path.
+        ("d08_nested_path", "select doc_id, doc->'author'->>'name' as author from docs order by doc_id".to_string()),
+        // Group by an extracted JSON field.
+        ("d09_group_by_json", "select doc->'author'->>'country' as country, count(*) as n from docs group by doc->'author'->>'country' order by country".to_string()),
+        // json_extract_path_text function form (portable alternative to ->>).
+        ("d10_json_extract_fn", "select doc_id, json_extract_path_text(doc, 'title') as title from docs order by doc_id".to_string()),
+        // Boolean field extraction.
+        ("d11_bool_field", "select doc_id from docs where (doc->>'in_stock')::boolean = true order by doc_id".to_string()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn document_json_pgwire_conformance() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for (name, ddl) in SCHEMA {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    eprintln!("✓ schema: {} tables created", SCHEMA.len());
+
+    for sql in DATA {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT failed: {}\n  sql: {sql}", explain_err(&e)));
+    }
+    eprintln!("✓ data: {} documents loaded", DATA.len());
+
+    let mut materialized = 0;
+    for (name, _) in SCHEMA {
+        match client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            Ok(_) => materialized += 1,
+            Err(e) => eprintln!("  · MATERIALIZE {name}: {}", explain_err(&e)),
+        }
+    }
+    eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
+
+    let queries = doc_queries();
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    for (id, sql) in &queries {
+        match client.simple_query(sql).await {
+            Ok(_) => {
+                eprintln!("  ✓ {id}");
+                passed.push(*id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {id}: {}", explain_err(&e));
+                failed.push((*id, explain_err(&e)));
+            }
+        }
+    }
+
+    eprintln!(
+        "\n=== Document JSON pgwire conformance: {}/{} passed (ratchet {}) ===",
+        passed.len(),
+        queries.len(),
+        DOC_RATCHET
+    );
+    if !failed.is_empty() {
+        eprintln!("failing:");
+        for (id, err) in &failed {
+            eprintln!("  {id}: {err}");
+        }
+    }
+
+    assert!(
+        passed.len() >= DOC_RATCHET,
+        "Document JSON conformance regressed: {} passed < ratchet {}",
+        passed.len(),
+        DOC_RATCHET
+    );
+
+    // Value-correctness: GROUP BY a nested JSON field. The seeded authors are
+    // Ann/CA, Bob/US, Ann/CA → grouping by author.country yields CA=2, US=1.
+    // Proves JSON extraction + aggregation compute correct values on the OLAP
+    // route, not merely that the SQL runs.
+    let rows: Vec<_> = client
+        .simple_query(
+            "select doc->'author'->>'country' as country, count(*) as n from docs \
+             group by doc->'author'->>'country' order by country",
+        )
+        .await
+        .expect("group-by-json re-run")
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    let got: Vec<(String, String)> = rows
+        .iter()
+        .map(|r| {
+            (
+                r.get(0).unwrap_or("").to_string(),
+                r.get(1).unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            ("CA".to_string(), "2".to_string()),
+            ("US".to_string(), "1".to_string())
+        ],
+        "GROUP BY nested JSON field should yield CA=2, US=1"
+    );
+    eprintln!("✓ value-correctness: GROUP BY author.country = CA:2, US:1");
+}

--- a/tests/events_tsbs_pgwire_e2e.rs
+++ b/tests/events_tsbs_pgwire_e2e.rs
@@ -1,0 +1,324 @@
+//! Events / time-series (TSBS-style) over pgwire — conformance harness.
+//!
+//! Models the TSBS "DevOps" workload: a `cpu` metrics table (timestamp + host/region
+//! tags + gauges), queried over the PostgreSQL wire protocol with the standard TSBS
+//! query shapes (single/double group-by, last-point, high-cpu threshold,
+//! groupby-orderby-limit, time-bucketed aggregation). Same harness model as the
+//! TPC-H/TPC-DS suites: CREATE → INSERT → MATERIALIZE → query one by one, routed by
+//! ProximaDB to the DataFusion OLAP engine. Each query that executes cleanly counts
+//! toward `TSBS_RATCHET`.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test events_tsbs_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+const TSBS_RATCHET: usize = 10;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+const SCHEMA: &[(&str, &str)] = &[(
+    "cpu",
+    "CREATE TABLE cpu (ts TIMESTAMP, hostname VARCHAR, region VARCHAR, datacenter VARCHAR, usage_user DOUBLE PRECISION, usage_system DOUBLE PRECISION, usage_idle DOUBLE PRECISION)",
+)];
+
+/// Two hosts, two regions, several timestamps across two hours.
+fn data() -> Vec<String> {
+    let rows = [
+        (
+            "2016-01-01 00:00:00",
+            "host_0",
+            "us-east",
+            "us-east-1a",
+            25.0,
+            10.0,
+            65.0,
+        ),
+        (
+            "2016-01-01 00:10:00",
+            "host_0",
+            "us-east",
+            "us-east-1a",
+            35.0,
+            12.0,
+            53.0,
+        ),
+        (
+            "2016-01-01 00:20:00",
+            "host_0",
+            "us-east",
+            "us-east-1a",
+            95.0,
+            20.0,
+            5.0,
+        ),
+        (
+            "2016-01-01 01:00:00",
+            "host_0",
+            "us-east",
+            "us-east-1a",
+            40.0,
+            15.0,
+            45.0,
+        ),
+        (
+            "2016-01-01 00:00:00",
+            "host_1",
+            "us-west",
+            "us-west-2b",
+            50.0,
+            30.0,
+            20.0,
+        ),
+        (
+            "2016-01-01 00:10:00",
+            "host_1",
+            "us-west",
+            "us-west-2b",
+            92.0,
+            35.0,
+            3.0,
+        ),
+        (
+            "2016-01-01 00:20:00",
+            "host_1",
+            "us-west",
+            "us-west-2b",
+            60.0,
+            25.0,
+            15.0,
+        ),
+        (
+            "2016-01-01 01:00:00",
+            "host_1",
+            "us-west",
+            "us-west-2b",
+            70.0,
+            28.0,
+            12.0,
+        ),
+    ];
+    let values: Vec<String> = rows
+        .iter()
+        .map(|(ts, h, r, dc, u, s, i)| {
+            format!("(TIMESTAMP '{ts}', '{h}', '{r}', '{dc}', {u}, {s}, {i})")
+        })
+        .collect();
+    vec![format!(
+        "INSERT INTO cpu (ts, hostname, region, datacenter, usage_user, usage_system, usage_idle) VALUES {}",
+        values.join(", ")
+    )]
+}
+
+/// TSBS DevOps-style query shapes.
+fn tsbs_queries() -> Vec<(&'static str, String)> {
+    vec![
+        // single-groupby-1-1-1: max usage_user for one host over a time range.
+        ("single_groupby", "select date_trunc('hour', ts) as hour, max(usage_user) as max_user from cpu where hostname = 'host_0' and ts >= TIMESTAMP '2016-01-01 00:00:00' and ts < TIMESTAMP '2016-01-01 02:00:00' group by date_trunc('hour', ts) order by hour".to_string()),
+        // double-groupby: avg of every metric per host per hour.
+        ("double_groupby", "select date_trunc('hour', ts) as hour, hostname, avg(usage_user) as au, avg(usage_system) as as_, avg(usage_idle) as ai from cpu group by date_trunc('hour', ts), hostname order by hour, hostname".to_string()),
+        // cpu-max-all: max of all gauges per host.
+        ("max_all", "select hostname, max(usage_user) as mu, max(usage_system) as ms, max(usage_idle) as mi from cpu group by hostname order by hostname".to_string()),
+        // high-cpu: rows where usage_user > threshold.
+        ("high_cpu", "select ts, hostname, usage_user from cpu where usage_user > 90.0 order by usage_user desc, hostname".to_string()),
+        // high-cpu per region (filter + group).
+        ("high_cpu_by_region", "select region, count(*) as n from cpu where usage_user > 90.0 group by region order by region".to_string()),
+        // groupby-orderby-limit: top-N time buckets by max usage.
+        ("groupby_orderby_limit", "select date_trunc('hour', ts) as hour, max(usage_user) as max_user from cpu group by date_trunc('hour', ts) order by max_user desc limit 5".to_string()),
+        // last-point: latest reading per host (window).
+        ("last_point", "select hostname, ts, usage_user from (select hostname, ts, usage_user, row_number() over (partition by hostname order by ts desc) as rn from cpu) t where rn = 1 order by hostname".to_string()),
+        // EXTRACT over the time column (datetime expr).
+        ("extract_hour", "select extract(hour from ts) as hr, count(*) as n from cpu group by extract(hour from ts) order by hr".to_string()),
+        // group by tag + region with HAVING.
+        ("region_having", "select region, avg(usage_user) as au from cpu group by region having avg(usage_user) > 40.0 order by region".to_string()),
+        // moving aggregate (window frame over time per host).
+        ("windowed_avg", "select hostname, ts, avg(usage_user) over (partition by hostname order by ts rows between 1 preceding and current row) as moving_avg from cpu order by hostname, ts".to_string()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn events_tsbs_pgwire_conformance() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for (name, ddl) in SCHEMA {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    eprintln!("✓ schema: {} tables created", SCHEMA.len());
+
+    for sql in data() {
+        client
+            .simple_query(&sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT failed: {}\n  sql: {sql}", explain_err(&e)));
+    }
+    eprintln!("✓ data: metrics loaded");
+
+    let mut materialized = 0;
+    for (name, _) in SCHEMA {
+        match client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            Ok(_) => materialized += 1,
+            Err(e) => eprintln!("  · MATERIALIZE {name}: {}", explain_err(&e)),
+        }
+    }
+    eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
+
+    let queries = tsbs_queries();
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    for (id, sql) in &queries {
+        match client.simple_query(sql).await {
+            Ok(_) => {
+                eprintln!("  ✓ {id}");
+                passed.push(*id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {id}: {}", explain_err(&e));
+                failed.push((*id, explain_err(&e)));
+            }
+        }
+    }
+
+    eprintln!(
+        "\n=== Events TSBS pgwire conformance: {}/{} passed (ratchet {}) ===",
+        passed.len(),
+        queries.len(),
+        TSBS_RATCHET
+    );
+    if !failed.is_empty() {
+        eprintln!("failing:");
+        for (id, err) in &failed {
+            eprintln!("  {id}: {err}");
+        }
+    }
+
+    assert!(
+        passed.len() >= TSBS_RATCHET,
+        "Events TSBS conformance regressed: {} passed < ratchet {}",
+        passed.len(),
+        TSBS_RATCHET
+    );
+
+    // Value-correctness: high-CPU rows (usage_user > 90) are host_0@00:20 (95.0)
+    // and host_1@00:10 (92.0). Proves time-series filtering + ordering over the
+    // materialized Parquet computes correct values, not just that the SQL runs.
+    let rows: Vec<_> = client
+        .simple_query(
+            "select hostname, usage_user from cpu where usage_user > 90.0 \
+             order by usage_user desc, hostname",
+        )
+        .await
+        .expect("high-cpu re-run")
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rows.len(), 2, "two readings exceed 90% usage_user");
+    assert_eq!(rows[0].get(0).unwrap_or(""), "host_0", "top high-cpu host");
+    assert_eq!(
+        rows[1].get(0).unwrap_or(""),
+        "host_1",
+        "second high-cpu host"
+    );
+    eprintln!("✓ value-correctness: high-cpu = host_0(95), host_1(92)");
+}

--- a/tests/graph_ldbc_pgwire_e2e.rs
+++ b/tests/graph_ldbc_pgwire_e2e.rs
@@ -1,0 +1,239 @@
+//! Graph (LDBC SNB-style) over pgwire — conformance harness (first cut).
+//!
+//! Models the LDBC Social Network Benchmark property graph as relational tables
+//! (`person` nodes, `knows` friendship edges) queried over the PostgreSQL wire
+//! protocol — graph traversals expressed as SQL joins and recursive CTEs, the open
+//! standard for graph-over-SQL. Same harness model as the other modality suites:
+//! CREATE → INSERT → MATERIALIZE → query one by one, routed by ProximaDB. Each
+//! query that executes cleanly counts toward `GRAPH_RATCHET`.
+//!
+//! Edges are stored BOTH directions (knows is symmetric in LDBC) so 1-hop is a
+//! direct lookup. The seeded graph: triangle 1-2-3, then 3-4, 4-5, 5-6.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test graph_ldbc_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+const GRAPH_RATCHET: usize = 10;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+const SCHEMA: &[(&str, &str)] = &[
+    (
+        "person",
+        "CREATE TABLE person (p_id INT PRIMARY KEY, p_firstname VARCHAR, p_lastname VARCHAR, p_creationdate DATE)",
+    ),
+    (
+        "knows",
+        "CREATE TABLE knows (k_person1 INT, k_person2 INT, k_creationdate DATE)",
+    ),
+];
+
+fn data() -> Vec<String> {
+    let persons = "INSERT INTO person (p_id, p_firstname, p_lastname, p_creationdate) VALUES \
+        (1, 'Alice', 'A', DATE '2010-01-01'), (2, 'Bob', 'B', DATE '2010-02-01'), \
+        (3, 'Carol', 'C', DATE '2010-03-01'), (4, 'Dan', 'D', DATE '2010-04-01'), \
+        (5, 'Eve', 'E', DATE '2010-05-01'), (6, 'Frank', 'F', DATE '2010-06-01')"
+        .to_string();
+    // Undirected edges: triangle 1-2-3, then 3-4, 4-5, 5-6. Stored both ways.
+    let undirected = [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5), (5, 6)];
+    let mut vals = Vec::new();
+    for (a, b) in undirected {
+        vals.push(format!("({a}, {b}, DATE '2011-01-01')"));
+        vals.push(format!("({b}, {a}, DATE '2011-01-01')"));
+    }
+    let knows = format!(
+        "INSERT INTO knows (k_person1, k_person2, k_creationdate) VALUES {}",
+        vals.join(", ")
+    );
+    vec![persons, knows]
+}
+
+/// LDBC SNB-style traversal queries.
+fn graph_queries() -> Vec<(&'static str, String)> {
+    vec![
+        // IS1-style: node profile lookup by id.
+        ("g01_node_lookup", "select p_id, p_firstname, p_lastname from person where p_id = 1".to_string()),
+        // 1-hop: direct friends of person 1 (expect {2,3}).
+        ("g02_one_hop", "select k.k_person2 as friend from knows k where k.k_person1 = 1 order by friend".to_string()),
+        // 1-hop with the friend's profile (join edge → node).
+        ("g03_one_hop_profile", "select p.p_id, p.p_firstname from knows k join person p on k.k_person2 = p.p_id where k.k_person1 = 1 order by p.p_id".to_string()),
+        // 2-hop friends-of-friends of person 1, excluding self and direct friends.
+        ("g04_two_hop_fof", "select distinct k2.k_person2 as fof from knows k1 join knows k2 on k1.k_person2 = k2.k_person1 where k1.k_person1 = 1 and k2.k_person2 <> 1 and k2.k_person2 not in (select k_person2 from knows where k_person1 = 1) order by fof".to_string()),
+        // Degree: friend count per person.
+        ("g05_degree", "select k_person1 as person, count(*) as degree from knows group by k_person1 order by degree desc, person".to_string()),
+        // Mutual friends of person 1 and person 4 (INTERSECT; expect {3}).
+        ("g06_mutual", "select k_person2 as f from knows where k_person1 = 1 intersect select k_person2 as f from knows where k_person1 = 4".to_string()),
+        // Triangles: 3-cycles a<b<c all mutually connected (expect 1-2-3).
+        ("g07_triangle", "select e1.k_person1 as a, e1.k_person2 as b, e2.k_person2 as c from knows e1 join knows e2 on e1.k_person2 = e2.k_person1 join knows e3 on e2.k_person2 = e3.k_person1 and e3.k_person2 = e1.k_person1 where e1.k_person1 < e1.k_person2 and e1.k_person2 < e2.k_person2 order by a, b, c".to_string()),
+        // Top-N most-connected persons (degree + orderby + limit).
+        ("g08_top_degree", "select p.p_firstname, count(*) as degree from knows k join person p on k.k_person1 = p.p_id group by p.p_firstname order by degree desc, p.p_firstname limit 3".to_string()),
+        // Friendships created after a date, joined to both endpoints' names.
+        ("g09_edge_filter_join", "select a.p_firstname as f1, b.p_firstname as f2 from knows k join person a on k.k_person1 = a.p_id join person b on k.k_person2 = b.p_id where k.k_creationdate >= DATE '2011-01-01' and k.k_person1 < k.k_person2 order by f1, f2".to_string()),
+        // Variable-hop reachability from person 1 via a recursive CTE (expect all 6).
+        ("g10_recursive_reach", "with recursive reach(id) as (select 1 union select k.k_person2 from knows k join reach r on k.k_person1 = r.id) select count(distinct id) as reachable from reach".to_string()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn graph_ldbc_pgwire_conformance() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for (name, ddl) in SCHEMA {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    eprintln!("✓ schema: {} tables created", SCHEMA.len());
+
+    for sql in data() {
+        client
+            .simple_query(&sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT failed: {}\n  sql: {sql}", explain_err(&e)));
+    }
+    eprintln!("✓ data: graph loaded");
+
+    let mut materialized = 0;
+    for (name, _) in SCHEMA {
+        match client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            Ok(_) => materialized += 1,
+            Err(e) => eprintln!("  · MATERIALIZE {name}: {}", explain_err(&e)),
+        }
+    }
+    eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
+
+    let queries = graph_queries();
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    for (id, sql) in &queries {
+        match client.simple_query(sql).await {
+            Ok(_) => {
+                eprintln!("  ✓ {id}");
+                passed.push(*id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {id}: {}", explain_err(&e));
+                failed.push((*id, explain_err(&e)));
+            }
+        }
+    }
+
+    eprintln!(
+        "\n=== Graph LDBC pgwire conformance: {}/{} passed (ratchet {}) ===",
+        passed.len(),
+        queries.len(),
+        GRAPH_RATCHET
+    );
+    if !failed.is_empty() {
+        eprintln!("failing:");
+        for (id, err) in &failed {
+            eprintln!("  {id}: {err}");
+        }
+    }
+
+    assert!(
+        passed.len() >= GRAPH_RATCHET,
+        "Graph LDBC conformance regressed: {} passed < ratchet {}",
+        passed.len(),
+        GRAPH_RATCHET
+    );
+}

--- a/tests/iceberg_interop_e2e.rs
+++ b/tests/iceberg_interop_e2e.rs
@@ -1,0 +1,174 @@
+//! Iceberg interop e2e: materialize a table over pgwire, then prove ProximaDB wrote a
+//! spec-shaped Iceberg v3 table to the warehouse (a `v*.metadata.json` referencing an Avro
+//! manifest list + manifest), so external Iceberg engines can read it.
+//!
+//!   cargo test --test iceberg_interop_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::path::{Path as FsPath, PathBuf};
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    data_dir: PathBuf,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let data_dir = tmp.path().to_path_buf();
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = data_dir.clone();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", data_dir.display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", data_dir.display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            data_dir,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Recursively collect every file path under `dir`.
+fn walk(dir: &FsPath, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn materialize_emits_readable_iceberg_v3_table() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let _ = client.simple_query("DROP TABLE IF EXISTS region").await;
+    client
+        .simple_query("CREATE TABLE region (r_regionkey INT PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)")
+        .await
+        .expect("create");
+    client
+        .simple_query("INSERT INTO region (r_regionkey, r_name, r_comment) VALUES (0, 'AMERICA', 'rc0'), (1, 'EUROPE', 'rc1')")
+        .await
+        .expect("insert");
+    client
+        .simple_query("ALTER TABLE region MATERIALIZE")
+        .await
+        .expect("materialize");
+    // Materialize publishes the Iceberg snapshot best-effort after the layout flip.
+    sleep(Duration::from_millis(300)).await;
+
+    // Walk the warehouse tree and classify the Iceberg artifacts.
+    let warehouse = server.data_dir.join("warehouse");
+    let mut files = Vec::new();
+    walk(&warehouse, &mut files);
+    let names: Vec<String> = files
+        .iter()
+        .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+        .collect();
+    eprintln!("warehouse files: {names:?}");
+
+    let metadata_json: Vec<&PathBuf> = files
+        .iter()
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".metadata.json"))
+        })
+        .collect();
+    let has_manifest_list = names.iter().any(|n| n.ends_with("-list.avro"));
+    let has_manifest = names.iter().any(|n| n.ends_with("-m0.avro"));
+    let has_data = names.iter().any(|n| n.ends_with(".parquet"));
+
+    assert!(has_data, "materialize wrote a Parquet data file");
+    assert!(
+        !metadata_json.is_empty(),
+        "materialize wrote an Iceberg TableMetadata json; files={names:?}"
+    );
+    assert!(has_manifest_list, "wrote an Avro manifest list; files={names:?}");
+    assert!(has_manifest, "wrote an Avro manifest; files={names:?}");
+
+    // The metadata is Iceberg format-version 3 and references a manifest list.
+    let meta_bytes = std::fs::read(metadata_json[0]).expect("read metadata.json");
+    let meta: serde_json::Value = serde_json::from_slice(&meta_bytes).expect("parse metadata.json");
+    assert_eq!(meta["format-version"], 3, "Iceberg v3 (ProximaDB default)");
+    let snapshots = meta["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(snapshots.len(), 1, "one snapshot");
+    assert!(
+        snapshots[0]["manifest-list"].is_string(),
+        "snapshot points at a manifest list"
+    );
+    eprintln!("✓ materialize emitted a readable Iceberg v3 table");
+}

--- a/tests/iceberg_interop_e2e.rs
+++ b/tests/iceberg_interop_e2e.rs
@@ -116,7 +116,9 @@ async fn materialize_emits_readable_iceberg_v3_table() {
 
     let _ = client.simple_query("DROP TABLE IF EXISTS region").await;
     client
-        .simple_query("CREATE TABLE region (r_regionkey INT PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)")
+        .simple_query(
+            "CREATE TABLE region (r_regionkey INT PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)",
+        )
         .await
         .expect("create");
     client
@@ -157,7 +159,10 @@ async fn materialize_emits_readable_iceberg_v3_table() {
         !metadata_json.is_empty(),
         "materialize wrote an Iceberg TableMetadata json; files={names:?}"
     );
-    assert!(has_manifest_list, "wrote an Avro manifest list; files={names:?}");
+    assert!(
+        has_manifest_list,
+        "wrote an Avro manifest list; files={names:?}"
+    );
     assert!(has_manifest, "wrote an Avro manifest; files={names:?}");
 
     // The metadata is Iceberg format-version 3 and references a manifest list.

--- a/tests/tpcds_pgwire_e2e.rs
+++ b/tests/tpcds_pgwire_e2e.rs
@@ -1,0 +1,287 @@
+//! TPC-DS over pgwire — ANSI SQL conformance harness (first-cut subset).
+//!
+//! Same model as the TPC-H harness: a coherent star-schema subset
+//! (date_dim / item / store / customer / customer_address / store_sales) is
+//! created, seeded, and materialized to Parquet, then a representative slice of
+//! TPC-DS queries runs ONE BY ONE over the PostgreSQL wire protocol — routed by
+//! ProximaDB to the DataFusion OLAP engine, never bypassing pgwire.
+//!
+//! The query slice is chosen to exercise SQL features TPC-H does NOT: window
+//! functions, ROLLUP / GROUPING SETS, INTERSECT / EXCEPT, and CTEs. Each query
+//! that executes cleanly counts toward `TPCDS_RATCHET`.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test tpcds_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+/// TPC-DS subset queries expected to execute cleanly over pgwire (the ratchet).
+const TPCDS_RATCHET: usize = 16;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+/// Core TPC-DS star-schema subset (standard column names, subset of columns).
+const SCHEMA: &[(&str, &str)] = &[
+    (
+        "date_dim",
+        "CREATE TABLE date_dim (d_date_sk INT PRIMARY KEY, d_date DATE, d_year INT, d_moy INT, d_qoy INT, d_dom INT, d_dow INT)",
+    ),
+    (
+        "item",
+        "CREATE TABLE item (i_item_sk INT PRIMARY KEY, i_item_id VARCHAR, i_brand_id INT, i_brand VARCHAR, i_class_id INT, i_class VARCHAR, i_category_id INT, i_category VARCHAR, i_manufact_id INT, i_current_price DOUBLE PRECISION)",
+    ),
+    (
+        "store",
+        "CREATE TABLE store (s_store_sk INT PRIMARY KEY, s_store_id VARCHAR, s_store_name VARCHAR, s_state VARCHAR)",
+    ),
+    (
+        "customer",
+        "CREATE TABLE customer (c_customer_sk INT PRIMARY KEY, c_customer_id VARCHAR, c_first_name VARCHAR, c_last_name VARCHAR, c_current_addr_sk INT, c_birth_country VARCHAR)",
+    ),
+    (
+        "customer_address",
+        "CREATE TABLE customer_address (ca_address_sk INT PRIMARY KEY, ca_state VARCHAR, ca_city VARCHAR, ca_zip VARCHAR, ca_country VARCHAR, ca_gmt_offset DOUBLE PRECISION)",
+    ),
+    (
+        "store_sales",
+        "CREATE TABLE store_sales (ss_sold_date_sk INT, ss_item_sk INT, ss_store_sk INT, ss_customer_sk INT, ss_addr_sk INT, ss_ticket_number INT, ss_quantity INT, ss_sales_price DOUBLE PRECISION, ss_ext_sales_price DOUBLE PRECISION, ss_ext_discount_amt DOUBLE PRECISION, ss_net_profit DOUBLE PRECISION)",
+    ),
+];
+
+/// Tiny coherent dataset (keys join across the star).
+const DATA: &[&str] = &[
+    "INSERT INTO date_dim (d_date_sk, d_date, d_year, d_moy, d_qoy, d_dom, d_dow) VALUES (24001, DATE '2000-11-01', 2000, 11, 4, 1, 3), (24002, DATE '2000-11-15', 2000, 11, 4, 15, 3), (24003, DATE '2000-12-10', 2000, 12, 4, 10, 0), (23001, DATE '1999-11-05', 1999, 11, 4, 5, 5)",
+    "INSERT INTO item (i_item_sk, i_item_id, i_brand_id, i_brand, i_class_id, i_class, i_category_id, i_category, i_manufact_id, i_current_price) VALUES (1, 'ITEM001', 11, 'brandA', 1, 'classX', 1, 'Electronics', 100, 19.99), (2, 'ITEM002', 12, 'brandB', 1, 'classX', 1, 'Electronics', 101, 29.50), (3, 'ITEM003', 21, 'brandC', 2, 'classY', 2, 'Books', 200, 9.99), (4, 'ITEM004', 22, 'brandD', 2, 'classY', 2, 'Books', 201, 14.00)",
+    "INSERT INTO store (s_store_sk, s_store_id, s_store_name, s_state) VALUES (1, 'STORE01', 'Downtown', 'CA'), (2, 'STORE02', 'Uptown', 'NY')",
+    "INSERT INTO customer_address (ca_address_sk, ca_state, ca_city, ca_zip, ca_country, ca_gmt_offset) VALUES (1, 'CA', 'San Jose', '95101', 'United States', -8.0), (2, 'NY', 'Albany', '12201', 'United States', -5.0)",
+    "INSERT INTO customer (c_customer_sk, c_customer_id, c_first_name, c_last_name, c_current_addr_sk, c_birth_country) VALUES (1, 'CUST001', 'Ann', 'Lee', 1, 'CANADA'), (2, 'CUST002', 'Bob', 'Ng', 2, 'MEXICO'), (3, 'CUST003', 'Cy', 'Ortiz', 1, 'CANADA')",
+    "INSERT INTO store_sales (ss_sold_date_sk, ss_item_sk, ss_store_sk, ss_customer_sk, ss_addr_sk, ss_ticket_number, ss_quantity, ss_sales_price, ss_ext_sales_price, ss_ext_discount_amt, ss_net_profit) VALUES (24001, 1, 1, 1, 1, 1001, 2, 19.99, 39.98, 0.0, 12.0), (24001, 2, 1, 2, 2, 1002, 1, 29.50, 29.50, 2.0, 8.0), (24002, 3, 2, 1, 1, 1003, 5, 9.99, 49.95, 5.0, 20.0), (24003, 4, 2, 3, 1, 1004, 3, 14.00, 42.00, 0.0, 10.0), (23001, 1, 1, 1, 1, 1005, 1, 19.99, 19.99, 0.0, 6.0)",
+];
+
+/// TPC-DS subset: real queries (q3/q42/q52/q55/q98 adapted to the subset
+/// columns) plus targeted probes for features TPC-H lacks.
+fn tpcds_queries() -> Vec<(&'static str, String)> {
+    vec![
+        // q42 — year/category revenue.
+        ("q42", "select dt.d_year, item.i_category_id, item.i_category, sum(ss_ext_sales_price) as revenue from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and item.i_manufact_id = 100 and dt.d_moy = 11 and dt.d_year = 2000 group by dt.d_year, item.i_category_id, item.i_category order by revenue desc, dt.d_year".to_string()),
+        // q52 — brand revenue by year/month.
+        ("q52", "select dt.d_year, item.i_brand_id as brand_id, item.i_brand as brand, sum(ss_ext_sales_price) as ext_price from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and dt.d_moy = 11 and dt.d_year = 2000 group by dt.d_year, item.i_brand, item.i_brand_id order by dt.d_year, ext_price desc, brand_id".to_string()),
+        // q55 — single-brand revenue.
+        ("q55", "select i_brand_id as brand_id, i_brand as brand, sum(ss_ext_sales_price) as ext_price from date_dim, store_sales, item where store_sales.ss_sold_date_sk = date_dim.d_date_sk and store_sales.ss_item_sk = item.i_item_sk and i_manufact_id = 100 and d_moy = 11 and d_year = 2000 group by i_brand, i_brand_id order by ext_price desc, i_brand_id".to_string()),
+        // q3 — manufacturer revenue by year/brand.
+        ("q3", "select dt.d_year, item.i_brand_id as brand_id, item.i_brand as brand, sum(ss_ext_sales_price) as sum_agg from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and item.i_manufact_id = 100 and dt.d_moy = 11 group by dt.d_year, item.i_brand, item.i_brand_id order by dt.d_year, sum_agg desc, brand_id".to_string()),
+        // q98 — WINDOW: ratio of each item's revenue to its class total.
+        ("q98", "select i_item_id, i_category, i_class, i_current_price, sum(ss_ext_sales_price) as itemrevenue, sum(ss_ext_sales_price)*100/sum(sum(ss_ext_sales_price)) over (partition by i_class) as revenueratio from store_sales, item, date_dim where ss_item_sk = i_item_sk and i_category in ('Electronics', 'Books') and ss_sold_date_sk = d_date_sk and d_year = 2000 group by i_item_id, i_category, i_class, i_current_price order by i_category, i_class, i_item_id, revenueratio".to_string()),
+        // WINDOW: rank items by revenue within category.
+        ("win_rank", "select i_category, i_brand, sum(ss_ext_sales_price) as rev, rank() over (partition by i_category order by sum(ss_ext_sales_price) desc) as rnk from store_sales, item where ss_item_sk = i_item_sk group by i_category, i_brand order by i_category, rnk".to_string()),
+        // WINDOW: running sum (frame).
+        ("win_running", "select d_date, sum(ss_ext_sales_price) as daily, sum(sum(ss_ext_sales_price)) over (order by d_date rows between unbounded preceding and current row) as running from store_sales, date_dim where ss_sold_date_sk = d_date_sk group by d_date order by d_date".to_string()),
+        // ROLLUP.
+        ("rollup", "select i_category, i_class, sum(ss_net_profit) as profit from store_sales, item where ss_item_sk = i_item_sk group by rollup(i_category, i_class) order by i_category, i_class".to_string()),
+        // GROUPING SETS.
+        ("grouping_sets", "select i_category, i_brand, sum(ss_quantity) as qty from store_sales, item where ss_item_sk = i_item_sk group by grouping sets ((i_category), (i_brand), ()) order by i_category, i_brand".to_string()),
+        // CUBE.
+        ("cube", "select d_year, i_category, sum(ss_ext_sales_price) as rev from store_sales, item, date_dim where ss_item_sk = i_item_sk and ss_sold_date_sk = d_date_sk group by cube(d_year, i_category) order by d_year, i_category".to_string()),
+        // INTERSECT — customers who bought Electronics AND Books.
+        ("intersect", "select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Electronics' intersect select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Books'".to_string()),
+        // EXCEPT — customers who bought Electronics but NOT Books.
+        ("except", "select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Electronics' except select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Books'".to_string()),
+        // CTE (WITH).
+        ("cte", "with cat_rev as (select i_category, sum(ss_ext_sales_price) as rev from store_sales, item where ss_item_sk = i_item_sk group by i_category) select i_category, rev from cat_rev where rev > 10 order by rev desc".to_string()),
+        // COUNT(DISTINCT) + HAVING.
+        ("count_distinct", "select i_category, count(distinct ss_customer_sk) as buyers from store_sales, item where ss_item_sk = i_item_sk group by i_category having count(distinct ss_customer_sk) >= 1 order by buyers desc, i_category".to_string()),
+        // Correlated scalar subquery.
+        ("correlated", "select i_item_sk, i_current_price from item where i_current_price > (select avg(i_current_price) from item i2 where i2.i_category = item.i_category) order by i_item_sk".to_string()),
+        // CASE + aggregate.
+        ("case_agg", "select i_category, sum(case when ss_net_profit > 10 then 1 else 0 end) as hi, sum(case when ss_net_profit <= 10 then 1 else 0 end) as lo from store_sales, item where ss_item_sk = i_item_sk group by i_category order by i_category".to_string()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tpcds_pgwire_conformance() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for (name, ddl) in SCHEMA {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    eprintln!("✓ schema: {} tables created", SCHEMA.len());
+
+    for sql in DATA {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT failed: {}\n  sql: {sql}", explain_err(&e)));
+    }
+    eprintln!("✓ data: {} insert batches loaded", DATA.len());
+
+    let mut materialized = 0;
+    for (name, _) in SCHEMA {
+        match client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            Ok(_) => materialized += 1,
+            Err(e) => eprintln!("  · MATERIALIZE {name}: {}", explain_err(&e)),
+        }
+    }
+    eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
+
+    let queries = tpcds_queries();
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    for (id, sql) in &queries {
+        match client.simple_query(sql).await {
+            Ok(_) => {
+                eprintln!("  ✓ {id}");
+                passed.push(*id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {id}: {}", explain_err(&e));
+                failed.push((*id, explain_err(&e)));
+            }
+        }
+    }
+
+    eprintln!(
+        "\n=== TPC-DS pgwire conformance: {}/{} passed (ratchet {}) ===",
+        passed.len(),
+        queries.len(),
+        TPCDS_RATCHET
+    );
+    if !failed.is_empty() {
+        eprintln!("failing:");
+        for (id, err) in &failed {
+            eprintln!("  {id}: {err}");
+        }
+    }
+
+    assert!(
+        passed.len() >= TPCDS_RATCHET,
+        "TPC-DS conformance regressed: {} passed < ratchet {}",
+        passed.len(),
+        TPCDS_RATCHET
+    );
+
+    // Value-correctness spot check on the INTERSECT: customers who bought both an
+    // Electronics item (1,2) and a Books item (3,4). From the seeded sales only
+    // customer 1 bought from both categories → exactly one row, ss_customer_sk=1.
+    // Proves set-op semantics compute correctly, not just that they parse.
+    let intersect = &tpcds_queries()
+        .into_iter()
+        .find(|(id, _)| *id == "intersect")
+        .expect("intersect query present")
+        .1;
+    let rows: Vec<_> = client
+        .simple_query(intersect)
+        .await
+        .expect("intersect re-run")
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(rows.len(), 1, "INTERSECT should yield exactly 1 customer");
+    assert_eq!(
+        rows[0].get(0).unwrap_or(""),
+        "1",
+        "INTERSECT customer should be ss_customer_sk=1"
+    );
+    eprintln!("✓ INTERSECT value-correctness: exactly customer 1");
+}

--- a/tests/tpch_pgwire_e2e.rs
+++ b/tests/tpch_pgwire_e2e.rs
@@ -1,0 +1,317 @@
+//! TPC-H over pgwire — ANSI SQL conformance harness.
+//!
+//! Submits the standard TPC-H schema, a tiny deterministic dataset, materializes
+//! each table to Parquet (so the router sends SELECTs to the DataFusion OLAP
+//! engine), then runs the 22 TPC-H queries ONE BY ONE through the PostgreSQL wire
+//! protocol — never bypassing pgwire or the router.
+//!
+//! This is the conformance ratchet for "full ANSI SQL over pgwire": each query
+//! that executes cleanly counts toward `TPCH_RATCHET`. As SQL wiring/lowering
+//! gaps are fixed, the ratchet rises. Run with logs to see the real server-side
+//! cause behind any opaque pgwire `db error`:
+//!   RUST_LOG=proximadb=debug cargo test --test tpch_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+/// Number of TPC-H queries expected to execute cleanly over pgwire. Raised as
+/// SQL wiring/lowering gaps are fixed (the ratchet). Never lower without cause.
+const TPCH_RATCHET: usize = 22;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Render a tokio_postgres error including the real server-side DbError cause.
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+/// The 8 TPC-H tables, standard column names/types. Short SQL identifiers — these
+/// only became creatable over pgwire once the vestigial 8-char name floor was
+/// dropped.
+const SCHEMA: &[(&str, &str)] = &[
+    (
+        "region",
+        "CREATE TABLE region (r_regionkey INT PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)",
+    ),
+    (
+        "nation",
+        "CREATE TABLE nation (n_nationkey INT PRIMARY KEY, n_name VARCHAR, n_regionkey INT, n_comment VARCHAR)",
+    ),
+    (
+        "supplier",
+        "CREATE TABLE supplier (s_suppkey INT PRIMARY KEY, s_name VARCHAR, s_address VARCHAR, s_nationkey INT, s_phone VARCHAR, s_acctbal DOUBLE PRECISION, s_comment VARCHAR)",
+    ),
+    (
+        "part",
+        "CREATE TABLE part (p_partkey INT PRIMARY KEY, p_name VARCHAR, p_mfgr VARCHAR, p_brand VARCHAR, p_type VARCHAR, p_size INT, p_container VARCHAR, p_retailprice DOUBLE PRECISION, p_comment VARCHAR)",
+    ),
+    (
+        "partsupp",
+        "CREATE TABLE partsupp (ps_partkey INT, ps_suppkey INT, ps_availqty INT, ps_supplycost DOUBLE PRECISION, ps_comment VARCHAR)",
+    ),
+    (
+        "customer",
+        "CREATE TABLE customer (c_custkey INT PRIMARY KEY, c_name VARCHAR, c_address VARCHAR, c_nationkey INT, c_phone VARCHAR, c_acctbal DOUBLE PRECISION, c_mktsegment VARCHAR, c_comment VARCHAR)",
+    ),
+    (
+        "orders",
+        "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_orderstatus VARCHAR, o_totalprice DOUBLE PRECISION, o_orderdate DATE, o_orderpriority VARCHAR, o_clerk VARCHAR, o_shippriority INT, o_comment VARCHAR)",
+    ),
+    (
+        "lineitem",
+        "CREATE TABLE lineitem (l_orderkey INT, l_partkey INT, l_suppkey INT, l_linenumber INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION, l_discount DOUBLE PRECISION, l_tax DOUBLE PRECISION, l_returnflag VARCHAR, l_linestatus VARCHAR, l_shipdate DATE, l_commitdate DATE, l_receiptdate DATE, l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)",
+    ),
+];
+
+/// A tiny, internally-consistent dataset (keys join across tables). Enough rows to
+/// exercise joins/aggregates/subqueries; not for value-scale correctness.
+const DATA: &[&str] = &[
+    // region / nation
+    "INSERT INTO region (r_regionkey, r_name, r_comment) VALUES (0, 'AMERICA', 'rc0'), (1, 'EUROPE', 'rc1')",
+    "INSERT INTO nation (n_nationkey, n_name, n_regionkey, n_comment) VALUES (0, 'UNITED STATES', 0, 'nc0'), (1, 'GERMANY', 1, 'nc1'), (2, 'FRANCE', 1, 'nc2')",
+    // supplier
+    "INSERT INTO supplier (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment) VALUES (1, 'Supplier#1', 'addr1', 0, '11-111', 1000.0, 'sc1'), (2, 'Supplier#2', 'addr2', 1, '22-222', 2000.0, 'sc2'), (3, 'Supplier#3', 'addr3', 2, '33-333', 500.0, 'Customer Complaints')",
+    // part
+    "INSERT INTO part (p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment) VALUES (1, 'forest part', 'Mfgr#1', 'Brand#13', 'PROMO BRUSHED STEEL', 15, 'SM CASE', 100.0, 'pc1'), (2, 'green part', 'Mfgr#2', 'Brand#23', 'STANDARD POLISHED TIN', 25, 'LG BOX', 200.0, 'pc2'), (3, 'sky part', 'Mfgr#3', 'Brand#34', 'SMALL PLATED COPPER', 36, 'WRAP PKG', 300.0, 'pc3')",
+    // partsupp
+    "INSERT INTO partsupp (ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment) VALUES (1, 1, 100, 10.0, 'psc1'), (2, 2, 200, 20.0, 'psc2'), (3, 3, 300, 30.0, 'psc3'), (1, 2, 150, 15.0, 'psc4')",
+    // customer
+    "INSERT INTO customer (c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment) VALUES (1, 'Customer#1', 'caddr1', 0, '11-001', 700.0, 'BUILDING', 'cc1'), (2, 'Customer#2', 'caddr2', 1, '22-002', 800.0, 'AUTOMOBILE', 'cc2 special requests'), (3, 'Customer#3', 'caddr3', 2, '33-003', -10.0, 'BUILDING', 'cc3')",
+    // orders
+    "INSERT INTO orders (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment) VALUES (1, 1, 'O', 1000.0, DATE '1995-02-15', '1-URGENT', 'Clerk#1', 0, 'oc1'), (2, 2, 'F', 2000.0, DATE '1994-06-10', '2-HIGH', 'Clerk#2', 0, 'oc2'), (3, 3, 'O', 3000.0, DATE '1995-03-20', '3-MEDIUM', 'Clerk#3', 0, 'oc3')",
+    // lineitem
+    "INSERT INTO lineitem (l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES (1, 1, 1, 1, 17.0, 1700.0, 0.04, 0.02, 'N', 'O', DATE '1995-03-10', DATE '1995-03-12', DATE '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'lc1'), (2, 2, 2, 1, 36.0, 7200.0, 0.09, 0.06, 'R', 'F', DATE '1994-07-02', DATE '1994-07-05', DATE '1994-07-10', 'NONE', 'MAIL', 'lc2'), (3, 3, 3, 1, 28.0, 8400.0, 0.06, 0.08, 'A', 'F', DATE '1994-08-01', DATE '1994-08-04', DATE '1994-08-09', 'TAKE BACK RETURN', 'SHIP', 'lc3'), (1, 2, 2, 2, 10.0, 2000.0, 0.10, 0.05, 'N', 'O', DATE '1995-04-01', DATE '1995-04-03', DATE '1995-04-10', 'NONE', 'RAIL', 'lc4')",
+];
+
+/// The 22 standard TPC-H queries, substitution parameters fixed to constants that
+/// the tiny dataset can satisfy. Listed (id, sql) so failures report which.
+fn tpch_queries() -> Vec<(&'static str, String)> {
+    vec![
+        ("Q1", "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= DATE '1998-09-01' group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus".to_string()),
+        ("Q2", "select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%STEEL' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA' and ps_supplycost = (select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA') order by s_acctbal desc, n_name, s_name, p_partkey".to_string()),
+        ("Q3", "select l_orderkey, sum(l_extendedprice*(1-l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < DATE '1995-03-15' and l_shipdate > DATE '1995-03-15' group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate".to_string()),
+        ("Q4", "select o_orderpriority, count(*) as order_count from orders where o_orderdate >= DATE '1993-07-01' and o_orderdate < DATE '1993-10-01' and exists (select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate) group by o_orderpriority order by o_orderpriority".to_string()),
+        ("Q5", "select n_name, sum(l_extendedprice*(1-l_discount)) as revenue from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA' and o_orderdate >= DATE '1994-01-01' and o_orderdate < DATE '1995-01-01' group by n_name order by revenue desc".to_string()),
+        ("Q6", "select sum(l_extendedprice*l_discount) as revenue from lineitem where l_shipdate >= DATE '1994-01-01' and l_shipdate < DATE '1995-01-01' and l_discount between 0.05 and 0.07 and l_quantity < 24".to_string()),
+        ("Q7", "select supp_nation, cust_nation, l_year, sum(volume) as revenue from (select n1.n_name as supp_nation, n2.n_name as cust_nation, extract(year from l_shipdate) as l_year, l_extendedprice*(1-l_discount) as volume from supplier, lineitem, orders, customer, nation n1, nation n2 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n2.n_nationkey and ((n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE') or (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')) and l_shipdate between DATE '1995-01-01' and DATE '1996-12-31') as shipping group by supp_nation, cust_nation, l_year order by supp_nation, cust_nation, l_year".to_string()),
+        ("Q8", "select o_year, sum(case when nation = 'GERMANY' then volume else 0 end) / sum(volume) as mkt_share from (select extract(year from o_orderdate) as o_year, l_extendedprice*(1-l_discount) as volume, n2.n_name as nation from part, supplier, lineitem, orders, customer, nation n1, nation n2, region where p_partkey = l_partkey and s_suppkey = l_suppkey and l_orderkey = o_orderkey and o_custkey = c_custkey and c_nationkey = n1.n_nationkey and n1.n_regionkey = r_regionkey and r_name = 'EUROPE' and s_nationkey = n2.n_nationkey and o_orderdate between DATE '1995-01-01' and DATE '1996-12-31' and p_type = 'STANDARD POLISHED TIN') as all_nations group by o_year order by o_year".to_string()),
+        ("Q9", "select nation, o_year, sum(amount) as sum_profit from (select n_name as nation, extract(year from o_orderdate) as o_year, l_extendedprice*(1-l_discount) - ps_supplycost*l_quantity as amount from part, supplier, lineitem, partsupp, orders, nation where s_suppkey = l_suppkey and ps_suppkey = l_suppkey and ps_partkey = l_partkey and p_partkey = l_partkey and o_orderkey = l_orderkey and s_nationkey = n_nationkey and p_name like '%green%') as profit group by nation, o_year order by nation, o_year desc".to_string()),
+        ("Q10", "select c_custkey, c_name, sum(l_extendedprice*(1-l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= DATE '1993-10-01' and o_orderdate < DATE '1994-01-01' and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc".to_string()),
+        ("Q11", "select ps_partkey, sum(ps_supplycost*ps_availqty) as value from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY' group by ps_partkey having sum(ps_supplycost*ps_availqty) > (select sum(ps_supplycost*ps_availqty) * 0.0001 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY') order by value desc".to_string()),
+        ("Q12", "select l_shipmode, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count from orders, lineitem where o_orderkey = l_orderkey and l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= DATE '1994-01-01' and l_receiptdate < DATE '1995-01-01' group by l_shipmode order by l_shipmode".to_string()),
+        ("Q13", "select c_count, count(*) as custdist from (select c_custkey, count(o_orderkey) as c_count from customer left outer join orders on c_custkey = o_custkey and o_comment not like '%special%requests%' group by c_custkey) as c_orders group by c_count order by custdist desc, c_count desc".to_string()),
+        ("Q14", "select 100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice*(1-l_discount) else 0 end) / sum(l_extendedprice*(1-l_discount)) as promo_revenue from lineitem, part where l_partkey = p_partkey and l_shipdate >= DATE '1995-09-01' and l_shipdate < DATE '1995-10-01'".to_string()),
+        ("Q15", "select s_suppkey, s_name, s_address, s_phone, total_revenue from supplier, (select l_suppkey as supplier_no, sum(l_extendedprice*(1-l_discount)) as total_revenue from lineitem where l_shipdate >= DATE '1996-01-01' and l_shipdate < DATE '1996-04-01' group by l_suppkey) as revenue0 where s_suppkey = supplier_no order by s_suppkey".to_string()),
+        ("Q16", "select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt from partsupp, part where p_partkey = ps_partkey and p_brand <> 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and p_size in (49, 14, 23, 45, 19, 3, 36, 9) group by p_brand, p_type, p_size order by supplier_cnt desc, p_brand, p_type, p_size".to_string()),
+        ("Q17", "select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < (select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey)".to_string()),
+        ("Q18", "select c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum(l_quantity) from customer, orders, lineitem where o_orderkey in (select l_orderkey from lineitem group by l_orderkey having sum(l_quantity) > 300) and c_custkey = o_custkey and o_orderkey = l_orderkey group by c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice order by o_totalprice desc, o_orderdate".to_string()),
+        ("Q19", "select sum(l_extendedprice*(1-l_discount)) as revenue from lineitem, part where (p_partkey = l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and l_quantity >= 1 and l_quantity <= 11 and p_size between 1 and 5 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and l_quantity >= 10 and l_quantity <= 20 and p_size between 1 and 10 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON')".to_string()),
+        ("Q20", "select s_name, s_address from supplier, nation where s_suppkey in (select ps_suppkey from partsupp where ps_partkey in (select p_partkey from part where p_name like 'forest%') and ps_availqty > (select 0.5 * sum(l_quantity) from lineitem where l_partkey = ps_partkey and l_suppkey = ps_suppkey and l_shipdate >= DATE '1994-01-01' and l_shipdate < DATE '1995-01-01')) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name".to_string()),
+        ("Q21", "select s_name, count(*) as numwait from supplier, lineitem l1, orders, nation where s_suppkey = l1.l_suppkey and o_orderkey = l1.l_orderkey and o_orderstatus = 'F' and l1.l_receiptdate > l1.l_commitdate and exists (select * from lineitem l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey <> l1.l_suppkey) and not exists (select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey and l3.l_receiptdate > l3.l_commitdate) and s_nationkey = n_nationkey and n_name = 'SAUDI ARABIA' group by s_name order by numwait desc, s_name".to_string()),
+        ("Q22", "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal from (select substring(c_phone from 1 for 2) as cntrycode, c_acctbal from customer where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') and c_acctbal > (select avg(c_acctbal) from customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17')) and not exists (select * from orders where o_custkey = c_custkey)) as custsale group by cntrycode order by cntrycode".to_string()),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tpch_pgwire_conformance() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // 1. Schema (idempotent — the catalog persists outside the per-test tmpdir).
+    for (name, ddl) in SCHEMA {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    eprintln!("✓ schema: {} tables created", SCHEMA.len());
+
+    // 2. Data.
+    for sql in DATA {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT failed: {}\n  sql: {sql}", explain_err(&e)));
+    }
+    eprintln!("✓ data: {} insert batches loaded", DATA.len());
+
+    // 3. Materialize each table to Parquet so the router routes SELECTs to the
+    //    DataFusion OLAP engine.
+    let mut materialized = 0;
+    for (name, _) in SCHEMA {
+        match client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            Ok(_) => materialized += 1,
+            Err(e) => eprintln!("  · MATERIALIZE {name}: {}", explain_err(&e)),
+        }
+    }
+    eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
+
+    // 4. Run the 22 TPC-H queries one by one; record pass/fail.
+    let queries = tpch_queries();
+    let mut passed = Vec::new();
+    let mut failed = Vec::new();
+    for (id, sql) in &queries {
+        match client.simple_query(sql).await {
+            Ok(_) => {
+                eprintln!("  ✓ {id}");
+                passed.push(*id);
+            }
+            Err(e) => {
+                eprintln!("  ✗ {id}: {}", explain_err(&e));
+                failed.push((*id, explain_err(&e)));
+            }
+        }
+    }
+
+    eprintln!(
+        "\n=== TPC-H pgwire conformance: {}/{} passed (ratchet {}) ===",
+        passed.len(),
+        queries.len(),
+        TPCH_RATCHET
+    );
+    if !failed.is_empty() {
+        eprintln!("failing:");
+        for (id, err) in &failed {
+            eprintln!("  {id}: {err}");
+        }
+    }
+
+    assert!(
+        passed.len() >= TPCH_RATCHET,
+        "TPC-H conformance regressed: {} passed < ratchet {}",
+        passed.len(),
+        TPCH_RATCHET
+    );
+
+    // Value-correctness spot check: Q1 groups lineitem by (l_returnflag,
+    // l_linestatus). Over the seeded data the groups are (A,F)=1 row, (N,O)=2
+    // rows, (R,F)=1 row, ordered by returnflag, linestatus. This proves the
+    // DataFusion route computes CORRECT aggregates over the materialized Parquet —
+    // not merely that the SQL parses and executes.
+    let q1 = &tpch_queries()[0].1;
+    let rows: Vec<_> = client
+        .simple_query(q1)
+        .await
+        .expect("Q1 re-run")
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        rows.len(),
+        3,
+        "Q1 should yield 3 (returnflag,linestatus) groups"
+    );
+    // (returnflag, linestatus, count_order=last column)
+    let got: Vec<(String, String, String)> = rows
+        .iter()
+        .map(|r| {
+            let last = r.len() - 1;
+            (
+                r.get(0).unwrap_or("").to_string(),
+                r.get(1).unwrap_or("").to_string(),
+                r.get(last).unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(got[0].0, "A", "Q1 row0 returnflag");
+    assert_eq!(got[0].2, "1", "Q1 (A,F) count_order");
+    assert_eq!(got[1].0, "N", "Q1 row1 returnflag");
+    assert_eq!(got[1].2, "2", "Q1 (N,O) count_order");
+    assert_eq!(got[2].0, "R", "Q1 row2 returnflag");
+    assert_eq!(got[2].2, "1", "Q1 (R,F) count_order");
+    eprintln!("✓ Q1 value-correctness: 3 groups, counts A,F=1 N,O=2 R,F=1");
+}

--- a/tests/vector_ann_recall_e2e.rs
+++ b/tests/vector_ann_recall_e2e.rs
@@ -1,0 +1,281 @@
+//! Vector ANN recall@k over the native REST v2 surface (ANN-Benchmarks style).
+//!
+//! Spins up an in-process ProximaDB, creates a vector collection, inserts a
+//! deterministic dataset, then for a set of query vectors compares the engine's
+//! k-NN results against BRUTE-FORCE cosine ground truth computed in-test. The
+//! metric is mean recall@k — the standard ANN-Benchmarks quality measure.
+//!
+//! This is the vector modality's qa-gate conformance harness; it ratchets on
+//! mean recall (no-regression). Modeled on tests/filtered_ann_recall_bands.rs
+//! but UNFILTERED (the filter-eval path is Beta in v0.2) so it exercises the
+//! core ANN quality path only.
+//!
+//!   cargo test --test vector_ann_recall_e2e -- --nocapture
+
+use std::collections::HashSet;
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+/// Mean recall@k floor (ratchet). Measured mean is 1.000 at this scale (small N
+/// is exact/brute-force-served); 0.90 leaves headroom for cross-platform float
+/// drift on borderline neighbors while still catching real index regressions.
+const RECALL_RATCHET: f64 = 0.90;
+
+const DIM: usize = 32;
+const N: usize = 300;
+const TOP_K: usize = 10;
+const N_QUERIES: usize = 20;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct VecServer {
+    rest_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl VecServer {
+    async fn start() -> anyhow::Result<Self> {
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let flight_port = free_port();
+        let pg_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.arrow_flight_port = flight_port;
+        config.api.pg_port = Some(pg_port);
+        config.api.unified_mode = false;
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        Ok(Self {
+            rest_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn base(&self) -> String {
+        format!("http://127.0.0.1:{}", self.rest_port)
+    }
+}
+
+impl Drop for VecServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Deterministic pseudo-random vector (splitmix64-seeded) — distinct directions
+/// so brute-force top-k is a real ranking, stable across runs without a PRNG dep.
+fn gen_vec(seed: u64, dim: usize) -> Vec<f32> {
+    let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+    (0..dim)
+        .map(|_| {
+            s ^= s >> 30;
+            s = s.wrapping_mul(0xBF58476D1CE4E5B9);
+            s ^= s >> 27;
+            s = s.wrapping_mul(0x94D049BB133111EB);
+            s ^= s >> 31;
+            // map to [-1, 1)
+            ((s >> 11) as f32 / (1u64 << 53) as f32) * 2.0 - 1.0
+        })
+        .collect()
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+fn brute_force_topk(corpus: &[(String, Vec<f32>)], query: &[f32], k: usize) -> Vec<String> {
+    let mut scored: Vec<(&String, f32)> = corpus
+        .iter()
+        .map(|(id, v)| (id, cosine(v, query)))
+        .collect();
+    // Descending cosine (higher = closer).
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored
+        .into_iter()
+        .take(k)
+        .map(|(id, _)| id.clone())
+        .collect()
+}
+
+fn ids_from_search_body(body: &Value) -> Vec<String> {
+    body.get("results")
+        .or_else(|| body.get("matches"))
+        .or_else(|| body.get("hits"))
+        .or_else(|| body.get("records"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    m.get("id")
+                        .or_else(|| m.get("record_id"))
+                        .and_then(|s| s.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vector_ann_recall_at_k() {
+    let server = VecServer::start().await.expect("server start");
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .no_proxy()
+        .build()
+        .unwrap();
+    let base = server.base();
+
+    let coll = format!(
+        "ann_recall_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+
+    // 1. Create vector collection (cosine / fp32 / SST).
+    let create = http
+        .post(format!("{base}/api/v2/collections"))
+        .json(&json!({
+            "name": coll,
+            "dimension": DIM,
+            "engine": "sst",
+            "distance_metric": "cosine",
+            "canonical_embedding_precision": "fp32",
+            "enable_proxima_record": false,
+        }))
+        .send()
+        .await
+        .expect("create send");
+    assert!(
+        create.status().is_success(),
+        "create: {} {}",
+        create.status(),
+        create.text().await.unwrap_or_default()
+    );
+
+    // 2. Build the corpus and insert it.
+    let corpus: Vec<(String, Vec<f32>)> = (0..N)
+        .map(|i| (format!("rec-{i}"), gen_vec(i as u64, DIM)))
+        .collect();
+    let records: Vec<Value> = corpus
+        .iter()
+        .map(|(id, v)| json!({ "id": id, "vector": v }))
+        .collect();
+    let insert = http
+        .post(format!("{base}/api/v2/collections/{coll}/records/batch"))
+        .json(&json!({ "records": records }))
+        .send()
+        .await
+        .expect("insert send");
+    assert!(
+        insert.status().is_success(),
+        "insert: {} {}",
+        insert.status(),
+        insert.text().await.unwrap_or_default()
+    );
+    sleep(Duration::from_millis(750)).await;
+
+    // 3. For each query (an existing vector + small perturbation), compare the
+    //    engine's k-NN to brute-force cosine ground truth.
+    let mut recalls = Vec::new();
+    let mut empty_results = 0;
+    for q in 0..N_QUERIES {
+        let base_idx = (q * (N / N_QUERIES)) % N;
+        let mut query = corpus[base_idx].1.clone();
+        // Small perturbation so the query isn't byte-identical to a stored vector.
+        let noise = gen_vec((q as u64).wrapping_add(1_000_000), DIM);
+        for j in 0..DIM {
+            query[j] += noise[j] * 0.01;
+        }
+
+        let resp = http
+            .post(format!("{base}/api/v2/collections/{coll}/search"))
+            .json(&json!({ "vector": query, "top_k": TOP_K }))
+            .send()
+            .await
+            .expect("search send");
+        assert!(
+            resp.status().is_success(),
+            "search: {} {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default()
+        );
+        let body: Value = resp.json().await.expect("search json");
+        let ann = ids_from_search_body(&body);
+        if ann.is_empty() {
+            empty_results += 1;
+        }
+        let exact = brute_force_topk(&corpus, &query, TOP_K);
+        let exact_set: HashSet<&String> = exact.iter().collect();
+        let hits = ann.iter().filter(|id| exact_set.contains(id)).count();
+        recalls.push(hits as f64 / TOP_K as f64);
+    }
+
+    let mean = recalls.iter().sum::<f64>() / recalls.len() as f64;
+    eprintln!(
+        "=== Vector ANN recall@{TOP_K}: mean={mean:.3} over {N_QUERIES} queries (N={N}, dim={DIM}); ratchet {RECALL_RATCHET} ==="
+    );
+
+    assert_eq!(
+        empty_results, 0,
+        "{empty_results}/{N_QUERIES} searches returned ZERO results — insert→search index wiring is broken"
+    );
+    assert!(
+        mean >= RECALL_RATCHET,
+        "Vector ANN recall@{TOP_K} regressed: mean {mean:.3} < ratchet {RECALL_RATCHET}"
+    );
+}


### PR DESCRIPTION
Rebased cleanly onto the latest `develop` (zero conflicts); all suites verified green locally before raising CI.

## What's in this PR

### Full ANSI SQL + multi-modal conformance over pgwire (qa-gate harnesses)
- **TPC-H 22/22** and **TPC-DS subset 16/16** over pgwire (CREATE → INSERT → `ALTER TABLE … MATERIALIZE` → DataFusion OLAP route). SQL wiring fixes: DATE/TIMESTAMP typed-string literals in INSERT + coercion, comma-separated FROM → CROSS join, DataFusion ANSI fallback on the pgwire OLAP route, `datetime_expressions`, derived-table routing.
- **4 modality harnesses**: vector ANN recall@10 (=1.0), document JSON (`->`/`->>` + JSON UDFs + GROUP BY), events/TSBS time-series (timestamp materialization), graph/LDBC SNB (joins + recursive CTE).
- Removed the vestigial 8-char collection-name floor (enables SQL identifiers) + name-authoritative TDD.

### Lakehouse format strategy (Iceberg/Delta/Lance) — v3-first
- **Real Iceberg v3 manifests**: `MATERIALIZE` now emits a spec-shaped Avro manifest + manifest list + `TableMetadata` (format-version 3, `FormatVersion::{V2,V3}`) so external Iceberg engines can read ProximaDB tables. Additive — SELECTs read the catalog storage layout, not the manifest.
- **CDC change-feed core**: `changes_since` over the canonical WAL (`ChangeRow`, op/lsn-ordered).
- **Cross-surface convergence**: REST/gRPC and pgwire now share ONE canonical WAL-backed record store (was: REST/gRPC on a vector-compat stub, pgwire on the WAL store) — proven by `cross_surface_unification_e2e` (pgwire write visible on the shared REST/gRPC store).
- Design doc: `docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc` (all 8 workstreams; P2 surfaces / P3 RaBitQ / P4 clustering scoped as follow-ups).

### qa-gate CI
- `qa-gate.yml` (promotion guard dev→qa→main, tpch/tpcds, coverage ratchet) + `coverage_ratchet.py`.

## Verification (local, pre-CI)
TPC-H 22/22 · TPC-DS 16 · document 11 · events 10 · vector recall · graph 10 · iceberg-engine 24 · iceberg interop e2e · cross-surface unification e2e · CDC service test — all green on the rebased base. Layering check passes; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)