### PR TITLE
feat(sdk-ts): route remaining graph/health ops through generated REST client (TD-126)

### DIFF
--- a/clients/nodejs-embedded/src/client.ts
+++ b/clients/nodejs-embedded/src/client.ts
@@ -524,24 +524,176 @@ export class ProximaDBClient implements CollectionHttpClient, GraphHttpClient {
   /**
    * Delete a graph
    *
+   * Routed through the generated typed transport (TD-126 Phase 4).
    * Wire endpoint: DELETE /api/v2/graphs/{graph_id}
    * OpenAPI operationId: deleteGraph
    */
   async deleteGraph(name: string): Promise<void> {
-    const requestUrl = this.config.url + "/api/v2/graphs/" + name;
-    await this.delete<unknown>(requestUrl);
+    await this.gen.DELETE("/api/v2/graphs/{graph_id}", {
+      params: { path: { graph_id: name } },
+    });
   }
 
   /**
    * List all graphs
    *
+   * Routed through the generated typed transport (TD-126 Phase 4).
    * Wire endpoint: GET /api/v2/graphs
    * OpenAPI operationId: listGraphs
    */
   async listGraphs(): Promise<GraphInfo[]> {
-    const requestUrl = this.config.url + "/api/v2/graphs";
-    const response = await this.get<{ graphs: GraphInfo[] }>(requestUrl);
-    return response.graphs;
+    const { data } = await this.gen.GET("/api/v2/graphs", {});
+    return ((data?.graphs ?? []) as unknown[]) as GraphInfo[];
+  }
+
+  // =========================================================================
+  // Typed transport for graph ops (TD-126 Phase 4)
+  //
+  // Seam methods routing the graph builders' / handle's wire calls through the
+  // generated typed client, mirroring the core collection / record / search
+  // seams above. The public graph API (graph.ts builders + handle) is
+  // unchanged; only the wire dispatch moves off hand-built URL strings.
+  // =========================================================================
+
+  /**
+   * Create a graph collection.
+   * Wire endpoint: POST /api/v2/graphs (createGraph)
+   */
+  async createGraphRequest(body: Record<string, unknown>): Promise<unknown> {
+    const { data } = await this.gen.POST("/api/v2/graphs", {
+      body: body as never,
+    });
+    return data;
+  }
+
+  /**
+   * Get a graph collection by id.
+   * Wire endpoint: GET /api/v2/graphs/{graph_id} (getGraph)
+   */
+  async getGraphRequest(graphId: string): Promise<unknown> {
+    const { data } = await this.gen.GET("/api/v2/graphs/{graph_id}", {
+      params: { path: { graph_id: graphId } },
+    });
+    return data;
+  }
+
+  /**
+   * Get graph statistics.
+   * Wire endpoint: GET /api/v2/graphs/{graph_id}/stats (getGraphStats)
+   */
+  async getGraphStatsRequest(graphId: string): Promise<unknown> {
+    const { data } = await this.gen.GET("/api/v2/graphs/{graph_id}/stats", {
+      params: { path: { graph_id: graphId } },
+    });
+    return data;
+  }
+
+  /**
+   * Create a node in a graph.
+   * Wire endpoint: POST /api/v2/graphs/{graph_id}/nodes (createNode)
+   */
+  async createNodeRequest(
+    graphId: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const { data } = await this.gen.POST("/api/v2/graphs/{graph_id}/nodes", {
+      params: { path: { graph_id: graphId } },
+      body: body as never,
+    });
+    return data;
+  }
+
+  /**
+   * Create multiple nodes in a single call.
+   * Wire endpoint: POST /api/v2/graphs/{graph_id}/nodes/batch (batchCreateNodes)
+   */
+  async batchCreateNodesRequest(
+    graphId: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const { data } = await this.gen.POST(
+      "/api/v2/graphs/{graph_id}/nodes/batch",
+      {
+        params: { path: { graph_id: graphId } },
+        body: body as never,
+      },
+    );
+    return data;
+  }
+
+  /**
+   * Get a node by id.
+   * Wire endpoint: GET /api/v2/graphs/{graph_id}/nodes/{node_id} (getNode)
+   */
+  async getNodeRequest(graphId: string, nodeId: string): Promise<unknown> {
+    const { data } = await this.gen.GET(
+      "/api/v2/graphs/{graph_id}/nodes/{node_id}",
+      {
+        params: { path: { graph_id: graphId, node_id: nodeId } },
+      },
+    );
+    return data;
+  }
+
+  /**
+   * Delete a node by id.
+   * Wire endpoint: DELETE /api/v2/graphs/{graph_id}/nodes/{node_id} (deleteNode)
+   */
+  async deleteNodeRequest(graphId: string, nodeId: string): Promise<void> {
+    await this.gen.DELETE("/api/v2/graphs/{graph_id}/nodes/{node_id}", {
+      params: { path: { graph_id: graphId, node_id: nodeId } },
+    });
+  }
+
+  /**
+   * Create an edge in a graph.
+   * Wire endpoint: POST /api/v2/graphs/{graph_id}/edges (createEdge)
+   */
+  async createEdgeRequest(
+    graphId: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const { data } = await this.gen.POST("/api/v2/graphs/{graph_id}/edges", {
+      params: { path: { graph_id: graphId } },
+      body: body as never,
+    });
+    return data;
+  }
+
+  /**
+   * Create multiple edges in a single call.
+   * Wire endpoint: POST /api/v2/graphs/{graph_id}/edges/batch (batchCreateEdges)
+   */
+  async batchCreateEdgesRequest(
+    graphId: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const { data } = await this.gen.POST(
+      "/api/v2/graphs/{graph_id}/edges/batch",
+      {
+        params: { path: { graph_id: graphId } },
+        body: body as never,
+      },
+    );
+    return data;
+  }
+
+  /**
+   * Traverse a graph from a start node.
+   * Wire endpoint: POST /api/v2/graphs/{graph_id}/traverse (traverseGraph)
+   */
+  async traverseGraphRequest(
+    graphId: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const { data } = await this.gen.POST(
+      "/api/v2/graphs/{graph_id}/traverse",
+      {
+        params: { path: { graph_id: graphId } },
+        body: body as never,
+      },
+    );
+    return data;
   }
 
   // =========================================================================
@@ -550,32 +702,38 @@ export class ProximaDBClient implements CollectionHttpClient, GraphHttpClient {
 
   /**
    * Check if the server is healthy
+   *
+   * Routed through the generated typed transport (TD-126 Phase 4).
+   * Wire endpoint: GET /health
+   * OpenAPI operationId: getHealth
    */
   async health(): Promise<HealthStatus> {
-    const requestUrl = this.config.url + "/health";
-    return await this.get<HealthStatus>(requestUrl);
+    const { data } = await this.gen.GET("/health", {});
+    return data as unknown as HealthStatus;
   }
 
   /**
    * Kubernetes-style liveness probe
    *
+   * Routed through the generated typed transport (TD-126 Phase 4).
    * Wire endpoint: GET /health/live
    * OpenAPI operationId: getLiveness
    */
   async healthLive(): Promise<ProbeResponse> {
-    const requestUrl = this.config.url + "/health/live";
-    return await this.get<ProbeResponse>(requestUrl);
+    const { data } = await this.gen.GET("/health/live", {});
+    return data as unknown as ProbeResponse;
   }
 
   /**
    * Kubernetes-style readiness probe
    *
+   * Routed through the generated typed transport (TD-126 Phase 4).
    * Wire endpoint: GET /health/ready
    * OpenAPI operationId: getReadiness
    */
   async healthReady(): Promise<ProbeResponse> {
-    const requestUrl = this.config.url + "/health/ready";
-    return await this.get<ProbeResponse>(requestUrl);
+    const { data } = await this.gen.GET("/health/ready", {});
+    return data as unknown as ProbeResponse;
   }
 
   /**

--- a/clients/nodejs-embedded/src/graph.ts
+++ b/clients/nodejs-embedded/src/graph.ts
@@ -21,13 +21,29 @@ import {
 } from "./types";
 
 /**
- * HTTP client interface for graph operations
+ * HTTP client interface for graph operations.
+ *
+ * Wire calls route through the typed `*Request` seam methods (TD-126 Phase 4),
+ * which dispatch via the generated openapi-fetch transport. The generic
+ * `get`/`delete` + `url()` remain ONLY for `deleteEdge`, whose 3-segment route
+ * shape (`/edges/{source}/{target}/{rel}`) has no matching generated op (the
+ * spec uses `/edges/{edge_id}`); see `GraphHandle.deleteEdge`.
  */
 export interface GraphHttpClient {
   get<T>(url: string): Promise<T>;
-  post<T>(url: string, body: unknown): Promise<T>;
   delete<T>(url: string): Promise<T>;
   url(): string;
+  // Typed transport seams (route through the generated client).
+  createGraphRequest(body: Record<string, unknown>): Promise<unknown>;
+  getGraphRequest(graphId: string): Promise<unknown>;
+  getGraphStatsRequest(graphId: string): Promise<unknown>;
+  createNodeRequest(graphId: string, body: Record<string, unknown>): Promise<unknown>;
+  batchCreateNodesRequest(graphId: string, body: Record<string, unknown>): Promise<unknown>;
+  getNodeRequest(graphId: string, nodeId: string): Promise<unknown>;
+  deleteNodeRequest(graphId: string, nodeId: string): Promise<void>;
+  createEdgeRequest(graphId: string, body: Record<string, unknown>): Promise<unknown>;
+  batchCreateEdgesRequest(graphId: string, body: Record<string, unknown>): Promise<unknown>;
+  traverseGraphRequest(graphId: string, body: Record<string, unknown>): Promise<unknown>;
 }
 
 // ============================================================================
@@ -115,8 +131,10 @@ export class NodeBuilder {
     }
 
     const request = { node };
-    const url = this.handle.getClient().url() + "/api/v2/graphs/" + this.handle.getName() + "/nodes";
-    await this.handle.getClient().post<{ id: string }>(url, request);
+    await this.handle.getClient().createNodeRequest(
+      this.handle.getName(),
+      request as unknown as Record<string, unknown>,
+    );
   }
 
   /**
@@ -258,8 +276,10 @@ export class EdgeBuilder {
     }
 
     const request = { edge };
-    const url = this.handle.getClient().url() + "/api/v2/graphs/" + this.handle.getName() + "/edges";
-    await this.handle.getClient().post<{ id: string }>(url, request);
+    await this.handle.getClient().createEdgeRequest(
+      this.handle.getName(),
+      request as unknown as Record<string, unknown>,
+    );
   }
 
   /**
@@ -451,8 +471,11 @@ export class TraversalBuilder {
     void this.traversalDirection;
     void this.filterExpr;
 
-    const url = this.handle.getClient().url() + "/api/v2/graphs/" + this.handle.getName() + "/traverse";
-    return await this.handle.getClient().post<TraversalResult>(url, request);
+    const data = await this.handle.getClient().traverseGraphRequest(
+      this.handle.getName(),
+      request,
+    );
+    return data as TraversalResult;
   }
 }
 
@@ -523,12 +546,11 @@ export class GraphHandle {
   async addNodes(nodes: NodeInput[] | GraphNode[]): Promise<number> {
     const normalized: NodeInput[] = nodes.map(n => normalizeNodeInput(n));
     const request = { nodes: normalized };
-    const url = this.client.url() + "/api/v2/graphs/" + this.graphName + "/nodes/batch";
-    const response = await this.client.post<{ data?: { count?: number }; count?: number }>(
-      url,
-      request,
-    );
-    return response.data?.count ?? response.count ?? normalized.length;
+    const response = (await this.client.batchCreateNodesRequest(
+      this.graphName,
+      request as unknown as Record<string, unknown>,
+    )) as { data?: { count?: number }; count?: number } | null;
+    return response?.data?.count ?? response?.count ?? normalized.length;
   }
 
   /**
@@ -549,12 +571,11 @@ export class GraphHandle {
   async addEdges(edges: EdgeInput[] | GraphEdge[]): Promise<number> {
     const normalized: EdgeInput[] = edges.map(e => normalizeEdgeInput(e));
     const request = { edges: normalized };
-    const url = this.client.url() + "/api/v2/graphs/" + this.graphName + "/edges/batch";
-    const response = await this.client.post<{ data?: { count?: number }; count?: number }>(
-      url,
-      request,
-    );
-    return response.data?.count ?? response.count ?? normalized.length;
+    const response = (await this.client.batchCreateEdgesRequest(
+      this.graphName,
+      request as unknown as Record<string, unknown>,
+    )) as { data?: { count?: number }; count?: number } | null;
+    return response?.data?.count ?? response?.count ?? normalized.length;
   }
 
   /**
@@ -562,9 +583,16 @@ export class GraphHandle {
    */
   async getNode(nodeId: string): Promise<GraphNode | null> {
     try {
-      const url = this.client.url() + "/api/v2/graphs/" + this.graphName + "/nodes/" + nodeId;
-      return await this.client.get<GraphNode>(url);
+      const data = await this.client.getNodeRequest(this.graphName, nodeId);
+      return data as GraphNode;
     } catch (e: unknown) {
+      // The facade maps a 404 to a ProximaDBError (statusCode 404, message =
+      // server body). Treat "not found" as a null result, preserving the
+      // pre-rebase behavior; match on status or the body text.
+      const status = (e as { statusCode?: number }).statusCode;
+      if (status === 404) {
+        return null;
+      }
       if (e instanceof Error && e.message.includes("404")) {
         return null;
       }
@@ -576,11 +604,17 @@ export class GraphHandle {
    * Delete a node by ID
    */
   async deleteNode(nodeId: string): Promise<void> {
-    const url = this.client.url() + "/api/v2/graphs/" + this.graphName + "/nodes/" + nodeId;
-    await this.client.delete<unknown>(url);
+    await this.client.deleteNodeRequest(this.graphName, nodeId);
   }
 
-  // TODO(graph-edge-delete-shape): server route is DELETE /api/v2/graphs/{id}/edges/{edge_id} with a single edge_id; this SDK signature doesn't match. Tracked separately.
+  // deleteEdge is intentionally LEFT facade-built (generic URL path): the
+  // generated REST client has no matching typed op for this 3-segment route
+  // shape. The OpenAPI spec / generated client model edge deletion as
+  // `DELETE /api/v2/graphs/{graph_id}/edges/{edge_id}` (single `edge_id`),
+  // whereas this SDK's public signature is `(source, target, relationship)` →
+  // `/edges/{source}/{target}/{relationship}`. Until the SDK signature is
+  // reconciled to `{edge_id}` (separate change), this cannot route through the
+  // generated client. Tracked separately.
   /**
    * Delete an edge
    */
@@ -590,11 +624,14 @@ export class GraphHandle {
   }
 
   /**
-   * Get graph statistics
+   * Get graph statistics.
+   *
+   * Routed through the generated typed transport (TD-126 Phase 4).
+   * Wire endpoint: GET /api/v2/graphs/{graph_id} (getGraph)
    */
   async info(): Promise<GraphInfo> {
-    const url = this.client.url() + "/api/v2/graphs/" + this.graphName;
-    return await this.client.get<GraphInfo>(url);
+    const data = await this.client.getGraphRequest(this.graphName);
+    return data as GraphInfo;
   }
 }
 
@@ -650,8 +687,7 @@ export class GraphBuilder {
       request.description = this.graphDescription;
     }
 
-    const url = this.client.url() + "/api/v2/graphs";
-    await this.client.post<{ graph_id?: string; success?: boolean }>(url, request);
+    await this.client.createGraphRequest(request);
   }
 }
 


### PR DESCRIPTION
## Summary

Re-bases the remaining hand-built TypeScript SDK operations onto the generated
openapi-fetch transport (`src/generated/schema.ts`), following the same seam
pattern as the already-migrated core collection/record/search ops (TD-126
Phase 4). Public API is unchanged.

## Re-based ops (file:method)

client.ts:
- `listGraphs` → `this.gen.GET("/api/v2/graphs")`
- `deleteGraph` → `this.gen.DELETE("/api/v2/graphs/{graph_id}")`
- `health` → `this.gen.GET("/health")`
- `healthLive` → `this.gen.GET("/health/live")`
- `healthReady` → `this.gen.GET("/health/ready")`
- New typed graph seam methods added (createGraph/getGraph/getGraphStats/
  createNode/batchCreateNodes/getNode/deleteNode/createEdge/batchCreateEdges/
  traverseGraph `*Request`).

graph.ts (now dispatch via the seams):
- `GraphBuilder.execute` (createGraph)
- `NodeBuilder.execute` (createNode)
- `EdgeBuilder.execute` (createEdge)
- `TraversalBuilder.execute` (traverseGraph)
- `GraphHandle.addNodes` (batchCreateNodes)
- `GraphHandle.addEdges` (batchCreateEdges)
- `GraphHandle.getNode` (getNode; 404→null preserved)
- `GraphHandle.deleteNode` (deleteNode)
- `GraphHandle.info` (getGraph)

Response unwrapping, the traverse direction/filter drop, and the batch-count
fan-out are all preserved exactly — only the wire dispatch changed.

## Left facade-built (with reason)

- `GraphHandle.deleteEdge(source, target, relationship)`: the generated client
  has no matching typed op for the SDK's 3-segment route shape
  (`/edges/{source}/{target}/{relationship}`). The OpenAPI spec / generated
  client model edge deletion as `DELETE /api/v2/graphs/{graph_id}/edges/{edge_id}`
  (single `edge_id`). Until the SDK signature is reconciled to `{edge_id}`
  (separate change) this stays on the generic path. Documented inline.

No body-shape exceptions: all re-based graph bodies match the generated
`paths` request types (`{ graph_id, name?, description? }`, `{ node }`,
`{ edge }`, `{ nodes }`, `{ edges }`, flat `TraverseRequest`).

## schema.ts coverage

All remaining ops have a matching generated `paths` entry: `/api/v2/graphs`,
`/api/v2/graphs/{graph_id}`, `/edges`, `/edges/batch`, `/nodes`, `/nodes/batch`,
`/nodes/{node_id}`, `/stats`, `/traverse`, `/health`, `/health/live`,
`/health/ready`. The only gap is the edge-delete 3-segment shape noted above.

## Contract-test disposition: KEPT (as-is)

`tests/openapi_contract.test.ts` is kept. It validates facade↔generated wiring
(each public method reaches the correct endpoint/method) AND request-body
required-key shapes against the YAML spec via a stubbed fetch. The git-diff
drift gate only checks `generated/` is unchanged — it does NOT verify that the
facade methods actually call the right generated path or send required body
keys. The now-fuller generated coverage does not subsume that wiring assertion,
so the contract test remains load-bearing. No CI job removed (CI-job retirement
is a separate coordinated PR).

## Gates

- `npm run build` (tsc + ESM): clean
- `npm run lint` (tsc --noEmit): clean
- `npm test` (vitest): 17 passed, 1 skipped (smoke, gated on env) — all contract
  tests incl. graph ops green
- Drift gate: `make gen-ts-sdk` → `git diff --exit-code src/generated/` clean
  (generated client untouched)

## Live e2e smoke

Built `proximadb-server`, ran it locally, and exercised the re-based ops via the
built SDK against the live server:
- `/health` 200, `healthLive` 200, `healthReady` correctly surfaces the
  server's transient "not_ready" as an error (server still starting; expected)
- `createGraph`, `listGraphs`, `createNode`, `getNode`, `info`, `traverse` all
  succeeded end-to-end through the generated transport
- `deleteGraph` surfaced a pre-existing facade quirk: the server returns
  `204 No Content`, and the facade's `handleResponse` calls `.json()` on a 2xx
  body → "Failed to parse response JSON". This is unchanged by this PR (the old
  `deleteGraph` used the identical `this.delete`→`handleResponse` path) and is
  not a regression from the re-base.