### PR TITLE
chore: soft-deprecate SQL over gRPC/REST in favor of pgwire (TD-121)

### DIFF
--- a/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
@@ -10,6 +10,7 @@ Features:
 
 import json
 import logging
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -603,7 +604,15 @@ class ProximaDBSyncGrpcClient:
         parameters: list | None = None,
         collection: str | None = None,
     ):
-        """Execute SQL via proximadb.v1.QueryService.ExecuteQuery
+        """Execute SQL over gRPC.
+
+        .. deprecated::
+            SQL over gRPC/REST is deprecated. pgwire (the PostgreSQL wire
+            protocol) is the canonical SQL surface — connect any PostgreSQL
+            driver (psycopg2, asyncpg, JDBC, psql) and run SQL there. gRPC/REST
+            own record/vector/collection operations; SQL belongs on pgwire.
+            This method (and the v2 ``ExecuteQuery`` RPC) will be removed in a
+            future release.
 
         Args:
             query: SQL text
@@ -612,6 +621,13 @@ class ProximaDBSyncGrpcClient:
         Returns:
             ExecuteQueryResponse as dict-like (via proto object fields)
         """
+        warnings.warn(
+            "execute_sql over gRPC is deprecated; use pgwire (PostgreSQL wire "
+            "protocol) for SQL via any PostgreSQL driver. The gRPC SQL path will "
+            "be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not GRPC_AVAILABLE:
             raise ProximaDBError(
                 "gRPC not available. Install with: pip install grpcio grpcio-tools"

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -783,7 +783,10 @@ service ProximaRecordService {
   rpc ListCollections(V2ListCollectionsRequest) returns (V2ListCollectionsResponse);
   rpc DeleteCollection(V2DeleteCollectionRequest) returns (V2DeleteCollectionResponse);
 
-  // SQL query (v2 parity with v1 QueryService)
+  // DEPRECATED: SQL over gRPC is deprecated. pgwire (the PostgreSQL wire
+  // protocol) is the canonical SQL surface; connect any PostgreSQL driver and
+  // run SQL there. gRPC owns record/vector/collection operations, not SQL.
+  // This RPC will be removed in a future release (see TD-121).
   rpc ExecuteQuery(V2QueryRequest) returns (V2QueryResponse);
 
   // Point record get-by-id (v2 parity with v1 VectorService.VectorGet)

--- a/roadmap/techdebt/TD_121_DEPRECATE_SQL_OVER_GRPC_REST_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_121_DEPRECATE_SQL_OVER_GRPC_REST_2026_06_21.adoc
@@ -1,0 +1,57 @@
+= TD-121 Deprecate SQL over gRPC/REST in favour of pgwire
+:toc:
+:toclevels: 3
+:sectnums:
+
+Status: Open / proposed (soft-deprecation landed) +
+Date: 2026-06-21 +
+Owner: Network/pgwire, SDK
+
+== Context
+
+ProximaDB exposes SQL on three surfaces: the v2 gRPC `ProximaRecordService.ExecuteQuery`
+RPC, the REST `POST /api/v2/query` endpoint, and **pgwire** (the PostgreSQL wire protocol).
+pgwire is the canonical, feature-rich SQL surface: it is PostgreSQL-wire compatible (any
+standard driver — psql, psycopg2, asyncpg, JDBC), supports full SQL semantics, and the
+TPC-H suite already passes over it.
+
+The gRPC/REST SQL paths are a **redundant, inferior second SQL surface**: bespoke, lean
+(the v2 `V2QueryResponse` had to drop `parameters`/`rows_scanned`/`column_types` to stay
+self-contained), and inherently bound to the legacy `SqlValue` query frontend — i.e. they
+reach back into v1-shaped internals that the codebase is migrating away from (TD-106
+SqlValue->ProximaValue). Maintaining two SQL surfaces duplicates effort and gives external
+clients a worse interface than pgwire.
+
+== Decision
+
+**SQL belongs on pgwire.** gRPC and REST own *record/vector/collection operations*
+(insert/upsert/delete/search/get + collection lifecycle) — the operations that are not
+naturally SQL. SQL clients use a PostgreSQL driver against the pgwire port.
+
+The gRPC `ExecuteQuery` RPC + REST `/api/v2/query` + the SDK `execute_sql` helper are
+**soft-deprecated** (this change): kept working for one cycle, marked deprecated, and
+redirected to pgwire. They are slated for removal.
+
+== Soft-deprecation landed (2026-06-21)
+
+* SDK `grpc_sync.py::execute_sql` emits a `DeprecationWarning` pointing to pgwire; docstring
+  updated.
+* Proto `ProximaRecordService.ExecuteQuery` carries a DEPRECATED comment referencing this TD.
+* REST `execute_query` (`/api/v2/query`) handler doc-comment marked DEPRECATED.
+
+== Remaining work (removal)
+
+. Confirm no first-party caller depends on SQL-over-gRPC/REST (SDK, internal tools).
+. Remove the SDK `execute_sql` gRPC helper (or, if SQL convenience is wanted, reimplement it
+  as a thin pgwire client shim — separate decision).
+. Remove the `ExecuteQuery` RPC from `proto/proximadb/v2/record.proto` + its server handler
+  in `src/network/grpc/v2/record_service.rs`, regenerate stubs.
+. Remove the REST `/api/v2/query` (+ `/query/explain`) routes/handlers.
+. Document pgwire as the sole SQL surface in the supported-surface docs.
+
+== Notes
+
+* This reverses part of PR #114 (which added `ExecuteQuery` for SDK gRPC v1->v2 parity). The
+  parity goal stands for record/vector/collection ops; SQL was the wrong thing to put on gRPC.
+* Aligns with the "right transport for the job" principle: pgwire for SQL, gRPC/REST for
+  operations, Arrow Flight for bulk columnar.

--- a/src/network/rest/v2/query.rs
+++ b/src/network/rest/v2/query.rs
@@ -59,6 +59,11 @@ fn json_to_proxima_values(params: Option<Vec<serde_json::Value>>) -> Option<Vec<
 }
 
 /// POST /api/v2/query
+///
+/// DEPRECATED: SQL over REST is deprecated. pgwire (the PostgreSQL wire
+/// protocol) is the canonical SQL surface — connect any PostgreSQL driver and
+/// run SQL there. REST owns record/vector/collection operations, not SQL. This
+/// endpoint will be removed in a future release (see TD-121).
 pub async fn execute_query(
     State(state): State<AppState>,
     Json(request): Json<QueryRequest>,


### PR DESCRIPTION
**Decision (yours):** pgwire is the canonical SQL surface; SQL over gRPC/REST is redundant and should be retired. This is the **soft-deprecation** step (mark + redirect, non-breaking).

## Why
- **pgwire** is full PostgreSQL-wire compatible (psql/psycopg2/asyncpg/JDBC), feature-rich, TPC-H passes. The *right transport for SQL*.
- **SQL over gRPC (`ExecuteQuery`) / REST (`/api/v2/query`)** is a bespoke, lean second SQL path bound to the legacy `SqlValue` frontend (the v1-shaped internals we're moving off, TD-106). Duplicative + inferior.
- Clean separation: **gRPC/REST → record/vector/collection operations**; **pgwire → SQL**.

## Changes (non-breaking — comment + warning only)
- SDK `execute_sql` emits a `DeprecationWarning` → pgwire; docstring updated.
- Proto `ExecuteQuery` + REST `execute_query` carry `DEPRECATED` doc comments → pgwire.
- **TD-121** documents the decision + the removal steps.

Reverses the SQL part of #114 — the record/vector/collection v2 parity stands; SQL was the wrong thing to put on gRPC. No regen (comment-only); `py_compile`/black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)