### PR TITLE
feat(pgwire): bring pgwire under the edge policy plane — io_trace + request-id (edge E0)

### DIFF
--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -975,12 +975,20 @@ impl PostgresProtocol {
         controls: ExecutionControls,
     ) -> Result<()> {
         let tenant = self.pgwire_resolve_read_tenant().await;
-        crate::observability::io_trace::instrument(
-            Some(tenant),
-            "pgwire.query",
-            self.execute_query_with_controls_inner(query, controls),
-        )
-        .await
+        // E0 (edge consistency): give every pgwire query a request-id correlation
+        // scope — matching REST's request_id middleware — so logs and error
+        // envelopes carry it; then the per-query io_trace span (tenant-attributed).
+        let request_id = crate::network::middleware::request_id::RequestId::generate();
+        proximadb_api::rest::errors::REQUEST_ID
+            .scope(
+                request_id.0,
+                crate::observability::io_trace::instrument(
+                    Some(tenant),
+                    "pgwire.query",
+                    self.execute_query_with_controls_inner(query, controls),
+                ),
+            )
+            .await
     }
 
     async fn execute_query_with_controls_inner(

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -960,7 +960,30 @@ impl PostgresProtocol {
     }
 
     /// Execute a translated query with request-scoped execution controls.
+    ///
+    /// E0 (in-process edge — `IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19`): every
+    /// pgwire query is scoped in a per-query `io_trace` span with tenant
+    /// attribution, so the pgwire surface emits the *same* per-query I/O trace
+    /// (object-store GETs/bytes, footer-cache outcomes, engine-ms) as REST/gRPC
+    /// — closing the consistency gap where pgwire bypassed the edge middleware
+    /// entirely. The tenant is the one already resolved for read routing
+    /// (TD-064); no new identity source is introduced. The wrapper is a thin
+    /// scope around the unchanged body in `_inner`.
     async fn execute_query_with_controls(
+        &mut self,
+        query: &str,
+        controls: ExecutionControls,
+    ) -> Result<()> {
+        let tenant = self.pgwire_resolve_read_tenant().await;
+        crate::observability::io_trace::instrument(
+            Some(tenant),
+            "pgwire.query",
+            self.execute_query_with_controls_inner(query, controls),
+        )
+        .await
+    }
+
+    async fn execute_query_with_controls_inner(
         &mut self,
         query: &str,
         controls: ExecutionControls,
@@ -4525,6 +4548,11 @@ impl PostgresProtocol {
                 return self.emit_portal_page(portal_name, max_rows as usize).await;
             }
 
+            // E0 follow-up: this portal-SELECT fast-path returns before reaching
+            // `execute_query_with_controls`, so it is the one pgwire query path
+            // not yet under the per-query `io_trace` span. Bring it under the
+            // same scope in the next slice (kept out here to avoid restructuring
+            // the borrow in this `&&` let-chain).
             if query.trim_start().to_uppercase().starts_with("SELECT")
                 && let Some(result) = self
                     .try_run_relational_select_pipeline(query, ExecutionControls::default())


### PR DESCRIPTION
## Summary

E0 of the in-process edge collapse (`IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19`): close the consistency gap where the **pgwire surface bypasses the edge middleware**. pgwire runs as a separate TCP server (5433) outside `network/multiplex` + `network/middleware`, so per-query tracing and request-id correlation that REST/gRPC get were absent on pgwire. This brings the two legs into parity.

## Commits

1. **`562c3f95a` — per-query io_trace span.** Wrap the universal pgwire query chokepoint `execute_query_with_controls` in `io_trace::instrument(tenant, "pgwire.query", …)` via a thin wrapper around the unchanged body (`_inner`). Tenant is the one already resolved for read routing (TD-064). Because `record_store`'s PAX read paths record into the active io_trace scope (C0, #90), **pgwire SELECTs now emit the same per-query I/O trace as REST/gRPC** — making the trace plane consistent across surfaces.
2. **`908ec0011` — request-id correlation scope.** Every pgwire query runs inside a `RequestId` scope via the shared `proximadb_api::rest::errors::REQUEST_ID` task-local (matching REST's request_id middleware), around the io_trace span — so a query's correlation id, tenant, and I/O trace all line up in logs and error envelopes.

## Notes

- Transparent wraps (return the inner output unchanged): `pgwire_relational_engine_e2e` passes 1/1; `cargo check` clean; layering hook passed.
- Covers the simple-query path and the extended-query/portal fallthrough. One narrower path (the portal-SELECT relational fast-path) is marked with a precise in-code follow-up note.
- Composes with C4 (#92): every routed pgwire query now under a trace will teach the route cost model, widening its training signal.

## Next E0 slices

Per-tenant rate-limiting on pgwire — by exposing a reusable per-key check on the existing middleware `RateLimitState` (converge, don't duplicate the limiter) and threading a shared limiter to `PostgresServer` — then backpressure and auth, toward the unified `EdgePolicyPlane` (E1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)