### PR TITLE
feat(catalog): SystemCatalog over WAL + boot cutover (system-catalog Phase 2)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -434,10 +434,43 @@ impl SharedServices {
         debug!("✅ SharedServices: Metadata backend created successfully");
 
         if catalog_manager.list_catalogs().await.is_empty() {
-            catalog_manager
-                .create_native_catalog("default", &storage_config.metadata_url)
-                .await
-                .context("Failed to initialize default xCatalog backend")?;
+            // System-catalog redesign (Phase 2): the default catalog is the
+            // read-heavy, WAL-backed `SystemCatalog` (in-RAM authority + canonical
+            // WAL) rather than the file-per-object `NativeCatalog`. It serves
+            // catalog reads from RAM and persists each DDL as one fsync'd WAL
+            // append. Scoped to `file://` for now (object-store paths land in
+            // Phase 5); `PROXIMADB_DISABLE_SYSTEM_CATALOG` is a kill-switch back
+            // to `NativeCatalog` for the duration of the cutover.
+            let use_system_catalog = std::env::var("PROXIMADB_DISABLE_SYSTEM_CATALOG").is_err()
+                && storage_config.metadata_url.starts_with("file://");
+            if use_system_catalog {
+                let base = storage_config.metadata_url.trim_start_matches("file://");
+                let wal_path = std::path::Path::new(base).join("system-catalog.wal");
+                if let Some(parent) = wal_path.parent() {
+                    tokio::fs::create_dir_all(parent).await.with_context(|| {
+                        format!("creating system-catalog dir {}", parent.display())
+                    })?;
+                }
+                let system_catalog =
+                    crate::services::system_catalog::SystemCatalog::open("default", &wal_path)
+                        .await
+                        .with_context(|| {
+                            format!("opening SystemCatalog WAL at {}", wal_path.display())
+                        })?;
+                catalog_manager
+                    .register(Arc::new(system_catalog))
+                    .await
+                    .context("Failed to register default SystemCatalog backend")?;
+                info!(
+                    "✅ SharedServices: registered WAL-backed SystemCatalog (default) at {}",
+                    wal_path.display()
+                );
+            } else {
+                catalog_manager
+                    .create_native_catalog("default", &storage_config.metadata_url)
+                    .await
+                    .context("Failed to initialize default xCatalog backend")?;
+            }
         }
         // TD-080 (2026-05-28 round 2): explicitly designate the "default"
         // catalog as the manager's default so `catalog_manager.default_catalog()`

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -193,6 +193,7 @@ pub mod scan_cursor;
 pub mod schema;
 pub mod search;
 pub mod snapshot;
+pub mod system_catalog;
 pub mod system_catalog_state;
 #[cfg(feature = "tenant_access")]
 pub mod tenant_access;

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -1,0 +1,646 @@
+//! `SystemCatalog` — the read-heavy system catalog as a [`Catalog`] implementation.
+//!
+//! Backs the `proximadb_catalog::Catalog` trait with the in-RAM authority
+//! ([`SystemCatalogState`]) made durable by a canonical WAL
+//! ([`FramedTableWalAppender`]). It is the WAL-native replacement for the
+//! file-per-object `NativeCatalog`: reads are served from RAM (no `path.exists()`
+//! per `table_exists`, no `read_dir` per `list_tables`, no `CatalogCache` TTL),
+//! and every DDL is one durable, fsync'd WAL append folded into the in-RAM index.
+//!
+//! Phase 2 of the system-catalog redesign. Semantics mirror `NativeCatalog`
+//! method-for-method so the live cutover (boot wires this in place of
+//! `create_native_catalog`) is behaviour-preserving for all `Catalog` callers
+//! (DML, introspection, REST, pgwire). It lives in the root crate because the
+//! canonical-WAL substrate does, and a control-layer crate cannot depend on the
+//! root crate (mirrors the `function_store` / `rank_profile_store` recipe).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+
+use proximadb_catalog::schema::{apply_evolution, validate_schema};
+use proximadb_catalog::{
+    Catalog, CatalogIndex, CatalogNamespace, CatalogPrimaryPod, CatalogSchemaEvolution,
+    CatalogStorageLayout, CatalogTableSchema, CatalogTableStatistics, TableIdentifier,
+};
+
+use crate::services::record_store::TableWalAppender;
+use crate::services::system_catalog_state::{CatalogDelta, SystemCatalogState};
+
+/// Current wall-clock milliseconds since the Unix epoch.
+fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+/// WAL-backed read-heavy system catalog.
+pub struct SystemCatalog {
+    name: String,
+    state: Arc<SystemCatalogState>,
+    appender: Arc<dyn TableWalAppender>,
+    /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
+    /// never interleave such that a lower-LSN mutation applies after a higher
+    /// one (which the idempotent `apply_committed` would then drop). DDL is
+    /// rare, so this coarse lock is free in practice and also gives
+    /// read-your-writes on the committing path.
+    write_lock: tokio::sync::Mutex<()>,
+}
+
+impl SystemCatalog {
+    /// Construct over an in-RAM state (already replayed from the WAL by the
+    /// caller) and the appender that owns the same WAL file.
+    pub fn new(
+        name: impl Into<String>,
+        state: SystemCatalogState,
+        appender: Arc<dyn TableWalAppender>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            state: Arc::new(state),
+            appender,
+            write_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// Open (or create) the catalog WAL at `wal_path`, replay it into a fresh
+    /// in-RAM authority, and return a ready catalog. Boot entry point.
+    pub async fn open(
+        name: impl Into<String>,
+        wal_path: impl Into<std::path::PathBuf>,
+    ) -> Result<Self> {
+        let appender =
+            Arc::new(crate::services::FramedTableWalAppender::open(wal_path.into()).await?);
+        let entries = appender.read_entries().await?;
+        let state = SystemCatalogState::from_wal_entries(&entries)?;
+        Ok(Self::new(name, state, appender))
+    }
+
+    /// Durably append the deltas to the WAL, then fold them into the in-RAM
+    /// authority — atomically with respect to other writers.
+    async fn commit_batch(&self, deltas: Vec<CatalogDelta>) -> Result<()> {
+        let _guard = self.write_lock.lock().await;
+        let ops = deltas
+            .iter()
+            .map(|d| d.to_operation())
+            .collect::<Result<Vec<_>>>()?;
+        let entries = self.appender.append_operations(ops, None).await?;
+        for (entry, delta) in entries.into_iter().zip(deltas) {
+            self.state.apply_committed(entry.sequence_number, delta);
+        }
+        Ok(())
+    }
+
+    async fn commit(&self, delta: CatalogDelta) -> Result<()> {
+        self.commit_batch(vec![delta]).await
+    }
+
+    /// Load a table's current schema or fail (the catalog's "table not found").
+    fn require_table(&self, identifier: &TableIdentifier) -> Result<CatalogTableSchema> {
+        self.state
+            .get_table(identifier)
+            .map(|arc| (*arc).clone())
+            .ok_or_else(|| anyhow!("Table '{}' not found", identifier))
+    }
+
+    async fn create_namespace_inner(
+        &self,
+        namespace: &[String],
+        properties: HashMap<String, String>,
+        tenant_id: Option<String>,
+    ) -> Result<CatalogNamespace> {
+        if self.state.namespace_exists(namespace) {
+            return Err(anyhow!(
+                "Namespace '{}' already exists",
+                namespace.join(".")
+            ));
+        }
+        let mut ns = CatalogNamespace::new(namespace.to_vec());
+        ns.properties = properties;
+        // Opaque, rename-stable server-issued id that drives physical paths
+        // (DrPathBuilder); `tenant_id` records the owning tenant when created in
+        // a tenant scope. Mirrors NativeCatalog::create_namespace_inner.
+        ns.namespace_id = Some(format!("ns_{}", uuid::Uuid::new_v4()));
+        ns.tenant_id = tenant_id;
+        self.commit(CatalogDelta::UpsertNamespace {
+            namespace: ns.clone(),
+        })
+        .await?;
+        Ok(ns)
+    }
+}
+
+#[async_trait]
+impl Catalog for SystemCatalog {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn catalog_type(&self) -> &str {
+        // Same type string as NativeCatalog so downstream behaviour/introspection
+        // that keys on the catalog type is unchanged across the cutover.
+        "native"
+    }
+
+    // ── Namespace operations ──────────────────────────────────────────────
+
+    async fn create_namespace(
+        &self,
+        namespace: &[String],
+        properties: HashMap<String, String>,
+    ) -> Result<CatalogNamespace> {
+        self.create_namespace_inner(namespace, properties, None)
+            .await
+    }
+
+    async fn create_namespace_for_tenant(
+        &self,
+        namespace: &[String],
+        properties: HashMap<String, String>,
+        tenant: Option<&str>,
+    ) -> Result<CatalogNamespace> {
+        let tenant_id = tenant.filter(|t| !t.is_empty()).map(str::to_string);
+        self.create_namespace_inner(namespace, properties, tenant_id)
+            .await
+    }
+
+    async fn drop_namespace(&self, namespace: &[String], cascade: bool) -> Result<bool> {
+        if !self.state.namespace_exists(namespace) {
+            return Ok(false);
+        }
+        if !cascade && !self.state.list_tables(namespace).is_empty() {
+            return Err(anyhow!(
+                "Namespace '{}' is not empty. Use cascade=true to force drop.",
+                namespace.join(".")
+            ));
+        }
+        // The DropNamespace fold cascades to child tables + their statistics.
+        self.commit(CatalogDelta::DropNamespace {
+            levels: namespace.to_vec(),
+        })
+        .await?;
+        Ok(true)
+    }
+
+    async fn list_namespaces(&self, parent: Option<&[String]>) -> Result<Vec<CatalogNamespace>> {
+        let all = self.state.all_namespaces();
+        let results = all
+            .into_iter()
+            .filter(|ns| match parent {
+                Some(p) => ns.levels.len() == p.len() + 1 && ns.levels.starts_with(p),
+                None => true,
+            })
+            .collect();
+        Ok(results)
+    }
+
+    async fn namespace_exists(&self, namespace: &[String]) -> Result<bool> {
+        Ok(self.state.namespace_exists(namespace))
+    }
+
+    async fn get_namespace(&self, namespace: &[String]) -> Result<CatalogNamespace> {
+        self.state
+            .get_namespace(namespace)
+            .ok_or_else(|| anyhow!("Namespace '{}' not found", namespace.join(".")))
+    }
+
+    async fn update_namespace_properties(
+        &self,
+        namespace: &[String],
+        updates: HashMap<String, String>,
+        removals: Vec<String>,
+    ) -> Result<()> {
+        let mut ns = self
+            .state
+            .get_namespace(namespace)
+            .ok_or_else(|| anyhow!("Namespace '{}' not found", namespace.join(".")))?;
+        for (k, v) in updates {
+            ns.properties.insert(k, v);
+        }
+        for k in removals {
+            ns.properties.remove(&k);
+        }
+        ns.updated_at_ms = now_millis();
+        self.commit(CatalogDelta::UpsertNamespace { namespace: ns })
+            .await
+    }
+
+    // ── Table operations ──────────────────────────────────────────────────
+
+    async fn create_table(
+        &self,
+        identifier: &TableIdentifier,
+        schema: CatalogTableSchema,
+    ) -> Result<CatalogTableSchema> {
+        validate_schema(&schema)?;
+        if !self.state.namespace_exists(&identifier.namespace) {
+            return Err(anyhow!(
+                "Namespace '{}' does not exist",
+                identifier.namespace.join(".")
+            ));
+        }
+        if self.state.table_exists(identifier) {
+            return Err(anyhow!("Table '{}' already exists", identifier));
+        }
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(schema.clone()),
+        })
+        .await?;
+        Ok(schema)
+    }
+
+    async fn drop_table(&self, identifier: &TableIdentifier, _purge: bool) -> Result<bool> {
+        // `_purge` (physical data removal) is the storage engine's concern, not
+        // the catalog's; the catalog only owns metadata. Mirrors the
+        // metadata-only side of NativeCatalog::drop_table.
+        if !self.state.table_exists(identifier) {
+            return Ok(false);
+        }
+        self.commit(CatalogDelta::DropTable {
+            identifier: identifier.clone(),
+        })
+        .await?;
+        Ok(true)
+    }
+
+    async fn list_tables(&self, namespace: &[String]) -> Result<Vec<TableIdentifier>> {
+        Ok(self.state.list_tables(namespace))
+    }
+
+    async fn table_exists(&self, identifier: &TableIdentifier) -> Result<bool> {
+        Ok(self.state.table_exists(identifier))
+    }
+
+    async fn get_table(&self, identifier: &TableIdentifier) -> Result<CatalogTableSchema> {
+        self.require_table(identifier)
+    }
+
+    async fn rename_table(&self, from: &TableIdentifier, to: &TableIdentifier) -> Result<()> {
+        let mut schema = self.require_table(from)?;
+        if self.state.table_exists(to) {
+            return Err(anyhow!("Table '{}' already exists", to));
+        }
+        schema.name = to.name.clone();
+        schema.updated_at_ms = now_millis();
+        // Atomic batch: drop the old key + insert the new one in one durable
+        // append, so a crash between them can't leave the table doubly-present.
+        self.commit_batch(vec![
+            CatalogDelta::DropTable {
+                identifier: from.clone(),
+            },
+            CatalogDelta::UpsertTable {
+                identifier: to.clone(),
+                schema: Box::new(schema),
+            },
+        ])
+        .await
+    }
+
+    // ── Schema evolution ──────────────────────────────────────────────────
+
+    async fn evolve_schema(
+        &self,
+        identifier: &TableIdentifier,
+        evolution: CatalogSchemaEvolution,
+    ) -> Result<CatalogTableSchema> {
+        let schema = self.require_table(identifier)?;
+        let evolved = apply_evolution(&schema, &evolution)?;
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(evolved.clone()),
+        })
+        .await?;
+        Ok(evolved)
+    }
+
+    async fn get_schema_version(&self, identifier: &TableIdentifier) -> Result<i32> {
+        Ok(self.require_table(identifier)?.schema_version)
+    }
+
+    async fn get_schema_by_version(
+        &self,
+        identifier: &TableIdentifier,
+        version: i32,
+    ) -> Result<CatalogTableSchema> {
+        // Like NativeCatalog, only the current version is retained.
+        let schema = self.require_table(identifier)?;
+        if schema.schema_version == version {
+            Ok(schema)
+        } else {
+            Err(anyhow!(
+                "Schema version {} not found for table '{}' (current: {})",
+                version,
+                identifier,
+                schema.schema_version
+            ))
+        }
+    }
+
+    // ── Index operations ──────────────────────────────────────────────────
+
+    async fn create_index(
+        &self,
+        identifier: &TableIdentifier,
+        index: CatalogIndex,
+    ) -> Result<CatalogIndex> {
+        let mut schema = self.require_table(identifier)?;
+        if schema.indexes.iter().any(|i| i.name == index.name) {
+            return Err(anyhow!(
+                "Index '{}' already exists on table '{}'",
+                index.name,
+                identifier
+            ));
+        }
+        for col in &index.columns {
+            if !schema.columns.iter().any(|c| &c.name == col) {
+                return Err(anyhow!(
+                    "Column '{}' not found in table '{}'",
+                    col,
+                    identifier
+                ));
+            }
+        }
+        schema.indexes.push(index.clone());
+        schema.updated_at_ms = now_millis();
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(schema),
+        })
+        .await?;
+        Ok(index)
+    }
+
+    async fn drop_index(&self, identifier: &TableIdentifier, index_name: &str) -> Result<bool> {
+        let mut schema = self.require_table(identifier)?;
+        let initial = schema.indexes.len();
+        schema.indexes.retain(|i| i.name != index_name);
+        if schema.indexes.len() == initial {
+            return Ok(false);
+        }
+        schema.updated_at_ms = now_millis();
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(schema),
+        })
+        .await?;
+        Ok(true)
+    }
+
+    async fn list_indexes(&self, identifier: &TableIdentifier) -> Result<Vec<CatalogIndex>> {
+        Ok(self.require_table(identifier)?.indexes)
+    }
+
+    // ── Statistics ────────────────────────────────────────────────────────
+
+    async fn get_statistics(&self, identifier: &TableIdentifier) -> Result<CatalogTableStatistics> {
+        if !self.state.table_exists(identifier) {
+            return Err(anyhow!("Table '{}' not found", identifier));
+        }
+        Ok(self.state.get_statistics(identifier).unwrap_or_default())
+    }
+
+    async fn update_statistics(
+        &self,
+        identifier: &TableIdentifier,
+        stats: CatalogTableStatistics,
+    ) -> Result<()> {
+        if !self.state.table_exists(identifier) {
+            return Err(anyhow!("Table '{}' not found", identifier));
+        }
+        self.commit(CatalogDelta::UpsertStatistics {
+            identifier: identifier.clone(),
+            stats: Box::new(stats),
+        })
+        .await
+    }
+
+    // ── Physical/publication attributes (override the error defaults) ─────
+
+    async fn set_primary_pod(
+        &self,
+        identifier: &TableIdentifier,
+        primary: Option<CatalogPrimaryPod>,
+    ) -> Result<()> {
+        let mut schema = self.require_table(identifier)?;
+        schema.primary_pod = primary;
+        schema.updated_at_ms = now_millis();
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(schema),
+        })
+        .await
+    }
+
+    async fn set_storage_layouts(
+        &self,
+        identifier: &TableIdentifier,
+        layouts: Vec<CatalogStorageLayout>,
+    ) -> Result<CatalogTableSchema> {
+        let mut schema = self.require_table(identifier)?;
+        schema.storage_layouts = layouts;
+        schema.updated_at_ms = now_millis();
+        self.commit(CatalogDelta::UpsertTable {
+            identifier: identifier.clone(),
+            schema: Box::new(schema.clone()),
+        })
+        .await?;
+        Ok(schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proximadb_catalog::{CatalogColumn, CatalogIndexType};
+    use proximadb_data_model::ProximaType;
+
+    async fn catalog(dir: &std::path::Path) -> SystemCatalog {
+        SystemCatalog::open("default", dir.join("catalog.wal"))
+            .await
+            .expect("open system catalog")
+    }
+
+    fn nslevels(levels: &[&str]) -> Vec<String> {
+        levels.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn vec_schema(name: &str) -> CatalogTableSchema {
+        CatalogTableSchema::new(name)
+            .with_column(CatalogColumn::new(1, "id", ProximaType::Int64).nullable(false))
+            .with_column(CatalogColumn::new(2, "body", ProximaType::String))
+            .with_primary_key(vec!["id".to_string()])
+    }
+
+    #[tokio::test]
+    async fn namespace_and_table_crud() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cat = catalog(dir.path()).await;
+
+        let ns = cat
+            .create_namespace(&nslevels(&["sales"]), HashMap::new())
+            .await?;
+        assert!(ns.namespace_id.is_some());
+        assert!(cat.namespace_exists(&nslevels(&["sales"])).await?);
+
+        cat.create_table(
+            &TableIdentifier::new(nslevels(&["sales"]), "orders"),
+            vec_schema("orders"),
+        )
+        .await?;
+        assert!(
+            cat.table_exists(&TableIdentifier::new(nslevels(&["sales"]), "orders"))
+                .await?
+        );
+        let got = cat
+            .get_table(&TableIdentifier::new(nslevels(&["sales"]), "orders"))
+            .await?;
+        assert_eq!(got.name, "orders");
+        assert_eq!(cat.list_tables(&nslevels(&["sales"])).await?.len(), 1);
+
+        // duplicate + missing-namespace are rejected
+        assert!(
+            cat.create_table(
+                &TableIdentifier::new(nslevels(&["sales"]), "orders"),
+                vec_schema("orders")
+            )
+            .await
+            .is_err()
+        );
+        assert!(
+            cat.create_table(
+                &TableIdentifier::new(nslevels(&["nope"]), "x"),
+                vec_schema("x")
+            )
+            .await
+            .is_err()
+        );
+
+        assert!(
+            cat.drop_table(&TableIdentifier::new(nslevels(&["sales"]), "orders"), false)
+                .await?
+        );
+        assert!(
+            !cat.table_exists(&TableIdentifier::new(nslevels(&["sales"]), "orders"))
+                .await?
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn index_statistics_primary_pod_and_layouts() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cat = catalog(dir.path()).await;
+        cat.create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        let id = TableIdentifier::new(nslevels(&["s"]), "t");
+        cat.create_table(&id, vec_schema("t")).await?;
+
+        // index: create on a real column, reject duplicate + unknown column
+        let idx = CatalogIndex::new("by_body", vec!["body".to_string()], CatalogIndexType::BTree);
+        cat.create_index(&id, idx.clone()).await?;
+        assert_eq!(cat.list_indexes(&id).await?.len(), 1);
+        assert!(cat.create_index(&id, idx).await.is_err());
+        let bad = CatalogIndex::new("bad", vec!["ghost".to_string()], CatalogIndexType::BTree);
+        assert!(cat.create_index(&id, bad).await.is_err());
+        assert!(cat.drop_index(&id, "by_body").await?);
+        assert!(!cat.drop_index(&id, "by_body").await?);
+
+        // statistics default then round-trip
+        assert_eq!(cat.get_statistics(&id).await?.row_count, 0);
+        let mut stats = CatalogTableStatistics::default();
+        stats.row_count = 42;
+        cat.update_statistics(&id, stats).await?;
+        assert_eq!(cat.get_statistics(&id).await?.row_count, 42);
+
+        // primary pod + storage layouts persist on the schema
+        cat.set_primary_pod(
+            &id,
+            Some(proximadb_catalog::CatalogPrimaryPod::now(
+                "pod-a",
+                proximadb_catalog::CatalogPrimaryPodReason::Create,
+            )),
+        )
+        .await?;
+        assert_eq!(cat.get_table(&id).await?.primary_pod.unwrap().pod, "pod-a");
+
+        let updated = cat
+            .set_storage_layouts(&id, vec![CatalogStorageLayout::default()])
+            .await?;
+        assert!(!updated.storage_layouts.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rename_drop_namespace_cascade() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cat = catalog(dir.path()).await;
+        cat.create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        cat.create_table(
+            &TableIdentifier::new(nslevels(&["s"]), "a"),
+            vec_schema("a"),
+        )
+        .await?;
+
+        cat.rename_table(
+            &TableIdentifier::new(nslevels(&["s"]), "a"),
+            &TableIdentifier::new(nslevels(&["s"]), "b"),
+        )
+        .await?;
+        assert!(
+            !cat.table_exists(&TableIdentifier::new(nslevels(&["s"]), "a"))
+                .await?
+        );
+        assert_eq!(
+            cat.get_table(&TableIdentifier::new(nslevels(&["s"]), "b"))
+                .await?
+                .name,
+            "b"
+        );
+
+        // non-cascade drop of a populated namespace fails; cascade succeeds
+        assert!(cat.drop_namespace(&nslevels(&["s"]), false).await.is_err());
+        assert!(cat.drop_namespace(&nslevels(&["s"]), true).await?);
+        assert!(!cat.namespace_exists(&nslevels(&["s"])).await?);
+        assert!(cat.list_tables(&nslevels(&["s"])).await?.is_empty());
+        Ok(())
+    }
+
+    /// The whole point: state survives a process restart by replaying the WAL,
+    /// with zero filesystem stats on the read path.
+    #[tokio::test]
+    async fn persists_across_reopen() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        {
+            let cat = catalog(dir.path()).await;
+            cat.create_namespace(&nslevels(&["db"]), HashMap::new())
+                .await?;
+            cat.create_table(
+                &TableIdentifier::new(nslevels(&["db"]), "users"),
+                vec_schema("users"),
+            )
+            .await?;
+            cat.set_primary_pod(
+                &TableIdentifier::new(nslevels(&["db"]), "users"),
+                Some(proximadb_catalog::CatalogPrimaryPod::now(
+                    "pod-x",
+                    proximadb_catalog::CatalogPrimaryPodReason::Create,
+                )),
+            )
+            .await?;
+        }
+        // Fresh catalog over the same WAL file = a "restart".
+        let reopened = catalog(dir.path()).await;
+        assert!(reopened.namespace_exists(&nslevels(&["db"])).await?);
+        let users = reopened
+            .get_table(&TableIdentifier::new(nslevels(&["db"]), "users"))
+            .await?;
+        assert_eq!(users.name, "users");
+        assert_eq!(users.primary_pod.unwrap().pod, "pod-x");
+        Ok(())
+    }
+}

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -29,7 +29,9 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use proximadb_catalog::{CatalogNamespace, CatalogTableSchema, TableIdentifier};
+use proximadb_catalog::{
+    CatalogNamespace, CatalogTableSchema, CatalogTableStatistics, TableIdentifier,
+};
 use proximadb_storage_common::{CanonicalOperation, CanonicalWalEntry};
 
 /// One catalog DDL delta — the unit of change folded into the in-RAM authority
@@ -53,6 +55,11 @@ pub enum CatalogDelta {
     },
     /// Drop a table/collection.
     DropTable { identifier: TableIdentifier },
+    /// Set (replace) a table's statistics. Boxed to keep the enum small.
+    UpsertStatistics {
+        identifier: TableIdentifier,
+        stats: Box<CatalogTableStatistics>,
+    },
 }
 
 impl CatalogDelta {
@@ -70,6 +77,9 @@ impl CatalogDelta {
             }
             CatalogDelta::DropTable { identifier } => {
                 format!("table-delete:{}", identifier.to_fqn())
+            }
+            CatalogDelta::UpsertStatistics { identifier, .. } => {
+                format!("stats:{}", identifier.to_fqn())
             }
         }
     }
@@ -106,6 +116,9 @@ struct CatalogInner {
     /// Secondary index: namespace path → child table names, so `list_tables`
     /// never touches the filesystem.
     ns_children: HashMap<Vec<String>, HashSet<String>>,
+    /// Per-table statistics (stored separately, like NativeCatalog's
+    /// `TableMetadata.statistics`, not on the schema).
+    statistics: HashMap<TableIdentifier, CatalogTableStatistics>,
     /// Highest WAL sequence number folded in (the replay watermark).
     applied_seq: u64,
 }
@@ -122,8 +135,9 @@ impl CatalogInner {
                 self.namespaces.remove(&levels);
                 if let Some(children) = self.ns_children.remove(&levels) {
                     for name in children {
-                        self.tables
-                            .remove(&TableIdentifier::new(levels.clone(), name));
+                        let id = TableIdentifier::new(levels.clone(), name);
+                        self.tables.remove(&id);
+                        self.statistics.remove(&id);
                     }
                 }
             }
@@ -136,9 +150,13 @@ impl CatalogInner {
             }
             CatalogDelta::DropTable { identifier } => {
                 self.tables.remove(&identifier);
+                self.statistics.remove(&identifier);
                 if let Some(children) = self.ns_children.get_mut(&identifier.namespace) {
                     children.remove(&identifier.name);
                 }
+            }
+            CatalogDelta::UpsertStatistics { identifier, stats } => {
+                self.statistics.insert(identifier, *stats);
             }
         }
     }
@@ -151,6 +169,8 @@ impl CatalogInner {
 struct CatalogSnapshot {
     namespaces: HashMap<Vec<String>, CatalogNamespace>,
     tables: HashMap<TableIdentifier, CatalogTableSchema>,
+    #[serde(default)]
+    statistics: HashMap<TableIdentifier, CatalogTableStatistics>,
     applied_seq: u64,
 }
 
@@ -244,6 +264,16 @@ impl SystemCatalogState {
         self.inner.read().namespaces.keys().cloned().collect()
     }
 
+    /// List all namespace objects (clones).
+    pub fn all_namespaces(&self) -> Vec<CatalogNamespace> {
+        self.inner.read().namespaces.values().cloned().collect()
+    }
+
+    /// Get a table's statistics, if any have been recorded.
+    pub fn get_statistics(&self, identifier: &TableIdentifier) -> Option<CatalogTableStatistics> {
+        self.inner.read().statistics.get(identifier).cloned()
+    }
+
     /// The highest WAL sequence number folded in (replay watermark / snapshot
     /// cutover LSN).
     pub fn applied_seq(&self) -> u64 {
@@ -262,6 +292,7 @@ impl SystemCatalogState {
                 .iter()
                 .map(|(id, schema)| (id.clone(), (**schema).clone()))
                 .collect(),
+            statistics: inner.statistics.clone(),
             applied_seq: inner.applied_seq,
         };
         rmp_serde::to_vec_named(&snapshot).context("encoding catalog snapshot")
@@ -291,6 +322,7 @@ impl SystemCatalogState {
                 namespaces: snapshot.namespaces,
                 tables,
                 ns_children,
+                statistics: snapshot.statistics,
                 applied_seq: snapshot.applied_seq,
             }),
         })


### PR DESCRIPTION
## What

Phase 2 of the read-heavy **system-catalog redesign**: a WAL-backed `SystemCatalog` that implements `proximadb_catalog::Catalog` over the Phase-1 in-RAM `SystemCatalogState`, and the **live boot cutover** that makes it the default catalog in place of the file-per-object `NativeCatalog`.

> Stacked on #150 (Phase 1) → #146 (Phase 0). Base branch is `feat/system-catalog-wal-state`; retargets down the stack as each merges.

## Changes

- **`services::system_catalog::SystemCatalog`** — implements all 22 required `Catalog` methods + the `set_primary_pod` / `set_storage_layouts` / `create_namespace_for_tenant` overrides, **mirroring `NativeCatalog` semantics method-for-method** (verified line-by-line): `ns_<uuid>` minting, `validate_schema` on create, parent-filtered `list_namespaces`, `apply_evolution` reuse, index column validation, RMW for physical/publication attributes. Reads are **pure-RAM** — the hot-path syscalls are gone (no `path.exists()` per `table_exists`, no `read_dir` per `list_tables`, no `CatalogCache` TTL). Each DDL is one fsync'd WAL append folded into the in-RAM authority under a write-lock, so the `append → apply` pair is atomic (no lost-update under concurrent DDL).
- **`SystemCatalogState`** gains per-table statistics (`UpsertStatistics` delta + map + snapshot field, evicted on table/namespace drop) and `all_namespaces` / `get_statistics` helpers.
- **Boot cutover** (`shared_services`): the default catalog is now the WAL-backed `SystemCatalog` for `file://` metadata URLs, behind a **`PROXIMADB_DISABLE_SYSTEM_CATALOG` kill-switch** that falls back to `NativeCatalog` for the duration of the cutover. Object-store URLs keep `NativeCatalog` until Phase 5 lands their DrPath layout.

## Why root crate / why `register`

`SystemCatalog` lives in the root crate (the canonical-WAL substrate does, and control can't depend on root). It plugs in via `CatalogManager::register(Arc<dyn Catalog>)` — *not* the `MetadataBackendFactory`, which builds the separate storage backend (Phase 4).

## Tests (10 green)

4 trait-level (namespace/table CRUD + dup/missing-ns rejection; index + statistics + primary-pod + storage-layout round-trip; rename + cascade drop; **persists-across-reopen** = restart replays the WAL) + the 6 Phase-1 state tests.

## Verification

- `cargo clippy -p proximadb --lib` → Finished, **zero warnings**.
- `cargo test -p proximadb --lib system_catalog` → **10 passed**.
- `cargo fmt -- --check` clean; `scripts/check-layering.sh` → No boundary findings.
- The cutover is behaviour-preserving for all `Catalog` callers (DML, introspection, REST, pgwire); CI integration suites validate end-to-end. Kill-switch allows instant rollback.