### PR TITLE
feat(catalog): TD-122 — persist detailed index/quantization config in collection catalog

### DIFF
--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2224,6 +2224,21 @@ impl CollectionService {
             })
             .collect();
 
+        // TD-122: prefer the neutral per-index/quant blob when present so the
+        // detailed HNSW/IVF params, is_primary, and quantization survive the
+        // round-trip. Legacy collections persisted before this lack the blob and
+        // keep the coarse reconstruction above (mixed-read-safe).
+        if let Some(json) = schema.properties.get("collection.index_config") {
+            let restored = crate::storage::metadata::catalog_config::index_configs_from_json(json);
+            if !restored.is_empty() {
+                config.index_configs = restored;
+            }
+        }
+        if let Some(json) = schema.properties.get("collection.quantization") {
+            config.quantization =
+                crate::storage::metadata::catalog_config::quantization_from_json(json);
+        }
+
         let location = schema
             .storage_layouts
             .first()
@@ -2455,6 +2470,24 @@ impl CollectionService {
                     // Unspecified / Fp32 / unknown all map to the legacy default
                     _ => proximadb_records::EmbeddingScalarType::Fp32,
                 };
+        }
+
+        // TD-122: persist the detailed per-index (HNSW m/ef, IVF n_lists/n_probe,
+        // is_primary) and quantization (enabled, strategy) config in a neutral,
+        // wire-independent form so GetCollection echoes back what CreateCollection
+        // set. The CatalogIndex entries above only carry the index identity/type;
+        // these JSON blobs carry the tuning knobs the catalog schema can't model.
+        if let Some(json) = crate::storage::metadata::catalog_config::index_configs_to_json(config)?
+        {
+            schema
+                .properties
+                .insert("collection.index_config".to_string(), json);
+        }
+        if let Some(json) = crate::storage::metadata::catalog_config::quantization_to_json(config)?
+        {
+            schema
+                .properties
+                .insert("collection.quantization".to_string(), json);
         }
 
         Ok(schema)
@@ -3318,6 +3351,80 @@ mod tests {
 
         assert!(response.success);
         assert_eq!(response.processing_time_us, 1000);
+    }
+
+    /// TD-122: the detailed per-index (HNSW m/ef, IVF n_lists/n_probe,
+    /// is_primary) and quantization (enabled, strategy) config must survive a
+    /// round-trip through the read-authoritative xCatalog table asset. Before
+    /// the fix this reconstruction returned `m=0`, `is_primary=false`, and
+    /// quantization disabled.
+    #[test]
+    fn catalog_asset_round_trips_detailed_index_and_quant_config() {
+        use crate::proto::proximadb_v1::{
+            Collection, HnswConfig, IndexConfig, IvfConfig, QuantizationConfig, StorageAssignment,
+            quantization_config::Strategy,
+        };
+
+        let collection = Collection {
+            id: "col-td122".to_string(),
+            config: Some(CollectionConfig {
+                name: "td122_round_trip".to_string(),
+                dimension: 128,
+                index_configs: vec![IndexConfig {
+                    index_name: "primary_hnsw".to_string(),
+                    hnsw_config: Some(HnswConfig {
+                        m: Some(24),
+                        ef_construction: Some(150),
+                        ef_search: Some(64),
+                        ..Default::default()
+                    }),
+                    ivf_config: Some(IvfConfig {
+                        n_lists: Some(256),
+                        n_probe: Some(16),
+                        ..Default::default()
+                    }),
+                    is_primary: Some(true),
+                    ..Default::default()
+                }],
+                quantization: Some(QuantizationConfig {
+                    enabled: Some(true),
+                    strategy: Some(Strategy::Aggressive as i32),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                primary_path: "file:///tmp/td122".to_string(),
+                base_location: "file:///tmp/td122".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let schema = CollectionService::catalog_schema_from_collection(&collection)
+            .expect("schema from collection");
+        let identifier = CollectionService::collection_table_identifier(
+            collection.config.as_ref().expect("config"),
+        );
+        let restored = CollectionService::collection_from_catalog_schema(&identifier, &schema)
+            .expect("collection from schema")
+            .expect("collection present");
+
+        let config = restored.config.expect("restored config");
+        assert_eq!(config.index_configs.len(), 1, "one ANN index retained");
+        let ic = &config.index_configs[0];
+        assert_eq!(ic.index_name, "primary_hnsw");
+        assert_eq!(ic.is_primary, Some(true));
+        let hnsw = ic.hnsw_config.as_ref().expect("hnsw config restored");
+        assert_eq!(hnsw.m, Some(24));
+        assert_eq!(hnsw.ef_construction, Some(150));
+        assert_eq!(hnsw.ef_search, Some(64));
+        let ivf = ic.ivf_config.as_ref().expect("ivf config restored");
+        assert_eq!(ivf.n_lists, Some(256));
+        assert_eq!(ivf.n_probe, Some(16));
+        let quant = config.quantization.as_ref().expect("quantization restored");
+        assert_eq!(quant.enabled, Some(true));
+        assert_eq!(quant.strategy, Some(Strategy::Aggressive as i32));
     }
 }
 

--- a/src/storage/metadata/atomic.rs
+++ b/src/storage/metadata/atomic.rs
@@ -333,6 +333,17 @@ impl AtomicMetadataStore {
         for operation in &transaction.operations {
             match operation {
                 MetadataOperation::CreateCollection(collection) => {
+                    let mut config_map = std::collections::HashMap::new();
+                    if let Some(c) = collection.config.as_ref() {
+                        config_map.insert("dimension".to_string(), serde_json::json!(c.dimension));
+                        if let Some(dm) = c.distance_metric {
+                            config_map.insert("distance_metric".to_string(), serde_json::json!(dm));
+                        }
+                        if let Some(se) = c.storage_engine {
+                            config_map.insert("storage_engine".to_string(), serde_json::json!(se));
+                        }
+                        super::catalog_config::write_index_and_quant(c, &mut config_map)?;
+                    }
                     let versioned = VersionedCollectionMetadata {
                         id: collection.id.clone(),
                         name: collection
@@ -360,21 +371,7 @@ impl AtomicMetadataStore {
                             .stats
                             .as_ref()
                             .map_or(0, |s| s.data_size_bytes as u64),
-                        config: collection
-                            .config
-                            .as_ref()
-                            .map(|c| {
-                                let mut m = std::collections::HashMap::new();
-                                m.insert("dimension".to_string(), serde_json::json!(c.dimension));
-                                if let Some(dm) = c.distance_metric {
-                                    m.insert("distance_metric".to_string(), serde_json::json!(dm));
-                                }
-                                if let Some(se) = c.storage_engine {
-                                    m.insert("storage_engine".to_string(), serde_json::json!(se));
-                                }
-                                m
-                            })
-                            .unwrap_or_default(),
+                        config: config_map,
                         description: None,
                         tags: Vec::new(),
                         owner: None,
@@ -467,6 +464,12 @@ impl AtomicMetadataStore {
                         dimension: versioned_metadata.dimension as u32,
                         distance_metric: Some(distance_metric_val),
                         storage_engine: Some(storage_engine_val),
+                        index_configs: super::catalog_config::read_index_configs(
+                            &versioned_metadata.config,
+                        ),
+                        quantization: super::catalog_config::read_quantization(
+                            &versioned_metadata.config,
+                        ),
                         ..Default::default()
                     }),
                     stats: Some(crate::proto::proximadb_v1::CollectionStats {
@@ -697,6 +700,8 @@ impl MetadataStoreInterface for AtomicMetadataStore {
 
         // Read from write buffer manager (which handles caching)
         if let Some(versioned) = self.write_buffer_manager.collection(collection_id).await? {
+            let index_configs = super::catalog_config::read_index_configs(&versioned.config);
+            let quantization = super::catalog_config::read_quantization(&versioned.config);
             let collection = crate::proto::proximadb_v1::Collection {
                 id: versioned.id,
                 config: Some(crate::proto::proximadb_v1::CollectionConfig {
@@ -705,6 +710,8 @@ impl MetadataStoreInterface for AtomicMetadataStore {
                     distance_metric: Some(
                         crate::proto::proximadb_v1::DistanceMetric::Cosine as i32,
                     ), // Default for now
+                    index_configs,
+                    quantization,
                     ..Default::default()
                 }),
                 stats: Some(crate::proto::proximadb_v1::CollectionStats {
@@ -805,6 +812,8 @@ impl MetadataStoreInterface for AtomicMetadataStore {
                         distance_metric: Some(
                             crate::proto::proximadb_v1::DistanceMetric::Cosine as i32,
                         ), // Default for now
+                        index_configs: super::catalog_config::read_index_configs(&versioned.config),
+                        quantization: super::catalog_config::read_quantization(&versioned.config),
                         ..Default::default()
                     }),
                     stats: Some(crate::proto::proximadb_v1::CollectionStats {

--- a/src/storage/metadata/catalog_config.rs
+++ b/src/storage/metadata/catalog_config.rs
@@ -1,0 +1,320 @@
+//! Neutral, wire-independent persistence of per-index and quantization config.
+//!
+//! The collection catalog drops everything except the coarse shape (dimension,
+//! distance metric, storage engine) when it serializes a collection, so a
+//! `GetCollection` after `CreateCollection` returned `m=0`, `is_primary=false`,
+//! and quantization disabled even though the request set them (TD-122). This
+//! affects both persistence layers:
+//!
+//! * the `MetadataStore` WAL bag (`HashMap<String, serde_json::Value>`), and
+//! * the xCatalog table-asset properties bag (`HashMap<String, String>`), which
+//!   is the read-authoritative source on the live (catalog-backed) path.
+//!
+//! Rather than serialize the v1 wire protos straight into storage (which would
+//! couple the internal catalog to a frozen wire type), we persist small
+//! **neutral** structs owned by the storage layer. The v1 proto types appear
+//! only at the read boundary, where the rest of the catalog pipeline still
+//! consumes them — the *stored* representation stays decoupled from the wire.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::proto::proximadb_v1::{
+    CollectionConfig, HnswConfig, IndexConfig, IvfConfig, QuantizationConfig,
+};
+
+/// Catalog-bag key holding the neutral per-index config array.
+pub const INDEX_CONFIGS_KEY: &str = "index_configs";
+/// Catalog-bag key holding the neutral quantization config.
+pub const QUANTIZATION_KEY: &str = "quantization";
+
+/// Neutral HNSW parameters retained across a catalog round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoredHnsw {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    m: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ef_construction: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ef_search: Option<u32>,
+}
+
+/// Neutral IVF parameters retained across a catalog round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoredIvf {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    n_lists: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    n_probe: Option<u32>,
+}
+
+/// Neutral per-index config retained across a catalog round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoredIndex {
+    index_name: String,
+    /// v1 `IndexingAlgorithm` enum value (a stable scalar, not a wire message).
+    algorithm: i32,
+    #[serde(default)]
+    is_primary: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    hnsw: Option<StoredHnsw>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ivf: Option<StoredIvf>,
+}
+
+/// Neutral quantization config retained across a catalog round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoredQuant {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    /// v1 `QuantizationConfig.Strategy` enum value (a stable scalar).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    strategy: Option<i32>,
+}
+
+// --- wire <-> neutral conversions (the only place the v1 proto is touched) ---
+
+fn to_stored_indexes(config: &CollectionConfig) -> Vec<StoredIndex> {
+    config
+        .index_configs
+        .iter()
+        .map(|ic| StoredIndex {
+            index_name: ic.index_name.clone(),
+            algorithm: ic.algorithm,
+            is_primary: ic.is_primary.unwrap_or(false),
+            hnsw: ic.hnsw_config.as_ref().map(|h| StoredHnsw {
+                m: h.m,
+                ef_construction: h.ef_construction,
+                ef_search: h.ef_search,
+            }),
+            ivf: ic.ivf_config.as_ref().map(|i| StoredIvf {
+                n_lists: i.n_lists,
+                n_probe: i.n_probe,
+            }),
+        })
+        .collect()
+}
+
+fn from_stored_index(s: StoredIndex) -> IndexConfig {
+    IndexConfig {
+        index_name: s.index_name,
+        algorithm: s.algorithm,
+        hnsw_config: s.hnsw.map(|h| HnswConfig {
+            m: h.m,
+            ef_construction: h.ef_construction,
+            ef_search: h.ef_search,
+            ..Default::default()
+        }),
+        ivf_config: s.ivf.map(|i| IvfConfig {
+            n_lists: i.n_lists,
+            n_probe: i.n_probe,
+            ..Default::default()
+        }),
+        is_primary: Some(s.is_primary),
+        ..Default::default()
+    }
+}
+
+fn to_stored_quant(config: &CollectionConfig) -> Option<StoredQuant> {
+    config.quantization.as_ref().map(|q| StoredQuant {
+        enabled: q.enabled,
+        strategy: q.strategy,
+    })
+}
+
+fn from_stored_quant(s: StoredQuant) -> QuantizationConfig {
+    QuantizationConfig {
+        enabled: s.enabled,
+        strategy: s.strategy,
+        ..Default::default()
+    }
+}
+
+// --- JSON `Value` bag API (MetadataStore WAL) ---
+
+/// Serialize the per-index and quantization config into the neutral `Value`
+/// catalog bag. No-op for fields that are absent.
+pub(crate) fn write_index_and_quant(
+    config: &CollectionConfig,
+    map: &mut HashMap<String, Value>,
+) -> Result<()> {
+    if !config.index_configs.is_empty() {
+        let stored = to_stored_indexes(config);
+        map.insert(
+            INDEX_CONFIGS_KEY.to_string(),
+            serde_json::to_value(&stored)
+                .map_err(|e| anyhow::anyhow!("serialize index_configs for catalog: {e}"))?,
+        );
+    }
+    if let Some(stored) = to_stored_quant(config) {
+        map.insert(
+            QUANTIZATION_KEY.to_string(),
+            serde_json::to_value(&stored)
+                .map_err(|e| anyhow::anyhow!("serialize quantization for catalog: {e}"))?,
+        );
+    }
+    Ok(())
+}
+
+/// Reconstruct the per-index config (as wire `IndexConfig`) from the neutral
+/// `Value` bag. Empty when nothing was persisted; a corrupt entry is ignored.
+pub(crate) fn read_index_configs(map: &HashMap<String, Value>) -> Vec<IndexConfig> {
+    let Some(value) = map.get(INDEX_CONFIGS_KEY) else {
+        return Vec::new();
+    };
+    match serde_json::from_value::<Vec<StoredIndex>>(value.clone()) {
+        Ok(stored) => stored.into_iter().map(from_stored_index).collect(),
+        Err(e) => {
+            tracing::warn!("⚠️ catalog index_configs decode failed, ignoring: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Reconstruct the quantization config (as wire `QuantizationConfig`) from the
+/// neutral `Value` bag, or `None` when nothing was persisted.
+pub(crate) fn read_quantization(map: &HashMap<String, Value>) -> Option<QuantizationConfig> {
+    let value = map.get(QUANTIZATION_KEY)?;
+    match serde_json::from_value::<StoredQuant>(value.clone()) {
+        Ok(stored) => Some(from_stored_quant(stored)),
+        Err(e) => {
+            tracing::warn!("⚠️ catalog quantization decode failed, ignoring: {e}");
+            None
+        }
+    }
+}
+
+// --- JSON-string API (xCatalog table-asset `String` properties bag) ---
+
+/// Serialize the per-index config to a neutral JSON string for the catalog
+/// properties bag, or `None` when there are no indexes to persist.
+pub(crate) fn index_configs_to_json(config: &CollectionConfig) -> Result<Option<String>> {
+    if config.index_configs.is_empty() {
+        return Ok(None);
+    }
+    let stored = to_stored_indexes(config);
+    serde_json::to_string(&stored)
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("serialize index_configs for catalog asset: {e}"))
+}
+
+/// Serialize the quantization config to a neutral JSON string, or `None`.
+pub(crate) fn quantization_to_json(config: &CollectionConfig) -> Result<Option<String>> {
+    match to_stored_quant(config) {
+        Some(stored) => serde_json::to_string(&stored)
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("serialize quantization for catalog asset: {e}")),
+        None => Ok(None),
+    }
+}
+
+/// Reconstruct the per-index config from a neutral JSON string. Empty when the
+/// string is unparseable (legacy/corrupt) so the caller can fall back.
+pub(crate) fn index_configs_from_json(json: &str) -> Vec<IndexConfig> {
+    match serde_json::from_str::<Vec<StoredIndex>>(json) {
+        Ok(stored) => stored.into_iter().map(from_stored_index).collect(),
+        Err(e) => {
+            tracing::warn!("⚠️ catalog-asset index_configs decode failed, ignoring: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Reconstruct the quantization config from a neutral JSON string, or `None`.
+pub(crate) fn quantization_from_json(json: &str) -> Option<QuantizationConfig> {
+    match serde_json::from_str::<StoredQuant>(json) {
+        Ok(stored) => Some(from_stored_quant(stored)),
+        Err(e) => {
+            tracing::warn!("⚠️ catalog-asset quantization decode failed, ignoring: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> CollectionConfig {
+        CollectionConfig {
+            index_configs: vec![IndexConfig {
+                index_name: "primary_hnsw".to_string(),
+                algorithm: 1,
+                hnsw_config: Some(HnswConfig {
+                    m: Some(24),
+                    ef_construction: Some(150),
+                    ef_search: Some(64),
+                    ..Default::default()
+                }),
+                ivf_config: Some(IvfConfig {
+                    n_lists: Some(256),
+                    n_probe: Some(16),
+                    ..Default::default()
+                }),
+                is_primary: Some(true),
+                ..Default::default()
+            }],
+            quantization: Some(QuantizationConfig {
+                enabled: Some(true),
+                strategy: Some(3),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn assert_round_trip(indexes: &[IndexConfig], quant: &Option<QuantizationConfig>) {
+        assert_eq!(indexes.len(), 1);
+        let ic = &indexes[0];
+        assert_eq!(ic.index_name, "primary_hnsw");
+        assert_eq!(ic.is_primary, Some(true));
+        let hnsw = ic.hnsw_config.as_ref().expect("hnsw");
+        assert_eq!(hnsw.m, Some(24));
+        assert_eq!(hnsw.ef_construction, Some(150));
+        assert_eq!(hnsw.ef_search, Some(64));
+        let ivf = ic.ivf_config.as_ref().expect("ivf");
+        assert_eq!(ivf.n_lists, Some(256));
+        assert_eq!(ivf.n_probe, Some(16));
+        let q = quant.as_ref().expect("quant");
+        assert_eq!(q.enabled, Some(true));
+        assert_eq!(q.strategy, Some(3));
+    }
+
+    #[test]
+    fn round_trips_through_value_bag() {
+        let config = sample_config();
+        let mut map = HashMap::new();
+        write_index_and_quant(&config, &mut map).expect("write");
+        assert_round_trip(&read_index_configs(&map), &read_quantization(&map));
+    }
+
+    #[test]
+    fn round_trips_through_json_strings() {
+        let config = sample_config();
+        let idx_json = index_configs_to_json(&config)
+            .expect("idx json")
+            .expect("some");
+        let quant_json = quantization_to_json(&config)
+            .expect("quant json")
+            .expect("some");
+        assert_round_trip(
+            &index_configs_from_json(&idx_json),
+            &quantization_from_json(&quant_json),
+        );
+    }
+
+    #[test]
+    fn empty_config_persists_nothing() {
+        let config = CollectionConfig::default();
+        let mut map = HashMap::new();
+        write_index_and_quant(&config, &mut map).expect("write");
+        assert!(map.is_empty());
+        assert!(read_index_configs(&map).is_empty());
+        assert!(read_quantization(&map).is_none());
+        assert!(index_configs_to_json(&config).expect("idx").is_none());
+        assert!(quantization_to_json(&config).expect("quant").is_none());
+    }
+}

--- a/src/storage/metadata/mod.rs
+++ b/src/storage/metadata/mod.rs
@@ -69,6 +69,7 @@
 pub use crate::storage::transaction_coordinator;
 pub mod atomic;
 pub mod backends;
+pub mod catalog_config;
 pub mod checkpoint;
 // universal_backend moved to backends/universal_backend.rs
 pub mod indexes;

--- a/src/storage/metadata/store.rs
+++ b/src/storage/metadata/store.rs
@@ -468,6 +468,7 @@ impl MetadataStoreInterface for MetadataStore {
                     if let Some(se) = config.storage_engine {
                         m.insert("storage_engine".to_string(), serde_json::json!(se));
                     }
+                    super::catalog_config::write_index_and_quant(config, &mut m)?;
                     m
                 },
                 description: Some(format!("Collection {}", config.name)),
@@ -495,11 +496,11 @@ impl MetadataStoreInterface for MetadataStore {
                     ), // Default
                     storage_engine: Some(crate::proto::proximadb_v1::StorageEngine::Viper as i32), // Default
                     storage_config: None,
-                    index_configs: Vec::new(),
+                    index_configs: super::catalog_config::read_index_configs(&versioned.config),
                     primary_index: Some(String::new()),
                     auto_index_selection: Some(true),
                     filterable_columns: Vec::new(),
-                    quantization: None,
+                    quantization: super::catalog_config::read_quantization(&versioned.config),
                     description: versioned.description.clone(),
                     tags: versioned.tags.clone(),
                     owner: versioned.owner.clone(),
@@ -567,6 +568,7 @@ impl MetadataStoreInterface for MetadataStore {
                     if let Some(se) = config.storage_engine {
                         m.insert("storage_engine".to_string(), serde_json::json!(se));
                     }
+                    super::catalog_config::write_index_and_quant(config, &mut m)?;
                     m
                 },
                 description: Some(format!("Collection {}", config.name)),


### PR DESCRIPTION
## What

Fixes the **TD-122 round-trip gap**: `CreateCollection` accepted detailed per-index params (HNSW `m`/`ef_construction`/`ef_search`, IVF `n_lists`/`n_probe`, `is_primary`) and quantization (`enabled`, `strategy`) and echoed them in the create *response*, but a read-after-create `GetCollection` returned `m=0`, `is_primary=false`, quant disabled. The collection catalog persisted only the coarse shape and zero-filled the rest on read. Pre-existing and surface-agnostic (REST and v1/v2 GET share the gap); **not** introduced by #124.

## Root cause

The read-authoritative path on the live (catalog-backed) server is the **xCatalog table asset**:
- `catalog_schema_from_collection()` built `CatalogIndex` entries carrying only index identity/type — never the tuning knobs, and never quantization.
- `collection_from_catalog_schema()` rebuilt `IndexConfig`s without hnsw/ivf/is_primary and never reconstructed quantization.

The `MetadataStore` WAL backend had the identical drop.

## Approach — neutral internal format, no wire coupling

Per review feedback, the fix does **not** extend or serialize the frozen v1 wire protos into storage. Instead it persists small **neutral** structs owned by the storage layer (new `storage::metadata::catalog_config`). The v1 proto types appear only at the read boundary; the *stored* representation stays decoupled from the wire.

- `catalog_config`: neutral `StoredIndex`/`StoredHnsw`/`StoredIvf`/`StoredQuant` with a JSON-`Value` bag API (MetadataStore WAL) and a JSON-string API (xCatalog `String` properties bag); the single place that maps wire ↔ neutral.
- `manager.rs`: write the neutral index/quant JSON into the table-asset properties on create; on read **prefer the neutral blob**, falling back to the coarse reconstruction for collections persisted before this change (**mixed-read-safe**, per the storage-format-migration mandate).
- `store.rs` / `atomic.rs`: persist + restore the same fields through the MetadataStore WAL bag (all create + reconstruction sites).
- **No v2-surface change** (`collection_to_v2` already correct) and **no v1 proto change**.

## Tests

- Neutral round-trip (Value bag + JSON strings).
- Catalog-asset round-trip asserting `m=24`/`ef_construction=150`/`ef_search=64`, IVF `256`/`16`, `is_primary=true`, quant `enabled`+`aggressive` survive create→get at the exact lossy boundary.
- Touched-module suites green: `services::collection::manager` 8/8, `storage::metadata` 59/59.

## Gates

- `cargo build --lib` + `cargo build -p proximadb-server` clean.
- `cargo fmt --check` 0 diffs; `cargo clippy --lib` clean for changed files.
- Runtime wire-smoke was blocked by a concurrent session holding the default ports (pgwire has no config key to remap); the fix is verified by the deterministic catalog-asset round-trip test instead.