### PR TITLE
perf(graph): batch adjacency projection apply in bulk edge insert (TD-130)

### DIFF
--- a/src/graph/adjacency_projection.rs
+++ b/src/graph/adjacency_projection.rs
@@ -178,6 +178,46 @@ impl InMemoryGraphAdjacencyProjection {
         }
         removed
     }
+
+    /// TD-130: apply a batch of canonical edge records under a SINGLE write-lock
+    /// acquisition and a SINGLE epoch bump, instead of one lock-cycle + epoch
+    /// bump per edge (`apply_edge`). This removes the per-edge serialization that
+    /// dominated bulk edge ingest — the projection lock, not the O(1) composite
+    /// probe, was the measured per-edge cost on the batch path (e.g. ~96.5K
+    /// edges/repo at initial code-graph index). Entries are computed outside the
+    /// lock; upsert semantics match `apply_edge` (each edge's prior entries are
+    /// removed first). Returns the total adjacency entries written.
+    pub fn apply_edges(&self, edge_records: &[ProximaRecord]) -> ProjectionResult<usize> {
+        // Compute all entries before taking the lock; fail closed on any record
+        // that is not a canonical graph edge (same contract as `apply_edge`).
+        let mut prepared = Vec::with_capacity(edge_records.len());
+        for edge_record in edge_records {
+            let entries = adjacency_entries_for_edge(edge_record).ok_or_else(|| {
+                proximadb_kernel::error::ProximaDBError::InvalidInput(
+                    "record is not a canonical graph edge".to_string(),
+                )
+            })?;
+            prepared.push((edge_record.oid.as_str(), entries));
+        }
+        if prepared.is_empty() {
+            return Ok(0);
+        }
+
+        let mut state = self.state.write().map_err(|_| {
+            proximadb_kernel::error::ProximaDBError::Internal(
+                "graph adjacency projection write lock poisoned".to_string(),
+            )
+        })?;
+        let mut entries_written = 0;
+        for (edge_oid, entries) in prepared {
+            Self::remove_edge_oid(&mut state, edge_oid);
+            entries_written += Self::apply_entries(&mut state, entries);
+        }
+        // One epoch transition for the whole batch, so readers observe the batch
+        // atomically rather than N intermediate epochs.
+        state.epoch = state.epoch.next();
+        Ok(entries_written)
+    }
 }
 
 /// Convert the root graph edge compatibility shape into a canonical edge
@@ -471,6 +511,81 @@ mod tests {
             "graph/g1/edge/e1"
         );
         assert_eq!(projection.applied_epoch(), TopologyEpoch(2));
+    }
+
+    #[test]
+    fn apply_edges_batches_under_one_epoch() {
+        let projection = InMemoryGraphAdjacencyProjection::new("g1");
+        let records = vec![
+            edge_record("g1", "e1", "n1", "n2"),
+            edge_record("g1", "e2", "n1", "n3"),
+            edge_record("g1", "e3", "n2", "n3"),
+        ];
+
+        // Whole batch applied: 2 adjacency entries per edge (src + dst).
+        let written = projection.apply_edges(&records).expect("apply batch");
+        assert_eq!(written, 6);
+
+        // The key property (TD-130): ONE epoch transition for the batch, not one
+        // per edge — three `apply_edge` calls would land at TopologyEpoch(3).
+        assert_eq!(projection.applied_epoch(), TopologyEpoch(1));
+
+        // Topology is identical to the per-edge path.
+        assert_eq!(projection.edge_count().expect("edge count"), 3);
+        assert_eq!(
+            projection
+                .edges_by_src("graph/g1/node/n1")
+                .expect("n1 outgoing")
+                .len(),
+            2
+        );
+        assert_eq!(
+            projection
+                .edges_by_dst("graph/g1/node/n3")
+                .expect("n3 incoming")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn apply_edges_upserts_and_rejects_non_edges() {
+        let projection = InMemoryGraphAdjacencyProjection::new("g1");
+        // Seed an edge, then re-point it via a later batch — upsert must drop the
+        // old destination, matching `apply_edge`'s replace semantics.
+        projection
+            .apply_edges(&[edge_record("g1", "e1", "n1", "n2")])
+            .expect("seed");
+        projection
+            .apply_edges(&[edge_record("g1", "e1", "n1", "n3")])
+            .expect("repoint");
+        assert_eq!(projection.edge_count().expect("edge count"), 1);
+        assert!(
+            projection
+                .edges_by_dst("graph/g1/node/n2")
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            projection.edges_by_dst("graph/g1/node/n3").unwrap()[0]
+                .key
+                .edge_oid,
+            "graph/g1/edge/e1"
+        );
+
+        // A non-edge record fails closed before any state is mutated.
+        let node = node_to_canonical_record(
+            "g1",
+            &Node {
+                id: "n9".to_string(),
+                labels: vec!["Person".to_string()],
+                properties: HashMap::new(),
+                embedding: None,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+            },
+        );
+        assert!(projection.apply_edges(&[node]).is_err());
     }
 
     #[tokio::test]

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -106,7 +106,7 @@ use crate::storage::cache::orchestrator::{
     CacheStatsProvider, CacheType, CrossCacheOrchestrator, UsageStats,
 };
 use dashmap::DashMap;
-use proximadb_graph::projection::{GraphTopologyProjection, TopologyEpoch};
+use proximadb_graph::projection::TopologyEpoch;
 use proximadb_kernel::error::ProximaDBError;
 use proximadb_records::{RecordKey, RecordStore};
 use proximadb_storage_common::{CanonicalOperation, CanonicalWalEntry, SnapshotManifest};
@@ -2352,11 +2352,16 @@ impl GraphOperationsService {
 
         let projection_start = std::time::Instant::now();
         if !inserted.is_empty() {
-            let projection = self.adjacency_projection(graph_id);
-            for edge in &inserted {
-                let edge_record = edge_to_canonical_record(graph_id, edge);
-                projection.apply_edge(&edge_record).await?;
-            }
+            // TD-130: build every canonical edge record, then apply the whole
+            // batch under ONE projection write-lock + ONE epoch bump — was one
+            // lock-cycle + epoch bump (and one await) per edge, the per-edge
+            // serialization that dominated bulk ingest.
+            let edge_records: Vec<_> = inserted
+                .iter()
+                .map(|edge| edge_to_canonical_record(graph_id, edge))
+                .collect();
+            self.adjacency_projection(graph_id)
+                .apply_edges(&edge_records)?;
             self.advance_edge_epoch(graph_id);
         }
         let projection_time = projection_start.elapsed();


### PR DESCRIPTION
## What

Second item in the code-graph native sequence (after TD-127/128 secondary indexes, #215). Removes the last per-edge serialization point on the **bulk graph-edge insert** path — the hot path for initial code-graph indexing (~96.5K cross-fn edges/repo).

## Trace, don't tune

The plan hypothesized a "sorted LSM merge to kill per-edge uniqueness serialization." Reading the actual batch path (`batch_create_edges`, `service.rs:2237`) shows the composite-uniqueness check is already **O(1) per edge** (a `DashMap` probe) — not a serialization bottleneck. ORION's CSR build and the canonical record write are **already batched**.

The real remaining per-edge cost is the **adjacency-projection apply loop** (`service.rs:2356`): each edge separately
- acquires the projection-state `RwLock`,
- bumps the topology epoch,
- and is `await`ed.

So per the co-design mandate (optimize the *measured* dominant term, not a hypothesized one), this PR batches **that** seam and leaves the composite probe alone.

## How

- New inherent `InMemoryGraphAdjacencyProjection::apply_edges(&[ProximaRecord])` (`adjacency_projection.rs`): compute all adjacency entries **outside** the lock, then apply the whole batch under **one** write-lock acquisition and **one** epoch transition. Upsert semantics (prior entries removed first) and the fail-closed-on-non-edge contract match `apply_edge`.
- `batch_create_edges` builds the canonical edge records and calls `apply_edges` once, instead of looping `apply_edge().await` per edge.

Result: N lock-cycles + N epoch bumps + N awaits → **1 + 1 + 0**. Readers observe the batch atomically (single epoch transition) rather than N intermediate epochs.

## Tests

- `apply_edges_batches_under_one_epoch`: a 3-edge batch lands at `TopologyEpoch(1)` (the per-edge path would reach `(3)`), with identical topology (edge_count + neighbor sets).
- `apply_edges_upserts_and_rejects_non_edges`: batch re-point drops the old destination; a non-edge record fails **before** any state mutation.
- Existing `edge_crud_maintains_adjacency_projection` (service-level batch) and all `adjacency_projection` tests still pass — wiring validated.

`cargo fmt` + `cargo clippy --lib` clean on the changed files; no `unwrap/expect/panic` in new production code.

## Scope

Single-edge `create_edge` is unchanged. Composite-uniqueness semantics unchanged. Follow-on (separate): batch the per-edge canonical-record build (currently built twice — once for the record store, once for the projection) and extend the same batching to node projections if a bulk-node path shows the same cost.