### PR TITLE
fix(ci): attribution guard checks PR title/body only, not commit range

### DIFF
--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -36,20 +36,18 @@ jobs:
 
     # The human drives the code, not the agents: block AI-agent authorship
     # attribution (co-author trailers, "Generated with ...", robot emoji, agent
-    # signatures) in commit messages and the PR title/body (the latter becomes the
-    # squash-merge commit message). Mirrors the local `.githooks/commit-msg` hook.
-    - name: Block AI-agent attribution (commit messages + PR text)
+    # signatures) in the PR title/body. The repo squash-merges, so the PR
+    # title/body IS the commit message that lands on the branch — that is the
+    # surface to enforce. Per-commit messages are checked locally by the
+    # `.githooks/commit-msg` hook; CI does NOT scan the commit range, since on a
+    # promotion PR that range contains pre-policy historical commits and would
+    # block the merge over messages that never land.
+    - name: Block AI-agent attribution (PR title/body)
       if: github.event_name == 'pull_request'
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
-        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
-        if git rev-parse "origin/${{ github.base_ref }}" >/dev/null 2>&1; then
-          python3 scripts/check_no_agent_attribution.py --range "origin/${{ github.base_ref }}..HEAD"
-        else
-          echo "::warning::base ref unavailable; skipping commit-range attribution check"
-        fi
         printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | python3 scripts/check_no_agent_attribution.py --stdin
 
     - name: Run layering validation


### PR DESCRIPTION
## Summary
Follow-up to the attribution guard (#131). The repo **squash-merges**, so the PR title/body becomes the commit that lands — that is the surface CI should enforce. The previous CI step also scanned the full commit range, which would **falsely block every promotion PR**: a develop→qa or qa→main range includes pre-policy historical commits whose messages carry attribution but never land (squash discards per-commit messages).

## Change
- `layering-check.yml`: the attribution check now validates only the PR title/body (the squash-merge message). The commit-range scan is removed.
- Per-commit enforcement is retained locally via `.githooks/commit-msg` for anyone who wants it in their own history.

## Why now
Without this, the next develop→qa/qa→main promotion would fail CI on historical attributed commits that never reach the target branch.