### PR TITLE
docs(design): in-process edge collapse HLD (co-design Network refinement)

### DIFF
--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -173,6 +173,18 @@ $0.02/GB is justified. The frontier (RDMA-disaggregated ANN — d-HNSW, 117× lo
 memory, arXiv 2505.11783) is the closest external analogue to ProximaDB's ANN-over-object-storage
 thesis and the long-horizon target.
 
+*Edge collapse (the inbound half of this dimension):* the reverse-proxy / load-balancer / API-gateway
+tier in front of the database is *pure boundary cost* — each L7 hop re-terminates TLS, re-parses the
+protocol, and re-derives identity/routing/policy the database already owns. The industry is itself
+dismantling the per-pod L7 sidecar (Istio Ambient GA Nov 2024, Cilium eBPF, Cloudflare's one-process
+model) toward "thin shared L4 front + L7 where the data context lives." For a database that *is* where
+the data context lives, the co-design move is to collapse the L7 edge *into the process* as a library
+(`proximadb-edge`), running *one* policy plane (TLS, authn, ABAC authz, tenant, rate-limit, trace) over
+*one* canonical envelope across the full surface area (pgwire + REST + gRPC + Flight) — removing the
+mesh tax (a sidecar ~halves throughput / doubles p99; ~70 GB RAM across 1000 pods) and the per-hop
+ALB-LCU / API-GW-per-request / cross-AZ cost, while making cross-surface policy consistency *structural*.
+Full HLD: link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19].
+
 *Billing meter:* presently *unmetered* — a gap. Add an egress/bytes-moved counter keyed by
 `(tenant, az_locality)` so cross-AZ and result-egress become a billable, optimizable dimension
 (→ *KEU*, the egress unit already named in the OSS boundary doc but not yet sourced from a trace).
@@ -358,6 +370,9 @@ enforcement; Arrow Flight SQL bulk-egress GA. | TENANT_COLLECTION_POD_AFFINITY, 
 retire static heuristics; seed the RL-planner cost model. | compute_scheduler.rs, course-correction P7
 | C5 — Governance SKUs | Tier-entitlement multiplier in the cost model; per-tier cache floor/ceiling;
 anvaiops authors tier→limit + pricing via claims. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver
+| C6 — Edge collapse | Collapse the L7 proxy/LB/gateway into `proximadb-edge`: one canonical envelope +
+one policy plane (TLS/authn/ABAC/tenant/rate-limit/trace) across pgwire+REST+gRPC+Flight; E0 closes the
+live pgwire-bypasses-middleware consistency gap. | network/multiplex+middleware, proximadb-security, io_trace; see link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[edge HLD]
 |===
 
 == 6. TAM Summary (per dimension)
@@ -395,3 +410,9 @@ predicate.
 policy boundary, freshness behavior, and maturity (P8).
 . *Meter every dimension.* Storage, read, egress, compute, and cache are each metered per-tenant;
 egress (KEU) is the open gap to close. Governance is metered as tier entitlement.
+. *One edge plane across all surfaces.* Authn/authz, rate-limiting, tenant extraction, and tracing run
+*once* over a canonical request envelope for *every* surface (pgwire, REST, gRPC, Arrow Flight) — never
+per-protocol and never in a separate gateway box that re-derives state the database owns. New surfaces
+or policies attach to the one `EdgePolicyPlane` stage, not a parallel path. Collapse L7 in-process;
+keep only a thin L4 front (P2, P8, P10; see
+link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[the edge HLD]).

--- a/docs/12-design/IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc
+++ b/docs/12-design/IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc
@@ -1,0 +1,287 @@
+= In-Process Edge Collapse: Proxy / Load-Balancer / API-Gateway as Library
+:toc: left
+:toclevels: 3
+:icons: font
+:sectnums:
+:revdate: 2026-06-19
+
+[.lead]
+A co-design refinement of *Dimension 2 — Networking*
+(link:CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19]):
+collapse the reverse-proxy / application-load-balancer / API-gateway tier *into the database process*
+as a cargo-workspace crate, so TLS, routing, authn/authz, rate-limiting, and tracing are handled
+*once, in-process, over shared memory* — across the full surface area (pgwire + REST + gRPC + Arrow
+Flight, carrying SQL/QL/UQL) — rather than replicated across separately-deployed, separately-billed
+network components that each add a hop, a TLS termination, and a copy of the policy. This removes the
+"mesh tax," eliminates cross-component policy drift, and makes consistency *structural* rather than
+configured.
+
+[IMPORTANT]
+====
+Owner: Architecture / Network. Scope: refinement of the co-design Network dimension; HLD + sequenced
+roadmap. Status: *Accepted direction; phased*. Subordinate to
+link:CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[the co-design spec] and the 2026-06-04 course
+correction. Builds directly on the *existing* in-process edge (`src/network/multiplex/**`,
+`src/network/middleware/**`, `src/network/tls/**`) and the C0 trace substrate
+(`src/observability/io_trace.rs`). Adds no new catalog/record/WAL/routing *authority* — it consolidates
+the edge into one policy plane and names the deployment seam. Proposed crate/type names
+(`proximadb-edge`, `EdgeRequest`, `EdgePolicyPlane`) are proposals, not yet code.
+====
+
+== 1. Thesis: the edge is pure boundary cost for a system that owns both sides
+
+A reverse proxy (nginx/Envoy), an L7 application load balancer (ALB), and an API gateway
+(Kong/Apigee/AWS API Gateway) are three boxes that each *terminate a connection, re-parse the
+protocol, evaluate policy, and re-emit to the next hop*. In a Kubernetes deployment they are separate
+pods or managed services chained in front of the database. Each chain link adds:
+
+* a *network hop* (serialize → TLS handshake → TCP → deserialize → process → re-serialize);
+* *latency* — every L7 hop adds ~0.5–3 ms + a TLS handshake (1–2 RTT cold) + an RTT;
+* *cost* — ALB hourly + per-LCU + $0.005/hr per public IPv4; API Gateway $1.00–3.50 per million
+requests; sidecar CPU/memory in *every* pod; and cross-AZ transfer at $0.01/GB *each direction* per
+hop that lands in another zone;
+* a *consistency hazard* — the identity, routing, rate-limit, and audit policy these components
+enforce is fragmented across components that do not share state, so it *drifts*.
+
+This is co-design principle *P2* ("the API/boundary is where performance and cost leak") at its
+sharpest: for a *stateful, multi-tenant database that already owns identity, routing, and policy
+internally* (`TenantContext`, `DrPathBuilder`, RBAC, `ComputeScheduler`), every external edge box
+*re-derives state the database already has* — and does it dumber, because it lacks the database's
+context (which tenant, which collection, which engine, what freshness SLA).
+
+The co-design move (P8 — *vertically integrate to optimize, then open at stable interfaces*): collapse
+the L7 edge into the process as a library, pay its cost *once* over shared memory, and keep only a
+*thin L4 front* external for connection-scale and HA. The request crosses the edge→engine boundary as
+a *function call*, not a network hop: zero extra serialization, zero extra TLS, one identity object,
+one trace.
+
+== 2. The surface area, and the consistency gap that already exists
+
+The edge must serve ProximaDB's *full surface area* uniformly:
+
+[cols="1,2,2", options="header"]
+|===
+| Surface | Carries | Today
+| *pgwire* (5433) | SQL / QL | *Separate TCP server — bypasses the multiplexer and its entire middleware
+stack.*
+| *REST* (5678) | JSON, UQL | Full Tower middleware stack.
+| *gRPC* (5679) | proto, UQL | *Subset* — Tonic interceptors for auth+metrics; rate-limit/backpressure
+not wired.
+| *Arrow Flight* (5680) | Flight SQL / IPC | Similar to gRPC (HTTP/2 native), subset coverage.
+|===
+
+[WARNING]
+====
+*The policy plane is not consistent across the surface area today.* pgwire — a primary wedge for the
+data-warehouse strategy — runs as its own TCP server and never traverses the `multiplex` + `middleware`
+edge, so tenant extraction, rate-limiting, authz, and tracing are applied *unevenly* across
+pgwire / REST / gRPC / Flight. This is not a hypothetical: it is a live correctness/security gap. An
+*external* gateway tier cannot fix it cleanly — it would have to re-implement edge logic *per protocol*
+(a pgwire proxy ≠ an HTTP API gateway ≠ a gRPC LB), producing four configs that drift. The in-process
+collapse fixes it *structurally*: one plane, one policy, all four surfaces.
+====
+
+== 3. External validation: the industry is dismantling the per-pod L7 tier
+
+The case is not contrarian — it is where the ecosystem is already converging:
+
+* *Istio Ambient Mesh* (GA v1.24, Nov 2024) *removes the per-pod sidecar*: L4 (mTLS/HBONE/telemetry)
+moves to a shared *ztunnel DaemonSet — one per node, not per pod*; L7 moves to *opt-in* waypoint
+proxies *per-namespace, not per-pod*. Stated motivation, verbatim: "large CPU and memory requirement
+for a proxy with every workload," sidecars "can break applications," and needing to "restart
+application pods with every new release." Claimed overhead reduction "can exceed 90%"; one user cut
+~45% of running containers. (istio.io/latest/blog/2024/ambient-reaches-ga)
+* *Cilium* does L4 service mesh *in the kernel via eBPF* — no proxy at all for L4, ~40–60% network
+overhead reduction. (reintech 2026 mesh comparison)
+* *The measured sidecar tax*: avg latency 2.1 ms → 4.8 ms (2.3×), p99 5.2 ms → 11.4 ms (2.2×),
+throughput 7,600 → 3,330 QPS — a per-pod sidecar roughly *halves throughput and doubles p99*; 1,000
+pods × ~70 MB ≈ 70 GB of RAM doing zero application work. (oneuptime 2026; Istio perf docs)
+* *L4-vs-L7 guidance* is exactly the co-design pattern: "use L4 at the edge for raw throughput, stable
+VIPs, and connection scale; L7 behind it for routing, TLS, and policy." For a database, *"behind it"
+= in the database process.* (sujeet.pro; gravitee)
+* *Embedded-edge precedents*: ScyllaDB/Cassandra *token-aware drivers eliminate the coordinator hop*
+("the protocol is the router"); Vitess `vtgate` is DB-aware routing that speaks MySQL-wire + gRPC;
+Cloudflare Workers pays the runtime cost *once per process* (thousands of isolates, ~1–5 MB each vs
+~50–500 MB/container); Rust `rpxy` (hyper + rustls + tokio) runs *30–60% faster than NGINX* at 100k+
+RPS on 4 cores — proving library-grade L7 in-process is real, not a science project.
+
+*Conclusion:* "thin shared L4 front + L7 where the data context lives" is the industry endpoint.
+Collapsing L7 into the DB process is the logical conclusion of that trend, not a departure from it.
+
+== 4. Design
+
+=== 4.1. The load-bearing idea: one canonical envelope, one policy plane
+
+The four protocol surfaces are *adapters*; behind them sits *one* request representation and *one*
+policy pipeline. This is what makes consistency structural.
+
+[source]
+----
+   pgwire │ REST │ gRPC │ Arrow Flight     ← wire protocols (unchanged, P8: standard seams)
+      └──────┴──────┴──────┴── protocol adapters (normalize → canonical) ──┐
+                                                                            ▼
+                                                          EdgeRequest { surface, tenant_hint,
+                                                            credential, op, payload, peer, tls_id }
+                                                                            │
+        ┌───────────────────────── EdgePolicyPlane (runs ONCE per request) ─────────────────────────┐
+        │ 1 TLS identity   → 2 authn   → 3 authz (policy/ABAC)   → 4 TenantContext (born here, P10)   │
+        │ → 5 rate-limit/quota (LimitsResolver)  → 6 io_trace span root (C0)  → 7 admission/backpressure│
+        └───────────────────────────────────────────────────────────────────────────────────────────┘
+                                                                            │
+                                                  in-process router → ComputeScheduler (data-aware)
+                                                                            │
+                                                              engine / storage (function call, no hop)
+----
+
+* *Protocol adapters* (extend the existing `multiplex` detectors; *add pgwire to the multiplexer*)
+normalize every surface into an `EdgeRequest`. SQL/QL/UQL ride inside `payload.op`; the plane is
+language-agnostic.
+* *`EdgePolicyPlane`* runs the seven steps *once*, over the canonical envelope, for *all four
+surfaces*. Each existing middleware (`tenant.rs`, `auth.rs`, `rate_limit.rs`, `backpressure.rs`,
+`request_id.rs`, `tls.rs`) becomes a *stage* of this single plane rather than a Tower layer wired
+unevenly per protocol.
+* *`TenantContext` is born at step 4* and threaded everywhere downstream (P10 — the boundary *is* the
+isolation + billing contract, fail-closed). There is exactly one place identity is established.
+
+=== 4.2. The security consistency plane (authn/authz, rate-limit, trace) — built for future needs
+
+This directly answers the requirement that *traces, rate-limiting, and policy-based authn/authz be
+consistent across the surface area and ready for future security/compliance needs*:
+
+* *Authn (step 2)* — one credential extractor over the envelope: JWT / API-key / mTLS client-cert
+identity, regardless of surface. (`proximadb-security` already holds this logic and is tokio-free —
+the right home for the policy core; the edge crate orchestrates it.)
+* *Authz (step 3)* — a *single policy engine* evaluating a *policy-based / ABAC* decision over
+`(identity, tenant, resource, action)` *once*, for pgwire and REST and gRPC and Flight alike. Today's
+RBAC becomes the first policy backend; the seam is shaped so a richer engine (OPA/Cedar-style ABAC,
+per-tenant policy, data-residency rules — *Dimension 5 governance*) plugs into *one* place rather than
+being bolted onto a separate gateway later. *Future security needs land at one seam, not four.*
+* *Rate-limit / quota (step 5)* — in-process, *tenant-aware* (the token bucket keys on the
+`TenantContext` born one step earlier, not a sidecar's IP guess), feeding the `LimitsResolver`
+OSS/enterprise seam. A tenant's quota is enforced where the tenant is actually known.
+* *Trace (step 6)* — the edge is the *root of the `io_trace` span tree* (the C0 substrate). One span
+covers edge → policy → router → engine → storage, so a request's identity, the policy decision, the
+bytes/GETs paid, and the engine chosen are *one correlated trace* — instead of stitching gateway access
+logs to DB logs across pods after the fact. This is also P12 (verify the integrated system) made
+operational.
+
+Because all of this runs over the *one* canonical envelope, *consistency is not enforced by discipline
+— it is the only thing the architecture can express.*
+
+=== 4.3. TLS, routing, and the capabilities still missing
+
+* *TLS termination* — unified at the edge via `rustls` (already present), *including pgwire* once it
+joins the multiplexer. One termination, one cert story, one mTLS identity feeding authn. Hot
+cert-reload (today requires restart) becomes an edge concern.
+* *Data-aware routing* — after the policy plane, the in-process router hands off to the
+`ComputeScheduler` (engine selection by `QueryShape`) and the tenant-partition resolver. This is the
+ScyllaDB lesson: routing that *knows the data layout* beats a generic L7 proxy's round-robin, and it
+costs nothing because it is a function call.
+* *Capabilities to add as in-process middleware* (the gap the code-map found): circuit-breaking /
+bulkhead, retry + tail-hedging (ties to the §4.2 I/O-scheduler trace), connection draining on graceful
+shutdown, and admission control under load. These are *stages added to the one plane*, automatically
+covering all four surfaces.
+
+=== 4.4. Deployment topologies — vertical inside, horizontal at L4 (P8)
+
+The crate enables *both* topologies from *one* binary, chosen by a role flag — never by forking code:
+
+. *Co-located (default).* Edge + policy + engine in one process; the boundary is a function call. A
+*thin shared L4 front* (cloud NLB, or a ztunnel-style per-node DaemonSet) provides stable VIPs,
+connection-scale, health-based node selection, and TLS *passthrough* (not termination) — the cheap,
+microsecond-latency layer the whole industry now keeps. *We collapse L7, not L4.*
+. *Disaggregated edge (opt-in, when measured to help).* The *same binary* in an `edge` role does
+TLS + policy + routing and forwards a canonical envelope to `compute`-role nodes over an internal
+transport — for workloads where edge work (TLS-heavy short connections, massive fan-out) genuinely
+dominates and should scale independently. This is the legitimate "independent scaling" case answered
+*without a different component or a second codebase* — P8's "open it horizontally" at a stable internal
+seam.
+
+== 5. Crate design (cargo workspace)
+
+[cols="1,2,2", options="header"]
+|===
+| Crate | Layer | Role
+| `proximadb-security` (exists) | horizontal, tokio-free | The *policy core*: credential parsing, RBAC →
+ABAC decision, identity types. Pure, testable, no runtime.
+| `proximadb-edge` (proposed) | platform | The *edge runtime*: protocol adapters, `EdgeRequest`,
+`EdgePolicyPlane` stages, TLS acceptor, router → scheduler handoff, L4/disaggregation transport.
+Orchestrates *proven libraries* (`rustls`, `hyper`, `tonic`, the pgwire codec) — it does **not**
+re-implement TLS/HTTP.
+| root `proximadb` | library | Hosts the engines/services the edge routes into; today's
+`network/multiplex` + `network/middleware` migrate into `proximadb-edge` as plane stages.
+|===
+
+*Robustness via proven libs, not hand-rolling* (the key counterargument-mitigation): the edge crate is
+an *orchestration* of `rustls` + `hyper` + `tonic` + the existing pgwire/Flight codecs — the same
+hardened components a standalone proxy uses — minus the extra hop, process, and bill.
+
+== 6. Cost & TAM framing (refinement of Dimension 2)
+
+What collapsing the L7 edge removes, mapped to the co-design cost model:
+
+[cols="2,3", options="header"]
+|===
+| Removed cost term | Source
+| ALB hourly + per-LCU + $0.005/hr/IPv4; API-Gateway $1.00–3.50 / M requests | one less *billed* L7 tier
+| Sidecar CPU/memory in every pod (~0.4 vCPU + ~50 MB / 1000 RPS; ~70 GB across 1000 pods) | no per-pod L7 proxy
+| Cross-AZ $0.01/GB *each way* per inter-hop | one less hop between gateway and DB (Dimension 2 / KEU)
+| Per-hop TLS handshake + RTT + parse (0.5–3 ms/hop) | one termination, one parse, in-process
+| Throughput halving / p99 doubling under sidecars | L7 paid once over shared memory, not per hop
+|===
+
+What is *retained* externally: a thin L4 VIP (cheap, microsecond, TLS-passthrough) for HA and
+connection scale, plus L3/L4/CDN DDoS scrubbing (which was never the L7 gateway's job anyway). The net
+is the "mesh tax" line item — frequently 10–20% of cluster compute at scale — *deleted*, with the
+latency and consistency wins on top. This is the Dimension-2 (Network, KEU) lever made concrete, and it
+compounds the Dimension-5 (Governance) margin story: one policy plane is also one *auditable*,
+*compliant*, *certifiable* surface instead of four.
+
+== 7. Tradeoffs and honest mitigations
+
+[cols="2,3", options="header"]
+|===
+| Legitimate case for a separate edge tier | In-process mitigation
+| *Blast radius* — an edge bug shouldn't crash the DB; TLS/parse CPU shouldn't starve queries. | Run the
+edge plane on a *dedicated tokio runtime / thread pool with explicit CPU+memory budgets* (the DB
+already isolates query vs ingest); bounded queues + admission control; keep the L4 front external.
+| *Independent scaling* of edge vs compute. | The *disaggregated-edge role* (§4.4.2) — same binary,
+scales the edge tier independently when *measured* to help, without a second component.
+| *DDoS scrubbing.* | Volumetric defense belongs at L3/L4/CDN regardless; the L7 gateway was never the
+right layer. Per-tenant rate-limits move *in-process* where tenant context lives.
+| *Battle-tested robustness.* | Embed *proven libraries* (`rustls`/`hyper`/`tonic`), don't hand-roll —
+the same code the standalone proxies run.
+| *Polyglot backend aggregation.* | Low value here — ProximaDB is one logical system; the gateway
+features that matter (authn, rate-limit, routing, trace) *are* the database's own concerns.
+|===
+
+*Guardrail (P11 — measure first):* the disaggregated-edge role and any "remove the external gateway"
+claim must be gated on the C0 trace + a load test, not asserted. The co-located default is the
+low-risk starting point; disaggregation is an evidence-gated option.
+
+== 8. Roadmap (sequenced; mapped to existing code)
+
+[cols="1,3,2", options="header"]
+|===
+| Phase | Work | Builds on
+| *E0 — close the consistency gap* | Route *pgwire* through the same policy stages as REST/gRPC (tenant,
+authn/authz, rate-limit, trace); wire rate-limit/backpressure to the gRPC/Flight paths. *Highest
+priority — it is a live security inconsistency.* | `network/multiplex`, `network/middleware`, pgwire server
+| *E1 — canonical envelope + one plane* | Introduce `EdgeRequest` + `EdgePolicyPlane`; refactor existing
+middleware into plane stages run once over the envelope for all four surfaces. | `proximadb-edge` (new)
+| *E2 — missing edge capabilities* | Circuit-breaker, retry/tail-hedge, connection draining, admission
+control as plane stages; hot TLS-cert reload. | §4.2 I/O-scheduler trace, `rustls` acceptor
+| *E3 — deployment roles* | `edge` / `compute` / co-located role flag; thin L4-front docs; internal
+edge→compute transport. | `src/bin/server.rs`, course-correction pseudo-distributed seam
+| *E4 — policy engine for future security* | ABAC/Cedar-style authz backend behind the step-3 seam;
+per-tenant policy, residency, audit — the Dimension-5 governance plug-in. | `proximadb-security`, OSS/enterprise boundary
+|===
+
+== 9. What this does *not* change
+
+* The *wire protocols are unchanged* — pgwire, HTTP/REST, gRPC, Arrow Flight stay standard (P8: open at
+stable seams). Clients, BI tools, and drivers see no difference.
+* No new *catalog/record/WAL/routing authority* — the edge consolidates existing policy/identity/trace
+into one plane and names the deployment seam; `ComputeScheduler` remains the routing authority,
+`TenantContext`/`DrPathBuilder` the isolation authority.
+* The external *L4* layer stays — this collapses L7, mirroring ambient mesh, not all load balancing.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -94,7 +94,15 @@ Read these in order for future-shaping architecture work:
    minimize, the per-query trace substrate that must feed it, the TAM/billing meter for each dimension,
    and the trace-before-tune mandate. Subordinate to the 2026-06-04 course correction; consolidates the
    caching recalibration, vector object economy, and OSS/enterprise boundary docs.
-17. `[SUPERSEDED] roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` +
+17. `IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc` +
+   Co-design refinement of the Network dimension: collapse the reverse-proxy / load-balancer /
+   API-gateway L7 tier *into the process* as a `proximadb-edge` cargo crate — one canonical request
+   envelope and one policy plane (TLS, authn, ABAC authz, tenant, rate-limit, trace) across the full
+   surface area (pgwire + REST + gRPC + Arrow Flight). Closes the live consistency gap (pgwire bypasses
+   the multiplexer/middleware today), removes the mesh tax + per-hop LB/gateway cost, and makes
+   cross-surface security policy structural. Keeps a thin L4 front (mirrors the industry's ambient-mesh
+   shift). Subordinate to `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
+18. `[SUPERSEDED] roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` +
    Legacy foundational mandate. Superseded by the Data Warehouse course correction on 2026-06-04.
 
 == Stable Reference Docs


### PR DESCRIPTION
## Summary

Extends the co-design architecture with the **inbound half of the Network dimension**: collapse the reverse-proxy / load-balancer / API-gateway L7 tier **into the database process** as a `proximadb-edge` cargo crate, instead of chaining separately-deployed, separately-billed network components that each add a hop, a TLS termination, and a copy of the policy.

**Thesis (co-design principle P2 — the boundary is where cost leaks):** for a stateful multi-tenant DB that already owns identity, routing, and policy (`TenantContext`, `DrPathBuilder`, RBAC, `ComputeScheduler`), every external edge box re-derives state the DB already has — and dumber, lacking the data context. Collapse L7 in-process, keep only a thin L4 front.

**Strongest validator — the industry is already doing this:** Istio Ambient (GA Nov 2024) removed the per-pod L7 sidecar (L4 → shared per-node ztunnel, L7 → opt-in), claiming >90% overhead reduction; Cilium does L4 in-kernel; Cloudflare Workers pays the runtime cost once per process. The convergent pattern — *"thin shared L4 front + L7 where the data context lives"* — is exactly this design, since for a database that *is* the DB process.

## Design

- **One canonical `EdgeRequest` envelope.** Protocol adapters normalize the **full surface area — pgwire + REST + gRPC + Arrow Flight (carrying SQL/QL/UQL)** — into one representation.
- **One `EdgePolicyPlane`, run once per request:** TLS identity → authn → **ABAC authz** → `TenantContext` (born here, P10) → tenant-aware rate-limit (`LimitsResolver`) → **`io_trace` span root** (the C0 substrate) → admission. Cross-surface consistency is **structural, not configured**.
- **Security consistency for future needs:** traces, rate-limiting, and policy-based authn/authz unified across all surfaces; future needs (Cedar/OPA-style ABAC, per-tenant policy, residency, audit — Dimension 5) plug into **one** seam.

## Live gap this names (E0, top priority)

The codebase map found that **pgwire currently runs as a separate TCP server (5433) bypassing the multiplexer + middleware entirely** — so tenant extraction, authz, rate-limit, and tracing are applied *unevenly* across pgwire / REST / gRPC / Flight today. That's a real security-consistency gap; roadmap **E0** routes pgwire through the same plane.

## Deployment, robustness, cost

- **Co-located default** (edge→engine = function call) + **opt-in disaggregated-edge role from the same binary** (P8 vertical-then-horizontal); thin L4 front for HA/DDoS.
- **Robustness via proven libraries** (`rustls`/`hyper`/`tonic`), not hand-rolling.
- **Removes:** ALB-LCU + $/hr-IPv4 + API-GW per-request + sidecar CPU/mem (~70 GB across 1000 pods; a sidecar ~halves throughput / doubles p99) + cross-AZ per hop + per-hop TLS/RTT. Honest tradeoffs (blast radius, scaling, DDoS, robustness) + mitigations included; disaggregation gated on the C0 trace (P11).

## Integration

- New `docs/12-design/IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc` (full HLD, roadmap E0–E4).
- Folded into `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (Dimension 2 edge-collapse note, roadmap row **C6**, mandate **#6 "one edge plane across all surfaces"**).
- Registered in the 12-design README (item 17).

## Notes

- Docs-only; adds **no new** catalog/record/WAL/routing authority — consolidates existing policy/identity/trace into one plane and names the deployment seam. Wire protocols stay standard (P8). Grounded in a 2-agent research + codebase map (sidecar/mesh tax, ambient-mesh validator, L4/L7, embedded-edge precedents; multiplex/middleware/TLS/pgwire code map). All three docs render clean (asciidoctor exit 0); layering hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)