### PR TITLE
feat(graph): full edge scan for the columnar Flight export

### DIFF
--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -253,6 +253,32 @@ impl super::GraphOperationsService {
         Ok(results)
     }
 
+    /// Enumerate every edge in a graph.
+    ///
+    /// The engine has no full edge scan — edges live in per-source adjacency, so
+    /// [`query_edges`](Self::query_edges) deliberately returns empty without an
+    /// endpoint. But every edge has exactly one source node, so iterating each
+    /// node's *outgoing* edges yields every edge exactly once (no dedup). Used by
+    /// the columnar Flight export to dump a whole graph's edges (a whole-graph
+    /// Arrow dump needs all edges, not just one node's adjacency).
+    ///
+    /// Materializes the node set and walks adjacency — an O(N+E) scan intended
+    /// for export/ETL, not the hot traversal path.
+    pub async fn all_edges(&self, graph_id: &str) -> Result<Vec<Arc<Edge>>> {
+        if !self.graph_enabled() {
+            return Err(proximadb_kernel::error::ProximaDBError::InvalidInput(
+                "Graph operations disabled in current mode".to_string(),
+            ));
+        }
+        let engine = self.get_or_create_graph_engine(graph_id).await?;
+        let nodes = engine.get_all_nodes()?;
+        let mut edges = Vec::new();
+        for node in nodes {
+            edges.extend(engine.get_outgoing_edges(&node.id, None)?);
+        }
+        Ok(edges)
+    }
+
     fn query_edges_from_fresh_csr(
         &self,
         engine: &crate::graph::engines::GraphEngineImpl,

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -2839,28 +2839,34 @@ impl ProximaFlightService {
             });
             (schema, Box::pin(stream))
         } else {
-            // Edge export is endpoint-scoped (no full edge scan); require an
-            // endpoint rather than silently returning an empty stream.
-            if ticket.from_node_id.is_none() && ticket.to_node_id.is_none() {
-                return Err(TonicStatus::invalid_argument(
-                    "graph_edges export requires `from_node_id` or `to_node_id` \
-                     (the engine has no full edge scan)",
-                ));
-            }
-            let query = crate::graph::EdgeQuery {
-                graph_id: gid.clone(),
-                from_node_id: ticket.from_node_id.clone(),
-                to_node_id: ticket.to_node_id.clone(),
-                edge_types: ticket.edge_type.clone().into_iter().collect(),
-                filters: Vec::new(),
-                limit: None,
-                offset: None,
-                continuation_token: None,
+            // Edges live in per-source adjacency. With an endpoint, use the
+            // adjacency-scoped query; without one, do a full graph edge scan
+            // (export/ETL — dump every edge), filtering by type if requested.
+            let edges = if ticket.from_node_id.is_none() && ticket.to_node_id.is_none() {
+                let mut all = graph
+                    .all_edges(&gid)
+                    .await
+                    .map_err(|e| TonicStatus::internal(format!("scan edges: {e}")))?;
+                if let Some(et) = &ticket.edge_type {
+                    all.retain(|e| e.edge_type == *et);
+                }
+                all
+            } else {
+                let query = crate::graph::EdgeQuery {
+                    graph_id: gid.clone(),
+                    from_node_id: ticket.from_node_id.clone(),
+                    to_node_id: ticket.to_node_id.clone(),
+                    edge_types: ticket.edge_type.clone().into_iter().collect(),
+                    filters: Vec::new(),
+                    limit: None,
+                    offset: None,
+                    continuation_token: None,
+                };
+                graph
+                    .query_edges(&gid, query)
+                    .await
+                    .map_err(|e| TonicStatus::internal(format!("query edges: {e}")))?
             };
-            let edges = graph
-                .query_edges(&gid, query)
-                .await
-                .map_err(|e| TonicStatus::internal(format!("query edges: {e}")))?;
             let edges: Vec<crate::graph::Edge> = edges.iter().map(|e| (**e).clone()).collect();
             let batches: Vec<GraphBatchResult> = edges
                 .chunks(page)

--- a/tests/graph_flight_columnar_test.rs
+++ b/tests/graph_flight_columnar_test.rs
@@ -274,3 +274,61 @@ async fn columnar_node_export_paginates_with_fixed_schema() {
         "pagination reconstructs every node exactly once"
     );
 }
+
+/// `all_edges` (the full-graph edge scan backing the endpoint-less `graph_edges`
+/// Flight export) returns every edge exactly once — even those whose source node
+/// differs — and the columnar codec round-trips the whole set. Without this, a
+/// whole-graph Arrow dump can export all nodes but not all edges.
+#[tokio::test]
+async fn all_edges_full_scan_returns_every_edge() {
+    use proximadb::graph::model::Edge;
+    let graph = Arc::new(GraphOperationsService::new());
+    let graph_id = "g_all_edges";
+    create_graph(&graph, graph_id).await;
+
+    let nodes = vec![node("a", 0), node("b", 0), node("c", 0)];
+    let nb = graph_codec::nodes_to_batch(&nodes).expect("encode nodes");
+    graph
+        .batch_create_nodes_with_strategy(
+            graph_id,
+            graph_codec::batch_to_nodes(&nb).unwrap(),
+            "update",
+        )
+        .await
+        .expect("create nodes");
+
+    // Edges spread across two distinct source nodes (a, b) — a per-source
+    // adjacency query for any single node would miss the others.
+    let mk = |id: &str, from: &str, to: &str| Edge {
+        id: id.to_string(),
+        from_node_id: from.to_string(),
+        to_node_id: to.to_string(),
+        edge_type: "KNOWS".to_string(),
+        properties: HashMap::new(),
+        weight: None,
+        created_at_ms: 0,
+        updated_at_ms: 0,
+    };
+    graph
+        .batch_create_edges(
+            graph_id,
+            vec![mk("e1", "a", "b"), mk("e2", "b", "c"), mk("e3", "a", "c")],
+        )
+        .await
+        .expect("create edges");
+
+    let all = graph.all_edges(graph_id).await.expect("all_edges");
+    let mut ids: Vec<String> = all.iter().map(|e| e.id.clone()).collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["e1", "e2", "e3"],
+        "full scan returns every edge exactly once (no dups, no misses)"
+    );
+
+    // The whole edge set survives the columnar codec round-trip.
+    let owned: Vec<Edge> = all.iter().map(|e| (**e).clone()).collect();
+    let batch = graph_codec::edges_to_batch(&owned).expect("encode all edges");
+    let back = graph_codec::batch_to_edges(&batch).expect("decode all edges");
+    assert_eq!(back.len(), 3);
+}


### PR DESCRIPTION
## Summary

Completes the batched columnar graph export (#198/#216/#227): the `graph_edges` Flight `DoGet` now supports a **full graph edge scan** when no endpoint is given, instead of erroring. This closes an asymmetry — a whole-graph Arrow dump could export *all nodes* (label-less `query_nodes`) but not *all edges*, which is exactly what export/ETL/backup needs.

## What changed

- **`GraphOperationsService::all_edges(graph_id)`** — the engine has no full edge scan (edges live in per-source adjacency, so `query_edges` deliberately returns empty without an endpoint). But every edge has exactly one source node, so iterating each node's *outgoing* edges yields every edge **exactly once** (no dedup). O(N+E), intended for export/ETL, not the hot path.
- **`graph_edges` `DoGet` export** — no endpoint → `all_edges` (full scan, optional `edge_type` filter applied); with an endpoint → the existing adjacency-scoped `query_edges`. The streamed columnar chunking/encoding is unchanged.

## Verification

- `cargo check -p proximadb --lib` — green
- `cargo test --test graph_flight_columnar_test` — 4/4, incl. the new `all_edges_full_scan_returns_every_edge` (edges across two source nodes → full scan returns each exactly once, codec round-trips the whole set)
- `cargo fmt --check` — clean

> ⚠️ **Blocked on an unrelated develop break:** develop's lib currently does not compile — #226 ("system-catalog 5c") committed `services/mod.rs` declaring `pub mod catalog_snapshot_store;` but the `catalog_snapshot_store.rs` file was silently gitignored (`.gitignore:414 *snapshot*`) and never committed (E0583). Flagged on #226. This change was verified on the pre-#226 develop commit; CI here will be red on that snapshot module until #226 lands the missing file. No overlap with my files.