### PR TITLE
fix(rest): add missing ToSchema derives to v2 collection DTOs (develop build red)

### DIFF
--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -176,7 +176,7 @@ pub struct IndexConfigInput {
 
 /// REST input for quantization config (mirrors proto `QuantizationConfig`;
 /// gRPC-v2 parity with `V2QuantizationConfig`).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct QuantizationConfigInput {
     /// Enable quantization for this collection.
     pub enabled: Option<bool>,
@@ -695,7 +695,7 @@ pub struct CollectionV2Response {
 }
 
 /// REST output for a single index config (mirrors gRPC `V2IndexSpec`).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct IndexSpecOutput {
     /// Algorithm: "hnsw" | "ivf" | "pq" | "flat" | "annoy" | "lsh".
     pub algorithm: String,
@@ -708,7 +708,7 @@ pub struct IndexSpecOutput {
 }
 
 /// REST output for HNSW params (mirrors gRPC `V2HnswConfig`).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HnswConfigOutput {
     pub m: Option<u32>,
     pub ef_construction: Option<u32>,
@@ -716,14 +716,14 @@ pub struct HnswConfigOutput {
 }
 
 /// REST output for IVF params (mirrors gRPC `V2IvfConfig`).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct IvfConfigOutput {
     pub n_lists: Option<u32>,
     pub n_probe: Option<u32>,
 }
 
 /// REST output for quantization config (mirrors gRPC `V2QuantizationConfig`).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct QuantizationConfigOutput {
     pub enabled: bool,
     /// Strategy label, e.g. "smart_defaults" | "minimal" | "aggressive".


### PR DESCRIPTION
## Summary
**`develop` HEAD does not compile** — `cargo check -p proximadb --lib` fails. Five REST v2 DTOs in `src/network/rest/v2/collections.rs` are embedded in `ToSchema`-deriving parents (`CreateCollection…Request`, `CollectionV2Response`) but are themselves missing the `ToSchema` derive, so the parent derives fail (`trait bound … : ToSchema is not satisfied`). Their `…Input` (Hnsw/Ivf) siblings already derive it — an omission from the TD-122 REST-parity work.

Adds `ToSchema` to: `QuantizationConfigInput`, `IndexSpecOutput`, `QuantizationConfigOutput`, `HnswConfigOutput`, `IvfConfigOutput` (derive-only, no behavioural change; `ToSchema` already imported).

## Why this matters
This blocks **all** develop-based CI (every open PR). Verified locally: clean `cargo check -p proximadb --lib` is **red** at current develop HEAD and **green** with these 5 derives.

## Note
`collections.rs` is actively edited by other sessions; this PR is intentionally minimal (5 one-word derive additions) to minimize conflict.