### PR TITLE
fix(compute_bridge): repoint stale super::quantization_engine path (Q2 #217 follow-up)

### DIFF
--- a/src/storage/compute_bridge/global_cache.rs
+++ b/src/storage/compute_bridge/global_cache.rs
@@ -825,15 +825,18 @@ impl GlobalQuantizationCache {
     pub async fn get_or_create_engine(
         &self,
         _collection_id: String,
-    ) -> Arc<super::quantization_engine::UnifiedQuantizationEngine> {
+    ) -> Arc<crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine> {
         // For now, create a simple UnifiedQuantizationEngine with the global cache as codebook store
         // This provides the unified interface expected by the engines
-        Arc::new(super::quantization_engine::UnifiedQuantizationEngine::new(
-            Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+        Arc::new(
+            crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(
+                Arc::new(
+                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+                ),
+                Self::global()
+                    as Arc<dyn crate::compute::quantization::quantization_engine::CodebookStore>,
             ),
-            Self::global() as Arc<dyn super::quantization_engine::CodebookStore>,
-        ))
+        )
     }
 
     /// Update collection size for adaptive storage strategy decisions


### PR DESCRIPTION
## What

Fixes the `E0433` x86_64 **`Rust Build (release)`** regression #217 (Q2) left on develop.

When Q2 moved `global_cache.rs` into `src/storage/compute_bridge/`, three **inline** `super::quantization_engine::` references in `get_or_create_engine` (`global_cache.rs:828/831/835`) were missed — #217 repointed the two `use` lines (14, 290) but the grep didn't catch inline path refs. After the move `super` = `crate::storage::compute_bridge` (no `quantization_engine` module), so the release build failed:

```
error[E0433]: cannot find `quantization_engine` in `super`
  --> src/storage/compute_bridge/global_cache.rs:828/831/835
```

`Rust Build` is non-gating (only `CI Success` gates), so #217 auto-merged before this surfaced.

## Fix

Repoint the 3 sites to the canonical `crate::compute::quantization::quantization_engine` — the exact path the `use` lines at 14/290 already use. (The kernel sibling-ref at `storage_engine.rs:12` is still *inside* `compute/quantization/`, so its `super::` correctly resolves and is left unchanged.) rustfmt reflowed the `Arc::new(...)` block accordingly.

## Verification

- Grep: no `super::quantization_engine` left in `src/storage/compute_bridge/`.
- `cargo check -p proximadb --lib`: **green**.
- `cargo fmt -p proximadb -- --check`: clean.

Thanks @vjsingh1984 for the precise handoff on #217.