### PR TITLE
docs(design): root-crate decomposition plan

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
@@ -1,0 +1,143 @@
+= Root Crate Decomposition Plan (2026-06-21)
+:toc: macro
+:icons: font
+
+[abstract]
+The monolithic root `proximadb` crate is the root cause of a recurring class of CI
+failures (instrumented test-binary OOM, compile-memory hacks), slow builds, and weak
+test isolation. This plan tackles it head-on — decomposing the root crate into workspace
+crates — rather than masking the symptom with larger-memory runners. It is the
+*authoritative sequencing + coordination plan*; execution is incremental and spans
+multiple sessions.
+
+toc::[]
+
+== Why this, why now
+
+A larger-RAM coverage runner was proposed to fix the `Code Coverage` job's exit-143 OOM.
+Investigation showed the OOM is at *link time* of the root crate's instrumented test
+binary — i.e. the real cause is the size of the root crate, and more RAM only masks it.
+
+[cols="1,1,1",options="header"]
+|===
+| Surface | Lines | Files
+| Root crate `src/` | ~973,000 | 1,702
+| Extracted `crates/` (62 members) | ~238,000 | 450
+|===
+
+The root crate is ~80% of the codebase and pulls ~494 dependency entries into a single
+compilation unit. `src/storage` alone is ~386K lines. Consequences already observed:
+
+* `Code Coverage` (tarpaulin, `ubuntu-latest` 16 GB) OOM-kills at link **every run** — the
+  coverage signal is effectively dead (no report produced; job is `continue-on-error`).
+* The unit-test job already needed `CARGO_BUILD_JOBS=1` + `--test-threads=2` to survive the
+  same root-crate compile peak.
+* Long compile times and coarse test isolation across all of CI.
+
+*Decision (2026-06-21):* prioritise decomposition; do **not** mask with a larger runner.
+The coverage job stays as-is (non-blocking) until the root crate is small enough to measure
+without exclusions or special runners.
+
+== Target end-state
+
+* Root `proximadb` crate becomes a *thin composition layer*: bootstrap, wiring, and port
+  composition only — no large module bodies.
+* Module bodies live in workspace `crates/` behind the existing layering rules
+  (`scripts/check-layering.sh`), with no upward edges (a crate never depends on the root).
+* Acceptance signals:
+  ** root-crate instrumented test binary links within a standard 16 GB runner;
+  ** coverage is producible with no module exclusions and no swap/larger runner;
+  ** `scripts/affected_crates.py` maps most changes to a leaf crate, not the root.
+
+== Current coupling (measured)
+
+`src/storage` is simultaneously a *deep dependency* (≈51 root files `use crate::storage`)
+and *deeply entangled upward*: **~403 references** from `src/storage` reach up into
+`crate::index` / `crate::compute`. The worst up-edges (which must be inverted before engine
+extraction) are:
+
+[cols="1,2",options="header"]
+|===
+| Up-edge | Where
+| `crate::index::AxisManager` | `src/storage/engine.rs`, SST compaction — storage instantiates/drives the ANN index
+| `crate::compute::distance_computation::UnifiedDistanceCompute` | `src/storage/engine.rs` — distance dispatch at the storage layer
+| `crate::services::InternalCollectionProvider` | `src/storage/engine.rs` — metadata lookup injected post-construction
+|===
+
+These up-edges are the architectural smell: storage should depend *down* (records, codec,
+block-format, object-store — already extracted) and expose *ports* for index/compute/metadata
+rather than reaching up into them.
+
+Existing seams that help:
+
+* `src/storage/trait_components/` — `StorageReader/Writer/Compactor/Scan/...` ports (engines
+  are already pluggable).
+* `src/storage/formats/` — `StorageFormat` trait + `FormatRegistry` (mature, leaf-ish seam).
+* Extracted: `proximadb-{records,codec,block-format,storage-common,object-store,iceberg-engine}`.
+
+== Strategy
+
+1. *Invert up-edges via ports, then move bodies.* Introduce small port crates
+   (`IndexManager`, distance, metadata-provider) so storage depends on traits, not on
+   `crate::index`/`crate::compute`/`crate::services`. Only then can engines move out cleanly.
+2. *Pure mechanical moves.* Each extraction is `git mv` of a subtree into a new crate plus a
+   `pub use` re-export from the old path — so consumers are untouched and diffs stay
+   reviewable. No behavioural change per slice.
+3. *One slice per PR, land fast.* Minimise the window a large file-move diverges from the
+   hot branches.
+4. *Cold subtrees first.* Verify a subtree is not under active edit before moving it (see
+   Coordination).
+
+== Sequencing (incremental)
+
+[cols="1,3,1,1",options="header"]
+|===
+| Slice | Scope | ~LOC | Risk
+| A | `proximadb-storage-formats` ← `src/storage/formats/` (re-export) | ~5K | Low
+| B | `proximadb-storage-cache` ← `src/storage/cache/` (wraps `proximadb-cache`) | ~11K | Low
+| C | Persistence: WAL + disk-manager port crates | ~? | Med
+| D | *Enabler:* `IndexManager` (+ distance, metadata) **port crate(s)**; refactor engine/compaction to inject ports | n/a | Med-High
+| E | Engines: `proximadb-{sst,nova,viper}-engine` (depend on ports from D) | large | High
+| F | Multimodel / document / entity / transaction stores | large | High
+|===
+
+Slices A and B are independent quick wins that prove the re-export pattern and start
+shrinking the binary. D is the linchpin: the ~403 up-edges mean engines cannot move until
+the index/compute/metadata boundaries are ports. E/F are large and must be coordinated.
+
+== Multi-session coordination protocol (mandatory)
+
+This repo is worked by many concurrent sessions; at time of writing ~7 worktrees are active
+and several edit `src/storage`. Large file-moves conflict violently with in-flight work, so:
+
+* *Pick cold subtrees.* Before moving a subtree, check open PRs and active worktrees touching
+  it; defer if hot.
+* *Mechanical-only PRs.* A decomposition slice is `git mv` + re-export + `Cargo.toml` member
+  add — nothing else. Easy to review, easy to rebase.
+* *Land within the day.* Don't let an extraction branch sit; divergence cost is the dominant
+  risk.
+* *Announce hot moves.* Engines (E) and multimodel (F) touch everyone — these need an explicit
+  coordination window, not an opportunistic PR.
+* The `layering-check` workflow + `scripts/affected_crates.py` already enforce/observe the
+  boundaries; keep them green at every slice.
+
+== Non-goals / explicitly deferred
+
+* Feature-gating as a substitute for extraction — measured weak: storage is largely not
+  feature-gated (`datafusion-integration` is default-on but a separate module). Gating won't
+  meaningfully shrink the storage binary.
+* Changing the `Code Coverage` job — left as-is (non-blocking) until the root crate is small
+  enough to measure normally.
+
+== Metrics to track per slice
+
+* root-crate `src/` LOC (down),
+* peak RSS of the default `cargo test --lib` link step (down),
+* coverage producible without exclusions (eventually yes),
+* CI compile wall-clock for the root crate (down).
+
+== First action
+
+Execute *Slice A* (`proximadb-storage-formats`) once a cold-subtree check confirms
+`src/storage/formats/` is not under active edit, as a pure `git mv` + re-export PR. It is the
+smallest, lowest-coupling proof of the pattern and starts the shrink.


### PR DESCRIPTION
Authoritative, incremental plan to decompose the ~973K-line monolithic root crate into workspace crates — the head-on fix for the coverage link-time OOM and compile-memory hacks (instead of masking with a larger-RAM runner).

Includes measured coupling (storage's ~403 up-edges into index/compute), existing seams, a phased slice sequence (formats/cache first, IndexManager port as the engine-extraction enabler), a mandatory multi-session coordination protocol, and per-slice metrics. First slice: extract proximadb-storage-formats as a pure move + re-export.