### PR TITLE
chore(governance): block AI-agent authorship attribution in commit/PR text

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Block AI-agent authorship attribution in commit messages.
+# The human drives the code, not the agents (Claude/Codex/Gemini/Copilot/...).
+# Active when core.hooksPath=.githooks (set by scripts/worktree.sh and documented
+# in docs/10-quality/WORKSPACE_ISOLATION.md). Bypass once with `git commit --no-verify`.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+checker="$root/scripts/check_no_agent_attribution.py"
+
+# Fail open only if the checker is missing (older checkouts); otherwise enforce.
+if [ -f "$checker" ]; then
+  exec python3 "$checker" --message-file "$1"
+fi

--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -34,6 +34,24 @@ jobs:
       with:
         python-version: '3.x'
 
+    # The human drives the code, not the agents: block AI-agent authorship
+    # attribution (co-author trailers, "Generated with ...", robot emoji, agent
+    # signatures) in commit messages and the PR title/body (the latter becomes the
+    # squash-merge commit message). Mirrors the local `.githooks/commit-msg` hook.
+    - name: Block AI-agent attribution (commit messages + PR text)
+      if: github.event_name == 'pull_request'
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
+        if git rev-parse "origin/${{ github.base_ref }}" >/dev/null 2>&1; then
+          python3 scripts/check_no_agent_attribution.py --range "origin/${{ github.base_ref }}..HEAD"
+        else
+          echo "::warning::base ref unavailable; skipping commit-range attribution check"
+        fi
+        printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | python3 scripts/check_no_agent_attribution.py --stdin
+
     - name: Run layering validation
       run: |
         chmod +x scripts/check-layering.sh

--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -68,6 +68,16 @@ the full `make test` (a dependent in another crate won't be picked up).
 drift — no compile, so it stays quick. Activate manually in an existing clone
 with `git config core.hooksPath .githooks`; bypass once with `git push --no-verify`.
 
+**Commit-msg hook (no agent attribution).** `.githooks/commit-msg` (same
+`core.hooksPath`) rejects AI-agent authorship attribution in commit messages —
+co-author trailers naming an agent, "Generated with ..." taglines, the robot
+emoji, and agent signatures (e.g. "Claude Opus", "Claude Code"). The human drives
+the code, not the agents. Mere mentions of `CLAUDE.md`/`GEMINI.md` or the
+Anthropic/OpenAI APIs are fine — only attribution is blocked. The same check runs
+in CI (`layering-check.yml`) over PR commits and the PR title/body (which becomes
+the squash-merge message); logic lives in `scripts/check_no_agent_attribution.py`.
+Bypass a single commit with `git commit --no-verify`.
+
 ## Lifecycle
 
 ```

--- a/scripts/check_no_agent_attribution.py
+++ b/scripts/check_no_agent_attribution.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Block AI-agent authorship attribution in commit messages and PR text.
+
+Policy (the human drives the code, not the agents): commit titles/bodies and PR
+title/body must not carry AI-agent *authorship attribution* — co-author trailers
+naming an agent, "Generated with ..." taglines, the robot emoji, agent-email
+trailers, or agent signature strings (e.g. "Claude Opus 4.8", "Claude Code",
+"Gemini Pro").
+
+This targets *attribution*, not mere mention: legitimate references such as the
+`CLAUDE.md`/`GEMINI.md`/`AGENTS.md` rule files or integrating the Anthropic/OpenAI
+APIs are allowed. Adjust FORBIDDEN_PATTERNS if you want a stricter bare-word rule.
+
+Modes:
+  --message-file <path>   check a single commit message file (commit-msg hook)
+  --range <base>..<head>  check every commit message in the range (CI)
+  --stdin                 check text read from stdin (e.g. PR title+body)
+
+Exit 0 = clean, 1 = violation(s) found, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# Case-insensitive attribution patterns. Each entry: (compiled regex, human label).
+_AGENTS = r"claude|codex|gemini|copilot|chatgpt|gpt-\d|anthropic|openai|bard|llm"
+FORBIDDEN_PATTERNS = [
+    (re.compile(rf"^\s*co-authored-by:.*(?:{_AGENTS})", re.I | re.M),
+     "co-author trailer naming an AI agent"),
+    (re.compile(r"generated\s+with\s+\[?\s*(?:claude|codex|gemini|copilot|chatgpt)", re.I),
+     '"Generated with <agent>" tagline'),
+    (re.compile(r"🤖"),
+     "robot emoji (agent-generated marker)"),
+    (re.compile(r"(?:authored|written|created|generated|produced)\s+by\s+(?:claude|codex|gemini|copilot|chatgpt|anthropic|openai)", re.I),
+     '"<verb> by <agent>" attribution'),
+    (re.compile(r"\b(?:claude|gemini)\s+(?:opus|sonnet|haiku|code|pro|flash|\d)", re.I),
+     "agent model/product signature (e.g. 'Claude Opus', 'Claude Code')"),
+    (re.compile(r"noreply@anthropic\.com|noreply@openai\.com|@users\.noreply\.github\.com.*(?:claude|copilot)", re.I),
+     "agent no-reply email trailer"),
+    (re.compile(r"\bco-authored-by:\s*(?:claude|copilot|codex)\b", re.I),
+     "agent co-author trailer"),
+]
+
+
+def scan(text: str, source: str) -> list[str]:
+    """Return a list of violation descriptions for the given text."""
+    violations: list[str] = []
+    for rx, label in FORBIDDEN_PATTERNS:
+        for m in rx.finditer(text):
+            line = m.group(0).strip().replace("\n", " ")
+            violations.append(f"{source}: {label} -> '{line[:120]}'")
+    return violations
+
+
+def commit_messages_in_range(rng: str) -> list[tuple[str, str]]:
+    """Return [(sha, message)] for each commit in the range."""
+    out = subprocess.run(
+        ["git", "rev-list", "--no-merges", rng],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    msgs = []
+    for sha in out:
+        msg = subprocess.run(
+            ["git", "log", "-1", "--format=%B", sha],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        msgs.append((sha, msg))
+    return msgs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--message-file")
+    g.add_argument("--range")
+    g.add_argument("--stdin", action="store_true")
+    args = ap.parse_args()
+
+    violations: list[str] = []
+    if args.message_file:
+        with open(args.message_file, encoding="utf-8", errors="replace") as fh:
+            violations += scan(fh.read(), "commit message")
+    elif args.stdin:
+        violations += scan(sys.stdin.read(), "PR title/body")
+    else:
+        try:
+            for sha, msg in commit_messages_in_range(args.range):
+                violations += scan(msg, f"commit {sha[:9]}")
+        except subprocess.CalledProcessError as exc:
+            print(f"error: could not read commit range '{args.range}': {exc}", file=sys.stderr)
+            return 2
+
+    if violations:
+        print("ERROR: AI-agent authorship attribution is not allowed in commit/PR text.", file=sys.stderr)
+        print("The human drives the code; remove the agent attribution below:\n", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        print("\n(Mentions of CLAUDE.md/GEMINI.md or the Anthropic/OpenAI APIs are fine; "
+              "this blocks authorship attribution only. See scripts/check_no_agent_attribution.py.)",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
The human drives the code, not the agents. This adds a guard that rejects AI-agent **authorship attribution** in commit messages and PR text — co-author trailers naming an agent, "Generated with ..." taglines, the robot emoji, agent no-reply email trailers, and agent model/product signature strings.

It targets *attribution only*: mentions of the `CLAUDE.md`/`GEMINI.md`/`AGENTS.md` rule files or integrating vendor APIs are allowed (no false positives).

## Changes
- `scripts/check_no_agent_attribution.py` — reusable checker (`--message-file` / `--range` / `--stdin`).
- `.githooks/commit-msg` — local enforcement, active via the existing `core.hooksPath=.githooks` that `scripts/worktree.sh` already sets.
- `.github/workflows/layering-check.yml` — CI enforcement on PRs over the commit range and the PR title/body (the latter becomes the squash-merge commit message).
- `docs/10-quality/WORKSPACE_ISOLATION.md` — documents the hook + `--no-verify` bypass.

## Validation
Checker verified against clean and attribution-bearing samples (co-author trailer, "Generated with", robot emoji, "<verb> by <agent>", model signatures) and against rule-file / vendor-API mentions (no false positives). The hook self-validated this PR's own commit.