### PR TITLE
docs(design): storage<->index/compute decoupling contracts (design-before-extract)

### DIFF
--- a/docs/12-design/STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc
+++ b/docs/12-design/STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc
@@ -1,0 +1,112 @@
+= Storage ↔ Index/Compute Decoupling Contracts (2026-06-21)
+:toc: macro
+:icons: font
+
+[abstract]
+Firm interface contracts for decoupling `src/storage` from `src/index` (AXIS) and
+`src/compute`, designed *before* any extraction. This is the next phase of the root-crate
+decomposition (`ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`) after the mechanical leaf
+slices (kv/optimization/strategy/tenant). Status: *Proposed* — the contracts below are the
+review artifact engine sessions align to; exact signatures/LOC are finalized against code at
+implementation time (the figures here come from a read-only review and are design inputs,
+not gospel).
+
+toc::[]
+
+== Principles
+* *Design before extract.* Establish the trait/type contracts first; move code second.
+* *ISP (segregate interfaces).* Engines depend only on the narrow role they use, never a
+  30-method god-object.
+* *DIP (depend on abstractions).* Engines hold `Arc<dyn Trait>`, injected at construction;
+  the concrete `AxisManager` is one implementor.
+* *Additive, not renames.* Add new crates that layer on the existing `proximadb-*-types`
+  crates; do NOT rename/break them.
+* *Downward only.* storage→compute is a legal downward dep (extract to a crate); storage↔index
+  query/rebuild is a genuine inversion (traits).
+* *Coordinate hot moves.* Engine-file adoption is announced + sequenced (see Coordination).
+
+== Part A — Index contract (DIP/ISP)
+
+Measured reality: storage touches `AxisManager` through only ~7 methods (the ~75 `index::axis`
+refs are mostly *types*). Engines already hold `Option<Arc<AxisManager>>` injected at
+`src/storage/engine.rs:~151` (global `set_sst_axis_manager`) or via ctor params — the DIP seam
+exists; we narrow its type.
+
+=== A1. Segregated traits (ISP)
+[cols="1,3,2",options="header"]
+|===
+| Trait | Methods (signatures finalized at impl) | Storage callers
+| `IndexQuery` | `query(&self, q: IndexHybridQuery) -> Result<IndexQueryResult>` | all 6 engines + Orion (search)
+| `IndexIngest` | `handle_flushed_vectors(&self, collection, records, files) -> Result<()>` | SST flush/search
+| `IndexMetrics` | `registered_vector_count(&self, collection) -> usize`; `get_metrics`; `get_collection_stats` | warm-load checks
+| `IndexMaintenance` | `get_collection_indexes(&self, collection) -> Result<Vec<(String, Arc<dyn IndexReader>)>>`; `rebuild_index(&self, collection, name)` | compaction
+| `IndexLifecycle` | `drop_collection` / `suspend_collection` / `resume_collection` | none yet (post-MVP — define, don't wire)
+|===
+
+Engines hold per-role handles (`Option<Arc<dyn IndexQuery>>`, etc.); `AxisManager`
+`impl`s all five. No behavioural change — only field/param types narrow.
+
+=== A2. The query-envelope crux (the key design decision)
+`IndexQuery::query()` takes/returns `AxisHybridQuery` / `AxisManagerQueryResult`, which today
+carry `proximadb_catalog::AnnFilteringPolicy`, `core::search::SearchEffort`, and an
+observability `PredicateShortfall`. **They cannot move into a clean foundation crate** without
+dragging catalog/core/observability down with them. Resolution (pick at impl, A2 gates A1):
+
+. *Storage-facing query DTO* — define a slim `IndexHybridQuery`/`IndexQueryResult` in the
+  traits crate with only what storage passes/reads; convert to/from the rich AXIS envelope at
+  the index boundary. (Preferred — keeps the trait crate dep-light.)
+. *Or* host the behavioral traits in a non-foundation `proximadb-index-ports` crate that may
+  depend on catalog/core. (Heavier; only if the DTO proves lossy.)
+
+`Arc<dyn AxisVectorIndex>` returned by `get_collection_indexes` similarly needs a shared
+`IndexReader` trait (compaction depends on the trait, not the concrete).
+
+=== A3. Shared index *types* (prerequisite cut)
+New foundation crate *`proximadb-index-types`* (template: existing `proximadb-*-types` —
+`serde`+`thiserror` only, pure data). Moves the pure config/algorithm types from
+`src/index/axis/types.rs`: `IndexAlgorithm`, `AxisConfig` (+ nested thresholds/strategy),
+`Data`, `IndexSpecification`, `IndexSelectionStrategy`, `ClusterAssignment`, migration/monitoring
+configs. Storage→index *type* imports are only ~9 files, so this cut is low-risk and unblocks
+both storage and the query planner. `StorageEngineType` is *already* extracted to
+`proximadb-storage-common` ✅. **Stays in index** (do NOT extract): `AxisHybridQuery`,
+`AxisManagerQueryResult`, `EventLogService` (async/I-O), `AxisMetadataFilter`.
+
+== Part B — Compute contract (downward extraction, no inversion)
+
+Storage calls distance (`UnifiedDistanceCompute::{new,calculate_distance,batch}`,
+`DistanceMetric`, `SimilarityResult`, quantized-vector payloads) and quantization
+(`UnifiedQuantizationEngine::{quantize,dequantize}`, `Codebook`/`CodebookStore`). The existing
+`proximadb-distance-types` / `proximadb-quantization-types` are *types-only*; `src/compute`
+(~28K LOC) holds the impls. `proximadb-vector` already mirrors compute for non-storage users.
+
+Proposed (additive — layer on existing `-types`, don't rename them):
+[cols="1,3",options="header"]
+|===
+| New crate | Contents
+| `proximadb-distance-kernel` | `UnifiedDistanceCompute` engine + `SimilarityResult` (impls over `proximadb-distance-types`); SIMD via `proximadb-hardware`; GPU behind a feature
+| `proximadb-quantization-kernel` | `UnifiedQuantizationEngine`, `Codebook`/`CodebookStore` (depends on distance-kernel — resolves the internal quant→distance cycle by layering)
+| `proximadb-quantized-distance` | `QuantizedDistanceCalculator`, `Int8VectorData`/`PQVectorData` (bridge)
+| `src/storage/compute_bridge/` | storage-specific glue that stays in storage: progressive search, codec selection heuristics, columnar serialization config
+|===
+`src/compute` then becomes a thin facade re-exporting the kernels (query/index keep working).
+Layering check enforces storage never imports `src/compute` directly.
+
+== Sequencing (each a separate, build-verified PR)
+. *`proximadb-index-types`* (pure types) — lowest risk, unblocks ~9 storage files + planner. Do first.
+. *Compute kernels* (distance-kernel → quantization-kernel → quantized-distance) — parallel
+  track, downward dep; large but mechanical-ish. Then `compute_bridge` + facade.
+. *Index traits + DIP adoption* — define the 5 traits + resolve A2 (query DTO), then narrow
+  engine fields to `Arc<dyn …>` one engine per PR. *This touches the hot engine files — gated on Coordination.*
+
+== Coordination
+Survey (2026-06-21): the only active sessions in `src/storage` are working `entity_store`/`graph`
+and `metadata` files — *zero overlap* with the index/compute/engine files these contracts touch,
+so steps 1–2 have a clear runway now. Step 3 (engine field narrowing) must be an *announced
+window*: one engine per PR, mechanical type-narrowing only, landed fast, after the index-types
+and (ideally) the query-DTO land. Keep `layering-check` green at every step.
+
+== Caveats
+Signatures, LOC, and module names above are review-derived design inputs — finalize against the
+code when implementing. Prefer additive crates over renaming existing `-types` crates. No
+on-disk/wire format changes here (pure in-memory refactor), so the mixed-read-safe mandate does
+not apply.


### PR DESCRIPTION
Firm interface contracts for the next decomposition phase — designed **before** any extraction, from a read-only review of `src/storage`'s coupling to the AXIS index and `src/compute`. SOLID-shaped (ISP segregated traits + DIP injection).

**Index:** ~7 `AxisManager` methods → 5 small role traits (`IndexQuery`/`Ingest`/`Metrics`/`Maintenance`/`Lifecycle`); engines narrow their existing `Arc<AxisManager>` field to `Arc<dyn …>`. Surfaces the key decision: the query envelope (`AxisHybridQuery`/`Result`) carries catalog/core/observability deps and can't live in a foundation crate → slim storage-facing query DTO converted at the boundary.

**Shared types:** new `proximadb-index-types` foundation crate for pure config/algorithm types (`StorageEngineType` already extracted).

**Compute:** additive kernel crates (`distance-kernel`→`quantization-kernel`→`quantized-distance`) layered on the existing types-only crates + a storage `compute_bridge`; downward dep, no inversion.

Sequenced (index-types first → compute kernels parallel → engine DIP adoption last, coordinated) with a coordination section: the two active storage sessions are in graph/metadata, **zero overlap** with these targets. Signatures/LOC are review-derived design inputs to finalize at implementation time.

This is the authoritative artifact engine sessions align to before code moves.