### PR TITLE
feat(kou): result-egress instrumentation + unified edge context (D1+D2)

### DIFF
--- a/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
+++ b/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
@@ -104,9 +104,16 @@ WARN (visible), never silent.
 
 * Exact Azure Private Link *deeper* data-processing tiers (canonical bandwidth /
 private-link pages timed out; only "~$0.01/GB, tiered" confirmed).
-* Exact GCP PSC per-GB *consumed* rate (PSC is mostly per-endpoint-hour + underlying
-LB/transfer; primary per-GB not captured).
-* GCP Standard Network Service Tier exact internet ladder.
+* "Exact GCP PSC per-GB" — *resolved by reframing* (anvaiops S1). PSC has no
+primary per-GB *egress* rate: it is billed per-endpoint-hour (+ per-rule +
+standard transfer on top), so it is modeled as a **private-connectivity add-on**
+(`unit_rates.private_connectivity_per_endpoint_hour`, a Business+
+`features.private_connectivity` entitlement), *not* a `kou_per_gb` bucket and not
+an egress waiver. The same shape covers AWS PrivateLink / Azure Private Link.
+* GCP Standard Network Service Tier — *now encoded* (anvaiops S1): GCP `internet`
+is the per-GB NST axis `{premium, standard}` (`kou_rate_per_gb(..., network_tier=)`,
+default conservative Premium). Exact Standard volume ladder still to re-pin before
+quoting deep discounts.
 * Qualitative: customer acceptance of egress as a visible pass-through line vs
 bundled; realistic BYOC per-customer ops cost + minimum ACV for a solo operator.
 

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -453,6 +453,48 @@ pub fn classify_client(ip: IpAddr) -> KouLocality {
         .classify(ip)
 }
 
+/// Per-request edge classification — the client IP and its derived KOU locality,
+/// computed ONCE at a surface boundary (REST / pgwire / Arrow Flight) and carried
+/// for the request. This is the unifying seam of the edge consolidation (HLD
+/// E0→E1): every surface classifies the client identically and meters
+/// result-egress through one entry point, instead of each re-deriving locality.
+/// OSS carries only the neutral bucket; the per-(provider, bucket) $ weight is
+/// anvaiops policy.
+#[derive(Debug, Clone, Copy)]
+pub struct EdgePolicyContext {
+    /// The client's source IP (the rate-limit + locality subject).
+    pub client_ip: IpAddr,
+    /// The client's KOU locality (free vs chargeable result-egress).
+    pub kou_locality: KouLocality,
+}
+
+impl EdgePolicyContext {
+    /// Classify a client source IP against the installed scope map. An
+    /// unspecified (`0.0.0.0`/`::`) or loopback address is treated as `Local`
+    /// (free, inert): these are embedded / same-host callers, never a chargeable
+    /// remote, so result-egress is never mis-charged for an in-process or
+    /// loopback client.
+    pub fn classify(client_ip: IpAddr) -> Self {
+        let kou_locality = if client_ip.is_unspecified() || client_ip.is_loopback() {
+            KouLocality::Local
+        } else {
+            classify_client(client_ip)
+        };
+        Self {
+            client_ip,
+            kou_locality,
+        }
+    }
+
+    /// Record result-egress (compute → this client) bytes for the request's
+    /// tenant through the convergent KOU meter (`direction = "result"`). No-ops on
+    /// zero bytes and on the free path; folds chargeable bytes into the active
+    /// query's egress trace, exactly like the read-egress boundary.
+    pub fn record_result_egress(&self, tenant_id: Option<&str>, bytes: u64) {
+        record_kou_bytes(tenant_id, self.kou_locality, "result", bytes);
+    }
+}
+
 /// Helper to record an object store operation.
 pub fn record_object_store_op(tenant_id: Option<&str>, operation: &str) {
     let t_id = tenant_id.unwrap_or("default");
@@ -736,6 +778,33 @@ mod tests {
         // No active trace: the counter still records, but nothing panics and the
         // trace stays empty (helper silently no-ops the egress term).
         record_kou_bytes(Some("t"), KouLocality::CrossRegion, "read", 1_234);
+        assert!(io_trace::snapshot().is_none());
+    }
+
+    #[test]
+    fn edge_context_treats_in_process_and_loopback_callers_as_free() {
+        // Unspecified (embedded / unset peer) and loopback callers are never a
+        // chargeable remote — they classify Local so result-egress is never
+        // mis-charged for an in-process or same-host client, regardless of the
+        // scope map. This is the guard that keeps the meter inert by default.
+        let unspec = EdgePolicyContext::classify("0.0.0.0".parse().unwrap());
+        assert_eq!(unspec.kou_locality, KouLocality::Local);
+        assert!(!unspec.kou_locality.is_chargeable_egress());
+        assert_eq!(
+            EdgePolicyContext::classify("::".parse().unwrap()).kou_locality,
+            KouLocality::Local
+        );
+        assert_eq!(
+            EdgePolicyContext::classify("127.0.0.1".parse().unwrap()).kou_locality,
+            KouLocality::Local
+        );
+        assert_eq!(
+            EdgePolicyContext::classify("::1".parse().unwrap()).kou_locality,
+            KouLocality::Local
+        );
+
+        // Recording result-egress on the free path mutates no trace.
+        unspec.record_result_egress(Some("t"), 4096);
         assert!(io_trace::snapshot().is_none());
     }
 }

--- a/src/network/middleware/metrics.rs
+++ b/src/network/middleware/metrics.rs
@@ -41,6 +41,12 @@ pub async fn metrics_middleware(request: Request, next: Next) -> Response {
         .map(|m| m.as_str().to_owned())
         .unwrap_or_else(|| "<unmatched>".to_owned());
 
+    // KOU result-egress: classify the client once, before the request is
+    // consumed by the handler. Same IP-extraction seam as the rate limiter.
+    let edge = crate::metrics::consumption_metrics::EdgePolicyContext::classify(
+        crate::network::middleware::rate_limit::get_client_ip(&request),
+    );
+
     let start = Instant::now();
     let response = next.run(request).await;
     let elapsed = start.elapsed().as_secs_f64();
@@ -52,6 +58,21 @@ pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     HTTP_REQUESTS_TOTAL
         .with_label_values(&[&route, &method, &status])
         .inc();
+
+    // Meter response-body egress to the KOU meter (direction=result) when the
+    // client is genuinely remote (the direct data-plane case) and the body size
+    // is known. Buffered responses (e.g. `Json`) carry `Content-Length`;
+    // streamed/chunked bodies are not buffered here and are left uncounted. The
+    // common in-cluster gateway client classifies free → this is a no-op for it.
+    if edge.kou_locality.is_chargeable_egress()
+        && let Some(len) = response
+            .headers()
+            .get(axum::http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    {
+        edge.record_result_egress(None, len);
+    }
 
     response
 }

--- a/src/network/middleware/rate_limit.rs
+++ b/src/network/middleware/rate_limit.rs
@@ -321,8 +321,9 @@ pub async fn rate_limit_middleware(
     }
 }
 
-/// Extract client IP from request
-fn get_client_ip(request: &Request) -> IpAddr {
+/// Extract client IP from request. `pub(crate)` so the metrics middleware can
+/// classify the same client (one IP-extraction seam shared across the edge).
+pub(crate) fn get_client_ip(request: &Request) -> IpAddr {
     // Try to get IP from X-Forwarded-For header first (for proxies)
     if let Some(forwarded_for) = request.headers().get("X-Forwarded-For")
         && let Ok(forwarded_str) = forwarded_for.to_str()

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -92,8 +92,13 @@ pub struct PostgresProtocol {
     /// E0 rate-limiting: shared per-IP limiter (None = disabled), checked once at
     /// query entry. Converged with the REST limiter via `RateLimitState`.
     rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
-    /// This connection's peer IP — the rate-limit subject.
+    /// This connection's peer IP — the rate-limit subject and the KOU
+    /// result-egress locality subject (classified at each result-set boundary).
     peer_ip: std::net::IpAddr,
+    /// KOU result-egress: bytes of DataRow payload accumulated for the current
+    /// result set, flushed to the meter (direction=result) at CommandComplete /
+    /// PortalSuspended. Zero on the free path / non-row commands.
+    result_bytes_pending: u64,
 }
 
 /// Slice 6.3 gate-input bundle. Distinct type per surface for module
@@ -394,6 +399,7 @@ impl PostgresProtocol {
             suppress_row_description: false,
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            result_bytes_pending: 0,
         }
     }
 
@@ -441,6 +447,7 @@ impl PostgresProtocol {
             suppress_row_description: false,
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            result_bytes_pending: 0,
         }
     }
 
@@ -485,6 +492,7 @@ impl PostgresProtocol {
             suppress_row_description: false,
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            result_bytes_pending: 0,
         }
     }
 
@@ -1576,6 +1584,11 @@ impl PostgresProtocol {
                 }
             }
         }
+        // KOU result-egress: wire bytes = tag(1) + payload_len (which already
+        // counts the 4-byte length field + the 2-byte field count + values).
+        self.result_bytes_pending = self
+            .result_bytes_pending
+            .saturating_add(1 + payload_len as u64);
         self.flush_write_buffer().await
     }
 
@@ -4380,6 +4393,10 @@ impl PostgresProtocol {
             self.write_buffer.put_slice(value.as_bytes()); // Value data
         }
 
+        // KOU result-egress: wire bytes = tag(1) + length(4) + data_len.
+        self.result_bytes_pending = self
+            .result_bytes_pending
+            .saturating_add(5 + data_len as u64);
         self.flush_write_buffer().await
     }
 
@@ -4862,8 +4879,26 @@ impl PostgresProtocol {
         self.flush_write_buffer().await
     }
 
+    /// Flush the result set's accumulated DataRow bytes to the KOU result-egress
+    /// meter (`direction = "result"`), attributed to the query's tenant and the
+    /// client's edge locality. Called at each result-set boundary (CommandComplete
+    /// and PortalSuspended). No-ops when nothing was sent or the client is on the
+    /// free path (in-VPC / loopback / same-region) — only genuinely remote clients
+    /// (the direct data-plane case) classify as chargeable.
+    async fn flush_result_egress(&mut self) {
+        let bytes = std::mem::take(&mut self.result_bytes_pending);
+        if bytes == 0 {
+            return;
+        }
+        let edge = crate::metrics::consumption_metrics::EdgePolicyContext::classify(self.peer_ip);
+        let tenant = self.pgwire_resolve_read_tenant().await;
+        let tenant_scope = (!tenant.is_empty()).then_some(tenant.as_str());
+        edge.record_result_egress(tenant_scope, bytes);
+    }
+
     /// Send command complete
     async fn send_command_complete(&mut self, tag: &str) -> Result<()> {
+        self.flush_result_egress().await;
         let len = 4 + tag.len() + 1;
         self.write_buffer.put_u8(b'C');
         self.write_buffer.put_i32(len as i32);
@@ -4875,6 +4910,9 @@ impl PostgresProtocol {
     /// Send PortalSuspended for an extended-protocol Execute that has more
     /// portal rows available after satisfying the current max_rows budget.
     async fn send_portal_suspended(&mut self) -> Result<()> {
+        // Partial result set delivered — meter the rows sent so far; the rest
+        // flushes at the resumed Execute's CommandComplete.
+        self.flush_result_egress().await;
         self.write_buffer.put_u8(b's');
         self.write_buffer.put_i32(4);
         self.flush_write_buffer().await


### PR DESCRIPTION
## What (Phase 1 / D1+D2 of the KOU deferred follow-ups)

Completes the engine-side KOU **egress accounting & metering (EAM)** surface. Read-egress (object store → compute) was already metered; **result-egress (compute → client) had zero call sites**. This wires it at the engine's own result boundaries and unifies the client→locality seam across surfaces — the HLD **E0→E1** edge consolidation.

### D1 — unified edge context
New `EdgePolicyContext { client_ip, kou_locality }` (`consumption_metrics.rs`): classify a client IP **once** at a surface boundary and meter result-egress through one entry point, instead of each surface re-deriving locality. Unspecified/loopback callers are forced to `Local` (free) so an embedded / same-host client is **never mis-charged** as internet egress — the guard that keeps the meter inert by default.

### D2 — result-egress instrumentation (`record_kou_bytes(.., "result", ..)`)
- **pgwire** — `send_data_row` / `send_data_row_nullable` accumulate the exact DataRow wire bytes; flushed to the meter at **CommandComplete** and **PortalSuspended**, attributed to the query's tenant + client locality. *(This is the "pgwire result-byte instrumentation" gap — `data_len` was computed then discarded.)*
- **REST** — `metrics_middleware` meters the response body via `Content-Length` (buffered `Json` responses), reusing the shared `get_client_ip` seam.

**No double-count:** in-cluster gateway→engine hops classify free; only genuinely remote *direct-data-plane* clients are chargeable. Chargeable bytes fold into the per-query `io_trace` egress term (cost model `per_mib_egress`), unchanged.

## Scope / boundary
- **Arrow Flight** result bytes (Tonic stream) remain the one uninstrumented surface — tracked as the remaining D2 slice (stream-wrapping + peer-addr extraction is materially riskier; deferred deliberately).
- **Open-core clean:** OSS emits only the neutral `proximadb_kou_bytes_total{kou_locality,direction}` meter (`check_oss_boundary.py --strict`: 0 errors); $ rates live in anvaiops.
- Spec doc updated: PSC reframed as a per-endpoint-hour add-on; GCP NST as the per-GB axis (paired with anvaiops S1).

## Verification
`cargo check` ✓ · `cargo clippy -p proximadb --lib` ✓ (0 warnings) · 10 `consumption_metrics` tests ✓ (incl. new `edge_context_treats_in_process_and_loopback_callers_as_free`) · `cargo fmt --check` ✓ · OSS boundary ✓.

Stacked on `feat/codesign-cost-model` (#101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)