### PR TITLE
refactor(storage): extract kv into proximadb-storage-kv crate (decomp slice A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,6 +6524,7 @@ dependencies = [
  "proximadb-sdk",
  "proximadb-security",
  "proximadb-storage-common",
+ "proximadb-storage-kv",
  "proximadb-telemetry",
  "proximadb-uql",
  "proximadb-vector",
@@ -7447,6 +7448,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.23",
+ "tracing",
+]
+
+[[package]]
+name = "proximadb-storage-kv"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "crates/storage/proximadb-block-format",
     "crates/storage/proximadb-object-store",
     "crates/storage/proximadb-iceberg-engine",
+    "crates/storage/proximadb-storage-kv",
     "crates/query/proximadb-document-query",
     "crates/query/proximadb-graph-arrow",
     "crates/query/proximadb-graph-query",
@@ -189,6 +190,7 @@ proximadb-compression = { path = "crates/horizontal/proximadb-compression" }
 proximadb-runtime-common = { path = "crates/horizontal/proximadb-runtime-common" }
 proximadb-storage-common = { path = "crates/storage/proximadb-storage-common" }
 proximadb-block-format = { path = "crates/storage/proximadb-block-format" }
+proximadb-storage-kv = { path = "crates/storage/proximadb-storage-kv" }
 crc32fast = "1.4"
 rmp-serde = "1.1"
 tonic-prost = "0.14"
@@ -271,6 +273,7 @@ proximadb-security = { path = "crates/horizontal/proximadb-security" }
 proximadb-storage-common = { path = "crates/storage/proximadb-storage-common" }
 proximadb-block-format = { path = "crates/storage/proximadb-block-format" }
 proximadb-iceberg-engine = { path = "crates/storage/proximadb-iceberg-engine" }
+proximadb-storage-kv = { path = "crates/storage/proximadb-storage-kv" }
 proximadb-telemetry = { path = "crates/horizontal/proximadb-telemetry" }
 proximadb-filter-expression = { path = "crates/foundation/proximadb-filter-expression" }
 proximadb-cache = { path = "crates/foundation/proximadb-cache" }

--- a/crates/storage/proximadb-storage-kv/Cargo.toml
+++ b/crates/storage/proximadb-storage-kv/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "proximadb-storage-kv"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Minimal filesystem-backed key-value storage abstraction for ProximaDB (StorageKV trait + FsKV)"
+
+[lib]
+name = "proximadb_storage_kv"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+tokio = { version = "1", features = ["fs", "io-util"] }
+tracing = "0.1"

--- a/crates/storage/proximadb-storage-kv/src/lib.rs
+++ b/crates/storage/proximadb-storage-kv/src/lib.rs
@@ -1,7 +1,11 @@
 //! Simple key-value storage abstraction
 //!
-//! This module provides a minimal key-value storage interface with a filesystem-based
+//! This crate provides a minimal key-value storage interface with a filesystem-based
 //! implementation. Used for storing configuration, metadata, and other small data items.
+//!
+//! Extracted from the root crate's `src/storage/kv` as the first slice of the root-crate
+//! decomposition (see `docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`).
+//! The root crate re-exports it as `crate::storage::kv` for source compatibility.
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -235,8 +235,10 @@ pub mod transaction;
 pub mod entity_store;
 pub mod relations;
 
-// Key-value storage interface
-pub mod kv;
+// Key-value storage interface — extracted to the `proximadb-storage-kv` crate
+// (root-crate decomposition Slice A); re-exported here for source compatibility
+// (`crate::storage::kv::{StorageKV, FsKV}`).
+pub use proximadb_storage_kv as kv;
 
 // Unified operations coordination (flush, compaction, re-quantization)
 pub mod operations;


### PR DESCRIPTION
## Summary
First slice of the root-crate decomposition (plan: `docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`). Moves the self-contained key-value abstraction (`StorageKV` trait + `FsKV` filesystem impl, 96 LOC, **zero up-edges**) out of the ~973K-line monolithic root crate into a new leaf workspace crate.

This is the smallest provable inch — a pure **mechanical move + re-export, no behavioural change** — that establishes the new-crate / `git mv` / re-export / workspace-member pattern every subsequent leaf slice (`transaction`, `encryption`, `schema`, …) repeats.

## Changes
- New crate `crates/storage/proximadb-storage-kv` (deps: anyhow, async-trait, tokio, tracing).
- `src/storage/mod.rs` re-exports it: `pub use proximadb_storage_kv as kv;` — existing `crate::storage::kv::{StorageKV, FsKV}` call sites (`entity_store_legacy.rs`) are unchanged.
- Registered in workspace `members` + root `[dependencies]` / `[workspace.dependencies]`.

## Verification
- New crate builds clean.
- Full `cargo check -p proximadb --lib` green (re-export resolves; no other call-site changes needed).
- Cold-subtree confirmed before moving (0 commits in 10 days, no active worktree touches it).

## Why this approach (context)
The root-crate monolith causes the coverage link-time OOM and compile-memory hacks. Rather than mask it with a larger-RAM runner, we decompose incrementally. The agent's initial "formats first" pick was disproven (`formats/adapters.rs` binds all six engines); `kv` is the verified clean leaf.