### PR TITLE
fix(rest): v2 collection_id is the canonical UUID on create/get/list

### DIFF
--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -637,9 +637,22 @@ pub async fn create_collection_v2(
         .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
         .await
     {
-        Ok(_resp) => {
+        Ok(resp) => {
+            // #176 follow-up: `collection_id` is the collection's canonical UUID
+            // (`Collection.id`), NOT the request echo. Both the UUID and the user
+            // `name` resolve to the same collection on every endpoint (get/insert/
+            // search/delete) via `CollectionService::collection` → `get_native_proto`,
+            // so returning the UUID keeps a `create → use collection_id` flow working.
+            // Fall back to the request name only if the handler somehow omitted the
+            // created collection (it always populates it on success).
+            let canonical_id = resp
+                .collection
+                .as_ref()
+                .map(|c| c.id.clone())
+                .filter(|id| !id.is_empty())
+                .unwrap_or_else(|| request.name.clone());
             let response = CreateCollectionV2Response {
-                collection_id: request.name.clone(),
+                collection_id: canonical_id,
                 name: request.name,
                 dimension: request.dimension,
                 engine: engine.to_string(),
@@ -912,8 +925,19 @@ pub async fn get_collection_v2(
             } else {
                 config.name.clone()
             };
+            // #176 follow-up: return the canonical UUID (`Collection.id`), not the
+            // path echo (which may be the user-supplied name). The path identifier
+            // resolved to this collection by name OR UUID, and the returned UUID is
+            // itself a valid lookup key on every endpoint, so name- and UUID-based
+            // lookup both keep working. Fall back to the path echo only if the
+            // handler returned a collection without an id.
+            let canonical_id = if collection.id.is_empty() {
+                collection_id.clone()
+            } else {
+                collection.id.clone()
+            };
             let response = CollectionV2Response {
-                collection_id: collection_id.clone(),
+                collection_id: canonical_id,
                 name,
                 dimension: config.dimension,
                 engine: engine_str.to_string(),

--- a/tests/api_v2_integration_test.rs
+++ b/tests/api_v2_integration_test.rs
@@ -269,6 +269,77 @@ impl V2ApiTestHarness {
         Ok(body)
     }
 
+    /// Get collection details by an arbitrary identifier (name OR UUID).
+    async fn get_collection_by(
+        &self,
+        identifier: &str,
+    ) -> Result<(reqwest::StatusCode, JsonValue), Box<dyn std::error::Error>> {
+        let response = self
+            .http_client
+            .get(&format!(
+                "{}/api/v2/collections/{}",
+                REST_BASE_URL, identifier
+            ))
+            .send()
+            .await?;
+        let status = response.status();
+        let body: JsonValue = response.json().await?;
+        Ok((status, body))
+    }
+
+    /// Insert records targeting an arbitrary identifier (name OR UUID).
+    async fn insert_records_to(
+        &self,
+        identifier: &str,
+        records: Vec<JsonValue>,
+    ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
+        let response = self
+            .http_client
+            .post(&format!(
+                "{}/api/v2/collections/{}/records/batch",
+                REST_BASE_URL, identifier
+            ))
+            .json(&json!({ "records": records }))
+            .send()
+            .await?;
+        Ok(response.status())
+    }
+
+    /// Search targeting an arbitrary identifier (name OR UUID).
+    async fn search_in(
+        &self,
+        identifier: &str,
+        query_vector: Vec<f32>,
+        top_k: usize,
+    ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
+        let response = self
+            .http_client
+            .post(&format!(
+                "{}/api/v2/collections/{}/search",
+                REST_BASE_URL, identifier
+            ))
+            .json(&json!({ "vector": query_vector, "top_k": top_k }))
+            .send()
+            .await?;
+        Ok(response.status())
+    }
+
+    /// Delete a collection via V2 API by an arbitrary identifier (name OR UUID).
+    async fn delete_collection_by(
+        &self,
+        identifier: &str,
+    ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
+        let response = self
+            .http_client
+            .delete(&format!(
+                "{}/api/v2/collections/{}",
+                REST_BASE_URL, identifier
+            ))
+            .send()
+            .await?;
+        Ok(response.status())
+    }
+
     /// Cleanup: Delete test collection
     async fn cleanup(&self) {
         // Try to delete via V1 API (V2 may not have delete endpoint yet)
@@ -401,6 +472,140 @@ async fn test_create_collection_basic() {
         }
     }
 
+    harness.cleanup().await;
+}
+
+/// Regression (#176 follow-up): the v2 `collection_id` identity is the
+/// collection's canonical UUID on create/get/list — NOT the request echo —
+/// while `name` stays the user-supplied name, and the returned UUID is a valid
+/// lookup key on every endpoint (get/insert/search/delete) alongside the name.
+#[tokio::test]
+async fn test_collection_id_is_canonical_uuid_and_resolves_both_ways() {
+    let harness = match V2ApiTestHarness::new().await {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Skipping test: Failed to create test harness: {}", e);
+            return;
+        }
+    };
+
+    if !harness.check_server().await {
+        eprintln!("Skipping test: Server not available at {}", REST_BASE_URL);
+        return;
+    }
+
+    let name = harness.test_collection_name.clone();
+
+    // --- CREATE: collection_id must be a UUID (≠ name), name == user name. ---
+    let create = match harness.create_basic_collection().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Skipping test: create failed: {}", e);
+            return;
+        }
+    };
+    let uuid = create
+        .get("collection_id")
+        .and_then(|v| v.as_str())
+        .expect("create response has collection_id")
+        .to_string();
+    assert_ne!(
+        uuid, name,
+        "create collection_id must be the canonical UUID, not the request name"
+    );
+    assert!(
+        !uuid.is_empty(),
+        "create collection_id (UUID) must not be empty"
+    );
+    assert_eq!(
+        create.get("name").and_then(|v| v.as_str()),
+        Some(name.as_str()),
+        "create name must be the user-supplied name"
+    );
+
+    // --- GET by NAME: collection_id is the same UUID, name is the user name. ---
+    let (st, by_name) = harness.get_collection_by(&name).await.expect("get by name");
+    assert!(st.is_success(), "get by name should succeed, got {}", st);
+    assert_eq!(
+        by_name.get("collection_id").and_then(|v| v.as_str()),
+        Some(uuid.as_str()),
+        "get-by-name collection_id must be the canonical UUID"
+    );
+    assert_eq!(
+        by_name.get("name").and_then(|v| v.as_str()),
+        Some(name.as_str()),
+        "get-by-name name must be the user-supplied name"
+    );
+
+    // --- GET by UUID: must succeed and round-trip the same identity. ---
+    let (st, by_uuid) = harness.get_collection_by(&uuid).await.expect("get by uuid");
+    assert!(st.is_success(), "get by UUID should succeed, got {}", st);
+    assert_eq!(
+        by_uuid.get("collection_id").and_then(|v| v.as_str()),
+        Some(uuid.as_str()),
+        "get-by-UUID collection_id must be the canonical UUID"
+    );
+    assert_eq!(
+        by_uuid.get("name").and_then(|v| v.as_str()),
+        Some(name.as_str()),
+        "get-by-UUID name must be the user-supplied name"
+    );
+
+    // --- LIST: our collection appears with UUID collection_id + user name. ---
+    let list = harness
+        .list_collections(Some(1000), Some(0), Some(false))
+        .await
+        .expect("list collections");
+    let empty = vec![];
+    let cols = list
+        .get("collections")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&empty);
+    let ours = cols
+        .iter()
+        .find(|c| c.get("name").and_then(|v| v.as_str()) == Some(name.as_str()))
+        .expect("listed by user name");
+    assert_eq!(
+        ours.get("collection_id").and_then(|v| v.as_str()),
+        Some(uuid.as_str()),
+        "list collection_id must be the canonical UUID"
+    );
+
+    // --- INSERT + SEARCH by UUID (the create-returned key) must work. ---
+    let records = generate_test_records(3, TEST_DIMENSION as usize);
+    let st = harness
+        .insert_records_to(&uuid, records)
+        .await
+        .expect("insert by uuid");
+    assert!(
+        st.is_success(),
+        "insert by the returned UUID should succeed, got {}",
+        st
+    );
+    let st = harness
+        .search_in(&uuid, vec![0.1f32; TEST_DIMENSION as usize], 3)
+        .await
+        .expect("search by uuid");
+    assert!(
+        st.is_success(),
+        "search by the returned UUID should succeed, got {}",
+        st
+    );
+
+    // --- DELETE by the returned UUID must succeed (the create→delete flow). ---
+    // (Post-delete read-visibility is a separate, pre-existing concern — a stale
+    // read may briefly return a default stub — so we don't assert a 404 here.)
+    let st = harness
+        .delete_collection_by(&uuid)
+        .await
+        .expect("delete by uuid");
+    assert!(
+        st.is_success(),
+        "delete by the returned UUID should succeed, got {}",
+        st
+    );
+
+    println!("test_collection_id_is_canonical_uuid_and_resolves_both_ways PASSED");
     harness.cleanup().await;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #176. v2 collection responses set `collection_id` inconsistently: **create** echoed the request `name` (or UUID), **get** echoed the path identifier, while **list** already returned the canonical UUID (`Collection.id`). The three endpoints disagreed on the identity.

Now **create / get / list all return `collection_id` = the collection's canonical UUID** (`Collection.id`). `name` continues to return the user-supplied name (#176).

- **create**: reads the UUID from the handler response, which already carries the created `Collection` (`resp.collection.id`).
- **get**: reads the UUID from the resolved `Collection`.
- **list**: unchanged (already `c.id`).
- Each site falls back to the previous echo only in the degenerate case where the handler returns a collection with an empty id.

## Why this is safe (UUID + name both resolve everywhere)

Collection resolution is **dual-key**. Every endpoint — get / insert / search / delete — resolves an identifier through `CollectionService::collection` → `get_native_proto`, which looks up the catalog asset **by name** first, then the metadata backend **by UUID** (a `DashMap` name→UUID secondary index plus the UUID primary store). IDs are opaque UUIDs with no overlap with user names.

So the returned UUID is a valid lookup key on **every** endpoint, and existing name-based lookup (`GET /api/v2/collections/{name}`) keeps working. A `create → take collection_id → get / insert / search / delete by it` flow round-trips. No path keys strictly by name, so no gating was needed.

## No spec / SDK cascade

Pure value mapping — response struct shapes are unchanged (`collection_id` stays a `string`). The OpenAPI spec and generated SDK transports are unaffected; the spec was not edited.

## Verification

- `cargo build -p proximadb-server` green; `cargo fmt --check` 0 diffs; `cargo clippy -p proximadb --lib` exit 0, no warnings.
- New live v2 integration regression `test_collection_id_is_canonical_uuid_and_resolves_both_ways`: after creating `my_coll`, asserts create / get-by-name / get-by-UUID / list all return `collection_id` = a UUID (≠ name) with `name == "my_coll"`, and that get / insert / search by the returned UUID and delete by the UUID all succeed. **PASSED** against a live server.
- Live e2e smoke (running `target/debug/proximadb-server`, `/health` 200): create → returned `collection_id` = UUID `ad85db4f-…`, name = user name → get-by-UUID (UUID echoed) → insert-by-UUID 200 → search-by-UUID 200 → get-by-name (same UUID + user name) → delete-by-UUID 200. All succeeded.