### PR TITLE
feat(query): trace-driven route cost model — the co-design routing loop (C4)

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -111,6 +111,12 @@ impl ProximaDB {
         }
         CrossCacheOrchestrator::register_global(orchestrator.clone());
 
+        // Co-design C4: wire the io_trace flush to feed the trace-driven route
+        // cost model, so completed routed queries teach the ComputeScheduler the
+        // measured cost of each (shape-class, backend). Observe-mode today —
+        // routing is unchanged until a later flag-gated slice.
+        crate::query::route_cost_model::install_route_cost_observer();
+
         let (shared_services, collection_service) = network::multi_server::SharedServices::new(
             Some(metrics_collector.clone()),
             &config.storage,

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -222,11 +222,14 @@ pub async fn try_run_select(
     #[cfg(not(feature = "datafusion-integration"))]
     let parquet_backed = false;
 
-    let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select(
+    let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
             parquet_backed,
         },
+        // C4: observe-mode advisory from the trace-driven cost model — augments
+        // the reason for telemetry/EXPLAIN, never changes the backend.
+        Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
     );
     tracing::debug!(
         target: "proximadb::compute_route",
@@ -738,11 +741,12 @@ pub fn classify_select_route(
     };
     let engages = query_engages_relational_engine(query);
     Some(
-        crate::query::compute_scheduler::ComputeScheduler::new().route_select(
+        crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
             crate::query::compute_scheduler::QueryShape {
                 engages_relational: engages,
                 parquet_backed: false,
             },
+            Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
         ),
     )
 }
@@ -933,11 +937,12 @@ async fn route_and_plan_select(
             }
         }
     }
-    let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select(
+    let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: engages,
             parquet_backed,
         },
+        Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
     );
     let mut explanation = decision_to_explanation(&decision);
     // For the DataFusion route, disclose the concrete Parquet row-group split
@@ -1098,6 +1103,33 @@ mod route_explain_tests {
         assert!(
             !json.contains("execution_rows") && !json.contains("execution_elapsed_us"),
             "None ANALYZE metrics are skipped in JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn explain_surfaces_cost_model_advisory_once_warm() {
+        // C4 slice 3: once the trace-driven cost model has warmed history for a
+        // shape-class, the EXPLAIN reason discloses its (observe-mode) advisory.
+        use crate::observability::io_trace::IoTraceSnapshot;
+        use crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL;
+        let snap = IoTraceSnapshot {
+            range_gets: 5,
+            bytes_read: 1 << 20,
+            ..Default::default()
+        };
+        // The GROUP BY query classifies as "olap/native"; warm Native there.
+        for _ in 0..3 {
+            GLOBAL_ROUTE_COST_MODEL.observe_by_label("olap/native", "Native(Volcano)", &snap);
+        }
+        let expl = explain_select_route("SELECT service, count(*) FROM events GROUP BY service")
+            .expect("routable");
+        // Observe-mode: the chosen engine is unchanged ...
+        assert_eq!(expl.compute_route, "Native(Volcano)");
+        // ... but the cost-model advisory is now visible in the EXPLAIN reason.
+        assert!(
+            expl.reason.contains("cost-model"),
+            "advisory surfaced in EXPLAIN reason: {}",
+            expl.reason
         );
     }
 }

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -139,12 +139,30 @@ pub struct IoTrace {
     /// in a small map so a single query that touches multiple engines (e.g. a
     /// Volcano point lookup plus a DataFusion aggregate) attributes each.
     compute_ms: Mutex<BTreeMap<String, u64>>,
+    /// The route this query was served on, as `(shape_class, backend_label)`
+    /// strings (co-design C4). Stamped by the `ComputeScheduler` so the flush can
+    /// feed the trace-driven cost model the cost of *this kind of query on that
+    /// engine* — without io_trace depending on any query-layer type. `None` until
+    /// a route is chosen.
+    route: Mutex<Option<(String, String)>>,
 }
 
 impl IoTrace {
     /// Create an empty trace.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Stamp the route this query is served on (`shape_class`, `backend_label`).
+    /// Last write wins (a query is served by one engine). Neutral strings only.
+    pub fn record_route(&self, shape_class: &str, backend_label: &str) {
+        *self.route.lock().unwrap_or_else(|p| p.into_inner()) =
+            Some((shape_class.to_string(), backend_label.to_string()));
+    }
+
+    /// The stamped route, if any.
+    pub fn route(&self) -> Option<(String, String)> {
+        self.route.lock().unwrap_or_else(|p| p.into_inner()).clone()
     }
 
     /// Record one classified object-store operation.
@@ -368,9 +386,41 @@ pub fn record_compute_ms(engine: &str, ms: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_compute_ms(engine, ms));
 }
 
+/// Stamp the route (`shape_class`, `backend_label`) onto the active query trace.
+/// Silently no-ops outside an active scope. Neutral strings — io_trace never
+/// depends on a query-layer type.
+pub fn record_route(shape_class: &str, backend_label: &str) {
+    let _ = IO_TRACE.try_with(|t| t.record_route(shape_class, backend_label));
+}
+
 /// Snapshot the active query trace, if any.
 pub fn snapshot() -> Option<IoTraceSnapshot> {
     IO_TRACE.try_with(|t| t.snapshot()).ok()
+}
+
+/// Observer invoked at trace flush with `(snapshot, shape_class, backend_label)`
+/// when the query stamped a route. This is the dependency-inversion seam: the
+/// query layer registers a sink that feeds the trace-driven route cost model
+/// (C4), so io_trace ingests into routing *without depending on it*.
+type RouteObserver = dyn Fn(&IoTraceSnapshot, &str, &str) + Send + Sync;
+
+static ROUTE_OBSERVER: Mutex<Option<Box<RouteObserver>>> = Mutex::new(None);
+
+/// Install (or clear with `None`) the route-trace observer. Called once at
+/// startup by the query layer; replaceable in tests.
+pub fn set_route_observer(observer: Option<Box<RouteObserver>>) {
+    *ROUTE_OBSERVER.lock().unwrap_or_else(|p| p.into_inner()) = observer;
+}
+
+/// Feed the registered observer, if any, with a completed query's route trace.
+fn notify_route_observer(snap: &IoTraceSnapshot, shape_class: &str, backend_label: &str) {
+    if let Some(obs) = ROUTE_OBSERVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .as_ref()
+    {
+        obs(snap, shape_class, backend_label);
+    }
 }
 
 /// Bind a fresh [`IoTrace`] to `future` and await it. Lower-level than
@@ -393,8 +443,15 @@ where
         .scope(IoTrace::new(), async move {
             let out = future.await;
             // Still inside the scope: read and emit before the binding drops.
-            if let Ok(snap) = IO_TRACE.try_with(|t| t.snapshot()) {
+            if let Ok((snap, stamped_route)) = IO_TRACE.try_with(|t| (t.snapshot(), t.route())) {
                 snap.emit(tenant_id.as_deref(), &route);
+                // C4 ingestion: if a route was stamped, feed the cost model the
+                // measured cost of this (shape-class, backend). Skip empty traces.
+                if !snap.is_empty()
+                    && let Some((shape_class, backend_label)) = stamped_route
+                {
+                    notify_route_observer(&snap, &shape_class, &backend_label);
+                }
             }
             out
         })
@@ -498,6 +555,62 @@ mod tests {
         assert_eq!(s.footer_hits, 8);
         assert_eq!(s.footer_misses, 3);
         assert_eq!(s.footer_hit_ratio(), Some(8.0 / 11.0));
+    }
+
+    #[tokio::test]
+    async fn record_route_round_trips_in_scope_and_noops_outside() {
+        record_route("olap/parquet", "DataFusionLocal"); // outside scope: no-op
+        let r = scope(async {
+            record_route("olap/parquet", "DataFusionLocal");
+            IO_TRACE.try_with(|t| t.route()).ok().flatten()
+        })
+        .await;
+        assert_eq!(
+            r,
+            Some(("olap/parquet".to_string(), "DataFusionLocal".to_string()))
+        );
+    }
+
+    // Both flush→observer cases live in ONE test: the route observer is a
+    // process-global, so running the set/clear cases sequentially here avoids a
+    // race with a parallel sibling test. (Other instrument tests stamp no route,
+    // so they never invoke the observer regardless of install order.)
+    #[tokio::test]
+    async fn flush_feeds_route_observer_only_when_route_is_stamped() {
+        use std::sync::Arc;
+        let seen: Arc<Mutex<Vec<(IoTraceSnapshot, String, String)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        set_route_observer(Some(Box::new(move |snap, class, backend| {
+            sink.lock()
+                .unwrap()
+                .push((snap.clone(), class.to_string(), backend.to_string()));
+        })));
+
+        // (1) Stamped route → observer fires with the measured snapshot.
+        instrument(Some("t".to_string()), "pgwire.query", async {
+            record_op_str("fetch_pax_ranged");
+            record_bytes_read(8 << 20);
+            record_range_gets(2);
+            record_route("olap/parquet", "DataFusionLocal");
+        })
+        .await;
+
+        // (2) I/O but NO route stamped → observer must NOT fire.
+        instrument(None, "rest.v2.records.search", async {
+            record_op_str("fetch_pax");
+        })
+        .await;
+
+        set_route_observer(None); // reset global so other tests are unaffected
+
+        let got = seen.lock().unwrap();
+        assert_eq!(got.len(), 1, "observer fired exactly once (only the routed query)");
+        let (snap, class, backend) = &got[0];
+        assert_eq!(class, "olap/parquet");
+        assert_eq!(backend, "DataFusionLocal");
+        assert_eq!(snap.range_gets, 2);
+        assert_eq!(snap.bytes_read, 8 << 20);
     }
 
     #[test]

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -116,8 +116,10 @@ impl SelectRouteDecision {
     }
 }
 
-/// Short, stable label for a backend in EXPLAIN/telemetry output.
-fn backend_label(backend: &ComputeBackend) -> String {
+/// Short, stable label for a backend in EXPLAIN/telemetry output. Also the
+/// canonical key the trace-driven [`crate::query::route_cost_model`] aggregates
+/// observations under, so labels and cost-model keys never diverge.
+pub(crate) fn backend_label(backend: &ComputeBackend) -> String {
     match backend {
         ComputeBackend::Native => "Native(Volcano)".to_string(),
         ComputeBackend::DataFusionLocal => "DataFusionLocal".to_string(),
@@ -228,6 +230,44 @@ impl ComputeScheduler {
     pub fn route_select_plan(&self, shape: QueryShape) -> RoutedReadPlan {
         self.route_select(shape).routed_read_plan()
     }
+
+    /// Route a `SELECT`, then — if a trace-driven cost model is supplied —
+    /// **observe-mode** advise: consult the measured per-(shape-class, backend)
+    /// cost (co-design C4) and fold its recommendation into the decision's
+    /// `reason` for EXPLAIN/telemetry, *without changing the backend*.
+    ///
+    /// This closes the co-design loop (C0 trace → cost model → router) at the
+    /// lowest-risk altitude: the scheduler discloses what the trace *would*
+    /// recommend and whether it diverges from the static rule, so the
+    /// recommendation can be validated against real workloads before a later,
+    /// flag-gated slice flips live routing onto it. When the model has no warmed
+    /// history for the shape-class, the static decision is returned unchanged.
+    pub fn route_select_advised(
+        &self,
+        shape: QueryShape,
+        model: Option<&crate::query::route_cost_model::RouteCostModel>,
+    ) -> SelectRouteDecision {
+        let mut decision = self.route_select(shape);
+        let Some(model) = model else {
+            return decision;
+        };
+        let class = crate::query::route_cost_model::shape_class(&shape);
+        // Candidate engines the read path can actually serve this shape on today.
+        let candidates = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        if let Some(rec) = model.recommend(&class, &candidates) {
+            let advisory = if rec.backend == decision.backend {
+                format!("cost-model concurs ({})", rec.reason())
+            } else {
+                format!(
+                    "cost-model would prefer {} ({}) — observe-mode, route unchanged",
+                    backend_label(&rec.backend),
+                    rec.reason()
+                )
+            };
+            decision.reason = format!("{} | {advisory}", decision.reason);
+        }
+        decision
+    }
 }
 
 #[cfg(test)]
@@ -308,6 +348,76 @@ mod tests {
             })
             .explain_line();
         assert!(line.starts_with("Compute Route: Native(Volcano) (workload=Olap"));
+    }
+
+    fn io_snap(range_gets: u64, bytes_read: u64) -> crate::observability::io_trace::IoTraceSnapshot {
+        crate::observability::io_trace::IoTraceSnapshot {
+            range_gets,
+            bytes_read,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn advised_without_model_is_identical_to_static() {
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: false,
+        };
+        let s = ComputeScheduler::new();
+        let plain = s.route_select(shape);
+        let advised = s.route_select_advised(shape, None);
+        assert_eq!(advised.backend, plain.backend);
+        assert_eq!(advised.reason, plain.reason);
+    }
+
+    #[test]
+    fn advised_is_observe_mode_never_overrides_backend() {
+        use crate::query::route_cost_model::RouteCostModel;
+        // OLAP-on-native shape: static rule => Native(Volcano).
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: false,
+        };
+        let model = RouteCostModel::new().with_min_samples(1);
+        // Teach the model that DataFusion is far cheaper for this shape-class
+        // (few coalesced GETs vs Native's many small GETs).
+        for _ in 0..4 {
+            model.observe(
+                "olap/native",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(3, 16 << 20),
+            );
+            model.observe(
+                "olap/native",
+                &ComputeBackend::Native,
+                &io_snap(300, 16 << 20),
+            );
+        }
+        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        // Backend is UNCHANGED (observe-mode) ...
+        assert_eq!(advised.backend, ComputeBackend::Native);
+        // ... but the divergence is disclosed for EXPLAIN/validation.
+        assert!(advised.reason.contains("would prefer DataFusionLocal"));
+        assert!(advised.reason.contains("observe-mode"));
+    }
+
+    #[test]
+    fn advised_notes_when_cost_model_concurs() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: false,
+            parquet_backed: false,
+        };
+        let model = RouteCostModel::new().with_min_samples(1);
+        // Only Native has history for this shape-class → it is the min, concurring
+        // with the static OLTP→Native rule.
+        for _ in 0..3 {
+            model.observe("oltp/native", &ComputeBackend::Native, &io_snap(2, 8192));
+        }
+        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(advised.backend, ComputeBackend::Native);
+        assert!(advised.reason.contains("cost-model concurs"));
     }
 
     #[test]

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -202,7 +202,7 @@ impl ComputeScheduler {
     /// classification and reason vary, so the contract is locked before any
     /// second physical executor exists.
     pub fn route_select(&self, shape: QueryShape) -> SelectRouteDecision {
-        match (shape.engages_relational, shape.parquet_backed) {
+        let decision = match (shape.engages_relational, shape.parquet_backed) {
             // P1: OLAP shape over Parquet-backed (object-store) table(s) → DataFusion.
             (true, true) => SelectRouteDecision {
                 backend: ComputeBackend::DataFusionLocal,
@@ -223,7 +223,16 @@ impl ComputeScheduler {
                 workload_profile: CatalogWorkloadProfile::Oltp,
                 reason: "OLTP shape (point/simple select) — Volcano".to_string(),
             },
-        }
+        };
+        // C4 ingestion: stamp the chosen route onto the active io_trace scope (a
+        // no-op when unscoped, e.g. unit tests / EXPLAIN-only). The completed
+        // query's measured snapshot then feeds the trace-driven cost model at
+        // flush; empty traces are skipped, so EXPLAIN-only calls cost nothing.
+        crate::observability::io_trace::record_route(
+            &crate::query::route_cost_model::shape_class(&shape),
+            &backend_label(&decision.backend),
+        );
+        decision
     }
 
     /// Route a relational `SELECT` and materialize the typed read-route plan.

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -245,12 +245,13 @@ impl ComputeScheduler {
     /// cost (co-design C4) and fold its recommendation into the decision's
     /// `reason` for EXPLAIN/telemetry, *without changing the backend*.
     ///
-    /// This closes the co-design loop (C0 trace → cost model → router) at the
-    /// lowest-risk altitude: the scheduler discloses what the trace *would*
-    /// recommend and whether it diverges from the static rule, so the
-    /// recommendation can be validated against real workloads before a later,
-    /// flag-gated slice flips live routing onto it. When the model has no warmed
-    /// history for the shape-class, the static decision is returned unchanged.
+    /// This closes the co-design loop (C0 trace → cost model → router). By
+    /// default it is **observe-mode**: the scheduler discloses what the trace
+    /// *would* recommend and whether it diverges from the static rule, without
+    /// changing the backend. When the model's live override is enabled (slice 4,
+    /// flag-gated via `PROXIMADB_ROUTE_COST_OVERRIDE`) and a freshness-safe
+    /// challenger is confidently cheaper, the route is *flipped* to it. With no
+    /// warmed history the static decision is returned unchanged.
     pub fn route_select_advised(
         &self,
         shape: QueryShape,
@@ -261,7 +262,27 @@ impl ComputeScheduler {
             return decision;
         };
         let class = crate::query::route_cost_model::shape_class(&shape);
-        // Candidate engines the read path can actually serve this shape on today.
+
+        // Live override (flag-gated, confidence-gated). Only consider backends
+        // that are freshness-SAFE for this shape (see `override_candidates`), so
+        // the cost model can never flip a query onto an engine that would serve
+        // it incorrectly (e.g. a point/OLTP query onto a stale base snapshot).
+        if model.override_active() {
+            let safe = override_candidates(shape, &decision.backend);
+            if let Some(rec) = model.recommend_override(&class, &decision.backend, &safe) {
+                let prev = backend_label(&decision.backend);
+                decision.reason = format!(
+                    "{} | cost-model OVERRIDE {prev}→{} ({})",
+                    decision.reason,
+                    backend_label(&rec.backend),
+                    rec.reason()
+                );
+                decision.backend = rec.backend;
+                return decision;
+            }
+        }
+
+        // Observe-mode advisory (no behavior change): disclose the recommendation.
         let candidates = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
         if let Some(rec) = model.recommend(&class, &candidates) {
             let advisory = if rec.backend == decision.backend {
@@ -276,6 +297,23 @@ impl ComputeScheduler {
             decision.reason = format!("{} | {advisory}", decision.reason);
         }
         decision
+    }
+}
+
+/// The freshness-SAFE backend set a live override may choose among for `shape`.
+///
+/// Only OLAP-over-Parquet has more than one freshness-compatible engine: both
+/// Native's strong-freshness scan (WAL+RecordStorage) and DataFusion's
+/// base-snapshot scan correctly answer an analytic query, and both are already
+/// used by the static rule for this shape — so flipping between them is safe.
+/// OLTP (point/simple) is freshness-critical → never override off Native; OLAP
+/// on native storage has no Parquet base → DataFusion cannot serve it. Those
+/// keep only the static backend, so `recommend_override` can never flip them.
+fn override_candidates(shape: QueryShape, static_backend: &ComputeBackend) -> Vec<ComputeBackend> {
+    if shape.engages_relational && shape.parquet_backed {
+        vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal]
+    } else {
+        vec![static_backend.clone()]
     }
 }
 
@@ -427,6 +465,81 @@ mod tests {
         let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
         assert_eq!(advised.backend, ComputeBackend::Native);
         assert!(advised.reason.contains("cost-model concurs"));
+    }
+
+    #[test]
+    fn override_off_keeps_static_backend_even_when_model_disagrees() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+        }; // static => DataFusionLocal
+        let model = RouteCostModel::new().with_min_samples(1); // override OFF (default)
+        for _ in 0..5 {
+            model.observe("olap/parquet", &ComputeBackend::Native, &io_snap(3, 16 << 20));
+            model.observe(
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(300, 16 << 20),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        // Native is far cheaper, but override is off → static DataFusion holds.
+        assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
+        assert!(d.reason.contains("would prefer Native") && d.reason.contains("observe-mode"));
+    }
+
+    #[test]
+    fn override_on_flips_olap_parquet_to_the_cheaper_backend() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+        }; // static => DataFusionLocal
+        let model = RouteCostModel::new().with_min_samples(1);
+        model.set_override_enabled(true);
+        for _ in 0..5 {
+            model.observe("olap/parquet", &ComputeBackend::Native, &io_snap(3, 16 << 20));
+            model.observe(
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(300, 16 << 20),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        // Override fires: the route is flipped to the measured-cheaper engine.
+        assert_eq!(d.backend, ComputeBackend::Native);
+        assert!(d.reason.contains("OVERRIDE"));
+    }
+
+    #[test]
+    fn override_never_flips_freshness_critical_oltp() {
+        use crate::query::route_cost_model::RouteCostModel;
+        // Point/OLTP shape: static => Native, MUST stay Native (strong freshness)
+        // no matter what the cost model says.
+        let shape = QueryShape {
+            engages_relational: false,
+            parquet_backed: true,
+        };
+        let model = RouteCostModel::new().with_min_samples(1);
+        model.set_override_enabled(true);
+        // Even if DataFusion looks absurdly cheap for this class, it is not a
+        // freshness-safe candidate for OLTP, so it can never be chosen.
+        for _ in 0..5 {
+            model.observe("oltp/parquet", &ComputeBackend::Native, &io_snap(500, 16 << 20));
+            model.observe(
+                "oltp/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(1, 4096),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(
+            d.backend,
+            ComputeBackend::Native,
+            "OLTP must never be overridden off Native"
+        );
+        assert!(!d.reason.contains("OVERRIDE"));
     }
 
     #[test]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -120,6 +120,7 @@ pub mod cache; // C2: Query result caching for agentic AI workloads with repetit
 pub mod capability; // Capability registry for query validation and API parity
 pub mod columnar; // M2: Dual Columnar Execution - ColumnarReadProvider abstraction
 pub mod compute_scheduler; // Course-correction §5 P0: read-side multi-engine route selection
+pub mod route_cost_model; // Co-design C4: trace-driven route cost model (feeds the scheduler)
 pub mod ddl_dml; // DDL/DML execution (CREATE TABLE, INSERT, UPDATE, DELETE)
 pub mod distributed; // Distributed query coordination across cluster nodes
 pub mod execution; // New unified execution engine

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -37,6 +37,7 @@
 //! tunable. They are deliberately *not* calibrated dollar figures.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use crate::observability::io_trace::IoTraceSnapshot;
@@ -58,6 +59,13 @@ pub fn install_route_cost_observer() {
             GLOBAL_ROUTE_COST_MODEL.observe_by_label(shape_class, backend_label, snap);
         },
     )));
+    // Flag-gated live override (default OFF). When PROXIMADB_ROUTE_COST_OVERRIDE
+    // is truthy, the warmed model may flip freshness-safe routes to the cheaper
+    // backend (slice 4); otherwise the model stays observe-only.
+    let on = std::env::var("PROXIMADB_ROUTE_COST_OVERRIDE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    GLOBAL_ROUTE_COST_MODEL.set_override_enabled(on);
 }
 
 /// Stable shape-class key the model aggregates under. Coarse on purpose at C4 —
@@ -176,6 +184,13 @@ pub struct RouteCostModel {
     weights: CostWeights,
     /// Minimum samples before a backend's estimate is trusted enough to compare.
     min_samples: u64,
+    /// Live route override (flag-gated; default OFF → observe-only). Interior
+    /// mutability so the process-global model can be toggled at startup.
+    override_enabled: AtomicBool,
+    /// Minimum fractional cost advantage the recommended backend must beat the
+    /// static choice by before a live override fires — guards against flapping
+    /// on marginal/noisy differences.
+    min_advantage: f64,
 }
 
 impl Default for RouteCostModel {
@@ -185,13 +200,16 @@ impl Default for RouteCostModel {
 }
 
 impl RouteCostModel {
-    /// EWMA α=0.2, default neutral weights, 3-sample warmup before a cell counts.
+    /// EWMA α=0.2, default neutral weights, 3-sample warmup, override OFF,
+    /// 15% min advantage before an override fires.
     pub fn new() -> Self {
         Self {
             cells: Mutex::new(HashMap::new()),
             alpha: 0.2,
             weights: CostWeights::default(),
             min_samples: 3,
+            override_enabled: AtomicBool::new(false),
+            min_advantage: 0.15,
         }
     }
 
@@ -199,6 +217,22 @@ impl RouteCostModel {
     pub fn with_min_samples(mut self, n: u64) -> Self {
         self.min_samples = n.max(1);
         self
+    }
+
+    /// Tune the minimum cost advantage (fraction in [0,1)) required to override.
+    pub fn with_min_advantage(mut self, frac: f64) -> Self {
+        self.min_advantage = frac.clamp(0.0, 0.99);
+        self
+    }
+
+    /// Enable/disable live route override (flag-gated; default OFF).
+    pub fn set_override_enabled(&self, on: bool) {
+        self.override_enabled.store(on, Ordering::Relaxed);
+    }
+
+    /// Whether live override is currently enabled.
+    pub fn override_active(&self) -> bool {
+        self.override_enabled.load(Ordering::Relaxed)
     }
 
     fn score(&self, range_gets: f64, bytes_read: f64, compute_ms: f64) -> f64 {
@@ -281,6 +315,38 @@ impl RouteCostModel {
             samples: cost.samples,
             ranked,
         })
+    }
+
+    /// Live-override recommendation. Returns `Some(better)` ONLY when ALL hold:
+    /// override is enabled; a candidate other than `static_backend` is the
+    /// cheapest with warmed history; the static choice itself has warmed history
+    /// (so we have evidence to beat, not a cold guess); and the challenger is
+    /// cheaper by at least `min_advantage`. Otherwise `None` — the scheduler
+    /// keeps its static route. The freshness-safe `candidates` set is chosen by
+    /// the scheduler; this method only ranks cost, so it can never propose a
+    /// backend the caller didn't deem correct for the query.
+    pub fn recommend_override(
+        &self,
+        shape_class: &str,
+        static_backend: &ComputeBackend,
+        candidates: &[ComputeBackend],
+    ) -> Option<RouteRecommendation> {
+        if !self.override_active() {
+            return None;
+        }
+        let rec = self.recommend(shape_class, candidates)?;
+        if backend_label(&rec.backend) == backend_label(static_backend) {
+            return None; // the model already agrees with the static choice
+        }
+        let static_cost = self.estimate(shape_class, static_backend)?;
+        if static_cost.samples < self.min_samples {
+            return None; // not enough evidence about the static route to beat it
+        }
+        if rec.score < static_cost.score * (1.0 - self.min_advantage) {
+            Some(rec)
+        } else {
+            None // advantage too small — don't flap
+        }
     }
 }
 
@@ -419,6 +485,79 @@ mod tests {
             GLOBAL_ROUTE_COST_MODEL
                 .estimate(key, &ComputeBackend::Native)
                 .is_some()
+        );
+    }
+
+    /// Warm a model so DataFusion is much cheaper than Native for "olap/parquet".
+    fn warm_df_cheaper(m: &RouteCostModel) {
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 16 << 20, 50));
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(400, 16 << 20, 20));
+        }
+    }
+
+    #[test]
+    fn override_respects_the_enable_flag() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        warm_df_cheaper(&m);
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        // Default OFF → no override even with a huge advantage.
+        assert!(
+            m.recommend_override("olap/parquet", &ComputeBackend::Native, &cands)
+                .is_none()
+        );
+        m.set_override_enabled(true);
+        let rec = m
+            .recommend_override("olap/parquet", &ComputeBackend::Native, &cands)
+            .expect("confident, enabled → override");
+        assert_eq!(rec.backend, ComputeBackend::DataFusionLocal);
+    }
+
+    #[test]
+    fn override_requires_min_advantage() {
+        // DataFusion only ~5% cheaper than Native → below the 15% gate → no flip.
+        let m = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_min_advantage(0.15);
+        m.set_override_enabled(true);
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(95, 1 << 20, 10));
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(100, 1 << 20, 10));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        assert!(
+            m.recommend_override("olap/parquet", &ComputeBackend::Native, &cands)
+                .is_none(),
+            "marginal advantage must not flip the route"
+        );
+    }
+
+    #[test]
+    fn override_none_when_static_is_already_cheapest() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        m.set_override_enabled(true);
+        warm_df_cheaper(&m); // DataFusion cheapest
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        // Static already DataFusion → nothing cheaper to flip to.
+        assert!(
+            m.recommend_override("olap/parquet", &ComputeBackend::DataFusionLocal, &cands)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn override_needs_warmed_history_for_the_static_route() {
+        // Challenger has history but the static route does not → can't prove the
+        // override beats it, so no flip.
+        let m = RouteCostModel::new().with_min_samples(3);
+        m.set_override_enabled(true);
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 1 << 20, 5));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        assert!(
+            m.recommend_override("olap/parquet", &ComputeBackend::Native, &cands)
+                .is_none()
         );
     }
 }

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -1,0 +1,372 @@
+// Copyright 2026 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! Trace-driven route cost model (co-design C4 — the keystone of the loop).
+//!
+//! The `ComputeScheduler` ([`crate::query::compute_scheduler`]) chooses a
+//! physical engine from *static* shape heuristics. C4 closes the co-design loop
+//! the C0 trace substrate was built for: feed the *measured* per-query
+//! [`IoTraceSnapshot`] back so the scheduler can cost candidate routes from what
+//! they *actually paid* (object-store GETs, bytes moved, compute-ms) rather than
+//! a fixed rule — the Policy→RL evolution named in the course correction §5.2.
+//!
+//! ## How the loop works
+//!
+//! 1. A query runs under an `io_trace` scope (C0) and, at completion, yields an
+//!    [`IoTraceSnapshot`] of the physical quantities it paid.
+//! 2. [`RouteCostModel::observe`] folds that snapshot into a per-(shape-class,
+//!    backend) EWMA — the running cost of serving *this kind of query* on *that
+//!    engine*.
+//! 3. At the next route decision for the same shape-class,
+//!    [`RouteCostModel::recommend`] compares the learned cost of each candidate
+//!    backend and names the cheapest. The scheduler surfaces this as an
+//!    EXPLAIN/telemetry advisory (**observe-mode** — see
+//!    `ComputeScheduler::route_select_advised`); flipping live routing onto the
+//!    recommendation is a later, flag-gated slice.
+//!
+//! ## OSS boundary — neutral cost, not pricing
+//!
+//! The score combines *neutral relative I/O/compute units*, NOT currency. Per
+//! the OSS/enterprise boundary, *pricing* (KSU/KRU/KEU $ weights, tenant
+//! tiers) belongs to the commercial control plane; *routing* is OSS mechanism.
+//! The default [`CostWeights`] only encode the co-design ordering — an
+//! object-store round-trip dominates bandwidth, which dominates CPU (P5: the
+//! dominant cost term for a cloud DB is I/O round-trips, not compute) — and are
+//! tunable. They are deliberately *not* calibrated dollar figures.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::observability::io_trace::IoTraceSnapshot;
+use crate::query::compute_scheduler::{QueryShape, backend_label};
+use crate::query::table_write_plan::ComputeBackend;
+
+/// Stable shape-class key the model aggregates under. Coarse on purpose at C4 —
+/// it mirrors today's scheduler signals (`engages_relational` × `parquet_backed`);
+/// finer classes (cardinality, partition count, point-lookup) arrive with the
+/// §5.2 Phase-1 shape inputs and slot in here without changing the model.
+pub fn shape_class(shape: &QueryShape) -> String {
+    let workload = if shape.engages_relational {
+        "olap"
+    } else {
+        "oltp"
+    };
+    let base = if shape.parquet_backed {
+        "parquet"
+    } else {
+        "native"
+    };
+    format!("{workload}/{base}")
+}
+
+/// Neutral relative weights for the route cost score. NOT dollars (see module
+/// docs). They encode only the co-design cost ordering: a GET's fixed
+/// first-byte latency dominates a MiB of bandwidth, which dominates a ms of CPU.
+#[derive(Debug, Clone, Copy)]
+pub struct CostWeights {
+    /// Per ranged GET — the fixed-latency, per-request term (the dominant cost
+    /// for object-store-served reads).
+    pub per_get: f64,
+    /// Per MiB read — the bandwidth term.
+    pub per_mib_read: f64,
+    /// Per compute-millisecond — the CPU term (smallest for I/O-bound DB work).
+    pub per_compute_ms: f64,
+}
+
+impl Default for CostWeights {
+    fn default() -> Self {
+        // Illustrative neutral ordering (round-trip ≫ bandwidth ≫ CPU), tunable.
+        Self {
+            per_get: 20.0,
+            per_mib_read: 5.0,
+            per_compute_ms: 1.0,
+        }
+    }
+}
+
+/// One (shape-class, backend) cell: EWMA means of the cost-bearing quantities.
+#[derive(Debug, Clone, Copy, Default)]
+struct Cell {
+    range_gets: f64,
+    bytes_read: f64,
+    compute_ms: f64,
+    samples: u64,
+}
+
+impl Cell {
+    fn fold(&mut self, alpha: f64, range_gets: f64, bytes_read: f64, compute_ms: f64) {
+        if self.samples == 0 {
+            self.range_gets = range_gets;
+            self.bytes_read = bytes_read;
+            self.compute_ms = compute_ms;
+        } else {
+            self.range_gets = alpha * range_gets + (1.0 - alpha) * self.range_gets;
+            self.bytes_read = alpha * bytes_read + (1.0 - alpha) * self.bytes_read;
+            self.compute_ms = alpha * compute_ms + (1.0 - alpha) * self.compute_ms;
+        }
+        self.samples += 1;
+    }
+}
+
+/// Learned cost estimate for serving a shape-class on one backend.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RouteCost {
+    pub samples: u64,
+    pub range_gets: f64,
+    pub bytes_read: f64,
+    pub compute_ms: f64,
+    /// Weighted neutral score (lower is cheaper).
+    pub score: f64,
+}
+
+/// The scheduler-facing recommendation: the cheapest candidate that has enough
+/// history, plus the runners-up for EXPLAIN.
+#[derive(Debug, Clone)]
+pub struct RouteRecommendation {
+    pub backend: ComputeBackend,
+    pub score: f64,
+    pub samples: u64,
+    /// `(backend_label, score)` for every candidate with history, cheapest first.
+    pub ranked: Vec<(String, f64)>,
+}
+
+impl RouteRecommendation {
+    /// Compact reason string for the EXPLAIN/telemetry advisory.
+    pub fn reason(&self) -> String {
+        let ranked = self
+            .ranked
+            .iter()
+            .map(|(b, s)| format!("{b}={s:.1}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "min-cost over {} sample(s): {} [{}]",
+            self.samples,
+            backend_label(&self.backend),
+            ranked
+        )
+    }
+}
+
+/// Trace-driven, thread-safe route cost model. One instance is consulted at the
+/// route decision and fed by completed-query traces.
+#[derive(Debug)]
+pub struct RouteCostModel {
+    cells: Mutex<HashMap<(String, String), Cell>>,
+    alpha: f64,
+    weights: CostWeights,
+    /// Minimum samples before a backend's estimate is trusted enough to compare.
+    min_samples: u64,
+}
+
+impl Default for RouteCostModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RouteCostModel {
+    /// EWMA α=0.2, default neutral weights, 3-sample warmup before a cell counts.
+    pub fn new() -> Self {
+        Self {
+            cells: Mutex::new(HashMap::new()),
+            alpha: 0.2,
+            weights: CostWeights::default(),
+            min_samples: 3,
+        }
+    }
+
+    /// Override the warmup threshold (samples required before a cell is trusted).
+    pub fn with_min_samples(mut self, n: u64) -> Self {
+        self.min_samples = n.max(1);
+        self
+    }
+
+    fn score(&self, range_gets: f64, bytes_read: f64, compute_ms: f64) -> f64 {
+        self.weights.per_get * range_gets
+            + self.weights.per_mib_read * (bytes_read / (1024.0 * 1024.0))
+            + self.weights.per_compute_ms * compute_ms
+    }
+
+    /// Fold a completed query's measured trace into the (shape-class, backend)
+    /// cell. `compute_ms` is the snapshot's total across engines (the query was
+    /// served by `backend`, so its compute is attributed there).
+    pub fn observe(&self, shape_class: &str, backend: &ComputeBackend, snap: &IoTraceSnapshot) {
+        let key = (shape_class.to_string(), backend_label(backend));
+        let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+        cells.entry(key).or_default().fold(
+            self.alpha,
+            snap.range_gets as f64,
+            snap.bytes_read as f64,
+            snap.total_compute_ms() as f64,
+        );
+    }
+
+    /// Current learned estimate for one (shape-class, backend), if any history.
+    pub fn estimate(&self, shape_class: &str, backend: &ComputeBackend) -> Option<RouteCost> {
+        let key = (shape_class.to_string(), backend_label(backend));
+        let cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+        let c = cells.get(&key)?;
+        if c.samples == 0 {
+            return None;
+        }
+        Some(RouteCost {
+            samples: c.samples,
+            range_gets: c.range_gets,
+            bytes_read: c.bytes_read,
+            compute_ms: c.compute_ms,
+            score: self.score(c.range_gets, c.bytes_read, c.compute_ms),
+        })
+    }
+
+    /// Among `candidates`, recommend the cheapest backend whose cell has reached
+    /// the warmup threshold. Returns `None` when no candidate has enough history
+    /// (the scheduler then keeps its static decision). Ties keep candidate order.
+    pub fn recommend(
+        &self,
+        shape_class: &str,
+        candidates: &[ComputeBackend],
+    ) -> Option<RouteRecommendation> {
+        let mut scored: Vec<(ComputeBackend, RouteCost)> = candidates
+            .iter()
+            .filter_map(|b| {
+                self.estimate(shape_class, b)
+                    .filter(|c| c.samples >= self.min_samples)
+                    .map(|c| (b.clone(), c))
+            })
+            .collect();
+        if scored.is_empty() {
+            return None;
+        }
+        // Stable: sort by score, ties keep input order (sort_by is stable).
+        scored.sort_by(|a, b| {
+            a.1.score
+                .partial_cmp(&b.1.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let ranked = scored
+            .iter()
+            .map(|(b, c)| (backend_label(b), c.score))
+            .collect::<Vec<_>>();
+        let (backend, cost) = scored.into_iter().next()?;
+        Some(RouteRecommendation {
+            backend,
+            score: cost.score,
+            samples: cost.samples,
+            ranked,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(range_gets: u64, bytes_read: u64, compute_ms: u64) -> IoTraceSnapshot {
+        let mut s = IoTraceSnapshot {
+            range_gets,
+            bytes_read,
+            ..Default::default()
+        };
+        if compute_ms > 0 {
+            s.compute_ms.insert("engine".to_string(), compute_ms);
+        }
+        s
+    }
+
+    #[test]
+    fn shape_class_mirrors_scheduler_signals() {
+        assert_eq!(
+            shape_class(&QueryShape {
+                engages_relational: true,
+                parquet_backed: true
+            }),
+            "olap/parquet"
+        );
+        assert_eq!(
+            shape_class(&QueryShape {
+                engages_relational: false,
+                parquet_backed: false
+            }),
+            "oltp/native"
+        );
+    }
+
+    #[test]
+    fn no_history_yields_no_estimate_or_recommendation() {
+        let m = RouteCostModel::new();
+        assert!(m.estimate("olap/parquet", &ComputeBackend::Native).is_none());
+        assert!(
+            m.recommend(
+                "olap/parquet",
+                &[ComputeBackend::Native, ComputeBackend::DataFusionLocal]
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn warmup_threshold_gates_recommendation() {
+        let m = RouteCostModel::new().with_min_samples(3);
+        // Two observations — below the 3-sample warmup → not yet trusted.
+        m.observe("olap/parquet", &ComputeBackend::Native, &snap(100, 1 << 20, 5));
+        m.observe("olap/parquet", &ComputeBackend::Native, &snap(100, 1 << 20, 5));
+        assert!(
+            m.recommend("olap/parquet", &[ComputeBackend::Native])
+                .is_none()
+        );
+        m.observe("olap/parquet", &ComputeBackend::Native, &snap(100, 1 << 20, 5));
+        assert!(
+            m.recommend("olap/parquet", &[ComputeBackend::Native])
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn recommends_the_cheaper_backend_from_measured_traces() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        // DataFusion route pays FEW big coalesced GETs; Native pays MANY small
+        // GETs for the same shape — the trace says DataFusion is cheaper here.
+        for _ in 0..5 {
+            m.observe(
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &snap(4, 16 << 20, 50),
+            );
+            m.observe(
+                "olap/parquet",
+                &ComputeBackend::Native,
+                &snap(400, 16 << 20, 20),
+            );
+        }
+        let rec = m
+            .recommend(
+                "olap/parquet",
+                &[ComputeBackend::Native, ComputeBackend::DataFusionLocal],
+            )
+            .expect("history exists");
+        // GET-dominated score → DataFusion (4 GETs) beats Native (400 GETs).
+        assert_eq!(rec.backend, ComputeBackend::DataFusionLocal);
+        assert_eq!(rec.ranked.len(), 2);
+        assert_eq!(rec.ranked[0].0, "DataFusionLocal");
+        // Cheapest-first ordering.
+        assert!(rec.ranked[0].1 < rec.ranked[1].1);
+    }
+
+    #[test]
+    fn estimate_reflects_ewma_of_observations() {
+        let m = RouteCostModel::new();
+        for _ in 0..10 {
+            m.observe("oltp/native", &ComputeBackend::Native, &snap(2, 8192, 1));
+        }
+        let est = m
+            .estimate("oltp/native", &ComputeBackend::Native)
+            .expect("history");
+        assert_eq!(est.samples, 10);
+        // EWMA of a constant series converges to that constant.
+        assert!((est.range_gets - 2.0).abs() < 1e-6);
+        assert!(est.score > 0.0);
+    }
+}

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -37,11 +37,28 @@
 //! tunable. They are deliberately *not* calibrated dollar figures.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use crate::observability::io_trace::IoTraceSnapshot;
 use crate::query::compute_scheduler::{QueryShape, backend_label};
 use crate::query::table_write_plan::ComputeBackend;
+
+/// Process-global trace-driven route cost model. Fed by completed routed queries
+/// (via [`install_route_cost_observer`]) and consulted at the route decision.
+pub static GLOBAL_ROUTE_COST_MODEL: LazyLock<RouteCostModel> = LazyLock::new(RouteCostModel::new);
+
+/// Wire the io_trace flush to feed [`GLOBAL_ROUTE_COST_MODEL`]: every completed
+/// query that stamped a route (via `ComputeScheduler`) folds its measured
+/// snapshot into the model. Call once at startup. This is the query-layer half
+/// of the dependency-inversion seam — io_trace defines the observer type and
+/// never depends on this module.
+pub fn install_route_cost_observer() {
+    crate::observability::io_trace::set_route_observer(Some(Box::new(
+        |snap, shape_class, backend_label| {
+            GLOBAL_ROUTE_COST_MODEL.observe_by_label(shape_class, backend_label, snap);
+        },
+    )));
+}
 
 /// Stable shape-class key the model aggregates under. Coarse on purpose at C4 —
 /// it mirrors today's scheduler signals (`engages_relational` × `parquet_backed`);
@@ -194,7 +211,14 @@ impl RouteCostModel {
     /// cell. `compute_ms` is the snapshot's total across engines (the query was
     /// served by `backend`, so its compute is attributed there).
     pub fn observe(&self, shape_class: &str, backend: &ComputeBackend, snap: &IoTraceSnapshot) {
-        let key = (shape_class.to_string(), backend_label(backend));
+        self.observe_by_label(shape_class, &backend_label(backend), snap);
+    }
+
+    /// Like [`Self::observe`] but keyed by the backend's label string directly —
+    /// the form the io_trace ingestion observer uses, since io_trace stamps a
+    /// neutral label, not a `ComputeBackend` (no layer-up dependency).
+    pub fn observe_by_label(&self, shape_class: &str, backend_label: &str, snap: &IoTraceSnapshot) {
+        let key = (shape_class.to_string(), backend_label.to_string());
         let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
         cells.entry(key).or_default().fold(
             self.alpha,
@@ -368,5 +392,33 @@ mod tests {
         // EWMA of a constant series converges to that constant.
         assert!((est.range_gets - 2.0).abs() < 1e-6);
         assert!(est.score > 0.0);
+    }
+
+    #[test]
+    fn observe_by_label_matches_typed_observe() {
+        // The label-keyed ingestion form (used by the io_trace observer) lands in
+        // the same cell as the typed observe.
+        let m = RouteCostModel::new();
+        m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 16 << 20, 50));
+        let by_label = m
+            .estimate("olap/parquet", &ComputeBackend::DataFusionLocal)
+            .expect("label-keyed observation is visible to typed estimate");
+        assert_eq!(by_label.samples, 1);
+        assert!((by_label.range_gets - 4.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn global_model_is_usable() {
+        // Feed the process-global model directly under a unique key (avoids the
+        // observer global, so no cross-test race) and read it back.
+        let key = "test/global-usable-unique";
+        for _ in 0..3 {
+            GLOBAL_ROUTE_COST_MODEL.observe_by_label(key, "Native(Volcano)", &snap(2, 4096, 1));
+        }
+        assert!(
+            GLOBAL_ROUTE_COST_MODEL
+                .estimate(key, &ComputeBackend::Native)
+                .is_some()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the co-design loop the C0 trace substrate was built for: a `ComputeScheduler` that costs routes from **measured per-query traces** instead of static shape heuristics — the "intelligent multi-engine routing over decoupled object storage" thesis (course-correction §5.2, Policy→RL), now mechanized. Four slices take it from observe-only to a safe, flag-gated live override.

## The loop (4 commits)

1. **`829404843` — trace-driven cost model (observe-mode).** New `route_cost_model.rs`: a `RouteCostModel` learns a per-(shape-class, backend) EWMA from `IoTraceSnapshot`s and recommends the cheapest via a **neutral** weighted score (per-GET ≫ per-MiB ≫ per-compute-ms — the co-design ordering that I/O round-trips dominate; *not* dollars — pricing stays the commercial control plane per the OSS boundary). `route_select_advised` consults it in observe-mode: augments the decision reason, never changes the backend.
2. **`1b81acd8d` — self-feeding ingestion.** Dependency-inverted seam (io_trace never depends on the query layer): a query stamps its route via `record_route`; at flush, `instrument` invokes a registered observer with the snapshot; the query layer's `install_route_cost_observer` (wired in `ProximaDB::new`) feeds `GLOBAL_ROUTE_COST_MODEL`. `route_select` stamps the chosen route universally (no-op when unscoped). The loop now self-feeds in production.
3. **`7f6661a02` — EXPLAIN surfacing.** The three pgwire route-decision builders use `route_select_advised(GLOBAL)`, so the SELECT EXPLAIN `reason` discloses the trace-driven advisory and any divergence from the static rule. Byte-identical when the model is cold.
4. **`14dc893e6` — flag-gated live override.** The first real routing change, **safe by construction**: flag-gated (`PROXIMADB_ROUTE_COST_OVERRIDE`, default OFF); **freshness-safe** (only OLAP-over-Parquet has >1 correct engine — OLTP/point and OLAP-on-native can *never* be flipped off Native); confidence-gated (challenger must be cheapest-with-warmed-history, the static route must also be warmed, and cheaper by ≥15% to prevent flapping). Reversible by the flag.

## Safety

- Default behavior is **unchanged** (override OFF; observe-mode only).
- The override can never route a freshness-critical query onto a stale/incompatible engine — enforced by `override_candidates(shape)`, not by luck.
- No new authority: `ComputeScheduler` stays the routing authority; this adds a measured cost input. Cost units are neutral (OSS mechanism), not pricing.

## Tests

36 green across `route_cost_model` + `compute_scheduler` + `relational_pipeline`, including the safety guards: `override_never_flips_freshness_critical_oltp`, `override_off_keeps_static_backend`, `override_on_flips_olap_parquet_to_the_cheaper_backend`, warmup/min-advantage gating, and `explain_surfaces_cost_model_advisory_once_warm`. `cargo check` clean; layering hook passed on every commit.

## Follow-ups (Phase 2 / RLPlanner, not in scope)

An exploration policy so both backends accrue history (today the override is conservative — it won't flip until both are warm), and richer shape-classes (cardinality, partition count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)