### PR TITLE
feat(catalog): P1 — index/MV as addressable catalog objects (location resolution)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -1776,6 +1776,14 @@ pub struct CatalogProjection {
     pub benchmark_gate: Option<String>,
     /// Human-readable support status: experimental, beta, supported, deprecated.
     pub support_status: String,
+    /// Catalog-resolved physical location (URI/path prefix) of this projection's
+    /// materialized bytes — the index/MV files. `None` means "not yet resolved";
+    /// the engine then derives the default path from `DrPathBuilder`
+    /// (`data/{tenant}/{namespace}/{collection}/indexes/{name}/`). When set, it is
+    /// authoritative, so a projection can be relocated/tiered independently. This
+    /// is the catalog-resolution of index/MV addressing (CATALOG_OBJECT_MODEL P1).
+    #[serde(default)]
+    pub location: Option<String>,
     /// Additional implementation-specific metadata.
     pub properties: HashMap<String, String>,
 }
@@ -1804,6 +1812,7 @@ impl CatalogProjection {
             lossy: false,
             benchmark_gate: None,
             support_status: "experimental".to_string(),
+            location: None,
             properties: HashMap::new(),
         }
     }
@@ -1812,6 +1821,14 @@ impl CatalogProjection {
     pub fn with_bounded_lag(mut self, max_lag_ms: i64) -> Self {
         self.freshness = ProjectionFreshness::BoundedLag;
         self.max_lag_ms = Some(max_lag_ms);
+        self
+    }
+
+    /// Set the catalog-resolved physical location (URI/path prefix) of this
+    /// projection's materialized bytes. Authoritative when set; otherwise the
+    /// engine derives the default `DrPathBuilder` index path.
+    pub fn with_location(mut self, location: impl Into<String>) -> Self {
+        self.location = Some(location.into());
         self
     }
 

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -248,6 +248,15 @@ pub struct AxisManager {
     /// (falls back to the local `index_persist_dir`).
     filesystem_factory: Option<Arc<crate::storage::persistence::filesystem::FilesystemFactory>>,
 
+    /// CATALOG_OBJECT_MODEL P1: per-collection catalog-resolved index location
+    /// (a `CatalogProjection.location`, or the `DrPathBuilder`-derived
+    /// `indexes/<projection>/` default). When set for a collection it is
+    /// authoritative and takes precedence over the `index_persist_url` /
+    /// `index_persist_dir` conventions, so an index can be relocated/tiered from
+    /// the catalog. Populated by the boot adapter that resolves projections;
+    /// empty ⇒ the legacy convention is used unchanged (mixed-safe, default-off).
+    index_location_overrides: std::collections::HashMap<String, String>,
+
     /// Phase 8 F4a (TD-094): collections whose in-memory IVF index was evicted by
     /// `suspend_collection` to free memory. The persisted `ivf.bin` remains, so
     /// the next query (or `resume_collection`) warm-loads it; the marker is
@@ -446,6 +455,7 @@ impl AxisManager {
             recall_probe_gate: None,  // Set later via set_recall_probe_gate (TD-075)
             index_persist_dir: None,  // Set later via set_index_persist_dir (TD-087 Slice B)
             index_persist_url: None,  // Set later via set_index_persist_url (ADR-023 R3 Slice 4)
+            index_location_overrides: std::collections::HashMap::new(), // catalog-resolved (P1)
             filesystem_factory: None, // Set later via set_filesystem_factory (ADR-023 R3 Slice 4)
             suspended_collections: Arc::new(RwLock::new(std::collections::HashSet::new())), // F4a
             cold_lazy_warm: false,    // ADR-023 R3 (c): eager warm by default
@@ -499,6 +509,24 @@ impl AxisManager {
             url
         );
         self.index_persist_url = Some(url);
+    }
+
+    /// CATALOG_OBJECT_MODEL P1: register the catalog-resolved index location for a
+    /// collection's ANN projection. When set, it takes precedence over the
+    /// `index_persist_url`/`index_persist_dir` conventions in
+    /// [`index_fs_and_path`](Self::index_fs_and_path), so the index path is
+    /// authoritative-from-catalog (relocatable/tierable per projection). The boot
+    /// adapter computes this via `DrResolvedPath::resolve_index_location`
+    /// (projection `location`, else the derived `indexes/<projection>/` default).
+    pub fn set_index_location(&mut self, collection_id: impl Into<String>, location: String) {
+        let collection_id = collection_id.into();
+        tracing::info!(
+            "🔗 AXIS: catalog-resolved index location for '{}' → '{}'",
+            collection_id,
+            location
+        );
+        self.index_location_overrides
+            .insert(collection_id, location);
     }
 
     /// ADR-023 R3 Slice 4: inject the shared `FilesystemFactory` that
@@ -559,6 +587,27 @@ impl AxisManager {
         Arc<dyn crate::storage::persistence::filesystem::FileSystem>,
         String,
     )> {
+        // CATALOG_OBJECT_MODEL P1: a catalog-resolved index location is
+        // authoritative — it already encodes the per-projection path (and any
+        // relocation/tiering), so we append the index file and dispatch by scheme
+        // via the factory, ahead of the legacy url/dir conventions.
+        if let (Some(loc), Some(factory)) = (
+            self.index_location_overrides.get(collection_id),
+            &self.filesystem_factory,
+        ) {
+            let path = format!("{}/ivf.bin", loc.trim_end_matches('/'));
+            return match factory.get_filesystem(&path) {
+                Ok(fs) => Some((fs, path)),
+                Err(e) => {
+                    tracing::warn!(
+                        "AXIS: no filesystem for catalog index location '{}' ({}); persistence disabled",
+                        path,
+                        e
+                    );
+                    None
+                }
+            };
+        }
         if let (Some(url), Some(factory)) = (&self.index_persist_url, &self.filesystem_factory) {
             let path = format!("{}/{}/ivf.bin", url.trim_end_matches('/'), collection_id);
             return match factory.get_filesystem(&path) {
@@ -5759,6 +5808,42 @@ mod recluster_apply_tests {
             m2.has_ivf_index("col").await,
             "index cold-loaded via object-store URI through the factory"
         );
+    }
+
+    /// CATALOG_OBJECT_MODEL P1: a catalog-resolved index location takes precedence
+    /// over the `index_persist_url` convention, and round-trips through the same
+    /// factory/scheme path. Proves the index is addressable from the catalog
+    /// (relocatable/tierable per projection), not just the base-url convention.
+    #[tokio::test]
+    async fn catalog_index_location_overrides_persist_url() {
+        use crate::storage::persistence::filesystem::FilesystemFactory;
+        let base = tempfile::TempDir::new().unwrap();
+        let catalog_dir = tempfile::TempDir::new().unwrap();
+        let factory = Arc::new(FilesystemFactory::create_default().await.unwrap());
+
+        let mut m = AxisManager::new(AxisConfig::default()).await.unwrap();
+        m.set_filesystem_factory(factory.clone());
+        // Convention base would resolve under {base}/col/ivf.bin …
+        m.set_index_persist_url(format!("file://{}", base.path().display()));
+        // … but the catalog-resolved per-projection location wins.
+        let catalog_loc = format!("file://{}/indexes/vector_ann", catalog_dir.path().display());
+        m.set_index_location("col", catalog_loc.clone());
+
+        let (_, resolved) = m.index_fs_and_path("col").await.unwrap();
+        assert_eq!(
+            resolved,
+            format!("{}/ivf.bin", catalog_loc),
+            "catalog index location must take precedence over index_persist_url"
+        );
+        assert!(
+            !resolved.contains(&base.path().display().to_string()),
+            "must NOT fall back to the convention base when a catalog location is set"
+        );
+
+        // And it actually persists + cold-loads through that catalog location.
+        let v = batch("cat", 60, 8, 1);
+        assert!(m.rebuild_and_swap_ivf_index("col", &v).await.unwrap());
+        assert!(m.has_persisted_ivf_index("col").await);
     }
 
     // ─── Phase 8 F4a: suspend / resume ──────────────────────────────────────

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -1789,6 +1789,7 @@ fn add_specialty_projection_layouts(
             lossy: true,
             benchmark_gate: Some("hybrid-vector-smoke".to_string()),
             support_status: "experimental".to_string(),
+            location: None,
             properties: HashMap::new(),
         });
     }
@@ -1823,6 +1824,7 @@ fn add_specialty_projection_layouts(
             lossy: false,
             benchmark_gate: Some("json-path-smoke".to_string()),
             support_status: "experimental".to_string(),
+            location: None,
             properties: HashMap::new(),
         });
     }

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -472,6 +472,32 @@ impl DrResolvedPath {
         format!("{}indexes/", self.root_prefix())
     }
 
+    /// Per-projection index subprefix `<root>indexes/<projection_name>/` — the
+    /// default physical path for one catalog `CatalogProjection`'s materialized
+    /// bytes (an ANN/full-text/columnar index, or an MV). Each projection maps to
+    /// its own path so it can be relocated/tiered independently
+    /// (CATALOG_OBJECT_MODEL P1). `validate_id` is NOT re-run on `projection_name`
+    /// here — the caller passes a catalog-validated name.
+    pub fn index_prefix(&self, projection_name: &str) -> String {
+        format!("{}{}/", self.indexes_subprefix(), projection_name)
+    }
+
+    /// Resolve a projection's physical location, catalog-resolved with the
+    /// `DrPathBuilder` default as fallback: the catalog `location` wins when set
+    /// (authoritative — the projection was relocated/tiered), otherwise the
+    /// derived per-projection [`index_prefix`](Self::index_prefix). This is the
+    /// single precedence rule for index/MV addressing.
+    pub fn resolve_index_location(
+        &self,
+        projection_name: &str,
+        projection_location: Option<&str>,
+    ) -> String {
+        match projection_location {
+            Some(loc) if !loc.is_empty() => loc.to_string(),
+            _ => self.index_prefix(projection_name),
+        }
+    }
+
     /// Restore-checkpoint subprefix `<root>restore-checkpoints/`.
     pub fn restore_checkpoints_subprefix(&self) -> String {
         format!("{}restore-checkpoints/", self.root_prefix())
@@ -784,6 +810,34 @@ mod tests {
             "data/tnt_acme/ns_01HX7Q8K2N5R9P3M1B2C3D4E5F/col_orders/restore-checkpoints/"
         );
         assert_eq!(path.storage_pool_class, StoragePoolClass::Standard);
+    }
+
+    #[test]
+    fn per_projection_index_path_and_location_precedence() {
+        let ns = dr_addressable_namespace();
+        let path = DrPathBuilder::build(&ns, "col_orders").unwrap();
+
+        // Each projection maps to its own path under indexes/.
+        assert_eq!(
+            path.index_prefix("vector_ann"),
+            "data/tnt_acme/ns_01HX7Q8K2N5R9P3M1B2C3D4E5F/col_orders/indexes/vector_ann/"
+        );
+
+        // Unset (or empty) catalog location → derive the DrPathBuilder default.
+        assert_eq!(
+            path.resolve_index_location("vector_ann", None),
+            path.index_prefix("vector_ann")
+        );
+        assert_eq!(
+            path.resolve_index_location("vector_ann", Some("")),
+            path.index_prefix("vector_ann")
+        );
+
+        // A set catalog location is authoritative (relocated/tiered projection).
+        assert_eq!(
+            path.resolve_index_location("vector_ann", Some("s3://hot-tier/idx/ann/")),
+            "s3://hot-tier/idx/ann/"
+        );
     }
 
     #[test]


### PR DESCRIPTION
First slice of `CATALOG_OBJECT_MODEL_2026_06_21`: make a projection's physical location **catalog-resolved**, so an index/MV is an *addressable catalog object* (relocatable/tierable per projection) instead of an object-URL/convention.

### Changes
- **`CatalogProjection.location: Option<String>`** (serde default) + `with_location` builder. `None` = engine derives the default; when set it is authoritative.
- **`DrResolvedPath::index_prefix(name)`** → `data/{tenant}/{namespace}/{collection}/indexes/{name}/` (each projection maps to its own path) + **`resolve_index_location(name, location)`** — the single precedence rule: catalog `location` wins, else the DrPathBuilder default.
- **AXIS `set_index_location(collection, location)`** + an override map that `index_fs_and_path` prefers over the legacy `index_persist_url`/`index_persist_dir` conventions. Additive, **default-off**: an empty map keeps today's behavior exactly (mixed-safe) — addressing only changes once a boot adapter populates catalog-resolved locations.

### Finding (informs the spec)
AXIS has **no catalog read-port**, so it consumes the resolved location via the override map (boot-adapter-populated) rather than reading the catalog directly — exactly `CATALOG_OBJECT_MODEL` **open question #3** (Catalog trait placement / read-port for the vector plane).

### Verification
- `per_projection_index_path_and_location_precedence` (path_resolver) + `catalog_index_location_overrides_persist_url` (AXIS, round-trips persist+cold-load through the same factory/scheme path) — both pass.
- `proximadb-catalog` builds clean; `cargo fmt --all`; leaf + root `clippy` clean; `CARGO_INCREMENTAL=0`.

### Next (per roadmap)
Wire the boot adapter (resolve each ANN projection's location via `resolve_index_location` and call `set_index_location`) + register the index as a `CatalogProjection{VectorAnn}` at create; then spec P2 (resolver persists `location`) → P4 (collapse the parallel `Collection` model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)