### PR TITLE
docs: reconcile supported-surface with shipped develop reality

### DIFF
--- a/docs/04-operations/production-readiness.adoc
+++ b/docs/04-operations/production-readiness.adoc
@@ -450,6 +450,41 @@ Criteria evolve based on:
 4. Communicate changes to development team
 5. Update feature evaluation process
 
+=== CI Tiers and Branch Protection
+
+Feature maturity is enforced operationally by a three-tier CI gate matched to the
+`feat → develop → qa → main` promotion flow. Each protected branch merges only when the
+single `CI Success` aggregator check is green (chosen over many individually-required
+contexts to avoid skipped-check deadlock).
+
+[cols="1,1,3,1",options="header"]
+|===
+| Promotion | Tier | Checks (summary) | Workflows
+
+| feat → `develop`
+| LIGHT
+| compile + fmt/clippy + layering + proto + panic-policy + security-audit + docs
+| `ci.yml`
+
+| `develop` → `qa`
+| MEDIUM
+| LIGHT + unit/integration tests + feature-matrix
+| `ci.yml`, `qa-gate.yml`
+
+| `qa` → `main`
+| FULL
+| MEDIUM + coverage + python multi-version + docker + benchmarks + CodeQL
+| `ci.yml`, `qa-gate.yml`, `codeql.yml`
+|===
+
+Branch protection (live): `develop`, `qa`, and `main` all require the `CI Success` check.
+`develop` and `main` additionally enforce it for admins (`enforce_admins`); `qa` and `main`
+require the branch to be up to date before merge (`strict`); `main` also requires linear
+history (merge via rebase/squash, not a merge commit). Heavy scans (CodeQL) run only at the
+`qa → main` boundary plus a weekly schedule. The canonical description of the tier contract
+is `CLAUDE.md` Core Directive #9 (CI/CD Tiering & Security Governance); this section is the
+operator-facing projection of it.
+
 == Summary
 
 Production readiness at ProximaDB means:

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -206,6 +206,16 @@ must not list them under "supported", "production", or "ready":
   native row/delta indexes, DataFusion snapshot-plus-delta reads, and distributed consistency gates
   are tracked in TD-110 and are not part of v0.2.
 * External-table execution (Iceberg / Delta / Hudi as Proxima-owned hot authority).
+* Iceberg v3 interop _write/export_ — `ALTER TABLE … MATERIALIZE` over pgwire emits a
+  spec-shaped Iceberg v3 table (`v*.metadata.json` referencing an Avro manifest list + manifest)
+  to the warehouse so external Iceberg engines can read it (verified by `tests/iceberg_interop_e2e.rs`).
+  One-way publish only; this is distinct from the hot-authority item above (still experimental), and
+  external read-back plus multi-writer coordination are unverified.
+* Columnar vector quantization (RaBitQ / SQ8) in PAX vector segments — _flag-gated, default OFF_.
+  Enabled with `PROXIMADB_PAX_VECTOR_SEGMENTS=1` plus `PROXIMADB_PAX_VECTOR_QUANT=rabitq|sq8|auto`
+  (deployment-level env selector; per-collection proto config is the productionization follow-up).
+  Reads are mixed-format-safe — existing ProximaBlocks segments still read back when the flag is on.
+  Codecs/kernels are tested; no per-collection policy or recall SLA is claimed.
 * Arrow Flight / gRPC service multiplexing as a customer-facing transport.
 * Trino / Spark compute adapters — _scaffolded_ (Spark JNI bridge per TD-097; Trino Flight per TD-098). Structural contract gates land in 2026-05-30 connector sprint (`tests/connectors_flight_contract.rs`); end-to-end wire impl deferred.
 * Hadoop InputFormat / OutputFormat — _write-side wire-true_ (`ProximaRecordWriter::flush_now` posts spec-true `/api/v2/.../records/batch`); read-side blocked on the records-scan endpoint gap tracked under TD-099.


### PR DESCRIPTION
## Summary
Doc-only reconciliation. A drift audit of the authority docs vs `origin/develop` found **asymmetric drift**: recently-shipped features landed in code+tests but were never backfilled into the support matrix (the docs *under-claim*, never over-claim — no false "supported" entries). This closes the three clear gaps. No code or tier changes; nothing already-correct was re-tiered.

## Changes
**`docs/SUPPORTED_SURFACE.adoc`** — two new entries under *Experimental in v0.2*:
- **Iceberg v3 interop write/export** — `ALTER TABLE … MATERIALIZE` emits a spec-shaped v3 table (`v*.metadata.json` + Avro manifest list + manifest); one-way publish, external read-back unverified. Evidence: `tests/iceberg_interop_e2e.rs`. Distinct from the existing Iceberg *hot-authority* bullet (still experimental).
- **Columnar vector quantization (RaBitQ / SQ8)** in PAX vector segments — flag-gated default-OFF (`PROXIMADB_PAX_VECTOR_SEGMENTS=1` + `PROXIMADB_PAX_VECTOR_QUANT=rabitq|sq8|auto`); reads mixed-format-safe; kernels tested, no per-collection policy / recall SLA claimed. Evidence: `src/storage/engines/sst/flush/mod.rs`.

**`docs/04-operations/production-readiness.adoc`** — new *CI Tiers and Branch Protection* subsection: operator-facing projection of the 3-tier gate (feat→dev LIGHT / dev→qa MEDIUM / qa→main FULL) + live branch protection (`CI Success` everywhere; `enforce_admins` on develop+main; `strict` on qa+main; linear history on main; CodeQL at qa→main + weekly). Canonical contract stays `CLAUDE.md` directive #9.

## Validation
- `scripts/validate_capability_matrix.py` → **passed**.
- New AsciiDoc table renders clean (the 4 pre-existing asciidoctor warnings elsewhere in `production-readiness.adoc` are untouched and already present on develop).
- Doc-only → LIGHT tier; no heavy lanes.

## Provenance
Findings from a read-only drift audit cross-checking each authority-doc claim against shipped tests/code on `origin/develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)