### PR TITLE
feat(catalog): CatalogRole + account-aware (flag-gated) catalog storage path (system-catalog 5b)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -72,6 +72,50 @@ pub enum StoragePoolClass {
     Dedicated,
 }
 
+/// Plane a catalog instance serves in the two-tier operator/account isolation
+/// model (Phase 5).
+///
+/// * [`Operator`](Self::Operator) — the SaaS provider's **control-plane**
+///   registry of all customer accounts (entitlements, storage bindings,
+///   billing). It holds metadata-*about*-accounts, never tenant table data,
+///   and is stored under the reserved `_operator/` root.
+/// * [`Account`](Self::Account) — a customer account's **data-plane** catalog
+///   (its tenants → namespaces → objects), stored under
+///   `accounts/{account_id}/…`. A per-account catalog is structurally unable to
+///   name another account's objects — isolation is structural, not a query
+///   predicate.
+///
+/// Single-deployment default is one `Operator`-roled system catalog (it holds
+/// the whole deployment's objects until multi-account provisioning splits
+/// data-plane catalogs out per account).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogRole {
+    /// Control-plane registry of accounts (under `_operator/`).
+    Operator,
+    /// Data-plane catalog scoped to one customer account.
+    Account {
+        /// The owning account ID (roots the catalog under `accounts/{id}/…`).
+        account_id: String,
+    },
+}
+
+impl CatalogRole {
+    /// The owning account ID for an [`Account`](Self::Account) catalog, or
+    /// `None` for the [`Operator`](Self::Operator) control plane.
+    pub fn account_id(&self) -> Option<&str> {
+        match self {
+            CatalogRole::Operator => None,
+            CatalogRole::Account { account_id } => Some(account_id.as_str()),
+        }
+    }
+
+    /// True for the control-plane operator catalog.
+    pub fn is_operator(&self) -> bool {
+        matches!(self, CatalogRole::Operator)
+    }
+}
+
 /// Namespace metadata.
 ///
 /// Serves two roles:
@@ -2858,6 +2902,28 @@ mod tests {
         assert!(ns.default_dr_region_pair_id.is_none());
         assert_eq!(ns.storage_pool_class, StoragePoolClass::Pooled);
         assert!(!ns.is_dr_addressable());
+    }
+
+    #[test]
+    fn catalog_role_accessors_and_serde() {
+        let op = CatalogRole::Operator;
+        assert!(op.is_operator());
+        assert_eq!(op.account_id(), None);
+
+        let acct = CatalogRole::Account {
+            account_id: "acct_acme".to_string(),
+        };
+        assert!(!acct.is_operator());
+        assert_eq!(acct.account_id(), Some("acct_acme"));
+
+        // snake_case, round-trips.
+        let j = serde_json::to_string(&op).expect("ser operator");
+        assert_eq!(j, "\"operator\"");
+        let back: CatalogRole = serde_json::from_str(&j).expect("de operator");
+        assert_eq!(back, op);
+        let j2 = serde_json::to_string(&acct).expect("ser account");
+        let back2: CatalogRole = serde_json::from_str(&j2).expect("de account");
+        assert_eq!(back2, acct);
     }
 
     #[test]

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -65,9 +65,16 @@ pub type TenantContext = MiddlewareTenantContext;
 pub struct MiddlewareTenantContext {
     /// The tenant identifier
     pub tenant_id: String,
+    /// Owning customer **account** — the SaaS billing/isolation boundary above
+    /// `tenant_id` (a tenant is a workspace/sub-org inside an account). `None`
+    /// is single-account / default mode (resolve via
+    /// [`account_or_default`](Self::account_or_default)); the account tier is
+    /// inert until provisioned (Phase 5 two-tier operator/account model).
+    pub account_id: Option<String>,
     /// Source of the tenant ID (for audit logging)
     pub source: TenantIdSource,
-    /// Whether this is a system/admin tenant with elevated privileges
+    /// Whether this is a system/admin tenant with elevated privileges. Doubles
+    /// as the operator (control-plane) marker.
     pub is_system_tenant: bool,
 }
 
@@ -78,6 +85,7 @@ impl MiddlewareTenantContext {
         let is_system_tenant = tenant_id == "system" || tenant_id == "admin";
         Self {
             tenant_id,
+            account_id: None,
             source,
             is_system_tenant,
         }
@@ -86,6 +94,23 @@ impl MiddlewareTenantContext {
     /// Create a default/anonymous tenant context
     pub fn default_tenant() -> Self {
         Self::new("default", TenantIdSource::Default)
+    }
+
+    /// Set the owning customer account (Phase 5). Activates the account-rooted
+    /// isolation tree for this request; leaving it unset keeps single-account
+    /// / default behaviour.
+    pub fn with_account(mut self, account_id: impl Into<String>) -> Self {
+        self.account_id = Some(account_id.into());
+        self
+    }
+
+    /// The owning account ID, falling back to the reserved default-account ID
+    /// when none was provisioned. Use at I/O boundaries that always need an
+    /// account segment (e.g. `DrPathBuilder` account-rooted paths).
+    pub fn account_or_default(&self) -> &str {
+        self.account_id.as_deref().unwrap_or(
+            crate::storage::trait_components::path_resolver::DrPathBuilder::DEFAULT_ACCOUNT_ID,
+        )
     }
 
     /// Check if this is a valid tenant (not empty)
@@ -482,6 +507,19 @@ mod tests {
         let ctx = MiddlewareTenantContext::default_tenant();
         assert_eq!(ctx.tenant_id, "default");
         assert_eq!(ctx.source, TenantIdSource::Default);
+    }
+
+    #[test]
+    fn test_account_tier_inert_until_set() {
+        // Unset account → resolves to the reserved default-account ID.
+        let ctx = MiddlewareTenantContext::new("tnt_acme", TenantIdSource::Header);
+        assert!(ctx.account_id.is_none());
+        assert_eq!(ctx.account_or_default(), "default");
+
+        // Provisioned account → used verbatim.
+        let ctx = ctx.with_account("acct_acme");
+        assert_eq!(ctx.account_id.as_deref(), Some("acct_acme"));
+        assert_eq!(ctx.account_or_default(), "acct_acme");
     }
 
     #[test]

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -427,7 +427,21 @@ impl SharedServices {
                 && storage_config.metadata_url.starts_with("file://");
             if use_system_catalog {
                 let base = storage_config.metadata_url.trim_start_matches("file://");
-                let wal_path = std::path::Path::new(base).join("system-catalog.wal");
+                // Phase 5 (two-tier operator/account): route the system
+                // catalog's own WAL + snapshot under the DrPathBuilder-validated
+                // operator control-plane prefix (`_operator/catalog/…`) so
+                // catalog I/O honours the structural-isolation mandate instead
+                // of a raw `{base}/system-catalog.wal`. Flag-gated + inert by
+                // default (mirrors `PROXIMADB_WAREHOUSE_DRPATH`): the local path
+                // is unchanged until a deployment opts in, keeping existing
+                // on-disk catalog state in place. The catalog is `Operator`-roled.
+                let wal_path = if std::env::var("PROXIMADB_CATALOG_DRPATH").is_ok() {
+                    std::path::Path::new(base).join(
+                        crate::storage::trait_components::path_resolver::DrPathBuilder::system_catalog_wal_relpath(),
+                    )
+                } else {
+                    std::path::Path::new(base).join("system-catalog.wal")
+                };
                 if let Some(parent) = wal_path.parent() {
                     tokio::fs::create_dir_all(parent).await.with_context(|| {
                         format!("creating system-catalog dir {}", parent.display())

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -90,6 +90,11 @@ struct SnapshotConfig {
 /// WAL-backed read-heavy system catalog.
 pub struct SystemCatalog {
     name: String,
+    /// Plane this catalog serves (Phase 5 two-tier operator/account model).
+    /// Defaults to [`CatalogRole::Operator`] — the single-deployment system
+    /// catalog holds the whole deployment's objects until multi-account
+    /// provisioning splits data-plane catalogs out per account.
+    role: proximadb_catalog::CatalogRole,
     state: Arc<SystemCatalogState>,
     appender: Arc<dyn TableWalAppender>,
     /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
@@ -114,12 +119,25 @@ impl SystemCatalog {
     ) -> Self {
         Self {
             name: name.into(),
+            role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: None,
             commits_since_snapshot: AtomicU64::new(0),
         }
+    }
+
+    /// Set this catalog's plane in the two-tier operator/account model
+    /// (Phase 5). Default is [`CatalogRole::Operator`].
+    pub fn with_role(mut self, role: proximadb_catalog::CatalogRole) -> Self {
+        self.role = role;
+        self
+    }
+
+    /// The plane this catalog serves.
+    pub fn role(&self) -> &proximadb_catalog::CatalogRole {
+        &self.role
     }
 
     /// Open (or create) the catalog WAL at `wal_path`, restore the in-RAM
@@ -158,6 +176,7 @@ impl SystemCatalog {
 
         Ok(Self {
             name: name.into(),
+            role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
@@ -272,7 +291,7 @@ impl SystemCatalog {
         ns.namespace_id = Some(format!("ns_{}", uuid::Uuid::new_v4()));
         ns.tenant_id = tenant_id;
         self.commit(CatalogDelta::UpsertNamespace {
-            namespace: ns.clone(),
+            namespace: Box::new(ns.clone()),
         })
         .await?;
         Ok(ns)
@@ -370,8 +389,10 @@ impl Catalog for SystemCatalog {
             ns.properties.remove(&k);
         }
         ns.updated_at_ms = now_millis();
-        self.commit(CatalogDelta::UpsertNamespace { namespace: ns })
-            .await
+        self.commit(CatalogDelta::UpsertNamespace {
+            namespace: Box::new(ns),
+        })
+        .await
     }
 
     // ── Table operations ──────────────────────────────────────────────────

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -44,8 +44,9 @@ use proximadb_storage_common::{CanonicalOperation, CanonicalWalEntry};
 /// implement it (it absorbs storage-plane fields that are not comparable).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CatalogDelta {
-    /// Create or replace a namespace.
-    UpsertNamespace { namespace: CatalogNamespace },
+    /// Create or replace a namespace. Boxed to keep the enum small (the
+    /// namespace carries the account/tenant/DR authority fields).
+    UpsertNamespace { namespace: Box<CatalogNamespace> },
     /// Drop a namespace and all of its tables.
     DropNamespace { levels: Vec<String> },
     /// Create or replace a table/collection.
@@ -129,7 +130,7 @@ impl CatalogInner {
             CatalogDelta::UpsertNamespace { namespace } => {
                 let key = namespace.levels.clone();
                 self.ns_children.entry(key.clone()).or_default();
-                self.namespaces.insert(key, namespace);
+                self.namespaces.insert(key, *namespace);
             }
             CatalogDelta::DropNamespace { levels } => {
                 self.namespaces.remove(&levels);
@@ -367,7 +368,7 @@ mod tests {
                 .append_operations(
                     vec![
                         CatalogDelta::UpsertNamespace {
-                            namespace: ns(&["sales"]),
+                            namespace: Box::new(ns(&["sales"])),
                         }
                         .to_operation()?,
                         upsert_table_op(&["sales"], "orders"),
@@ -413,7 +414,7 @@ mod tests {
         state.apply_committed(
             1,
             CatalogDelta::UpsertNamespace {
-                namespace: ns(&["app"]),
+                namespace: Box::new(ns(&["app"])),
             },
         );
         state.apply_committed(
@@ -485,7 +486,7 @@ mod tests {
         state.apply_committed(
             1,
             CatalogDelta::UpsertNamespace {
-                namespace: ns(&["db", "public"]),
+                namespace: Box::new(ns(&["db", "public"])),
             },
         );
         state.apply_committed(
@@ -536,7 +537,7 @@ mod tests {
             .append_operations(
                 vec![
                     CatalogDelta::UpsertNamespace {
-                        namespace: ns(&["s"]),
+                        namespace: Box::new(ns(&["s"])),
                     }
                     .to_operation()?,
                     upsert_table_op(&["s"], "committed"),

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -726,6 +726,15 @@ impl DrPathBuilder {
     /// `None` account keeps the legacy flat `data/…` render instead.
     pub const DEFAULT_ACCOUNT_ID: &'static str = "default";
 
+    /// Reserved subpath under [`OPERATOR_ROOT`](Self::OPERATOR_ROOT) that holds
+    /// the deployment's system catalog (WAL + snapshot). Single canonical
+    /// constant so boot and any tooling agree on the location.
+    pub const SYSTEM_CATALOG_SUBPATH: &'static str = "catalog";
+
+    /// File name of the system catalog's canonical WAL within
+    /// [`system_catalog_subprefix`](Self::system_catalog_subprefix).
+    pub const SYSTEM_CATALOG_WAL_FILE: &'static str = "system-catalog.wal";
+
     /// Build a validated control-plane (operator) subprefix
     /// `_operator/<subpath>/`. `subpath` runs through the same
     /// [`validate_id`](Self::validate_id) guard as a path segment (e.g.
@@ -733,6 +742,27 @@ impl DrPathBuilder {
     pub fn operator_subprefix(subpath: &str) -> Result<String, PathResolverError> {
         Self::validate_id("operator_subpath", subpath)?;
         Ok(format!("{}{}/", Self::OPERATOR_ROOT, subpath))
+    }
+
+    /// Control-plane subprefix for the deployment's **system catalog**:
+    /// `_operator/catalog/`. The system catalog is the (currently single)
+    /// `Operator`-roled catalog holding the deployment's objects until
+    /// multi-account provisioning splits data-plane catalogs out per account.
+    pub fn system_catalog_subprefix() -> String {
+        // Constants are pre-validated single segments — infallible.
+        format!("{}{}/", Self::OPERATOR_ROOT, Self::SYSTEM_CATALOG_SUBPATH)
+    }
+
+    /// Relative object key of the system catalog WAL under
+    /// [`system_catalog_subprefix`](Self::system_catalog_subprefix):
+    /// `_operator/catalog/system-catalog.wal`. The snapshot blob is derived
+    /// from this by the catalog (`.with_extension("snapshot")`).
+    pub fn system_catalog_wal_relpath() -> String {
+        format!(
+            "{}{}",
+            Self::system_catalog_subprefix(),
+            Self::SYSTEM_CATALOG_WAL_FILE
+        )
     }
 }
 
@@ -1095,6 +1125,24 @@ mod tests {
         // The subpath cannot escape the operator root.
         assert!(DrPathBuilder::operator_subprefix("../etc").is_err());
         assert!(DrPathBuilder::operator_subprefix("a/b").is_err());
+    }
+
+    #[test]
+    fn system_catalog_path_is_under_operator_root() {
+        // The deployment's system catalog lives under the control-plane root.
+        assert_eq!(
+            DrPathBuilder::system_catalog_subprefix(),
+            "_operator/catalog/"
+        );
+        assert_eq!(
+            DrPathBuilder::system_catalog_wal_relpath(),
+            "_operator/catalog/system-catalog.wal"
+        );
+        // It is exactly the validated operator subprefix for "catalog".
+        assert_eq!(
+            DrPathBuilder::system_catalog_subprefix(),
+            DrPathBuilder::operator_subprefix(DrPathBuilder::SYSTEM_CATALOG_SUBPATH).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Phase 5, slice 2** of the two-tier operator/account isolation model (builds on #213). Introduces the **control-plane vs data-plane catalog identity** and routes the system catalog's own WAL+snapshot under a `DrPathBuilder`-validated prefix. All additive + **inert** — default behaviour is byte-for-byte unchanged.

## Changes
- **`CatalogRole { Operator, Account { account_id } }`** (proximadb-catalog) — types the control-plane (operator registry of accounts) vs data-plane (per-account) distinction. `account_id()` / `is_operator()` accessors; snake_case serde + round-trip test.
- **`DrPathBuilder`** — reserved `SYSTEM_CATALOG_SUBPATH` / `SYSTEM_CATALOG_WAL_FILE` + `system_catalog_subprefix()` (`_operator/catalog/`) and `system_catalog_wal_relpath()`: one canonical location for the system catalog under the operator control-plane root.
- **`SystemCatalog`** — carries a `role` (default `Operator`) + `with_role`/`role()`.
- **`TenantContext`** — `account_id: Option<String>` + `with_account` + `account_or_default()` (falls back to the reserved default-account ID). The account tier is inert until provisioned.
- **Boot (`shared_services`)** — when `PROXIMADB_CATALOG_DRPATH` is set, the system catalog WAL+snapshot live under `_operator/catalog/…` via `DrPathBuilder` (honouring the structural-isolation mandate); **default OFF** keeps the existing `{base}/system-catalog.wal` so on-disk state is undisturbed (mirrors `PROXIMADB_WAREHOUSE_DRPATH`).
- `CatalogDelta::UpsertNamespace` now boxes its `CatalogNamespace` (`clippy::large_enum_variant`, matching the already-boxed `UpsertTable`) — the new account field grew the variant.

## Verification
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo test -p proximadb-catalog --lib` — **287/287** (incl. new `CatalogRole` test)
- `cargo test -p proximadb --lib -- path_resolver system_catalog account_tier` — **40/40**
- `check_tenant_path_guard.py` — green

## Follow-up (Phase 5)
- **5c** — real `ProximaObjectStore` snapshot persistence under the account/operator prefix for `s3/gs/az` (replacing `NativeCatalog::parse_storage_url`'s temp-cache fake), with `memory://` deterministic tests.