### PR TITLE
feat(index): storage↔index decoupling contract — ISP role traits + slim query DTO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6539,6 +6539,7 @@ dependencies = [
  "proximadb-hardware",
  "proximadb-hardware-caps",
  "proximadb-iceberg-engine",
+ "proximadb-index-traits",
  "proximadb-index-types",
  "proximadb-kernel",
  "proximadb-multimodel-plan",
@@ -7003,6 +7004,18 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "proximadb-index-traits"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "proximadb-records",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/foundation/proximadb-proto",
     "crates/foundation/proximadb-quantization-types",
     "crates/foundation/proximadb-index-types",
+    "crates/foundation/proximadb-index-traits",
     "crates/foundation/proximadb-records",
     "crates/foundation/proximadb-relational-types",
     "crates/foundation/proximadb-functions",
@@ -156,6 +157,7 @@ proximadb-distance-types = { path = "crates/foundation/proximadb-distance-types"
 proximadb-filter-expression = { path = "crates/foundation/proximadb-filter-expression" }
 proximadb-quantization-types = { path = "crates/foundation/proximadb-quantization-types" }
 proximadb-index-types = { path = "crates/foundation/proximadb-index-types" }
+proximadb-index-traits = { path = "crates/foundation/proximadb-index-traits" }
 proximadb-records = { path = "crates/foundation/proximadb-records" }
 proximadb-relational-types = { path = "crates/foundation/proximadb-relational-types" }
 proximadb-functions = { path = "crates/foundation/proximadb-functions" }
@@ -289,6 +291,7 @@ proximadb-relational-executor = { path = "crates/query/proximadb-relational-exec
 proximadb-relational-frontend = { path = "crates/query/proximadb-relational-frontend" }
 proximadb-relational-engine = { path = "crates/query/proximadb-relational-engine" }
 proximadb-index-types = { path = "crates/foundation/proximadb-index-types" }
+proximadb-index-traits = { path = "crates/foundation/proximadb-index-traits" }
 proximadb-records = { path = "crates/foundation/proximadb-records" }
 proximadb-quantization-types = { path = "crates/foundation/proximadb-quantization-types" }
 proximadb-catalog = { path = "crates/control/proximadb-catalog" }

--- a/crates/foundation/proximadb-index-traits/Cargo.toml
+++ b/crates/foundation/proximadb-index-traits/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "proximadb-index-traits"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Segregated index role traits (ISP) + slim storage-facing query DTO for the storage↔index (AXIS) DIP boundary — foundation layer; AxisManager implements these at the boundary"
+
+[lib]
+name = "proximadb_index_traits"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+proximadb-records.workspace = true

--- a/crates/foundation/proximadb-index-traits/src/lib.rs
+++ b/crates/foundation/proximadb-index-traits/src/lib.rs
@@ -1,0 +1,236 @@
+//! Storage↔Index (AXIS) decoupling contract — segregated role traits (ISP) plus a
+//! slim, storage-facing query DTO that resolves the "query-envelope crux" from
+//! `docs/12-design/STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc`.
+//!
+//! # Why this crate exists
+//!
+//! `src/storage` reaches the AXIS index through the concrete `AxisManager`, but a
+//! read-only survey (against `develop`) showed storage actually touches it through
+//! only a handful of methods — and the rich query envelope
+//! (`AxisHybridQuery`/`AxisManagerQueryResult`) drags in `proximadb_catalog`,
+//! `core::search`, and `observability` types that cannot live in a foundation crate.
+//!
+//! The resolution (contract doc §A2, option 1 — the preferred one) is a **slim
+//! storage-facing DTO**: define exactly what storage passes/reads, and convert
+//! to/from the rich envelope *at the index boundary* (in the root crate, where
+//! `AxisManager` lives). This keeps the trait crate dependency-light and lets it
+//! sit in the foundation layer.
+//!
+//! Measured facts that shaped the DTO (all verified against the storage call sites):
+//! * storage sets only `collection_id`, `vector_query`, `metadata_filters`,
+//!   `id_filters`, `top_k`, `include_expired`, and `search_effort` on the query;
+//!   it never sets `ann_filtering_policy`, `estimated_selectivity`, or
+//!   `ann_filtering_mode` (all defaulted at the boundary), so the DTO omits them;
+//! * storage reads only `results` from the query result — the observability fields
+//!   (`strategy_used`, `predicate_shortfall`, `selected_filtering_mode`,
+//!   `quantized_route`) are consumed by the service layer, which calls
+//!   `AxisManager` directly, so the result DTO omits them.
+//!
+//! # Depend on the role, not the god-object (ISP + DIP)
+//!
+//! Engines should hold `Arc<dyn IndexQuery>` (etc.) injected at construction; the
+//! concrete `AxisManager` is one implementor. This crate only defines the
+//! abstractions and the boundary DTO — the implementations and conversions live in
+//! the root crate next to `AxisManager`, and the per-engine field narrowing
+//! (`Arc<AxisManager>` → `Arc<dyn IndexQuery>`) is a separate, coordinated step.
+
+use async_trait::async_trait;
+use proximadb_records::ProximaRecord;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Slim storage-facing query DTO (§A2 resolution)
+// ---------------------------------------------------------------------------
+
+/// Storage-facing hybrid query — the slim mirror of the AXIS `AxisHybridQuery`
+/// carrying only the fields storage actually sets. The root-crate boundary
+/// converts this into the rich AXIS envelope (defaulting the catalog/selectivity/
+/// mode fields storage never populates).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IndexHybridQuery {
+    /// Target collection for the query.
+    pub collection_id: String,
+    /// Optional vector-similarity component.
+    pub vector_query: Option<IndexVectorQuery>,
+    /// Metadata field filter predicates.
+    pub metadata_filters: Vec<IndexMetadataFilter>,
+    /// Exact vector-ID filters for point lookups.
+    pub id_filters: Vec<String>,
+    /// Maximum number of results to return.
+    pub top_k: usize,
+    /// Whether to include MVCC-expired records.
+    pub include_expired: bool,
+    /// Per-query accuracy-vs-latency intent. `None` keeps each index's own
+    /// size-aware default (behavior-identical to no knob). The *mechanism*
+    /// (HNSW `ef` / IVF `nprobe`) is applied at the AXIS boundary, not here.
+    pub search_effort: Option<IndexSearchEffort>,
+}
+
+/// Vector-similarity component of an [`IndexHybridQuery`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IndexVectorQuery {
+    /// Dense full-precision query vector.
+    Dense {
+        /// Query vector in f32.
+        vector: Vec<f32>,
+        /// Minimum similarity score threshold.
+        similarity_threshold: f32,
+    },
+    /// Sparse query vector (dimension-index → value).
+    Sparse {
+        /// Sparse query vector.
+        vector: std::collections::HashMap<u32, f32>,
+        /// Minimum similarity score threshold.
+        similarity_threshold: f32,
+    },
+}
+
+/// Metadata filter predicate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexMetadataFilter {
+    /// Metadata field to filter on.
+    pub field: String,
+    /// Comparison operator.
+    pub operator: IndexFilterOperator,
+    /// Value to compare against.
+    pub value: serde_json::Value,
+}
+
+/// Comparison operators for [`IndexMetadataFilter`]. Mirrors the AXIS
+/// `FilterOperator`; converted at the boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum IndexFilterOperator {
+    /// Exact equality.
+    Equals,
+    /// Inequality.
+    NotEquals,
+    /// Strictly greater than.
+    GreaterThan,
+    /// Greater than or equal.
+    GreaterThanOrEqual,
+    /// Strictly less than.
+    LessThan,
+    /// Less than or equal.
+    LessThanOrEqual,
+    /// Membership in a set.
+    In,
+    /// Exclusion from a set.
+    NotIn,
+    /// String contains substring.
+    Contains,
+    /// String starts with prefix.
+    StartsWith,
+    /// String ends with suffix.
+    EndsWith,
+    /// SQL-style LIKE pattern.
+    Like,
+    /// Inclusive `[lower, upper]` range.
+    Between,
+    /// Value is null or missing.
+    IsNull,
+    /// Value is present and non-null.
+    IsNotNull,
+}
+
+/// Per-query search intent — the slim mirror of `core::search::SearchEffort`.
+/// Carries only the *intent*; the per-index mechanism (`hnsw_ef_override` /
+/// `ivf_nprobe`) is reconstructed at the AXIS boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IndexSearchEffort {
+    /// Maximize recall — keep the index's full / size-aware effort.
+    Exact,
+    /// Trade recall for latency. `hint` is the caller's explicit budget
+    /// (HNSW `ef` / IVF `nprobe`); `None` asks the engine for a recall-trading
+    /// default below the exact ceiling.
+    Approximate {
+        /// Explicit per-query effort budget.
+        hint: Option<usize>,
+    },
+}
+
+/// Storage-facing query result — only the scored hits storage reads. The rich
+/// AXIS result keeps its observability fields for the service layer.
+#[derive(Debug, Clone, Default)]
+pub struct IndexQueryResult {
+    /// Scored results ordered by relevance.
+    pub results: Vec<IndexScoredResult>,
+}
+
+/// A single scored hit (with MVCC expiry).
+#[derive(Debug, Clone)]
+pub struct IndexScoredResult {
+    /// Identifier of the matching vector.
+    pub vector_id: String,
+    /// Similarity score between the query and this result.
+    pub similarity: f32,
+    /// MVCC expiration timestamp, if the record has a TTL.
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+// ---------------------------------------------------------------------------
+// Segregated role traits (ISP) — engines depend only on the role they use
+// ---------------------------------------------------------------------------
+
+/// Read path: execute a hybrid query against the index.
+///
+/// Implemented by `AxisManager`; held by every storage engine + Orion as the
+/// search seam. This is the highest-traffic role — narrowing engine fields to
+/// `Arc<dyn IndexQuery>` is the bulk of the DIP win.
+#[async_trait]
+pub trait IndexQuery: Send + Sync {
+    /// Execute a hybrid query and return the scored hits.
+    async fn query(&self, query: IndexHybridQuery) -> anyhow::Result<IndexQueryResult>;
+}
+
+/// Write path: index vectors produced by a storage flush.
+#[async_trait]
+pub trait IndexIngest: Send + Sync {
+    /// Index the records emitted by a flush of `collection_id`; `files_created`
+    /// names the SST/segment files the flush produced.
+    async fn handle_flushed_vectors(
+        &self,
+        collection_id: &str,
+        flushed_vectors: Vec<ProximaRecord>,
+        files_created: Vec<String>,
+    ) -> anyhow::Result<()>;
+}
+
+/// Metrics the storage warm-load path inspects.
+#[async_trait]
+pub trait IndexMetrics: Send + Sync {
+    /// Number of vectors currently registered in the index for `collection_id`.
+    async fn registered_vector_count(&self, collection_id: &str) -> usize;
+}
+
+/// Maintenance hooks invoked by compaction / background optimization.
+///
+/// `get_collection_indexes` (returning per-index reader handles) is intentionally
+/// *not* part of this contract yet: on `develop` it is a stub returning an empty
+/// vec, and its return type (`Arc<dyn AxisVectorIndex>`) would force a shared
+/// reader trait + supertrait wiring across the concrete index impls. It lands
+/// with the compaction-reader follow-up, once compaction actually consumes it.
+#[async_trait]
+pub trait IndexMaintenance: Send + Sync {
+    /// Rebuild a single named index for `collection_id`.
+    async fn rebuild_index(&self, collection_id: &str, index_name: &str) -> anyhow::Result<()>;
+
+    /// Analyze the collection and apply adaptive index optimizations.
+    async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()>;
+}
+
+/// Collection lifecycle on the index side. Defined for completeness; storage
+/// wiring is post-MVP (the contract doc marks lifecycle "define, don't wire").
+#[async_trait]
+pub trait IndexLifecycle: Send + Sync {
+    /// Drop all index state for `collection_id`.
+    async fn drop_collection(&self, collection_id: &str) -> anyhow::Result<()>;
+
+    /// Suspend indexing/serving for `collection_id`.
+    async fn suspend_collection(&self, collection_id: &str) -> anyhow::Result<()>;
+
+    /// Resume a suspended collection. Returns `true` if it was suspended.
+    async fn resume_collection(&self, collection_id: &str) -> anyhow::Result<bool>;
+
+    /// Whether `collection_id` is currently suspended.
+    async fn is_suspended(&self, collection_id: &str) -> bool;
+}

--- a/src/index/axis/contract.rs
+++ b/src/index/axis/contract.rs
@@ -1,0 +1,199 @@
+//! Boundary implementation of the storage↔index decoupling contract
+//! ([`proximadb_index_traits`]) for [`AxisManager`].
+//!
+//! This is the "convert at the index boundary" half of the §A2 resolution from
+//! `docs/12-design/STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc`:
+//! the slim, dependency-light DTO lives in the foundation `proximadb-index-traits`
+//! crate; the conversions to/from the rich AXIS envelope
+//! (`AxisHybridQuery`/`AxisManagerQueryResult`, which carry catalog/core/
+//! observability types) live here, next to `AxisManager`.
+//!
+//! Implementing the role traits here — with no behavioural change — lets us prove
+//! the DTO is lossless for storage's measured use *before* any engine field is
+//! narrowed from `Arc<AxisManager>` to `Arc<dyn IndexQuery>` (the separate,
+//! coordinated DIP-adoption step).
+
+use async_trait::async_trait;
+
+use proximadb_index_traits::{
+    IndexFilterOperator, IndexHybridQuery, IndexIngest, IndexLifecycle, IndexMaintenance,
+    IndexMetadataFilter, IndexMetrics, IndexQuery, IndexQueryResult, IndexScoredResult,
+    IndexSearchEffort, IndexVectorQuery,
+};
+use proximadb_records::ProximaRecord;
+
+use crate::core::search::SearchEffort;
+use crate::index::axis::management::manager::{
+    AxisHybridQuery, AxisManager, AxisManagerQueryResult, AxisMetadataFilter, FilterOperator,
+    ScoredResult, VectorQuery,
+};
+
+// ---------------------------------------------------------------------------
+// Input conversions: slim DTO -> rich AXIS envelope (DTO target types are local,
+// so these are `From` impls; orphan rule satisfied).
+// ---------------------------------------------------------------------------
+
+impl From<IndexSearchEffort> for SearchEffort {
+    fn from(e: IndexSearchEffort) -> Self {
+        match e {
+            IndexSearchEffort::Exact => SearchEffort::Exact,
+            IndexSearchEffort::Approximate { hint } => SearchEffort::Approximate { hint },
+        }
+    }
+}
+
+impl From<IndexFilterOperator> for FilterOperator {
+    fn from(op: IndexFilterOperator) -> Self {
+        match op {
+            IndexFilterOperator::Equals => FilterOperator::Equals,
+            IndexFilterOperator::NotEquals => FilterOperator::NotEquals,
+            IndexFilterOperator::GreaterThan => FilterOperator::GreaterThan,
+            IndexFilterOperator::GreaterThanOrEqual => FilterOperator::GreaterThanOrEqual,
+            IndexFilterOperator::LessThan => FilterOperator::LessThan,
+            IndexFilterOperator::LessThanOrEqual => FilterOperator::LessThanOrEqual,
+            IndexFilterOperator::In => FilterOperator::In,
+            IndexFilterOperator::NotIn => FilterOperator::NotIn,
+            IndexFilterOperator::Contains => FilterOperator::Contains,
+            IndexFilterOperator::StartsWith => FilterOperator::StartsWith,
+            IndexFilterOperator::EndsWith => FilterOperator::EndsWith,
+            IndexFilterOperator::Like => FilterOperator::Like,
+            IndexFilterOperator::Between => FilterOperator::Between,
+            IndexFilterOperator::IsNull => FilterOperator::IsNull,
+            IndexFilterOperator::IsNotNull => FilterOperator::IsNotNull,
+        }
+    }
+}
+
+impl From<IndexMetadataFilter> for AxisMetadataFilter {
+    fn from(f: IndexMetadataFilter) -> Self {
+        AxisMetadataFilter {
+            field: f.field,
+            operator: f.operator.into(),
+            value: f.value,
+        }
+    }
+}
+
+impl From<IndexVectorQuery> for VectorQuery {
+    fn from(q: IndexVectorQuery) -> Self {
+        match q {
+            IndexVectorQuery::Dense {
+                vector,
+                similarity_threshold,
+            } => VectorQuery::Dense {
+                vector,
+                similarity_threshold,
+            },
+            IndexVectorQuery::Sparse {
+                vector,
+                similarity_threshold,
+            } => VectorQuery::Sparse {
+                vector,
+                similarity_threshold,
+            },
+        }
+    }
+}
+
+impl From<IndexHybridQuery> for AxisHybridQuery {
+    fn from(q: IndexHybridQuery) -> Self {
+        AxisHybridQuery {
+            collection_id: q.collection_id,
+            vector_query: q.vector_query.map(Into::into),
+            metadata_filters: q.metadata_filters.into_iter().map(Into::into).collect(),
+            id_filters: q.id_filters,
+            top_k: q.top_k,
+            include_expired: q.include_expired,
+            search_effort: q.search_effort.map(Into::into),
+            // Storage never sets these on the query path (verified at the call
+            // sites); the AXIS query path defaults them. Keeping them here makes
+            // the "DTO is lossless for storage" property explicit.
+            ..AxisHybridQuery::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Output conversions: rich AXIS result -> slim DTO. The DTO result types are
+// foreign (defined in proximadb-index-traits), so these are free functions, not
+// `From` impls (orphan rule).
+// ---------------------------------------------------------------------------
+
+fn to_index_scored_result(s: ScoredResult) -> IndexScoredResult {
+    IndexScoredResult {
+        vector_id: s.vector_id,
+        similarity: s.similarity,
+        expires_at: s.expires_at,
+    }
+}
+
+fn to_index_query_result(r: AxisManagerQueryResult) -> IndexQueryResult {
+    IndexQueryResult {
+        results: r.results.into_iter().map(to_index_scored_result).collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Role-trait implementations. Each delegates to the corresponding inherent
+// `AxisManager` method (called via `AxisManager::method(self, ..)` so inherent
+// resolution is unambiguous against the same-named trait method). No behavioural
+// change — only the call shape.
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl IndexQuery for AxisManager {
+    async fn query(&self, query: IndexHybridQuery) -> anyhow::Result<IndexQueryResult> {
+        let result = AxisManager::query(self, query.into()).await?;
+        Ok(to_index_query_result(result))
+    }
+}
+
+#[async_trait]
+impl IndexIngest for AxisManager {
+    async fn handle_flushed_vectors(
+        &self,
+        collection_id: &str,
+        flushed_vectors: Vec<ProximaRecord>,
+        files_created: Vec<String>,
+    ) -> anyhow::Result<()> {
+        AxisManager::handle_flushed_vectors(self, collection_id, flushed_vectors, files_created)
+            .await
+    }
+}
+
+#[async_trait]
+impl IndexMetrics for AxisManager {
+    async fn registered_vector_count(&self, collection_id: &str) -> usize {
+        AxisManager::registered_vector_count(self, collection_id).await
+    }
+}
+
+#[async_trait]
+impl IndexMaintenance for AxisManager {
+    async fn rebuild_index(&self, collection_id: &str, index_name: &str) -> anyhow::Result<()> {
+        AxisManager::rebuild_index(self, collection_id, index_name).await
+    }
+
+    async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()> {
+        AxisManager::analyze_and_optimize(self, collection_id).await
+    }
+}
+
+#[async_trait]
+impl IndexLifecycle for AxisManager {
+    async fn drop_collection(&self, collection_id: &str) -> anyhow::Result<()> {
+        AxisManager::drop_collection(self, collection_id).await
+    }
+
+    async fn suspend_collection(&self, collection_id: &str) -> anyhow::Result<()> {
+        AxisManager::suspend_collection(self, collection_id).await
+    }
+
+    async fn resume_collection(&self, collection_id: &str) -> anyhow::Result<bool> {
+        AxisManager::resume_collection(self, collection_id).await
+    }
+
+    async fn is_suspended(&self, collection_id: &str) -> bool {
+        AxisManager::is_suspended(self, collection_id).await
+    }
+}

--- a/src/index/axis/mod.rs
+++ b/src/index/axis/mod.rs
@@ -82,6 +82,10 @@ pub mod storage; // Storage and serialization // Integration with other systems
 // TD-064: Filterable metadata for predicate-aware HNSW
 pub mod filterable_metadata;
 
+// Storage↔index decoupling contract (DIP/ISP): boundary impl of the
+// `proximadb-index-traits` role traits for `AxisManager`.
+pub mod contract;
+
 // Shared utilities and types
 pub mod avro_analysis;
 /// Cluster manager for IVF-based index partitioning.


### PR DESCRIPTION
## What

Introduces **`proximadb-index-traits`** (foundation): the storage↔index (AXIS)
decoupling **contract** — segregated index role traits (ISP) plus a slim,
dependency-light storage-facing query DTO. `AxisManager` implements the traits
at the boundary, proving the DTO is lossless with **zero behavioural change**.

This is step 3 (the contract half) of the root-crate decomposition's
storage↔index/compute decoupling, after `proximadb-index-types` (#160) and the
compute kernels (#194 distance, #229 quantization). It implements the **§A2
resolution** from `docs/12-design/STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc`.

## Why a slim DTO (the §A2 crux)

The rich AXIS query envelope (`AxisHybridQuery` / `AxisManagerQueryResult`)
carries `proximadb_catalog::AnnFilteringPolicy`, `core::search::SearchEffort`,
and an `observability::PredicateShortfall` — so it **cannot live in a foundation
crate** without dragging control/core/observability down with it. Resolution:
define exactly what storage passes/reads as a slim DTO and convert at the index
boundary.

## Measured, not asserted

A read-only survey of every storage call site (verified against `develop`) showed:

- storage **sets** only `collection_id`, `vector_query`, `metadata_filters`,
  `id_filters`, `top_k`, `include_expired`, and `search_effort` on the query —
  **never** `ann_filtering_policy` / `estimated_selectivity` / `ann_filtering_mode`
  (all defaulted at the boundary);
- storage **reads** only `results` off the result — the observability fields
  (`strategy_used` / `predicate_shortfall` / `selected_filtering_mode` /
  `quantized_route`) are consumed by the service layer, which calls `AxisManager`
  directly.

So the DTO carries exactly that. `search_effort` is mirrored as a slim
`IndexSearchEffort` enum (intent only); the per-index mechanism
(`hnsw_ef_override` / `ivf_nprobe`) stays at the AXIS boundary.

## Surface

- **`IndexQuery`** — `query(IndexHybridQuery) -> IndexQueryResult` (all 6 engines + Orion)
- **`IndexIngest`** — `handle_flushed_vectors` (SST flush)
- **`IndexMetrics`** — `registered_vector_count` (warm-load)
- **`IndexMaintenance`** — `rebuild_index`, `analyze_and_optimize` (compaction)
- **`IndexLifecycle`** — `drop_collection` / `suspend_collection` / `resume_collection` / `is_suspended`

`AxisManager` implements all five in `src/index/axis/contract.rs`, delegating to
the existing inherent methods (conversions in/out are total → compile-proves the
DTO is lossless).

## Deferred (intentionally)

`get_collection_indexes` (returns `Arc<dyn AxisVectorIndex>`) is **a stub on
`develop` that returns an empty vec**; threading it through a shared `IndexReader`
trait would need supertrait wiring across the concrete index impls. It lands with
the compaction-reader follow-up, once compaction actually consumes it.

## Not in this PR (gated)

No engine field is narrowed. The per-engine `Arc<AxisManager>` →
`Arc<dyn IndexQuery>` DIP adoption touches the hot engine files and is a
separate, coordinated/announced-window step (one engine per PR) — held for
explicit go-ahead.

## Verification (pinned 1.95.0)

- `cargo build --lib` (root, with boundary impls) — clean
- `cargo clippy --lib -- -D warnings` (root) — clean
- `cargo clippy -p proximadb-index-traits --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean (exit 0)
- `scripts/check_workspace_boundaries.py` — `proximadb-index-traits` classified
  **foundation**, depends only on foundation crates, **no boundary findings**
