### PR TITLE
fix(rest): un-deprecate /api/v2/query — it's UQL/federated, not SQL

### DIFF
--- a/src/network/rest/v2/query.rs
+++ b/src/network/rest/v2/query.rs
@@ -60,10 +60,11 @@ fn json_to_proxima_values(params: Option<Vec<serde_json::Value>>) -> Option<Vec<
 
 /// POST /api/v2/query
 ///
-/// DEPRECATED: SQL over REST is deprecated. pgwire (the PostgreSQL wire
-/// protocol) is the canonical SQL surface — connect any PostgreSQL driver and
-/// run SQL there. REST owns record/vector/collection operations, not SQL. This
-/// endpoint will be removed in a future release (see TD-121).
+/// The canonical unified query surface: UQL (unified multi-modal), federated SQL
+/// extensions, and AQL. This is NOT plain SQL-over-REST and is NOT deprecated:
+/// pgwire is the canonical *SQL* surface, but UQL/AQL are non-SQL languages that
+/// pgwire cannot serve, so this endpoint is their canonical home. (TD-121 retires
+/// only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
 pub async fn execute_query(
     State(state): State<AppState>,
     Json(request): Json<QueryRequest>,


### PR DESCRIPTION
Reverts an over-reach from #122. The v2 query endpoint `execute_query` was marked *"DEPRECATED → use pgwire"*, but it dispatches on `QueryLanguage::{Uql, Aql, Federated}` (the unified multi-modal query port via `UQLParser`) — **not plain SQL**. pgwire is SQL-only and **cannot** serve UQL/AQL, so the comment was misleading.

- **`/api/v2/query`** = canonical home for the non-SQL languages (UQL / federated SQL extensions / AQL) — stays.
- **pgwire** = canonical SQL surface.
- **TD-121** retires only the plain-SQL gRPC `ExecuteQuery` (`execute_sql_v1`) path; that deprecation stands.

Comment-only change; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)