### PR TITLE
feat(kou): egress-aware shaping (ResultShapePolicy) + Arrow Flight result metering (D3 + Flight)

### DIFF
--- a/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
+++ b/docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc
@@ -100,6 +100,27 @@ surface `cross_az` / `cross_region` / `cross_cloud` / `internet` as distinct met
 tiers so users self-select cheap topologies; default unknown placement to free +
 WARN (visible), never silent.
 
+== 3a. Egress-aware response shaping (active, lossless-by-default)
+
+Client locality drives *how* a result is serialized, not just how it is billed
+(`ResultShapePolicy`, the EdgePolicyPlane shaping stage). For a chargeable (far)
+client, shaping is **active** but **lossless**: the bytes are minimized in a way
+the client decodes transparently — results are never silently dropped.
+
+* *Arrow Flight* (OSS engine, `do_get`): chargeable client ⇒ encode batches with
+  ZSTD (Arrow IPC decompresses transparently). Near/free clients stay uncompressed
+  (save CPU). Result-egress is metered on the *actual encoded* bytes, so the meter
+  reflects the compressed egress that really left.
+* *REST* (anvaiops gateway, the dominant internet boundary): chargeable client that
+  accepts gzip ⇒ gzip the response; meter the *compressed* bytes (never the
+  uncompressed size). Free-path clients are untouched.
+* *Lossy* levers (result caps, reduced rerank) are deliberately NOT on by default —
+  a database must not silently truncate; they require an explicit, signaled opt-in
+  (tier/config), surfaced via the existing truncation/`PortalSuspended` path.
+* OSS REST compression at the engine is deferred on purpose: it would strip the
+  `Content-Length` the result-egress meter reads, so engine REST stays metered and
+  the gateway owns REST compression.
+
 == 4. Open gaps (honest — re-pin before quoting)
 
 * Exact Azure Private Link *deeper* data-processing tiers (canonical bandwidth /

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -493,6 +493,44 @@ impl EdgePolicyContext {
     pub fn record_result_egress(&self, tenant_id: Option<&str>, bytes: u64) {
         record_kou_bytes(tenant_id, self.kou_locality, "result", bytes);
     }
+
+    /// The egress-aware result-shaping decision for this request (see
+    /// [`ResultShapePolicy`]).
+    pub fn shape_policy(&self) -> ResultShapePolicy {
+        ResultShapePolicy::for_locality(self.kou_locality)
+    }
+}
+
+/// Egress-aware result-shaping decision, derived from a request's KOU locality.
+/// This is the one place the edge decides *how* to serialize a response based on
+/// where the client is — the EdgePolicyPlane "shaping stage" consulted by every
+/// surface (Arrow Flight compression, REST advisory) so the policy is uniform and
+/// not re-derived per surface.
+///
+/// Active for chargeable/far clients but **lossless only by default**: it enables
+/// byte-minimization (compression / columnar density) that the client decodes
+/// transparently — it never drops or truncates results. Lossy levers (result
+/// caps, reduced rerank) are intentionally NOT decided here; they require an
+/// explicit, signaled opt-in. The $ weight of "far" stays anvaiops policy; OSS
+/// keys purely on the neutral locality bucket.
+#[derive(Debug, Clone, Copy)]
+pub struct ResultShapePolicy {
+    /// The locality this decision was derived from.
+    pub kou_locality: KouLocality,
+    /// Prefer compressing the result body (lossless). Set for chargeable
+    /// (cross-region/-cloud/on-prem/internet) clients where egress dominates.
+    pub compress: bool,
+}
+
+impl ResultShapePolicy {
+    /// Derive the shaping decision from a KOU locality. Compression is on for
+    /// chargeable localities, off on the free path (saves CPU for near clients).
+    pub fn for_locality(kou_locality: KouLocality) -> Self {
+        Self {
+            kou_locality,
+            compress: kou_locality.is_chargeable_egress(),
+        }
+    }
 }
 
 /// Helper to record an object store operation.
@@ -806,5 +844,33 @@ mod tests {
         // Recording result-egress on the free path mutates no trace.
         unspec.record_result_egress(Some("t"), 4096);
         assert!(io_trace::snapshot().is_none());
+    }
+
+    #[test]
+    fn shape_policy_compresses_only_for_chargeable_clients() {
+        // Lossless byte-minimization is on for far/chargeable clients (egress
+        // dominates), off on the free path (save CPU) and for Unknown (never act
+        // on an unclassified client).
+        for loc in [
+            KouLocality::CrossRegion,
+            KouLocality::CrossCloud,
+            KouLocality::OnPrem,
+            KouLocality::Internet,
+        ] {
+            assert!(ResultShapePolicy::for_locality(loc).compress, "{loc:?}");
+        }
+        for loc in [
+            KouLocality::Local,
+            KouLocality::CrossAz,
+            KouLocality::Unknown,
+        ] {
+            assert!(!ResultShapePolicy::for_locality(loc).compress, "{loc:?}");
+        }
+        // EdgePolicyContext exposes the same decision for a loopback (free) caller.
+        assert!(
+            !EdgePolicyContext::classify("127.0.0.1".parse().unwrap())
+                .shape_policy()
+                .compress
+        );
     }
 }

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -56,6 +56,16 @@ type TonicStreaming<T> = tonic::Streaming<T>;
 type TonicResult<T> = std::result::Result<TonicResponse<T>, TonicStatus>;
 type TonicStream<T> = Pin<Box<dyn Stream<Item = std::result::Result<T, TonicStatus>> + Send>>;
 
+/// Total wire bytes a `do_get` response will egress: the encoded header + body +
+/// app-metadata across every `FlightData` frame. Used to meter KOU result-egress
+/// on the actual (post-compression) bytes leaving the engine.
+fn flight_data_wire_bytes(flight_data: &[FlightData]) -> u64 {
+    flight_data
+        .iter()
+        .map(|fd| (fd.data_header.len() + fd.data_body.len() + fd.app_metadata.len()) as u64)
+        .sum()
+}
+
 #[derive(Debug, Clone, Default)]
 struct AuthenticatedFlightContext {
     tenant_id: Option<String>,
@@ -1202,6 +1212,15 @@ impl FlightService for ProximaFlightService {
     }
 
     async fn do_get(&self, request: TonicRequest<Ticket>) -> TonicResult<Self::DoGetStream> {
+        // KOU result-egress: classify the client's peer IP once for this request
+        // (no remote addr ⇒ unspecified ⇒ Local/free). Drives both the egress
+        // meter and the egress-aware shaping decision below.
+        let edge = crate::metrics::consumption_metrics::EdgePolicyContext::classify(
+            request
+                .remote_addr()
+                .map(|a| a.ip())
+                .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)),
+        );
         let auth_context = self
             .authenticated_flight_context(request.metadata(), request.peer_certs())
             .await?;
@@ -1245,6 +1264,13 @@ impl FlightService for ProximaFlightService {
                         TonicStatus::internal(format!("Failed to encode batches: {}", e))
                     })?;
 
+            // KOU result-egress: meter the actual encoded FlightData bytes (the
+            // client picked the compression via the ticket).
+            edge.record_result_egress(
+                auth_context.tenant_id.as_deref(),
+                flight_data_wire_bytes(&flight_data),
+            );
+
             let stream = stream::iter(flight_data.into_iter().map(Ok));
 
             return Ok(TonicResponse::new(Box::pin(stream)));
@@ -1265,8 +1291,23 @@ impl FlightService for ProximaFlightService {
             .await
             .map_err(|e| TonicStatus::internal(format!("Search failed: {}", e)))?;
 
-        let flight_data = ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, None)
-            .map_err(|e| TonicStatus::internal(format!("Failed to encode batches: {}", e)))?;
+        // Egress-aware shaping (co-design D2): for a chargeable (far) client, encode
+        // the result batches with ZSTD — a lossless byte-minimization the Arrow
+        // reader decompresses transparently. Near/free clients stay uncompressed
+        // (save CPU). Then meter the ACTUAL encoded bytes so the bill reflects the
+        // compressed egress that really left.
+        let compression = if edge.shape_policy().compress {
+            FlightCompression::Zstd.to_arrow_compression()
+        } else {
+            None
+        };
+        let flight_data =
+            ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
+                .map_err(|e| TonicStatus::internal(format!("Failed to encode batches: {}", e)))?;
+        edge.record_result_egress(
+            auth_context.tenant_id.as_deref(),
+            flight_data_wire_bytes(&flight_data),
+        );
         let stream = stream::iter(flight_data.into_iter().map(Ok));
 
         Ok(TonicResponse::new(Box::pin(stream)))


### PR DESCRIPTION
## What (Phase 2 OSS — D3 + the deferred Flight slice)

Two changes that compose cleanly because Flight meters the **encoded** output, so compression and metering don't fight.

### 1. `ResultShapePolicy` — the EdgePolicyPlane "shaping stage"
One decision, derived from a request's `KouLocality`, that every surface consults instead of re-deriving locality. **Active for chargeable/far clients but lossless by default** (`compress`). Lossy levers (result caps, reduced rerank) are deliberately **not** decided here — a database must not silently truncate; they need an explicit, signaled opt-in. Exposed via `EdgePolicyContext::shape_policy()`.

### 2. Arrow Flight `do_get` — the deferred D2 slice + D3 shaping
- **Result-byte instrumentation:** meter the actual encoded `FlightData` wire bytes (header + body + app_metadata) via `record_kou_bytes(.., "result", ..)` on **both** the file-export and vector-search paths. Flight was previously the one uninstrumented result surface.
- **Shaping:** for a chargeable (far) client, encode the search batches with **ZSTD** (Arrow IPC decompresses transparently) — lossless byte-minimization; near/free clients stay uncompressed (save CPU). Metered on the **actual compressed** bytes.
- Peer IP from `request.remote_addr()` → `EdgePolicyContext` (no addr ⇒ `Local`/free).

## Why no engine-REST compression here
OSS REST compression at the engine would strip the `Content-Length` the result-egress meter reads (D2/#110). So the engine REST path stays accurately metered and the **gateway owns REST compression** (anvaiops S2). Documented in spec §3a.

## Open-core
OSS keys purely on the neutral `KouLocality`; the $ weight of "far" stays anvaiops policy.

## Verification
`cargo check` ✓ · `cargo clippy -p proximadb --lib` ✓ (0 warnings) · 11 `consumption_metrics` tests ✓ (incl. `shape_policy_compresses_only_for_chargeable_clients`) · `cargo fmt --check` ✓ · OSS boundary `--strict`: 0 errors.

Stacked on `feat/codesign-eam-result-egress` (#110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)