### PR TITLE
docs(grpc): TD-121 reposition — SQL-over-gRPC is a supported SSO/performant SQL surface

### DIFF
--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -2004,10 +2004,14 @@ pub mod proxima_record_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// DEPRECATED: SQL over gRPC is deprecated. pgwire (the PostgreSQL wire
-        /// protocol) is the canonical SQL surface; connect any PostgreSQL driver and
-        /// run SQL there. gRPC owns record/vector/collection operations, not SQL.
-        /// This RPC will be removed in a future release (see TD-121).
+        /// SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
+        /// (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
+        /// is Postgres-native (password/MD5) and cannot carry a bearer token — so this
+        /// RPC is the SQL path for token/SSO-authenticated and high-throughput
+        /// programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
+        /// surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
+        /// complementary, not redundant. For bulk columnar result sets prefer Arrow
+        /// Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
         pub async fn execute_query(
             &mut self,
             request: impl tonic::IntoRequest<super::V2QueryRequest>,
@@ -2196,10 +2200,14 @@ pub mod proxima_record_service_server {
             tonic::Response<super::V2DeleteCollectionResponse>,
             tonic::Status,
         >;
-        /// DEPRECATED: SQL over gRPC is deprecated. pgwire (the PostgreSQL wire
-        /// protocol) is the canonical SQL surface; connect any PostgreSQL driver and
-        /// run SQL there. gRPC owns record/vector/collection operations, not SQL.
-        /// This RPC will be removed in a future release (see TD-121).
+        /// SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
+        /// (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
+        /// is Postgres-native (password/MD5) and cannot carry a bearer token — so this
+        /// RPC is the SQL path for token/SSO-authenticated and high-throughput
+        /// programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
+        /// surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
+        /// complementary, not redundant. For bulk columnar result sets prefer Arrow
+        /// Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
         async fn execute_query(
             &self,
             request: tonic::Request<super::V2QueryRequest>,

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -79,6 +79,13 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 | SQL clients and tools — psql, psycopg2/asyncpg, JDBC, BI/ORM ecosystem.
 | Supported
 
+| *gRPC `proximadb.v2.ProximaRecordService.ExecuteQuery`*
+| ANSI *SQL* (same DataFusion execution as pgwire)
+| Token/SSO-authenticated and high-throughput programmatic SQL: gRPC carries
+  bearer/JWT in metadata (pgwire cannot) and uses HTTP/2 + protobuf. The SQL
+  path for SaaS/SSO and SDK clients.
+| Supported
+
 | *REST/gRPC `/api/v2/query`* (unified query port)
 | *UQL* (unified multi-modal), *Federated* SQL extensions, *AQL*
 | ProximaDB-native cross-modal queries (vector + graph + relational) that SQL cannot express.
@@ -110,9 +117,13 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 ====
 * pgwire is *SQL-only* and cannot serve UQL/AQL/Cypher; those non-SQL languages require the
   unified query port (`/api/v2/query`) or the graph service — they are not replaceable by pgwire.
-* The plain-SQL gRPC `proximadb.v2.ProximaRecordService.ExecuteQuery` RPC is *deprecated* in
-  favour of pgwire (TD-121); it is the only SQL path on gRPC/REST being retired. The
-  `/api/v2/query` UQL/Federated surface is *not* deprecated.
+* SQL is served by *two complementary, supported* surfaces (TD-121), not one: *pgwire* for the
+  PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth), and the gRPC
+  `ProximaRecordService.ExecuteQuery` RPC for *token/SSO-authenticated and high-throughput
+  programmatic* SQL. They differ by *auth mechanism and transport*, not by SQL dialect (both
+  execute through DataFusion). pgwire auth is password/MD5 and cannot carry a bearer/JWT, so the
+  gRPC SQL path is required for SSO/OIDC clients — it is *not* deprecated. For large columnar
+  result sets prefer Arrow Flight.
 * *Apache Calcite*, if adopted, is an *internal* federated-SQL planner behind pgwire and the
   Federated path — not a client surface, and not a substitute for the non-SQL languages.
 * SSO/governance (auth, RLS, tenancy) is enforced uniformly at the `TenantContext` I/O boundary,

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -813,10 +813,14 @@ service ProximaRecordService {
   rpc ListCollections(V2ListCollectionsRequest) returns (V2ListCollectionsResponse);
   rpc DeleteCollection(V2DeleteCollectionRequest) returns (V2DeleteCollectionResponse);
 
-  // DEPRECATED: SQL over gRPC is deprecated. pgwire (the PostgreSQL wire
-  // protocol) is the canonical SQL surface; connect any PostgreSQL driver and
-  // run SQL there. gRPC owns record/vector/collection operations, not SQL.
-  // This RPC will be removed in a future release (see TD-121).
+  // SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
+  // (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
+  // is Postgres-native (password/MD5) and cannot carry a bearer token — so this
+  // RPC is the SQL path for token/SSO-authenticated and high-throughput
+  // programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
+  // surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
+  // complementary, not redundant. For bulk columnar result sets prefer Arrow
+  // Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
   rpc ExecuteQuery(V2QueryRequest) returns (V2QueryResponse);
 
   // Point record get-by-id (v2 parity with v1 VectorService.VectorGet)


### PR DESCRIPTION
## Why

The #122 deprecation framed **pgwire as the sole canonical SQL surface** and marked the v2 `ProximaRecordService.ExecuteQuery` RPC for removal. Verifying against the code, that premise doesn't hold:

- **SSO**: pgwire auth is Postgres-native (`trust`/`password`/`MD5`, `src/network/postgres/protocol.rs`) and **cannot carry a bearer/JWT**. gRPC/REST carry `Authorization: Bearer` + JWT claims at the `TenantContext` boundary (`middleware/auth.rs`, `middleware/tenant.rs`). So SSO/OIDC-authenticated SQL **must** use gRPC/REST.
- **Multi-modal**: pgwire is SQL-only; UQL/AQL/Federated already require `/api/v2/query`.
- **Performance**: for SQL result sets, gRPC (HTTP/2 + protobuf, streaming) outperforms REST/JSON — and there is no plain-SQL-over-REST path. Removing gRPC SQL would leave only the SSO-incapable pgwire path for programmatic SQL.

So SQL is served by **two complementary, supported surfaces**: pgwire for the PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth) and gRPC `ExecuteQuery` for token/SSO-authenticated, high-throughput programmatic SQL. Both execute through DataFusion — they differ by **auth mechanism + transport**, not dialect. Arrow Flight remains the bulk columnar path.

## Changes (docs/comments only — zero behavior change)

- `proto/proximadb/v2/record.proto`: replace the `DEPRECATED` comment on `ExecuteQuery` with the positive taxonomy; **regenerated** the v2 stub (`PROXIMADB_REGEN_PROTO=1`) — diff is doc-comments only.
- `docs/SUPPORTED_SURFACE.adoc`: add the gRPC SQL `ExecuteQuery` row (**Supported**) and rewrite the note to describe the two complementary SQL surfaces + the auth distinction, instead of "deprecated/being retired".

The RPC + handler (`execute_query` → `execute_sql_v1`) are **unchanged and functional**. Does **not** touch the gRPC **v1 compat** sunset (`PROXIMADB_GRPC_V1_COMPAT`) — that remains flag-OFF + sunset-documented.

## Gates

- `cargo build --lib` clean; `cargo fmt --check` 0 diffs; `scripts/validate_capability_matrix.py` passes (the v1-compat sunset rule is unaffected).