### PR TITLE
feat(oltp): secondary index for non-PK equality/IN-list lookups (TD-127/TD-128)

### DIFF
--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -303,6 +303,10 @@ pub struct RelationalSelectPredicateInput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RelationalSelectAccessPath {
     PrimaryKeyLookup,
+    /// TD-127: a single-column equality / `IN`-list on a non-PK secondary-indexed
+    /// column was answered by probing the OLTP secondary index for candidate oids
+    /// (each re-checked against the full predicate) instead of a full scan.
+    SecondaryIndexLookup,
     TableScan,
 }
 
@@ -1309,6 +1313,51 @@ impl DmlService {
                 }
             }
             return Ok((RelationalSelectAccessPath::PrimaryKeyLookup, records));
+        }
+
+        // TD-127 secondary-index fast-path: a single-column equality / IN-list on
+        // a non-PK secondary-indexed column → probe the index for candidate oids,
+        // then re-check each against the FULL tree (the index only narrows; the
+        // tree still decides). `None` from `lookup_secondary` (no built index /
+        // kill-switch) falls through to the scan below.
+        if let Some((column, values)) =
+            self.extract_secondary_index_probe(where_clause, table_schema)?
+        {
+            let value_set: std::collections::HashSet<String> = values.into_iter().collect();
+            if let Some(candidate_oids) = self
+                .record_store
+                .lookup_secondary(table_schema, &column, &value_set, tenant_context)
+                .await?
+            {
+                let cap = limit.unwrap_or(usize::MAX);
+                let mut records = Vec::new();
+                for oid in candidate_oids {
+                    if records.len() >= cap {
+                        break;
+                    }
+                    let Some(rich) = self
+                        .record_store
+                        .get_by_key(
+                            table_schema,
+                            TableRecordGetRequest {
+                                table_id: table_id_name.to_string(),
+                                key: oid,
+                                include_vector: true,
+                                include_props: true,
+                            },
+                            tenant_context,
+                        )
+                        .await?
+                    else {
+                        continue;
+                    };
+                    let record = Self::rich_result_to_record(rich);
+                    if Self::eval_predicate_tree(&record, tree, primary_key) {
+                        records.push(record);
+                    }
+                }
+                return Ok((RelationalSelectAccessPath::SecondaryIndexLookup, records));
+            }
         }
 
         // No usable PK predicate: push the full tree into the store scan + limit.
@@ -3659,6 +3708,76 @@ impl DmlService {
     /// an empty Vec (NOT an error) when the clause has no usable PK predicate, so
     /// the caller can fall back to a predicate scan. Candidates are still
     /// re-checked against the full predicate by [`Self::resolve_matching_ids`].
+    /// TD-127: extract a single-column equality / non-negated `IN`-list on a
+    /// secondary-indexed non-PK column from `where_clause`, returning
+    /// `(column, value-texts)` to probe the OLTP secondary index. Value text is
+    /// rendered through the SAME [`proxima_value_to_unique_text`] the index uses,
+    /// so the probe text matches the indexed text exactly. Returns `None` (scan
+    /// fallback) when no such leaf exists.
+    ///
+    /// OR-safety: only sound under a top-level conjunction — `name = 'x' OR ...`
+    /// would under-bound the match set — mirroring [`Self::extract_pk_candidate_ids`].
+    fn extract_secondary_index_probe(
+        &self,
+        where_clause: &WhereClause,
+        table_schema: &CatalogTableSchema,
+    ) -> Result<Option<(String, Vec<String>)>> {
+        if matches!(where_clause.operator, LogicalOperator::Or) && where_clause.conditions.len() > 1
+        {
+            return Ok(None);
+        }
+        let indexed = crate::services::record_store::schema_secondary_index_columns(table_schema);
+        if indexed.is_empty() {
+            return Ok(None);
+        }
+        let is_indexed = |column: &String| indexed.iter().any(|c| c == column);
+        for condition in &where_clause.conditions {
+            match condition {
+                Condition::Comparison {
+                    column,
+                    operator,
+                    value,
+                } if matches!(operator, ComparisonOperator::Equal)
+                    && is_indexed(column)
+                    && !Self::literal_is_null(value) =>
+                {
+                    return Ok(Some((
+                        column.clone(),
+                        vec![self.literal_to_secondary_text(value)?],
+                    )));
+                }
+                Condition::In {
+                    column,
+                    values,
+                    negated,
+                } if !*negated && is_indexed(column) && !values.is_empty() => {
+                    let mut texts = Vec::with_capacity(values.len());
+                    for value in values {
+                        if Self::literal_is_null(value) {
+                            continue; // NULL never equals anything; skip the term
+                        }
+                        texts.push(self.literal_to_secondary_text(value)?);
+                    }
+                    if !texts.is_empty() {
+                        return Ok(Some((column.clone(), texts)));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(None)
+    }
+
+    /// Render a WHERE literal as secondary-index probe text, going through the
+    /// same `ProximaValue` → [`proxima_value_to_unique_text`] path the index uses
+    /// for stored values so probe text and indexed text are byte-identical. (TD-127.)
+    fn literal_to_secondary_text(&self, val: &SqlValueLiteral) -> Result<String> {
+        let value = self.literal_to_proxima_value(val)?;
+        Ok(crate::services::record_store::proxima_value_to_unique_text(
+            &value,
+        ))
+    }
+
     fn extract_pk_candidate_ids(
         &self,
         where_clause: &WhereClause,
@@ -6386,6 +6505,177 @@ mod tests {
         assert_eq!(path, RelationalSelectAccessPath::TableScan);
         assert_eq!(pc, 0, "no WHERE → zero predicate leaves");
         assert_eq!(ids, vec!["i1", "i2", "i3", "i4"]);
+    }
+
+    /// TD-127: a single-column equality / IN-list on a non-PK secondary-indexed
+    /// column is answered by the OLTP secondary index (`SecondaryIndexLookup`),
+    /// not a full `TableScan`, and returns exactly the rows the scan would — while
+    /// the kill-switch falls back to a scan with identical rows. The schema is
+    /// registered programmatically because no DDL surface declares secondary
+    /// indexes yet (a noted follow-on); the cataloged `secondary_indexes` survive
+    /// the `ObjectSchema` round-trip, so the read path sees them.
+    #[tokio::test]
+    async fn select_where_uses_secondary_index_for_nonpk_name_and_file() {
+        use crate::services::record_store::DirectWalTableRecordStore;
+        use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+        use proximadb_catalog::{
+            CatalogColumn, CatalogIndex, CatalogIndexType, CatalogStorageSpecialization,
+            CatalogTableSchema, RelationalCapabilities,
+        };
+        use proximadb_data_model::ProximaType;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let wal_path = temp_dir.path().join("dml-secondary-index.wal");
+        let manager = Arc::new(CatalogManager::new());
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+
+        // Register a `code_symbol` table with non-unique secondary indexes on the
+        // code-graph lookup columns (`name`, `file`), PK `oid`.
+        let (catalog, table_id) = manager
+            .resolve_table_scoped("code_symbol", None)
+            .await
+            .expect("resolve table");
+        if !catalog
+            .namespace_exists(&table_id.namespace)
+            .await
+            .expect("namespace_exists")
+        {
+            catalog
+                .create_namespace_for_tenant(&table_id.namespace, HashMap::new(), None)
+                .await
+                .expect("create namespace");
+        }
+        let schema = CatalogTableSchema::new(&table_id.name)
+            .with_column(CatalogColumn::new(1, "oid", ProximaType::String).nullable(false))
+            .with_column(CatalogColumn::new(2, "name", ProximaType::String))
+            .with_column(CatalogColumn::new(3, "file", ProximaType::String))
+            .with_primary_key(vec!["oid".to_string()])
+            .with_storage_specialization(CatalogStorageSpecialization::PaxOltp)
+            .with_relational_capabilities(RelationalCapabilities {
+                primary_key: vec!["oid".to_string()],
+                secondary_indexes: vec![
+                    CatalogIndex::new(
+                        "sym_name_idx",
+                        vec!["name".to_string()],
+                        CatalogIndexType::Hash,
+                    ),
+                    CatalogIndex::new(
+                        "sym_file_idx",
+                        vec!["file".to_string()],
+                        CatalogIndexType::Hash,
+                    ),
+                ],
+                ..Default::default()
+            });
+        catalog
+            .create_table(&table_id, schema)
+            .await
+            .expect("register table");
+
+        let record_store = Arc::new(DirectWalTableRecordStore::new(
+            Arc::new(MemtableRecordStorage::new()),
+            Arc::new(
+                FramedTableWalAppender::open(&wal_path)
+                    .await
+                    .expect("open WAL"),
+            ),
+        ));
+        let dml = DmlService::with_record_store_and_table_write_executor(
+            manager.clone(),
+            record_store,
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        );
+
+        let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+        for (oid, name, file) in [
+            ("s1", "parse", "a.rs"),
+            ("s2", "parse", "b.rs"),
+            ("s3", "emit", "b.rs"),
+            ("s4", "emit", "c.rs"),
+        ] {
+            let stmt = parser
+                .parse_dml(&format!(
+                    "INSERT INTO code_symbol (oid, name, file) VALUES ('{oid}', '{name}', '{file}');"
+                ))
+                .expect("parse insert")
+                .expect("insert stmt");
+            dml.execute(stmt).await.expect("insert");
+        }
+
+        async fn run(
+            dml: &DmlService,
+            parser: &crate::query::sql_frontend::SqlFrontendParser,
+            sql: &str,
+        ) -> (RelationalSelectAccessPath, Vec<String>) {
+            let where_clause = parser.parse_select_where_clause(sql).expect("parse where");
+            let res = dml
+                .select_table_records_with_projection_where(
+                    "code_symbol",
+                    &["oid".to_string()],
+                    None,
+                    where_clause.as_ref(),
+                    None,
+                )
+                .await
+                .expect("select");
+            let mut ids: Vec<String> = res
+                .rows
+                .iter()
+                .map(|row| match &row[0] {
+                    ProximaValue::String(s) => s.clone(),
+                    other => format!("{other:?}"),
+                })
+                .collect();
+            ids.sort();
+            (res.route_metadata.access_path, ids)
+        }
+
+        // Equality on the indexed non-PK `name` → secondary-index lookup, both rows.
+        let (path, ids) = run(
+            &dml,
+            &parser,
+            "SELECT oid FROM code_symbol WHERE name = 'parse'",
+        )
+        .await;
+        assert_eq!(path, RelationalSelectAccessPath::SecondaryIndexLookup);
+        assert_eq!(ids, vec!["s1", "s2"]);
+
+        // IN-list on the indexed `file` → secondary-index lookup, union a.rs + c.rs.
+        let (path, ids) = run(
+            &dml,
+            &parser,
+            "SELECT oid FROM code_symbol WHERE file IN ('a.rs', 'c.rs')",
+        )
+        .await;
+        assert_eq!(path, RelationalSelectAccessPath::SecondaryIndexLookup);
+        assert_eq!(ids, vec!["s1", "s4"]);
+
+        // The index narrows; the FULL predicate still decides: name='parse' AND
+        // file='b.rs' → only s2 (s1 is a.rs, dropped by the re-check).
+        let (path, ids) = run(
+            &dml,
+            &parser,
+            "SELECT oid FROM code_symbol WHERE name = 'parse' AND file = 'b.rs'",
+        )
+        .await;
+        assert_eq!(path, RelationalSelectAccessPath::SecondaryIndexLookup);
+        assert_eq!(ids, vec!["s2"]);
+
+        // Kill-switch → scan fallback with identical rows.
+        // SAFETY: single-threaded test; restored immediately after the probe.
+        unsafe { std::env::set_var("PROXIMADB_SECONDARY_INDEX_DISABLE", "1") };
+        let (path, ids) = run(
+            &dml,
+            &parser,
+            "SELECT oid FROM code_symbol WHERE name = 'parse'",
+        )
+        .await;
+        unsafe { std::env::remove_var("PROXIMADB_SECONDARY_INDEX_DISABLE") };
+        assert_eq!(path, RelationalSelectAccessPath::TableScan);
+        assert_eq!(ids, vec!["s1", "s2"], "scan fallback returns the same rows");
     }
 
     /// `scan_table_relational` (PATH B reader backend) pushes the output

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -570,6 +570,26 @@ pub trait TableRecordStore: Send + Sync {
         Ok(None)
     }
 
+    /// TD-127: probe a single-column OLTP secondary index for the oids whose
+    /// `column` value text is in `values`. Returns `None` when the store has no
+    /// secondary index for `column` (or it is disabled) so the caller falls back
+    /// to a scan; `Some(oids)` (possibly empty) when the index answered. The
+    /// caller MUST still re-check each candidate against the full predicate — the
+    /// index only narrows the candidate set.
+    ///
+    /// Default opts out (`None`); index-backed stores (e.g.
+    /// `DirectWalTableRecordStore`) override this.
+    async fn lookup_secondary(
+        &self,
+        table_schema: &CatalogTableSchema,
+        column: &str,
+        values: &std::collections::HashSet<String>,
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Option<Vec<String>>> {
+        let _ = (table_schema, column, values, tenant_context);
+        Ok(None)
+    }
+
     /// CDC change-feed: return row-level changes for `collection_id` with WAL sequence
     /// number strictly greater than `since_lsn`, oldest first. The default returns nothing
     /// (stores without a readable change log opt out); the WAL-backed store overrides it.
@@ -702,6 +722,79 @@ pub(crate) fn schema_primary_key_column(table_schema: &CatalogTableSchema) -> Op
     })
 }
 
+/// Index-eligible scalar column types for an OLTP secondary (hash-equality)
+/// index. Floats/decimals are excluded — equality on a float is semantically
+/// fragile and `f32`/`f64` shortest-round-trip text can diverge for the same
+/// decimal, which would make the probe text miss the indexed text — as are
+/// non-scalar, temporal, and binary types; those columns fall back to the scan
+/// path. (TD-127.)
+fn is_secondary_indexable_type(data_type: &proximadb_data_model::ProximaType) -> bool {
+    use proximadb_data_model::ProximaType;
+    matches!(
+        data_type,
+        ProximaType::Boolean
+            | ProximaType::Int8
+            | ProximaType::Int16
+            | ProximaType::Int32
+            | ProximaType::Int64
+            | ProximaType::UInt8
+            | ProximaType::UInt16
+            | ProximaType::UInt32
+            | ProximaType::UInt64
+            | ProximaType::String
+            | ProximaType::Symbol
+    )
+}
+
+/// The single-column non-unique secondary indexes declared on a table,
+/// restricted to index-eligible scalar columns. The motivating consumer is the
+/// code-graph workload (look up symbols by `name`/`file`, neither the PK). Unit
+/// #1 indexes single columns only (composite is a follow-on). Shared by
+/// `DmlService` (probe extraction) and `DirectWalTableRecordStore` (index
+/// build/maintenance) so both agree on exactly which columns are indexed.
+/// (TD-127.)
+pub(crate) fn schema_secondary_index_columns(table_schema: &CatalogTableSchema) -> Vec<String> {
+    let eligible: std::collections::HashMap<&str, &proximadb_data_model::ProximaType> =
+        table_schema
+            .columns
+            .iter()
+            .map(|column| (column.name.as_str(), &column.data_type))
+            .collect();
+    let mut columns: Vec<String> = Vec::new();
+    for index in &table_schema.relational_capabilities.secondary_indexes {
+        let [column] = index.columns.as_slice() else {
+            continue; // single-column hash indexes only in unit #1
+        };
+        if columns.iter().any(|existing| existing == column) {
+            continue;
+        }
+        if eligible
+            .get(column.as_str())
+            .is_some_and(|data_type| is_secondary_indexable_type(data_type))
+        {
+            columns.push(column.clone());
+        }
+    }
+    columns
+}
+
+/// Render a record's scalar value for `column` as comparable text for the
+/// secondary index — `None` when NULL/absent/non-scalar. Reuses
+/// [`record_unique_tuple`] (with no primary key, so the value is read from
+/// `props`) so the indexed text and the query-side probe text derive
+/// identically through [`proxima_value_to_unique_text`]. (TD-127.)
+fn record_secondary_text(record: &ProximaRecord, column: &str) -> Option<String> {
+    let columns = [column.to_string()];
+    record_unique_tuple(record, &columns, None).map(|mut tuple| tuple.remove(0))
+}
+
+/// TD-127 kill-switch: `PROXIMADB_SECONDARY_INDEX_DISABLE` forces the OLTP
+/// secondary-index build/maintain/probe off (scan fallback), mirroring the
+/// scan-index escape hatch (`PROXIMADB_SCAN_INDEX_DISABLE`).
+fn secondary_index_disabled() -> bool {
+    std::env::var_os("PROXIMADB_SECONDARY_INDEX_DISABLE").is_some()
+}
+
 /// Build the per-set candidate tuples for `records`, rejecting a tuple that
 /// repeats within this statement (NULL tuples exempt). Shared by the INSERT /
 /// UPDATE enforcement in `DmlService` and the INSERT-SELECT native executor so
@@ -824,6 +917,22 @@ impl TableRecordStore for CatalogRoutingTableRecordStore {
     ) -> Result<TableRecordScanResponse> {
         self.store_for_schema(table_schema)
             .scan_records_filtered(table_schema, request, predicate, tenant_context)
+            .await
+    }
+
+    /// TD-127: forward the secondary-index probe to the schema's routed store, so
+    /// an index-backed route (the WAL-backed native store) is actually consulted
+    /// instead of falling through to the `None` trait default (which would force
+    /// every reader behind the router onto the scan path).
+    async fn lookup_secondary(
+        &self,
+        table_schema: &CatalogTableSchema,
+        column: &str,
+        values: &std::collections::HashSet<String>,
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Option<Vec<String>>> {
+        self.store_for_schema(table_schema)
+            .lookup_secondary(table_schema, column, values, tenant_context)
             .await
     }
 
@@ -1192,6 +1301,103 @@ impl TableUniqueIndex {
     }
 }
 
+/// TD-127: one column's hash secondary index — `value-text → owning oids`.
+#[derive(Default)]
+struct ColumnSecondaryIndex {
+    column: String,
+    value_to_oids: std::collections::HashMap<String, std::collections::HashSet<String>>,
+}
+
+/// Per-table non-unique secondary index over single columns. Each oid
+/// self-tracks its current per-column value text (`oid_values`) so an update or
+/// delete drops the OLD value without re-reading storage — the same maintenance
+/// shape as [`TableUniqueIndex`]. Built lazily on first probe (scanning the
+/// WAL-rebuilt current state) and maintained incrementally on every write.
+#[derive(Default)]
+struct TableSecondaryIndex {
+    /// One per indexed column, in `schema_secondary_index_columns` order.
+    columns: Vec<ColumnSecondaryIndex>,
+    /// oid → its current per-column value text (`None` = NULL/absent for that
+    /// column, so it is not indexed).
+    oid_values: std::collections::HashMap<String, Vec<Option<String>>>,
+}
+
+impl TableSecondaryIndex {
+    fn with_columns(columns: &[String]) -> Self {
+        Self {
+            columns: columns
+                .iter()
+                .map(|column| ColumnSecondaryIndex {
+                    column: column.clone(),
+                    value_to_oids: std::collections::HashMap::new(),
+                })
+                .collect(),
+            oid_values: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Insert/update `record`: drop its previous per-column values (if any) then
+    /// add its current ones. Uniform across INSERT/UPSERT/UPDATE.
+    fn upsert(&mut self, record: &ProximaRecord) {
+        self.remove_oid(&record.oid);
+        let mut per_column = Vec::with_capacity(self.columns.len());
+        for column in &mut self.columns {
+            let text = record_secondary_text(record, &column.column);
+            if let Some(text) = &text {
+                column
+                    .value_to_oids
+                    .entry(text.clone())
+                    .or_default()
+                    .insert(record.oid.clone());
+            }
+            per_column.push(text);
+        }
+        self.oid_values.insert(record.oid.clone(), per_column);
+    }
+
+    /// Remove `oid` entirely (DELETE).
+    fn delete(&mut self, oid: &str) {
+        self.remove_oid(oid);
+        self.oid_values.remove(oid);
+    }
+
+    /// Detach `oid`'s currently-indexed values from `value_to_oids` (shared by
+    /// upsert's replace and delete). Leaves `oid_values[oid]` for the caller.
+    fn remove_oid(&mut self, oid: &str) {
+        let Some(previous) = self.oid_values.get(oid).cloned() else {
+            return;
+        };
+        for (column, value) in self.columns.iter_mut().zip(previous.iter()) {
+            if let Some(value) = value
+                && let Some(oids) = column.value_to_oids.get_mut(value)
+            {
+                oids.remove(oid);
+                if oids.is_empty() {
+                    column.value_to_oids.remove(value);
+                }
+            }
+        }
+    }
+
+    /// Union of oids whose `column` value text is in `values`. `None` when the
+    /// column is not indexed by this table index (caller scans); `Some` (possibly
+    /// empty) when the column is indexed.
+    fn probe(
+        &self,
+        column: &str,
+        values: &std::collections::HashSet<String>,
+    ) -> Option<std::collections::HashSet<String>> {
+        let index = self.columns.iter().find(|c| c.column == column)?;
+        let mut oids = std::collections::HashSet::new();
+        for value in values {
+            if let Some(owners) = index.value_to_oids.get(value) {
+                oids.extend(owners.iter().cloned());
+            }
+        }
+        Some(oids)
+    }
+}
+
 pub struct DirectWalTableRecordStore {
     /// Per-(tenant_id, collection) record partitions, created on demand via
     /// `storage_factory`. TD-064: tenant + collection isolation is STRUCTURAL —
@@ -1210,6 +1416,12 @@ pub struct DirectWalTableRecordStore {
     /// every `write_mutations`.
     unique_index:
         parking_lot::RwLock<std::collections::HashMap<(String, String), TableUniqueIndex>>,
+    /// TD-127: non-unique OLTP secondary index keyed by `(tenant_id, collection)`
+    /// so a table's secondary indexes are per-tenant, mirroring `unique_index`.
+    /// Presence of a key == "index built". Lazily built on first
+    /// `lookup_secondary`, then maintained on every `write_mutations`.
+    secondary_index:
+        parking_lot::RwLock<std::collections::HashMap<(String, String), TableSecondaryIndex>>,
 }
 
 impl DirectWalTableRecordStore {
@@ -1242,6 +1454,7 @@ impl DirectWalTableRecordStore {
             storage_factory,
             wal_appender,
             unique_index: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            secondary_index: parking_lot::RwLock::new(std::collections::HashMap::new()),
         }
     }
 
@@ -1344,6 +1557,52 @@ impl DirectWalTableRecordStore {
         }
         // Double-checked insert: keep an index another writer built meanwhile.
         self.unique_index.write().entry(index_key).or_insert(index);
+        Ok(())
+    }
+
+    /// TD-127: build the secondary index for `(tenant_id, table_schema)` if not
+    /// already built, by scanning the tenant's current visible state (WAL
+    /// recovery has rebuilt it). A no-op when the table declares no eligible
+    /// secondary-index columns or the kill-switch is set.
+    async fn ensure_secondary_index_built(
+        &self,
+        table_schema: &CatalogTableSchema,
+        tenant_id: &str,
+    ) -> Result<()> {
+        if secondary_index_disabled() {
+            return Ok(());
+        }
+        let index_key = (tenant_id.to_string(), table_schema.name.clone());
+        if self.secondary_index.read().contains_key(&index_key) {
+            return Ok(());
+        }
+        let columns = schema_secondary_index_columns(table_schema);
+        if columns.is_empty() {
+            return Ok(());
+        }
+        let existing =
+            RecordStorageTableRecordStore::new(self.partition(tenant_id, &table_schema.name))
+                .scan_records(
+                    table_schema,
+                    TableRecordScanRequest {
+                        filter: None,
+                        table_id: table_schema.name.clone(),
+                        limit: None,
+                        include_vector: false,
+                        include_props: true,
+                    },
+                    None,
+                )
+                .await?;
+        let mut index = TableSecondaryIndex::with_columns(&columns);
+        for record in &existing {
+            index.upsert(record);
+        }
+        // Double-checked insert: keep an index another writer built meanwhile.
+        self.secondary_index
+            .write()
+            .entry(index_key)
+            .or_insert(index);
         Ok(())
     }
 }
@@ -1491,6 +1750,13 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let index_primary_key = schema_primary_key_column(table_schema);
         let maintain_index = !schema_unique_column_sets(table_schema).is_empty()
             && self.unique_index.read().contains_key(&index_key);
+        // TD-127: maintain the secondary index on the same once-built basis as the
+        // UNIQUE/PK index — until first `lookup_secondary` builds it, the lazy
+        // build captures these writes from current state, so skipping is safe.
+        let maintain_secondary = !secondary_index_disabled()
+            && !schema_secondary_index_columns(table_schema).is_empty()
+            && self.secondary_index.read().contains_key(&index_key);
+        let maintain_any = maintain_index || maintain_secondary;
 
         let mut record_ids = Vec::with_capacity(storage_actions.len());
         for (kind, record) in storage_actions {
@@ -1498,11 +1764,18 @@ impl TableRecordStore for DirectWalTableRecordStore {
                 TableRecordMutationKind::Insert
                 | TableRecordMutationKind::Upsert
                 | TableRecordMutationKind::Update => {
-                    if maintain_index {
+                    if maintain_any {
                         let written = partition.upsert_record(record.clone()).await?;
                         record_ids.push(written.oid);
-                        if let Some(index) = self.unique_index.write().get_mut(&index_key) {
+                        if maintain_index
+                            && let Some(index) = self.unique_index.write().get_mut(&index_key)
+                        {
                             index.upsert(&record, index_primary_key.as_deref());
+                        }
+                        if maintain_secondary
+                            && let Some(index) = self.secondary_index.write().get_mut(&index_key)
+                        {
+                            index.upsert(&record);
                         }
                     } else {
                         let written = partition.upsert_record(record).await?;
@@ -1513,6 +1786,11 @@ impl TableRecordStore for DirectWalTableRecordStore {
                     partition.delete_record(&RecordKey::from(&record)).await?;
                     if maintain_index
                         && let Some(index) = self.unique_index.write().get_mut(&index_key)
+                    {
+                        index.delete(&record.oid);
+                    }
+                    if maintain_secondary
+                        && let Some(index) = self.secondary_index.write().get_mut(&index_key)
                     {
                         index.delete(&record.oid);
                     }
@@ -1597,6 +1875,39 @@ impl TableRecordStore for DirectWalTableRecordStore {
             }
         }
         Ok(None)
+    }
+
+    /// TD-127: index-backed secondary lookup. Builds the per-table index on first
+    /// use (from current state), then probes for candidate oids. Returns `None`
+    /// (scan fallback) when `column` is not an indexed column or the kill-switch
+    /// is set.
+    async fn lookup_secondary(
+        &self,
+        table_schema: &CatalogTableSchema,
+        column: &str,
+        values: &std::collections::HashSet<String>,
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Option<Vec<String>>> {
+        if secondary_index_disabled() {
+            return Ok(None);
+        }
+        if !schema_secondary_index_columns(table_schema)
+            .iter()
+            .any(|indexed| indexed == column)
+        {
+            return Ok(None);
+        }
+        let tenant_scope = Self::tenant_key(tenant_context);
+        self.ensure_secondary_index_built(table_schema, &tenant_scope)
+            .await?;
+        let index_key = (tenant_scope, table_schema.name.clone());
+        let index = self.secondary_index.read();
+        let Some(table_index) = index.get(&index_key) else {
+            return Ok(None);
+        };
+        Ok(table_index
+            .probe(column, values)
+            .map(|oids| oids.into_iter().collect()))
     }
 }
 
@@ -2229,6 +2540,204 @@ mod tests {
             wal.entries.lock().expect("recording WAL read lock").len(),
             1
         );
+    }
+
+    // ── TD-127: OLTP secondary index (build / probe / IN-list / maintenance) ──────
+
+    /// Build a `code_symbol`-shaped schema declaring non-unique secondary indexes
+    /// on `name` and `file` (the code-graph lookup columns) plus an unindexed
+    /// `lang` column, PK `oid`.
+    fn secondary_index_schema() -> CatalogTableSchema {
+        use proximadb_catalog::{CatalogIndex, CatalogIndexType, RelationalCapabilities};
+        CatalogTableSchema::new("code_symbol")
+            .with_column(CatalogColumn::new(1, "oid", ProximaType::String).nullable(false))
+            .with_column(CatalogColumn::new(2, "name", ProximaType::String))
+            .with_column(CatalogColumn::new(3, "file", ProximaType::String))
+            .with_column(CatalogColumn::new(4, "lang", ProximaType::String))
+            .with_primary_key(vec!["oid".to_string()])
+            .with_storage_specialization(CatalogStorageSpecialization::PaxOltp)
+            .with_relational_capabilities(RelationalCapabilities {
+                primary_key: vec!["oid".to_string()],
+                secondary_indexes: vec![
+                    CatalogIndex::new(
+                        "sym_name_idx",
+                        vec!["name".to_string()],
+                        CatalogIndexType::Hash,
+                    ),
+                    CatalogIndex::new(
+                        "sym_file_idx",
+                        vec!["file".to_string()],
+                        CatalogIndexType::Hash,
+                    ),
+                ],
+                ..Default::default()
+            })
+    }
+
+    fn symbol_record(oid: &str, name: &str, file: &str) -> ProximaRecord {
+        ProximaRecord {
+            oid: oid.to_string(),
+            local_id: Some(oid.to_string()),
+            variation_id: Some("code_symbol".to_string()),
+            props: proximadb_records::ProximaTree::from([
+                (
+                    "name".to_string(),
+                    ProximaTreeNode::Value(ProximaValue::String(name.to_string())),
+                ),
+                (
+                    "file".to_string(),
+                    ProximaTreeNode::Value(ProximaValue::String(file.to_string())),
+                ),
+            ]),
+            ..Default::default()
+        }
+    }
+
+    async fn write_one(
+        store: &DirectWalTableRecordStore,
+        schema: &CatalogTableSchema,
+        kind: TableRecordMutationKind,
+        record: ProximaRecord,
+    ) {
+        let result = store
+            .write_mutations(schema, vec![TableRecordMutation::new(kind, record)], None)
+            .await
+            .expect("write_mutations");
+        assert!(result.success, "write failed: {:?}", result.error_code);
+    }
+
+    /// Probe `column IN values` and return the matching oids, sorted.
+    async fn probe_sorted(
+        store: &DirectWalTableRecordStore,
+        schema: &CatalogTableSchema,
+        column: &str,
+        values: &[&str],
+    ) -> Option<Vec<String>> {
+        let set: std::collections::HashSet<String> = values.iter().map(|v| v.to_string()).collect();
+        store
+            .lookup_secondary(schema, column, &set, None)
+            .await
+            .expect("lookup_secondary")
+            .map(|mut oids| {
+                oids.sort();
+                oids
+            })
+    }
+
+    #[tokio::test]
+    async fn secondary_index_probes_equality_and_in_list() {
+        let store = DirectWalTableRecordStore::new(
+            Arc::new(MemoryRecordStorage::default()),
+            Arc::new(RecordingWalAppender::default()),
+        );
+        let schema = secondary_index_schema();
+        for (oid, name, file) in [
+            ("s1", "parse", "a.rs"),
+            ("s2", "parse", "b.rs"), // same name in another file
+            ("s3", "emit", "b.rs"),
+            ("s4", "emit", "c.rs"),
+        ] {
+            write_one(
+                &store,
+                &schema,
+                TableRecordMutationKind::Insert,
+                symbol_record(oid, name, file),
+            )
+            .await;
+        }
+
+        // Equality on the indexed `name` column → both `parse` symbols.
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["parse"]).await,
+            Some(vec!["s1".to_string(), "s2".to_string()])
+        );
+        // IN-list on the indexed `file` column → union of a.rs + c.rs.
+        assert_eq!(
+            probe_sorted(&store, &schema, "file", &["a.rs", "c.rs"]).await,
+            Some(vec!["s1".to_string(), "s4".to_string()])
+        );
+        // A value with no rows → an empty (but present) answer, NOT a scan fallback.
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["missing"]).await,
+            Some(vec![])
+        );
+        // An unindexed column → `None` so the caller scans.
+        assert_eq!(probe_sorted(&store, &schema, "lang", &["rust"]).await, None);
+    }
+
+    #[tokio::test]
+    async fn secondary_index_maintained_on_update_and_delete() {
+        let store = DirectWalTableRecordStore::new(
+            Arc::new(MemoryRecordStorage::default()),
+            Arc::new(RecordingWalAppender::default()),
+        );
+        let schema = secondary_index_schema();
+        write_one(
+            &store,
+            &schema,
+            TableRecordMutationKind::Insert,
+            symbol_record("s1", "parse", "a.rs"),
+        )
+        .await;
+        // First probe builds the index from current state.
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["parse"]).await,
+            Some(vec!["s1".to_string()])
+        );
+
+        // UPDATE the indexed value: the OLD value must stop matching, the NEW one start.
+        write_one(
+            &store,
+            &schema,
+            TableRecordMutationKind::Update,
+            symbol_record("s1", "lex", "a.rs"),
+        )
+        .await;
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["parse"]).await,
+            Some(vec![]),
+            "old indexed value detached on update"
+        );
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["lex"]).await,
+            Some(vec!["s1".to_string()]),
+            "new indexed value attached on update"
+        );
+
+        // DELETE removes the oid from the index entirely.
+        write_one(
+            &store,
+            &schema,
+            TableRecordMutationKind::Delete,
+            symbol_record("s1", "lex", "a.rs"),
+        )
+        .await;
+        assert_eq!(
+            probe_sorted(&store, &schema, "name", &["lex"]).await,
+            Some(vec![])
+        );
+    }
+
+    #[tokio::test]
+    async fn secondary_index_kill_switch_disables_probe() {
+        // SAFETY: single-threaded test; set + remove the process env around the probe.
+        unsafe { std::env::set_var("PROXIMADB_SECONDARY_INDEX_DISABLE", "1") };
+        let store = DirectWalTableRecordStore::new(
+            Arc::new(MemoryRecordStorage::default()),
+            Arc::new(RecordingWalAppender::default()),
+        );
+        let schema = secondary_index_schema();
+        write_one(
+            &store,
+            &schema,
+            TableRecordMutationKind::Insert,
+            symbol_record("s1", "parse", "a.rs"),
+        )
+        .await;
+        // Kill-switch on → `None` (scan fallback), even for an indexed column.
+        let result = probe_sorted(&store, &schema, "name", &["parse"]).await;
+        unsafe { std::env::remove_var("PROXIMADB_SECONDARY_INDEX_DISABLE") };
+        assert_eq!(result, None, "kill-switch forces the scan fallback");
     }
 
     // ── Retirement gate #2: prior-version closure and tombstone visibility ─────────


### PR DESCRIPTION
## What

The first, most-foundational engine prerequisite for the **code-graph correlated substrate** (`docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`): an OLTP **secondary index** so non-PK lookups stop scanning the whole table.

Code-graph (and any OLTP) workloads look up rows by **`name` / `file`, not the PK `oid`**. Today `WHERE pk = x` / `pk IN (...)` already point-batch, but `WHERE name = 'x'` / `WHERE file IN (...)` fell through to a **full table scan + in-memory filter** (`select_table_records_with_tree`). This is the dominant cost term for the re-index hot path (measured: 54k distinct symbol names, ~22.8 symbols/file, batch-of-files per debounce).

This ships **TD-127** (secondary index) + the **non-PK portion of TD-128** (multi-key point-batch) as one coherent unit — a built index is useless without a probe.

## How

- **`TableSecondaryIndex`** (`src/services/record_store.rs`) mirrors the proven TD-110 `TableUniqueIndex` shape: per-table hash index `value-text → oids`, lazily built on first probe from current state, maintained incrementally after each WAL append (insert/upsert/update/delete), with oid self-tracking so an UPDATE detaches the old value.
- **`lookup_secondary`** on the `TableRecordStore` trait (default `None` → scan); `DirectWalTableRecordStore` probes the index; `CatalogRoutingTableRecordStore` **forwards** so the routed native store is actually consulted.
- **`SecondaryIndexLookup`** access path inserted in `select_table_records_with_tree` between the PK fast-path and the scan fallback: extract a single-column equality / non-negated `IN` leaf on an indexed non-PK column (OR-safe), probe → candidate oids → re-check each against the **full** predicate tree → return.
- **Text alignment:** the probe renders the literal through the same `proxima_value_to_unique_text` the index stores, so probe/index text are byte-identical. Float columns are excluded (f32/f64 shortest-round-trip can diverge); eligible types are string/integer/boolean.
- **Kill-switch:** `PROXIMADB_SECONDARY_INDEX_DISABLE` forces the scan fallback (mirrors `PROXIMADB_SCAN_INDEX_DISABLE`).
- Column source is the cataloged `relational_capabilities.secondary_indexes` (single-column entries), which survives the `ObjectSchema` round-trip — so the read path sees it.

Correctness holds **with or without** an index (default `None` → identical scan results). No `unwrap/expect/panic` in new production code.

## Tests

- `record_store.rs`: build/probe/IN-list union; UPDATE/DELETE incremental maintenance; unindexed-column → `None`; kill-switch → `None`.
- `dml/mod.rs` end-to-end (programmatic schema): `WHERE name = 'parse'` and `WHERE file IN (...)` report **`SecondaryIndexLookup`** (not `TableScan`) with correct rows; full-predicate re-check (`name=parse AND file=b.rs → s2`); kill-switch → `TableScan` with identical rows.

All 4 pass (`cargo test --lib secondary_index`). `cargo fmt` + `cargo clippy --lib` clean on the changed files.

## Scope / follow-ons

- The **DDL/API surface to declare** secondary indexes (`CREATE INDEX` → catalog mutation; v2 collection-create indexed columns → `secondary_indexes`) is a deliberate follow-on; this PR is the engine mechanism, exercised via programmatically-registered schemas.
- Deferred under TD-128: range/`BETWEEN` pushdown (needs an ordered BTree index) and the relational-planner `ScanAccess::BatchLookup` seam.

> Note: pre-existing `tests/integration/*` files reference symbols deleted in the base commit #208 (`InternalCollectionProvider`/`universal_backend`); they are unrelated to this change and untouched here.