### PR TITLE
fix(compute-bridge): repoint stale super::quantization_engine paths (#217 regression)

### DIFF
--- a/src/storage/compute_bridge/global_cache.rs
+++ b/src/storage/compute_bridge/global_cache.rs
@@ -825,15 +825,18 @@ impl GlobalQuantizationCache {
     pub async fn get_or_create_engine(
         &self,
         _collection_id: String,
-    ) -> Arc<super::quantization_engine::UnifiedQuantizationEngine> {
+    ) -> Arc<crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine> {
         // For now, create a simple UnifiedQuantizationEngine with the global cache as codebook store
         // This provides the unified interface expected by the engines
-        Arc::new(super::quantization_engine::UnifiedQuantizationEngine::new(
-            Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+        Arc::new(
+            crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(
+                Arc::new(
+                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+                ),
+                Self::global()
+                    as Arc<dyn crate::compute::quantization::quantization_engine::CodebookStore>,
             ),
-            Self::global() as Arc<dyn super::quantization_engine::CodebookStore>,
-        ))
+        )
     }
 
     /// Update collection size for adaptive storage strategy decisions


### PR DESCRIPTION
## Problem

develop's `proximadb` lib currently **does not compile** (any target/feature set):

```
error[E0433]: cannot find `quantization_engine` in `super`
  --> src/storage/compute_bridge/global_cache.rs:828 / :831 / :835
```

The Q2 quantization-glue relocation (#217) moved `global_cache.rs` into `storage::compute_bridge` but left three `super::quantization_engine::...` references. `super::` now resolves against `crate::storage::compute_bridge` (which has no `quantization_engine` module) instead of the engine's real home, `crate::compute::quantization::quantization_engine`.

It merged because "Rust Build" is non-gating, but the lib is red on develop now, blocking everyone.

## Fix

Repoint the three sites to the absolute path — the same module `global_cache.rs` already imports `CodebookStore`/`Codebook` from (line 14). `UnifiedQuantizationEngine` and `CodebookStore` live at `src/compute/quantization/quantization_engine.rs`.

## Verification

- `cargo check -p proximadb --lib` — green
- `cargo fmt --all --check` — clean

Heads-up posted on #217. This is the minimal regression fix; if the decomp owner prefers a re-export shim under `compute_bridge` instead, happy to defer.