### PR TITLE
feat(wal): resolve collection config from the catalog (provider as fallback)

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -182,6 +182,12 @@ impl ProximaDB {
         )
         .await;
         tracing::info!("✅ ProximaDB::new - Global metadata provider set for WAL");
+        // The catalog is the read authority for WAL/recovery collection
+        // resolution; set it so the legacy metadata provider becomes fallback-only.
+        if let Some(catalog_manager) = collection_service.catalog_manager() {
+            storage::persistence::write_ahead_log::set_global_catalog(catalog_manager).await;
+            tracing::info!("✅ ProximaDB::new - Global catalog set for WAL/recovery");
+        }
 
         // Step 5: Initialize the storage engine (SST/VIPER/etc)
         tracing::info!("🌐 ProximaDB::new - Creating StorageEngine...");

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -1102,6 +1102,10 @@ impl EmbeddedProximaDB {
         )
         .await;
         tracing::debug!("✅ Embedded: Global metadata provider set for WAL path resolution");
+        if let Some(catalog_manager) = collection_service.catalog_manager() {
+            crate::storage::persistence::write_ahead_log::set_global_catalog(catalog_manager).await;
+            tracing::debug!("✅ Embedded: Global catalog set for WAL/recovery resolution");
+        }
 
         let collection_port: std::sync::Arc<dyn proximadb_runtime::CollectionPort> =
             collection_service;

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1629,6 +1629,12 @@ impl CollectionService {
         &self.metadata_backend
     }
 
+    /// The catalog this service reads/writes collection assets through, if wired.
+    /// Used to make the catalog the WAL/recovery collection-resolution authority.
+    pub fn catalog_manager(&self) -> Option<Arc<CatalogManager>> {
+        self.catalog_manager.clone()
+    }
+
     /// Resolve compression configuration based on SDK request and server defaults
     fn resolve_compression_config(
         &self,
@@ -2081,7 +2087,7 @@ impl CollectionService {
         Ok(collections)
     }
 
-    fn collection_from_catalog_schema(
+    pub(crate) fn collection_from_catalog_schema(
         table_id: &TableIdentifier,
         schema: &CatalogTableSchema,
     ) -> Result<Option<Collection>> {

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1059,6 +1059,7 @@ static GLOBAL_METADATA_PROVIDER: ResettableOnceLock<GlobalMetadataValue> =
 pub(crate) unsafe fn reset_global_wal_state_for_tests() {
     unsafe {
         GLOBAL_METADATA_PROVIDER.reset();
+        GLOBAL_CATALOG.reset();
         GLOBAL_WRITE_BUFFER_BEHAVIOR.wal_behavior.reset();
         WAL_MANAGER_REGISTRY.reset();
     }
@@ -1094,6 +1095,84 @@ pub async fn set_global_metadata_provider(
     let mut lock = global.write().await;
     *lock = Some(provider);
     tracing::info!("✅ Global metadata provider set for WAL path resolution");
+}
+
+/// Global catalog singleton — the read-authoritative source for collection
+/// metadata during WAL path resolution and recovery. Mirrors the global metadata
+/// provider above. When set, WAL/recovery resolve a collection's config + storage
+/// assignment straight from the catalog (the system-of-record), falling back to
+/// the legacy `InternalCollectionProvider` only when the catalog has no entry —
+/// the path by which the WAL stops depending on the legacy provider.
+type GlobalCatalogValue = Arc<tokio::sync::RwLock<Option<Arc<crate::catalog::CatalogManager>>>>;
+
+static GLOBAL_CATALOG: ResettableOnceLock<GlobalCatalogValue> = ResettableOnceLock::new();
+
+fn get_global_catalog() -> GlobalCatalogValue {
+    GLOBAL_CATALOG
+        .get()
+        .get_or_init(|| Arc::new(tokio::sync::RwLock::new(None)))
+        .clone()
+}
+
+/// Set the global catalog used for WAL/recovery collection resolution. Call once
+/// at boot, before any WAL writes or recovery.
+pub async fn set_global_catalog(catalog: Arc<crate::catalog::CatalogManager>) {
+    let global = get_global_catalog();
+    let mut lock = global.write().await;
+    *lock = Some(catalog);
+    tracing::info!("✅ Global catalog set for WAL/recovery collection resolution");
+}
+
+/// Resolve a collection (by id or name) to its proto `Collection` via the
+/// catalog, or `None` if no catalog is wired / the collection is absent. The
+/// catalog asset carries the full collection shape (config, storage assignment,
+/// stats), so this faithfully replaces a legacy `provider.get_collection()`
+/// lookup. Resolves by FQN first, then scans by collection id/name (collections
+/// are catalog tables keyed by name, with the id carried as an asset property).
+pub(crate) async fn resolve_collection_from_catalog(
+    collection_id: &str,
+) -> Option<crate::proto::proximadb_v1::Collection> {
+    let global = get_global_catalog();
+    let catalog_manager = global.read().await.clone()?;
+
+    // Fast path: the identifier is a fully-qualified table name.
+    if let Ok((catalog, table_id)) = catalog_manager.resolve_table(collection_id).await
+        && catalog.table_exists(&table_id).await.unwrap_or(false)
+        && let Ok(schema) = catalog.get_table(&table_id).await
+        && let Ok(Some(collection)) =
+            crate::services::collection::manager::CollectionService::collection_from_catalog_schema(
+                &table_id, &schema,
+            )
+    {
+        return Some(collection);
+    }
+
+    // Fallback: the identifier is an opaque collection id (UUID). Scan the
+    // catalog and match by id or name.
+    let catalog = catalog_manager.default_catalog().await.ok()?;
+    for namespace in catalog.list_namespaces(None).await.ok()? {
+        let Ok(table_ids) = catalog.list_tables(&namespace.levels).await else {
+            continue;
+        };
+        for table_id in table_ids {
+            let Ok(schema) = catalog.get_table(&table_id).await else {
+                continue;
+            };
+            if let Ok(Some(collection)) =
+                crate::services::collection::manager::CollectionService::collection_from_catalog_schema(
+                    &table_id, &schema,
+                )
+                && (collection.id == collection_id
+                    || collection
+                        .config
+                        .as_ref()
+                        .is_some_and(|cfg| cfg.name == collection_id))
+            {
+                return Some(collection);
+            }
+        }
+    }
+    None
 }
 
 /// Check if global metadata provider is available
@@ -1634,7 +1713,24 @@ impl WriteAheadLogManager {
             }
         }
 
-        // Now try to resolve from metadata provider
+        // The catalog is the read authority: resolve from it first.
+        if let Some(collection) = resolve_collection_from_catalog(collection_id).await {
+            if let Some(assignment) = collection.storage_assignment {
+                tracing::debug!(
+                    "WAL path resolved via catalog: {} -> {}",
+                    collection_id,
+                    assignment.base_location
+                );
+                return Ok(assignment.base_location.clone());
+            }
+            tracing::warn!(
+                "Collection {} in catalog has no storage_assignment, using fallback",
+                collection_id
+            );
+            return Ok(self.get_fallback_base_location());
+        }
+
+        // Fall back to the legacy metadata provider while it still exists.
         let metadata_provider_lock = self.metadata_provider.read().await;
         if let Some(provider) = metadata_provider_lock.as_ref() {
             match provider.get_collection(collection_id).await {
@@ -2336,7 +2432,21 @@ impl WriteAheadLogManager {
 
             // Get base location for this collection from metadata provider
             // CRITICAL FIX: Query collection metadata for actual storage_assignment
-            let base_location = {
+            let base_location = if let Some(collection) =
+                resolve_collection_from_catalog(&collection_id).await
+            {
+                // Catalog is the read authority.
+                match collection.storage_assignment {
+                    Some(assignment) => assignment.base_location.clone(),
+                    None => self
+                        .config
+                        .multi_disk
+                        .data_directories
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "/tmp/proximadb/d1".to_string()),
+                }
+            } else {
                 let metadata_provider_lock = self.metadata_provider.read().await;
                 if let Some(provider) = metadata_provider_lock.as_ref() {
                     match provider.get_collection(&collection_id).await {

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -727,8 +727,17 @@ impl RecoveryManager {
             )
         })?;
 
-        // Try to get REAL collection config from metadata provider
-        let collection_config = if let Some(provider) = metadata_provider.read().await.as_ref() {
+        // The catalog is the read authority; resolve collection config from it
+        // first, then fall back to the legacy metadata provider.
+        let collection_config = if let Some(collection) =
+            super::resolve_collection_from_catalog(&file_info.collection_id).await
+        {
+            info!(
+                "✅ Using collection config from catalog for {}",
+                file_info.collection_id
+            );
+            Some(collection)
+        } else if let Some(provider) = metadata_provider.read().await.as_ref() {
             match provider.get_collection(&file_info.collection_id).await {
                 Ok(Some(collection)) => {
                     info!(


### PR DESCRIPTION
## What

The keystone of the collection-unification: **WAL path resolution and recovery now resolve a collection's `storage_assignment` + config from the catalog** (the system-of-record), falling back to the legacy `InternalCollectionProvider` only when the catalog has no entry. This is the step that lets the WAL stop depending on the legacy provider.

## How

- **Global catalog singleton** (`set_global_catalog` / `resolve_collection_from_catalog`) mirroring the existing global metadata-provider pattern in `write_ahead_log/mod.rs`, wired at boot in `database.rs` and `embedded/mod.rs`. `resolve_collection_from_catalog` resolves by FQN, then scans by collection id/name, returning the full proto `Collection` via the now-`pub(crate)` `CollectionService::collection_from_catalog_schema` converter — which already reproduces `config` + `storage_assignment` + `stats` faithfully (verified earlier when wiring `distance_metric`).
- The two WAL path-resolution sites + the `recovery_manager` collection-config lookup now try the catalog first.
- Added a `CollectionService::catalog_manager()` accessor for the boot wiring.

## Why no shim

This resolves **directly against the catalog** (`CatalogManager` → `get_table` → typed `CatalogTableSchema` → `Collection`) — no `InternalCollectionProvider` adapter. The legacy provider stays only as a *fallback* during the transition; a follow-up PR removes it together with `UniversalMetadataBackend` and the dead metastore files.

## Safety

Additive: catalog-first, provider fallback, then the existing minimal-config fallback — so behaviour is unchanged where the catalog has the collection (which, post-dual-write, is always), and strictly safer elsewhere.

## Verification

- `cargo clippy --lib --bins -- -D warnings` → Finished, zero warnings.
- `cargo test -p proximadb --lib -- services::collection::manager::tests` → 8 passed.
- `cargo fmt -- --check` clean. Recovery behaviour is exercised by the CI integration suites.