### PR TITLE
feat(p3): catalog-resolution — drop per-row tenant_id from PAX segments

### DIFF
--- a/crates/storage/proximadb-block-format/src/record.rs
+++ b/crates/storage/proximadb-block-format/src/record.rs
@@ -266,10 +266,17 @@ impl FlatRow {
     /// Reconstruct a `ProximaRecord` from a decoded `FlatRow`.
     ///
     /// Embedding model IDs and user column keys are provided externally (from the collection schema).
+    /// Reconstruct a [`ProximaRecord`]. `tenant_ctx` is the segment's owning tenant
+    /// (resolved from the catalog/path); it is stamped onto `tenant_id` only when the
+    /// row carries no stored tenant — i.e. a segment written with the tenant column
+    /// dropped (catalog-resolution). Segments that still store the column keep their
+    /// own value, so this is mixed-read-safe (old and new segments both reconstruct
+    /// the correct tenant). Pass `None` to keep the stored value verbatim.
     pub fn into_record(
         self,
         embedding_model_ids: &[String],
         user_column_keys: &[String],
+        tenant_ctx: Option<&str>,
     ) -> anyhow::Result<ProximaRecord> {
         use proximadb_records::{EdgeShape, EmbeddingCell, LabelSet};
         use std::collections::HashMap;
@@ -327,9 +334,17 @@ impl FlatRow {
             })
             .collect();
 
+        // Catalog-resolution: a segment with the tenant column dropped yields an
+        // empty stored tenant; stamp it from the segment's owning tenant context.
+        let tenant_id = if self.tenant_id.is_empty() {
+            tenant_ctx.unwrap_or_default().to_string()
+        } else {
+            self.tenant_id
+        };
+
         Ok(ProximaRecord {
             oid: self.oid,
-            tenant_id: self.tenant_id,
+            tenant_id,
             created_at_ns: self.created_at_ns,
             updated_at_ns: self.updated_at_ns,
             valid_from_ns: self.valid_from_ns,
@@ -629,6 +644,68 @@ mod tests {
         let emb0 = embeddings[0].as_ref().unwrap();
         assert!((emb0[0] - 0.1f32).abs() < 1e-6);
         assert!((emb0[3] - 0.4f32).abs() < 1e-6);
+    }
+
+    /// Catalog-resolution: with the flag on, the per-row tenant stripe is dropped
+    /// and `into_record` stamps tenant from the segment's catalog/path context. The
+    /// block-header RLS hash is retained. With the flag off (default) the stripe is
+    /// present, used, and a context argument never overrides it (mixed-read safety).
+    #[test]
+    fn tenant_col_dropped_and_stamped_from_context() {
+        let rec = |oid: &str, ts: i64| ProximaRecord {
+            oid: oid.into(),
+            tenant_id: "tenant-A".into(),
+            created_at_ns: ts,
+            updated_at_ns: ts,
+            ..Default::default()
+        };
+
+        // Flag ON: the tenant stripe is omitted entirely.
+        let mut w = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "c", 0, 0)
+            .with_drop_tenant_col(true);
+        w.add_record(&rec("a", 1)).unwrap();
+        w.add_record(&rec("b", 2)).unwrap();
+        let block = w.flush().unwrap();
+        let reader = PaxBlockReader::open(&block).unwrap();
+        assert!(
+            !reader
+                .column_metas()
+                .iter()
+                .any(|m| m.column_id == col_id::TENANT_ID),
+            "tenant stripe must be dropped when the flag is on"
+        );
+        // The block-header RLS skip is still derived from the tenant.
+        assert!(
+            reader
+                .header()
+                .tenant_matches(crate::header::fnv1a_hash("tenant-A")),
+            "block-header tenant hash must survive dropping the column"
+        );
+        // Reading back stamps tenant from the catalog/path context.
+        for flat in FlatRow::from_block_reader(&reader).unwrap() {
+            let record = flat.into_record(&[], &[], Some("tenant-A")).unwrap();
+            assert_eq!(record.tenant_id, "tenant-A");
+        }
+
+        // Flag OFF (default): the stripe is present and used; a different context
+        // never overrides the stored value (old segments stay correct).
+        let mut w2 = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "c", 0, 0);
+        w2.add_record(&rec("a", 1)).unwrap();
+        let block2 = w2.flush().unwrap();
+        let reader2 = PaxBlockReader::open(&block2).unwrap();
+        assert!(
+            reader2
+                .column_metas()
+                .iter()
+                .any(|m| m.column_id == col_id::TENANT_ID),
+            "tenant stripe present by default"
+        );
+        let flat2 = FlatRow::from_block_reader(&reader2).unwrap().remove(0);
+        let record2 = flat2.into_record(&[], &[], Some("tenant-OTHER")).unwrap();
+        assert_eq!(
+            record2.tenant_id, "tenant-A",
+            "a stored tenant must not be overridden by context"
+        );
     }
 
     #[test]

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -137,6 +137,12 @@ pub struct PaxBlockWriter {
     embedding_count: usize,
     /// Vector quantization strategy for this writer (P3 Phase D; `Auto` = env-driven).
     quant: VectorQuant,
+    /// Drop the per-row `tenant_id` stripe (catalog-resolution): the segment is
+    /// path-isolated to one tenant, so the reader stamps tenant from the
+    /// catalog/path context. The block-header `tenant_id_hash` (the RLS skip) is
+    /// retained. Default from `PROXIMADB_PAX_DROP_TENANT_COL` (off) so the write
+    /// format only changes once readers that stamp tenant are deployed.
+    drop_tenant_col: bool,
 
     // Accumulated column data
     oids: Vec<String>,
@@ -177,6 +183,7 @@ impl PaxBlockWriter {
             schema_fingerprint,
             embedding_count,
             quant: VectorQuant::Auto,
+            drop_tenant_col: drop_tenant_col_enabled(),
             oids: Vec::new(),
             tenant_ids: Vec::new(),
             created_at: Vec::new(),
@@ -202,6 +209,14 @@ impl PaxBlockWriter {
     /// `new(..)` call sites are unchanged; `Auto` (the default) keeps env behavior.
     pub fn with_quant(mut self, quant: VectorQuant) -> Self {
         self.quant = quant;
+        self
+    }
+
+    /// Enable (or disable) dropping the per-row `tenant_id` stripe
+    /// (catalog-resolution). Builder form mirroring [`with_quant`]; the default
+    /// comes from `PROXIMADB_PAX_DROP_TENANT_COL`.
+    pub fn with_drop_tenant_col(mut self, enabled: bool) -> Self {
+        self.drop_tenant_col = enabled;
         self
     }
 
@@ -320,19 +335,26 @@ impl PaxBlockWriter {
                         .collect::<Vec<_>>(),
                 ),
             );
-            stripes.push(
-                self.build_str_stripe(
-                    col_id::TENANT_ID,
-                    "tenant_id",
-                    ColumnRole::Tenant,
-                    false,
-                    &self
-                        .tenant_ids
-                        .iter()
-                        .map(|s| Some(s.as_str()))
-                        .collect::<Vec<_>>(),
-                ),
-            );
+            // Catalog-resolution: a segment is path-isolated to one tenant
+            // (DrPathBuilder data/{tenant}/{namespace}/...), so the per-row tenant
+            // is redundant — the reader stamps it from the catalog/path context.
+            // When the flag is set, drop the stripe entirely; the block-header
+            // tenant_id_hash (computed in `add_record`) still carries the RLS skip.
+            if !self.drop_tenant_col {
+                stripes.push(
+                    self.build_str_stripe(
+                        col_id::TENANT_ID,
+                        "tenant_id",
+                        ColumnRole::Tenant,
+                        false,
+                        &self
+                            .tenant_ids
+                            .iter()
+                            .map(|s| Some(s.as_str()))
+                            .collect::<Vec<_>>(),
+                    ),
+                );
+            }
             stripes.push(self.build_i64_stripe(
                 col_id::CREATED_AT,
                 ColumnRole::Timestamp,
@@ -1311,6 +1333,13 @@ fn sq8_disabled() -> bool {
 /// (SQ8 reconstructs more faithfully without a rerank tier).
 fn rabitq_enabled() -> bool {
     std::env::var_os("PROXIMADB_VECTOR_RABITQ").is_some()
+}
+
+/// Default for dropping the per-row tenant stripe (catalog-resolution). Off
+/// unless `PROXIMADB_PAX_DROP_TENANT_COL` is set, so the on-disk format only
+/// changes once readers that stamp tenant from context are deployed.
+fn drop_tenant_col_enabled() -> bool {
+    std::env::var_os("PROXIMADB_PAX_DROP_TENANT_COL").is_some()
 }
 
 /// Encode a RaBitQ vector stripe: validity bitmap + per row

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -491,15 +491,23 @@ impl PaxSegmentScanner {
     /// (the segment stores embeddings positionally and does not persist model ids
     /// or promoted-column names). Pass empty slices for best-effort defaults
     /// (`model_0`, `model_1`, …).
+    /// `tenant_ctx` is the segment's owning tenant (from the catalog/path); it is
+    /// stamped onto rows whose tenant column was dropped (catalog-resolution) and
+    /// ignored when the column is still present. Pass `None` to keep stored values.
     pub fn read_records(
         &mut self,
         embedding_model_ids: &[String],
         user_column_keys: &[String],
+        tenant_ctx: Option<&str>,
     ) -> Result<Vec<ProximaRecord>> {
         let mut records = Vec::new();
         while let Some(block) = self.next_block() {
             for flat in FlatRow::from_block_reader(&block)? {
-                records.push(flat.into_record(embedding_model_ids, user_column_keys)?);
+                records.push(flat.into_record(
+                    embedding_model_ids,
+                    user_column_keys,
+                    tenant_ctx,
+                )?);
             }
         }
         Ok(records)
@@ -540,6 +548,7 @@ pub fn compact_pax_segments(
     embedding_count: usize,
     embedding_model_ids: &[String],
     user_column_keys: &[String],
+    tenant_ctx: Option<&str>,
     now_ns: i64,
 ) -> Result<CompactionStats> {
     let mut writer = PaxSegmentWriter::new(
@@ -557,7 +566,7 @@ pub fn compact_pax_segments(
 
     for input in inputs {
         let mut scanner = PaxSegmentScanner::open(input, ScanPredicate::default())?;
-        for record in scanner.read_records(embedding_model_ids, user_column_keys)? {
+        for record in scanner.read_records(embedding_model_ids, user_column_keys, tenant_ctx)? {
             records_in += 1;
             if record.is_tombstone_at(now_ns) {
                 tombstones_dropped += 1;
@@ -664,6 +673,7 @@ mod tests {
             0,
             &[],
             &[],
+            None,
             1000,
         )
         .unwrap();
@@ -675,7 +685,7 @@ mod tests {
 
         // The merged L1 segment holds exactly the 3 survivors; no tombstone remains.
         let mut scanner = PaxSegmentScanner::open(&out, ScanPredicate::default()).unwrap();
-        let survivors = scanner.read_records(&[], &[]).unwrap();
+        let survivors = scanner.read_records(&[], &[], None).unwrap();
         assert_eq!(survivors.len(), 3);
         assert!(
             survivors
@@ -783,7 +793,7 @@ mod tests {
         writer.finish().unwrap();
 
         let mut scanner = PaxSegmentScanner::open(&path, ScanPredicate::default()).unwrap();
-        let records = scanner.read_records(&[], &[]).unwrap();
+        let records = scanner.read_records(&[], &[], None).unwrap();
 
         assert_eq!(records.len(), 2);
         let r1 = records.iter().find(|r| r.oid == "r1").expect("r1 present");

--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -338,8 +338,12 @@ impl<'b> RangedSegmentReader<'b> {
             let reader = PaxBlockReader::open(&block_bytes).map_err(|e| fs_err("open block", e))?;
             for flat in FlatRow::from_block_reader(&reader).map_err(|e| fs_err("flat rows", e))? {
                 out.push(
-                    flat.into_record(embedding_model_ids, user_column_keys)
-                        .map_err(|e| fs_err("into record", e))?,
+                    flat.into_record(
+                        embedding_model_ids,
+                        user_column_keys,
+                        self.tenant_id.as_deref(),
+                    )
+                    .map_err(|e| fs_err("into record", e))?,
                 );
             }
         }
@@ -600,7 +604,7 @@ mod tests {
 
         // Whole-segment reference decode.
         let mut scanner = PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default()).unwrap();
-        let records = scanner.read_records(&[], &[]).unwrap();
+        let records = scanner.read_records(&[], &[], None).unwrap();
         let expected: Vec<Option<Vec<f32>>> = records
             .iter()
             .map(|r| r.embeddings.first().map(|e| e.values.to_fp32_owned()))

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3310,7 +3310,7 @@ fn pax_segment_to_records(
 ) -> Result<Vec<ProximaRecord>> {
     let mut scanner = PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default())
         .map_err(|err| anyhow!("ObjectStoreVectorRecordStore failed to open PAX segment: {err}"))?;
-    let mut records = scanner.read_records(&[], &[]).map_err(|err| {
+    let mut records = scanner.read_records(&[], &[], None).map_err(|err| {
         anyhow!("ObjectStoreVectorRecordStore failed to decode PAX segment: {err}")
     })?;
     for record in &mut records {

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -272,7 +272,16 @@ impl SstEngine {
                 let bytes = tokio::fs::read(local)
                     .await
                     .map_err(|e| anyhow::anyhow!("read pax segment {file}: {e}"))?;
-                crate::storage::engines::sst::segment_format::read_segment_records(&bytes, &[], &[])
+                // tenant_ctx None: the AXIS rebuild indexes vectors per-collection and
+                // does not consume record.tenant_id. (Deriving the owning tenant from
+                // the DrPathBuilder segment path is a follow-up for when the
+                // tenant-column-drop flag is enabled end-to-end.)
+                crate::storage::engines::sst::segment_format::read_segment_records(
+                    &bytes,
+                    &[],
+                    &[],
+                    None,
+                )
             }
         }
     }

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -74,16 +74,21 @@ fn is_pax_segment(bytes: &[u8]) -> bool {
 /// `embedding_model_ids` / `user_column_keys` are the collection's schema keys used
 /// to reconstruct PAX records positionally (empty slices = best-effort defaults);
 /// they are ignored for the legacy format, which is self-describing.
+///
+/// `tenant_ctx` is the segment's owning tenant (from the catalog/path); it is
+/// stamped onto rows whose tenant column was dropped (catalog-resolution) and is
+/// ignored when the column is present. `None` keeps stored values verbatim.
 pub fn read_segment_records(
     bytes: &[u8],
     embedding_model_ids: &[String],
     user_column_keys: &[String],
+    tenant_ctx: Option<&str>,
 ) -> Result<Vec<ProximaRecord>> {
     match SegmentFormat::detect(bytes) {
         SegmentFormat::Pax => {
             let mut scanner =
                 PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())?;
-            scanner.read_records(embedding_model_ids, user_column_keys)
+            scanner.read_records(embedding_model_ids, user_column_keys, tenant_ctx)
         }
         SegmentFormat::ProximaBlocks => Ok(ProximaDataBlock::deserialize(bytes, None)?.records),
     }
@@ -324,7 +329,7 @@ mod tests {
             "PAX segment must be detected as Pax"
         );
 
-        let records = read_segment_records(&bytes, &[], &[]).unwrap();
+        let records = read_segment_records(&bytes, &[], &[], None).unwrap();
         assert_eq!(records.len(), 2);
         let mut oids: Vec<&str> = records.iter().map(|r| r.oid.as_str()).collect();
         oids.sort_unstable();
@@ -349,7 +354,7 @@ mod tests {
             "ProximaDataBlock must be detected as ProximaBlocks"
         );
 
-        let back = read_segment_records(&bytes, &[], &[]).unwrap();
+        let back = read_segment_records(&bytes, &[], &[], None).unwrap();
         let mut oids: Vec<&str> = back.iter().map(|r| r.oid.as_str()).collect();
         oids.sort_unstable();
         assert_eq!(oids, vec!["x", "y"]);
@@ -400,7 +405,7 @@ mod tests {
 
         let bytes = std::fs::read(&path).unwrap();
         assert_eq!(SegmentFormat::detect(&bytes), SegmentFormat::Pax);
-        let back = read_segment_records(&bytes, &[], &[]).unwrap();
+        let back = read_segment_records(&bytes, &[], &[], None).unwrap();
         let mut oids: Vec<&str> = back.iter().map(|r| r.oid.as_str()).collect();
         oids.sort_unstable();
         assert_eq!(oids, vec!["w1", "w2"]);
@@ -436,7 +441,7 @@ mod tests {
 
         // And it still reads back through the mixed-format router.
         let bytes2 = std::fs::read(&path).unwrap();
-        let back = read_segment_records(&bytes2, &[], &[]).unwrap();
+        let back = read_segment_records(&bytes2, &[], &[], None).unwrap();
         assert_eq!(back.len(), records.len());
     }
 


### PR DESCRIPTION
## P3: catalog-resolution — drop per-row tenant_id from PAX segments

A PAX segment is **path-isolated to one tenant** (`DrPathBuilder` `data/{tenant_id}/{namespace_id}/…`), so the per-row `tenant_id` column is **redundant** — the reader stamps it from the segment's catalog/path context. **Supersedes the constant-column approach (#118, closed):** instead of cheaply encoding a redundant column, this drops it and resolves tenant from the catalog, matching the *"isolation is structural, never per-row data"* mandate.

### Reader — always-on, mixed-read-safe
`FlatRow::into_record` gains a `tenant_ctx` and stamps `tenant_id` from it **only when the stored value is empty**. Old segments (column present) keep their value; new segments (column dropped) get stamped; a stored tenant is **never** overridden. Threaded through `PaxSegmentScanner::read_records` and `segment_format::read_segment_records`; the ranged path stamps from the existing `RangedSegmentReader.tenant_id` (zero caller churn).

### Writer — flag-gated, default-OFF
`with_drop_tenant_col` (default from `PROXIMADB_PAX_DROP_TENANT_COL`, mirroring Phase D's `with_quant`) skips the TENANT_ID stripe. The block-header `tenant_id_hash` (the RLS skip) is **retained** — computed in `add_record` from the record's tenant, independent of the stripe. The format only changes once readers that stamp tenant are deployed; then the flag flips on.

### Scope note
AXIS-rebuild passes `tenant_ctx=None` (it indexes vectors per-collection and doesn't consume `tenant_id`); deriving tenant from the segment path there is a follow-up for when the flag goes live.

### Verification
- block-format **39/39** (new `tenant_col_dropped_and_stamped_from_context`: drops stripe, stamps via context, keeps header RLS hash, never overrides a stored value).
- storage-common **395/395**; root `segment_format` **8/8**.
- `cargo fmt --all`, `CARGO_INCREMENTAL=0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
