### PR TITLE
docs(catalog): vision spec — catalog as the central object model for multitenancy

### DIFF
--- a/docs/12-design/CATALOG_OBJECT_MODEL_2026_06_21.adoc
+++ b/docs/12-design/CATALOG_OBJECT_MODEL_2026_06_21.adoc
@@ -1,0 +1,272 @@
+= Catalog Object Model: The Catalog at the Core of Multitenancy
+:toc: left
+:toclevels: 3
+:icons: font
+:sectnums:
+:revdate: 2026-06-21
+
+[.lead]
+This blueprint makes the *catalog* the single central object model for everything ProximaDB stores
+on behalf of a tenant — relational tables, vector/document/graph collections, event streams, audit
+logs, time-series — and for every access method stacked on them (indexes, materialized views, ANN,
+full-text, rollups). One *object type* (`CatalogObject`) expresses all modalities as *facets*; a
+uniform *four-layer stack* hides modality complexity behind the object; and the catalog — not a
+convention, env flag, or injected URL — is the authority that resolves *what* a tenant has, *of what
+modality*, with *which access methods*, *stored where*. It is the macro generalization of the pattern
+already proven by tenant catalog-resolution (drop the redundant per-row tenant column; resolve tenant
+from the catalog/path): isolation is structural, addressing is catalog-resolved, modality complexity
+is stacked.
+
+[IMPORTANT]
+====
+Owner: Architecture. Scope: cross-cutting object/catalog model over all modalities and multitenancy.
+Status: *Vision accepted; phased implementation*. Subordinate to
+link:DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc[the course correction] and
+link:CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[the co-design spine]; consolidates the catalog
+authority that those docs assume.
+
+*Decisions locked with the user (2026-06-21):*
+
+. *Object abstraction* — **one `CatalogObject`, modality as a facet** (not typed subtypes per
+  modality). Vector vs graph vs document is *which layouts/projections are attached* + a workload/
+  specialization facet, not a different type.
+. *Parallel-model migration* — **collapse now**: the legacy `Collection` / `MetadataStoreInterface`
+  vector-plane model is replaced by `CatalogObject`; the proto `Collection` becomes a wire projection
+  of it. One object model, no parallel schema/index/collection representations.
+. *Sequencing* — **this spec first**, then a phased implementation roadmap (§12).
+====
+
+== 1. Thesis: the catalog is the multitenant object model
+
+The catalog is *the central authority and registry for the entire multitenant mechanism*. Every
+tenant's objects, of every modality, with every index/view, and every physical location, are
+*registered in and resolved from* the catalog. Two truths hold simultaneously, at different levels:
+
+* *Central registry across all tenants* — the `proximadb-catalog` control plane holds and resolves
+  every tenant's metadata. `CatalogNamespace` carries `tenant_id`, so the store registers all
+  tenants' namespaces, each tenant-tagged.
+* *Logical catalog = one tenant* — the TD-064 model is *account = tenant = catalog, schema =
+  namespace* (the Postgres analogy: a cluster holds many catalogs/databases, each catalog is a tenant
+  boundary, with schemas inside).
+
+Everything tenant- or path-scoped — `tenant_id`, index location, DR policy, tiering, freshness —
+*resolves from the catalog* rather than being re-encoded in the data (per-row columns) or in URL/env
+conventions. That is the whole design.
+
+== 2. Where we are (grounded)
+
+The catalog is *already rich*, and the *stacking model already exists* — the gap is purely
+*addressing authority*.
+
+.Existing spine
+[%autowidth]
+|===
+| Level | Type (`crates/control/proximadb-catalog/src/lib.rs`) | Role
+
+| Tenant/account = catalog | `TenantContext.tenant_id` | request authority (header/JWT)
+| Schema = namespace | `CatalogNamespace` (:94) | `namespace_id` (`ns_<uuid>`) + `tenant_id`; DR/path authority
+| Object | `CatalogTableSchema` (:429) | ~30 fields: columns, PK, `indexes[]`, `storage_layouts[]`, `projections[]`, capabilities, workload/specialization facets
+| Physical layout | `CatalogStorageLayout` (:1564) | `layout_kind`, `physical_format`, `authority`, `write_mode`, **`location: Option<String>`**
+| Access method | `CatalogProjection` (:1734) | `kind`, `rebuild_source`, `freshness`, `rebuildable` — **no `location`**
+|===
+
+The *authority stack* is modeled: `CatalogAuthorityMode` (:1371) layers `ProximaAuthoritative`
+(WAL + `ProximaRecord` = canonical truth) *under* `RebuildableProjection` / `ProjectionPublication`,
+with `rebuildable` / `freshness` / `freshness_state` / `rebuild_source` per projection.
+
+.The four gaps this spec closes
+[%autowidth]
+|===
+| # | Gap | Evidence
+
+| G1 | *Two parallel object models* | unified `CatalogTableSchema` (control plane) vs legacy `Collection` (`src/core/service_types.rs:163`) + `MetadataStoreInterface` (`src/storage/metadata/mod.rs:179`) + proto `Collection`
+| G2 | *Addressing is convention/env-derived, not catalog-resolved* | only *external* layouts set `location`; internal paths recomputed by `DrPathBuilder`; ANN path from injected `index_persist_url` (`src/index/axis/management/manager.rs:496/563`); env fork `PROXIMADB_WAREHOUSE_DRPATH` (`src/services/dml/mod.rs:80`)
+| G3 | *Indexes/MVs have 2–3 partial reps, none with location* | `CatalogIndex` (:1193) + `CatalogProjection{VectorAnn}` (:1734) + `CatalogStorageLayoutKind::VectorAnn`; MVs are name-only `Vec<String>` (:2308)
+| G4 | *Some modalities live outside the catalog* | graph adjacency in-memory; event/queue separate subsystem (`{queue_root}/...`); audit has no catalog object
+|===
+
+== 3. The unified model: one `CatalogObject`, modality as a facet
+
+There is *one* object type. Modality is expressed by a *facet*, not a subtype:
+
+[source]
+----
+CatalogObject {
+  identity:   { namespace_id, tenant_id, name, object_id }
+  schema:     CatalogColumn[]               // ProximaType (ADR-024), PK, nullability
+  facet:      { workload_profile,           // Oltp|Olap|Htap|Vector|Document|Graph|Observability|Mixed
+                storage_specialization,     // PaxRowFamily|VectorAnn|DocumentJson|GraphTopology|...
+                modality_ext: ModalityExt }  // typed, optional: VectorExt{dim,quant} | GraphExt{..} | EventExt{retention}
+  layouts:    CatalogStorageLayout[]        // L2 physical substrate(s), each with location
+  projections: CatalogProjection[]          // L3 access methods (index/MV/ANN/...), each with location
+  policy:     { dr_policy, primary_pod, branch_merge_policy, relational_capabilities }
+}
+----
+
+A *vector collection* is a `CatalogObject` with `facet.workload_profile = Vector`, a PAX layout, and a
+`VectorAnn` projection. A *graph* is the same object with a `GraphTopology` layout/projection. A
+*relational table* has BTree projections and full `relational_capabilities`. The user/planner sees a
+uniform "object with access methods"; the engine resolves modality internals from the facet +
+projections. (`modality_ext` keeps strongly-typed modality config — vector dim/quant, event retention
+— without splitting the object into per-modality types: *modality as facet*, decision §IMPORTANT.1.)
+
+== 4. The stack: four layers, each catalog-resolved
+
+Complexity is *stacked* so each layer has one job and one catalog-resolved `location`:
+
+[source]
+----
+CatalogObject                                   identity + schema + modality facet
+  └─ L1  Canonical Authority   WAL + ProximaRecord     authority=ProximaAuthoritative   location ✔   ── the truth, always present
+  └─ L2  Physical Layout(s)    PAX | CSR(graph) | append-log(event) | columnar           location ✔   ── how it is stored (hot substrate)
+  └─ L3  Projection(s)         index · MV · ANN · full-text · rollup   rebuildable+freshness location ✔  ── access methods stacked on top
+----
+
+Invariants:
+
+* *L1 is authority*; L2/L3 are *rebuildable from L1* (`rebuildable=true`, `rebuild_source` points at
+  L1 or another layout). This is the existing `CatalogAuthorityMode` layering — now made the
+  addressing source.
+* *Every layer carries a catalog-resolved `location`.* The model already has it on
+  `CatalogStorageLayout`; this spec *adds `location` to `CatalogProjection`* (closes G3).
+* *Modality lives in L2/L3 + facet*, never in the object's identity. Switching a collection from
+  HNSW to IVF, or adding a columnar publication, is adding/replacing an L3 projection — not a new
+  object type.
+
+== 5. Object algebra: every modality is a `CatalogObject` facet
+
+.Per-modality expression (target state)
+[%autowidth]
+|===
+| Modality | facet.workload / specialization | L2 layout(s) | L3 projections (access methods) | modality_ext
+
+| Relational | Oltp/Olap/Htap / PaxRowFamily | PAX (`ProximaBlock`) | BTree/Hash index; **MaterializedView** | —
+| Vector | Vector / VectorAnn | PAX (SQ8/RaBitQ) | **VectorAnn** (HNSW/IVF/PQ) | `VectorExt{dim, metric, quant}`
+| Document | Document / DocumentJson | PAX + props | JsonPath/FullText/GIN; Columnar | `DocExt{props_promotion}`
+| Graph | Graph / GraphTopology | CSR/COO topology layout | GraphTopology (adjacency/algorithm) | `GraphExt{branch_merge}`
+| Event/Stream | Mixed / (AppendOnlyEvent) | append-only event layout | CDC/rollup projections | `EventExt{retention, partitions}`
+| Time-series/Obs | Observability / ObservabilityTimeSeries | PAX (delta-delta/XOR) | TimeSeries/Observability rollups | `TsExt{compression}`
+| Audit | Mixed / (AppendOnlyEvent) | append-only event layout | — | `AuditExt{immutability}`
+| External (Iceberg/Delta/…) | Olap / ExternalOpenTable | external layout (`location` ✔ today) | federated/published projections | —
+|===
+
+G4 closes by making graph topology, event/queue, and audit *first-class L2 layouts under a
+`CatalogObject`* (each with `location`), instead of separate convention-addressed subsystems.
+
+== 6. Indexes and materialized views = `CatalogProjection`
+
+One authoritative representation per access method (closes G3):
+
+* An *index* is a `CatalogProjection` whose `kind` is `VectorAnn` | `FullText` | `JsonPath` |
+  `GraphTopology` | `Columnar`, carrying its own `location`. `CatalogIndex` (logical name/columns/
+  unique/type) is retained only as the *declaration* that produces a projection; the projection is
+  the *physical, addressable, rebuildable* object. `CatalogStorageLayoutKind::VectorAnn` is dropped
+  in favor of the projection.
+* A *materialized view* is a `CatalogProjection{kind: MaterializedView}` with `location` and a SQL/
+  logical `rebuild_source`. The name-only `RelationalCapabilities.materialized_views: Vec<String>` is
+  replaced by these projections (the names become a derived view over them).
+* Freshness/recall is already modeled (`freshness`, `freshness_state`, `max_lag_ms`,
+  `last_included_position`) and now travels with the addressable projection.
+
+This is the *indexes-as-catalog-objects* increment: each index/MV registered in its namespace,
+resolved to its own path, relocatable/tierable per-projection.
+
+== 7. Addressing: catalog-resolved `location`, `DrPathBuilder` as default resolver
+
+The single change that closes G2:
+
+* The catalog stores *where each layer lives* in its `location` field (L1/L2/L3).
+* `DrPathBuilder` (`src/storage/trait_components/path_resolver.rs`) becomes the *default resolver*
+  that *computes* a `location` when one is unset — `data/{tenant_id}/{namespace_id}/{collection_id}/
+  {wal|segments|indexes/<projection>|manifests|...}` — and *persists* it back to the catalog on
+  create. It is no longer the *only* source recomputed on every read.
+* Mixed-safe: when `location` is set, it wins; when unset (legacy rows), the resolver derives the
+  conventional path — identical behavior to today. The `PROXIMADB_WAREHOUSE_DRPATH` env fork is
+  retired by making the DrPath layout the single resolver output.
+* `indexes/<projection_name>/` becomes a first-class `DrResolvedPath` subprefix so each index maps to
+  its own catalog-registered path (replaces the injected `index_persist_url`; that URL becomes the
+  *object-store root* the resolver composes under, not the index addressing).
+
+== 8. Collapsing the parallel model (decision §IMPORTANT.2)
+
+`Collection` / `MetadataStoreInterface` (vector plane) and proto `Collection` are *projections of*
+`CatalogObject`, not parallel authorities:
+
+* `core::service_types::Collection` (`id/name/dimension/distance_metric/storage_engine/
+  indexing_algorithm/metadata`) maps onto `CatalogObject` (`identity` + `VectorExt{dim, metric}` +
+  a `VectorAnn` projection + facet). It is *deleted*; call sites read `CatalogObject`.
+* `MetadataStoreInterface` (vector metadata store) is replaced by the `Catalog` trait
+  (`NativeCatalog`); the vector plane reads tenant/namespace/layout/projection from the catalog.
+* proto `Collection`/`CollectionConfig` (`proximadb.v1`) becomes a *wire DTO* generated from
+  `CatalogObject` at the API boundary — one internal model, stable external shape.
+
+This is a large, cross-cutting collapse (vector storage, services, proto). It is sequenced as its own
+phase with a hard CI guard that no second collection/schema/index authority is reintroduced.
+
+== 9. Namespace dual-role disambiguation (closes part of G2)
+
+`CatalogNamespace` today conflates two roles with `Option<>` legacy fields:
+
+* *Federation identifier* — mutable `levels`/`properties`/`location` (Iceberg-REST).
+* *Engine DR/tenant authority* — stable `namespace_id`/`tenant_id`/`storage_pool_class`.
+
+Target: the authority fields are *non-optional* (after P0.5 backfill completes) and the federation
+fields move to a `federation: Option<NamespaceFederation>` sub-struct. The `ns_default` mock-namespace
+escape hatch in `record_store.object_store_write_base_path` is removed — every write resolves a real
+namespace from the catalog.
+
+== 10. Multitenancy: the catalog as central authority
+
+With the above, the catalog answers — for any tenant — *what objects exist, of what modality, with
+which access methods, stored where, under what DR/tiering policy, at what freshness*. Isolation stays
+*structural* (path + catalog, never a per-query predicate, never per-row data). The tenant
+catalog-resolution PR (drop per-row `tenant_id`, stamp from context) is the first concrete proof; the
+index/MV/location work is the same move for access methods; the modality pull-ins (graph/event/audit)
+complete the coverage.
+
+== 11. Migration and safety
+
+Every step obeys the storage-format-migration mandate: *mixed-read-safe, magic/version-detected,
+default-OFF, recall/trace-gated*.
+
+* *Reader-forward, writer-flagged.* Readers learn the new shape first (e.g. stamp tenant from context,
+  read `location` when present); writers adopt it behind a default-OFF flag, flipped on once readers
+  are deployed. (Pattern proven by `PROXIMADB_PAX_DROP_TENANT_COL`.)
+* *Location is additive.* Unset `location` ⇒ resolver derives the conventional path ⇒ no behavior
+  change. Setting it is opt-in per object/layer.
+* *One model, guarded.* A CI check forbids reintroducing a parallel `Collection`/schema/index
+  authority once collapsed.
+
+== 12. Implementation roadmap (PR slices)
+
+Each slice is an independently shippable, gated increment (one meaty PR each):
+
+. *P1 — `CatalogProjection.location` + index/MV addressing.* Add `location` to `CatalogProjection`;
+  add the `indexes/<projection>` `DrResolvedPath` subprefix; ANN index persistence resolves its path
+  from the projection (falls back to `index_persist_url` when unset). *Unblocks indexes-as-catalog-
+  objects.* (Queued.)
+. *P2 — Resolver-persists-location.* `DrPathBuilder` writes the computed `location` back to the
+  catalog on create for L1/L2; reads prefer stored `location`. Retire `PROXIMADB_WAREHOUSE_DRPATH`.
+. *P3 — MV as projection.* Replace name-only `materialized_views` with `CatalogProjection{
+  MaterializedView}` + `location`; planners/EXPLAIN read projections.
+. *P4 — Collapse the parallel model.* `Collection`/`MetadataStoreInterface` → `CatalogObject`; proto
+  `Collection` becomes a wire DTO; CI guard. (Largest; decision §IMPORTANT.2.)
+. *P5 — Namespace dual-role split + remove `ns_default` escape hatch.*
+. *P6 — Modality pull-ins.* Graph topology, event/queue, audit become first-class L2 layouts under
+  `CatalogObject` with `location`.
+
+== 13. Open questions for the next iterations
+
+. *`modality_ext` shape* — a closed enum (`VectorExt|GraphExt|EventExt|...`) vs an open typed-property
+  bag. Closed gives compile-time exhaustiveness; open eases adding modalities without core churn.
+. *Object vs collection naming* — does the external API keep "collection"/"table" vocabulary
+  (mapped to `CatalogObject`) or expose "object"? Affects SDK/pgwire/REST surface.
+. *Where the `Catalog` trait lives for the vector plane after P4* — direct dependency vs a thin
+  read-port to avoid a control→storage layering inversion.
+. *Per-projection tiering* — does `location` alone carry tier, or a separate `tier`/`StoragePoolClass`
+  per projection (hot ANN on premium, cold f32 rerank on standard)?
+. *Audit immutability* — is audit a write-once L2 layout with a retention/legal-hold policy, or a
+  distinct authority mode?
+
+These are the back-and-forth items; nothing here is frozen except the three locked decisions in the
+header.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -104,6 +104,16 @@ Read these in order for future-shaping architecture work:
    shift). Subordinate to `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 18. `[SUPERSEDED] roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` +
    Legacy foundational mandate. Superseded by the Data Warehouse course correction on 2026-06-04.
+19. `CATALOG_OBJECT_MODEL_2026_06_21.adoc` +
+   Makes the catalog the single central object model for all multitenant objects and access methods.
+   One `CatalogObject` expresses every modality (relational, vector, document, graph, event, audit,
+   time-series, external) as a *facet*; a uniform four-layer stack (canonical authority → physical
+   layouts → projections) hides modality complexity, each layer carrying a catalog-resolved `location`.
+   Closes the four gaps: parallel `Collection`/`MetadataStoreInterface` model (collapse), convention/
+   env-derived addressing (catalog-resolved `location`, `DrPathBuilder` as default resolver), partial
+   index/MV representations (one `CatalogProjection` with `location`), and out-of-catalog modalities
+   (graph/event/audit as first-class layouts). The macro generalization of tenant catalog-resolution.
+   Subordinate to the 2026-06-04 course correction and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 
 == Stable Reference Docs
 


### PR DESCRIPTION
Vision-level spec (per the converged design decisions) making the catalog the single central object model for all multitenant objects and access methods.

**Locked decisions captured:** one `CatalogObject` with modality as a *facet*; collapse the parallel `Collection`/`MetadataStoreInterface` model; spec-first sequencing.

**What it covers:**
- The unified `CatalogObject` (modality as facet, not typed subtypes) + four-layer stack (canonical authority → physical layouts → projections), each layer carrying a catalog-resolved `location`.
- Object algebra per modality (relational, vector, document, graph, event, audit, time-series, external).
- Indexes & MVs as one authoritative `CatalogProjection` with `location` (the indexes-as-catalog-objects work).
- Addressing: `location` authoritative, `DrPathBuilder` as default resolver; retire the `PROXIMADB_WAREHOUSE_DRPATH` env fork.
- The four gaps it closes (parallel object model, convention/env addressing, partial index/MV reps, out-of-catalog modalities).
- Migration safety (reader-forward/writer-flagged, mixed-read-safe, default-OFF) and a 6-slice implementation roadmap (P1 index location → … → P4 collapse parallel model → P6 modality pull-ins).
- Open questions for the next iterations.

Grounded in a full inventory of the existing catalog model (anchors throughout). Indexed in `docs/12-design/README.adoc`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)