### PR TITLE
fix(rust-sdk): tolerate nullable record_count and record fields in response DTOs

### DIFF
--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -498,8 +498,15 @@ pub struct CollectionInfo {
     pub name: String,
     /// Vector dimension
     pub dimension: u32,
-    /// Number of vectors
-    #[serde(default, alias = "record_count")]
+    /// Number of vectors. The v2 list surface
+    /// (`CollectionV2Summary.record_count`) emits `null` when
+    /// `include_stats=false`, so tolerate an explicit JSON `null` (→ 0)
+    /// in addition to an absent field.
+    #[serde(
+        default,
+        alias = "record_count",
+        deserialize_with = "crate::serde_compat::null_as_default"
+    )]
     pub vector_count: u64,
     /// Storage engine type
     #[serde(default)]
@@ -854,6 +861,57 @@ mod tests {
         assert_eq!(info.engine.as_deref(), Some("sst"));
         assert_eq!(info.stats.as_ref().unwrap().record_count, 19);
         assert_eq!(info.stats.as_ref().unwrap().storage_size_bytes, 1024);
+    }
+
+    /// Regression (TD-126 Phase 4): the v2 list surface
+    /// (`CollectionV2Summary.record_count`) is `Option<u64>` server-side
+    /// and emits an explicit JSON `null` when `include_stats=false`. The
+    /// facade `CollectionInfo.vector_count` is a non-`Option` `u64` for
+    /// callers, so a plain `#[serde(default)]` errored on `null` and broke
+    /// `list_collections` decode. `null_as_default` must map `null` → 0.
+    #[test]
+    fn collection_info_tolerates_null_record_count() {
+        let info: CollectionInfo = serde_json::from_value(json!({
+            "collection_id": "uuid-1",
+            "name": "items",
+            "dimension": 384,
+            "record_count": null,
+            "engine": "sst"
+        }))
+        .unwrap();
+
+        assert_eq!(info.name, "items");
+        assert_eq!(info.vector_count, 0);
+        assert_eq!(info.engine.as_deref(), Some("sst"));
+    }
+
+    /// The full wrapped list payload the server sends for
+    /// `GET /api/v2/collections` without stats — every summary carries a
+    /// `null` `record_count`. Exercises the same decode path
+    /// `list_collections` uses.
+    #[test]
+    fn list_collections_response_tolerates_null_record_counts() {
+        let response: ListCollectionsResponse = serde_json::from_value(json!({
+            "collections": [
+                {
+                    "collection_id": "uuid-1",
+                    "name": "items",
+                    "dimension": 128,
+                    "engine": "sst",
+                    "proxima_record_enabled": true,
+                    "record_count": null
+                }
+            ],
+            "total": 1,
+            "limit": 50,
+            "offset": 0,
+            "has_more": false
+        }))
+        .unwrap();
+
+        assert_eq!(response.collections.len(), 1);
+        assert_eq!(response.collections[0].name, "items");
+        assert_eq!(response.collections[0].vector_count, 0);
     }
 
     #[test]

--- a/clients/rust/src/collection.rs
+++ b/clients/rust/src/collection.rs
@@ -654,8 +654,14 @@ pub struct CollectionInfo {
     pub name: String,
     /// Vector dimension
     pub dimension: u32,
-    /// Number of vectors
-    #[serde(default, alias = "record_count")]
+    /// Number of vectors. The v2 collection surfaces may report
+    /// `record_count` as `null` (e.g. list without stats), so tolerate
+    /// an explicit JSON `null` (→ 0) as well as an absent field.
+    #[serde(
+        default,
+        alias = "record_count",
+        deserialize_with = "crate::serde_compat::null_as_default"
+    )]
     pub vector_count: u64,
     /// Storage engine
     #[serde(default)]
@@ -1006,8 +1012,15 @@ struct ProximaRecordBatchRequest {
 pub struct ProximaRecord {
     /// Record ID
     pub id: String,
-    /// Dense vector embedding
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Dense vector embedding. The v2 `GET .../records/{id}` surface
+    /// (`RecordV2Response.vector`) emits `null` when `include_vector=false`,
+    /// so tolerate an explicit JSON `null` (→ empty) as well as an absent
+    /// field.
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_compat::null_as_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub vector: Vec<f32>,
     /// Rich record properties
     #[serde(default, alias = "metadata", skip_serializing_if = "HashMap::is_empty")]
@@ -1015,7 +1028,15 @@ pub struct ProximaRecord {
     /// TEXT field payloads attached to the record (BM25 indexing / rerank
     /// inputs). v0.2 supports plain UTF-8 strings; richer encodings tracked
     /// post-v0.2. See `src/network/rest/v2/records.rs::TextFieldInput`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// The v2 `GET .../records/{id}` surface emits `text_fields: null`
+    /// when `include_text=false`; `null_as_default` maps that to empty.
+    /// `TextFieldInput` decodes the server's richer `TextFieldOutput`
+    /// shape by ignoring its extra `chunk_count` / `truncated` fields.
+    #[serde(
+        default,
+        deserialize_with = "crate::serde_compat::null_as_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub text_fields: Vec<TextFieldInput>,
     /// Original source text or external reference
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1294,6 +1315,61 @@ mod tests {
                 ]
             })
         );
+    }
+
+    /// Regression (TD-126 Phase 4): `get_vector` decodes the server's
+    /// `RecordV2Response`, whose `vector` and `text_fields` are
+    /// `Option<...>` and emit an explicit JSON `null` when
+    /// `include_vector` / `include_text` are false. The facade
+    /// `ProximaRecord` keeps non-`Option` `Vec` fields, so a plain
+    /// `#[serde(default)]` errored on `null` and broke `get_vector`
+    /// decode. `null_as_default` must map `null` → empty, and the
+    /// props-shaped record (rich `props`, server-only `version` /
+    /// `timestamp`) must round-trip.
+    #[test]
+    fn proxima_record_tolerates_null_vector_and_text_fields() {
+        let record: ProximaRecord = serde_json::from_value(json!({
+            "id": "rec_1",
+            "vector": null,
+            "props": {"category": "tech", "score": 0.9},
+            "text_fields": null,
+            "version": 3,
+            "timestamp": 1718000000
+        }))
+        .unwrap();
+
+        assert_eq!(record.id, "rec_1");
+        assert!(record.vector.is_empty());
+        assert!(record.text_fields.is_empty());
+        assert_eq!(record.props["category"], json!("tech"));
+        assert_eq!(record.props["score"], json!(0.9));
+    }
+
+    /// The server's `RecordV2Response` populates `text_fields` with the
+    /// richer `TextFieldOutput` shape (`name`, `content`, `chunk_count`,
+    /// `truncated`). `get_vector` decodes those into the SDK's
+    /// `TextFieldInput` by ignoring the extra fields, and a present
+    /// `vector` decodes normally.
+    #[test]
+    fn proxima_record_decodes_record_v2_response_shape() {
+        let record: ProximaRecord = serde_json::from_value(json!({
+            "id": "rec_2",
+            "vector": [0.1, 0.2, 0.3],
+            "props": {"k": "v"},
+            "text_fields": [
+                {"name": "title", "content": "ProximaDB", "chunk_count": 1, "truncated": false}
+            ],
+            "version": 1,
+            "timestamp": 42
+        }))
+        .unwrap();
+
+        assert_eq!(record.id, "rec_2");
+        assert_eq!(record.vector, vec![0.1, 0.2, 0.3]);
+        assert_eq!(record.text_fields.len(), 1);
+        assert_eq!(record.text_fields[0].name, "title");
+        assert_eq!(record.text_fields[0].content, "ProximaDB");
+        assert_eq!(record.props["k"], json!("v"));
     }
 
     /// TD-083: chained text_field builder calls accumulate. Matches the

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -211,6 +211,31 @@
 pub mod error;
 pub mod filter;
 
+/// Serde compatibility shims for tolerant response deserialization.
+///
+/// The ProximaDB REST surface models several response fields as
+/// nullable (`Option<T>` server-side, `nullable: true` in the OpenAPI
+/// spec) — e.g. `CollectionV2Summary.record_count` is `null` when
+/// `include_stats=false`, and `RecordV2Response.vector` / `.text_fields`
+/// are `null` when not requested. The hand-written facade DTOs keep the
+/// ergonomic non-`Option` Rust types (`u64`, `Vec<_>`) for callers, so
+/// they need a deserializer that treats an explicit JSON `null` the same
+/// as an absent field: fall back to `Default`. Plain `#[serde(default)]`
+/// only covers the *absent* case and errors on explicit `null`.
+pub(crate) mod serde_compat {
+    use serde::{Deserialize, Deserializer};
+
+    /// Deserialize `T`, mapping an explicit JSON `null` (and an absent
+    /// field, via `#[serde(default)]` on the field) to `T::default()`.
+    pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Deserialize<'de> + Default,
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+    }
+}
+
 // Generated, do-not-edit REST transport (TD-126 Phase 4). progenitor emits the
 // typed low-level client + models from the published OpenAPI spec; the
 // hand-written `client` facade below wraps it. Regenerate with `make

--- a/clients/rust/tests/openapi_contract.rs
+++ b/clients/rust/tests/openapi_contract.rs
@@ -58,14 +58,12 @@ fn load_spec() -> Value {
 }
 
 fn operation<'a>(spec: &'a Value, path_template: &str, method: &str) -> &'a Value {
-    let op = spec
-        .pointer(&format!(
-            "/paths/{}/{}",
-            json_pointer_escape(path_template),
-            method.to_lowercase()
-        ))
-        .unwrap_or_else(|| panic!("{method} {path_template} not in OpenAPI spec"));
-    op
+    spec.pointer(&format!(
+        "/paths/{}/{}",
+        json_pointer_escape(path_template),
+        method.to_lowercase()
+    ))
+    .unwrap_or_else(|| panic!("{method} {path_template} not in OpenAPI spec"))
 }
 
 fn json_pointer_escape(s: &str) -> String {
@@ -117,7 +115,7 @@ fn request_body_schema<'a>(_spec: &'a Value, op: &'a Value) -> Option<&'a Value>
         .get("schema")
 }
 
-fn operation_id<'a>(op: &'a Value) -> &'a str {
+fn operation_id(op: &Value) -> &str {
     op.get("operationId")
         .and_then(Value::as_str)
         .unwrap_or("<missing operationId>")
@@ -421,6 +419,98 @@ async fn list_collections_matches_spec() {
     let client = ProximaClient::connect(server.base_url()).unwrap();
     let collections = client.list_collections().await.unwrap();
     assert!(collections.is_empty());
+
+    mock.assert_async().await;
+}
+
+/// Regression (TD-126 Phase 4): `list_collections` previously failed to
+/// deserialize when the server emitted `record_count: null` (the v2
+/// `CollectionV2Summary.record_count` is `Option<u64>` and is `null`
+/// unless `include_stats=true`). End-to-end through the SDK over a mock
+/// server.
+#[tokio::test]
+async fn list_collections_decodes_null_record_count() {
+    let spec = load_spec();
+    let server = MockServer::start_async().await;
+    let op = operation(&spec, "/api/v2/collections", "get");
+    assert_eq!(operation_id(op), "listCollections");
+
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(Method::GET).path("/api/v2/collections");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "collections": [
+                        {
+                            "collection_id": "col_1",
+                            "name": "items",
+                            "dimension": 128,
+                            "engine": "sst",
+                            "proxima_record_enabled": true,
+                            "record_count": null
+                        }
+                    ],
+                    "total": 1,
+                    "limit": 50,
+                    "offset": 0,
+                    "has_more": false
+                }));
+        })
+        .await;
+
+    let client = ProximaClient::connect(server.base_url()).unwrap();
+    let collections = client.list_collections().await.unwrap();
+    assert_eq!(collections.len(), 1);
+    assert_eq!(collections[0].name, "items");
+    assert_eq!(collections[0].vector_count, 0);
+
+    mock.assert_async().await;
+}
+
+/// Regression (TD-126 Phase 4): `get_vector` decodes the server's
+/// `RecordV2Response`, whose `vector` and `text_fields` are nullable and
+/// arrive as explicit JSON `null` when not requested. End-to-end through
+/// the SDK over a mock server, exercising the props-shaped record.
+#[tokio::test]
+async fn get_vector_decodes_props_record_with_null_vector() {
+    let spec = load_spec();
+    let server = MockServer::start_async().await;
+    let op = operation(
+        &spec,
+        "/api/v2/collections/{collection_id}/records/{record_id}",
+        "get",
+    );
+    assert_eq!(operation_id(op), "getRecord");
+
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v2/collections/items/records/rec_1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "rec_1",
+                    "vector": null,
+                    "props": {"category": "tech", "score": 0.9},
+                    "text_fields": null,
+                    "version": 3,
+                    "timestamp": 1718000000_i64
+                }));
+        })
+        .await;
+
+    let client = ProximaClient::connect(server.base_url()).unwrap();
+    let record = client
+        .collection("items")
+        .get_vector("rec_1")
+        .await
+        .unwrap()
+        .expect("record should be present");
+    assert_eq!(record.id, "rec_1");
+    assert!(record.vector.is_empty());
+    assert!(record.text_fields.is_empty());
+    assert_eq!(record.props["category"], json!("tech"));
 
     mock.assert_async().await;
 }


### PR DESCRIPTION
## Summary

Fixes two pre-existing Rust SDK response-DTO deserialization gaps flagged during TD-126 Phase 4 (PR #156). The generated REST transport (`src/genrest.rs`) delivers the payload fine; the **hand-written facade response models** were stricter than the documented contract and failed to decode two real server responses.

Both are **DTO-too-strict** bugs (case a), not spec inaccuracies. The OpenAPI spec (`docs/openapi/proximadb-openapi.yaml`) already declares all the affected fields `type: [..., 'null']`, so the contract was accurate — **no spec change and no codegen cascade**. The fix is confined to `clients/rust/src/`.

### Gap 1 — `list_collections`
The dev server emits `record_count: null` in the default (no-stats) list response (`CollectionV2Summary.record_count` is `Option<u64>`, `null` unless `include_stats=true`). The facade `CollectionInfo.vector_count` is a non-`Option` `u64`; `#[serde(default)]` only handles an *absent* field, so serde errored with `invalid type: null, expected u64`.

### Gap 2 — `get_vector`
The server's `RecordV2Response` has nullable `vector` and `text_fields` that arrive as explicit `null` when `include_vector` / `include_text` are false. `ProximaRecord.vector` (`Vec<f32>`) and `.text_fields` (`Vec<TextFieldInput>`) errored on `null` (`invalid type: null, expected a sequence`).

## Fix
- Add a shared `serde_compat::null_as_default` deserializer (lib.rs) that maps an explicit JSON `null` — and, with `#[serde(default)]`, an absent field — to `T::default()`.
- Apply it to `vector_count` in both `CollectionInfo` structs (client.rs and collection.rs) and to `vector` / `text_fields` on `ProximaRecord` (collection.rs).

## Tests
- Unit regressions: deserialize `record_count: null`, a wrapped list payload with null record_counts, and a props record with `vector: null` / `text_fields: null` (plus the richer `TextFieldOutput` shape with `chunk_count`/`truncated`).
- Two end-to-end `openapi_contract` tests driving `list_collections` and `get_vector` over a mock server with the null shapes.
- Elided two pre-existing clippy findings in `openapi_contract.rs` so the SDK passes `clippy -D warnings` clean.

## Verification
- `cargo fmt --check` (0 diffs), `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` (lib 77 + contract 22) all clean.
- Live e2e: built the server, `/health` 200, then through the SDK created a collection, `list_collections` (server returned `record_count: null` — confirmed via raw curl), inserted a record, and `get_vector` by id (props-shaped record) — both formerly-failing decode paths now succeed.