### PR TITLE
feat(graph): stream the Flight columnar graph export with pagination

### DIFF
--- a/src/graph/service_node_ops.rs
+++ b/src/graph/service_node_ops.rs
@@ -298,6 +298,12 @@ impl super::GraphOperationsService {
             }
         }
 
+        // Stable total order by node id before paging. The candidate set is
+        // gathered from hash maps (non-deterministic iteration), so without this
+        // sort `offset`/`limit` would shift between calls and paginated reads
+        // (e.g. the Flight columnar export) would duplicate or skip rows.
+        results.sort_by(|a, b| a.id.cmp(&b.id));
+
         // Apply offset/limit for pagination
         let offset = query.offset.unwrap_or(0) as usize;
         let limit = query.limit.unwrap_or(results.len() as u32) as usize;

--- a/src/network/arrow_ipc/graph_codec.rs
+++ b/src/network/arrow_ipc/graph_codec.rs
@@ -120,6 +120,14 @@ pub fn graph_edge_schema() -> Arc<Schema> {
 /// first node that carries an embedding. Returns 0 when no node has one.
 /// Errors if two nodes carry embeddings of differing length (a single
 /// `FixedSizeList` batch is one stride wide — split mixed dims per graph).
+///
+/// Exposed so a streaming export can fix the schema dimension from the first
+/// page and reuse it for every subsequent page (one consistent Arrow schema
+/// across the whole DoGet stream).
+pub fn embedding_dim_of(nodes: &[Node]) -> Result<usize> {
+    batch_embedding_dim(nodes)
+}
+
 fn batch_embedding_dim(nodes: &[Node]) -> Result<usize> {
     let mut dim: Option<usize> = None;
     for n in nodes {
@@ -143,9 +151,18 @@ fn batch_embedding_dim(nodes: &[Node]) -> Result<usize> {
 
 // ── Node encode / decode ────────────────────────────────────────────────────
 
-/// Encode neutral graph nodes into a columnar Arrow [`RecordBatch`].
+/// Encode neutral graph nodes into a columnar Arrow [`RecordBatch`], deriving
+/// the embedding dimension from the batch.
 pub fn nodes_to_batch(nodes: &[Node]) -> Result<RecordBatch> {
     let embedding_dim = batch_embedding_dim(nodes)?;
+    nodes_to_batch_with_dim(nodes, embedding_dim)
+}
+
+/// Encode nodes with an explicit, caller-fixed embedding dimension. Used by the
+/// streaming export so every page shares one schema; a node whose embedding
+/// length differs from `embedding_dim` is rejected (mixed strides can't share a
+/// `FixedSizeList` column), and a node without an embedding emits a null list.
+pub fn nodes_to_batch_with_dim(nodes: &[Node], embedding_dim: usize) -> Result<RecordBatch> {
     let schema = graph_node_schema(embedding_dim);
 
     let ids = StringArray::from_iter_values(nodes.iter().map(|n| n.id.as_str()));
@@ -186,6 +203,12 @@ pub fn nodes_to_batch(nodes: &[Node]) -> Result<RecordBatch> {
                     present.push(true);
                     metas.push(serde_json::to_string(&EmbeddingMeta::from_embedding(e)).ok());
                 }
+                Some(e) if !e.vector.is_empty() => bail!(
+                    "node `{}` embedding dimension {} does not match the batch dimension {}",
+                    n.id,
+                    e.vector.len(),
+                    embedding_dim
+                ),
                 _ => {
                     flat.extend(std::iter::repeat_n(0.0f32, embedding_dim));
                     present.push(false);

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -15,7 +15,8 @@ use anyhow::{Context, Result};
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
-    decode::FlightRecordBatchStream, flight_service_server::FlightService,
+    decode::FlightRecordBatchStream, encode::FlightDataEncoderBuilder, error::FlightError,
+    flight_service_server::FlightService,
 };
 use arrow_schema::Schema;
 use futures::{Stream, StreamExt, stream};
@@ -90,6 +91,25 @@ struct GraphTicket {
     to_node_id: Option<String>,
     #[serde(default)]
     limit: Option<u32>,
+}
+
+/// `RecordBatch` source item for the streaming graph export (the input to the
+/// Flight `FlightDataEncoder`).
+type GraphBatchResult = std::result::Result<arrow_array::RecordBatch, FlightError>;
+
+/// Pagination state for the streaming node export.
+enum NodePage {
+    /// Pre-fetched first page — also used to fix the stream's schema dimension.
+    First(Vec<crate::graph::Node>),
+    /// Fetch the page starting at this offset next.
+    More(usize),
+    /// No more pages.
+    Done,
+}
+
+/// Map a graph/codec error into a Flight stream error.
+fn graph_flight_err(e: anyhow::Error) -> FlightError {
+    FlightError::ProtocolError(e.to_string())
 }
 
 /// ProximaDB Flight service implementation
@@ -1317,32 +1337,17 @@ impl FlightService for ProximaFlightService {
         }
 
         // Batched columnar graph export: a graph ticket reads nodes/edges from
-        // the live graph engine and streams them as columnar Arrow batches.
+        // the live graph engine and streams them, paginated, as columnar Arrow
+        // batches — the server never materializes the whole result set.
         if let Some(graph_ticket) = Self::parse_graph_ticket(&ticket) {
             Self::validate_flight_search_capability(
                 auth_context.capability.as_ref(),
                 &graph_ticket.graph_id,
             )?;
-            let batches = self
-                .handle_graph_export(&graph_ticket, auth_context.tenant_id.as_deref())
-                .await
-                .map_err(|e| TonicStatus::internal(format!("Graph export failed: {}", e)))?;
-            let compression = if edge.shape_policy().compress {
-                FlightCompression::Zstd.to_arrow_compression()
-            } else {
-                None
-            };
-            let flight_data =
-                ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
-                    .map_err(|e| {
-                        TonicStatus::internal(format!("Failed to encode graph batches: {}", e))
-                    })?;
-            edge.record_result_egress(
-                auth_context.tenant_id.as_deref(),
-                flight_data_wire_bytes(&flight_data),
-            );
-            let stream = stream::iter(flight_data.into_iter().map(Ok));
-            return Ok(TonicResponse::new(Box::pin(stream)));
+            let stream = self
+                .graph_export_flight_stream(graph_ticket, auth_context.tenant_id.clone(), edge)
+                .await?;
+            return Ok(TonicResponse::new(stream));
         }
 
         // Otherwise, handle as vector search request
@@ -2744,55 +2749,169 @@ impl ProximaFlightService {
         matches!(parsed.model.as_str(), "graph_nodes" | "graph_edges").then_some(parsed)
     }
 
-    /// Read nodes or edges from the live graph engine and encode them as columnar
-    /// Arrow batches (the DoGet half of the batched columnar graph path).
-    async fn handle_graph_export(
+    /// Stream a graph export as a paginated columnar Flight response (the DoGet
+    /// half of the batched columnar graph path).
+    ///
+    /// Nodes are paged through `query_nodes` (limit/offset), so the server never
+    /// holds the whole node set; the schema dimension is fixed from the first
+    /// page so every page shares one Arrow schema. Edges are endpoint-scoped (the
+    /// engine has no full edge scan) and chunked. The `FlightDataEncoder` emits
+    /// one schema frame then a data frame per page; `ticket.limit` sets the page
+    /// size (the client streams pages and may cancel early). Egress bytes are
+    /// metered per frame.
+    async fn graph_export_flight_stream(
         &self,
-        ticket: &GraphTicket,
-        tenant_id: Option<&str>,
-    ) -> Result<Vec<arrow_array::RecordBatch>> {
-        let graph = self
-            .graph_service
-            .as_ref()
-            .context("graph Flight path requires the graph backing service")?;
-        let effective_graph_id = Self::effective_graph_id(tenant_id, &ticket.graph_id);
+        ticket: GraphTicket,
+        tenant_id: Option<String>,
+        edge: crate::metrics::consumption_metrics::EdgePolicyContext,
+    ) -> std::result::Result<<Self as FlightService>::DoGetStream, TonicStatus> {
+        const DEFAULT_PAGE: usize = 1024;
+        let graph = self.graph_service.clone().ok_or_else(|| {
+            TonicStatus::unimplemented("graph Flight path requires the graph backing service")
+        })?;
+        let gid = Self::effective_graph_id(tenant_id.as_deref(), &ticket.graph_id);
+        let page = ticket
+            .limit
+            .map(|l| l as usize)
+            .filter(|&l| l > 0)
+            .unwrap_or(DEFAULT_PAGE);
 
-        if ticket.model == "graph_nodes" {
-            let query = crate::graph::NodeQuery {
-                graph_id: effective_graph_id.clone(),
-                labels: ticket.label.clone().into_iter().collect(),
-                filters: Vec::new(),
-                limit: ticket.limit,
-                offset: None,
-                continuation_token: None,
-            };
-            let nodes = graph.query_nodes(&effective_graph_id, query).await?;
-            let nodes: Vec<crate::graph::Node> = nodes.iter().map(|n| (**n).clone()).collect();
-            Ok(vec![super::graph_codec::nodes_to_batch(&nodes)?])
+        // Egress-aware shaping (co-design D2): compress the columnar body for
+        // chargeable (far) clients; the Arrow reader decompresses transparently.
+        let ipc_options = if edge.shape_policy().compress {
+            FlightCompression::Zstd.to_ipc_write_options()
         } else {
-            // The graph engine has no full edge scan; edge export is scoped to a
-            // node's adjacency. Require an endpoint so the contract is explicit
-            // rather than silently returning an empty batch.
+            FlightCompression::None.to_ipc_write_options()
+        };
+
+        let (schema, rb_stream): (
+            Arc<Schema>,
+            Pin<Box<dyn Stream<Item = GraphBatchResult> + Send>>,
+        ) = if ticket.model == "graph_nodes" {
+            let labels: Vec<String> = ticket.label.clone().into_iter().collect();
+            // Peek the first page to fix the schema dimension for the whole stream.
+            let first = Self::query_node_page(&graph, &gid, &labels, page, 0)
+                .await
+                .map_err(|e| TonicStatus::internal(format!("query nodes: {e}")))?;
+            let dim = super::graph_codec::embedding_dim_of(&first)
+                .map_err(|e| TonicStatus::invalid_argument(format!("embedding dim: {e}")))?;
+            let schema = super::graph_codec::graph_node_schema(dim);
+
+            let stream = stream::unfold(NodePage::First(first), move |state| {
+                let graph = graph.clone();
+                let gid = gid.clone();
+                let labels = labels.clone();
+                async move {
+                    match state {
+                        NodePage::First(nodes) => {
+                            let next = if nodes.len() < page {
+                                NodePage::Done
+                            } else {
+                                NodePage::More(page)
+                            };
+                            Some((
+                                super::graph_codec::nodes_to_batch_with_dim(&nodes, dim)
+                                    .map_err(graph_flight_err),
+                                next,
+                            ))
+                        }
+                        NodePage::More(offset) => {
+                            match Self::query_node_page(&graph, &gid, &labels, page, offset).await {
+                                Ok(nodes) if !nodes.is_empty() => {
+                                    let next = if nodes.len() < page {
+                                        NodePage::Done
+                                    } else {
+                                        NodePage::More(offset + page)
+                                    };
+                                    Some((
+                                        super::graph_codec::nodes_to_batch_with_dim(&nodes, dim)
+                                            .map_err(graph_flight_err),
+                                        next,
+                                    ))
+                                }
+                                Ok(_) => None,
+                                Err(e) => Some((Err(graph_flight_err(e)), NodePage::Done)),
+                            }
+                        }
+                        NodePage::Done => None,
+                    }
+                }
+            });
+            (schema, Box::pin(stream))
+        } else {
+            // Edge export is endpoint-scoped (no full edge scan); require an
+            // endpoint rather than silently returning an empty stream.
             if ticket.from_node_id.is_none() && ticket.to_node_id.is_none() {
-                anyhow::bail!(
+                return Err(TonicStatus::invalid_argument(
                     "graph_edges export requires `from_node_id` or `to_node_id` \
-                     (the engine has no full edge scan)"
-                );
+                     (the engine has no full edge scan)",
+                ));
             }
             let query = crate::graph::EdgeQuery {
-                graph_id: effective_graph_id.clone(),
+                graph_id: gid.clone(),
                 from_node_id: ticket.from_node_id.clone(),
                 to_node_id: ticket.to_node_id.clone(),
                 edge_types: ticket.edge_type.clone().into_iter().collect(),
                 filters: Vec::new(),
-                limit: ticket.limit,
+                limit: None,
                 offset: None,
                 continuation_token: None,
             };
-            let edges = graph.query_edges(&effective_graph_id, query).await?;
+            let edges = graph
+                .query_edges(&gid, query)
+                .await
+                .map_err(|e| TonicStatus::internal(format!("query edges: {e}")))?;
             let edges: Vec<crate::graph::Edge> = edges.iter().map(|e| (**e).clone()).collect();
-            Ok(vec![super::graph_codec::edges_to_batch(&edges)?])
-        }
+            let batches: Vec<GraphBatchResult> = edges
+                .chunks(page)
+                .map(|chunk| super::graph_codec::edges_to_batch(chunk).map_err(graph_flight_err))
+                .collect();
+            (
+                super::graph_codec::graph_edge_schema(),
+                Box::pin(stream::iter(batches)),
+            )
+        };
+
+        let encoder = FlightDataEncoderBuilder::new()
+            .with_schema(schema)
+            .with_options(ipc_options)
+            .build(rb_stream);
+
+        // Meter the actual encoded bytes per frame, then surface encode errors
+        // as a stream-level status.
+        let metered = encoder.map(move |res| match res {
+            Ok(fd) => {
+                edge.record_result_egress(
+                    tenant_id.as_deref(),
+                    flight_data_wire_bytes(std::slice::from_ref(&fd)),
+                );
+                Ok(fd)
+            }
+            Err(e) => Err(TonicStatus::internal(format!("graph export encode: {e}"))),
+        });
+
+        Ok(Box::pin(metered))
+    }
+
+    /// Fetch one page of nodes (label-scoped, or full scan when `labels` is
+    /// empty) as neutral nodes.
+    async fn query_node_page(
+        graph: &crate::graph::GraphOperationsService,
+        graph_id: &str,
+        labels: &[String],
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<crate::graph::Node>> {
+        let query = crate::graph::NodeQuery {
+            graph_id: graph_id.to_string(),
+            labels: labels.to_vec(),
+            filters: Vec::new(),
+            limit: Some(limit as u32),
+            offset: Some(offset as u32),
+            continuation_token: None,
+        };
+        let nodes = graph.query_nodes(graph_id, query).await?;
+        Ok(nodes.iter().map(|n| (**n).clone()).collect())
     }
 
     /// Handle bulk search exchange - stream query vectors and return results

--- a/tests/graph_flight_columnar_test.rs
+++ b/tests/graph_flight_columnar_test.rs
@@ -193,3 +193,84 @@ async fn columnar_edge_ingest_and_export_round_trip() {
         assert_eq!(orig.weight, got.weight);
     }
 }
+
+/// Read one page of nodes (full scan; empty label set) — mirrors the streaming
+/// export's `query_node_page`.
+async fn query_page(
+    graph: &GraphOperationsService,
+    graph_id: &str,
+    limit: u32,
+    offset: u32,
+) -> Vec<Node> {
+    let query = proximadb::graph::NodeQuery {
+        graph_id: graph_id.to_string(),
+        labels: Vec::new(),
+        filters: Vec::new(),
+        limit: Some(limit),
+        offset: Some(offset),
+        continuation_token: None,
+    };
+    let nodes = graph
+        .query_nodes(graph_id, query)
+        .await
+        .expect("query page");
+    nodes.iter().map(|n| (**n).clone()).collect()
+}
+
+/// The streaming export pages `query_nodes` and re-encodes each page with the
+/// dimension fixed from the first page, so every page shares ONE Arrow schema.
+/// This verifies that paginated re-encode reconstructs every node and the
+/// per-page schema is stable (what the `FlightDataEncoder` requires).
+#[tokio::test]
+async fn columnar_node_export_paginates_with_fixed_schema() {
+    let graph = Arc::new(GraphOperationsService::new());
+    let graph_id = "g_columnar_paged";
+    create_graph(&graph, graph_id).await;
+
+    // Ingest 5 nodes, all embedding dim 4.
+    let originals: Vec<Node> = (0..5).map(|i| node(&format!("n{i}"), 4)).collect();
+    let batch = graph_codec::nodes_to_batch(&originals).expect("encode");
+    let decoded = graph_codec::batch_to_nodes(&batch).expect("decode");
+    graph
+        .batch_create_nodes_with_strategy(graph_id, decoded, "update")
+        .await
+        .expect("bulk create");
+
+    // Fix the schema dimension from the first page (the streaming contract).
+    let page = 2u32;
+    let first = query_page(&graph, graph_id, page, 0).await;
+    let dim = graph_codec::embedding_dim_of(&first).expect("dim");
+    assert_eq!(dim, 4);
+    let fixed_schema = graph_codec::graph_node_schema(dim);
+
+    // Page through, re-encoding each page with the FIXED dim; every page must
+    // carry the identical schema, and the union reconstructs all nodes.
+    let mut all: Vec<Node> = Vec::new();
+    let mut offset = 0u32;
+    loop {
+        let nodes = if offset == 0 {
+            first.clone()
+        } else {
+            query_page(&graph, graph_id, page, offset).await
+        };
+        if nodes.is_empty() {
+            break;
+        }
+        let b = graph_codec::nodes_to_batch_with_dim(&nodes, dim as usize).expect("encode page");
+        assert_eq!(b.schema(), fixed_schema, "every page shares one schema");
+        all.extend(graph_codec::batch_to_nodes(&b).expect("decode page"));
+        let n = nodes.len();
+        offset += page;
+        if (n as u32) < page {
+            break;
+        }
+    }
+
+    let mut ids: Vec<String> = all.iter().map(|n| n.id.clone()).collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["n0", "n1", "n2", "n3", "n4"],
+        "pagination reconstructs every node exactly once"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to the batched columnar graph path (#198): replaces the single-materialized-batch graph `DoGet` export with a **true streaming, paginated** response, so exporting a large graph never holds the whole result set on the server.

## What changed

- **`service.rs` — `graph_export_flight_stream`:** lazily pages `query_nodes` (limit/offset) and feeds a `FlightDataEncoder`, emitting **one schema frame + a data frame per page**. The schema dimension is fixed from the first page so every page shares one Arrow schema; `ticket.limit` sets the page size (the client streams pages and may cancel early). Edges are endpoint-scoped and chunked. Egress bytes are metered **per frame**, and the egress-aware zstd shaping for far clients is preserved (via `IpcWriteOptions`).
- **`graph_codec.rs`:** `nodes_to_batch_with_dim(nodes, dim)` (fixed-schema encode) + `embedding_dim_of()`; `nodes_to_batch` delegates to it. A node whose embedding length differs from the fixed batch dimension now **errors** instead of silently dropping the vector.
- **`service_node_ops.rs` — `query_nodes` now sorts results by node id before `offset`/`limit`.** The candidate set is gathered from hash maps (non-deterministic iteration order), so without a stable total order, paginated reads would duplicate or skip rows. This is required for correct offset pagination (and makes query results deterministic generally).

## Verification

- `cargo check -p proximadb --lib` — green (against current develop)
- `cargo clippy -p proximadb --lib --bins -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --test graph_flight_columnar_test` — 3/3, incl. `columnar_node_export_paginates_with_fixed_schema` (5 nodes, page size 2: asserts every page shares one schema and pagination reconstructs each node exactly once)
- `cargo test -p proximadb --lib graph_codec` — 5/5