### PR TITLE
feat(p3): constant-column encoding for single-valued Tenant/Identity strings

### DIFF
--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -498,8 +498,26 @@ fn decode_str_with_encoding(
     match scheme {
         ProximaScheme::Raw => decode_raw_str_col(data, count),
         ProximaScheme::Dictionary => decode_dictionary_str_col(data, count),
+        // Constant-column (single stored value → N copies). Always decodable so a
+        // reader is forward-compatible regardless of the writer's flag state.
+        ProximaScheme::RunLength => decode_constant_str_col(data, count),
         other => bail!("unsupported PAX string encoding: {}", other.name()),
     }
+}
+
+/// Decode a constant string stripe (`[value_len u32][value bytes]`) into `count`
+/// copies of the single value — the inverse of the writer's `encode_str_constant_col`.
+fn decode_constant_str_col(data: &[u8], count: usize) -> Result<Vec<Option<String>>> {
+    if data.len() < 4 {
+        bail!("constant string stripe missing value length");
+    }
+    let len = u32::from_le_bytes(data[0..4].try_into()?) as usize;
+    let end = 4 + len;
+    if end > data.len() {
+        bail!("constant string value exceeds stripe length");
+    }
+    let value = String::from_utf8(data[4..end].to_vec())?;
+    Ok(vec![Some(value); count])
 }
 
 fn decode_raw_str_col(data: &[u8], count: usize) -> Result<Vec<Option<String>>> {
@@ -969,6 +987,59 @@ mod tests {
                 assert!((g - o).abs() <= bound + 1e-6, "got {g}, orig {o}");
             }
         }
+    }
+
+    /// Constant-column encoding: a single-tenant block's `tenant_id` collapses to one
+    /// stored value (RunLength marker) that reconstructs N copies on read, and is
+    /// strictly smaller than the dictionary encoding the default writer emits.
+    #[test]
+    fn constant_str_tenant_column_round_trips_and_shrinks() {
+        const N: usize = 200;
+
+        let build = |constant: bool| -> Vec<u8> {
+            let mut w = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 0)
+                .with_constant_str(constant);
+            for i in 0..N {
+                w.add_record(&make_record(&format!("r{i}"), "tenant-A", 1000 + i as i64))
+                    .unwrap();
+            }
+            w.flush().unwrap()
+        };
+        let tenant_meta = |block: &[u8]| {
+            let reader = PaxBlockReader::open(block).unwrap();
+            reader
+                .column_metas()
+                .iter()
+                .find(|m| m.column_id == col_id::TENANT_ID)
+                .unwrap()
+                .clone()
+        };
+
+        // Constant-encoded: every row reconstructs, stripe is RunLength-marked.
+        let cblock = build(true);
+        let creader = PaxBlockReader::open(&cblock).unwrap();
+        let tenants = creader.decode_str_stripe(col_id::TENANT_ID).unwrap();
+        assert_eq!(tenants.len(), N);
+        assert!(tenants.iter().all(|t| t.as_deref() == Some("tenant-A")));
+        let cmeta = tenant_meta(&cblock);
+        assert_eq!(cmeta.encoding_id, ProximaScheme::RunLength.to_marker());
+
+        // Default writer (flag off) keeps dictionary — no default behaviour change.
+        let dblock = build(false);
+        let dmeta = tenant_meta(&dblock);
+        assert_eq!(dmeta.encoding_id, ProximaScheme::Dictionary.to_marker());
+
+        // The win: constant stores one value; dictionary carries ~N per-row codes.
+        assert!(
+            cmeta.stripe_len < dmeta.stripe_len,
+            "constant ({}) must be smaller than dictionary ({})",
+            cmeta.stripe_len,
+            dmeta.stripe_len
+        );
+        assert!(
+            dmeta.stripe_len as usize >= 4 * N,
+            "dictionary carries ~N per-row codes"
+        );
     }
 
     #[test]

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -137,6 +137,11 @@ pub struct PaxBlockWriter {
     embedding_count: usize,
     /// Vector quantization strategy for this writer (P3 Phase D; `Auto` = env-driven).
     quant: VectorQuant,
+    /// Emit a constant-column stripe for single-valued `Tenant`/`Identity` string
+    /// columns (`distinct == 1`) instead of a dictionary — O(1) instead of N
+    /// per-row codes. Default from `PROXIMADB_PAX_CONSTANT_STR` (off) so the write
+    /// format only changes once readers that understand it are deployed.
+    constant_str: bool,
 
     // Accumulated column data
     oids: Vec<String>,
@@ -177,6 +182,7 @@ impl PaxBlockWriter {
             schema_fingerprint,
             embedding_count,
             quant: VectorQuant::Auto,
+            constant_str: constant_str_enabled(),
             oids: Vec::new(),
             tenant_ids: Vec::new(),
             created_at: Vec::new(),
@@ -202,6 +208,14 @@ impl PaxBlockWriter {
     /// `new(..)` call sites are unchanged; `Auto` (the default) keeps env behavior.
     pub fn with_quant(mut self, quant: VectorQuant) -> Self {
         self.quant = quant;
+        self
+    }
+
+    /// Enable (or disable) constant-column encoding for single-valued
+    /// `Tenant`/`Identity` string columns. Builder form mirroring [`with_quant`];
+    /// the default comes from `PROXIMADB_PAX_CONSTANT_STR`.
+    pub fn with_constant_str(mut self, enabled: bool) -> Self {
+        self.constant_str = enabled;
         self
     }
 
@@ -595,7 +609,7 @@ impl PaxBlockWriter {
         nullable: bool,
         vals: &[Option<&str>],
     ) -> ColumnStripe {
-        let scheme = select_str_scheme(role, nullable, vals);
+        let scheme = select_str_scheme(role, nullable, vals, self.constant_str);
         let (data, null_count) = encode_str_with_scheme(vals, &scheme);
         let stats = string_stats(vals);
         let meta = ColumnMeta {
@@ -1107,7 +1121,18 @@ fn select_f64_scheme(role: ColumnRole, _nullable: bool, values: &[Option<f64>]) 
     }
 }
 
-fn select_str_scheme(role: ColumnRole, nullable: bool, values: &[Option<&str>]) -> ProximaScheme {
+fn select_str_scheme(
+    role: ColumnRole,
+    nullable: bool,
+    values: &[Option<&str>],
+    constant_str: bool,
+) -> ProximaScheme {
+    // Constant-column: a single-valued canonical structural column collapses to
+    // one stored value (decoder reconstructs N copies). RunLength is the wire
+    // scheme (marker 0x62); its doc-intent is exactly "constant/near-constant".
+    if constant_str && is_constant_str(role, values) {
+        return ProximaScheme::RunLength;
+    }
     let codes = string_category_codes(values);
     if codes.is_empty() {
         return ProximaScheme::Raw;
@@ -1165,11 +1190,40 @@ fn string_category_codes(values: &[Option<&str>]) -> Vec<i64> {
     codes
 }
 
+/// True iff `values` is a constant column eligible for constant-column encoding:
+/// a canonical low-cardinality structural column (`Tenant`/`Identity`) where every
+/// row carries the SAME non-null value (`distinct == 1`, no nulls). The common case
+/// is a single-tenant segment's `tenant_id` — N identical strings collapse to one.
+fn is_constant_str(role: ColumnRole, values: &[Option<&str>]) -> bool {
+    if !matches!(role, ColumnRole::Tenant | ColumnRole::Identity) {
+        return false;
+    }
+    let mut iter = values.iter();
+    let first = match iter.next() {
+        Some(Some(v)) => *v,
+        _ => return false, // empty, or first row null
+    };
+    values.iter().all(|v| matches!(v, Some(s) if *s == first))
+}
+
 fn encode_str_with_scheme(values: &[Option<&str>], scheme: &ProximaScheme) -> (Vec<u8>, u32) {
     match scheme {
         ProximaScheme::Dictionary => encode_str_dictionary_col(values),
+        ProximaScheme::RunLength => encode_str_constant_col(values),
         _ => encode_str_col(values),
     }
+}
+
+/// Encode a constant string column as `[value_len u32][value bytes]` — one stored
+/// value for the whole stripe (the row count comes from the block footer at decode
+/// time). The caller guarantees [`is_constant_str`], i.e. every row is this value.
+fn encode_str_constant_col(values: &[Option<&str>]) -> (Vec<u8>, u32) {
+    let value = values.iter().flatten().next().copied().unwrap_or("");
+    let bytes = value.as_bytes();
+    let mut buf = Vec::with_capacity(4 + bytes.len());
+    buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(bytes);
+    (buf, 0) // constant columns are non-null → null_count = 0
 }
 
 fn encode_str_dictionary_col(values: &[Option<&str>]) -> (Vec<u8>, u32) {
@@ -1311,6 +1365,13 @@ fn sq8_disabled() -> bool {
 /// (SQ8 reconstructs more faithfully without a rerank tier).
 fn rabitq_enabled() -> bool {
     std::env::var_os("PROXIMADB_VECTOR_RABITQ").is_some()
+}
+
+/// Default for constant-column string encoding. Off unless
+/// `PROXIMADB_PAX_CONSTANT_STR` is set, so the on-disk format only changes once
+/// readers that decode it (any build with this change) are deployed.
+fn constant_str_enabled() -> bool {
+    std::env::var_os("PROXIMADB_PAX_CONSTANT_STR").is_some()
 }
 
 /// Encode a RaBitQ vector stripe: validity bitmap + per row


### PR DESCRIPTION
## P3: constant-column encoding for single-valued Tenant/Identity strings

A single-tenant PAX segment stored `tenant_id` as a **dictionary** (1 entry + N per-row codes ≈ N bytes) even though every row is identical. This makes that column **O(1)** when it's constant.

### Why the per-row column stays (and why this is the right fix)
Tenant isolation is already **structural** — the `DrPathBuilder` path (`data/{tenant}/{namespace}/…`) plus the block-header `tenant_id_hash` RLS skip. The per-row `tenant_id` column exists only for (1) canonical-record fidelity (authority = WAL + `ProximaRecord`), (2) row-level RLS in shared (header-hash 0) blocks, and (3) fail-closed defense-in-depth. So we keep it — but stop paying ~N bytes for a constant.

### Changes
- **Writer**: a constant string column (`ColumnRole::Tenant`/`Identity`, `distinct == 1`, no nulls) is emitted as `[value_len][value]` under the **existing `RunLength` wire scheme** (marker `0x62` — its documented intent is "constant/near-constant"). No new `ProximaScheme` variant → no match fan-out. `select_str_scheme` gains the constant branch; `encode_str_with_scheme` dispatches `RunLength`.
- **Reader**: `decode_str_with_encoding` handles the `RunLength` marker, reconstructing N copies. **Always decodable** → any reader carrying this change is forward-compatible regardless of writer flag state.
- **Gating** (storage-format-migration mandate): default **OFF** via the `with_constant_str` builder (mirrors Phase D's `with_quant`), default from `PROXIMADB_PAX_CONSTANT_STR`. `PaxSegmentWriter` inherits it through `PaxBlockWriter::new`, so production stays on dictionary until readers are deployed, then the flag flips on. **No default behaviour change.**

### Verification
- `proximadb-block-format` leaf: **39/39** (new `constant_str_tenant_column_round_trips_and_shrinks` — round-trips all N rows, `RunLength`-marked, strictly smaller than the dictionary the default flag-off writer still emits).
- `cargo fmt --all` (only touched files), leaf + root `clippy` clean, `CARGO_INCREMENTAL=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
