### PR TITLE
docs(grpc): correct #178 — gRPC SQL is vector/graph SQL, not a full relational peer of pgwire

### DIFF
--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -2004,14 +2004,16 @@ pub mod proxima_record_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
-        /// (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
-        /// is Postgres-native (password/MD5) and cannot carry a bearer token — so this
-        /// RPC is the SQL path for token/SSO-authenticated and high-throughput
-        /// programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
-        /// surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
-        /// complementary, not redundant. For bulk columnar result sets prefer Arrow
-        /// Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
+        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
+        /// vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
+        /// in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
+        /// this is the token-authenticated SQL path. NOTE: this RPC routes through the
+        /// legacy unified query engine and does NOT execute relational table SQL
+        /// (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
+        /// execution not yet supported". Full relational SQL is *pgwire-only* (the
+        /// tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
+        /// tracked future work. For bulk columnar results prefer Arrow Flight; for
+        /// UQL/AQL/Federated (non-SQL) use /api/v2/query.
         pub async fn execute_query(
             &mut self,
             request: impl tonic::IntoRequest<super::V2QueryRequest>,
@@ -2200,14 +2202,16 @@ pub mod proxima_record_service_server {
             tonic::Response<super::V2DeleteCollectionResponse>,
             tonic::Status,
         >;
-        /// SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
-        /// (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
-        /// is Postgres-native (password/MD5) and cannot carry a bearer token — so this
-        /// RPC is the SQL path for token/SSO-authenticated and high-throughput
-        /// programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
-        /// surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
-        /// complementary, not redundant. For bulk columnar result sets prefer Arrow
-        /// Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
+        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
+        /// vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
+        /// in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
+        /// this is the token-authenticated SQL path. NOTE: this RPC routes through the
+        /// legacy unified query engine and does NOT execute relational table SQL
+        /// (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
+        /// execution not yet supported". Full relational SQL is *pgwire-only* (the
+        /// tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
+        /// tracked future work. For bulk columnar results prefer Arrow Flight; for
+        /// UQL/AQL/Federated (non-SQL) use /api/v2/query.
         async fn execute_query(
             &self,
             request: tonic::Request<super::V2QueryRequest>,

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -80,11 +80,13 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 | Supported
 
 | *gRPC `proximadb.v2.ProximaRecordService.ExecuteQuery`*
-| ANSI *SQL* (same DataFusion execution as pgwire)
-| Token/SSO-authenticated and high-throughput programmatic SQL: gRPC carries
-  bearer/JWT in metadata (pgwire cannot) and uses HTTP/2 + protobuf. The SQL
-  path for SaaS/SSO and SDK clients.
-| Supported
+| *SQL with vector/graph extensions* (e.g. `VECTOR_SEARCH`), via the legacy
+  unified query engine — *not* relational table SQL.
+| Token/SSO-authenticated programmatic queries: gRPC carries bearer/JWT in
+  metadata (pgwire cannot) and uses HTTP/2 + protobuf. Relational
+  `SELECT/JOIN/aggregate` over `CREATE TABLE` is *not* executed here (returns
+  "Relational execution not yet supported") — use pgwire for those.
+| Supported (vector/graph SQL; relational is pgwire-only)
 
 | *REST/gRPC `/api/v2/query`* (unified query port)
 | *UQL* (unified multi-modal), *Federated* SQL extensions, *AQL*
@@ -117,13 +119,17 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 ====
 * pgwire is *SQL-only* and cannot serve UQL/AQL/Cypher; those non-SQL languages require the
   unified query port (`/api/v2/query`) or the graph service — they are not replaceable by pgwire.
-* SQL is served by *two complementary, supported* surfaces (TD-121), not one: *pgwire* for the
-  PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth), and the gRPC
-  `ProximaRecordService.ExecuteQuery` RPC for *token/SSO-authenticated and high-throughput
-  programmatic* SQL. They differ by *auth mechanism and transport*, not by SQL dialect (both
-  execute through DataFusion). pgwire auth is password/MD5 and cannot carry a bearer/JWT, so the
-  gRPC SQL path is required for SSO/OIDC clients — it is *not* deprecated. For large columnar
-  result sets prefer Arrow Flight.
+* SQL is served by *two surfaces with different capabilities* (TD-121), not one. *pgwire* is the
+  *only* full relational SQL surface — it lowers through `ComputeScheduler::route_select`
+  (DataFusion/Volcano) with *tenant-scoped* relational execution (TD-064), and serves the
+  PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth). The gRPC
+  `ProximaRecordService.ExecuteQuery` RPC is *token/SSO-authenticated* (bearer/JWT in metadata,
+  which pgwire's password/MD5 auth cannot carry) but routes through the *legacy unified query
+  engine*: it serves vector/graph-extension SQL (e.g. `VECTOR_SEARCH`) and *does not* execute
+  relational table SQL (returns "Relational execution not yet supported"). It is *not* deprecated.
+  Making gRPC SQL a full SSO relational surface (route it through the pgwire relational pipeline
+  with the request tenant threaded) is tracked future work. For large columnar result sets prefer
+  Arrow Flight.
 * *Apache Calcite*, if adopted, is an *internal* federated-SQL planner behind pgwire and the
   Federated path — not a client surface, and not a substitute for the non-SQL languages.
 * SSO/governance (auth, RLS, tenancy) is enforced uniformly at the `TenantContext` I/O boundary,

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -813,14 +813,16 @@ service ProximaRecordService {
   rpc ListCollections(V2ListCollectionsRequest) returns (V2ListCollectionsResponse);
   rpc DeleteCollection(V2DeleteCollectionRequest) returns (V2DeleteCollectionResponse);
 
-  // SQL over gRPC: the SSO-authenticated, performant programmatic SQL surface
-  // (TD-121). gRPC carries bearer/JWT in request metadata, whereas pgwire auth
-  // is Postgres-native (password/MD5) and cannot carry a bearer token — so this
-  // RPC is the SQL path for token/SSO-authenticated and high-throughput
-  // programmatic clients (HTTP/2 + protobuf). pgwire remains the canonical SQL
-  // surface for the PostgreSQL ecosystem (psql/JDBC/BI/ORM); the two are
-  // complementary, not redundant. For bulk columnar result sets prefer Arrow
-  // Flight; for UQL/AQL/Federated (non-SQL) use /api/v2/query.
+  // SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
+  // vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
+  // in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
+  // this is the token-authenticated SQL path. NOTE: this RPC routes through the
+  // legacy unified query engine and does NOT execute relational table SQL
+  // (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
+  // execution not yet supported". Full relational SQL is *pgwire-only* (the
+  // tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
+  // tracked future work. For bulk columnar results prefer Arrow Flight; for
+  // UQL/AQL/Federated (non-SQL) use /api/v2/query.
   rpc ExecuteQuery(V2QueryRequest) returns (V2QueryResponse);
 
   // Point record get-by-id (v2 parity with v1 VectorService.VectorGet)


### PR DESCRIPTION
## Why

#178 repositioned gRPC `ProximaRecordService.ExecuteQuery` as *"ANSI SQL (same DataFusion execution as pgwire), the SSO/performant SQL surface."* An empirical check shows that **over-claims** — so this corrects it.

## What I verified (2-tenant probe)

Stood up a fresh server (isolated data dir), created table `iso_t` under tenant `acme` and tenant `default` via pgwire (tenant = `dbname`), confirmed pgwire isolation (acme→`acme-secret`, default→`default-secret`), then queried the same table via gRPC `ExecuteQuery`:

- `SELECT * / id / COUNT(*)` → **"Relational execution not yet supported"** (`src/query/execution/planner.rs:137`).

`execute_sql_v1 → execute_sql_frontend` routes through the **legacy unified query engine** (vector/graph), **not** the tenant-scoped relational pipeline pgwire uses (`ComputeScheduler::route_select`, TD-064).

## Corrections

- gRPC SQL serves **SSO/bearer-authenticated vector/graph-extension SQL** (e.g. `VECTOR_SEARCH`) — genuinely the token-authenticated SQL path (pgwire password/MD5 can't carry bearer/JWT), so it **stays un-deprecated**.
- **Full relational SQL is pgwire-only.**
- Routing gRPC SQL through the pgwire relational pipeline (with the request tenant threaded) is noted as **tracked future work**.

## Security note (good news)

The discarded `_tenant_id` on the gRPC SQL handler is **not** a cross-tenant relational leak — that path can't execute relational queries at all (**fails closed**). No isolation breach.

## Change

Proto comment corrected + stub regenerated (`PROXIMADB_REGEN_PROTO=1`, doc-comments only) + `SUPPORTED_SURFACE.adoc` row/note corrected. **Docs/comments only — no behavior change.**

## Gates

`cargo fmt --check` 0 diffs; generated-stub diff is comment-only; `scripts/validate_capability_matrix.py` passes.