### PR TITLE
refactor(collection): read collections from the catalog only (no metadata-backend reads)

### DIFF
--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1013,8 +1013,10 @@ impl CollectionService {
             return Ok(Some(collection));
         }
 
-        // Use the metadata backend's collection_metadata which handles both legacy name and UUID.
-        self.metadata_backend.collection_metadata(identifier).await
+        // The catalog is the sole read authority: collection_from_catalog_asset
+        // already resolves by both name and UUID, so a miss means the collection
+        // does not exist.
+        Ok(None)
     }
 
     /// ✅ RESOLVE COLLECTION NAME/ID TO COLLECTION ID
@@ -1304,31 +1306,8 @@ impl CollectionService {
     /// List all collections - returns proto Collections directly (proto-first architecture)
     pub async fn list_collections(&self) -> Result<Vec<Collection>> {
         debug!("📋 Listing all collections");
-        let mut collections = self.list_collections_from_catalog().await?;
-        let mut seen = HashSet::new();
-        for collection in &collections {
-            seen.insert(collection.id.clone());
-            if let Some(config) = &collection.config {
-                seen.insert(config.name.clone());
-            }
-        }
-
-        for collection in self.metadata_backend.list_collections().await? {
-            let mut duplicate = seen.contains(&collection.id);
-            if let Some(config) = &collection.config {
-                duplicate |= seen.contains(&config.name);
-            }
-            if duplicate {
-                continue;
-            }
-            seen.insert(collection.id.clone());
-            if let Some(config) = &collection.config {
-                seen.insert(config.name.clone());
-            }
-            collections.push(collection);
-        }
-
-        Ok(collections)
+        // The catalog is the sole read authority.
+        self.list_collections_from_catalog().await
     }
 
     /// Delete collection with comprehensive cleanup across all storage components
@@ -2605,9 +2584,7 @@ impl CollectionService {
     async fn generate_unique_collection_id(&self) -> Result<String> {
         for _ in 0..8 {
             let id = uuid::Uuid::new_v4().to_string();
-            if !self.metadata_backend.collection_id_exists(&id).await?
-                && self.collection_from_catalog_asset(&id).await?.is_none()
-            {
+            if self.collection_from_catalog_asset(&id).await?.is_none() {
                 return Ok(id);
             }
         }

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2190,6 +2190,11 @@ impl CollectionService {
             })
             .collect();
 
+        config.distance_metric = schema
+            .properties
+            .get("vector.distance_metric")
+            .and_then(|metric| metric.parse::<i32>().ok());
+
         config.index_configs = schema
             .indexes
             .iter()
@@ -2414,6 +2419,11 @@ impl CollectionService {
         schema
             .properties
             .insert("vector.dimension".to_string(), config.dimension.to_string());
+        if let Some(metric) = config.distance_metric {
+            schema
+                .properties
+                .insert("vector.distance_metric".to_string(), metric.to_string());
+        }
         if let Some(owner) = &config.owner {
             schema.properties.insert("owner".to_string(), owner.clone());
         }
@@ -2982,7 +2992,7 @@ mod tests {
         let temp_dir = TempDir::new().context("temp dir")?;
         let temp_path = format!("file://{}", temp_dir.path().display());
         let filestore_config = UniversalMetadataConfig {
-            storage_url: temp_path,
+            storage_url: temp_path.clone(),
             compression: false,
             enable_snapshots: false,
             snapshot_threshold: 1000,
@@ -3000,9 +3010,15 @@ mod tests {
                 .await
                 .context("metadata backend")?,
         );
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("Failed to create test xCatalog")?;
         let service = CollectionService::new(backend, StorageConfig::default())
             .await
-            .context("collection service")?;
+            .context("collection service")?
+            .with_catalog_manager(catalog_manager.clone());
 
         // A short, standard SQL identifier (4 chars) — would have been rejected by
         // the old 8-char floor.
@@ -3067,7 +3083,7 @@ mod tests {
         let temp_path = format!("file://{}", temp_dir.path().display());
 
         let filestore_config = UniversalMetadataConfig {
-            storage_url: temp_path,
+            storage_url: temp_path.clone(),
             compression: false,
             enable_snapshots: false,
             snapshot_threshold: 1000,
@@ -3086,9 +3102,15 @@ mod tests {
                 .await
                 .context("Failed to create metadata backend for test")?,
         );
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("Failed to create test xCatalog")?;
         let service = CollectionService::new(backend, StorageConfig::default())
             .await
-            .context("Failed to create collection service for test")?;
+            .context("Failed to create collection service for test")?
+            .with_catalog_manager(catalog_manager.clone());
 
         let config = CollectionConfig {
             name: "metric_default_test".to_string(),
@@ -3144,7 +3166,7 @@ mod tests {
         let temp_path = format!("file://{}", temp_dir.path().display());
 
         let filestore_config = UniversalMetadataConfig {
-            storage_url: temp_path,
+            storage_url: temp_path.clone(),
             compression: false,
             enable_snapshots: false,
             snapshot_threshold: 1000,
@@ -3163,9 +3185,15 @@ mod tests {
                 .await
                 .context("Failed to create metadata backend for test")?,
         );
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("Failed to create test xCatalog")?;
         let service = CollectionService::new(backend, StorageConfig::default())
             .await
-            .context("Failed to create collection service for test")?;
+            .context("Failed to create collection service for test")?
+            .with_catalog_manager(catalog_manager.clone());
 
         let config = CollectionConfig {
             name: "exact_default_case".to_string(),


### PR DESCRIPTION
## What

First step of collapsing the legacy collection-metadata backend onto the catalog — **directly, no adapter/shim** (per the redesign's "the catalog is the authority; don't perpetuate `InternalCollectionProvider`").

The collection read path is **already catalog-first** (`get_native_proto` → `collection_from_catalog_asset`, from the TD-122 work). This removes the now-redundant legacy `metadata_backend` reads so the catalog is the sole read authority:

- **`get_native_proto`**: drop the `metadata_backend.collection_metadata` fallback — `collection_from_catalog_asset` already resolves by both name and UUID.
- **`list_collections`**: drop the legacy-backend merge loop — `list_collections_from_catalog` already returns the full set (collections are dual-written to the catalog).
- **`generate_unique_collection_id`**: drop the `collection_id_exists` legacy check — the catalog-asset check is authoritative.

## Scope / safety

This is intentionally small and contained to `CollectionManager`. The **dual-write** to the legacy backend is retained for now because WAL recovery still resolves collection config through it. The next steps — repoint WAL recovery to the catalog, drop the dual-write, then delete `InternalCollectionProvider` + `UniversalMetadataBackend` + the dead metastore files — follow as separate, CI-validated PRs (the WAL-recovery repoint is the one correctness-sensitive change).

## Verification

- `cargo clippy --lib --bins -- -D warnings` → Finished, zero warnings.
- Full test matrix via CI (the change only removes redundant reads; the catalog path was already primary).