### PR TITLE
refactor(core): break hardware_capabilities ↔ compute::distance_computation cycle (#162)

### DIFF
--- a/src/core/hardware_capabilities.rs
+++ b/src/core/hardware_capabilities.rs
@@ -221,13 +221,14 @@ use num_cpus;
 use std::sync::{Arc, OnceLock};
 use tracing::info;
 
-// Import feature detection macros - these are macros, not functions
-// Only import ARM64 patch on ARM64 architecture
-#[cfg(target_arch = "aarch64")]
-#[allow(unused_imports)]
-use crate::compute::distance_computation::platform::distance_arm64_patch;
-
-// No longer importing duplicate CpuFeatures from compute module
+// NOTE: previously imported `crate::compute::distance_computation::platform::distance_arm64_patch`
+// here (aarch64-gated, allow(unused_imports)). Removed to break the
+// hardware_capabilities <-> compute::distance_computation circular dependency
+// (GitHub issue #162 / decomposition contracts). The x86 stub macros it provided
+// are only needed inside the `#[cfg(target_arch = "x86_64")]` SIMD block below —
+// which uses the std `is_x86_feature_detected!` on amd64 and is compiled out on
+// aarch64 — so the import was dead on every target. No behavioural change on
+// amd64 or arm64.
 use crate::core::config::HardwareConfig;
 
 // No longer importing PlatformCapability from compute - using our own HardwareBackend


### PR DESCRIPTION
## Summary
Breaks the circular dependency tracked in #162 — the prerequisite for extracting the compute distance/quantization kernels (decomposition contracts step 2).

`hardware_capabilities.rs` imported `crate::compute::distance_computation::platform::distance_arm64_patch` (aarch64-gated, `#[allow(unused_imports)]`) for x86 SIMD stub macros. But the only `is_x86_feature_detected!` calls are inside the `#[cfg(target_arch = "x86_64")]` SIMD block — which uses the **std** macro on amd64 and is **compiled out** on aarch64 — so the import was **dead on every target**. Removing it severs `core::hardware_capabilities → compute::distance_computation`.

## Multi-arch correctness (amd64 + arm64)
`SimdCapabilities::detect()` keeps its explicit per-arch `cfg` blocks: real SSE/AVX/FMA + AVX2/AVX512/SSE4.1 detection on **x86_64/amd64**, NEON on **aarch64**, all-false elsewhere. **No behavioural change on either arch.** Verified green locally on aarch64; CI verifies amd64 (x86_64 runners), and the multi-arch container build (`publish-image.yml`, `linux/amd64`+`linux/arm64`) compiles both.

## Scope
- Default-build cycle: **broken** here.
- The remaining `#[cfg(feature = "gpu")]` GPU-detection edge stays within the root crate (gpu isn't being extracted) — separate follow-up for when `hardware_capabilities` itself is extracted under the gpu feature.

Closes the cycle-break portion of #162.