### PR TITLE
feat(fusion): graph instance on the cross-modal fusion seam — v2 fusion-search (TD-137)

### DIFF
--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -1,0 +1,151 @@
+//! REST v2 graph fusion endpoints — the graph instance of the cross-modal fusion seam on a transport.
+//!
+//! `POST /api/v2/graphs/{graph_id}/fusion-search` runs vector ANN seed → k-hop graph expand →
+//! calibrated fuse-by-`oid`, via [`crate::services::fusion_service::FusionService`]. See
+//! `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` (TD-137).
+
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::core::search::cross_modal_fusion::{FusionPolicy, FusionStats};
+use crate::errors::{ApiError, ApiResult};
+use crate::network::middleware::tenant::TenantContext;
+use crate::network::rest::v1::handlers::AppState;
+use crate::services::fusion_service::{FusionService, GraphFusionParams};
+
+fn default_limit() -> usize {
+    10
+}
+fn default_depth() -> u32 {
+    1
+}
+fn default_max_seeds() -> usize {
+    5
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FusionSearchRequest {
+    /// Vector collection to seed from (its records co-indexed with this graph by `oid`).
+    pub vector_collection: String,
+    /// Query embedding for the ANN seed.
+    pub query_vector: Vec<f32>,
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// k-hop expansion depth (bounded; default 1 — the validated sweet spot).
+    #[serde(default = "default_depth")]
+    pub max_depth: u32,
+    #[serde(default)]
+    pub edge_types: Vec<String>,
+    /// How many of the top vector seeds to expand from (bounded expansion).
+    #[serde(default = "default_max_seeds")]
+    pub max_seeds: usize,
+    pub vector_weight: Option<f32>,
+    pub graph_weight: Option<f32>,
+    /// Use the rank-based RRF fallback instead of PIT-calibrated linear.
+    #[serde(default)]
+    pub rrf: bool,
+    /// Consensus boost added to any `oid` present in ≥2 sources.
+    pub consensus_beta: Option<f32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FusionHit {
+    pub oid: String,
+    pub score: f32,
+    pub source_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FusionStatsDto {
+    pub sources_fused: usize,
+    pub sources_skipped: usize,
+    pub candidates_in: usize,
+    pub items_out: usize,
+}
+
+impl From<FusionStats> for FusionStatsDto {
+    fn from(stats: FusionStats) -> Self {
+        Self {
+            sources_fused: stats.sources_fused,
+            sources_skipped: stats.sources_skipped,
+            candidates_in: stats.candidates_in,
+            items_out: stats.items_out,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct FusionSearchResponse {
+    pub results: Vec<FusionHit>,
+    pub stats: FusionStatsDto,
+}
+
+/// `POST /api/v2/graphs/{graph_id}/fusion-search` — vector seed → graph expand → calibrated fuse-by-oid.
+pub async fn fusion_search_v2(
+    Path(graph_id): Path<String>,
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    Json(request): Json<FusionSearchRequest>,
+) -> ApiResult<Json<FusionSearchResponse>> {
+    if request.query_vector.is_empty() {
+        return Err(ApiError::InvalidArgument(
+            "query_vector must not be empty".to_string(),
+        ));
+    }
+    if request.vector_collection.trim().is_empty() {
+        return Err(ApiError::InvalidArgument(
+            "vector_collection is required".to_string(),
+        ));
+    }
+    tracing::debug!(
+        tenant_id = %tenant.tenant_id,
+        graph_id = %graph_id,
+        "v2 graph fusion-search"
+    );
+
+    let mut policy = if request.rrf {
+        FusionPolicy::rrf()
+    } else {
+        FusionPolicy::default()
+    };
+    if let Some(beta) = request.consensus_beta {
+        policy.consensus_beta = beta;
+    }
+
+    let service = FusionService::new(
+        state.vector_operations_service.clone(),
+        state.request_handlers.graph_operations_service.clone(),
+    );
+    let params = GraphFusionParams {
+        graph_id,
+        vector_collection: request.vector_collection,
+        query_vector: request.query_vector,
+        max_depth: request.max_depth,
+        edge_types: request.edge_types,
+        max_seeds: request.max_seeds,
+        limit: request.limit,
+        vector_weight: request.vector_weight.unwrap_or(1.0),
+        graph_weight: request.graph_weight.unwrap_or(1.0),
+        policy,
+    };
+
+    let (items, stats) = service
+        .graph_fusion_search(params)
+        .await
+        .map_err(|error| ApiError::Internal(format!("fusion search failed: {error}")))?;
+
+    Ok(Json(FusionSearchResponse {
+        results: items
+            .into_iter()
+            .map(|item| FusionHit {
+                oid: item.oid,
+                score: item.score,
+                source_count: item.source_count,
+            })
+            .collect(),
+        stats: stats.into(),
+    }))
+}

--- a/src/network/rest/v2/mod.rs
+++ b/src/network/rest/v2/mod.rs
@@ -45,6 +45,7 @@
 pub mod collections;
 pub mod discovery;
 pub mod external_collection;
+pub mod graphs;
 pub mod query;
 pub mod records;
 pub mod schema;
@@ -138,6 +139,12 @@ pub fn create_v2_router() -> Router<AppState> {
         // Query facade operations
         .route("/query", post(query::execute_query))
         .route("/query/explain", post(query::explain_query))
+        // Cross-modal fusion seam — graph instance (TD-137): vector seed → graph
+        // expand → calibrated fuse-by-oid.
+        .route(
+            "/graphs/{graph_id}/fusion-search",
+            post(graphs::fusion_search_v2),
+        )
         // Phase 8 (F1) — Continuous Discovery jobs (experimental).
         .route(
             "/collections/{collection_id}/discovery-jobs",

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -1,0 +1,238 @@
+//! Graph-modality fusion service — the first instance of the cross-modal fusion seam.
+//!
+//! Phase 1 (F-B / TD-137) of `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`. Wires the real
+//! vector ANN seed + graph k-hop expand into the neutral [`Fuser`] core:
+//!
+//! ```text
+//! vector ANN seed → graph k-hop expand (from the top seeds) → calibrate → fuse-by-oid → rank
+//! ```
+//!
+//! The conversion adapters (`*_to_source`, `seed_node_ids`) are pure functions over the service result
+//! types, so the correlation logic is unit-testable without standing up the engines. The graph node's
+//! BFS visitation rank is a proximity proxy (closer = earlier) — only the *order* matters because the
+//! Fuser's PIT calibration normalizes each source to its empirical CDF (D3). Correlation is by the
+//! canonical `oid` (`graph/{graph_id}/node/{node_id}`), so a vector hit and a graph-expanded node that
+//! are the same entity are the same `oid` and fuse without a join (D1).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use proximadb_graph::record::GraphNodeKey;
+
+use crate::core::search::cross_modal_fusion::{
+    FusedItem, Fuser, FusionPolicy, FusionStats, SourceCandidates, SourceId,
+};
+use crate::core::search::results::OptimizedSearchRecord;
+use crate::graph::GraphOperationsService;
+use crate::graph::model::Node;
+use crate::services::VectorOperationsService;
+
+/// `TraversalAlgorithm::Bfs` proto tag.
+const ALGORITHM_BFS: i32 = 1;
+
+/// Vector ANN hits → an `oid`-keyed vector source. The record `id` is the canonical `oid`.
+pub(crate) fn vector_hits_to_source(
+    hits: &[OptimizedSearchRecord],
+    weight: f32,
+) -> SourceCandidates {
+    let scores = hits.iter().map(|hit| (hit.id.clone(), hit.score)).collect();
+    SourceCandidates::new(SourceId::Vector, weight, scores)
+}
+
+/// Graph traversal nodes → an `oid`-keyed graph source. Raw score = `1/(rank+1)` from the node's BFS
+/// visitation order (proximity proxy); a node reached more than once keeps its best (earliest) score.
+/// `oid` is the canonical `graph/{graph_id}/node/{node_id}` so it merges with the vector source.
+pub(crate) fn traversal_nodes_to_source(
+    graph_id: &str,
+    nodes: &[Node],
+    weight: f32,
+) -> SourceCandidates {
+    let mut scores: HashMap<String, f32> = HashMap::new();
+    for (rank, node) in nodes.iter().enumerate() {
+        let oid = GraphNodeKey::new(graph_id, node.id.clone()).canonical_oid();
+        let score = 1.0 / (rank as f32 + 1.0);
+        scores
+            .entry(oid)
+            .and_modify(|existing| {
+                if score > *existing {
+                    *existing = score;
+                }
+            })
+            .or_insert(score);
+    }
+    SourceCandidates::new(SourceId::Graph, weight, scores)
+}
+
+/// Recover the graph `node_id` to seed traversal from each vector hit. When the vector collection is
+/// co-indexed with the graph the record `id` is the canonical `oid` (`graph/{graph_id}/node/{node_id}`),
+/// so strip the prefix; otherwise fall back to the raw `id`. Bounded by `max_seeds` (D8 — conservative
+/// expansion).
+pub(crate) fn seed_node_ids(
+    graph_id: &str,
+    hits: &[OptimizedSearchRecord],
+    max_seeds: usize,
+) -> Vec<String> {
+    let prefix = format!("graph/{graph_id}/node/");
+    hits.iter()
+        .take(max_seeds)
+        .map(|hit| {
+            hit.id
+                .strip_prefix(&prefix)
+                .map(str::to_string)
+                .unwrap_or_else(|| hit.id.clone())
+        })
+        .collect()
+}
+
+/// Parameters for one graph-modality fusion query.
+#[derive(Debug, Clone)]
+pub struct GraphFusionParams {
+    pub graph_id: String,
+    pub vector_collection: String,
+    pub query_vector: Vec<f32>,
+    pub max_depth: u32,
+    pub edge_types: Vec<String>,
+    /// How many of the top vector seeds to expand from (bounded — D8).
+    pub max_seeds: usize,
+    pub limit: usize,
+    pub vector_weight: f32,
+    pub graph_weight: f32,
+    pub policy: FusionPolicy,
+}
+
+/// Orchestrates the graph instance of the fusion seam over the live vector + graph engines.
+pub struct FusionService {
+    vector: Arc<VectorOperationsService>,
+    graph: Arc<GraphOperationsService>,
+}
+
+impl FusionService {
+    pub fn new(vector: Arc<VectorOperationsService>, graph: Arc<GraphOperationsService>) -> Self {
+        Self { vector, graph }
+    }
+
+    /// Vector-seed → graph-expand → fuse-by-`oid`. Tenant isolation is structural (the collection and
+    /// graph carry the tenant boundary), per the co-design mandate — never a post-fusion predicate.
+    pub async fn graph_fusion_search(
+        &self,
+        params: GraphFusionParams,
+    ) -> Result<(Vec<FusedItem>, FusionStats)> {
+        // 1. Vector ANN seed.
+        let hits = self
+            .vector
+            .unified_search_native(
+                &params.vector_collection,
+                params.query_vector.clone(),
+                params.limit,
+                None,
+                None,
+            )
+            .await?;
+        let vector_source = vector_hits_to_source(&hits, params.vector_weight);
+
+        // 2. Graph expand from the top seeds (bounded). A seed that is not a node in this graph simply
+        //    contributes nothing (its traverse errors are skipped) rather than failing the query.
+        let seeds = seed_node_ids(&params.graph_id, &hits, params.max_seeds);
+        let mut nodes: Vec<Node> = Vec::new();
+        for seed in seeds {
+            let request = crate::graph::model::TraversalRequest {
+                graph_id: params.graph_id.clone(),
+                start_node_id: seed,
+                max_depth: params.max_depth,
+                edge_types: params.edge_types.clone(),
+                node_labels: Vec::new(),
+                filters: Vec::new(),
+                algorithm: ALGORITHM_BFS,
+                limit: Some(params.limit as u32),
+                timeout_ms: None,
+                max_frontier: None,
+            };
+            if let Ok(response) = self.graph.traverse(&params.graph_id, request).await {
+                nodes.extend(response.nodes);
+            }
+        }
+        let graph_source = traversal_nodes_to_source(&params.graph_id, &nodes, params.graph_weight);
+
+        // 3. Calibrate + fuse-by-oid + rank.
+        let fuser = Fuser::new(params.policy);
+        Ok(fuser.fuse(vec![vector_source, graph_source], params.limit))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(id: &str, score: f32) -> OptimizedSearchRecord {
+        OptimizedSearchRecord {
+            id: id.to_string(),
+            score,
+            ..Default::default()
+        }
+    }
+
+    fn node(id: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn vector_hits_become_oid_keyed_source() {
+        let hits = [hit("a", 0.9), hit("b", 0.7)];
+        let source = vector_hits_to_source(&hits, 1.0);
+        assert_eq!(source.source, SourceId::Vector);
+        assert_eq!(source.scores.get("a"), Some(&0.9));
+        assert_eq!(source.scores.get("b"), Some(&0.7));
+    }
+
+    #[test]
+    fn traversal_nodes_use_canonical_oid_and_best_rank_score() {
+        // n1 appears first (rank 0 → 1.0) and again later (rank 2 → 0.333) → keeps the best (1.0).
+        let nodes = [node("n1"), node("n2"), node("n1")];
+        let source = traversal_nodes_to_source("g1", &nodes, 1.0);
+        assert_eq!(source.source, SourceId::Graph);
+        // Canonical oid form, matching the vector/record spine.
+        assert_eq!(source.scores.get("graph/g1/node/n1"), Some(&1.0));
+        assert_eq!(source.scores.get("graph/g1/node/n2"), Some(&0.5));
+        assert_eq!(source.scores.len(), 2, "n1 deduped to its best score");
+    }
+
+    #[test]
+    fn seed_node_ids_strip_canonical_prefix_and_bound() {
+        let hits = [
+            hit("graph/g1/node/n1", 0.9),
+            hit("graph/g1/node/n2", 0.8),
+            hit("raw_id", 0.7), // not in canonical form → used as-is
+        ];
+        let seeds = seed_node_ids("g1", &hits, 2);
+        assert_eq!(
+            seeds,
+            vec!["n1".to_string(), "n2".to_string()],
+            "prefix stripped, bounded to 2"
+        );
+        let all = seed_node_ids("g1", &hits, 10);
+        assert_eq!(all[2], "raw_id", "non-canonical id falls through");
+    }
+
+    /// The conversions feed the Fuser: a vector hit and a graph node that are the SAME entity (same
+    /// canonical oid) fuse into one item with `source_count == 2`.
+    #[test]
+    fn vector_and_graph_sources_fuse_by_shared_oid() {
+        let oid = "graph/g1/node/n1";
+        let vector = vector_hits_to_source(&[hit(oid, 0.9)], 1.0);
+        let graph = traversal_nodes_to_source("g1", &[node("n1")], 1.0);
+        let (items, stats) = Fuser::new(FusionPolicy::default()).fuse(vec![vector, graph], 10);
+        assert_eq!(stats.sources_fused, 2);
+        let fused = items
+            .iter()
+            .find(|i| i.oid == oid)
+            .expect("shared oid fused");
+        assert_eq!(
+            fused.source_count, 2,
+            "vector + graph hit on the same oid merge"
+        );
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -182,6 +182,7 @@ pub mod embedding_drainer;
 pub mod events;
 pub mod external_collection;
 pub mod function_store;
+pub mod fusion_service;
 pub mod graph_collection;
 pub mod operations;
 pub mod queue_fs_adapter;


### PR DESCRIPTION
## What

The **first modality expander on the cross-modal fusion seam** from #228 (TD-136), and the missing transport for graph hybrid: `POST /api/v2/graphs/{graph_id}/fusion-search` runs **vector ANN seed → bounded k-hop graph expand → calibrated fuse-by-`oid`**. Subsumes the old TD-131 "graph on REST v2" goal — done on the seam rather than as a one-off.

## How

- **`src/services/fusion_service.rs`** — `FusionService::graph_fusion_search`: vector seed (`VectorOperationsService::unified_search_native`) → expand the ORION graph (`GraphOperationsService::traverse`, bounded BFS) from the top seeds → feed both into the neutral `Fuser` (from #228). The conversion adapters are **pure functions** over the service result types, so the correlation logic is unit-tested without standing up the engines:
  - `vector_hits_to_source` — hits → `oid`-keyed vector source;
  - `traversal_nodes_to_source` — graph nodes → `oid`-keyed graph source at the **canonical `oid`** (`graph/{graph_id}/node/{id}`), BFS rank as the proximity proxy (PIT calibration normalizes it, so only order matters), best-score-per-node;
  - `seed_node_ids` — recover graph node-ids from seed `oid`s (strip the canonical prefix), bounded.
- **`POST /api/v2/graphs/{graph_id}/fusion-search`** (`src/network/rest/v2/graphs.rs`) — tenant-scoped handler; PIT-calibrated linear by default, `rrf=true` for the rank-fusion fallback, optional `consensus_beta` + per-source weights.

**Correlation is by shared `oid`** (D1): a vector hit and a graph-expanded node that are the *same entity* are the same `oid`, so they fuse (dedup + co-score) without a join. **Tenant isolation is structural** — the collection and graph carry the boundary; it is never a post-fusion predicate (D6).

## Tests

4 unit tests on the pure adapters (`cargo test --lib fusion_service` → 4/4): `oid`-keyed vector source; graph nodes use the canonical `oid` + best-rank score + dedup; **a vector hit and a graph node on the same `oid` fuse with `source_count == 2`**; seed-id prefix stripping + bounded expansion. (The `Fuser` calibration/fusion core itself is covered by #228's 6 tests.) `cargo fmt` + `cargo clippy --lib` clean on the changed files; no `unwrap/expect/panic` in new production code; compiles on the latest develop.

## Scope / follow-on

A seed that isn't a node in the graph contributes nothing (skipped) rather than failing the query. Multi-seed expansion is bounded (`max_seeds`, default 5; `max_depth` default 1 — the validated sweet spot). Follow-on per the design doc: `DocumentExpander` convergence folding the 12-strategy engine (TD-138), `RelationalExpander` prefilter (TD-139), edge-grain fusion (TD-140), the cost-routed planner (TD-141).