### PR TITLE
fix(collection): lossless catalog round-trip of collection config + fix compression update

### DIFF
--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1711,7 +1711,12 @@ impl CollectionService {
             }
         }
 
-        // Store updated collection
+        // Store the updated collection. The catalog is the read authority, so the
+        // catalog asset write is what makes the compression change visible; the
+        // legacy backend write stays (dual-write) until it is removed wholesale.
+        self.upsert_collection_catalog_asset(&updated_collection)
+            .await
+            .context("Failed to update collection compression in catalog")?;
         self.metadata_backend
             .upsert_collection_proto(&updated_collection)
             .await
@@ -2236,6 +2241,16 @@ impl CollectionService {
                 json,
             );
         }
+        // Lossless round-trip: if the asset carries the full serialized config it
+        // is authoritative — it captures every field (including ones not mapped to
+        // a typed catalog property), so no collection config is ever silently
+        // dropped on read. The per-field properties above remain for pg_catalog
+        // introspection.
+        if let Some(json) = schema.properties.get("collection.config_json")
+            && let Ok(full) = serde_json::from_str::<CollectionConfig>(json)
+        {
+            config = full;
+        }
 
         let location = schema
             .storage_layouts
@@ -2501,6 +2516,15 @@ impl CollectionService {
                 .properties
                 .insert("collection.record_schema".to_string(), json);
         }
+        // Lossless round-trip: store the full serialized config so the catalog
+        // asset never drops any collection field (the typed properties above stay
+        // for pg_catalog introspection). This makes the catalog a complete,
+        // sole-authority store for collection metadata.
+        schema.properties.insert(
+            "collection.config_json".to_string(),
+            serde_json::to_string(config)
+                .context("serializing collection config for catalog asset")?,
+        );
 
         Ok(schema)
     }


### PR DESCRIPTION
## What

Make the catalog a **complete, sole-authority store** for collection metadata by round-tripping the *full* `CollectionConfig` losslessly — and fix a latent post-#174 bug along the way.

## The problem

Removing the legacy-backend reads (#174) exposed that the catalog↔collection conversion **drops any config field it has no typed property for**. `distance_metric` was one gap (already fixed); `storage_config`/compression was another — the **update-compression path wrote only the legacy backend**, so with catalog-only reads that change was silently lost.

## The fix (no whack-a-mole)

Rather than chase each field, store the **full serialized `CollectionConfig`** as a `collection.config_json` asset property and treat it as authoritative on read. This closes every fidelity gap at once and is consistent with how the conversion already persists `quantization` / `index_config` / `record_schema` as JSON. The typed per-field properties stay for `pg_catalog` introspection.

- `catalog_schema_from_collection`: persist `collection.config_json`.
- `collection_from_catalog_schema`: when present, the deserialized config is authoritative — nothing is dropped.
- The update-compression path now also writes the catalog asset (fixing the latent bug).

## Why it matters

This is the **prerequisite for dropping the dual-write** and deleting the legacy backend: the catalog now faithfully carries everything, so the legacy `UniversalMetadataBackend` is no longer needed as a completeness backstop.

## Verification

- `cargo clippy --lib --bins -- -D warnings` → Finished, zero warnings.
- `cargo test -p proximadb --lib -- services::collection::manager::tests` → 8 passed (the create→read round-trip tests now exercise config_json).
- `cargo fmt -- --check` clean.

(Note: the `raw_cpuid` / `proximadb-hardware-caps` aarch64-runner CI failures are a separate, pre-existing infra issue being fixed elsewhere — unrelated to this change.)