### PR TITLE
chore(chunking): bump tree-sitter extras to >=0.25 / >=1.0 + record refinement TD

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -76,14 +76,14 @@ llm = [
 # load lazily on first access (see proximadb_sdk/__init__.py __getattr__).
 #   pip install 'proximadb[chunking]'
 chunking = [
-    "tree-sitter>=0.24.0",
-    "tree-sitter-language-pack>=0.13.0",
+    "tree-sitter>=0.25",
+    "tree-sitter-language-pack>=1.0",
 ]
 
 # Back-compat alias for the pre-TD-126 extra name; identical to `chunking`.
 code-chunking = [
-    "tree-sitter>=0.24.0",
-    "tree-sitter-language-pack>=0.13.0",
+    "tree-sitter>=0.25",
+    "tree-sitter-language-pack>=1.0",
 ]
 
 langchain = [

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -556,6 +556,51 @@ are the remaining transport-gen increments.
 * The Python core install is lightweight (no tree-sitter/onnx/langchain in the default dependency
   set); chunking/embeddings/integrations are separate installable packages/extras.
 
+== Chunking concern refinement (2026-06-22)
+
+Post-review cleanup of the `chunking` extra (`clients/python/.../chunking_strategies/`),
+keeping the differentiator (symbol + call/import/inheritance extraction) — fixes/cleanups,
+not a rewrite. Landed as three sequenced PRs:
+
+* *Perf + correctness (PR #196, merged):*
+** *Lazy parser init* — `CodeChunkingStrategy` no longer eager-instantiates all ~23
+   tree-sitter parsers at construction (it loaded 23 grammars to chunk one file). Parsers
+   are now built per-language on first `chunk()` and cached; unavailable grammars are
+   remembered so they are not retried. Measured: chunking one file loads exactly **1/23**
+   grammars instead of 23.
+** *Narrowed exception swallowing* — the ~20 `_init_parser` sites used
+   `except (ImportError, TypeError, Exception)`, which swallowed every error into the regex
+   fallback and hid real bugs. Now `(ImportError, OSError)` for the expected missing-grammar
+   case + a broad `except` that **logs** the unexpected failure before falling back.
+** *Honest streaming docstring* — `PipelineExecutor.process_stream`/`_async` claimed
+   "memory-efficient for large documents" but materialize the whole input + chunk list first.
+   Docstrings corrected (see deferred item below for true streaming).
+* *Dead-code removal (PR #199):* deleted the parallel parser stack in `parser_utils.py`
+  (`ParserCache`/`get_parser_cache`, `ParserPlugin`/`ParserPluginRegistry`/`get_plugin_registry`,
+  the `CFamilyParser`/`JVMFamilyParser`/`DynamicLanguageParser`/`FunctionalLanguageParser`/
+  `MarkupParser` family base classes, `with_fallback`/`cached_parser` decorators,
+  `FallbackConfig`/`FallbackStrategy`, `parser_context`/`detect_language_from_content`,
+  `UnsupportedLanguageError`/`ParserInitializationError`) — never referenced by the live path
+  (~2.2k lines incl. tests). Kept the live surface (`ParserError`/`ParseError`, the metrics
+  collector + `with_metrics`, `BaseLanguageParser`, `ConfigValidator`/`ValidationResult`).
+  Also rewired `ConfigValidator.validate_languages` off the always-empty plugin registry onto
+  the real `code.get_supported_languages()` registry. Deleted the already-broken
+  `tests/chunking/test_parser_utils.py` (imported the long-renamed `proximadb` package; failed
+  pytest collection).
+* *Dependency currency (this PR):* bumped the `chunking`/`code-chunking` extras to
+  `tree-sitter>=0.25` and `tree-sitter-language-pack>=1.0` (code uses Query-free node traversal,
+  so it is 0.25-safe — verified no `Query()`/`captures()`/`QueryCursor` usage).
+
+*Deferred (follow-up):*
+
+* *True incremental streaming* — `process_stream`/`_async` still materialize the full document
+  and chunk list (every underlying strategy is a batch API). Real constant-memory streaming
+  requires an incremental contract across all strategies; out of scope for a cleanup pass.
+* *Embedding-based semantic chunking* — a percentile-breakpoint-over-sentence-embeddings mode
+  alongside the structural `SemanticStrategy`. The SDK has embedding infra to support it, but it
+  needs an embedding-provider injection seam, sentence splitting, and factory/config wiring +
+  tests; deferred rather than risk an oversized PR.
+
 == Related
 
 * TD-121 (retire plain-SQL gRPC `ExecuteQuery` -> pgwire) — narrows the gRPC surface the SDK wraps.


### PR DESCRIPTION
## Summary
Currency + housekeeping for the chunking refinement series (stacks after #196, #199).

- **Dependency currency** — bump the `chunking` and `code-chunking` extras' floors to `tree-sitter>=0.25` and `tree-sitter-language-pack>=1.0`. The code-chunking strategy uses **Query-free node traversal** (verified: no `Query()`/`captures()`/`QueryCursor` in `code.py`), so it is 0.25-safe. No stale `tree-sitter-languages` references remain. Touches **only** the chunking extra lines in `pyproject.toml`.
- **TD-126 note** — records the full chunking-concern refinement (lazy parser init, narrowed exception swallowing, honest streaming docstring, dead parser-stack deletion, dependency currency) and the two deferred items.

## Deferred (documented in TD-126)
- **True incremental streaming** — `process_stream`/`_async` still materialize the full doc + chunk list (every strategy is a batch API); constant-memory streaming needs an incremental contract across all strategies.
- **Embedding-based semantic chunking** — percentile-breakpoint-over-sentence-embeddings mode alongside the structural `SemanticStrategy`; needs a provider-injection seam + factory/config wiring + tests. Deferred rather than ship an oversized PR.

## Tests
Behavior-neutral (deps + docs only). Chunking + code-cov suites green (**156 passed**); chunk smoke confirms lazy init loads 1/23 grammars with symbols extracted. `black` / `isort` / `ruff (E9,F63,F7)` clean.

## Scope
Python pyproject extra + roadmap doc only. Does not touch OpenAPI spec, generated transport, embeddings, or integrations sections of pyproject.