### PR TITLE
test(repair-chain): fix SearchPlanTrace template missing actual_egress_gb

### DIFF
--- a/tests/repair_chain_integration_test.rs
+++ b/tests/repair_chain_integration_test.rs
@@ -46,6 +46,7 @@ fn trace_template() -> SearchPlanTrace {
         gls_score: None,
         estimated_scan_gb: None,
         actual_scan_gb: 0.1,
+        actual_egress_gb: 0.0,
         index_stats: IndexStats::default(),
         candidate_count: 64,
         rerank_count: 10,


### PR DESCRIPTION
`tests/repair_chain_integration_test.rs` failed to compile on develop — its `trace_template()` was missing the `actual_egress_gb` field added to `SearchPlanTrace` by the egress/KOU cost model. Initialize it to `0.0` (matching the struct's own default). Pure test fix, no production change.

Verified: `cargo test --test repair_chain_integration_test --no-run` compiles clean.