### PR TITLE
docs(design): dimensional co-design architecture spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,37 @@ You must also strictly enforce SaaS Operational constraints:
 - **Financial Telemetry:** Plumb `TenantContext` to all I/O boundaries to emit accurate billing metrics.
 ====
 
+[IMPORTANT]
+====
+**🧬 CO-DESIGN MANDATE (2026-06-19)**
+ProximaDB is co-designed the way NVIDIA co-designs silicon+compilers and RISC co-designed the
+ISA+compiler: the five physical dimensions — **object storage, network, local disk/cache,
+compute-per-modality, and governance/security** — are co-optimized as one system against the
+**measured trace distribution**, toward each dimension's **dominant cost term** (for a cloud DB that
+is I/O round-trips and egress, *not* CPU). See `docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
+
+When changing a storage format, reader, codec, cache, or engine you MUST:
+1. **Co-design, don't locally optimize.** State which *dimensional cost term* the change moves
+   (a 4× codec is irrelevant if you still pay N footer round-trips). Optimize across the
+   storage↔compute boundary, not within one layer.
+2. **Trace before you tune.** Justify with a *measured per-query trace* (bytes/requests/latency/
+   cache-hit), never a component-kernel microbenchmark. New routes/readers/writers must emit the
+   query-scoped I/O trace so the dimension they touch is observable; the `ComputeScheduler` costs
+   routes from measured quantities, not static heuristics.
+3. **Treat the boundary as the contract.** Every I/O boundary carries `TenantContext` (isolation +
+   billing, fail-closed) and writes under `DrPathBuilder`. Isolation is *structural*, never a
+   per-query predicate.
+4. **Vertical inside, standard outside.** Co-design internals (PAX + engine + cache) freely; expose
+   only at stable seams (pgwire, Arrow Flight, Iceberg manifests, REST v2).
+5. **Meter every dimension as a TAM surface.** Storage (KSU), read/compute (KRU/KIU), egress (KEU —
+   the open gap to close), and cache are metered per-tenant; governance is metered as tier entitlement.
+====
+
 ### Core Directives
 1.  **Workspace Isolation (MANDATORY — this repo is worked on by multiple concurrent sessions):** NEVER edit, commit, `checkout`, `reset`, `stash`, or `branch -f` in the main checkout, and NEVER touch another worktree's branch or uncommitted WIP. Every task gets its own git worktree + branch off `origin/develop`: run `eval "$(scripts/worktree.sh new <type/topic>)"` to create one and `cd` into it. Run `scripts/worktree.sh guard` before editing — if it fails, you are in the shared checkout; stop and make a worktree. Clean up with `scripts/worktree.sh rm <type/topic>` once your PR merges. Full rationale + commands: `docs/10-quality/WORKSPACE_ISOLATION.md`.
-2.  **Architecture Source Of Truth:** Use `docs/12-design/README.adoc` as the architecture index. Pay special attention to the `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` document.
+2.  **Architecture Source Of Truth:** Use `docs/12-design/README.adoc` as the architecture index. Pay special attention to the `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` (strategic pivot) and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (co-design cost spine) documents.
 3.  **Safety First:** NO `.unwrap()`, `.expect()`, or `panic!()` in production code. Use `Result` and `?`.
 4.  **Token Efficiency:** When running long-output commands, use `grep` with context flags.
+5.  **Measure, Don't Assert:** Gate performance claims on the evidence ledger (`BENCHMARK_EVIDENCE.toml`); reject "indicative" kernel benchmarks masquerading as end-to-end metrics.
 
 *See `GEMINI.md` for the comprehensive list of engineering mandates.*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,6 +19,30 @@ You must also strictly enforce SaaS Operational constraints:
 - **Financial Telemetry:** Plumb `TenantContext` to all I/O boundaries to emit accurate billing metrics.
 ====
 
+[IMPORTANT]
+====
+**🧬 CO-DESIGN MANDATE (2026-06-19)**
+The five physical dimensions — **object storage, network, local disk/cache, compute-per-modality, and
+governance/security** — are co-optimized as one system against the **measured trace distribution**,
+toward each dimension's **dominant cost term** (for a cloud DB that is I/O round-trips and egress, not
+CPU), the way NVIDIA co-designs silicon+compilers and RISC co-designed the ISA+compiler. See
+`docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
+
+When changing a storage format, reader, codec, cache, or engine you MUST:
+1. **Co-design, don't locally optimize** — state which *dimensional cost term* the change moves (a 4×
+   codec is irrelevant if you still pay N footer round-trips); optimize across the storage↔compute
+   boundary, not within one layer.
+2. **Trace before you tune** — justify with a *measured per-query trace*, never a kernel microbench;
+   new routes/readers/writers emit the query-scoped I/O trace and the `ComputeScheduler` costs routes
+   from measured quantities.
+3. **Boundary is the contract** — every I/O boundary carries `TenantContext` (isolation + billing,
+   fail-closed) and writes under `DrPathBuilder`; isolation is structural, never a per-query predicate.
+4. **Vertical inside, standard outside** — co-design internals freely; expose only at stable seams
+   (pgwire, Arrow Flight, Iceberg, REST v2).
+5. **Meter every dimension as a TAM surface** — storage (KSU), read/compute (KRU/KIU), egress (KEU —
+   open gap), cache per-tenant; governance as tier entitlement.
+====
+
 ### Key Technologies
 - **Rust (2024 Edition):** Core implementation.
 - **Tokio & Axum/Tonic:** Asynchronous runtime and networking (REST/gRPC).

--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -1,0 +1,389 @@
+= Co-Design: Dimensional Architecture for Serverless Decoupling
+:toc: left
+:toclevels: 3
+:icons: font
+:sectnums:
+:revdate: 2026-06-19
+
+[.lead]
+This blueprint applies *hardware/software co-design* — the discipline Jensen Huang calls "extreme
+co-design" and that Hennessy & Patterson formalized for the microprocessor/compiler interface — to a
+software-defined cloud database. It treats ProximaDB's five physical dimensions (object storage,
+network, local disk/cache, compute-per-modality, and governance/security) not as independently
+optimized layers behind clean APIs, but as one system co-optimized against the measured *trace
+distribution* of each workload, toward the dimension's *dominant cost term*, while keeping the seams
+clean enough to enforce isolation/billing and to evolve. Each dimension is also a *Total Addressable
+Market* surface: the meter that prices it is the business.
+
+[IMPORTANT]
+====
+Owner: Architecture. Scope: cross-cutting co-design mandate over the 2026-06-04 course correction.
+Status: *Accepted direction; phased implementation*. Subordinate to
+link:DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc[the course correction] and
+link:SYSTEM_MAP_2026_05_30.adoc[SYSTEM_MAP]; consolidates and gives a first-principles spine to
+link:CACHING_AND_MULTITENANCY_RECALIBRATION_2026_06_17.adoc[CACHING_AND_MULTITENANCY_RECALIBRATION],
+link:VECTOR_OBJECT_ECONOMY_ROUTE_HLD_LLD_2026_05_27.adoc[VECTOR_OBJECT_ECONOMY], and
+link:OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc[OSS_ENTERPRISE_BOUNDARY]. This doc adds no new catalog,
+record, WAL, or routing authority — it names the cost objective the existing authorities must serve.
+====
+
+== 1. The Co-Design Thesis
+
+=== 1.1. What the two traditions actually teach
+
+Co-design is not "optimize harder." It is a specific set of moves that apply whenever single-layer
+scaling flattens and the *system* — not the component — becomes the product:
+
+[cols="1,3,3", options="header"]
+|===
+| # | Principle (source) | Database translation
+| P1 | *Co-optimize across boundaries, not within a layer.* The unit of optimization is the whole
+system (NVIDIA "extreme co-design"; Hennessy & Patterson, _A New Golden Age_, CACM 2019). | A faster
+scan kernel is wasted if the byte-fetch boundary is the bottleneck. Co-design the planner, the PAX
+format, the I/O scheduler, and the S3 range-read strategy *together*, against the real query mix.
+| P2 | *The API/boundary is where performance and cost leak.* The CPU↔GPU interface is the canonical
+"accelerator idle because it can't be fed" leak (Huang, Stratechery 2026). | The storage↔compute
+interface (footer reads, manifest lookups, deserialization, predicate-pushdown handoff) is
+ProximaDB's load-bearing surface. Move *bytes that matter*, not whole pages.
+| P3 | *Make the common case fast; design for the trace distribution.* RISC removed rare instructions
+because compilers never emitted them (IBM 801; Patterson). | Instrument the real query mix and
+optimize the dominant path (point lookup vs. analytic scan vs. ANN), not the worst case. Zone-map
+pruning + footer cache + fast-path planner with full-planner fallback is exactly this.
+| P4 | *Push complexity to the layer with the most context — usually up the stack.* RISC relegated
+scheduling to the compiler, which sees the whole program. | Codec choice (SQ8/RaBitQ), block layout,
+and merge-on-read policy belong to the planner/`ComputeScheduler` — which knows cardinality and
+predicates — not hardwired into the storage engine.
+| P5 | *Amortize fixed costs; attack the steepest cost term (Amdahl).* Speedup is bounded by the
+un-accelerated fraction. | For cloud DBs the dominant term is *I/O round-trips and egress, not CPU*. A
+4× codec saving is irrelevant if you still pay N footer round-trips. Coalesce, cache, batch.
+| P6 | *When general scaling stalls, specialize to the domain.* Dennard/Moore ending → domain-specific
+architectures. | Do not force one engine over every workload. ProximaDB's dual path — DataFusion/Parquet
+for OLAP, SST/HELIX/NOVA + PAX for ANN — *is* this. Routing is the specialization seam.
+| P7 | *The data center is the computer — optimize at the largest deployed unit.* | The unit of
+optimization is *the tenant's workload over object storage*, not a single node. Partitioning,
+manifest commits, and cache tiering are designed for the multi-tenant whole.
+| P8 | *Vertically integrate to optimize, then open horizontally at stable interfaces* (Huang's explicit
+recipe). | Co-design PAX format + executor + cache tightly; expose them only at stable seams (pgwire,
+Arrow Flight, Iceberg manifests, REST v2). Internal verticality buys speed; external modularity buys
+ecosystem and avoids lock-in.
+| P9 | *Algorithm–substrate co-evolution is a flywheel.* CUDA kept the same silicon getting faster via
+software. | The PAX format and the query algorithms co-evolve and are *versioned deliberately*
+(PAX v1→v2), never frozen. New pruning/quant algorithms feed format revisions.
+| P10 | *The interface is also the security/billing contract.* The ISA carries correctness and security
+invariants, not just performance. | `DrPathBuilder` tenant prefixes, manifest fences, and
+`TenantContext` plumbed to every I/O boundary make the seam the *fail-closed* enforcement point for
+isolation and financial telemetry.
+| P11 | *Measure before you optimize.* Every RISC decision came from workload statistics. | Gate every
+co-design decision (codec, cache size, prune threshold, oversample) on a measured trace + the evidence
+ledger. Reject component-kernel microbenchmarks masquerading as e2e claims.
+| P12 | *Verify the integrated system before committing* (NVIDIA digital-twins the AI factory before a
+rack lands). | A green per-layer unit test does not prove the integrated path. Deterministic recall
+harnesses, pgwire conformance, multi-tenant isolation e2e gate format/engine changes.
+|===
+
+=== 1.2. The prerequisite move: capture the trace before tuning the dimension
+
+Every principle above (especially P3, P5, P11) presupposes a *measured trace distribution*. The
+audit of ProximaDB's telemetry (2026-06-19) found the load-bearing gap:
+
+* The consumption substrate (`src/metrics/consumption_metrics.rs`) meters *four per-tenant
+aggregates* — `proximadb_object_store_ops_total`, `proximadb_storage_bytes_seconds`,
+`proximadb_task_execution_time_ms`, `proximadb_cache_tenant` — which is excellent for *billing*.
+* But there is *no per-query I/O audit trail* (which block, how many bytes, footer-cache hit/miss),
+*no I/O-scheduler trace* (outstanding requests, byte backpressure, tail-latency hedging), and *no
+cold-object-store latency trace* — the e2e bench (`bench_vector_object_economy_e2e.rs`) runs over a
+local filesystem, so the S3 latency floor that dominates cold ANN is *never observed*. OpenTelemetry
+scaffolding (`src/monitoring/opentelemetry.rs`) exists but is not wired to a backend.
+
+[WARNING]
+====
+*You cannot co-design against a trace distribution you do not capture.* The first co-design
+deliverable (§4) is closing this loop: a query-scoped I/O trace span that records, per dimension, the
+bytes/requests/latency actually paid. Every other lever in this document is tuned against that span.
+====
+
+== 2. Dimensional Decomposition
+
+For each dimension: the *physical cost/latency curve* (what the universe charges), the *co-design
+lever* ProximaDB owns, the *serverless decoupling boundary* (what scales independently and where the
+cold/warm cliff is), the *billing meter* (how it becomes revenue), and the *TAM*.
+
+=== 2.1. Dimension 1 — Object Storage (durable base)
+
+*Physical curve (S3 Standard, us-east-1, post-2025 cuts):* storage $0.023/GB-mo; GET $0.40/M; PUT
+$5.00/M; first-byte p50 ~20–26 ms, p99 ~86 ms; per-request bandwidth ≈ one ~50 MiB/s disk;
+5,500 GET / 3,500 PUT per second *per prefix*. The canonical model (Durner et al., VLDB 2023):
+`first-byte ≈ 30 ms + 20 ms/MiB`, and the *cost-throughput optimum is an 8–16 MiB request* — below it
+the per-GET fee and latency floor dominate; above it throughput plateaus. S3 Express One Zone gives
+single-digit-ms first byte and ~13× cheaper GET, at ~4.8× the per-GB storage price — a *hot/metadata*
+tier, not bulk.
+
+*Co-design lever (ProximaDB owns the byte layout):* this is the PAX format = co-design artifact, the
+direct analogue of shaping an ISA to the silicon. The levers:
+
+* *Block/object sizing to the curve.* PAX blocks and Parquet row groups sized to land reads in the
+8–16 MiB optimum; Iceberg target file ~128 MB–512 MB; never emit <128 KB objects (small-tenant
+*pack store*, R5 in the recalibration doc, coalesces tiny objects). Owner:
+link:PAX_CODEC_LAYOUT_COMPRESSION_LLD_2026_05_20.adoc[PAX_CODEC_LAYOUT_COMPRESSION_LLD].
+* *Footer-first ranged reads* (P2, P5). One suffix-range GET for the footer, then coalesce
+column-chunk reads with the arrow-rs defaults (merge gaps ≤1 MB, cap merged range ≤64 MB) instead of
+naive 5-round-trip opens. Already live in `IcebergObjectStoreBridge` + `RangedSegmentReader`.
+* *Quantization as I/O reduction, not just memory.* SQ8 (4×) and the reserved RaBitQ slot (~30×,
+1-bit, provably near-optimal — Gao & Long, SIGMOD 2025) shrink the *bytes fetched per probe*. The
+co-designed pattern (validated by Milvus 2.6: 72% memory cut, 94.9% recall, 4× throughput) is
+*1-bit primary scan → SQ refine → f32 cold rerank* — exactly the R3 tiered-cache shape. RaBitQ
+search→rerank wiring is the open residual (TURBOQUANT; PAX v2 leftover).
+
+*Serverless boundary:* storage is the always-on, scales-independently tier; compute scales to zero
+against it. The cold/warm cliff *is* the product problem — turbopuffer publishes ~444 ms p90 cold →
+~10–18 ms warm; the co-design job is to make ProximaDB's cold path pay the *fewest, largest,
+best-pruned* GETs and the warm path hit cache.
+
+*Billing meter:* `proximadb_object_store_ops_total` (per op type: list/read/write parquet, fetch_pax,
+fetch_pax_ranged) + `proximadb_storage_bytes_seconds`. → pricing units *KSU* (storage) and the read
+share of *KRU*.
+
+*TAM:* object storage is the substrate of the *data lakehouse market* — $3.5B–$14B (2025, scope
+dependent), ~20–25% CAGR — and underlies the *cloud-database/DBaaS* market at ~$24B (2025) → ~$70B
+(2031), 19.6% CAGR (Mordor).
+
+=== 2.2. Dimension 2 — Networking (data movement)
+
+*Physical curve:* cross-AZ $0.01/GB *each direction* (~$0.02/GB round-trip); same-AZ over private IP
+*free*; internet egress $0.09/GB (first 10 TB) tiering down; same-region S3 via VPC gateway endpoint
+*free*. In chatty distributed systems, cross-AZ transfer can be *50–88% of the total bill* (Kafka
+RF=3 analyses) — networking, not storage, is frequently the dominant TCO term (P5). Result-egress
+serialization is its own leak: row-oriented ODBC/JDBC burns 60–90% of transfer time; Arrow Flight
+sustains ~6 GB/s by using ~95% of interconnect bandwidth.
+
+*Co-design lever:*
+
+* *Same-AZ placement of compute + cache + S3 access* (free path) — collapses the dominant transfer
+term. Owner: link:TENANT_COLLECTION_POD_AFFINITY_2026_05_27.adoc[TENANT_COLLECTION_POD_AFFINITY].
+* *Prefix spread* to multiply the 5,500-GET/s-per-prefix ceiling; *hundreds of concurrent GETs*
+(io_uring-style async, not thread-per-request) to convert latency into bandwidth (~200–250 outstanding
+requests saturate 100 Gbit/s); *request hedging* for the tail ~5% of GETs over 200 ms.
+* *Arrow Flight SQL as the columnar bulk-egress path* (`src/network/multiplex/detectors/arrow_flight.rs`)
+alongside pgwire/REST for compatibility — the proven 10–30× faster analytical read surface (P8: open
+at a stable seam).
+
+*Serverless boundary:* the data plane (compute touching storage) must be co-located per-AZ and
+separated from the metadata/control plane; cross-AZ is reserved for durability/replication where
+$0.02/GB is justified. The frontier (RDMA-disaggregated ANN — d-HNSW, 117× lower latency over RDMA
+memory, arXiv 2505.11783) is the closest external analogue to ProximaDB's ANN-over-object-storage
+thesis and the long-horizon target.
+
+*Billing meter:* presently *unmetered* — a gap. Add an egress/bytes-moved counter keyed by
+`(tenant, az_locality)` so cross-AZ and result-egress become a billable, optimizable dimension
+(→ *KEU*, the egress unit already named in the OSS boundary doc but not yet sourced from a trace).
+
+*TAM:* networking is captured indirectly as the cost floor of every serverless DB; the
+disaggregation/RDMA research wave (GaussDB, PolarDB-MP, PVLDB 2024–2025) signals where the
+AI-infra-scale (~$160B, 2025) money flows.
+
+=== 2.3. Dimension 3 — Local Disk / Cache Tier (the latency bridge)
+
+*Physical curve (the ~2,000–5,000× hierarchy):* RAM ~250 ns → NVMe ~20–150 µs → S3 ~tens of ms
+(p99.99 ~500 ms). A cache hit saves the GET fee *plus* any cross-AZ/egress bytes. Footer/metadata is
+disproportionately valuable: small, immutable, hot — Iceberg metadata prunes 90–99% of files before
+any Parquet read, collapsing planning from ~45 s to ~200 ms.
+
+*Co-design lever:* this is exactly the
+link:CACHING_AND_MULTITENANCY_RECALIBRATION_2026_06_17.adoc[recalibration] R1–R6, unified under one
+*temperature/cost model* (like OS paging) rather than 12 ad-hoc caches:
+
+* *Permanent footer/metadata cache* per `(tenant, segment, etag)` — highest ROI, kills S3 round-trips
+(R2). Already over `RangedSegmentReader`.
+* *Quantized hot tier + f32 cold rerank* (R3) — cache the 1-bit/SQ8 bytes hot, fetch f32 only to
+rerank survivors.
+* *Tenant-fair unified `TenantCache<K,V>`* (`crates/foundation/proximadb-cache`) — byte-weighted,
+work-conserving ELASTIC (borrow idle pool + weighted fair-share reclaim with floor/ceiling) — kills
+noisy-neighbor (P7, P10). *Size-aware eviction* (SIEVE/GDSF beat size-blind LRU for object caches);
+target *>80–90% hit rate* as the break-even where local NVMe delivers near-local performance.
+* *Same-AZ cache placement* (a cross-AZ cache fetch can cost more than the GET it saves).
+
+*Serverless boundary:* cache is *volatile and lost on suspend* — this is the cold-start tax. Decouple
+the cache from compute (ClickHouse's distributed-cache pattern: restarts stay warm; warm pools give
+Snowflake/Databricks ~2–6 s, Neon ~500 ms cold resume vs Aurora ~15 s). Branch/agent state
+(`BranchRef`, O(1) metadata) shares the same warm tier.
+
+*Billing meter:* `proximadb_cache_tenant` (bytes/hits/misses/evictions/hit_ratio per tenant per
+cache) — already wired; drives both tenant-fair policy *and* a cache-tier upsell.
+
+*TAM:* the cache tier is the margin lever — it converts the same object-storage TAM into a
+higher-performance, higher-priced serverless tier (the warm-pool / provisioned-cache SKU).
+
+=== 2.4. Dimension 4 — Compute per Modality (specialized engines under one router)
+
+*Physical curve:* compute is *rarely* the dominant cost for I/O-bound DB work (P5) — but it dominates
+for vectorized scan/agg (Photon ~3× avg, >10× max over JVM), quantization kernels, and ANN graph
+walks. The cost is per-compute-second (ACU/CU-hour) and, on per-TiB-scanned engines (BigQuery
+$6.25/TiB), *per byte not pruned* — which is why pruning (Dimension 1) is also a compute-cost lever.
+
+*Co-design lever — the `ComputeScheduler` is the specialization seam (P4, P6):*
+`src/query/compute_scheduler.rs` evaluates `QueryShape {engages_relational, parquet_backed, …}` and
+emits `SelectRouteDecision {backend, workload_profile, reason}` over a *shared logical plane* split
+into a *specialized physical plane*:
+
+[cols="1,2,3", options="header"]
+|===
+| Modality | Engine(s) | Co-design routing rule
+| Relational OLTP | Native Volcano (`src/query/execution/**`) | point / high-selectivity / read-after-write
+freshness → row/delta authority.
+| Relational OLAP | DataFusion (`src/datafusion/**`) | scan / aggregate / join over Parquet snapshots;
+pruning + late materialization minimize bytes scanned.
+| Vector / ANN | SST, HELIX, NOVA, VIPER (`src/storage/engines/**`) | PAX block + centroid pruning;
+quantized scan → rerank; `SearchEffort`→ef/nprobe knob.
+| Graph | RAPTOR (`crates/modalities/proximadb-graph`) | CSR topology; BFS/PageRank/Cypher.
+| Document / FTS | Tantivy (`crates/modalities/proximadb-document`) | JSONB shredding; BM25.
+| Local analytics | Polars (reserved) | benchmark-gated; enable only if DataFusion overhead is measured.
+|===
+
+The co-design discipline: the scheduler must *cost* each route against the *measured* dimensional
+trace (bytes fetched, requests, cache hit-rate, compute-ms) — not a static heuristic — and the cost
+model evolves toward the RL planner (course-correction P7). This is where P11 (measure first) becomes
+operational: the scheduler is only as good as the trace substrate (§4) feeding its cost estimates.
+
+*Serverless boundary:* compute is the scale-to-zero tier. Per-modality engines are independently
+provisionable; the router is the placement brain. Cold-start is masked by warm pools (Dimension 3).
+
+*Billing meter:* `proximadb_task_execution_time_ms` per `(tenant, engine)` — already wired; plus
+bytes-scanned (from the I/O trace) for a per-TiB-scanned SKU. → pricing units *KRU* (read/compute)
+and *KIU* (ingest/index compute).
+
+*TAM:* the compute router is what lets ProximaDB address the *whole* cloud-database (~$24B) and
+serverless-database ($5.3B 2024 → $38.7B 2033, 21.7% CAGR) markets rather than only the narrow
+*vector-DB* segment (~$2.6–3B 2025 → ~$9B 2030, 27.5% CAGR — MarketsandMarkets). *This TAM gap is the
+core strategic argument for the multi-engine pivot:* the pure vector box is a rounding error against
+AI-infra (~$160B+); co-designing compute to serve relational + vector + graph + document over one
+lakehouse captures the larger, faster container.
+
+=== 2.5. Dimension 5 — Governance & Security (the enterprise margin surface)
+
+*Physical "curve":* governance has no byte cost — its cost is *trust and compliance*, and the market
+prices it steeply. The "SSO tax" is +87–500%+ over base (GitHub +425%, Airtable +500%, Figma +275%);
+BYOK/CMK, audit logs, and advanced RBAC are *edition-gated* across Snowflake (Business Critical),
+Databricks (Enterprise), MongoDB Atlas (+10% per cluster for auditing), Confluent (Dedicated-only).
+Compliance certs (SOC 2 $7.5K→$80K+, HIPAA BAA, FedRAMP) are hard *sales gates*.
+
+*Co-design lever — isolation enforced at the I/O boundary, not per-query predicate (P10):* the seam
+is the contract.
+
+* *`DrPathBuilder` path isolation* (`data/{tenant_id}/{namespace_id}/{collection_id}/`,
+`src/storage/trait_components/path_resolver.rs`) — structural isolation in the object key, not a
+WHERE clause that one missed predicate leaks (the exact Postgres-RLS failure mode the research flags).
+* *`TenantContext` plumbed to every I/O boundary* — carries isolation *and* financial telemetry,
+fail-closed (the 42P01 write gate, TD-064).
+* *Open-core split (P8):* OSS ships *mechanism* (tiering, consumption metrics, isolation primitives);
+anvaiops ships *policy + data* (tier→limit values, pricing units, billing ledger, tenant→tier
+authority) via config + claims — *not* a Rust plugin. Enforced by `check_oss_boundary.py`. Owner:
+link:OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc[OSS_ENTERPRISE_BOUNDARY].
+
+*Serverless boundary:* the pool/bridge/silo taxonomy maps onto pricing tiers — pooled (shared) for
+the base tier, dedicated silo for premium (deliberately unpublished "private pricing"). Data
+residency = deployment stamps per region, assigned by `TenantContext`.
+
+*Billing meter:* governance is metered as *tier entitlement* (`TenantContext.tier` claim + feature
+gates), not bytes — the highest-margin meter.
+
+*TAM:* data governance $3.35B (2023) → $12.66B (2030, 21.7% CAGR); data security platform $2.46B
+(2024) → $9.02B (2030, 23.2% CAGR); privacy management $5.07B (2025) → $17.63B (2031, 23% CAGR).
+Smaller than DBaaS but faster-growing and far higher margin — which is *why* it is the enterprise
+tier on top of a commoditizing compute/storage base.
+
+== 3. The Unified Cost Objective
+
+Co-design needs one objective the `ComputeScheduler` and cache policy minimize. Per query/operation,
+expected total cost is the sum across dimensions:
+
+[source]
+----
+Cost(q) =  w_storage · bytes_stored·time          (KSU)
+         + w_read    · (GET_count·get_fee + bytes_read·bw_cost)   (KRU, Dimension 1+2)
+         + w_egress  · bytes_moved·az_locality_cost  (KEU, Dimension 2)   ← currently unmetered
+         + w_compute · engine_ms·rate              (KRU/KIU, Dimension 4)
+         - cache_hit_savings(hit_ratio)            (Dimension 3 offsets read+egress)
+         × tier_entitlement_multiplier             (Dimension 5)
+----
+
+The weights are *not* guessed — they are the published cost curves in §2, and the quantities
+(`GET_count`, `bytes_read`, `bytes_moved`, `engine_ms`, `hit_ratio`) must come from the *measured
+per-query trace* (§4), closing the loop between P3 (trace distribution), P5 (dominant term), and P11
+(measure first). The four existing `consumption_metrics` aggregates already cover storage, read-ops,
+compute-ms, and cache; the *missing quantity is per-query bytes-moved/egress* and the *missing
+granularity is per-query (not per-tenant-aggregate)*.
+
+== 4. The Trace Substrate (the first deliverable)
+
+Before tuning any dimension, capture the trace. Sequenced, low-risk, additive:
+
+. *Query-scoped I/O span.* Extend the existing `tracing` spans (request_id middleware) with a
+per-query `IoTrace` recording, per dimension: GET/PUT count, bytes read/written, footer-cache
+hit/miss, bytes moved cross-AZ, engine-ms by backend. Emit as an OTel span *and* fold into the
+`consumption_metrics` counters (no new authority — same sinks, finer source).
+. *I/O-scheduler trace.* Instrument outstanding-request depth, byte backpressure, and tail-hedge
+fires in the ranged-reader path (corroborates the Durner 200–250-outstanding / 8–16 MiB model against
+*our* workload).
+. *Cold-object-store evidence.* Add a `cloud_latency` claim to `BENCHMARK_EVIDENCE.toml` backed by a
+real S3-compatible (MinIO/Wasabi) run of `bench_vector_object_economy_e2e.rs` — today only local-FS
+cold/warm is MEASURED, so the S3 latency floor that dominates cold ANN is unverified.
+. *Wire OTel to a backend.* `src/monitoring/opentelemetry.rs` exists but exports nowhere; point it at
+an OTLP collector so traces are *persisted* and the distribution is analyzable (P12: verify the
+integrated system).
+
+These four are the prerequisite for trusting §3's cost model and every §2 lever. *No dimension is
+tuned on intuition.*
+
+== 5. Co-Design Roadmap (mapped to existing tracks)
+
+[cols="1,3,2", options="header"]
+|===
+| Phase | Co-design work | Builds on
+| C0 — Trace loop | §4.1–4.4: query I/O span, scheduler trace, cloud_latency evidence, OTel export. | consumption_metrics, BENCHMARK_EVIDENCE, opentelemetry.rs
+| C1 — Storage levers | PAX block sizing to 8–16 MiB optimum; finish RaBitQ search→rerank wiring;
+small-tenant pack store (R5). | PAX v2 leftover, TURBOQUANT, recalibration R5
+| C2 — Cache unification | Collapse cache zoo → one `TenantCache` temperature/cost model; size-aware
+eviction; decouple cache from compute for warm restarts. | proximadb-cache, recalibration R2/R3/R4/R6
+| C3 — Network metering | Add `(tenant, az_locality)` bytes-moved counter (KEU); same-AZ placement
+enforcement; Arrow Flight SQL bulk-egress GA. | TENANT_COLLECTION_POD_AFFINITY, arrow_flight detector
+| C4 — Cost-based routing | Feed measured dimensional cost into `ComputeScheduler` route selection;
+retire static heuristics; seed the RL-planner cost model. | compute_scheduler.rs, course-correction P7
+| C5 — Governance SKUs | Tier-entitlement multiplier in the cost model; per-tier cache floor/ceiling;
+anvaiops authors tier→limit + pricing via claims. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver
+|===
+
+== 6. TAM Summary (per dimension)
+
+[cols="1,2,2,2", options="header"]
+|===
+| Dimension | Billing unit | Market anchor (2025→) | CAGR
+| Object storage | KSU + read-KRU | Data lakehouse $3.5–14B; DBaaS $24B→$70B (2031) | ~20–25% / 19.6%
+| Networking | KEU (to add) | Cost floor of serverless DB; AI-infra ~$160B+ | ~25% (AI-infra)
+| Local disk / cache | cache-tier SKU | Margin lever on storage TAM (warm-pool SKU) | —
+| Compute / modality | KRU + KIU | Serverless DB $5.3B→$38.7B (2033); vector-DB $2.6B→$9B (2030) | 21.7% / 27.5%
+| Governance / security | tier entitlement | Governance $3.35B→$12.66B; data-security $2.46B→$9.02B | 21.7% / 23.2%
+|===
+
+*Strategic read:* the narrow vector-DB box (~$2.6–3B) is where the brand was born but is a rounding
+error against the cloud-database (~$24B), lakehouse, serverless, and AI-infra (~$160B+) containers.
+Co-design across the five dimensions — one engine, one router, one trace-driven cost model, open
+seams — is precisely the move that lets ProximaDB price *each dimension as its own surface* and
+address the larger, faster-growing markets rather than competing only inside the vector segment.
+
+== 7. Mandate Deltas
+
+This blueprint adds these standing constraints (reflected in `CLAUDE.md` and `GEMINI.md`):
+
+. *Co-design over local optimization.* Changes to a storage format, reader, codec, cache, or engine
+must state which *dimensional cost term* they move and cite the *measured trace* (not a kernel
+microbench) justifying it (P1, P5, P11).
+. *Trace-before-tune.* New routes/readers/writers must emit the query-scoped I/O trace (§4.1) so the
+dimension they touch is observable; the `ComputeScheduler` costs routes from measured quantities.
+. *Boundary as contract.* Every I/O boundary carries `TenantContext` (isolation + billing,
+fail-closed) and writes under `DrPathBuilder` (P10). Isolation is structural, never a per-query
+predicate.
+. *Vertical inside, standard outside.* Co-design internals freely; expose only at stable seams
+(pgwire, Arrow Flight, Iceberg, REST v2). No new external surface without a named authority mode,
+policy boundary, freshness behavior, and maturity (P8).
+. *Meter every dimension.* Storage, read, egress, compute, and cache are each metered per-tenant;
+egress (KEU) is the open gap to close. Governance is metered as tier entitlement.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -31,6 +31,11 @@ OLTP row/delta storage for PostgreSQL-style freshness and constraints, Parquet/I
 for DataFusion analytics, and PAX/specialized layouts as cataloged access methods/projections.
 Always prioritize `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` plus
 `RELATIONAL_STORAGE_FORMAT_AND_INTEROPERABILITY_2026_05_19.adoc` for current mandates.
+
+For the first-principles **co-design** spine over this pivot — how object storage, network, local
+cache, compute-per-modality, and governance are co-optimized against the measured trace distribution
+toward each dimension's dominant cost term, and metered as TAM surfaces — see
+link:CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19].
 ====
 
 Read these in order for future-shaping architecture work:
@@ -82,7 +87,14 @@ Read these in order for future-shaping architecture work:
    multi-engine dispatch over decoupled lakehouse storage, an LSM/WAL hot tier for OLTP read-after-write,
    and object-store-metadata agent branching. Spawns TD-114…TD-120 (see
    `docs/10-quality/TECHNICAL_DEBT.adoc`). Subordinate to the 2026-06-04 course correction above.
-16. `[SUPERSEDED] roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` +
+16. `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` +
+   Cross-cutting co-design mandate (Huang "extreme co-design" + Hennessy/Patterson) applied to the five
+   physical dimensions — object storage, network, local disk/cache, compute-per-modality, and
+   governance/security. Names the unified cost objective the `ComputeScheduler` and cache policy must
+   minimize, the per-query trace substrate that must feed it, the TAM/billing meter for each dimension,
+   and the trace-before-tune mandate. Subordinate to the 2026-06-04 course correction; consolidates the
+   caching recalibration, vector object economy, and OSS/enterprise boundary docs.
+17. `[SUPERSEDED] roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` +
    Legacy foundational mandate. Superseded by the Data Warehouse course correction on 2026-06-04.
 
 == Stable Reference Docs


### PR DESCRIPTION
## Summary

Applies **hardware/software co-design** — NVIDIA's "extreme co-design" and the Hennessy/Patterson RISC ISA/compiler tradition — to ProximaDB as a software-defined cloud database. Adds a new canonical blueprint plus the standing mandate in `CLAUDE.md`/`GEMINI.md`.

The thesis: the five physical dimensions — **object storage, network, local disk/cache, compute-per-modality, governance/security** — are co-optimized as one system against the **measured trace distribution**, toward each dimension's **dominant cost term** (for a cloud DB that is I/O round-trips and egress, *not* CPU), while keeping seams clean enough to enforce isolation/billing and to evolve. Each dimension is also a TAM/billing surface.

## What's in it

- **`docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`** (new): 12 transferable co-design principles; per-dimension decomposition (cost curve | co-design lever ProximaDB owns | serverless decoupling boundary | billing meter | TAM); a unified cost objective the `ComputeScheduler` + cache policy must minimize; the per-query trace substrate that must feed it; a sequenced C0–C5 roadmap; and a TAM summary table.
- **`docs/12-design/README.adoc`**: registered in the Canonical Architecture Path (item 16) + pointer in the pivot WARNING block.
- **`CLAUDE.md` / `GEMINI.md`**: mirrored CO-DESIGN MANDATE block + "Measure, Don't Assert" directive.

## Key findings driving it

- **Load-bearing gap:** `consumption_metrics.rs` meters four per-tenant *aggregates* (great for billing) but there is **no per-query I/O trace, no I/O-scheduler trace, no cold-S3 latency trace** (the e2e bench is local-FS only), and OTel exports nowhere. *You can't co-design against a trace you don't capture* → first deliverable (C0) closes that loop.
- **Egress (KEU) is currently unmetered** — the open billing-dimension gap.
- **Strategic TAM read:** the vector-DB segment (~\$2.6–3B) is a rounding error vs cloud-DB (~\$24B), lakehouse, and AI-infra (~\$160B+) — the quantitative backbone for the existing multi-engine pivot.

## Notes

- Adds **no new** catalog/record/WAL/routing authority — it names the cost objective existing authorities serve.
- Docs-only; renders clean (asciidoctor exit 0); workspace layering hook passed.
- Grounded in a 9-agent research + codebase/telemetry audit (co-design principles, S3 economics, vector-DB market/TAM, serverless governance; maps of design docs, storage/compute/network crates, and the telemetry substrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)