### PR TITLE
fix(chunking): lazy parser init + narrow exception swallowing + honest stream docstring

### DIFF
--- a/clients/python/src/proximadb_sdk/chunking_strategies/code.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/code.py
@@ -193,12 +193,22 @@ class PythonParser(LanguageParser):
 
             self._parser = get_parser("python")
             self._language = get_language("python")
-        except (ImportError, TypeError, Exception) as e:
-            # Fallback to regex-based parsing if tree-sitter not available
-            # or if there's a version incompatibility (e.g., tree-sitter 0.25.x with older tree-sitter-languages)
+        except (ImportError, OSError) as e:
+            # Grammar not installed / native module unavailable -> regex fallback.
             import logging
 
-            logging.debug(f"Tree-sitter init failed, using regex fallback: {e}")
+            logging.debug(f"Tree-sitter unavailable, using regex fallback: {e}")
+            self._parser = None
+            self._language = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for python; "
+                "using regex fallback",
+                exc_info=True,
+            )
             self._parser = None
             self._language = None
 
@@ -896,7 +906,19 @@ class JavaScriptParser(LanguageParser):
 
             lang = "typescript" if self._typescript else "javascript"
             self._parser = get_parser(lang)
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -941,7 +963,19 @@ class RustParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("rust")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -1430,7 +1464,19 @@ class GoParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("go")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -1689,7 +1735,19 @@ class JavaParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("java")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2102,7 +2160,19 @@ class CppParser(LanguageParser):
 
             lang = "c" if self._c_mode else "cpp"
             self._parser = get_parser(lang)
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2387,7 +2457,19 @@ class RubyParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("ruby")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2688,7 +2770,19 @@ class CSharpParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("c_sharp")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2724,7 +2818,19 @@ class PhpParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("php")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2759,7 +2865,19 @@ class SwiftParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("swift")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2794,7 +2912,19 @@ class KotlinParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("kotlin")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2829,7 +2959,19 @@ class ScalaParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("scala")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -2864,7 +3006,19 @@ class BashParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("bash")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3001,7 +3155,19 @@ class SqlParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("sql")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3177,7 +3343,19 @@ class YamlParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("yaml")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3318,7 +3496,19 @@ class JsonParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("json")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3512,7 +3702,19 @@ class PerlParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("perl")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3687,7 +3889,19 @@ class LuaParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("lua")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3723,7 +3937,19 @@ class HaskellParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("haskell")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3758,7 +3984,19 @@ class ElixirParser(LanguageParser):
             from tree_sitter_language_pack import get_parser
 
             self._parser = get_parser("elixir")
-        except (ImportError, TypeError, Exception):
+        except (ImportError, OSError):
+            # Grammar not installed / native module unavailable -> regex fallback.
+            self._parser = None
+        except Exception:
+            # Unexpected failure: surface it (do not silently swallow), then fall back.
+            import logging
+
+            logging.warning(
+                "Unexpected tree-sitter parser init failure for %s; "
+                "using regex fallback",
+                getattr(self, "language", "unknown"),
+                exc_info=True,
+            )
             self._parser = None
 
     @property
@@ -3955,24 +4193,47 @@ class CodeChunkingStrategy(ChunkingStrategyInterface):
 
     def __init__(self, config: CodeChunkingConfig | None = None):
         self.config = config or CodeChunkingConfig()
+        # Lazily-instantiated parsers, keyed by language. We do NOT eagerly
+        # build all ~23 tree-sitter parsers here: loading every grammar to chunk
+        # a single file is wasteful. Each language's parser is instantiated on
+        # first use (see `_get_parser`) and cached for subsequent calls.
         self._parsers: dict[str, LanguageParser] = {}
-        self._init_parsers()
+        # `None` sentinel marks a language we already tried and failed to load,
+        # so we don't repeatedly retry a broken/unavailable grammar.
+        self._failed_languages: set[str] = set()
+        # Set of languages this strategy is allowed to parse (config-scoped).
+        self._allowed_languages: set[str] = set(
+            self.config.languages or LANGUAGE_PARSERS.keys()
+        )
 
-    def _init_parsers(self):
-        """Initialize parsers for configured languages"""
-        languages = self.config.languages or list(LANGUAGE_PARSERS.keys())
-        for lang in languages:
-            if lang in LANGUAGE_PARSERS:
-                parser_class = LANGUAGE_PARSERS[lang]
-                try:
-                    self._parsers[lang] = (
-                        parser_class() if callable(parser_class) else parser_class
-                    )
-                except (AttributeError, ImportError, OSError) as e:
-                    # Skip languages that aren't available in tree-sitter-languages
-                    import logging
+    def _get_parser(self, language: str | None) -> LanguageParser | None:
+        """Return the parser for `language`, instantiating it on first use.
 
-                    logging.debug(f"Skipping parser for {lang}: {e}")
+        Returns None if the language is unknown, not in the configured set, or
+        previously failed to initialize.
+        """
+        if (
+            language is None
+            or language not in LANGUAGE_PARSERS
+            or language not in self._allowed_languages
+            or language in self._failed_languages
+        ):
+            return None
+        parser = self._parsers.get(language)
+        if parser is not None:
+            return parser
+        parser_class = LANGUAGE_PARSERS[language]
+        try:
+            parser = parser_class() if callable(parser_class) else parser_class
+        except (AttributeError, ImportError, OSError) as e:
+            # Grammar not available in tree-sitter-language-pack -> fall back.
+            import logging
+
+            logging.debug(f"Skipping parser for {language}: {e}")
+            self._failed_languages.add(language)
+            return None
+        self._parsers[language] = parser
+        return parser
 
     def chunk(
         self, text: str, source_id: str, metadata: dict[str, Any] | None = None
@@ -3991,11 +4252,12 @@ class CodeChunkingStrategy(ChunkingStrategyInterface):
         metadata = metadata or {}
         language = metadata.get("language") or self._detect_language(source_id)
 
-        if language not in self._parsers:
+        parser = self._get_parser(language)
+        if parser is None:
             # Fall back to semantic text chunking
             return self._fallback_chunk(text, source_id, metadata)
 
-        parsed = self._parsers[language].parse(text, source_id)
+        parsed = parser.parse(text, source_id)
 
         chunks = []
         for i, symbol in enumerate(parsed.symbols):

--- a/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
@@ -790,9 +790,14 @@ class ChunkingPipeline:
         self, text: str, source_id: str, metadata: dict[str, Any] | None = None
     ) -> Generator[TextChunk, None, None]:
         """
-        Process text as a stream, yielding chunks as they're ready.
+        Yield validated/enriched chunks one at a time.
 
-        Memory-efficient for large documents.
+        NOTE: This is *not* an incremental (constant-memory) stream. The full
+        input ``text`` and the complete chunk list are materialized first (the
+        underlying chunking strategies are batch APIs); only the downstream
+        validation/enrichment stages run per-chunk as chunks are yielded. Use
+        this to begin consuming chunks without waiting for the whole pipeline,
+        not to bound memory on very large documents.
         """
         try:
             chunks = self.chunker.chunk(text, source_id, metadata)
@@ -816,7 +821,10 @@ class ChunkingPipeline:
         self, text: str, source_id: str, metadata: dict[str, Any] | None = None
     ) -> AsyncGenerator[TextChunk, None]:
         """
-        Async version of stream processing.
+        Async version of :meth:`process_stream`.
+
+        Same caveat applies: the input and chunk list are materialized first
+        (chunking runs in an executor); this is not constant-memory streaming.
         """
         try:
             loop = asyncio.get_event_loop()

--- a/clients/python/tests/chunking/test_code_chunking_strategy.py
+++ b/clients/python/tests/chunking/test_code_chunking_strategy.py
@@ -83,16 +83,22 @@ class TestCodeChunkingStrategy:
         assert isinstance(strategy.config, CodeChunkingConfig)
 
     def test_strategy_has_parsers(self, strategy):
-        """Test strategy initializes parsers."""
+        """Test strategy exposes the lazy parser cache and allowed languages."""
         assert hasattr(strategy, "_parsers")
         assert isinstance(strategy._parsers, dict)
-        assert len(strategy._parsers) > 0
+        # Parsers are instantiated lazily on first chunk(), so the cache starts
+        # empty, but the allowed-language set is populated at construction.
+        assert strategy._parsers == {}
+        assert len(strategy._allowed_languages) > 0
 
     def test_strategy_with_limited_languages(self, python_strategy):
-        """Test strategy with limited languages."""
+        """Test strategy with limited languages restricts the allowed set."""
+        assert python_strategy._allowed_languages == {"python"}
+        # Nothing instantiated until the first chunk() call.
+        assert python_strategy._parsers == {}
+        python_strategy.chunk("def f():\n    return 1\n", "x.py")
         assert "python" in python_strategy._parsers
-        # Should only have python parser
-        assert len(python_strategy._parsers) == 1
+        assert set(python_strategy._parsers) == {"python"}
 
     def test_chunk_python_code(self, strategy):
         """Test chunking Python code."""
@@ -216,8 +222,7 @@ class TestCreateCodeChunker:
     def test_create_chunker_with_languages(self):
         """Test creating a code chunker with specific languages."""
         chunker = create_code_chunker(languages=["python", "rust"])
-        assert "python" in chunker._parsers
-        assert "rust" in chunker._parsers
+        assert chunker._allowed_languages == {"python", "rust"}
 
     def test_create_chunker_with_config_kwargs(self):
         """Test creating a code chunker with config kwargs."""

--- a/clients/python/tests/unit/test_chunking_code_cov.py
+++ b/clients/python/tests/unit/test_chunking_code_cov.py
@@ -970,13 +970,23 @@ def test_placeholder_parsers(cls, lang, ext):
 
 def test_strategy_init_default(no_ts_pack):
     strat = CodeChunkingStrategy()
+    # Parsers are lazy: nothing instantiated until the first chunk(), but
+    # python must be in the allowed set.
+    assert strat._parsers == {}
+    assert "python" in strat._allowed_languages
+    # On demand, a python parser is instantiated even without tree-sitter
+    # (regex fallback) and then cached.
+    assert strat._get_parser("python") is not None
     assert "python" in strat._parsers
-    # parsers init even without tree-sitter (regex fallback)
 
 
 def test_strategy_init_specific_languages(no_ts_pack):
     cfg = CodeChunkingConfig(languages=["python", "unknownlang"])
     strat = CodeChunkingStrategy(cfg)
+    assert strat._allowed_languages == {"python", "unknownlang"}
+    # python resolves; an unknown language never produces a parser.
+    assert strat._get_parser("python") is not None
+    assert strat._get_parser("unknownlang") is None
     assert "python" in strat._parsers
     assert "unknownlang" not in strat._parsers
 


### PR DESCRIPTION
## Summary
Perf + correctness quick wins in the Python SDK code-chunking strategy (`clients/python/.../chunking_strategies/`). Fixes/cleanups only — keeps the symbol + call/import/inheritance differentiator.

1. **Lazy parser init** — `CodeChunkingStrategy` previously eager-instantiated all ~23 tree-sitter parsers (23 grammars loaded to chunk one file). Now a language's parser is built on first `chunk()` for that language and cached; unavailable grammars are remembered so they aren't retried. Smoke: chunking one `.py` file loads exactly 1/23 grammars.
2. **Narrow exception anti-pattern** (~20 `_init_parser` sites) — `except (ImportError, TypeError, Exception)` swallowed *all* errors into the regex fallback, hiding real bugs. Now `(ImportError, OSError)` for the expected missing-grammar case + a broad `except` that **logs** the unexpected failure before falling back.
3. **Honest streaming docstring** — `PipelineExecutor.process_stream`/`process_stream_async` claimed "memory-efficient for large documents" but materialize the whole input + chunk list first (underlying strategies are batch APIs). Corrected the docstrings rather than faking incremental streaming (true streaming would require rewriting every strategy — deferred as a follow-up).

## Tests
- Updated `test_code_chunking_strategy.py` + `test_chunking_code_cov.py` to assert the lazy contract (allowed-language set at construction; cache fills on first chunk).
- Full chunking suites green: **768 passed, 8 skipped**.
- `black --check` / `isort --check-only` / `ruff (E9,F63,F7)` clean; `py_compile` clean.

## Scope
Python-only. Does not touch OpenAPI spec, generated REST transport, embeddings, or integrations.