### PR TITLE
fix(gpu): dedup GpuDevice import so --features gpu compiles

### DIFF
--- a/src/compute/gpu/distance.rs
+++ b/src/compute/gpu/distance.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info, warn};
 // Import DistanceMetric from proto module
 use crate::compute::distance_computation::engine::{GpuAccelerator, HardwareBackend};
 use crate::core::hardware_capabilities::{
-    GpuBackend, GpuDevice, HardwareCapabilities, get_hardware_capabilities,
+    GpuBackend, HardwareCapabilities, get_hardware_capabilities,
 };
 use crate::proto::proximadb_v1::DistanceMetric;
 


### PR DESCRIPTION
## Summary
`--features gpu` (`gpu = ["metal"]`) does **not compile** on develop — `error[E0252]` in `src/compute/gpu/distance.rs:33`: `GpuDevice` is imported both in the `use crate::core::hardware_capabilities::{…}` brace list **and** via the `pub use …::GpuDevice;` re-export below it. Pre-existing rot — the feature was built by no CI job until #171.

Fix: drop `GpuDevice` from the brace import (the `pub use` is the intended one — re-exports the central type and keeps it in scope internally).

## Verification
`cargo check -p proximadb --lib --features gpu` is **green** on macOS after this change (verified locally on M1). The new `gpu-feature-check` job (#171, now on develop) runs on this PR — since it touches `src/compute/gpu/distance.rs` (matches the `gpu_paths` filter) — so it **self-validates** the fix on a macOS runner.

## Why
First real prerequisite for decomposition step 2: with `--features gpu` compiling + CI-guarded, the `hardware_capabilities` GPU-edge inversion (#162) becomes verifiable, unblocking `hw_caps` extraction → `distance-kernel`. Addresses the `--features gpu` half of #168.