### PR TITLE
ci+hooks: pin Rust toolchain to rust-toolchain.toml's 1.95.0 (CI + pre-push in sync)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,9 +17,19 @@ if ! "$root/scripts/worktree.sh" guard >/dev/null 2>&1; then
 fi
 
 # 2) Formatting (fast, no compile) — the most frequent avoidable CI red.
+# Pin to the rust-toolchain.toml channel so local rustfmt matches CI exactly (CI
+# pins dtolnay/rust-toolchain to the same version). Without this the default
+# `cargo` can resolve to a newer stable rustfmt, producing "green local, red CI"
+# (or vice-versa) formatting drift. Reads the channel from the toml = single
+# source of truth.
 if command -v cargo >/dev/null 2>&1; then
-  if ! cargo fmt --all -- --check >/dev/null 2>&1; then
-    echo "pre-push: BLOCKED — rustfmt drift. Run: cargo fmt --all   (bypass: git push --no-verify)" >&2
+  tc="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' "$root/rust-toolchain.toml" 2>/dev/null)"
+  fmt_cargo=(cargo)
+  if [ -n "$tc" ] && command -v rustup >/dev/null 2>&1 && rustup run "$tc" cargo --version >/dev/null 2>&1; then
+    fmt_cargo=(rustup run "$tc" cargo)
+  fi
+  if ! "${fmt_cargo[@]}" fmt --all -- --check >/dev/null 2>&1; then
+    echo "pre-push: BLOCKED — rustfmt drift (toolchain ${tc:-default}). Run: ${fmt_cargo[*]} fmt --all   (bypass: git push --no-verify)" >&2
     exit 1
   fi
 fi

--- a/.github/workflows/_shared-build.yml
+++ b/.github/workflows/_shared-build.yml
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
@@ -358,7 +358,7 @@ jobs:
   #         python-version: ${{ matrix.python }}
   #
   #     - name: Install Rust Toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  #       uses: dtolnay/rust-toolchain@1.95.0
   #
   #     - name: Setup Rust Cache
   #       uses: Swatinem/rust-cache@v2
@@ -456,7 +456,7 @@ jobs:
   #         python-version: "3.11"
   #
   #     - name: Install Rust Toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  #       uses: dtolnay/rust-toolchain@1.95.0
   #
   #     - name: Setup Rust Cache
   #       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - name: Install System Dependencies
@@ -286,7 +286,7 @@ jobs:
     if: needs.changes.outputs.proto == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install System Dependencies
         run: |
           sudo apt-get update
@@ -328,7 +328,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.openapi_spec == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install System Dependencies
         run: |
           sudo apt-get update
@@ -415,7 +415,7 @@ jobs:
     if: needs.changes.outputs.rust_sdk == 'true' || needs.changes.outputs.openapi_spec == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - name: Install System Dependencies
@@ -536,7 +536,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
       - name: Install System Dependencies
@@ -582,7 +582,7 @@ jobs:
           - { label: "enterprise-catalogs", pkg: proximadb,        feats: "enterprise-catalogs" }
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install System Dependencies
         # g++ provides libstdc++ for the onnxruntime (ort) build script.
         run: |
@@ -604,7 +604,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run security audit
@@ -694,7 +694,7 @@ jobs:
     if: needs.changes.outputs.rust_sdk == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
       - name: Check formatting
@@ -743,7 +743,7 @@ jobs:
 
       # Toolchain setup — one branch per matrix cell
       - if: matrix.setup == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
       - if: matrix.setup == 'rust'
         uses: Swatinem/rust-cache@v2
         with:
@@ -811,7 +811,7 @@ jobs:
         kind: [rest, flight]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install System Dependencies
         run: |
           sudo apt-get update
@@ -853,7 +853,7 @@ jobs:
     if: needs.changes.outputs.spark_jni == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -991,7 +991,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1024,7 +1024,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1073,7 +1073,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -1121,7 +1121,7 @@ jobs:
        needs.changes.outputs.core_changes == 'true')
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust-nightly-dev"
@@ -1154,7 +1154,7 @@ jobs:
        needs.changes.outputs.core_changes == 'true')
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust-nightly-dev"
@@ -1186,7 +1186,7 @@ jobs:
        needs.changes.outputs.core_changes == 'true')
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust-nightly-dev"
@@ -1218,7 +1218,7 @@ jobs:
        needs.changes.outputs.core_changes == 'true')
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust-nightly-dev"
@@ -1247,7 +1247,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust-nightly-coverage"
@@ -1554,7 +1554,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -180,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
@@ -328,7 +328,7 @@ jobs:
   #         python-version: "3.11"
   #
   #     - name: Install Rust Toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  #       uses: dtolnay/rust-toolchain@1.95.0
   #       with:
   #         toolchain: stable
   #

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install system deps
         run: |
           sudo apt-get update
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Install system deps
         run: |
           sudo apt-get update
@@ -124,7 +124,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
       - name: Install system deps + cargo-llvm-cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
@@ -390,7 +390,7 @@ jobs:
   #         python-version: "3.11"
   #
   #     - name: Install Rust Toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  #       uses: dtolnay/rust-toolchain@1.95.0
   #       with:
   #         toolchain: stable
   #
@@ -1216,7 +1216,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           toolchain: stable
 
@@ -1465,7 +1465,7 @@ jobs:
           python -c "import proximadb; print(f'ProximaDB version: {proximadb.__version__}')" || true
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           toolchain: stable
 


### PR DESCRIPTION
## What

Make CI **and** the local pre-push hook use the same Rust toolchain as `rust-toolchain.toml` (`channel = "1.95.0"`, the single source of truth), eliminating the "green local / red CI" formatting+lint drift.

- **CI:** pin every active `dtolnay/rust-toolchain@stable` → `@1.95.0` across `ci.yml`, `_shared-build.yml`, `qa-gate.yml`, `prerelease-ci.yml`, `release.yml`.
- **Pre-push hook (`.githooks/pre-push`):** read the channel from `rust-toolchain.toml` and run rustfmt under that toolchain (`rustup run <tc> cargo fmt`) instead of plain `cargo fmt`, which can resolve to a newer default rustfmt.

## Why

`rust-toolchain.toml` pins 1.95.0, but `@stable` overrides it and installs the latest stable (1.96+). That drift is why **#229** went red on `Rust Format` / `Rust Clippy` / `Rust Build` even though the code builds clean on 1.95.0 (verified: app crates, `cargo fmt --all --check`, `clippy --lib --bins -D warnings` all green on 1.95.0). The hook had the same issue from the other direction (flagging 1.95-clean trees).

## Best practice

Single source of truth = `rust-toolchain.toml`. Local and CI now both resolve to it; bump the toml and the CI `@x.y.z` refs together. `ci.yml`'s `gpu-feature-check` was already pinned to 1.95.0 (precedent).

## Scope

Workflow YAML + the pre-push hook only — no Rust code changes. Rebased onto develop after #230 (which restored `catalog_snapshot_store.rs` that `.gitignore` had swallowed) so the tree compiles + formats clean.