### PR TITLE
feat(rabitq): P3 foundation — block-scoring recall test + segment-migration plan

### DIFF
--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -981,6 +981,107 @@ mod tests {
         assert!(cos > 0.3, "reconstruction cosine {cos} too low");
     }
 
+    /// RaBitQ recall@k with f32 rerank, through the on-disk stripe scoring path — the
+    /// contract the ANN search executor will rely on: rank candidates by the binary
+    /// estimator over decoded codes, then rerank the top candidates against full f32.
+    /// Proves recall is preserved at ~16-30x compression. Uses `encode_f32_vec_rabitq`
+    /// directly to avoid the process-global env kill-switch (same reason as the test above).
+    #[test]
+    fn rabitq_block_scoring_preserves_recall_at_k_with_rerank() {
+        use proximadb_codec::functions::rabitq;
+
+        const DIM: usize = 64;
+        const N: usize = 200;
+        const Q: usize = 20;
+        const K: usize = 10;
+        const REFINE: usize = 40; // candidate pool before f32 rerank
+
+        // Deterministic splitmix-seeded corpus (distinct directions → real ranking).
+        let gen_vec = |seed: u64| -> Vec<f32> {
+            let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+            (0..DIM)
+                .map(|_| {
+                    s ^= s >> 30;
+                    s = s.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    s ^= s >> 27;
+                    ((s >> 11) as f32 / (1u64 << 53) as f32) * 2.0 - 1.0
+                })
+                .collect()
+        };
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| gen_vec(i as u64)).collect();
+
+        // Encode the corpus to a RaBitQ stripe, then decode the codes back.
+        let refs: Vec<Option<&[f32]>> = corpus.iter().map(|v| Some(v.as_slice())).collect();
+        let (stripe, col) =
+            crate::writer::encode_f32_vec_rabitq(&refs, DIM as u32, col_id::EMBED_BASE);
+        let codes = parse_rabitq_codes(&stripe, N, DIM).unwrap();
+        let params = RaBitQParams {
+            dim: DIM,
+            seed: col.seed,
+            centroid: col.centroid.clone(),
+        };
+        let rotation = rabitq::build_rotation(DIM, col.seed);
+
+        // ~Compression: RaBitQ stride (8 + ceil(dim/8)) vs raw f32 (dim*4).
+        let stride = 8 + DIM.div_ceil(8);
+        let raw = DIM * 4;
+        assert!(
+            raw / stride >= 10,
+            "RaBitQ compression {}x below 10x (stride={stride}, raw={raw})",
+            raw / stride
+        );
+
+        let l2 =
+            |a: &[f32], b: &[f32]| -> f32 { a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum() };
+        let exact_topk = |q: &[f32]| -> Vec<usize> {
+            let mut idx: Vec<usize> = (0..N).collect();
+            idx.sort_by(|&a, &b| {
+                l2(&corpus[a], q)
+                    .partial_cmp(&l2(&corpus[b], q))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            idx.into_iter().take(K).collect()
+        };
+
+        let mut recalls = Vec::new();
+        for qi in 0..Q {
+            // Query = a corpus vector + small perturbation.
+            let base = (qi * (N / Q)) % N;
+            let noise = gen_vec((qi as u64).wrapping_add(1_000_000));
+            let query: Vec<f32> = corpus[base]
+                .iter()
+                .zip(&noise)
+                .map(|(v, n)| v + n * 0.01)
+                .collect();
+
+            // Stage 1: rank ALL candidates by the binary estimator over codes.
+            let q_rot = rabitq::rotate_query(&query, &params, &rotation);
+            let mut scored: Vec<(usize, f32)> = (0..N)
+                .filter_map(|i| codes[i].as_ref().map(|c| (i, c.l2_rank_score(&q_rot))))
+                .collect();
+            scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            // Stage 2: f32 rerank the top-REFINE candidates → final top-K.
+            let mut refine: Vec<usize> = scored.iter().take(REFINE).map(|(i, _)| *i).collect();
+            refine.sort_by(|&a, &b| {
+                l2(&corpus[a], &query)
+                    .partial_cmp(&l2(&corpus[b], &query))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let got: std::collections::HashSet<usize> = refine.into_iter().take(K).collect();
+
+            let truth = exact_topk(&query);
+            let hits = truth.iter().filter(|i| got.contains(i)).count();
+            recalls.push(hits as f32 / K as f32);
+        }
+        let mean = recalls.iter().sum::<f32>() / recalls.len() as f32;
+        assert!(
+            mean >= 0.80,
+            "RaBitQ recall@{K} with rerank = {mean:.3} < 0.80 (compression {}x)",
+            raw / stride
+        );
+    }
+
     #[test]
     fn raw_fallback_vector_stripe_round_trips_exactly() {
         // The raw fixed-stride path (quant_kind = RAW_F32) is exact. Exercise the

--- a/docs/12-design/RABITQ_ANN_INTEGRATION_SCOPING_2026_06.adoc
+++ b/docs/12-design/RABITQ_ANN_INTEGRATION_SCOPING_2026_06.adoc
@@ -1,0 +1,51 @@
+= P3: RaBitQ ANN Integration — Scoping (the real gap is the segment format)
+2026-06-19
+
+== Summary
+
+Wiring RaBitQ (~30× quant) into ANN search is NOT a search-executor tweak. The
+RaBitQ *format + kernel + scoring contract* are done; the blocker is that the vector
+storage engines don't read/write the PAX block format that carries RaBitQ codes.
+
+== What's already done (verified)
+
+* RaBitQ kernel (`proximadb-codec` rabitq.rs): encode / `rotate_query` / `l2_rank_score`
+  / reconstruct — tested.
+* PAX on-disk RaBitQ: `encode_f32_vec_rabitq` (writer, env-gated `PROXIMADB_VECTOR_RABITQ`)
+  + `decode_rabitq_codes` / `decode_f32_vec_stripe` (reader) — tested.
+* **Recall contract (this branch):** `rabitq_block_scoring_preserves_recall_at_k_with_rerank`
+  in `proximadb-block-format/src/reader.rs` — rank by codes → f32 rerank top-K →
+  recall@10 ≥ 0.80 at ≥10× compression. This is the contract the search path must honor.
+
+== The real gap
+
+The SST cold-search path (`src/storage/engines/sst/readers/sst_query_engine.rs:2330-2375`)
+deserializes each segment into `ProximaDataBlock { records: Vec<ProximaRecord> }` with
+fully-decoded f32 vectors and scores raw f32 via `distance_compute.calculate_distance`.
+It never opens a `PaxBlockReader`. So:
+
+* SST/HELIX/NOVA vector segments are persisted as `ProximaDataBlock` (raw f32), *not* PAX
+  blocks → RaBitQ codes are not written on the engine read/write path at all.
+* `PaxBlockReader::decode_rabitq_codes` has no caller in search.
+
+== Required work to close P3 (foundational, sequenced)
+
+1. **Segment-format migration:** make the SST (then HELIX/NOVA) vector flush write PAX
+   blocks (`PaxBlockWriter`, which already selects RaBitQ when configured) instead of
+   (or alongside) `ProximaDataBlock`; make the cold reader open `PaxBlockReader`.
+2. **Search scoring branch:** in the cold scan, when `decode_rabitq_codes(EMBED_BASE)` is
+   `Some`, `rotate_query` once → `l2_rank_score` per candidate → take top-(k·refine) →
+   f32 rerank via `decode_f32_vec_stripe` → top-k. (Contract proven by the test above.)
+3. **Per-collection config:** replace the global `PROXIMADB_VECTOR_RABITQ` env gate with a
+   `QuantizationStrategy::RaBitQ` on `CollectionConfig`, threaded to the writer.
+4. **Cold-recall harness:** mirror `tests/helix_cold_search_recall_test.rs` (insert →
+   flush → NEW engine cold read → recall ≥ ratchet) with RaBitQ enabled, on the SST
+   engine, N≥1000 so the cold PAX scan path is actually exercised (small-N is brute-force
+   served and won't touch it).
+
+== Risk / why it's its own workstream
+
+Changing the on-disk vector segment format for the core storage engines is high blast
+radius (recovery, compaction, cold reads, all three engines). It warrants a dedicated,
+carefully-verified effort — not a tail-of-session patch. The recall contract test in this
+branch de-risks step 2; steps 1/3/4 are the substantive remaining work.

--- a/docs/12-design/RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc
+++ b/docs/12-design/RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc
@@ -1,0 +1,147 @@
+= P3: Vector-Segment PAX Migration Plan (enables RaBitQ in ANN search)
+:toc: macro
+2026-06-19
+
+toc::[]
+
+== Context
+
+RaBitQ (~30× quant) + its kernel, on-disk codec, and the rank→f32-rerank recall
+contract are done (see `RABITQ_ANN_INTEGRATION_SCOPING_2026_06.adoc` + the
+`rabitq_block_scoring_preserves_recall_at_k_with_rerank` test). The blocker to using
+RaBitQ in actual ANN search is the *vector-segment on-disk format*: the SST/HELIX/SWIFT
+engines persist segments as **`ProximaDataBlock`** (row-based, raw f32) and the cold
+search scores raw f32 — they never touch the **PAX block format** that carries RaBitQ
+codes. This plan migrates the vector-segment storage to PAX (additively, flag-gated) so
+RaBitQ codes live on the read/write path, then wires the search scoring branch.
+
+This is a high-blast-radius, multi-engine storage change. The plan sequences it so each
+phase is independently shippable + verifiable, with the format change always
+mixed-read-safe and default-OFF until baked.
+
+== Current state (file:line)
+
+* *Write/flush*: `sst/flush/mod.rs:92` `flush_implementation` → `perform_atomic_flush`
+  (`:263/:306`) → `SstableWriter::write_sorted_vector_records` (`writer.rs:430`) →
+  `ProximaDataBlock::serialize_*` (`core/formats/proximablocks/block_structures.rs:1753`).
+  Format chosen at `flush/mod.rs:152` from `config().block_format`
+  (`BlockFormat::{ProximaBlocks,ArrowBlock}`, `block_format.rs:93`).
+* *Read (cold search)*: `sst/readers/sst_query_engine.rs:2330-2375` deserializes
+  `ProximaDataBlock` (`block_structures.rs:2678`) → `Vec<ProximaRecord>` → scores raw f32.
+* *Compaction*: `sst/compaction.rs` reads → `ProximaDataBlock` → rewrites same format.
+* *Recovery/index*: `sst/manifest.rs:27` `SstableFileInfo` (per-file metadata, *no format
+  field* — boot assumes ProximaBlocks).
+* *PAX*: `proximadb-block-format` (`PaxBlockWriter::add_record`/`flush`, `PaxBlockReader`)
+  + `proximadb-storage-common` `PaxSegmentWriter`/`pax_block.rs` — *unused by the vector
+  engines* (only the warehouse/Iceberg materialize path uses PAX-adjacent code).
+* Shared: SST/HELIX/SWIFT share `ProximaDataBlock`; NOVA is query-only.
+* Version-detectable: `ProximaDataBlock::deserialize` already branches on the first byte
+  (0x01 version / 0x02-0x0E compression markers) → a new PAX magic range (e.g. 0x0F+) can
+  coexist for mixed reads.
+* Records↔PAX adapter exists: `PaxBlockWriter::add_record(&ProximaRecord)` (row→columnar)
+  and `proxima_arrow::record_batch_to_proxima_records` (columnar→row).
+
+== Design
+
+*PAX as a third `BlockFormat`*, selected per-collection, written by the existing
+`PaxBlockWriter`/`PaxSegmentWriter`, read via a magic-byte-routed deserializer so old
+`ProximaDataBlock` segments and new PAX segments coexist. The ANN cold scan gains a
+branch: PAX+RaBitQ block → rank by codes → f32 rerank; else the current raw-f32 path.
+
+Key invariants:
+
+* *Mixed-read-safe always*: a reader must transparently handle both formats (by magic
+  byte + the manifest `block_format` field). No flag-day.
+* *Default OFF*: PAX segments only written when a collection opts in
+  (`QuantizationStrategy::RaBitQ` or `block_format=pax`); env override for tests.
+* *Recall-gated*: RaBitQ search must hold cold recall ≥ the raw-f32 baseline minus a
+  small tolerance (the contract test + a cold-recall e2e are the gates).
+
+== Phased implementation (low blast radius → high)
+
+=== Phase A — Read-side mixed-format support  [additive, no behavior change]
+Make the segment deserializer detect a PAX segment (new magic, e.g. `PAXSEG01` / first
+byte 0x0F) and route to `PaxBlockReader` → `Vec<ProximaRecord>` (via the existing
+records adapter). Add an optional `block_format` field to `SstableFileInfo`
+(`manifest.rs:27`, default `ProximaBlocks` for existing files). NO PAX is written yet, so
+behavior is unchanged. *Test*: hand-write a PAX segment, read it back through the engine
+reader → records match. *Risk*: low (pure addition; default path untouched).
+
+=== Phase B — Write-side PAX flush (SST), flag-gated OFF
+Add `BlockFormat::PaxBlock` (`block_format.rs`) + a dispatch arm in
+`perform_atomic_flush` (`flush/mod.rs:306`) that writes via `PaxSegmentWriter`
+(`PaxBlockWriter::add_record` per record → `flush`), stamping the manifest
+`block_format="PaxBlock"`. Gated by env `PROXIMADB_PAX_VECTOR_SEGMENTS` (default OFF) for
+the first cut. *Test*: flush with the flag ON → segment is PAX → Phase-A reader returns
+the same records; round-trip recall (exact) holds. Compaction (Phase E) still TODO, so
+keep the flag off in prod. *Risk*: medium (new write path; isolated by the flag).
+
+=== Phase C — RaBitQ scoring branch in cold search
+In the cold scan (`sst_query_engine.rs:2330`), when the block is PAX and
+`decode_rabitq_codes(EMBED_BASE)` is `Some`: `rotate_query` once → `l2_rank_score` per
+candidate → take top-(k·refine) → f32 rerank via `decode_f32_vec_stripe` → top-k; extract
+id/metadata from the PAX block (id filter column + props) for results. Else fall through
+to the current raw-f32 path. Contract already proven by the recall-contract test.
+*Risk*: high (hot path) — mitigated by the contract test + Phase-G cold-recall e2e; the
+branch only activates for PAX+RaBitQ blocks (opt-in), so non-PAX collections are untouched.
+
+=== Phase D — Per-collection config
+Add `QuantizationStrategy::RaBitQ` to `CollectionConfig.quantization` (proto already has
+the slot) and thread it to the flush format decision (RaBitQ ⇒ `BlockFormat::PaxBlock` +
+RaBitQ codes), replacing the global env gate for production. v2 create-collection +
+gRPC/pgwire DDL carry it. *Risk*: low/medium (config plumbing).
+
+=== Phase E — Compaction + recovery
+Compaction (`compaction.rs`) reads mixed formats (Phase A) and writes the collection's
+configured format (converting ProximaDataBlock→PAX when the collection opted in, or
+preserving). Recovery reads `block_format` from the manifest (Phase A). Add a one-shot
+"rewrite to PAX on next compaction" path for opted-in collections. *Risk*: medium/high
+(compaction correctness, recovery of mixed manifests).
+
+=== Phase F — Extend to HELIX / SWIFT
+HELIX/SWIFT share the segment writer/reader, so Phases A-E largely cover them; verify
+their flush/read entrypoints route through the same dispatch + add per-engine cold-recall
+tests. NOVA is query-only (covered by the read path). *Risk*: high (two more engines).
+
+=== Phase G — Cold-recall harness + perf/size validation (the gate)
+Mirror `tests/helix_cold_search_recall_test.rs` (insert → flush → NEW engine cold read →
+recall) with RaBitQ on the SST (then HELIX/SWIFT) engine at *N ≥ 1000* (small-N is
+brute-force served and won't exercise the cold PAX scan). Assert: cold recall@10 within
+tolerance of the raw-f32 baseline; segment size ≥ ~10× smaller; query latency not worse.
+
+== Critical files
+
+[cols="2,3",options="header"]
+|===
+| Area | File:line
+| BlockFormat enum + parse | `src/storage/engines/sst/.../block_format.rs:93`
+| Flush format dispatch | `src/storage/engines/sst/flush/mod.rs:152, 306`
+| Segment writer | `src/storage/engines/sst/writer.rs:430`
+| Block (de)serialize + magic detection | `.../proximablocks/block_structures.rs:1753, 2678`
+| Cold-search scan/score | `src/storage/engines/sst/readers/sst_query_engine.rs:2330-2375`
+| Compaction | `src/storage/engines/sst/compaction.rs`
+| Manifest / SstableFileInfo | `src/storage/engines/sst/manifest.rs:27`
+| PAX writer/reader | `crates/storage/proximadb-block-format` (`writer.rs`/`reader.rs`), `proximadb-storage-common/src/pax_block.rs`
+| Records↔PAX adapter | `proximadb-storage-common/src/proxima_arrow.rs`
+| RaBitQ codec + scoring | `crates/horizontal/proximadb-codec/.../rabitq.rs`
+|===
+
+== Risks & mitigations
+
+* *Recovery of mixed manifests* — default `block_format=ProximaBlocks` when the field is
+  absent; never assume PAX. Phase-A read support lands before any PAX is written.
+* *Compaction across formats* — Phase E reads both, writes configured; gate behind the
+  per-collection opt-in; add a compaction round-trip recall test.
+* *Hot-path regression* — the RaBitQ branch only runs for PAX+RaBitQ blocks; raw-f32 path
+  is byte-for-byte unchanged for existing collections. Recall-contract + cold-recall gates.
+* *Row vs columnar impedance* — reuse the existing `add_record`/`record_batch_to_proxima_records`
+  adapters; don't hand-roll a converter.
+* *Three engines* — sequence SST → HELIX → SWIFT; each behind the same flag + its own
+  cold-recall test before flipping default.
+
+== Rollout
+
+Flag default OFF → opt-in per collection (`QuantizationStrategy::RaBitQ`) → bake on SST
+with cold-recall + size gates → extend to HELIX/SWIFT → consider default-on for new
+collections after a bake period. Old ProximaDataBlock segments are read forever (mixed
+reads); conversion happens lazily on compaction for opted-in collections only.


### PR DESCRIPTION
## What

Lands the **P3 (RaBitQ ~30× quantization) foundation** on top of the merged qa-gate base (#86):

- **`test(rabitq)`** `proximadb-block-format` — `rabitq_block_scoring_preserves_recall_at_k_with_rerank`: proves block-level RaBitQ scoring + f32 rerank preserves recall@k (the quality gate the full wiring must hold).
- **`docs(rabitq)`** scoping doc — the real gap is the **vector segment format** (ProximaDataBlock raw-f32 SST/HELIX/SWIFT), *not* the scan path: RaBitQ codes aren't on the ANN read path yet.
- **`docs(rabitq)`** 7-phase PAX segment-migration plan (mixed-read-safe, so existing f32 segments stay readable during rollout).

## What this is NOT

This does **not** yet wire RaBitQ into the live ANN scan→rerank path — that's the migration plan's scope, deferred to a focused follow-up. This PR is the scoped foundation + recall gate so the wiring can land incrementally against a quality bar.

## Verification
- `cargo test -p proximadb-block-format` → 37/37 pass (incl. the new recall test).
- Rebased cleanly onto develop `2699c665e` (only the 3 unique commits; qa-gate base dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)