### PR TITLE
feat(py-sdk): explicit async integration paths + TD-126 refinement record (P2)

### DIFF
--- a/clients/python/src/proximadb_sdk/integrations/haystack.py
+++ b/clients/python/src/proximadb_sdk/integrations/haystack.py
@@ -37,6 +37,7 @@ Example::
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from typing import Any, cast
 
@@ -431,6 +432,22 @@ class ProximaDBRetriever:
             filters=filters if filters is not None else self._filters,
         )
         return {"documents": results[0] if results else []}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query_embedding: list[float],
+        top_k: int | None = None,
+        filters: dict[str, Any] | None = None,
+    ) -> dict[str, list[Document]]:
+        """Async variant of :meth:`run` for Haystack's ``AsyncPipeline``.
+
+        The ProximaDB SDK client is synchronous, so the blocking retrieval is
+        offloaded to a worker thread to keep the event loop responsive.
+        """
+        return await asyncio.to_thread(
+            self.run, query_embedding, top_k=top_k, filters=filters
+        )
 
     def retrieve(self, query_embedding: list[float]) -> list[Document]:
         """Backward-compatible retrieve returning a plain list of documents."""

--- a/clients/python/src/proximadb_sdk/integrations/langchain.py
+++ b/clients/python/src/proximadb_sdk/integrations/langchain.py
@@ -24,6 +24,7 @@ Example::
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -160,6 +161,78 @@ class ProximaDBVectorStore(VectorStore):
             )
 
         return docs_and_scores
+
+    # ------------------------------------------------------------------
+    # Async API
+    #
+    # The ProximaDB SDK client is synchronous, so these offload the blocking
+    # calls to a worker thread via ``asyncio.to_thread`` rather than relying on
+    # ``VectorStore``'s default executor wrappers. This keeps the event loop
+    # responsive and gives explicit, documented async entry points for the
+    # async retriever path (``as_retriever().ainvoke``) and async chains.
+    # ------------------------------------------------------------------
+
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict[str, Any]] | None = None,
+        *,
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Async embed texts and insert them into ProximaDB."""
+        return await asyncio.to_thread(
+            self.add_texts, texts, metadatas=metadatas, ids=ids, **kwargs
+        )
+
+    async def adelete(self, ids: list[str] | None = None, **kwargs: Any) -> bool | None:
+        """Async delete vectors by ID."""
+        return await asyncio.to_thread(self.delete, ids, **kwargs)
+
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> list[Document]:
+        """Async return documents most similar to the query string."""
+        results = await self.asimilarity_search_with_score(query, k=k, **kwargs)
+        return [doc for doc, _ in results]
+
+    async def asimilarity_search_with_score(
+        self,
+        query: str,
+        k: int = 4,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        """Async return documents most similar to the query with scores."""
+        query_vector = await asyncio.to_thread(self._embedding.embed_query, query)
+        return await self.asimilarity_search_by_vector_with_score(
+            query_vector, k=k, **kwargs
+        )
+
+    async def asimilarity_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = 4,
+        **kwargs: Any,
+    ) -> list[Document]:
+        """Async return documents most similar to the given embedding vector."""
+        results = await self.asimilarity_search_by_vector_with_score(
+            embedding, k=k, **kwargs
+        )
+        return [doc for doc, _ in results]
+
+    async def asimilarity_search_by_vector_with_score(
+        self,
+        embedding: list[float],
+        k: int = 4,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        """Async return documents and scores for the given embedding vector."""
+        return await asyncio.to_thread(
+            self.similarity_search_by_vector_with_score, embedding, k=k, **kwargs
+        )
 
     @classmethod
     def from_texts(

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -667,6 +667,67 @@ not a rewrite. Landed as three sequenced PRs:
   needs an embedding-provider injection seam, sentence splitting, and factory/config wiring +
   tests; deferred rather than risk an oversized PR.
 
+== Integrations concern refinement (2026-06-22)
+
+Post-review cleanup of the framework integrations
+(`clients/python/.../integrations/`) — fixing adapters that were broken or stale
+against current stable framework versions. Fixes/cleanups, not a rewrite. Landed
+as three sequenced PRs.
+
+* *P0 — dead-on-load fixes (PR #202, merged):*
+** *LangGraph* — `from langchain_core.tools import create_retriever_tool` raised
+   `ImportError`; corrected to the canonical, version-stable
+   `langchain_core.tools.retriever` submodule (works on 0.3.x + 1.x; the
+   `langchain.tools.retriever` shim was removed in 1.x). Integration was
+   dead-on-arrival before this.
+** *Haystack* — the `DuplicatePolicy.FAIL` write path called
+   `client.get_vectors(...)`, which the SDK does not expose (`AttributeError` on
+   every default `write_documents`). Replaced with a `_record_exists()` helper
+   backed by the real `get_vector()` get-by-id API.
+** *LlamaIndex* — `ProximaDBVectorStore(BasePydanticVectorStore)` assigned
+   undeclared private attrs on a Pydantic v2 model (raised on construction with
+   current `llama-index-core`); now declared as `PrivateAttr`. Switched to
+   `TextNode` (the `Node` alias was removed) + `BaseNode.get_content()`, called
+   `super().__init__()` in the retriever, and added async `aquery()`.
+** Hardened `test_integrations_frameworks_cov` (new submodule stub + order-
+   independent langgraph test).
+* *P1 — currency/correctness (PR #204, merged):*
+** *AutoGen* — the module reimplemented AutoGen *0.2's* `VectorDB` abstraction
+   (removed in the 0.4 rewrite) and `get_docs_by_ids` returned empty-content
+   stubs. Added `ProximaDBMemory` implementing the 0.4
+   `autogen_core.memory.Memory` protocol (the canonical 0.4 RAG seam), re-scoped
+   `ProximaDBVectorDB` as an explicit standalone 0.2-shaped helper (fixed the
+   overclaiming docstring), and fixed `get_docs_by_ids` to fetch real records via
+   `get_vector` (skip missing ids, no empty stubs).
+** *Haystack `filter_documents`* — replaced the fake dummy-zero-vector ANN
+   (`top_k=10000`) with real Haystack 2.x filter-tree conversion (AND/OR/NOT,
+   `meta.` prefix stripped) pushed down as a server-side metadata predicate over a
+   bounded, configurable window; made `ProximaDBRetriever` a proper Haystack 2.x
+   `@component`.
+** *Floors* — `langchain-core>=0.3`, `langgraph>=1.0`, `llama-index-core>=0.12`,
+   `crewai>=1.0`, `dspy>=3.0`; `autogen-agentchat>=0.4` retained.
+* *P2 — async (PR #205):* explicit async paths offloading the sync SDK client to a
+  worker thread via `asyncio.to_thread`: LangChain `aadd_texts` / `adelete` /
+  `asimilarity_search(_with_score)` / `asimilarity_search_by_vector(_with_score)`
+  (the async retriever `ainvoke` flows through these); Haystack
+  `ProximaDBRetriever.run_async` for `AsyncPipeline`. LlamaIndex `aquery` shipped
+  in P0.
+
+*Not changed (idiomatic, only stale floors bumped in P1):* LangChain, CrewAI,
+DSPy adapters.
+
+*Deferred (follow-up):*
+
+* *Pure metadata scan for Haystack `filter_documents`* — the SDK has no
+  vector-free scan endpoint, so the filter predicate is evaluated over a bounded
+  retrieval window (`max_filter_window`, default 10000) using a constant probe
+  vector. A true unbounded metadata-only scan needs a server-side scan API
+  (out of scope for an integration cleanup).
+* *Native async SDK client* — these async paths thread-offload a synchronous
+  client. A genuinely async transport (`unified_client_async` currently only
+  covers graph ops) would let the integrations await real async I/O instead of a
+  worker thread; tracked as a transport-layer follow-up.
+
 == Related
 
 * TD-121 (retire plain-SQL gRPC `ExecuteQuery` -> pgwire) — narrows the gRPC surface the SDK wraps.


### PR DESCRIPTION
## Summary

P2 (final) of the integration-refinement series (follows #202, #204). Adds explicit async paths where the framework supports them, and records the whole refinement in TD-126.

The ProximaDB SDK client is synchronous, so these offload the blocking calls to a worker thread via `asyncio.to_thread` — giving explicit, documented async entry points rather than relying on framework executor-default wrappers.

### LangChain (`langchain.py`)
Override `aadd_texts` / `adelete` / `asimilarity_search` / `asimilarity_search_with_score` / `asimilarity_search_by_vector` / `asimilarity_search_by_vector_with_score`. The async retriever path (`as_retriever().ainvoke`) now flows through these.

### Haystack (`haystack.py`)
Add `ProximaDBRetriever.run_async` for Haystack's `AsyncPipeline`.

### LlamaIndex
`aquery` shipped in the P0 fix (#202).

### Docs
Recorded the full integrations refinement (P0/P1/P2 + deferrals) as an "Integrations concern refinement" section in `TD_126_SDK_SPEC_DRIVEN_MODULARIZATION`, mirroring the existing chunking-refinement record.

## Verification
- LangChain async round-trips live against `langchain-core` 1.4 (aadd_texts / asimilarity_search / by_vector / adelete / async retriever ainvoke).
- Haystack `run_async` verified via real-API stubs.
- Gates: black / isort / ruff (E9,F63,F7) / py_compile clean; integration unit tests pass.

## Notes
- The "Validate Workspace Layering" job fails on a pre-existing Rust break (`proximadb-distance-kernel -> proximadb-runtime-common`) present on clean develop — inherited, unrelated. Required `CI Success` is the merge gate.
- Full Python SDK Tests run at the dev->qa MEDIUM tier (`extensive`); the feat->develop LIGHT tier runs Python Lint, which passes. Tests verified locally.