### PR TITLE
fix(hardware-caps): declare the missing raw-cpuid x86_64 dependency

### DIFF
--- a/crates/foundation/proximadb-hardware-caps/Cargo.toml
+++ b/crates/foundation/proximadb-hardware-caps/Cargo.toml
@@ -26,3 +26,12 @@ serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 proximadb-hardware.workspace = true
 proximadb-config.workspace = true
+
+# `raw_cpuid` is used only inside `#[cfg(target_arch = "x86_64")]` blocks
+# (CPUID vendor/model/cache probing in `get_cpu_info`), so gate the dependency to
+# x86_64 — non-x86 targets (e.g. aarch64/macOS) don't compile those paths. The
+# crate extraction (#180) moved the code here but left the dependency on the root
+# crate, which broke the x86_64 build (`use raw_cpuid` resolved to an undeclared
+# crate). Pinned to match the root crate's existing `raw-cpuid = "11.0"`.
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+raw-cpuid = "11.0"


### PR DESCRIPTION
## Problem

`proximadb-hardware-caps/src/lib.rs` uses `raw_cpuid::CpuId` inside `#[cfg(target_arch = "x86_64")]` blocks (CPU vendor/model/cache probing in `get_cpu_info`), but the crate's `Cargo.toml` never declared `raw-cpuid`. The hardware-caps extraction (#180) moved the code into this crate while the `raw-cpuid` dependency stayed on the root crate's `[dependencies]`.

**Effect:** on **x86_64** the cfg blocks compile and `use raw_cpuid` resolves to an undeclared crate → `error[E0432]/[E0433]: unresolved import / cannot find module raw_cpuid`. This fails **both** `Rust Build (dev)` and `Rust Build (release)` on the x86_64 Linux runners — currently red on develop and blocking every PR's build (e.g. #216).

It went unnoticed because **aarch64/macOS** builds (local dev on Apple Silicon and the macOS CI) never compile the `#[cfg(target_arch = "x86_64")]` paths.

## Fix

Declare `raw-cpuid = "11.0"` (matching the root crate's existing pin) as an **x86_64-target** dependency in `proximadb-hardware-caps/Cargo.toml`, so the cfg-gated code links. Non-x86 targets are unaffected.

## Verification

- `cargo metadata` parses the manifest.
- `cargo tree -p proximadb-hardware-caps --target x86_64-unknown-linux-gnu -i raw-cpuid` → `raw-cpuid v11.6.0` now linked.
- `cargo tree --target aarch64-apple-darwin` → not linked (correctly gated off).
- The code itself was already correct; only the dependency declaration was missing. The x86_64 CI build is the authoritative check (can't be compiled on an aarch64 dev box).