### PR TITLE
fix(py): resolve CodeQL high-severity Python findings

### DIFF
--- a/clients/python/src/proximadb_sdk/unified_client.py
+++ b/clients/python/src/proximadb_sdk/unified_client.py
@@ -313,7 +313,12 @@ class ProximaDBClient:
                 api_key=api_key,  # Can be used as a fallback or for initial auth
             )
         else:
-            logger.warning(f"Unsupported authentication method: {method}")
+            # Log only the type, never the raw value: in misuse cases the
+            # caller-supplied method may carry credential material, and
+            # type(...).__name__ is a constant class name, not the value.
+            logger.warning(
+                "Unsupported authentication method of type %s", type(method).__name__
+            )
             return
 
         base_url = config.url if hasattr(config, "url") else config.base_url

--- a/clients/python/tests/unit/test_config_cov.py
+++ b/clients/python/tests/unit/test_config_cov.py
@@ -111,7 +111,10 @@ def test_serialization_roundtrip():
     rebuilt = ClientConfig(**dumped)
     assert rebuilt.url == cfg.url
     js = cfg.model_dump_json()
-    assert "example.com" in js
+    # Parse and assert the exact url field rather than a substring match: a
+    # substring check is satisfied by an arbitrary position in the JSON
+    # (CodeQL py/incomplete-url-substring-sanitization).
+    assert json.loads(js)["url"] == "https://example.com:5678"
 
 
 # --------------------------------------------------------------------------- #

--- a/clients/python/tests/unit/test_security_cov.py
+++ b/clients/python/tests/unit/test_security_cov.py
@@ -135,7 +135,10 @@ def test_config_get_token_url_okta():
 
 def test_config_get_token_url_auth0():
     cfg = OAuth2Config(provider=OAuth2Provider.AUTH0, audience="tenant.auth0.com")
-    assert "tenant.auth0.com" in cfg.get_token_url()
+    # Assert the full URL, not a substring: a substring check would also pass
+    # for a host like "tenant.auth0.com.evil.example" (CodeQL
+    # py/incomplete-url-substring-sanitization).
+    assert cfg.get_token_url() == "https://tenant.auth0.com/oauth/token"
 
 
 def test_config_get_token_url_generic_empty():

--- a/scripts/convert_println_to_log.py
+++ b/scripts/convert_println_to_log.py
@@ -51,8 +51,12 @@ def convert_println_to_log(file_path):
     # Track if we need to add use statement
     needs_log_import = False
     
-    # Find all println! statements (including multi-line)
-    pattern = r'println!\s*\(((?:[^()]+|\([^()]*\))*)\)'
+    # Find all println! statements (including multi-line).
+    # The inner alternation uses a single [^()] (not [^()]+) so the two
+    # branches are disjoint (non-paren char vs a "(...)" group) and the
+    # outer * cannot backtrack exponentially. Same matched language as
+    # [^()]+, but linear time — avoids ReDoS (CodeQL py/redos).
+    pattern = r'println!\s*\(((?:[^()]|\([^()]*\))*)\)'
     
     def replace_println(match):
         nonlocal needs_log_import


### PR DESCRIPTION
## Summary
Resolves the **4 high-severity CodeQL Python alerts**. Second of three scoped, lane-isolated PRs closing the 60 open code-scanning alerts — this PR touches only Python (SDK + one dev script + two unit tests), so it exercises only the Python CI lane. **No dependency changes** (all are first-party fixes; none are CVEs).

## Findings fixed
| Alert | File | Fix |
|---|---|---|
| `py/clear-text-logging-sensitive-data` | `unified_client.py` | The "unsupported auth method" branch logged the raw `method` value (tainted as credential-adjacent in the auth path). Now logs only `type(method).__name__` — breaks the value→sink flow, keeps the diagnostic. |
| `py/redos` | `scripts/convert_println_to_log.py` | Nested-quantifier regex `(?:[^()]+|\(...\))*` → exponential backtracking. Inner `+` dropped to single `[^()]`; branches disjoint, outer `*` linear. Same matched language; 40k pathological input now ~2ms. |
| `py/incomplete-url-substring-sanitization` ×2 | `test_security_cov.py`, `test_config_cov.py` | `"host" in url` substring asserts replaced with exact equality (full token URL / parsed JSON `url` field) — a look-alike host can no longer satisfy them. |

## Validation
- Affected pytest cases pass (`test_config_get_token_url_auth0`, `test_serialization_roundtrip`).
- Regex: verified correct capture (incl. nested parens) and linear timing on a pathological input.
- Logging: verified the raw value never reaches the log record.

## Co-design adherence
Governance/security dimension hardening; no storage/compute/network/egress cost term moved, so no trace gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)