### PR TITLE
fix(py-embeddings): P0 — repair OpenAI/Cohere providers, register cloud providers, fix E5 passage prefix

### DIFF
--- a/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
@@ -42,6 +42,14 @@ _PROVIDER_EXPORTS = {
         ".providers.testing.simulated",
         "SimulatedEmbeddingProvider",
     ),
+    # Cloud / OpenAI-compatible providers (registered onto core.BaseEmbeddingProvider).
+    "OpenAIProvider": (".openai_provider", "OpenAIProvider"),
+    "CohereProvider": (".cohere", "CohereProvider"),
+    "FastEmbedProvider": (".fastembed", "FastEmbedProvider"),
+    "OpenAICompatibleProvider": (
+        ".openai_compatible",
+        "OpenAICompatibleProvider",
+    ),
 }
 
 _providers_registered = False
@@ -181,9 +189,12 @@ def recommend_free_providers() -> None:
     print("   provider = get_provider('bge')")
     print()
 
-    print("\n💡 For production, consider OpenAI or Cohere (paid services)")
-    print("   provider = get_provider('openai', api_key='...')")
-    print("   provider = get_provider('cohere', api_key='...')")
+    print("\n💡 For production, consider OpenAI or Cohere (PAID hosted APIs)")
+    print("   These are reachable via get_provider() but require an API key:")
+    print("   provider = get_provider('openai')   # OPENAI_API_KEY")
+    print("   provider = get_provider('cohere')   # COHERE_API_KEY")
+    print("   Or point at a local OpenAI-compatible server (free):")
+    print("   provider = get_provider('ollama')   # OpenAI-compatible endpoint")
 
 
 __all__ = [
@@ -204,4 +215,8 @@ __all__ = [
     # Providers
     "GTEQwenProvider",
     "SimulatedEmbeddingProvider",
+    "OpenAIProvider",
+    "CohereProvider",
+    "FastEmbedProvider",
+    "OpenAICompatibleProvider",
 ]

--- a/clients/python/src/proximadb_sdk/embedding_providers/cohere.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/cohere.py
@@ -1,318 +1,205 @@
 """
 Cohere embedding provider
 
-Uses Cohere's embedding API.
-WARNING: Requires API key and incurs costs per token.
+Uses Cohere's embedding API via the modern ``cohere.ClientV2``.
+
+WARNING: Requires an API key and incurs costs per token.
 """
 
 import logging
 import os
 import warnings
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
-from .base import EmbeddingConfig, EmbeddingProvider
+from .core.base import BaseEmbeddingProvider
+from .core.config import ModelMetadata, ProviderConfig
+from .core.registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
+COHERE_MODELS = {
+    "embed-english-light-v3.0": ModelMetadata(
+        name="embed-english-light-v3.0",
+        dimension=384,
+        max_length=512,
+        provider_type="api",
+        languages="en",
+        description="Lightweight English model, very cost-effective",
+        use_case="Cost-effective English retrieval",
+    ),
+    "embed-english-v3.0": ModelMetadata(
+        name="embed-english-v3.0",
+        dimension=1024,
+        max_length=512,
+        provider_type="api",
+        languages="en",
+        description="High-quality English embeddings",
+        use_case="High-accuracy English retrieval",
+    ),
+    "embed-multilingual-v3.0": ModelMetadata(
+        name="embed-multilingual-v3.0",
+        dimension=1024,
+        max_length=512,
+        provider_type="api",
+        languages="100+",
+        description="Supports 100+ languages",
+        use_case="Multilingual retrieval",
+    ),
+}
 
-class CohereProvider(EmbeddingProvider):
+# Cohere maps embedding intent to an `input_type` argument (v3 models).
+_INPUT_TYPES = (
+    "search_document",
+    "search_query",
+    "classification",
+    "clustering",
+)
+
+# Pricing (USD per 1M tokens) for rough cost estimates.
+_COST_PER_1M = {
+    "embed-english-light-v3.0": 0.02,
+    "embed-english-v3.0": 0.10,
+    "embed-multilingual-v3.0": 0.10,
+}
+
+
+@ProviderRegistry.register(
+    name="cohere",
+    models=COHERE_MODELS,
+    aliases=["cohere-embeddings"],
+    description="Cohere hosted embeddings (requires API key, incurs cost)",
+)
+class CohereProvider(BaseEmbeddingProvider):
     """
-    Embedding provider using Cohere's API
+    Embedding provider using Cohere's API (``cohere.ClientV2``).
 
-    ⚠️ WARNING: This provider requires a Cohere API key and will incur costs!
+    WARNING: This provider requires a Cohere API key and will incur costs.
 
-    Pricing (as of 2024):
-    - embed-english-v3.0: ~$0.1 per 1M tokens
-    - embed-multilingual-v3.0: ~$0.1 per 1M tokens
-    - embed-english-light-v3.0: ~$0.02 per 1M tokens
+    Set the API key via:
+    - Environment variable ``COHERE_API_KEY``
+    - ``extra={"api_key": "..."}`` on the :class:`ProviderConfig`
 
-    Models:
-    - embed-english-v3.0: 1024 dims, best for English
-    - embed-multilingual-v3.0: 1024 dims, supports 100+ languages
-    - embed-english-light-v3.0: 384 dims, faster and cheaper
-    - embed-english-v2.0: 4096 dims, legacy model
-
-    Set API key via:
-    - Environment variable: COHERE_API_KEY
-    - Config parameter: api_key
-
-    Special features:
-    - Input types: "search_document", "search_query", "classification", "clustering"
-    - Compression support for reduced dimensions
+    Optional ``extra`` parameters:
+    - ``api_key``: API key (falls back to ``COHERE_API_KEY``)
+    - ``input_type``: one of ``search_document`` (default), ``search_query``,
+      ``classification``, ``clustering``
+    - ``truncate``: ``NONE`` / ``START`` / ``END`` (default ``END``)
+    - ``show_cost_warnings``: emit a UserWarning about per-token cost (default True)
     """
 
-    MODEL_DIMENSIONS = {
-        "embed-english-v3.0": 1024,
-        "embed-multilingual-v3.0": 1024,
-        "embed-english-light-v3.0": 384,
-        "embed-english-v2.0": 4096,
-        "embed-multilingual-v2.0": 768,
-    }
-
-    # Supported input types for different use cases
-    INPUT_TYPES = ["search_document", "search_query", "classification", "clustering"]
-
-    def _get_default_config(self) -> EmbeddingConfig:
-        """Get default configuration"""
-        return EmbeddingConfig(
-            model_name="embed-english-light-v3.0",  # Cheaper option
-            dimension=384,
+    def default_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            model=COHERE_MODELS["embed-english-light-v3.0"],
             batch_size=96,  # Cohere max batch size
             normalize=True,
-            cache_embeddings=True,  # Cache to reduce costs
-            device=None,
-            extra_params={
+            extra={
                 "api_key": None,
                 "input_type": "search_document",
-                "truncate": "END",  # How to handle long texts
-                "compress": False,  # Whether to use compression
-                "compression_codebook": None,
+                "truncate": "END",
                 "show_cost_warnings": True,
-                "timeout": 60.0,
             },
         )
 
-    def _initialize(self) -> None:
-        """Initialize the Cohere client"""
+    def _load_model(self) -> Any:
         try:
             import cohere
+        except ImportError as exc:  # pragma: no cover - exercised via stub
+            raise ImportError(
+                "cohere is required for CohereProvider. "
+                "Install with: pip install 'cohere>=5'"
+            ) from exc
 
-            # Get API key
-            api_key = self.config.extra_params.get("api_key") or os.getenv(
-                "COHERE_API_KEY"
+        extra = self.config.extra
+        api_key = extra.get("api_key") or os.getenv("COHERE_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "Cohere API key not found. Set COHERE_API_KEY or pass "
+                "extra={'api_key': ...} in the provider config."
             )
 
-            if not api_key:
-                self._available = False
-                logger.error(
-                    "Cohere API key not found. Set COHERE_API_KEY environment variable or pass api_key in config."
-                )
-                return
-
-            # Show cost warning
-            if self.config.extra_params.get("show_cost_warnings", True):
-                warnings.warn(
-                    f"⚠️  Cohere embeddings will incur costs! Model '{self.config.model_name}' charges per token. "
-                    f"Consider using free alternatives like SentenceTransformer or FastEmbed for development.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-
-            # Initialize client
-            self.client = cohere.Client(api_key=api_key)
-
-            # Update dimension
-            if self.config.model_name in self.MODEL_DIMENSIONS:
-                self.config.dimension = self.MODEL_DIMENSIONS[self.config.model_name]
-
-            self._available = True
-            self._token_count = 0  # Track usage
-
-            logger.info(
-                f"Initialized Cohere provider with model: {self.config.model_name} "
-                f"(dimension: {self.config.dimension})"
+        if extra.get("show_cost_warnings", True):
+            warnings.warn(
+                f"Cohere embeddings incur cost. Model '{self.config.model.name}' "
+                "charges per token. Consider a local provider for development.",
+                UserWarning,
+                stacklevel=2,
             )
-            logger.warning("Remember: Cohere embeddings incur costs per token!")
 
-        except ImportError:
-            self._available = False
-            logger.warning("cohere not installed. Install with: pip install cohere")
-        except Exception as e:
-            self._available = False
-            logger.error(f"Failed to initialize Cohere: {e}")
+        self._token_count = 0
+        client = cohere.ClientV2(api_key=api_key)
+        logger.info(
+            "Initialized Cohere provider with model %s (dimension %s)",
+            self.config.model.name,
+            self.config.model.dimension,
+        )
+        return client
 
-    def embed_texts(self, texts: list[str]) -> np.ndarray:
-        """
-        Generate embeddings for multiple texts
-
-        Args:
-            texts: List of texts to embed
-
-        Returns:
-            Array of embeddings with shape (len(texts), dimension)
-        """
-        if not self._available:
-            raise RuntimeError("Cohere not available. Check API key and installation.")
-
+    def embed(self, texts: list[str], input_type: str | None = None) -> np.ndarray:
         if not texts:
             return np.array([])
 
-        all_embeddings = []
+        self.ensure_initialized()
 
-        # Estimate tokens (rough estimate for Cohere)
-        estimated_tokens = sum(len(text.split()) for text in texts)
-        self._token_count += estimated_tokens
-
-        if (
-            self.config.extra_params.get("show_cost_warnings", True)
-            and estimated_tokens > 100000
-        ):
-            warnings.warn(
-                f"⚠️  About to process ~{estimated_tokens:,} tokens with {self.config.model_name}. "
-                f"Estimated cost: ${self._estimate_cost(estimated_tokens):.4f}",
-                UserWarning,
+        resolved_type = input_type or self.config.extra.get(
+            "input_type", "search_document"
+        )
+        if resolved_type not in _INPUT_TYPES:
+            raise ValueError(
+                f"Invalid input_type '{resolved_type}'. Expected one of {_INPUT_TYPES}."
             )
 
-        # Process in batches (Cohere max batch size is 96)
+        all_embeddings: list[list[float]] = []
         for i in range(0, len(texts), self.config.batch_size):
             batch = texts[i : i + self.config.batch_size]
-
             try:
-                response = self.client.embed(
+                response = self._model.embed(
                     texts=batch,
-                    model=self.config.model_name,
-                    input_type=self.config.extra_params.get(
-                        "input_type", "search_document"
-                    ),
-                    truncate=self.config.extra_params.get("truncate", "END"),
-                    compress=self.config.extra_params.get("compress", False),
-                    compression_codebook=self.config.extra_params.get(
-                        "compression_codebook"
-                    ),
+                    model=self.config.model.name,
+                    input_type=resolved_type,
+                    embedding_types=["float"],
+                    truncate=self.config.extra.get("truncate", "END"),
                 )
+            except Exception as exc:
+                logger.error("Cohere API error: %s", exc)
+                raise RuntimeError(f"Failed to generate embeddings: {exc}") from exc
 
-                # Extract embeddings
-                batch_embeddings = response.embeddings
-                all_embeddings.extend(batch_embeddings)
+            # ClientV2 returns embeddings keyed by type: response.embeddings.float
+            batch_embeddings = response.embeddings.float
+            all_embeddings.extend(batch_embeddings)
 
-                # Log token usage if available
-                if hasattr(response, "meta") and hasattr(response.meta, "billed_units"):
-                    tokens = response.meta.billed_units.input_tokens
-                    logger.info(
-                        f"Cohere API used {tokens} tokens for {len(batch)} texts"
-                    )
+            meta = getattr(response, "meta", None)
+            billed = getattr(meta, "billed_units", None) if meta else None
+            tokens = getattr(billed, "input_tokens", None) if billed else None
+            if tokens is not None:
+                self._token_count = getattr(self, "_token_count", 0) + tokens
 
-            except Exception as e:
-                logger.error(f"Cohere API error: {e}")
-                raise RuntimeError(f"Failed to generate embeddings: {e}")
+        embeddings = np.array(all_embeddings, dtype=np.float32)
 
-        embeddings = np.array(all_embeddings)
-
-        # Normalize if requested
         if self.config.normalize:
             norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
-            norms[norms == 0] = 1  # Avoid division by zero
+            norms[norms == 0] = 1.0
             embeddings = embeddings / norms
 
         return embeddings
 
-    def embed_with_type(
-        self,
-        texts: list[str],
-        input_type: Literal[
-            "search_document", "search_query", "classification", "clustering"
-        ],
-    ) -> np.ndarray:
-        """
-        Generate embeddings with specific input type
+    def embed_query(self, query: str) -> np.ndarray:
+        """Embed a single query with the ``search_query`` input type."""
+        return self.embed([query], input_type="search_query")[0]
 
-        Args:
-            texts: List of texts to embed
-            input_type: Type of input for optimization
-
-        Returns:
-            Array of embeddings
-        """
-        # Temporarily override input type
-        original_type = self.config.extra_params.get("input_type")
-        self.config.extra_params["input_type"] = input_type
-
-        try:
-            embeddings = self.embed_texts(texts)
-        finally:
-            # Restore original type
-            self.config.extra_params["input_type"] = original_type
-
-        return embeddings
+    def embed_passages(self, passages: list[str]) -> np.ndarray:
+        """Embed documents with the ``search_document`` input type."""
+        return self.embed(passages, input_type="search_document")
 
     def _estimate_cost(self, tokens: int) -> float:
-        """Estimate cost based on token count"""
-        # Cohere pricing per 1M tokens
-        cost_per_1m = {
-            "embed-english-v3.0": 0.10,
-            "embed-multilingual-v3.0": 0.10,
-            "embed-english-light-v3.0": 0.02,
-            "embed-english-v2.0": 0.10,
-            "embed-multilingual-v2.0": 0.10,
-        }
-
-        rate = cost_per_1m.get(self.config.model_name, 0.10)
+        rate = _COST_PER_1M.get(self.config.model.name, 0.10)
         return (tokens / 1_000_000) * rate
 
-    @property
-    def dimension(self) -> int:
-        """Get embedding dimension"""
-        return self.config.dimension
-
-    @property
-    def model_name(self) -> str:
-        """Get model name"""
-        return self.config.model_name
-
-    def is_available(self) -> bool:
-        """Check if provider is available"""
-        if self._available is None:
-            self._initialize()
-        return self._available
-
     def get_token_usage(self) -> dict[str, Any]:
-        """Get token usage statistics"""
+        tokens = getattr(self, "_token_count", 0)
         return {
-            "estimated_tokens": self._token_count,
-            "estimated_cost": self._estimate_cost(self._token_count),
-            "model": self.config.model_name,
+            "estimated_tokens": tokens,
+            "estimated_cost": self._estimate_cost(tokens),
+            "model": self.config.model.name,
         }
-
-    @classmethod
-    def list_models(cls) -> dict[str, dict[str, Any]]:
-        """List available models with details"""
-        return {
-            "embed-english-light-v3.0": {
-                "dimension": 384,
-                "description": "Lightweight English model, very cost-effective",
-                "cost_per_1m_tokens": "$0.02",
-                "max_tokens": 512,
-                "languages": ["en"],
-            },
-            "embed-english-v3.0": {
-                "dimension": 1024,
-                "description": "High-quality English embeddings",
-                "cost_per_1m_tokens": "$0.10",
-                "max_tokens": 512,
-                "languages": ["en"],
-            },
-            "embed-multilingual-v3.0": {
-                "dimension": 1024,
-                "description": "Supports 100+ languages",
-                "cost_per_1m_tokens": "$0.10",
-                "max_tokens": 512,
-                "languages": ["100+ languages"],
-            },
-            "embed-english-v2.0": {
-                "dimension": 4096,
-                "description": "Legacy model with larger dimensions",
-                "cost_per_1m_tokens": "$0.10",
-                "max_tokens": 512,
-                "languages": ["en"],
-            },
-        }
-
-    @classmethod
-    def create_for_search(
-        cls, model_name: str = "embed-english-light-v3.0", **kwargs
-    ) -> "CohereProvider":
-        """
-        Create provider optimized for search
-
-        Returns separate providers for documents and queries
-        """
-        # Document provider
-        doc_config = EmbeddingConfig(
-            model_name=model_name,
-            dimension=cls.MODEL_DIMENSIONS.get(model_name, 384),
-            extra_params={"input_type": "search_document", **kwargs},
-        )
-
-        return cls(doc_config)

--- a/clients/python/src/proximadb_sdk/embedding_providers/fastembed.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/fastembed.py
@@ -1,8 +1,8 @@
 """
 FastEmbed embedding provider
 
-Uses the fastembed library (Apache 2.0 license) for fast,
-lightweight embedding models with ONNX runtime.
+Uses the fastembed library (Apache 2.0) for fast, lightweight ONNX embedding
+models with minimal dependencies.
 """
 
 import logging
@@ -10,175 +10,121 @@ from typing import Any
 
 import numpy as np
 
-from .base import EmbeddingConfig, EmbeddingProvider
+from .core.base import BaseEmbeddingProvider
+from .core.config import ModelMetadata, ProviderConfig
+from .core.registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
+FASTEMBED_MODELS = {
+    "BAAI/bge-small-en-v1.5": ModelMetadata(
+        name="BAAI/bge-small-en-v1.5",
+        dimension=384,
+        max_length=512,
+        provider_type="onnx",
+        languages="en",
+        description="Fast and efficient, great for most use cases",
+        use_case="High-throughput CPU inference",
+    ),
+    "BAAI/bge-base-en-v1.5": ModelMetadata(
+        name="BAAI/bge-base-en-v1.5",
+        dimension=768,
+        max_length=512,
+        provider_type="onnx",
+        languages="en",
+        description="Better quality, still fast",
+        use_case="Balanced CPU inference",
+    ),
+    "sentence-transformers/all-MiniLM-L6-v2": ModelMetadata(
+        name="sentence-transformers/all-MiniLM-L6-v2",
+        dimension=384,
+        max_length=512,
+        provider_type="onnx",
+        languages="en",
+        description="Classic lightweight model",
+        use_case="Edge / low-resource inference",
+    ),
+}
 
-class FastEmbedProvider(EmbeddingProvider):
+# Known dimensions for models not in the curated metadata table above.
+_MODEL_DIMENSIONS = {
+    "BAAI/bge-small-en-v1.5": 384,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-large-en-v1.5": 1024,
+    "sentence-transformers/all-MiniLM-L6-v2": 384,
+    "sentence-transformers/all-MiniLM-L12-v2": 384,
+    "jinaai/jina-embeddings-v2-small-en": 512,
+    "jinaai/jina-embeddings-v2-base-en": 768,
+    "snowflake/snowflake-arctic-embed-xs": 384,
+    "snowflake/snowflake-arctic-embed-s": 384,
+    "snowflake/snowflake-arctic-embed-m": 768,
+    "snowflake/snowflake-arctic-embed-l": 1024,
+}
+
+
+@ProviderRegistry.register(
+    name="fastembed",
+    models=FASTEMBED_MODELS,
+    aliases=["qdrant-fastembed"],
+    description="FastEmbed ONNX embeddings (fast, lightweight, Apache 2.0)",
+)
+class FastEmbedProvider(BaseEmbeddingProvider):
     """
-    Embedding provider using FastEmbed models
+    Embedding provider using FastEmbed models.
 
-    FastEmbed provides optimized ONNX models for fast inference
-    with minimal dependencies. All models are quantized for speed
-    and small model size.
-
-    Popular models:
-    - BAAI/bge-small-en-v1.5: 384 dims, fast and efficient
-    - BAAI/bge-base-en-v1.5: 768 dims, better quality
-    - sentence-transformers/all-MiniLM-L6-v2: 384 dims, classic choice
-    - jinaai/jina-embeddings-v2-small-en: 512 dims, optimized for search
-
-    All models use Apache 2.0 or similar permissive licenses.
+    FastEmbed provides optimized ONNX models for fast CPU inference with minimal
+    dependencies. Install with ``pip install fastembed``.
     """
 
-    # Model dimension mapping
-    MODEL_DIMENSIONS = {
-        "BAAI/bge-small-en-v1.5": 384,
-        "BAAI/bge-base-en-v1.5": 768,
-        "BAAI/bge-large-en-v1.5": 1024,
-        "sentence-transformers/all-MiniLM-L6-v2": 384,
-        "sentence-transformers/all-MiniLM-L12-v2": 384,
-        "jinaai/jina-embeddings-v2-small-en": 512,
-        "jinaai/jina-embeddings-v2-base-en": 768,
-        "snowflake/snowflake-arctic-embed-xs": 384,
-        "snowflake/snowflake-arctic-embed-s": 384,
-        "snowflake/snowflake-arctic-embed-m": 768,
-        "snowflake/snowflake-arctic-embed-l": 1024,
-    }
-
-    def _get_default_config(self) -> EmbeddingConfig:
-        """Get default configuration"""
-        return EmbeddingConfig(
-            model_name="BAAI/bge-small-en-v1.5",
-            dimension=384,
+    def default_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            model=FASTEMBED_MODELS["BAAI/bge-small-en-v1.5"],
             batch_size=256,  # FastEmbed handles large batches well
             normalize=True,
-            cache_embeddings=True,
-            device=None,  # CPU optimized
+            extra={"max_length": 512},
         )
 
-    def _initialize(self) -> None:
-        """Initialize the FastEmbed model"""
+    def _load_model(self) -> Any:
         try:
             from fastembed import TextEmbedding
+        except ImportError as exc:  # pragma: no cover - exercised via stub
+            raise ImportError(
+                "fastembed is required for FastEmbedProvider. "
+                "Install with: pip install fastembed"
+            ) from exc
 
-            # Initialize model
-            self.model = TextEmbedding(
-                model_name=self.config.model_name,
-                max_length=512,  # Standard max length
-                normalize=self.config.normalize,
-                cache_dir=None,  # Use default cache
-            )
+        model = TextEmbedding(
+            model_name=self.config.model.name,
+            max_length=self.config.extra.get("max_length", 512),
+            cache_dir=self.config.cache_dir,
+        )
+        logger.info(
+            "Initialized FastEmbed with model %s (dimension %s)",
+            self.config.model.name,
+            self.get_dimension(),
+        )
+        return model
 
-            # Update dimension
-            if self.config.model_name in self.MODEL_DIMENSIONS:
-                self.config.dimension = self.MODEL_DIMENSIONS[self.config.model_name]
-            else:
-                # Get dimension from model
-                dummy_embedding = list(self.model.embed(["test"]))[0]
-                self.config.dimension = len(dummy_embedding)
-
-            self._available = True
-            logger.info(
-                f"Initialized FastEmbed with model: {self.config.model_name} "
-                f"(dimension: {self.config.dimension})"
-            )
-
-        except ImportError:
-            self._available = False
-            logger.warning(
-                "fastembed not installed. " "Install with: pip install fastembed"
-            )
-        except Exception as e:
-            self._available = False
-            logger.error(f"Failed to initialize FastEmbed: {e}")
-
-    def embed_texts(self, texts: list[str]) -> np.ndarray:
-        """
-        Generate embeddings for multiple texts
-
-        Args:
-            texts: List of texts to embed
-
-        Returns:
-            Array of embeddings with shape (len(texts), dimension)
-        """
-        if not self._available:
-            raise RuntimeError(
-                "FastEmbed not available. " "Install with: pip install fastembed"
-            )
-
+    def embed(self, texts: list[str]) -> np.ndarray:
         if not texts:
             return np.array([])
 
-        # Generate embeddings
-        # FastEmbed returns a generator, so we need to convert to list
-        embeddings_list = list(
-            self.model.embed(texts, batch_size=self.config.batch_size)
-        )
+        self.ensure_initialized()
 
-        # Convert to numpy array
-        embeddings = np.array(embeddings_list)
+        # FastEmbed returns a generator of (already L2-normalized) vectors.
+        embeddings_list = list(
+            self._model.embed(texts, batch_size=self.config.batch_size)
+        )
+        embeddings = np.array(embeddings_list, dtype=np.float32)
+
+        if self.config.normalize and embeddings.size:
+            norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            embeddings = embeddings / norms
 
         return embeddings
 
-    @property
-    def dimension(self) -> int:
-        """Get embedding dimension"""
-        return self.config.dimension
-
-    @property
-    def model_name(self) -> str:
-        """Get model name"""
-        return self.config.model_name
-
-    def is_available(self) -> bool:
-        """Check if provider is available"""
-        if self._available is None:
-            self._initialize()
-        return self._available
-
-    @classmethod
-    def list_recommended_models(cls) -> dict[str, dict[str, Any]]:
-        """List recommended models with their properties"""
-        return {
-            "BAAI/bge-small-en-v1.5": {
-                "dimension": 384,
-                "description": "Fast and efficient, great for most use cases",
-                "speed": "very fast",
-                "quality": "good",
-                "size_mb": 33,
-            },
-            "BAAI/bge-base-en-v1.5": {
-                "dimension": 768,
-                "description": "Better quality, still fast",
-                "speed": "fast",
-                "quality": "very good",
-                "size_mb": 109,
-            },
-            "jinaai/jina-embeddings-v2-small-en": {
-                "dimension": 512,
-                "description": "Optimized for search, supports long contexts",
-                "speed": "fast",
-                "quality": "very good",
-                "size_mb": 33,
-            },
-            "snowflake/snowflake-arctic-embed-s": {
-                "dimension": 384,
-                "description": "Optimized for retrieval tasks",
-                "speed": "very fast",
-                "quality": "good",
-                "size_mb": 33,
-            },
-        }
-
-    @classmethod
-    def list_all_models(cls) -> list[str]:
-        """List all available models"""
-        try:
-            from fastembed import TextEmbedding
-
-            return TextEmbedding.list_supported_models()
-        except:
-            return list(cls.MODEL_DIMENSIONS.keys())
+    def get_dimension(self) -> int:
+        return _MODEL_DIMENSIONS.get(
+            self.config.model.name, self.config.model.dimension
+        )

--- a/clients/python/src/proximadb_sdk/embedding_providers/openai_compatible.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/openai_compatible.py
@@ -1,204 +1,170 @@
 """
 OpenAI-compatible embedding provider
 
-Supports any OpenAI-compatible API including local models
+Supports any OpenAI-compatible ``/embeddings`` endpoint, including local models
 served by vLLM, Ollama, LocalAI, etc.
 """
 
 import logging
 import os
-from urllib.parse import urljoin
+from typing import Any
 
 import numpy as np
 import requests
 
-from .base import EmbeddingConfig, EmbeddingProvider
+from .core.base import BaseEmbeddingProvider
+from .core.config import ModelMetadata, ProviderConfig
+from .core.registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
+OPENAI_COMPATIBLE_MODELS = {
+    "nomic-embed-text": ModelMetadata(
+        name="nomic-embed-text",
+        dimension=768,
+        max_length=8192,
+        provider_type="api",
+        languages="en",
+        description="Free local Ollama embedding model",
+        use_case="Local OpenAI-compatible inference (Ollama)",
+    ),
+    "all-minilm": ModelMetadata(
+        name="all-minilm",
+        dimension=384,
+        max_length=512,
+        provider_type="api",
+        languages="en",
+        description="Lightweight local model",
+        use_case="Local OpenAI-compatible inference",
+    ),
+    "mxbai-embed-large": ModelMetadata(
+        name="mxbai-embed-large",
+        dimension=1024,
+        max_length=512,
+        provider_type="api",
+        languages="en",
+        description="Higher-quality local model",
+        use_case="Local OpenAI-compatible inference",
+    ),
+}
 
-class OpenAICompatibleProvider(EmbeddingProvider):
+_MODEL_DIMENSIONS = {
+    "text-embedding-ada-002": 1536,
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "nomic-embed-text": 768,
+    "all-minilm": 384,
+    "mxbai-embed-large": 1024,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-small-en-v1.5": 384,
+    "sentence-transformers/all-MiniLM-L6-v2": 384,
+}
+
+
+def _embeddings_url(api_base: str) -> str:
+    """Join the ``/embeddings`` path onto an API base WITHOUT dropping a path
+    segment such as ``/v1``.
+
+    ``urljoin("http://x/v1", "/embeddings")`` returns ``http://x/embeddings`` —
+    the leading slash makes it absolute and discards ``/v1``. We instead append
+    to the (slash-normalized) base.
     """
-    Embedding provider for OpenAI-compatible APIs
+    return api_base.rstrip("/") + "/embeddings"
 
-    This provider works with:
-    - Local models served by vLLM, Ollama, LocalAI
-    - OpenAI API (requires API key)
-    - Any OpenAI-compatible endpoint
 
-    For truly free usage, use with local models like:
-    - Ollama with nomic-embed-text, all-minilm, etc.
-    - vLLM with any HuggingFace embedding model
-    - LocalAI with BERT, sentence-transformers models
+@ProviderRegistry.register(
+    name="openai-compatible",
+    models=OPENAI_COMPATIBLE_MODELS,
+    aliases=["ollama", "vllm", "localai"],
+    description="Any OpenAI-compatible /embeddings endpoint (Ollama, vLLM, LocalAI)",
+)
+class OpenAICompatibleProvider(BaseEmbeddingProvider):
+    """
+    Embedding provider for OpenAI-compatible REST endpoints.
+
+    Works with local models served by vLLM, Ollama, LocalAI, or any
+    OpenAI-compatible ``/embeddings`` endpoint.
+
+    Optional ``extra`` parameters:
+    - ``api_base``: base URL (default ``http://localhost:11434/v1`` for Ollama;
+      also honours the ``OPENAI_API_BASE`` env var)
+    - ``api_key``: bearer token (falls back to ``OPENAI_API_KEY``; not needed
+      for local models)
+    - ``timeout``: per-request timeout in seconds (default 30.0)
     """
 
-    # Known model dimensions for common models
-    MODEL_DIMENSIONS = {
-        # OpenAI models (require API key)
-        "text-embedding-ada-002": 1536,
-        "text-embedding-3-small": 1536,
-        "text-embedding-3-large": 3072,
-        # Common Ollama models (free, local)
-        "nomic-embed-text": 768,
-        "all-minilm": 384,
-        "mxbai-embed-large": 1024,
-        # Common vLLM/LocalAI models (free, local)
-        "BAAI/bge-base-en-v1.5": 768,
-        "BAAI/bge-small-en-v1.5": 384,
-        "sentence-transformers/all-MiniLM-L6-v2": 384,
-    }
-
-    def _get_default_config(self) -> EmbeddingConfig:
-        """Get default configuration"""
-        return EmbeddingConfig(
-            model_name="nomic-embed-text",  # Free Ollama model
-            dimension=768,
+    def default_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            model=OPENAI_COMPATIBLE_MODELS["nomic-embed-text"],
             batch_size=100,
             normalize=True,
-            cache_embeddings=True,
-            device=None,
-            extra_params={
+            extra={
                 "api_base": "http://localhost:11434/v1",  # Ollama default
-                "api_key": None,  # Not needed for local models
+                "api_key": None,
                 "timeout": 30.0,
-                "max_retries": 3,
             },
         )
 
-    def _initialize(self) -> None:
-        """Initialize the OpenAI-compatible client"""
-        try:
-            # Get API configuration
-            self.api_base = self.config.extra_params.get("api_base") or os.getenv(
-                "OPENAI_API_BASE", "http://localhost:11434/v1"
-            )
-            self.api_key = self.config.extra_params.get("api_key") or os.getenv(
-                "OPENAI_API_KEY", ""
-            )
+    def _load_model(self) -> Any:
+        """Resolve connection settings; there is no in-process model to load."""
+        extra = self.config.extra
+        self.api_base = extra.get("api_base") or os.getenv(
+            "OPENAI_API_BASE", "http://localhost:11434/v1"
+        )
+        self.api_key = extra.get("api_key") or os.getenv("OPENAI_API_KEY", "")
+        logger.info(
+            "Initialized OpenAI-compatible provider with model %s at %s",
+            self.config.model.name,
+            self.api_base,
+        )
+        return self.api_base
 
-            # Update dimension if known
-            if self.config.model_name in self.MODEL_DIMENSIONS:
-                self.config.dimension = self.MODEL_DIMENSIONS[self.config.model_name]
-
-            # Test connection with a simple embedding
-            self._test_connection()
-
-            self._available = True
-            logger.info(
-                f"Initialized OpenAI-compatible provider with model: {self.config.model_name} "
-                f"at {self.api_base}"
-            )
-
-        except Exception as e:
-            self._available = False
-            logger.error(f"Failed to initialize OpenAI-compatible provider: {e}")
-
-    def _test_connection(self):
-        """Test the connection with a simple embedding request"""
+    def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
 
-        data = {
-            "model": self.config.model_name,
-            "input": ["test"],
-        }
-
-        response = requests.post(
-            urljoin(self.api_base, "/embeddings"),
-            json=data,
-            headers=headers,
-            timeout=self.config.extra_params.get("timeout", 30.0),
-        )
-
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"API test failed: {response.status_code} - {response.text}"
-            )
-
-        # Update dimension from response
-        result = response.json()
-        if "data" in result and len(result["data"]) > 0:
-            embedding = result["data"][0]["embedding"]
-            self.config.dimension = len(embedding)
-
-    def embed_texts(self, texts: list[str]) -> np.ndarray:
-        """
-        Generate embeddings for multiple texts
-
-        Args:
-            texts: List of texts to embed
-
-        Returns:
-            Array of embeddings with shape (len(texts), dimension)
-        """
-        if not self._available:
-            raise RuntimeError("OpenAI-compatible provider not available")
-
+    def embed(self, texts: list[str]) -> np.ndarray:
         if not texts:
             return np.array([])
 
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        self.ensure_initialized()
 
-        all_embeddings = []
+        url = _embeddings_url(self.api_base)
+        timeout = self.config.extra.get("timeout", 30.0)
+        all_embeddings: list[list[float]] = []
 
-        # Process in batches
         for i in range(0, len(texts), self.config.batch_size):
             batch = texts[i : i + self.config.batch_size]
-
-            data = {
-                "model": self.config.model_name,
-                "input": batch,
-            }
-
-            # Add encoding format if normalizing
-            if self.config.normalize:
-                data["encoding_format"] = "float"
+            data = {"model": self.config.model.name, "input": batch}
 
             response = requests.post(
-                urljoin(self.api_base, "/embeddings"),
-                json=data,
-                headers=headers,
-                timeout=self.config.extra_params.get("timeout", 30.0),
+                url, json=data, headers=self._headers(), timeout=timeout
             )
-
             if response.status_code != 200:
                 raise RuntimeError(
-                    f"Embedding request failed: {response.status_code} - {response.text}"
+                    f"Embedding request failed: {response.status_code} - "
+                    f"{response.text}"
                 )
 
             result = response.json()
+            ordered = sorted(result["data"], key=lambda item: item.get("index", 0))
+            all_embeddings.extend(item["embedding"] for item in ordered)
 
-            # Extract embeddings
-            batch_embeddings = [item["embedding"] for item in result["data"]]
-            all_embeddings.extend(batch_embeddings)
+        embeddings = np.array(all_embeddings, dtype=np.float32)
 
-        embeddings = np.array(all_embeddings)
-
-        # Normalize if requested and not already done by API
-        if self.config.normalize and not data.get("encoding_format"):
+        if self.config.normalize and embeddings.size:
             norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
             embeddings = embeddings / norms
 
         return embeddings
 
-    @property
-    def dimension(self) -> int:
-        """Get embedding dimension"""
-        return self.config.dimension
-
-    @property
-    def model_name(self) -> str:
-        """Get model name"""
-        return self.config.model_name
-
-    def is_available(self) -> bool:
-        """Check if provider is available"""
-        if self._available is None:
-            self._initialize()
-        return self._available
+    def get_dimension(self) -> int:
+        return _MODEL_DIMENSIONS.get(
+            self.config.model.name, self.config.model.dimension
+        )
 
     @classmethod
     def create_ollama_provider(
@@ -206,27 +172,20 @@ class OpenAICompatibleProvider(EmbeddingProvider):
         model_name: str = "nomic-embed-text",
         host: str = "localhost",
         port: int = 11434,
-        **kwargs,
+        **extra: Any,
     ) -> "OpenAICompatibleProvider":
-        """
-        Create provider configured for Ollama
-
-        Args:
-            model_name: Ollama model name
-            host: Ollama host
-            port: Ollama port
-            **kwargs: Additional config parameters
-
-        Returns:
-            Configured provider for Ollama
-        """
-        config = EmbeddingConfig(
-            model_name=model_name,
-            dimension=cls.MODEL_DIMENSIONS.get(model_name, 768),
-            extra_params={
+        """Create a provider configured for an Ollama endpoint."""
+        model = OPENAI_COMPATIBLE_MODELS.get(model_name) or ModelMetadata(
+            name=model_name,
+            dimension=_MODEL_DIMENSIONS.get(model_name, 768),
+            provider_type="api",
+        )
+        config = ProviderConfig(
+            model=model,
+            extra={
                 "api_base": f"http://{host}:{port}/v1",
                 "api_key": None,
-                **kwargs,
+                **extra,
             },
         )
         return cls(config)
@@ -237,27 +196,20 @@ class OpenAICompatibleProvider(EmbeddingProvider):
         model_name: str = "BAAI/bge-base-en-v1.5",
         host: str = "localhost",
         port: int = 8000,
-        **kwargs,
+        **extra: Any,
     ) -> "OpenAICompatibleProvider":
-        """
-        Create provider configured for vLLM
-
-        Args:
-            model_name: HuggingFace model name
-            host: vLLM host
-            port: vLLM port
-            **kwargs: Additional config parameters
-
-        Returns:
-            Configured provider for vLLM
-        """
-        config = EmbeddingConfig(
-            model_name=model_name,
-            dimension=cls.MODEL_DIMENSIONS.get(model_name, 768),
-            extra_params={
+        """Create a provider configured for a vLLM endpoint."""
+        model = OPENAI_COMPATIBLE_MODELS.get(model_name) or ModelMetadata(
+            name=model_name,
+            dimension=_MODEL_DIMENSIONS.get(model_name, 768),
+            provider_type="api",
+        )
+        config = ProviderConfig(
+            model=model,
+            extra={
                 "api_base": f"http://{host}:{port}/v1",
                 "api_key": None,
-                **kwargs,
+                **extra,
             },
         )
         return cls(config)

--- a/clients/python/src/proximadb_sdk/embedding_providers/openai_provider.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/openai_provider.py
@@ -1,8 +1,9 @@
 """
 OpenAI embedding provider
 
-Uses OpenAI's embedding API.
-WARNING: Requires API key and incurs costs per token.
+Uses OpenAI's embedding API via the modern (>=1.0) ``openai`` client.
+
+WARNING: Requires an API key and incurs costs per token.
 """
 
 import logging
@@ -12,241 +13,210 @@ from typing import Any
 
 import numpy as np
 
-from .base import EmbeddingConfig, EmbeddingProvider
+from .core.base import BaseEmbeddingProvider
+from .core.config import ModelMetadata, ProviderConfig
+from .core.registry import ProviderRegistry
 
 logger = logging.getLogger(__name__)
 
+OPENAI_MODELS = {
+    "text-embedding-3-small": ModelMetadata(
+        name="text-embedding-3-small",
+        dimension=1536,
+        max_length=8191,
+        provider_type="api",
+        mteb_score=62.3,
+        languages="multilingual",
+        description="Newest small model, very cost-effective (Matryoshka dims)",
+        use_case="Cost-effective production embeddings",
+    ),
+    "text-embedding-3-large": ModelMetadata(
+        name="text-embedding-3-large",
+        dimension=3072,
+        max_length=8191,
+        provider_type="api",
+        mteb_score=64.6,
+        languages="multilingual",
+        description="Highest quality OpenAI model (Matryoshka dims)",
+        use_case="Maximum accuracy",
+    ),
+    "text-embedding-ada-002": ModelMetadata(
+        name="text-embedding-ada-002",
+        dimension=1536,
+        max_length=8191,
+        provider_type="api",
+        languages="multilingual",
+        description="Legacy model, being phased out",
+        use_case="Legacy compatibility",
+    ),
+}
 
-class OpenAIProvider(EmbeddingProvider):
+# text-embedding-3-* support the Matryoshka `dimensions` parameter.
+_MATRYOSHKA_MODELS = {"text-embedding-3-small", "text-embedding-3-large"}
+
+# Rough pricing (USD per 1K tokens) for cost estimates.
+_COST_PER_1K = {
+    "text-embedding-ada-002": 0.0001,
+    "text-embedding-3-small": 0.00002,
+    "text-embedding-3-large": 0.00013,
+}
+
+
+@ProviderRegistry.register(
+    name="openai",
+    models=OPENAI_MODELS,
+    aliases=["openai-embeddings"],
+    description="OpenAI hosted embeddings (requires API key, incurs cost)",
+)
+class OpenAIProvider(BaseEmbeddingProvider):
     """
-    Embedding provider using OpenAI's API
+    Embedding provider using OpenAI's API (openai>=1.0 client).
 
-    ⚠️ WARNING: This provider requires an OpenAI API key and will incur costs!
+    WARNING: This provider requires an OpenAI API key and will incur costs.
 
-    Pricing (as of 2024):
-    - text-embedding-ada-002: ~$0.0001 per 1K tokens
-    - text-embedding-3-small: ~$0.00002 per 1K tokens
-    - text-embedding-3-large: ~$0.00013 per 1K tokens
+    Set the API key via:
+    - Environment variable ``OPENAI_API_KEY``
+    - ``extra={"api_key": "sk-..."}`` on the :class:`ProviderConfig`
 
-    Models:
-    - text-embedding-ada-002: 1536 dims, legacy model
-    - text-embedding-3-small: 1536 dims, newer, cheaper
-    - text-embedding-3-large: 3072 dims, highest quality
-
-    Set API key via:
-    - Environment variable: OPENAI_API_KEY
-    - Config parameter: api_key
+    Optional ``extra`` parameters:
+    - ``api_key``: API key (falls back to ``OPENAI_API_KEY``)
+    - ``organization``: OpenAI organization id
+    - ``base_url``: override the API base URL (also accepts legacy ``api_base``)
+    - ``dimensions``: truncated Matryoshka dimension for text-embedding-3-*
+    - ``max_retries`` / ``timeout``: client-level retry/timeout knobs
+    - ``show_cost_warnings``: emit a UserWarning about per-token cost (default True)
     """
 
-    MODEL_DIMENSIONS = {
-        "text-embedding-ada-002": 1536,
-        "text-embedding-3-small": 1536,
-        "text-embedding-3-large": 3072,
-    }
-
-    def _get_default_config(self) -> EmbeddingConfig:
-        """Get default configuration"""
-        return EmbeddingConfig(
-            model_name="text-embedding-3-small",  # Cheaper option
-            dimension=1536,
+    def default_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            model=OPENAI_MODELS["text-embedding-3-small"],
             batch_size=100,  # OpenAI supports large batches
-            normalize=False,  # OpenAI embeddings are already normalized
-            cache_embeddings=True,  # Cache to reduce costs
-            device=None,
-            extra_params={
+            normalize=False,  # OpenAI embeddings are already unit-norm
+            extra={
                 "api_key": None,
                 "organization": None,
-                "api_base": None,
-                "api_version": None,
+                "base_url": None,
+                "dimensions": None,
                 "max_retries": 3,
                 "timeout": 60.0,
                 "show_cost_warnings": True,
             },
         )
 
-    def _initialize(self) -> None:
-        """Initialize the OpenAI client"""
+    def _load_model(self) -> Any:
+        """Construct and return the OpenAI client (the 'model' for this provider)."""
         try:
-            import openai
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - exercised via stub
+            raise ImportError(
+                "openai is required for OpenAIProvider. "
+                "Install with: pip install 'openai>=2'"
+            ) from exc
 
-            # Get API key
-            api_key = self.config.extra_params.get("api_key") or os.getenv(
-                "OPENAI_API_KEY"
+        extra = self.config.extra
+        api_key = extra.get("api_key") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OpenAI API key not found. Set OPENAI_API_KEY or pass "
+                "extra={'api_key': ...} in the provider config."
             )
 
-            if not api_key:
-                self._available = False
-                logger.error(
-                    "OpenAI API key not found. Set OPENAI_API_KEY environment variable or pass api_key in config."
-                )
-                return
-
-            # Show cost warning
-            if self.config.extra_params.get("show_cost_warnings", True):
-                warnings.warn(
-                    f"⚠️  OpenAI embeddings will incur costs! Model '{self.config.model_name}' charges per token. "
-                    f"Consider using free alternatives like SentenceTransformer or FastEmbed for development.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-
-            # Configure client
-            openai.api_key = api_key
-
-            if self.config.extra_params.get("organization"):
-                openai.organization = self.config.extra_params["organization"]
-
-            if self.config.extra_params.get("api_base"):
-                openai.api_base = self.config.extra_params["api_base"]
-
-            if self.config.extra_params.get("api_version"):
-                openai.api_version = self.config.extra_params["api_version"]
-
-            self.client = openai
-
-            # Update dimension
-            if self.config.model_name in self.MODEL_DIMENSIONS:
-                self.config.dimension = self.MODEL_DIMENSIONS[self.config.model_name]
-
-            self._available = True
-            self._token_count = 0  # Track usage
-
-            logger.info(
-                f"Initialized OpenAI provider with model: {self.config.model_name} "
-                f"(dimension: {self.config.dimension})"
+        if extra.get("show_cost_warnings", True):
+            warnings.warn(
+                f"OpenAI embeddings incur cost. Model '{self.config.model.name}' "
+                "charges per token. Consider a local provider "
+                "(sentence-transformer, fastembed) for development.",
+                UserWarning,
+                stacklevel=2,
             )
-            logger.warning("Remember: OpenAI embeddings incur costs per token!")
 
-        except ImportError:
-            self._available = False
-            logger.warning("openai not installed. Install with: pip install openai")
-        except Exception as e:
-            self._available = False
-            logger.error(f"Failed to initialize OpenAI: {e}")
+        # `api_base` is accepted as a legacy alias for `base_url`.
+        base_url = extra.get("base_url") or extra.get("api_base")
 
-    def embed_texts(self, texts: list[str]) -> np.ndarray:
-        """
-        Generate embeddings for multiple texts
+        client = OpenAI(
+            api_key=api_key,
+            organization=extra.get("organization"),
+            base_url=base_url,
+            max_retries=extra.get("max_retries", 3),
+            timeout=extra.get("timeout", 60.0),
+        )
+        self._token_count = 0
+        logger.info(
+            "Initialized OpenAI provider with model %s (dimension %s)",
+            self.config.model.name,
+            self.get_dimension(),
+        )
+        return client
 
-        Args:
-            texts: List of texts to embed
-
-        Returns:
-            Array of embeddings with shape (len(texts), dimension)
-        """
-        if not self._available:
-            raise RuntimeError("OpenAI not available. Check API key and installation.")
-
+    def embed(self, texts: list[str]) -> np.ndarray:
         if not texts:
             return np.array([])
 
-        all_embeddings = []
+        self.ensure_initialized()
 
-        # Estimate tokens (rough estimate: 1 token ≈ 4 characters)
-        estimated_tokens = sum(len(text) for text in texts) // 4
-        self._token_count += estimated_tokens
-
-        if (
-            self.config.extra_params.get("show_cost_warnings", True)
-            and estimated_tokens > 10000
-        ):
-            warnings.warn(
-                f"⚠️  About to process ~{estimated_tokens:,} tokens with {self.config.model_name}. "
-                f"Estimated cost: ${self._estimate_cost(estimated_tokens):.4f}",
-                UserWarning,
+        model_name = self.config.model.name
+        # `dimensions` is a Matryoshka truncation supported by 3-* models only.
+        dimensions = self.config.extra.get("dimensions")
+        create_kwargs: dict[str, Any] = {
+            "model": model_name,
+            "encoding_format": "float",
+        }
+        if dimensions and model_name in _MATRYOSHKA_MODELS:
+            create_kwargs["dimensions"] = dimensions
+        elif dimensions:
+            logger.warning(
+                "Model %s does not support the 'dimensions' parameter; ignoring.",
+                model_name,
             )
 
-        # Process in batches
+        all_embeddings: list[list[float]] = []
         for i in range(0, len(texts), self.config.batch_size):
             batch = texts[i : i + self.config.batch_size]
-
             try:
-                response = self.client.Embedding.create(
-                    model=self.config.model_name,
-                    input=batch,
-                    encoding_format="float",  # Get as floats, not base64
+                response = self._model.embeddings.create(input=batch, **create_kwargs)
+            except Exception as exc:
+                logger.error("OpenAI API error: %s", exc)
+                raise RuntimeError(f"Failed to generate embeddings: {exc}") from exc
+
+            # Preserve request order (the API returns an `index` per item).
+            ordered = sorted(response.data, key=lambda item: item.index)
+            all_embeddings.extend(item.embedding for item in ordered)
+
+            usage = getattr(response, "usage", None)
+            if usage is not None and getattr(usage, "total_tokens", None) is not None:
+                self._token_count = (
+                    getattr(self, "_token_count", 0) + usage.total_tokens
+                )
+                logger.info(
+                    "OpenAI API used %s tokens for %s texts",
+                    usage.total_tokens,
+                    len(batch),
                 )
 
-                # Extract embeddings
-                batch_embeddings = [item["embedding"] for item in response["data"]]
-                all_embeddings.extend(batch_embeddings)
+        embeddings = np.array(all_embeddings, dtype=np.float32)
 
-                # Log usage if available
-                if "usage" in response:
-                    actual_tokens = response["usage"]["total_tokens"]
-                    logger.info(
-                        f"OpenAI API used {actual_tokens} tokens for {len(batch)} texts"
-                    )
-
-            except Exception as e:
-                logger.error(f"OpenAI API error: {e}")
-                raise RuntimeError(f"Failed to generate embeddings: {e}")
-
-        embeddings = np.array(all_embeddings)
-
-        # OpenAI embeddings are already normalized, but normalize if requested
         if self.config.normalize:
             norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
             embeddings = embeddings / norms
 
         return embeddings
 
-    def _estimate_cost(self, tokens: int) -> float:
-        """Estimate cost based on token count"""
-        # Rough pricing estimates (check OpenAI for current prices)
-        cost_per_1k = {
-            "text-embedding-ada-002": 0.0001,
-            "text-embedding-3-small": 0.00002,
-            "text-embedding-3-large": 0.00013,
-        }
+    def get_dimension(self) -> int:
+        """Effective dimension (honours a Matryoshka ``dimensions`` override)."""
+        dimensions = self.config.extra.get("dimensions")
+        if dimensions and self.config.model.name in _MATRYOSHKA_MODELS:
+            return dimensions
+        return self.config.model.dimension
 
-        rate = cost_per_1k.get(self.config.model_name, 0.0001)
+    def _estimate_cost(self, tokens: int) -> float:
+        rate = _COST_PER_1K.get(self.config.model.name, 0.0001)
         return (tokens / 1000) * rate
 
-    @property
-    def dimension(self) -> int:
-        """Get embedding dimension"""
-        return self.config.dimension
-
-    @property
-    def model_name(self) -> str:
-        """Get model name"""
-        return self.config.model_name
-
-    def is_available(self) -> bool:
-        """Check if provider is available"""
-        if self._available is None:
-            self._initialize()
-        return self._available
-
     def get_token_usage(self) -> dict[str, Any]:
-        """Get token usage statistics"""
+        tokens = getattr(self, "_token_count", 0)
         return {
-            "estimated_tokens": self._token_count,
-            "estimated_cost": self._estimate_cost(self._token_count),
-            "model": self.config.model_name,
-        }
-
-    @classmethod
-    def list_models(cls) -> dict[str, dict[str, Any]]:
-        """List available models with details"""
-        return {
-            "text-embedding-3-small": {
-                "dimension": 1536,
-                "description": "Newest small model, very cost-effective",
-                "cost_per_1k_tokens": "$0.00002",
-                "max_tokens": 8191,
-            },
-            "text-embedding-3-large": {
-                "dimension": 3072,
-                "description": "Highest quality, more expensive",
-                "cost_per_1k_tokens": "$0.00013",
-                "max_tokens": 8191,
-            },
-            "text-embedding-ada-002": {
-                "dimension": 1536,
-                "description": "Legacy model, being phased out",
-                "cost_per_1k_tokens": "$0.0001",
-                "max_tokens": 8191,
-            },
+            "estimated_tokens": tokens,
+            "estimated_cost": self._estimate_cost(tokens),
+            "model": self.config.model.name,
         }

--- a/clients/python/src/proximadb_sdk/embedding_providers/providers/local/e5.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/providers/local/e5.py
@@ -4,6 +4,8 @@ E5 (Text Embeddings by Weakly-Supervised Contrastive Pre-training) Provider
 Microsoft's excellent general-purpose embeddings with query/passage prefix support.
 """
 
+import numpy as np
+
 from ...core.base import BaseEmbeddingProvider
 from ...core.config import ModelMetadata, ProviderConfig
 from ...core.registry import ProviderRegistry
@@ -97,6 +99,9 @@ class E5Provider(InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvid
     - Passages: "passage: {text}" (handled automatically)
     """
 
+    #: E5 models require this prefix on documents/passages (not just queries).
+    PASSAGE_PREFIX = "passage: "
+
     def default_config(self) -> ProviderConfig:
         """Default to large model"""
         return ProviderConfig(
@@ -105,3 +110,14 @@ class E5Provider(InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvid
             normalize=True,
             extra={"use_query_instruction": True},
         )
+
+    def embed_passages(self, passages: list[str]) -> np.ndarray:
+        """Embed passages with the mandatory E5 ``"passage: "`` prefix.
+
+        Unlike the generic :class:`InstructionMixin` (which leaves passages
+        unprefixed), E5 was trained with an asymmetric ``query:``/``passage:``
+        scheme. Omitting the passage prefix silently degrades retrieval recall,
+        so we prepend it here.
+        """
+        prefixed = [f"{self.PASSAGE_PREFIX}{p}" for p in passages]
+        return self.embed(prefixed)

--- a/clients/python/tests/unit/test_emb_providers_cloud_cov.py
+++ b/clients/python/tests/unit/test_emb_providers_cloud_cov.py
@@ -1,117 +1,83 @@
 """
-Offline unit tests for the legacy cloud / optional-dep embedding providers:
+Offline unit tests for the cloud / optional-dep embedding providers, after they
+were ported onto ``core.BaseEmbeddingProvider`` + ``@ProviderRegistry.register``:
 
     proximadb_sdk.embedding_providers.openai_provider.OpenAIProvider
-    proximadb_sdk.embedding_providers.openai_compatible.OpenAICompatibleProvider
     proximadb_sdk.embedding_providers.cohere.CohereProvider
-    proximadb_sdk.embedding_providers.instructor.InstructorProvider
     proximadb_sdk.embedding_providers.fastembed.FastEmbedProvider
+    proximadb_sdk.embedding_providers.openai_compatible.OpenAICompatibleProvider
 
-These five modules do ``from .base import EmbeddingConfig, EmbeddingProvider``.
-There is no ``proximadb_sdk.embedding_providers.base`` module on disk (the
-package was reorganised into ``core/`` + ``providers/`` but these legacy
-overlays were never repointed), so they are at 0% coverage purely because
-they cannot be imported.
+The heavy/cloud SDKs (openai, cohere, fastembed) are stubbed via ``sys.modules``
+so the providers' lazy ``_load_model`` succeeds with no real package, model
+download, or network. ``requests`` is monkeypatched for the REST provider.
 
-To make them importable and exercisable FULLY OFFLINE we:
-
-  1. Inject a faithful stub ``proximadb_sdk.embedding_providers.base`` module
-     into ``sys.modules`` BEFORE importing the targets. The stub provides the
-     minimal ``EmbeddingConfig`` dataclass + ``EmbeddingProvider`` base that
-     the overlays were written against (lazy ``_available`` + ``__init__``
-     that falls back to ``_get_default_config()``).
-  2. Stub the optional heavy deps ``openai`` / ``cohere`` / ``fastembed`` /
-     ``InstructorEmbedding`` via ``sys.modules`` so the providers' internal
-     ``import`` succeeds without any real package, model download, or network.
-  3. Monkeypatch ``requests`` for the OpenAI-compatible provider so no socket
-     is ever opened.
-
-No real network, no model download, no real server.
+The legacy InstructorProvider (still on the System-B base shim) is covered
+separately.
 """
 
 import sys
 import types
-from dataclasses import dataclass, field
-from typing import Any
 
 import numpy as np
 import pytest
 
-
-# --------------------------------------------------------------------------- #
-# 1. Inject the stub `proximadb_sdk.embedding_providers.base` module.
-# --------------------------------------------------------------------------- #
-def _install_base_stub() -> types.ModuleType:
-    """Create + register the legacy base module the overlays import from."""
-    mod = types.ModuleType("proximadb_sdk.embedding_providers.base")
-
-    @dataclass
-    class EmbeddingConfig:  # noqa: D401 - minimal shim
-        model_name: str
-        dimension: int
-        batch_size: int = 32
-        normalize: bool = True
-        cache_embeddings: bool = True
-        timeout_seconds: float = 30.0
-        device: Any = None
-        api_key: str | None = None
-        api_url: str | None = None
-        extra_params: dict[str, Any] = field(default_factory=dict)
-
-    class EmbeddingProvider:
-        """Lazy base matching what the legacy overlays expect."""
-
-        def __init__(self, config: "EmbeddingConfig | None" = None):
-            self.config = config if config is not None else self._get_default_config()
-            self._available = None
-            self.client = None
-            self.model = None
-            self._token_count = 0
-
-        # Subclasses override these.
-        def _get_default_config(self):  # pragma: no cover - overridden
-            raise NotImplementedError
-
-        def _initialize(self):  # pragma: no cover - overridden
-            raise NotImplementedError
-
-    mod.EmbeddingConfig = EmbeddingConfig
-    mod.EmbeddingProvider = EmbeddingProvider
-    sys.modules["proximadb_sdk.embedding_providers.base"] = mod
-    return mod
-
-
-_BASE = _install_base_stub()
-EmbeddingConfig = _BASE.EmbeddingConfig
+from proximadb_sdk.embedding_providers.core.config import ModelMetadata, ProviderConfig
 
 
 # --------------------------------------------------------------------------- #
-# 2. Stub the optional heavy / cloud SDKs BEFORE importing the targets.
+# Stub the optional heavy / cloud SDKs BEFORE importing the targets.
 # --------------------------------------------------------------------------- #
 def _install_optional_stubs():
-    # ---- openai ---------------------------------------------------------- #
+    # ---- openai (>=1.0 client) ------------------------------------------- #
     openai_mod = types.ModuleType("openai")
-    openai_mod.api_key = None
 
-    class _Embedding:
-        # response: dict-like indexing used by the provider
-        @staticmethod
-        def create(model=None, input=None, encoding_format=None):
-            n = len(input)
-            return {
-                "data": [{"embedding": [0.1, 0.2, 0.3, 0.4]} for _ in range(n)],
-                "usage": {"total_tokens": 7 * n},
+    class _Item:
+        def __init__(self, index, embedding):
+            self.index = index
+            self.embedding = embedding
+
+    class _Usage:
+        total_tokens = 7
+
+    class _Resp:
+        def __init__(self, n, dim=4):
+            # Return out-of-order to exercise index-based reordering.
+            self.data = [_Item(n - 1 - i, [0.1, 0.2, 0.3, 0.4][:dim]) for i in range(n)]
+            self.usage = _Usage()
+
+    class _Embeddings:
+        def __init__(self, client):
+            self._client = client
+
+        def create(self, input=None, model=None, encoding_format=None, dimensions=None):
+            self._client.last_create = {
+                "input": input,
+                "model": model,
+                "dimensions": dimensions,
             }
+            return _Resp(len(input))
 
-    openai_mod.Embedding = _Embedding
+    class _OpenAI:
+        def __init__(self, api_key=None, organization=None, base_url=None, **kw):
+            self.api_key = api_key
+            self.organization = organization
+            self.base_url = base_url
+            self.embeddings = _Embeddings(self)
+            self.last_create = None
+
+    openai_mod.OpenAI = _OpenAI
     sys.modules["openai"] = openai_mod
 
-    # ---- cohere ---------------------------------------------------------- #
+    # ---- cohere (ClientV2) ----------------------------------------------- #
     cohere_mod = types.ModuleType("cohere")
+
+    class _Embeddings2:
+        def __init__(self, n):
+            self.float = [[0.5, 0.6, 0.7] for _ in range(n)]
 
     class _CohereResp:
         def __init__(self, n):
-            self.embeddings = [[0.5, 0.6, 0.7] for _ in range(n)]
+            self.embeddings = _Embeddings2(n)
 
             class _Billed:
                 input_tokens = 11 * n
@@ -121,7 +87,7 @@ def _install_optional_stubs():
 
             self.meta = _Meta()
 
-    class _CohereClient:
+    class _ClientV2:
         def __init__(self, api_key=None):
             self.api_key = api_key
 
@@ -130,87 +96,248 @@ def _install_optional_stubs():
             texts=None,
             model=None,
             input_type=None,
+            embedding_types=None,
             truncate=None,
-            compress=None,
-            compression_codebook=None,
         ):
+            self.last_embed = {"input_type": input_type, "model": model}
             return _CohereResp(len(texts))
 
-    cohere_mod.Client = _CohereClient
+    cohere_mod.ClientV2 = _ClientV2
     sys.modules["cohere"] = cohere_mod
 
     # ---- fastembed ------------------------------------------------------- #
     fastembed_mod = types.ModuleType("fastembed")
 
     class _TextEmbedding:
-        last_kwargs = None
-
-        def __init__(
-            self, model_name=None, max_length=None, normalize=None, cache_dir=None
-        ):
+        def __init__(self, model_name=None, max_length=None, cache_dir=None):
             self.model_name = model_name
-            _TextEmbedding.last_kwargs = {
-                "model_name": model_name,
-                "max_length": max_length,
-                "normalize": normalize,
-                "cache_dir": cache_dir,
-            }
 
         def embed(self, texts, batch_size=None):
             for _ in texts:
                 yield np.array([0.9, 0.8, 0.7], dtype=np.float32)
 
-        @staticmethod
-        def list_supported_models():
-            return [{"model": "BAAI/bge-small-en-v1.5"}]
-
     fastembed_mod.TextEmbedding = _TextEmbedding
     sys.modules["fastembed"] = fastembed_mod
-
-    # ---- InstructorEmbedding -------------------------------------------- #
-    instructor_mod = types.ModuleType("InstructorEmbedding")
-
-    class _INSTRUCTOR:
-        def __init__(self, model_name=None, device=None):
-            self.model_name = model_name
-            self.device = device
-
-        def encode(
-            self,
-            instruction_pairs,
-            batch_size=None,
-            show_progress_bar=None,
-            normalize_embeddings=None,
-            convert_to_numpy=None,
-        ):
-            return np.array([[0.1, 0.2, 0.3, 0.4] for _ in instruction_pairs])
-
-    instructor_mod.INSTRUCTOR = _INSTRUCTOR
-    sys.modules["InstructorEmbedding"] = instructor_mod
 
 
 _install_optional_stubs()
 
 
-# --------------------------------------------------------------------------- #
-# 3. Import the target modules now that everything resolves.
-# --------------------------------------------------------------------------- #
-from proximadb_sdk.embedding_providers.cohere import CohereProvider  # noqa: E402
-from proximadb_sdk.embedding_providers.fastembed import FastEmbedProvider  # noqa: E402
-from proximadb_sdk.embedding_providers.instructor import (  # noqa: E402
-    InstructorProvider,
+from proximadb_sdk.embedding_providers.cohere import (  # noqa: E402
+    COHERE_MODELS,
+    CohereProvider,
+)
+from proximadb_sdk.embedding_providers.fastembed import (  # noqa: E402
+    FASTEMBED_MODELS,
+    FastEmbedProvider,
 )
 from proximadb_sdk.embedding_providers.openai_compatible import (  # noqa: E402
     OpenAICompatibleProvider,
+    _embeddings_url,
 )
 from proximadb_sdk.embedding_providers.openai_provider import (  # noqa: E402
+    OPENAI_MODELS,
     OpenAIProvider,
 )
 
 
-# --------------------------------------------------------------------------- #
-# Helpers for the OpenAI-compatible REST provider (mock `requests`).
-# --------------------------------------------------------------------------- #
+def _cfg(models, key, **overrides):
+    extra = {"show_cost_warnings": False}
+    extra.update(overrides.pop("extra", {}))
+    return ProviderConfig(model=models[key], extra=extra, **overrides)
+
+
+# =========================================================================== #
+# OpenAIProvider
+# =========================================================================== #
+class TestOpenAIProvider:
+    def test_default_config(self):
+        cfg = OpenAIProvider().default_config()
+        assert cfg.model.name == "text-embedding-3-small"
+        assert cfg.model.dimension == 1536
+        assert cfg.normalize is False
+
+    def test_missing_key_raises_on_use(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        p = OpenAIProvider(_cfg(OPENAI_MODELS, "text-embedding-3-small"))
+        with pytest.raises(RuntimeError):
+            p.embed(["hi"])
+        assert p.is_available() is False
+
+    def test_embed_parses_and_orders(self):
+        cfg = _cfg(
+            OPENAI_MODELS,
+            "text-embedding-3-small",
+            batch_size=2,
+            normalize=False,
+            extra={"api_key": "sk-key"},
+        )
+        p = OpenAIProvider(cfg)
+        out = p.embed(["a", "b", "c"])
+        assert out.shape == (3, 4)
+        assert p.get_token_usage()["estimated_tokens"] > 0
+
+    def test_embed_normalizes(self):
+        cfg = _cfg(
+            OPENAI_MODELS,
+            "text-embedding-3-small",
+            normalize=True,
+            extra={"api_key": "sk-key"},
+        )
+        out = OpenAIProvider(cfg).embed(["hello"])
+        np.testing.assert_allclose(np.linalg.norm(out[0]), 1.0, rtol=1e-5)
+
+    def test_embed_empty(self):
+        cfg = _cfg(OPENAI_MODELS, "text-embedding-3-small", extra={"api_key": "k"})
+        assert OpenAIProvider(cfg).embed([]).size == 0
+
+    def test_matryoshka_dimensions_passed(self):
+        cfg = _cfg(
+            OPENAI_MODELS,
+            "text-embedding-3-large",
+            extra={"api_key": "k", "dimensions": 256},
+        )
+        p = OpenAIProvider(cfg)
+        assert p.get_dimension() == 256
+        p.embed(["x"])
+        assert p._model.last_create["dimensions"] == 256
+
+    def test_matryoshka_ignored_for_ada(self):
+        cfg = _cfg(
+            OPENAI_MODELS,
+            "text-embedding-ada-002",
+            extra={"api_key": "k", "dimensions": 256},
+        )
+        p = OpenAIProvider(cfg)
+        # ada-002 is not Matryoshka -> dimension unchanged + param dropped.
+        assert p.get_dimension() == 1536
+        p.embed(["x"])
+        assert p._model.last_create["dimensions"] is None
+
+    def test_cost_warning_emitted(self):
+        cfg = ProviderConfig(
+            model=OPENAI_MODELS["text-embedding-3-small"],
+            extra={"api_key": "k", "show_cost_warnings": True},
+        )
+        p = OpenAIProvider(cfg)
+        with pytest.warns(UserWarning):
+            p.embed(["a"])
+
+    def test_api_error_wrapped(self):
+        cfg = _cfg(OPENAI_MODELS, "text-embedding-3-small", extra={"api_key": "k"})
+        p = OpenAIProvider(cfg)
+        p.ensure_initialized()
+
+        def _boom(**kw):
+            raise ValueError("api down")
+
+        p._model.embeddings.create = _boom
+        with pytest.raises(RuntimeError):
+            p.embed(["a"])
+
+
+# =========================================================================== #
+# CohereProvider
+# =========================================================================== #
+class TestCohereProvider:
+    def test_default_config(self):
+        cfg = CohereProvider().default_config()
+        assert cfg.model.name == "embed-english-light-v3.0"
+        assert cfg.extra["input_type"] == "search_document"
+
+    def test_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        p = CohereProvider(_cfg(COHERE_MODELS, "embed-english-v3.0"))
+        with pytest.raises(RuntimeError):
+            p.embed(["a"])
+
+    def test_embed_dispatch(self):
+        cfg = _cfg(
+            COHERE_MODELS,
+            "embed-english-light-v3.0",
+            batch_size=2,
+            normalize=False,
+            extra={"api_key": "co-key"},
+        )
+        out = CohereProvider(cfg).embed(["a b c", "d e", "f"])
+        assert out.shape == (3, 3)
+
+    def test_embed_query_uses_search_query(self):
+        cfg = _cfg(
+            COHERE_MODELS,
+            "embed-english-light-v3.0",
+            normalize=False,
+            extra={"api_key": "co-key"},
+        )
+        p = CohereProvider(cfg)
+        p.embed_query("a query")
+        assert p._model.last_embed["input_type"] == "search_query"
+
+    def test_embed_passages_uses_search_document(self):
+        cfg = _cfg(
+            COHERE_MODELS,
+            "embed-english-light-v3.0",
+            normalize=False,
+            extra={"api_key": "co-key"},
+        )
+        p = CohereProvider(cfg)
+        p.embed_passages(["a doc"])
+        assert p._model.last_embed["input_type"] == "search_document"
+
+    def test_invalid_input_type(self):
+        cfg = _cfg(
+            COHERE_MODELS, "embed-english-light-v3.0", extra={"api_key": "co-key"}
+        )
+        with pytest.raises(ValueError):
+            CohereProvider(cfg).embed(["a"], input_type="nonsense")
+
+    def test_token_usage(self):
+        cfg = _cfg(
+            COHERE_MODELS, "embed-english-light-v3.0", extra={"api_key": "co-key"}
+        )
+        p = CohereProvider(cfg)
+        p.embed(["hello world"])
+        assert p.get_token_usage()["model"] == "embed-english-light-v3.0"
+
+    def test_api_error_wrapped(self):
+        cfg = _cfg(
+            COHERE_MODELS, "embed-english-light-v3.0", extra={"api_key": "co-key"}
+        )
+        p = CohereProvider(cfg)
+        p.ensure_initialized()
+
+        def _boom(**kw):
+            raise ValueError("cohere down")
+
+        p._model.embed = _boom
+        with pytest.raises(RuntimeError):
+            p.embed(["a"])
+
+
+# =========================================================================== #
+# FastEmbedProvider
+# =========================================================================== #
+class TestFastEmbedProvider:
+    def test_default_config(self):
+        cfg = FastEmbedProvider().default_config()
+        assert cfg.model.name == "BAAI/bge-small-en-v1.5"
+        assert cfg.model.dimension == 384
+
+    def test_embed_dispatch(self):
+        out = FastEmbedProvider().embed(["a", "b", "c"])
+        assert out.shape == (3, 3)
+
+    def test_embed_empty(self):
+        assert FastEmbedProvider().embed([]).size == 0
+
+    def test_dimension_lookup(self):
+        cfg = _cfg(FASTEMBED_MODELS, "BAAI/bge-base-en-v1.5")
+        assert FastEmbedProvider(cfg).get_dimension() == 768
+
+
+# =========================================================================== #
+# OpenAICompatibleProvider (REST via mocked `requests`)
+# =========================================================================== #
 class _FakeResp:
     def __init__(self, status_code=200, payload=None, text=""):
         self.status_code = status_code
@@ -221,700 +348,100 @@ class _FakeResp:
         return self._payload
 
 
-def _fake_post_factory(embedding=(0.1, 0.2, 0.3, 0.4), status=200, n_each=None):
+def _fake_post_factory(embedding=(0.1, 0.2, 0.3, 0.4), status=200):
     calls = []
 
     def _post(url, json=None, headers=None, timeout=None):
-        calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        calls.append({"url": url, "json": json, "headers": headers})
         if status != 200:
             return _FakeResp(status_code=status, text="boom")
-        inputs = json["input"]
-        data = [{"embedding": list(embedding)} for _ in inputs]
+        data = [
+            {"index": i, "embedding": list(embedding)}
+            for i, _ in enumerate(json["input"])
+        ]
         return _FakeResp(status_code=200, payload={"data": data})
 
     _post.calls = calls
     return _post
 
 
-# =========================================================================== #
-# OpenAIProvider
-# =========================================================================== #
-class TestOpenAIProvider:
-    def test_default_config_shape(self):
-        p = OpenAIProvider()
-        cfg = p._get_default_config()
-        assert cfg.model_name == "text-embedding-3-small"
-        assert cfg.dimension == 1536
-        assert cfg.extra_params["show_cost_warnings"] is True
-
-    def test_initialize_without_key_unavailable(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            extra_params={"api_key": None, "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        assert p._available is False
-        assert p.is_available() is False
-
-    def test_initialize_with_key_sets_dimension(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-large",
-            dimension=1,
-            extra_params={
-                "api_key": "sk-key",
-                "organization": "org-1",
-                "api_base": "https://example/v1",
-                "api_version": "2024",
-                "show_cost_warnings": False,
-            },
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        # 3-large -> 3072 dims from MODEL_DIMENSIONS
-        assert p.config.dimension == 3072
-        assert p.dimension == 3072
-        assert p.model_name == "text-embedding-3-large"
-
-    def test_initialize_cost_warning_emitted(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": True},
-        )
-        p = OpenAIProvider(cfg)
-        with pytest.warns(UserWarning):
-            p._initialize()
-        assert p._available is True
-
-    def test_initialize_import_error(self, monkeypatch):
-        # Force the in-function `import openai` to fail.
-        monkeypatch.setitem(sys.modules, "openai", None)
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        assert p._available is False
-
-    @pytest.mark.skip(
-        reason="Passes in isolation; fails only in the aggregate run due to a "
-        "collection-time sys.modules stub interaction with test_llm_cov.py "
-        "(a real proximadb_sdk submodule is faked at import). Quarantined for a "
-        "CI-clean suite; test-isolation follow-up tracked separately."
-    )
-    def test_embed_texts_dispatch_and_parse(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            batch_size=2,
-            normalize=False,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        out = p.embed_texts(["a", "b", "c"])
-        assert isinstance(out, np.ndarray)
-        assert out.shape == (3, 4)
-        # token accounting happened
-        assert p._token_count > 0
-
-    def test_embed_texts_normalize(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            batch_size=10,
-            normalize=True,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        out = p.embed_texts(["hello"])
-        # normalized -> unit norm
-        np.testing.assert_allclose(np.linalg.norm(out[0]), 1.0, rtol=1e-5)
-
-    def test_embed_texts_empty(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        out = p.embed_texts([])
-        assert out.size == 0
-
-    def test_embed_texts_unavailable_raises(self):
-        cfg = EmbeddingConfig(
-            model_name="x", dimension=4, extra_params={"show_cost_warnings": False}
-        )
-        p = OpenAIProvider(cfg)
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_embed_texts_large_token_warning(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            batch_size=100,
-            normalize=False,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": True},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        big = ["x" * 50000]  # >10k estimated tokens
-        with pytest.warns(UserWarning):
-            out = p.embed_texts(big)
-        assert out.shape[0] == 1
-
-    def test_embed_texts_api_error_wrapped(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            batch_size=10,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-
-        class _Boom:
-            @staticmethod
-            def create(**kw):
-                raise ValueError("api down")
-
-        # Replace the client on this instance only (do NOT mutate the shared
-        # `openai` module stub, which other tests depend on).
-        p.client = types.SimpleNamespace(Embedding=_Boom)
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_estimate_cost_known_and_unknown(self):
-        p = OpenAIProvider()
-        p.config.model_name = "text-embedding-3-large"
-        assert p._estimate_cost(1000) == pytest.approx(0.00013)
-        p.config.model_name = "mystery-model"
-        assert p._estimate_cost(1000) == pytest.approx(0.0001)
-
-    def test_get_token_usage(self):
-        cfg = EmbeddingConfig(
-            model_name="text-embedding-3-small",
-            dimension=1536,
-            extra_params={"api_key": "sk-key", "show_cost_warnings": False},
-        )
-        p = OpenAIProvider(cfg)
-        p._initialize()
-        p.embed_texts(["hello world"])
-        usage = p.get_token_usage()
-        assert usage["model"] == "text-embedding-3-small"
-        assert usage["estimated_tokens"] >= 0
-        assert "estimated_cost" in usage
-
-    def test_list_models(self):
-        models = OpenAIProvider.list_models()
-        assert "text-embedding-3-small" in models
-        assert models["text-embedding-3-large"]["dimension"] == 3072
-
-
-# =========================================================================== #
-# OpenAICompatibleProvider (REST via mocked `requests`)
-# =========================================================================== #
 class TestOpenAICompatibleProvider:
-    def _provider(self, monkeypatch, post):
-        import proximadb_sdk.embedding_providers.openai_compatible as mod
-
-        monkeypatch.setattr(mod.requests, "post", post)
-        return mod
+    def test_embeddings_url_preserves_v1(self):
+        # Regression: urljoin(".../v1", "/embeddings") dropped "/v1".
+        assert _embeddings_url("http://x/v1") == "http://x/v1/embeddings"
+        assert _embeddings_url("http://x/v1/") == "http://x/v1/embeddings"
+        assert _embeddings_url("http://x") == "http://x/embeddings"
 
     def test_default_config(self):
-        p = OpenAICompatibleProvider()
-        cfg = p._get_default_config()
-        assert cfg.model_name == "nomic-embed-text"
-        assert cfg.dimension == 768
-        assert cfg.extra_params["api_base"].endswith("/v1")
+        cfg = OpenAICompatibleProvider().default_config()
+        assert cfg.model.name == "nomic-embed-text"
+        assert cfg.extra["api_base"].endswith("/v1")
 
-    def test_initialize_success_updates_dim(self, monkeypatch):
-        post = _fake_post_factory(embedding=(0.1, 0.2, 0.3))
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="nomic-embed-text",
-            dimension=768,
-            extra_params={"api_base": "http://x/v1", "api_key": "k", "timeout": 1.0},
-        )
-        p = OpenAICompatibleProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        # dimension picked up from the (3-len) embedding in the test response
-        assert p.config.dimension == 3
-        assert p.api_base == "http://x/v1"
-        # Authorization header sent because api_key present
-        assert post.calls[0]["headers"]["Authorization"] == "Bearer k"
+    def test_embed_dispatch_and_url(self, monkeypatch):
+        import proximadb_sdk.embedding_providers.openai_compatible as mod
 
-    def test_initialize_no_key_no_auth_header(self, monkeypatch):
-        post = _fake_post_factory(embedding=(0.1, 0.2))
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="all-minilm",
-            dimension=384,
-            extra_params={"api_base": "http://x/v1", "api_key": None},
-        )
-        p = OpenAICompatibleProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        # known model dim applied before test connection (384) then overwritten by resp (2)
-        assert p.config.dimension == 2
-        assert "Authorization" not in post.calls[0]["headers"]
-
-    def test_initialize_failure_sets_unavailable(self, monkeypatch):
-        post = _fake_post_factory(status=500)
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="nomic-embed-text",
-            dimension=768,
-            extra_params={"api_base": "http://x/v1", "api_key": None},
-        )
-        p = OpenAICompatibleProvider(cfg)
-        p._initialize()
-        assert p._available is False
-        assert p.is_available() is False
-
-    def test_embed_texts_dispatch(self, monkeypatch):
         post = _fake_post_factory(embedding=(1.0, 0.0, 0.0))
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="nomic-embed-text",
-            dimension=3,
+        monkeypatch.setattr(mod.requests, "post", post)
+        cfg = ProviderConfig(
+            model=OPENAI_COMPATIBLE_MODEL(),
             batch_size=2,
             normalize=False,
-            extra_params={"api_base": "http://x/v1", "api_key": "k"},
+            extra={"api_base": "http://x/v1", "api_key": "k"},
         )
         p = OpenAICompatibleProvider(cfg)
-        p._available = True
-        p.api_base = "http://x/v1"
-        p.api_key = "k"
-        out = p.embed_texts(["a", "b", "c"])
+        out = p.embed(["a", "b", "c"])
         assert out.shape == (3, 3)
-        # batched into 2 + 1 = 2 embed calls (test_connection not called here)
-        embed_calls = [c for c in post.calls if "/embeddings" in c["url"]]
-        assert len(embed_calls) == 2
-        # request shape: model + input present
-        assert embed_calls[0]["json"]["model"] == "nomic-embed-text"
-        assert isinstance(embed_calls[0]["json"]["input"], list)
+        # /v1 preserved on the request URL.
+        assert post.calls[0]["url"] == "http://x/v1/embeddings"
+        assert post.calls[0]["headers"]["Authorization"] == "Bearer k"
 
-    def test_embed_texts_normalize_adds_encoding_format(self, monkeypatch):
-        post = _fake_post_factory(embedding=(3.0, 4.0))
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="nomic-embed-text",
-            dimension=2,
-            batch_size=10,
-            normalize=True,
-            extra_params={"api_base": "http://x/v1", "api_key": None},
+    def test_embed_no_key_no_auth(self, monkeypatch):
+        import proximadb_sdk.embedding_providers.openai_compatible as mod
+
+        post = _fake_post_factory(embedding=(0.1, 0.2))
+        monkeypatch.setattr(mod.requests, "post", post)
+        cfg = ProviderConfig(
+            model=OPENAI_COMPATIBLE_MODEL(),
+            normalize=False,
+            extra={"api_base": "http://x/v1", "api_key": None},
         )
         p = OpenAICompatibleProvider(cfg)
-        p._available = True
-        p.api_base = "http://x/v1"
-        p.api_key = None
-        out = p.embed_texts(["a"])
-        assert post.calls[0]["json"].get("encoding_format") == "float"
-        # encoding_format present => provider does NOT re-normalize, raw (3,4) kept
-        np.testing.assert_allclose(out[0], [3.0, 4.0])
+        p.embed(["a"])
+        assert "Authorization" not in post.calls[0]["headers"]
 
-    def test_embed_texts_failure_raises(self, monkeypatch):
+    def test_embed_failure_raises(self, monkeypatch):
+        import proximadb_sdk.embedding_providers.openai_compatible as mod
+
         post = _fake_post_factory(status=503)
-        self._provider(monkeypatch, post)
-        cfg = EmbeddingConfig(
-            model_name="nomic-embed-text",
-            dimension=3,
-            batch_size=10,
-            extra_params={"api_base": "http://x/v1", "api_key": None},
+        monkeypatch.setattr(mod.requests, "post", post)
+        cfg = ProviderConfig(
+            model=OPENAI_COMPATIBLE_MODEL(),
+            extra={"api_base": "http://x/v1", "api_key": None},
         )
-        p = OpenAICompatibleProvider(cfg)
-        p._available = True
-        p.api_base = "http://x/v1"
-        p.api_key = None
         with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
+            OpenAICompatibleProvider(cfg).embed(["a"])
 
-    def test_embed_texts_unavailable_raises(self):
-        p = OpenAICompatibleProvider()
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_embed_texts_empty(self):
-        p = OpenAICompatibleProvider()
-        p._available = True
-        p.api_base = "http://x/v1"
-        p.api_key = None
-        assert p.embed_texts([]).size == 0
+    def test_embed_empty(self):
+        assert OpenAICompatibleProvider().embed([]).size == 0
 
     def test_create_ollama_provider(self):
         p = OpenAICompatibleProvider.create_ollama_provider(
             model_name="all-minilm", host="h", port=1234
         )
-        assert isinstance(p, OpenAICompatibleProvider)
-        assert p.config.extra_params["api_base"] == "http://h:1234/v1"
-        assert p.config.dimension == 384
+        assert p.config.extra["api_base"] == "http://h:1234/v1"
+        assert p.get_dimension() == 384
 
     def test_create_vllm_provider(self):
         p = OpenAICompatibleProvider.create_vllm_provider(
             model_name="BAAI/bge-base-en-v1.5", host="h", port=8001
         )
-        assert isinstance(p, OpenAICompatibleProvider)
-        assert p.config.extra_params["api_base"] == "http://h:8001/v1"
-        assert p.config.dimension == 768
-
-    def test_props(self):
-        p = OpenAICompatibleProvider()
-        assert p.dimension == p.config.dimension
-        assert p.model_name == p.config.model_name
+        assert p.config.extra["api_base"] == "http://h:8001/v1"
+        assert p.get_dimension() == 768
 
 
-# =========================================================================== #
-# CohereProvider
-# =========================================================================== #
-class TestCohereProvider:
-    def test_default_config(self):
-        p = CohereProvider()
-        cfg = p._get_default_config()
-        assert cfg.model_name == "embed-english-light-v3.0"
-        assert cfg.dimension == 384
-        assert cfg.extra_params["input_type"] == "search_document"
+def OPENAI_COMPATIBLE_MODEL():
+    from proximadb_sdk.embedding_providers.openai_compatible import (
+        OPENAI_COMPATIBLE_MODELS,
+    )
 
-    def test_initialize_no_key(self, monkeypatch):
-        monkeypatch.delenv("COHERE_API_KEY", raising=False)
-        cfg = EmbeddingConfig(
-            model_name="embed-english-v3.0",
-            dimension=1024,
-            extra_params={"api_key": None, "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        assert p._available is False
-
-    def test_initialize_with_key(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-v3.0",
-            dimension=1,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        assert p.config.dimension == 1024
-        assert p.client.api_key == "co-key"
-
-    def test_initialize_cost_warning(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-v3.0",
-            dimension=1024,
-            extra_params={"api_key": "co-key", "show_cost_warnings": True},
-        )
-        p = CohereProvider(cfg)
-        with pytest.warns(UserWarning):
-            p._initialize()
-        assert p._available is True
-
-    def test_initialize_import_error(self, monkeypatch):
-        monkeypatch.setitem(sys.modules, "cohere", None)
-        cfg = EmbeddingConfig(
-            model_name="embed-english-v3.0",
-            dimension=1024,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        assert p._available is False
-
-    def test_embed_texts_dispatch(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            batch_size=2,
-            normalize=False,
-            extra_params={
-                "api_key": "co-key",
-                "show_cost_warnings": False,
-                "input_type": "search_document",
-            },
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        out = p.embed_texts(["a b c", "d e", "f"])
-        assert out.shape == (3, 3)
-        assert p._token_count > 0
-
-    def test_embed_texts_normalize_zero_safe(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            batch_size=10,
-            normalize=True,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        out = p.embed_texts(["hello world"])
-        np.testing.assert_allclose(np.linalg.norm(out[0]), 1.0, rtol=1e-5)
-
-    def test_embed_texts_empty(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        assert p.embed_texts([]).size == 0
-
-    def test_embed_texts_unavailable(self):
-        cfg = EmbeddingConfig(model_name="x", dimension=3, extra_params={})
-        p = CohereProvider(cfg)
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_embed_texts_api_error_wrapped(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            batch_size=10,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-
-        def _boom(**kw):
-            raise ValueError("cohere down")
-
-        p.client.embed = _boom
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_embed_with_type_restores_input_type(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            batch_size=10,
-            normalize=False,
-            extra_params={
-                "api_key": "co-key",
-                "show_cost_warnings": False,
-                "input_type": "search_document",
-            },
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        out = p.embed_with_type(["q"], "search_query")
-        assert out.shape == (1, 3)
-        # original input_type restored after call
-        assert p.config.extra_params["input_type"] == "search_document"
-
-    def test_estimate_cost(self):
-        p = CohereProvider()
-        p.config.model_name = "embed-english-light-v3.0"
-        assert p._estimate_cost(1_000_000) == pytest.approx(0.02)
-        p.config.model_name = "unknown"
-        assert p._estimate_cost(1_000_000) == pytest.approx(0.10)
-
-    def test_get_token_usage(self):
-        cfg = EmbeddingConfig(
-            model_name="embed-english-light-v3.0",
-            dimension=3,
-            extra_params={"api_key": "co-key", "show_cost_warnings": False},
-        )
-        p = CohereProvider(cfg)
-        p._initialize()
-        u = p.get_token_usage()
-        assert u["model"] == "embed-english-light-v3.0"
-
-    def test_list_models(self):
-        m = CohereProvider.list_models()
-        assert "embed-english-v3.0" in m
-        assert m["embed-english-v2.0"]["dimension"] == 4096
-
-    def test_create_for_search(self):
-        p = CohereProvider.create_for_search()
-        assert isinstance(p, CohereProvider)
-        assert p.config.extra_params["input_type"] == "search_document"
-
-    def test_props(self):
-        p = CohereProvider()
-        assert p.dimension == p.config.dimension
-        assert p.model_name == p.config.model_name
-
-
-# =========================================================================== #
-# InstructorProvider
-# =========================================================================== #
-class TestInstructorProvider:
-    def test_default_config(self):
-        p = InstructorProvider()
-        cfg = p._get_default_config()
-        assert cfg.model_name == "hkunlp/instructor-base"
-        assert cfg.dimension == 768
-        assert "instruction" in cfg.extra_params
-
-    def test_initialize_success(self):
-        p = InstructorProvider()
-        p._initialize()
-        assert p._available is True
-        assert p.config.dimension == 768
-        assert p.instruction == InstructorProvider.DEFAULT_INSTRUCTIONS["retrieval"]
-        assert p.is_available() is True
-
-    def test_initialize_import_error(self, monkeypatch):
-        monkeypatch.setitem(sys.modules, "InstructorEmbedding", None)
-        p = InstructorProvider()
-        p._initialize()
-        assert p._available is False
-
-    def test_initialize_generic_error(self, monkeypatch):
-        # INSTRUCTOR constructor raises -> generic except path
-        bad = types.ModuleType("InstructorEmbedding")
-
-        class _Bad:
-            def __init__(self, *a, **k):
-                raise ValueError("load fail")
-
-        bad.INSTRUCTOR = _Bad
-        monkeypatch.setitem(sys.modules, "InstructorEmbedding", bad)
-        p = InstructorProvider()
-        p._initialize()
-        assert p._available is False
-
-    def test_embed_texts_dispatch(self):
-        p = InstructorProvider()
-        p._initialize()
-        out = p.embed_texts(["foo", "bar"])
-        assert out.shape == (2, 4)
-
-    def test_embed_texts_empty(self):
-        p = InstructorProvider()
-        p._initialize()
-        assert p.embed_texts([]).size == 0
-
-    def test_embed_texts_unavailable(self):
-        p = InstructorProvider()
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_embed_texts_with_instructions_str(self):
-        p = InstructorProvider()
-        p._initialize()
-        out = p.embed_texts_with_instructions(["a", "b"], "do this:")
-        assert out.shape == (2, 4)
-
-    def test_embed_texts_with_instructions_list(self):
-        p = InstructorProvider()
-        p._initialize()
-        out = p.embed_texts_with_instructions(["a", "b"], ["i1:", "i2:"])
-        assert out.shape == (2, 4)
-
-    def test_embed_texts_with_instructions_unavailable(self):
-        p = InstructorProvider()
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts_with_instructions(["a"], "x:")
-
-    def test_create_with_instruction(self):
-        p = InstructorProvider.create_with_instruction(
-            "represent:", model_name="hkunlp/instructor-large"
-        )
-        assert isinstance(p, InstructorProvider)
-        assert p.config.extra_params["instruction"] == "represent:"
-        assert p.config.model_name == "hkunlp/instructor-large"
-
-    def test_props(self):
-        p = InstructorProvider()
-        assert p.dimension == p.config.dimension
-        assert p.model_name == p.config.model_name
-
-
-# =========================================================================== #
-# FastEmbedProvider
-# =========================================================================== #
-class TestFastEmbedProvider:
-    def test_default_config(self):
-        p = FastEmbedProvider()
-        cfg = p._get_default_config()
-        assert cfg.model_name == "BAAI/bge-small-en-v1.5"
-        assert cfg.dimension == 384
-
-    def test_initialize_known_model(self):
-        cfg = EmbeddingConfig(model_name="BAAI/bge-base-en-v1.5", dimension=1)
-        p = FastEmbedProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        assert p.config.dimension == 768
-        assert p.is_available() is True
-
-    def test_initialize_unknown_model_probes_dim(self):
-        cfg = EmbeddingConfig(model_name="some/unknown-model", dimension=1)
-        p = FastEmbedProvider(cfg)
-        p._initialize()
-        assert p._available is True
-        # probed via embed(["test"]) -> 3-dim vector from stub
-        assert p.config.dimension == 3
-
-    def test_initialize_import_error(self, monkeypatch):
-        monkeypatch.setitem(sys.modules, "fastembed", None)
-        p = FastEmbedProvider()
-        p._initialize()
-        assert p._available is False
-
-    def test_initialize_generic_error(self, monkeypatch):
-        bad = types.ModuleType("fastembed")
-
-        class _BadTE:
-            def __init__(self, *a, **k):
-                raise ValueError("download fail")
-
-        bad.TextEmbedding = _BadTE
-        monkeypatch.setitem(sys.modules, "fastembed", bad)
-        p = FastEmbedProvider()
-        p._initialize()
-        assert p._available is False
-
-    def test_embed_texts_dispatch(self):
-        p = FastEmbedProvider()
-        p._initialize()
-        out = p.embed_texts(["a", "b", "c"])
-        assert out.shape == (3, 3)
-
-    def test_embed_texts_empty(self):
-        p = FastEmbedProvider()
-        p._initialize()
-        assert p.embed_texts([]).size == 0
-
-    def test_embed_texts_unavailable(self):
-        p = FastEmbedProvider()
-        p._available = False
-        with pytest.raises(RuntimeError):
-            p.embed_texts(["a"])
-
-    def test_list_recommended_models(self):
-        m = FastEmbedProvider.list_recommended_models()
-        assert "BAAI/bge-small-en-v1.5" in m
-
-    def test_list_all_models_success(self):
-        models = FastEmbedProvider.list_all_models()
-        assert models == [{"model": "BAAI/bge-small-en-v1.5"}]
-
-    def test_list_all_models_fallback(self, monkeypatch):
-        monkeypatch.setitem(sys.modules, "fastembed", None)
-        models = FastEmbedProvider.list_all_models()
-        assert "BAAI/bge-small-en-v1.5" in models
-
-    def test_props(self):
-        p = FastEmbedProvider()
-        assert p.dimension == p.config.dimension
-        assert p.model_name == p.config.model_name
+    return OPENAI_COMPATIBLE_MODELS["nomic-embed-text"]

--- a/clients/python/tests/unit/test_emb_providers_instructor_cov.py
+++ b/clients/python/tests/unit/test_emb_providers_instructor_cov.py
@@ -1,0 +1,130 @@
+"""
+Offline unit tests for the legacy InstructorProvider.
+
+InstructorProvider still subclasses the System-B ``EmbeddingProvider`` base
+(via the ``embedding_providers.base`` shim), so we stub the optional
+``InstructorEmbedding`` dep through ``sys.modules`` and exercise it without any
+real model download. (The cloud providers were ported onto core and are covered
+in ``test_emb_providers_cloud_cov.py``.)
+"""
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+def _install_base_stub() -> types.ModuleType:
+    """Inject the permissive legacy base the overlay was written against.
+
+    The canonical ``embedding_interface.EmbeddingProvider`` is abstract
+    (``__init__`` + ``embed_text`` are abstractmethods), so we provide the
+    lazy, concrete base the InstructorProvider overlay expects.
+    """
+    mod = types.ModuleType("proximadb_sdk.embedding_providers.base")
+
+    @dataclass
+    class EmbeddingConfig:
+        model_name: str
+        dimension: int
+        batch_size: int = 32
+        normalize: bool = True
+        cache_embeddings: bool = True
+        timeout_seconds: float = 30.0
+        device: Any = None
+        api_key: str | None = None
+        api_url: str | None = None
+        extra_params: dict[str, Any] = field(default_factory=dict)
+
+    class EmbeddingProvider:
+        def __init__(self, config: "EmbeddingConfig | None" = None):
+            self.config = config if config is not None else self._get_default_config()
+            self._available = None
+            self.client = None
+            self.model = None
+            self._token_count = 0
+
+        def _get_default_config(self):  # pragma: no cover - overridden
+            raise NotImplementedError
+
+        def _initialize(self):  # pragma: no cover - overridden
+            raise NotImplementedError
+
+    mod.EmbeddingConfig = EmbeddingConfig
+    mod.EmbeddingProvider = EmbeddingProvider
+    sys.modules["proximadb_sdk.embedding_providers.base"] = mod
+    return mod
+
+
+_install_base_stub()
+
+
+def _install_instructor_stub():
+    instructor_mod = types.ModuleType("InstructorEmbedding")
+
+    class _INSTRUCTOR:
+        def __init__(self, model_name=None, device=None):
+            self.model_name = model_name
+            self.device = device
+
+        def encode(
+            self,
+            instruction_pairs,
+            batch_size=None,
+            show_progress_bar=None,
+            normalize_embeddings=None,
+            convert_to_numpy=None,
+        ):
+            return np.array([[0.1, 0.2, 0.3, 0.4] for _ in instruction_pairs])
+
+    instructor_mod.INSTRUCTOR = _INSTRUCTOR
+    sys.modules["InstructorEmbedding"] = instructor_mod
+
+
+_install_instructor_stub()
+
+from proximadb_sdk.embedding_providers.instructor import (  # noqa: E402
+    InstructorProvider,
+)
+
+
+class TestInstructorProvider:
+    def test_default_config(self):
+        p = InstructorProvider()
+        cfg = p._get_default_config()
+        assert cfg.model_name == "hkunlp/instructor-base"
+        assert cfg.dimension == 768
+        assert "instruction" in cfg.extra_params
+
+    def test_initialize_success(self):
+        p = InstructorProvider()
+        p._initialize()
+        assert p._available is True
+        assert p.config.dimension == 768
+        assert p.is_available() is True
+
+    def test_initialize_import_error(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "InstructorEmbedding", None)
+        p = InstructorProvider()
+        p._initialize()
+        assert p._available is False
+
+    def test_embed_texts_dispatch(self):
+        p = InstructorProvider()
+        p._initialize()
+        out = p.embed_texts(["foo", "bar"])
+        assert out.shape == (2, 4)
+
+    def test_embed_texts_unavailable(self):
+        p = InstructorProvider()
+        p._available = False
+        with pytest.raises(RuntimeError):
+            p.embed_texts(["a"])
+
+    def test_props(self):
+        p = InstructorProvider()
+        assert p.dimension == p.config.dimension
+        assert p.model_name == p.config.model_name

--- a/clients/python/tests/unit/test_emb_providers_local_cov.py
+++ b/clients/python/tests/unit/test_emb_providers_local_cov.py
@@ -236,6 +236,18 @@ def test_e5_query_prefix_is_distinct_from_bge():
     assert e5_instructed == "query: cats"
 
 
+def test_e5_applies_passage_prefix_to_documents():
+    """E5 REQUIRES a "passage: " prefix on documents (asymmetric query/passage
+    training). The generic InstructionMixin leaves passages unprefixed; E5
+    overrides embed_passages so recall does not silently degrade."""
+    e5 = e5_mod.E5Provider()
+    e5.embed_passages(["doc one", "doc two"])
+    assert e5._model.encode_calls[-1]["texts"] == [
+        "passage: doc one",
+        "passage: doc two",
+    ]
+
+
 def test_non_instruction_provider_query_is_plain():
     """SentenceTransformerProvider has no InstructionMixin, so embed exists but
     there is no embed_query; embedding text passes through unchanged."""


### PR DESCRIPTION
## PR 1 of 3 — P0 broken-against-current

Refines the Python SDK embeddings concern. Keeps the good `core/` design (config/registry/cache/mixins, lazy thread-safe init, float32-out contract); touches only embeddings providers + their tests.

### What changed
1. **OpenAI provider was broken on `openai` 2.x.** It used the pre-1.0 API removed Nov 2023 (`openai.api_key=`, `client.Embedding.create(...)`, dict `response["data"]`) → `AttributeError`. Rewritten onto `OpenAI()` + `client.embeddings.create` + `response.data[i].embedding` (mirroring `llm/embedding.py`). Adds the Matryoshka `dimensions` param for `text-embedding-3-*` and index-ordered parsing.
2. **OpenAI-compatible `/v1` drop.** `urljoin(api_base='.../v1', '/embeddings')` discarded `/v1`. Fixed via `_embeddings_url()` (regression-tested).
3. **E5 passage-prefix regression.** `E5Provider.embed_passages` now prepends the mandatory `"passage: "` prefix; the generic `InstructionMixin` left documents unprefixed, silently degrading recall on E5's asymmetric scheme.
4. **Cloud providers were unreachable.** `get_provider('openai'|'cohere'|'fastembed')` raised `ValueError` (they subclassed the legacy base, not registered). Ported OpenAI/Cohere/FastEmbed/OpenAI-compatible onto `core.BaseEmbeddingProvider` + `@ProviderRegistry.register`; corrected `recommend_free_providers()` messaging.
5. **Cohere modernized** onto `cohere.ClientV2` (`embedding_types=['float']`, `response.embeddings.float`) with `embed_query`/`embed_passages` input-type helpers.

### Tests / gates
- Embedding unit suite green (231 passed, expected skips for unavailable local models).
- Rewrote `test_emb_providers_cloud_cov.py` onto the core API; added `test_emb_providers_instructor_cov.py` (Instructor stays on legacy base, collapsed in a later PR) and an E5 passage-prefix assertion.
- black / isort / ruff(E9,F63,F7) / py_compile clean. Smoke: `get_provider('openai')` constructs with mock key, `simulated` embeds, E5 applies `passage:`.

### Follow-ups (next PRs in this series)
- PR2: currency bumps (`sentence-transformers`, `openai`, `cohere`), delete dead `*_new` scaffolding + registry collision guard.
- PR3: collapse the orphaned System-B base overlay; ONNX backend / device auto-detect / LRU model-cache perf levers.