### PR TITLE
feat(graph): batched columnar graph path over Arrow Flight

### DIFF
--- a/src/network/arrow_ipc/graph_codec.rs
+++ b/src/network/arrow_ipc/graph_codec.rs
@@ -1,0 +1,495 @@
+// Copyright 2025 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! Columnar Arrow codec for the batched graph path over Arrow Flight.
+//!
+//! Bulk graph ingest/export is a *columnar* workload, so it belongs on Arrow
+//! Flight (zero-copy) rather than per-row unary gRPC. This module is the
+//! neutral-graph-model <-> Arrow `RecordBatch` boundary: it builds a stable
+//! node/edge batch schema from [`crate::graph::model::{Node, Edge}`] and reads
+//! it back. The Flight handlers route decoded batches to
+//! `GraphOperationsService` batch APIs (so the rows land in the live graph
+//! engine, not the generic record store) and stream query results back.
+//!
+//! ## Schema
+//!
+//! Node batch (`embedding_dim > 0` adds the two embedding columns):
+//! - `id: Utf8`, `labels: Utf8` (JSON array), `properties: Utf8` (JSON object),
+//!   `created_at_ms: Int64`, `updated_at_ms: Int64`
+//! - `embedding_vector: FixedSizeList<Float32, dim>` (nullable),
+//!   `embedding_meta: Utf8` (JSON; model id/version/dimension/params/modality)
+//!
+//! Edge batch:
+//! - `id, from_node_id, to_node_id, edge_type: Utf8`, `weight: Float64`
+//!   (nullable), `properties: Utf8` (JSON), `created_at_ms: Int64`,
+//!   `updated_at_ms: Int64`
+//!
+//! Heterogeneous node/edge properties (`HashMap<String, PropertyValue>`) are
+//! carried as a single JSON `Utf8` column via the neutral model's serde — the
+//! same convention the federated executor and `multimodel_codec` already use.
+//! The embedding *vector* is the one payload kept native-columnar (a
+//! `FixedSizeList<Float32>` child buffer) for throughput; its metadata rides
+//! alongside as JSON.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow, bail};
+use arrow_array::{
+    Array, ArrayRef, FixedSizeListArray, Float32Array, Float64Array, Int64Array, RecordBatch,
+    StringArray,
+};
+use arrow_schema::{DataType, Field, Schema};
+use serde::{Deserialize, Serialize};
+
+use crate::graph::model::{Edge, EmbeddingVersion, Node};
+
+/// Sidecar for the embedding columns: everything in [`EmbeddingVersion`] except
+/// the vector itself, which lives in the native `embedding_vector` column.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct EmbeddingMeta {
+    #[serde(default)]
+    model_id: String,
+    #[serde(default)]
+    model_version: String,
+    #[serde(default)]
+    dimension: u32,
+    #[serde(default)]
+    created_at_ms: i64,
+    #[serde(default)]
+    model_params: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    modality: i32,
+}
+
+impl EmbeddingMeta {
+    fn from_embedding(e: &EmbeddingVersion) -> Self {
+        Self {
+            model_id: e.model_id.clone(),
+            model_version: e.model_version.clone(),
+            dimension: e.dimension,
+            created_at_ms: e.created_at_ms,
+            model_params: e.model_params.clone(),
+            modality: e.modality,
+        }
+    }
+}
+
+// ── Schemas ─────────────────────────────────────────────────────────────────
+
+/// Stable Arrow schema for a graph-node batch. When `embedding_dim == 0` the
+/// two embedding columns are omitted (nodes without vectors).
+pub fn graph_node_schema(embedding_dim: usize) -> Arc<Schema> {
+    let mut fields = vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("labels", DataType::Utf8, false),
+        Field::new("properties", DataType::Utf8, false),
+        Field::new("created_at_ms", DataType::Int64, false),
+        Field::new("updated_at_ms", DataType::Int64, false),
+    ];
+    if embedding_dim > 0 {
+        fields.push(Field::new(
+            "embedding_vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, false)),
+                embedding_dim as i32,
+            ),
+            true,
+        ));
+        fields.push(Field::new("embedding_meta", DataType::Utf8, true));
+    }
+    Arc::new(Schema::new(fields))
+}
+
+/// Stable Arrow schema for a graph-edge batch.
+pub fn graph_edge_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("from_node_id", DataType::Utf8, false),
+        Field::new("to_node_id", DataType::Utf8, false),
+        Field::new("edge_type", DataType::Utf8, false),
+        Field::new("weight", DataType::Float64, true),
+        Field::new("properties", DataType::Utf8, false),
+        Field::new("created_at_ms", DataType::Int64, false),
+        Field::new("updated_at_ms", DataType::Int64, false),
+    ]))
+}
+
+/// Determine the embedding dimension for a node batch: the dimension of the
+/// first node that carries an embedding. Returns 0 when no node has one.
+/// Errors if two nodes carry embeddings of differing length (a single
+/// `FixedSizeList` batch is one stride wide — split mixed dims per graph).
+fn batch_embedding_dim(nodes: &[Node]) -> Result<usize> {
+    let mut dim: Option<usize> = None;
+    for n in nodes {
+        if let Some(e) = &n.embedding {
+            let len = e.vector.len();
+            if len == 0 {
+                continue;
+            }
+            match dim {
+                None => dim = Some(len),
+                Some(d) if d != len => bail!(
+                    "graph node batch carries mixed embedding dimensions ({d} vs {len}); \
+                     a columnar batch is single-stride"
+                ),
+                _ => {}
+            }
+        }
+    }
+    Ok(dim.unwrap_or(0))
+}
+
+// ── Node encode / decode ────────────────────────────────────────────────────
+
+/// Encode neutral graph nodes into a columnar Arrow [`RecordBatch`].
+pub fn nodes_to_batch(nodes: &[Node]) -> Result<RecordBatch> {
+    let embedding_dim = batch_embedding_dim(nodes)?;
+    let schema = graph_node_schema(embedding_dim);
+
+    let ids = StringArray::from_iter_values(nodes.iter().map(|n| n.id.as_str()));
+    let labels = StringArray::from(
+        nodes
+            .iter()
+            .map(|n| serde_json::to_string(&n.labels).ok())
+            .collect::<Vec<_>>(),
+    );
+    let properties = StringArray::from(
+        nodes
+            .iter()
+            .map(|n| serde_json::to_string(&n.properties).ok())
+            .collect::<Vec<_>>(),
+    );
+    let created = Int64Array::from_iter_values(nodes.iter().map(|n| n.created_at_ms));
+    let updated = Int64Array::from_iter_values(nodes.iter().map(|n| n.updated_at_ms));
+
+    let mut columns: Vec<ArrayRef> = vec![
+        Arc::new(ids),
+        Arc::new(labels),
+        Arc::new(properties),
+        Arc::new(created),
+        Arc::new(updated),
+    ];
+
+    if embedding_dim > 0 {
+        // Native FixedSizeList<Float32> child buffer must hold exactly
+        // len*dim floats; rows without an embedding emit a NULL list but still
+        // reserve `dim` backing slots (mirrors the vector-search codec).
+        let mut flat = Vec::with_capacity(nodes.len() * embedding_dim);
+        let mut present = Vec::with_capacity(nodes.len());
+        let mut metas: Vec<Option<String>> = Vec::with_capacity(nodes.len());
+        for n in nodes {
+            match &n.embedding {
+                Some(e) if e.vector.len() == embedding_dim => {
+                    flat.extend_from_slice(&e.vector);
+                    present.push(true);
+                    metas.push(serde_json::to_string(&EmbeddingMeta::from_embedding(e)).ok());
+                }
+                _ => {
+                    flat.extend(std::iter::repeat_n(0.0f32, embedding_dim));
+                    present.push(false);
+                    metas.push(None);
+                }
+            }
+        }
+        let child = Arc::new(Float32Array::from(flat)) as ArrayRef;
+        let item_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let nulls = present
+            .iter()
+            .any(|p| !p)
+            .then(|| arrow_buffer::NullBuffer::from(present));
+        let vector_array = FixedSizeListArray::new(item_field, embedding_dim as i32, child, nulls);
+        columns.push(Arc::new(vector_array));
+        columns.push(Arc::new(StringArray::from(metas)));
+    }
+
+    RecordBatch::try_new(schema, columns).context("build graph node RecordBatch")
+}
+
+/// Decode a graph-node [`RecordBatch`] back into neutral nodes.
+pub fn batch_to_nodes(batch: &RecordBatch) -> Result<Vec<Node>> {
+    let n = batch.num_rows();
+    let ids = str_col(batch, "id")?;
+    let labels = str_col(batch, "labels")?;
+    let properties = str_col(batch, "properties")?;
+    let created = i64_col(batch, "created_at_ms")?;
+    let updated = i64_col(batch, "updated_at_ms")?;
+
+    // Embedding columns are optional (absent when no node carried a vector).
+    let embedding = batch
+        .schema()
+        .column_with_name("embedding_vector")
+        .map(|(idx, _)| {
+            batch
+                .column(idx)
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .ok_or_else(|| anyhow!("embedding_vector column is not a FixedSizeList"))
+                .cloned()
+        })
+        .transpose()?;
+    let embedding_meta = batch
+        .schema()
+        .column_with_name("embedding_meta")
+        .map(|_| str_col(batch, "embedding_meta"))
+        .transpose()?;
+
+    let mut out = Vec::with_capacity(n);
+    for row in 0..n {
+        let labels_json = labels.value(row);
+        let props_json = properties.value(row);
+        let node_embedding = match &embedding {
+            Some(col) if !col.is_null(row) => {
+                let values = col.value(row);
+                let f32s = values
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .ok_or_else(|| anyhow!("embedding_vector child is not Float32"))?;
+                let vector: Vec<f32> = f32s.values().to_vec();
+                let meta: EmbeddingMeta = match &embedding_meta {
+                    Some(m) if !m.is_null(row) => {
+                        serde_json::from_str(m.value(row)).context("parse embedding_meta JSON")?
+                    }
+                    _ => EmbeddingMeta {
+                        dimension: vector.len() as u32,
+                        ..Default::default()
+                    },
+                };
+                Some(EmbeddingVersion {
+                    model_id: meta.model_id,
+                    model_version: meta.model_version,
+                    vector,
+                    dimension: meta.dimension,
+                    created_at_ms: meta.created_at_ms,
+                    model_params: meta.model_params,
+                    modality: meta.modality,
+                })
+            }
+            _ => None,
+        };
+        out.push(Node {
+            id: ids.value(row).to_string(),
+            labels: serde_json::from_str(labels_json).context("parse node labels JSON")?,
+            properties: serde_json::from_str(props_json).context("parse node properties JSON")?,
+            embedding: node_embedding,
+            created_at_ms: created.value(row),
+            updated_at_ms: updated.value(row),
+        });
+    }
+    Ok(out)
+}
+
+// ── Edge encode / decode ────────────────────────────────────────────────────
+
+/// Encode neutral graph edges into a columnar Arrow [`RecordBatch`].
+pub fn edges_to_batch(edges: &[Edge]) -> Result<RecordBatch> {
+    let schema = graph_edge_schema();
+    let ids = StringArray::from_iter_values(edges.iter().map(|e| e.id.as_str()));
+    let from = StringArray::from_iter_values(edges.iter().map(|e| e.from_node_id.as_str()));
+    let to = StringArray::from_iter_values(edges.iter().map(|e| e.to_node_id.as_str()));
+    let etype = StringArray::from_iter_values(edges.iter().map(|e| e.edge_type.as_str()));
+    let weight = Float64Array::from(edges.iter().map(|e| e.weight).collect::<Vec<_>>());
+    let properties = StringArray::from(
+        edges
+            .iter()
+            .map(|e| serde_json::to_string(&e.properties).ok())
+            .collect::<Vec<_>>(),
+    );
+    let created = Int64Array::from_iter_values(edges.iter().map(|e| e.created_at_ms));
+    let updated = Int64Array::from_iter_values(edges.iter().map(|e| e.updated_at_ms));
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(from),
+            Arc::new(to),
+            Arc::new(etype),
+            Arc::new(weight),
+            Arc::new(properties),
+            Arc::new(created),
+            Arc::new(updated),
+        ],
+    )
+    .context("build graph edge RecordBatch")
+}
+
+/// Decode a graph-edge [`RecordBatch`] back into neutral edges.
+pub fn batch_to_edges(batch: &RecordBatch) -> Result<Vec<Edge>> {
+    let n = batch.num_rows();
+    let ids = str_col(batch, "id")?;
+    let from = str_col(batch, "from_node_id")?;
+    let to = str_col(batch, "to_node_id")?;
+    let etype = str_col(batch, "edge_type")?;
+    let properties = str_col(batch, "properties")?;
+    let created = i64_col(batch, "created_at_ms")?;
+    let updated = i64_col(batch, "updated_at_ms")?;
+    let weight = batch
+        .column(
+            batch
+                .schema()
+                .column_with_name("weight")
+                .ok_or_else(|| anyhow!("missing edge weight column"))?
+                .0,
+        )
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .ok_or_else(|| anyhow!("edge weight column is not Float64"))?
+        .clone();
+
+    let mut out = Vec::with_capacity(n);
+    for row in 0..n {
+        out.push(Edge {
+            id: ids.value(row).to_string(),
+            from_node_id: from.value(row).to_string(),
+            to_node_id: to.value(row).to_string(),
+            edge_type: etype.value(row).to_string(),
+            properties: serde_json::from_str(properties.value(row))
+                .context("parse edge properties JSON")?,
+            weight: (!weight.is_null(row)).then(|| weight.value(row)),
+            created_at_ms: created.value(row),
+            updated_at_ms: updated.value(row),
+        });
+    }
+    Ok(out)
+}
+
+// ── Column accessors ────────────────────────────────────────────────────────
+
+fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    let (idx, _) = batch
+        .schema()
+        .column_with_name(name)
+        .ok_or_else(|| anyhow!("graph batch missing required column `{name}`"))?;
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow!("graph batch column `{name}` is not Utf8"))
+}
+
+fn i64_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int64Array> {
+    let (idx, _) = batch
+        .schema()
+        .column_with_name(name)
+        .ok_or_else(|| anyhow!("graph batch missing required column `{name}`"))?;
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| anyhow!("graph batch column `{name}` is not Int64"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::model::{PropertyValue, property_value::Value};
+
+    fn sample_node(id: &str, dim: usize) -> Node {
+        let mut properties = std::collections::HashMap::new();
+        properties.insert(
+            "name".to_string(),
+            PropertyValue {
+                value: Some(Value::StringValue(format!("name-{id}"))),
+            },
+        );
+        properties.insert(
+            "score".to_string(),
+            PropertyValue {
+                value: Some(Value::DoubleValue(1.5)),
+            },
+        );
+        Node {
+            id: id.to_string(),
+            labels: vec!["Person".to_string(), "Author".to_string()],
+            properties,
+            embedding: (dim > 0).then(|| EmbeddingVersion {
+                model_id: "bge".to_string(),
+                model_version: "v1".to_string(),
+                vector: (0..dim).map(|i| i as f32 * 0.1).collect(),
+                dimension: dim as u32,
+                created_at_ms: 7,
+                model_params: Default::default(),
+                modality: 0,
+            }),
+            created_at_ms: 11,
+            updated_at_ms: 22,
+        }
+    }
+
+    #[test]
+    fn node_round_trip_with_embeddings() {
+        let nodes = vec![sample_node("n1", 4), sample_node("n2", 4)];
+        let batch = nodes_to_batch(&nodes).expect("encode");
+        assert_eq!(batch.num_rows(), 2);
+        let back = batch_to_nodes(&batch).expect("decode");
+        assert_eq!(back, nodes);
+    }
+
+    #[test]
+    fn node_round_trip_mixed_presence() {
+        // One node with an embedding, one without — null list row.
+        let nodes = vec![sample_node("n1", 3), sample_node("n2", 0)];
+        let batch = nodes_to_batch(&nodes).expect("encode");
+        let back = batch_to_nodes(&batch).expect("decode");
+        assert_eq!(back, nodes);
+        assert!(back[1].embedding.is_none());
+    }
+
+    #[test]
+    fn node_round_trip_no_embeddings_omits_columns() {
+        let nodes = vec![sample_node("n1", 0)];
+        let batch = nodes_to_batch(&nodes).expect("encode");
+        assert!(
+            batch
+                .schema()
+                .column_with_name("embedding_vector")
+                .is_none()
+        );
+        let back = batch_to_nodes(&batch).expect("decode");
+        assert_eq!(back, nodes);
+    }
+
+    #[test]
+    fn mixed_embedding_dims_rejected() {
+        let nodes = vec![sample_node("n1", 3), sample_node("n2", 4)];
+        assert!(nodes_to_batch(&nodes).is_err());
+    }
+
+    #[test]
+    fn edge_round_trip() {
+        let mut props = std::collections::HashMap::new();
+        props.insert(
+            "since".to_string(),
+            PropertyValue {
+                value: Some(Value::IntValue(2020)),
+            },
+        );
+        let edges = vec![
+            Edge {
+                id: "e1".to_string(),
+                from_node_id: "n1".to_string(),
+                to_node_id: "n2".to_string(),
+                edge_type: "KNOWS".to_string(),
+                properties: props,
+                weight: Some(0.9),
+                created_at_ms: 1,
+                updated_at_ms: 2,
+            },
+            Edge {
+                id: "e2".to_string(),
+                from_node_id: "n2".to_string(),
+                to_node_id: "n1".to_string(),
+                edge_type: "CITES".to_string(),
+                properties: std::collections::HashMap::new(),
+                weight: None,
+                created_at_ms: 3,
+                updated_at_ms: 4,
+            },
+        ];
+        let batch = edges_to_batch(&edges).expect("encode");
+        let back = batch_to_edges(&batch).expect("decode");
+        assert_eq!(back, edges);
+    }
+}

--- a/src/network/arrow_ipc/mod.rs
+++ b/src/network/arrow_ipc/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod codec;
 pub mod file_export;
+pub mod graph_codec;
 pub mod multimodal_codec;
 pub mod multimodel_codec;
 /// `rank_features_export` Flight action (R-7c.4b) — streams the rank

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -72,6 +72,26 @@ struct AuthenticatedFlightContext {
     capability: Option<DataPlaneCapability>,
 }
 
+/// DoGet ticket for the batched columnar graph export path. JSON-encoded in the
+/// Flight `Ticket` bytes; `model` selects nodes vs edges and the optional fields
+/// scope the query (label / edge type / endpoints / limit).
+#[derive(Debug, Clone, serde::Deserialize)]
+struct GraphTicket {
+    /// `"graph_nodes"` or `"graph_edges"`.
+    model: String,
+    graph_id: String,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    edge_type: Option<String>,
+    #[serde(default)]
+    from_node_id: Option<String>,
+    #[serde(default)]
+    to_node_id: Option<String>,
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
 /// ProximaDB Flight service implementation
 ///
 /// Thin wrapper around UnifiedHandlers that converts Arrow Flight messages
@@ -112,6 +132,13 @@ pub struct ProximaFlightService {
     /// any of them landing on the wrong pod's memtable would be
     /// invisible to the readers on the primary pod.
     primary_pod_gate: Option<FlightPrimaryPodGate>,
+    /// Graph backing service for the batched columnar graph path
+    /// (`graph_nodes`/`graph_edges` DoExchange + DoGet). Held directly (like the
+    /// vector-ops service) so bulk graph ingest lands in the live graph engine
+    /// rather than the generic record store. `None` outside production wiring
+    /// (e.g. the port-only test constructor), in which case the graph Flight
+    /// routes return `Unimplemented`.
+    graph_service: Option<Arc<crate::graph::GraphOperationsService>>,
     _codec: ArrowProtoCodec,
     file_export_handler: ArrowFileExportHandler,
 }
@@ -195,9 +222,21 @@ impl ProximaFlightService {
             catalog_manager: None,
             rank_services: None,
             primary_pod_gate: None,
+            graph_service: None,
             _codec: ArrowProtoCodec,
             file_export_handler: ArrowFileExportHandler::new(storage_locations),
         }
+    }
+
+    /// Attach the graph backing service so the `graph_nodes`/`graph_edges`
+    /// DoExchange ingest and DoGet export routes are live. Same
+    /// `GraphOperationsService` the gRPC/REST graph surfaces use.
+    pub fn with_graph_service(
+        mut self,
+        graph_service: Arc<crate::graph::GraphOperationsService>,
+    ) -> Self {
+        self.graph_service = Some(graph_service);
+        self
     }
 
     /// Boot adapter that derives the injected pieces from a root `UnifiedHandlers`.
@@ -229,6 +268,7 @@ impl ProximaFlightService {
             collection_service,
             storage_locations,
         )
+        .with_graph_service(request_handlers.graph_operations_service.clone())
     }
 
     /// Slice 6.2: attach the primary-pod write router. Once set,
@@ -1273,6 +1313,35 @@ impl FlightService for ProximaFlightService {
 
             let stream = stream::iter(flight_data.into_iter().map(Ok));
 
+            return Ok(TonicResponse::new(Box::pin(stream)));
+        }
+
+        // Batched columnar graph export: a graph ticket reads nodes/edges from
+        // the live graph engine and streams them as columnar Arrow batches.
+        if let Some(graph_ticket) = Self::parse_graph_ticket(&ticket) {
+            Self::validate_flight_search_capability(
+                auth_context.capability.as_ref(),
+                &graph_ticket.graph_id,
+            )?;
+            let batches = self
+                .handle_graph_export(&graph_ticket, auth_context.tenant_id.as_deref())
+                .await
+                .map_err(|e| TonicStatus::internal(format!("Graph export failed: {}", e)))?;
+            let compression = if edge.shape_policy().compress {
+                FlightCompression::Zstd.to_arrow_compression()
+            } else {
+                None
+            };
+            let flight_data =
+                ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
+                    .map_err(|e| {
+                        TonicStatus::internal(format!("Failed to encode graph batches: {}", e))
+                    })?;
+            edge.record_result_egress(
+                auth_context.tenant_id.as_deref(),
+                flight_data_wire_bytes(&flight_data),
+            );
+            let stream = stream::iter(flight_data.into_iter().map(Ok));
             return Ok(TonicResponse::new(Box::pin(stream)));
         }
 
@@ -2386,6 +2455,26 @@ impl FlightService for ProximaFlightService {
                 )
                 .await
             }
+            "graph_nodes" | "graph_edges" => {
+                // Bulk columnar graph ingest. Upsert semantics: the columnar
+                // batch is idempotent re-ingestible. Capability + tenant
+                // namespacing mirror the record write path.
+                Self::validate_flight_write_capability(
+                    auth_context.capability.as_ref(),
+                    &collection_id,
+                    FlightWriteOperation::Upsert,
+                    0,
+                )?;
+                let is_nodes = exchange_type == "graph_nodes";
+                self.handle_graph_write_exchange(
+                    collection_id,
+                    is_nodes,
+                    auth_context.tenant_id.clone(),
+                    first_msg,
+                    stream,
+                )
+                .await
+            }
             "bulk_search" => {
                 Self::validate_flight_search_capability(
                     auth_context.capability.as_ref(),
@@ -2404,7 +2493,7 @@ impl FlightService for ProximaFlightService {
                     .await
             }
             _ => Err(TonicStatus::unimplemented(format!(
-                "Unknown exchange type: {}. Supported: bulk_insert, bulk_upsert, bulk_delete, bulk_search, data_transfer",
+                "Unknown exchange type: {}. Supported: bulk_insert, bulk_upsert, bulk_delete, bulk_search, data_transfer, graph_nodes, graph_edges",
                 exchange_type
             ))),
         }
@@ -2538,6 +2627,172 @@ impl ProximaFlightService {
 
         let stream = stream::iter(results);
         Ok(TonicResponse::new(Box::pin(stream)))
+    }
+
+    /// Derive the effective backing graph namespace from the request tenant.
+    ///
+    /// Structural isolation: the tenant is folded into the graph storage key
+    /// (mirrors the gRPC v2 graph surface's `effective_graph_id`), never a
+    /// per-query predicate. Unauthenticated calls (no tenant) fall back to the
+    /// raw graph id.
+    fn effective_graph_id(tenant: Option<&str>, graph_id: &str) -> String {
+        match tenant {
+            Some(t) if !t.is_empty() => format!("{t}::{graph_id}"),
+            _ => graph_id.to_string(),
+        }
+    }
+
+    /// Handle the batched columnar graph ingest exchange (`graph_nodes` /
+    /// `graph_edges`). Each streamed Arrow `RecordBatch` is decoded via
+    /// [`super::graph_codec`] into neutral nodes/edges and upserted through the
+    /// live `GraphOperationsService`, so the rows are immediately
+    /// queryable/traversable (not parked in the generic record store).
+    async fn handle_graph_write_exchange(
+        &self,
+        graph_id: String,
+        is_nodes: bool,
+        tenant_id: Option<String>,
+        first_msg: FlightData,
+        stream: TonicStreaming<FlightData>,
+    ) -> TonicResult<<Self as FlightService>::DoExchangeStream> {
+        let graph = self.graph_service.as_ref().ok_or_else(|| {
+            TonicStatus::unimplemented("graph Flight path requires the graph backing service")
+        })?;
+        let effective_graph_id = Self::effective_graph_id(tenant_id.as_deref(), &graph_id);
+
+        let mut total_rows = 0u64;
+        let mut total_batches = 0u64;
+        let mut all_success = true;
+        let mut results = Vec::new();
+
+        let mut batch_stream = Self::record_batch_stream(first_msg, stream);
+        while let Some(batch) = batch_stream.next().await {
+            let batch = batch.map_err(|e| TonicStatus::internal(format!("Stream error: {}", e)))?;
+            total_batches += 1;
+            let row_count = batch.num_rows() as u64;
+
+            let written = if is_nodes {
+                let nodes = super::graph_codec::batch_to_nodes(&batch)
+                    .map_err(|e| TonicStatus::invalid_argument(format!("decode nodes: {}", e)))?;
+                graph
+                    .batch_create_nodes_with_strategy(&effective_graph_id, nodes, "update")
+                    .await
+                    .map(|created| created.len() as u64)
+            } else {
+                let edges = super::graph_codec::batch_to_edges(&batch)
+                    .map_err(|e| TonicStatus::invalid_argument(format!("decode edges: {}", e)))?;
+                graph
+                    .batch_create_edges(&effective_graph_id, edges)
+                    .await
+                    .map(|created| created.len() as u64)
+            };
+
+            let (written, ok) = match written {
+                Ok(n) => (n, true),
+                Err(e) => {
+                    all_success = false;
+                    tracing::error!(graph_id = %effective_graph_id, error = %e, "graph Flight ingest batch failed");
+                    (0, false)
+                }
+            };
+            total_rows += written;
+
+            let progress = serde_json::json!({
+                "kind": if is_nodes { "graph_nodes" } else { "graph_edges" },
+                "batch": total_batches,
+                "rows_in": row_count,
+                "rows_written": written,
+                "success": ok,
+            });
+            results.push(Ok(FlightData {
+                flight_descriptor: None,
+                data_header: Default::default(),
+                app_metadata: progress.to_string().into_bytes().into(),
+                data_body: Default::default(),
+            }));
+        }
+
+        let final_meta = serde_json::json!({
+            "kind": if is_nodes { "graph_nodes" } else { "graph_edges" },
+            "complete": true,
+            "total_batches": total_batches,
+            "total_rows_written": total_rows,
+            "success": all_success,
+        });
+        results.push(Ok(FlightData {
+            flight_descriptor: None,
+            data_header: Default::default(),
+            app_metadata: final_meta.to_string().into_bytes().into(),
+            data_body: Default::default(),
+        }));
+
+        info!(
+            graph_id = %effective_graph_id,
+            kind = if is_nodes { "graph_nodes" } else { "graph_edges" },
+            total_batches = total_batches,
+            total_rows_written = total_rows,
+            "Arrow Flight: graph columnar ingest completed"
+        );
+
+        Ok(TonicResponse::new(Box::pin(stream::iter(results))))
+    }
+
+    /// Parse a DoGet `Ticket` as a graph export request. Returns `None` for
+    /// non-graph tickets so they fall through to the vector-search path.
+    fn parse_graph_ticket(ticket: &Ticket) -> Option<GraphTicket> {
+        let parsed: GraphTicket = serde_json::from_slice(&ticket.ticket).ok()?;
+        matches!(parsed.model.as_str(), "graph_nodes" | "graph_edges").then_some(parsed)
+    }
+
+    /// Read nodes or edges from the live graph engine and encode them as columnar
+    /// Arrow batches (the DoGet half of the batched columnar graph path).
+    async fn handle_graph_export(
+        &self,
+        ticket: &GraphTicket,
+        tenant_id: Option<&str>,
+    ) -> Result<Vec<arrow_array::RecordBatch>> {
+        let graph = self
+            .graph_service
+            .as_ref()
+            .context("graph Flight path requires the graph backing service")?;
+        let effective_graph_id = Self::effective_graph_id(tenant_id, &ticket.graph_id);
+
+        if ticket.model == "graph_nodes" {
+            let query = crate::graph::NodeQuery {
+                graph_id: effective_graph_id.clone(),
+                labels: ticket.label.clone().into_iter().collect(),
+                filters: Vec::new(),
+                limit: ticket.limit,
+                offset: None,
+                continuation_token: None,
+            };
+            let nodes = graph.query_nodes(&effective_graph_id, query).await?;
+            let nodes: Vec<crate::graph::Node> = nodes.iter().map(|n| (**n).clone()).collect();
+            Ok(vec![super::graph_codec::nodes_to_batch(&nodes)?])
+        } else {
+            // The graph engine has no full edge scan; edge export is scoped to a
+            // node's adjacency. Require an endpoint so the contract is explicit
+            // rather than silently returning an empty batch.
+            if ticket.from_node_id.is_none() && ticket.to_node_id.is_none() {
+                anyhow::bail!(
+                    "graph_edges export requires `from_node_id` or `to_node_id` \
+                     (the engine has no full edge scan)"
+                );
+            }
+            let query = crate::graph::EdgeQuery {
+                graph_id: effective_graph_id.clone(),
+                from_node_id: ticket.from_node_id.clone(),
+                to_node_id: ticket.to_node_id.clone(),
+                edge_types: ticket.edge_type.clone().into_iter().collect(),
+                filters: Vec::new(),
+                limit: ticket.limit,
+                offset: None,
+                continuation_token: None,
+            };
+            let edges = graph.query_edges(&effective_graph_id, query).await?;
+            let edges: Vec<crate::graph::Edge> = edges.iter().map(|e| (**e).clone()).collect();
+            Ok(vec![super::graph_codec::edges_to_batch(&edges)?])
+        }
     }
 
     /// Handle bulk search exchange - stream query vectors and return results

--- a/tests/graph_flight_columnar_test.rs
+++ b/tests/graph_flight_columnar_test.rs
@@ -1,0 +1,195 @@
+//! Batched columnar graph path over Arrow Flight — service-level round-trip.
+//!
+//! Exercises exactly what the Flight `graph_nodes`/`graph_edges` DoExchange
+//! ingest and DoGet export handlers delegate to: encode neutral nodes/edges to a
+//! columnar Arrow `RecordBatch` (`graph_codec`), decode them, bulk-create them
+//! through the live `GraphOperationsService`, query them back, and re-encode —
+//! all through the public API. The handler glue is thin streaming over this
+//! core (the Flight streaming/descriptor plumbing it reuses is already e2e-tested
+//! by the vector/record path); a socket-level client e2e is a follow-up.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use proximadb::graph::GraphOperationsService;
+use proximadb::graph::model::{EmbeddingVersion, Node, PropertyValue, property_value::Value};
+use proximadb::network::arrow_ipc::graph_codec;
+
+/// Provision a graph collection (DDL is proto-typed, like the v2 gRPC surface;
+/// the Flight ingest/export routes assume the graph already exists, created via
+/// REST in production).
+async fn create_graph(graph: &GraphOperationsService, graph_id: &str) {
+    graph
+        .create_graph_collection(proximadb::proto::proximadb_v1::CreateGraphRequest {
+            graph_id: graph_id.to_string(),
+            name: Some(graph_id.to_string()),
+            description: None,
+            schema: None,
+            storage_config: None,
+            engine_config: None,
+            access_control: None,
+        })
+        .await
+        .expect("create graph collection");
+}
+
+fn node(id: &str, dim: usize) -> Node {
+    let mut properties = HashMap::new();
+    properties.insert(
+        "name".to_string(),
+        PropertyValue {
+            value: Some(Value::StringValue(format!("name-{id}"))),
+        },
+    );
+    properties.insert(
+        "rank".to_string(),
+        PropertyValue {
+            value: Some(Value::IntValue(7)),
+        },
+    );
+    Node {
+        id: id.to_string(),
+        labels: vec!["Person".to_string()],
+        properties,
+        embedding: (dim > 0).then(|| EmbeddingVersion {
+            model_id: "bge".to_string(),
+            model_version: "v1".to_string(),
+            vector: (0..dim).map(|i| i as f32 * 0.25).collect(),
+            dimension: dim as u32,
+            created_at_ms: 0,
+            model_params: Default::default(),
+            modality: 0,
+        }),
+        created_at_ms: 0,
+        updated_at_ms: 0,
+    }
+}
+
+/// Ingest nodes via the columnar codec + graph batch API, read them back via a
+/// label query, and confirm the columnar round-trip preserves identity,
+/// labels, properties, and the embedding vector.
+#[tokio::test]
+async fn columnar_node_ingest_and_export_round_trip() {
+    let graph = Arc::new(GraphOperationsService::new());
+    let graph_id = "g_columnar_nodes";
+    create_graph(&graph, graph_id).await;
+
+    let originals = vec![node("n1", 4), node("n2", 4), node("n3", 0)];
+
+    // --- DoExchange ingest half: encode -> wire batch -> decode -> bulk create.
+    let batch = graph_codec::nodes_to_batch(&originals).expect("encode node batch");
+    assert_eq!(batch.num_rows(), 3);
+    let decoded = graph_codec::batch_to_nodes(&batch).expect("decode node batch");
+    let created = graph
+        .batch_create_nodes_with_strategy(graph_id, decoded, "update")
+        .await
+        .expect("bulk create nodes");
+    assert_eq!(created.len(), 3);
+
+    // --- DoGet export half: query the live engine -> encode -> decode.
+    let query = proximadb::graph::NodeQuery {
+        graph_id: graph_id.to_string(),
+        labels: vec!["Person".to_string()],
+        filters: Vec::new(),
+        limit: None,
+        offset: None,
+        continuation_token: None,
+    };
+    let fetched = graph
+        .query_nodes(graph_id, query)
+        .await
+        .expect("query nodes");
+    assert_eq!(fetched.len(), 3, "all three nodes are queryable");
+
+    let fetched_nodes: Vec<Node> = fetched.iter().map(|n| (**n).clone()).collect();
+    let export = graph_codec::nodes_to_batch(&fetched_nodes).expect("encode fetched");
+    let mut round_tripped = graph_codec::batch_to_nodes(&export).expect("decode fetched");
+    round_tripped.sort_by(|a, b| a.id.cmp(&b.id));
+
+    // Identity / labels / properties / embedding survive the columnar trip
+    // (timestamps are engine-assigned, so compare the stable fields).
+    for (orig, got) in originals.iter().zip(round_tripped.iter()) {
+        assert_eq!(orig.id, got.id);
+        assert_eq!(orig.labels, got.labels);
+        assert_eq!(orig.properties, got.properties);
+        assert_eq!(
+            orig.embedding.as_ref().map(|e| &e.vector),
+            got.embedding.as_ref().map(|e| &e.vector),
+            "embedding vector preserved for {}",
+            orig.id
+        );
+    }
+}
+
+/// Ingest edges via the columnar codec + graph batch API and read them back.
+#[tokio::test]
+async fn columnar_edge_ingest_and_export_round_trip() {
+    use proximadb::graph::model::Edge;
+    let graph = Arc::new(GraphOperationsService::new());
+    let graph_id = "g_columnar_edges";
+    create_graph(&graph, graph_id).await;
+
+    // Edges need endpoints to exist for adjacency; create the nodes first.
+    let nodes = vec![node("a", 0), node("b", 0), node("c", 0)];
+    let node_batch = graph_codec::nodes_to_batch(&nodes).expect("encode nodes");
+    let decoded_nodes = graph_codec::batch_to_nodes(&node_batch).expect("decode nodes");
+    graph
+        .batch_create_nodes_with_strategy(graph_id, decoded_nodes, "update")
+        .await
+        .expect("create endpoint nodes");
+
+    let edge = |id: &str, from: &str, to: &str, w: Option<f64>| Edge {
+        id: id.to_string(),
+        from_node_id: from.to_string(),
+        to_node_id: to.to_string(),
+        edge_type: "KNOWS".to_string(),
+        properties: HashMap::new(),
+        weight: w,
+        created_at_ms: 0,
+        updated_at_ms: 0,
+    };
+    let originals = vec![edge("e1", "a", "b", Some(0.5)), edge("e2", "b", "c", None)];
+
+    let batch = graph_codec::edges_to_batch(&originals).expect("encode edge batch");
+    let decoded = graph_codec::batch_to_edges(&batch).expect("decode edge batch");
+    let created = graph
+        .batch_create_edges(graph_id, decoded)
+        .await
+        .expect("bulk create edges");
+    assert_eq!(created.len(), 2);
+
+    // Edge export is endpoint-scoped (the engine has no full edge scan), so
+    // read each source node's outgoing edges — the columnar `graph_edges` DoGet
+    // contract. Round-trip every fetched edge through the codec.
+    let query_from = |from: &str| proximadb::graph::EdgeQuery {
+        graph_id: graph_id.to_string(),
+        from_node_id: Some(from.to_string()),
+        to_node_id: None,
+        edge_types: vec!["KNOWS".to_string()],
+        filters: Vec::new(),
+        limit: None,
+        offset: None,
+        continuation_token: None,
+    };
+    let mut round_tripped: Vec<Edge> = Vec::new();
+    for from in ["a", "b"] {
+        let fetched = graph
+            .query_edges(graph_id, query_from(from))
+            .await
+            .expect("query edges by source");
+        assert_eq!(fetched.len(), 1, "node {from} has one outgoing KNOWS edge");
+        let fetched_edges: Vec<Edge> = fetched.iter().map(|e| (**e).clone()).collect();
+        let export = graph_codec::edges_to_batch(&fetched_edges).expect("encode fetched edges");
+        round_tripped.extend(graph_codec::batch_to_edges(&export).expect("decode fetched edges"));
+    }
+    round_tripped.sort_by(|a, b| a.id.cmp(&b.id));
+    assert_eq!(round_tripped.len(), 2);
+
+    for (orig, got) in originals.iter().zip(round_tripped.iter()) {
+        assert_eq!(orig.id, got.id);
+        assert_eq!(orig.from_node_id, got.from_node_id);
+        assert_eq!(orig.to_node_id, got.to_node_id);
+        assert_eq!(orig.edge_type, got.edge_type);
+        assert_eq!(orig.weight, got.weight);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **batched columnar graph path over Arrow Flight** — bulk node/edge ingest (`DoExchange`) and export (`DoGet`) encoded as Arrow `RecordBatch`es, routed to the live `GraphOperationsService`. Built on the neutral graph model (TD-123 Step 1).

**Dimensional cost term (network/transport):** bulk graph ingest/export is a *columnar* workload — one proto encode per node/edge over unary gRPC is the wrong shape. Per the co-design transport mandate ("route bulk/columnar work to Arrow Flight, zero-copy"), this puts it on Flight, complementing the existing per-RPC gRPC/REST surfaces. No existing surface changes — this is **additive**.

## What's added

- **`src/network/arrow_ipc/graph_codec.rs`** — the neutral-model ↔ Arrow boundary:
  - Stable **node batch** schema: `id`, `labels` (JSON), `properties` (JSON), `created_at_ms`, `updated_at_ms`, and — when present — a native **`embedding_vector: FixedSizeList<Float32, dim>`** (nullable) + `embedding_meta` (JSON). The embedding vector is kept native-columnar (zero-copy child buffer) for throughput; heterogeneous properties ride as JSON (same convention as the federated executor / `multimodel_codec`).
  - Stable **edge batch** schema: `id`, `from_node_id`, `to_node_id`, `edge_type`, `weight` (nullable), `properties` (JSON), timestamps.
  - `nodes_to_batch`/`batch_to_nodes`, `edges_to_batch`/`batch_to_edges`. 5 unit tests cover round-trip, mixed embedding-presence (null list rows), no-embedding column omission, mixed-dim rejection, and edges.
- **Flight wiring (`service.rs`):**
  - `DoExchange` types `graph_nodes` / `graph_edges` → decode each streamed batch → `batch_create_nodes_with_strategy` / `batch_create_edges` on the live engine (so rows are immediately queryable/traversable, not parked in the generic record store). Per-batch + final progress acks.
  - `DoGet` graph ticket (`{"model","graph_id",label?/edge_type?/endpoints?/limit?}`) → `query_nodes`/`query_edges` → columnar batch stream.
  - **Structural tenant isolation**: `effective_graph_id(tenant, graph_id)` mirrors the gRPC v2 graph surface — the tenant is folded into the storage key, never a per-query predicate.

## Design notes / known limits (additive follow-ups, not redesigns)

- **Edge export is endpoint-scoped.** The graph engine has no full edge scan, so `graph_edges` `DoGet` requires `from_node_id` or `to_node_id` and returns a clear error otherwise (rather than a silent empty batch).
- **Export materializes one batch.** For very large graphs the export should paginate `query_nodes` and *stream* batches; this slice returns a single batch. Tracked as a follow-up.
- **Socket-level client e2e** is a follow-up; the Flight streaming/descriptor plumbing these routes reuse (`record_batch_stream`, descriptor parse, FlightData encode) is already e2e-tested by the vector/record path. This PR covers the new logic with codec unit tests + a service-level round-trip integration test (`tests/graph_flight_columnar_test.rs`) that exercises exactly what the handlers delegate to (codec ↔ graph batch ingest/query/export through the public API).

## Verification

- `cargo check -p proximadb --lib` — green
- `cargo clippy -p proximadb --lib --bins -- -D warnings` — clean (also validates the server binary builds)
- `cargo fmt --check` — clean
- `cargo test -p proximadb --lib graph_codec` — 5/5
- `cargo test --test graph_flight_columnar_test` — 2/2 (node + edge ingest→query→export round-trips)
