### PR TITLE
feat(sdk-python): route remaining graph/document/observability/meta ops through generated REST client (TD-126)

### DIFF
--- a/clients/python/src/proximadb_sdk/protocols/_rest_codegen.py
+++ b/clients/python/src/proximadb_sdk/protocols/_rest_codegen.py
@@ -38,6 +38,20 @@ from .._generated.rest.api.collections import (
 )
 from .._generated.rest.api.collections import get_collection as _gen_get_collection
 from .._generated.rest.api.collections import list_collections as _gen_list_collections
+from .._generated.rest.api.graphs import create_edge as _gen_create_edge
+from .._generated.rest.api.graphs import create_graph as _gen_create_graph
+from .._generated.rest.api.graphs import create_node as _gen_create_node
+from .._generated.rest.api.graphs import delete_graph as _gen_delete_graph
+from .._generated.rest.api.graphs import delete_node as _gen_delete_node
+from .._generated.rest.api.graphs import get_graph as _gen_get_graph
+from .._generated.rest.api.graphs import get_graph_stats as _gen_get_graph_stats
+from .._generated.rest.api.graphs import get_node as _gen_get_node
+from .._generated.rest.api.graphs import list_graphs as _gen_list_graphs
+from .._generated.rest.api.graphs import traverse_graph as _gen_traverse_graph
+from .._generated.rest.api.health import get_health as _gen_get_health
+from .._generated.rest.api.health import get_liveness as _gen_get_liveness
+from .._generated.rest.api.health import get_readiness as _gen_get_readiness
+from .._generated.rest.api.meta import get_capabilities as _gen_get_capabilities
 from .._generated.rest.api.query import execute_query as _gen_execute_query
 from .._generated.rest.api.query import explain_query as _gen_explain_query
 from .._generated.rest.api.records import get_record as _gen_get_record
@@ -46,9 +60,13 @@ from .._generated.rest.api.search import search_records as _gen_search_records
 from .._generated.rest.models.create_collection_v2_request import (
     CreateCollectionV2Request,
 )
+from .._generated.rest.models.create_edge_request import CreateEdgeRequest
+from .._generated.rest.models.create_graph_request import CreateGraphRequest
+from .._generated.rest.models.create_node_request import CreateNodeRequest
 from .._generated.rest.models.explain_query_request import ExplainQueryRequest
 from .._generated.rest.models.insert_records_request import InsertRecordsRequest
 from .._generated.rest.models.query_request import QueryRequest
+from .._generated.rest.models.traverse_request import TraverseRequest
 from .._generated.rest.models.typed_search_request import TypedSearchRequest
 from .._generated.rest.types import UNSET
 
@@ -195,3 +213,86 @@ def execute_query(body: dict[str, Any]) -> RestCall:
 
 def explain_query(body: dict[str, Any]) -> RestCall:
     return _path_only(_gen_explain_query._get_kwargs, body, ExplainQueryRequest)
+
+
+# ---------------------------------------------------------------------------
+# Health / meta (path-only — no request body)
+# ---------------------------------------------------------------------------
+
+
+def get_health() -> RestCall:
+    return _normalize(_gen_get_health._get_kwargs())
+
+
+def get_liveness() -> RestCall:
+    return _normalize(_gen_get_liveness._get_kwargs())
+
+
+def get_readiness() -> RestCall:
+    return _normalize(_gen_get_readiness._get_kwargs())
+
+
+def get_capabilities() -> RestCall:
+    return _normalize(_gen_get_capabilities._get_kwargs())
+
+
+# ---------------------------------------------------------------------------
+# Graph — nodes / edges / traversal
+# ---------------------------------------------------------------------------
+
+
+def create_node(graph_id: str, body: dict[str, Any]) -> RestCall:
+    # The public API accepts ``node.embedding`` as a bare ``list[float]``, but the
+    # generated ``CreateNodeRequest`` nests it through ``EmbeddingInput`` (an
+    # object with a ``vector`` field), whose ``from_dict`` rejects a raw list.
+    # Round-tripping valid facade input would therefore raise (the AQL/UQL
+    # precedent), so we bind the spec-governed method+URL and send the raw body.
+    return _path_only(
+        lambda **_kw: _gen_create_node._get_kwargs(graph_id=graph_id, **_kw),
+        body,
+        CreateNodeRequest,
+    )
+
+
+def create_edge(graph_id: str, body: dict[str, Any]) -> RestCall:
+    model = _from_dict(CreateEdgeRequest, body)
+    return _normalize(_gen_create_edge._get_kwargs(graph_id=graph_id, body=model))
+
+
+def traverse_graph(graph_id: str, body: dict[str, Any]) -> RestCall:
+    model = _from_dict(TraverseRequest, body)
+    return _normalize(_gen_traverse_graph._get_kwargs(graph_id=graph_id, body=model))
+
+
+def get_node(graph_id: str, node_id: str) -> RestCall:
+    return _normalize(_gen_get_node._get_kwargs(graph_id=graph_id, node_id=node_id))
+
+
+def delete_node(graph_id: str, node_id: str) -> RestCall:
+    return _normalize(_gen_delete_node._get_kwargs(graph_id=graph_id, node_id=node_id))
+
+
+# ---------------------------------------------------------------------------
+# Graph — collection management
+# ---------------------------------------------------------------------------
+
+
+def create_graph(body: dict[str, Any]) -> RestCall:
+    model = _from_dict(CreateGraphRequest, body)
+    return _normalize(_gen_create_graph._get_kwargs(body=model))
+
+
+def delete_graph(graph_id: str) -> RestCall:
+    return _normalize(_gen_delete_graph._get_kwargs(graph_id))
+
+
+def get_graph(graph_id: str) -> RestCall:
+    return _normalize(_gen_get_graph._get_kwargs(graph_id))
+
+
+def list_graphs() -> RestCall:
+    return _normalize(_gen_list_graphs._get_kwargs())
+
+
+def get_graph_stats(graph_id: str) -> RestCall:
+    return _normalize(_gen_get_graph_stats._get_kwargs(graph_id))

--- a/clients/python/src/proximadb_sdk/protocols/rest_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/rest_sync.py
@@ -272,7 +272,8 @@ class ProximaDBClient:
         if cached is not None and not refresh:
             return cached
         try:
-            resp = self._make_request("GET", "/api/v2/_meta/capabilities")
+            call = _gen.get_capabilities()
+            resp = self._make_request(call.method, call.endpoint)
             caps = resp.json() if hasattr(resp, "json") else {}
             if not isinstance(caps, dict):
                 caps = {}
@@ -491,7 +492,8 @@ class ProximaDBClient:
 
     def health(self) -> HealthStatus:
         """Check server health status"""
-        response = self._make_request("GET", "/health")
+        call = _gen.get_health()
+        response = self._make_request(call.method, call.endpoint)
         data = response.json()
 
         # Transform response to match HealthStatus model
@@ -528,12 +530,14 @@ class ProximaDBClient:
 
     def live(self) -> ProbeResponse:
         """Kubernetes liveness probe — GET /health/live."""
-        response = self._make_request("GET", "/health/live")
+        call = _gen.get_liveness()
+        response = self._make_request(call.method, call.endpoint)
         return ProbeResponse.model_validate(response.json())
 
     def ready(self) -> ProbeResponse:
         """Kubernetes readiness probe — GET /health/ready."""
-        response = self._make_request("GET", "/health/ready")
+        call = _gen.get_readiness()
+        response = self._make_request(call.method, call.endpoint)
         return ProbeResponse.model_validate(response.json())
 
     def create_collection(
@@ -2766,10 +2770,8 @@ class ProximaDBClient:
 
         payload = {"node": node_data}
 
-        response = self._http_client.post(
-            f"/api/v2/graphs/{graph_id}/nodes", json=payload
-        )
-        response.raise_for_status()
+        call = _gen.create_node(graph_id, payload)
+        response = self._make_request(call.method, call.endpoint, json=call.json)
         return response.json()
 
     def create_edge(
@@ -2808,10 +2810,8 @@ class ProximaDBClient:
 
         payload = {"edge": edge_data}
 
-        response = self._http_client.post(
-            f"/api/v2/graphs/{graph_id}/edges", json=payload
-        )
-        response.raise_for_status()
+        call = _gen.create_edge(graph_id, payload)
+        response = self._make_request(call.method, call.endpoint, json=call.json)
         return response.json()
 
     def traverse_graph(
@@ -2849,10 +2849,8 @@ class ProximaDBClient:
         if limit is not None:
             payload["limit"] = limit
 
-        response = self._http_client.post(
-            f"/api/v2/graphs/{graph_id}/traverse", json=payload
-        )
-        response.raise_for_status()
+        call = _gen.traverse_graph(graph_id, payload)
+        response = self._make_request(call.method, call.endpoint, json=call.json)
         result = response.json()
 
         # Transform REST response to match gRPC format
@@ -2960,8 +2958,8 @@ class ProximaDBClient:
         graph_id: str = "default",
     ) -> dict[str, Any] | None:
         """Get a graph node by ID via REST."""
-        response = self._http_client.get(f"/api/v2/graphs/{graph_id}/nodes/{node_id}")
-        response.raise_for_status()
+        call = _gen.get_node(graph_id, node_id)
+        response = self._make_request(call.method, call.endpoint)
         result = response.json()
         return result.get("data", result)
 
@@ -3009,10 +3007,8 @@ class ProximaDBClient:
         graph_id: str = "default",
     ) -> dict[str, Any]:
         """Delete a graph node by ID via REST."""
-        response = self._http_client.delete(
-            f"/api/v2/graphs/{graph_id}/nodes/{node_id}"
-        )
-        response.raise_for_status()
+        call = _gen.delete_node(graph_id, node_id)
+        response = self._make_request(call.method, call.endpoint)
         result = response.json()
         return result.get("data", result)
 
@@ -3048,8 +3044,8 @@ class ProximaDBClient:
         if schema is not None:
             payload["schema"] = schema
 
-        response = self._http_client.post("/api/v2/graphs", json=payload)
-        response.raise_for_status()
+        call = _gen.create_graph(payload)
+        response = self._make_request(call.method, call.endpoint, json=call.json)
         return response.json()
 
     def delete_graph(self, graph_id: str) -> dict[str, Any]:
@@ -3064,8 +3060,8 @@ class ProximaDBClient:
         Example:
             >>> result = client.delete_graph("social_network")
         """
-        response = self._http_client.delete(f"/api/v2/graphs/{graph_id}")
-        response.raise_for_status()
+        call = _gen.delete_graph(graph_id)
+        response = self._make_request(call.method, call.endpoint)
         return response.json()
 
     def get_graph(self, graph_id: str) -> dict[str, Any]:
@@ -3081,8 +3077,8 @@ class ProximaDBClient:
             >>> graph = client.get_graph("social_network")
             >>> print(graph["name"])
         """
-        response = self._http_client.get(f"/api/v2/graphs/{graph_id}")
-        response.raise_for_status()
+        call = _gen.get_graph(graph_id)
+        response = self._make_request(call.method, call.endpoint)
         return response.json()
 
     def list_graphs(self) -> dict[str, Any]:
@@ -3096,8 +3092,8 @@ class ProximaDBClient:
             >>> for graph in graphs.get("graphs", []):
             ...     print(graph["graph_id"])
         """
-        response = self._http_client.get("/api/v2/graphs")
-        response.raise_for_status()
+        call = _gen.list_graphs()
+        response = self._make_request(call.method, call.endpoint)
         return response.json()
 
     def get_graph_stats(self, graph_id: str) -> dict[str, Any]:
@@ -3113,8 +3109,8 @@ class ProximaDBClient:
             >>> stats = client.get_graph_stats("social_network")
             >>> print(f"Nodes: {stats['node_count']}, Edges: {stats['edge_count']}")
         """
-        response = self._http_client.get(f"/api/v2/graphs/{graph_id}/stats")
-        response.raise_for_status()
+        call = _gen.get_graph_stats(graph_id)
+        response = self._make_request(call.method, call.endpoint)
         return response.json()
 
     # ==================== End Graph Collection Management ====================

--- a/clients/python/tests/unit/test_openapi_contract.py
+++ b/clients/python/tests/unit/test_openapi_contract.py
@@ -308,3 +308,44 @@ def test_update_schema_request_matches_spec(monkeypatch, openapi_spec, ref_resol
     assert req_schema is not None
     _validate(req_schema, captured.json_body, ref_resolver)
     assert captured.json_body["force"] is True
+
+
+def test_create_graph_request_matches_spec(monkeypatch, openapi_spec, ref_resolver):
+    # Proves the rebased graph create_graph op (full-model round-trip through
+    # CreateGraphRequest) emits a spec-conformant method/URL/body via the
+    # generated REST client.
+    response_body = {"graph_id": "social", "name": "Social", "node_count": 0}
+    client, captured = _patched_client(monkeypatch, response_body)
+
+    client.create_graph("social", name="Social", description="people")
+
+    op = _operation_for(openapi_spec, "/api/v2/graphs", "post")
+    assert op["operationId"] == "createGraph"
+    assert captured.method == "POST"
+    assert captured.endpoint == "/api/v2/graphs"
+
+    req_schema = _request_body_schema(openapi_spec, op)
+    assert req_schema is not None
+    _validate(req_schema, captured.json_body, ref_resolver)
+    assert captured.json_body["graph_id"] == "social"
+
+
+def test_create_node_request_matches_spec(monkeypatch, openapi_spec, ref_resolver):
+    # Proves the rebased graph create_node op (sourced via _path_only because the
+    # public API's bare-list embedding does not conform to EmbeddingInput) still
+    # emits the spec-governed method/URL and a spec-conformant body when no
+    # embedding is supplied.
+    response_body = {"id": "n1", "labels": ["Person"]}
+    client, captured = _patched_client(monkeypatch, response_body)
+
+    client.create_node("n1", ["Person"], properties={"age": 30}, graph_id="social")
+
+    op = _operation_for(openapi_spec, "/api/v2/graphs/{graph_id}/nodes", "post")
+    assert op["operationId"] == "createNode"
+    assert captured.method == "POST"
+    assert captured.endpoint == "/api/v2/graphs/social/nodes"
+
+    req_schema = _request_body_schema(openapi_spec, op)
+    assert req_schema is not None
+    _validate(req_schema, captured.json_body, ref_resolver)
+    assert captured.json_body["node"]["id"] == "n1"

--- a/clients/python/tests/unit/test_rest_sync_extend_cov.py
+++ b/clients/python/tests/unit/test_rest_sync_extend_cov.py
@@ -332,62 +332,68 @@ def test_graph_traverse_minimal(monkeypatch):
 
 
 def test_create_node(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"id": "n1"}))
+    # Rebased through the generated REST op -> goes via _make_request.
+    c = _make_client(monkeypatch, resp_body={"id": "n1"})
     out = c.create_node("n1", ["Person"], properties={"age": 30}, embedding=[1.0, 2.0])
     assert out["id"] == "n1"
-    verb, path, kw = _last_http(c)
+    verb, path, kw = _last(c)
     assert (verb, path) == ("POST", "/api/v2/graphs/default/nodes")
     assert kw["json"]["node"]["embedding"] == [1.0, 2.0]
 
 
 def test_create_node_no_embedding(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"id": "n2"}))
+    c = _make_client(monkeypatch, resp_body={"id": "n2"})
     c.create_node("n2", ["L"])
-    _, _, kw = _last_http(c)
+    _, _, kw = _last(c)
     assert "embedding" not in kw["json"]["node"]
 
 
+def test_create_node_custom_graph(monkeypatch):
+    c = _make_client(monkeypatch, resp_body={"id": "n3"})
+    c.create_node("n3", ["L"], graph_id="g7")
+    _, path, _ = _last(c)
+    assert path == "/api/v2/graphs/g7/nodes"
+
+
 def test_create_edge(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"id": "e1"}))
+    c = _make_client(monkeypatch, resp_body={"id": "e1"})
     out = c.create_edge("e1", "a", "b", "knows", properties={"w": 1}, weight=0.5)
     assert out["id"] == "e1"
-    verb, path, kw = _last_http(c)
+    verb, path, kw = _last(c)
     assert (verb, path) == ("POST", "/api/v2/graphs/default/edges")
     assert kw["json"]["edge"]["weight"] == 0.5
 
 
 def test_create_edge_no_weight(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"id": "e2"}))
+    c = _make_client(monkeypatch, resp_body={"id": "e2"})
     c.create_edge("e2", "a", "b", "rel")
-    _, _, kw = _last_http(c)
+    _, _, kw = _last(c)
     assert "weight" not in kw["json"]["edge"]
 
 
 def test_traverse_graph_extracts_nested_data(monkeypatch):
     c = _make_client(
         monkeypatch,
-        http_resp=FakeResp(
-            {
-                "success": True,
-                "data": {
-                    "nodes": [{"id": "n1"}],
-                    "edges": [{"id": "e1"}],
-                    "paths": [["n1"]],
-                    "stats": {"nodes_visited": 1},
-                },
-            }
-        ),
+        resp_body={
+            "success": True,
+            "data": {
+                "nodes": [{"id": "n1"}],
+                "edges": [{"id": "e1"}],
+                "paths": [["n1"]],
+                "stats": {"nodes_visited": 1},
+            },
+        },
     )
     out = c.traverse_graph("n1", limit=5, edge_types=["k"], node_labels=["L"])
     assert out["nodes"] == [{"id": "n1"}]
     assert out["stats"]["nodes_visited"] == 1
-    _, _, kw = _last_http(c)
+    _, _, kw = _last(c)
     assert kw["json"]["limit"] == 5
     assert kw["json"]["return_path"] is True
 
 
 def test_traverse_graph_flat_response_defaults(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"foo": "bar"}))
+    c = _make_client(monkeypatch, resp_body={"foo": "bar"})
     out = c.traverse_graph("n1")
     assert out["nodes"] == []
     assert out["stats"]["nodes_visited"] == 0
@@ -429,15 +435,15 @@ def test_query_edges(monkeypatch):
 
 
 def test_get_node(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"data": {"id": "n1"}}))
+    c = _make_client(monkeypatch, resp_body={"data": {"id": "n1"}})
     out = c.get_node("n1")
     assert out["id"] == "n1"
-    verb, path, _ = _last_http(c)
+    verb, path, _ = _last(c)
     assert (verb, path) == ("GET", "/api/v2/graphs/default/nodes/n1")
 
 
 def test_get_node_no_data_wrapper(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"id": "raw"}))
+    c = _make_client(monkeypatch, resp_body={"id": "raw"})
     out = c.get_node("raw")
     assert out["id"] == "raw"
 
@@ -467,10 +473,10 @@ def test_get_incoming_edges(monkeypatch):
 
 
 def test_delete_node(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"data": {"deleted": True}}))
+    c = _make_client(monkeypatch, resp_body={"data": {"deleted": True}})
     out = c.delete_node("n1")
     assert out["deleted"] is True
-    verb, path, _ = _last_http(c)
+    verb, path, _ = _last(c)
     assert (verb, path) == ("DELETE", "/api/v2/graphs/default/nodes/n1")
 
 
@@ -478,45 +484,45 @@ def test_delete_node(monkeypatch):
 
 
 def test_create_graph(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"graph_id": "g1"}))
+    c = _make_client(monkeypatch, resp_body={"graph_id": "g1"})
     out = c.create_graph("g1", name="G", description="d", schema={"x": 1})
     assert out["graph_id"] == "g1"
-    verb, path, kw = _last_http(c)
+    verb, path, kw = _last(c)
     assert (verb, path) == ("POST", "/api/v2/graphs")
     assert kw["json"]["schema"] == {"x": 1}
 
 
 def test_create_graph_no_schema(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"graph_id": "g2"}))
+    c = _make_client(monkeypatch, resp_body={"graph_id": "g2"})
     c.create_graph("g2")
-    _, _, kw = _last_http(c)
+    _, _, kw = _last(c)
     assert "schema" not in kw["json"]
 
 
 def test_delete_graph(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"deleted": True}))
+    c = _make_client(monkeypatch, resp_body={"deleted": True})
     out = c.delete_graph("g1")
     assert out["deleted"] is True
-    verb, path, _ = _last_http(c)
+    verb, path, _ = _last(c)
     assert (verb, path) == ("DELETE", "/api/v2/graphs/g1")
 
 
 def test_get_graph(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"name": "G"}))
+    c = _make_client(monkeypatch, resp_body={"name": "G"})
     assert c.get_graph("g1")["name"] == "G"
-    assert _last_http(c)[:2] == ("GET", "/api/v2/graphs/g1")
+    assert _last(c)[:2] == ("GET", "/api/v2/graphs/g1")
 
 
 def test_list_graphs(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"graphs": []}))
+    c = _make_client(monkeypatch, resp_body={"graphs": []})
     assert c.list_graphs() == {"graphs": []}
-    assert _last_http(c)[:2] == ("GET", "/api/v2/graphs")
+    assert _last(c)[:2] == ("GET", "/api/v2/graphs")
 
 
 def test_get_graph_stats(monkeypatch):
-    c = _make_client(monkeypatch, http_resp=FakeResp({"node_count": 3}))
+    c = _make_client(monkeypatch, resp_body={"node_count": 3})
     assert c.get_graph_stats("g1")["node_count"] == 3
-    assert _last_http(c)[:2] == ("GET", "/api/v2/graphs/g1/stats")
+    assert _last(c)[:2] == ("GET", "/api/v2/graphs/g1/stats")
 
 
 # ------------------------------------------------------------- query API

--- a/clients/python/tests/unit/test_rest_sync_methods_coverage.py
+++ b/clients/python/tests/unit/test_rest_sync_methods_coverage.py
@@ -127,12 +127,12 @@ def test_execute_uql_aql_federated_sql(client):
     assert _req_paths(client) == ["/api/v2/query"] * 3
 
 
-# ---- graph nodes/edges/traverse (via _http_client) ---------------------------
+# ---- graph nodes/edges/traverse (rebased via _make_request) ------------------
 
 
 def test_create_node_path_and_payload(client):
     client.create_node("n1", ["L"], {"k": "v"}, embedding=[0.1, 0.2])
-    verb, path, kw = client._captured["http"].calls[-1]
+    verb, path, kw = client._captured["req"][-1]
     assert verb == "POST"
     assert path == "/api/v2/graphs/default/nodes"
     assert kw["json"]["node"]["id"] == "n1"
@@ -141,12 +141,12 @@ def test_create_node_path_and_payload(client):
 
 def test_create_node_custom_graph(client):
     client.create_node("n2", ["L"], graph_id="g7")
-    assert _http_paths(client)[-1] == "/api/v2/graphs/g7/nodes"
+    assert _req_paths(client)[-1] == "/api/v2/graphs/g7/nodes"
 
 
 def test_create_edge_path_and_payload(client):
     client.create_edge("e1", "n1", "n2", "REL", {"p": 1}, weight=2.5)
-    verb, path, kw = client._captured["http"].calls[-1]
+    verb, path, kw = client._captured["req"][-1]
     assert verb == "POST"
     assert path == "/api/v2/graphs/default/edges"
     assert kw["json"]["edge"]["weight"] == 2.5
@@ -156,7 +156,10 @@ def test_traverse_graph_path(client):
     client.traverse_graph(
         "n1", max_depth=2, edge_types=["R"], algorithm="dfs", limit=10
     )
-    assert _http_paths(client)[-1] == "/api/v2/graphs/default/traverse"
+    assert _req_paths(client)[-1] == "/api/v2/graphs/default/traverse"
+
+
+# ---- graph queries (still via _http_client — no generated op) ----------------
 
 
 def test_query_nodes_and_edges(client):
@@ -170,7 +173,7 @@ def test_query_nodes_and_edges(client):
 def test_get_node_and_delete_node(client):
     client.get_node("n1", graph_id="default")
     client.delete_node("n1", graph_id="default")
-    paths = _http_paths(client)
+    paths = _req_paths(client)
     assert any(p == "/api/v2/graphs/default/nodes/n1" for p in paths)
 
 
@@ -191,7 +194,7 @@ def test_create_get_list_delete_graph(client):
     client.list_graphs()
     client.delete_graph("default")
     client.get_graph_stats("default")
-    paths = _http_paths(client)
+    paths = _req_paths(client)
     assert any(p == "/api/v2/graphs" for p in paths)
     assert any(p == "/api/v2/graphs/default" for p in paths)
     assert any(p == "/api/v2/graphs/default/stats" for p in paths)


### PR DESCRIPTION
## Summary

Completes the TD-126 Phase-4 rebase of the Python SDK's REST facade onto the generated openapi-python-client transport. The remaining hand-built REST operations in `rest_sync.py` now derive their HTTP method, URL template, and body shape from the generated `_get_kwargs` (and generated attrs request models) via the `_rest_codegen` adapter. Public API, method signatures, and the `_make_request` seam are unchanged.

## Ops re-based (full-model round-trip through the generated attrs request model)
- Graph: `create_edge`, `traverse_graph`, `create_graph`, `delete_graph`, `get_graph`, `list_graphs`, `get_graph_stats`, `get_node`, `delete_node`
- Health/meta (path-only, no body): `health`, `live`, `ready`, `server_capabilities`

Verified each body round-trips through its generated model without dropping/rejecting fields the public API accepts:
- `create_edge` → `CreateEdgeRequest`/`EdgeInput` (optional `weight` omitted when None — OK)
- `traverse_graph` → `TraverseRequest` (the facade's extra `return_path: true` survives via `additional_properties`)
- `create_graph` → `CreateGraphRequest` (`name`/`description` nullable per spec; extra `schema` survives via `additional_properties`)

## Ops re-based via `_path_only` (spec method+URL, raw facade body)
- `create_node` — the public API accepts `node.embedding` as a bare `list[float]`, but the generated `CreateNodeRequest` nests embedding through `EmbeddingInput` (an object with a `vector` field) whose `from_dict` raises on a raw list. This is the AQL/UQL precedent: round-tripping valid facade input through the strict model would reject it. Confirmed empirically (`TypeError`) and against the spec (`EmbeddingInput.required=[vector]`). `_path_only` binds the spec-governed POST + `/api/v2/graphs/{graph_id}/nodes` URL while sending the facade body verbatim.

## Left hand-built (no generated op / no spec path)
- `query_nodes`, `query_edges`, `get_outgoing_edges`, `get_incoming_edges` — `/api/v2/graphs/{id}/query/{nodes,edges}` are not in the OpenAPI spec, so there is no generated `_get_kwargs` to bind. These still call `self._http_client` directly.

## Generated op availability
Every remaining exposed op that the spec covers had a generated `_get_kwargs` (graphs/{create_node,create_edge,traverse_graph,get_node,delete_node,create_graph,delete_graph,get_graph,list_graphs,get_graph_stats}, health/{get_health,get_liveness,get_readiness}, meta/get_capabilities). The four `query_*`/edge-listing ops have none.

## Seam change
The graph node/edge/collection ops previously called `self._http_client.<verb>(...)` + `raise_for_status()` directly. They now route through `self._make_request(...)`, sharing the facade's retry + error-mapping seam (the same seam the OpenAPI contract test patches). Affected coverage tests were updated to assert on the `_make_request` capture instead of the `_http_client` fake; response-transform behavior is unchanged.

## Contract-test disposition — KEPT + extended
`test_openapi_contract` validates the facade↔generated wiring (outbound method/URL/body vs the spec) that the drift gate (`git diff` on `_generated/`) cannot. It is **not** subsumed by the rebase, so it is kept, and extended with two new cases to cover the newly-rebased graph ops: `create_graph` (full-model round-trip) and `create_node` (the `_path_only` path). 6 → 8 cases, all green. The `proto-compat` CI job that runs it is untouched.

## Gate results
- `black --check` / `isort --check-only` (5 edited files): clean
- `ruff check --select E9,F63,F7 src/proximadb_sdk/`: clean
- `python -m py_compile` (5 files): clean
- Rebased REST/graph/contract suites in isolation: `test_rest_sync_extend_cov` 85, `test_rest_sync_methods_coverage` 13, `test_openapi_contract` 8, `test_rest_adapter_cov` 84, `test_graph_cov` 50, `test_rest_sync_collections` 4, `test_graph_rest_sync_overrides`/`_overrides` 2+2 — all pass
- **Drift gate**: ran `make gen-python-sdk` from worktree root, then `git diff --exit-code _generated/` → NO DIFF (clean; `_generated/` untouched)

### Pre-existing (inherited) develop breaks — NOT from this change
Verified by stashing my changes and running on the clean base (b5dec6490) in this core-only venv:
- `test_rest_sync_more_cov::test_list_collections_with_params` (asserts `include_stats == "true"` string; generated client now sends native bool — list_collections was rebased in an earlier phase, test not updated)
- `test_misc_core_cov`, `test_unified_client_async` (missing `pytest-asyncio`), `test_grpc_sync_cov` (grpc deps) — environment/optional-dep failures, fail identically on base

## E2E smoke
Built `proximadb-server`; exercised a re-based op against the running server via the Python SDK (see PR comments for result).