### PR TITLE
feat(p3): Phase A+B — mixed-format read primitive + flag-gated PAX write flush

### DIFF
--- a/src/storage/engines/sst/block_format.rs
+++ b/src/storage/engines/sst/block_format.rs
@@ -137,7 +137,7 @@ impl BlockFormatWriter {
     /// Write records to a file using the configured format
     pub fn write_records<P: AsRef<Path>>(&self, path: P, records: &[ProximaRecord]) -> Result<()> {
         match self.format {
-            BlockFormat::ProximaBlocks => {
+            BlockFormat::ProximaBlocks | BlockFormat::PaxBlock => {
                 // ProximaBlocks uses existing SST writer path
                 debug!("Using ProximaBlocks format for {}", path.as_ref().display());
                 Ok(()) // Caller handles ProximaBlocks writing
@@ -193,7 +193,7 @@ impl BlockFormatReader {
         vector_id: &str,
     ) -> Result<Option<ProximaRecord>> {
         match self.format {
-            BlockFormat::ProximaBlocks => {
+            BlockFormat::ProximaBlocks | BlockFormat::PaxBlock => {
                 // ProximaBlocks uses existing SST reader path
                 debug!(
                     "ProximaBlocks lookup for {} in {}",
@@ -213,7 +213,7 @@ impl BlockFormatReader {
     /// Read all records from a file
     pub fn read_all<P: AsRef<Path>>(&self, path: P) -> Result<Vec<ProximaRecord>> {
         match self.format {
-            BlockFormat::ProximaBlocks => {
+            BlockFormat::ProximaBlocks | BlockFormat::PaxBlock => {
                 debug!("ProximaBlocks read_all from {}", path.as_ref().display());
                 Ok(vec![]) // Caller handles ProximaBlocks reading
             }
@@ -232,7 +232,7 @@ impl BlockFormatReader {
         ids: &[&str],
     ) -> Result<Vec<(String, ProximaRecord)>> {
         match self.format {
-            BlockFormat::ProximaBlocks => {
+            BlockFormat::ProximaBlocks | BlockFormat::PaxBlock => {
                 debug!("ProximaBlocks batch_lookup in {}", path.as_ref().display());
                 Ok(vec![]) // Caller handles ProximaBlocks reading
             }

--- a/src/storage/engines/sst/block_format.rs
+++ b/src/storage/engines/sst/block_format.rs
@@ -97,6 +97,9 @@ pub enum BlockFormat {
     ProximaBlocks,
     /// Arrow IPC based storage format
     ArrowBlock,
+    /// Columnar PAX segment (carries SQ8 / RaBitQ quant codes; enables quantized ANN).
+    /// P3 migration — flag-gated default-OFF; reads are mixed-format-safe (`segment_format`).
+    PaxBlock,
 }
 
 impl BlockFormat {
@@ -104,6 +107,7 @@ impl BlockFormat {
     pub fn parse_block_format(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "arrowblock" | "arrow" | "arrow_block" => BlockFormat::ArrowBlock,
+            "paxblock" | "pax" | "pax_block" => BlockFormat::PaxBlock,
             _ => BlockFormat::ProximaBlocks,
         }
     }
@@ -113,6 +117,7 @@ impl BlockFormat {
         match self {
             BlockFormat::ProximaBlocks => ".sst",
             BlockFormat::ArrowBlock => ".arrow",
+            BlockFormat::PaxBlock => ".pax",
         }
     }
 }

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1165,6 +1165,13 @@ impl Compaction {
             debug!("🔍 COMPACTION: Using block format: {:?}", block_format);
 
             match block_format {
+                BlockFormat::PaxBlock => {
+                    // PAX segment compaction lands in P3 Phase E (reads mixed formats,
+                    // rewrites to the configured format). Fail closed until then.
+                    return Err(crate::core::StorageError::SstEngine(
+                        "PAX segment compaction not yet supported (P3 Phase E)".into(),
+                    ));
+                }
                 BlockFormat::ArrowBlock => {
                     // Use ArrowBlockWriter for Arrow IPC format
                     debug!("🔍 COMPACTION: Using ArrowBlockWriter for Arrow format");
@@ -1279,6 +1286,12 @@ impl Compaction {
             );
 
             match block_format {
+                BlockFormat::PaxBlock => {
+                    // PAX segment compaction lands in P3 Phase E. Fail closed until then.
+                    return Err(crate::core::StorageError::SstEngine(
+                        "PAX segment compaction not yet supported (P3 Phase E)".into(),
+                    ));
+                }
                 BlockFormat::ArrowBlock => {
                     // Use ArrowBlockWriter for Arrow IPC format
                     debug!("🔍 COMPACTION (non-atomic): Using ArrowBlockWriter for Arrow format");
@@ -1789,6 +1802,7 @@ impl Compaction {
         let extension = match block_format {
             BlockFormat::ArrowBlock => "arrow",
             BlockFormat::ProximaBlocks => "sst",
+            BlockFormat::PaxBlock => "pax",
         };
         let filename = codec.generate(level as u32, extension);
         collection_dir.join(filename)

--- a/src/storage/engines/sst/compactor_impl.rs
+++ b/src/storage/engines/sst/compactor_impl.rs
@@ -966,6 +966,11 @@ impl SstCompactor {
         );
 
         match block_format {
+            super::block_format::BlockFormat::PaxBlock => {
+                // PAX segment compaction lands in P3 Phase E. Fail closed until then.
+                // (Unreachable today: detect_format only yields Arrow/ProximaBlocks.)
+                anyhow::bail!("PAX segment compaction not yet supported (P3 Phase E)");
+            }
             super::block_format::BlockFormat::ArrowBlock => {
                 // Use ArrowBlockWriter for Arrow IPC format
                 debug!("🔍 SST_COMPACTOR: Using ArrowBlockWriter for Arrow format");

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -428,6 +428,7 @@ impl SstEngine {
                     .map(|(_, rec)| rec.embeddings.len().max(1))
                     .unwrap_or(1);
                 let records: Vec<_> = sorted_vectors.into_iter().map(|(_, rec)| rec).collect();
+                let collection_id = params.collection_id.as_deref().unwrap_or("default");
                 let meta = write_pax_segment(
                     std::path::Path::new(staging_path),
                     &records,

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -149,10 +149,20 @@ impl SstEngine {
 
         // Generate SSTable filename with appropriate extension based on block format
         let codec = FilenameCodec::new();
-        let block_format = BlockFormat::parse_block_format(&self.config().block_format);
+        let mut block_format = BlockFormat::parse_block_format(&self.config().block_format);
+        // P3 Phase B: flag-gated PAX vector segments (default OFF). Reads stay
+        // mixed-format-safe (see `segment_format`), so flipping this on only changes
+        // newly written segments; existing ProximaBlocks segments still read back.
+        if std::env::var("PROXIMADB_PAX_VECTOR_SEGMENTS")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+            .unwrap_or(false)
+        {
+            block_format = BlockFormat::PaxBlock;
+        }
         let file_extension = match block_format {
             BlockFormat::ArrowBlock => "arrow",
             BlockFormat::ProximaBlocks => "sst",
+            BlockFormat::PaxBlock => "pax",
         };
         let sst_filename = codec.generate(0, file_extension); // Level 0 for flush
         debug!(
@@ -398,6 +408,36 @@ impl SstEngine {
 
                 tracing::debug!("SSTable write operation completed");
                 write_outcome = Some(outcome);
+            }
+            BlockFormat::PaxBlock => {
+                // P3 Phase B: write a columnar PAX vector segment (flag-gated, default
+                // OFF). Mirrors the Arrow arm's local-staging approach — write to the
+                // local staging path; the atomic op promotes it to the final (possibly
+                // object-store) URL. Reads are mixed-format-safe via
+                // `segment_format::read_segment_records` (magic-byte detection), so no
+                // manifest/reader change is required for this segment to be read back.
+                use crate::storage::engines::sst::segment_format::write_pax_segment;
+                let staging_path = staging_url.strip_prefix("file://").unwrap_or(&staging_url);
+                if let Some(parent) = std::path::Path::new(staging_path).parent() {
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .context("Failed to create PAX staging directory")?;
+                }
+                let embedding_count = sorted_vectors
+                    .first()
+                    .map(|(_, rec)| rec.embeddings.len().max(1))
+                    .unwrap_or(1);
+                let records: Vec<_> = sorted_vectors.into_iter().map(|(_, rec)| rec).collect();
+                let meta = write_pax_segment(
+                    std::path::Path::new(staging_path),
+                    &records,
+                    collection_id,
+                    embedding_count,
+                )
+                .context("Failed to write PAX vector segment")?;
+                tracing::debug!(blocks = meta.block_count, "PAX segment write completed");
+                // write_outcome stays None — PAX doesn't expose SstableWriteOutcome yet
+                // (block-directory emission is the ProximaBlocks-only path, like Arrow).
             }
         }
 

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -253,6 +253,7 @@ pub mod manifest;
 pub mod pca_manager; // PCA caching for Z-Order spatial encoding
 pub mod progressive_stages; // ISP-compliant progressive search stages
 pub mod search;
+pub mod segment_format; // P3 Phase A: mixed-format (ProximaBlocks/PAX) read primitives
 pub mod text_column_support; // TEXT column storage integration
 pub mod tiering_integration;
 pub mod trait_impl;

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -265,6 +265,15 @@ impl SstEngine {
                     .read_all_records_for_compaction(&[file.to_string()])
                     .await
             }
+            BlockFormat::PaxBlock => {
+                // P3: read a PAX segment via the mixed-format primitive (magic-detected,
+                // reuses PaxSegmentScanner). Best-effort schema keys (empty) for now.
+                let local = file.strip_prefix("file://").unwrap_or(file);
+                let bytes = tokio::fs::read(local)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("read pax segment {file}: {e}"))?;
+                crate::storage::engines::sst::segment_format::read_segment_records(&bytes, &[], &[])
+            }
         }
     }
 

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -18,10 +18,14 @@
 //! starts with the columnar version byte `0x01` or a compression marker
 //! `0x02..=0x0E` — disjoint from `PBLK`, so the legacy path is never mis-routed.
 
+use std::path::Path;
+
 use anyhow::Result;
-use proximadb_block_format::BLOCK_MAGIC;
+use proximadb_block_format::{BLOCK_MAGIC, BlockCompression, BlockMode};
 use proximadb_records::ProximaRecord;
-use proximadb_storage_common::pax_block::{PaxSegmentScanner, SEGMENT_MAGIC, ScanPredicate};
+use proximadb_storage_common::pax_block::{
+    PaxSegmentScanner, PaxSegmentWriter, SEGMENT_MAGIC, ScanPredicate, SegmentMeta,
+};
 
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 
@@ -83,13 +87,39 @@ pub fn read_segment_records(
     }
 }
 
+/// Write `records` as a PAX vector segment at `path` — the write-side inverse of
+/// [`read_segment_records`] for the PAX format, via the canonical [`PaxSegmentWriter`]
+/// (no hand-rolled encoder, per the storage-format-migration mandate). Phase B's
+/// flag-gated SST flush arm calls this against the local staging path; the resulting
+/// file is detected as [`SegmentFormat::Pax`] and reads back through the same router.
+///
+/// `embedding_count` is the collection's embedding-modality count (≥1).
+pub fn write_pax_segment(
+    path: &Path,
+    records: &[ProximaRecord],
+    collection_id: &str,
+    embedding_count: usize,
+) -> Result<SegmentMeta> {
+    let mut writer = PaxSegmentWriter::new(
+        path,
+        BlockMode::Pax,
+        BlockCompression::None,
+        collection_id,
+        0, // schema_fingerprint — derived from the catalog schema in Phase D
+        embedding_count.max(1),
+        None,
+    );
+    for record in records {
+        writer.add_record(record)?;
+    }
+    writer.finish()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::storage::engines::core::formats::proximablocks::BlockCompressionConfig;
-    use proximadb_block_format::{BlockCompression, BlockMode};
     use proximadb_records::{EmbeddingCell, EmbeddingValues};
-    use proximadb_storage_common::pax_block::PaxSegmentWriter;
 
     fn rec(oid: &str, ts: i64, vec: Vec<f32>) -> ProximaRecord {
         let mut r = ProximaRecord {
@@ -193,5 +223,30 @@ mod tests {
     #[test]
     fn default_is_proxima_blocks() {
         assert_eq!(SegmentFormat::default(), SegmentFormat::ProximaBlocks);
+    }
+
+    /// `write_pax_segment` is the write-side inverse: what it writes is detected as PAX
+    /// and reads back through `read_segment_records` (the Phase B flush↔read round-trip,
+    /// exercised without the flush harness).
+    #[test]
+    fn write_pax_segment_round_trips_through_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("written.pax");
+        let records = vec![
+            rec("w1", 1_700_000_000_000_000_000, vec![1.0, 2.0, 3.0]),
+            rec("w2", 1_700_000_000_000_000_001, vec![4.0, 5.0, 6.0]),
+        ];
+        let meta = write_pax_segment(&path, &records, "col", 1).unwrap();
+        assert!(
+            meta.block_count >= 1,
+            "segment should have at least one block"
+        );
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(SegmentFormat::detect(&bytes), SegmentFormat::Pax);
+        let back = read_segment_records(&bytes, &[], &[]).unwrap();
+        let mut oids: Vec<&str> = back.iter().map(|r| r.oid.as_str()).collect();
+        oids.sort_unstable();
+        assert_eq!(oids, vec!["w1", "w2"]);
     }
 }

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -1,0 +1,197 @@
+//! Mixed-format vector-segment read primitives (P3 Phase A).
+//!
+//! ProximaDB's vector engines (SST/HELIX/SWIFT) historically persist segments as
+//! row-based [`ProximaDataBlock`] (raw f32). The RaBitQ path (P3) stores vectors in
+//! the columnar PAX segment format, which carries quantized codes and enables ~30×
+//! ANN. To migrate additively — mixed-read-safe and default-OFF — a reader must
+//! recognise both formats straight from the on-disk bytes.
+//!
+//! This module is the read-side foundation: a byte-based [`SegmentFormat::detect`]
+//! and a [`read_segment_records`] router that decodes either format back to
+//! `Vec<ProximaRecord>`, reusing the canonical PAX inverse
+//! ([`PaxSegmentScanner::read_records`]). It writes nothing and changes no live read
+//! path. The wiring into the cold-search / compaction / recovery sites (Phase A.2)
+//! and the PAX write side (Phase B) build on top of this primitive.
+//!
+//! Detection is unambiguous by magic: a PAX segment starts with the PAX block magic
+//! `PBLK` (`0x50…`) and ends with the segment magic `PAXSEG01`; a `ProximaDataBlock`
+//! starts with the columnar version byte `0x01` or a compression marker
+//! `0x02..=0x0E` — disjoint from `PBLK`, so the legacy path is never mis-routed.
+
+use anyhow::Result;
+use proximadb_block_format::BLOCK_MAGIC;
+use proximadb_records::ProximaRecord;
+use proximadb_storage_common::pax_block::{PaxSegmentScanner, SEGMENT_MAGIC, ScanPredicate};
+
+use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
+
+/// On-disk format of a persisted vector segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum SegmentFormat {
+    /// Legacy row-based block (raw f32). The default for segments written before P3
+    /// and for any manifest entry that predates the format field.
+    #[default]
+    ProximaBlocks,
+    /// Columnar PAX segment (carries SQ8 / RaBitQ codes; enables quantized ANN).
+    Pax,
+}
+
+impl SegmentFormat {
+    /// Detect a persisted segment's format from its raw bytes, mixed-read-safe.
+    ///
+    /// Returns [`SegmentFormat::ProximaBlocks`] for anything not recognisably a PAX
+    /// segment, so the legacy path is never mis-routed on truncated or unknown input.
+    pub fn detect(bytes: &[u8]) -> Self {
+        if is_pax_segment(bytes) {
+            SegmentFormat::Pax
+        } else {
+            SegmentFormat::ProximaBlocks
+        }
+    }
+}
+
+/// True iff `bytes` is a PAX segment: leading PAX block magic AND trailing segment
+/// magic. Both ends are checked so a stray prefix or suffix alone can't false-positive.
+fn is_pax_segment(bytes: &[u8]) -> bool {
+    bytes.len() >= BLOCK_MAGIC.len() + SEGMENT_MAGIC.len()
+        && bytes.starts_with(&BLOCK_MAGIC)
+        && bytes.ends_with(SEGMENT_MAGIC)
+}
+
+/// Decode a persisted vector segment back to records, routing on the detected format.
+///
+/// PAX segments are decoded via the canonical inverse
+/// ([`PaxSegmentScanner::read_records`]); legacy segments via
+/// [`ProximaDataBlock::deserialize`]. This is the single mixed-read entry the
+/// Phase A.2 wiring will call from the cold-search, compaction, and recovery paths.
+///
+/// `embedding_model_ids` / `user_column_keys` are the collection's schema keys used
+/// to reconstruct PAX records positionally (empty slices = best-effort defaults);
+/// they are ignored for the legacy format, which is self-describing.
+pub fn read_segment_records(
+    bytes: &[u8],
+    embedding_model_ids: &[String],
+    user_column_keys: &[String],
+) -> Result<Vec<ProximaRecord>> {
+    match SegmentFormat::detect(bytes) {
+        SegmentFormat::Pax => {
+            let mut scanner =
+                PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())?;
+            scanner.read_records(embedding_model_ids, user_column_keys)
+        }
+        SegmentFormat::ProximaBlocks => Ok(ProximaDataBlock::deserialize(bytes, None)?.records),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::engines::core::formats::proximablocks::BlockCompressionConfig;
+    use proximadb_block_format::{BlockCompression, BlockMode};
+    use proximadb_records::{EmbeddingCell, EmbeddingValues};
+    use proximadb_storage_common::pax_block::PaxSegmentWriter;
+
+    fn rec(oid: &str, ts: i64, vec: Vec<f32>) -> ProximaRecord {
+        let mut r = ProximaRecord {
+            oid: oid.into(),
+            tenant_id: "t".into(),
+            created_at_ns: ts,
+            updated_at_ns: ts,
+            ..Default::default()
+        };
+        let dim = vec.len();
+        r.embeddings.push(EmbeddingCell {
+            modality: "dense".into(),
+            dim: dim as u32,
+            values: EmbeddingValues::Fp32(vec),
+            ..Default::default()
+        });
+        r
+    }
+
+    /// A PAX segment written by `PaxSegmentWriter` is detected as `Pax` and round-trips
+    /// back to the same records through the format-routing reader.
+    #[test]
+    fn pax_segment_detected_and_read_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1, // embedding_count
+            None,
+        );
+        w.add_record(&rec("a", 1_700_000_000_000_000_000, vec![1.0, 2.0, 3.0]))
+            .unwrap();
+        w.add_record(&rec("b", 1_700_000_000_000_000_001, vec![4.0, 5.0, 6.0]))
+            .unwrap();
+        w.finish().unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(
+            SegmentFormat::detect(&bytes),
+            SegmentFormat::Pax,
+            "PAX segment must be detected as Pax"
+        );
+
+        let records = read_segment_records(&bytes, &[], &[]).unwrap();
+        assert_eq!(records.len(), 2);
+        let mut oids: Vec<&str> = records.iter().map(|r| r.oid.as_str()).collect();
+        oids.sort_unstable();
+        assert_eq!(oids, vec!["a", "b"]);
+    }
+
+    /// A legacy `ProximaDataBlock` is detected as `ProximaBlocks` and round-trips back
+    /// to the same records — proving the router preserves the existing path.
+    #[test]
+    fn proxima_block_detected_and_read_back() {
+        let records = vec![
+            rec("x", 1_700_000_000_000_000_000, vec![1.0, 2.0, 3.0, 4.0]),
+            rec("y", 1_700_000_000_000_000_001, vec![5.0, 6.0, 7.0, 8.0]),
+        ];
+        let bytes = ProximaDataBlock::new(records, BlockCompressionConfig::default())
+            .serialize()
+            .unwrap();
+
+        assert_eq!(
+            SegmentFormat::detect(&bytes),
+            SegmentFormat::ProximaBlocks,
+            "ProximaDataBlock must be detected as ProximaBlocks"
+        );
+
+        let back = read_segment_records(&bytes, &[], &[]).unwrap();
+        let mut oids: Vec<&str> = back.iter().map(|r| r.oid.as_str()).collect();
+        oids.sort_unstable();
+        assert_eq!(oids, vec!["x", "y"]);
+    }
+
+    /// Detection never mis-routes the legacy path: version/compression-marker first
+    /// bytes, empty input, and a PBLK prefix without the trailing segment magic all
+    /// resolve to `ProximaBlocks`.
+    #[test]
+    fn detection_defaults_to_legacy_and_guards_false_positives() {
+        assert_eq!(SegmentFormat::detect(&[]), SegmentFormat::ProximaBlocks);
+        assert_eq!(
+            SegmentFormat::detect(&[0x01, 0, 0]),
+            SegmentFormat::ProximaBlocks
+        );
+        assert_eq!(
+            SegmentFormat::detect(&[0x05, 0, 0]),
+            SegmentFormat::ProximaBlocks
+        );
+        // Leading PBLK but no trailing PAXSEG01 → not a PAX segment.
+        let mut faux = BLOCK_MAGIC.to_vec();
+        faux.extend_from_slice(&[0u8; 16]);
+        assert_eq!(SegmentFormat::detect(&faux), SegmentFormat::ProximaBlocks);
+    }
+
+    /// The default format is the legacy one (serde-absent manifests recover unchanged).
+    #[test]
+    fn default_is_proxima_blocks() {
+        assert_eq!(SegmentFormat::default(), SegmentFormat::ProximaBlocks);
+    }
+}


### PR DESCRIPTION
First two implementation increments of the P3 RaBitQ-in-ANN migration (`docs/12-design/RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc`), bundled into one PR per Directive #7. Governed by the **Storage-Format Migration** mandate — mixed-read-safe, default-OFF, round-trip gated.

## Phase A — mixed-format read primitive (zero change to the live read path)
`src/storage/engines/sst/segment_format.rs`:
- **`SegmentFormat::detect(&[u8])`** — byte-based, unambiguous (PAX = leading `PBLK` + trailing `PAXSEG01`; `ProximaDataBlock` = `0x01` / `0x02..=0x0E`, disjoint). Defaults to legacy on unknown input, false-positive guarded.
- **`read_segment_records(...)`** — mixed-read router reusing `PaxSegmentScanner::read_records` (no hand-rolled decoder).

## Phase B — flag-gated PAX write flush
- **`write_pax_segment(...)`** — write-side inverse via `PaxSegmentWriter` + write→read round-trip test.
- **`BlockFormat::PaxBlock`** (enum + parser + `.pax`).
- SST flush dispatch arm gated by **`PROXIMADB_PAX_VECTOR_SEGMENTS`** (default OFF); writes to local staging (atomic-op promotes), `embedding_count` from records.

No manifest schema change: reads are self-describing via magic (manifest `block_format` deferred to Phase E). Flipping the flag only affects newly-written segments; existing segments read back unchanged.

## Verified locally
`cargo test -p proximadb --lib segment_format` → **5/5**; `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Next increments
Phase A.2 (wire router into cold-read/compaction/recovery) · **Phase C** (RaBitQ scoring branch + f32 rerank) · **Phase G** (cold-recall harness, N≥1000 — the recall gate) · Phase D config · Phase E compaction/recovery + manifest field · Phase F HELIX/SWIFT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)