### PR TITLE
fix(rest): list/get collections return user name, not UUID id

### DIFF
--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -907,9 +907,14 @@ pub async fn get_collection_v2(
                 .count() as u32;
             let text_field_count = config.text_columns.len() as u32;
 
+            let name = if config.name.is_empty() {
+                collection_id.clone()
+            } else {
+                config.name.clone()
+            };
             let response = CollectionV2Response {
                 collection_id: collection_id.clone(),
-                name: collection_id,
+                name,
                 dimension: config.dimension,
                 engine: engine_str.to_string(),
                 distance_metric: distance_metric_str.to_string(),
@@ -1079,7 +1084,10 @@ pub async fn list_collections_v2(
                     };
                     CollectionV2Summary {
                         collection_id: c.id.clone(),
-                        name: c.id.clone(),
+                        name: cfg
+                            .map(|c| c.name.clone())
+                            .filter(|n| !n.is_empty())
+                            .unwrap_or_else(|| c.id.clone()),
                         dimension: cfg.map_or(0, |cfg| cfg.dimension),
                         engine: engine_str.to_string(),
                         proxima_record_enabled: false,

--- a/tests/api_v2_integration_test.rs
+++ b/tests/api_v2_integration_test.rs
@@ -628,11 +628,33 @@ async fn test_list_collections() {
                 .and_then(|v| v.as_array())
                 .unwrap_or(&empty_vec);
 
-            let found = collections.iter().any(|c| {
+            let our_collection = collections.iter().find(|c| {
                 c.get("name").and_then(|v| v.as_str()) == Some(&harness.test_collection_name)
             });
 
-            assert!(found, "Created collection should be in the list");
+            assert!(
+                our_collection.is_some(),
+                "Created collection should be in the list (matched by user-supplied name, not UUID id)"
+            );
+
+            // Regression (list_collections name vs UUID): the summary `name`
+            // MUST be the user-supplied collection name, not the UUID id.
+            let coll = our_collection.unwrap();
+            let listed_name = coll.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let listed_id = coll
+                .get("collection_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            assert_eq!(
+                listed_name, harness.test_collection_name,
+                "Listed name should equal the user-supplied name, got '{}'",
+                listed_name
+            );
+            assert_ne!(
+                listed_name, listed_id,
+                "Listed name must not be the UUID collection_id ('{}')",
+                listed_id
+            );
 
             println!("test_list_collections PASSED");
         }
@@ -753,6 +775,13 @@ async fn test_get_collection_details() {
             assert!(
                 response.get("name").is_some(),
                 "Response should contain name"
+            );
+            // Regression (get_collection name vs UUID): `name` must be the
+            // user-supplied collection name, not the UUID id.
+            assert_eq!(
+                response.get("name").and_then(|v| v.as_str()),
+                Some(harness.test_collection_name.as_str()),
+                "Get should return the user-supplied name, not the UUID id"
             );
             assert!(
                 response.get("dimension").is_some(),


### PR DESCRIPTION
## Problem
`GET /api/v2/collections` (and `GET /api/v2/collections/{id}`) returned the collection's UUID `id` in the `name` field instead of the user-supplied collection name. A user who creates `my_coll` and then lists collections saw `"name": "<uuid>"`.

## Fix
- `list_collections_v2`: `name` now comes from `cfg.name` (the persisted `CollectionConfig.name` create set from `request.name`), falling back to the UUID id only when the config name is absent/empty.
- `get_collection_v2`: had the same `name: collection_id` bug — now sources `name` from `config.name`, falling back to the requested id.

This is a pure value mapping; the response struct shapes (`CollectionV2Summary`, `CollectionV2Response`) are unchanged, so the OpenAPI spec and generated SDK transports are unaffected (no drift).

## Verification
- `cargo build -p proximadb-server` green; `cargo fmt --check` clean; `cargo clippy -p proximadb --lib -- -D warnings` exit 0.
- Extended the live v2 integration tests (`tests/api_v2_integration_test.rs`) to assert listed/returned `name` equals the user name and differs from the UUID `collection_id`.
- Live e2e smoke: created `my_coll_smoke`; list returned `collection_id=<uuid>, name=my_coll_smoke`; get-by-uuid returned `name=my_coll_smoke` (previously the UUID).

## Note (follow-up, out of scope)
The `collection_id` field in the single-get/create responses echoes whatever identifier the request used (name or UUID) rather than always the canonical UUID — collections are resolvable by either. Worth a follow-up to standardize `collection_id` to always be the canonical UUID.