### PR TITLE
docs(design): code-graph correlated substrate spec + TD-127..134

### DIFF
--- a/docs/09-roadmap/implementation/competitive-enhancement-features.adoc
+++ b/docs/09-roadmap/implementation/competitive-enhancement-features.adoc
@@ -1438,11 +1438,35 @@ cargo bench --bench streaming_search_bench
 cargo bench
 ----
 
+== Code-Graph Vertical (correlated OLTP + graph + vector) — roadmap
+
+A first-class _code intelligence_ workload: host an external coding agent's Code Property Graph as a
+correlated substrate where one `ProximaRecord`/`oid` per symbol is simultaneously a relational row, an
+ORION graph node, and an HNSW vector. Embedded (local single-repo) and multi-tenant service (anvaiops)
+shapes. Full design: link:../../12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc[CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22].
+
+Trace-driven from a measured 1.26M-node CPG → a three-tier split (Tier-A semantic graph in-RAM,
+Tier-B intra-procedural CPG in columnar PAX, Tier-C relational over Volcano-OLTP). Enabling work:
+
+[cols="1,4,1", options="header"]
+|===
+| TD | Item | Priority
+| TD-127 | OLTP secondary indexes (name/file) on native tables | HIGH
+| TD-128 | Volcano IN-list/range pushdown → multi-key point-batch | HIGH
+| TD-129 | pgwire `ON CONFLICT DO UPDATE` upsert | MED
+| TD-130 | Graph edge bulk-load (sorted LSM merge) | MED
+| TD-131 | Graph on REST v2 + co-planned hybrid endpoint | MED
+| TD-132 | Tier-B CPG-fragment PAX storage contract + I/O trace | MED
+| TD-133 | Optional transactional multi-modal write | LOW
+| TD-134 | Code-embedding KEU meter + per-repo RBAC | MED
+|===
+
 == Related Documentation
 
 * link:../../_internal/roadmap/completed/077-distributed-operations.adoc[Distributed Operations]
 * link:../../_internal/archive/architecture/storage_architecture.adoc[Storage Architecture]
 * link:../../_internal/roadmap/implementation/active/Q4_2025_IMPLEMENTATION.adoc[Q4 2025 Implementation Guide]
+* link:../../12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc[Code-Graph Correlated Substrate (OLTP + Graph + Vector)]
 
 ---
 

--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -353,6 +353,78 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | Graph has WAL but no cross-model atomicity. Cannot guarantee consistency for vector+graph operations.
 | 4-6 weeks
 | *COMPLETED Feb 2025*: `CrossModelTransactionCoordinator` implemented in `src/transaction/` with two-phase commit protocol. TransactionParticipant implementations for VectorEngineParticipant, DocumentEngineParticipant, GraphEngineParticipant, TimeSeriesEngineParticipant in `src/transaction/participants.rs`. 6 integration tests passing. Cross-model ACID transactions with prepare/commit/rollback phases. WAL coordination across models.
+
+| TD-127
+| Relational/OLTP — secondary indexes
+| P2
+| HIGH
+| *Open*
+| Volcano OLTP point lookup only covers PRIMARY KEY (`ScanAccess::PkLookup`). Code-graph lookups are by `name`/`file`, not oid → fall back to full scan + memory filter. Blocks the re-index hot path (symbols-in-file, by-name resolution). See `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
+| 2-3 weeks
+| Add secondary-index support on native (LsmWriteOptimized) tables; planner emits an index-scan access path; reader capability `secondary_lookup`. Targets `crates/query/proximadb-relational-planner` (`push_predicates`) + `record_store.rs`.
+
+| TD-128
+| Relational/OLTP — IN-list / range pushdown
+| P2
+| HIGH
+| *Open*
+| `WHERE col IN (...)` / `BETWEEN` are not pushed to a multi-key point-batch; today full scan + in-memory filter. Incremental re-index touches a batch of files per debounce, so this is on the hot path.
+| 1-2 weeks
+| Extend planner predicate pushdown + `ScanAccess` with a multi-key batch lookup; reader `pk_lookup_batch`. Companion to TD-127.
+
+| TD-129
+| pgwire — `ON CONFLICT DO UPDATE`
+| P2
+| MED
+| *Open*
+| `TableRecordMutationKind::Upsert` exists at the DML boundary but pgwire has no `INSERT ... ON CONFLICT DO UPDATE` surface; idempotent re-index must read-then-write. Wire the upsert mutation through the pgwire parser/planner.
+| 1 week
+| `src/network/postgres/` parser + `src/services/dml/`. Map conflict target (PK) to `Upsert`.
+
+| TD-130
+| Graph — edge bulk-load
+| P3
+| MED
+| *Open*
+| `batch_create_edges` enforces per-edge composite uniqueness against a global in-memory index, serialized; bulk-loading large edge sets is minutes–hours. The code-graph Tier-A/B split avoids the worst case, but incremental re-index of a hot file still benefits.
+| 2-3 weeks
+| Add a sorted LSM-style bulk path (sort by `(from,to,type)`, single merge) mirroring the vector `BulkLoader`. `src/graph/service.rs`.
+
+| TD-131
+| Graph — REST v2 + co-planned hybrid endpoint
+| P3
+| MED
+| *Open*
+| Graph CRUD/traversal is REST v1 (legacy); v2 is vector-only. Hybrid (semantic-seed → k-hop expand → metadata filter) is clean only over gRPC `ExecuteHybridQuery`; REST `/api/v2/query` is rewrite-join, not co-planned.
+| 2-3 weeks
+| Promote graph routes to REST v2; add a first-class co-planned hybrid endpoint. `src/network/rest/v2/`.
+
+| TD-132
+| Storage — Tier-B CPG-fragment PAX + I/O trace
+| P3
+| MED
+| *Open*
+| Intra-procedural CPG (1.18M statements + 2.88M DDG/CFG/CDG edges; measured 100% intra-file) should be a per-function columnar PAX fragment, ranged-read on drill-down, NOT first-class graph elements. Needs a fragment storage contract + per-query I/O trace emission (co-design mandate).
+| 3-4 weeks
+| Define `cpg_fragment` layout + zone-map; emit query-scoped I/O trace so `ComputeScheduler` can cost it. See `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
+
+| TD-133
+| Cross-modal — transactional multi-modal write
+| P3
+| LOW
+| *Open*
+| Writing a symbol's node + embedding + edges is multiple record-store ops (no cross-modal atomicity for the code-graph collection). Acceptable today (idempotent single-writer re-index, eventual consistency), but an optional atomic multi-modal upsert would close gap G7.
+| 2-3 weeks
+| Optional; leverage `CrossModelTransactionCoordinator` (TD-020) for the code-graph collection.
+
+| TD-134
+| Metering/Governance — code-embedding KEU + per-repo RBAC
+| P2
+| MED
+| *Open*
+| Multi-tenant code-graph service needs a KEU meter variant for code embeddings and per-repo RBAC entitlement (tenant is atomic today). Mostly anvaiops-side; ProximaDB exposes the meter hook + field/row governance seam.
+| 2 weeks
+| KEU variant in the meter spine; per-repo `permitted_principals` scoping. See `../anvaiops` ADR.
 |===
 
 == Debt by Category

--- a/docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc
+++ b/docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc
@@ -1,0 +1,274 @@
+= Code-Graph Correlated Substrate (OLTP + Graph + Vector) — Co-Design Spec
+:toc: macro
+:toclevels: 3
+:sectnums:
+Date: 2026-06-22
+Status: Draft (design intent; engine work tracked as TD-127..TD-134)
+
+toc::[]
+
+== Context (why)
+
+An external coding agent ("Victor", `../codingagent`) drives an AI coding assistant from a
+*Code Property Graph (CPG)* so the agent is _less LLM-dependent and has durable long memory_:
+it answers "who calls X / blast radius / what is semantically near this" from a graph + vector
+index instead of re-reading files and re-reasoning each turn. Today that memory lives in *two
+embedded stores* — SQLite (`graph_node`/`graph_edge`/`graph_module_metric`/FTS5, 2.4 GB) plus a
+LanceDB vector table (384-d BGE embeddings) — hand-joined, with an unpopulated `embedding_ref`
+column and a watch daemon doing incremental re-index. Victor already carries the swap seam: a
+`proximadb_provider.py` (ProximaDB SST vector + ORION graph) behind a `GraphStoreProtocol` /
+`EmbeddingProvider` abstraction.
+
+This spec co-designs that memory onto *three correlated ProximaDB seams* — relational/OLTP
+(Volcano-native), graph (ORION), and vector (HNSW/IVF) — where a code _symbol_ is *one entity
+addressable as a row, a node, and a vector at once*. It targets two deployment shapes:
+
+. *Embedded* — local single-repo DB (replaces SQLite + LanceDB in-process).
+. *Service* — multi-tenant, multi-repo over the SaaS ops layer (`../anvaiops`).
+
+It is engineered to the *measured CPG trace*, toward the dominant cost term for a cloud DB (I/O
+round-trips + egress, not CPU), per `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
+
+== First-principles framing — what the workload actually is
+
+Measured from one real repo (`.victor/project.db`, 3,659 files):
+
+[cols="3,2,5", options="header"]
+|===
+| Fact | Value | Consequence
+| Nodes | 1.26M; *94% are `statement`* | statement-level CPG ≠ symbol graph; do NOT put all in the graph engine
+| Symbol nodes | *79,744* (module/class/function/method) | the _traversable_ graph is tiny
+| Edges | 2.97M | —
+| Tier-A cross-fn edges | *96,538* (CALLS 12K, IMPORTS 6.9K, INHERITS 1.2K, CONTAINS 76K, …) | the global graph the agent walks is small
+| Tier-B intra-fn edges | *2,875,449* (DDG 1.68M, CFG ~1.04M, CDG ~150K) | dataflow/control edges never cross a function body
+| DDG locality (measured) | *20,000 same-file / 0 cross-file* | intra-procedural is 100% local ⇒ columnar-per-function
+| CALLS locality (measured) | 4,671 same-file / *7,372 cross-file (61%)* | Tier-A genuinely needs a graph engine
+| Fan-out | out avg 3.1 / p99 26 / max 676; CALLS max 51; in-deg max 369 | no super-nodes; BFS is cheap
+| Symbol lookups | 54,226 distinct names; ~22.8 symbols/file | needs `name` + `file` secondary indexes
+| Embeddings (measured Lance) | *77,902 vectors* @ 384-d; 114 MB f32 / 29 MB SQ8; co-stored code 5.5 MB | embed at *symbol* granularity; correlate to node by id
+|===
+
+The embedding store is independently confirmed to be at *symbol granularity* — 77,902 vectors
+(function 65,622 + class 12,280), not the 1.18M statements — with the symbol snippet (avg 74 B)
+co-stored. Embedding nodes at symbol granularity is therefore the established shape, not a new idea.
+
+=== Headline principle — three-tier physical split (co-design, not local optimization)
+
+* *Tier A — Semantic graph (HOT, in-RAM):* 79.7K symbol nodes + 96.5K cross-fn edges + per-node
+384-d embedding → *ORION graph + co-indexed vector*. Drives impact analysis and semantic-seed
+expansion. Tiny → CSR is tens of MB, < 1 µs node lookup.
+* *Tier B — Intra-procedural CPG (COLD, columnar):* 1.18M statements + 2.88M DDG/CFG/CDG edges →
+*columnar PAX fragment partitioned by function-id*, queried on demand via Volcano/DataFusion on a
+dataflow drill-down. Never globally loaded; one ranged read per function.
+* *Tier C — Relational facts (OLTP + OLAP):* symbol/file/import/module_metric/mtime/requirement →
+relational tables; OLTP point-reads/upserts on the re-index hot path, OLAP scans for dashboards.
+
+This converts a "3M-edge bulk-load (minutes–hours, current bottleneck)" into "96.5K graph edges +
+2.88M columnar-bulk edges (seconds)".
+
+== Correlation model (the keystone) — one ProximaRecord, three indexes
+
+`ProximaRecord` (`crates/foundation/proximadb-records/src/lib.rs`) is the single durable envelope
+for all modalities: `oid`, `local_id`, `record_version` (OCC), `tenant_id`, `branch_id`,
+`valid_from/to_ns` (bitemporal), `props: ProximaTree`, `refs: Vec<TypedRef>`,
+`edge: Option<EdgeShape>`, `embeddings: Vec<EmbeddingCell>`, `labels: LabelSet`. Graph keys are
+deterministic: `GraphNodeKey{graph_id,node_id}.canonical_oid()` = `graph/{graph_id}/node/{node_id}`
+(`crates/modalities/proximadb-graph/src/record.rs`); `CanonicalNode::into_proxima_record()` projects
+a node onto a record. Vector HNSW and ORION CSR *both key on the same `oid`*; `HybridQueryEngine`
+(`src/graph/hybrid/mod.rs`) fuses vector hits and graph hits by that shared id.
+
+A code symbol is *one ProximaRecord*:
+
+[source]
+----
+oid:        graph/{repo_graph_id}/node/{symbol_oid}   # = graph node id = vector id = relational PK
+labels:     ["graph_node","code_symbol"]
+props:      { name, file, line, end_line, lang, signature, visibility, ast_kind, module_path,
+              snippet }                               # relational/OLTP columns + embed provenance (≈74 B)
+embeddings: [ EmbeddingCell{ model_id:"bge-small-en-v1.5", modality:"code", dim:384,
+              values:Fp32|Int8 } ]                    # vector
+branch_id:  {git branch}                              # per-branch graph, native
+refs:       [ TypedRef -> cpg_fragment oid ]          # link to Tier-B columnar fragment
+----
+
+* *Edges* = separate records: `labels:["graph_edge"]`, `edge: EdgeShape{from_oid,to_oid,edge_type}`.
+* *Tier-B fragment* = record `labels:["cpg_fragment"]` holding one function's columnar statements +
+DDG/CFG/CDG, referenced from the symbol node via `TypedRef`.
+* *Tier-C relational* = the symbol record's `props` ARE the relational columns → a pgwire `SELECT`
+over collection `code_symbol` reads props; point-lookup by oid uses the PK fast lane.
+* One collection per repo holds all of it: one WAL, one PAX set, one Iceberg manifest.
+
+This satisfies "vector and graph are correlated" *structurally* (shared oid), not by a join.
+
+=== Measured current layout (why one record matters)
+
+The source agent does NOT have this today — it has two disjoint stores with no shared key (measured):
+
+* *SQLite `graph_node` is pure structure:* `signature`, `docstring`, and `embedding_ref` are *0%
+populated* across all 1,261,579 nodes. The graph holds topology + location (file/line/type), nothing else.
+* *Code snippet + embedding are LanceDB-only*, keyed `symbol:{file}:{symbol_name}`. The graph's hex
+`node_id` and the Lance id namespace *do not intersect* (∩ = 0) — correlation is _implicit_ by
+(file, symbol_name), reconstructed per query, with the `embedding_ref` bridge column left empty.
+* *Embeddings are sparse vs the graph:* only *68,612 distinct symbols* carry a vector — *~5.4% of the
+1.26M nodes* (~86% of the 79,744 symbol nodes; statements and modules carry none).
+
+In the one-`ProximaRecord` model these stop being two stores with an empty bridge: `embeddings:
+Vec<EmbeddingCell>` is *optional per node* and `props` is an NF² `ProximaTree`, so heterogeneous
+population is native — a module node (no vector), an embedded function (props + vector), and a Tier-B
+fragment coexist with *no always-empty column*. The shared `oid` replaces the implicit (file,name) join.
+
+[NOTE]
+====
+*Accepted consistency gap (G7):* node + embedding + edges are separate writes (no cross-modal
+ACID). Re-index is an idempotent, single-writer-per-repo upsert, so eventual consistency is fine —
+the watch daemon re-runs a file on crash. An optional transactional multi-modal write is filed as
+TD-133.
+====
+
+== Vector design
+
+* Store the 384-d BGE embedding in the symbol record's `EmbeddingCell` (`model_id`,
+`modality:"code"`, `dim:384`, cosine). Granularity = *symbol/chunk (Tier-A), not statements* —
+measured 77,902 vectors; HNSW fits memory trivially.
+* *Embedded-vectors vs correlated-by-oid is ONE knob, not two designs* (`EmbeddingMode`):
+** `EmbeddingMode::Memory` (embedded vectors on node) — vector co-located in RAM beside the ORION
+CSR; semantic/guided BFS scores neighbors inline, zero extra lookup. Use for the *embedded/Tier-A
+hot path*.
+** `EmbeddingMode::Cold` (correlated-by-oid) — vector in the vector engine (HNSW + SST/PAX,
+SQ8-quantizable); resolve `oid → vector` via *`VectorGet`/`get_vector(oid)`* or
+`get_by_key(include_vector)` (`src/network/router.rs:181`; batch form over Arrow IPC `vector_ids[]`).
+Use for the *service* to bound per-tenant RAM.
+** Both are the *same ProximaRecord / same `oid`* — no separate UUID, no manual join. This retires
+Victor's unpopulated `embedding_ref` + SQLite↔Lance dual-write skew.
+* *Two honest nuances:* (1) the *ANN seed always uses the HNSW index* regardless of mode —
+embed-on-node only saves the _traversal-time_ per-neighbor lookup, not the seed search; (2) `Memory`
+duplicates the embedding (node cache + index) — fine at Tier-A scale, and the reason the service uses
+`Cold` + `get_vector`.
+* *Decision:* co-index for ANN (HNSW) in both deployments; embed-on-node (`Memory`) for embedded,
+`Cold` + `get_vector(oid)` for the service. SQ8 + f32 rerank (PAX v2 lever) on the Cold path.
+* *Re-embed without schema change:* `EmbeddingCell.model_id`/`precision_epoch` version embeddings →
+a future code-tuned model (GraphCodeBERT-class) for the service is a re-index, not a migration.
+
+== Graph design
+
+* *ORION holds Tier-A only.* Node `labels=[function|class|module|method]`;
+`edge_type ∈ {CALLS,IMPORTS,INHERITS,CONTAINS,COMPOSITION,IMPLEMENTS}`. 79.7K/96.5K → in-RAM CSR.
+* *Reuse native algorithms* (`src/graph/engines/orion/algorithms/`): BFS/DFS for `impact_analysis`
+forward/backward (replaces Victor's `MultiHopRetriever`); ShortestPath for call paths;
+PageRank/betweenness/closeness + coupling to _compute_ `graph_module_metric` natively (Victor computes
+these in Python today); Louvain for module clustering.
+* *`GraphHybridQuery` (VectorFirst fusion)* replaces Victor's hand-rolled seed→expand + RRF: one call
+does semantic-seed ANN → k-hop expand → fuse by oid.
+* *Branch & time:* `branch_id` → per-git-branch graphs natively; `valid_from/to_ns` → time-travel over
+commit history (durable long memory across refactors).
+* *Tier-B stays out of ORION:* fetched as a PAX fragment on drill-down (Volcano scan + predicate
+pushdown + zone-map), keeping the traversable graph small.
+* CSR is an in-RAM projection rebuilt from canonical edge records on boot; at 96.5K edges rebuild is
+sub-second.
+
+=== Cohesion and sizing — why symbol granularity
+
+The symbol node carries its *code snippet + embedding as properties of one ProximaRecord*, so a code
+change rewrites text _and_ re-embedding in a single atomic upsert (one `record_version` bump / one WAL
+entry). This cohesion is the reason to converge on one record rather than two stores, and it retires
+the `embedding_ref` drift. Edges (relationships) are independent records, updated when the relationship
+changes. Sizing at *symbol granularity* keeps the cohesive graph small (measured):
+
+[cols="3,1,2,3", options="header"]
+|===
+| Model | Nodes | Embeddings (f32) | Verdict
+| Embed every node (statement-level) | 1.26M | *1,848 MB* | the "graph is big" explosion — avoid
+| *Tier-A symbols only* | *79,744* | *117 MB* (≈29 MB SQ8) | in-RAM friendly
+| Measured Lance store | 77,902 rows / *68,612 distinct* | *~100 MB* (25 MB SQ8) + code 5.5 MB | only ~5.4% of nodes embedded
+|===
+
+Only ~5.4% of graph nodes (and ~86% of symbol nodes) carry a vector, so the embedding tier is *sparse* —
+the cohesive record handles this natively (optional `embeddings` per node), unlike a fixed vector column.
+
+Whole-repo source text = 49.8 MB (storing code on nodes is cheap; the bloat is _row/edge/index/
+embedding overhead from statement-level elements_, not source bytes). Cohesive Tier-A graph ≈ code
+(snippet 5.5 MB) + embeddings (114 MB f32 / 29 MB SQ8) + 96.5K edges + metadata ≈ *~120 MB f32 / ~35 MB
+SQ8, fully in-RAM*. The dense statement CPG (the real size driver) is offloaded to cold columnar Tier-B,
+referenced by oid. ⇒ nodes _do_ mostly store code + embeddings — at symbol granularity; statements are
+not embedded nodes.
+
+== Relational / Volcano-OLTP design
+
+*Engine facts (verified).* `NativeVolcanoEngine::execute_physical[_stream]`
+(`src/query/execution/engine.rs`) is a pull-based, streaming, cancellation-safe iterator. Operators:
+Scan/Filter/Project/Join/Aggregate/Sort/Limit/Distinct/AssertMaxOneRow/Union/SetOp/Values.
+`ComputeScheduler::route_select(QueryShape{engages_relational,parquet_backed})`
+(`src/query/compute_scheduler.rs`): `!engages_relational` → *Native(Volcano)* OLTP fast path (strong
+freshness, always); relational+parquet → DataFusion (OLAP); relational+native → Volcano (OLAP over WAL).
+PK fast lane: planner `push_predicates` rewrites filter → `ScanAccess::PkLookup{key}` →
+`RecordStorage::get_record(RecordKey)` (direct WAL/memtable). DML (`src/services/dml/mod.rs`):
+`TableRecordMutationKind::{Insert,Upsert,Update,Delete,Merge,…}`, `NativeTableWriteExecutor`; txn =
+READ COMMITTED, `TransactionBuffer`, atomic commit, last-write-wins (no MVCC).
+
+*Design.* Tier-C lives as the symbol/edge records themselves (props = columns) plus small native
+tables (`code_file`, `code_import`, `code_module_metric`, `code_file_mtime`) with
+`workload_profile=OLTP`, `storage_specialization=LsmWriteOptimized` → WAL+memtable freshness, routed
+to Volcano. Module-metric dashboards keep a Parquet secondary layout for OLAP. The hot path is
+incremental re-index: point upserts + small predicate scans (symbols-in-file, files-in-dir).
+
+*OLTP gaps to close* (the dominant-cost terms for this workload):
+
+. *Secondary indexes* on `code_symbol(name)`, `code_symbol(file)`, `code_import(file)` — code lookups
+are by _name/file_, not PK oid; today only PK lookup exists → else full scan. *(TD-127, HIGH)*
+. *IN-list/range pushdown* (`WHERE file IN (...)`, `BETWEEN`) → multi-key point-batch; re-index touches
+a batch of files per debounce. Today: full scan + memory filter. *(TD-128, HIGH)*
+. *`ON CONFLICT DO UPDATE`* (upsert-by-PK) in pgwire for idempotent re-index. Mutation kind exists; the
+SQL surface does not. *(TD-129, MED)*
+. MVCC/row-lock — *not needed* (single-writer-per-repo, last-write-wins fine). No TD.
+
+== Deployment
+
+=== Embedded (local single-repo)
+
+One `EmbeddedProximaDB` (PyO3), one collection per repo, `EmbeddingMode::Memory`. Victor
+`GraphStoreProtocol` → a new `ProximaGraphStore`; `EmbeddingProvider` → make `proximadb_provider.py`
+real. The watch daemon → incremental `insert_proxima_records` upsert; initial load via Arrow Flight
+bulk (Tier-A nodes/edges + Tier-B fragments). Footprint: Tier-A ~80K nodes + 96.5K edges +
+~114 MB f32 vectors + metrics; Tier-B columnar on disk; ~512 MB cache.
+
+=== Service (anvaiops, multi-tenant/multi-repo)
+
+Collection `{tenant}_{repo}_codegraph`, `graph_id`=repo, `branch_id`=git branch. Pool-mode for
+free/team (shared collection + `tenant_id` filter — proven by `tests/uat/test_10_dataplane_isolation.py`
+in anvaiops); dedicated pool for enterprise (`DrPathBuilder data/{tenant}/{repo}/…`).
+`EmbeddingMode::Cold` (SQ8) to bound RAM; per-repo ORION partition loaded on demand, *routed by
+xCatalog — NOT one cross-tenant graph* (PULSAR is experimental). Billing reuses the meter spine: KIU
+(index writes), *KEU-code variant* (code embeddings), KRU (graph/vector scan GB), KSU (storage), KOU
+(result egress). The data-plane capability JWT already issues rest/grpc/flight URLs + scopes → add
+code-graph scopes. SaaS-layer gaps (tracked in anvaiops): multi-repo per workspace, git-webhook →
+code-graph-sync worker, per-repo RBAC.
+
+== Engine refinements → tech-debt
+
+See `docs/10-quality/TECHNICAL_DEBT.adoc`:
+
+[cols="1,5,1", options="header"]
+|===
+| TD | Item | Priority
+| TD-127 | OLTP secondary indexes (name/file) on native tables | HIGH
+| TD-128 | Volcano IN-list/range pushdown → multi-key point-batch | HIGH
+| TD-129 | pgwire `ON CONFLICT DO UPDATE` upsert | MED
+| TD-130 | Graph edge bulk-load (sorted LSM merge; kills per-edge uniqueness serialization) | MED
+| TD-131 | Graph on REST v2 + first-class co-planned hybrid endpoint (seed→expand→filter) | MED
+| TD-132 | Tier-B CPG-fragment PAX storage contract + per-query I/O trace emission | MED
+| TD-133 | Optional transactional multi-modal write (node+embedding+edges atomic) | LOW
+| TD-134 | Code-embedding meter (KEU variant) + per-repo RBAC entitlement | MED
+|===
+
+A benchmark gap (no e2e cold trace for graph/hybrid at 80K-node scale) is registered in
+`docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml` (`code_graph_tier_a_footprint`, status
+`aspirational`).
+
+== Verification
+
+* Spec self-consistency: every TD referenced here has a matching ledger row; every measured number
+traces to a query against `.victor/project.db` or the Lance table.
+* (Future, when TDs are picked up) Embedded parity test: index a small fixture repo via
+`ProximaGraphStore`; assert `impact_analysis(forward/backward)` and hybrid seed→expand match the SQLite
+store on known symbols; record Arrow Flight bulk-load timing in `BENCHMARK_EVIDENCE.toml`; 2-tenant
+isolation test on a code-graph collection; `branch_id` scoping check.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -121,6 +121,15 @@ Read these in order for future-shaping architecture work:
    hand-written ergonomic facade, and split the kitchen-sink per-language packages (e.g. Python's
    ~86k `proximadb_sdk`, of which the wire client is only ~19k) into focused, opt-in packages
    (core client / chunking / embeddings / integrations). Tracked as TD-126.
+21. `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc` +
+   Co-design spec for hosting an external coding agent's Code Property Graph as a correlated
+   OLTP + graph + vector substrate: one `ProximaRecord`/`oid` per code symbol simultaneously a
+   relational row, an ORION graph node, and an HNSW vector. Trace-driven from a measured 1.26M-node
+   CPG (94% statements, 96.5K cross-fn edges, 77,902 symbol embeddings) → a three-tier split:
+   Tier-A semantic graph in ORION + co-indexed vector (in-RAM, ~120 MB f32 / ~35 MB SQ8), Tier-B
+   intra-procedural CPG in columnar PAX (offloaded), Tier-C relational over Volcano-OLTP. Embedded
+   and multi-tenant (anvaiops) shapes. Engine asks: TD-127..TD-134. Subordinate to the 2026-06-04
+   course correction and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 
 == Stable Reference Docs
 

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -204,3 +204,17 @@ hardware = ""
 date = ""
 version = ""
 notes = "Co-design C0 §4.3. The e2e bench currently runs over a tempdir-backed LOCAL filesystem (object_economy_e2e measured local-FS cold p50 20.83 ms / warm 19.97 ms @10K, 2026-06-16) — the S3 first-byte floor (~tens of ms cold; turbopuffer reports ~444 ms p90 cold to ~10-18 ms warm) that DOMINATES real cold ANN is NOT captured. To promote to measured: point the bench's FilesystemFactory at an S3-compatible backend (MinIO/Wasabi/real S3) and check in a dated artifact. The per-query GET-count + bytes half of the bench's own stated gap is now captured by the io_trace substrate (src/observability/io_trace.rs); the remaining half is real cloud latency."
+
+[[claims]]
+id = "code_graph_tier_a_footprint"
+claim = "Tier-A code-graph (symbol nodes + cross-fn edges + co-indexed 384-d vector) fits in-RAM at ~120 MB f32 / ~35 MB SQ8 per repo, and hybrid seed->expand is sub-ms at this scale"
+metric = "graph_footprint_mb, hybrid_query_latency_ms"
+status = "aspirational"
+asserted_in = ["docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc"]
+bench_source = ""
+bench_command = ""
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "Sizing is PROJECTED from a measured SOURCE dataset (one real repo's SQLite CPG + LanceDB vectors): 79,744 symbol nodes, 96,538 cross-fn edges, 77,902 symbol embeddings @ 384-d = 114 MB f32 / 29 MB SQ8 + 5.5 MB co-stored snippet. No ProximaDB-side e2e bench yet for ingest/traversal/hybrid at this scale. To promote to measured: load Tier-A into an EmbeddedProximaDB, bench (a) Arrow Flight bulk-load time, (b) k-hop impact_analysis latency, (c) GraphHybridQuery seed->expand latency; check in a dated artifact. Tracked with TD-127..TD-132."


### PR DESCRIPTION
Persists the co-design spec for hosting an external coding agent's Code Property Graph on ProximaDB as a correlated **OLTP + graph + vector** substrate — one `ProximaRecord`/`oid` per code symbol (relational row + ORION node + HNSW vector).

Trace-driven from a **measured** 1.26M-node CPG (94% statements, 96.5K cross-fn edges, 68.6K distinct symbol embeddings ≈ 100 MB f32 / 25 MB SQ8):
- **Three-tier split** — Tier-A semantic graph in-RAM (ORION + co-indexed vector), Tier-B intra-procedural CPG in columnar PAX (offloaded), Tier-C relational over **Volcano-OLTP**.
- **Correlation keystone** — shared `oid`; `get_vector(oid)` / `EmbeddingMode` knob; optional-per-node embeddings handle the measured sparsity (only ~5.4% of nodes embedded).

Docs only. Adds the spec, indexes it in `12-design/README.adoc`, files **TD-127..TD-134**, a roadmap entry, and an aspirational benchmark claim (validator passes: 13 claims).