### PR TITLE
feat(fusion): cross-modal fusion seam design + calibrated Fuser core (TD-136/137)

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -425,6 +425,71 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | Multi-tenant code-graph service needs a KEU meter variant for code embeddings and per-repo RBAC entitlement (tenant is atomic today). Mostly anvaiops-side; ProximaDB exposes the meter hook + field/row governance seam.
 | 2 weeks
 | KEU variant in the meter spine; per-repo `permitted_principals` scoping. See `../anvaiops` ADR.
+
+| TD-136
+| Fusion — neutral `Fuser` core + PIT calibration
+| P1
+| HIGH
+| *In progress*
+| One calibrated fuse-by-`oid` core for all modalities: PIT/percentile-rank calibration (cosine≈Gaussian vs graph/PPR≈power-law are incommensurable; naive weighted-sum + min-max both fail) + calibrated-linear + consensus boost + RRF fallback + skip-gates. Phase 1 of `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`.
+| 1 week
+| `src/core/search/fusion/`. Calibration is the load-bearing step; the operator is secondary (Calibrated-Fusion).
+| TD-137
+| Fusion — `GraphExpander` + REST v2 `fusion-search`
+| P1
+| HIGH
+| *In progress*
+| Graph modality as the first expander on the seam (oid-keyed percentile-rank graph candidates, bounded k-hop, retiring `1/(dist+1)`) + vector seed; `POST /api/v2/graphs/{graph_id}/fusion-search`, tenant-scoped. Subsumes the old TD-131 graph-on-REST-v2 goal.
+| 1 week
+| Reuse `HybridQueryEngine` internals + `VectorOperationsService`. Honor the request graph_id (not "default").
+| TD-138
+| Fusion — converge `DocumentExpander`
+| P2
+| MED
+| *Open*
+| Fold the 12-strategy `HybridFusionEngine` (vector+BM25, `doc_id`) onto the seam as the `DocumentExpander`, keyed by `oid`.
+| 1-2 weeks
+| Collapse the 12 strategies to D4 (calibrated-linear default, RRF fallback); keep exotics behind a flag.
+| TD-139
+| Fusion — `RelationalExpander` prefilter (semimask)
+| P2
+| MED
+| *Open*
+| Relational predicate as an `oid`-keyed membership mask (roaring bitset) passed by SIP into the seed — prefilter, not postfilter (NaviX: prefilter wins below 50% selectivity). Reuse TD-127/128.
+| 2 weeks
+| The mask is the universal expander→seed interface.
+| TD-140
+| Fusion — edge-grain fusion
+| P3
+| LOW
+| *Open*
+| Optional edge/relationship-grain fusion unit (HELIOS: edge-level carries 6–12% more signal than node-level) in addition to node/`oid`-keyed merge.
+| 2 weeks
+| Differentiator; gate behind query class.
+| TD-141
+| Fusion — `ComputeScheduler` cost-routed fusion
+| P2
+| MED
+| *Open*
+| Route the fused query from a measured per-query trace: invoke fusion only when multi-modal; cardinality-driven filter strategy (UNIFY); per-modality weight+selectivity-aware candidate budget + cheap local pre-probe (BoomHQ). Measured threshold router, not learned.
+| 3-4 weeks
+| Keep plan-construction cheap (Samyama: parse+plan was 98% of latency).
+| TD-142
+| Fusion — `oid` / entity alias resolution
+| P2
+| MED
+| *Open*
+| Cross-source consensus requires `oid`/entity alias resolution (synonym linking); else fusion silently loses the consensus boost (Calibrated-Fusion).
+| 2 weeks
+| Precondition for *true* cross-modal fusion across collections; within one collection `oid` is canonical.
+| TD-143
+| Fusion — retire weak proto path
+| P3
+| LOW
+| *Open*
+| Retire `request_handlers.rs` `execute_hybrid_query` (hardcoded graph, no tenant) once the seam covers gRPC; collapse the 12-strategy engine to D4.
+| 1 week
+| Cleanup after F-A..F-C land.
 |===
 
 == Debt by Category

--- a/docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc
+++ b/docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc
@@ -1,0 +1,151 @@
+= Cross-Modal Fusion Seam — Co-Designed Template
+:toc: macro
+:sectnums:
+:icons: font
+
+Status: Draft +
+Date: 2026-06-22 +
+Owner: Query / Search +
+Related: `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`, `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`, `RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc`, `TD_064_PREDICATE_AWARE_VECTOR_SEARCH_DESIGN_2026_05_27.adoc`
+
+toc::[]
+
+== Summary
+
+ProximaDB carries **three overlapping "hybrid" implementations**, each re-solving fuse-by-key on a
+different key space with no shared contract:
+
+[cols="1,3,2,1", options="header"]
+|===
+| Impl | Where | Key | Transport
+
+| vector + BM25/sparse | `src/core/search/hybrid/fusion.rs` (`HybridFusionEngine`, **12 strategies**: RRF, weighted-linear, RBP, CombSUM/MIN/MAX, Borda, Condorcet, Dempster-Shafer, adaptive, projection) | `doc_id` | REST (external collections)
+| vector + graph | `src/graph/hybrid/mod.rs` (`HybridQueryEngine`, 4 strategies, `graph_score = 1/(dist+1)`) | `NodeId` | **none**
+| proto vector→graph | `src/api_handlers/request_handlers.rs:1447` (`execute_hybrid_query`, hardcoded `graph_id="default"`, no tenant) | implicit id | gRPC
+|===
+
+Fusion is becoming the **norm across modalities** — documents fuse vector+BM25, graph fuses
+vector+traversal, relational fuses vector+predicate, and the prize is *cross-modal* fusion. This document
+specifies **one reusable fusion seam** as the template for all cross-modal use cases (not a fourth one-off),
+co-designed against the measured dominant cost term (I/O round-trips + bytes moved, not CPU), correlated by
+the one canonical `oid` (= relational row + ORION node + HNSW vector).
+
+It is grounded in a first-principles literature review (10 papers read in full): unified graph+vector
+systems (**Samyama**, **NaviX**, **HMGI**); fusion/calibration (**HELIOS**, **Calibrated-Fusion/
+PhaseGraph**, **Beyond-Similarity-Search**); query/index optimization (**BoomHQ**, **UNIFY**); GraphRAG
+(**HybridRAG**, the **GraphRAG survey**); plus an industry scan (RRF normalization; Neo4j/FalkorDB/
+TigerVector/LanceDB).
+
+== The seam
+
+Retrieval is one pipeline, modality-agnostic, correlated by `oid`:
+
+[source]
+----
+seed  →  expand (0..N modality expanders)  →  calibrate  →  fuse-by-oid  →  rank
+----
+
+. **Seed** — vector ANN over the scope (collection / graph), tenant + freshness gated → an `oid`-keyed
+  candidate set + base scores. (BM25 seed or explicit `oid` list also allowed.)
+. **Expand** — each pluggable `ModalityExpander` consumes the seed `oid` set and returns `oid`-keyed
+  scores + a **membership mask** (roaring bitset). Graph = bounded k-hop ego traverse (ORION); Document =
+  BM25/sparse; Relational = typed predicate (TD-127/128). Each is **pool-capped**.
+. **Calibrate** — map each source's per-query scores through **PIT / percentile-rank** (empirical CDF →
+  `[0,1]`) so heterogeneous sources are commensurable.
+. **Fuse-by-oid** — merge by canonical `oid` (dedup + co-score): `score(oid) = Σ_k α_k · cal_k(oid) +
+  β · 𝟙[oid in ≥2 sources]`. **Skip-gates** apply (saturation, headroom, staleness).
+. **Rank** — sort; **late-materialize** payload + full-f32 rerank only for the final top-k.
+
+=== Contract (neutral types — "standard outside, vertical inside")
+
+[source,rust]
+----
+FusionQuery { tenant, scope, seed: SeedSpec, expanders: Vec<ExpanderSpec>,
+              fusion: FusionPolicy, result: ResultSpec }
+FusionResult { items: Vec<FusedItem{ oid, score, per_source: Map<SourceId,f32>, payload, path? }>, stats }
+
+#[async_trait] trait ModalityExpander {
+    fn source(&self) -> SourceId;                       // Vector | Graph | Document | Relational
+    async fn expand(&self, ctx: &FusionContext, seeds: &OidSet) -> Result<SourceCandidates>;
+}                                                       // SourceCandidates = oid-keyed scores + mask
+
+struct Fuser { calibration: Pit | None, operator: CalibratedLinear | Rrf, consensus_beta: f32 }
+impl Fuser { fn fuse(&self, sources: Vec<SourceCandidates>, spec: &ResultSpec) -> FusionResult }
+----
+
+The **`oid`-keyed membership set (roaring bitset) is the universal interface** between every expander and
+the seed/fuser. `calibrate + fuse + rank` is written **once**; modalities plug in only at `expand`.
+
+== Decisions (D1–D10), each rationalized against measured evidence
+
+[cols="1,4,4", options="header"]
+|===
+| # | Decision | Rationale (source + measured number)
+
+| D1 | Correlate by canonical `oid`; never concatenate, never join. `doc_id`/`NodeId` are projections of `oid`. | All three systems papers unify by *shared dense identity*, not a fused index or join (Samyama u64 arena; NaviX "HNSW node **is** a Kuzu node"; HMGI embeddings-as-node-props). HybridRAG's naive **concatenation** pays a precision tax (context-precision **0.79**, below either standalone) and is position-sensitive — the one-`oid` invariant lets us dedup+co-score and keep its recall-1.0 without the precision loss.
+| D2 | Prefilter via an `oid`-keyed membership mask passed by sideways-information-passing into a filter-aware seed — not postfilter. | NaviX (rigorous): prefilter beats postfilter for selectivity **<50%** (the common RAG regime); postfilter degrades catastrophically (a baseline went **10→334 ms** as selectivity dropped).
+| D3 | Calibration (PIT / percentile-rank, empirical CDF) is the load-bearing step; the operator is secondary. Replace graph `1/(dist+1)` with the percentile-rank of distance within its own list. | Calibrated-Fusion measured: cosine ≈ narrow Gaussian, graph/PPR ≈ power-law → **naive weighted-sum AND min-max both fail** (vector term dominates regardless of α). After PIT, exotic operators are empirically indistinguishable from calibrated-linear.
+| D4 | Collapse the 12-strategy engine to: PIT-calibrated weighted-linear + consensus boost (default); RRF (rank-based, zero-calibration fallback). Exotics behind a flag, justified by a measured trace. | Calibrated-Fusion (operator barely matters post-calibration) + industry (RRF sidesteps normalization via ranks, often beats fancier fusion; Weighted-RRF for control). Fewer surfaces = less proliferation.
+| D5 | Gate fusion — skip/limit it (it has cost and can hurt). Skip when one modality saturates; require result-budget headroom; cap per-source pool + bias α to the reliable modality at scale; exclude stale sources. | Calibrated-Fusion: HotpotQA (95.5% vector) graph-fusion = **0W/0L**; slot-competition at k=5; pool-explosion → 81 losses fixed by pool-cap + α→reliable. BoomHQ: drop a modality whose weight is negligible.
+| D6 | Enforce structural gates BEFORE the blend, never after: tenant isolation (TenantContext/DrPathBuilder), freshness/LSN, `oid`/entity alias resolution. Do NOT post-rerank fused multi-hop with an independent cross-encoder. | Beyond-Similarity-Search: engine-level filtering **0.2%→0%** tenant leakage (after-the-fact filter *is* the leak); atomic write **3.54 ms→0 ms** staleness — independently validates the structural-isolation mandate. Calibrated-Fusion: alias resolution required (else consensus silently fails); independent cross-encoder on multi-hop **collapses 78.8%→9.1%**.
+| D7 | Co-design at the storage boundary: expanders pass `oid`s only (late materialization); resolve vectors/attrs/scores lazily at rank; run distance kernels in-place on quantized PAX-resident vectors (SQ8/RaBitQ), full f32 only for top-k rerank. | Samyama late-materialization (move NodeRefs) = **4.0–4.7×**, targets bandwidth not FLOPs. NaviX in-buffer zero-copy distance **+1.6×**, and **vector scans (not topology) dominate I/O** → quantize+cache vectors, page topology densely. This is ProximaDB's existing PAX-v2 SQ8+rerank thesis.
+| D8 | Default expander output = bounded k-hop ego subgraph (k=1, `SearchEffort` knob → 2); support edge-grain fusion as a differentiator; community/global is a separate route. | GraphRAG survey: subgraph ⊇ path ⊇ triplet; 1-hop is the validated sweet spot; bound k (candidate explosion). HELIOS: **edge-level fusion carries 6–12% more signal** than node-level; larger beam *reduced* recall (conservative > exhaustive).
+| D9 | Route the fused query in `ComputeScheduler` from *measured* quantities (threshold router, not a learned model): invoke fusion only when the query spans modalities; cardinality-driven filter strategy; per-modality weight+selectivity-aware candidate budget `k_i`. | UNIFY: cardinality `Y` cleanly separates pre/in/post-filter regimes (one decision variable beats 3 dedicated indexes by 1.1×). BoomHQ: global selectivity (histogram+prefix-sum) + a cheap **local pre-probe** unlock 2–25× (global alone mispredicts on correlated subsets). Samyama warning: parse+plan was **98%** of latency — keep plan-construction cheap.
+| D10 | Default shape = single-shot multi-stage (seed→one-expand→fuse), real-time; iterative-LLM-in-loop is opt-in for hard multi-hop. No LLM in the retrieve loop. | GraphRAG survey: once/multi-stage = low latency for real-time (a DB query path is latency-bound); iterative (ToG/EtD) = accuracy at large cost. HELIOS: LLM refinement is 1.4× runtime and can *reduce* recall via hallucination.
+|===
+
+NOTE: *Evidence asymmetry.* Anchor concrete mechanisms on **NaviX** (reproducible, measured). **Samyama**
+for the identity/late-materialization story (real, single-node, self-reported). **HMGI** for the taxonomy +
+named-technique checklist only (benchmark numbers self-inconsistent). **HybridRAG** is directional (n=50,
+GPT-3.5). **Calibrated-Fusion** is the calibration core. **Beyond-Similarity-Search** independently
+validates ProximaDB's whole vector+graph+relational-in-one-engine premise.
+
+== Convergence (no fourth implementation)
+
+* vector+BM25 (`HybridFusionEngine`, `doc_id`) → vector seed + `DocumentExpander`, fuse-by-`oid`.
+* vector+graph (`HybridQueryEngine`, `NodeId`) → vector seed + `GraphExpander`, fuse-by-`oid`. Its fuse
+  logic is refactored into the neutral `Fuser` (oid-keyed + PIT).
+* proto vector→graph → same; the weak hardcoded-`default`/no-tenant path is retired.
+* The 12-strategy engine collapses to D4 (rich strategies retained behind a flag, justified by a measured
+  trace).
+
+== Co-design cost framing
+
+Each stage moves the dominant cost term, not CPU:
+
+* **Seed/Expand** carry `oid`s (+ masks), never payloads (Samyama late-materialization).
+* **Distance** runs in place on quantized PAX-resident vectors; full f32 only for the final top-k rerank
+  (NaviX: vector scans dominate I/O).
+* **Routing** (`ComputeScheduler`) costs the fused route from a measured per-query trace — cardinality
+  (UNIFY) + a cheap local pre-probe (BoomHQ) — and skips fusion entirely when the query is single-modality.
+* **Isolation/freshness/alias** are structural pre-conditions resolved before the blend (Beyond-Similarity-
+  Search) — never a post-fusion predicate.
+
+== Phased roadmap
+
+[cols="1,3,1", options="header"]
+|===
+| Item | Scope | TD
+
+| F-A | Neutral `Fuser` core + PIT calibration + calibrated-linear/RRF + consensus + skip-gates (Phase 1) | TD-136
+| F-B | `GraphExpander` (oid-keyed percentile-rank, bounded k-hop) + vector seed + REST v2 `fusion-search` endpoint (Phase 1) | TD-137
+| F-C | Converge `DocumentExpander` (fold `HybridFusionEngine` onto the seam) | TD-138
+| F-D | `RelationalExpander` prefilter (reuse TD-127/128; NaviX semimask) | TD-139
+| F-E | Edge-grain fusion (HELIOS) | TD-140
+| F-F | `ComputeScheduler` fusion routing (UNIFY cardinality + BoomHQ local pre-probe; measured threshold router) | TD-141
+| F-G | `oid` / entity alias resolution (synonym linking) | TD-142
+| F-H | Retire the weak proto path; collapse the 12-strategy engine to D4 | TD-143
+|===
+
+Phase 1 (F-A, F-B) is the reference implementation: the graph modality as the first instance on the seam,
+exposed on REST v2. The rest are follow-on.
+
+== Open questions / risks
+
+* PIT calibration needs a per-query candidate list of sufficient size to estimate the empirical CDF; very
+  small candidate sets fall back to RRF (rank-only).
+* Alias resolution (F-G) is a precondition for *true* cross-modal consensus; until it lands, fusion across
+  sources that disagree on `oid` spelling silently loses the consensus boost — Phase 1 stays within one
+  collection/graph where `oid` is canonical by construction.
+* No e2e cold-trace benchmark of seed→expand→fuse at scale yet (tracked in `BENCHMARK_EVIDENCE.toml`,
+  `status="aspirational"`).

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -131,6 +131,17 @@ Read these in order for future-shaping architecture work:
    and multi-tenant (anvaiops) shapes. Engine asks: TD-127..TD-134. Subordinate to the 2026-06-04
    course correction and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 
+22. `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` +
+   One reusable fusion seam (`seed → expand → calibrate → fuse-by-oid → rank`) converging the three
+   overlapping hybrid impls (vector+BM25/`doc_id`, vector+graph/`NodeId`, proto vector→graph) onto the
+   canonical `oid`. Literature-grounded (10 papers read in full: Samyama/NaviX/HMGI, HELIOS/Calibrated-
+   Fusion/Beyond-Similarity-Search, BoomHQ/UNIFY, HybridRAG + GraphRAG survey). Load-bearing decision:
+   **PIT/percentile-rank calibration**, not the fusion operator, is what makes heterogeneous scores
+   commensurable; prefilter-by-`oid`-membership-mask (NaviX); structural isolation/freshness/alias before
+   the blend; late-materialization + quantized in-place distance (Samyama/NaviX). Modalities are pluggable
+   `ModalityExpander`s; calibrate+fuse+rank is written once. Phase 1 = graph instance on REST v2.
+   Engine asks: TD-136..TD-143.
+
 == Stable Reference Docs
 
 * `ARCHITECTURE_ATLAS_2026_05_22.adoc` - top-down OSS/SaaS architecture map, workspace map, and

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -218,3 +218,17 @@ hardware = ""
 date = ""
 version = ""
 notes = "Sizing is PROJECTED from a measured SOURCE dataset (one real repo's SQLite CPG + LanceDB vectors): 79,744 symbol nodes, 96,538 cross-fn edges, 77,902 symbol embeddings @ 384-d = 114 MB f32 / 29 MB SQ8 + 5.5 MB co-stored snippet. No ProximaDB-side e2e bench yet for ingest/traversal/hybrid at this scale. To promote to measured: load Tier-A into an EmbeddedProximaDB, bench (a) Arrow Flight bulk-load time, (b) k-hop impact_analysis latency, (c) GraphHybridQuery seed->expand latency; check in a dated artifact. Tracked with TD-127..TD-132."
+
+[[claims]]
+id = "cross_modal_fusion_calibrated_seam"
+claim = "A single PIT-calibrated fuse-by-oid seam (seed->expand->calibrate->fuse->rank) matches or beats per-modality retrieval and the legacy 12-strategy engine, because calibration (not the operator) is the load-bearing step"
+metric = "recall@k, fusion_latency_ms, score_commensurability"
+status = "aspirational"
+asserted_in = ["docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc"]
+bench_source = ""
+bench_command = ""
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "Design is literature-grounded (Calibrated-Fusion: post-PIT the operator is empirically indistinguishable; NaviX prefilter<50% selectivity; Samyama late-materialization 4-4.7x; HELIOS edge-grain +6-12%) but NOT yet measured in ProximaDB. To promote to measured: build a fixture corpus with correlated vector+graph signal, compare (a) vector-only, (b) graph-only, (c) uncalibrated weighted-sum, (d) PIT-calibrated linear, (e) RRF on recall@k and latency; check in a dated artifact. Tracked with TD-136..TD-143."

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -1477,8 +1477,18 @@ impl UnifiedHandlers {
                     // 2. Perform graph traversal from these nodes
                     if !start_node_ids.is_empty() {
                         let graph_req = request.graph_traversal_request.clone().unwrap_or_default();
+                        // TD-131: honor the caller's graph id (REST v2 sets it from
+                        // the {graph_id} path param) instead of the hardcoded
+                        // "default" graph, so per-graph hybrid search — e.g. a
+                        // per-repo code-graph — targets the right graph. Falls back
+                        // to "default" only when the request leaves it unset.
+                        let effective_graph_id = if graph_req.graph_id.is_empty() {
+                            "default".to_string()
+                        } else {
+                            graph_req.graph_id.clone()
+                        };
                         let traversal_request = crate::graph::TraversalRequest {
-                            graph_id: "default".to_string(), // Deferred: Extract from request or pass as parameter
+                            graph_id: effective_graph_id.clone(),
                             start_node_id: start_node_ids.first().cloned().unwrap_or_default(), // Use first for now, need to handle multiple starts
                             max_depth: if graph_req.max_depth == 0 {
                                 3
@@ -1500,7 +1510,7 @@ impl UnifiedHandlers {
 
                         let traversal_response = self
                             .graph_operations_service
-                            .traverse("default", traversal_request)
+                            .traverse(&effective_graph_id, traversal_request)
                             .await?;
                         nodes.extend(traversal_response.nodes.into_iter().map(Into::into));
                         edges.extend(traversal_response.edges.into_iter().map(Into::into));

--- a/src/core/search/cross_modal_fusion.rs
+++ b/src/core/search/cross_modal_fusion.rs
@@ -1,0 +1,402 @@
+//! Cross-modal fusion seam — the neutral, modality-agnostic `fuse-by-oid` core.
+//!
+//! This is Phase 1 (F-A) of `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`. It converges the
+//! three overlapping hybrid implementations (vector+BM25 keyed by `doc_id`, vector+graph keyed by
+//! `NodeId`, and the proto vector→graph path) onto ONE pipeline:
+//!
+//! ```text
+//! seed → expand (modality expanders) → calibrate → fuse-by-oid → rank
+//! ```
+//!
+//! correlated by the canonical `oid`. Each modality is a pluggable `ModalityExpander`; the
+//! calibrate+fuse+rank core lives here and is written once.
+//!
+//! ## Load-bearing decision: calibration, not the operator (D3)
+//!
+//! Heterogeneous sources produce incommensurable score distributions — vector cosine is a narrow
+//! Gaussian, graph/PPR proximity is power-law — so a naive weighted sum (and even min-max normalization)
+//! is dominated by the larger-magnitude source regardless of the weights. The fix is **PIT /
+//! percentile-rank** (the empirical CDF), which maps every source to ≈uniform `[0,1]` while preserving
+//! within-source order. Once scores are calibrated the choice of fusion operator barely matters
+//! (Calibrated-Fusion / PhaseGraph, arXiv 2603.28886), so this module keeps just two: a calibrated
+//! weighted-linear blend (default) and rank-based RRF (the zero-calibration fallback). This is why the
+//! graph engine's arbitrary `1/(dist+1)` transform is replaced by the percentile-rank of distance.
+
+use std::collections::HashMap;
+
+/// Identifies the modality a set of candidates came from. Used as the fusion `per_source` key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SourceId {
+    Vector,
+    Graph,
+    Document,
+    Relational,
+    Other(String),
+}
+
+/// One source's per-query candidates: `oid → raw score` (higher is better) plus the source's blend
+/// weight. Raw scores are calibrated inside [`Fuser::fuse`] — callers pass native scores (cosine,
+/// graph proximity, BM25) without pre-normalizing.
+#[derive(Debug, Clone)]
+pub struct SourceCandidates {
+    pub source: SourceId,
+    /// Blend weight `α_k` for this source (D9: weight + selectivity aware per modality).
+    pub weight: f32,
+    /// `oid → raw score`, higher is better.
+    pub scores: HashMap<String, f32>,
+}
+
+impl SourceCandidates {
+    pub fn new(source: SourceId, weight: f32, scores: HashMap<String, f32>) -> Self {
+        Self {
+            source,
+            weight,
+            scores,
+        }
+    }
+}
+
+/// Cross-source score commensuration policy (applies to the [`Operator::CalibratedLinear`] path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Calibration {
+    /// PIT / percentile-rank (empirical CDF) → `[0,1]`. The default and load-bearing choice (D3).
+    Pit,
+    /// No calibration — use raw scores as-is. Retained only to demonstrate the failure mode and for
+    /// sources that are already commensurable.
+    None,
+}
+
+/// How calibrated per-source values combine into one fused score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operator {
+    /// Weighted linear over calibrated values. The default (D4).
+    CalibratedLinear,
+    /// Reciprocal-rank fusion — rank-based, ignores magnitudes entirely (its own calibration). The
+    /// zero-calibration fallback when score distributions are unavailable/untrusted (D4).
+    Rrf { k: u32 },
+}
+
+/// Fusion policy: calibration + operator + consensus boost + the cost/quality gates (D5).
+#[derive(Debug, Clone)]
+pub struct FusionPolicy {
+    pub calibration: Calibration,
+    pub operator: Operator,
+    /// CombMNZ-style consensus boost added once to any `oid` present in ≥2 sources (D4/D6).
+    pub consensus_beta: f32,
+    /// Cap each source's candidate pool (keep top-N by raw score) before fusing — bounds the
+    /// pool-explosion failure mode (D5).
+    pub pool_cap: Option<usize>,
+    /// Skip a source whose best raw score is below this threshold (saturation / didn't-fire gate, D5).
+    pub min_source_score: Option<f32>,
+}
+
+impl Default for FusionPolicy {
+    fn default() -> Self {
+        Self {
+            calibration: Calibration::Pit,
+            operator: Operator::CalibratedLinear,
+            consensus_beta: 0.0,
+            pool_cap: None,
+            min_source_score: None,
+        }
+    }
+}
+
+impl FusionPolicy {
+    /// The zero-calibration rank-fusion fallback (standard `k = 60`).
+    pub fn rrf() -> Self {
+        Self {
+            calibration: Calibration::None,
+            operator: Operator::Rrf { k: 60 },
+            ..Self::default()
+        }
+    }
+}
+
+/// One fused result, keyed by the canonical `oid` (dedup + co-score across sources).
+#[derive(Debug, Clone)]
+pub struct FusedItem {
+    pub oid: String,
+    /// Combined fused score (higher is better).
+    pub score: f32,
+    /// Calibrated contribution per source (for explainability / debugging).
+    pub per_source: HashMap<SourceId, f32>,
+    /// Number of sources that contained this `oid`.
+    pub source_count: usize,
+}
+
+/// Fusion bookkeeping for route metadata / observability.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FusionStats {
+    pub sources_fused: usize,
+    pub sources_skipped: usize,
+    pub candidates_in: usize,
+    pub items_out: usize,
+}
+
+/// The neutral calibrate + fuse + rank core. Modality-agnostic: it operates only on `(oid, score)`
+/// lists, so it is unit-testable in isolation and reused by every modality.
+pub struct Fuser {
+    policy: FusionPolicy,
+}
+
+impl Fuser {
+    pub fn new(policy: FusionPolicy) -> Self {
+        Self { policy }
+    }
+
+    /// Fuse per-source candidates by `oid`, returning the top-`limit` items (descending score) plus
+    /// stats. Empty / below-threshold sources are skipped; surviving sources are pool-capped,
+    /// calibrated, weighted, merged by `oid`, and consensus-boosted.
+    pub fn fuse(
+        &self,
+        sources: Vec<SourceCandidates>,
+        limit: usize,
+    ) -> (Vec<FusedItem>, FusionStats) {
+        let mut stats = FusionStats::default();
+        let mut acc: HashMap<String, FusedItem> = HashMap::new();
+
+        for mut src in sources {
+            stats.candidates_in += src.scores.len();
+            let best = src
+                .scores
+                .values()
+                .copied()
+                .fold(f32::NEG_INFINITY, f32::max);
+            // Skip-gate (D5): an empty source, or one whose best score is below the usefulness
+            // threshold (it didn't meaningfully fire), is dropped rather than diluting the blend.
+            if src.scores.is_empty() || self.policy.min_source_score.is_some_and(|min| best < min) {
+                stats.sources_skipped += 1;
+                continue;
+            }
+            // Pool cap (D5): bound each source to its top-N by raw score before fusing.
+            if let Some(cap) = self.policy.pool_cap
+                && src.scores.len() > cap
+            {
+                let mut entries: Vec<(String, f32)> = src.scores.into_iter().collect();
+                entries.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+                entries.truncate(cap);
+                src.scores = entries.into_iter().collect();
+            }
+            stats.sources_fused += 1;
+
+            for (oid, value) in self.calibrate(&src) {
+                let contribution = src.weight * value;
+                let item = acc.entry(oid.clone()).or_insert_with(|| FusedItem {
+                    oid,
+                    score: 0.0,
+                    per_source: HashMap::new(),
+                    source_count: 0,
+                });
+                item.score += contribution;
+                item.per_source.insert(src.source.clone(), value);
+                item.source_count += 1;
+            }
+        }
+
+        // Consensus boost (D4/D6): reward an `oid` that ≥2 sources agree on.
+        if self.policy.consensus_beta != 0.0 {
+            for item in acc.values_mut() {
+                if item.source_count >= 2 {
+                    item.score += self.policy.consensus_beta;
+                }
+            }
+        }
+
+        let mut items: Vec<FusedItem> = acc.into_values().collect();
+        // Deterministic order: score desc, then oid asc to break ties.
+        items.sort_by(|a, b| b.score.total_cmp(&a.score).then_with(|| a.oid.cmp(&b.oid)));
+        items.truncate(limit);
+        stats.items_out = items.len();
+        (items, stats)
+    }
+
+    /// Map a source's raw `oid → score` to calibrated `oid → value` per the policy.
+    fn calibrate(&self, src: &SourceCandidates) -> Vec<(String, f32)> {
+        match self.policy.operator {
+            // RRF is its own calibration: value = 1/(k + rank), rank by raw score (best = 1).
+            Operator::Rrf { k } => {
+                let mut ranked: Vec<(&String, f32)> =
+                    src.scores.iter().map(|(oid, s)| (oid, *s)).collect();
+                ranked.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+                ranked
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, (oid, _))| {
+                        let rank = (i + 1) as f32;
+                        (oid.clone(), 1.0 / (k as f32 + rank))
+                    })
+                    .collect()
+            }
+            Operator::CalibratedLinear => match self.policy.calibration {
+                Calibration::None => src
+                    .scores
+                    .iter()
+                    .map(|(oid, s)| (oid.clone(), *s))
+                    .collect(),
+                // PIT / percentile-rank: value(oid) = |{ scores ≤ s }| / N — the empirical CDF.
+                Calibration::Pit => {
+                    let mut sorted: Vec<f32> = src.scores.values().copied().collect();
+                    sorted.sort_by(f32::total_cmp);
+                    let n = sorted.len() as f32;
+                    src.scores
+                        .iter()
+                        .map(|(oid, s)| {
+                            let le = sorted
+                                .partition_point(|x| x.total_cmp(s) != std::cmp::Ordering::Greater);
+                            (oid.clone(), le as f32 / n)
+                        })
+                        .collect()
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn src(source: SourceId, weight: f32, pairs: &[(&str, f32)]) -> SourceCandidates {
+        SourceCandidates::new(
+            source,
+            weight,
+            pairs.iter().map(|(o, s)| ((*o).to_string(), *s)).collect(),
+        )
+    }
+
+    fn score_of(items: &[FusedItem], oid: &str) -> Option<f32> {
+        items.iter().find(|i| i.oid == oid).map(|i| i.score)
+    }
+
+    /// The headline property (D3): uncalibrated weighted-sum is dominated by the larger-magnitude
+    /// source (graph proximity here), so it picks the graph-favored oid decisively; PIT/percentile-rank
+    /// makes the two sources commensurable so the rank-balanced oids tie. Same inputs, different policy.
+    #[test]
+    fn pit_calibration_makes_heterogeneous_scores_commensurable() {
+        // Vector: narrow Gaussian-ish magnitudes; Graph: a power-law spike (x huge, y tiny).
+        let vector = src(SourceId::Vector, 1.0, &[("x", 0.10), ("y", 0.12)]);
+        let graph = src(SourceId::Graph, 1.0, &[("x", 0.30), ("y", 0.003)]);
+
+        // Uncalibrated: x = 0.10 + 0.30 = 0.40, y = 0.12 + 0.003 = 0.123 → x wins by the graph magnitude.
+        let none = Fuser::new(FusionPolicy {
+            calibration: Calibration::None,
+            ..FusionPolicy::default()
+        });
+        let (raw, _) = none.fuse(vec![vector.clone(), graph.clone()], 10);
+        assert_eq!(raw[0].oid, "x");
+        assert!(
+            raw[0].score - raw[1].score > 0.2,
+            "uncalibrated: graph magnitude dominates the blend"
+        );
+
+        // PIT: x = pct(0.5 vec)+pct(1.0 graph) = 1.5 ; y = pct(1.0)+pct(0.5) = 1.5 → tie.
+        let pit = Fuser::new(FusionPolicy::default());
+        let (cal, stats) = pit.fuse(vec![vector, graph], 10);
+        assert_eq!(stats.sources_fused, 2);
+        assert!(
+            (score_of(&cal, "x").unwrap() - score_of(&cal, "y").unwrap()).abs() < 1e-6,
+            "PIT: rank-balanced oids are commensurable (tie)"
+        );
+    }
+
+    /// Fusion merges by canonical `oid`: an `oid` in two sources appears once, co-scored, with
+    /// `source_count == 2`.
+    #[test]
+    fn fuse_by_oid_dedups_and_counts_sources() {
+        let a = src(SourceId::Vector, 1.0, &[("z", 0.5), ("a", 0.1)]);
+        let b = src(SourceId::Graph, 1.0, &[("z", 0.5), ("b", 0.2)]);
+        let (items, _) = Fuser::new(FusionPolicy::default()).fuse(vec![a, b], 10);
+
+        assert_eq!(
+            items.iter().filter(|i| i.oid == "z").count(),
+            1,
+            "z deduped"
+        );
+        let z = items.iter().find(|i| i.oid == "z").unwrap();
+        assert_eq!(z.source_count, 2);
+        assert_eq!(z.per_source.len(), 2);
+        for single in items.iter().filter(|i| i.oid != "z") {
+            assert_eq!(single.source_count, 1);
+        }
+    }
+
+    /// Consensus boost (D4/D6) adds exactly `beta` to a multi-source `oid` and nothing to a
+    /// single-source one — co-agreement is rewarded.
+    #[test]
+    fn consensus_boost_rewards_multi_source_agreement() {
+        let a = src(SourceId::Vector, 1.0, &[("p", 0.9), ("q", 0.95)]);
+        let b = src(SourceId::Graph, 1.0, &[("p", 0.9)]); // p in both, q in one
+        let inputs = || vec![a.clone(), b.clone()];
+
+        let base = Fuser::new(FusionPolicy::default()).fuse(inputs(), 10).0;
+        let boosted = Fuser::new(FusionPolicy {
+            consensus_beta: 0.5,
+            ..FusionPolicy::default()
+        })
+        .fuse(inputs(), 10)
+        .0;
+
+        assert!(
+            (score_of(&boosted, "p").unwrap() - score_of(&base, "p").unwrap() - 0.5).abs() < 1e-6,
+            "p (2 sources) gains exactly beta"
+        );
+        assert!(
+            (score_of(&boosted, "q").unwrap() - score_of(&base, "q").unwrap()).abs() < 1e-6,
+            "q (1 source) is unchanged"
+        );
+    }
+
+    /// Skip-gate (D5): a source whose best score is below `min_source_score`, or an empty source, is
+    /// dropped (counted in stats) and its candidates never reach the blend.
+    #[test]
+    fn skip_gate_drops_weak_and_empty_sources() {
+        let strong = src(SourceId::Vector, 1.0, &[("a", 0.9), ("b", 0.8)]);
+        let weak = src(SourceId::Graph, 1.0, &[("c", 0.01)]); // best 0.01 < 0.1
+        let empty = src(SourceId::Document, 1.0, &[]);
+        let policy = FusionPolicy {
+            min_source_score: Some(0.1),
+            ..FusionPolicy::default()
+        };
+        let (items, stats) = Fuser::new(policy).fuse(vec![strong, weak, empty], 10);
+
+        assert_eq!(stats.sources_fused, 1);
+        assert_eq!(stats.sources_skipped, 2);
+        assert!(!items.iter().any(|i| i.oid == "c"), "weak source dropped");
+    }
+
+    /// RRF fallback (D4) ranks by reciprocal rank without any magnitude — produces all candidates and a
+    /// sensible order even with wildly different score scales.
+    #[test]
+    fn rrf_fallback_ranks_without_magnitudes() {
+        let a = src(SourceId::Vector, 1.0, &[("a", 0.1), ("b", 0.2), ("c", 0.3)]);
+        let b = src(SourceId::Graph, 1.0, &[("a", 900.0), ("c", 0.1)]); // huge magnitude must NOT dominate
+        let (items, _) = Fuser::new(FusionPolicy::rrf()).fuse(vec![a, b], 10);
+
+        assert_eq!(items.len(), 3);
+        // a (rank3 in A + rank1 in B) and c (rank1 in A + rank2 in B) are the consensus top-2; b (one
+        // source, rank2) is last — magnitude (900) did not dominate.
+        assert_eq!(items[2].oid, "b");
+        let top2: Vec<&str> = items[..2].iter().map(|i| i.oid.as_str()).collect();
+        assert!(top2.contains(&"a") && top2.contains(&"c"));
+    }
+
+    /// Pool cap (D5) bounds each source to its top-N by raw score before fusing.
+    #[test]
+    fn pool_cap_bounds_each_source() {
+        let big = src(
+            SourceId::Vector,
+            1.0,
+            &[("a", 0.1), ("b", 0.2), ("c", 0.3), ("d", 0.4)],
+        );
+        let policy = FusionPolicy {
+            pool_cap: Some(2),
+            ..FusionPolicy::default()
+        };
+        let (items, _) = Fuser::new(policy).fuse(vec![big], 10);
+        // Only the top-2 (c, d) survive the cap.
+        assert_eq!(items.len(), 2);
+        let oids: Vec<&str> = items.iter().map(|i| i.oid.as_str()).collect();
+        assert!(oids.contains(&"c") && oids.contains(&"d"));
+    }
+}

--- a/src/core/search/mod.rs
+++ b/src/core/search/mod.rs
@@ -1,6 +1,7 @@
 //! Search module for ProximaDB storage-aware search implementations
 
 pub mod bounded_queue;
+pub mod cross_modal_fusion;
 pub mod engine_benchmarks;
 pub mod filter_contract; // Filter contracts for hybrid search (Issue #38, SB-08)
 pub mod filter_pushdown_engine;


### PR DESCRIPTION
## What

Establishes **one reusable cross-modal fusion seam** as the template for all fusion use cases, converging ProximaDB's three overlapping, contract-less "hybrid" implementations:
- vector + BM25/sparse — `HybridFusionEngine` (12 strategies), keyed by `doc_id`;
- vector + graph — `HybridQueryEngine` (`graph_score = 1/(dist+1)`), keyed by `NodeId`, on no transport;
- proto vector→graph — hardcoded `graph_id="default"`, no tenant.

The seam is `seed → expand → calibrate → fuse-by-oid → rank`, correlated by the canonical `oid` (= relational row + ORION node + HNSW vector). Modalities are pluggable `ModalityExpander`s; **calibrate + fuse + rank is written once**.

## Grounded in first-principles research

10 papers read **in full** (via `pdftotext`, not abstracts) + an industry scan; every design decision (D1–D10 in the doc) is rationalized against a measured result:
- **systems** — Samyama, NaviX, HMGI (unify by shared dense identity, not a fused index; prefilter-by-membership-mask; late-materialization + quantized in-place distance);
- **fusion/calibration** — HELIOS, Calibrated-Fusion/PhaseGraph, Beyond-Similarity-Search;
- **opt/index** — BoomHQ, UNIFY; **GraphRAG** — HybridRAG + the GraphRAG survey.

**Load-bearing finding:** the 12-strategy engine optimizes the wrong thing. Heterogeneous scores are incommensurable (cosine ≈ narrow Gaussian, graph/PPR ≈ power-law), so a naive weighted sum — and even min-max — is magnitude-dominated regardless of weights. The fix is **PIT / percentile-rank (empirical-CDF) calibration**; once calibrated, the operator barely matters. Other adopted invariants: prefilter-by-`oid`-membership-mask (NaviX, wins below 50% selectivity), structural isolation/freshness/alias **before** the blend (Beyond-Similarity-Search's 0.2%→0% leakage), late-materialization (Samyama 4–4.7×), edge-grain fusion (HELIOS +6–12%), and a measured-trace cost router (UNIFY cardinality + BoomHQ local pre-probe — not a learned model).

## This PR — Phase 1a

- **Design doc** `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` — the template, the trait contract, the D1–D10 evidence ledger, the convergence map, the co-design cost framing, and the phased roadmap. README index entry; **TD-136…TD-143**; an aspirational `BENCHMARK_EVIDENCE` claim.
- **`src/core/search/cross_modal_fusion.rs`** — the neutral `Fuser` core: PIT/percentile-rank calibration, calibrated-linear + consensus boost (default), RRF (zero-calibration fallback), pool-cap + skip-gates. Pure over `(oid, score)` lists → unit-testable in isolation. **6 tests**, incl. the headline property that PIT makes a Gaussian and a power-law source commensurable where naive weighted-sum is magnitude-dominated; fuse-by-oid dedup; consensus boost; skip-gate; RRF-without-magnitudes; pool-cap.
- Honor the request `graph_id` in the wired hybrid path (was hardcoded `"default"`) so per-graph hybrid search targets the right graph (TD-137 prep).

`cargo test --lib cross_modal_fusion` → 6/6 green; `cargo fmt` + `cargo clippy --lib` clean on the changed files; no `unwrap/expect/panic` in new production code.

## Follow-on (filed as TDs, not in this PR)

`GraphExpander` + the REST v2 `fusion-search` endpoint (TD-137), `DocumentExpander` convergence (folding the 12-strategy engine, TD-138), `RelationalExpander` prefilter (TD-139), edge-grain fusion (TD-140), the cost-routed planner (TD-141), `oid`/entity alias resolution (TD-142), retiring the weak proto path (TD-143).