### PR TITLE
fix(graph): align Python SDK to v2 edge-list envelope + deprecate real v1 (Vector/Collection)

### DIFF
--- a/clients/python/src/proximadb_sdk/protocols/rest_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/rest_sync.py
@@ -83,6 +83,22 @@ from . import _rest_codegen as _gen
 logger = logging.getLogger(__name__)
 
 
+def _unwrap_v2_list(data: Any) -> tuple[list[dict[str, Any]], bool]:
+    """Unwrap a v2 list-endpoint ``data`` payload into ``(items, has_more)``.
+
+    The xCatalog v2 graph query endpoints (``/query/nodes``, ``/query/edges``)
+    return paginated results as ``{"items": [...], "has_more": bool}`` nested
+    under ``data``. Older builds returned ``data`` as a bare list. This tolerates
+    both so callers always get a plain list of records.
+    """
+    if isinstance(data, dict):
+        items = data.get("items", [])
+        return (list(items) if items else []), bool(data.get("has_more", False))
+    if isinstance(data, list):
+        return data, False
+    return [], False
+
+
 def _convert_quantization_config_to_proto(quant_config) -> dict[str, Any]:
     """Convert SDK's flat QuantizationConfig to proto's nested structure
 
@@ -2906,13 +2922,16 @@ class ProximaDBClient:
         response.raise_for_status()
         result = response.json()
 
-        # Transform REST response to match gRPC format
-        # REST returns: {"success": true, "data": [...], "next_token": "..."}
-        # gRPC returns: {"success": true, "nodes": [...], "total_count": N}
+        # Transform REST response to match gRPC format.
+        # v2 list endpoints wrap results in a paginated envelope:
+        #   {"success": true, "data": {"items": [...], "has_more": bool}}
+        # (older builds returned data as a bare list; tolerate both).
+        nodes, has_more = _unwrap_v2_list(result.get("data"))
         return {
             "success": result.get("success", True),
-            "nodes": result.get("data", []),
-            "total_count": len(result.get("data", [])),
+            "nodes": nodes,
+            "total_count": len(nodes),
+            "has_more": has_more,
             "next_token": result.get("next_token"),
         }
 
@@ -2945,10 +2964,13 @@ class ProximaDBClient:
         )
         response.raise_for_status()
         result = response.json()
+        # v2 wraps results in {"data": {"items": [...], "has_more": bool}}.
+        edges, has_more = _unwrap_v2_list(result.get("data"))
         return {
             "success": result.get("success", True),
-            "edges": result.get("data", []),
-            "total_count": len(result.get("data", [])),
+            "edges": edges,
+            "total_count": len(edges),
+            "has_more": has_more,
             "next_token": result.get("next_token"),
         }
 

--- a/proto/proximadb/v1/collection.proto
+++ b/proto/proximadb/v1/collection.proto
@@ -4,10 +4,16 @@ package proximadb.v1;
 
 import "proximadb/v1/collection_types.proto";
 
+// Collection management (v1 compatibility shim).
+//
+// DEPRECATED: superseded by the canonical ProximaRecord API in
+// `proximadb/v2/record.proto` (and `/api/v2/...` REST). Slated for removal as
+// part of the v1/v2 untangle before release; do not build new clients on it.
 service CollectionService {
-  rpc CreateCollection(CollectionConfig) returns (Collection);
-  rpc GetCollection(GetCollectionRequest) returns (Collection);
-  rpc ListCollections(ListCollectionsRequest) returns (ListCollectionsResponse);
-  rpc DeleteCollection(DeleteCollectionRequest) returns (DeleteCollectionResponse);
+  option deprecated = true;
+  rpc CreateCollection(CollectionConfig) returns (Collection) { option deprecated = true; }
+  rpc GetCollection(GetCollectionRequest) returns (Collection) { option deprecated = true; }
+  rpc ListCollections(ListCollectionsRequest) returns (ListCollectionsResponse) { option deprecated = true; }
+  rpc DeleteCollection(DeleteCollectionRequest) returns (DeleteCollectionResponse) { option deprecated = true; }
 }
 

--- a/proto/proximadb/v1/vector.proto
+++ b/proto/proximadb/v1/vector.proto
@@ -4,11 +4,16 @@ package proximadb.v1;
 
 import "proximadb/v1/vector_types.proto";
 
-// Vector operations (v1, versioned namespace)
+// Vector operations (v1 compatibility shim).
+//
+// DEPRECATED: superseded by the canonical ProximaRecord API in
+// `proximadb/v2/record.proto` (and `/api/v2/...` REST). Slated for removal as
+// part of the v1/v2 untangle before release; do not build new clients on it.
 service VectorService {
-  rpc VectorBatch(VectorBatchRequest) returns (VectorOperationResponse);
-  rpc VectorSearch(VectorSearchRequest) returns (VectorOperationResponse);
-  rpc VectorGet(VectorGetRequest) returns (VectorOperationResponse);
+  option deprecated = true;
+  rpc VectorBatch(VectorBatchRequest) returns (VectorOperationResponse) { option deprecated = true; }
+  rpc VectorSearch(VectorSearchRequest) returns (VectorOperationResponse) { option deprecated = true; }
+  rpc VectorGet(VectorGetRequest) returns (VectorOperationResponse) { option deprecated = true; }
   // Streaming search for large result sets - streams individual search results
-  rpc VectorSearchStream(VectorSearchRequest) returns (stream SearchVectorRecord);
+  rpc VectorSearchStream(VectorSearchRequest) returns (stream SearchVectorRecord) { option deprecated = true; }
 }

--- a/roadmap/techdebt/V1_DEPRECATION_UNTANGLE.md
+++ b/roadmap/techdebt/V1_DEPRECATION_UNTANGLE.md
@@ -1,0 +1,58 @@
+# v1/v2 API Untangle — Deprecate the Real v1, Collapse to One Clean v1
+
+Date: 2026-06-22
+Status: In progress (step 1 — deprecation markers)
+
+## Goal
+
+Collapse the current messy v1/v2 split into a single coherent API so that, **after
+release, the outside world only ever sees `v1`**. The "v2" surface today is a
+single canonical data plane (`proto/proximadb/v2/record.proto`); most "v1"
+services are in fact the *current* API that merely live in a `v1/`-named
+directory. We deprecate and remove the genuinely-superseded v1, then rename the
+surviving surface to a clean `v1` before release.
+
+## Two distinct buckets (do not conflate)
+
+**Real v1 — deprecate now → remove:** compatibility shims superseded by the
+canonical ProximaRecord API (`v2/record.proto`, `/api/v2/...`):
+
+- gRPC `VectorService` (`proto/proximadb/v1/vector.proto`)
+- gRPC `CollectionService` (`proto/proximadb/v1/collection.proto`)
+- REST `/api/v1/{search,vectors/batch,collections}` compat endpoints
+
+**Current API in a v1-named dir — DO NOT deprecate** (no v2 replacement exists;
+will be renamed to clean `v1` at the pre-release collapse): `GraphService`,
+`HybridSearchService`, `DocumentService`, `QueryService` (sql), observability,
+ranking, relations, cluster, security, streaming, catalog. (Note: the graph REST
+routes already serve `/api/v2/graphs/...` even though the server module is named
+`rest/v1/graph.rs` — that's a naming artifact, resolved at the collapse, not a
+deprecation.)
+
+## Done
+
+- ✅ `option deprecated = true` on `VectorService` + `CollectionService` (services
+  and all RPCs). Generated stubs in **all client languages** inherit the marker
+  on their next regen — the single-source-of-truth deprecation.
+- ✅ REST `/api/v1/*` already emits `Deprecation: true` + migration message via
+  `add_rest_v1_deprecation_headers` (`crates/.../rest/v1/mod.rs`).
+- ✅ Python SDK graph fix: `query_nodes`/`query_edges` now unwrap the v2
+  `{data:{items,has_more}}` envelope (was yielding dict keys → broke
+  `get_outgoing_edges`/`get_incoming_edges`). Verified against a live embedded
+  engine via Victor's code-graph parity battery.
+
+## Follow-up (tracked)
+
+- ☐ **Hand-wrapper deprecation markers** in each of the 9 client SDKs (`clients/`:
+  go, go-embedded, java-embedded, jvm, nodejs-embedded, python, python-embedded,
+  python-queue-embedded, rust). Add idiomatic markers **only** on the
+  hand-written convenience methods that call the v1 shim
+  (`/api/v1/*` or the v1 `VectorService`/`CollectionService` stubs) — **not** the
+  high-level methods that already route to v2 records. Do per client as it is next
+  touched/built so each can be compile-verified.
+- ☐ **Remove** the deprecated v1 (`VectorService`/`CollectionService`,
+  `/api/v1/*`) once consumers are off it.
+- ☐ **Pre-release rename**: collapse the surviving surface to a single clean `v1`.
+- ☐ (Optional) Stand up a spec→codegen pipeline so the 9 clients regenerate
+  instead of drifting (the edge-list envelope bug above was drift a generated
+  client would not have had).


### PR DESCRIPTION
## Summary

Two folded changes from the v1/v2 untangle, driven by Victor's code-graph backend work:

### 1. Fix: v2 graph edge-list envelope (root cause of broken neighbors)
The xCatalog v2 graph query endpoints (`/api/v2/graphs/{id}/query/nodes`, `/query/edges`) return results as `{success, data: {items: [...], has_more}}`, but the Python REST client read `data` as a bare list — so `get_outgoing_edges`/`get_incoming_edges` extended a list with the envelope **dict** and yielded its keys (`'items'`,`'has_more'`) instead of edges. Added `_unwrap_v2_list()` and applied it to both `query_nodes` and `query_edges`.

Verified end-to-end against a real embedded `proximadb-server`: neighbors now match a SQLite reference store on impact_analysis (forward/backward) + hybrid seed-to-expand. SDK `rest_sync` unit tests: 13 passed.

### 2. Deprecate the real v1 (step 1 of the untangle)
`option deprecated = true` on the genuinely-superseded shims — gRPC `VectorService` + `CollectionService` (services and all RPCs) — replaced by the canonical ProximaRecord API (`proto/proximadb/v2/record.proto`, `/api/v2`). Generated stubs in all client languages inherit the marker on regen. `protoc` validates.

Not touched (current API, no v2 replacement — will collapse into a clean `v1` pre-release): GraphService, HybridSearchService, DocumentService, sql, observability, etc. REST `/api/v1/*` already emits `Deprecation` headers via existing middleware; the OpenAPI spec documents only v2 paths.

Plan + tracked follow-ups (hand-wrapper markers per client; removal; pre-release rename to one clean v1) in `roadmap/techdebt/V1_DEPRECATION_UNTANGLE.md`.