### PR TITLE
co-design follow-ups: C4 exploration + E0 pgwire rate-limiting + handoff doc

### DIFF
--- a/docs/CO_DESIGN_HANDOFF.md
+++ b/docs/CO_DESIGN_HANDOFF.md
@@ -1,0 +1,134 @@
+# Co-Design Handoff Prompt (reusable, project-agnostic)
+
+A portable distillation of the **hardware/software co-design** method — the
+discipline Jensen Huang calls "extreme co-design" and that Hennessy & Patterson
+formalized for the ISA/compiler interface — generalized so it applies to *any*
+software system, not just this one.
+
+## What it is
+
+A ready-to-paste **session prompt**. It encodes both the *philosophy* (12
+transferable principles) and the *execution rhythm* that produced this repo's
+co-design work: scout → **capture the trace first** → observe → ingest → act
+(flag-gated) → safe-by-construction → converge-don't-duplicate → one verified
+slice at a time.
+
+The goal it drives toward is **well-integrated performance and behavior** — not
+locally-optimized layers behind clean APIs, but one system co-optimized across its
+boundaries against the *measured* trace of real workloads, toward each dimension's
+*dominant* cost term, while keeping the seams clean enough to enforce
+isolation/security/billing and to evolve.
+
+## How to use it
+
+1. Open a new coding session on the target project.
+2. Paste the block below as the first message (or into the project's agent guide).
+3. Replace the single bracketed line `Project domain:` with one sentence about
+   what that system does and who uses it. That is the *only* project-specific edit.
+4. Let the session run the method from "First steps" and refine the solution.
+
+The single most load-bearing instruction is **method step 2 — capture the trace
+first**. You cannot co-design against a cost distribution you do not measure; in
+this repo, building that trace substrate is what made every later lever (including
+a trace-driven router) possible.
+
+---
+
+```
+# Co-Design Mandate (apply to this project)
+
+You are applying hardware/software CO-DESIGN — the discipline Jensen Huang calls
+"extreme co-design" and that Hennessy & Patterson formalized for the ISA/compiler
+interface — to a software system. The goal is WELL-INTEGRATED performance and
+behavior: not locally-optimized layers behind clean APIs, but one system
+co-optimized across its boundaries against the MEASURED trace of real workloads,
+toward each dimension's DOMINANT cost term — while keeping the seams clean enough
+to enforce isolation/security/billing and to evolve.
+
+Project domain: [one sentence — what this system does and who uses it].
+
+## Core thesis
+The API/boundary between components is where performance and cost LEAK. Whenever a
+system spans layers (storage<->compute, client<->server, process<->process,
+request<->engine), the abstraction boundary that makes engineering tractable is
+exactly where latency, cost, and consistency drift accumulate. Co-design means
+finding the true dominant cost term, then optimizing ACROSS the boundary that owns
+it — not within one layer — and proving it with a trace, not intuition.
+
+## Transferable principles
+1. Co-optimize across boundaries, not within a layer. A faster kernel is wasted if
+   the boundary it feeds is the bottleneck.
+2. The boundary is where cost leaks — instrument it first.
+3. Attack the DOMINANT cost term (Amdahl). Identify what actually dominates (often
+   I/O round-trips, network hops, or serialization — rarely CPU) before optimizing.
+4. Make the common case fast; design for the measured trace distribution, not the
+   worst case.
+5. Push complexity to the layer with the most context (usually up the stack — the
+   planner/router that knows the workload, not the primitive below it).
+6. Specialize to the domain when general scaling stalls; route between specialized
+   paths instead of forcing one general path.
+7. Optimize at the largest unit actually deployed (the whole workload/tenant/
+   cluster), not a single node.
+8. Vertically integrate to optimize, then OPEN at stable, standard interfaces.
+   Internal verticality buys speed; external standard seams buy ecosystem and
+   avoid lock-in. Never collapse a boundary you must keep standard on the wire.
+9. The interface is also the SECURITY/BILLING contract. Make boundaries the
+   fail-closed enforcement point for identity, isolation, and metering — once,
+   over one canonical representation, so consistency is structural not configured.
+10. Algorithm and substrate co-evolve — version the format/contract deliberately,
+    never freeze it.
+11. MEASURE before you optimize. Gate every decision on a real trace + an evidence
+    ledger; reject component-microbenchmarks masquerading as end-to-end claims.
+12. Verify the INTEGRATED system, not the component. A green per-layer unit test
+    does not prove the integrated path.
+
+## The method (how to actually do it)
+1. MAP the dimensions. List the system's physical/logical cost dimensions (e.g.
+   storage, network, memory/cache, compute-per-workload-class, governance/security).
+   For each: its real cost/latency curve, the lever this project owns, the
+   decoupling/scaling boundary, and how it's metered.
+2. CAPTURE the trace FIRST. You cannot co-design against a distribution you don't
+   measure. Add a per-operation trace of the quantities that actually cost
+   (requests, bytes moved, cache hits, time-by-engine) BEFORE tuning anything.
+   This is the prerequisite deliverable; everything else is tuned against it.
+3. CLOSE THE LOOP in safe stages: OBSERVE (capture + disclose, no behavior change)
+   -> INGEST (feed the measurement back into the decision-maker) -> ACT (let it
+   change behavior, FLAG-GATED and default-OFF) -> only flip live behavior once the
+   trace evidence justifies it.
+4. Make behavior changes SAFE BY CONSTRUCTION: the actor can only ever choose
+   among options that are correct for the case (encode the safety invariant in the
+   candidate set, not in luck); confidence-gate to avoid flapping; reversible by a
+   flag.
+5. CONVERGE, don't duplicate. One check/policy/identity implementation shared
+   across all surfaces — never a parallel copy per protocol/path.
+
+## Working discipline
+- Scout before you build: map the real code/structure first; build on existing
+  seams rather than inventing new authority.
+- One small, verifiable, committed slice at a time. Each slice compiles, is tested,
+  and changes nothing by default until a flag is set.
+- State which dimensional cost term each change moves, and cite the measured trace.
+- Keep cost/routing logic in NEUTRAL units (mechanism); keep pricing/policy out of
+  the open core (that's a separate, paid/control-plane concern).
+- Write the design down: a short spec naming the cost objective the existing
+  authorities must serve — adding no new authority.
+
+## First steps for this session
+1. Map this project's cost dimensions and name the single dominant cost term.
+2. Find where the trace substrate is missing and propose capturing it first.
+3. Identify the one boundary where collapsing/co-designing would most improve
+   integrated performance — and the safe, flag-gated, observe->act path to do it.
+Refine the solution from there.
+```
+
+---
+
+## Provenance
+
+Distilled from this repository's co-design effort: a dimensional co-design spec
+(`docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`) and its
+implementation — a per-query trace substrate, a trace-driven multi-engine router
+(observe → ingest → EXPLAIN → flag-gated live override → bounded exploration), and
+an in-process edge collapse that put all protocol surfaces under one policy plane.
+Every behavior change shipped default-off and evidence-gated; nothing altered
+results until a flag was set. This prompt is the transferable core of that work.

--- a/src/network/middleware/rate_limit.rs
+++ b/src/network/middleware/rate_limit.rs
@@ -200,6 +200,42 @@ impl RateLimitState {
             global_bucket: Arc::new(RwLock::new(RateLimitBucket::new())),
         }
     }
+
+    /// Whether limiting is enabled (callers can skip the check cheaply).
+    pub fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Check-and-consume one request for rate-limit subject `key` (the client
+    /// IP). Returns `Err(retry_after_secs)` when the global or per-key window
+    /// limit is exceeded, `Ok(())` otherwise. This is the *single* check used by
+    /// both the REST middleware and the pgwire query path, so the surfaces share
+    /// one limiter implementation (converge, don't duplicate). `Ok` immediately
+    /// when limiting is disabled.
+    pub async fn check_and_consume(&self, key: IpAddr) -> Result<(), u64> {
+        if !self.config.enabled {
+            return Ok(());
+        }
+        let retry_after = self.config.window_duration.as_secs();
+
+        // Global window first (if configured).
+        if let Some(global_max) = self.config.global_max_requests {
+            let mut global_bucket = self.global_bucket.write().await;
+            global_bucket.increment(self.config.window_duration);
+            if !global_bucket.is_within_limit(global_max, self.config.window_duration) {
+                return Err(retry_after);
+            }
+        }
+
+        // Per-key window.
+        let mut buckets = self.buckets.write().await;
+        let bucket = buckets.entry(key).or_insert_with(RateLimitBucket::new);
+        bucket.increment(self.config.window_duration);
+        if !bucket.is_within_limit(self.config.max_requests, self.config.window_duration) {
+            return Err(retry_after);
+        }
+        Ok(())
+    }
 }
 
 /// Rate limit error response
@@ -265,54 +301,23 @@ pub async fn rate_limit_middleware<B>(
     // Extract client IP
     let client_ip = get_client_ip(&request);
 
-    // Check global rate limit first (if configured)
-    if let Some(global_max) = rate_limit_state.config.global_max_requests {
-        let mut global_bucket = rate_limit_state.global_bucket.write().await;
-        global_bucket.increment(rate_limit_state.config.window_duration);
-
-        if !global_bucket.is_within_limit(global_max, rate_limit_state.config.window_duration) {
-            let retry_after = rate_limit_state.config.window_duration.as_secs();
-            return Err((
-                StatusCode::TOO_MANY_REQUESTS,
-                Json(RateLimitErrorResponse {
-                    error: "global_rate_limit_exceeded".to_string(),
-                    message: "Global rate limit exceeded. Please try again later.".to_string(),
-                    retry_after,
-                }),
-            ));
-        }
+    // Single converged check (shared with the pgwire path). Map the limiter's
+    // retry-after into the HTTP 429 envelope this surface returns.
+    match rate_limit_state.check_and_consume(client_ip).await {
+        Ok(()) => Ok(next.run(request).await),
+        Err(retry_after) => Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(RateLimitErrorResponse {
+                error: "rate_limit_exceeded".to_string(),
+                message: format!(
+                    "Rate limit exceeded. Maximum {} requests per {} seconds.",
+                    rate_limit_state.config.max_requests,
+                    rate_limit_state.config.window_duration.as_secs()
+                ),
+                retry_after,
+            }),
+        )),
     }
-
-    // Check per-IP rate limit
-    {
-        let mut buckets = rate_limit_state.buckets.write().await;
-        let bucket = buckets
-            .entry(client_ip)
-            .or_insert_with(RateLimitBucket::new);
-
-        bucket.increment(rate_limit_state.config.window_duration);
-
-        if !bucket.is_within_limit(
-            rate_limit_state.config.max_requests,
-            rate_limit_state.config.window_duration,
-        ) {
-            let retry_after = rate_limit_state.config.window_duration.as_secs();
-            return Err((
-                StatusCode::TOO_MANY_REQUESTS,
-                Json(RateLimitErrorResponse {
-                    error: "rate_limit_exceeded".to_string(),
-                    message: format!(
-                        "Rate limit exceeded. Maximum {} requests per {} seconds.",
-                        rate_limit_state.config.max_requests,
-                        rate_limit_state.config.window_duration.as_secs()
-                    ),
-                    retry_after,
-                }),
-            ));
-        }
-    }
-
-    Ok(next.run(request).await)
 }
 
 /// Extract client IP from request
@@ -349,6 +354,40 @@ fn is_health_endpoint(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn check_and_consume_enforces_per_key_window() {
+        let state = RateLimitState::new(MiddlewareRateLimitConfig {
+            enabled: true,
+            max_requests: 2,
+            window_duration: Duration::from_secs(60),
+            limit_health_endpoints: false,
+            global_max_requests: None,
+        });
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        assert!(state.check_and_consume(ip).await.is_ok());
+        assert!(state.check_and_consume(ip).await.is_ok());
+        // Third request in the window exceeds max_requests=2.
+        assert!(state.check_and_consume(ip).await.is_err());
+        // A different key keeps its own bucket.
+        let ip2: IpAddr = "10.0.0.2".parse().unwrap();
+        assert!(state.check_and_consume(ip2).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn check_and_consume_is_ok_when_disabled() {
+        let state = RateLimitState::new(MiddlewareRateLimitConfig {
+            enabled: false,
+            max_requests: 1,
+            window_duration: Duration::from_secs(60),
+            limit_health_endpoints: false,
+            global_max_requests: None,
+        });
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        for _ in 0..10 {
+            assert!(state.check_and_consume(ip).await.is_ok());
+        }
+    }
 
     #[test]
     fn test_rate_limit_bucket() {

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -744,6 +744,23 @@ impl MultiServer {
             // the server data dir the same way document/observability roots are.
             let warehouse_root_url = format!("file://{}/warehouse", self.config.data_dir.display());
 
+            // E0: env-gated per-IP rate limiter for the pgwire query path
+            // (PROXIMADB_PGWIRE_RATE_LIMIT_RPM=<n>). Unset/0 → no limiting, so
+            // default behavior is unchanged. Uses the converged RateLimitState
+            // the REST middleware also checks against.
+            let pgwire_rate_limiter = std::env::var("PROXIMADB_PGWIRE_RATE_LIMIT_RPM")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .filter(|rpm| *rpm > 0)
+                .map(|rpm| {
+                    std::sync::Arc::new(
+                        crate::network::middleware::rate_limit::RateLimitState::new(
+                            crate::network::middleware::RateLimitConfig::production(rpm, rpm)
+                                .to_middleware_config(),
+                        ),
+                    )
+                });
+
             let postgres_handle = tokio::spawn(async move {
                 use crate::network::postgres::PostgresServer;
                 let mut server = PostgresServer::new(
@@ -762,6 +779,9 @@ impl MultiServer {
                     server.with_rank_pipeline(rank_services, rank_profile_store, function_store);
                 server = server.with_primary_pod_gate(primary_pod_registry, self_pod_id);
                 server = server.with_warehouse_materialization(warehouse_root_url);
+                if let Some(limiter) = pgwire_rate_limiter {
+                    server = server.with_rate_limiter(limiter);
+                }
                 if let Err(e) = server.start().await {
                     tracing::error!("❌ PostgreSQL Server error: {}", e);
                 }

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -99,6 +99,9 @@ pub struct PostgresServer {
     /// `ALTER TABLE … MATERIALIZE` works; when `None` the trigger returns a clean
     /// "requires a configured warehouse object store" error.
     warehouse_root_url: Option<String>,
+    /// E0: shared per-IP rate limiter applied to the pgwire query path,
+    /// consistent with REST. `None` (default) = no pgwire rate-limiting.
+    rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
     /// Whether the server is running
     running: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -139,8 +142,20 @@ impl PostgresServer {
             primary_pod_registry: None,
             self_pod_id: None,
             warehouse_root_url: None,
+            rate_limiter: None,
             running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    /// E0: attach a shared per-IP rate limiter so each per-connection
+    /// `PostgresProtocol` rate-limits its query path consistently with REST,
+    /// using the same converged `RateLimitState`.
+    pub fn with_rate_limiter(
+        mut self,
+        limiter: Arc<crate::network::middleware::rate_limit::RateLimitState>,
+    ) -> Self {
+        self.rate_limiter = Some(limiter);
+        self
     }
 
     /// Slice 6.3: attach the primary-pod write router so each
@@ -229,6 +244,7 @@ impl PostgresServer {
                     let primary_pod_registry = self.primary_pod_registry.clone();
                     let self_pod_id = self.self_pod_id.clone();
                     let warehouse_root_url = self.warehouse_root_url.clone();
+                    let rate_limiter = self.rate_limiter.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) = Self::handle_connection(
@@ -246,6 +262,7 @@ impl PostgresServer {
                             primary_pod_registry,
                             self_pod_id,
                             warehouse_root_url,
+                            rate_limiter,
                         )
                         .await
                         {
@@ -285,6 +302,7 @@ impl PostgresServer {
         primary_pod_registry: Option<Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>>,
         self_pod_id: Option<String>,
         warehouse_root_url: Option<String>,
+        rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
     ) -> Result<()> {
         // Create session
         let session = session_manager.create_session(addr).await?;
@@ -323,6 +341,11 @@ impl PostgresServer {
         // gate, legacy behavior) rather than silently misconfigured.
         if let (Some(registry), Some(pod_id)) = (primary_pod_registry, self_pod_id) {
             protocol = protocol.with_primary_pod_gate(registry, pod_id);
+        }
+        // E0: apply the shared per-IP rate limiter (subject = this peer's IP) so
+        // the pgwire query path is rate-limited consistently with REST.
+        if let Some(limiter) = rate_limiter {
+            protocol = protocol.with_rate_limiter(limiter, addr.ip());
         }
 
         // Run protocol loop

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -89,6 +89,11 @@ pub struct PostgresProtocol {
     /// Set only around the extended Execute call; the simple-query path leaves
     /// it false and emits RowDescription as before.
     suppress_row_description: bool,
+    /// E0 rate-limiting: shared per-IP limiter (None = disabled), checked once at
+    /// query entry. Converged with the REST limiter via `RateLimitState`.
+    rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
+    /// This connection's peer IP — the rate-limit subject.
+    peer_ip: std::net::IpAddr,
 }
 
 /// Slice 6.3 gate-input bundle. Distinct type per surface for module
@@ -387,7 +392,22 @@ impl PostgresProtocol {
             observability_service,
             primary_pod_gate: None,
             suppress_row_description: false,
+            rate_limiter: None,
+            peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         }
+    }
+
+    /// Attach a shared per-IP rate limiter (and this connection's peer IP) so the
+    /// pgwire query path is rate-limited consistently with REST (E0). When unset
+    /// or disabled, queries are not rate-limited (default).
+    pub fn with_rate_limiter(
+        mut self,
+        limiter: Arc<crate::network::middleware::rate_limit::RateLimitState>,
+        peer_ip: std::net::IpAddr,
+    ) -> Self {
+        self.rate_limiter = Some(limiter);
+        self.peer_ip = peer_ip;
+        self
     }
 
     /// Create a new protocol handler with DDL/DML services for catalog integration
@@ -419,6 +439,8 @@ impl PostgresProtocol {
             observability_service: None,
             primary_pod_gate: None,
             suppress_row_description: false,
+            rate_limiter: None,
+            peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         }
     }
 
@@ -461,6 +483,8 @@ impl PostgresProtocol {
             observability_service: None,
             primary_pod_gate: None,
             suppress_row_description: false,
+            rate_limiter: None,
+            peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
         }
     }
 
@@ -974,6 +998,21 @@ impl PostgresProtocol {
         query: &str,
         controls: ExecutionControls,
     ) -> Result<()> {
+        // E0 rate-limiting: reject over-quota queries up front with a pgwire
+        // error, using the SAME converged RateLimitState check REST uses (no
+        // duplicate limiter). No-op when unset/disabled.
+        if let Some(limiter) = self.rate_limiter.clone()
+            && limiter.enabled()
+            && let Err(retry_after) = limiter.check_and_consume(self.peer_ip).await
+        {
+            return self
+                .send_error(
+                    "ERROR",
+                    "53400",
+                    &format!("rate limit exceeded; retry after {retry_after}s"),
+                )
+                .await;
+        }
         let tenant = self.pgwire_resolve_read_tenant().await;
         // E0 (edge consistency): give every pgwire query a request-id correlation
         // scope — matching REST's request_id middleware — so logs and error

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -269,6 +269,22 @@ impl ComputeScheduler {
         // it incorrectly (e.g. a point/OLTP query onto a stale base snapshot).
         if model.override_active() {
             let safe = override_candidates(shape, &decision.backend);
+            // Exploration (Phase 2) first: warm an under-explored freshness-safe
+            // candidate so it accrues history the override can later act on.
+            // Bounded + rate-limited + freshness-safe (see `exploration_choice`).
+            if let Some(explore) = model.exploration_choice(&class, &safe)
+                && backend_label(&explore) != backend_label(&decision.backend)
+            {
+                let prev = backend_label(&decision.backend);
+                decision.reason = format!(
+                    "{} | cost-model EXPLORE {prev}→{} (gathering cost history)",
+                    decision.reason,
+                    backend_label(&explore)
+                );
+                decision.backend = explore;
+                return decision;
+            }
+            // Exploitation: override to the confidently-cheaper backend.
             if let Some(rec) = model.recommend_override(&class, &decision.backend, &safe) {
                 let prev = backend_label(&decision.backend);
                 decision.reason = format!(
@@ -510,6 +526,59 @@ mod tests {
         // Override fires: the route is flipped to the measured-cheaper engine.
         assert_eq!(d.backend, ComputeBackend::Native);
         assert!(d.reason.contains("OVERRIDE"));
+    }
+
+    #[test]
+    fn override_on_explores_under_explored_olap_parquet_candidate() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+        }; // static => DataFusionLocal
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_exploration_interval(1);
+        model.set_override_enabled(true);
+        // DataFusion (the static route) is warm; Native is unexplored → explore it.
+        for _ in 0..5 {
+            model.observe(
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(4, 8192),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(
+            d.backend,
+            ComputeBackend::Native,
+            "exploration routes to the under-explored freshness-safe candidate"
+        );
+        assert!(d.reason.contains("EXPLORE"));
+    }
+
+    #[test]
+    fn exploration_never_targets_freshness_critical_oltp() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: false,
+            parquet_backed: true,
+        }; // static => Native (OLTP)
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_exploration_interval(1);
+        model.set_override_enabled(true);
+        // Even with DataFusion history for this class, OLTP's freshness-safe set
+        // is just [Native], so exploration has nothing to probe.
+        for _ in 0..5 {
+            model.observe(
+                "oltp/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(1, 4096),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(d.backend, ComputeBackend::Native);
+        assert!(!d.reason.contains("EXPLORE"));
     }
 
     #[test]

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -37,7 +37,7 @@
 //! tunable. They are deliberately *not* calibrated dollar figures.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 use crate::observability::io_trace::IoTraceSnapshot;
@@ -191,6 +191,10 @@ pub struct RouteCostModel {
     /// static choice by before a live override fires — guards against flapping
     /// on marginal/noisy differences.
     min_advantage: f64,
+    /// Phase-2 exploration: counter rate-limiting how often an under-explored
+    /// freshness-safe candidate is sampled (~1 in `exploration_interval`).
+    explore_tick: AtomicU64,
+    exploration_interval: u64,
 }
 
 impl Default for RouteCostModel {
@@ -210,7 +214,16 @@ impl RouteCostModel {
             min_samples: 3,
             override_enabled: AtomicBool::new(false),
             min_advantage: 0.15,
+            explore_tick: AtomicU64::new(0),
+            exploration_interval: 16,
         }
+    }
+
+    /// Tune how often exploration samples an under-explored candidate (~1 in N
+    /// eligible decisions). Lower = warms faster but costs more; min 1.
+    pub fn with_exploration_interval(mut self, n: u64) -> Self {
+        self.exploration_interval = n.max(1);
+        self
     }
 
     /// Override the warmup threshold (samples required before a cell is trusted).
@@ -346,6 +359,49 @@ impl RouteCostModel {
             Some(rec)
         } else {
             None // advantage too small — don't flap
+        }
+    }
+
+    /// Phase-2 exploration pick (warm-up). When override is enabled and a
+    /// freshness-safe candidate is still under-explored (`< min_samples`),
+    /// occasionally route to the LEAST-sampled candidate so it accrues cost
+    /// history — otherwise the static rule always picks one engine, the other
+    /// never warms, and `recommend_override` could never fire. Properties:
+    ///
+    /// * **Bounded** — returns `None` once every candidate is warm (exploration
+    ///   then yields to exploitation).
+    /// * **Rate-limited** — fires ~1 in `exploration_interval` eligible
+    ///   decisions, so the cost of probing a non-optimal engine stays small.
+    /// * **Freshness-safe** — the caller passes the freshness-safe candidate set,
+    ///   so exploration can never target an engine that would serve the query
+    ///   incorrectly (OLTP gets a single-candidate set → always `None`).
+    /// * **Flag-gated** — `None` unless override is enabled.
+    pub fn exploration_choice(
+        &self,
+        shape_class: &str,
+        candidates: &[ComputeBackend],
+    ) -> Option<ComputeBackend> {
+        if !self.override_active() || candidates.len() < 2 {
+            return None;
+        }
+        let (cand, samples) = candidates
+            .iter()
+            .map(|c| {
+                let s = self
+                    .estimate(shape_class, c)
+                    .map(|e| e.samples)
+                    .unwrap_or(0);
+                (c.clone(), s)
+            })
+            .min_by_key(|(_, s)| *s)?;
+        if samples >= self.min_samples {
+            return None; // all candidates warm — exploit, don't explore
+        }
+        let tick = self.explore_tick.fetch_add(1, Ordering::Relaxed);
+        if tick % self.exploration_interval == 0 {
+            Some(cand)
+        } else {
+            None
         }
     }
 }
@@ -557,6 +613,70 @@ mod tests {
         let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
         assert!(
             m.recommend_override("olap/parquet", &ComputeBackend::Native, &cands)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn exploration_is_off_unless_override_enabled() {
+        let m = RouteCostModel::new().with_exploration_interval(1);
+        // Native warm, DataFusion unexplored — but override flag is OFF.
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 4096, 1));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        assert!(m.exploration_choice("olap/parquet", &cands).is_none());
+    }
+
+    #[test]
+    fn exploration_targets_the_least_sampled_candidate() {
+        let m = RouteCostModel::new().with_exploration_interval(1);
+        m.set_override_enabled(true);
+        // Native warm; DataFusion has no history → it is the under-explored one.
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 4096, 1));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        assert_eq!(
+            m.exploration_choice("olap/parquet", &cands),
+            Some(ComputeBackend::DataFusionLocal)
+        );
+    }
+
+    #[test]
+    fn exploration_stops_once_every_candidate_is_warm() {
+        let m = RouteCostModel::new().with_exploration_interval(1);
+        m.set_override_enabled(true);
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 4096, 1));
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 8192, 2));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        assert!(m.exploration_choice("olap/parquet", &cands).is_none());
+    }
+
+    #[test]
+    fn exploration_is_rate_limited_by_interval() {
+        let m = RouteCostModel::new().with_exploration_interval(3);
+        m.set_override_enabled(true);
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 4096, 1));
+        }
+        let cands = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
+        // ticks 0,3 explore; 1,2,4,5 do not (1-in-3).
+        let fired: Vec<bool> = (0..6)
+            .map(|_| m.exploration_choice("olap/parquet", &cands).is_some())
+            .collect();
+        assert_eq!(fired, vec![true, false, false, true, false, false]);
+    }
+
+    #[test]
+    fn exploration_never_fires_with_a_single_candidate() {
+        // OLTP gets a single freshness-safe candidate → nothing to explore.
+        let m = RouteCostModel::new().with_exploration_interval(1);
+        m.set_override_enabled(true);
+        assert!(
+            m.exploration_choice("oltp/native", &[ComputeBackend::Native])
                 .is_none()
         );
     }


### PR DESCRIPTION
## Summary

Three independent, file-disjoint co-design follow-ups bundled into one PR to run CI once. Each was developed and verified on its own branch; combined here cleanly (no conflicts) and re-verified together.

## What's in it (3 commits)

1. **`feat(query)` — C4 Phase 2 exploration policy.** Makes the trace-driven live override (already merged) actually useful over time: without exploration the static rule always picks one engine, so the alternative never accrues history and the override can't fire. Adds `RouteCostModel::exploration_choice` — **flag-gated** (off unless override enabled), **bounded** (stops once every candidate is warm), **rate-limited** (~1 in N via a per-model counter), **freshness-safe** (reuses `override_candidates`, so OLTP/point queries — a single-candidate set — are never explored), and **deterministic** (counter, not RNG → unit-testable). The scheduler explores before exploiting. `src/query/route_cost_model.rs`, `src/query/compute_scheduler.rs`.

2. **`feat(pgwire)` — per-IP rate limiting on the query path (edge E0).** Closes the rate-limiting leg of the pgwire↔REST consistency gap by **converging the check** (one `RateLimitState::check_and_consume(ip)`; the REST middleware is refactored to delegate to it — one implementation, two surfaces), threading a shared limiter through `PostgresServer::with_rate_limiter → handle_connection → PostgresProtocol`, and enforcing at the universal query chokepoint with a pgwire 53400 error. **Env-gated** (`PROXIMADB_PGWIRE_RATE_LIMIT_RPM`, default unset → behavior unchanged). `rate_limit.rs`, `postgres/{protocol,mod}.rs`, `multi_server.rs`.

3. **`docs` — reusable project-agnostic co-design handoff prompt.** `docs/CO_DESIGN_HANDOFF.md`: a portable distillation (12 principles + observe→ingest→act method + working discipline) to seed the same co-design approach on other projects.

## Safety / defaults

- **Default behavior is unchanged** everywhere: exploration is off unless the override flag is set; pgwire rate-limiting is off unless `PROXIMADB_PGWIRE_RATE_LIMIT_RPM` is set.
- Exploration is freshness-safe by construction (can never probe a wrong/stale engine for OLTP).
- Rate-limiting converges the check rather than duplicating a limiter.

## Tests

Combined: **53 lib tests** green (`route_cost_model` + `compute_scheduler` + `rate_limit`, incl. exploration off/bounded/rate-limited/freshness-safe and `check_and_consume` per-key/disabled) + `pgwire_relational_engine` e2e 1/1. `cargo check` clean; layering hook passed on every commit.

## Follow-ups (noted, not in scope)

C4: richer shape-classes (cardinality/partitions) + a real RLPlanner learner. E0: share the exact same `RateLimitState` instance across REST + pgwire (hoist to SharedServices) + a per-tenant subject option; then backpressure → auth → the unified E1 EdgePolicyPlane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)