### PR TITLE
feat(p3): Phase C.1 — public RaBitQ stage-1 ranking primitive

### DIFF
--- a/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
@@ -257,6 +257,23 @@ impl RaBitQCode {
     }
 }
 
+/// Stage-1 RaBitQ candidate ranking: score every present code with the binary L2
+/// estimator against an already-[`rotate_query`]'d query and return up to `pool` row
+/// indices ordered nearest-first (lower estimator score = nearer). This is the
+/// approximate prefilter; the caller reranks the returned candidates against the
+/// full-precision source (decoupled rerank, per RABITQ_ANN_INTEGRATION_SCOPING) — the
+/// codes alone are ~30× smaller and too coarse to be the final answer.
+pub fn rank_candidates(q_rotated: &[f32], codes: &[Option<RaBitQCode>], pool: usize) -> Vec<usize> {
+    let mut scored: Vec<(usize, f32)> = codes
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| c.as_ref().map(|c| (i, c.l2_rank_score(q_rotated))))
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(pool);
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
 /// Convenience: encode a whole column (used by tests / the block writer).
 pub fn encode_column(vectors: &[&[f32]], params: &RaBitQParams) -> Result<Vec<RaBitQCode>> {
     if params.dim == 0 {

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -320,6 +320,19 @@ impl<'a> PaxBlockReader<'a> {
         Some((params, codes))
     }
 
+    /// Stage-1 RaBitQ candidate ranking for this block's `EMBED_BASE` column: decode the
+    /// codes, rotate the query once, and return up to `pool` row indices ordered
+    /// nearest-first (the approximate prefilter). Returns `None` if the column isn't
+    /// RaBitQ-quantized. The caller reranks the returned rows against the full-precision
+    /// source (decoupled rerank) before taking the final top-k — this is the seam Phase C
+    /// wires into the cold scan.
+    pub fn rabitq_rank(&self, query: &[f32], pool: usize) -> Option<Vec<usize>> {
+        let (params, codes) = self.decode_rabitq_codes(crate::col_id::EMBED_BASE)?;
+        let rotation = rabitq::build_rotation(params.dim, params.seed);
+        let q_rotated = rabitq::rotate_query(query, &params, &rotation);
+        Some(rabitq::rank_candidates(&q_rotated, &codes, pool))
+    }
+
     /// Decode opaque byte blobs from a raw length-prefixed binary stripe — the
     /// inverse of the writer's `build_bytes_stripe` (used for the msgpack `PROPS`
     /// and `LABELS` columns). Each value is a 4-byte little-endian length prefix
@@ -1054,15 +1067,12 @@ mod tests {
                 .map(|(v, n)| v + n * 0.01)
                 .collect();
 
-            // Stage 1: rank ALL candidates by the binary estimator over codes.
+            // Stage 1: rank candidates by the binary estimator over codes — via the
+            // public `rank_candidates` primitive that Phase C wires into the cold scan.
             let q_rot = rabitq::rotate_query(&query, &params, &rotation);
-            let mut scored: Vec<(usize, f32)> = (0..N)
-                .filter_map(|i| codes[i].as_ref().map(|c| (i, c.l2_rank_score(&q_rot))))
-                .collect();
-            scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+            let mut refine = rabitq::rank_candidates(&q_rot, &codes, REFINE);
 
             // Stage 2: f32 rerank the top-REFINE candidates → final top-K.
-            let mut refine: Vec<usize> = scored.iter().take(REFINE).map(|(i, _)| *i).collect();
             refine.sort_by(|&a, &b| {
                 l2(&corpus[a], &query)
                     .partial_cmp(&l2(&corpus[b], &query))


### PR DESCRIPTION
Next increment of the P3 RaBitQ-in-ANN migration (after #104 Phase A+B). Extracts the block-scoring logic proven by #100's recall test into a **reusable public primitive** — the seam Phase C.2 wires into the cold ANN scan.

## What
- **`rabitq::rank_candidates(q_rotated, codes, pool)`** — pure stage-1 prefilter (score every code with the binary L2 estimator, return up to `pool` row indices nearest-first). In the codec, directly testable at the stripe level.
- **`PaxBlockReader::rabitq_rank(query, pool)`** — thin wrapper over `EMBED_BASE` (decode → rotate → rank); `None` if not RaBitQ-quantized.
- The proven recall test now drives stage-1 through `rank_candidates`, so its recall guarantee transfers to the public primitive.

## Design
RaBitQ stores **codes only** (~30×, no co-located f32), so the primitive does **stage-1 ranking only** and returns candidates — **f32 rerank is decoupled**, owned by the scan layer that holds the full-precision source (per `RABITQ_ANN_INTEGRATION_SCOPING`).

## Verified
`proximadb-codec` 228/228, `proximadb-block-format` 37/37 (incl. recall test), clippy `-D warnings` clean.

## Next — Phase C.2 (separate PR, highest blast radius)
Wire `rabitq_rank` into the cold scan (detect PAX+RaBitQ block → rank → rerank against the f32 source → top-k), gated by **Phase G** cold-recall harness (N≥1000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)