### PR TITLE
perf(py-embeddings): PR3 — ONNX backend, ST prompts, device auto-detect, LRU model cache

### DIFF
--- a/clients/python/src/proximadb_sdk/embedding_providers/core/cache.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/core/cache.py
@@ -6,19 +6,44 @@ and improve initialization performance.
 """
 
 import logging
+import os
 import threading
+from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# Default maximum number of distinct models held resident. Embedding models are
+# large (hundreds of MB to GBs each), so an unbounded cache pins memory forever
+# as different models/devices/backends are exercised. Override with the
+# PROXIMADB_MODEL_CACHE_CAPACITY env var (<= 0 disables eviction).
+_DEFAULT_CAPACITY = 4
+
+
+def _env_capacity() -> int:
+    raw = os.getenv("PROXIMADB_MODEL_CACHE_CAPACITY")
+    if raw is None:
+        return _DEFAULT_CAPACITY
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid PROXIMADB_MODEL_CACHE_CAPACITY=%r; using default %d",
+            raw,
+            _DEFAULT_CAPACITY,
+        )
+        return _DEFAULT_CAPACITY
+
 
 class ModelCache:
     """
-    Thread-safe singleton model cache
+    Thread-safe singleton model cache with LRU eviction
 
     This cache allows sharing model instances across multiple provider instances,
-    reducing memory usage and initialization time.
+    reducing memory usage and initialization time. It is capacity-bounded: the
+    least-recently-used model is evicted (and best-effort released) when the
+    capacity is exceeded, so loading many large models does not pin GBs forever.
 
     Example:
         # Provider 1
@@ -34,8 +59,9 @@ class ModelCache:
 
     _instance: Optional["ModelCache"] = None
     _lock = threading.Lock()
-    _models: dict[str, Any] = {}
-    _stats: dict[str, int] = {"hits": 0, "misses": 0, "loads": 0}
+    _models: "OrderedDict[str, Any]" = OrderedDict()
+    _stats: dict[str, int] = {"hits": 0, "misses": 0, "loads": 0, "evictions": 0}
+    _capacity: int = _env_capacity()
 
     def __new__(cls):
         """Singleton pattern"""
@@ -44,6 +70,40 @@ class ModelCache:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
         return cls._instance
+
+    def set_capacity(self, capacity: int) -> None:
+        """Set the maximum number of resident models (<= 0 disables eviction).
+
+        Evicts immediately if the new capacity is smaller than the current size.
+        """
+        with self._lock:
+            type(self)._capacity = capacity
+            self._evict_to_capacity_locked()
+
+    @property
+    def capacity(self) -> int:
+        return type(self)._capacity
+
+    def _evict_to_capacity_locked(self) -> None:
+        """Evict LRU entries until size <= capacity. Caller must hold the lock."""
+        cap = type(self)._capacity
+        if cap is None or cap <= 0:
+            return
+        while len(self._models) > cap:
+            key, model = self._models.popitem(last=False)  # LRU = oldest
+            self._stats["evictions"] += 1
+            logger.info("Evicting LRU cached model: %s", key)
+            self._release(model)
+
+    @staticmethod
+    def _release(model: Any) -> None:
+        """Best-effort release of an evicted model's resources."""
+        cleanup = getattr(model, "cleanup", None)
+        if callable(cleanup):
+            try:
+                cleanup()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Model cleanup on eviction raised: %s", exc)
 
     def get_or_load(
         self, key: str, loader: Callable[[], Any], force_reload: bool = False
@@ -72,18 +132,12 @@ class ModelCache:
                 logger.info(f"Force reloading model: {key}")
                 self._models.pop(key, None)
 
-        # Fast path: model already cached
-        if key in self._models:
-            self._stats["hits"] += 1
-            logger.debug(f"Cache hit: {key}")
-            return self._models[key]
-
-        # Slow path: load model
+        # Fast path: model already cached (refresh LRU recency under the lock).
         with self._lock:
-            # Double-check locking pattern
             if key in self._models:
                 self._stats["hits"] += 1
-                logger.debug(f"Cache hit (after lock): {key}")
+                self._models.move_to_end(key)
+                logger.debug(f"Cache hit: {key}")
                 return self._models[key]
 
             # Load model
@@ -94,6 +148,8 @@ class ModelCache:
             try:
                 model = loader()
                 self._models[key] = model
+                self._models.move_to_end(key)
+                self._evict_to_capacity_locked()
                 logger.info(f"Model loaded and cached: {key}")
                 return model
             except Exception as e:
@@ -198,7 +254,7 @@ class ModelCache:
             >>> cache.reset_stats()
         """
         with self._lock:
-            self._stats = {"hits": 0, "misses": 0, "loads": 0}
+            self._stats = {"hits": 0, "misses": 0, "loads": 0, "evictions": 0}
             logger.debug("Cache statistics reset")
 
     def __repr__(self) -> str:

--- a/clients/python/src/proximadb_sdk/embedding_providers/core/config.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/core/config.py
@@ -65,6 +65,8 @@ class ProviderConfig:
         device: Device for computation ("cpu", "cuda", "mps", None=auto-detect)
         cache_dir: Directory for caching models (None=use default)
         trust_remote_code: Whether to allow custom model code execution
+        backend: sentence-transformers compute backend ("torch" default, or
+            "onnx"/"openvino" for faster CPU inference). None = library default.
         extra: Provider-specific additional parameters
     """
 
@@ -74,6 +76,7 @@ class ProviderConfig:
     device: str | None = None
     cache_dir: str | None = None
     trust_remote_code: bool = False
+    backend: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
     def merge(self, **kwargs) -> "ProviderConfig":

--- a/clients/python/src/proximadb_sdk/embedding_providers/core/device.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/core/device.py
@@ -1,0 +1,43 @@
+"""
+Compute-device auto-detection.
+
+Makes :attr:`ProviderConfig.device` ``None`` actually mean "auto-detect" (as its
+docstring promises) instead of deferring to whatever default the underlying
+library picks. Preference order: CUDA -> Apple MPS -> CPU.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_device(device: str | None) -> str | None:
+    """Resolve a device string, auto-detecting when ``device`` is None.
+
+    Args:
+        device: Explicit device ("cpu", "cuda", "mps", ...) or None to
+            auto-detect.
+
+    Returns:
+        The resolved device string, or None if torch is unavailable (in which
+        case the caller should let the backend choose its own default).
+    """
+    if device is not None:
+        return device
+
+    try:
+        import torch
+    except ImportError:
+        # No torch (e.g. an ONNX-only install): let the backend default.
+        return None
+
+    try:
+        if torch.cuda.is_available():
+            return "cuda"
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return "mps"
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Device auto-detect fell back to CPU: %s", exc)
+
+    return "cpu"

--- a/clients/python/src/proximadb_sdk/embedding_providers/mixins/sentence_transformer.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/mixins/sentence_transformer.py
@@ -9,6 +9,7 @@ import logging
 import numpy as np
 
 from ..core.cache import ModelCache
+from ..core.device import resolve_device
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +20,10 @@ class SentenceTransformerMixin:
 
     This mixin provides:
     - Automatic model loading with caching
-    - Standard embedding generation
-    - Normalization support
-    - Batch processing
+    - Compute-device auto-detection (cuda -> mps -> cpu) when config.device is None
+    - Optional ONNX / OpenVINO backend for faster CPU inference
+    - sentence-transformers native prompt support (encode_query / encode_document)
+    - Standard embedding generation, normalization, batch processing
 
     Usage:
         class MyProvider(SentenceTransformerMixin, BaseEmbeddingProvider):
@@ -30,6 +32,15 @@ class SentenceTransformerMixin:
 
     Note:
         This mixin assumes the provider has a `config` attribute of type ProviderConfig.
+
+    Perf levers (via ProviderConfig):
+    - ``device=None`` auto-detects cuda -> mps -> cpu.
+    - ``backend="onnx"`` (or ``"openvino"``) selects a faster CPU inference
+      runtime (sentence-transformers >= 3.x). Falls back to the default torch
+      backend with a warning if the runtime is unavailable.
+    - ``extra["prompts"]`` (a ``{name: template}`` dict, e.g.
+      ``{"query": "query: ", "document": "passage: "}``) registers native ST
+      prompts so ``encode_query`` / ``encode_document`` apply them in-model.
     """
 
     def _load_model(self):
@@ -37,6 +48,8 @@ class SentenceTransformerMixin:
         Load sentence-transformer model with caching
 
         Uses ModelCache to share model instances across provider instances.
+        Honours device auto-detect, an optional onnx/openvino backend, and
+        native ST prompts.
 
         Returns:
             Loaded SentenceTransformer model
@@ -49,21 +62,79 @@ class SentenceTransformerMixin:
                 "Install with: pip install sentence-transformers"
             )
 
+        device = resolve_device(self.config.device)
+        backend = self.config.backend
+        prompts = self.config.extra.get("prompts")
+
         cache = ModelCache()
-        cache_key = f"st_{self.config.model.name}_{self.config.trust_remote_code}"
+        # Device + backend + prompts participate in identity: two providers that
+        # ask for different runtimes must NOT share a cached instance.
+        cache_key = (
+            f"st_{self.config.model.name}_{self.config.trust_remote_code}"
+            f"_{device}_{backend}_{sorted(prompts) if prompts else None}"
+        )
 
         def loader():
-            logger.info(f"Loading sentence-transformer model: {self.config.model.name}")
-            model = SentenceTransformer(
+            logger.info(
+                "Loading sentence-transformer model %s (device=%s, backend=%s)",
                 self.config.model.name,
-                device=self.config.device,
-                trust_remote_code=self.config.trust_remote_code,
-                cache_folder=self.config.cache_dir,
+                device,
+                backend or "torch",
             )
-            logger.info(f"Model loaded: {self.config.model.name}")
+            kwargs = {
+                "device": device,
+                "trust_remote_code": self.config.trust_remote_code,
+                "cache_folder": self.config.cache_dir,
+            }
+            if backend is not None:
+                kwargs["backend"] = backend
+            if prompts:
+                kwargs["prompts"] = prompts
+            try:
+                model = SentenceTransformer(self.config.model.name, **kwargs)
+            except TypeError:
+                # Older sentence-transformers without backend/prompts kwargs:
+                # retry with the universally-supported subset.
+                logger.warning(
+                    "sentence-transformers does not support backend/prompts "
+                    "kwargs; loading %s with the default torch backend.",
+                    self.config.model.name,
+                )
+                model = SentenceTransformer(
+                    self.config.model.name,
+                    device=device,
+                    trust_remote_code=self.config.trust_remote_code,
+                    cache_folder=self.config.cache_dir,
+                )
+            logger.info("Model loaded: %s", self.config.model.name)
             return model
 
         return cache.get_or_load(cache_key, loader)
+
+    def _encode_with_prompt(self, texts: list[str], prompt_name: str) -> np.ndarray:
+        """Encode using a registered native ST prompt, falling back to a plain
+        encode if the prompt was not configured."""
+        if not texts:
+            return np.array([])
+        self.ensure_initialized()
+        configured = self.config.extra.get("prompts") or {}
+        encode_kwargs = {
+            "batch_size": self.config.batch_size,
+            "normalize_embeddings": self.config.normalize,
+            "show_progress_bar": False,
+            "convert_to_numpy": True,
+        }
+        if prompt_name in configured:
+            encode_kwargs["prompt_name"] = prompt_name
+        return self._model.encode(texts, **encode_kwargs)
+
+    def encode_query(self, query: str) -> np.ndarray:
+        """Embed a query using the native ST ``query`` prompt (if configured)."""
+        return self._encode_with_prompt([query], "query")[0]
+
+    def encode_document(self, documents: list[str]) -> np.ndarray:
+        """Embed documents using the native ST ``document`` prompt (if configured)."""
+        return self._encode_with_prompt(documents, "document")
 
     def embed(self, texts: list[str]) -> np.ndarray:
         """

--- a/clients/python/tests/unit/test_emb_core_mixins_cov.py
+++ b/clients/python/tests/unit/test_emb_core_mixins_cov.py
@@ -483,7 +483,7 @@ def test_cache_reset_stats_and_repr():
     cache = ModelCache()
     cache.get_or_load("k", lambda: 1)
     cache.reset_stats()
-    assert cache.stats() == {"hits": 0, "misses": 0, "loads": 0}
+    assert cache.stats() == {"hits": 0, "misses": 0, "loads": 0, "evictions": 0}
     assert "ModelCache(" in repr(cache)
 
 
@@ -778,3 +778,208 @@ def test_st_embed_batch_no_override(monkeypatch):
     p = STProvider(config=make_config(model=make_model(dimension=384), batch_size=16))
     p.embed_batch(["x"])
     assert FakeST.last_bs == 16
+
+
+# --------------------------------------------------------------------------
+# core/device.py  (auto-detect)
+# --------------------------------------------------------------------------
+def test_resolve_device_explicit_passthrough():
+    from proximadb_sdk.embedding_providers.core.device import resolve_device
+
+    assert resolve_device("cuda") == "cuda"
+    assert resolve_device("cpu") == "cpu"
+
+
+def test_resolve_device_autodetect_prefers_cuda(monkeypatch):
+    from proximadb_sdk.embedding_providers.core import device as device_mod
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: True)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: True)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    assert device_mod.resolve_device(None) == "cuda"
+
+
+def test_resolve_device_autodetect_mps_then_cpu(monkeypatch):
+    from proximadb_sdk.embedding_providers.core import device as device_mod
+
+    # No CUDA, yes MPS -> mps
+    t1 = types.ModuleType("torch")
+    t1.cuda = types.SimpleNamespace(is_available=lambda: False)
+    t1.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: True)
+    )
+    monkeypatch.setitem(sys.modules, "torch", t1)
+    assert device_mod.resolve_device(None) == "mps"
+
+    # No CUDA, no MPS -> cpu
+    t2 = types.ModuleType("torch")
+    t2.cuda = types.SimpleNamespace(is_available=lambda: False)
+    t2.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", t2)
+    assert device_mod.resolve_device(None) == "cpu"
+
+
+def test_resolve_device_no_torch_returns_none(monkeypatch):
+    from proximadb_sdk.embedding_providers.core import device as device_mod
+
+    monkeypatch.setitem(sys.modules, "torch", None)  # import torch -> ImportError
+    assert device_mod.resolve_device(None) is None
+
+
+# --------------------------------------------------------------------------
+# sentence_transformer mixin: backend + prompts + device auto-detect
+# --------------------------------------------------------------------------
+def test_st_load_passes_backend_and_prompts(monkeypatch):
+    captured = {}
+
+    class FakeST:
+        def __init__(self, name, **kwargs):
+            captured["name"] = name
+            captured.update(kwargs)
+
+        def encode(self, texts, **kwargs):
+            captured["encode_kwargs"] = kwargs
+            return np.ones((len(texts), 384), dtype=np.float32)
+
+    monkeypatch.setattr(
+        sys.modules["sentence_transformers"], "SentenceTransformer", FakeST
+    )
+    p = STProvider(
+        config=make_config(
+            model=make_model(dimension=384, name="onnx-st"),
+            device="cpu",
+            backend="onnx",
+            extra={"prompts": {"query": "query: ", "document": "passage: "}},
+        )
+    )
+    out = p.encode_document(["d1", "d2"])
+    assert out.shape == (2, 384)
+    assert captured["backend"] == "onnx"
+    assert captured["prompts"] == {"query": "query: ", "document": "passage: "}
+    # native ST prompt routed via prompt_name on encode
+    assert captured["encode_kwargs"].get("prompt_name") == "document"
+
+
+def test_st_load_old_st_without_backend_falls_back(monkeypatch):
+    """If sentence-transformers rejects backend/prompts (older version), the
+    mixin retries with the universally supported subset."""
+    calls = {"n": 0}
+
+    class FakeST:
+        def __init__(
+            self,
+            name,
+            device=None,
+            trust_remote_code=False,
+            cache_folder=None,
+            **kwargs,
+        ):
+            calls["n"] += 1
+            if kwargs:  # first attempt passed backend/prompts -> reject
+                raise TypeError("unexpected keyword argument")
+
+        def encode(self, texts, **kwargs):
+            return np.ones((len(texts), 384), dtype=np.float32)
+
+    monkeypatch.setattr(
+        sys.modules["sentence_transformers"], "SentenceTransformer", FakeST
+    )
+    p = STProvider(
+        config=make_config(
+            model=make_model(dimension=384, name="old-st"),
+            device="cpu",
+            backend="onnx",
+        )
+    )
+    out = p.embed(["x"])
+    assert out.shape == (1, 384)
+    assert calls["n"] == 2  # first (with backend) failed, retried without
+
+
+def test_encode_query_without_prompt_is_plain(monkeypatch):
+    captured = {}
+
+    class FakeST:
+        def __init__(self, name, **kwargs):
+            pass
+
+        def encode(self, texts, **kwargs):
+            captured["encode_kwargs"] = kwargs
+            return np.ones((len(texts), 384), dtype=np.float32)
+
+    monkeypatch.setattr(
+        sys.modules["sentence_transformers"], "SentenceTransformer", FakeST
+    )
+    # No prompts configured -> encode_query must NOT pass prompt_name.
+    p = STProvider(config=make_config(model=make_model(dimension=384), device="cpu"))
+    p.encode_query("hello")
+    assert "prompt_name" not in captured["encode_kwargs"]
+
+
+# --------------------------------------------------------------------------
+# core/cache.py: LRU eviction + capacity
+# --------------------------------------------------------------------------
+def test_cache_lru_eviction_evicts_oldest():
+    cache = ModelCache()
+    cache.set_capacity(2)
+    try:
+        cache.get_or_load("a", lambda: "A")
+        cache.get_or_load("b", lambda: "B")
+        # touch "a" so "b" becomes LRU
+        cache.get_or_load("a", lambda: "A")
+        cache.get_or_load("c", lambda: "C")  # exceeds cap -> evict LRU ("b")
+        assert set(cache.keys()) == {"a", "c"}
+        assert cache.stats()["evictions"] == 1
+    finally:
+        cache.set_capacity(4)
+        cache.clear()
+
+
+def test_cache_set_capacity_shrinks_immediately():
+    cache = ModelCache()
+    cache.set_capacity(4)
+    try:
+        for k in ("a", "b", "c"):
+            cache.get_or_load(k, lambda k=k: k.upper())
+        cache.set_capacity(1)
+        assert len(cache.keys()) == 1
+        # most-recently-used survives
+        assert cache.keys() == ["c"]
+    finally:
+        cache.set_capacity(4)
+        cache.clear()
+
+
+def test_cache_capacity_zero_disables_eviction():
+    cache = ModelCache()
+    cache.set_capacity(0)
+    try:
+        for k in ("a", "b", "c", "d", "e"):
+            cache.get_or_load(k, lambda k=k: k.upper())
+        assert len(cache.keys()) == 5
+    finally:
+        cache.set_capacity(4)
+        cache.clear()
+
+
+def test_cache_eviction_releases_model():
+    cache = ModelCache()
+    cache.set_capacity(1)
+    released = {"n": 0}
+
+    class _Model:
+        def cleanup(self):
+            released["n"] += 1
+
+    try:
+        cache.get_or_load("a", _Model)
+        cache.get_or_load("b", _Model)  # evicts "a", calls a.cleanup()
+        assert released["n"] == 1
+    finally:
+        cache.set_capacity(4)
+        cache.clear()

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -542,6 +542,72 @@ ops). The remaining open Phase-4 language is **jvm**; closing it + generating th
 are the remaining transport-gen increments.
 ====
 
+[NOTE]
+.Embeddings concern refinement — provider currency + perf levers (2026-06-22) — Python
+====
+A 3-PR sequence refining `clients/python/.../embedding_providers` (+ `llm/`) against current
+dependency versions. The good `core/` design (config / registry / cache / mixins, lazy thread-safe
+init, float32-out + server-side-quantization contract) was kept; only the providers, registry
+guard, mixin, cache, and their tests changed. The OpenAPI spec, generated transport, and the
+chunking / integration concerns were untouched.
+
+*PR #197 — P0 broken-against-current.*
+
+* *OpenAI provider was broken on `openai` 2.x.* `openai_provider.py` used the pre-1.0 API removed
+  Nov 2023 (`openai.api_key=`, `client.Embedding.create(...)`, dict `response["data"]`) →
+  `AttributeError`. Rewritten onto `OpenAI()` + `client.embeddings.create` +
+  `response.data[i].embedding` (mirroring the already-correct `llm/embedding.py`), with the
+  Matryoshka `dimensions` param for `text-embedding-3-*` and index-ordered result parsing.
+* *OpenAI-compatible `/v1` drop.* `urljoin(api_base=".../v1", "/embeddings")` discarded `/v1`;
+  fixed via `_embeddings_url()` (regression-tested).
+* *E5 passage-prefix regression.* `E5Provider.embed_passages` now prepends the mandatory
+  `"passage: "` prefix (the generic `InstructionMixin` left documents unprefixed → silent recall
+  degradation on E5's asymmetric query/passage scheme).
+* *Cloud providers were unreachable.* `get_provider('openai'|'cohere'|'fastembed')` raised
+  `ValueError` (they subclassed the legacy base, not registered). OpenAI / Cohere / FastEmbed /
+  OpenAI-compatible were ported onto `core.BaseEmbeddingProvider` + `@ProviderRegistry.register`;
+  `recommend_free_providers()` messaging corrected. Cohere modernized onto `cohere.ClientV2`
+  (`embedding_types=['float']`, `response.embeddings.float`).
+
+*PR #201 — currency + dedup.*
+
+* `pyproject` bumped `sentence-transformers>=2.2.0` → `>=3.2,<6` (current 5.x) across the
+  embeddings / llm / dev / test extras; added an opt-in `embeddings-cloud` extra
+  (`openai>=2`, `cohere>=5`, `fastembed>=0.3`).
+* Deleted dead scaffolding (`__init__new.py`, `providers/local/gte_qwen_new.py`,
+  `providers/testing/simulated_new.py`) that re-registered LIVE primary names and was never wired
+  into `__init__`. Added a *primary-name collision guard* to `ProviderRegistry.register` (duplicate
+  primary name now raises instead of silently overwriting; idempotent same-class re-import allowed).
+
+*PR #203 — P2 perf levers (local sentence-transformers path).*
+
+* ONNX / OpenVINO backend via a new `ProviderConfig.backend` flag (~2-4x CPU inference), with a
+  graceful fallback to the torch backend on older sentence-transformers.
+* Native ST `prompts` / `prompt_name` (v2.4+) support with `encode_query` / `encode_document`,
+  alongside the existing `InstructionMixin`.
+* Device auto-detect (`core/device.resolve_device`): `device=None` now means cuda → mps → cpu.
+* Capacity-bounded LRU model cache (`PROXIMADB_MODEL_CACHE_CAPACITY`, default 4; best-effort
+  release on eviction; key includes device + backend + prompts).
+
+*Deferred (follow-up).*
+
+* *System-B base-overlay collapse.* The orphaned legacy overlay — the `embedding_providers/base.py`
+  shim plus the root-level duplicate providers (`bge`, `e5`, `sfr`, `sentence_transformer`,
+  `finbert_provider`, `multi_bert_provider`, `instructor`) and the `embedding_interface`
+  `EmbeddingProvider`/`EmbeddingConfig` duplicate-provider stack (~2500 LOC, only exercised by
+  `*_cov` tests, no live importers in `src` except the chunking concern's use of
+  `embedding_interface`) — should be deleted/collapsed onto `core.BaseEmbeddingProvider`. Deferred
+  as its own PR because `instructor`/`finbert`/`multi_bert` still ride the legacy base and
+  `embedding_interface` is referenced by the chunking concern; bundling it risked an oversized,
+  cross-concern PR.
+* *Embedding-provider DI seam for semantic chunking* — see the chunking "Deferred" item above.
+
+*Test isolation.* Same pre-existing hazard noted above: `test_emb_providers_local_cov` stubs
+`sentence_transformers` in `sys.modules`, which leaks to the real-model `requires_models`
+`TestGTEQwenProvider` tests when the whole embedding suite runs in one process. They pass per-file /
+under CI process isolation; reproduced on a clean tree, so unrelated to these PRs.
+====
+
 == Scope / non-goals
 
 * The `*-embedded` SDKs (maturin/FFI in-process) are NOT spec-generated — they stay hand-written.


### PR DESCRIPTION
## PR 3 of 3 — P2 perf levers (follows #197, #201, both merged)

Co-design framing: these levers target the **local compute-per-modality** dimension (CPU inference cost) and **cache** memory footprint — not the I/O spine — and are all inert by default.

### What changed
- **ONNX / OpenVINO backend** (`mixins/sentence_transformer.py` + new `ProviderConfig.backend` flag): `backend='onnx'` (or `'openvino'`) selects a faster CPU runtime (sentence-transformers >= 3.x) — the biggest single CPU-inference win (~2-4x). Falls back to the default torch backend with a warning on older sentence-transformers.
- **Native ST prompts**: `_load_model` registers `extra['prompts']` (`{name: template}`) and adds `encode_query`/`encode_document` that pass `prompt_name`, using sentence-transformers' in-model prompt support (v2.4+) alongside the existing hand-rolled `InstructionMixin`.
- **Device auto-detect** (new `core/device.resolve_device`): `device=None` now actually means cuda -> mps -> cpu (fulfilling `config.py`'s docstring). Returns None when torch is absent so an ONNX-only install lets the backend choose.
- **Capacity-bounded model cache** (`core/cache.py`): `ModelCache` is now LRU (OrderedDict) with a default 4-model cap (`PROXIMADB_MODEL_CACHE_CAPACITY` env override; <=0 disables). Eviction best-effort releases the model via `model.cleanup()`. The cache key now includes device+backend+prompts so distinct runtimes never share an instance.

### Gates
- Embedding cov suites green per-file (core+mixins 69 passed incl. +11 new; v2 25; local 25). black/isort/ruff(E9,F63,F7)/py_compile clean.
- New tests: `resolve_device` (cuda/mps/cpu/no-torch), ST backend+prompts load + old-ST fallback + plain `encode_query`, LRU eviction/capacity/release.

### Note on local test isolation
The 4 `TestGTEQwenProvider` real-model tests fail only when the whole embedding suite is run in ONE process (a pre-existing hazard: `test_emb_providers_local_cov` stubs `sentence_transformers` in `sys.modules`, which leaks to the real-model tests). They pass per-file / under process isolation (CI). Confirmed unrelated to this change (reproduced on a clean tree).