### PR TITLE
feat(python-sdk): native-async core client over the generated asyncio transport (TD-126)

### DIFF
--- a/clients/python/src/proximadb_sdk/integrations/langchain.py
+++ b/clients/python/src/proximadb_sdk/integrations/langchain.py
@@ -54,11 +54,17 @@ class ProximaDBVectorStore(VectorStore):
         embedding: Embeddings,
         *,
         text_key: str = "text",
+        async_client: Any | None = None,
     ) -> None:
         self._client = client
         self._collection_name = collection_name
         self._embedding = embedding
         self._text_key = text_key
+        # Optional native-async client (ProximaDBAsyncUnified). When provided +
+        # started, the async read path awaits real async I/O instead of
+        # thread-offloading the sync client. Sync construction/methods are
+        # unaffected when this is omitted.
+        self._async_client = async_client
 
     @property
     def embeddings(self) -> Embeddings:
@@ -229,7 +235,30 @@ class ProximaDBVectorStore(VectorStore):
         k: int = 4,
         **kwargs: Any,
     ) -> list[tuple[Document, float]]:
-        """Async return documents and scores for the given embedding vector."""
+        """Async return documents and scores for the given embedding vector.
+
+        Uses the native-async client (real async I/O over the generated REST
+        transport) when one was provided at construction; otherwise falls back
+        to offloading the synchronous client onto a worker thread.
+        """
+        if self._async_client is not None:
+            search_results = await self._async_client.search(
+                self._collection_name,
+                vector=embedding,
+                top_k=k,
+                metadata_filter=kwargs.get("filter"),
+            )
+            docs_and_scores: list[tuple[Document, float]] = []
+            for result in search_results:
+                metadata = dict(result.metadata) if result.metadata else {}
+                page_content = result.source or metadata.pop(self._text_key, "")
+                docs_and_scores.append(
+                    (
+                        Document(page_content=page_content, metadata=metadata),
+                        result.score,
+                    )
+                )
+            return docs_and_scores
         return await asyncio.to_thread(
             self.similarity_search_by_vector_with_score, embedding, k=k, **kwargs
         )

--- a/clients/python/src/proximadb_sdk/integrations/llama_index.py
+++ b/clients/python/src/proximadb_sdk/integrations/llama_index.py
@@ -64,6 +64,7 @@ class ProximaDBVectorStore(BasePydanticVectorStore):
     _client: Any = PrivateAttr()
     _collection_name: str = PrivateAttr()
     _text_key: str = PrivateAttr()
+    _async_client: Any = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -71,11 +72,17 @@ class ProximaDBVectorStore(BasePydanticVectorStore):
         collection_name: str,
         *,
         text_key: str = "text",
+        async_client: Any | None = None,
     ) -> None:
         super().__init__()
         self._client = client
         self._collection_name = collection_name
         self._text_key = text_key
+        # Optional native-async client (ProximaDBAsyncUnified). When provided +
+        # started, aquery awaits real async I/O over the generated REST
+        # transport instead of thread-offloading the sync client. Sync
+        # construction/methods are unaffected when omitted.
+        self._async_client = async_client
 
     @property
     def client(self) -> Any:
@@ -162,10 +169,20 @@ class ProximaDBVectorStore(BasePydanticVectorStore):
     ) -> VectorStoreQueryResult:
         """Asynchronously query ProximaDB for similar nodes.
 
-        The ProximaDB SDK exposes a synchronous ``search`` only, so this awaits
-        the blocking call on a worker thread to keep the event loop responsive
-        and satisfy LlamaIndex's async query contract.
+        When a native-async client was supplied at construction, this awaits
+        real async I/O over the generated REST transport; otherwise it offloads
+        the synchronous ``search`` onto a worker thread to keep the event loop
+        responsive and satisfy LlamaIndex's async query contract.
         """
+        if self._async_client is not None:
+            search_results = await self._async_client.search(
+                self._collection_name,
+                vector=self._query_vector(query),
+                top_k=query.similarity_top_k,
+                metadata_filter=self._query_filter(query),
+            )
+            return self._results_to_query_result(search_results)
+
         import asyncio
 
         search_results = await asyncio.to_thread(

--- a/clients/python/src/proximadb_sdk/protocols/_rest_codegen_async.py
+++ b/clients/python/src/proximadb_sdk/protocols/_rest_codegen_async.py
@@ -1,0 +1,137 @@
+"""Spec-driven **async** request adapter over the generated REST transport.
+
+This is the async analog of :mod:`_rest_codegen` (TD-126 Phase 4 / the
+native-async follow-up). Where the sync adapter sources only the operation's
+``method``/``url``/body-shape from the generated ``_get_kwargs`` (the facade then
+executes the call through its own ``_make_request`` seam), the async path goes
+one step further and wires the GENERATED ``asyncio_detailed`` endpoint functions
+directly — exactly as the sync ``sync``/``sync_detailed`` functions are wired —
+so the async client *also* gets the spec-governed response parsing
+(``Response.parsed`` typed models) for free, with zero hand-rolled httpx.
+
+Each helper takes the generated ``Client`` (whose shared ``httpx.AsyncClient`` is
+owned by the facade) plus the facade-built body dict, builds the generated attrs
+request model (reusing the same ``from_dict`` round-trip as the sync adapter so
+the wire body matches the published spec), and ``await``s the generated
+``asyncio_detailed``. It returns the generated ``Response`` so the facade can
+read the typed ``.parsed`` model and coerce it into the SDK's public Pydantic
+types — the same return types the sync facade produces.
+
+Do NOT hand-roll REST request-building or response-parsing here (Core Directive
+#15 / GEMINI #29): the request shape, URL, method, and response decoding are all
+the generated client's job; this module only binds them onto a shared async
+transport.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+from .._generated.rest.api.collections import (
+    create_collection as _gen_create_collection,
+)
+from .._generated.rest.api.collections import (
+    delete_collection as _gen_delete_collection,
+)
+from .._generated.rest.api.collections import get_collection as _gen_get_collection
+from .._generated.rest.api.collections import list_collections as _gen_list_collections
+from .._generated.rest.api.records import delete_record as _gen_delete_record
+from .._generated.rest.api.records import get_record as _gen_get_record
+from .._generated.rest.api.records import insert_records as _gen_insert_records
+from .._generated.rest.api.search import search_records as _gen_search_records
+from .._generated.rest.client import AuthenticatedClient, Client
+from .._generated.rest.models.create_collection_v2_request import (
+    CreateCollectionV2Request,
+)
+from .._generated.rest.models.insert_records_request import InsertRecordsRequest
+from .._generated.rest.models.typed_search_request import TypedSearchRequest
+from .._generated.rest.types import UNSET, Response
+from ._rest_codegen import _from_dict
+
+GenClient = Union[AuthenticatedClient, Client]
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+async def create_collection(client: GenClient, body: dict[str, Any]) -> Response[Any]:
+    model = _from_dict(CreateCollectionV2Request, body)
+    return await _gen_create_collection.asyncio_detailed(client=client, body=model)
+
+
+async def get_collection(client: GenClient, collection_id: str) -> Response[Any]:
+    return await _gen_get_collection.asyncio_detailed(collection_id, client=client)
+
+
+async def delete_collection(client: GenClient, collection_id: str) -> Response[Any]:
+    return await _gen_delete_collection.asyncio_detailed(collection_id, client=client)
+
+
+async def list_collections(
+    client: GenClient,
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+    include_stats: bool | None = None,
+) -> Response[Any]:
+    return await _gen_list_collections.asyncio_detailed(
+        client=client,
+        limit=UNSET if limit is None else limit,
+        offset=UNSET if offset is None else offset,
+        include_stats=UNSET if include_stats is None else include_stats,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Records / vectors
+# ---------------------------------------------------------------------------
+
+
+async def insert_records(
+    client: GenClient, collection_id: str, body: dict[str, Any]
+) -> Response[Any]:
+    model = _from_dict(InsertRecordsRequest, body)
+    return await _gen_insert_records.asyncio_detailed(
+        collection_id=collection_id, client=client, body=model
+    )
+
+
+async def get_record(
+    client: GenClient,
+    collection_id: str,
+    record_id: str,
+    *,
+    include_vector: bool | None = None,
+    include_text: bool | None = None,
+) -> Response[Any]:
+    return await _gen_get_record.asyncio_detailed(
+        collection_id=collection_id,
+        record_id=record_id,
+        client=client,
+        include_vector=UNSET if include_vector is None else include_vector,
+        include_text=UNSET if include_text is None else include_text,
+    )
+
+
+async def delete_record(
+    client: GenClient, collection_id: str, record_id: str
+) -> Response[Any]:
+    return await _gen_delete_record.asyncio_detailed(
+        collection_id=collection_id, record_id=record_id, client=client
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+async def search_records(
+    client: GenClient, collection_id: str, body: dict[str, Any]
+) -> Response[Any]:
+    model = _from_dict(TypedSearchRequest, body)
+    return await _gen_search_records.asyncio_detailed(
+        collection_id=collection_id, client=client, body=model
+    )

--- a/clients/python/src/proximadb_sdk/unified_client_async.py
+++ b/clients/python/src/proximadb_sdk/unified_client_async.py
@@ -1,12 +1,41 @@
 """
 ProximaDB Unified Async Python Client
 
-Picks between gRPC async client (if available) and REST async client for graph operations.
+Native-async core operations (collections CRUD, record insert/upsert/delete,
+search, get_vector) wire the **generated** ``asyncio``/``asyncio_detailed``
+endpoint functions over a single shared ``httpx.AsyncClient`` — the spec-driven
+transport mandated by Core Directive #15 (CLAUDE.md) / #29 (GEMINI.md), TD-126.
+The async ops mirror the sync facade (``unified_client.py`` /
+``protocols/rest_sync.py``) signatures + return types; they delegate to
+``protocols/_rest_codegen_async`` (the async analog of the sync
+``protocols/_rest_codegen``), which calls the generated ``asyncio_detailed``
+functions exactly as the sync path uses the generated ``sync``/``_get_kwargs``.
+
+Graph operations are NOT in the generated OpenAPI client; they stay on the
+hand-written ``rest_async.py`` httpx path (and async gRPC when available).
 """
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Any
 
 from .config import ClientConfig, Protocol, load_config
+from .exceptions import CollectionNotFoundError, ProximaDBError
+from .models import (
+    BatchResult,
+    Collection,
+    CollectionConfig,
+    CollectionStats,
+    DeleteResult,
+    OperationMetrics,
+    SearchResult,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as np
+
+    from .models_v2 import ProximaRecord
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +48,30 @@ except Exception:
 from .protocols.rest_async import ProximaDBAsyncClient as RestAsyncClient
 
 
+def _coalesce_name(raw_name: Any, collection_id: str) -> str:
+    """Return a collection name satisfying CollectionConfig's 8-char minimum.
+
+    Mirrors the sync facade's get_collection name-padding so async returns the
+    same Collection shape for short ids/names.
+    """
+    name = raw_name if isinstance(raw_name, str) and raw_name else collection_id
+    if len(name) < 8:
+        name = (
+            collection_id if len(collection_id) >= 8 else f"collection_{collection_id}"
+        )
+    return name
+
+
 class ProximaDBAsyncUnified:
+    """Async ProximaDB client.
+
+    Core REST ops route through the generated async transport; graph ops use the
+    hand-written async REST/gRPC paths. Use as an async context manager::
+
+        async with ProximaDBAsyncUnified(url="http://localhost:5678") as client:
+            await client.create_collection("my_vectors", CollectionConfig(...))
+    """
+
     def __init__(
         self,
         url: str | None = None,
@@ -37,8 +89,27 @@ class ProximaDBAsyncUnified:
 
         self._grpc = None
         self._rest = None
+        # Shared async transport for the generated REST client.
+        self._async_http = None
+        self._gen_client = None
 
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
     async def astart(self):
+        # Always stand up the generated-async REST transport for core ops: a
+        # single pooled httpx.AsyncClient injected into the generated Client.
+        import httpx
+
+        from ._generated.rest.client import Client as GenClient
+
+        base_url = (self.rest_url or "").rstrip("/")
+        self._async_http = httpx.AsyncClient(base_url=base_url, timeout=self.timeout)
+        self._gen_client = GenClient(base_url=base_url).set_async_httpx_client(
+            self._async_http
+        )
+
+        # Graph ops: prefer async gRPC when available/selected, else async REST.
         if self.protocol == Protocol.GRPC or (
             self.protocol == Protocol.AUTO and GRPC_OK
         ):
@@ -46,19 +117,395 @@ class ProximaDBAsyncUnified:
                 self._grpc = GrpcAsyncClient(
                     endpoint=self.grpc_endpoint, timeout=self.timeout
                 )
-                logger.info("Using async gRPC client")
+                logger.info("Using async gRPC client for graph ops")
             except Exception as e:
                 logger.warning(f"gRPC async init failed: {e}; falling back to REST")
                 self._rest = RestAsyncClient(url=self.rest_url, timeout=self.timeout)
         else:
             self._rest = RestAsyncClient(url=self.rest_url, timeout=self.timeout)
-            logger.info("Using async REST client")
+            logger.info("Using async REST client for graph ops")
+        return self
 
     async def aclose(self):
         if self._rest:
             await self._rest.aclose()
+        if self._async_http is not None:
+            await self._async_http.aclose()
+            self._async_http = None
+            self._gen_client = None
 
-    # Graph operations
+    async def __aenter__(self):
+        await self.astart()
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.aclose()
+
+    def _require_gen_client(self):
+        if self._gen_client is None:
+            raise RuntimeError("Client not started; call astart() first")
+        return self._gen_client
+
+    @staticmethod
+    def _raise_for_error(parsed: Any, *, context: str) -> None:
+        """Raise if the generated parsed model is an ErrorResponse-shaped object."""
+        if parsed is None:
+            raise ProximaDBError(f"{context}: empty response from server")
+        err = getattr(parsed, "error", None) or getattr(parsed, "error_message", None)
+        if err:
+            raise ProximaDBError(f"{context}: {err}")
+
+    # ------------------------------------------------------------------
+    # Collections (generated-async transport)
+    # ------------------------------------------------------------------
+    async def create_collection(
+        self,
+        name: str,
+        config: CollectionConfig | None = None,
+        **kwargs,
+    ) -> Collection:
+        """Create a collection via the generated ``create_collection`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        if config is None:
+            config = CollectionConfig(name=name, **kwargs)
+        body: dict[str, Any] = {
+            "name": name,
+            "dimension": config.dimension,
+            "engine": getattr(config.storage_engine, "value", config.storage_engine),
+            "distance_metric": getattr(
+                config.distance_metric, "value", config.distance_metric
+            ),
+            "enable_proxima_record": True,
+        }
+        resp = await _gen_async.create_collection(self._require_gen_client(), body)
+        parsed = resp.parsed
+        self._raise_for_error(parsed, context="create_collection failed")
+        data = parsed.to_dict()
+        return Collection(
+            id=data.get("collection_id", name),
+            config=CollectionConfig(
+                name=_coalesce_name(data.get("name"), name),
+                dimension=data.get("dimension", config.dimension),
+                distance_metric=body["distance_metric"] or "cosine",
+                storage_engine=data.get("engine") or "sst",
+            ),
+        )
+
+    async def get_collection(self, collection_id: str) -> Collection:
+        """Get collection metadata via the generated ``get_collection`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        resp = await _gen_async.get_collection(
+            self._require_gen_client(), collection_id
+        )
+        parsed = resp.parsed
+        if parsed is None or getattr(parsed, "error", None):
+            raise CollectionNotFoundError(f"Collection '{collection_id}' not found")
+        data = parsed.to_dict()
+        if data.get("error") or data.get("error_message"):
+            raise CollectionNotFoundError(f"Collection '{collection_id}' not found")
+        stats_src = data.get("stats") or {}
+        # The generated CollectionStatsV2 uses record_count / storage_size_bytes.
+        vector_count = stats_src.get("record_count", stats_src.get("vector_count", 0))
+        return Collection(
+            id=data.get("collection_id", collection_id),
+            config=CollectionConfig(
+                name=_coalesce_name(data.get("name"), collection_id),
+                dimension=data.get("dimension", 128),
+                distance_metric=data.get("distance_metric") or "cosine",
+                storage_engine=data.get("engine") or "sst",
+            ),
+            stats=CollectionStats(
+                vector_count=vector_count or 0,
+                index_size_bytes=stats_src.get("index_size_bytes", 0),
+                data_size_bytes=stats_src.get("storage_size_bytes", 0),
+            ),
+        )
+
+    async def list_collections(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        include_stats: bool | None = None,
+    ) -> list[Collection]:
+        """List collections via the generated ``list_collections`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        resp = await _gen_async.list_collections(
+            self._require_gen_client(),
+            limit=limit,
+            offset=offset,
+            include_stats=include_stats,
+        )
+        parsed = resp.parsed
+        self._raise_for_error(parsed, context="list_collections failed")
+        data = parsed.to_dict()
+        out: list[Collection] = []
+        for coll in data.get("collections", []) or []:
+            cid = coll.get("collection_id", coll.get("id", ""))
+            out.append(
+                Collection(
+                    id=cid,
+                    config=CollectionConfig(
+                        name=_coalesce_name(coll.get("name"), cid),
+                        dimension=coll.get("dimension", 0),
+                        distance_metric=coll.get("distance_metric") or "cosine",
+                        storage_engine=coll.get("engine") or "sst",
+                    ),
+                    stats=CollectionStats(
+                        vector_count=coll.get("record_count", 0) or 0,
+                    ),
+                )
+            )
+        return out
+
+    async def delete_collection(self, collection_id: str) -> bool:
+        """Delete a collection via the generated ``delete_collection`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        resp = await _gen_async.delete_collection(
+            self._require_gen_client(), collection_id
+        )
+        parsed = resp.parsed
+        if parsed is None:
+            return False
+        data = parsed.to_dict()
+        return bool(data.get("success", False))
+
+    # ------------------------------------------------------------------
+    # Records / vectors (generated-async transport)
+    # ------------------------------------------------------------------
+    def _normalize_record(self, record: Any, index: int = 0) -> dict[str, Any]:
+        """Normalize SDK record-like inputs to the v2 REST ProximaRecord shape.
+
+        Shapes the SDK's own input model only; the wire request body + method +
+        URL still come from the generated InsertRecordsRequest / asyncio_detailed.
+        """
+        if hasattr(record, "model_dump"):
+            record = record.model_dump(exclude_none=True)
+        elif hasattr(record, "dict"):
+            record = record.dict(exclude_none=True)
+        if not isinstance(record, dict):
+            if hasattr(record, "vector"):
+                record = {
+                    "id": getattr(record, "id", None),
+                    "vector": record.vector,
+                    "props": getattr(record, "metadata", {}) or {},
+                }
+            else:
+                raise TypeError(f"Unsupported record input: {type(record)!r}")
+
+        vector = record.get("vector")
+        if vector is None:
+            raise ValueError("record is missing vector")
+        try:
+            import numpy as _np
+
+            if isinstance(vector, _np.ndarray):
+                vector = vector.astype(_np.float32, copy=False).tolist()
+        except Exception:
+            pass
+        vector = [float(v) for v in vector]
+        if not vector:
+            raise ValueError("record vector cannot be empty")
+
+        props: dict[str, Any] = {}
+        for src in ("props", "metadata", "flexible_fields"):
+            values = record.get(src)
+            if isinstance(values, dict):
+                props.update({str(k): v for k, v in values.items()})
+
+        normalized: dict[str, Any] = {
+            "id": record.get("id") or record.get("oid") or f"record_{index}",
+            "vector": vector,
+            "props": props,
+        }
+        text_fields = record.get("text_fields")
+        if text_fields:
+            normalized["text_fields"] = text_fields
+        return normalized
+
+    async def insert_records(
+        self,
+        collection_id: str,
+        records: list[ProximaRecord | dict[str, Any]],
+        *,
+        upsert: bool = False,
+        validate_schema: bool = True,
+    ) -> BatchResult:
+        """Insert records via the generated ``insert_records`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        body = {
+            "records": [self._normalize_record(r, i) for i, r in enumerate(records)],
+            "validate_schema": validate_schema,
+            "upsert": upsert,
+        }
+        resp = await _gen_async.insert_records(
+            self._require_gen_client(), collection_id, body
+        )
+        parsed = resp.parsed
+        self._raise_for_error(parsed, context="insert_records failed")
+        data = parsed.to_dict()
+        inserted = int(data.get("inserted_count", 0) or 0)
+        failed = int(data.get("failed_count", 0) or 0)
+        total = inserted + failed
+        return BatchResult(
+            total=total,
+            success=inserted,
+            failed=failed,
+            errors=data.get("errors", []) or [],
+            duration_ms=0.0,
+            metrics=OperationMetrics(
+                total_processed=total,
+                successful_count=inserted,
+                failed_count=failed,
+            ),
+        )
+
+    async def upsert_records(
+        self,
+        collection_id: str,
+        records: list[ProximaRecord | dict[str, Any]],
+        *,
+        validate_schema: bool = True,
+    ) -> BatchResult:
+        """Upsert records (insert_records with upsert=True)."""
+        return await self.insert_records(
+            collection_id,
+            records,
+            upsert=True,
+            validate_schema=validate_schema,
+        )
+
+    async def get_vector(
+        self,
+        collection_id: str,
+        vector_id: str,
+        include_vector: bool = True,
+        include_metadata: bool = True,
+    ) -> dict[str, Any] | None:
+        """Get a single record via the generated ``get_record`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        resp = await _gen_async.get_record(
+            self._require_gen_client(),
+            collection_id,
+            vector_id,
+            include_vector=include_vector,
+            include_text=False,
+        )
+        parsed = resp.parsed
+        if parsed is None:
+            raise ProximaDBError(f"Vector not found: {vector_id}")
+        data = parsed.to_dict()
+        if data.get("error") or data.get("error_message") or data.get("error_code"):
+            raise ProximaDBError(f"Vector not found: {vector_id}")
+        return data
+
+    async def delete_vector(self, collection_id: str, vector_id: str) -> DeleteResult:
+        """Delete a single record via the generated ``delete_record`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        resp = await _gen_async.delete_record(
+            self._require_gen_client(), collection_id, vector_id
+        )
+        parsed = resp.parsed
+        success = bool(parsed.to_dict().get("success", False)) if parsed else False
+        return DeleteResult(
+            success=success,
+            deleted_count=1 if success else 0,
+            errors=[],
+        )
+
+    async def delete_vectors(
+        self, collection_id: str, vector_ids: list[str]
+    ) -> DeleteResult:
+        """Delete multiple records via the generated ``delete_record`` async op."""
+        deleted = 0
+        errors: list[str] = []
+        for vid in vector_ids:
+            try:
+                result = await self.delete_vector(collection_id, vid)
+                if result.success:
+                    deleted += result.deleted_count
+                else:
+                    errors.append(f"Delete failed for {vid}")
+            except Exception as e:  # noqa: BLE001 - surface per-id failures
+                errors.append(f"Delete failed for {vid}: {e}")
+        return DeleteResult(
+            success=not errors,
+            deleted_count=deleted,
+            errors=errors,
+        )
+
+    # ------------------------------------------------------------------
+    # Search (generated-async transport)
+    # ------------------------------------------------------------------
+    async def search(
+        self,
+        collection_id: str,
+        vector: list[float] | np.ndarray,
+        top_k: int = 10,
+        metadata_filter: dict[str, Any] | None = None,
+        include_vectors: bool = False,
+        include_metadata: bool = True,
+    ) -> list[SearchResult]:
+        """Search via the generated ``search_records`` async op."""
+        from .protocols import _rest_codegen_async as _gen_async
+
+        try:
+            import numpy as _np
+
+            if isinstance(vector, _np.ndarray):
+                vector = vector.astype(_np.float32, copy=False).tolist()
+        except Exception:
+            pass
+
+        body: dict[str, Any] = {
+            "vector": list(vector),
+            "top_k": top_k,
+            "include_vector": include_vectors,
+            "include_text": False,
+        }
+        if metadata_filter:
+            body["filters"] = [
+                {"field": k, "op": "eq", "value": v} for k, v in metadata_filter.items()
+            ]
+
+        resp = await _gen_async.search_records(
+            self._require_gen_client(), collection_id, body
+        )
+        parsed = resp.parsed
+        if parsed is None:
+            return []
+        data = parsed.to_dict()
+        if data.get("error") or data.get("error_message"):
+            err = data.get("error") or data.get("error_message")
+            if isinstance(err, str) and "not found" in err.lower():
+                return []
+            raise ProximaDBError(f"Search failed: {err}")
+
+        results: list[SearchResult] = []
+        for rank, item in enumerate(data.get("results", []) or [], start=1):
+            if not isinstance(item, dict):
+                continue
+            props = item.get("props") if isinstance(item.get("props"), dict) else None
+            results.append(
+                SearchResult(
+                    id=str(item.get("id", "")),
+                    score=float(item.get("score", 0.0)),
+                    vector=item.get("vector") if include_vectors else None,
+                    metadata=props if include_metadata else None,
+                    rank=rank,
+                )
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Graph operations (hand-written async REST/gRPC — not in OpenAPI spec)
+    # ------------------------------------------------------------------
     async def graph_shortest_path(
         self,
         start_node_id: str,

--- a/clients/python/tests/unit/test_langchain_integration.py
+++ b/clients/python/tests/unit/test_langchain_integration.py
@@ -166,3 +166,42 @@ class TestClassMethods:
         records = mock_client.insert_records.call_args.args[1]
         assert records[0]["source"] == "doc1"
         assert records[0]["props"]["src"] == "test"
+
+
+class TestNativeAsyncClient:
+    """The async read path uses a native-async client when one is supplied."""
+
+    @pytest.mark.asyncio
+    async def test_async_search_uses_native_async_client(self, mock_client):
+        from unittest.mock import AsyncMock
+
+        async_client = MagicMock()
+        async_client.search = AsyncMock(
+            return_value=[
+                SearchResult(id="a", score=0.9, metadata={"text": "hello"}),
+            ]
+        )
+        store = ProximaDBVectorStore(
+            client=mock_client,
+            collection_name="test_collection",
+            embedding=FakeEmbeddings(),
+            async_client=async_client,
+        )
+        out = await store.asimilarity_search_by_vector_with_score([0.1, 0.2], k=3)
+        # Native async client awaited; sync client.search NOT used.
+        async_client.search.assert_awaited_once()
+        mock_client.search.assert_not_called()
+        assert len(out) == 1
+        doc, score = out[0]
+        assert isinstance(doc, Document)
+        assert doc.page_content == "hello"
+        assert score == 0.9
+
+    @pytest.mark.asyncio
+    async def test_async_search_falls_back_to_thread_without_async_client(
+        self, store, mock_client
+    ):
+        # No async_client supplied -> offloads the sync client on a worker thread.
+        out = await store.asimilarity_search_by_vector_with_score([0.1, 0.2], k=3)
+        mock_client.search.assert_called_once()
+        assert out == []

--- a/clients/python/tests/unit/test_unified_client_async_core_ops.py
+++ b/clients/python/tests/unit/test_unified_client_async_core_ops.py
@@ -1,0 +1,332 @@
+"""Async core-ops tests for ProximaDBAsyncUnified.
+
+These assert the native-async facade wires the GENERATED ``asyncio_detailed``
+endpoint functions (spec-driven transport, TD-126) for each core op:
+
+  * Every request hits the spec-derived method + URL the generated client
+    builds (proving the generated endpoint module — not a hand-rolled route —
+    was invoked).
+  * The parsed result is coerced into the SAME public return type the sync
+    sibling produces (Collection / list[Collection] / BatchResult /
+    list[SearchResult] / DeleteResult / dict for get_vector).
+
+We mock only the HTTP transport (``httpx.MockTransport`` injected into the
+generated Client's shared AsyncClient), so the real generated request-building
+and response-parsing run end to end.
+"""
+
+import httpx
+import pytest
+
+from proximadb_sdk.models import (
+    BatchResult,
+    Collection,
+    CollectionConfig,
+    DeleteResult,
+    SearchResult,
+)
+from proximadb_sdk.unified_client_async import ProximaDBAsyncUnified
+
+
+class _Recorder:
+    """Captures each request and serves a canned JSON response per route."""
+
+    def __init__(self, routes):
+        # routes: list of (method, url_predicate, status, json_body)
+        self.routes = routes
+        self.seen = []  # (method, path)
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.seen.append((request.method, request.url.path))
+        for method, pred, status, body in self.routes:
+            if request.method == method and pred(request.url.path):
+                return httpx.Response(status, json=body)
+        return httpx.Response(404, json={"error": "no mock route"})
+
+
+async def _started_client(recorder: _Recorder) -> ProximaDBAsyncUnified:
+    client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="rest")
+    await client.astart()
+    # Swap the generated client's shared async transport for our mock so the
+    # real generated asyncio_detailed runs against canned responses.
+    mock = httpx.AsyncClient(
+        base_url="http://localhost:5678",
+        transport=httpx.MockTransport(recorder.handler),
+    )
+    client._async_http = mock
+    client._gen_client.set_async_httpx_client(mock)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_create_collection_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "POST",
+                lambda p: p == "/api/v2/collections",
+                200,
+                {
+                    "collection_id": "products",
+                    "created_at": "now",
+                    "dimension": 8,
+                    "engine": "sst",
+                    "name": "products",
+                    "proxima_record_enabled": True,
+                },
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        out = await client.create_collection(
+            "products", CollectionConfig(name="products", dimension=8)
+        )
+    finally:
+        await client.aclose()
+
+    assert isinstance(out, Collection)
+    assert out.id == "products"
+    assert out.config.dimension == 8
+    # Spec-derived route from the generated create_collection endpoint.
+    assert ("POST", "/api/v2/collections") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_get_collection_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "GET",
+                lambda p: p == "/api/v2/collections/products",
+                200,
+                {
+                    "collection_id": "products",
+                    "created_at": "now",
+                    "dimension": 16,
+                    "distance_metric": "cosine",
+                    "engine": "sst",
+                    "index_specs": [],
+                    "name": "products",
+                    "proxima_record_enabled": True,
+                    "stats": {
+                        "indexed_fields": 0,
+                        "record_count": 3,
+                        "storage_size_bytes": 0,
+                        "text_field_count": 0,
+                    },
+                },
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        out = await client.get_collection("products")
+    finally:
+        await client.aclose()
+
+    assert isinstance(out, Collection)
+    assert out.id == "products"
+    assert out.stats.vector_count == 3
+    assert ("GET", "/api/v2/collections/products") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_list_collections_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "GET",
+                lambda p: p == "/api/v2/collections",
+                200,
+                {
+                    "collections": [
+                        {
+                            "collection_id": "products",
+                            "dimension": 8,
+                            "engine": "sst",
+                            "name": "products",
+                            "proxima_record_enabled": True,
+                            "record_count": 5,
+                        }
+                    ],
+                    "has_more": False,
+                    "limit": 100,
+                    "offset": 0,
+                    "total": 1,
+                },
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        out = await client.list_collections()
+    finally:
+        await client.aclose()
+
+    assert isinstance(out, list)
+    assert all(isinstance(c, Collection) for c in out)
+    assert out[0].id == "products"
+    assert out[0].stats.vector_count == 5
+    assert ("GET", "/api/v2/collections") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "DELETE",
+                lambda p: p == "/api/v2/collections/products",
+                200,
+                {"collection_id": "products", "deleted": True, "success": True},
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        ok = await client.delete_collection("products")
+    finally:
+        await client.aclose()
+
+    assert ok is True
+    assert ("DELETE", "/api/v2/collections/products") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_insert_and_upsert_records_hit_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "POST",
+                lambda p: p == "/api/v2/collections/products/records/batch",
+                200,
+                {
+                    "errors": [],
+                    "failed_count": 0,
+                    "inserted_count": 2,
+                    "inserted_ids": ["a", "b"],
+                },
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        res = await client.insert_records(
+            "products",
+            [
+                {"id": "a", "vector": [0.1, 0.2], "props": {"k": "v"}},
+                {"id": "b", "vector": [0.3, 0.4]},
+            ],
+        )
+        up = await client.upsert_records(
+            "products", [{"id": "a", "vector": [0.1, 0.2]}]
+        )
+    finally:
+        await client.aclose()
+
+    assert isinstance(res, BatchResult)
+    assert res.success == 2 and res.failed == 0 and res.total == 2
+    assert isinstance(up, BatchResult)
+    assert ("POST", "/api/v2/collections/products/records/batch") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_search_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "POST",
+                lambda p: p == "/api/v2/collections/products/search",
+                200,
+                {
+                    "latency_ms": 1,
+                    "request_id": "r1",
+                    "results": [
+                        {"id": "a", "props": {"k": "v"}, "score": 0.9},
+                        {"id": "b", "props": {}, "score": 0.7},
+                    ],
+                },
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        results = await client.search("products", [0.1, 0.2], top_k=2)
+    finally:
+        await client.aclose()
+
+    assert isinstance(results, list)
+    assert all(isinstance(r, SearchResult) for r in results)
+    assert [r.id for r in results] == ["a", "b"]
+    assert results[0].rank == 1
+    assert ("POST", "/api/v2/collections/products/search") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_get_vector_hits_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "GET",
+                lambda p: p == "/api/v2/collections/products/records/a",
+                200,
+                {"id": "a", "props": {"k": "v"}, "vector": [0.1, 0.2]},
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        out = await client.get_vector("products", "a")
+    finally:
+        await client.aclose()
+
+    assert isinstance(out, dict)
+    assert out["id"] == "a"
+    assert ("GET", "/api/v2/collections/products/records/a") in rec.seen
+
+
+@pytest.mark.asyncio
+async def test_delete_vectors_hit_generated_endpoint():
+    rec = _Recorder(
+        [
+            (
+                "DELETE",
+                lambda p: p.startswith("/api/v2/collections/products/records/"),
+                200,
+                {"id": "x", "processing_time_us": 1, "success": True},
+            )
+        ]
+    )
+    client = await _started_client(rec)
+    try:
+        single = await client.delete_vector("products", "a")
+        batch = await client.delete_vectors("products", ["b", "c"])
+    finally:
+        await client.aclose()
+
+    assert isinstance(single, DeleteResult)
+    assert single.success is True and single.deleted_count == 1
+    assert isinstance(batch, DeleteResult)
+    assert batch.deleted_count == 2 and batch.success is True
+    deletes = [s for s in rec.seen if s[0] == "DELETE"]
+    assert len(deletes) == 3  # 1 single + 2 batch
+
+
+@pytest.mark.asyncio
+async def test_context_manager_lifecycle():
+    rec = _Recorder([])
+    client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="rest")
+    async with client:
+        assert client._gen_client is not None
+        assert client._async_http is not None
+    # aclose ran on __aexit__: shared transport torn down.
+    assert client._async_http is None
+    assert client._gen_client is None
+
+
+@pytest.mark.asyncio
+async def test_methods_require_astart():
+    client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="rest")
+    with pytest.raises(RuntimeError):
+        await client.get_collection("products")

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -11,7 +11,10 @@ TypeScript (REST transport generated via `openapi-typescript` + `openapi-fetch`)
 Phase 3 done (Python `chunking`, `embeddings`, and `integrations`/`adapters` concerns all made
 opt-in + lazy behind extras — `import proximadb_sdk` pulls zero heavy deps; core =
 transport+facade+models); remaining-ops re-base done (2026-06-22 — graph/health/observability/meta
-ops routed through the generated client across Go/TS/Rust/Python, contract tests kept); Phase 5 +
+ops routed through the generated client across Go/TS/Rust/Python, contract tests kept);
+Python native-async core ops done (2026-06-22 — `ProximaDBAsyncUnified` wires the generated
+`asyncio_detailed` for collections CRUD + records insert/upsert/get/delete + search behind a
+shared `httpx.AsyncClient`, drift-gated; async gRPC deferred); Phase 5 +
 remaining Phase-4 languages (jvm) + generating the facades themselves open +
 Date: 2026-06-21 (updated 2026-06-22) +
 Owner: SDK / API surface
@@ -782,10 +785,35 @@ DSPy adapters.
   retrieval window (`max_filter_window`, default 10000) using a constant probe
   vector. A true unbounded metadata-only scan needs a server-side scan API
   (out of scope for an integration cleanup).
-* *Native async SDK client* — these async paths thread-offload a synchronous
-  client. A genuinely async transport (`unified_client_async` currently only
-  covers graph ops) would let the integrations await real async I/O instead of a
-  worker thread; tracked as a transport-layer follow-up.
+* *Native async SDK client (REST core ops)* — SHIPPED (2026-06-22). The
+  spec-driven mandate now applies to async as well as sync (CLAUDE.md Core
+  Directive #15 / GEMINI.md #29). `ProximaDBAsyncUnified` (`unified_client_async.py`)
+  gained native-async core ops — `create_collection`, `get_collection`,
+  `list_collections`, `delete_collection`, `insert_records`, `upsert_records`,
+  `get_vector`, `delete_vector`/`delete_vectors`, and `search` — that wire the
+  GENERATED `asyncio_detailed` endpoint functions over a single shared
+  `httpx.AsyncClient` (injected into the generated `Client` via
+  `set_async_httpx_client`). The wiring lives in `protocols/_rest_codegen_async.py`,
+  the async analog of `protocols/_rest_codegen.py`: it calls the generated
+  modules' `asyncio_detailed` (`collections.{create,get,list,delete}_collection`,
+  `records.{insert_records,get_record,delete_record}`, `search.search_records`)
+  exactly as the sync path uses the generated `sync`/`_get_kwargs`, so the async
+  client stays spec-conformant and covered by the `python-sdk-codegen-drift` gate
+  (no `_generated/` edits). Method signatures + Pydantic return types mirror the
+  sync facade. `astart` creates the shared transport, `aclose` tears it down, and
+  the client is an async context manager. LangChain
+  `asimilarity_search_by_vector_with_score` and LlamaIndex `aquery` accept an
+  optional `async_client=` and await it natively when supplied, falling back to
+  the `asyncio.to_thread` path otherwise (sync construction/methods unchanged).
+* *Native async gRPC client* — DEFERRED. `protocols/grpc_async.py` is currently a
+  thin (sync) subclass; genuine async gRPC needs a `grpc.aio` channel + async
+  stub generation (a separate codegen effort), so the async facade's graph ops
+  still use the hand-written async REST path (and the sync gRPC client where
+  available). Tracked as a follow-up.
+* *Pure async record/collection coercion sharing with sync* — the async facade
+  re-derives its (small) request-body shaping and response coercion rather than
+  importing the sync facade's private helpers; a future refactor could lift the
+  pure (non-HTTP) body/coercion helpers into a shared module used by both.
 
 == Related
 


### PR DESCRIPTION
## Summary

PR 2 of the sequenced pair (PR 1 = #238, the spec-driven mandate). Delivers a **genuine native-async** ProximaDB Python core client that wires the **generated** `asyncio`/`asyncio_detailed` endpoint functions — the same spec-driven way the sync facade wires `sync`/`_get_kwargs`. No hand-rolled `httpx` / response-parsing.

## What's new

**Async wiring — `protocols/_rest_codegen_async.py`** (async analog of `_rest_codegen.py`): each helper takes the generated `Client` + facade body dict and `await`s the generated `asyncio_detailed`, returning the typed `Response`. Generated modules used:
- `collections.create_collection` / `get_collection` / `list_collections` / `delete_collection`
- `records.insert_records` / `get_record` / `delete_record`
- `search.search_records`

Request models built via the existing `_rest_codegen._from_dict` round-trip (spec-conformant body).

**Facade — `ProximaDBAsyncUnified` (`unified_client_async.py`)**: async core ops mirroring the sync facade's signatures + Pydantic return types — `create_collection`, `get_collection`, `list_collections`, `delete_collection`, `insert_records`, `upsert_records`, `get_vector`, `delete_vector`/`delete_vectors`, `search`. `astart` creates a single shared `httpx.AsyncClient` and injects it into the generated `Client` via `set_async_httpx_client`; `aclose` tears it down; usable as an async context manager. **Graph ops stay on the hand-written `rest_async.py` path** (not in the OpenAPI spec).

**Integrations repointed (clean, non-breaking)**: LangChain `asimilarity_search_by_vector_with_score` and LlamaIndex `aquery` accept an optional `async_client=` and await it natively when supplied; otherwise fall back to the existing `asyncio.to_thread` path. Sync construction + methods unchanged (new param defaults to `None`).

**Deferred (documented in TD-126)**: native async **gRPC** — `grpc_async.py` is a sync subclass; real async gRPC needs a `grpc.aio` channel + async stub generation (separate effort).

## Verification
- `python-sdk-codegen-drift` gate stays GREEN — only **consuming** generated `asyncio` fns; **no `_generated/` edits** (the gate diffs only that dir).
- Async unit tests (`test_unified_client_async_core_ops.py`): each facade op hits the spec-derived generated route (proves the right generated endpoint module) and parses into the same return type as its sync sibling; covers collections CRUD, insert/upsert, search, get_vector, delete; async context-manager lifecycle; "requires astart".
- `import proximadb_sdk` lazy boundary intact (no eager `httpx`/generated import).
- black/isort/ruff(E9,F63,F7)+py_compile clean; existing sync + integration + async tests pass (66 async/pools/graph + 14 langchain green locally).

Ref TD-126.