### PR TITLE
ci(security): least-privilege GITHUB_TOKEN permissions across workflows

### DIFF
--- a/.github/workflows/capability-contract-tests.yml
+++ b/.github/workflows/capability-contract-tests.yml
@@ -27,6 +27,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   capability-contract-tests:
     name: Capability Contract Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ env:
 #                             -> docker-build
 # ============================================================================
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   # ============================================================================
   # CHANGES DETECTION - Determine what to build/test

--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -65,6 +65,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Default read-only; jobs that assume an AWS role via OIDC or comment on a PR
+# elevate only the specific scope they need at the job level.
+permissions:
+  contents: read
+
 jobs:
   # ============================================================================
   # NOTE: All infrastructure deployment jobs are DISABLED for v0.2.0 release
@@ -165,6 +171,10 @@ jobs:
     name: Terraform Plan (Dev)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read        # checkout
+      id-token: write       # assume AWS role via OIDC (configure-aws-credentials)
+      pull-requests: write  # post the plan as a PR comment (actions/github-script)
     needs: [terraform-validate, helm-validate]
 
     steps:
@@ -238,6 +248,9 @@ jobs:
     name: Terraform Apply (Dev)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: terraform-plan-dev
     environment:
       name: dev
@@ -310,6 +323,9 @@ jobs:
     name: Terraform Plan (Staging)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: [terraform-validate, helm-validate]
 
     steps:
@@ -361,6 +377,9 @@ jobs:
     name: Terraform Apply (Staging)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: terraform-plan-staging
     environment:
       name: staging
@@ -420,6 +439,9 @@ jobs:
     name: Terraform Plan (Production)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: [terraform-validate, helm-validate]
 
     steps:
@@ -471,6 +493,9 @@ jobs:
     name: Terraform Apply (Production)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: terraform-plan-production
     environment:
       name: production
@@ -548,6 +573,9 @@ jobs:
     name: Post-Deploy Monitoring
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read   # checkout
+      id-token: write  # assume AWS role via OIDC (configure-aws-credentials)
     needs: [terraform-apply-dev]
 
     steps:

--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -12,10 +12,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Default read-only; the single job elevates only what it needs.
+permissions:
+  contents: read
+
 jobs:
   layering-validation:
     name: Validate Workspace Layering
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # checkout
+      pull-requests: write  # "Post results to PR (on failure)" via actions/github-script
 
     steps:
     - name: Checkout code

--- a/.github/workflows/prerelease-ci-v0.2.1-macos.yml
+++ b/.github/workflows/prerelease-ci-v0.2.1-macos.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   notes:
     name: Documentation Notes

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -18,6 +18,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   # ========================================
   # Unit Tests with TDD methodology

--- a/.github/workflows/tier-config-fingerprint.yml
+++ b/.github/workflows/tier-config-fingerprint.yml
@@ -31,6 +31,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   fingerprint-check:
     name: Verify tier-config.json fingerprint


### PR DESCRIPTION
## Summary
Resolves **all 53 CodeQL `actions/missing-workflow-permissions` (medium)** alerts by adding explicit, least-privilege `permissions:` blocks to the 7 workflows that were inheriting the repo-default `GITHUB_TOKEN` scope.

This is the first of three scoped, lane-isolated PRs closing the 60 open code-scanning alerts (grouped for runner economy — this PR touches only `.github/workflows/`).

## Changes
| Workflow | Default | Job elevation |
|---|---|---|
| ci, tdd, capability-contract-tests, tier-config-fingerprint, prerelease-ci-v0.2.1-macos | `contents: read` | none needed |
| layering-check | `contents: read` | validation job → `pull-requests: write` (on-failure PR comment) |
| infrastructure-deploy | `contents: read` | terraform plan/apply + monitoring → `id-token: write` (AWS OIDC); terraform-plan-dev also `pull-requests: write` (plan comment) |

## Co-design adherence
Hardens the **governance/security** dimension. Least privilege is applied **structurally** at the workflow/job boundary — never as a per-run predicate — shrinking the `GITHUB_TOKEN` blast radius (the reduce-surface / "do more with less" lever for CI credentials). No dimensional cost term (I/O, egress, compute) is moved, so no trace gate applies; no job logic changes.

## Validation
- `actionlint` clean on all 7 changed files (no new findings)
- YAML parses for the whole `.github/workflows/` tree
- No dependency changes (these are config-only fixes; no CVEs involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)