### PR TITLE
ci(security): least-privilege permissions on qa-gate workflow

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -20,6 +20,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
+# Read-only is sufficient: every job only checks out and runs tests/ratchets — none
+# writes to the repo, posts comments, or uses OIDC.
+permissions:
+  contents: read
+
 jobs:
   # Enforce the promotion path: main may only be promoted FROM qa.
   promotion-source-guard:


### PR DESCRIPTION
## Summary
Extends the #98 workflow-permissions hardening to **`qa-gate.yml`**, which landed via the qa-gate program merge *after* #98 and so never got an explicit `permissions:` block. CodeQL (`actions/missing-workflow-permissions`) flags it on every `qa→main` PR — these are the **5 review threads currently blocking the qa→main promotion (#108)**.

## Fix
Top-level `permissions: contents: read`. Read-only is sufficient — all five jobs (`promotion-source-guard`, `tpch-pgwire`, `tpcds-pgwire`, `sdk-coverage-ratchet`, `rust-coverage-ratchet`) only check out and run tests/ratchets; none writes, comments, or uses OIDC.

`codeql.yml` was checked and is **not** affected — its `analyze` job already carries explicit job-level permissions, which satisfies the rule.

## Validation
YAML parse + actionlint clean. Doc/workflow-only → LIGHT tier.

## Why this matters for 60→0
Without it, promoting `qa→main` would trade the 53 alerts fixed in #98 for new `qa-gate.yml` ones on `main`. This closes that gap so the re-promotion actually reaches zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)