### PR TITLE
feat(catalog): object-store boot cutover + fix .gitignore-swallowed snapshot source + require rust compile in CI (system-catalog 5d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,6 +969,44 @@ jobs:
           echo "Documentation validation complete"
 
   # ============================================================================
+  # COMPILE GATE - lib + test shapes must both type-check, in parallel
+  # ============================================================================
+  # ALWAYS runs — deliberately NOT gated on the `changes` filter. A non-compiling
+  # lib OR test shape must block the merge, and a *skipped* job does not trip
+  # `ci-success`'s `grep '"failure"'` check, so this gate must never be skippable.
+  # This is the guard that would have caught a non-compiling `develop` (e.g. a
+  # source file silently `.gitignore`'d away, or `#[cfg(test)]` code that breaks
+  # while the lib still compiles). `cargo check` (no codegen/link) keeps it fast.
+  rust-compile:
+    name: Rust Compile (${{ matrix.shape }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shape: lib
+            args: "--workspace --lib --bins"
+          - shape: test
+            args: "--workspace --all-targets"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-compile-${{ matrix.shape }}"
+          shared-key: "build"
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+
+      - name: cargo check ${{ matrix.args }}
+        run: cargo check ${{ matrix.args }}
+
+  # ============================================================================
   # BUILD - Compile Rust binaries
   # ============================================================================
   rust-build:
@@ -1552,6 +1590,7 @@ jobs:
       - panic-policy-report
       - panic-policy-no-regression
       - panic-policy-module-guard
+      - rust-compile
       - rust-clippy
       - feature-matrix
       - rust-security
@@ -1589,9 +1628,9 @@ jobs:
           # Check each job result
           results="${{ toJSON(needs.*.result) }}"
 
-          if echo "$results" | grep -q '"failure"'; then
-            echo "::error::One or more CI jobs failed"
-            echo "Some jobs failed. Check the workflow run for details." >> $GITHUB_STEP_SUMMARY
+          if echo "$results" | grep -qE '"(failure|cancelled)"'; then
+            echo "::error::One or more CI jobs failed or were cancelled"
+            echo "Some jobs failed or were cancelled. Check the workflow run for details." >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -413,6 +413,11 @@ COPILOT.md
 *prompt*.txt
 *snapshot*
 !src/**/snapshot.rs
+# Rust SOURCE files whose name contains "snapshot" are code, not snapshot data
+# artifacts — never ignore them (the broad `*snapshot*` above silently swallowed
+# src/services/catalog_snapshot_store.rs once, landing a non-compiling develop).
+!src/**/*snapshot*.rs
+!crates/**/*snapshot*.rs
 # Phase 8 snapshot-publish coordinator module (source, not a snapshot artifact)
 !src/services/snapshot/
 !src/services/snapshot/**

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -416,17 +416,33 @@ impl SharedServices {
             storage_config.metadata_url
         );
         if catalog_manager.list_catalogs().await.is_empty() {
-            // System-catalog redesign (Phase 2): the default catalog is the
-            // read-heavy, WAL-backed `SystemCatalog` (in-RAM authority + canonical
-            // WAL) rather than the file-per-object `NativeCatalog`. It serves
-            // catalog reads from RAM and persists each DDL as one fsync'd WAL
-            // append. Scoped to `file://` for now (object-store paths land in
-            // Phase 5); `PROXIMADB_DISABLE_SYSTEM_CATALOG` is a kill-switch back
-            // to `NativeCatalog` for the duration of the cutover.
-            let use_system_catalog = std::env::var("PROXIMADB_DISABLE_SYSTEM_CATALOG").is_err()
-                && storage_config.metadata_url.starts_with("file://");
-            if use_system_catalog {
-                let base = storage_config.metadata_url.trim_start_matches("file://");
+            // System-catalog redesign: the default catalog is the read-heavy,
+            // WAL-backed `SystemCatalog` (in-RAM authority + canonical WAL)
+            // rather than the file-per-object `NativeCatalog`. It serves catalog
+            // reads from RAM and persists each DDL as one fsync'd WAL append.
+            // `PROXIMADB_DISABLE_SYSTEM_CATALOG` is a kill-switch back to
+            // `NativeCatalog` for the duration of the cutover.
+            let disable_system_catalog = std::env::var("PROXIMADB_DISABLE_SYSTEM_CATALOG").is_ok();
+            let metadata_url = storage_config.metadata_url.clone();
+            let is_objstore = metadata_url.starts_with("s3://")
+                || metadata_url.starts_with("gs://")
+                || metadata_url.starts_with("az://")
+                || metadata_url.starts_with("memory://");
+            // Phase 5d: object-store deployments use the SystemCatalog too — its
+            // snapshot blob persists to the object store under
+            // `_operator/catalog/…` (real durability, replacing NativeCatalog's
+            // temp-cache fake) while the per-DDL WAL stays on the local working
+            // volume (object-store-native WAL is Phase 6). Needs `opt_config`
+            // for the local `data_dir`; without it (some test/embedded paths) we
+            // fall back to `NativeCatalog`.
+            let objstore_data_dir = if is_objstore && !disable_system_catalog {
+                opt_config.map(|c| c.server.data_dir.clone())
+            } else {
+                None
+            };
+
+            if !disable_system_catalog && metadata_url.starts_with("file://") {
+                let base = metadata_url.trim_start_matches("file://");
                 // Phase 5 (two-tier operator/account): route the system
                 // catalog's own WAL + snapshot under the DrPathBuilder-validated
                 // operator control-plane prefix (`_operator/catalog/…`) so
@@ -461,9 +477,51 @@ impl SharedServices {
                     "✅ SharedServices: registered WAL-backed SystemCatalog (default) at {}",
                     wal_path.display()
                 );
+            } else if let Some(data_dir) = objstore_data_dir {
+                use crate::storage::trait_components::path_resolver::DrPathBuilder;
+                // Per-DDL WAL on the local working volume under the operator
+                // control-plane prefix; snapshot blob in the object store.
+                let wal_path = data_dir.join(DrPathBuilder::system_catalog_wal_relpath());
+                if let Some(parent) = wal_path.parent() {
+                    tokio::fs::create_dir_all(parent).await.with_context(|| {
+                        format!("creating system-catalog dir {}", parent.display())
+                    })?;
+                }
+                let snapshot_store = Arc::new(
+                    crate::services::catalog_snapshot_store::ObjectStoreSnapshotStore::from_url(
+                        &metadata_url,
+                        DrPathBuilder::system_catalog_snapshot_relpath(),
+                    )
+                    .with_context(|| {
+                        format!("opening object-store catalog snapshot at {metadata_url}")
+                    })?,
+                );
+                let system_catalog =
+                    crate::services::system_catalog::SystemCatalog::open_with_snapshot_store(
+                        "default",
+                        &wal_path,
+                        snapshot_store,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "opening object-store SystemCatalog (WAL {})",
+                            wal_path.display()
+                        )
+                    })?;
+                catalog_manager
+                    .register(Arc::new(system_catalog))
+                    .await
+                    .context("Failed to register object-store SystemCatalog backend")?;
+                info!(
+                    "✅ SharedServices: registered object-store-backed SystemCatalog (default); \
+                     local WAL at {}, snapshot in {}",
+                    wal_path.display(),
+                    metadata_url
+                );
             } else {
                 catalog_manager
-                    .create_native_catalog("default", &storage_config.metadata_url)
+                    .create_native_catalog("default", &metadata_url)
                     .await
                     .context("Failed to initialize default xCatalog backend")?;
             }

--- a/src/services/catalog_snapshot_store.rs
+++ b/src/services/catalog_snapshot_store.rs
@@ -1,0 +1,222 @@
+//! Pluggable durable home for the system catalog's snapshot blob (Phase 5c of
+//! the two-tier operator/account system-catalog redesign).
+//!
+//! The catalog's bounded-restart machinery (Phase 3) periodically writes a
+//! point-in-time snapshot of the in-RAM authority, then compacts the WAL up to
+//! that watermark. This trait abstracts **only** the snapshot blob's durable
+//! read/write so the snapshot can live on the local filesystem (the default,
+//! behaviour-identical to before) or on object storage
+//! (`s3://`/`gs://`/`az://`/`memory://`) under the tenant/operator `DrPathBuilder`
+//! prefix — without touching the crash-consistency ordering or the local WAL.
+//!
+//! Object-store-*native* WAL durability (per-DDL delta objects) is deferred to
+//! Phase 6, where that delta-object log doubles as the multi-pod CAS substrate;
+//! building it here would mean building it twice. Until then an object-store
+//! deployment keeps its per-DDL WAL on the local working volume and replicates
+//! the snapshot to object storage.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+
+use object_store::path::Path as ObjectPath;
+use proximadb_kernel::error::StorageError;
+use proximadb_object_store::ProximaObjectStore;
+
+/// Durable, atomically-replaceable home for the catalog snapshot blob.
+///
+/// `write_atomic` must guarantee a reader concurrent with the write observes
+/// either the previous blob or the complete new one — never a torn write. This
+/// is the load-bearing property the Phase-3 crash-consistency ordering relies
+/// on (snapshot made durable *before* the WAL is compacted).
+#[async_trait]
+pub trait CatalogSnapshotStore: Send + Sync {
+    /// Read the current snapshot blob, or `None` if none has been written yet.
+    async fn read(&self) -> Result<Option<Vec<u8>>>;
+
+    /// Durably + atomically replace the snapshot blob.
+    async fn write_atomic(&self, bytes: &[u8]) -> Result<()>;
+
+    /// Human-readable location, for logs and error context.
+    fn describe(&self) -> String;
+}
+
+/// Local-filesystem snapshot store: temp file → fsync → atomic rename →
+/// best-effort parent-dir fsync. The default; behaviour-identical to the
+/// pre-5c inline `write_atomic`.
+pub struct LocalSnapshotStore {
+    path: PathBuf,
+}
+
+impl LocalSnapshotStore {
+    /// Snapshot blob at `path` (conventionally the WAL path with a `.snapshot`
+    /// extension).
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// The blob path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait]
+impl CatalogSnapshotStore for LocalSnapshotStore {
+    async fn read(&self) -> Result<Option<Vec<u8>>> {
+        if tokio::fs::try_exists(&self.path).await.unwrap_or(false) {
+            let bytes = tokio::fs::read(&self.path)
+                .await
+                .with_context(|| format!("reading catalog snapshot {}", self.path.display()))?;
+            Ok(Some(bytes))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn write_atomic(&self, bytes: &[u8]) -> Result<()> {
+        let path = &self.path;
+        let tmp = path.with_extension("snapshot-tmp");
+        {
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp)
+                .await
+                .with_context(|| format!("opening snapshot temp {}", tmp.display()))?;
+            file.write_all(bytes)
+                .await
+                .with_context(|| format!("writing snapshot temp {}", tmp.display()))?;
+            file.flush().await?;
+            file.sync_data()
+                .await
+                .with_context(|| format!("fsync snapshot temp {}", tmp.display()))?;
+        }
+        tokio::fs::rename(&tmp, path)
+            .await
+            .with_context(|| format!("atomically replacing snapshot {}", path.display()))?;
+        if let Some(dir) = path.parent()
+            && let Ok(handle) = std::fs::File::open(dir)
+        {
+            let _ = handle.sync_all();
+        }
+        Ok(())
+    }
+
+    fn describe(&self) -> String {
+        format!("file:{}", self.path.display())
+    }
+}
+
+/// Object-store snapshot store: a single whole-object PUT/GET under `key`.
+///
+/// Object stores give atomic whole-object PUT semantics, so no temp/rename
+/// dance is needed — a reader sees either the old object or the new one, never
+/// a partial write. Works for `memory://` (deterministic tests) and, behind the
+/// `proximadb-object-store` crate's cloud features, `s3://`/`gs://`/`az://`.
+pub struct ObjectStoreSnapshotStore {
+    store: ProximaObjectStore,
+    key: ObjectPath,
+    label: String,
+}
+
+impl ObjectStoreSnapshotStore {
+    /// Build from an object-store base URL (e.g. `s3://bucket/prefix`,
+    /// `memory:///`) and the snapshot object's relative key under it (e.g.
+    /// `_operator/catalog/system-catalog.snapshot`).
+    pub fn from_url(base_url: &str, key: impl Into<String>) -> Result<Self> {
+        let store = ProximaObjectStore::from_url(base_url)
+            .with_context(|| format!("opening object store at {base_url}"))?;
+        Ok(Self::new(store, base_url, key))
+    }
+
+    /// Build from an already-open store, its base URL (for labelling), and the
+    /// snapshot object's relative key. Used by tests and by callers that share
+    /// one store across catalog opens.
+    pub fn new(store: ProximaObjectStore, base_url: &str, key: impl Into<String>) -> Self {
+        let key = key.into();
+        let label = format!("{base_url}::{key}");
+        Self {
+            store,
+            key: ObjectPath::from(key),
+            label,
+        }
+    }
+}
+
+#[async_trait]
+impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
+    async fn read(&self) -> Result<Option<Vec<u8>>> {
+        match self.store.get(&self.key).await {
+            Ok(bytes) => Ok(Some(bytes.to_vec())),
+            // A not-yet-written snapshot is the empty-catalog boot case, not an
+            // error — the caller then replays the WAL from empty.
+            Err(StorageError::NotFound(_)) => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("reading catalog snapshot {}", self.label)),
+        }
+    }
+
+    async fn write_atomic(&self, bytes: &[u8]) -> Result<()> {
+        self.store
+            .put(&self.key, bytes::Bytes::copy_from_slice(bytes))
+            .await
+            .with_context(|| format!("writing catalog snapshot {}", self.label))?;
+        Ok(())
+    }
+
+    fn describe(&self) -> String {
+        self.label.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_store_round_trips_and_reports_absence() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cat.snapshot");
+        let store = LocalSnapshotStore::new(&path);
+
+        // Absent before any write.
+        assert!(store.read().await.unwrap().is_none());
+
+        store.write_atomic(b"hello-catalog").await.unwrap();
+        assert_eq!(
+            store.read().await.unwrap().as_deref(),
+            Some(&b"hello-catalog"[..])
+        );
+
+        // Atomic replace.
+        store.write_atomic(b"v2").await.unwrap();
+        assert_eq!(store.read().await.unwrap().as_deref(), Some(&b"v2"[..]));
+    }
+
+    #[tokio::test]
+    async fn object_store_round_trips_and_reports_absence() {
+        // `memory://` exercises the real ProximaObjectStore PUT/GET path
+        // deterministically (no cloud creds).
+        let store = ObjectStoreSnapshotStore::from_url(
+            "memory:///",
+            "_operator/catalog/system-catalog.snapshot",
+        )
+        .expect("memory store");
+
+        assert!(store.read().await.unwrap().is_none());
+
+        store.write_atomic(b"snap-bytes").await.unwrap();
+        assert_eq!(
+            store.read().await.unwrap().as_deref(),
+            Some(&b"snap-bytes"[..])
+        );
+
+        store.write_atomic(b"snap-bytes-2").await.unwrap();
+        assert_eq!(
+            store.read().await.unwrap().as_deref(),
+            Some(&b"snap-bytes-2"[..])
+        );
+    }
+}

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -735,6 +735,12 @@ impl DrPathBuilder {
     /// [`system_catalog_subprefix`](Self::system_catalog_subprefix).
     pub const SYSTEM_CATALOG_WAL_FILE: &'static str = "system-catalog.wal";
 
+    /// File name of the system catalog's snapshot blob within
+    /// [`system_catalog_subprefix`](Self::system_catalog_subprefix). For
+    /// object-store deployments this is the relative object key the snapshot is
+    /// PUT under (the per-DDL WAL stays local — Phase 6).
+    pub const SYSTEM_CATALOG_SNAPSHOT_FILE: &'static str = "system-catalog.snapshot";
+
     /// Build a validated control-plane (operator) subprefix
     /// `_operator/<subpath>/`. `subpath` runs through the same
     /// [`validate_id`](Self::validate_id) guard as a path segment (e.g.
@@ -762,6 +768,19 @@ impl DrPathBuilder {
             "{}{}",
             Self::system_catalog_subprefix(),
             Self::SYSTEM_CATALOG_WAL_FILE
+        )
+    }
+
+    /// Relative object key of the system catalog **snapshot** under
+    /// [`system_catalog_subprefix`](Self::system_catalog_subprefix):
+    /// `_operator/catalog/system-catalog.snapshot`. For object-store
+    /// deployments this is the key the snapshot blob is PUT under (relative to
+    /// the object-store base prefix).
+    pub fn system_catalog_snapshot_relpath() -> String {
+        format!(
+            "{}{}",
+            Self::system_catalog_subprefix(),
+            Self::SYSTEM_CATALOG_SNAPSHOT_FILE
         )
     }
 }
@@ -1137,6 +1156,10 @@ mod tests {
         assert_eq!(
             DrPathBuilder::system_catalog_wal_relpath(),
             "_operator/catalog/system-catalog.wal"
+        );
+        assert_eq!(
+            DrPathBuilder::system_catalog_snapshot_relpath(),
+            "_operator/catalog/system-catalog.snapshot"
         );
         // It is exactly the validated operator subprefix for "catalog".
         assert_eq!(


### PR DESCRIPTION
## Summary

**Phase 5, slice 4** of the two-tier operator/account model, **plus two infra fixes** for a `develop` that has not compiled since #226.

### 🔴 Restores a lost source file + fixes the root cause
PR #226 (5c) declared `pub mod catalog_snapshot_store;` but **the file never landed**: `.gitignore`'s broad `*snapshot*` (an AI-artifact / data-dir ignore) silently matched `src/services/catalog_snapshot_store.rs`, so `git add -A` skipped it and `develop`'s lib stopped compiling (CI didn't block it — the rust jobs are `changes`-gated and a *skipped* job doesn't trip `ci-success`'s failure check). Fix:
- `.gitignore` negations `!src/**/*snapshot*.rs` + `!crates/**/*snapshot*.rs` — snapshot-named **source** is code, never a data artifact.
- Restore `catalog_snapshot_store.rs` (verified tracked this time).

### Object-store boot cutover (5d)
Object-store metadata URLs (`s3/gs/az/memory`) now use the `SystemCatalog` too: the snapshot blob persists to the object store under `_operator/catalog/system-catalog.snapshot` (real durability, replacing `NativeCatalog::parse_storage_url`'s temp-cache fake), while the per-DDL WAL stays on the local working volume under `_operator/catalog/system-catalog.wal` (object-store-native WAL is **Phase 6**). Needs `opt_config` for the local `data_dir`; without it (some test/embedded paths) it falls back to `NativeCatalog`. `PROXIMADB_DISABLE_SYSTEM_CATALOG` remains the kill-switch; `file://` is unchanged. Adds `DrPathBuilder::system_catalog_snapshot_relpath()` + `SYSTEM_CATALOG_SNAPSHOT_FILE`.

### 🟢 Require Rust compile in CI (both shapes, in parallel)
New **always-run** `rust-compile` matrix job — `lib` (`cargo check --workspace --lib --bins`) and `test` (`cargo check --workspace --all-targets`) — wired into the `ci-success` required gate. **Deliberately not `changes`-gated**: a *skipped* job does not trip `ci-success`'s failure check, so the compile gate must be un-skippable. This is exactly what would have caught the non-compiling `develop` above. Also hardens `ci-success` to fail on `cancelled`, not just `failure`.

> Note: for this to *block* merges, GitHub branch-protection must require the `CI Success` check (it already does per repo policy); the two new `Rust Compile (lib)` / `Rust Compile (test)` jobs feed into it.

## Verification
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo test -p proximadb --lib -- path_resolver catalog_snapshot_store system_catalog` — **42/42**
- `check_tenant_path_guard.py` — green
- `ci.yml` YAML validates; `rust-compile` present in `ci-success.needs` with `lib`+`test` shapes

## Follow-up
- **Phase 6** — object-store-native catalog WAL (per-DDL delta objects) + multi-pod fence/coherence (the CAS substrate).