### PR TITLE
feat(catalog): #3 read-port — AXIS pulls catalog-resolved index location on demand

### DIFF
--- a/src/catalog/index_location_resolver.rs
+++ b/src/catalog/index_location_resolver.rs
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Catalog adapter for AXIS's index-location read-port (CATALOG_OBJECT_MODEL #3).
+//!
+//! AXIS depends only on the catalog-free [`IndexLocationResolver`] trait; this
+//! adapter — in the control layer — implements it over the catalog, inverting the
+//! dependency so the index/storage plane never imports `proximadb-catalog`.
+//!
+//! Resolution is on demand: given a `collection_id`, it resolves the owning table
+//! and namespace from the catalog and runs the same
+//! [`ann_index_locations`](crate::storage::trait_components::path_resolver::ann_index_locations)
+//! rule the boot adapter uses (explicit `projection.location` wins; the
+//! `PROXIMADB_INDEX_CATALOG_PATHS` migration derives the `DrPathBuilder` default).
+//! The caller ([`AxisManager`](crate::index::AxisManager)) memoizes the result, so
+//! this is consulted at most once per collection.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::catalog::CatalogManager;
+use crate::index::IndexLocationResolver;
+use crate::storage::trait_components::path_resolver::ann_index_locations;
+
+/// Resolves a collection's ANN index location from the catalog on demand — the
+/// control-layer implementation of AXIS's [`IndexLocationResolver`] read-port.
+pub struct CatalogIndexLocationResolver {
+    catalog_manager: Arc<CatalogManager>,
+    /// When true, ANN projections without an explicit `location` are migrated to
+    /// the `DrPathBuilder` `indexes/<projection>/` layout; when false they keep the
+    /// `index_persist_url`/`dir` convention (resolver returns `None`).
+    migrate: bool,
+}
+
+impl CatalogIndexLocationResolver {
+    pub fn new(catalog_manager: Arc<CatalogManager>, migrate: bool) -> Self {
+        Self {
+            catalog_manager,
+            migrate,
+        }
+    }
+}
+
+#[async_trait]
+impl IndexLocationResolver for CatalogIndexLocationResolver {
+    async fn resolve_index_location(&self, collection_id: &str) -> Option<String> {
+        let (catalog, table_id) = self
+            .catalog_manager
+            .resolve_table(collection_id)
+            .await
+            .ok()?;
+        let namespace = catalog.get_namespace(&table_id.namespace).await.ok()?;
+        let schema = catalog.get_table(&table_id).await.ok()?;
+        // A collection has at most one ANN projection in AXIS's per-collection
+        // index model; take the first resolved location (or None to fall back).
+        ann_index_locations(&namespace, &schema, self.migrate)
+            .into_iter()
+            .next()
+            .map(|(_collection, location)| location)
+    }
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -28,6 +28,9 @@ pub mod traits {
 // Partition pruning for query optimization
 pub mod partition_pruning;
 
+// CATALOG_OBJECT_MODEL #3 read-port: catalog adapter for AXIS index-location resolution.
+pub mod index_location_resolver;
+
 // Internal schema registry (multi-model unified catalog)
 pub mod internal;
 

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -158,6 +158,20 @@ use proximadb_records::{ProximaRecord, ProximaTreeNode};
 ///                              ↓
 ///                        Background Build
 /// ```
+///
+/// Resolves a collection's catalog-addressed index location on demand
+/// (CATALOG_OBJECT_MODEL read-port, open-Q #3). Catalog-free **by design**: AXIS
+/// depends only on this trait, never on `proximadb-catalog`, so the dependency is
+/// inverted — an adapter in the wiring/control layer implements it over the
+/// catalog. Returning `None` means "no catalog-resolved location", and AXIS falls
+/// back to the `index_persist_url` / `index_persist_dir` convention. The result is
+/// memoized by [`AxisManager`], so this is consulted at most once per collection.
+#[async_trait::async_trait]
+pub trait IndexLocationResolver: Send + Sync {
+    /// Resolve `collection_id`'s ANN index location, or `None` for the convention.
+    async fn resolve_index_location(&self, collection_id: &str) -> Option<String>;
+}
+
 pub struct AxisManager {
     /// Core index components for different data types
 
@@ -253,9 +267,21 @@ pub struct AxisManager {
     /// `indexes/<projection>/` default). When set for a collection it is
     /// authoritative and takes precedence over the `index_persist_url` /
     /// `index_persist_dir` conventions, so an index can be relocated/tiered from
-    /// the catalog. Populated by the boot adapter that resolves projections;
-    /// empty ⇒ the legacy convention is used unchanged (mixed-safe, default-off).
-    index_location_overrides: std::collections::HashMap<String, String>,
+    /// the catalog. Empty ⇒ the legacy convention is used unchanged (mixed-safe,
+    /// default-off).
+    ///
+    /// This is a **memo cache**: populated eagerly by the boot adapter and lazily
+    /// by [`index_location_resolver`](Self::index_location_resolver) on first use,
+    /// so it is interior-mutable (`Arc<RwLock>`) to allow runtime fills after the
+    /// manager is shared.
+    index_location_overrides: Arc<RwLock<std::collections::HashMap<String, String>>>,
+
+    /// CATALOG_OBJECT_MODEL read-port: resolves a collection's index location from
+    /// the catalog on demand (the pull seam). When present, a memo miss consults
+    /// it once and caches the result — this is what makes catalog-resolved index
+    /// locations cover *runtime-created* collections, not just those present at
+    /// boot. `None` keeps the eager-only (boot-pushed) behavior.
+    index_location_resolver: Option<Arc<dyn IndexLocationResolver>>,
 
     /// Phase 8 F4a (TD-094): collections whose in-memory IVF index was evicted by
     /// `suspend_collection` to free memory. The persisted `ivf.bin` remains, so
@@ -455,7 +481,8 @@ impl AxisManager {
             recall_probe_gate: None,  // Set later via set_recall_probe_gate (TD-075)
             index_persist_dir: None,  // Set later via set_index_persist_dir (TD-087 Slice B)
             index_persist_url: None,  // Set later via set_index_persist_url (ADR-023 R3 Slice 4)
-            index_location_overrides: std::collections::HashMap::new(), // catalog-resolved (P1)
+            index_location_overrides: Arc::new(RwLock::new(std::collections::HashMap::new())), // catalog-resolved memo (P1)
+            index_location_resolver: None, // read-port injected at boot (open-Q #3)
             filesystem_factory: None, // Set later via set_filesystem_factory (ADR-023 R3 Slice 4)
             suspended_collections: Arc::new(RwLock::new(std::collections::HashSet::new())), // F4a
             cold_lazy_warm: false,    // ADR-023 R3 (c): eager warm by default
@@ -518,7 +545,11 @@ impl AxisManager {
     /// authoritative-from-catalog (relocatable/tierable per projection). The boot
     /// adapter computes this via `DrResolvedPath::resolve_index_location`
     /// (projection `location`, else the derived `indexes/<projection>/` default).
-    pub fn set_index_location(&mut self, collection_id: impl Into<String>, location: String) {
+    ///
+    /// `&self` + async because the location memo is interior-mutable (filled at
+    /// boot AND lazily at runtime via the read-port), so a shared `AxisManager`
+    /// can still register a location after it has been `Arc`-wrapped.
+    pub async fn set_index_location(&self, collection_id: impl Into<String>, location: String) {
         let collection_id = collection_id.into();
         tracing::info!(
             "🔗 AXIS: catalog-resolved index location for '{}' → '{}'",
@@ -526,7 +557,19 @@ impl AxisManager {
             location
         );
         self.index_location_overrides
+            .write()
+            .await
             .insert(collection_id, location);
+    }
+
+    /// CATALOG_OBJECT_MODEL read-port (open-Q #3): inject the resolver that pulls a
+    /// collection's index location from the catalog on demand. A memo miss in
+    /// [`index_fs_and_path`](Self::index_fs_and_path) consults it once and caches
+    /// the result, so catalog-resolved locations cover runtime-created collections
+    /// — not just those the boot adapter enumerated. Catalog-free trait, so AXIS
+    /// stays independent of `proximadb-catalog` (the dependency is inverted).
+    pub fn set_index_location_resolver(&mut self, resolver: Arc<dyn IndexLocationResolver>) {
+        self.index_location_resolver = Some(resolver);
     }
 
     /// ADR-023 R3 Slice 4: inject the shared `FilesystemFactory` that
@@ -587,14 +630,37 @@ impl AxisManager {
         Arc<dyn crate::storage::persistence::filesystem::FileSystem>,
         String,
     )> {
-        // CATALOG_OBJECT_MODEL P1: a catalog-resolved index location is
+        // CATALOG_OBJECT_MODEL P1 + read-port: a catalog-resolved index location is
         // authoritative — it already encodes the per-projection path (and any
         // relocation/tiering), so we append the index file and dispatch by scheme
-        // via the factory, ahead of the legacy url/dir conventions.
-        if let (Some(loc), Some(factory)) = (
-            self.index_location_overrides.get(collection_id),
-            &self.filesystem_factory,
-        ) {
+        // via the factory, ahead of the legacy url/dir conventions. The location
+        // is taken from the memo (boot-pushed) or, on a miss, pulled once from the
+        // read-port and cached — this is what covers runtime-created collections.
+        let catalog_location = {
+            let memo = self
+                .index_location_overrides
+                .read()
+                .await
+                .get(collection_id)
+                .cloned();
+            match memo {
+                Some(loc) => Some(loc),
+                None => match &self.index_location_resolver {
+                    Some(resolver) => match resolver.resolve_index_location(collection_id).await {
+                        Some(loc) => {
+                            self.index_location_overrides
+                                .write()
+                                .await
+                                .insert(collection_id.to_string(), loc.clone());
+                            Some(loc)
+                        }
+                        None => None,
+                    },
+                    None => None,
+                },
+            }
+        };
+        if let (Some(loc), Some(factory)) = (catalog_location, &self.filesystem_factory) {
             let path = format!("{}/ivf.bin", loc.trim_end_matches('/'));
             return match factory.get_filesystem(&path) {
                 Ok(fs) => Some((fs, path)),
@@ -5827,7 +5893,7 @@ mod recluster_apply_tests {
         m.set_index_persist_url(format!("file://{}", base.path().display()));
         // … but the catalog-resolved per-projection location wins.
         let catalog_loc = format!("file://{}/indexes/vector_ann", catalog_dir.path().display());
-        m.set_index_location("col", catalog_loc.clone());
+        m.set_index_location("col", catalog_loc.clone()).await;
 
         let (_, resolved) = m.index_fs_and_path("col").await.unwrap();
         assert_eq!(
@@ -5844,6 +5910,83 @@ mod recluster_apply_tests {
         let v = batch("cat", 60, 8, 1);
         assert!(m.rebuild_and_swap_ivf_index("col", &v).await.unwrap());
         assert!(m.has_persisted_ivf_index("col").await);
+    }
+
+    /// CATALOG_OBJECT_MODEL #3 read-port: with no boot push and no convention URL,
+    /// AXIS pulls the index location from the injected resolver on first use and
+    /// memoizes it — the resolver is consulted at most once per collection. This is
+    /// what makes catalog-resolved locations cover runtime-created collections.
+    #[tokio::test]
+    async fn read_port_resolves_index_location_lazily_and_memoizes() {
+        use crate::storage::persistence::filesystem::FilesystemFactory;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingResolver {
+            location: String,
+            calls: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl IndexLocationResolver for CountingResolver {
+            async fn resolve_index_location(&self, _collection_id: &str) -> Option<String> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Some(self.location.clone())
+            }
+        }
+
+        let catalog_dir = tempfile::TempDir::new().unwrap();
+        let factory = Arc::new(FilesystemFactory::create_default().await.unwrap());
+        let loc = format!("file://{}/indexes/vector_ann", catalog_dir.path().display());
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let mut m = AxisManager::new(AxisConfig::default()).await.unwrap();
+        m.set_filesystem_factory(factory);
+        // No explicit push and no convention url — only the read-port resolver.
+        m.set_index_location_resolver(Arc::new(CountingResolver {
+            location: loc.clone(),
+            calls: calls.clone(),
+        }));
+
+        // First resolution pulls from the resolver …
+        let (_, p1) = m.index_fs_and_path("col").await.unwrap();
+        assert_eq!(p1, format!("{}/ivf.bin", loc));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // … and the result is memoized (no second pull).
+        let (_, p2) = m.index_fs_and_path("col").await.unwrap();
+        assert_eq!(p2, p1);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "resolver consulted at most once per collection (memoized)"
+        );
+    }
+
+    /// Read-port returning `None` (no catalog location) falls back to the legacy
+    /// `index_persist_url` convention — mixed-safe, default behavior preserved.
+    #[tokio::test]
+    async fn read_port_none_falls_back_to_convention() {
+        use crate::storage::persistence::filesystem::FilesystemFactory;
+
+        struct NoneResolver;
+        #[async_trait::async_trait]
+        impl IndexLocationResolver for NoneResolver {
+            async fn resolve_index_location(&self, _c: &str) -> Option<String> {
+                None
+            }
+        }
+
+        let base = tempfile::TempDir::new().unwrap();
+        let factory = Arc::new(FilesystemFactory::create_default().await.unwrap());
+        let mut m = AxisManager::new(AxisConfig::default()).await.unwrap();
+        m.set_filesystem_factory(factory);
+        m.set_index_persist_url(format!("file://{}", base.path().display()));
+        m.set_index_location_resolver(Arc::new(NoneResolver));
+
+        let (_, resolved) = m.index_fs_and_path("col").await.unwrap();
+        assert!(
+            resolved.ends_with("/col/ivf.bin")
+                && resolved.contains(&base.path().display().to_string()),
+            "None resolver must fall back to the convention: {resolved}"
+        );
     }
 
     // ─── Phase 8 F4a: suspend / resume ──────────────────────────────────────

--- a/src/index/axis/management/mod.rs
+++ b/src/index/axis/management/mod.rs
@@ -14,8 +14,8 @@ pub mod strategy;
 
 // Re-export main types
 pub use manager::{
-    AxisManager, FilterOperator, HotSwapEfChange, HotSwapOutcome, HybridQuery, MetadataFilter,
-    MigrationStatus, QueryResult, ScoredResult, VectorQuery,
+    AxisManager, FilterOperator, HotSwapEfChange, HotSwapOutcome, HybridQuery,
+    IndexLocationResolver, MetadataFilter, MigrationStatus, QueryResult, ScoredResult, VectorQuery,
 };
 
 pub use adaptive_engine::{

--- a/src/index/axis/mod.rs
+++ b/src/index/axis/mod.rs
@@ -127,6 +127,7 @@ pub use management::{
     CollectionCharacteristics,
     FilterOperator,
     HybridQuery,
+    IndexLocationResolver,
     MetadataComplexity,
     MetadataFilter,
     MigrationStatus,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -92,7 +92,7 @@ pub mod turboquant_bridge;
 // The canonical implementations live in `src/index/axis/indexes/`.
 
 // Re-export main types for easier access
-pub use axis::{AxisConfig, AxisManager};
+pub use axis::{AxisConfig, AxisManager, IndexLocationResolver};
 pub use config::{
     IndexUpdateMode, RuntimeHnswConfig, RuntimeIndexConfig, RuntimeIvfConfig, RuntimeLshConfig,
 };

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -903,49 +903,24 @@ impl SharedServices {
             axis_manager_inner.set_index_persist_dir(cfg.server.data_dir.join("axis_indexes"));
         }
 
-        // CATALOG_OBJECT_MODEL P1 boot adapter: make catalog-resolved index
-        // locations live. For each cataloged collection's VectorAnn projection,
-        // register its catalog location with AXIS so index persistence/cold-load is
-        // addressed from the catalog rather than only the `index_persist_url`
-        // convention. Explicit `projection.location` is always honored (relocated/
-        // tiered indexes); `PROXIMADB_INDEX_CATALOG_PATHS=1` additionally opts the
-        // fleet into the DrPathBuilder `indexes/<projection>/` layout. Default-off
-        // and additive — with no projection locations set it is a no-op, so existing
-        // indexes stay exactly where they are (mixed-safe). Runs here, before the
-        // manager is shared, while it is still uniquely owned (`&mut`).
+        // CATALOG_OBJECT_MODEL #3 read-port: make catalog-resolved index locations
+        // live for ALL collections — boot-present AND runtime-created — by injecting
+        // a catalog resolver that AXIS pulls from on demand (and memoizes). For each
+        // collection's VectorAnn projection, an explicit `projection.location` is
+        // honored (relocated/tiered indexes); `PROXIMADB_INDEX_CATALOG_PATHS=1`
+        // additionally opts the fleet into the DrPathBuilder `indexes/<projection>/`
+        // layout. Default-off and additive: with no projection locations set the
+        // resolver returns `None` and AXIS keeps the `index_persist_url`/`dir`
+        // convention (mixed-safe). The resolver is catalog-free at the AXIS seam —
+        // this adapter lives in the control layer (dependency inversion).
         {
-            use crate::storage::trait_components::path_resolver::ann_index_locations;
             let migrate = std::env::var_os("PROXIMADB_INDEX_CATALOG_PATHS").is_some();
-            let mut registered = 0usize;
-            for catalog_name in catalog_manager.list_catalogs().await {
-                let Ok(catalog) = catalog_manager.get_catalog(&catalog_name).await else {
-                    continue;
-                };
-                let Ok(namespaces) = catalog.list_namespaces(None).await else {
-                    continue;
-                };
-                for ns in namespaces {
-                    let Ok(tables) = catalog.list_tables(&ns.levels).await else {
-                        continue;
-                    };
-                    for table_id in tables {
-                        let Ok(schema) = catalog.get_table(&table_id).await else {
-                            continue;
-                        };
-                        for (collection_id, location) in ann_index_locations(&ns, &schema, migrate)
-                        {
-                            axis_manager_inner.set_index_location(collection_id, location);
-                            registered += 1;
-                        }
-                    }
-                }
-            }
-            if registered > 0 {
-                debug!(
-                    "🔗 SharedServices: registered {} catalog-resolved index location(s) with AXIS (migrate={})",
-                    registered, migrate
-                );
-            }
+            axis_manager_inner.set_index_location_resolver(Arc::new(
+                crate::catalog::index_location_resolver::CatalogIndexLocationResolver::new(
+                    catalog_manager.clone(),
+                    migrate,
+                ),
+            ));
         }
 
         let axis_manager = Arc::new(axis_manager_inner);


### PR DESCRIPTION
Closes the runtime gap the boot adapter (#125) couldn't: catalog-resolved index locations now cover **runtime-created** collections, not just those present at boot. Implements `CATALOG_OBJECT_MODEL` open-Q #3 as a **dependency-inverted, memoized read-port** (the approved robust design).

### Changes
- **Catalog-free trait** `IndexLocationResolver { resolve(collection_id) -> Option<String> }` (AXIS-owned). AXIS depends only on this trait, never on `proximadb-catalog` — the dependency is inverted.
- **AXIS**: the index-location override map becomes an interior-mutable **memo** (`Arc<RwLock<HashMap>>`); `set_index_location` is now `&self`/async; new `set_index_location_resolver` injects the port. `index_fs_and_path` resolves **memo → resolver (lazy pull, memoized) → `index_persist_url`/`dir` convention** — resolver consulted at most once per collection.
- **Adapter** `CatalogIndexLocationResolver` (control layer) implements the trait via `resolve_table → get_namespace + get_table → ann_index_locations` — the same rule the boot adapter used. Lives in the control layer so the index/storage plane stays catalog-free.
- **shared_services** injects the adapter at boot, **replacing the eager enumeration** — one uniform lazy mechanism for boot-present *and* runtime-created collections. `PROXIMADB_INDEX_CATALOG_PATHS=1` still opts into the DrPath migration.

**Default-off and additive:** with no projection locations set the resolver returns `None` and AXIS keeps the convention (mixed-safe).

### Verification
`read_port_resolves_index_location_lazily_and_memoizes` (≤1 pull/collection), `read_port_none_falls_back_to_convention`, plus the existing explicit-location precedence test — all pass. `cargo fmt --all`; leaf + root `clippy` clean; `CARGO_INCREMENTAL=0`.

### Next
#4 per-projection tiering (`tier` field on `CatalogProjection`) rides on this; auto tier→bucket deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)