### PR TITLE
Co-design: complete the §3 Cost(q) cost model (C3 KEU egress + egress/ingest/shape/tier terms)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6442,6 +6442,7 @@ dependencies = [
  "httpmock",
  "hyper 1.9.0",
  "hyper-util",
+ "ipnet",
  "jni",
  "jsonpath-rust",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,6 +317,7 @@ once_cell = "1.19"
 lazy_static = "1.5"
 
 # Networking & gRPC
+ipnet = "2.12" # CIDR longest-prefix client-locality classification (KOU, co-design D2)
 tonic = { version = "0.14", features = ["gzip", "tls-native-roots"] }
 tonic-prost = "0.14"  # Runtime codec for tonic-build 0.14+ generated code
 tonic-health = "0.14"  # Standard grpc.health.v1.Health service

--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -383,8 +383,11 @@ per-query `bytes_cross_az`. Remaining: same-AZ placement enforcement; Arrow Flig
 | TENANT_COLLECTION_POD_AFFINITY, arrow_flight detector, consumption_metrics
 | C4 — Cost-based routing | [*cost model DONE*] full `Cost(q)` (read+egress+ingest+compute) +
 enriched shape-classes (cardinality, partition fan-out) fed from the measured trace; observe→override→
-explore loop shipped. Remaining: populate the new shape signals from a real estimator; seed the
-RL-planner. | compute_scheduler.rs, route_cost_model.rs, course-correction P7
+explore loop shipped. *RL planner DEFERRED* (premature for a solo operator: no 2nd live read backend
+yet, and the EWMA observe→override→explore model is policy-complete). Decide the override flag on
+evidence via `scripts/route_cost_report.py` (summarizes observe-mode advisories → divergence + neutral
+advantage → verdict). *Revisit RL only when both:* ≥2 live read backends AND sustained per-shape-class
+trace volume. Remaining: populate shape signals from a real estimator. | compute_scheduler.rs, route_cost_model.rs, route_cost_report.py, course-correction P7
 | C5 — Governance SKUs | [*DONE*] tier-entitlement multiplier (DI resolver, default 1.0,
 routing-neutral) completes `Cost(q)`; config-driven startup adapter
 (`tenant_tier::install_tier_cost_multiplier_resolver`) reads per-tier multipliers from the

--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -385,9 +385,11 @@ per-query `bytes_cross_az`. Remaining: same-AZ placement enforcement; Arrow Flig
 enriched shape-classes (cardinality, partition fan-out) fed from the measured trace; observe→override→
 explore loop shipped. Remaining: populate the new shape signals from a real estimator; seed the
 RL-planner. | compute_scheduler.rs, route_cost_model.rs, course-correction P7
-| C5 — Governance SKUs | [*multiplier seam DONE*] tier-entitlement multiplier (DI resolver, default
-1.0, routing-neutral) completes `Cost(q)`. Remaining: per-tier cache floor/ceiling; anvaiops authors
-tier→limit + pricing via claims. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver, route_cost_model.rs
+| C5 — Governance SKUs | [*DONE*] tier-entitlement multiplier (DI resolver, default 1.0,
+routing-neutral) completes `Cost(q)`; config-driven startup adapter
+(`tenant_tier::install_tier_cost_multiplier_resolver`) reads per-tier multipliers from the
+tier-config overlay via the `tenant_id→Tier` Port. Remaining: register a real tenant→tier resolver
+in the integrated build; per-tier cache floor/ceiling. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver, route_cost_model.rs, tenant_tier.rs
 | C6 — Edge collapse | Collapse the L7 proxy/LB/gateway into `proximadb-edge`: one canonical envelope +
 one policy plane (TLS/authn/ABAC/tenant/rate-limit/trace) across pgwire+REST+gRPC+Flight; E0 closes the
 live pgwire-bypasses-middleware consistency gap. | network/multiplex+middleware, proximadb-security, io_trace; see link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[edge HLD]

--- a/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
+++ b/docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc
@@ -185,9 +185,13 @@ mesh tax (a sidecar ~halves throughput / doubles p99; ~70 GB RAM across 1000 pod
 ALB-LCU / API-GW-per-request / cross-AZ cost, while making cross-surface policy consistency *structural*.
 Full HLD: link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19].
 
-*Billing meter:* presently *unmetered* — a gap. Add an egress/bytes-moved counter keyed by
-`(tenant, az_locality)` so cross-AZ and result-egress become a billable, optimizable dimension
-(→ *KEU*, the egress unit already named in the OSS boundary doc but not yet sourced from a trace).
+*Billing meter:* [*DONE — C3*] `proximadb_egress_bytes_total{tenant_id, az_locality}` (the *KEU*
+meter) plus the per-query `io_trace.bytes_cross_az` term, fed by one convergent
+`consumption_metrics::record_egress_bytes` at the object-store read boundaries. `AzLocality`
+(`same_az`/`cross_az`/`internet`) is OSS *mechanism*: the deployment declares its object-store
+locality via `PROXIMADB_OBJECT_STORE_LOCALITY` (default `same_az` = the free path, so the egress
+*cost* term is inert until a cross-AZ topology is declared); the AZ topology and per-locality $
+weights stay anvaiops *policy*. Closes the previously-unmetered networking dimension.
 
 *TAM:* networking is captured indirectly as the cost floor of every serverless DB; the
 disaggregation/RDMA research wave (GaussDB, PolarDB-MP, PVLDB 2024–2025) signals where the
@@ -310,13 +314,23 @@ expected total cost is the sum across dimensions:
 
 [source]
 ----
-Cost(q) =  w_storage · bytes_stored·time          (KSU)
-         + w_read    · (GET_count·get_fee + bytes_read·bw_cost)   (KRU, Dimension 1+2)
-         + w_egress  · bytes_moved·az_locality_cost  (KEU, Dimension 2)   ← currently unmetered
-         + w_compute · engine_ms·rate              (KRU/KIU, Dimension 4)
-         - cache_hit_savings(hit_ratio)            (Dimension 3 offsets read+egress)
-         × tier_entitlement_multiplier             (Dimension 5)
+Cost(q) =  w_storage · bytes_stored·time          (KSU)            ← per-tenant aggregate, not per-query
+         + w_read    · (GET_count·get_fee + bytes_read·bw_cost)   (KRU, Dimension 1+2)   [DONE]
+         + w_egress  · bytes_moved·az_locality_cost  (KEU, Dimension 2)   [DONE — C3 meter + cost term]
+         + w_ingest  · bytes_written·bw_cost        (KIU, storage-write)  [DONE]
+         + w_compute · engine_ms·rate              (KRU/KIU, Dimension 4)   [DONE]
+         - cache_hit_savings(hit_ratio)            (Dimension 3: fewer GETs/bytes in the trace)
+         × tier_entitlement_multiplier             (Dimension 5)   [DONE — C5 seam, routing-neutral]
 ----
+
+Status: the per-query route cost model (`src/query/route_cost_model.rs`) now scores the read,
+*egress* (KEU), ingest (KIU), and compute terms in neutral units from the measured
+`IoTraceSnapshot`, and applies the per-tenant tier multiplier (C5 DI seam) to the *reported* cost.
+The egress and ingest terms are *inert by default* (zero on the free same-AZ path / for read-only
+routes), so routing is unchanged until a cross-AZ topology is declared. `w_storage·time` (KSU) stays
+a per-tenant aggregate the consumption meter owns — it is not a per-query routing discriminator — and
+the tier multiplier is routing-neutral (a per-tenant scalar scales all candidates equally), so both
+serve *reporting/billing*, not engine selection.
 
 The weights are *not* guessed — they are the published cost curves in §2, and the quantities
 (`GET_count`, `bytes_read`, `bytes_moved`, `engine_ms`, `hit_ratio`) must come from the *measured
@@ -364,12 +378,16 @@ tuned on intuition.*
 small-tenant pack store (R5). | PAX v2 leftover, TURBOQUANT, recalibration R5
 | C2 — Cache unification | Collapse cache zoo → one `TenantCache` temperature/cost model; size-aware
 eviction; decouple cache from compute for warm restarts. | proximadb-cache, recalibration R2/R3/R4/R6
-| C3 — Network metering | Add `(tenant, az_locality)` bytes-moved counter (KEU); same-AZ placement
-enforcement; Arrow Flight SQL bulk-egress GA. | TENANT_COLLECTION_POD_AFFINITY, arrow_flight detector
-| C4 — Cost-based routing | Feed measured dimensional cost into `ComputeScheduler` route selection;
-retire static heuristics; seed the RL-planner cost model. | compute_scheduler.rs, course-correction P7
-| C5 — Governance SKUs | Tier-entitlement multiplier in the cost model; per-tier cache floor/ceiling;
-anvaiops authors tier→limit + pricing via claims. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver
+| C3 — Network metering | [*meter DONE*] `(tenant, az_locality)` bytes-moved counter (KEU) +
+per-query `bytes_cross_az`. Remaining: same-AZ placement enforcement; Arrow Flight SQL bulk-egress GA.
+| TENANT_COLLECTION_POD_AFFINITY, arrow_flight detector, consumption_metrics
+| C4 — Cost-based routing | [*cost model DONE*] full `Cost(q)` (read+egress+ingest+compute) +
+enriched shape-classes (cardinality, partition fan-out) fed from the measured trace; observe→override→
+explore loop shipped. Remaining: populate the new shape signals from a real estimator; seed the
+RL-planner. | compute_scheduler.rs, route_cost_model.rs, course-correction P7
+| C5 — Governance SKUs | [*multiplier seam DONE*] tier-entitlement multiplier (DI resolver, default
+1.0, routing-neutral) completes `Cost(q)`. Remaining: per-tier cache floor/ceiling; anvaiops authors
+tier→limit + pricing via claims. | OSS_ENTERPRISE_BOUNDARY, LimitsResolver, route_cost_model.rs
 | C6 — Edge collapse | Collapse the L7 proxy/LB/gateway into `proximadb-edge`: one canonical envelope +
 one policy plane (TLS/authn/ABAC/tenant/rate-limit/trace) across pgwire+REST+gRPC+Flight; E0 closes the
 live pgwire-bypasses-middleware consistency gap. | network/multiplex+middleware, proximadb-security, io_trace; see link:IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc[edge HLD]

--- a/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
+++ b/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
@@ -43,7 +43,7 @@ leaks in non-gated OSS code.
 | Data models (multimodal) | vector, relational/OLTP, OLAP, document, graph (ORION), time-series + queue (maturity-gated, not license-gated)
 | Compute | Volcano, DataFusion, Polars, specialized ANN engines, UDF/UDAF/UDTF, ranking/RERANK
 | Query | SQL frontend, pgwire, REST v2, gRPC v2, Arrow Flight, predicate/projection pushdown, subqueries, joins/aggregates
-| Multitenancy **mechanism** | `TenantContext`, `DrPathBuilder` path isolation, tenant-scoped catalog/DML/search (TD-064), generic tier/quota **hooks**, generic `TierPolicy` parser + `LimitsResolver` port, consumption telemetry (generic counters)
+| Multitenancy **mechanism** | `TenantContext`, `DrPathBuilder` path isolation, tenant-scoped catalog/DML/search (TD-064), generic tier/quota **hooks**, generic `TierPolicy` parser + `LimitsResolver` port, `set_tier_multiplier_resolver` port (route-cost), consumption telemetry (generic counters incl. `proximadb_egress_bytes_total` — the KEU egress *meter*; the cost-model scores egress/read/ingest/compute in **neutral units**)
 | Security **mechanism** | authN/authZ ports, SSO/SAML, RLS, security modes
 |===
 
@@ -52,8 +52,9 @@ leaks in non-gated OSS code.
 |===
 | Category | Where it belongs
 | Go-to-market surfaces (revenue, sales, licensing, executive intel) | feature-gated OFF today → **externalize to anvaiops** (or keep gated as stubs)
-| Pricing / billing **data + compute** (tier→limit values, pricing units KSU/KRU/KIU/KEU, invoices, cost) | **anvaiops** (OSS emits generic consumption metrics only)
-| tenant→tier **authority** | **anvaiops** (stamps `TenantContext.tier` claim)
+| Pricing / billing **data + compute** (tier→limit values, pricing units KSU/KRU/KIU/KEU, invoices, cost) | **anvaiops** (OSS emits generic consumption metrics only — incl. the new KEU egress *meter* `proximadb_egress_bytes_total{tenant_id, az_locality}`; anvaiops applies the per-`az_locality` KEU $ rate)
+| tenant→tier **authority** + tier→cost-**multiplier** values | **anvaiops** (stamps `TenantContext.tier` claim; supplies the `set_tier_multiplier_resolver` adapter — OSS default is `1.0`, inert)
+| object-store **AZ topology** ($ weight per `same_az`/`cross_az`/`internet`) | **anvaiops** / operator (OSS only records the neutral locality *bucket*, declared via `PROXIMADB_OBJECT_STORE_LOCALITY`, default `same_az`)
 | SaaS quota **values** (paid-tier caps) | operator config (`tier-config.json`) / anvaiops; the *enforcement mechanism* stays OSS
 | DR/CRR **billing binding** (SKU, cost cents) | feature-gate / externalize (opaque pass-through at most)
 | Cloud control plane (provisioning, multi-region orchestration) | **anvaiops**
@@ -84,6 +85,7 @@ leaks in non-gated OSS code.
   ┌─────────────────────── ProximaDB OSS (Rust) ───────────────────────┐
   │ PORTS (OSS-defined abstractions):                                   │
   │   LimitsResolver        ← cache tier shares      (TenantCache)      │
+  │   TierCostMultiplier    ← tenant→cost multiplier  (route_cost_model) │
   │   MeteringSink          ← consumption events     (telemetry)        │
   │   LicenseProvider       ← edition/entitlements   (#[cfg] gated)     │
   │   AuthProvider/SSO      ← identity               (security)         │
@@ -96,6 +98,41 @@ Each enterprise concern = an OSS *port* + a *default OSS adapter* (neutral) +
 an *enterprise adapter* injected by config/claim or a gated crate. The
 `LimitsResolver`/`TierPolicy` from the cache work (commit `e1491d410`) is the
 reference implementation of this pattern.
+
+=== 4.1. Cost-model seams (PR #101 — co-design Cost(q))
+
+The trace-driven route cost model (`src/query/route_cost_model.rs`) completes the
+§3 `Cost(q)` of `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` while keeping
+*all* pricing/policy on the anvaiops side. Two new seams, both default-inert:
+
+. **KEU egress meter (OSS) → KEU pricing (anvaiops).** OSS emits
+`proximadb_egress_bytes_total{tenant_id, az_locality}` and a per-query
+`io_trace.bytes_cross_az`, via the single convergent
+`consumption_metrics::record_egress_bytes`. `AzLocality` is a *neutral bucket*
+(`same_az`/`cross_az`/`internet`) the deployment declares with
+`PROXIMADB_OBJECT_STORE_LOCALITY` (default `same_az` = the free path → the
+egress *cost* term is zero until a cross-AZ topology is declared). OSS never
+holds a $ figure or the real AZ topology — anvaiops multiplies the metered bytes
+by its per-`az_locality` KEU rate. This is the `MeteringSink` port specialized to
+the previously-unmetered networking dimension.
+
+. **Tier-entitlement multiplier port (OSS) → tier policy (anvaiops).**
+`set_tier_multiplier_resolver(Fn(&str /*tenant_id*/) -> f64)` is the OSS port; the
+default adapter returns `1.0` (no resolver installed → fully inert, uniform
+community behavior). anvaiops installs the adapter from its tenant→tier authority
+(the same authority that stamps `TenantContext.tier`), resolving
+tenant→tier→multiplier *inside the adapter* — so the OSS cost path stays
+tier-agnostic (no `Tier` enum leaks into routing). The multiplier scales only the
+*reported / billed* `Cost(q)` and is **routing-neutral** (a per-tenant scalar
+scales every candidate equally → never changes which engine is chosen), so it can
+never make engine selection depend on a commercial tier. `final_cost(base,
+tenant)` and `tier_entitlement_multiplier(tenant)` are the consumption points.
+
+Boundary invariants: OSS scores `Cost(q)` in **neutral units** only; the $ weights
+(KSU/KRU/KIU/KEU), the AZ-topology→locality mapping, the tenant→tier authority,
+and the tier→multiplier values are *all* anvaiops. The guard
+(`check_oss_boundary.py`) already denies `keu_per_*` pricing units and non-doc
+`anvai*` refs, so a future leak of these into the cost model fails CI.
 
 == 5. Enforcement: CI boundary guard (new, durable)
 

--- a/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
+++ b/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
@@ -114,7 +114,11 @@ The trace-driven route cost model (`src/query/route_cost_model.rs`) completes th
 egress *cost* term is zero until a cross-AZ topology is declared). OSS never
 holds a $ figure or the real AZ topology — anvaiops multiplies the metered bytes
 by its per-`az_locality` KEU rate. This is the `MeteringSink` port specialized to
-the previously-unmetered networking dimension.
+the previously-unmetered networking dimension. *Quantity delivery is wired:* the
+per-query egress GiB is surfaced as `SearchPlanTrace.actual_egress_gb` in the
+search-response envelope (mirroring `actual_scan_gb`/KRU) and carried on the
+metering event; anvaiops parses it and writes an `event_type="egress"` billing
+tick only when non-zero. Same-AZ (free) deployments report 0 and emit nothing.
 
 . **Tier-entitlement multiplier port (OSS) → tier policy (anvaiops).**
 `set_tier_multiplier_resolver(Fn(&str /*tenant_id*/) -> f64)` is the OSS port; the

--- a/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
+++ b/docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc
@@ -123,14 +123,20 @@ tick only when non-zero. Same-AZ (free) deployments report 0 and emit nothing.
 . **Tier-entitlement multiplier port (OSS) → tier policy (anvaiops).**
 `set_tier_multiplier_resolver(Fn(&str /*tenant_id*/) -> f64)` is the OSS port; the
 default adapter returns `1.0` (no resolver installed → fully inert, uniform
-community behavior). anvaiops installs the adapter from its tenant→tier authority
-(the same authority that stamps `TenantContext.tier`), resolving
-tenant→tier→multiplier *inside the adapter* — so the OSS cost path stays
-tier-agnostic (no `Tier` enum leaks into routing). The multiplier scales only the
-*reported / billed* `Cost(q)` and is **routing-neutral** (a per-tenant scalar
-scales every candidate equally → never changes which engine is chosen), so it can
-never make engine selection depend on a commercial tier. `final_cost(base,
-tenant)` and `tier_entitlement_multiplier(tenant)` are the consumption points.
+community behavior). *Startup adapter (DONE):* at boot
+(`database.rs` → `tenant_tier::install_tier_cost_multiplier_resolver`) OSS installs
+a **config-driven** resolver mapping `tenant_id → Tier → Tier::cost_multiplier`,
+where the per-tier multiplier is read from the tier-config overlay
+(`/config/tier-config.json`, baked from anvaiops `tiers.json`). The `tenant_id →
+Tier` half is itself a Port (`set_tenant_tier_resolver`): OSS standalone has no
+per-tenant tier authority, so it resolves every tenant to the configured default
+tier; the control plane registers a resolver from its registry. So the OSS cost
+path stays tier-agnostic (no `Tier` enum leaks into routing) and the values stay
+control-plane policy. The multiplier scales only the *reported / billed* `Cost(q)`
+and is **routing-neutral** (a per-tenant scalar scales every candidate equally →
+never changes which engine is chosen), so it can never make engine selection
+depend on a commercial tier. `final_cost(base, tenant)` and
+`tier_entitlement_multiplier(tenant)` are the consumption points.
 
 Boundary invariants: OSS scores `Cost(q)` in **neutral units** only; the $ weights
 (KSU/KRU/KIU/KEU), the AZ-topology→locality mapping, the tenant→tier authority,

--- a/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
+++ b/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
@@ -1,0 +1,117 @@
+= Outgress (KOU) Multi-Cloud Cost Model & Deployment Strategy (2026-06-21)
+:toc: macro
+:icons: font
+
+Refines co-design Dimension 2 (Networking, `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`
+§2.2) into a *cloud-neutral, mistake-proof* outbound-data-movement model verified
+against AWS, Azure, and GCP primary pricing. The unit is **KOU (Outgress Unit)** —
+distinct from **KEU (embedding units)**. This is the OSS *mechanism* spec; the
+retail $ rate card is anvaiops *policy* (open-core boundary). Public cloud cost
+curves below are cited only as the design justification (as §2.2 already does).
+
+toc::[]
+
+== 1. The neutral model (OSS mechanism — `KouLocality`)
+
+Outbound bytes are classified into cloud-neutral locality buckets, recorded by the
+meter `proximadb_kou_bytes_total{tenant_id, kou_locality, direction}`
+(`direction ∈ {read, result}`). Two flows share the enum: *read-egress* (object
+store → compute) and *result-egress* (compute → client).
+
+[cols="1,3,1",options="header"]
+|===
+| Bucket | Meaning | Chargeable?
+| `local` | same zone + region (or unknown placement) | no (free)
+| `cross_az` | same region, different AZ/zone | no for object-store reads (see §2)
+| `cross_region` | same cloud, different region | yes
+| `cross_cloud` | different cloud provider | yes
+| `on_prem` | to/from on-premises (VPN / dedicated link / declared CIDR) | yes
+| `internet` | public internet (dominant result-egress term) | yes
+| `unknown` | no scope-map rule matched | recorded + surfaced, never silently charged/freed
+|===
+
+*Mistake-proof by construction:* provider is **inferred** from the storage URL
+scheme (never declared); read-locality is **derived** from compute-region vs
+store-region; client/result-locality is **classified** from the source IP against
+a control-plane-authored CIDR scope map (terraform emits it from the VPC it
+builds). Unknown is visible, never silently free. Same-region object-store read is
+**free on all three clouds** (confirmed) → it maps to `local`.
+
+== 2. Verified per-cloud shapes (the nuance the pricing layer must encode)
+
+The 6-bucket model holds structurally on all three clouds, but three buckets need
+per-cloud nuance. Figures are mid-2026 public list prices (US/Tier-1 unless noted),
+multiply-sourced; re-pin to primary pages before quoting customers.
+
+[cols="1,2,2,2",options="header"]
+|===
+| Bucket | AWS | Azure | GCP
+| same-region object-store read | free | free | free
+| `cross_az` | $0.01/GB each direction (compute); S3 same-region free | *FREE* (eliminated May 2024, any IP) | $0.01/GB inter-zone VM only; regional buckets exempt (free)
+| `cross_region` | per (origin,dest) geography | $0.02 (intra-US/EU) → $0.16 (S.America) | $0.02 NA·NA / $0.05 NA·EU / $0.08 Asia·Asia / $0.14 →S.America
+| `internet` | $0.09/GB → $0.05 at volume; first 100 GB free | $0.087/GB Zone1 → $0.083/$0.07/$0.05; Zone2 $0.12; Zone3 $0.181; first 100 GB free | Premium $0.12→$0.085/GiB tiered; *Standard tier* cheaper; keyed by destination
+| ingress | free | free | free
+| private link | data proc $0.01/$0.006/$0.004 per GB (1/4/5+ PB) + $0.01/hr per AZ-endpoint | ~$0.01/GB tiered (in+out) + $0.01/hr (~$7.30/mo) + std transfer still applies | PSC ~$0.01/hr endpoint (5 fwd-rules/$0.025/hr) + LB/transfer; underlying CSP fees apply
+|===
+
+Special cases the design MUST encode:
+
+. *`cross_az` is not uniform and is direction-dependent.* For `read` it is free
+everywhere (object store is regional; Azure free entirely). For a future
+compute↔compute / `result` path it is $0.01/GB on AWS/GCP, $0 on Azure. The OSS
+enum records it; the per-cloud + per-direction $ is pricing-layer policy.
+. *`cross_region` is a (origin, destination) matrix, not a scalar.* The rate-card
+must be matrix-capable; v1 may use a conservative per-cloud intra-continent scalar
+(~$0.02) and refine to the matrix.
+. *`internet` has a per-cloud volume + zone ladder, and GCP adds a Network Service
+Tier axis* (Premium vs Standard). v1 may use a per-cloud first-tier scalar.
+. *Private connectivity is additive cost, never an egress waiver, never a bucket.*
+AWS PrivateLink / Azure Private Link / GCP PSC each add per-endpoint-per-hour +
+per-GB-processed (Azure layers a separate cross-region per-GB on top). Model it as
+a connectivity *add-on*, not a `KouLocality` value.
+. *GCP Private Google Access is a free private route, not a waiver* — same-region
+stays free, cross-region still charged. Use it (avoids NAT/external-IP cost) but it
+does not change bucket assignment.
+. *Ingress is free on all three* → no inbound meter.
+
+== 3. Who bears egress + deployment-model strategy (vision)
+
+The provider pays the cloud's egress and *passes it through* to the tenant as the
+KOU line item; the tenant's lever is region/cloud affinity (same-region = free).
+Endpoint naming encodes cloud+region (`{region}.{cloud}.<host>`) so a cost-conscious
+client self-selects the near, free endpoint. Industry norm (Snowflake, ClickHouse
+Cloud, MongoDB Atlas all price egress by (cloud, src-region, dst-region); same-region
+free) validates this exactly.
+
+Staged, solo-operator-optimized (lowest ops first):
+
+[cols="1,3,1",options="header"]
+|===
+| Stage | Move | Tier
+| 1 | Region-affinity metered multi-tenant SaaS + KOU pass-through; same-region free; cloud+region-encoded endpoints | Free/Team/Pro (default)
+| 2 | Egress-free object storage (Cloudflare R2 / Tigris, $0 egress) *under* the data plane → read-egress structurally $0; recover via storage+ops | all tiers (architectural)
+| 3 | PrivateLink / Private Link / PSC as a paid connectivity add-on (kills the internet hop; break-even ~80–95 GB/mo on Azure) | Business
+| 4 | BYOC — data plane in the customer's own account (customer bears storage+egress directly; pull-based outbound-only control, no inbound); strongest compliance, heaviest per-customer ops | Enterprise (on demand)
+|===
+
+Operator-mistake guardrails (evidence-backed): bill from *measured* (cloud,
+src-region, dst-region) tuples not flat rates; isolation structural not per-query;
+surface `cross_az` / `cross_region` / `cross_cloud` / `internet` as distinct metered
+tiers so users self-select cheap topologies; default unknown placement to free +
+WARN (visible), never silent.
+
+== 4. Open gaps (honest — re-pin before quoting)
+
+* Exact Azure Private Link *deeper* data-processing tiers (canonical bandwidth /
+private-link pages timed out; only "~$0.01/GB, tiered" confirmed).
+* Exact GCP PSC per-GB *consumed* rate (PSC is mostly per-endpoint-hour + underlying
+LB/transfer; primary per-GB not captured).
+* GCP Standard Network Service Tier exact internet ladder.
+* Qualitative: customer acceptance of egress as a visible pass-through line vs
+bundled; realistic BYOC per-customer ops cost + minimum ACV for a solo operator.
+
+Provenance: two adversarially-verified deep-research passes (AWS, then Azure/GCP;
+25 + 23 claims confirmed 3-0, 2 refuted/excluded) + in-session primary-source
+gap-fill (AWS PrivateLink, Azure bandwidth, GCP PSC, Private Google Access). Two
+refuted figures discarded: an Azure Private Link PB-tier schedule and a specific
+GCS inter-region $0.01–0.08 mapping.

--- a/scripts/route_cost_report.py
+++ b/scripts/route_cost_report.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Route-cost evidence report — decide PROXIMADB_ROUTE_COST_OVERRIDE on data, not faith.
+
+The trace-driven cost model (`src/query/route_cost_model.rs`) runs in **observe
+mode** by default: every routed query logs an advisory in its decision reason —
+either it *concurs* with the static route or it *would prefer* a cheaper backend
+(with the ranked neutral scores). This script summarizes those already-emitted
+advisories from a log so a solo operator can see, with real traffic, whether
+flipping the live-override flag would actually help — the co-design "measure
+before you optimize" discipline (P11) as a tiny report, not an RL system.
+
+It reads structured/plain log lines (a file arg, or stdin) and tallies, per
+backend, how often the model diverged from the static choice and by how much
+(neutral score advantage). No new instrumentation; pure read of existing output.
+
+Usage:
+    python scripts/route_cost_report.py path/to/proximadb.log
+    journalctl -u proximadb | python scripts/route_cost_report.py
+
+Exit: always 0 (a report, not a gate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import sys
+
+# route_select_advised emits one of these into the decision reason:
+#   "cost-model concurs (min-cost over N sample(s): Native(Volcano) [Native(Volcano)=12.0, ...])"
+#   "cost-model would prefer DataFusionLocal (min-cost over N sample(s): ... [Native(Volcano)=200.0, DataFusionLocal=120.0]) — observe-mode, route unchanged"
+#   "cost-model OVERRIDE Native(Volcano)→DataFusionLocal (...)"   "cost-model EXPLORE ..."
+_PREFER = re.compile(r"cost-model would prefer (?P<backend>[^\s(]+)")
+_CONCUR = re.compile(r"cost-model concurs")
+_OVERRIDE = re.compile(r"cost-model OVERRIDE \S+→(?P<backend>[^\s(]+)")
+_SAMPLES = re.compile(r"min-cost over (?P<n>\d+) sample")
+_RANKED = re.compile(r"\[(?P<ranked>[^\]]*)\]")  # "Native(Volcano)=200.0, DataFusionLocal=120.0"
+_SCORE = re.compile(r"=(?P<score>[0-9]+(?:\.[0-9]+)?)")
+
+# Override fires only above this neutral advantage (mirrors RouteCostModel::min_advantage).
+MIN_ADVANTAGE = 0.15
+# Need at least this many diverging observations before a recommendation is trustworthy.
+MIN_OBSERVATIONS = 20
+
+
+def advantage(ranked: str) -> float | None:
+    """Relative advantage of the cheapest over the next-cheapest in a ranked list:
+    (second - first) / second, in [0,1). Order-agnostic (sorts the parsed scores),
+    so it is robust to log formatting. None if < 2 usable scores."""
+    scores = sorted(float(m.group("score")) for m in _SCORE.finditer(ranked))
+    if len(scores) < 2 or scores[1] <= 0:
+        return None
+    return (scores[1] - scores[0]) / scores[1]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="ProximaDB route-cost observe-mode report")
+    ap.add_argument("log", nargs="?", help="log file (default: stdin)")
+    args = ap.parse_args()
+    src = open(args.log, encoding="utf-8", errors="ignore") if args.log else sys.stdin
+
+    concur = 0
+    overrides = 0
+    prefer_by_backend: dict[str, int] = {}
+    advantages: list[float] = []
+    max_samples = 0
+
+    with src:
+        for line in src:
+            if _CONCUR.search(line):
+                concur += 1
+                continue
+            if (mo := _OVERRIDE.search(line)) is not None:
+                overrides += 1
+                prefer_by_backend[mo.group("backend")] = (
+                    prefer_by_backend.get(mo.group("backend"), 0) + 1
+                )
+            elif (mp := _PREFER.search(line)) is not None:
+                prefer_by_backend[mp.group("backend")] = (
+                    prefer_by_backend.get(mp.group("backend"), 0) + 1
+                )
+            else:
+                continue
+            if (ms := _SAMPLES.search(line)) is not None:
+                max_samples = max(max_samples, int(ms.group("n")))
+            if (mr := _RANKED.search(line)) is not None and (adv := advantage(mr.group("ranked"))):
+                advantages.append(adv)
+
+    diverged = sum(prefer_by_backend.values())
+    total = concur + diverged + overrides
+    print("=== ProximaDB route-cost observe-mode report ===")
+    if total == 0:
+        print(
+            "No cost-model advisories found. Run routed SELECTs with the cost "
+            "observer installed (default), routing logs captured, then re-run."
+        )
+        return 0
+    print(f"advisories: {total}  (concur={concur}, would-prefer={diverged}, override-fired={overrides})")
+    print(f"max warmed samples per shape-class: {max_samples}")
+    if prefer_by_backend:
+        print("would-prefer by backend:")
+        for b, n in sorted(prefer_by_backend.items(), key=lambda kv: -kv[1]):
+            print(f"  {b}: {n}")
+    median_adv = statistics.median(advantages) if advantages else 0.0
+    print(f"median neutral advantage when diverging: {median_adv * 100:.1f}% (override gate: {MIN_ADVANTAGE * 100:.0f}%)")
+
+    # Verdict — enable override only with enough evidence AND a consistent,
+    # above-gate advantage; otherwise keep observing (don't flip on noise).
+    diverge_frac = diverged / total if total else 0.0
+    print("\nverdict:")
+    if diverged < MIN_OBSERVATIONS:
+        print(
+            f"  KEEP OBSERVING — only {diverged} diverging samples (< {MIN_OBSERVATIONS}). "
+            "Not enough evidence to flip PROXIMADB_ROUTE_COST_OVERRIDE."
+        )
+    elif median_adv >= MIN_ADVANTAGE and diverge_frac >= 0.2:
+        print(
+            f"  CONSIDER ENABLING PROXIMADB_ROUTE_COST_OVERRIDE — the model would "
+            f"re-route {diverge_frac * 100:.0f}% of queries to a backend that is "
+            f"{median_adv * 100:.0f}% cheaper (above the {MIN_ADVANTAGE * 100:.0f}% gate). "
+            "Enable in staging first; the override is freshness-safe + reversible."
+        )
+    else:
+        print(
+            f"  KEEP OBSERVING — divergence ({diverge_frac * 100:.0f}%) / advantage "
+            f"({median_adv * 100:.0f}%) below the bar; the static routes are close to optimal."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/catalog/tenant_tier.rs
+++ b/src/catalog/tenant_tier.rs
@@ -15,7 +15,7 @@
 // not the concrete backing, so the swap is transparent.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -78,6 +78,12 @@ struct PricingTier {
     id: String,
     prom_label: String,
     soft_caps: PricingSoftCaps,
+    /// C5 governance tier-entitlement multiplier (Dimension 5). Authored by the
+    /// control plane (anvaiops `tiers.json` → `/config/tier-config.json`); absent
+    /// in the OSS baseline overlay → `None` → neutral `1.0`. Other overlay fields
+    /// (pricing, display, …) are ignored by serde — this reads only the scalar.
+    #[serde(default)]
+    cost_multiplier: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -326,6 +332,18 @@ impl Tier {
     /// Default freshness SLA for async ingest, in seconds.
     pub fn default_freshness_sla_seconds(self) -> u32 {
         pricing_row(self).soft_caps.freshness_sla_seconds
+    }
+
+    /// C5 governance tier-entitlement multiplier (Dimension 5) for this tier,
+    /// read from the tier-config overlay. Neutral `1.0` when the overlay omits it
+    /// (the OSS baseline) or supplies a non-finite/non-positive value (rejected
+    /// fail-safe — a non-positive multiplier could invert the reported cost). The
+    /// $ values are control-plane policy; OSS only reads the configured scalar.
+    pub fn cost_multiplier(self) -> f64 {
+        match pricing_row(self).cost_multiplier {
+            Some(m) if m.is_finite() && m > 0.0 => m,
+            _ => 1.0,
+        }
     }
 
     /// Bounded Prometheus label — cardinality-safe. The label set is loaded
@@ -681,6 +699,68 @@ impl TenantTierStore for InMemoryTenantTierStore {
     }
 }
 
+// ── C5: governance tier cost-multiplier startup adapter (Dimension 5) ───────
+//
+// The route cost model exposes a tenant→multiplier Port
+// (`route_cost_model::set_tier_multiplier_resolver`, default 1.0). This is the
+// OSS adapter that fills it from the tier-config overlay (anvaiops policy values)
+// without leaking the `Tier` enum into the routing/cost path:
+//
+//   tenant_id ──(tenant→tier Port)──▶ Tier ──(tier-config)──▶ cost_multiplier
+//
+// The tenant→tier half is itself a Port: OSS standalone has no per-tenant tier
+// authority (that lives in the control plane's registry), so the default
+// resolves every tenant to the configured default tier — whose multiplier is
+// 1.0 in the OSS baseline, keeping the whole objective inert until a deployment
+// both registers a tenant→tier resolver AND ships non-neutral tier multipliers.
+
+type TenantTierFn = dyn Fn(&str) -> Tier + Send + Sync;
+
+static TENANT_TIER_RESOLVER: Mutex<Option<Box<TenantTierFn>>> = Mutex::new(None);
+
+/// Install (or clear with `None`) the sync tenant→tier resolver Port. The
+/// control-plane integration registers one mapping a tenant id to its `Tier`
+/// from its authority (e.g. a warmed snapshot of the tenant registry); OSS
+/// standalone leaves it unset, so every tenant resolves to the configured
+/// default tier. Sync by contract — the route cost model consults it inline.
+pub fn set_tenant_tier_resolver(resolver: Option<Box<TenantTierFn>>) {
+    *TENANT_TIER_RESOLVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = resolver;
+}
+
+/// The configured default tier (`pricing().default_tier`, alias-aware), or
+/// [`Tier::default`] if it somehow fails to parse.
+fn default_tier() -> Tier {
+    let raw = serde_json::Value::String(pricing().default_tier.clone());
+    serde_json::from_value::<Tier>(raw).unwrap_or_default()
+}
+
+/// Resolve a tenant to its `Tier` via the registered Port, falling back to the
+/// configured default tier when none is installed (OSS standalone).
+pub fn resolve_tier_for(tenant_id: &str) -> Tier {
+    match TENANT_TIER_RESOLVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .as_ref()
+    {
+        Some(resolve) => resolve(tenant_id),
+        None => default_tier(),
+    }
+}
+
+/// C5 startup adapter: install the config-driven tier cost-multiplier resolver
+/// into the route cost model. Called once at startup (after
+/// `route_cost_model::install_route_cost_observer`). Maps tenant → tier →
+/// `Tier::cost_multiplier`, so `route_cost_model::final_cost` reports the real
+/// per-tenant `Cost(q)`. Default-inert: with no tenant→tier resolver and the
+/// neutral baseline multipliers, every tenant resolves to `1.0`.
+pub fn install_tier_cost_multiplier_resolver() {
+    crate::query::route_cost_model::set_tier_multiplier_resolver(Some(Box::new(|tenant_id| {
+        resolve_tier_for(tenant_id).cost_multiplier()
+    })));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -919,5 +999,49 @@ mod tests {
             config.quantization_ceiling,
             ObjectEconomyQuantizationCeiling::FP32
         );
+    }
+
+    // ── C5 tier cost-multiplier adapter ─────────────────────────────────────
+
+    #[test]
+    fn cost_multiplier_is_neutral_in_oss_baseline() {
+        // The baked OSS baseline overlay ships no cost_multiplier → neutral 1.0
+        // on every tier (the objective stays inert until policy ships values).
+        for &t in Tier::all() {
+            assert_eq!(t.cost_multiplier(), 1.0, "{t:?} baseline multiplier");
+        }
+    }
+
+    #[test]
+    fn tenant_tier_resolver_port_defaults_to_config_default_then_honors_override() {
+        // No resolver installed → the configured default tier.
+        set_tenant_tier_resolver(None);
+        assert_eq!(resolve_tier_for("anyone"), default_tier());
+        // A registered resolver (the control-plane adapter) maps per tenant.
+        set_tenant_tier_resolver(Some(Box::new(|t: &str| {
+            if t == "vip" { Tier::Tier5 } else { Tier::Tier1 }
+        })));
+        assert_eq!(resolve_tier_for("vip"), Tier::Tier5);
+        assert_eq!(resolve_tier_for("other"), Tier::Tier1);
+        set_tenant_tier_resolver(None); // reset process-global for sibling tests
+    }
+
+    #[test]
+    fn install_wires_the_route_cost_model_tier_multiplier() {
+        use crate::query::route_cost_model::{
+            set_tier_multiplier_resolver, tier_entitlement_multiplier,
+        };
+        // Map a tenant to a concrete tier, install the adapter, and confirm the
+        // route cost model resolves that tenant's multiplier through it. Baseline
+        // multipliers are the neutral 1.0, so the assertion is also race-robust.
+        set_tenant_tier_resolver(Some(Box::new(|_| Tier::Tier5)));
+        install_tier_cost_multiplier_resolver();
+        assert_eq!(
+            tier_entitlement_multiplier(Some("vip")),
+            Tier::Tier5.cost_multiplier()
+        );
+        // reset both process-globals so other tests are unaffected.
+        set_tier_multiplier_resolver(None);
+        set_tenant_tier_resolver(None);
     }
 }

--- a/src/catalog/tenant_tier.rs
+++ b/src/catalog/tenant_tier.rs
@@ -334,6 +334,19 @@ impl Tier {
         pricing_row(self).soft_caps.freshness_sla_seconds
     }
 
+    /// Parse a tier *claim* string (e.g. the `X-Tenant-Tier` header the control
+    /// plane stamps) into a `Tier`, honoring the serde aliases — so both the
+    /// canonical ids (`tier1`..`tier5`) and the legacy/commercial ids
+    /// (`free_trial`/`free`/`team`/`pro`/`business`/`enterprise`/…) resolve.
+    /// `None` for an unrecognized claim (caller falls back to the default tier).
+    pub fn from_claim(claim: &str) -> Option<Tier> {
+        let trimmed = claim.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        serde_json::from_value::<Tier>(serde_json::Value::String(trimmed.to_string())).ok()
+    }
+
     /// C5 governance tier-entitlement multiplier (Dimension 5) for this tier,
     /// read from the tier-config overlay. Neutral `1.0` when the overlay omits it
     /// (the OSS baseline) or supplies a non-finite/non-positive value (rejected
@@ -731,7 +744,7 @@ pub fn set_tenant_tier_resolver(resolver: Option<Box<TenantTierFn>>) {
 
 /// The configured default tier (`pricing().default_tier`, alias-aware), or
 /// [`Tier::default`] if it somehow fails to parse.
-fn default_tier() -> Tier {
+pub fn default_tier() -> Tier {
     let raw = serde_json::Value::String(pricing().default_tier.clone());
     serde_json::from_value::<Tier>(raw).unwrap_or_default()
 }
@@ -1010,6 +1023,21 @@ mod tests {
         for &t in Tier::all() {
             assert_eq!(t.cost_multiplier(), 1.0, "{t:?} baseline multiplier");
         }
+    }
+
+    #[test]
+    fn from_claim_parses_canonical_and_legacy_ids() {
+        // Canonical ids and the control-plane / legacy aliases both resolve.
+        assert_eq!(Tier::from_claim("tier1"), Some(Tier::Tier1));
+        assert_eq!(Tier::from_claim("free_trial"), Some(Tier::Tier1));
+        assert_eq!(Tier::from_claim("free"), Some(Tier::Tier1));
+        assert_eq!(Tier::from_claim("pro"), Some(Tier::Tier3));
+        assert_eq!(Tier::from_claim("business"), Some(Tier::Tier4));
+        assert_eq!(Tier::from_claim("enterprise"), Some(Tier::Tier5));
+        assert_eq!(Tier::from_claim("  tier5  "), Some(Tier::Tier5));
+        // Unknown / empty → None (caller uses the default tier).
+        assert_eq!(Tier::from_claim("nonsense"), None);
+        assert_eq!(Tier::from_claim(""), None);
     }
 
     #[test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -116,6 +116,12 @@ impl ProximaDB {
         // measured cost of each (shape-class, backend). Observe-mode today —
         // routing is unchanged until a later flag-gated slice.
         crate::query::route_cost_model::install_route_cost_observer();
+        // Co-design C5: install the config-driven tier cost-multiplier resolver
+        // (Dimension 5, the final Cost(q) term) into the route cost model. Reads
+        // per-tier multipliers from the tier-config overlay (control-plane policy
+        // values) via the tenant→tier Port. Default-inert: neutral 1.0 until a
+        // tenant→tier resolver is registered and non-neutral multipliers shipped.
+        crate::catalog::tenant_tier::install_tier_cost_multiplier_resolver();
 
         let (shared_services, collection_service) = network::multi_server::SharedServices::new(
             Some(metrics_collector.clone()),

--- a/src/database.rs
+++ b/src/database.rs
@@ -130,6 +130,26 @@ impl ProximaDB {
         // values) via the tenant→tier Port. Default-inert: neutral 1.0 until a
         // tenant→tier resolver is registered and non-neutral multipliers shipped.
         crate::catalog::tenant_tier::install_tier_cost_multiplier_resolver();
+        // Co-design C3/KOU: derive this deployment's object-store read-egress
+        // locality from the storage URL (provider) + control-plane-stamped
+        // PROXIMADB_COMPUTE_REGION/PROXIMADB_STORE_REGION, and install it as the
+        // process-wide locality the egress meter uses. Default Local (free, inert)
+        // when unset; logs the derived locality. Turns B1's derivation live.
+        {
+            let storage_url = config
+                .storage
+                .storage_locations
+                .first()
+                .map(|loc| loc.url.as_str())
+                .unwrap_or("");
+            let placement = crate::metrics::consumption_metrics::placement_from_env(storage_url);
+            crate::metrics::consumption_metrics::install_placement(&placement);
+        }
+        // Co-design KOU result-egress: load the client-locality scope map (CIDR→
+        // locality, control-plane-authored via PROXIMADB_NETWORK_SCOPE_MAP).
+        // Default-empty → clients classify as Unknown (safe). Consumed by the
+        // gateway/result-egress path; the classifier (`classify_client`) is live.
+        crate::metrics::consumption_metrics::install_network_scope_map(None);
 
         let (shared_services, collection_service) = network::multi_server::SharedServices::new(
             Some(metrics_collector.clone()),

--- a/src/database.rs
+++ b/src/database.rs
@@ -116,6 +116,14 @@ impl ProximaDB {
         // measured cost of each (shape-class, backend). Observe-mode today —
         // routing is unchanged until a later flag-gated slice.
         crate::query::route_cost_model::install_route_cost_observer();
+        // Co-design C5 (integration): register the tenant→tier Port to read the
+        // header-fed tier registry (`X-Tenant-Tier` → `record_store::TENANT_TIERS`),
+        // so the per-tenant tier the cache LimitsResolver already sees also drives
+        // the cost-multiplier — one tier source, no new authority. Installed here
+        // (depends on both catalog + services) to keep catalog free of a services dep.
+        crate::catalog::tenant_tier::set_tenant_tier_resolver(Some(Box::new(
+            crate::services::record_store::tenant_tier_resolved,
+        )));
         // Co-design C5: install the config-driven tier cost-multiplier resolver
         // (Dimension 5, the final Cost(q) term) into the route cost model. Reads
         // per-tier multipliers from the tier-config overlay (control-plane policy

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -11,7 +11,7 @@
 //! task time). Pricing/billing is an operator/control-plane concern — this OSS
 //! module only emits neutral telemetry attributed by `tenant_id`.
 
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 
 use lazy_static::lazy_static;
 use prometheus::{CounterVec, GaugeVec, Opts, register_counter_vec, register_gauge_vec};
@@ -58,82 +58,245 @@ lazy_static! {
         "Per-tenant cache stats snapshot (metric label selects bytes/hits/misses/hit_ratio/evictions)",
         &["tenant_id", "cache", "metric"]
     );
-    /// Per-tenant bytes moved OUT of object storage, labelled by AZ locality —
-    /// the KEU egress meter (co-design Dimension 2 / §2.2), the one previously
-    /// unmetered dimension. Networking (cross-AZ $0.02/GB RT, internet egress
-    /// $0.09/GB) is frequently the dominant TCO term, yet same-AZ is free — so
-    /// the `az_locality` label is the discriminator that makes egress a billable,
-    /// optimizable dimension. Neutral telemetry only: the AZ topology and the $
-    /// weights are control-plane (anvaiops) policy.
-    pub static ref EGRESS_BYTES_TOTAL: CounterVec = registered_counter_vec(
-        "proximadb_egress_bytes_total",
-        "Bytes moved out of object storage per tenant, labelled by AZ locality (KEU egress)",
-        &["tenant_id", "az_locality"]
+    /// Per-tenant bytes moved OUT of the deployment — the **KOU** (Outgress Unit)
+    /// meter (co-design Dimension 2 / §2.2). `direction` separates `read`
+    /// (object store → compute) from `result` (compute → client); `kou_locality`
+    /// is the cost discriminator (cross-region ~$0.02/GB, internet ~$0.09-0.12/GB
+    /// by cloud; same-region/AZ free). Networking is frequently the dominant TCO
+    /// term. Neutral telemetry only: the cloud topology and the $ weights are
+    /// control-plane (anvaiops) policy. (KEU = embedding units is a separate meter.)
+    pub static ref KOU_BYTES_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_kou_bytes_total",
+        "Outgress bytes per tenant by locality + direction (KOU, Dimension 2)",
+        &["tenant_id", "kou_locality", "direction"]
     );
 }
 
-/// AZ-locality classification of bytes leaving object storage — the KEU egress
-/// dimension (§2.2). This is OSS **mechanism**: it records *which locality bucket*
-/// the bytes moved through; the real AZ topology and the per-locality dollar
-/// weights are commercial-control-plane (anvaiops) **policy**. Same-AZ is the
-/// co-designed free path; cross-AZ and internet egress are the chargeable terms
-/// the cost model's egress weight consumes.
+/// Cloud provider hosting the object store — the multi-cloud axis for egress
+/// pricing (AWS / Azure / GCP each price data movement differently). OSS
+/// **mechanism**: it is *inferred from the storage URL scheme* the operator
+/// already configures (so it can never be set wrong), never hand-declared. The
+/// $ weights per (provider, locality) are control-plane (anvaiops) **policy**.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AzLocality {
-    /// Compute, cache, and object store co-located in one AZ over private IP —
-    /// the free path. The default, so egress stays inert until a deployment
-    /// declares otherwise.
+pub enum CloudProvider {
+    Aws,
+    Azure,
+    Gcp,
+    /// Local filesystem / dev / unknown — no egress cost.
     #[default]
-    SameAz,
-    /// Bytes crossed an availability-zone boundary (~$0.02/GB round-trip).
-    CrossAz,
-    /// Bytes left the cloud to the public internet (egress, ~$0.09/GB).
-    Internet,
+    Local,
 }
 
-impl AzLocality {
+impl CloudProvider {
+    /// Stable label string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CloudProvider::Aws => "aws",
+            CloudProvider::Azure => "azure",
+            CloudProvider::Gcp => "gcp",
+            CloudProvider::Local => "local",
+        }
+    }
+
+    /// Infer the provider from an object-store URL scheme — the same scheme the
+    /// `FilesystemFactory` dispatches on (`s3`, `gs`/`gcs`, `az`/`adls`/`abfs`,
+    /// `file`). Unknown / empty → [`CloudProvider::Local`]. This is the
+    /// mistake-proof seam: the provider follows the storage URL, not a separate
+    /// env an operator could contradict.
+    pub fn from_url_scheme(scheme: &str) -> Self {
+        match scheme.trim().to_ascii_lowercase().as_str() {
+            "s3" | "s3a" => CloudProvider::Aws,
+            "gs" | "gcs" => CloudProvider::Gcp,
+            "az" | "azure" | "adls" | "abfs" | "abfss" => CloudProvider::Azure,
+            _ => CloudProvider::Local,
+        }
+    }
+}
+
+/// Locality of bytes moving out of the deployment — the **KOU** (Outgress Unit)
+/// dimension (§2.2), cloud-neutral. Used for two flows: *read-egress* (object
+/// store → compute) and *result-egress* (compute → client). Distinct from
+/// **KEU = embedding units** (a separate, embedding-compute meter).
+///
+/// Region-granular by design: object-store reads are billed by *region*, not
+/// availability zone — same-region access is **free on every cloud** (S3 via the
+/// VPC gateway endpoint, ADLS/Blob is regional, GCS via private access). So
+/// `Local`/`CrossAz` are recorded for visibility but **not** chargeable; only
+/// `CrossRegion`/`CrossCloud`/`OnPrem`/`Internet` cost. `Unknown` is recorded and
+/// surfaced (never silently charged or freed) so an operator fixes the scope map.
+/// OSS records the neutral bucket; the per-(provider, bucket) $ weight is
+/// anvaiops policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum KouLocality {
+    /// Compute and the other endpoint co-located (same region/zone) — free.
+    /// The safe default so outgress stays inert until placement is known.
+    #[default]
+    Local,
+    /// Same region, different availability zone — **free for object storage** on
+    /// all clouds (recorded for visibility + the future compute↔compute meter).
+    CrossAz,
+    /// Different region, same cloud — chargeable cross-region transfer (~$0.02/GB).
+    CrossRegion,
+    /// Different cloud provider — chargeable (internet-tier, expensive).
+    CrossCloud,
+    /// To/from on-premises (over VPN / dedicated link / declared CIDR).
+    OnPrem,
+    /// Public internet (~$0.09-0.12/GB by cloud) — the dominant result-egress term.
+    Internet,
+    /// Could not be classified (no scope-map rule matched) — recorded + surfaced,
+    /// never silently treated as free or charged.
+    Unknown,
+}
+
+impl KouLocality {
     /// Stable metric-label string.
     pub fn as_str(self) -> &'static str {
         match self {
-            AzLocality::SameAz => "same_az",
-            AzLocality::CrossAz => "cross_az",
-            AzLocality::Internet => "internet",
+            KouLocality::Local => "local",
+            KouLocality::CrossAz => "cross_az",
+            KouLocality::CrossRegion => "cross_region",
+            KouLocality::CrossCloud => "cross_cloud",
+            KouLocality::OnPrem => "on_prem",
+            KouLocality::Internet => "internet",
+            KouLocality::Unknown => "unknown",
         }
     }
 
-    /// Whether bytes through this locality are chargeable egress (i.e. *not* the
-    /// free same-AZ path). Only these bytes feed the per-query trace's
-    /// `bytes_cross_az` term, so same-AZ traffic never inflates the egress cost.
+    /// Whether bytes through this locality are chargeable outgress. `Local` and
+    /// `CrossAz` object-store access is free on every cloud, and `Unknown` is not
+    /// charged (it is surfaced for the operator to fix), so only genuinely
+    /// cross-boundary movement feeds the cost model's egress term + the trace.
     pub fn is_chargeable_egress(self) -> bool {
-        !matches!(self, AzLocality::SameAz)
+        matches!(
+            self,
+            KouLocality::CrossRegion
+                | KouLocality::CrossCloud
+                | KouLocality::OnPrem
+                | KouLocality::Internet
+        )
     }
 
-    /// Parse the deployment-declared object-store locality from a string
-    /// (`same_az` | `cross_az` | `internet`), accepting a couple of obvious
-    /// aliases. Unknown values fall back to the free `SameAz` default.
-    pub fn parse(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "cross_az" | "cross-az" | "crossaz" => AzLocality::CrossAz,
-            "internet" | "egress" | "public" => AzLocality::Internet,
-            _ => AzLocality::SameAz,
+    /// Parse an explicit operator override / scope-map value, accepting obvious
+    /// aliases. `None` for an unrecognized value (caller keeps the derived value
+    /// rather than silently mis-charging).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+            "local" | "same_az" | "colocated" | "same_zone" => Some(KouLocality::Local),
+            "cross_az" | "same_region" | "region" => Some(KouLocality::CrossAz),
+            "cross_region" | "crossregion" => Some(KouLocality::CrossRegion),
+            "cross_cloud" | "crosscloud" => Some(KouLocality::CrossCloud),
+            "on_prem" | "onprem" | "on_premises" => Some(KouLocality::OnPrem),
+            "internet" | "egress" | "public" => Some(KouLocality::Internet),
+            "unknown" => Some(KouLocality::Unknown),
+            _ => None,
+        }
+    }
+
+    /// Derive the **read-egress** locality (object store → compute) from a
+    /// [`PlacementContext`] — the per-cloud truth table, the mistake-proof core.
+    /// A different store cloud → `CrossCloud`; region equality (not zone) decides
+    /// the rest; GCS multi-region scopes (`US`/`EU`/`ASIA`) containing the compute
+    /// region count as same-region (`CrossAz`, free).
+    pub fn derive_read(ctx: &PlacementContext) -> Self {
+        // No cloud, or we don't know where compute runs → assume free (never
+        // invent a charge); the caller logs the assumption.
+        if ctx.store_provider == CloudProvider::Local || ctx.compute_region.trim().is_empty() {
+            return KouLocality::Local;
+        }
+        // Compute in a different cloud than the store → cross-cloud read.
+        if ctx.compute_provider != CloudProvider::Local
+            && ctx.compute_provider != ctx.store_provider
+        {
+            return KouLocality::CrossCloud;
+        }
+        let compute = ctx.compute_region.trim().to_ascii_lowercase();
+        let store = ctx.store_region.trim().to_ascii_lowercase();
+        if store.is_empty() {
+            return KouLocality::Local; // store region unknown → don't over-charge
+        }
+        if compute == store || gcs_multi_region_contains(&store, &compute) {
+            // Same region (object store is regional) → free. Recorded as CrossAz
+            // only when zones are known to differ; otherwise the free Local.
+            KouLocality::Local
+        } else {
+            KouLocality::CrossRegion
         }
     }
 }
 
-/// The deployment-declared locality of the object store relative to the compute
-/// reading it, from `PROXIMADB_OBJECT_STORE_LOCALITY` (read once). Default
-/// `SameAz` — the co-designed free path — so the egress cost term is inert until
-/// an operator declares a cross-AZ/internet topology. The actual $ weight per
-/// locality remains anvaiops policy; this only selects the neutral bucket.
-static OBJECT_STORE_LOCALITY: LazyLock<AzLocality> = LazyLock::new(|| {
-    std::env::var("PROXIMADB_OBJECT_STORE_LOCALITY")
-        .map(|v| AzLocality::parse(&v))
-        .unwrap_or_default()
-});
+/// Whether a GCS multi-region / dual-region bucket scope (`us`, `eu`, `asia`)
+/// contains a specific compute region (e.g. `us-central1` ∈ `us`). Region-scoped
+/// store values fall through to plain equality in the caller.
+fn gcs_multi_region_contains(store: &str, compute: &str) -> bool {
+    matches!(store, "us" | "eu" | "asia") && compute.starts_with(store)
+}
 
-/// The configured object-store egress locality for this deployment.
-pub fn object_store_egress_locality() -> AzLocality {
+/// Inputs to [`KouLocality::derive_read`]: the store cloud + region (from the
+/// storage URL scheme + backend config) and where compute runs
+/// (`PROXIMADB_COMPUTE_REGION`, control-plane stamped; `compute_provider`
+/// defaults to the store provider — same cloud — unless declared otherwise).
+#[derive(Debug, Clone, Default)]
+pub struct PlacementContext {
+    pub store_provider: CloudProvider,
+    pub compute_provider: CloudProvider,
+    pub compute_region: String,
+    pub store_region: String,
+}
+
+/// The process-wide derived object-store egress locality, computed once at
+/// startup by [`install_placement`]. Defaults to `Local` (free, inert) until the
+/// deployment installs a real [`PlacementContext`] — so OSS-standalone / dev runs
+/// never bill egress.
+static OBJECT_STORE_LOCALITY: LazyLock<Mutex<KouLocality>> =
+    LazyLock::new(|| Mutex::new(KouLocality::Local));
+
+/// Install the deployment's placement (called once at startup). Derives the
+/// read-egress locality from `ctx`, applies the `PROXIMADB_OBJECT_STORE_LOCALITY`
+/// override when present+valid, stores it, and returns the effective value so the
+/// caller can log it. A cloud provider with an unknown compute region logs a WARN
+/// (visible assumption, not a silent free pass).
+pub fn install_placement(ctx: &PlacementContext) -> KouLocality {
+    let derived = KouLocality::derive_read(ctx);
+    let effective = match std::env::var("PROXIMADB_OBJECT_STORE_LOCALITY") {
+        Ok(v) if !v.trim().is_empty() => match KouLocality::parse(&v) {
+            Some(override_loc) => override_loc,
+            None => {
+                tracing::warn!(
+                    value = %v,
+                    "ignoring invalid PROXIMADB_OBJECT_STORE_LOCALITY override; \
+                     using derived locality"
+                );
+                derived
+            }
+        },
+        _ => derived,
+    };
+    if ctx.store_provider != CloudProvider::Local && ctx.compute_region.trim().is_empty() {
+        tracing::warn!(
+            store_provider = ctx.store_provider.as_str(),
+            "PROXIMADB_COMPUTE_REGION unset on a cloud deployment; assuming \
+             same-region (free) egress — set it so cross-region egress is metered"
+        );
+    }
+    tracing::info!(
+        store_provider = ctx.store_provider.as_str(),
+        compute_region = %ctx.compute_region,
+        store_region = %ctx.store_region,
+        locality = effective.as_str(),
+        "co-design Dimension 2 (KOU): derived read-egress locality"
+    );
     *OBJECT_STORE_LOCALITY
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = effective;
+    effective
+}
+
+/// The effective object-store read-egress locality for this deployment (derived
+/// at startup; `Local` until [`install_placement`] runs).
+pub fn object_store_egress_locality() -> KouLocality {
+    *OBJECT_STORE_LOCALITY
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
 }
 
 /// Helper to record an object store operation.
@@ -160,29 +323,35 @@ pub fn record_task_execution_time(tenant_id: Option<&str>, engine: &str, duratio
         .inc_by(duration_ms);
 }
 
-/// Record bytes moved out of object storage for one tenant under `locality` —
-/// the single convergent KEU egress meter (Dimension 2). It does two things at
-/// once so every I/O boundary records egress identically:
+/// Record outgress bytes for one tenant — the single convergent **KOU** meter
+/// (Dimension 2). `direction` is `"read"` (object store → compute) or `"result"`
+/// (compute → client). It does two things at once so every boundary records
+/// identically:
 ///
-/// 1. Increments the per-tenant [`EGRESS_BYTES_TOTAL`] counter (the chargeback
-///    source of truth, attributed by `(tenant, az_locality)`).
-/// 2. When the locality is *chargeable* (cross-AZ / internet, never the free
-///    same-AZ path), folds the bytes into the active per-query I/O trace's
-///    `bytes_cross_az` term — the quantity the route cost model's egress weight
-///    minimizes. Outside a query scope this silently no-ops.
+/// 1. Increments the per-tenant [`KOU_BYTES_TOTAL`] counter (the chargeback
+///    source of truth, attributed by `(tenant, kou_locality, direction)`).
+/// 2. When the locality is *chargeable* (cross-region/-cloud/on-prem/internet,
+///    never the free local / cross-AZ / same-region path), folds the bytes into
+///    the active per-query I/O trace's egress term — the quantity the route cost
+///    model's egress weight minimizes. Outside a query scope this silently no-ops.
 ///
-/// Same-AZ bytes are metered (for visibility) but deliberately do NOT enter the
+/// Free-path bytes are metered (for visibility) but deliberately do NOT enter the
 /// cost model, so the egress cost term stays inert on the free path.
-pub fn record_egress_bytes(tenant_id: Option<&str>, locality: AzLocality, bytes: u64) {
+pub fn record_kou_bytes(
+    tenant_id: Option<&str>,
+    locality: KouLocality,
+    direction: &str,
+    bytes: u64,
+) {
     if bytes == 0 {
         return;
     }
     let t_id = tenant_id.unwrap_or("default");
-    EGRESS_BYTES_TOTAL
-        .with_label_values(&[t_id, locality.as_str()])
+    KOU_BYTES_TOTAL
+        .with_label_values(&[t_id, locality.as_str(), direction])
         .inc_by(bytes as f64);
     if locality.is_chargeable_egress() {
-        crate::observability::io_trace::record_cross_az_bytes(bytes);
+        crate::observability::io_trace::record_egress_bytes(bytes);
     }
 }
 
@@ -210,49 +379,129 @@ mod tests {
     use crate::observability::io_trace;
 
     #[test]
-    fn az_locality_strings_and_chargeability() {
-        assert_eq!(AzLocality::SameAz.as_str(), "same_az");
-        assert_eq!(AzLocality::CrossAz.as_str(), "cross_az");
-        assert_eq!(AzLocality::Internet.as_str(), "internet");
-        // The free path is not chargeable egress; the other two are.
-        assert!(!AzLocality::SameAz.is_chargeable_egress());
-        assert!(AzLocality::CrossAz.is_chargeable_egress());
-        assert!(AzLocality::Internet.is_chargeable_egress());
+    fn provider_inferred_from_url_scheme() {
+        assert_eq!(CloudProvider::from_url_scheme("s3"), CloudProvider::Aws);
+        assert_eq!(CloudProvider::from_url_scheme("gs"), CloudProvider::Gcp);
+        assert_eq!(CloudProvider::from_url_scheme("gcs"), CloudProvider::Gcp);
+        assert_eq!(CloudProvider::from_url_scheme("abfs"), CloudProvider::Azure);
+        assert_eq!(CloudProvider::from_url_scheme("adls"), CloudProvider::Azure);
+        assert_eq!(CloudProvider::from_url_scheme("file"), CloudProvider::Local);
+        assert_eq!(CloudProvider::from_url_scheme(""), CloudProvider::Local);
     }
 
     #[test]
-    fn az_locality_parse_defaults_to_free_path() {
-        assert_eq!(AzLocality::parse("cross_az"), AzLocality::CrossAz);
-        assert_eq!(AzLocality::parse("CROSS-AZ"), AzLocality::CrossAz);
-        assert_eq!(AzLocality::parse("internet"), AzLocality::Internet);
-        assert_eq!(AzLocality::parse("same_az"), AzLocality::SameAz);
-        // Unknown / empty → the conservative free default (egress stays inert).
-        assert_eq!(AzLocality::parse("nonsense"), AzLocality::SameAz);
-        assert_eq!(AzLocality::parse(""), AzLocality::SameAz);
-        assert_eq!(AzLocality::default(), AzLocality::SameAz);
+    fn kou_locality_strings_and_chargeability() {
+        assert_eq!(KouLocality::Local.as_str(), "local");
+        assert_eq!(KouLocality::CrossAz.as_str(), "cross_az");
+        assert_eq!(KouLocality::CrossRegion.as_str(), "cross_region");
+        assert_eq!(KouLocality::CrossCloud.as_str(), "cross_cloud");
+        assert_eq!(KouLocality::OnPrem.as_str(), "on_prem");
+        assert_eq!(KouLocality::Internet.as_str(), "internet");
+        assert_eq!(KouLocality::Unknown.as_str(), "unknown");
+        // Local / cross-AZ object-store access is FREE on every cloud; Unknown is
+        // surfaced, not charged. Only genuine cross-boundary movement is chargeable.
+        assert!(!KouLocality::Local.is_chargeable_egress());
+        assert!(!KouLocality::CrossAz.is_chargeable_egress());
+        assert!(!KouLocality::Unknown.is_chargeable_egress());
+        assert!(KouLocality::CrossRegion.is_chargeable_egress());
+        assert!(KouLocality::CrossCloud.is_chargeable_egress());
+        assert!(KouLocality::OnPrem.is_chargeable_egress());
+        assert!(KouLocality::Internet.is_chargeable_egress());
+        assert_eq!(KouLocality::default(), KouLocality::Local);
+    }
+
+    #[test]
+    fn derive_read_is_region_granular_per_cloud() {
+        let ctx = |p, c: &str, s: &str| PlacementContext {
+            store_provider: p,
+            compute_provider: p,
+            compute_region: c.into(),
+            store_region: s.into(),
+        };
+        // Same region → free (even if zones differ — object store is regional).
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Aws, "us-east-1", "us-east-1")),
+            KouLocality::Local
+        );
+        // Different region → chargeable cross-region.
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Azure, "eastus", "westus")),
+            KouLocality::CrossRegion
+        );
+        // GCS multi-region bucket "us" containing the compute region → free.
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Gcp, "us-central1", "us")),
+            KouLocality::Local
+        );
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Gcp, "europe-west1", "us")),
+            KouLocality::CrossRegion
+        );
+        // Compute in a different cloud than the store → cross-cloud read.
+        assert_eq!(
+            KouLocality::derive_read(&PlacementContext {
+                store_provider: CloudProvider::Gcp,
+                compute_provider: CloudProvider::Aws,
+                compute_region: "us-east-1".into(),
+                store_region: "us-central1".into(),
+            }),
+            KouLocality::CrossCloud
+        );
+        // Unknown compute region or local provider → free default (never charge).
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Aws, "", "us-east-1")),
+            KouLocality::Local
+        );
+        assert_eq!(
+            KouLocality::derive_read(&ctx(CloudProvider::Local, "us-east-1", "us-east-1")),
+            KouLocality::Local
+        );
+    }
+
+    #[test]
+    fn override_parse_rejects_unknown() {
+        assert_eq!(
+            KouLocality::parse("cross_region"),
+            Some(KouLocality::CrossRegion)
+        );
+        assert_eq!(
+            KouLocality::parse("CROSS-REGION"),
+            Some(KouLocality::CrossRegion)
+        );
+        assert_eq!(
+            KouLocality::parse("cross_cloud"),
+            Some(KouLocality::CrossCloud)
+        );
+        assert_eq!(KouLocality::parse("on_prem"), Some(KouLocality::OnPrem));
+        assert_eq!(KouLocality::parse("internet"), Some(KouLocality::Internet));
+        // Unknown → None so the caller keeps the derived value (no silent mischarge).
+        assert_eq!(KouLocality::parse("nonsense"), None);
+        assert_eq!(KouLocality::parse(""), None);
     }
 
     #[tokio::test]
-    async fn chargeable_egress_feeds_the_query_trace_but_same_az_does_not() {
+    async fn chargeable_egress_feeds_the_query_trace_but_free_path_does_not() {
         // Inside a query scope, only chargeable localities contribute to the
-        // per-query bytes_cross_az that the cost model's egress term consumes.
+        // per-query egress term the cost model consumes.
         let snap = io_trace::scope(async {
-            record_egress_bytes(Some("t"), AzLocality::CrossAz, 1_000);
-            record_egress_bytes(Some("t"), AzLocality::Internet, 2_000);
-            record_egress_bytes(Some("t"), AzLocality::SameAz, 9_000); // free → not traced
-            record_egress_bytes(Some("t"), AzLocality::CrossAz, 0); // zero → ignored
+            record_kou_bytes(Some("t"), KouLocality::CrossRegion, "read", 1_000);
+            record_kou_bytes(Some("t"), KouLocality::Internet, "result", 2_000);
+            record_kou_bytes(Some("t"), KouLocality::CrossAz, "read", 9_000); // free → not traced
+            record_kou_bytes(Some("t"), KouLocality::Local, "read", 5_000); // free → not traced
+            record_kou_bytes(Some("t"), KouLocality::Unknown, "result", 7_000); // surfaced, not charged
+            record_kou_bytes(Some("t"), KouLocality::CrossRegion, "read", 0); // zero → ignored
             io_trace::snapshot()
         })
         .await
         .expect("snapshot inside scope");
-        assert_eq!(snap.bytes_cross_az, 3_000);
+        assert_eq!(snap.egress_bytes, 3_000);
     }
 
     #[tokio::test]
-    async fn record_egress_outside_scope_is_a_noop() {
+    async fn record_kou_outside_scope_is_a_noop() {
         // No active trace: the counter still records, but nothing panics and the
-        // trace stays empty (helper silently no-ops the cross-AZ term).
-        record_egress_bytes(Some("t"), AzLocality::CrossAz, 1_234);
+        // trace stays empty (helper silently no-ops the egress term).
+        record_kou_bytes(Some("t"), KouLocality::CrossRegion, "read", 1_234);
         assert!(io_trace::snapshot().is_none());
     }
 }

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -11,6 +11,8 @@
 //! task time). Pricing/billing is an operator/control-plane concern — this OSS
 //! module only emits neutral telemetry attributed by `tenant_id`.
 
+use std::sync::LazyLock;
+
 use lazy_static::lazy_static;
 use prometheus::{CounterVec, GaugeVec, Opts, register_counter_vec, register_gauge_vec};
 use tracing::error;
@@ -56,6 +58,82 @@ lazy_static! {
         "Per-tenant cache stats snapshot (metric label selects bytes/hits/misses/hit_ratio/evictions)",
         &["tenant_id", "cache", "metric"]
     );
+    /// Per-tenant bytes moved OUT of object storage, labelled by AZ locality —
+    /// the KEU egress meter (co-design Dimension 2 / §2.2), the one previously
+    /// unmetered dimension. Networking (cross-AZ $0.02/GB RT, internet egress
+    /// $0.09/GB) is frequently the dominant TCO term, yet same-AZ is free — so
+    /// the `az_locality` label is the discriminator that makes egress a billable,
+    /// optimizable dimension. Neutral telemetry only: the AZ topology and the $
+    /// weights are control-plane (anvaiops) policy.
+    pub static ref EGRESS_BYTES_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_egress_bytes_total",
+        "Bytes moved out of object storage per tenant, labelled by AZ locality (KEU egress)",
+        &["tenant_id", "az_locality"]
+    );
+}
+
+/// AZ-locality classification of bytes leaving object storage — the KEU egress
+/// dimension (§2.2). This is OSS **mechanism**: it records *which locality bucket*
+/// the bytes moved through; the real AZ topology and the per-locality dollar
+/// weights are commercial-control-plane (anvaiops) **policy**. Same-AZ is the
+/// co-designed free path; cross-AZ and internet egress are the chargeable terms
+/// the cost model's egress weight consumes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AzLocality {
+    /// Compute, cache, and object store co-located in one AZ over private IP —
+    /// the free path. The default, so egress stays inert until a deployment
+    /// declares otherwise.
+    #[default]
+    SameAz,
+    /// Bytes crossed an availability-zone boundary (~$0.02/GB round-trip).
+    CrossAz,
+    /// Bytes left the cloud to the public internet (egress, ~$0.09/GB).
+    Internet,
+}
+
+impl AzLocality {
+    /// Stable metric-label string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AzLocality::SameAz => "same_az",
+            AzLocality::CrossAz => "cross_az",
+            AzLocality::Internet => "internet",
+        }
+    }
+
+    /// Whether bytes through this locality are chargeable egress (i.e. *not* the
+    /// free same-AZ path). Only these bytes feed the per-query trace's
+    /// `bytes_cross_az` term, so same-AZ traffic never inflates the egress cost.
+    pub fn is_chargeable_egress(self) -> bool {
+        !matches!(self, AzLocality::SameAz)
+    }
+
+    /// Parse the deployment-declared object-store locality from a string
+    /// (`same_az` | `cross_az` | `internet`), accepting a couple of obvious
+    /// aliases. Unknown values fall back to the free `SameAz` default.
+    pub fn parse(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "cross_az" | "cross-az" | "crossaz" => AzLocality::CrossAz,
+            "internet" | "egress" | "public" => AzLocality::Internet,
+            _ => AzLocality::SameAz,
+        }
+    }
+}
+
+/// The deployment-declared locality of the object store relative to the compute
+/// reading it, from `PROXIMADB_OBJECT_STORE_LOCALITY` (read once). Default
+/// `SameAz` — the co-designed free path — so the egress cost term is inert until
+/// an operator declares a cross-AZ/internet topology. The actual $ weight per
+/// locality remains anvaiops policy; this only selects the neutral bucket.
+static OBJECT_STORE_LOCALITY: LazyLock<AzLocality> = LazyLock::new(|| {
+    std::env::var("PROXIMADB_OBJECT_STORE_LOCALITY")
+        .map(|v| AzLocality::parse(&v))
+        .unwrap_or_default()
+});
+
+/// The configured object-store egress locality for this deployment.
+pub fn object_store_egress_locality() -> AzLocality {
+    *OBJECT_STORE_LOCALITY
 }
 
 /// Helper to record an object store operation.
@@ -82,6 +160,32 @@ pub fn record_task_execution_time(tenant_id: Option<&str>, engine: &str, duratio
         .inc_by(duration_ms);
 }
 
+/// Record bytes moved out of object storage for one tenant under `locality` —
+/// the single convergent KEU egress meter (Dimension 2). It does two things at
+/// once so every I/O boundary records egress identically:
+///
+/// 1. Increments the per-tenant [`EGRESS_BYTES_TOTAL`] counter (the chargeback
+///    source of truth, attributed by `(tenant, az_locality)`).
+/// 2. When the locality is *chargeable* (cross-AZ / internet, never the free
+///    same-AZ path), folds the bytes into the active per-query I/O trace's
+///    `bytes_cross_az` term — the quantity the route cost model's egress weight
+///    minimizes. Outside a query scope this silently no-ops.
+///
+/// Same-AZ bytes are metered (for visibility) but deliberately do NOT enter the
+/// cost model, so the egress cost term stays inert on the free path.
+pub fn record_egress_bytes(tenant_id: Option<&str>, locality: AzLocality, bytes: u64) {
+    if bytes == 0 {
+        return;
+    }
+    let t_id = tenant_id.unwrap_or("default");
+    EGRESS_BYTES_TOTAL
+        .with_label_values(&[t_id, locality.as_str()])
+        .inc_by(bytes as f64);
+    if locality.is_chargeable_egress() {
+        crate::observability::io_trace::record_cross_az_bytes(bytes);
+    }
+}
+
 /// Publish a per-tenant cache stats snapshot (e.g. from the footer cache's
 /// `tenant_stats()`) onto the `proximadb_cache_tenant` gauge. `cache` names the
 /// cache (e.g. "footer").
@@ -97,5 +201,58 @@ pub fn record_cache_tenant_stats(cache: &str, stats: &[proximadb_cache::TenantCa
         g("misses", s.misses as f64);
         g("evictions", s.evictions as f64);
         g("hit_ratio", s.hit_ratio);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::io_trace;
+
+    #[test]
+    fn az_locality_strings_and_chargeability() {
+        assert_eq!(AzLocality::SameAz.as_str(), "same_az");
+        assert_eq!(AzLocality::CrossAz.as_str(), "cross_az");
+        assert_eq!(AzLocality::Internet.as_str(), "internet");
+        // The free path is not chargeable egress; the other two are.
+        assert!(!AzLocality::SameAz.is_chargeable_egress());
+        assert!(AzLocality::CrossAz.is_chargeable_egress());
+        assert!(AzLocality::Internet.is_chargeable_egress());
+    }
+
+    #[test]
+    fn az_locality_parse_defaults_to_free_path() {
+        assert_eq!(AzLocality::parse("cross_az"), AzLocality::CrossAz);
+        assert_eq!(AzLocality::parse("CROSS-AZ"), AzLocality::CrossAz);
+        assert_eq!(AzLocality::parse("internet"), AzLocality::Internet);
+        assert_eq!(AzLocality::parse("same_az"), AzLocality::SameAz);
+        // Unknown / empty → the conservative free default (egress stays inert).
+        assert_eq!(AzLocality::parse("nonsense"), AzLocality::SameAz);
+        assert_eq!(AzLocality::parse(""), AzLocality::SameAz);
+        assert_eq!(AzLocality::default(), AzLocality::SameAz);
+    }
+
+    #[tokio::test]
+    async fn chargeable_egress_feeds_the_query_trace_but_same_az_does_not() {
+        // Inside a query scope, only chargeable localities contribute to the
+        // per-query bytes_cross_az that the cost model's egress term consumes.
+        let snap = io_trace::scope(async {
+            record_egress_bytes(Some("t"), AzLocality::CrossAz, 1_000);
+            record_egress_bytes(Some("t"), AzLocality::Internet, 2_000);
+            record_egress_bytes(Some("t"), AzLocality::SameAz, 9_000); // free → not traced
+            record_egress_bytes(Some("t"), AzLocality::CrossAz, 0); // zero → ignored
+            io_trace::snapshot()
+        })
+        .await
+        .expect("snapshot inside scope");
+        assert_eq!(snap.bytes_cross_az, 3_000);
+    }
+
+    #[tokio::test]
+    async fn record_egress_outside_scope_is_a_noop() {
+        // No active trace: the counter still records, but nothing panics and the
+        // trace stays empty (helper silently no-ops the cross-AZ term).
+        record_egress_bytes(Some("t"), AzLocality::CrossAz, 1_234);
+        assert!(io_trace::snapshot().is_none());
     }
 }

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -11,8 +11,10 @@
 //! task time). Pricing/billing is an operator/control-plane concern — this OSS
 //! module only emits neutral telemetry attributed by `tenant_id`.
 
+use std::net::IpAddr;
 use std::sync::{LazyLock, Mutex};
 
+use ipnet::IpNet;
 use lazy_static::lazy_static;
 use prometheus::{CounterVec, GaugeVec, Opts, register_counter_vec, register_gauge_vec};
 use tracing::error;
@@ -299,6 +301,158 @@ pub fn object_store_egress_locality() -> KouLocality {
         .unwrap_or_else(|p| p.into_inner())
 }
 
+/// Build a [`PlacementContext`] from the storage URL + control-plane-stamped env,
+/// for the startup [`install_placement`] call. Provider is *inferred* from the
+/// storage URL scheme (mistake-proof); `compute_region` / `store_region` are
+/// stamped by the control plane (`PROXIMADB_COMPUTE_REGION` / `PROXIMADB_STORE_REGION`,
+/// the latter falling back to the AWS region envs for the S3 backend). All default
+/// empty → derives `Local` (free, inert). `compute_provider` defaults to the store
+/// provider (same cloud); cross-cloud reads are a declared exception (not inferred).
+pub fn placement_from_env(storage_url: &str) -> PlacementContext {
+    let scheme = storage_url.split("://").next().unwrap_or("");
+    let provider = CloudProvider::from_url_scheme(scheme);
+    let env = |k: &str| std::env::var(k).ok().filter(|v| !v.trim().is_empty());
+    let store_region = env("PROXIMADB_STORE_REGION")
+        .or_else(|| {
+            if provider == CloudProvider::Aws {
+                env("PROXIMADB_S3_REGION")
+                    .or_else(|| env("AWS_REGION"))
+                    .or_else(|| env("AWS_DEFAULT_REGION"))
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+    PlacementContext {
+        store_provider: provider,
+        compute_provider: provider,
+        compute_region: env("PROXIMADB_COMPUTE_REGION").unwrap_or_default(),
+        store_region,
+    }
+}
+
+// ── Client-locality classification (KOU result-egress, co-design D2) ─────────
+//
+// Classify a client's source IP against a control-plane-authored CIDR→locality
+// scope map (terraform emits it from the VPC/subnet CIDRs it provisions, so it
+// can never be hand-mis-written). Longest-prefix match; no match → `Internet`
+// for a public IP, `Unknown` for an unrecognized private IP (surfaced, never
+// silently free/charged). No fragile cloud IP-range databases are consulted.
+
+/// One scope-map rule: a CIDR and the [`KouLocality`] of a client whose source
+/// IP falls in it (the terraform-baked AZ/region decision is encoded in the bucket).
+#[derive(Debug, Clone)]
+pub struct ScopeRule {
+    pub net: IpNet,
+    pub locality: KouLocality,
+}
+
+/// Ordered CIDR→locality rules; classification is **longest-prefix wins** (a /32
+/// host rule overrides a /16 VPC rule). Default-empty → every client is `Unknown`.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkScopeMap {
+    rules: Vec<ScopeRule>,
+}
+
+impl NetworkScopeMap {
+    pub fn from_rules(rules: Vec<ScopeRule>) -> Self {
+        Self { rules }
+    }
+
+    /// Parse a JSON array `[{"cidr":"10.0.0.0/16","locality":"cross_az"}, …]`.
+    /// Unparseable CIDRs / localities are skipped with a WARN (never panics) —
+    /// a malformed rule degrades to `Unknown` for those IPs, never a wrong charge.
+    pub fn from_json(json: &str) -> Self {
+        let mut rules = Vec::new();
+        let parsed: serde_json::Value = match serde_json::from_str(json) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("network scope map: invalid JSON ({e}); using empty map");
+                return Self::default();
+            }
+        };
+        if let Some(arr) = parsed.as_array() {
+            for entry in arr {
+                let cidr = entry.get("cidr").and_then(|v| v.as_str());
+                let loc = entry
+                    .get("locality")
+                    .and_then(|v| v.as_str())
+                    .and_then(KouLocality::parse);
+                match (cidr.and_then(|c| c.parse::<IpNet>().ok()), loc) {
+                    (Some(net), Some(locality)) => rules.push(ScopeRule { net, locality }),
+                    _ => error!("network scope map: skipping invalid rule {entry}"),
+                }
+            }
+        }
+        Self { rules }
+    }
+
+    /// Classify a client source IP. Longest-prefix match → the rule's locality;
+    /// no match → `Internet` if the IP is public, else `Unknown`.
+    pub fn classify(&self, ip: IpAddr) -> KouLocality {
+        match self
+            .rules
+            .iter()
+            .filter(|r| r.net.contains(&ip))
+            .max_by_key(|r| r.net.prefix_len())
+        {
+            Some(r) => r.locality,
+            None if is_public_ip(ip) => KouLocality::Internet,
+            None => KouLocality::Unknown,
+        }
+    }
+}
+
+/// Whether an IP is public (routable on the internet) — i.e. not loopback,
+/// private (RFC1918 / unique-local), or link-local. A non-public unmatched IP is
+/// `Unknown` (surfaced); a public unmatched IP is `Internet`.
+fn is_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !(v4.is_private() || v4.is_loopback() || v4.is_link_local() || v4.is_unspecified())
+        }
+        IpAddr::V6(v6) => {
+            // not loopback / unspecified / unique-local (fc00::/7) / link-local (fe80::/10)
+            let seg = v6.segments();
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || (seg[0] & 0xfe00) == 0xfc00
+                || (seg[0] & 0xffc0) == 0xfe80)
+        }
+    }
+}
+
+/// Process-wide client-locality scope map, installed at startup by
+/// [`install_network_scope_map`]. Default-empty → every client `Unknown` (safe).
+static NETWORK_SCOPE_MAP: LazyLock<Mutex<NetworkScopeMap>> =
+    LazyLock::new(|| Mutex::new(NetworkScopeMap::default()));
+
+/// Install the deployment's client scope map (called once at startup). Reads the
+/// JSON file at `PROXIMADB_NETWORK_SCOPE_MAP` when `map` is `None`; default-empty
+/// when the env is unset/unreadable (safe: clients classify as `Unknown`).
+pub fn install_network_scope_map(map: Option<NetworkScopeMap>) {
+    let map = map.unwrap_or_else(|| match std::env::var("PROXIMADB_NETWORK_SCOPE_MAP") {
+        Ok(path) if !path.trim().is_empty() => match std::fs::read_to_string(&path) {
+            Ok(json) => NetworkScopeMap::from_json(&json),
+            Err(e) => {
+                error!("network scope map: cannot read {path} ({e}); using empty map");
+                NetworkScopeMap::default()
+            }
+        },
+        _ => NetworkScopeMap::default(),
+    });
+    *NETWORK_SCOPE_MAP.lock().unwrap_or_else(|p| p.into_inner()) = map;
+}
+
+/// Classify a client source IP against the installed scope map (KOU result-egress
+/// locality). `Unknown` until [`install_network_scope_map`] loads rules.
+pub fn classify_client(ip: IpAddr) -> KouLocality {
+    NETWORK_SCOPE_MAP
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .classify(ip)
+}
+
 /// Helper to record an object store operation.
 pub fn record_object_store_op(tenant_id: Option<&str>, operation: &str) {
     let t_id = tenant_id.unwrap_or("default");
@@ -495,6 +649,86 @@ mod tests {
         .await
         .expect("snapshot inside scope");
         assert_eq!(snap.egress_bytes, 3_000);
+    }
+
+    #[test]
+    fn scope_map_classifies_by_longest_prefix_with_safe_defaults() {
+        // Terraform-style rules: compute subnet/AZ → local; rest of VPC → cross_az;
+        // a declared on-prem range → on_prem. Longest-prefix wins.
+        let map = NetworkScopeMap::from_json(
+            r#"[
+              {"cidr":"10.0.1.0/24","locality":"local"},
+              {"cidr":"10.0.0.0/16","locality":"cross_az"},
+              {"cidr":"203.0.113.0/24","locality":"on_prem"}
+            ]"#,
+        );
+        assert_eq!(
+            map.classify("10.0.1.5".parse().unwrap()),
+            KouLocality::Local
+        ); // /24 beats /16
+        assert_eq!(
+            map.classify("10.0.2.5".parse().unwrap()),
+            KouLocality::CrossAz
+        ); // /16
+        assert_eq!(
+            map.classify("203.0.113.7".parse().unwrap()),
+            KouLocality::OnPrem
+        );
+        // Unmatched public IP → Internet; unmatched private IP → Unknown (surfaced).
+        assert_eq!(
+            map.classify("8.8.8.8".parse().unwrap()),
+            KouLocality::Internet
+        );
+        assert_eq!(
+            map.classify("192.168.9.9".parse().unwrap()),
+            KouLocality::Unknown
+        );
+    }
+
+    #[test]
+    fn empty_scope_map_is_safe_unknown_or_internet() {
+        let empty = NetworkScopeMap::default();
+        assert_eq!(
+            empty.classify("10.0.0.1".parse().unwrap()),
+            KouLocality::Unknown
+        ); // private → surfaced
+        assert_eq!(
+            empty.classify("1.1.1.1".parse().unwrap()),
+            KouLocality::Internet
+        ); // public → notice
+        // Malformed JSON / rules degrade to empty, never panic.
+        assert_eq!(
+            NetworkScopeMap::from_json("not json").classify("10.0.0.1".parse().unwrap()),
+            KouLocality::Unknown
+        );
+        let partial = NetworkScopeMap::from_json(
+            r#"[{"cidr":"bogus","locality":"local"},{"cidr":"10.0.0.0/8","locality":"cross_region"}]"#,
+        );
+        assert_eq!(
+            partial.classify("10.1.2.3".parse().unwrap()),
+            KouLocality::CrossRegion
+        );
+    }
+
+    #[test]
+    fn placement_from_env_infers_provider_and_defaults_safe() {
+        // Provider inferred from the storage URL scheme; with no region env the
+        // context derives the free Local locality (safe default, no env mutation).
+        let p = placement_from_env("s3://my-bucket/data");
+        assert_eq!(p.store_provider, CloudProvider::Aws);
+        assert_eq!(p.compute_provider, CloudProvider::Aws);
+        assert_eq!(
+            placement_from_env("gs://b/x").store_provider,
+            CloudProvider::Gcp
+        );
+        assert_eq!(
+            placement_from_env("abfs://b/x").store_provider,
+            CloudProvider::Azure
+        );
+        let local = placement_from_env("file://./data");
+        assert_eq!(local.store_provider, CloudProvider::Local);
+        // file:// + no compute region → derive Local (free), regardless of env.
+        assert_eq!(KouLocality::derive_read(&local), KouLocality::Local);
     }
 
     #[tokio::test]

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -226,6 +226,7 @@ pub async fn try_run_select(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
             parquet_backed,
+            ..Default::default()
         },
         // C4: observe-mode advisory from the trace-driven cost model — augments
         // the reason for telemetry/EXPLAIN, never changes the backend.
@@ -751,6 +752,7 @@ pub fn classify_select_route(
             crate::query::compute_scheduler::QueryShape {
                 engages_relational: engages,
                 parquet_backed: false,
+                ..Default::default()
             },
             Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
         ),
@@ -947,6 +949,7 @@ async fn route_and_plan_select(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: engages,
             parquet_backed,
+            ..Default::default()
         },
         Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
     );

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1606,7 +1606,7 @@ pub async fn search_with_typed_filters(
             // above). 0 on the free same-AZ path. Flowed into the response
             // SearchPlanTrace as actual_egress_gb (the KEU billing quantity).
             let egress_bytes = crate::observability::io_trace::snapshot()
-                .map(|s| s.bytes_cross_az)
+                .map(|s| s.egress_bytes)
                 .unwrap_or(0);
             (
                 outcome,

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1573,6 +1573,7 @@ pub async fn search_with_typed_filters(
         cold_stage1_only,
         turboquant_hints,
         vector_bounds_pruned_blocks,
+        egress_bytes,
     ) = crate::observability::io_trace::instrument(
         Some(tenant.tenant_id.clone()),
         "rest.v2.records.search",
@@ -1599,7 +1600,22 @@ pub async fn search_with_typed_filters(
             // `SearchPlanHints.turboquant` (Phase J) and
             // `VectorHints.turboquant` (Phase F).
             let tq_hints = crate::observability::predicate_diagnostics::take_turboquant_hints();
-            (outcome, downgraded, cold_stage1, tq_hints, vb_pruned)
+            // C3 egress delivery: read the per-query cross-AZ bytes from the
+            // active io_trace BEFORE this scope closes (the task-local binding
+            // ends when this future completes — same constraint as the takes
+            // above). 0 on the free same-AZ path. Flowed into the response
+            // SearchPlanTrace as actual_egress_gb (the KEU billing quantity).
+            let egress_bytes = crate::observability::io_trace::snapshot()
+                .map(|s| s.bytes_cross_az)
+                .unwrap_or(0);
+            (
+                outcome,
+                downgraded,
+                cold_stage1,
+                tq_hints,
+                vb_pruned,
+                egress_bytes,
+            )
         }),
     )
     .await;
@@ -1727,6 +1743,10 @@ pub async fn search_with_typed_filters(
                     // builder skips the derivation and leaves
                     // actual_scan_gb at 0.0.
                     bytes_per_vector: 0.0,
+                    // C3 egress (Dimension 2): per-query cross-AZ bytes captured
+                    // in-scope above → actual_egress_gb (the KEU billing quantity
+                    // the control plane prices). 0 on the free same-AZ path.
+                    egress_bytes,
                     // TD-064: shortfall pulled from the task-local
                     // diagnostics bus established above. `None` when
                     // no AxisManager-level shortfall was recorded

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -132,9 +132,10 @@ pub struct IoTrace {
     /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
     footer_hits: AtomicU64,
     footer_misses: AtomicU64,
-    /// Bytes moved across an availability zone (Dimension 2 — KEU, the egress
-    /// term that is currently unmetered and the spec's named gap).
-    bytes_cross_az: AtomicU64,
+    /// Chargeable egress bytes — moved cross-region / to the internet off the
+    /// free same-region path (Dimension 2 — KEU). Recorded only for chargeable
+    /// localities; the route cost model's egress weight consumes this.
+    egress_bytes: AtomicU64,
     /// Compute milliseconds attributed by engine (Dimension 4 — KRU/KIU). Kept
     /// in a small map so a single query that touches multiple engines (e.g. a
     /// Volcano point lookup plus a DataFusion aggregate) attributes each.
@@ -208,9 +209,9 @@ impl IoTrace {
         self.footer_misses.fetch_add(misses, Ordering::Relaxed);
     }
 
-    /// Add to bytes moved across an availability zone (KEU / egress).
-    pub fn record_cross_az_bytes(&self, bytes: u64) {
-        self.bytes_cross_az.fetch_add(bytes, Ordering::Relaxed);
+    /// Add to chargeable egress bytes (cross-region / internet — KEU).
+    pub fn record_egress_bytes(&self, bytes: u64) {
+        self.egress_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
     /// Attribute compute milliseconds to a named engine.
@@ -231,7 +232,7 @@ impl IoTrace {
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
-            bytes_cross_az: self.bytes_cross_az.load(Ordering::Relaxed),
+            egress_bytes: self.egress_bytes.load(Ordering::Relaxed),
             compute_ms: self
                 .compute_ms
                 .lock()
@@ -258,7 +259,7 @@ pub struct IoTraceSnapshot {
     pub bytes_written: u64,
     pub footer_hits: u64,
     pub footer_misses: u64,
-    pub bytes_cross_az: u64,
+    pub egress_bytes: u64,
     pub compute_ms: BTreeMap<String, u64>,
 }
 
@@ -304,7 +305,7 @@ impl IoTraceSnapshot {
             && self.bytes_written == 0
             && self.footer_hits == 0
             && self.footer_misses == 0
-            && self.bytes_cross_az == 0
+            && self.egress_bytes == 0
             && self.compute_ms.is_empty()
     }
 
@@ -330,7 +331,7 @@ impl IoTraceSnapshot {
             footer_hits = self.footer_hits,
             footer_misses = self.footer_misses,
             footer_hit_ratio = self.footer_hit_ratio().unwrap_or(f64::NAN),
-            bytes_cross_az = self.bytes_cross_az,
+            egress_bytes = self.egress_bytes,
             compute_ms_total = self.total_compute_ms(),
             compute_ms_by_engine = ?self.compute_ms,
             "per-query I/O trace"
@@ -376,9 +377,10 @@ pub fn record_footers(hits: u64, misses: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_footers(hits, misses));
 }
 
-/// Record cross-AZ bytes (KEU/egress) for the active query.
-pub fn record_cross_az_bytes(bytes: u64) {
-    let _ = IO_TRACE.try_with(|t| t.record_cross_az_bytes(bytes));
+/// Record chargeable egress bytes (cross-region / internet — KEU) for the
+/// active query.
+pub fn record_egress_bytes(bytes: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_egress_bytes(bytes));
 }
 
 /// Attribute compute milliseconds to `engine` for the active query.
@@ -490,7 +492,7 @@ mod tests {
         t.record_footer(true);
         t.record_footer(true);
         t.record_footer(false);
-        t.record_cross_az_bytes(2_048);
+        t.record_egress_bytes(2_048);
         t.record_compute_ms("volcano", 3);
         t.record_compute_ms("volcano", 4);
         t.record_compute_ms("datafusion", 10);
@@ -502,7 +504,7 @@ mod tests {
         assert_eq!(s.bytes_read, 1_536);
         assert_eq!(s.range_gets, 3);
         assert_eq!(s.avg_get_bytes(), Some(1_536.0 / 3.0));
-        assert_eq!(s.bytes_cross_az, 2_048);
+        assert_eq!(s.egress_bytes, 2_048);
         assert_eq!(s.footer_hit_ratio(), Some(2.0 / 3.0));
         assert_eq!(s.total_compute_ms(), 17);
         assert_eq!(s.compute_ms.get("volcano"), Some(&7));
@@ -634,7 +636,7 @@ mod tests {
             range_gets: 2,
             footer_hits: 3,
             footer_misses: 1,
-            bytes_cross_az: 4_096,
+            egress_bytes: 4_096,
             compute_ms: compute,
             ..Default::default()
         };

--- a/src/observability/metering_event.rs
+++ b/src/observability/metering_event.rs
@@ -156,6 +156,10 @@ pub fn build_kru(inputs: &MeteringInputs<'_>) -> MeteringEvent {
         metadata.insert("estimated_scan_gb".into(), json!(v));
     }
     metadata.insert("actual_scan_gb".into(), json!(trace.actual_scan_gb));
+    // KEU egress (Dimension 2): the per-query cross-AZ/internet bytes (GiB). 0 on
+    // the free same-AZ path. Carried on the KRU event so the metering collection
+    // has the egress quantity per query; the control plane prices it by locality.
+    metadata.insert("actual_egress_gb".into(), json!(trace.actual_egress_gb));
     if let Some(v) = trace.recall_probe_score {
         metadata.insert("recall_probe_score".into(), json!(v));
     }
@@ -247,6 +251,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,
@@ -301,6 +306,19 @@ mod tests {
         assert_eq!(ev.quantity, 0.42);
         assert_eq!(ev.metadata["scanned_gb"], 0.42);
         assert_eq!(ev.metadata["actual_scan_gb"], 0.42);
+    }
+
+    #[test]
+    fn actual_egress_gb_is_carried_on_the_metering_event() {
+        // KEU egress (Dimension 2): the metering event carries the per-query
+        // cross-AZ bytes so the control plane can price it; 0 on the free path.
+        let mut t = trace_template();
+        t.actual_egress_gb = 0.125;
+        let ev = build_kru(&inputs(&t));
+        assert_eq!(ev.metadata["actual_egress_gb"], 0.125);
+        // Default (free same-AZ) path → 0.0, still present for a stable shape.
+        let ev0 = build_kru(&inputs(&trace_template()));
+        assert_eq!(ev0.metadata["actual_egress_gb"], 0.0);
     }
 
     #[test]

--- a/src/observability/route_explain.rs
+++ b/src/observability/route_explain.rs
@@ -396,6 +396,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,

--- a/src/observability/search_plan_trace.rs
+++ b/src/observability/search_plan_trace.rs
@@ -149,6 +149,15 @@ pub struct SearchPlanTrace {
     pub estimated_scan_gb: Option<f64>,
     /// Bytes actually scanned — the KRU billing value.
     pub actual_scan_gb: f64,
+    /// Bytes actually moved out of object storage across an AZ / to the internet
+    /// for this query, in GiB — the **KEU egress** billing value (co-design
+    /// Dimension 2). Sourced from the per-query `io_trace.bytes_cross_az`, so it
+    /// is **0 on the free same-AZ path** (the default) and non-zero only once a
+    /// cross-AZ object-store topology is declared. The control plane prices it by
+    /// AZ locality; the engine reports only the neutral quantity. `#[serde(default)]`
+    /// keeps older traces (and OSS builds that don't populate it) wire-compatible.
+    #[serde(default)]
+    pub actual_egress_gb: f64,
 
     // ── Per-index counters (also surfaced in IndexStats for backward compat) ─
     /// Index counters bundled for legacy gateway consumption.
@@ -237,6 +246,7 @@ impl SearchPlanTrace {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 0,
             rerank_count: 0,

--- a/src/observability/search_plan_trace.rs
+++ b/src/observability/search_plan_trace.rs
@@ -149,13 +149,14 @@ pub struct SearchPlanTrace {
     pub estimated_scan_gb: Option<f64>,
     /// Bytes actually scanned — the KRU billing value.
     pub actual_scan_gb: f64,
-    /// Bytes actually moved out of object storage across an AZ / to the internet
-    /// for this query, in GiB — the **KEU egress** billing value (co-design
-    /// Dimension 2). Sourced from the per-query `io_trace.bytes_cross_az`, so it
-    /// is **0 on the free same-AZ path** (the default) and non-zero only once a
-    /// cross-AZ object-store topology is declared. The control plane prices it by
-    /// AZ locality; the engine reports only the neutral quantity. `#[serde(default)]`
-    /// keeps older traces (and OSS builds that don't populate it) wire-compatible.
+    /// Bytes actually moved out of object storage cross-region / to the internet
+    /// for this query, in GiB — the **network egress** billing value (co-design
+    /// Dimension 2). Sourced from the per-query `io_trace.egress_bytes`, so it is
+    /// **0 on the free same-region path** (the default) and non-zero only once a
+    /// cross-region object-store topology is declared. The control plane prices it
+    /// by data locality; the engine reports only the neutral quantity.
+    /// `#[serde(default)]` keeps older traces (and OSS builds that don't populate
+    /// it) wire-compatible.
     #[serde(default)]
     pub actual_egress_gb: f64,
 

--- a/src/observability/search_plan_trace_builder.rs
+++ b/src/observability/search_plan_trace_builder.rs
@@ -49,6 +49,11 @@ pub struct TraceBuilderInputs<'a> {
     /// `index_stats.vectors_scanned` into `actual_scan_gb`. `0.0` skips the
     /// conversion (the trace `actual_scan_gb` stays 0).
     pub bytes_per_vector: f64,
+    /// Bytes moved cross-AZ / to the internet for this query (the per-query
+    /// `io_trace.bytes_cross_az`), converted to `actual_egress_gb` — the KEU
+    /// egress billing quantity (Dimension 2). `0` on the free same-AZ path, so
+    /// the trace's `actual_egress_gb` stays 0 there.
+    pub egress_bytes: u64,
     /// TD-064: Predicate-aware recall shortfall recorded by the executor when
     /// a post-filter / oversample path returned fewer matches than the
     /// requested `top_k`. `None` on the happy path. When `Some`, the builder
@@ -64,6 +69,7 @@ pub struct TraceBuilderInputs<'a> {
 /// Build a fully populated `SearchPlanTrace` from the inputs.
 pub fn build(inputs: TraceBuilderInputs<'_>) -> SearchPlanTrace {
     let actual_scan_gb = derive_actual_scan_gb(&inputs.index_stats, inputs.bytes_per_vector);
+    let actual_egress_gb = bytes_to_gib(inputs.egress_bytes);
     // TD-064: when a predicate shortfall is recorded, ensure failure_class
     // reflects it so a single field check can drive alerts.
     let failure_class = if inputs.predicate_shortfall.is_some() {
@@ -84,6 +90,7 @@ pub fn build(inputs: TraceBuilderInputs<'_>) -> SearchPlanTrace {
         gls_score: inputs.plan.gls_score,
         estimated_scan_gb: None,
         actual_scan_gb,
+        actual_egress_gb,
         index_stats: inputs.index_stats,
         candidate_count: inputs.candidate_count,
         rerank_count: inputs.rerank_count,
@@ -108,6 +115,13 @@ fn derive_actual_scan_gb(stats: &IndexStats, bytes_per_vector: f64) -> f64 {
     }
     let bytes = (stats.vectors_scanned as f64) * bytes_per_vector;
     bytes / 1_073_741_824.0
+}
+
+/// Convert a raw byte count to GiB — the unit `actual_egress_gb` (and
+/// `actual_scan_gb`) are billed in. `0` bytes → `0.0` (no egress on the free
+/// same-AZ path).
+fn bytes_to_gib(bytes: u64) -> f64 {
+    (bytes as f64) / 1_073_741_824.0
 }
 
 #[cfg(test)]
@@ -139,6 +153,7 @@ mod tests {
             cache_result: CacheResult::Miss,
             failure_class: None,
             bytes_per_vector: 0.0,
+            egress_bytes: 0,
             predicate_shortfall: None,
             turboquant_explain: None,
         }
@@ -306,6 +321,24 @@ mod tests {
         let p = plan();
         let t = build(inputs(&p));
         assert_eq!(t.plan_version, 1);
+    }
+
+    #[test]
+    fn actual_egress_gb_derived_from_cross_az_bytes() {
+        let p = plan();
+        let mut i = inputs(&p);
+        i.egress_bytes = 2 * 1_073_741_824; // 2 GiB moved cross-AZ
+        let t = build(i);
+        assert!((t.actual_egress_gb - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_egress_bytes_is_free_same_az_path() {
+        // Default (same-AZ): no cross-AZ bytes → the KEU egress quantity is 0,
+        // so no egress is billed on the free path.
+        let p = plan();
+        let t = build(inputs(&p));
+        assert_eq!(t.actual_egress_gb, 0.0);
     }
 
     #[test]

--- a/src/observability/trace_batcher.rs
+++ b/src/observability/trace_batcher.rs
@@ -187,6 +187,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,

--- a/src/observability/trace_fingerprint.rs
+++ b/src/observability/trace_fingerprint.rs
@@ -271,6 +271,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 0,
             rerank_count: 0,

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -40,11 +40,92 @@ use crate::query::table_write_plan::ComputeBackend;
 use proximadb_catalog::CatalogAuthorityMode;
 use proximadb_catalog::CatalogWorkloadProfile;
 
+/// Estimated cardinality bucket of a query's scan/result — a §5.2 Phase-1 shape
+/// input. Bucketed (not raw counts) so it refines the cost-model shape-class
+/// without exploding the key space. `Unknown` (the default) keeps the coarse
+/// 2-part class, so a planner that cannot estimate rows changes nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CardinalityClass {
+    /// No estimate available — class stays coarse (backward-compatible).
+    #[default]
+    Unknown,
+    /// Point / very small result (≲ 1k rows) — favors the low-latency row path.
+    Small,
+    /// Mid-size scan/result (≲ 1M rows).
+    Medium,
+    /// Large scan/result — favors the vectorized columnar engine.
+    Large,
+}
+
+impl CardinalityClass {
+    /// Bucket an estimated row count; `None` → [`CardinalityClass::Unknown`].
+    pub fn from_estimate(rows: Option<u64>) -> Self {
+        match rows {
+            None => CardinalityClass::Unknown,
+            Some(n) if n <= 1_000 => CardinalityClass::Small,
+            Some(n) if n <= 1_000_000 => CardinalityClass::Medium,
+            Some(_) => CardinalityClass::Large,
+        }
+    }
+
+    /// Stable shape-class suffix, or `None` when unknown (omitted from the key).
+    pub(crate) fn class_suffix(self) -> Option<&'static str> {
+        match self {
+            CardinalityClass::Unknown => None,
+            CardinalityClass::Small => Some("card=s"),
+            CardinalityClass::Medium => Some("card=m"),
+            CardinalityClass::Large => Some("card=l"),
+        }
+    }
+}
+
+/// Bucketed count of partitions / row-groups / segments a route fans out over —
+/// a §5.2 Phase-1 shape input. High fan-out is GET-round-trip-dominated (the
+/// dominant cost term), so it discriminates routes the binary signals cannot.
+/// `Unknown` (the default) keeps the coarse class.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PartitionFanout {
+    /// No partition count available — class stays coarse.
+    #[default]
+    Unknown,
+    /// A single partition / segment.
+    Single,
+    /// A handful (≤ 8) — bounded fan-out.
+    Few,
+    /// Many partitions — fan-out / GET-count dominated.
+    Many,
+}
+
+impl PartitionFanout {
+    /// Bucket a partition/segment count; `None` → [`PartitionFanout::Unknown`].
+    pub fn from_count(count: Option<u32>) -> Self {
+        match count {
+            None => PartitionFanout::Unknown,
+            Some(0) | Some(1) => PartitionFanout::Single,
+            Some(n) if n <= 8 => PartitionFanout::Few,
+            Some(_) => PartitionFanout::Many,
+        }
+    }
+
+    /// Stable shape-class suffix, or `None` when unknown (omitted from the key).
+    pub(crate) fn class_suffix(self) -> Option<&'static str> {
+        match self {
+            PartitionFanout::Unknown => None,
+            PartitionFanout::Single => Some("part=1"),
+            PartitionFanout::Few => Some("part=f"),
+            PartitionFanout::Many => Some("part=m"),
+        }
+    }
+}
+
 /// Shape signals the scheduler routes on.
 ///
-/// P0 uses only `engages_relational` — the existing join / `GROUP BY` /
-/// aggregate / set-op gate, which is the OLAP-shape signal. P1 (§5.2 policy
-/// inputs) adds cardinality, partition count, and point-lookup flags.
+/// P0 used only `engages_relational` — the join / `GROUP BY` / aggregate / set-op
+/// gate (the OLAP-shape signal). P1 added `parquet_backed`. C4 Phase-2b adds the
+/// §5.2 Phase-1 inputs — `cardinality` and `partition_fanout` — which refine the
+/// cost-model shape-class so routing and exploration discriminate beyond
+/// `olap/oltp × native/parquet`. Both default to `Unknown`, preserving the
+/// coarse class (and warmed cells) for planners that cannot estimate them.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct QueryShape {
     /// The query lowers against the relational algebra engine for a reason the
@@ -56,6 +137,10 @@ pub struct QueryShape {
     /// (`try_run_select`) only when the `datafusion-integration` feature is
     /// compiled in, so the route is never advertised when the build can't honor it.
     pub parquet_backed: bool,
+    /// Estimated scan/result cardinality bucket (§5.2 Phase-1). `Unknown` default.
+    pub cardinality: CardinalityClass,
+    /// Bucketed partition/row-group fan-out (§5.2 Phase-1). `Unknown` default.
+    pub partition_fanout: PartitionFanout,
 }
 
 /// A materialized read-route decision: the engine, the workload it was
@@ -342,6 +427,7 @@ mod tests {
         let decision = ComputeScheduler::new().route_select(QueryShape {
             engages_relational: true,
             parquet_backed: false,
+            ..Default::default()
         });
         // OLAP over native storage stays on Volcano (no Parquet base tier yet).
         assert_eq!(decision.backend, ComputeBackend::Native);
@@ -354,6 +440,7 @@ mod tests {
         let decision = ComputeScheduler::new().route_select(QueryShape {
             engages_relational: false,
             parquet_backed: false,
+            ..Default::default()
         });
         assert_eq!(decision.backend, ComputeBackend::Native);
         assert_eq!(decision.workload_profile, CatalogWorkloadProfile::Oltp);
@@ -364,6 +451,7 @@ mod tests {
         let d = ComputeScheduler::new().route_select(QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            ..Default::default()
         });
         assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
         assert_eq!(d.workload_profile, CatalogWorkloadProfile::Olap);
@@ -376,6 +464,7 @@ mod tests {
         let d = ComputeScheduler::new().route_select(QueryShape {
             engages_relational: false,
             parquet_backed: true,
+            ..Default::default()
         });
         assert_eq!(d.backend, ComputeBackend::Native);
     }
@@ -386,6 +475,7 @@ mod tests {
             .route_select(QueryShape {
                 engages_relational: true,
                 parquet_backed: true,
+                ..Default::default()
             })
             .routed_read_plan_with_splits(ReadSplitSummary::row_groups(
                 8,
@@ -408,6 +498,7 @@ mod tests {
             .route_select(QueryShape {
                 engages_relational: true,
                 parquet_backed: false,
+                ..Default::default()
             })
             .explain_line();
         assert!(line.starts_with("Compute Route: Native(Volcano) (workload=Olap"));
@@ -429,6 +520,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: false,
+            ..Default::default()
         };
         let s = ComputeScheduler::new();
         let plain = s.route_select(shape);
@@ -444,6 +536,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: false,
+            ..Default::default()
         };
         let model = RouteCostModel::new().with_min_samples(1);
         // Teach the model that DataFusion is far cheaper for this shape-class
@@ -474,6 +567,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: false,
             parquet_backed: false,
+            ..Default::default()
         };
         let model = RouteCostModel::new().with_min_samples(1);
         // Only Native has history for this shape-class → it is the min, concurring
@@ -492,6 +586,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            ..Default::default()
         }; // static => DataFusionLocal
         let model = RouteCostModel::new().with_min_samples(1); // override OFF (default)
         for _ in 0..5 {
@@ -518,6 +613,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            ..Default::default()
         }; // static => DataFusionLocal
         let model = RouteCostModel::new().with_min_samples(1);
         model.set_override_enabled(true);
@@ -545,6 +641,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            ..Default::default()
         }; // static => DataFusionLocal
         let model = RouteCostModel::new()
             .with_min_samples(1)
@@ -573,6 +670,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: false,
             parquet_backed: true,
+            ..Default::default()
         }; // static => Native (OLTP)
         let model = RouteCostModel::new()
             .with_min_samples(1)
@@ -600,6 +698,7 @@ mod tests {
         let shape = QueryShape {
             engages_relational: false,
             parquet_backed: true,
+            ..Default::default()
         };
         let model = RouteCostModel::new().with_min_samples(1);
         model.set_override_enabled(true);
@@ -631,6 +730,7 @@ mod tests {
         let plan = ComputeScheduler::new().route_select_plan(QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            ..Default::default()
         });
 
         assert_eq!(plan.backend, ComputeBackend::DataFusionLocal);

--- a/src/query/federated/optimizer/plan_quality.rs
+++ b/src/query/federated/optimizer/plan_quality.rs
@@ -153,6 +153,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,

--- a/src/query/federated/optimizer/plan_v2_training.rs
+++ b/src/query/federated/optimizer/plan_v2_training.rs
@@ -250,6 +250,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,

--- a/src/query/federated/optimizer/trace_replay.rs
+++ b/src/query/federated/optimizer/trace_replay.rs
@@ -229,6 +229,7 @@ mod tests {
             gls_score: None,
             estimated_scan_gb: None,
             actual_scan_gb: 0.0,
+            actual_egress_gb: 0.0,
             index_stats: IndexStats::default(),
             candidate_count: 64,
             rerank_count: 10,

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -154,7 +154,7 @@ pub fn shape_class(shape: &QueryShape) -> String {
 
 /// Neutral relative weights for the route cost score. NOT dollars (see module
 /// docs). They encode only the co-design cost ordering of the §3 unified cost
-/// objective `Cost(q)`: an object-store round-trip dominates cross-AZ egress,
+/// objective `Cost(q)`: an object-store round-trip dominates cross-region egress,
 /// which dominates same-region read bandwidth, which dominates a ms of CPU
 /// (P5: for a cloud DB the dominant cost term is I/O round-trips + egress, not
 /// compute — §2.2).
@@ -165,12 +165,12 @@ pub struct CostWeights {
     pub per_get: f64,
     /// Per MiB read — the same-region read-bandwidth term. §3 `bytes_read·bw_cost`.
     pub per_mib_read: f64,
-    /// Per MiB moved across an AZ / to the internet — the KEU **egress** term
-    /// (§2.2, §3 `bytes_moved·az_locality_cost`). Weighted above same-region read
-    /// bandwidth because cross-AZ ($0.02/GB RT) / internet egress ($0.09/GB) is
-    /// frequently the dominant TCO term. Fed by the trace's `bytes_cross_az`,
-    /// which is **zero on the free same-AZ path**, so this term is inert until a
-    /// deployment actually moves bytes cross-AZ.
+    /// Per MiB moved cross-region / to the internet — the KEU **egress** term
+    /// (§2.2, §3 `bytes_moved·locality_cost`). Weighted above same-region read
+    /// bandwidth because cross-region (~$0.02/GB) / internet egress
+    /// (~$0.09-0.12/GB by cloud) is frequently the dominant TCO term. Fed by the
+    /// trace's `egress_bytes`, which is **zero on the free same-region path**, so
+    /// this term is inert until a deployment actually moves bytes cross-region.
     pub per_mib_egress: f64,
     /// Per MiB written to object storage — the KIU ingest / storage-write term
     /// (§3 storage side). Zero for read-only SELECT routing, so inert today;
@@ -204,7 +204,7 @@ impl Default for CostWeights {
 struct CostQuantities {
     range_gets: f64,
     bytes_read: f64,
-    bytes_cross_az: f64,
+    egress_bytes: f64,
     bytes_written: f64,
     compute_ms: f64,
 }
@@ -214,7 +214,7 @@ impl CostQuantities {
         Self {
             range_gets: snap.range_gets as f64,
             bytes_read: snap.bytes_read as f64,
-            bytes_cross_az: snap.bytes_cross_az as f64,
+            egress_bytes: snap.egress_bytes as f64,
             bytes_written: snap.bytes_written as f64,
             compute_ms: snap.total_compute_ms() as f64,
         }
@@ -226,7 +226,7 @@ impl CostQuantities {
 struct Cell {
     range_gets: f64,
     bytes_read: f64,
-    bytes_cross_az: f64,
+    egress_bytes: f64,
     bytes_written: f64,
     compute_ms: f64,
     samples: u64,
@@ -237,14 +237,14 @@ impl Cell {
         if self.samples == 0 {
             self.range_gets = q.range_gets;
             self.bytes_read = q.bytes_read;
-            self.bytes_cross_az = q.bytes_cross_az;
+            self.egress_bytes = q.egress_bytes;
             self.bytes_written = q.bytes_written;
             self.compute_ms = q.compute_ms;
         } else {
             let blend = |old: f64, new: f64| alpha * new + (1.0 - alpha) * old;
             self.range_gets = blend(self.range_gets, q.range_gets);
             self.bytes_read = blend(self.bytes_read, q.bytes_read);
-            self.bytes_cross_az = blend(self.bytes_cross_az, q.bytes_cross_az);
+            self.egress_bytes = blend(self.egress_bytes, q.egress_bytes);
             self.bytes_written = blend(self.bytes_written, q.bytes_written);
             self.compute_ms = blend(self.compute_ms, q.compute_ms);
         }
@@ -255,7 +255,7 @@ impl Cell {
         CostQuantities {
             range_gets: self.range_gets,
             bytes_read: self.bytes_read,
-            bytes_cross_az: self.bytes_cross_az,
+            egress_bytes: self.egress_bytes,
             bytes_written: self.bytes_written,
             compute_ms: self.compute_ms,
         }
@@ -269,8 +269,8 @@ pub struct RouteCost {
     pub samples: u64,
     pub range_gets: f64,
     pub bytes_read: f64,
-    /// EWMA cross-AZ / internet egress bytes (KEU) — zero on the free same-AZ path.
-    pub bytes_cross_az: f64,
+    /// EWMA cross-region / internet egress bytes (KEU) — zero on the free same-region path.
+    pub egress_bytes: f64,
     /// EWMA bytes written to object storage (KIU) — zero for read-only routes.
     pub bytes_written: f64,
     pub compute_ms: f64,
@@ -391,7 +391,7 @@ impl RouteCostModel {
         let mib = |bytes: f64| bytes / (1024.0 * 1024.0);
         self.weights.per_get * q.range_gets
             + self.weights.per_mib_read * mib(q.bytes_read)
-            + self.weights.per_mib_egress * mib(q.bytes_cross_az)
+            + self.weights.per_mib_egress * mib(q.egress_bytes)
             + self.weights.per_mib_written * mib(q.bytes_written)
             + self.weights.per_compute_ms * q.compute_ms
     }
@@ -427,7 +427,7 @@ impl RouteCostModel {
             samples: c.samples,
             range_gets: c.range_gets,
             bytes_read: c.bytes_read,
-            bytes_cross_az: c.bytes_cross_az,
+            egress_bytes: c.egress_bytes,
             bytes_written: c.bytes_written,
             compute_ms: c.compute_ms,
             score: self.score(c.quantities()),
@@ -683,10 +683,10 @@ mod tests {
     }
 
     #[test]
-    fn egress_term_is_inert_on_the_free_same_az_path() {
-        // A read-only route with NO cross-AZ bytes must score exactly the read +
+    fn egress_term_is_inert_on_the_free_same_region_path() {
+        // A read-only route with NO cross-region bytes must score exactly the read +
         // compute terms — i.e. adding the egress dimension changes nothing on the
-        // free path (default-OFF behavior; KEU is zero until bytes move cross-AZ).
+        // free path (default-OFF behavior; KEU is zero until bytes move cross-region).
         let m = RouteCostModel::new().with_min_samples(1);
         m.observe(
             "olap/parquet",
@@ -698,37 +698,41 @@ mod tests {
             .expect("history");
         let w = CostWeights::default();
         let expected = w.per_get * 10.0 + w.per_mib_read * 4.0 + w.per_compute_ms * 7.0;
-        assert_eq!(est.bytes_cross_az, 0.0);
+        assert_eq!(est.egress_bytes, 0.0);
         assert!((est.score - expected).abs() < 1e-6);
     }
 
     #[test]
-    fn cross_az_egress_raises_the_route_cost() {
+    fn cross_region_egress_raises_the_route_cost() {
         // Two routes identical in GETs/bytes-read/compute; one also moves bytes
-        // cross-AZ. The egress (KEU) term must make the cross-AZ route cost more —
+        // cross-region. The egress (KEU) term must make that route cost more —
         // the whole point of metering Dimension 2 into Cost(q).
         let m = RouteCostModel::new().with_min_samples(1);
         // Identical in every term except egress, so the score delta isolates it.
-        let same_az = snap(4, 8 << 20, 0);
-        let cross_az = IoTraceSnapshot {
+        let same_region = snap(4, 8 << 20, 0);
+        let cross_region = IoTraceSnapshot {
             range_gets: 4,
             bytes_read: 8 << 20,
-            bytes_cross_az: 8 << 20,
+            egress_bytes: 8 << 20,
             ..Default::default()
         };
-        m.observe("olap/parquet", &ComputeBackend::DataFusionLocal, &same_az);
-        m.observe("olap/parquet", &ComputeBackend::Native, &cross_az);
+        m.observe(
+            "olap/parquet",
+            &ComputeBackend::DataFusionLocal,
+            &same_region,
+        );
+        m.observe("olap/parquet", &ComputeBackend::Native, &cross_region);
         let cheap = m
             .estimate("olap/parquet", &ComputeBackend::DataFusionLocal)
             .expect("history");
         let dear = m
             .estimate("olap/parquet", &ComputeBackend::Native)
             .expect("history");
-        assert!(dear.bytes_cross_az > 0.0 && cheap.bytes_cross_az == 0.0);
-        // The cross-AZ route is dearer by exactly the egress weight × 8 MiB.
+        assert!(dear.egress_bytes > 0.0 && cheap.egress_bytes == 0.0);
+        // The cross-region route is dearer by exactly the egress weight × 8 MiB.
         let delta = dear.score - cheap.score;
         assert!((delta - CostWeights::default().per_mib_egress * 8.0).abs() < 1e-6);
-        // And the trace-driven recommendation prefers the same-AZ route.
+        // And the trace-driven recommendation prefers the same-region route.
         let rec = m
             .recommend(
                 "olap/parquet",

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -68,10 +68,65 @@ pub fn install_route_cost_observer() {
     GLOBAL_ROUTE_COST_MODEL.set_override_enabled(on);
 }
 
-/// Stable shape-class key the model aggregates under. Coarse on purpose at C4 —
-/// it mirrors today's scheduler signals (`engages_relational` × `parquet_backed`);
-/// finer classes (cardinality, partition count, point-lookup) arrive with the
-/// §5.2 Phase-1 shape inputs and slot in here without changing the model.
+/// Per-tenant governance **tier-entitlement multiplier** resolver — the final
+/// term of the §3 `Cost(q)` objective (Dimension 5, C5). Maps a `tenant_id` to a
+/// neutral scalar applied to the *reported* cost.
+type TierMultiplierFn = dyn Fn(&str) -> f64 + Send + Sync;
+
+static TIER_MULTIPLIER_RESOLVER: Mutex<Option<Box<TierMultiplierFn>>> = Mutex::new(None);
+
+/// Install (or clear with `None`) the per-tenant tier-multiplier resolver. This
+/// is the OSS **mechanism** / DI seam (the `LimitsResolver` pattern): the OSS
+/// core ships no resolver (default multiplier `1.0`, fully inert); the commercial
+/// control plane (anvaiops) installs one at startup that maps a tenant to its
+/// tier entitlement from claims/config. Replaceable in tests. No new authority —
+/// the tenant→tier authority stays in the control plane; this only consults it.
+pub fn set_tier_multiplier_resolver(resolver: Option<Box<TierMultiplierFn>>) {
+    *TIER_MULTIPLIER_RESOLVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = resolver;
+}
+
+/// The tier-entitlement multiplier for `tenant_id`. Returns `1.0` (inert) when no
+/// resolver is installed, the tenant is unknown (`None`), or the resolver returns
+/// a non-finite / non-positive value — a non-positive multiplier could invert
+/// cost ordering, so it is rejected fail-safe.
+pub fn tier_entitlement_multiplier(tenant_id: Option<&str>) -> f64 {
+    let Some(id) = tenant_id else {
+        return 1.0;
+    };
+    let guard = TIER_MULTIPLIER_RESOLVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    match guard.as_ref() {
+        Some(resolve) => {
+            let m = resolve(id);
+            if m.is_finite() && m > 0.0 { m } else { 1.0 }
+        }
+        None => 1.0,
+    }
+}
+
+/// The §3 final per-tenant `Cost(q)`: the neutral base route score scaled by the
+/// tenant's tier-entitlement multiplier — the last term of the unified cost
+/// objective. This is deliberately **routing-neutral**: a single per-tenant
+/// scalar scales every candidate equally, so it can never change *which* engine
+/// is cheapest (entitlement that restricts the candidate *set* is the scheduler's
+/// `override_candidates`, safe-by-construction). Its role is to make the reported
+/// / billed cost the real per-tenant `Cost(q)` for EXPLAIN, chargeback, and a
+/// future budget-aware admission decision — completing the objective the C0/C4
+/// loop was built to minimize, while keeping pricing/policy out of the OSS core.
+pub fn final_cost(base_score: f64, tenant_id: Option<&str>) -> f64 {
+    base_score * tier_entitlement_multiplier(tenant_id)
+}
+
+/// Stable shape-class key the model aggregates under. The coarse base mirrors the
+/// scheduler's binary signals (`engages_relational` × `parquet_backed`); C4
+/// Phase-2b refines it with the §5.2 Phase-1 inputs — cardinality and partition
+/// fan-out — but only when they are *known*. An `Unknown` signal contributes no
+/// suffix, so a planner that cannot estimate them yields exactly the original
+/// 2-part key (`olap/parquet`, `oltp/native`, …) — backward-compatible with
+/// warmed cells and existing EXPLAIN output.
 pub fn shape_class(shape: &QueryShape) -> String {
     let workload = if shape.engages_relational {
         "olap"
@@ -83,30 +138,85 @@ pub fn shape_class(shape: &QueryShape) -> String {
     } else {
         "native"
     };
-    format!("{workload}/{base}")
+    let mut class = format!("{workload}/{base}");
+    for suffix in [
+        shape.cardinality.class_suffix(),
+        shape.partition_fanout.class_suffix(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        class.push('/');
+        class.push_str(suffix);
+    }
+    class
 }
 
 /// Neutral relative weights for the route cost score. NOT dollars (see module
-/// docs). They encode only the co-design cost ordering: a GET's fixed
-/// first-byte latency dominates a MiB of bandwidth, which dominates a ms of CPU.
+/// docs). They encode only the co-design cost ordering of the §3 unified cost
+/// objective `Cost(q)`: an object-store round-trip dominates cross-AZ egress,
+/// which dominates same-region read bandwidth, which dominates a ms of CPU
+/// (P5: for a cloud DB the dominant cost term is I/O round-trips + egress, not
+/// compute — §2.2).
 #[derive(Debug, Clone, Copy)]
 pub struct CostWeights {
     /// Per ranged GET — the fixed-latency, per-request term (the dominant cost
-    /// for object-store-served reads).
+    /// for object-store-served reads). §3 `GET_count·get_fee`.
     pub per_get: f64,
-    /// Per MiB read — the bandwidth term.
+    /// Per MiB read — the same-region read-bandwidth term. §3 `bytes_read·bw_cost`.
     pub per_mib_read: f64,
+    /// Per MiB moved across an AZ / to the internet — the KEU **egress** term
+    /// (§2.2, §3 `bytes_moved·az_locality_cost`). Weighted above same-region read
+    /// bandwidth because cross-AZ ($0.02/GB RT) / internet egress ($0.09/GB) is
+    /// frequently the dominant TCO term. Fed by the trace's `bytes_cross_az`,
+    /// which is **zero on the free same-AZ path**, so this term is inert until a
+    /// deployment actually moves bytes cross-AZ.
+    pub per_mib_egress: f64,
+    /// Per MiB written to object storage — the KIU ingest / storage-write term
+    /// (§3 storage side). Zero for read-only SELECT routing, so inert today;
+    /// present so a write-route cost (`table_write_plan`) folds in here too.
+    pub per_mib_written: f64,
     /// Per compute-millisecond — the CPU term (smallest for I/O-bound DB work).
+    /// §3 `engine_ms·rate`.
     pub per_compute_ms: f64,
 }
 
 impl Default for CostWeights {
     fn default() -> Self {
-        // Illustrative neutral ordering (round-trip ≫ bandwidth ≫ CPU), tunable.
+        // Illustrative neutral ordering (round-trip ≫ egress ≫ read-bw ≫ CPU),
+        // tunable. `per_mib_written` mirrors `per_mib_read` (a PUT's bandwidth).
         Self {
             per_get: 20.0,
             per_mib_read: 5.0,
+            per_mib_egress: 25.0,
+            per_mib_written: 5.0,
             per_compute_ms: 1.0,
+        }
+    }
+}
+
+/// The cost-bearing physical quantities of one query, extracted from its
+/// measured [`IoTraceSnapshot`]. Folded (EWMA) per (shape-class, backend) and
+/// scored by [`CostWeights`] into the §3 `Cost(q)`. Keeping them in one struct
+/// (rather than positional `f64` args) keeps `fold`/`score` self-documenting as
+/// terms are added.
+#[derive(Debug, Clone, Copy, Default)]
+struct CostQuantities {
+    range_gets: f64,
+    bytes_read: f64,
+    bytes_cross_az: f64,
+    bytes_written: f64,
+    compute_ms: f64,
+}
+
+impl CostQuantities {
+    fn from_snapshot(snap: &IoTraceSnapshot) -> Self {
+        Self {
+            range_gets: snap.range_gets as f64,
+            bytes_read: snap.bytes_read as f64,
+            bytes_cross_az: snap.bytes_cross_az as f64,
+            bytes_written: snap.bytes_written as f64,
+            compute_ms: snap.total_compute_ms() as f64,
         }
     }
 }
@@ -116,31 +226,53 @@ impl Default for CostWeights {
 struct Cell {
     range_gets: f64,
     bytes_read: f64,
+    bytes_cross_az: f64,
+    bytes_written: f64,
     compute_ms: f64,
     samples: u64,
 }
 
 impl Cell {
-    fn fold(&mut self, alpha: f64, range_gets: f64, bytes_read: f64, compute_ms: f64) {
+    fn fold(&mut self, alpha: f64, q: CostQuantities) {
         if self.samples == 0 {
-            self.range_gets = range_gets;
-            self.bytes_read = bytes_read;
-            self.compute_ms = compute_ms;
+            self.range_gets = q.range_gets;
+            self.bytes_read = q.bytes_read;
+            self.bytes_cross_az = q.bytes_cross_az;
+            self.bytes_written = q.bytes_written;
+            self.compute_ms = q.compute_ms;
         } else {
-            self.range_gets = alpha * range_gets + (1.0 - alpha) * self.range_gets;
-            self.bytes_read = alpha * bytes_read + (1.0 - alpha) * self.bytes_read;
-            self.compute_ms = alpha * compute_ms + (1.0 - alpha) * self.compute_ms;
+            let blend = |old: f64, new: f64| alpha * new + (1.0 - alpha) * old;
+            self.range_gets = blend(self.range_gets, q.range_gets);
+            self.bytes_read = blend(self.bytes_read, q.bytes_read);
+            self.bytes_cross_az = blend(self.bytes_cross_az, q.bytes_cross_az);
+            self.bytes_written = blend(self.bytes_written, q.bytes_written);
+            self.compute_ms = blend(self.compute_ms, q.compute_ms);
         }
         self.samples += 1;
     }
+
+    fn quantities(&self) -> CostQuantities {
+        CostQuantities {
+            range_gets: self.range_gets,
+            bytes_read: self.bytes_read,
+            bytes_cross_az: self.bytes_cross_az,
+            bytes_written: self.bytes_written,
+            compute_ms: self.compute_ms,
+        }
+    }
 }
 
-/// Learned cost estimate for serving a shape-class on one backend.
+/// Learned cost estimate for serving a shape-class on one backend — the EWMA of
+/// each §3 `Cost(q)` quantity plus the weighted neutral score.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RouteCost {
     pub samples: u64,
     pub range_gets: f64,
     pub bytes_read: f64,
+    /// EWMA cross-AZ / internet egress bytes (KEU) — zero on the free same-AZ path.
+    pub bytes_cross_az: f64,
+    /// EWMA bytes written to object storage (KIU) — zero for read-only routes.
+    pub bytes_written: f64,
     pub compute_ms: f64,
     /// Weighted neutral score (lower is cheaper).
     pub score: f64,
@@ -248,10 +380,20 @@ impl RouteCostModel {
         self.override_enabled.load(Ordering::Relaxed)
     }
 
-    fn score(&self, range_gets: f64, bytes_read: f64, compute_ms: f64) -> f64 {
-        self.weights.per_get * range_gets
-            + self.weights.per_mib_read * (bytes_read / (1024.0 * 1024.0))
-            + self.weights.per_compute_ms * compute_ms
+    /// The §3 unified `Cost(q)` in neutral units: read (GETs + bandwidth) +
+    /// egress (KEU) + ingest/storage-write (KIU) + compute. The storage·time
+    /// (KSU) term and the tenant tier multiplier are *not* per-query routing
+    /// discriminators — KSU is a per-tenant aggregate the consumption meter owns,
+    /// and a scalar tier multiplier cancels across candidates (slice 4 applies it
+    /// only to the *reported* cost). The cache-hit offset is already captured: a
+    /// footer-cache hit shows up as fewer GETs / fewer bytes in the trace.
+    fn score(&self, q: CostQuantities) -> f64 {
+        let mib = |bytes: f64| bytes / (1024.0 * 1024.0);
+        self.weights.per_get * q.range_gets
+            + self.weights.per_mib_read * mib(q.bytes_read)
+            + self.weights.per_mib_egress * mib(q.bytes_cross_az)
+            + self.weights.per_mib_written * mib(q.bytes_written)
+            + self.weights.per_compute_ms * q.compute_ms
     }
 
     /// Fold a completed query's measured trace into the (shape-class, backend)
@@ -267,12 +409,10 @@ impl RouteCostModel {
     pub fn observe_by_label(&self, shape_class: &str, backend_label: &str, snap: &IoTraceSnapshot) {
         let key = (shape_class.to_string(), backend_label.to_string());
         let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
-        cells.entry(key).or_default().fold(
-            self.alpha,
-            snap.range_gets as f64,
-            snap.bytes_read as f64,
-            snap.total_compute_ms() as f64,
-        );
+        cells
+            .entry(key)
+            .or_default()
+            .fold(self.alpha, CostQuantities::from_snapshot(snap));
     }
 
     /// Current learned estimate for one (shape-class, backend), if any history.
@@ -287,8 +427,10 @@ impl RouteCostModel {
             samples: c.samples,
             range_gets: c.range_gets,
             bytes_read: c.bytes_read,
+            bytes_cross_az: c.bytes_cross_az,
+            bytes_written: c.bytes_written,
             compute_ms: c.compute_ms,
-            score: self.score(c.range_gets, c.bytes_read, c.compute_ms),
+            score: self.score(c.quantities()),
         })
     }
 
@@ -424,20 +566,44 @@ mod tests {
 
     #[test]
     fn shape_class_mirrors_scheduler_signals() {
+        // Unknown finer signals (the default) keep the coarse 2-part class.
         assert_eq!(
             shape_class(&QueryShape {
                 engages_relational: true,
-                parquet_backed: true
+                parquet_backed: true,
+                ..Default::default()
             }),
             "olap/parquet"
         );
         assert_eq!(
             shape_class(&QueryShape {
                 engages_relational: false,
-                parquet_backed: false
+                parquet_backed: false,
+                ..Default::default()
             }),
             "oltp/native"
         );
+    }
+
+    #[test]
+    fn shape_class_refines_with_known_cardinality_and_partition_signals() {
+        use crate::query::compute_scheduler::{CardinalityClass, PartitionFanout};
+        // Known finer signals append stable suffixes (cardinality then partition).
+        let class = shape_class(&QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            cardinality: CardinalityClass::Large,
+            partition_fanout: PartitionFanout::Many,
+        });
+        assert_eq!(class, "olap/parquet/card=l/part=m");
+        // A partially-known shape only appends the known suffix.
+        let partial = shape_class(&QueryShape {
+            engages_relational: false,
+            parquet_backed: false,
+            cardinality: CardinalityClass::Small,
+            ..Default::default()
+        });
+        assert_eq!(partial, "oltp/native/card=s");
     }
 
     #[test]
@@ -514,6 +680,80 @@ mod tests {
         assert_eq!(rec.ranked[0].0, "DataFusionLocal");
         // Cheapest-first ordering.
         assert!(rec.ranked[0].1 < rec.ranked[1].1);
+    }
+
+    #[test]
+    fn egress_term_is_inert_on_the_free_same_az_path() {
+        // A read-only route with NO cross-AZ bytes must score exactly the read +
+        // compute terms — i.e. adding the egress dimension changes nothing on the
+        // free path (default-OFF behavior; KEU is zero until bytes move cross-AZ).
+        let m = RouteCostModel::new().with_min_samples(1);
+        m.observe(
+            "olap/parquet",
+            &ComputeBackend::Native,
+            &snap(10, 4 << 20, 7),
+        );
+        let est = m
+            .estimate("olap/parquet", &ComputeBackend::Native)
+            .expect("history");
+        let w = CostWeights::default();
+        let expected = w.per_get * 10.0 + w.per_mib_read * 4.0 + w.per_compute_ms * 7.0;
+        assert_eq!(est.bytes_cross_az, 0.0);
+        assert!((est.score - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cross_az_egress_raises_the_route_cost() {
+        // Two routes identical in GETs/bytes-read/compute; one also moves bytes
+        // cross-AZ. The egress (KEU) term must make the cross-AZ route cost more —
+        // the whole point of metering Dimension 2 into Cost(q).
+        let m = RouteCostModel::new().with_min_samples(1);
+        // Identical in every term except egress, so the score delta isolates it.
+        let same_az = snap(4, 8 << 20, 0);
+        let cross_az = IoTraceSnapshot {
+            range_gets: 4,
+            bytes_read: 8 << 20,
+            bytes_cross_az: 8 << 20,
+            ..Default::default()
+        };
+        m.observe("olap/parquet", &ComputeBackend::DataFusionLocal, &same_az);
+        m.observe("olap/parquet", &ComputeBackend::Native, &cross_az);
+        let cheap = m
+            .estimate("olap/parquet", &ComputeBackend::DataFusionLocal)
+            .expect("history");
+        let dear = m
+            .estimate("olap/parquet", &ComputeBackend::Native)
+            .expect("history");
+        assert!(dear.bytes_cross_az > 0.0 && cheap.bytes_cross_az == 0.0);
+        // The cross-AZ route is dearer by exactly the egress weight × 8 MiB.
+        let delta = dear.score - cheap.score;
+        assert!((delta - CostWeights::default().per_mib_egress * 8.0).abs() < 1e-6);
+        // And the trace-driven recommendation prefers the same-AZ route.
+        let rec = m
+            .recommend(
+                "olap/parquet",
+                &[ComputeBackend::Native, ComputeBackend::DataFusionLocal],
+            )
+            .expect("history");
+        assert_eq!(rec.backend, ComputeBackend::DataFusionLocal);
+    }
+
+    #[test]
+    fn ingest_write_term_costs_storage_writes() {
+        // The KIU storage-write term folds bytes_written into Cost(q) (inert for
+        // read-only routes, active once a route induces writes).
+        let m = RouteCostModel::new().with_min_samples(1);
+        let written = IoTraceSnapshot {
+            range_gets: 0,
+            bytes_written: 2 << 20,
+            ..Default::default()
+        };
+        m.observe("oltp/native", &ComputeBackend::Native, &written);
+        let est = m
+            .estimate("oltp/native", &ComputeBackend::Native)
+            .expect("history");
+        assert!((est.bytes_written - (2 << 20) as f64).abs() < 1.0);
+        assert!((est.score - CostWeights::default().per_mib_written * 2.0).abs() < 1e-6);
     }
 
     #[test]
@@ -683,6 +923,50 @@ mod tests {
             .map(|_| m.exploration_choice("olap/parquet", &cands).is_some())
             .collect();
         assert_eq!(fired, vec![true, false, false, true, false, false]);
+    }
+
+    #[test]
+    fn tier_multiplier_defaults_to_inert_one() {
+        // No resolver installed → multiplier 1.0, and None tenant is always 1.0.
+        assert_eq!(tier_entitlement_multiplier(Some("anyone")), 1.0);
+        assert_eq!(tier_entitlement_multiplier(None), 1.0);
+        // final_cost is then the unscaled base score.
+        assert_eq!(final_cost(42.0, Some("anyone")), 42.0);
+    }
+
+    #[test]
+    fn tier_multiplier_resolver_scales_reported_cost_but_is_routing_neutral() {
+        // Use a unique resolver, then clear it, to avoid racing sibling tests on
+        // the process-global (mirrors the io_trace observer test discipline).
+        set_tier_multiplier_resolver(Some(Box::new(|tenant: &str| match tenant {
+            "premium" => 0.5,   // entitled to a discounted reported cost
+            "throttled" => 4.0, // surcharged
+            "bad" => -1.0,      // invalid → must be rejected fail-safe to 1.0
+            _ => 1.0,
+        })));
+
+        assert_eq!(tier_entitlement_multiplier(Some("premium")), 0.5);
+        assert_eq!(tier_entitlement_multiplier(Some("throttled")), 4.0);
+        // Non-positive multiplier is rejected (could invert cost ordering).
+        assert_eq!(tier_entitlement_multiplier(Some("bad")), 1.0);
+        // Unknown tenant falls through the resolver's own default.
+        assert_eq!(tier_entitlement_multiplier(Some("someone-else")), 1.0);
+
+        // final_cost applies the multiplier to the reported cost...
+        assert_eq!(final_cost(100.0, Some("premium")), 50.0);
+        assert_eq!(final_cost(100.0, Some("throttled")), 400.0);
+
+        // ...but it is routing-neutral: scaling two candidates by the SAME
+        // per-tenant multiplier preserves which one is cheaper.
+        let (a, b) = (120.0_f64, 200.0_f64);
+        for tenant in ["premium", "throttled", "someone-else"] {
+            let fa = final_cost(a, Some(tenant));
+            let fb = final_cost(b, Some(tenant));
+            assert_eq!(a < b, fa < fb, "ordering preserved under tier {tenant}");
+        }
+
+        set_tier_multiplier_resolver(None); // reset global for other tests
+        assert_eq!(tier_entitlement_multiplier(Some("premium")), 1.0);
     }
 
     #[test]

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3186,6 +3186,41 @@ pub fn tenant_tier(tenant_id: &str) -> Option<String> {
     TENANT_TIERS.get(tenant_id).map(|r| r.clone())
 }
 
+/// Resolve a tenant to its [`Tier`] from the header-fed registry above — the
+/// co-design C5 tenant→tier bridge. Parses the stamped claim via
+/// [`Tier::from_claim`] (alias-aware) and falls back to the configured default
+/// tier when no claim was stamped or it is unrecognized. This converges the
+/// header-fed tier source (the cache `LimitsResolver`) with the route cost
+/// model's tier multiplier — one tier registry, not two. Installed at startup
+/// into `tenant_tier::set_tenant_tier_resolver` (see `database.rs`).
+pub fn tenant_tier_resolved(tenant_id: &str) -> crate::catalog::tenant_tier::Tier {
+    tenant_tier(tenant_id)
+        .and_then(|claim| crate::catalog::tenant_tier::Tier::from_claim(&claim))
+        .unwrap_or_else(crate::catalog::tenant_tier::default_tier)
+}
+
+#[cfg(test)]
+mod tenant_tier_bridge_tests {
+    use super::*;
+    use crate::catalog::tenant_tier::{Tier, default_tier};
+
+    #[test]
+    fn resolves_stamped_tier_else_default() {
+        // Unique tenant ids so this never races sibling tests on the global map.
+        let unknown = "bridge-test-unknown-tenant";
+        assert_eq!(tenant_tier_resolved(unknown), default_tier());
+
+        let t = "bridge-test-pro-tenant";
+        set_tenant_tier(t, "pro"); // control-plane stamped X-Tenant-Tier: pro
+        assert_eq!(tenant_tier_resolved(t), Tier::Tier3);
+
+        // An unrecognized claim falls back to the default tier (fail-safe).
+        let bad = "bridge-test-bad-claim-tenant";
+        set_tenant_tier(bad, "not-a-tier");
+        assert_eq!(tenant_tier_resolved(bad), default_tier());
+    }
+}
+
 pub struct ObjectStoreVectorRecordStore {
     bridge: Arc<dyn ObjectStoreBridge>,
     footer_cache: Option<Arc<proximadb_storage_common::ranged_segment::FooterCache>>,

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -37,7 +37,7 @@ use proximadb_storage_common::{
 };
 
 use crate::metrics::consumption_metrics::{
-    object_store_egress_locality, record_egress_bytes, record_object_store_op,
+    object_store_egress_locality, record_kou_bytes, record_object_store_op,
 };
 use crate::observability::io_trace;
 use crate::services::operations::VectorOps;
@@ -3266,12 +3266,14 @@ impl ObjectStoreVectorRecordStore {
                     anyhow!("ObjectStoreVectorRecordStore failed to fetch '{path}': {err}")
                 })?;
             io_trace::record_bytes_read(bytes.len() as u64);
-            // KEU egress (Dimension 2): the fetched bytes left object storage for
-            // compute. Metered per-(tenant, locality); only chargeable (cross-AZ /
-            // internet) localities feed the cost model's egress term.
-            record_egress_bytes(
+            // KOU read-egress (Dimension 2): the fetched bytes left object storage
+            // for compute. Metered per-(tenant, locality, direction); only
+            // chargeable (cross-region/-cloud/on-prem/internet) localities feed the
+            // cost model's egress term — same-region/AZ reads are free.
+            record_kou_bytes(
                 tenant_id,
                 object_store_egress_locality(),
+                "read",
                 bytes.len() as u64,
             );
             records.extend(pax_segment_to_records(bytes, schema)?);
@@ -3493,8 +3495,13 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
             io_trace::record_bytes_read(st.bytes_read);
             io_trace::record_range_gets(st.range_gets);
             io_trace::record_footers(st.footer_hits, st.footer_misses);
-            // KEU egress (Dimension 2): ranged-read bytes that left object storage.
-            record_egress_bytes(tenant_id, object_store_egress_locality(), st.bytes_read);
+            // KOU read-egress (Dimension 2): ranged-read bytes that left object storage.
+            record_kou_bytes(
+                tenant_id,
+                object_store_egress_locality(),
+                "read",
+                st.bytes_read,
+            );
             for mut record in recs {
                 record.variation_id = Some(table_schema.name.clone());
                 if predicate.is_none_or(|p| p(&record)) {

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -36,7 +36,9 @@ use proximadb_storage_common::{
     ranged_segment::RangedSegmentReader,
 };
 
-use crate::metrics::consumption_metrics::record_object_store_op;
+use crate::metrics::consumption_metrics::{
+    object_store_egress_locality, record_egress_bytes, record_object_store_op,
+};
 use crate::observability::io_trace;
 use crate::services::operations::VectorOps;
 use crate::services::operations::batch_result::OperationMetrics;
@@ -3229,6 +3231,14 @@ impl ObjectStoreVectorRecordStore {
                     anyhow!("ObjectStoreVectorRecordStore failed to fetch '{path}': {err}")
                 })?;
             io_trace::record_bytes_read(bytes.len() as u64);
+            // KEU egress (Dimension 2): the fetched bytes left object storage for
+            // compute. Metered per-(tenant, locality); only chargeable (cross-AZ /
+            // internet) localities feed the cost model's egress term.
+            record_egress_bytes(
+                tenant_id,
+                object_store_egress_locality(),
+                bytes.len() as u64,
+            );
             records.extend(pax_segment_to_records(bytes, schema)?);
         }
         Ok(records)
@@ -3448,6 +3458,8 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
             io_trace::record_bytes_read(st.bytes_read);
             io_trace::record_range_gets(st.range_gets);
             io_trace::record_footers(st.footer_hits, st.footer_misses);
+            // KEU egress (Dimension 2): ranged-read bytes that left object storage.
+            record_egress_bytes(tenant_id, object_store_egress_locality(), st.bytes_read);
             for mut record in recs {
                 record.variation_id = Some(table_schema.name.clone());
                 if predicate.is_none_or(|p| p(&record)) {


### PR DESCRIPTION
## Cohesive unit — complete the dimensional cost model

Closes the keystone the C0 trace + C4 router set up: the router now minimizes a **real per-dimension `Cost(q)`** over a **fully-metered trace**, instead of a partial proxy over a trace missing its egress term. Four tightly-coupled, individually-described slices; everything is **evidence-gated and inert by default**.

### Slice 1 — C3: meter the KEU egress dimension *(commit `C3`)*
Networking is the one previously-unmetered co-design dimension (§2.2) yet is frequently the dominant TCO term (cross-AZ ~\$0.02/GB RT, internet egress ~\$0.09/GB; same-AZ free).
- `proximadb_egress_bytes_total{tenant_id, az_locality}` counter — the KEU billing meter.
- `AzLocality` (`same_az`/`cross_az`/`internet`) is OSS **mechanism**: the deployment declares locality via `PROXIMADB_OBJECT_STORE_LOCALITY` (default `same_az` = free path); AZ topology + \$ weights stay anvaiops **policy**.
- One convergent `record_egress_bytes()` increments the counter **and** (only for chargeable localities) feeds the existing per-query `io_trace.bytes_cross_az`. Wired at the two PAX read boundaries that already feed `io_trace` bytes_read.

### Slice 2 — full `Cost(q)` *(commit `cost model`)*
`RouteCostModel` now scores **read (GETs+bandwidth) + EGRESS (KEU) + ingest/storage-write (KIU) + compute** in neutral units, extracted via `CostQuantities` from the measured snapshot. Egress weight > read-bandwidth (cross-AZ dominates) but is fed by `bytes_cross_az`, which is **zero on the free same-AZ path** → existing recommendations unchanged.

### Slice 3 — C4 Phase-2b: richer shape-classes
`QueryShape` gains the §5.2 Phase-1 inputs — `CardinalityClass` + `PartitionFanout` (bucketed; `Unknown` default). `shape_class()` appends a stable suffix **only when a signal is known**, so coarse shapes keep the original 2-part key (backward-compatible with warmed cells). Signals plumbed through the scheduler; population from a real estimator is a follow-up.

### Slice 4 — C5: governance tier multiplier
The final `Cost(q)` term as an OSS DI seam — `set_tier_multiplier_resolver` + `tier_entitlement_multiplier` + `final_cost`. Default `1.0` (no resolver) → inert; anvaiops installs the policy resolver from tier claims. **Routing-neutral by construction** (a per-tenant scalar scales all candidates equally → never changes which engine is cheapest); it makes the **reported/billed** cost the real per-tenant `Cost(q)`.

## Discipline
- **Observe → ingest → act, default-OFF.** No behavior change until a locality is declared, an estimator populates the signals, or a tier resolver is installed.
- **Converge, don't duplicate.** One egress meter / one cost fn shared across surfaces; no new catalog/record/WAL/routing authority.
- **OSS boundary clean.** Cost stays in neutral units; pricing/policy is the control plane.

## Verification
- 41 tests green across the touched modules (`consumption_metrics`, `route_cost_model`, `compute_scheduler`).
- `cargo clippy -p proximadb --lib` clean; workspace-layering check clean; `cargo fmt` clean.
- Spec updated: §2.2 meter DONE, §3 `Cost(q)` annotated per-term, §5 roadmap C3/C4/C5 statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)