### PR TITLE
docs(design): SDK modularization + spec-driven generation strategy (TD-126)

### DIFF
--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -115,6 +115,13 @@ Read these in order for future-shaping architecture work:
    (graph/event/audit as first-class layouts). The macro generalization of tenant catalog-resolution.
    Subordinate to the 2026-06-04 course correction and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 
+20. `SDK_MODULARIZATION_AND_SPEC_DRIVEN_GENERATION_2026_06_21.adoc` +
+   Stop hand-rolling clients: make the OpenAPI spec `utoipa`-generated from the REST handlers,
+   generate transport+models per shape (OpenAPI for REST, proto/buf for gRPC) behind a thin
+   hand-written ergonomic facade, and split the kitchen-sink per-language packages (e.g. Python's
+   ~86k `proximadb_sdk`, of which the wire client is only ~19k) into focused, opt-in packages
+   (core client / chunking / embeddings / integrations). Tracked as TD-126.
+
 == Stable Reference Docs
 
 * `ARCHITECTURE_ATLAS_2026_05_22.adoc` - top-down OSS/SaaS architecture map, workspace map, and

--- a/docs/12-design/SDK_MODULARIZATION_AND_SPEC_DRIVEN_GENERATION_2026_06_21.adoc
+++ b/docs/12-design/SDK_MODULARIZATION_AND_SPEC_DRIVEN_GENERATION_2026_06_21.adoc
@@ -1,0 +1,136 @@
+= SDK Modularization and Spec-Driven Generation
+:toc:
+:toclevels: 3
+:sectnums:
+
+Status: Proposed (design) +
+Date: 2026-06-21 +
+Owner: SDK / API surface +
+Tracking: TD-126
+
+== Problem
+
+The ProximaDB client surface is hand-maintained three times over and bundled into monolithic
+per-language packages. Two compounding issues:
+
+. *Triple hand-maintenance of the REST contract.* The axum REST handlers, the OpenAPI spec
+  (`docs/openapi/proximadb-openapi.yaml`, hand-edited — there is no `utoipa` generation), and each
+  hand-written SDK are kept in sync only by per-SDK `openapi_contract` tests that catch drift late.
+  Adding a language means hand-writing a new SDK.
+. *Kitchen-sink SDK packages.* The Python `proximadb_sdk` package is ~86k LOC in `src/`, but the
+  actual wire client is a minority of it; the bulk is unrelated value-add libraries that drag heavy
+  dependencies into `pip install proximadb`.
+
+This is the maintenance tax the co-design mandate warns against: optimize across the
+spec↔client boundary, not within one hand-rolled layer.
+
+== Current state (grounded, 2026-06-21)
+
+* *9 SDK variants*: `go`, `jvm`/`java`, `nodejs`, `python`, `rust`, plus four `*-embedded`.
+* *OpenAPI spec exists but is hand-maintained*: `docs/openapi/proximadb-openapi.yaml`, OpenAPI 3.1,
+  v2-first, 37 operations, ~1709 LOC. Used for *contract testing*, not *generation*. No
+  `openapi-generator` config in the repo.
+* *gRPC stubs are generated* (protoc / `tonic-prost-build`); the SDK wraps them by hand.
+* *Python `proximadb_sdk` composition* (~86k `src/` LOC; tests are a separate 120k, examples 7.6k):
+
+[cols="2,1,3"]
+|===
+| Concern | LOC | Belongs in the wire client?
+
+| Wire client (protocols + generated stubs + builders + v2 models)
+| ~19k
+| Yes — the only spec-driven part
+| Document/code chunking (`chunking_strategies`, tree-sitter)
+| 9.4k
+| No — a text-processing library
+| Embedding providers (`embedding_providers` + `llm`, sentence-transformers/onnx)
+| 7.6k
+| No — an embedding toolkit
+| Framework integrations (`integrations` + `adapters`, LangChain/LlamaIndex/MLOps)
+| ~10k
+| No — framework adapters
+|===
+
+The in-process embedded server is already a *separate* package (`clients/python-embedded`,
+maturin/FFI); it is not part of the 86k and is out of scope for spec generation.
+
+== Strategy
+
+Generate the plumbing, hand-write the ergonomics, and split concerns into focused packages so the
+client core can be strictly spec-driven and lightweight.
+
+=== 1. Make the spec generated, not hand-maintained (foundational)
+
+Annotate the axum handlers with *`utoipa`* and emit `proximadb-openapi.yaml` from the code; gate CI
+on drift. This removes one hand-maintained representation and eliminates server↔spec divergence —
+the spec can no longer lie. Everything else depends on a trustworthy spec.
+
+=== 2. Generate the transport + models layer per shape
+
+[cols="1,2,2"]
+|===
+| Shape | Source of truth | Generator
+
+| REST | `proximadb-openapi.yaml` (utoipa-emitted) | `openapi-generator` (or `openapi-ts`, `oapi-codegen`, `openapi-python-client`)
+| gRPC | `.proto` | protoc / `buf` (already generated)
+| Arrow Flight | Arrow schema | Arrow codegen
+| pgwire (SQL) | — | not generated; clients use a standard PostgreSQL driver
+|===
+
+=== 3. Keep a thin hand-written ergonomic facade
+
+Generators do not do ergonomics well. A small hand-written layer over the generated transports
+owns: connection pooling, retries, the locality-aware compression default
+(see `OUTGRESS_KOU_MULTICLOUD_COST_MODEL`), auth + `TenantContext`, and the idiomatic per-language
+API shape. Rule: *generate the plumbing, hand-write the ergonomics* — not all-or-nothing.
+
+=== 4. Modularize the per-language packages by concern
+
+Split the kitchen sink into independently versioned, installable packages (Python shown; mirror
+for other languages):
+
+[cols="2,3,2"]
+|===
+| Package | Contains | Dependencies
+
+| `proximadb` (core client) | Generated REST + gRPC transport + thin ergonomic facade | httpx/grpcio only — lightweight
+| `proximadb-chunking` | document/code chunking | tree-sitter
+| `proximadb-embeddings` | embedding providers | sentence-transformers/onnx
+| `proximadb-langchain` / `-llamaindex` | framework adapters (depend on core) | langchain / llama-index
+| `proximadb-embedded` | in-process FFI server (already separate) | maturin/pyo3
+|===
+
+Expose as extras (`pip install proximadb[chunking,langchain]`) so the default install is thin and
+heavy concerns are opt-in. Separating concerns is what *makes* the spec-driven core feasible: today
+the generate-able client is buried inside the monolith and cannot be cleanly regenerated.
+
+== LLM's bounded role
+
+Deterministic generation (openapi-generator / buf) owns the contract-bound transport + models —
+LLM codegen there reintroduces the drift and hallucinated-API risk we are eliminating. LLMs are
+appropriate for the *thin ergonomic layer*: porting it to a new language, examples, and migration.
+Set the bar at the generated contract, not the demo.
+
+== Caveats
+
+* The `*-embedded` SDKs bind an in-process server via FFI; they are not REST/gRPC and cannot be
+  spec-generated. They stay hand-written.
+* The win is scoped to the transport + DTO slice. Much of the Python tree is chunking/embeddings/
+  integrations; generation does not erase those — modularization moves them out of the core.
+
+== Sequencing (see TD-126)
+
+. `utoipa` spec-from-code + CI drift gate (foundational).
+. Pilot one SDK leg (e.g. TypeScript REST via `openapi-ts`): generated plumbing + hand-written
+  ergonomic wrapper. Prove the split.
+. Modularize Python: extract `chunking` / `embeddings` / `integrations` into separate packages;
+  reduce the core to generated transport + facade.
+. Roll out generation to the other network SDKs; retire now-redundant contract tests.
+. `buf`-ify the gRPC codegen; thin the wrappers.
+
+== Related
+
+* `OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc` — the locality-aware compression default the
+  ergonomic facade owns.
+* `docs/SUPPORTED_SURFACE.adoc` — query-surface taxonomy (pgwire vs `/api/v2/query` vs graph); the
+  SDK core wraps these canonical surfaces.

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -1,0 +1,55 @@
+= TD-126 Spec-driven, modular SDKs (stop hand-rolling the client surface)
+:toc:
+:toclevels: 3
+:sectnums:
+
+Status: Open / proposed +
+Date: 2026-06-21 +
+Owner: SDK / API surface
+
+== Context
+
+The client surface is hand-maintained three times (axum REST handlers, the hand-edited
+`docs/openapi/proximadb-openapi.yaml`, and N hand-written SDKs, linked only by `openapi_contract`
+tests), and the per-language packages are kitchen sinks (Python `proximadb_sdk` is ~86k `src/` LOC,
+of which the actual wire client is ~19k; the rest is chunking/embeddings/integrations). Full
+analysis + rationale: `docs/12-design/SDK_MODULARIZATION_AND_SPEC_DRIVEN_GENERATION_2026_06_21.adoc`.
+
+Goal: the wire client becomes *generated from a single source of truth per shape* (OpenAPI for
+REST, proto for gRPC) plus a thin hand-written ergonomic facade; the value-add libraries
+(chunking, embeddings, integrations) move into separate, opt-in packages.
+
+== Work (phased)
+
+. *Spec-from-code (foundational).* Add `utoipa` annotations to the REST handlers; emit
+  `proximadb-openapi.yaml` from the build; add a CI gate that fails on spec↔code drift. Removes the
+  hand-maintained spec copy.
+. *Pilot one generated SDK leg.* Pick one language (e.g. TypeScript REST via `openapi-ts`, or Go via
+  `oapi-codegen`): generate the transport + models, keep a thin hand-written ergonomic wrapper
+  (pooling/retries/locality-gzip/auth). Validate parity against the existing contract tests.
+. *Modularize Python.* Extract `chunking_strategies` -> `proximadb-chunking`, `embedding_providers`
+  + `llm` -> `proximadb-embeddings`, `integrations` + `adapters` -> `proximadb-langchain` /
+  `proximadb-llamaindex`. Reduce `proximadb` (core) to generated transport + facade with light deps;
+  expose the rest as extras.
+. *Roll out generation* to the remaining network SDKs (go, jvm, rust); retire the now-redundant
+  per-SDK contract tests (generation guarantees conformance).
+. *gRPC via `buf`.* Standardize proto -> stub codegen on `buf`; thin the hand-written gRPC wrappers.
+
+== Scope / non-goals
+
+* The `*-embedded` SDKs (maturin/FFI in-process) are NOT spec-generated — they stay hand-written.
+* pgwire (SQL) is not an SDK we generate — clients use a standard PostgreSQL driver.
+* This does not change wire behavior; it changes how the client code is produced and packaged.
+
+== Acceptance
+
+* `proximadb-openapi.yaml` is generated from the handlers with a CI drift gate (no hand edits).
+* At least one network SDK's transport + models are generated, behind a thin ergonomic facade,
+  passing the existing contract tests.
+* The Python core install is lightweight (no tree-sitter/onnx/langchain in the default dependency
+  set); chunking/embeddings/integrations are separate installable packages/extras.
+
+== Related
+
+* TD-121 (retire plain-SQL gRPC `ExecuteQuery` -> pgwire) — narrows the gRPC surface the SDK wraps.
+* `docs/SUPPORTED_SURFACE.adoc` query-surface taxonomy — the canonical surfaces the SDK core wraps.


### PR DESCRIPTION
Captures (as a design doc + TD-126) the strategy for retiring hand-rolled SDKs:

- **Problem**: REST contract hand-maintained 3× (handlers / hand-edited OpenAPI yaml / N SDKs, linked only by contract tests); kitchen-sink packages (Python `proximadb_sdk` ~86k src, wire client only ~19k — rest is chunking/embeddings/integrations dragging heavy deps).
- **Strategy**: (1) `utoipa` spec-from-code + CI drift gate; (2) generate transport+models per shape — OpenAPI for REST, proto/`buf` for gRPC — behind a thin hand-written ergonomic facade; (3) split per-language packages into focused, opt-in modules (core client / chunking / embeddings / integrations).
- **Scope**: `*-embedded` (maturin/FFI) and pgwire are out of scope; LLM codegen is bounded to the ergonomic veneer, not the contract-bound plumbing.

Docs-only: new design doc, `roadmap/techdebt/TD_126…`, and README index entry #20. Renders clean.