### PR TITLE
feat(python-sdk): make embeddings + integrations opt-in + lazy (TD-126 Phase 3)

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -52,6 +52,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Embeddings concern (TD-126 Phase 3): the built-in local embedding providers
+# (BGE, E5, GTE-Qwen, sentence-transformer, SFR) and their runtime model deps.
+# Opt-in so the core install stays light — `import proximadb_sdk` and even
+# `import proximadb_sdk.embedding_providers` no longer eagerly import the
+# provider modules; provider self-registration fires lazily on first registry
+# use (see embedding_providers/__init__.py). The `simulated` provider needs no
+# extra deps and works core-only.
+#   pip install 'proximadb[embeddings]'
+embeddings = [
+    "sentence-transformers>=2.2.0",  # Local embedding models (BGE/E5/GTE-Qwen/SFR)
+]
+
 # LLM integration via Victor framework
 llm = [
     "victor-ai>=0.2.0",  # Victor AI framework for embeddings and LLM

--- a/clients/python/src/proximadb_sdk/__init__.py
+++ b/clients/python/src/proximadb_sdk/__init__.py
@@ -11,11 +11,12 @@ Licensed under the Apache License, Version 2.0
 __version__ = "0.2.0"
 __author__ = "ProximaDB Contributors"
 
-# Protocol adapters
-from .adapters import (
-    BaseProtocolAdapter,
-    create_adapter,
-)
+# Protocol adapters (TD-126 Phase 3): loaded LAZILY via the package-level
+# `__getattr__` below. The adapter package itself is light, but it is the entry
+# point into the embedded / integration code paths, so deferring it keeps a bare
+# `import proximadb_sdk` strictly transport+facade+models. Public names stay
+# importable (`from proximadb_sdk import BaseProtocolAdapter, create_adapter`);
+# only the import timing moves to first access.
 
 # Authentication
 from .auth import (
@@ -636,6 +637,14 @@ _OPTIONAL_EXPORTS = {
     "ProximaDBVectorDB": (".integrations.autogen", "ProximaDBVectorDB"),
 }
 
+# TD-126 Phase 3: protocol adapters are always importable (light, no third-party
+# dep), but loaded lazily so they don't run at package import. public name ->
+# (submodule, attribute).
+_ADAPTER_EXPORTS = {
+    "BaseProtocolAdapter": (".adapters", "BaseProtocolAdapter"),
+    "create_adapter": (".adapters", "create_adapter"),
+}
+
 _OPTIONAL_EXPORT_DEPENDENCIES = {
     "ProximaDBVectorStore": ("langchain_core",),
     "ProximaDBEmbeddingProvider": ("victor", "victor_contracts"),
@@ -648,7 +657,14 @@ _OPTIONAL_EXPORT_DEPENDENCIES = {
 
 
 def _optional_export_is_available(name: str) -> bool:
-    import importlib
+    # TD-126 Phase 3: availability is probed with importlib.util.find_spec ONLY
+    # (no importlib.import_module) — mirroring the chunking concern probe above.
+    # Previously this *imported* each optional dependency to test it, which meant
+    # building `__all__` at package load eagerly pulled langchain_core / victor /
+    # crewai / dspy / autogen whenever they happened to be installed, defeating
+    # the lazy `__getattr__` below. find_spec answers "is it importable?" without
+    # running the import, so a bare `import proximadb_sdk` no longer touches the
+    # integration stacks; the heavy import still fires lazily on first access.
     import importlib.util
 
     dependencies = _OPTIONAL_EXPORT_DEPENDENCIES.get(name, ())
@@ -665,14 +681,9 @@ def _optional_export_is_available(name: str) -> bool:
                 # (e.g. one a test left with `__spec__ = None`) is on
                 # sys.modules; treat that as "not cleanly available".
                 continue
-            if spec is None:
-                continue
-            try:
-                importlib.import_module(alternative)
+            if spec is not None:
                 found = True
                 break
-            except Exception:
-                continue
         if not found:
             return False
     return True
@@ -691,6 +702,8 @@ __all__.extend(
 __all__.extend(
     name for name in _OPTIONAL_EXPORTS if _optional_export_is_available(name)
 )
+# Protocol adapters are always available (lazy, but unconditional).
+__all__.extend(_ADAPTER_EXPORTS)
 
 
 # TD-126 Phase 3: chunking exports are lazy too — same machinery, but their
@@ -704,7 +717,15 @@ _LAZY_CHUNKING_EXPORTS = {
 
 
 def __getattr__(name):
-    """Load optional integrations / chunking only when first accessed."""
+    """Load optional integrations / chunking / adapters only when first accessed."""
+    if name in _ADAPTER_EXPORTS:
+        import importlib
+
+        module_name, attr_name = _ADAPTER_EXPORTS[name]
+        module = importlib.import_module(module_name, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
     if name in _OPTIONAL_EXPORTS:
         import importlib
 

--- a/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
@@ -7,7 +7,7 @@ Clean, extensible embedding provider system with:
 - Plugin-based provider registration
 """
 
-# Core components
+# Core components (light — registry, config, base classes; no model deps)
 from .core import (
     BaseEmbeddingProvider,
     ModelCache,
@@ -15,14 +15,62 @@ from .core import (
     ProviderConfig,
     ProviderRegistry,
 )
-from .providers.local.bge import BGEProvider
-from .providers.local.e5 import E5Provider
 
-# Import providers to trigger registration
-from .providers.local.gte_qwen import GTEQwenProvider
-from .providers.local.sentence_transformer import SentenceTransformerProvider
-from .providers.local.sfr import SFRProvider
-from .providers.testing.simulated import SimulatedEmbeddingProvider
+# TD-126 Phase 3 (embeddings concern): the concrete providers self-register via
+# the `@ProviderRegistry.register(...)` decorator at *module import* time. They
+# used to be imported EAGERLY here, so `import proximadb_sdk.embedding_providers`
+# paid the cost of importing every provider module (and, on first model use,
+# sentence-transformers / onnx) even when only the registry API was wanted. The
+# provider imports are now deferred: registration fires LAZILY the first time the
+# registry is consulted (`get_provider` / `list_providers` / `get_provider_info`)
+# or a provider class name is accessed. Public names stay importable
+# (`from proximadb_sdk.embedding_providers import GTEQwenProvider`); only the
+# import timing moved. Install the runtime deps with `pip install
+# 'proximadb[embeddings]'`.
+#
+# Public provider-class name -> (submodule, attribute).
+_PROVIDER_EXPORTS = {
+    "BGEProvider": (".providers.local.bge", "BGEProvider"),
+    "E5Provider": (".providers.local.e5", "E5Provider"),
+    "GTEQwenProvider": (".providers.local.gte_qwen", "GTEQwenProvider"),
+    "SentenceTransformerProvider": (
+        ".providers.local.sentence_transformer",
+        "SentenceTransformerProvider",
+    ),
+    "SFRProvider": (".providers.local.sfr", "SFRProvider"),
+    "SimulatedEmbeddingProvider": (
+        ".providers.testing.simulated",
+        "SimulatedEmbeddingProvider",
+    ),
+}
+
+_providers_registered = False
+
+
+def _ensure_providers_registered() -> None:
+    """Import the built-in provider modules so they self-register (idempotent)."""
+    global _providers_registered
+    if _providers_registered:
+        return
+    import importlib
+
+    for module_name, _attr in _PROVIDER_EXPORTS.values():
+        # The import side effect runs each module's @ProviderRegistry.register.
+        importlib.import_module(module_name, __name__)
+    _providers_registered = True
+
+
+def __getattr__(name: str):
+    """Lazily import a provider class on first attribute access."""
+    if name in _PROVIDER_EXPORTS:
+        import importlib
+
+        module_name, attr_name = _PROVIDER_EXPORTS[name]
+        module = importlib.import_module(module_name, __name__)
+        value = getattr(module, attr_name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_provider(name: str, **config_kwargs):
@@ -40,6 +88,7 @@ def get_provider(name: str, **config_kwargs):
         >>> provider = get_provider("gte-qwen")
         >>> provider = get_provider("simulated", dimension=768)
     """
+    _ensure_providers_registered()
     provider_class = ProviderRegistry.get_provider(name)
 
     if not config_kwargs:
@@ -69,11 +118,13 @@ def get_provider(name: str, **config_kwargs):
 
 def list_providers(include_aliases: bool = False) -> list[str]:
     """List all available providers"""
+    _ensure_providers_registered()
     return ProviderRegistry.list_providers(include_aliases=include_aliases)
 
 
 def get_provider_info(name: str) -> dict:
     """Get detailed provider information"""
+    _ensure_providers_registered()
     return ProviderRegistry.get_provider_info(name)
 
 

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -8,9 +8,9 @@ transport generated from the spec, behind a thin facade, drift-gated); Phase 4 d
 TypeScript (REST transport generated via `openapi-typescript` + `openapi-fetch`), Rust
 (REST transport generated via progenitor), and Python (REST transport generated via
 `openapi-python-client`), all behind unchanged thin facades, drift-gated;
-Phase 3 first increment done (Python `chunking` concern made opt-in + lazy behind
-`proximadb[chunking]`); Phase 3 remaining splits (embeddings, integrations), Phase 5 +
-remaining Phase-4 languages (jvm) open +
+Phase 3 done (Python `chunking`, `embeddings`, and `integrations`/`adapters` concerns all made
+opt-in + lazy behind extras — `import proximadb_sdk` pulls zero heavy deps; core =
+transport+facade+models); Phase 5 + remaining Phase-4 languages (jvm) open +
 Date: 2026-06-21 +
 Owner: SDK / API surface
 
@@ -193,9 +193,11 @@ TS SDK method needs an operation the spec lacks, annotate the handler (Phase-1 `
 . *Modularize Python.* Extract `chunking_strategies` -> `proximadb-chunking`, `embedding_providers`
   + `llm` -> `proximadb-embeddings`, `integrations` + `adapters` -> `proximadb-langchain` /
   `proximadb-llamaindex`. Reduce `proximadb` (core) to generated transport + facade with light deps;
-  expose the rest as extras. *(First increment shipped 2026-06-22: the `chunking` concern is now
-  opt-in + lazy behind `proximadb[chunking]` — `import proximadb_sdk` no longer pulls tree-sitter;
-  embeddings / integrations splits remain as follow-ups. See the Phase-3 NOTE below.)*
+  expose the rest as extras. *(Shipped 2026-06-22 across two increments: the `chunking`,
+  `embeddings`, and `integrations`/`adapters` concerns are all now opt-in + lazy behind extras —
+  `import proximadb_sdk` pulls zero of tree-sitter / sentence-transformers / langchain; core is
+  transport+facade+models. Promoting any concern to a genuinely separate distribution is the only
+  optional follow-up left. See the Phase-3 NOTEs below.)*
 . *Roll out generation* to the remaining network SDKs (go, jvm, rust); retire the now-redundant
   per-SDK contract tests (generation guarantees conformance).
 +
@@ -389,6 +391,66 @@ lowest-risk reviewable step. Still open, as separate increments: (a) extract
 and the `embedding_providers` provider auto-registration remain the eager-pull sources to defer);
 (c) optionally promote any of these to genuinely separate distributions
 (`proximadb-chunking` / `-embeddings` / `-langchain`) once the in-tree lazy boundaries are proven.
+====
+
+[NOTE]
+.Phase 3 second increment shipped (2026-06-22) — embeddings + integrations made opt-in + lazy
+====
+Follow-ups (a) and (b) above are now done, completing the kitchen-sink modularization: a bare
+`import proximadb_sdk` (plus client construction) is now strictly transport + facade + models and
+pulls *zero* of sentence-transformers / onnx / langchain / llama-index / chromadb / lancedb /
+tree-sitter.
+
+*What changed (public API unchanged).*
+
+. *Integrations — the real measurable eager-pull.* `_optional_export_is_available()` in
+  `proximadb_sdk/__init__.py` used to *import* each optional dependency (`importlib.import_module`)
+  to test availability while building `__all__` at package load. That eagerly pulled
+  `langchain_core` / `victor` / `crewai` / `dspy` / `autogen` whenever they happened to be
+  installed, defeating the lazy `__getattr__`. It now probes with `importlib.util.find_spec` ONLY
+  (no import) — exactly the chunking-concern probe pattern from increment 1. Measured: with
+  `langchain-core` + `sentence-transformers` installed, `import proximadb_sdk` previously pulled
+  `langchain_core`; it now pulls none.
+
+. *Adapters.* The eager `from .adapters import (BaseProtocolAdapter, create_adapter)` at module top
+  (the entry point into the embedded / integration code paths) is now loaded lazily via the
+  package-level `__getattr__` through a new `_ADAPTER_EXPORTS` registry. Public names stay
+  importable (`from proximadb_sdk import BaseProtocolAdapter, create_adapter`) and unconditionally
+  present in `__all__`; only the import timing moved.
+
+. *Embeddings — provider auto-registration.* `embedding_providers/__init__.py` used to eagerly
+  `from .providers.local.X import …` for every built-in provider (BGE, E5, GTE-Qwen,
+  sentence-transformer, SFR, simulated), which self-register via the `@ProviderRegistry.register`
+  decorator at *module import*. So `import proximadb_sdk.embedding_providers` imported every
+  provider module up front. Registration is now deferred behind `_ensure_providers_registered()`
+  (idempotent), invoked lazily by `get_provider` / `list_providers` / `get_provider_info`; the
+  provider *classes* are exposed via a module-level `__getattr__` over `_PROVIDER_EXPORTS`. Public
+  names stay importable (`from proximadb_sdk.embedding_providers import GTEQwenProvider`); the
+  registry API behaves identically. (The provider modules already deferred the actual
+  `sentence_transformers` import to model-load time, so the *third-party* pull was already lazy;
+  this increment makes the provider-module imports + registration lazy too.)
+
+*Extras.* Added a canonical `embeddings` extra (`pip install 'proximadb[embeddings]'` →
+sentence-transformers). The `langchain` / `llama_index` integration extras already existed; the
+integration exports were already lazy via `_OPTIONAL_EXPORTS`.
+
+*Measured core-dep reduction.* Clean core-only venv (`pip install -e .`, no extras), then with
+`langchain-core` + `sentence-transformers` additionally installed to detect eager pulls:
+`import proximadb_sdk` + `ProximaDBClient(...)` heavy-module set went from `['langchain_core']`
+(before) to `[]` (after). With the extra installed, lazy access loads the concern on first use
+exactly as before. The remaining top-level third-party modules pulled by core import are all
+legitimate transport deps (numpy, grpc, httpx, pydantic, requests, rich, zstandard, …).
+
+*Test isolation.* No new stubs were introduced. The pre-existing, separately-quarantined
+collection-time `sys.modules` stub leak between the `*_cov` embedding tests and the real-model
+`test_embedding_providers_v2` (`requires_models`) is handled in CI by per-file process isolation
+(`ci.yml` runs each `tests/unit/test_*.py` in its own process via `xargs -P 4 -n 1`), so this
+change does not affect it.
+
+*Kitchen-sink status: fully modularized.* Core = transport + facade + models only. The three heavy
+concerns (chunking, embeddings, integrations) are all opt-in + lazy behind extras. Follow-up (c) —
+promoting any concern to a genuinely separate distribution (`proximadb-chunking` / `-embeddings` /
+`-langchain`) — remains optional and is the only Phase-3 work left.
 ====
 
 == Scope / non-goals


### PR DESCRIPTION
Second Phase-3 modularization increment, completing the Python SDK kitchen-sink split begun in #170 (chunking). After this, a bare `import proximadb_sdk` (plus client construction) is strictly **transport + facade + models** and pulls **zero** of sentence-transformers / onnx / langchain / llama-index / chromadb / lancedb / tree-sitter.

## What changed (public API unchanged)

**Integrations — the real, measurable eager-pull.** `_optional_export_is_available()` used to `importlib.import_module` each optional dependency to test it while building `__all__` at package load. That eagerly pulled `langchain_core` / `victor` / `crewai` / `dspy` / `autogen` whenever they were installed, defeating the lazy `__getattr__`. It now probes with `importlib.util.find_spec` **only** (no import) — the same pattern the chunking-concern probe uses (#170).

**Adapters.** The eager `from .adapters import (BaseProtocolAdapter, create_adapter)` at the top of the package (the entry point into the embedded / integration code paths) is now loaded lazily via the package-level `__getattr__` through a new `_ADAPTER_EXPORTS` registry. Public names stay importable (`from proximadb_sdk import BaseProtocolAdapter, create_adapter`) and remain unconditionally present in `__all__`; only the import timing moved.

**Embeddings — provider auto-registration.** `embedding_providers/__init__.py` used to eagerly `from .providers.local.X import ...` for every built-in provider, each of which self-registers via the `@ProviderRegistry.register` decorator at module import — so `import proximadb_sdk.embedding_providers` imported every provider module up front. Registration is now deferred behind an idempotent `_ensure_providers_registered()`, invoked lazily by `get_provider` / `list_providers` / `get_provider_info`; the provider classes are exposed via a module-level `__getattr__` over `_PROVIDER_EXPORTS`. Public names stay importable; the registry API behaves identically. (The provider modules already deferred the `sentence_transformers` import to model-load time, so the third-party pull was already lazy; this makes the provider-module imports + registration lazy too.)

**Extras.** Added a canonical `embeddings` extra (`pip install 'proximadb[embeddings]'` → sentence-transformers). The `langchain` / `llama_index` integration extras already existed; integration exports were already lazy via `_OPTIONAL_EXPORTS`.

## Measured core-dep reduction
Clean core-only venv (`pip install -e .`, no extras), then with `langchain-core` + `sentence-transformers` additionally installed to detect eager pulls:

| | `import proximadb_sdk` + `ProximaDBClient(...)` heavy-module set |
|---|---|
| **before** | `['langchain_core']` |
| **after** | `[]` |

The `simulated` embedding provider works core-only (no extra). Remaining top-level third-party modules pulled by core import are all legitimate transport deps (numpy, grpc, httpx, pydantic, requests, rich, zstandard, …).

## Tests / gates
- `black --check src tests`, `isort --check-only src tests`, `ruff check src tests --select=E9,F63,F7` all pass; changed files `py_compile` clean.
- Targeted unit suites green (per-file, as CI runs them): import / embedding-provider / embedded / integration (langchain, langgraph, dspy, crewai, autogen) / adapter / chunking files.
- No new test stubs introduced. The pre-existing, separately-quarantined collection-time `sys.modules` stub leak between the `*_cov` embedding tests and the real-model `test_embedding_providers_v2` (`requires_models`) is handled in CI by per-file process isolation (`ci.yml` runs each `tests/unit/test_*.py` in its own process), so this change does not affect it.

## Kitchen-sink status: fully modularized
Core = transport + facade + models. The three heavy concerns (chunking, embeddings, integrations) are all opt-in + lazy behind extras. Promoting any concern to a genuinely separate distribution (`proximadb-chunking` / `-embeddings` / `-langchain`) is the only optional Phase-3 follow-up left. Tracked in `roadmap/techdebt/TD_126_*.adoc`.