### PR TITLE
feat(python-sdk): make chunking concern opt-in + lazy (TD-126 Phase 3)

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -45,6 +45,10 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "tabulate>=0.9.0",
+    # auth.py uses requests (sync token/refresh flows) on the core path; it was
+    # previously only pulled in via the dev/test extras, so a core-only install
+    # failed to `import proximadb_sdk`. Light dep, belongs in core.
+    "requests>=2.28.0",
 ]
 
 [project.optional-dependencies]
@@ -54,7 +58,17 @@ llm = [
     "sentence-transformers>=2.2.0",  # Local embedding models
 ]
 
-# Code chunking with tree-sitter (requires Python 3.10+)
+# Chunking concern (TD-126 Phase 3): text + code-aware AST chunking via
+# tree-sitter (requires Python 3.10+). Opt-in so the core install stays light —
+# `import proximadb_sdk` no longer pulls tree-sitter; the chunking public names
+# load lazily on first access (see proximadb_sdk/__init__.py __getattr__).
+#   pip install 'proximadb[chunking]'
+chunking = [
+    "tree-sitter>=0.24.0",
+    "tree-sitter-language-pack>=0.13.0",
+]
+
+# Back-compat alias for the pre-TD-126 extra name; identical to `chunking`.
 code-chunking = [
     "tree-sitter>=0.24.0",
     "tree-sitter-language-pack>=0.13.0",

--- a/clients/python/src/proximadb_sdk/__init__.py
+++ b/clients/python/src/proximadb_sdk/__init__.py
@@ -254,61 +254,77 @@ def connect_arrow_flight(url: str = None, **kwargs) -> ProximaDBClient:
     return ProximaDBClient(**kwargs)
 
 
-# Text chunking utilities (if available)
-try:
-    from .chunking import (
-        ChunkingConfig,
-        ChunkingStrategy,
-        TextChunk,
-        TextChunker,
-        chunk_and_embed_records,
-        chunk_and_embed_text,
-        chunk_by_paragraphs,
-        chunk_by_sentences,
-        chunk_sliding_window,
-        create_chunker,
-        create_records,
-        create_vector_records,
-        prepare_records,
-        prepare_vector_records,
+# TD-126 Phase 3: the chunking concern (text chunking, code-aware AST chunking,
+# code-knowledge builder — the `proximadb_sdk.chunking` / `chunking_strategies` /
+# `code_knowledge` modules, ~9.4k LOC) is the heaviest non-transport concern: it
+# pulls tree-sitter and, transitively, the embedding/integration stacks. It used
+# to be imported EAGERLY here, so a bare `import proximadb_sdk` paid that cost
+# even for pure transport use. It is now opt-in (extra `proximadb[chunking]`) and
+# loaded LAZILY via the package-level `__getattr__` below — the public names stay
+# importable (`from proximadb_sdk import TextChunker`) but the heavy import only
+# fires on first access. Availability is probed without importing the heavy
+# modules (so `import proximadb_sdk` never touches tree-sitter).
+#
+# Each entry: public name -> (submodule, attribute).
+_CHUNKING_EXPORTS = {
+    name: (".chunking", name)
+    for name in (
+        "ChunkingConfig",
+        "ChunkingStrategy",
+        "TextChunk",
+        "TextChunker",
+        "chunk_and_embed_records",
+        "chunk_and_embed_text",
+        "chunk_by_paragraphs",
+        "chunk_by_sentences",
+        "chunk_sliding_window",
+        "create_chunker",
+        "create_records",
+        "create_vector_records",
+        "prepare_records",
+        "prepare_vector_records",
     )
-
-    _chunking_available = True
-except ImportError:
-    _chunking_available = False
-
-# Code-aware chunking and knowledge builder (if available)
-try:
-    from .chunking_strategies import (
-        CodeChunkingConfig,
-        CodeChunkingStrategy,
-        CodeRelation,
-        CodeRelationType,
-        CodeSymbol,
-        CodeSymbolType,
-        create_code_chunker,
-        get_supported_extensions,
-        get_supported_languages,
-        register_language_parser,
+}
+_CODE_CHUNKING_EXPORTS = {
+    name: (".chunking_strategies", name)
+    for name in (
+        "CodeChunkingConfig",
+        "CodeChunkingStrategy",
+        "CodeRelation",
+        "CodeRelationType",
+        "CodeSymbol",
+        "CodeSymbolType",
+        "create_code_chunker",
+        "get_supported_extensions",
+        "get_supported_languages",
+        "register_language_parser",
     )
-
-    _code_chunking_available = True
-except ImportError:
-    _code_chunking_available = False
-
-# Code knowledge builder (if available)
-try:
-    from .code_knowledge import (
-        CodeIndexConfig,
-        CodeKnowledgeBuilder,
-        CodeSearchResult,
-        IndexingResult,
-        create_code_knowledge_store,
+}
+_CODE_KNOWLEDGE_EXPORTS = {
+    name: (".code_knowledge", name)
+    for name in (
+        "CodeIndexConfig",
+        "CodeKnowledgeBuilder",
+        "CodeSearchResult",
+        "IndexingResult",
+        "create_code_knowledge_store",
     )
+}
 
-    _code_knowledge_available = True
-except ImportError:
-    _code_knowledge_available = False
+
+def _chunking_concern_available() -> bool:
+    """True if the `chunking` extra's deps are importable (no heavy import)."""
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec("tree_sitter") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+_chunking_available = _chunking_concern_available()
+_code_chunking_available = _chunking_available
+_code_knowledge_available = _chunking_available
 
 # Additional config classes
 try:
@@ -642,7 +658,14 @@ def _optional_export_is_available(name: str) -> bool:
         alternatives = dep if isinstance(dep, tuple) else (dep,)
         found = False
         for alternative in alternatives:
-            if importlib.util.find_spec(alternative) is None:
+            try:
+                spec = importlib.util.find_spec(alternative)
+            except (ImportError, ValueError):
+                # find_spec raises ValueError when a half-initialized module
+                # (e.g. one a test left with `__spec__ = None`) is on
+                # sys.modules; treat that as "not cleanly available".
+                continue
+            if spec is None:
                 continue
             try:
                 importlib.import_module(alternative)
@@ -670,8 +693,18 @@ __all__.extend(
 )
 
 
+# TD-126 Phase 3: chunking exports are lazy too — same machinery, but their
+# availability is gated on the `chunking` extra (tree-sitter) rather than a
+# per-integration dependency probe.
+_LAZY_CHUNKING_EXPORTS = {
+    **_CHUNKING_EXPORTS,
+    **_CODE_CHUNKING_EXPORTS,
+    **_CODE_KNOWLEDGE_EXPORTS,
+}
+
+
 def __getattr__(name):
-    """Load optional integrations only when their public export is accessed."""
+    """Load optional integrations / chunking only when first accessed."""
     if name in _OPTIONAL_EXPORTS:
         import importlib
 
@@ -687,6 +720,25 @@ def __getattr__(name):
             raise AttributeError(
                 f"module {__name__!r} has no attribute {name!r} "
                 f"(optional dependency import failed: {exc})"
+            ) from exc
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    if name in _LAZY_CHUNKING_EXPORTS:
+        import importlib
+
+        if not _chunking_available:
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r} "
+                f"(install the chunking extra: pip install 'proximadb[chunking]')"
+            )
+        module_name, attr_name = _LAZY_CHUNKING_EXPORTS[name]
+        try:
+            module = importlib.import_module(module_name, __name__)
+        except Exception as exc:
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r} "
+                f"(chunking extra import failed: {exc})"
             ) from exc
         value = getattr(module, attr_name)
         globals()[name] = value

--- a/clients/python/tests/unit/test_integrations_frameworks_cov.py
+++ b/clients/python/tests/unit/test_integrations_frameworks_cov.py
@@ -95,6 +95,22 @@ def _install_langchain_stubs() -> None:
     lc_core.vectorstores = vs_mod  # type: ignore[attr-defined]
     lc_core.tools = tools_mod  # type: ignore[attr-defined]
 
+    # Give each stub a valid ModuleSpec. Without it, `__spec__` is None, and a
+    # later test that does `importlib.util.find_spec("langchain_core")` (e.g. the
+    # SDK's optional-export availability probe) raises
+    # `ValueError: langchain_core.__spec__ is None`. The stub leaks into
+    # sys.modules for the rest of the session, so this isolates the pollution.
+    import importlib.machinery
+
+    for _name, _mod in (
+        ("langchain_core", lc_core),
+        ("langchain_core.documents", docs_mod),
+        ("langchain_core.embeddings", emb_mod),
+        ("langchain_core.vectorstores", vs_mod),
+        ("langchain_core.tools", tools_mod),
+    ):
+        _mod.__spec__ = importlib.machinery.ModuleSpec(_name, loader=None)
+
     sys.modules["langchain_core"] = lc_core
     sys.modules["langchain_core.documents"] = docs_mod
     sys.modules["langchain_core.embeddings"] = emb_mod

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -8,7 +8,9 @@ transport generated from the spec, behind a thin facade, drift-gated); Phase 4 d
 TypeScript (REST transport generated via `openapi-typescript` + `openapi-fetch`), Rust
 (REST transport generated via progenitor), and Python (REST transport generated via
 `openapi-python-client`), all behind unchanged thin facades, drift-gated;
-Phases 3, 5 + remaining Phase-4 languages (jvm) open +
+Phase 3 first increment done (Python `chunking` concern made opt-in + lazy behind
+`proximadb[chunking]`); Phase 3 remaining splits (embeddings, integrations), Phase 5 +
+remaining Phase-4 languages (jvm) open +
 Date: 2026-06-21 +
 Owner: SDK / API surface
 
@@ -191,7 +193,9 @@ TS SDK method needs an operation the spec lacks, annotate the handler (Phase-1 `
 . *Modularize Python.* Extract `chunking_strategies` -> `proximadb-chunking`, `embedding_providers`
   + `llm` -> `proximadb-embeddings`, `integrations` + `adapters` -> `proximadb-langchain` /
   `proximadb-llamaindex`. Reduce `proximadb` (core) to generated transport + facade with light deps;
-  expose the rest as extras.
+  expose the rest as extras. *(First increment shipped 2026-06-22: the `chunking` concern is now
+  opt-in + lazy behind `proximadb[chunking]` — `import proximadb_sdk` no longer pulls tree-sitter;
+  embeddings / integrations splits remain as follow-ups. See the Phase-3 NOTE below.)*
 . *Roll out generation* to the remaining network SDKs (go, jvm, rust); retire the now-redundant
   per-SDK contract tests (generation guarantees conformance).
 +
@@ -334,6 +338,57 @@ ops. Document/graph/observability/meta REST ops still build requests by hand in 
 (generated endpoints exist for them under `_generated/rest/api/`); routing them through the
 adapter is a mechanical follow-up. Phase 3 (modularizing the kitchen-sink package) is the next
 Python increment.
+====
++
+[NOTE]
+====
+*Phase 3 first increment shipped (2026-06-22) — Python `chunking` concern made opt-in + lazy.*
+The chunking concern (text chunking, code-aware AST chunking, the code-knowledge builder — the
+`proximadb_sdk.chunking` / `chunking_strategies` / `code_knowledge` modules, ~9.4k LOC) was the
+heaviest non-transport concern: importing it pulls tree-sitter and, transitively, the
+embedding/integration stacks. It used to be imported EAGERLY in `proximadb_sdk/__init__.py`, so a
+bare `import proximadb_sdk` paid that cost even for pure transport use.
+
+*What changed (public API unchanged).* The three eager `from .chunking* import (...)` blocks were
+replaced with lazy registry entries loaded on first access via the package-level `__getattr__`
+(the same mechanism the `integrations` exports already use). The public names stay importable —
+`from proximadb_sdk import TextChunker`, `CodeChunkingStrategy`, etc. — and the submodule import
+paths (`import proximadb_sdk.chunking_strategies`) are untouched; only the *timing* of the heavy
+import moved to first use. Availability is now probed with `importlib.util.find_spec` (no import),
+so `import proximadb_sdk` never touches tree-sitter. When the extra is absent, the chunking names
+are omitted from `__all__` and accessing one raises a helpful
+`AttributeError("... install the chunking extra: pip install 'proximadb[chunking]'")`.
+
+*Extras.* Added a canonical `chunking` extra (`pip install 'proximadb[chunking]'`); the
+pre-existing `code-chunking` extra is kept as a back-compat alias. Also fixed a latent core-install
+bug surfaced by the lighter import: `auth.py` imported `requests` unconditionally but it was only
+in the dev/test extras, so a core-only install failed to `import proximadb_sdk` — `requests` is now
+a (light) core dependency.
+
+*Dependency reduction (measured).* In a clean core-only virtualenv (core deps only — no
+tree-sitter / langchain / sentence-transformers / chromadb / lancedb / victor installed),
+`import proximadb_sdk` now pulls ZERO of those heavy modules and `ProximaDBClient` works; before
+this change the eager chunking + integration-availability probe pulled them in. With
+`proximadb[chunking]` installed, lazy access loads the chunking modules on first use exactly as
+before.
+
+*Test hardening.* The optional-export availability probe (`_optional_export_is_available`) and the
+chunking probe now tolerate a half-initialized module on `sys.modules` (catching the
+`ValueError: <mod>.__spec__ is None` that `find_spec` raises). Fixed a pre-existing test-isolation
+bug in `test_integrations_frameworks_cov.py` (its `langchain_core` stub leaked into `sys.modules`
+with `__spec__ = None`, breaking later tests' `find_spec`) by giving each stub a valid
+`ModuleSpec`. Unit suites green (1634 passed across chunking/import/integration/document/repository;
+`test_openapi_contract` still green).
+
+*Remaining Phase-3 splits (follow-ups).* This increment delivers the chunking concern as the first
+clean modularization (lazy + extra) without moving code across distribution boundaries — the
+lowest-risk reviewable step. Still open, as separate increments: (a) extract
+`embedding_providers` + `llm` behind a `proximadb[embeddings]` extra with the same lazy treatment;
+(b) extract `integrations` + `adapters` behind `proximadb[langchain]` / `proximadb[llamaindex]`
+(the integration *exports* are already lazy; the eager `from .adapters import ...` at module top
+and the `embedding_providers` provider auto-registration remain the eager-pull sources to defer);
+(c) optionally promote any of these to genuinely separate distributions
+(`proximadb-chunking` / `-embeddings` / `-langchain`) once the in-tree lazy boundaries are proven.
 ====
 
 == Scope / non-goals


### PR DESCRIPTION
## TD-126 Phase 3 — first Python modularization increment

The chunking concern (text chunking, code-aware AST chunking, code-knowledge builder — `proximadb_sdk.chunking` / `chunking_strategies` / `code_knowledge`, ~9.4k LOC) was the heaviest non-transport concern and was imported **eagerly** at package load, so a bare `import proximadb_sdk` pulled tree-sitter and, transitively, the embedding/integration stacks — even for pure transport use.

Per the TD-126 PR-sizing guidance ("if full modularization is too large/risky, scope to **one** concern, start with chunking"), this is the clean first increment: chunking is made **opt-in + lazy** without moving code across distribution boundaries.

### What changed (public API unchanged)
- The three eager `from .chunking* import (...)` blocks in `__init__.py` are replaced with **lazy registry entries** loaded on first access via the package-level `__getattr__` (the same machinery the `integrations` exports already use).
- **Public names stay importable** — `from proximadb_sdk import TextChunker`, `CodeChunkingStrategy`, etc. — and submodule import paths (`import proximadb_sdk.chunking_strategies`) are untouched. Only the *timing* of the heavy import moved to first use.
- Availability is probed with `importlib.util.find_spec` (no import), so `import proximadb_sdk` never touches tree-sitter. Without the extra, chunking names are omitted from `__all__` and access raises a helpful `AttributeError(... install proximadb[chunking])`.
- Added a canonical **`chunking`** extra (`pip install 'proximadb[chunking]'`); the pre-existing `code-chunking` extra is kept as a back-compat alias.
- Fixed a latent core-install bug surfaced by the lighter import: `auth.py` imported `requests` unconditionally though it was only in dev/test extras → core-only installs failed to `import proximadb_sdk`. `requests` is now a light core dep.

### Measured dependency reduction
In a **clean core-only virtualenv** (core deps only — no tree-sitter / langchain / sentence-transformers / chromadb / lancedb / victor), `import proximadb_sdk` now pulls **ZERO** of those heavy modules and `ProximaDBClient` works. With `proximadb[chunking]` installed, lazy access loads the chunking modules on first use exactly as before.

### Test hardening
- The optional-export + chunking availability probes now tolerate a half-initialized module on `sys.modules` (catching the `ValueError: <mod>.__spec__ is None` that `find_spec` raises).
- Fixed a **pre-existing test-isolation bug** in `test_integrations_frameworks_cov.py`: its `langchain_core` stub leaked into `sys.modules` with `__spec__ = None`, breaking later tests' `find_spec`. Each stub now gets a valid `ModuleSpec`.
- Unit suites green: 1634 passed across chunking/import/integration/document/repository; `test_openapi_contract` green.

### Remaining Phase-3 splits (follow-ups, documented in `TD_126_*.adoc`)
- (a) `embedding_providers` + `llm` behind `proximadb[embeddings]` (same lazy treatment).
- (b) `integrations` + `adapters` behind `proximadb[langchain]` / `proximadb[llamaindex]` (integration *exports* are already lazy; the eager `from .adapters import ...` at module top and the `embedding_providers` provider auto-registration are the remaining eager-pull sources to defer).
- (c) optionally promote any of these to genuinely separate distributions once the in-tree lazy boundaries are proven.