### PR TITLE
feat(sdk-chunking): embedding-breakpoint semantic chunking (TD-126)

### DIFF
--- a/clients/python/src/proximadb_sdk/chunking.py
+++ b/clients/python/src/proximadb_sdk/chunking.py
@@ -217,6 +217,14 @@ class TextChunker:
             preserve_tables=getattr(self.config, "preserve_tables", False),
             add_context=self.config.add_context,
             context_size=self.config.context_size,
+            # Embedding-based semantic chunking (SEMANTIC_EMBEDDING). Forward the
+            # injected provider + breakpoint knobs so they survive the config
+            # rebuild; getattr keeps older ChunkingConfig instances compatible.
+            embedding_provider=getattr(self.config, "embedding_provider", None),
+            buffer_size=getattr(self.config, "buffer_size", 1),
+            breakpoint_percentile_threshold=getattr(
+                self.config, "breakpoint_percentile_threshold", 95.0
+            ),
         )
 
     def chunk_text(

--- a/clients/python/src/proximadb_sdk/chunking_strategies/__init__.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/__init__.py
@@ -113,6 +113,7 @@ from .pipeline import (  # Configuration; Pipeline stages; Core components; Fact
 )
 from .recursive import RecursiveStrategy
 from .semantic import SemanticStrategy
+from .semantic_embedding import SemanticEmbeddingStrategy
 from .sentence import SentenceStrategy
 from .sliding_window import SlidingWindowStrategy
 
@@ -127,6 +128,7 @@ __all__ = [
     "SentenceStrategy",
     "ParagraphStrategy",
     "SemanticStrategy",
+    "SemanticEmbeddingStrategy",
     "RecursiveStrategy",
     # Factory
     "ChunkingStrategyFactory",

--- a/clients/python/src/proximadb_sdk/chunking_strategies/base.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/base.py
@@ -16,7 +16,8 @@ class ChunkingStrategy(Enum):
     SLIDING_WINDOW = "sliding_window"
     SENTENCE = "sentence"
     PARAGRAPH = "paragraph"
-    SEMANTIC = "semantic"
+    SEMANTIC = "semantic"  # structural/regex semantic boundaries (no embeddings)
+    SEMANTIC_EMBEDDING = "semantic_embedding"  # embedding-breakpoint semantic chunking (injected provider)
     RECURSIVE = "recursive"
     FIXED_SIZE = "fixed_size"
     CODE = "code"  # AST-aware code chunking using tree-sitter
@@ -99,6 +100,18 @@ class ChunkingConfig:
     # Semantic settings (no embeddings)
     section_patterns: list[str] = field(default_factory=list)
     topic_indicators: list[str] = field(default_factory=list)
+
+    # Embedding-based semantic chunking (SEMANTIC_EMBEDDING strategy only).
+    # The provider is INJECTED — a core.BaseEmbeddingProvider-style object with
+    # a batch embed/encode method, OR a Callable[[list[str]], list[list[float]]].
+    # Typed as Any so the base module pulls NO heavy embedding deps (the lazy
+    # boundary that keeps `import proximadb_sdk` light stays intact).
+    embedding_provider: Any | None = None
+    # Window of context sentences blended into each side of a breakpoint test.
+    buffer_size: int = 1
+    # Percentile of the consecutive-group distance distribution above which a
+    # breakpoint is placed (LlamaIndex default: 95th percentile).
+    breakpoint_percentile_threshold: float = 95.0
 
 
 class ChunkingStrategyInterface(ABC):

--- a/clients/python/src/proximadb_sdk/chunking_strategies/factory.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/factory.py
@@ -10,6 +10,7 @@ from .fixed_size import FixedSizeStrategy
 from .paragraph import ParagraphStrategy
 from .recursive import RecursiveStrategy
 from .semantic import SemanticStrategy
+from .semantic_embedding import SemanticEmbeddingStrategy
 from .sentence import SentenceStrategy
 from .sliding_window import SlidingWindowStrategy
 
@@ -23,6 +24,7 @@ class ChunkingStrategyFactory:
         ChunkingStrategy.SENTENCE: SentenceStrategy,
         ChunkingStrategy.PARAGRAPH: ParagraphStrategy,
         ChunkingStrategy.SEMANTIC: SemanticStrategy,
+        ChunkingStrategy.SEMANTIC_EMBEDDING: SemanticEmbeddingStrategy,
         ChunkingStrategy.RECURSIVE: RecursiveStrategy,
         ChunkingStrategy.FIXED_SIZE: FixedSizeStrategy,
         ChunkingStrategy.CODE: CodeChunkingStrategy,

--- a/clients/python/src/proximadb_sdk/chunking_strategies/semantic_embedding.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/semantic_embedding.py
@@ -1,0 +1,256 @@
+"""
+Embedding-based semantic chunking strategy
+
+This strategy splits text at *semantic* breakpoints discovered from embedding
+similarity (à la LlamaIndex's ``SemanticSplitterNodeParser``), as opposed to the
+purely structural/regex :class:`~.semantic.SemanticStrategy` (headers, topic
+words). Both have value and coexist:
+
+- :class:`~.semantic.SemanticStrategy` — structural boundaries, zero deps, fast.
+- :class:`SemanticEmbeddingStrategy` — true semantic boundaries from embeddings.
+
+Algorithm
+---------
+1. Split the text into sentences (reusing the same splitter as
+   :class:`~.sentence.SentenceStrategy` — no new dependency).
+2. Embed the sentences in a single batched call via an *injected* provider.
+3. For each adjacent pair of sentences, compute the cosine *distance* between
+   a window of ``buffer_size`` sentences ending at ``i`` and one starting at
+   ``i + 1`` (the buffer adds local context so single odd sentences don't
+   trigger spurious splits).
+4. Place a breakpoint wherever the distance exceeds the
+   ``breakpoint_percentile_threshold`` percentile of the distance distribution.
+5. Group sentences between breakpoints into :class:`TextChunk`s, honouring the
+   existing ``min_chunk_size`` / ``max_chunk_size`` guardrails.
+
+Provider-injection seam (lazy boundary)
+---------------------------------------
+The embedding provider is **injected**, never imported at module top level. It
+may be either a ``core.BaseEmbeddingProvider``-style object exposing a batch
+``embed`` (or ``encode``) method, or a plain ``Callable[[list[str]],
+list[list[float]]]``. Importing this module — and ``import proximadb_sdk`` /
+``proximadb_sdk.chunking_strategies`` — therefore pulls **no** heavy embedding
+deps (sentence-transformers etc.). If the strategy runs without a provider it
+raises a clear, actionable error rather than silently falling back.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from .base import ChunkingConfig, ChunkingStrategyInterface, TextChunk
+from .sentence import SentenceStrategy
+
+# An injected provider may be a BaseEmbeddingProvider-style object (with an
+# ``embed``/``encode`` batch method) OR a plain batch callable. We deliberately
+# avoid importing the concrete provider class so the lazy boundary stays intact.
+EmbeddingProvider = Any
+
+
+class SemanticEmbeddingStrategy(ChunkingStrategyInterface):
+    """
+    Embedding-breakpoint semantic chunking.
+
+    Requires an injected embedding provider on the config
+    (``ChunkingConfig.embedding_provider``). See the module docstring for the
+    accepted provider shapes and the algorithm.
+    """
+
+    def __init__(self, config: ChunkingConfig):
+        super().__init__(config)
+        # Reuse the sentence splitter wholesale — same config-driven endings,
+        # abbreviation handling, etc. No new dependency, no duplicated regex.
+        self._sentence_splitter = SentenceStrategy(config)
+
+    # ------------------------------------------------------------------ #
+    # Provider plumbing (lazy — no embeddings imported at module level)
+    # ------------------------------------------------------------------ #
+    def _embed_sentences(self, sentences: list[str]) -> np.ndarray:
+        """
+        Embed all sentences in a single batched call via the injected provider.
+
+        Returns an array of shape ``(len(sentences), dim)``. Raises a clear,
+        actionable error if no provider was injected.
+        """
+        provider: EmbeddingProvider | None = getattr(
+            self.config, "embedding_provider", None
+        )
+        if provider is None:
+            raise ValueError(
+                "SemanticEmbeddingStrategy requires an embedding provider, but "
+                "ChunkingConfig.embedding_provider is None. Inject a "
+                "proximadb_sdk.embedding_providers.core.BaseEmbeddingProvider "
+                "(e.g. via get_provider(...)) or a plain "
+                "Callable[[list[str]], list[list[float]]]. The built-in local "
+                "providers require the 'embeddings' extra: "
+                "pip install 'proximadb[embeddings]'."
+            )
+
+        # BATCHED: one call for all sentences, never per-sentence.
+        if callable(provider) and not hasattr(provider, "embed"):
+            # Plain Callable[[list[str]], list[list[float]]]
+            raw = provider(sentences)
+        elif hasattr(provider, "embed"):
+            # BaseEmbeddingProvider-style (.embed -> np.ndarray | list[list])
+            raw = provider.embed(sentences)
+        elif hasattr(provider, "encode"):
+            # sentence-transformers-style (.encode batch)
+            raw = provider.encode(sentences)
+        else:
+            raise TypeError(
+                "embedding_provider must be a Callable[[list[str]], "
+                "list[list[float]]] or expose an 'embed'/'encode' batch method; "
+                f"got {type(provider).__name__}."
+            )
+
+        embeddings = np.asarray(raw, dtype=np.float64)
+        if embeddings.ndim != 2 or embeddings.shape[0] != len(sentences):
+            raise ValueError(
+                "Embedding provider returned an unexpected shape "
+                f"{embeddings.shape}; expected ({len(sentences)}, dim)."
+            )
+        return embeddings
+
+    # ------------------------------------------------------------------ #
+    # Similarity / breakpoint math
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
+        """Cosine distance ``1 - cos_sim`` between two vectors (0..2)."""
+        na = float(np.linalg.norm(a))
+        nb = float(np.linalg.norm(b))
+        if na == 0.0 or nb == 0.0:
+            # Degenerate vector — treat as maximally dissimilar so a zero
+            # vector never silently glues unrelated content together.
+            return 1.0
+        return 1.0 - float(np.dot(a, b) / (na * nb))
+
+    def _grouped_distances(self, embeddings: np.ndarray) -> list[float]:
+        """
+        Distance between consecutive buffered sentence groups.
+
+        For each gap ``i`` (between sentence ``i`` and ``i+1``) we compare the
+        mean embedding of the ``buffer_size`` sentences ending at ``i`` against
+        the mean of the ``buffer_size`` sentences starting at ``i+1``.
+        """
+        buffer_size = max(1, int(getattr(self.config, "buffer_size", 1)))
+        n = embeddings.shape[0]
+        distances: list[float] = []
+        for i in range(n - 1):
+            left = embeddings[max(0, i - buffer_size + 1) : i + 1]
+            right = embeddings[i + 1 : min(n, i + 1 + buffer_size)]
+            left_mean = left.mean(axis=0)
+            right_mean = right.mean(axis=0)
+            distances.append(self._cosine_distance(left_mean, right_mean))
+        return distances
+
+    def _breakpoint_indices(self, distances: list[float]) -> set[int]:
+        """
+        Indices ``i`` after which to break (break between sentence ``i`` and
+        ``i+1``) — where the distance exceeds the configured percentile.
+        """
+        if not distances:
+            return set()
+        threshold_pct = float(
+            getattr(self.config, "breakpoint_percentile_threshold", 95.0)
+        )
+        threshold = float(np.percentile(distances, threshold_pct))
+        # Strictly-greater so a flat (single-topic) distribution where every gap
+        # equals the percentile produces NO breakpoints.
+        return {i for i, d in enumerate(distances) if d > threshold}
+
+    # ------------------------------------------------------------------ #
+    # Chunk assembly
+    # ------------------------------------------------------------------ #
+    def _emit_chunk(
+        self,
+        group: list[str],
+        start_pos: int,
+        source_id: str,
+        chunk_index: int,
+        base_metadata: dict[str, Any],
+    ) -> TextChunk:
+        chunk_text = " ".join(group)
+        chunk = TextChunk(
+            text=chunk_text,
+            start_pos=start_pos,
+            end_pos=start_pos + len(chunk_text),
+            chunk_id=f"{source_id}_chunk_{chunk_index}",
+            metadata={
+                **base_metadata,
+                "chunk_type": "semantic_embedding",
+                "sentence_count": len(group),
+            },
+        )
+        self.add_chunk_metadata(chunk, chunk_index, -1, "semantic_embedding")
+        return chunk
+
+    def chunk(
+        self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
+    ) -> list[TextChunk]:
+        """Create chunks at embedding-derived semantic breakpoints."""
+        self.validate_config()
+
+        if not text or not text.strip():
+            return []
+
+        base_metadata = base_metadata or {}
+
+        sentences = self._sentence_splitter._split_into_sentences(text)
+        if not sentences:
+            return []
+
+        # Trivial case: a single sentence is its own chunk; no embedding needed.
+        if len(sentences) == 1:
+            return [self._emit_chunk(sentences, 0, source_id, 0, base_metadata)]
+
+        embeddings = self._embed_sentences(sentences)
+        distances = self._grouped_distances(embeddings)
+        breakpoints = self._breakpoint_indices(distances)
+
+        chunks: list[TextChunk] = []
+        current: list[str] = []
+        current_start = 0
+        chunk_index = 0
+
+        def flush() -> None:
+            nonlocal current, current_start, chunk_index
+            if not current:
+                return
+            chunk = self._emit_chunk(
+                current, current_start, source_id, chunk_index, base_metadata
+            )
+            chunks.append(chunk)
+            chunk_index += 1
+            current_start = chunk.end_pos + 1
+            current = []
+
+        for i, sentence in enumerate(sentences):
+            prospective = (" ".join(current + [sentence])) if current else sentence
+            # max_chunk_size guardrail: force a break before we overflow.
+            if current and len(prospective) > self.config.max_chunk_size:
+                flush()
+
+            current.append(sentence)
+
+            # Semantic breakpoint after sentence i — but respect min_chunk_size
+            # so a breakpoint doesn't emit a sub-minimum chunk; in that case we
+            # keep accreting until the guardrail is met.
+            if i in breakpoints:
+                if len(" ".join(current)) >= self.config.min_chunk_size:
+                    flush()
+
+        flush()
+
+        for chunk in chunks:
+            chunk.metadata["total_chunks"] = len(chunks)
+
+        return chunks
+
+    def __repr__(self) -> str:
+        return (
+            "SemanticEmbeddingStrategy("
+            f"buffer_size={getattr(self.config, 'buffer_size', 1)}, "
+            "breakpoint_percentile_threshold="
+            f"{getattr(self.config, 'breakpoint_percentile_threshold', 95.0)})"
+        )

--- a/clients/python/tests/unit/test_chunking_strategies_rest_cov.py
+++ b/clients/python/tests/unit/test_chunking_strategies_rest_cov.py
@@ -558,8 +558,9 @@ def test_factory_list_strategies():
     names = ChunkingStrategyFactory.list_strategies()
     assert "paragraph" in names
     assert "semantic" in names
+    assert "semantic_embedding" in names
     assert "code" in names
-    assert len(names) == 7
+    assert len(names) == 8
 
 
 def test_get_chunking_strategy_by_string():

--- a/clients/python/tests/unit/test_semantic_embedding_chunking.py
+++ b/clients/python/tests/unit/test_semantic_embedding_chunking.py
@@ -1,0 +1,218 @@
+"""
+Deterministic unit tests for the embedding-based semantic chunking strategy.
+
+These tests use a STUB embedding provider returning fixed, controlled vectors so
+breakpoints are fully deterministic — NO real sentence-transformers model is
+loaded. They also assert the lazy import boundary stays intact (importing the
+strategy pulls no heavy embedding deps) and that embedding is batched.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from proximadb_sdk.chunking_strategies.base import ChunkingConfig, ChunkingStrategy
+from proximadb_sdk.chunking_strategies.factory import (
+    ChunkingStrategyFactory,
+    get_chunking_strategy,
+)
+from proximadb_sdk.chunking_strategies.semantic_embedding import (
+    SemanticEmbeddingStrategy,
+)
+
+# Two clearly-distinct topic clusters. Sentences 0-2 are topic A ("pets"),
+# sentences 3-5 are topic B ("markets"). With these vectors there is exactly
+# one large cosine jump — between sentence 2 and 3 — so a percentile threshold
+# yields exactly one breakpoint => two chunks.
+TWO_TOPIC_TEXT = (
+    "The cat sat on the warm mat. My dog loves the green park. "
+    "A pet always needs daily care. "
+    "Stock prices rose sharply today. The market closed much higher. "
+    "Investors felt very optimistic."
+)
+
+SINGLE_TOPIC_TEXT = (
+    "The cat sat on the warm mat. My dog loves the green park. "
+    "A pet always needs daily care. The kitten chased a small ball."
+)
+
+
+def _topic_vector(sentence: str) -> list[float]:
+    """Map a sentence to one of two orthogonal clusters by keyword."""
+    pet_words = ("cat", "dog", "pet", "kitten")
+    if any(w in sentence for w in pet_words):
+        return [1.0, 0.0]
+    return [0.0, 1.0]
+
+
+class _StubProvider:
+    """BaseEmbeddingProvider-style stub: a single batched `embed` call."""
+
+    def __init__(self):
+        self.calls = 0
+        self.batch_sizes = []
+
+    def embed(self, texts):
+        self.calls += 1
+        self.batch_sizes.append(len(texts))
+        return np.array([_topic_vector(t) for t in texts], dtype=np.float64)
+
+
+def _callable_provider_factory():
+    """Plain Callable[[list[str]], list[list[float]]] stub with a call counter."""
+    state = {"calls": 0}
+
+    def provider(texts):
+        state["calls"] += 1
+        return [_topic_vector(t) for t in texts]
+
+    return provider, state
+
+
+def _make(text_strategy_kwargs):
+    return get_chunking_strategy(
+        ChunkingStrategy.SEMANTIC_EMBEDDING,
+        min_chunk_size=1,
+        **text_strategy_kwargs,
+    )
+
+
+def test_clean_topic_shift_produces_single_breakpoint():
+    provider = _StubProvider()
+    strat = _make(
+        {"embedding_provider": provider, "breakpoint_percentile_threshold": 80.0}
+    )
+    chunks = strat.chunk(TWO_TOPIC_TEXT, "doc")
+
+    assert len(chunks) == 2, [c.text for c in chunks]
+    # The split lands between the two topics.
+    assert "pet" in chunks[0].text
+    assert "Stock prices" in chunks[1].text
+    for c in chunks:
+        assert c.metadata["chunk_type"] == "semantic_embedding"
+        assert c.metadata["total_chunks"] == 2
+        assert c.metadata["chunking_strategy"] == "semantic_embedding"
+
+
+def test_single_topic_produces_no_spurious_breaks():
+    provider = _StubProvider()
+    strat = _make(
+        {"embedding_provider": provider, "breakpoint_percentile_threshold": 95.0}
+    )
+    chunks = strat.chunk(SINGLE_TOPIC_TEXT, "doc")
+
+    # All sentences share one cluster -> all distances are 0 -> no gap exceeds
+    # the percentile -> a single chunk.
+    assert len(chunks) == 1, [c.text for c in chunks]
+    assert chunks[0].metadata["total_chunks"] == 1
+
+
+def test_empty_and_whitespace_input_returns_no_chunks():
+    provider = _StubProvider()
+    strat = _make({"embedding_provider": provider})
+    assert strat.chunk("", "doc") == []
+    assert strat.chunk("   \n  ", "doc") == []
+    # No embedding work for empty input.
+    assert provider.calls == 0
+
+
+def test_single_sentence_input_is_one_chunk_without_embedding():
+    provider = _StubProvider()
+    strat = _make({"embedding_provider": provider})
+    chunks = strat.chunk("Just one lonely sentence here.", "doc")
+    assert len(chunks) == 1
+    assert chunks[0].text == "Just one lonely sentence here."
+    # Trivial single-sentence path must not call the embedder.
+    assert provider.calls == 0
+
+
+def test_missing_provider_raises_actionable_error():
+    # No embedding_provider injected.
+    strat = ChunkingStrategyFactory.create_strategy(
+        ChunkingStrategy.SEMANTIC_EMBEDDING,
+        ChunkingConfig(strategy=ChunkingStrategy.SEMANTIC_EMBEDDING, min_chunk_size=1),
+    )
+    with pytest.raises(ValueError) as exc:
+        strat.chunk(TWO_TOPIC_TEXT, "doc")
+    msg = str(exc.value)
+    # Error must name the config field and the embeddings extra.
+    assert "embedding_provider" in msg
+    assert "proximadb[embeddings]" in msg
+
+
+def test_embedding_is_batched_single_call():
+    provider = _StubProvider()
+    strat = _make({"embedding_provider": provider})
+    strat.chunk(TWO_TOPIC_TEXT, "doc")
+    # Exactly one batched embed call covering all six sentences.
+    assert provider.calls == 1
+    assert provider.batch_sizes == [6]
+
+
+def test_accepts_plain_callable_provider():
+    provider, state = _callable_provider_factory()
+    strat = _make(
+        {"embedding_provider": provider, "breakpoint_percentile_threshold": 80.0}
+    )
+    chunks = strat.chunk(TWO_TOPIC_TEXT, "doc")
+    assert len(chunks) == 2
+    assert state["calls"] == 1  # batched
+
+
+def test_max_chunk_size_guardrail_forces_split_within_topic():
+    # Single topic (no semantic breakpoint) but a tiny max_chunk_size forces
+    # the guardrail to split anyway.
+    provider = _StubProvider()
+    strat = get_chunking_strategy(
+        ChunkingStrategy.SEMANTIC_EMBEDDING,
+        # chunk_size must also be small: ChunkingConfig.__post_init__ clamps
+        # max_chunk_size up to chunk_size (default 512) otherwise.
+        chunk_size=40,
+        chunk_overlap=0,
+        min_chunk_size=1,
+        max_chunk_size=40,
+        embedding_provider=provider,
+    )
+    chunks = strat.chunk(SINGLE_TOPIC_TEXT, "doc")
+    assert len(chunks) > 1
+    for c in chunks:
+        # Guardrail respected (allowing the final single-sentence remainder).
+        assert len(c.text) <= 40 or c.metadata["sentence_count"] == 1
+
+
+def test_lazy_import_boundary_no_heavy_deps():
+    # Importing the strategy + running it with a stub provider must NOT pull
+    # sentence-transformers. Run in a CLEAN subprocess so sibling tests in this
+    # process (which legitimately load real models) can't pollute the check.
+    code = (
+        "import sys\n"
+        "from proximadb_sdk.chunking_strategies.base import ChunkingConfig, ChunkingStrategy\n"
+        "from proximadb_sdk.chunking_strategies.factory import get_chunking_strategy\n"
+        "assert 'sentence_transformers' not in sys.modules\n"
+        "s = get_chunking_strategy(ChunkingStrategy.SEMANTIC_EMBEDDING, min_chunk_size=1,\n"
+        "    embedding_provider=lambda xs: [[1.0, 0.0] for _ in xs])\n"
+        "s.chunk('One sentence here. Another sentence there.', 'doc')\n"
+        "assert 'sentence_transformers' not in sys.modules, 'heavy dep leaked'\n"
+        "print('LAZY_OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "LAZY_OK" in result.stdout
+
+
+def test_factory_registers_strategy():
+    assert "semantic_embedding" in ChunkingStrategyFactory.list_strategies()
+    strat = ChunkingStrategyFactory.create_strategy(
+        ChunkingStrategy.SEMANTIC_EMBEDDING,
+        ChunkingConfig(
+            strategy=ChunkingStrategy.SEMANTIC_EMBEDDING,
+            embedding_provider=_StubProvider(),
+        ),
+    )
+    assert isinstance(strat, SemanticEmbeddingStrategy)

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -456,6 +456,35 @@ promoting any concern to a genuinely separate distribution (`proximadb-chunking`
 ====
 
 [NOTE]
+.Embedding-based semantic chunking shipped (2026-06-22) — `SemanticEmbeddingStrategy` (DONE)
+====
+The previously-deferred *true embedding-based* semantic chunking mode is now implemented as a new
+`SemanticEmbeddingStrategy` (`ChunkingStrategy.SEMANTIC_EMBEDDING`, value `"semantic_embedding"`),
+added *alongside* the existing structural/regex `SemanticStrategy` (both kept — different value).
+Algorithm follows LlamaIndex's `SemanticSplitterNodeParser`: split into sentences (reusing
+`SentenceStrategy._split_into_sentences` — no new dep), embed sentences in a single *batched* call,
+compute cosine distance between consecutive `buffer_size`-windowed sentence groups, and place a
+breakpoint wherever the distance exceeds the `breakpoint_percentile_threshold` (default 95th
+percentile); groups become `TextChunk`s under the existing `min_chunk_size`/`max_chunk_size`
+guardrails.
+
+*Provider-injection seam.* The embedding provider is *injected* via new `ChunkingConfig` fields
+(`embedding_provider`, `buffer_size`, `breakpoint_percentile_threshold`). It accepts either a
+`core.BaseEmbeddingProvider`-style object (batch `embed`/`encode`) or a plain
+`Callable[[list[str]], list[list[float]]]`. *Lazy boundary intact:* `proximadb_sdk.embedding_providers`
+is NOT imported at module top — the new strategy module pulls only `numpy` (core dep) + the
+sentence splitter, so `import proximadb_sdk` / `import proximadb_sdk.chunking_strategies` stay
+free of sentence-transformers. Selecting the strategy without a provider raises an actionable
+`ValueError` naming the `embedding_provider` field and the `proximadb[embeddings]` extra — no
+silent fallback. Registered in `ChunkingStrategyFactory`, the enum, `chunking_strategies.__init__`,
+and threaded through `TextChunker._initialize_strategy`. Deterministic unit tests
+(`tests/unit/test_semantic_embedding_chunking.py`) use a stub provider (no model download): clean
+topic-shift split, single-topic no-spurious-break, empty/1-sentence, missing-provider error,
+batched-embedding assertion, plain-callable acceptance, max-size guardrail, and a subprocess
+lazy-boundary check.
+====
+
+[NOTE]
 .Remaining-ops re-base + transport-gen-coverage closeout (2026-06-22) — Go / TS / Rust / Python
 ====
 The Phase-2/4 PRs re-based each SDK's *core* ops (collection / record / search / query) onto the


### PR DESCRIPTION
## Summary
Adds a **true embedding-based semantic chunking** mode to the ProximaDB Python SDK — the deferred TD-126 item — *alongside* the existing structural/regex \`SemanticStrategy\` (both kept; different value).

New \`SemanticEmbeddingStrategy\` (\`ChunkingStrategy.SEMANTIC_EMBEDDING\`, value \`"semantic_embedding"\`), modelled on LlamaIndex \`SemanticSplitterNodeParser\`:
1. Split into sentences — **reuses** \`SentenceStrategy._split_into_sentences\` (no new dep).
2. **Batched** embed of all sentences via an injected provider (single call).
3. Cosine distance between consecutive \`buffer_size\`-windowed sentence groups.
4. Breakpoint where distance exceeds \`breakpoint_percentile_threshold\` (default 95th).
5. Group into \`TextChunk\`s under existing \`min_chunk_size\`/\`max_chunk_size\` guardrails.

## Provider-injection seam (lazy boundary intact)
New \`ChunkingConfig\` fields: \`embedding_provider\`, \`buffer_size\`, \`breakpoint_percentile_threshold\`. The provider may be a \`core.BaseEmbeddingProvider\`-style object (batch \`embed\`/\`encode\`) **or** a plain \`Callable[[list[str]], list[list[float]]]\`.

\`proximadb_sdk.embedding_providers\` is **not** imported at module top — the strategy module pulls only \`numpy\` (core dep) + the sentence splitter. Verified: \`import proximadb_sdk\` and \`import proximadb_sdk.chunking_strategies\` pull **no** sentence-transformers. Selecting the strategy with no provider raises an actionable \`ValueError\` naming the config field + the \`proximadb[embeddings]\` extra (no silent fallback).

Wired into \`ChunkingStrategyFactory\`, the enum, \`chunking_strategies.__init__\`, and threaded through \`TextChunker._initialize_strategy\`.

## Tests (deterministic, no model download)
\`tests/unit/test_semantic_embedding_chunking.py\` — stub provider with fixed two-cluster vectors: clean topic-shift split (1 breakpoint → 2 chunks), single-topic (no spurious break), empty/whitespace, single-sentence (no embed call), missing-provider error, **batched** embedding (exactly one call), plain-callable acceptance, max-size guardrail, subprocess lazy-boundary check, factory registration. Updated one existing count assertion (7 → 8 strategies).

## Verify
- \`import proximadb_sdk\` / core chunking import pull no heavy deps (lazy boundary verified).
- black / isort / ruff(E9,F63,F7) / py_compile clean on changed files.
- New + existing chunking unit tests pass (420 passed / 30 skipped across the chunking suite).

Rust jobs are irrelevant to this Python-only diff.