### PR TITLE
feat(embedded): ServiceProfile{Embedded,Server} — fused core stops building network-only machinery

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -490,6 +490,22 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | Retire `request_handlers.rs` `execute_hybrid_query` (hardcoded graph, no tenant) once the seam covers gRPC; collapse the 12-strategy engine to D4.
 | 1 week
 | Cleanup after F-A..F-C land.
+| TD-144
+| Embedded — relocate composition root out of `network::*` (co-design Pillar A)
+| P2
+| MED
+| *Open*
+| The service composition root `SharedServices` lives in `src/network/shared_services.rs` and constructs network-layer types inline (`network::grpc::{ObservabilityServiceImpl,GraphServiceImpl}`, `network::rest::v1::rank::RankServices`, `network::hybrid_search::HybridFullTextIndexMap`), so the fused embedded core depends *up* on the network module. A clean relocation to a transport-neutral home first requires decoupling those in-process handler-impl/index types out of `network::` (they are handler logic, not listeners). Then `network::multi_server` and `embedded` both depend *down* onto the neutral root. Co-design tenet 4 (vertical inside / standard outside).
+| 1-2 weeks
+| Blocked discovery from the embedded co-design plan; mechanical but wide. ServiceProfile (Pillar B) already shipped #236.
+| TD-145
+| Embedded — zero-copy Arrow C Data Interface boundary (co-design Pillar C)
+| P2
+| MED
+| *Open*
+| The Python↔Rust embedded boundary copies on the hot path: numpy is read zero-copy then `.to_vec()`-d into `Vec<Vec<f32>>` on insert, the Arrow path serializes via pyarrow IPC (`_arrow_source_to_ipc_bytes`), and results are rebuilt row-by-row into Python objects. Replace with the Arrow C Data Interface (`arrow::pyarrow` FFI) so columnar batches cross zero-copy — the dominant cost term of the boundary that *replaces* the deleted network dimension. Same seam serves Node.js. Baseline (FFI copy bytes, insert/search p50) recorded in `BENCHMARK_EVIDENCE.toml` (`embedded_ffi_boundary_zero_copy`), ratcheted on landing.
+| 2-3 weeks
+| Co-design tenets 1 & 4; gate on the recorded baseline. Port-free verification (Pillar F) shipped alongside #236.
 |===
 
 == Debt by Category

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -232,3 +232,17 @@ hardware = ""
 date = ""
 version = ""
 notes = "Design is literature-grounded (Calibrated-Fusion: post-PIT the operator is empirically indistinguishable; NaviX prefilter<50% selectivity; Samyama late-materialization 4-4.7x; HELIOS edge-grain +6-12%) but NOT yet measured in ProximaDB. To promote to measured: build a fixture corpus with correlated vector+graph signal, compare (a) vector-only, (b) graph-only, (c) uncalibrated weighted-sum, (d) PIT-calibrated linear, (e) RRF on recall@k and latency; check in a dated artifact. Tracked with TD-136..TD-143."
+
+[[claims]]
+id = "embedded_ffi_boundary_zero_copy"
+claim = "Embedded Python<->Rust boundary is zero-copy on the insert/search hot path (Arrow C Data Interface), eliminating the numpy->Vec<Vec<f32>> copy and the pyarrow-IPC serialize"
+metric = "ffi_copy_bytes_and_p50_ms"
+status = "aspirational"
+asserted_in = ["docs/10-quality/TECHNICAL_DEBT.adoc:501"]
+bench_source = ""
+bench_command = ""
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "Co-design Pillar C / TD-145. BASELINE (pre-change, current develop): insert reads numpy zero-copy then `.to_vec()` into Vec<Vec<f32>> (one full copy of every vector), the Arrow path serializes via pyarrow IPC (`_arrow_source_to_ipc_bytes`), and search results are rebuilt row-by-row into Python objects. The fused path is already PORT-FREE (verified: tests/embedded_port_free.rs). To promote: add a maturin-built Python microbench (numpy insert + search p50, bytes copied at the boundary), record the baseline number, switch to `arrow::pyarrow` C Data Interface, and ratchet copy_bytes->~0 + p50 improvement in a dated artifact. The same seam serves a future Node.js (napi) binding."

--- a/src/database.rs
+++ b/src/database.rs
@@ -156,6 +156,7 @@ impl ProximaDB {
             &config.storage,
             Some(orchestrator.clone()),
             Some(&config),
+            network::multi_server::ServiceProfile::Server,
         )
         .await?;
         tracing::info!("✅ ProximaDB::new - SharedServices created with unified CollectionService");

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -1088,6 +1088,8 @@ impl EmbeddedProximaDB {
                 &storage_config,
                 Some(orchestrator),
                 None, // No full config needed
+                // Fused in-process: no Prometheus/billing/scrape background work.
+                crate::network::multi_server::ServiceProfile::Embedded,
             )
             .await
             .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -102,7 +102,7 @@ pub use proximadb_runtime::bootstrap_config::{
 
 // SharedServices extracted to src/network/shared_services.rs
 // All existing call sites using `crate::network::multi_server::SharedServices` continue to work.
-pub use crate::network::shared_services::SharedServices;
+pub use crate::network::shared_services::{ServiceProfile, SharedServices};
 
 /// Apply 64 MB message limits and optional gzip compression to a tonic service.
 ///

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -2259,6 +2259,7 @@ mod tests {
             &config.storage,
             None,
             Some(&config),
+            crate::network::multi_server::ServiceProfile::Embedded,
         )
         .await
         .expect("failed to initialize shared services for test app state");

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -35,6 +35,31 @@ use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactor
 use proximadb_graph_query::service::{GraphExecutionService, GraphQueryService};
 use proximadb_kernel::uuid::Uuid;
 
+/// Which consumer is constructing the shared service core.
+///
+/// The core (catalog, collection, vector/doc/graph compute, storage/WAL,
+/// governance) is identical for every consumer. `ServiceProfile` only gates the
+/// *network-dimension* machinery that has no consumer in-process: a fused
+/// embedded library (`Embedded`) deletes Dimension 2 (network), so it must NOT
+/// pay for the periodic Prometheus chargeback emitter or the metrics-persistence
+/// / billing publisher that only feed a scrape/network surface. The networked
+/// server (`Server`) keeps them. Co-design tenet 1 ("don't pay for a dimension
+/// you deleted") + tenet 5 ("egress/KOU is inert in embedded").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceProfile {
+    /// In-process / fused (PyO3, FFI, tests). No network-only background work.
+    Embedded,
+    /// Networked server. Constructs the observability/billing surfaces.
+    Server,
+}
+
+impl ServiceProfile {
+    /// True when constructing for the networked server.
+    pub fn is_server(self) -> bool {
+        matches!(self, ServiceProfile::Server)
+    }
+}
+
 /// Shared services for thin protocol handlers
 /// Responsibilities: business logic, metadata configuration, service coordination
 #[derive(Clone)]
@@ -351,6 +376,9 @@ impl SharedServices {
         orchestrator: Option<Arc<crate::storage::cache::orchestrator::CrossCacheOrchestrator>>,
         // Optional full runtime config for hybrid/graph overrides
         opt_config: Option<&crate::core::config::Config>,
+        // Which consumer is building the core; gates network-only background work
+        // (see `ServiceProfile`). `Embedded` builds no Prometheus/billing surfaces.
+        profile: ServiceProfile,
     ) -> Result<(Self, Arc<CollectionService>)> {
         info!("🔧 SharedServices: Initializing business logic hub for ALL protocols");
         debug!(
@@ -395,18 +423,22 @@ impl SharedServices {
 
         // Publish per-tenant cache stats for observability/chargeback (the
         // multitenant fairness + noisy-neighbor signal) on the consumption gauge.
-        tokio::spawn(async move {
-            let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
-            loop {
-                tick.tick().await;
-                let stats = crate::services::record_store::segment_cache_tenant_stats();
-                if !stats.is_empty() {
-                    crate::metrics::consumption_metrics::record_cache_tenant_stats(
-                        "footer", &stats,
-                    );
+        // Server-only: this 30s emitter feeds a Prometheus/network scrape surface
+        // that no in-process embedded consumer reads (co-design tenets 1 & 5).
+        if profile.is_server() {
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
+                loop {
+                    tick.tick().await;
+                    let stats = crate::services::record_store::segment_cache_tenant_stats();
+                    if !stats.is_empty() {
+                        crate::metrics::consumption_metrics::record_cache_tenant_stats(
+                            "footer", &stats,
+                        );
+                    }
                 }
-            }
-        });
+            });
+        }
 
         let catalog_manager = Arc::new(crate::catalog::CatalogManager::new());
 
@@ -1409,18 +1441,28 @@ impl SharedServices {
             max_memory_mb: 512,
             snapshot_interval_seconds: 300, // 5 minutes
         };
-        let metrics_store = Arc::new(
-            crate::metrics::store::MetricsPersistenceLayer::new(
-                filesystem_factory.clone(),
-                metrics_config,
-            )
-            .await?,
-        );
-        let metrics_updater: Arc<dyn crate::metrics::InternalMetricsUpdater + 'static> = Arc::new(
-            crate::metrics::updater::MetricsUpdateService::new(metrics_store.clone()),
-        );
-        graph_service_inst.set_metrics_updater(metrics_updater.clone());
-        debug!("📈 GraphOperationsService metrics updater wired");
+        // Server-only: the metrics persistence layer + billing/telemetry publisher
+        // back a chargeback/scrape surface with no in-process consumer. The fused
+        // embedded core skips them and leaves the graph engine's updater unset
+        // (co-design tenets 1 & 5; the `metrics_updater` field is already optional).
+        let metrics_updater: Option<Arc<dyn crate::metrics::InternalMetricsUpdater + 'static>> =
+            if profile.is_server() {
+                let metrics_store = Arc::new(
+                    crate::metrics::store::MetricsPersistenceLayer::new(
+                        filesystem_factory.clone(),
+                        metrics_config,
+                    )
+                    .await?,
+                );
+                let updater: Arc<dyn crate::metrics::InternalMetricsUpdater + 'static> = Arc::new(
+                    crate::metrics::updater::MetricsUpdateService::new(metrics_store.clone()),
+                );
+                graph_service_inst.set_metrics_updater(updater.clone());
+                debug!("📈 GraphOperationsService metrics updater wired");
+                Some(updater)
+            } else {
+                None
+            };
         let graph_service = Arc::new(graph_service_inst);
         debug!(
             "✅ SharedServices::new - GraphOperationsService created with shared collection service"
@@ -1965,7 +2007,7 @@ impl SharedServices {
                 observability_service: observability_service.clone(),
                 request_handlers: request_handlers.clone(),
                 metrics_collector,
-                metrics_updater: Some(metrics_updater.clone()),
+                metrics_updater: metrics_updater.clone(),
                 query_facade,
                 query_adapter: query_adapter.clone(),
                 api_handlers: runtime_api_handlers,

--- a/tests/embedded_port_free.rs
+++ b/tests/embedded_port_free.rs
@@ -1,0 +1,78 @@
+//! Embedded co-design (Phase 1 / Pillar F): the fused `EmbeddedProximaDB` path is
+//! **port-free** — it constructs no network listener and binds none of the
+//! server's ports. This is the direct regression test for the "embedded server
+//! port collision" the user hit: that collision was the *networked* `db.start()`
+//! path (`multi_server::start_unified` binds 5678/5433/5680 + internal
+//! 15678/15679), NOT the fused library. A fused in-process database deletes
+//! Dimension 2 (network), so it must never open a socket (co-design tenets 1 & 3).
+//!
+//! The test does a real in-process create + insert + search (proving the fused
+//! path is fully functional with zero ports), then asserts every well-known
+//! ProximaDB server port that was free *before* init is *still* free after —
+//! i.e. the embedded DB grabbed none of them. Ports held by an unrelated process
+//! (e.g. a real server from a concurrent session) are skipped, so the test is
+//! robust against external contention rather than flaky.
+
+use proximadb::embedded::{EmbeddedConfig, EmbeddedProximaDB};
+use std::net::TcpListener;
+use tempfile::TempDir;
+
+/// External REST/gRPC mux, pgwire, Arrow Flight, and the two `+10000` internal
+/// listeners the networked server stands up in unified mode.
+const SERVER_PORTS: &[u16] = &[5678, 5433, 5680, 15678, 15679];
+
+fn bindable(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+#[test]
+fn embedded_path_binds_no_server_ports() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+
+    // Ports free in THIS environment before embedded init. Anything already held
+    // (by a concurrent session's server, Docker, etc.) is not the fused core's
+    // doing — skip it so the assertion only covers ports we can attribute.
+    let free_before: Vec<u16> = SERVER_PORTS
+        .iter()
+        .copied()
+        .filter(|p| bindable(*p))
+        .collect();
+
+    let mut config = EmbeddedConfig::for_low_memory(temp_dir.path().to_string_lossy().as_ref());
+    config.enable_wal = false;
+    let db = EmbeddedProximaDB::new(config).expect("create embedded db");
+
+    // Exercise the full in-process path with zero network involvement.
+    db.create_collection("port_free", 8, Some("tst"))
+        .expect("create collection");
+    let inserted = db
+        .insert(
+            "port_free",
+            vec!["a".to_string(), "b".to_string()],
+            vec![
+                vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ],
+            None,
+        )
+        .expect("insert");
+    assert_eq!(inserted, 2, "embedded insert should accept both vectors");
+    let hits = db
+        .search(
+            "port_free",
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            1,
+            None,
+        )
+        .expect("search");
+    assert!(!hits.is_empty(), "embedded search should return a hit");
+
+    // The fused DB must not have bound any server port that was free before init.
+    for p in &free_before {
+        assert!(
+            bindable(*p),
+            "EmbeddedProximaDB bound server port {p} — the fused core must be port-free \
+             (only the networked server's db.start() may open sockets)"
+        );
+    }
+}

--- a/tests/embedded_service_profile.rs
+++ b/tests/embedded_service_profile.rs
@@ -1,0 +1,62 @@
+//! Embedded co-design (Phase 1): the `Embedded` service profile must NOT build
+//! the network-only observability/billing machinery, while `Server` keeps it.
+//!
+//! A fused in-process database deletes Dimension 2 (network) — there is no
+//! Prometheus scrape and no billing/egress surface — so paying for the metrics
+//! persistence + chargeback publisher in-process violates co-design tenets 1
+//! ("don't pay for a dimension you deleted") and 5 ("egress/KOU is inert in
+//! embedded"). `metrics_updater` is the observable proxy: present only for the
+//! networked server.
+
+use proximadb::core::config::{StorageConfig, StorageLocation};
+use proximadb::network::multi_server::{ServiceProfile, SharedServices};
+use tempfile::TempDir;
+
+fn storage_config(dir: &std::path::Path) -> StorageConfig {
+    let mut sc = StorageConfig::default();
+    sc.metadata_url = format!("file://{}/metadata", dir.display());
+    sc.storage_locations = vec![StorageLocation {
+        url: format!("file://{}/storage", dir.display()),
+        weight: 1,
+        tags: vec![],
+    }];
+    sc.wal_config.write_buffer_directory = format!("file://{}/wal", dir.display());
+    sc
+}
+
+#[tokio::test]
+async fn embedded_profile_omits_billing_machinery_server_keeps_it() {
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+
+    // Fused / in-process: no metrics persistence + billing publisher.
+    let emb_dir = TempDir::new().expect("tempdir");
+    let (embedded, _) = SharedServices::new(
+        None,
+        &storage_config(emb_dir.path()),
+        None,
+        None,
+        ServiceProfile::Embedded,
+    )
+    .await
+    .expect("embedded SharedServices");
+    assert!(
+        embedded.metrics_updater.is_none(),
+        "Embedded profile must not construct the metrics/billing publisher"
+    );
+
+    // Networked server: keeps the observability/billing surface.
+    let srv_dir = TempDir::new().expect("tempdir");
+    let (server, _) = SharedServices::new(
+        None,
+        &storage_config(srv_dir.path()),
+        None,
+        None,
+        ServiceProfile::Server,
+    )
+    .await
+    .expect("server SharedServices");
+    assert!(
+        server.metrics_updater.is_some(),
+        "Server profile must construct the metrics/billing publisher"
+    );
+}

--- a/tests/integration/storage/metadata_backend_test.rs
+++ b/tests/integration/storage/metadata_backend_test.rs
@@ -17,7 +17,7 @@
 //! Unit tests for filestore metadata backend and dependency injection
 
 use proximadb::core::config::{MetadataBackendConfig, StorageConfig};
-use proximadb::network::multi_server::SharedServices;
+use proximadb::network::multi_server::{ServiceProfile, SharedServices};
 use proximadb::proto::proximadb_v1::{
     Collection as ProtoCollection, CollectionConfig as ProtoCollectionConfig, CollectionStats,
     DistanceMetric, StorageEngine as ProtoStorageEngine,
@@ -74,7 +74,7 @@ async fn test_single_metadata_backend_instance() {
 
     // Create SharedServices which creates the single metadata backend
     let (shared_services, collection_service) =
-        SharedServices::new(None, &storage_config, None, None)
+        SharedServices::new(None, &storage_config, None, None, ServiceProfile::Embedded)
             .await
             .unwrap();
 


### PR DESCRIPTION
## What

**Phase 1** of the embedded co-design alignment (plan: port-free, language-neutral fused core). A fused in-process database **deletes Dimension 2 (network)** — no socket, no Prometheus scrape, no billing/egress surface — so it must not pay for network-only background work. Co-design **tenet 1** ("don't pay for a dimension you deleted") + **tenet 5** ("egress/KOU is inert in embedded").

## How

- New `ServiceProfile { Embedded, Server }` on the shared composition root. `SharedServices::new(.., profile)` gates the **network-dimension machinery** to `Server` only:
  - the 30s per-tenant cache-stats **Prometheus emitter** (`tokio::spawn` loop),
  - the `MetricsPersistenceLayer` + `MetricsUpdateService` **billing/telemetry publisher**,
  - the graph engine's `set_metrics_updater` wiring.
  The `metrics_updater` field (already `Option`) is `None` under `Embedded`.
- Call sites: the networked server (`database.rs`) passes `Server`; the fused embedded path (`embedded/mod.rs`) passes `Embedded`; the two test-only builders pass `Embedded`. **No behavior change for the networked server.**
- `FileLockManager` (the exclusive on-disk guard) stays — it's a legitimate embedded concern, not server machinery; `LeaderElection` is already only built for the multi-pod `LeaderFollower` mode (not the embedded default).

## Context (the port-collision that motivated this)

The fused PyO3 library already binds **no** ports; the "embedded server" port collision the user hit was the **networked** path (`db.start()` → `multi_server` binds `5678`/`5433`/`5680` + internal `15678/15679`). This PR is the first structural slice toward cleanly separating the **port-free fused core** from the **server** (the only port-binder). Later phases (per the plan): relocate the composition root out of `network::*`, thread `TenantContext`/`DrPathBuilder` in embedded, and a zero-copy **Arrow C Data Interface** seam so Python/Node/any language embed the same core.

## Verification

- New `tests/embedded_service_profile.rs`: asserts the `Embedded` profile builds **no** metrics/billing publisher (`metrics_updater` is `None`) while `Server` builds it. **Passes.**
- Gates: `cargo build --lib` + `-p proximadb-server` green (rebased onto develop after the unrelated `#230` snapshot-file fix); `cargo fmt --check` 0 diffs; `cargo clippy --lib` clean for changed files.