### PR TITLE
feat(grpc): TD-121 — tenant-scoped relational SELECT over gRPC SQL (reads)

### DIFF
--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -2004,16 +2004,17 @@ pub mod proxima_record_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
-        /// vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
-        /// in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
-        /// this is the token-authenticated SQL path. NOTE: this RPC routes through the
-        /// legacy unified query engine and does NOT execute relational table SQL
-        /// (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
-        /// execution not yet supported". Full relational SQL is *pgwire-only* (the
-        /// tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
-        /// tracked future work. For bulk columnar results prefer Arrow Flight; for
-        /// UQL/AQL/Federated (non-SQL) use /api/v2/query.
+        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL. gRPC
+        /// carries bearer/JWT in request metadata, which pgwire (Postgres-native
+        /// password/MD5) cannot — so this is the token-authenticated SQL path. Serves
+        /// vector/graph-extension queries (e.g. VECTOR_SEARCH) AND tenant-scoped
+        /// relational SELECT reads (SELECT/JOIN/aggregate over CREATE TABLE), which
+        /// route through the SAME relational pipeline pgwire uses (ComputeScheduler →
+        /// DataFusion/Volcano) with the request tenant from `x-tenant-id` scoping every
+        /// read to the tenant's partition (TD-064). Relational DDL/DML (CREATE/INSERT/
+        /// UPDATE/DELETE) over this RPC is not yet wired — use pgwire for writes. For
+        /// bulk columnar results prefer Arrow Flight; for UQL/AQL/Federated (non-SQL)
+        /// use /api/v2/query.
         pub async fn execute_query(
             &mut self,
             request: impl tonic::IntoRequest<super::V2QueryRequest>,
@@ -2202,16 +2203,17 @@ pub mod proxima_record_service_server {
             tonic::Response<super::V2DeleteCollectionResponse>,
             tonic::Status,
         >;
-        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
-        /// vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
-        /// in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
-        /// this is the token-authenticated SQL path. NOTE: this RPC routes through the
-        /// legacy unified query engine and does NOT execute relational table SQL
-        /// (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
-        /// execution not yet supported". Full relational SQL is *pgwire-only* (the
-        /// tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
-        /// tracked future work. For bulk columnar results prefer Arrow Flight; for
-        /// UQL/AQL/Federated (non-SQL) use /api/v2/query.
+        /// SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL. gRPC
+        /// carries bearer/JWT in request metadata, which pgwire (Postgres-native
+        /// password/MD5) cannot — so this is the token-authenticated SQL path. Serves
+        /// vector/graph-extension queries (e.g. VECTOR_SEARCH) AND tenant-scoped
+        /// relational SELECT reads (SELECT/JOIN/aggregate over CREATE TABLE), which
+        /// route through the SAME relational pipeline pgwire uses (ComputeScheduler →
+        /// DataFusion/Volcano) with the request tenant from `x-tenant-id` scoping every
+        /// read to the tenant's partition (TD-064). Relational DDL/DML (CREATE/INSERT/
+        /// UPDATE/DELETE) over this RPC is not yet wired — use pgwire for writes. For
+        /// bulk columnar results prefer Arrow Flight; for UQL/AQL/Federated (non-SQL)
+        /// use /api/v2/query.
         async fn execute_query(
             &self,
             request: tonic::Request<super::V2QueryRequest>,

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -80,13 +80,14 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 | Supported
 
 | *gRPC `proximadb.v2.ProximaRecordService.ExecuteQuery`*
-| *SQL with vector/graph extensions* (e.g. `VECTOR_SEARCH`), via the legacy
-  unified query engine — *not* relational table SQL.
+| *SQL with vector/graph extensions* (e.g. `VECTOR_SEARCH`) *and tenant-scoped
+  relational SELECT reads* (`SELECT`/`JOIN`/aggregate over `CREATE TABLE`).
 | Token/SSO-authenticated programmatic queries: gRPC carries bearer/JWT in
-  metadata (pgwire cannot) and uses HTTP/2 + protobuf. Relational
-  `SELECT/JOIN/aggregate` over `CREATE TABLE` is *not* executed here (returns
-  "Relational execution not yet supported") — use pgwire for those.
-| Supported (vector/graph SQL; relational is pgwire-only)
+  metadata (pgwire cannot) and uses HTTP/2 + protobuf. Relational SELECTs route
+  through the same pipeline as pgwire (ComputeScheduler → DataFusion/Volcano),
+  scoped to the `x-tenant-id` tenant (TD-064). Relational *DDL/DML*
+  (CREATE/INSERT/UPDATE/DELETE) is not yet wired here — use pgwire for writes.
+| Supported (vector/graph SQL + relational SELECT; relational DDL/DML is pgwire-only)
 
 | *REST/gRPC `/api/v2/query`* (unified query port)
 | *UQL* (unified multi-modal), *Federated* SQL extensions, *AQL*
@@ -119,17 +120,16 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 ====
 * pgwire is *SQL-only* and cannot serve UQL/AQL/Cypher; those non-SQL languages require the
   unified query port (`/api/v2/query`) or the graph service — they are not replaceable by pgwire.
-* SQL is served by *two surfaces with different capabilities* (TD-121), not one. *pgwire* is the
-  *only* full relational SQL surface — it lowers through `ComputeScheduler::route_select`
-  (DataFusion/Volcano) with *tenant-scoped* relational execution (TD-064), and serves the
-  PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth). The gRPC
-  `ProximaRecordService.ExecuteQuery` RPC is *token/SSO-authenticated* (bearer/JWT in metadata,
-  which pgwire's password/MD5 auth cannot carry) but routes through the *legacy unified query
-  engine*: it serves vector/graph-extension SQL (e.g. `VECTOR_SEARCH`) and *does not* execute
-  relational table SQL (returns "Relational execution not yet supported"). It is *not* deprecated.
-  Making gRPC SQL a full SSO relational surface (route it through the pgwire relational pipeline
-  with the request tenant threaded) is tracked future work. For large columnar result sets prefer
-  Arrow Flight.
+* SQL is served by *two surfaces with different capabilities* (TD-121), not one. *pgwire* serves
+  the PostgreSQL ecosystem (psql/JDBC/BI/ORM, Postgres-native auth) and is the surface for
+  full relational SQL incl. DDL/DML. The gRPC `ProximaRecordService.ExecuteQuery` RPC is
+  *token/SSO-authenticated* (bearer/JWT in metadata, which pgwire's password/MD5 auth cannot
+  carry) and serves vector/graph-extension SQL (e.g. `VECTOR_SEARCH`) plus *tenant-scoped
+  relational SELECT reads*: relational SELECTs route through the *same* pipeline pgwire uses
+  (`ComputeScheduler::route_select` → DataFusion/Volcano) with the `x-tenant-id` tenant scoping
+  every read (TD-064). Relational *DDL/DML* (CREATE/INSERT/UPDATE/DELETE) over gRPC SQL is not yet
+  wired — use pgwire for writes (tracked future work). It is *not* deprecated. For large columnar
+  result sets prefer Arrow Flight.
 * *Apache Calcite*, if adopted, is an *internal* federated-SQL planner behind pgwire and the
   Federated path — not a client surface, and not a substitute for the non-SQL languages.
 * SSO/governance (auth, RLS, tenancy) is enforced uniformly at the `TenantContext` I/O boundary,

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -813,16 +813,17 @@ service ProximaRecordService {
   rpc ListCollections(V2ListCollectionsRequest) returns (V2ListCollectionsResponse);
   rpc DeleteCollection(V2DeleteCollectionRequest) returns (V2DeleteCollectionResponse);
 
-  // SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL for
-  // vector/graph-extension queries (e.g. VECTOR_SEARCH). gRPC carries bearer/JWT
-  // in request metadata, which pgwire (Postgres-native password/MD5) cannot — so
-  // this is the token-authenticated SQL path. NOTE: this RPC routes through the
-  // legacy unified query engine and does NOT execute relational table SQL
-  // (SELECT/JOIN/aggregate over CREATE TABLE) — those return "Relational
-  // execution not yet supported". Full relational SQL is *pgwire-only* (the
-  // tenant-scoped relational pipeline). Wiring this RPC through that pipeline is
-  // tracked future work. For bulk columnar results prefer Arrow Flight; for
-  // UQL/AQL/Federated (non-SQL) use /api/v2/query.
+  // SQL over gRPC (TD-121): SSO/bearer-authenticated programmatic SQL. gRPC
+  // carries bearer/JWT in request metadata, which pgwire (Postgres-native
+  // password/MD5) cannot — so this is the token-authenticated SQL path. Serves
+  // vector/graph-extension queries (e.g. VECTOR_SEARCH) AND tenant-scoped
+  // relational SELECT reads (SELECT/JOIN/aggregate over CREATE TABLE), which
+  // route through the SAME relational pipeline pgwire uses (ComputeScheduler →
+  // DataFusion/Volcano) with the request tenant from `x-tenant-id` scoping every
+  // read to the tenant's partition (TD-064). Relational DDL/DML (CREATE/INSERT/
+  // UPDATE/DELETE) over this RPC is not yet wired — use pgwire for writes. For
+  // bulk columnar results prefer Arrow Flight; for UQL/AQL/Federated (non-SQL)
+  // use /api/v2/query.
   rpc ExecuteQuery(V2QueryRequest) returns (V2QueryResponse);
 
   // Point record get-by-id (v2 parity with v1 VectorService.VectorGet)

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -1996,6 +1996,9 @@ impl UnifiedHandlers {
         query: String,
         parameters: Option<Vec<crate::proto::proximadb_v1::SqlValue>>,
         collection: Option<String>,
+        // TD-121: the authenticated tenant (gRPC `x-tenant-id`, REST/JWT). Scopes
+        // relational SQL to the tenant's partition (TD-064), mirroring pgwire.
+        tenant_id: Option<&str>,
     ) -> Result<crate::proto::proximadb_v1::ExecuteQueryResponse> {
         let start_time = std::time::Instant::now();
 
@@ -2050,6 +2053,29 @@ impl UnifiedHandlers {
             // DmlService not wired — fall through to legacy path so EXPLAIN degrades gracefully.
         }
 
+        // TD-121: route RELATIONAL SQL through the same tenant-scoped relational
+        // pipeline pgwire uses (ComputeScheduler::route_select → DataFusion/Volcano,
+        // TD-064 tenant partitioning), instead of the legacy vector/graph engine
+        // which rejects relational plans. `require_engagement = false` routes any
+        // resolvable relational SELECT here; queries whose tables don't resolve
+        // (vector/graph SQL) return None and fall through to the legacy engine.
+        if let Some(dml) = self.get_dml_service()
+            && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
+                &query,
+                Some(&dml),
+                None,
+                tenant_id,
+                crate::query::execution::ExecutionControls::default(),
+                false,
+            )
+            .await
+        {
+            return match outcome {
+                Ok(result) => Ok(Self::pipeline_result_to_sql_response(result, start_time)),
+                Err(msg) => Err(anyhow::anyhow!("Relational query execution failed: {msg}")),
+            };
+        }
+
         // Route through unified facade when feature is enabled and adapter is available
         #[cfg(feature = "unified-facade-routing")]
         if let Some(adapter) = self.get_query_adapter() {
@@ -2096,6 +2122,59 @@ impl UnifiedHandlers {
             columns: result.columns.iter().map(|c| c.0.clone()).collect(),
             column_types: result.columns.iter().map(|c| c.1.clone()).collect(),
         })
+    }
+
+    /// Convert a relational [`ExecutionPipelineResult`] (the tenant-scoped pgwire
+    /// pipeline output) into the v1 `ExecuteQueryResponse` carried by the gRPC/REST
+    /// SQL surfaces (TD-121). Mirrors pgwire's `emit_pipeline_result`: column names
+    /// + types come from the result schema; each `ProximaValue` cell maps to a
+    /// typed `SqlValue` via the canonical converter.
+    fn pipeline_result_to_sql_response(
+        result: crate::query::execution::engine::ExecutionPipelineResult,
+        start_time: std::time::Instant,
+    ) -> crate::proto::proximadb_v1::ExecuteQueryResponse {
+        use crate::proto::proximadb_v1::{SqlRow, SqlRowField};
+        let columns: Vec<String> = result
+            .schema
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .collect();
+        let column_types: Vec<String> = result
+            .schema
+            .columns
+            .iter()
+            .map(|c| format!("{:?}", c.ty))
+            .collect();
+        let rows_returned = result.rows.len() as u64;
+        let rows: Vec<SqlRow> = result
+            .rows
+            .into_iter()
+            .map(|row| {
+                let fields = row
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, value)| SqlRowField {
+                        key: columns.get(i).cloned().unwrap_or_else(|| format!("col{i}")),
+                        value: Some(crate::core::search::results::proxima_value_to_sql_value(
+                            value,
+                        )),
+                    })
+                    .collect();
+                SqlRow {
+                    fields,
+                    similarity: None,
+                }
+            })
+            .collect();
+        crate::proto::proximadb_v1::ExecuteQueryResponse {
+            rows,
+            rows_scanned: 0,
+            rows_returned,
+            execution_time_ms: start_time.elapsed().as_millis() as u64,
+            columns,
+            column_types,
+        }
     }
 
     /// Convert QueryResult from unified facade to ExecuteQueryResponse
@@ -3740,7 +3819,10 @@ impl proximadb_runtime::ApiHandlersPort for UnifiedHandlers {
                 .map(proximadb_records::conversions::proxima_to_sql_value)
                 .collect()
         });
-        UnifiedHandlers::execute_sql_v1(self, query, legacy_parameters, collection).await
+        // ApiHandlersPort::execute_sql_v1 carries no tenant; relational SQL stays
+        // unscoped on this trait path (callers that need TD-064 scoping use the
+        // inherent method with a tenant — e.g. the gRPC ExecuteQuery handler).
+        UnifiedHandlers::execute_sql_v1(self, query, legacy_parameters, collection, None).await
     }
 }
 

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -4251,6 +4251,7 @@ impl EmbeddedProximaDB {
                     query.to_string(),
                     proto_params,
                     collection.map(str::to_string),
+                    None, // embedded single-process: no per-request tenant
                 )
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1891,7 +1891,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2QueryRequest>,
     ) -> Result<Response<V2QueryResponse>, Status> {
-        let _tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = Self::extract_tenant_id(&request);
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -1900,7 +1900,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .request_handlers
-            .execute_sql_v1(q.query, None, collection)
+            .execute_sql_v1(q.query, None, collection, tenant_id.as_deref())
             .await
             .map_err(|e| Status::internal(format!("ExecuteQuery failed: {e}")))?;
         let rows = resp

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -1554,6 +1554,9 @@ impl PostgresProtocol {
             Some(self.vector_ops.clone() as Arc<dyn proximadb_runtime::VectorOpsPort>),
             Some(read_tenant.as_str()),
             controls,
+            // pgwire keeps simple single-table SELECTs on its hardened legacy
+            // path; only relational-engaging shapes go through this pipeline.
+            true,
         )
         .await
     }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -129,6 +129,14 @@ pub async fn try_run_select(
     vector_ops: Option<Arc<dyn proximadb_runtime::VectorOpsPort>>,
     tenant: Option<&str>,
     controls: ExecutionControls,
+    // pgwire passes `true`: only joins/GROUP BY/aggregates/set-ops engage the
+    // real-data relational engine, leaving simple SELECTs on pgwire's hardened
+    // legacy path. Off-pgwire callers (gRPC/REST `ExecuteQuery`, TD-121) have no
+    // such legacy single-table path, so they pass `false` to route *any*
+    // resolvable relational SELECT through this tenant-scoped pipeline; queries
+    // whose tables don't resolve return `None` and fall back to the caller's
+    // vector/graph engine.
+    require_engagement: bool,
 ) -> Option<Result<ExecutionPipelineResult, String>> {
     // TD-064: the connection's tenant scopes every snapshot read to the tenant's
     // record partition (carried into the SnapshotCatalog → DmlTableReader).
@@ -171,8 +179,10 @@ pub async fn try_run_select(
         return None;
     };
     // Engaged = a relational shape the legacy single-table path can't serve
-    // (joins / GROUP BY / aggregates / set-ops). Simple SELECTs stay on legacy.
-    if !query_engages_relational_engine(query) {
+    // (joins / GROUP BY / aggregates / set-ops). pgwire keeps simple SELECTs on
+    // its legacy path (`require_engagement = true`); off-pgwire callers route any
+    // resolvable relational SELECT here (`require_engagement = false`).
+    if require_engagement && !query_engages_relational_engine(query) {
         return None;
     }
 

--- a/tests/grpc_td121_relational_tenant_isolation_e2e.rs
+++ b/tests/grpc_td121_relational_tenant_isolation_e2e.rs
@@ -1,0 +1,193 @@
+//! TD-121 — relational SQL over gRPC is tenant-isolated, end-to-end.
+//!
+//! Companion to `pgwire_td064_write_tenant_isolation_e2e`. Two tenants create
+//! the SAME table name with different rows via pgwire (tenant = startup
+//! `database`). Then the gRPC `ProximaRecordService.ExecuteQuery` RPC runs
+//! RELATIONAL SQL (`SELECT … FROM <table>`, `COUNT(*)`) carrying the tenant in
+//! the `x-tenant-id` metadata. The reads must:
+//!   1. actually execute (previously gRPC SQL returned "Relational execution not
+//!      yet supported"), and
+//!   2. return ONLY the calling tenant's rows — the same TD-064 partition scope
+//!      pgwire enforces, now reached through the shared relational pipeline.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::proto::proximadb_v2::V2QueryRequest;
+use proximadb::proto::proximadb_v2::proxima_record_service_client::ProximaRecordServiceClient;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct TestServer {
+    pg_port: u16,
+    grpc_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl TestServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{}/health", rest_port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http_client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!("REST server didn't become ready within 20s");
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        sleep(Duration::from_millis(300)).await;
+
+        Ok(Self {
+            pg_port,
+            grpc_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn conn_string_for(&self, database: &str) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname={} sslmode=disable",
+            self.pg_port, database
+        )
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Connect a pgwire client scoped to `database` (= tenant) and run a statement.
+async fn pg_run(server: &TestServer, database: &str, sql: &str) {
+    let (client, connection) =
+        tokio_postgres::connect(&server.conn_string_for(database), tokio_postgres::NoTls)
+            .await
+            .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client.simple_query(sql).await.expect("pgwire statement");
+}
+
+/// Run a relational SELECT over gRPC `ExecuteQuery` as `tenant` and return the
+/// number of rows returned.
+async fn grpc_select_row_count(grpc_port: u16, tenant: &str, query: &str) -> u64 {
+    let mut client = ProximaRecordServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .expect("gRPC connect");
+    let mut request = tonic::Request::new(V2QueryRequest {
+        query: query.to_string(),
+        collection_id: String::new(),
+        limit: None,
+        offset: None,
+    });
+    request
+        .metadata_mut()
+        .insert("x-tenant-id", tenant.parse().expect("tenant metadata"));
+    let response = client
+        .execute_query(request)
+        .await
+        .expect("gRPC ExecuteQuery")
+        .into_inner();
+    response.rows.len() as u64
+}
+
+#[tokio::test]
+async fn grpc_relational_select_is_tenant_isolated() {
+    let server = TestServer::start().await.expect("server start");
+    let table = format!("orders_{}", server.pg_port);
+    let ddl = format!("CREATE TABLE {table} (id TEXT NOT NULL, note TEXT, PRIMARY KEY (id));");
+
+    // Tenant acme: two rows. Tenant globex: one row (SAME table name + PK '1').
+    pg_run(&server, "acme", &ddl).await;
+    pg_run(
+        &server,
+        "acme",
+        &format!("INSERT INTO {table} (id, note) VALUES ('1','acme-one'),('2','acme-two');"),
+    )
+    .await;
+    pg_run(&server, "globex", &ddl).await;
+    pg_run(
+        &server,
+        "globex",
+        &format!("INSERT INTO {table} (id, note) VALUES ('1','globex-one');"),
+    )
+    .await;
+
+    // Full scan over gRPC relational SQL is tenant-scoped: acme sees its 2 rows,
+    // globex sees its 1 row — proving the SELECT executes (no "Relational
+    // execution not yet supported") AND honors the calling tenant (TD-064).
+    let acme_rows =
+        grpc_select_row_count(server.grpc_port, "acme", &format!("SELECT id FROM {table}")).await;
+    let globex_rows = grpc_select_row_count(
+        server.grpc_port,
+        "globex",
+        &format!("SELECT id FROM {table}"),
+    )
+    .await;
+    assert_eq!(
+        acme_rows, 2,
+        "acme must see only its own 2 rows over gRPC SQL"
+    );
+    assert_eq!(
+        globex_rows, 1,
+        "globex must see only its own 1 row over gRPC SQL"
+    );
+
+    // Aggregate (engages the relational engine) is likewise tenant-scoped and
+    // returns one COUNT row per call.
+    let acme_count = grpc_select_row_count(
+        server.grpc_port,
+        "acme",
+        &format!("SELECT COUNT(*) AS c FROM {table}"),
+    )
+    .await;
+    assert_eq!(acme_count, 1, "COUNT(*) returns a single aggregate row");
+}


### PR DESCRIPTION
## What

Phase 1 of making gRPC `ProximaRecordService.ExecuteQuery` a real **SSO relational SQL** surface. Previously gRPC/REST SQL routed only through the legacy unified query engine (vector/graph), so relational `SELECT`s returned **"Relational execution not yet supported"** and the authenticated tenant was extracted then **discarded**. This routes relational SELECT reads through the **same pipeline pgwire uses**, scoped to the request tenant — delivering the SSO-authenticated relational SQL that pgwire (password/MD5 auth) structurally can't.

## How

- `relational_pipeline::try_run_select` gains `require_engagement`: **pgwire passes `true`** (simple SELECTs stay on its hardened legacy path — no pgwire change); **off-pgwire callers pass `false`** to route any resolvable relational SELECT through the tenant-scoped pipeline (`ComputeScheduler::route_select` → DataFusion/Volcano; TD-064 partition scoping lives in the reader). Queries whose tables don't resolve return `None` → fall through to the caller's vector/graph engine, so **VECTOR_SEARCH SQL is unaffected**.
- `request_handlers::execute_sql_v1` takes `tenant_id: Option<&str>` and tries the relational pipeline before the legacy path; new `pipeline_result_to_sql_response` maps `ExecutionPipelineResult` → `ExecuteQueryResponse` (`ProximaValue` → `SqlValue` via the canonical converter).
- gRPC `ExecuteQuery` handler now **passes the `x-tenant-id` tenant** instead of discarding it; embedded/trait-impl callers pass `None`.
- **Additive** — pgwire path unchanged.

## Scope (phased)

- **This PR (Phase 1)**: tenant-scoped relational **SELECT reads** over gRPC. 
- **Phase 2 (separate)**: relational **DDL/DML** (CREATE/INSERT/UPDATE/DELETE) over gRPC SQL — still pgwire-only; the pgwire write paths need extraction. Docs say so.

## Verification

- **New e2e** `tests/grpc_td121_relational_tenant_isolation_e2e`: two tenants write the **same table + PK** via pgwire; gRPC `SELECT` under `x-tenant-id` returns **only the calling tenant's rows** (acme 2 / globex 1; `COUNT(*)` scoped). Passes.
- **Live wire check**: same scenario via `psql` + `grpcurl` — `SELECT note WHERE id='1'` → acme `acme-one`, globex `globex-one`; counts 2/1.
- Docs updated (proto comment + `SUPPORTED_SURFACE.adoc`); stub regenerated.

## Gates

`cargo build --lib`/`-p proximadb-server` clean; e2e test passes; `cargo fmt --check` 0 diffs; `cargo clippy --lib` clean; `validate_capability_matrix.py` passes.