### PR TITLE
feat(catalog): boot adapter — register catalog-resolved ANN index locations with AXIS

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -902,6 +902,52 @@ impl SharedServices {
         } else if let Some(cfg) = opt_config {
             axis_manager_inner.set_index_persist_dir(cfg.server.data_dir.join("axis_indexes"));
         }
+
+        // CATALOG_OBJECT_MODEL P1 boot adapter: make catalog-resolved index
+        // locations live. For each cataloged collection's VectorAnn projection,
+        // register its catalog location with AXIS so index persistence/cold-load is
+        // addressed from the catalog rather than only the `index_persist_url`
+        // convention. Explicit `projection.location` is always honored (relocated/
+        // tiered indexes); `PROXIMADB_INDEX_CATALOG_PATHS=1` additionally opts the
+        // fleet into the DrPathBuilder `indexes/<projection>/` layout. Default-off
+        // and additive — with no projection locations set it is a no-op, so existing
+        // indexes stay exactly where they are (mixed-safe). Runs here, before the
+        // manager is shared, while it is still uniquely owned (`&mut`).
+        {
+            use crate::storage::trait_components::path_resolver::ann_index_locations;
+            let migrate = std::env::var_os("PROXIMADB_INDEX_CATALOG_PATHS").is_some();
+            let mut registered = 0usize;
+            for catalog_name in catalog_manager.list_catalogs().await {
+                let Ok(catalog) = catalog_manager.get_catalog(&catalog_name).await else {
+                    continue;
+                };
+                let Ok(namespaces) = catalog.list_namespaces(None).await else {
+                    continue;
+                };
+                for ns in namespaces {
+                    let Ok(tables) = catalog.list_tables(&ns.levels).await else {
+                        continue;
+                    };
+                    for table_id in tables {
+                        let Ok(schema) = catalog.get_table(&table_id).await else {
+                            continue;
+                        };
+                        for (collection_id, location) in ann_index_locations(&ns, &schema, migrate)
+                        {
+                            axis_manager_inner.set_index_location(collection_id, location);
+                            registered += 1;
+                        }
+                    }
+                }
+            }
+            if registered > 0 {
+                debug!(
+                    "🔗 SharedServices: registered {} catalog-resolved index location(s) with AXIS (migrate={})",
+                    registered, migrate
+                );
+            }
+        }
+
         let axis_manager = Arc::new(axis_manager_inner);
         debug!("✅ SharedServices::new - AxisManager created successfully");
 

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -44,7 +44,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use proximadb_catalog::{CatalogNamespace, StoragePoolClass};
+use proximadb_catalog::{
+    CatalogNamespace, CatalogProjectionKind, CatalogTableSchema, StoragePoolClass,
+};
 use std::sync::Arc;
 
 /// Storage location assignment for a collection
@@ -512,6 +514,47 @@ impl DrResolvedPath {
     }
 }
 
+/// Resolve the catalog-addressed index locations for a collection's vector-ANN
+/// projections — the pure core of the CATALOG_OBJECT_MODEL P1 boot adapter.
+///
+/// For each `VectorAnn` projection on `schema`, returns `(collection_id,
+/// location)` to register with the index engine (`AxisManager::set_index_location`):
+///
+/// * A projection with an explicit catalog `location` is **always** honored — the
+///   catalog says where that index physically lives (it may have been relocated or
+///   tiered), so it is authoritative.
+/// * A projection without one is **skipped** unless `migrate_to_catalog_paths` is
+///   set, in which case the derived `DrPathBuilder` default
+///   (`…/indexes/<projection>/`) is used — the opt-in migration off the legacy
+///   `index_persist_url` convention. Default-off keeps existing indexes exactly
+///   where they are (mixed-safe).
+///
+/// Returns empty when the namespace is not DR-addressable (legacy pre-P0.5 rows)
+/// or the collection declares no ANN projection.
+pub fn ann_index_locations(
+    namespace: &CatalogNamespace,
+    schema: &CatalogTableSchema,
+    migrate_to_catalog_paths: bool,
+) -> Vec<(String, String)> {
+    let resolved = match DrPathBuilder::build(namespace, &schema.name) {
+        Ok(resolved) => resolved,
+        Err(_) => return Vec::new(), // legacy / non-DR-addressable namespace → leave convention
+    };
+    schema
+        .projections
+        .iter()
+        .filter(|p| p.kind == CatalogProjectionKind::VectorAnn)
+        .filter_map(|p| match p.location.as_deref() {
+            Some(loc) if !loc.is_empty() => Some((schema.name.clone(), loc.to_string())),
+            _ if migrate_to_catalog_paths => Some((
+                schema.name.clone(),
+                resolved.resolve_index_location(&p.name, None),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Errors returned by [`DrPathBuilder::build`]. The reconciler and engine
 /// API map these to specific operator-visible failure modes; the path
 /// resolver guard refuses any write whose builder returns one of these.
@@ -838,6 +881,55 @@ mod tests {
             path.resolve_index_location("vector_ann", Some("s3://hot-tier/idx/ann/")),
             "s3://hot-tier/idx/ann/"
         );
+    }
+
+    #[test]
+    fn ann_index_locations_honors_explicit_and_gates_migration() {
+        use proximadb_catalog::CatalogProjection;
+        let ns = dr_addressable_namespace();
+
+        let mut schema = CatalogTableSchema::new("col_orders");
+        schema.projections.push(CatalogProjection::rebuildable(
+            "vector_ann",
+            CatalogProjectionKind::VectorAnn,
+            "primary",
+        ));
+        // A non-ANN projection must be ignored.
+        schema.projections.push(CatalogProjection::rebuildable(
+            "json_path",
+            CatalogProjectionKind::JsonPath,
+            "primary",
+        ));
+
+        // No explicit location + migrate off → register nothing (convention kept).
+        assert!(ann_index_locations(&ns, &schema, false).is_empty());
+
+        // migrate on → DrPath default, ANN projection only.
+        let migrated = ann_index_locations(&ns, &schema, true);
+        assert_eq!(
+            migrated,
+            vec![(
+                "col_orders".to_string(),
+                "data/tnt_acme/ns_01HX7Q8K2N5R9P3M1B2C3D4E5F/col_orders/indexes/vector_ann/"
+                    .to_string()
+            )]
+        );
+
+        // An explicit catalog location is honored regardless of the migrate flag.
+        schema.projections[0] = CatalogProjection::rebuildable(
+            "vector_ann",
+            CatalogProjectionKind::VectorAnn,
+            "primary",
+        )
+        .with_location("s3://hot-tier/ann/");
+        assert_eq!(
+            ann_index_locations(&ns, &schema, false),
+            vec![("col_orders".to_string(), "s3://hot-tier/ann/".to_string())]
+        );
+
+        // Non-DR-addressable namespace (legacy) → empty, leave the convention.
+        let legacy = CatalogNamespace::new(vec!["legacy".into()]);
+        assert!(ann_index_locations(&legacy, &schema, true).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Makes `CATALOG_OBJECT_MODEL` **P1 live** (for collections present at boot/restart): each cataloged collection's `VectorAnn` projection has its catalog-resolved index location registered with AXIS, so index persistence/cold-load is addressed **from the catalog** rather than only the `index_persist_url` convention.

### Changes
- **`path_resolver::ann_index_locations(namespace, schema, migrate)`** (pure, tested): for each `VectorAnn` projection returns `(collection_id, location)`. An explicit `projection.location` is **always honored** (relocated/tiered index); without one the projection is skipped unless `migrate`, in which case the DrPathBuilder default (`indexes/<projection>/`) is used. Non-DR-addressable (legacy) namespaces yield nothing.
- **`shared_services`**: after the AXIS persist wiring (and before the manager is `Arc`-shared, while still `&mut`), enumerate the catalog (`list_catalogs → get_catalog → list_namespaces → list_tables → get_table`) and call `set_index_location` per result. **`PROXIMADB_INDEX_CATALOG_PATHS=1`** opts the fleet into the DrPath migration.

**Default-off and additive:** with no projection locations set and the migrate flag off, it registers nothing — existing indexes stay exactly where they are (mixed-safe).

### Follow-up (informs open-Q #3 / read-port)
Runtime-created collections can't call `set_index_location` because AXIS is `Arc`-wrapped (immutable) after boot. A create-time hook needs the override map to be interior-mutable (`Arc<RwLock<…>>`), or AXIS to resolve on-demand via a thin catalog read-port — the recommended next slice.

### Verification
`ann_index_locations_honors_explicit_and_gates_migration` passes; `shared_services` compiles; `cargo fmt --all`; leaf + root `clippy` clean; `CARGO_INCREMENTAL=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)