### PR TITLE
feat(observability): per-query I/O trace substrate (co-design C0)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -15,6 +15,7 @@
 //! `tenant_id` is threaded to every fetch for billing attribution.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use object_store::path::Path;
 use proximadb_block_format::{
@@ -57,6 +58,28 @@ pub struct RangedSegmentReader<'b> {
     index: Arc<SegmentIndex>,
     size: u64,
     footer_cache: Option<Arc<FooterCache>>,
+    /// Per-open physical read accounting (co-design C0 trace substrate): bytes
+    /// fetched via ranged GETs and footer-cache outcomes, surfaced to the
+    /// caller's per-query `IoTrace` via [`RangedSegmentReader::read_stats`].
+    /// Atomic because block reads within one open may run concurrently.
+    bytes_read: AtomicU64,
+    footer_hits: AtomicU64,
+    footer_misses: AtomicU64,
+}
+
+/// Snapshot of one [`RangedSegmentReader`] open's physical read accounting.
+/// Forwarded by callers into the per-query I/O trace so a query's object-store
+/// byte cost and footer-cache effectiveness become observable (Dimensions 1 & 3
+/// of the co-design spec).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SegmentReadStats {
+    /// Bytes fetched via ranged GETs during this open. Excludes the one-time
+    /// index-locate suffix read performed before the reader is constructed.
+    pub bytes_read: u64,
+    /// Block-layout footer/metadata cache hits (a hit skips all metadata GETs).
+    pub footer_hits: u64,
+    /// Block-layout footer/metadata cache misses (built from ranged GETs).
+    pub footer_misses: u64,
 }
 
 impl<'b> RangedSegmentReader<'b> {
@@ -119,7 +142,22 @@ impl<'b> RangedSegmentReader<'b> {
             index,
             size,
             footer_cache,
+            bytes_read: AtomicU64::new(0),
+            footer_hits: AtomicU64::new(0),
+            footer_misses: AtomicU64::new(0),
         })
+    }
+
+    /// Physical read accounting accumulated by this open (co-design C0 trace
+    /// substrate). `bytes_read` excludes the one-time index-locate suffix read
+    /// done before construction. Callers forward this into the per-query
+    /// `IoTrace`.
+    pub fn read_stats(&self) -> SegmentReadStats {
+        SegmentReadStats {
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            footer_hits: self.footer_hits.load(Ordering::Relaxed),
+            footer_misses: self.footer_misses.load(Ordering::Relaxed),
+        }
     }
 
     /// Range-read the tail suffix and locate the segment index (growing the
@@ -157,9 +195,13 @@ impl<'b> RangedSegmentReader<'b> {
     }
 
     async fn fetch(&self, offset: u64, length: u64) -> Result<Vec<u8>, StorageError> {
-        self.bridge
+        let out = self
+            .bridge
             .fetch_vector_segment_range(&self.path, offset, length, self.tenant_id.as_deref())
-            .await
+            .await?;
+        self.bytes_read
+            .fetch_add(out.len() as u64, Ordering::Relaxed);
+        Ok(out)
     }
 
     /// Assemble a block's [`BlockLayout`], consulting the footer cache first
@@ -177,8 +219,10 @@ impl<'b> RangedSegmentReader<'b> {
                 format!("{}#{}", self.path, block_offset),
             );
             if let Some(layout) = fc.get(&key).await {
+                self.footer_hits.fetch_add(1, Ordering::Relaxed);
                 return Ok(layout);
             }
+            self.footer_misses.fetch_add(1, Ordering::Relaxed);
             let layout = Arc::new(self.build_block_layout(block_offset, block_size).await?);
             fc.insert(key, layout.approx_bytes() as u32, layout.clone())
                 .await;
@@ -634,6 +678,22 @@ mod tests {
         let after_first = bridge.ranged_bytes.load(Ordering::Relaxed);
         footer_cache.sync().await;
 
+        // Co-design C0 read accounting: a cold open is all footer-cache misses
+        // (one per block) and its byte count is positive and bounded by the
+        // bridge total (which additionally includes the index-locate suffix).
+        let s1 = r1.read_stats();
+        assert_eq!(s1.footer_hits, 0, "cold open: no footer-cache hits");
+        assert_eq!(
+            s1.footer_misses as usize,
+            r1.block_count(),
+            "cold open: one footer miss per block"
+        );
+        assert!(
+            s1.bytes_read > 0 && s1.bytes_read <= after_first,
+            "reader byte accounting {} within bridge total {after_first}",
+            s1.bytes_read
+        );
+
         // Second read: footers come from cache → only stripe bytes are fetched.
         let r2 = RangedSegmentReader::open_with_cache(
             &bridge,
@@ -647,6 +707,20 @@ mod tests {
         let c2 = r2.read_i64_column(col_id::CREATED_AT).await.unwrap();
         assert_eq!(c2, c1, "cached read must decode identically");
         let delta2 = bridge.ranged_bytes.load(Ordering::Relaxed) - after_first;
+
+        // Warm open: every block's footer is served from cache (one hit per
+        // block, zero misses) and only stripe bytes are fetched.
+        let s2 = r2.read_stats();
+        assert_eq!(s2.footer_misses, 0, "warm open: no footer-cache misses");
+        assert_eq!(
+            s2.footer_hits as usize,
+            r2.block_count(),
+            "warm open: one footer hit per block"
+        );
+        assert!(
+            s2.bytes_read > 0 && s2.bytes_read <= delta2,
+            "warm-open stripe-byte accounting positive and bounded"
+        );
 
         assert!(delta2 > 0, "second read still fetches stripe bytes");
         assert!(

--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -65,6 +65,7 @@ pub struct RangedSegmentReader<'b> {
     bytes_read: AtomicU64,
     footer_hits: AtomicU64,
     footer_misses: AtomicU64,
+    range_gets: AtomicU64,
 }
 
 /// Snapshot of one [`RangedSegmentReader`] open's physical read accounting.
@@ -80,6 +81,14 @@ pub struct SegmentReadStats {
     pub footer_hits: u64,
     /// Block-layout footer/metadata cache misses (built from ranged GETs).
     pub footer_misses: u64,
+    /// Number of ranged GET requests issued (each `fetch`). With `bytes_read`
+    /// this yields the average GET size — the co-design read-granularity signal
+    /// (§2.1): are reads coalesced toward the ~8-16 MiB S3 cost-throughput
+    /// optimum, or fragmented into many small, per-request-fee-dominated GETs?
+    /// (Outstanding-request *depth*, byte backpressure, and tail-hedging are
+    /// deferred until the reader issues these concurrently — today it awaits
+    /// them serially, so depth is 1.)
+    pub range_gets: u64,
 }
 
 impl<'b> RangedSegmentReader<'b> {
@@ -145,18 +154,20 @@ impl<'b> RangedSegmentReader<'b> {
             bytes_read: AtomicU64::new(0),
             footer_hits: AtomicU64::new(0),
             footer_misses: AtomicU64::new(0),
+            range_gets: AtomicU64::new(0),
         })
     }
 
     /// Physical read accounting accumulated by this open (co-design C0 trace
-    /// substrate). `bytes_read` excludes the one-time index-locate suffix read
-    /// done before construction. Callers forward this into the per-query
-    /// `IoTrace`.
+    /// substrate). `bytes_read` / `range_gets` exclude the one-time index-locate
+    /// suffix read done before construction. Callers forward this into the
+    /// per-query `IoTrace`.
     pub fn read_stats(&self) -> SegmentReadStats {
         SegmentReadStats {
             bytes_read: self.bytes_read.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
+            range_gets: self.range_gets.load(Ordering::Relaxed),
         }
     }
 
@@ -201,6 +212,7 @@ impl<'b> RangedSegmentReader<'b> {
             .await?;
         self.bytes_read
             .fetch_add(out.len() as u64, Ordering::Relaxed);
+        self.range_gets.fetch_add(1, Ordering::Relaxed);
         Ok(out)
     }
 
@@ -692,6 +704,13 @@ mod tests {
             s1.bytes_read > 0 && s1.bytes_read <= after_first,
             "reader byte accounting {} within bridge total {after_first}",
             s1.bytes_read
+        );
+        // Read-granularity signal: a cold open issues multiple ranged GETs, and
+        // average GET size = bytes_read / range_gets is well-defined.
+        assert!(s1.range_gets > 0, "cold open issued ranged GETs");
+        assert!(
+            (s1.bytes_read / s1.range_gets) > 0,
+            "average GET size is well-defined and positive"
         );
 
         // Second read: footers come from cache → only stripe bytes are fetched.

--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -317,19 +317,27 @@ granularity is per-query (not per-tenant-aggregate)*.
 
 Before tuning any dimension, capture the trace. Sequenced, low-risk, additive:
 
-. *Query-scoped I/O span.* Extend the existing `tracing` spans (request_id middleware) with a
-per-query `IoTrace` recording, per dimension: GET/PUT count, bytes read/written, footer-cache
-hit/miss, bytes moved cross-AZ, engine-ms by backend. Emit as an OTel span *and* fold into the
-`consumption_metrics` counters (no new authority — same sinks, finer source).
-. *I/O-scheduler trace.* Instrument outstanding-request depth, byte backpressure, and tail-hedge
-fires in the ranged-reader path (corroborates the Durner 200–250-outstanding / 8–16 MiB model against
-*our* workload).
-. *Cold-object-store evidence.* Add a `cloud_latency` claim to `BENCHMARK_EVIDENCE.toml` backed by a
-real S3-compatible (MinIO/Wasabi) run of `bench_vector_object_economy_e2e.rs` — today only local-FS
-cold/warm is MEASURED, so the S3 latency floor that dominates cold ANN is unverified.
-. *Wire OTel to a backend.* `src/monitoring/opentelemetry.rs` exists but exports nowhere; point it at
-an OTLP collector so traces are *persisted* and the distribution is analyzable (P12: verify the
-integrated system).
+. *Query-scoped I/O span.* [*DONE*] `src/observability/io_trace.rs` — a per-query `IoTrace`
+task-local recording, per dimension: GET/PUT/LIST/DELETE count, bytes read/written, footer-cache
+hit/miss, bytes moved cross-AZ, engine-ms by backend. Emitted as a structured `tracing` event
+(`proximadb::io_trace`); wired at the PAX read paths + the search handler. No new authority — the
+per-tenant counters stay the chargeback source of truth; this is the finer per-query source.
+. *I/O-scheduler trace.* [*PARTIAL*] `range_gets` + `avg_get_bytes` (the read-granularity signal vs the
+8–16 MiB optimum) are captured via `RangedSegmentReader::read_stats`. Outstanding-request *depth*,
+byte backpressure, and tail-hedge fires are *deferred* until the reader issues GETs concurrently —
+today it awaits them serially (depth 1); they corroborate the Durner 200–250-outstanding model only
+once the concurrent fetch scheduler lands.
+. *Cold-object-store evidence.* [*DONE (claim) / pending artifact*] `cloud_latency` registered in
+`BENCHMARK_EVIDENCE.toml` as `unverified` with the reproduction recipe. Promotion to `measured` needs
+a real S3-compatible (MinIO/Wasabi) run of `bench_vector_object_economy_e2e.rs` — today only local-FS
+cold/warm is MEASURED, so the S3 latency floor that dominates cold ANN stays unverified.
+. *Wire OTel to a backend.* [*DEP-GATED*] `IoTraceSnapshot` is `serde`-serializable (export-ready
+payload). Full OTLP-collector export is a deliberate dependency decision not yet taken — the tree
+lacks `opentelemetry`/`opentelemetry-otlp`/`tracing-opentelemetry`. When approved: attach a
+`tracing_opentelemetry::layer()` to the `src/bin/server.rs` subscriber registry gated on
+`OTEL_EXPORTER_OTLP_ENDPOINT` and point `src/monitoring/opentelemetry.rs` at the collector. Interim
+persistence needs zero new deps (route the `proximadb::io_trace` target to a `tracing-appender` JSON
+sink).
 
 These four are the prerequisite for trusting §3's cost model and every §2 lever. *No dimension is
 tuned on intuition.*

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -190,3 +190,17 @@ hardware = ""
 date = ""
 version = ""
 notes = "PRD acceptance criterion for the Beta TST engine; no ASOF-join benchmark exists."
+
+[[claims]]
+id = "cloud_latency"
+claim = "Cold vs warm object-store (S3) query latency for the vector object-economy route"
+metric = "query_latency_ms"
+status = "unverified"
+asserted_in = ["docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc:327"]
+bench_source = "benches/bench_vector_object_economy_e2e.rs"
+bench_command = "BENCH_VECTORS=1000000 BENCH_DIM=768 cargo bench --bench bench_vector_object_economy_e2e"
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "Co-design C0 §4.3. The e2e bench currently runs over a tempdir-backed LOCAL filesystem (object_economy_e2e measured local-FS cold p50 20.83 ms / warm 19.97 ms @10K, 2026-06-16) — the S3 first-byte floor (~tens of ms cold; turbopuffer reports ~444 ms p90 cold to ~10-18 ms warm) that DOMINATES real cold ANN is NOT captured. To promote to measured: point the bench's FilesystemFactory at an S3-compatible backend (MinIO/Wasabi/real S3) and check in a dated artifact. The per-query GET-count + bytes half of the bench's own stated gap is now captured by the io_trace substrate (src/observability/io_trace.rs); the remaining half is real cloud latency."

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1573,7 +1573,10 @@ pub async fn search_with_typed_filters(
         cold_stage1_only,
         turboquant_hints,
         vector_bounds_pruned_blocks,
-    ) = crate::observability::predicate_diagnostics::scope(async {
+    ) = crate::observability::io_trace::instrument(
+        Some(tenant.tenant_id.clone()),
+        "rest.v2.records.search",
+        crate::observability::predicate_diagnostics::scope(async {
         let outcome = state
             .request_handlers
             .handle_record_search_for_tenant(search_request, Some(&tenant.tenant_id))
@@ -1595,7 +1598,8 @@ pub async fn search_with_typed_filters(
         // `VectorHints.turboquant` (Phase F).
         let tq_hints = crate::observability::predicate_diagnostics::take_turboquant_hints();
         (outcome, downgraded, cold_stage1, tq_hints, vb_pruned)
-    })
+    }),
+    )
     .await;
     let predicate_shortfall = crate::observability::predicate_diagnostics::take_shortfall();
 

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -152,6 +152,13 @@ impl IoTrace {
         counter.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record a batch of footer/metadata cache outcomes at once — convenient for
+    /// forwarding a `RangedSegmentReader`'s per-open `SegmentReadStats`.
+    pub fn record_footers(&self, hits: u64, misses: u64) {
+        self.footer_hits.fetch_add(hits, Ordering::Relaxed);
+        self.footer_misses.fetch_add(misses, Ordering::Relaxed);
+    }
+
     /// Add to bytes moved across an availability zone (KEU / egress).
     pub fn record_cross_az_bytes(&self, bytes: u64) {
         self.bytes_cross_az.fetch_add(bytes, Ordering::Relaxed);
@@ -289,6 +296,11 @@ pub fn record_footer(hit: bool) {
     let _ = IO_TRACE.try_with(|t| t.record_footer(hit));
 }
 
+/// Record a batch of footer/metadata cache outcomes for the active query.
+pub fn record_footers(hits: u64, misses: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_footers(hits, misses));
+}
+
 /// Record cross-AZ bytes (KEU/egress) for the active query.
 pub fn record_cross_az_bytes(bytes: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_cross_az_bytes(bytes));
@@ -411,6 +423,20 @@ mod tests {
         record_footer(true);
         record_compute_ms("sst", 1);
         assert!(snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn record_footers_batches_outcomes() {
+        let s = scope(async {
+            record_footers(7, 3);
+            record_footer(true); // one more hit on top
+            snapshot()
+        })
+        .await
+        .expect("snapshot inside scope");
+        assert_eq!(s.footer_hits, 8);
+        assert_eq!(s.footer_misses, 3);
+        assert_eq!(s.footer_hit_ratio(), Some(8.0 / 11.0));
     }
 
     #[tokio::test]

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -101,6 +101,11 @@ pub struct IoTrace {
     delete_ops: AtomicU64,
     /// Bytes fetched from object storage (Dimension 1 — the read term of KRU).
     bytes_read: AtomicU64,
+    /// Number of ranged GET requests issued. With `bytes_read` yields the
+    /// average GET size — the read-granularity signal (§2.1): coalesced toward
+    /// the ~8-16 MiB S3 optimum, or fragmented into per-request-fee-dominated
+    /// small GETs?
+    range_gets: AtomicU64,
     /// Bytes written to object storage (ingest/flush — KIU).
     bytes_written: AtomicU64,
     /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
@@ -135,6 +140,11 @@ impl IoTrace {
     /// Add to bytes fetched from object storage.
     pub fn record_bytes_read(&self, bytes: u64) {
         self.bytes_read.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add to the count of ranged GET requests issued.
+    pub fn record_range_gets(&self, gets: u64) {
+        self.range_gets.fetch_add(gets, Ordering::Relaxed);
     }
 
     /// Add to bytes written to object storage.
@@ -178,6 +188,7 @@ impl IoTrace {
             list_ops: self.list_ops.load(Ordering::Relaxed),
             delete_ops: self.delete_ops.load(Ordering::Relaxed),
             bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            range_gets: self.range_gets.load(Ordering::Relaxed),
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
@@ -200,6 +211,7 @@ pub struct IoTraceSnapshot {
     pub list_ops: u64,
     pub delete_ops: u64,
     pub bytes_read: u64,
+    pub range_gets: u64,
     pub bytes_written: u64,
     pub footer_hits: u64,
     pub footer_misses: u64,
@@ -229,10 +241,23 @@ impl IoTraceSnapshot {
         self.compute_ms.values().copied().sum()
     }
 
+    /// Average bytes per ranged GET — the read-granularity signal (§2.1).
+    /// `None` when no ranged GETs were issued. A value far below the ~8-16 MiB
+    /// S3 cost-throughput optimum means reads are fragmented and the per-GET fee
+    /// dominates; this is the number the storage co-design lever moves.
+    pub fn avg_get_bytes(&self) -> Option<f64> {
+        if self.range_gets == 0 {
+            None
+        } else {
+            Some(self.bytes_read as f64 / self.range_gets as f64)
+        }
+    }
+
     /// `true` when nothing was recorded — used to suppress empty trace events.
     pub fn is_empty(&self) -> bool {
         self.total_ops() == 0
             && self.bytes_read == 0
+            && self.range_gets == 0
             && self.bytes_written == 0
             && self.footer_hits == 0
             && self.footer_misses == 0
@@ -256,6 +281,8 @@ impl IoTraceSnapshot {
             list_ops = self.list_ops,
             delete_ops = self.delete_ops,
             bytes_read = self.bytes_read,
+            range_gets = self.range_gets,
+            avg_get_bytes = self.avg_get_bytes().unwrap_or(0.0),
             bytes_written = self.bytes_written,
             footer_hits = self.footer_hits,
             footer_misses = self.footer_misses,
@@ -284,6 +311,11 @@ pub fn record_op_str(operation: &str) {
 /// Add to bytes fetched from object storage for the active query.
 pub fn record_bytes_read(bytes: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_bytes_read(bytes));
+}
+
+/// Add to the count of ranged GET requests for the active query.
+pub fn record_range_gets(gets: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_range_gets(gets));
 }
 
 /// Add to bytes written to object storage for the active query.
@@ -368,6 +400,7 @@ mod tests {
         t.record_op(IoOp::Get);
         t.record_bytes_read(1_024);
         t.record_bytes_read(512);
+        t.record_range_gets(3);
         t.record_footer(true);
         t.record_footer(true);
         t.record_footer(false);
@@ -381,6 +414,8 @@ mod tests {
         assert_eq!(s.list_ops, 1);
         assert_eq!(s.total_ops(), 3);
         assert_eq!(s.bytes_read, 1_536);
+        assert_eq!(s.range_gets, 3);
+        assert_eq!(s.avg_get_bytes(), Some(1_536.0 / 3.0));
         assert_eq!(s.bytes_cross_az, 2_048);
         assert_eq!(s.footer_hit_ratio(), Some(2.0 / 3.0));
         assert_eq!(s.total_compute_ms(), 17);
@@ -392,6 +427,7 @@ mod tests {
     fn empty_snapshot_is_empty() {
         assert!(IoTrace::new().snapshot().is_empty());
         assert_eq!(IoTraceSnapshot::default().footer_hit_ratio(), None);
+        assert_eq!(IoTraceSnapshot::default().avg_get_bytes(), None);
     }
 
     #[tokio::test]

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -36,6 +36,27 @@
 //! grep-able structured logs. This module adds **no new billing authority** —
 //! the per-tenant counters stay the source of truth for chargeback; this is the
 //! finer, per-query *source* the spec calls for.
+//!
+//! ## OpenTelemetry export (§4.4 — dependency-gated follow-up)
+//!
+//! Today the snapshot is emitted as a structured [`tracing`] event under
+//! [`TARGET`] and is routable by any subscriber layer. Full export to an OTLP
+//! collector (so these become persisted, queryable spans on a trace backend) is
+//! a deliberate **dependency decision** not yet taken: the tree has
+//! `tracing-subscriber` + `tracing-appender` but none of `opentelemetry`,
+//! `opentelemetry_sdk`, `opentelemetry-otlp`, or `tracing-opentelemetry`. When
+//! that stack is approved the wiring is small and already enabled here:
+//!
+//! 1. [`IoTraceSnapshot`] is `serde`-serializable, so it maps directly to OTLP
+//!    span attributes (or a JSON sink) with no further plumbing.
+//! 2. Attach a `tracing_opentelemetry::layer()` to the subscriber registry in
+//!    `src/bin/server.rs` (beside the existing console/file `fmt` layers, at the
+//!    `tracing_subscriber::registry()` call), gated on `OTEL_EXPORTER_OTLP_ENDPOINT`.
+//! 3. Point the existing `crate::monitoring::opentelemetry` config's
+//!    `otlp_endpoint` at the collector.
+//!
+//! Until then, persistence is available with zero new deps by routing [`TARGET`]
+//! to a `tracing-appender` JSON file sink.
 
 use std::collections::BTreeMap;
 use std::sync::Mutex;
@@ -204,7 +225,11 @@ impl IoTrace {
 
 /// Immutable, plain-value view of an [`IoTrace`] at a point in time — what gets
 /// emitted as a `tracing` event and what a future cost-model reader consumes.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+///
+/// Serde-serializable so an export layer (OTLP span attributes, a JSON sink, or
+/// a cost-model reader) can consume the snapshot directly — the data-shape half
+/// of §4.4. See the module docs for the OTLP-collector wiring plan.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct IoTraceSnapshot {
     pub get_ops: u64,
     pub put_ops: u64,
@@ -473,6 +498,30 @@ mod tests {
         assert_eq!(s.footer_hits, 8);
         assert_eq!(s.footer_misses, 3);
         assert_eq!(s.footer_hit_ratio(), Some(8.0 / 11.0));
+    }
+
+    #[test]
+    fn snapshot_json_round_trips_for_export() {
+        // §4.4 enabler: the snapshot is the export payload (OTLP attrs / JSON
+        // sink / cost-model reader), so it must serde round-trip losslessly.
+        let mut compute = BTreeMap::new();
+        compute.insert("datafusion".to_string(), 12u64);
+        let s = IoTraceSnapshot {
+            get_ops: 5,
+            list_ops: 1,
+            bytes_read: 8_388_608,
+            range_gets: 2,
+            footer_hits: 3,
+            footer_misses: 1,
+            bytes_cross_az: 4_096,
+            compute_ms: compute,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        let back: IoTraceSnapshot = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(s, back);
+        // Spot-check a derived field survives the data it depends on.
+        assert_eq!(back.avg_get_bytes(), Some(8_388_608.0 / 2.0));
     }
 
     #[tokio::test]

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2026 ProximaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+//! Per-query I/O trace bus (C0 — co-design trace substrate)
+//!
+//! This is the foundational deliverable of the co-design mandate
+//! (`docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`, §4.1):
+//! *you cannot co-design against a trace distribution you do not capture.*
+//!
+//! The existing `consumption_metrics` counters meter four per-tenant
+//! **aggregates** (object-store ops, storage byte-seconds, task time, cache
+//! stats) — excellent for billing, but they cannot answer the questions
+//! co-design actually asks: *for this one query, how many GETs did we pay, how
+//! many bytes did we move, did the footer cache hit, and which engine burned
+//! the compute?* Those are the quantities the `ComputeScheduler` cost model
+//! (§3 of the spec) must minimize, and they are per-query, not per-tenant.
+//!
+//! `IoTrace` captures them. It is bound to the request future as a
+//! [`tokio::task_local!`] — exactly like
+//! [`crate::observability::predicate_diagnostics`] — so any depth of the
+//! storage/engine call stack can record into it without threading a new
+//! parameter through dozens of signatures (the dominant cost of doing this any
+//! other way). At the request boundary the handler wraps the query in
+//! [`instrument`] (or [`scope`]); downstream I/O sites call the free
+//! [`record_op`] / [`record_bytes_read`] / [`record_footer`] helpers, which
+//! **silently no-op outside an active scope** (so direct service/test callers
+//! keep working and the Prometheus counters remain the operator-visible signal).
+//!
+//! On completion the snapshot is emitted as a structured `tracing` event under
+//! the [`TARGET`] target. Once OpenTelemetry export is wired (§4.4) these
+//! events become spans on the trace backend; today they are already
+//! grep-able structured logs. This module adds **no new billing authority** —
+//! the per-tenant counters stay the source of truth for chargeback; this is the
+//! finer, per-query *source* the spec calls for.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// `tracing` target for emitted per-query I/O trace events. Kept distinct so
+/// operators can route/sample it independently (and the future OTLP layer can
+/// map it to a span).
+pub const TARGET: &str = "proximadb::io_trace";
+
+tokio::task_local! {
+    /// Active per-query I/O trace for the current task. Bound by [`scope`] /
+    /// [`instrument`].
+    static IO_TRACE: IoTrace;
+}
+
+/// Classification of an object-store operation by its cost shape. The universe
+/// prices GET, PUT, LIST and DELETE differently (LIST and GET dominate
+/// scan-heavy ANN/OLAP; PUT dominates ingest), so the trace keeps them apart
+/// rather than collapsing to a single "ops" count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoOp {
+    Get,
+    Put,
+    List,
+    Delete,
+}
+
+impl IoOp {
+    /// Best-effort classification of the operation strings already passed to
+    /// `consumption_metrics::record_object_store_op` (e.g. `"fetch_pax"`,
+    /// `"list_parquet"`, `"write_parquet"`) so existing call sites can feed the
+    /// trace with a one-line addition. Unknown verbs map to [`IoOp::Get`] (the
+    /// conservative read default) — the verb is still preserved by the caller's
+    /// Prometheus label.
+    pub fn classify(operation: &str) -> Self {
+        if operation.starts_with("list") {
+            IoOp::List
+        } else if operation.starts_with("write")
+            || operation.starts_with("put")
+            || operation.starts_with("delete")
+        {
+            if operation.starts_with("delete") {
+                IoOp::Delete
+            } else {
+                IoOp::Put
+            }
+        } else {
+            // read_parquet, fetch_pax, fetch_pax_ranged, get, ...
+            IoOp::Get
+        }
+    }
+}
+
+/// Per-query accumulator for the physical-dimension quantities the co-design
+/// cost model consumes. Held inside a [`tokio::task_local!`]; all counters are
+/// atomic so concurrent segment reads within one query aggregate correctly.
+#[derive(Debug, Default)]
+pub struct IoTrace {
+    get_ops: AtomicU64,
+    put_ops: AtomicU64,
+    list_ops: AtomicU64,
+    delete_ops: AtomicU64,
+    /// Bytes fetched from object storage (Dimension 1 — the read term of KRU).
+    bytes_read: AtomicU64,
+    /// Bytes written to object storage (ingest/flush — KIU).
+    bytes_written: AtomicU64,
+    /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
+    footer_hits: AtomicU64,
+    footer_misses: AtomicU64,
+    /// Bytes moved across an availability zone (Dimension 2 — KEU, the egress
+    /// term that is currently unmetered and the spec's named gap).
+    bytes_cross_az: AtomicU64,
+    /// Compute milliseconds attributed by engine (Dimension 4 — KRU/KIU). Kept
+    /// in a small map so a single query that touches multiple engines (e.g. a
+    /// Volcano point lookup plus a DataFusion aggregate) attributes each.
+    compute_ms: Mutex<BTreeMap<String, u64>>,
+}
+
+impl IoTrace {
+    /// Create an empty trace.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one classified object-store operation.
+    pub fn record_op(&self, op: IoOp) {
+        let counter = match op {
+            IoOp::Get => &self.get_ops,
+            IoOp::Put => &self.put_ops,
+            IoOp::List => &self.list_ops,
+            IoOp::Delete => &self.delete_ops,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add to bytes fetched from object storage.
+    pub fn record_bytes_read(&self, bytes: u64) {
+        self.bytes_read.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Add to bytes written to object storage.
+    pub fn record_bytes_written(&self, bytes: u64) {
+        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record a footer/metadata cache outcome.
+    pub fn record_footer(&self, hit: bool) {
+        let counter = if hit {
+            &self.footer_hits
+        } else {
+            &self.footer_misses
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add to bytes moved across an availability zone (KEU / egress).
+    pub fn record_cross_az_bytes(&self, bytes: u64) {
+        self.bytes_cross_az.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Attribute compute milliseconds to a named engine.
+    pub fn record_compute_ms(&self, engine: &str, ms: u64) {
+        let mut g = self.compute_ms.lock().unwrap_or_else(|p| p.into_inner());
+        *g.entry(engine.to_string()).or_insert(0) += ms;
+    }
+
+    /// Take a plain-value snapshot for emission/inspection.
+    pub fn snapshot(&self) -> IoTraceSnapshot {
+        IoTraceSnapshot {
+            get_ops: self.get_ops.load(Ordering::Relaxed),
+            put_ops: self.put_ops.load(Ordering::Relaxed),
+            list_ops: self.list_ops.load(Ordering::Relaxed),
+            delete_ops: self.delete_ops.load(Ordering::Relaxed),
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.bytes_written.load(Ordering::Relaxed),
+            footer_hits: self.footer_hits.load(Ordering::Relaxed),
+            footer_misses: self.footer_misses.load(Ordering::Relaxed),
+            bytes_cross_az: self.bytes_cross_az.load(Ordering::Relaxed),
+            compute_ms: self
+                .compute_ms
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .clone(),
+        }
+    }
+}
+
+/// Immutable, plain-value view of an [`IoTrace`] at a point in time — what gets
+/// emitted as a `tracing` event and what a future cost-model reader consumes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IoTraceSnapshot {
+    pub get_ops: u64,
+    pub put_ops: u64,
+    pub list_ops: u64,
+    pub delete_ops: u64,
+    pub bytes_read: u64,
+    pub bytes_written: u64,
+    pub footer_hits: u64,
+    pub footer_misses: u64,
+    pub bytes_cross_az: u64,
+    pub compute_ms: BTreeMap<String, u64>,
+}
+
+impl IoTraceSnapshot {
+    /// Total object-store operations across all verbs.
+    pub fn total_ops(&self) -> u64 {
+        self.get_ops + self.put_ops + self.list_ops + self.delete_ops
+    }
+
+    /// Footer-cache hit ratio in `[0, 1]`; `None` when the footer cache was not
+    /// consulted (no hits or misses recorded).
+    pub fn footer_hit_ratio(&self) -> Option<f64> {
+        let total = self.footer_hits + self.footer_misses;
+        if total == 0 {
+            None
+        } else {
+            Some(self.footer_hits as f64 / total as f64)
+        }
+    }
+
+    /// Total attributed compute milliseconds across engines.
+    pub fn total_compute_ms(&self) -> u64 {
+        self.compute_ms.values().copied().sum()
+    }
+
+    /// `true` when nothing was recorded — used to suppress empty trace events.
+    pub fn is_empty(&self) -> bool {
+        self.total_ops() == 0
+            && self.bytes_read == 0
+            && self.bytes_written == 0
+            && self.footer_hits == 0
+            && self.footer_misses == 0
+            && self.bytes_cross_az == 0
+            && self.compute_ms.is_empty()
+    }
+
+    /// Emit this snapshot as a structured `tracing` event under [`TARGET`].
+    /// No-op when empty. `tenant_id` and `route` label the query; all physical
+    /// quantities become event fields the OTLP layer (§4.4) maps to a span.
+    pub fn emit(&self, tenant_id: Option<&str>, route: &str) {
+        if self.is_empty() {
+            return;
+        }
+        tracing::info!(
+            target: TARGET,
+            tenant_id = tenant_id.unwrap_or("default"),
+            route = route,
+            get_ops = self.get_ops,
+            put_ops = self.put_ops,
+            list_ops = self.list_ops,
+            delete_ops = self.delete_ops,
+            bytes_read = self.bytes_read,
+            bytes_written = self.bytes_written,
+            footer_hits = self.footer_hits,
+            footer_misses = self.footer_misses,
+            footer_hit_ratio = self.footer_hit_ratio().unwrap_or(f64::NAN),
+            bytes_cross_az = self.bytes_cross_az,
+            compute_ms_total = self.total_compute_ms(),
+            compute_ms_by_engine = ?self.compute_ms,
+            "per-query I/O trace"
+        );
+    }
+}
+
+// ---- Free helpers: record into the active scope, or silently no-op. ----
+
+/// Record one object-store operation into the active query trace. Silently
+/// no-ops outside an active [`scope`]/[`instrument`].
+pub fn record_op(op: IoOp) {
+    let _ = IO_TRACE.try_with(|t| t.record_op(op));
+}
+
+/// Classify an operation verb (as used by `consumption_metrics`) and record it.
+pub fn record_op_str(operation: &str) {
+    record_op(IoOp::classify(operation));
+}
+
+/// Add to bytes fetched from object storage for the active query.
+pub fn record_bytes_read(bytes: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_bytes_read(bytes));
+}
+
+/// Add to bytes written to object storage for the active query.
+pub fn record_bytes_written(bytes: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_bytes_written(bytes));
+}
+
+/// Record a footer/metadata cache outcome for the active query.
+pub fn record_footer(hit: bool) {
+    let _ = IO_TRACE.try_with(|t| t.record_footer(hit));
+}
+
+/// Record cross-AZ bytes (KEU/egress) for the active query.
+pub fn record_cross_az_bytes(bytes: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_cross_az_bytes(bytes));
+}
+
+/// Attribute compute milliseconds to `engine` for the active query.
+pub fn record_compute_ms(engine: &str, ms: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_compute_ms(engine, ms));
+}
+
+/// Snapshot the active query trace, if any.
+pub fn snapshot() -> Option<IoTraceSnapshot> {
+    IO_TRACE.try_with(|t| t.snapshot()).ok()
+}
+
+/// Bind a fresh [`IoTrace`] to `future` and await it. Lower-level than
+/// [`instrument`]; use when the caller wants to read the snapshot itself before
+/// the scope ends.
+pub async fn scope<F: std::future::Future>(future: F) -> F::Output {
+    IO_TRACE.scope(IoTrace::new(), future).await
+}
+
+/// Wrap a query future in a fresh trace, run it, then emit the captured
+/// snapshot as a [`TARGET`] event labelled by `tenant_id`/`route`. This is the
+/// one call a request handler adds at the query boundary — co-locate it with
+/// the existing `predicate_diagnostics::scope`.
+pub async fn instrument<F>(tenant_id: Option<String>, route: impl Into<String>, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    let route = route.into();
+    IO_TRACE
+        .scope(IoTrace::new(), async move {
+            let out = future.await;
+            // Still inside the scope: read and emit before the binding drops.
+            if let Ok(snap) = IO_TRACE.try_with(|t| t.snapshot()) {
+                snap.emit(tenant_id.as_deref(), &route);
+            }
+            out
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_maps_known_verbs() {
+        assert_eq!(IoOp::classify("list_pax"), IoOp::List);
+        assert_eq!(IoOp::classify("list_parquet"), IoOp::List);
+        assert_eq!(IoOp::classify("read_parquet"), IoOp::Get);
+        assert_eq!(IoOp::classify("fetch_pax_ranged"), IoOp::Get);
+        assert_eq!(IoOp::classify("write_parquet"), IoOp::Put);
+        assert_eq!(IoOp::classify("delete_segment"), IoOp::Delete);
+        // Unknown verb is the conservative read default.
+        assert_eq!(IoOp::classify("mystery"), IoOp::Get);
+    }
+
+    #[test]
+    fn snapshot_aggregates_and_derives() {
+        let t = IoTrace::new();
+        t.record_op(IoOp::List);
+        t.record_op(IoOp::Get);
+        t.record_op(IoOp::Get);
+        t.record_bytes_read(1_024);
+        t.record_bytes_read(512);
+        t.record_footer(true);
+        t.record_footer(true);
+        t.record_footer(false);
+        t.record_cross_az_bytes(2_048);
+        t.record_compute_ms("volcano", 3);
+        t.record_compute_ms("volcano", 4);
+        t.record_compute_ms("datafusion", 10);
+
+        let s = t.snapshot();
+        assert_eq!(s.get_ops, 2);
+        assert_eq!(s.list_ops, 1);
+        assert_eq!(s.total_ops(), 3);
+        assert_eq!(s.bytes_read, 1_536);
+        assert_eq!(s.bytes_cross_az, 2_048);
+        assert_eq!(s.footer_hit_ratio(), Some(2.0 / 3.0));
+        assert_eq!(s.total_compute_ms(), 17);
+        assert_eq!(s.compute_ms.get("volcano"), Some(&7));
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn empty_snapshot_is_empty() {
+        assert!(IoTrace::new().snapshot().is_empty());
+        assert_eq!(IoTraceSnapshot::default().footer_hit_ratio(), None);
+    }
+
+    #[tokio::test]
+    async fn free_helpers_record_into_active_scope() {
+        let captured = scope(async {
+            record_op_str("fetch_pax");
+            record_op_str("list_pax");
+            record_bytes_read(4_096);
+            record_footer(false);
+            record_compute_ms("sst", 5);
+            snapshot()
+        })
+        .await;
+
+        let s = captured.expect("snapshot inside scope");
+        assert_eq!(s.get_ops, 1);
+        assert_eq!(s.list_ops, 1);
+        assert_eq!(s.bytes_read, 4_096);
+        assert_eq!(s.footer_misses, 1);
+        assert_eq!(s.compute_ms.get("sst"), Some(&5));
+    }
+
+    #[tokio::test]
+    async fn free_helpers_noop_outside_scope() {
+        // No active scope: every helper must silently no-op, never panic, and
+        // snapshot() returns None.
+        record_op(IoOp::Get);
+        record_bytes_read(999);
+        record_footer(true);
+        record_compute_ms("sst", 1);
+        assert!(snapshot().is_none());
+    }
+
+    #[tokio::test]
+    async fn instrument_runs_and_returns_output() {
+        let out = instrument(Some("tenant-a".to_string()), "rest.v2.records.scan", async {
+            record_op_str("fetch_pax");
+            record_bytes_read(2_048);
+            42
+        })
+        .await;
+        assert_eq!(out, 42);
+    }
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -75,6 +75,12 @@ pub mod metering_event;
 /// Embedding-precision metrics — Prometheus gauges/counters per
 /// EMBEDDING_PRECISION_LLD_2026_05_22 §"Observability (Q11)" (PR 7b).
 pub mod precision_metrics;
+/// Per-query I/O trace bus (C0 — co-design trace substrate). Task-local
+/// accumulator of the physical-dimension quantities (object-store ops, bytes
+/// moved, footer-cache outcomes, cross-AZ egress, compute-ms by engine) the
+/// co-design cost model minimizes. See
+/// `docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` §4.1.
+pub mod io_trace;
 /// TD-064 predicate diagnostics bus — task-local channel that carries
 /// recall-shortfall events from AxisManager-deep search paths to the
 /// REST/gRPC handler that builds the SearchPlanTrace.

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3368,6 +3368,7 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
             // effectiveness, Dimensions 1 & 3).
             let st = reader.read_stats();
             io_trace::record_bytes_read(st.bytes_read);
+            io_trace::record_range_gets(st.range_gets);
             io_trace::record_footers(st.footer_hits, st.footer_misses);
             for mut record in recs {
                 record.variation_id = Some(table_schema.name.clone());

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -37,6 +37,7 @@ use proximadb_storage_common::{
 };
 
 use crate::metrics::consumption_metrics::record_object_store_op;
+use crate::observability::io_trace;
 use crate::services::operations::VectorOps;
 use crate::services::operations::batch_result::OperationMetrics;
 use crate::services::operations::vectors::{RichRecordGetRequest, RichSearchResult};
@@ -3136,10 +3137,12 @@ impl ObjectStoreVectorRecordStore {
             list_objects_with_suffix(&self.bridge, &prefix, PAX_SEGMENT_EXT).await?;
         let tenant_id = tenant_context.map(|tc| tc.tenant_id.as_str());
         record_object_store_op(tenant_id, "list_pax");
+        io_trace::record_op_str("list_pax");
 
         let mut records = Vec::new();
         for path in segment_paths {
             record_object_store_op(tenant_id, "fetch_pax");
+            io_trace::record_op_str("fetch_pax");
             let bytes = self
                 .bridge
                 .fetch_vector_segment(&path, tenant_id)
@@ -3147,6 +3150,7 @@ impl ObjectStoreVectorRecordStore {
                 .map_err(|err| {
                     anyhow!("ObjectStoreVectorRecordStore failed to fetch '{path}': {err}")
                 })?;
+            io_trace::record_bytes_read(bytes.len() as u64);
             records.extend(pax_segment_to_records(bytes, schema)?);
         }
         Ok(records)
@@ -3339,11 +3343,13 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
             list_objects_with_suffix(&self.bridge, &prefix, PAX_SEGMENT_EXT).await?;
         let tenant_id = tenant_context.map(|tc| tc.tenant_id.as_str());
         record_object_store_op(tenant_id, "list_pax");
+        io_trace::record_op_str("list_pax");
         let field_to_col: &(dyn Fn(&str) -> Option<i32> + Sync) = &pax_field_to_col;
 
         let mut out = Vec::new();
         'segments: for path in segment_paths {
             record_object_store_op(tenant_id, "fetch_pax_ranged");
+            io_trace::record_op_str("fetch_pax_ranged");
             let reader = RangedSegmentReader::open_with_cache(
                 self.bridge.as_ref(),
                 path.clone(),

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3363,6 +3363,12 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
                 .read_records_pruned(&filter, field_to_col, &[], &[])
                 .await
                 .map_err(|err| anyhow!("ranged pruned read '{path}': {err}"))?;
+            // Forward this open's physical read accounting into the per-query
+            // I/O trace (co-design C0: object-store bytes + footer-cache
+            // effectiveness, Dimensions 1 & 3).
+            let st = reader.read_stats();
+            io_trace::record_bytes_read(st.bytes_read);
+            io_trace::record_footers(st.footer_hits, st.footer_misses);
             for mut record in recs {
                 record.variation_id = Some(table_schema.name.clone());
                 if predicate.is_none_or(|p| p(&record)) {


### PR DESCRIPTION
## Summary

First deliverable of the co-design mandate (`docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` §4): **you cannot co-design against a trace distribution you do not capture.** The existing `consumption_metrics` counters meter four per-tenant *aggregates* (great for billing) but cannot answer the per-query questions the `ComputeScheduler` cost model (§3) needs — GETs paid, bytes moved, footer-cache hit/miss, read granularity, compute-ms by engine. This PR makes those observable per query.

## What's in it (5 commits, each green + layering hook passing)

- **`io_trace.rs` substrate (§4.1)** — a `tokio::task_local!` `IoTrace` accumulator mirroring the established `predicate_diagnostics` idiom: GET/PUT/LIST/DELETE ops, bytes read/written, footer hit/miss, **cross-AZ bytes (the unmetered KEU/egress gap)**, compute-ms by engine. Free helpers no-op safely outside a scope; `instrument(tenant, route, future)` is the handler one-liner; the snapshot emits a structured `tracing` event under `proximadb::io_trace`. **Adds no new billing authority** — per-tenant counters stay the chargeback source of truth; this is the finer per-query source.
- **Reader accounting (§4.1/§4.2)** — `RangedSegmentReader` accumulates per-open `SegmentReadStats` (bytes fetched, footer hits/misses, **range-GET count → `avg_get_bytes`** — the §2.1 read-granularity signal vs the ~8–16 MiB S3 optimum). Lives in `proximadb-storage-common` with no root-crate dependency; `record_store.rs` forwards into the trace on the ranged path.
- **`cloud_latency` evidence (§4.3)** — registered `unverified` in `BENCHMARK_EVIDENCE.toml` with the reproduction recipe (the e2e bench is local-FS only; the S3 latency floor that dominates cold ANN stays unverified until a MinIO/Wasabi run).
- **Export-ready snapshot (§4.4 enabler)** — `IoTraceSnapshot` derives serde `Serialize`/`Deserialize` (the OTLP-span-attr / JSON-sink / cost-model payload). Full OTLP-collector export is left **dependency-gated** (the tree lacks `opentelemetry`/`opentelemetry-otlp`/`tracing-opentelemetry`); the precise wiring plan is in the module docs + spec §4.4.

## Wiring (live)

- Trace populated at both PAX read paths in `record_store.rs`.
- `io_trace::instrument` co-located with the existing `predicate_diagnostics::scope` at the search handler (`rest/v2/records.rs`) → emits per request.

## Honest scope notes

- **§4.2 partial:** outstanding-request *depth* / byte backpressure / tail-hedging are deferred — the ranged reader awaits GETs serially today (depth 1), so those fields only become meaningful once a concurrent fetch scheduler lands (ties to the LanceDB-study AIMD roadmap). `range_gets`/`avg_get_bytes` are the part that's real now.
- **§4.4 dep-gated:** real OTLP export needs a deliberate ~4-crate dependency decision + a live collector to verify; this PR lands the export-ready payload + plan, not the dep.
- Spec §4.4 list annotated with per-item C0 status.

## Tests

- `proximadb-storage-common` `ranged_segment` 6/6 · `proximadb --lib observability::io_trace` 8/8 · `cargo check -p proximadb --lib` clean · `validate_benchmark_evidence.py` 12 claims pass · asciidoctor renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)