### PR TITLE
docs(design): quantization-kernel split (design-before-extract)

### DIFF
--- a/docs/12-design/QUANTIZATION_KERNEL_SPLIT_2026_06_22.adoc
+++ b/docs/12-design/QUANTIZATION_KERNEL_SPLIT_2026_06_22.adoc
@@ -1,0 +1,155 @@
+= Quantization Kernel Split — Design (decomposition contracts step 2)
+:toc:
+:icons: font
+2026-06-22
+
+== Status
+
+PROPOSED — design-before-extract. Gates the `proximadb-quantization-kernel`
+extraction. Companion to
+`STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc` (the cost-spine
+contracts) and `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc` (the program).
+
+== Context
+
+Root-crate decomposition step 2 (compute kernels). Already shipped, in order:
+
+* `proximadb-hardware-caps` (#180) — GPU detection inverted via a registration hook.
+* `proximadb-distance-kernel` (#194) — `distance_computation` (6310 LOC), GPU
+  accelerator inverted via `register_gpu_accelerator_factory`. Clean: only 4
+  external `crate::` refs, all repointable/invertible.
+
+The contracts ADR sequenced `distance-kernel -> quantization-kernel ->
+quantized-distance`. `distance-kernel` is now a foundation crate, so the
+`quantization -> distance` layering edge is resolvable. **But measurement shows
+`quantization` is NOT a clean leaf** — it is the hot, coordinated boundary the
+decomposition plan reserves for last. This document specifies the split so the
+extraction can proceed safely (and incrementally) rather than as a flag-day.
+
+== Measured coupling (2026-06-22)
+
+`src/compute/quantization/` is 6584 LOC across 11 files. Coupling into the
+root's higher layers (storage / core) is concentrated in 4 files; the other 7
+(~2.7K LOC) are clean but **internally depend on the coupled core file**
+(`storage_engine.rs` uses `super::quantization_engine`), so no clean subset can
+be peeled off in isolation.
+
+[cols="2,2,3a",options="header"]
+|===
+| Coupling | File(s) | Severity / nature
+
+| `storage::traits::{QuantizationLevel, QuantizationType, ParsedQuantizationConfig}`
+| `quantization_engine.rs` (2746 LOC)
+| **Config types** used by 19–39 files repo-wide. CRUX: these are *duplicated* —
+  canonical versions already live in `proximadb-quantization-types`
+  (`QuantizationType`, `QuantizationLevel`, `ParsedQuantizationConfig`). The
+  storage::traits copies are a proliferation to reconcile, not a new type to move.
+
+| `storage::traits::FlushParameters`
+| `selection.rs` (368 LOC)
+| Used by **70 files**. A storage *flush* concept — it does NOT belong in a
+  quantization kernel. Its presence marks `selection.rs` as storage **glue**, not
+  kernel. Out of scope for relocation.
+
+| `storage::cache::orchestrator::{CacheType, CrossCacheOrchestrator}`
+| `global_cache.rs` (855 LOC)
+| **Behavioral** dependency on the storage cache orchestrator. Cannot live in a
+  foundation crate.
+
+| `core::Collection`
+| `precompute.rs` (446 LOC)
+| **Behavioral** dependency on a core domain type.
+|===
+
+Contrast: hw_caps had 2 refs, distance-kernel 4 (all narrow + an invertible GPU
+hook). Quantization has wide config-type duplication (19–70 consumers) plus two
+behavioral upward deps. This is why it is sequenced last.
+
+== Target architecture
+
+Three destinations, mirroring the contracts ADR's "kernel crate + storage
+`compute_bridge` + thin facade" shape:
+
+. **`proximadb-quantization-kernel`** (new foundation crate) — the pure kernel:
+  the SQ8 / PQ / RaBitQ encode·decode math, codebook store, the turboquant store
+  registry, and the in-memory quantized-storage engine. Depends ONLY on
+  `proximadb-distance-kernel` (the resolved quant->distance layering),
+  `proximadb-quantization-types` (canonical config), and `proximadb-vector`. No
+  `storage`, no `core`.
+
+. **`src/storage/compute_bridge/`** (stays in the root, in the storage layer) —
+  the glue that legitimately needs storage/core:
+  ** `global_cache.rs` → uses `CrossCacheOrchestrator` (storage cache).
+  ** `precompute.rs` → uses `core::Collection`.
+  ** `selection.rs` → uses `FlushParameters` (flush-driven codec selection).
+  ** the storage-config *parsing* portions of `quantization_engine.rs` (whatever
+     consumes the storage::traits config structs before handing the kernel a
+     canonical config).
+
+. **`src/compute/quantization`** → thin facade re-exporting the kernel (so the
+  existing `crate::compute::quantization::*` consumers stay unchanged, same as the
+  `distance_computation` shim).
+
+=== The boundary (the crux): canonicalize the config types
+
+The kernel must speak `proximadb-quantization-types` config
+(`ParsedQuantizationConfig` / `QuantizationType` / `QuantizationLevel`). The
+storage::traits duplicates must be **reconciled onto the canonical types** (a
+proliferation fix), with conversion at the storage boundary where the two genuinely
+differ (e.g. the storage `QuantizationLevel` is a *struct*, the canonical one an
+*enum* — these must be unified or an explicit `From` provided). `FlushParameters`
+is NOT reconciled — it stays a storage type; only the kernel-relevant fields cross
+the boundary as kernel-native inputs.
+
+This is the same "slim DTO converted at the boundary, isolation is structural"
+principle the index contract uses for `AxisHybridQuery`.
+
+== Sequence (each step its own PR; verify green before opening)
+
+[cols="1,4,2",options="header"]
+|===
+| Step | Work | Risk
+
+| Q1
+| **Reconcile the duplicated quant-config types** onto `proximadb-quantization-types`
+  (canonicalize `QuantizationType`/`QuantizationLevel`/`ParsedQuantizationConfig`;
+  add `From`/`Into` where storage's shape differs; storage::traits re-exports or
+  converts). Do NOT touch `FlushParameters`.
+| **HOT** — touches 19–39 consumers incl. storage::traits (engine sessions).
+  Needs an announced window per the plan's coordination protocol.
+
+| Q2
+| **Move the glue** (`global_cache.rs`, `precompute.rs`, `selection.rs`, and the
+  storage-config-parsing parts of `quantization_engine.rs`) into
+  `src/storage/compute_bridge/`. Kernel-facing surface is left behind.
+| Medium — storage-internal, but interacts with the cache + flush paths.
+
+| Q3
+| **Extract the pure kernel** → `proximadb-quantization-kernel` (git mv the
+  remaining files; `src/compute/quantization` becomes the re-export facade; register
+  the crate; mirror `gpu` + `experimental-turboquant` features). Resolve the
+  quant->distance layering by depending on `proximadb-distance-kernel`.
+| Low once Q1/Q2 land — mechanical, like distance-kernel.
+|===
+
+== Coordination
+
+Step Q1 edits `storage::traits` config types used across 19–39 files that 5+
+engine sessions actively touch. Per `ROOT_CRATE_DECOMPOSITION_PLAN`'s coordination
+protocol this is an **announced-window** change, not a solo opportunistic PR. Q2/Q3
+are low-conflict once Q1 lands. `FlushParameters` (70 files) is explicitly excluded
+to keep the blast radius bounded.
+
+== Non-goals
+
+* Relocating `FlushParameters` or any storage flush type.
+* The `quantized-distance` layer (a later kernel crate per the contracts ADR).
+* The index traits / per-engine DIP adoption (the separate, also-coordinated step).
+
+== Why now / why a doc first
+
+The two prior step-2 extractions (hw_caps, distance-kernel) were clean foundation
+moves verifiable solo. Quantization is the first that crosses into hot, multi-session
+storage interfaces. Writing the split + boundary contract first lets the engine
+sessions review the config-type reconciliation (Q1) before any code moves, per the
+co-design mandate (treat the boundary as the contract).


### PR DESCRIPTION
## Summary
Decomposition step 2's `quantization-kernel` is **not** a clean foundation leaf like `hardware-caps` (#180) or `distance-kernel` (#194). This doc records the measured coupling and specifies the split **before** any code moves (design-before-extract), so the engine sessions can review the config-type reconciliation first.

## Why a doc, not a PR
Measured coupling in `src/compute/quantization` (6584 LOC):
- `storage::traits::{QuantizationLevel, QuantizationType, ParsedQuantizationConfig}` — used by **19–39 files**, and **duplicated** against the canonical `proximadb-quantization-types`.
- `storage::traits::FlushParameters` — **70 files**, a storage flush type (stays in storage).
- `storage::cache::orchestrator::CrossCacheOrchestrator` (global_cache.rs) + `core::Collection` (precompute.rs) — behavioral upward deps.
- The "clean" files internally depend on the coupled `quantization_engine.rs`, so no subset peels off cleanly.

This is the hot, multi-session boundary the decomposition plan reserves for a coordinated, announced window.

## The plan (3 sequenced PRs)
1. **Q1** reconcile the duplicated quant-config types onto `proximadb-quantization-types` (HOT — coordinated).
2. **Q2** move glue (cache/Collection/flush-selection) → `src/storage/compute_bridge`.
3. **Q3** extract the pure kernel → `proximadb-quantization-kernel` (deps: distance-kernel + quantization-types + vector).

Companion to `STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc`. No code changes.