### PR TITLE
feat(python-sdk): genuine grpc.aio async client (TD-126 native-async completion)

### DIFF
--- a/clients/python/src/proximadb_sdk/protocols/_grpc_v2_codec.py
+++ b/clients/python/src/proximadb_sdk/protocols/_grpc_v2_codec.py
@@ -1,0 +1,275 @@
+"""Pure proto build/parse helpers for the v2 ``ProximaRecordService`` gRPC surface.
+
+These are the *transport-agnostic* converters: they build / parse the generated
+``proximadb.v2.record_pb2`` messages and have no dependency on a channel, stub,
+connection pool, or event loop. The synchronous client
+(``protocols/grpc_sync.py``) and the native-async client
+(``protocols/grpc_async.py``) share this single mapping so the wire encoding is
+defined once, not duplicated per transport. The generated stubs are reused
+as-is on whatever channel (``grpc`` or ``grpc.aio``) the caller supplies.
+
+Every function takes the generated ``pb2`` module explicitly (it is imported
+lazily at the call site) so this module itself imports nothing protobuf at
+import time, preserving the SDK's lazy gRPC boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..exceptions import ProximaDBError
+from ..models import BatchResult, OperationMetrics, SearchResult
+
+__all__ = [
+    "python_to_v2_typed_value",
+    "v2_typed_value_to_python",
+    "record_proto_for_grpc",
+    "v2_record_batch_result",
+]
+
+
+def python_to_v2_typed_value(pb2: Any, value: Any):
+    """Encode Python values into v2 ProximaValue/TypedValue protobufs."""
+    if pb2 is None:
+        raise ProximaDBError("v2 record protobuf stubs not available")
+
+    type_hint = None
+    if isinstance(value, dict) and set(value.keys()) == {"type", "value"}:
+        type_hint = str(value["type"]).lower()
+        value = value["value"]
+
+    tv = pb2.TypedValue()
+    if value is None:
+        tv.declared_type = pb2.COLUMN_TYPE_UNSPECIFIED
+        tv.is_null = True
+    elif isinstance(value, bool):
+        tv.declared_type = pb2.BOOLEAN
+        tv.boolean_value = value
+    elif isinstance(value, int) and not isinstance(value, bool):
+        tv.declared_type = pb2.INTEGER
+        tv.integer_value = value
+    elif isinstance(value, float):
+        tv.declared_type = pb2.FLOAT32 if type_hint == "float32" else pb2.FLOAT
+        if type_hint == "float32":
+            tv.float32_value = value
+        else:
+            tv.float_value = value
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        tv.declared_type = pb2.BINARY
+        tv.binary_value = bytes(value)
+    elif isinstance(value, str):
+        tv.declared_type = pb2.SYMBOL if type_hint == "symbol" else pb2.TEXT
+        if type_hint == "symbol":
+            tv.symbol_value = value
+        else:
+            tv.text_value = value
+    elif isinstance(value, (list, tuple)):
+        tv.declared_type = pb2.ARRAY_ANY
+        tv.array_value.values.extend(
+            python_to_v2_typed_value(pb2, item) for item in value
+        )
+    elif isinstance(value, dict):
+        tv.declared_type = pb2.JSONB
+        tv.jsonb_value = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    else:
+        tv.declared_type = pb2.TEXT
+        tv.text_value = str(value)
+    return tv
+
+
+def v2_typed_value_to_python(value: Any) -> Any:
+    """Decode v2 TypedValue protobufs into Python values."""
+    which = value.WhichOneof("value")
+    if which in (None, "is_null"):
+        return None
+    if which == "text_value":
+        return value.text_value
+    if which == "integer_value":
+        return value.integer_value
+    if which == "float_value":
+        return value.float_value
+    if which == "boolean_value":
+        return value.boolean_value
+    if which == "timestamp_value":
+        return value.timestamp_value
+    if which == "date_value":
+        return value.date_value
+    if which == "time_value":
+        return value.time_value
+    if which == "duration_value":
+        return value.duration_value
+    if which == "uuid_value":
+        return bytes(value.uuid_value).hex()
+    if which == "binary_value":
+        return bytes(value.binary_value)
+    if which == "json_value":
+        try:
+            return json.loads(value.json_value)
+        except json.JSONDecodeError:
+            return value.json_value
+    if which == "jsonb_value":
+        try:
+            return json.loads(bytes(value.jsonb_value).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return bytes(value.jsonb_value)
+    if which == "array_value":
+        return [v2_typed_value_to_python(item) for item in value.array_value.values]
+    if which == "map_value":
+        return {
+            key: v2_typed_value_to_python(item)
+            for key, item in value.map_value.entries.items()
+        }
+    if which == "struct_value":
+        return {
+            key: v2_typed_value_to_python(item)
+            for key, item in value.struct_value.entries.items()
+        }
+    if which == "float32_value":
+        return value.float32_value
+    if which.endswith("_array"):
+        return list(getattr(value, which).values)
+    return getattr(value, which)
+
+
+def record_proto_for_grpc(pb2: Any, record: Any, index: int = 0):
+    """Build a v2 ``ProximaRecord`` proto from an SDK record-like input."""
+    if pb2 is None:
+        raise ProximaDBError("v2 record protobuf stubs not available")
+
+    if hasattr(record, "model_dump"):
+        record = record.model_dump(exclude_none=True)
+    elif hasattr(record, "dict"):
+        record = record.dict(exclude_none=True)
+    if not isinstance(record, dict):
+        raise TypeError(f"Unsupported record input: {type(record)!r}")
+
+    vector = record.get("vector")
+    if vector is None and record.get("embeddings"):
+        first_embedding = record["embeddings"][0]
+        vector = (
+            first_embedding.get("values")
+            if isinstance(first_embedding, dict)
+            else first_embedding
+        )
+    if vector is None:
+        raise ValueError("record is missing vector")
+
+    proto = pb2.ProximaRecord()
+    proto.id = str(record.get("id") or record.get("oid") or f"record_{index}")
+    proto.vector.extend(float(v) for v in vector)
+    if record.get("vector_dimension") is not None:
+        proto.vector_dimension = int(record["vector_dimension"])
+
+    for source in ("props", "metadata", "flexible_fields"):
+        values = record.get(source)
+        if isinstance(values, dict):
+            for key, value in values.items():
+                proto.props[str(key)].CopyFrom(python_to_v2_typed_value(pb2, value))
+
+    typed_fields = record.get("typed_fields")
+    if isinstance(typed_fields, dict):
+        for key, value in typed_fields.items():
+            if hasattr(value, "model_dump"):
+                value = value.model_dump(exclude_none=True)
+            if isinstance(value, dict) and "value" in value:
+                value = {
+                    "type": value.get("value_type") or value.get("type"),
+                    "value": value["value"],
+                }
+            proto.props[str(key)].CopyFrom(python_to_v2_typed_value(pb2, value))
+
+    for text_field in record.get("text_fields") or []:
+        if hasattr(text_field, "model_dump"):
+            text_field = text_field.model_dump(exclude_none=True)
+        if isinstance(text_field, dict):
+            proto.text_fields.add(
+                name=str(text_field.get("name") or ""),
+                content=str(text_field.get("content") or ""),
+                storage_hint=str(text_field.get("storage_hint") or ""),
+                chunk_count=int(text_field.get("chunk_count") or 0),
+                chunk_reference=str(text_field.get("chunk_reference") or ""),
+            )
+
+    if record.get("timestamp_ms") is not None:
+        proto.timestamp_ms = int(record["timestamp_ms"])
+    for field in (
+        "updated_at_ms",
+        "expires_at_ms",
+        "version",
+        "source",
+        "source_type",
+        "schema_id",
+        "partition_key",
+        "created_by",
+        "updated_by",
+    ):
+        if record.get(field) is not None:
+            setattr(proto, field, record[field])
+    if isinstance(record.get("partition_values"), dict):
+        proto.partition_values.update(
+            {str(k): str(v) for k, v in record["partition_values"].items()}
+        )
+    if isinstance(record.get("custom_metadata"), dict):
+        proto.custom_metadata.update(
+            {str(k): str(v) for k, v in record["custom_metadata"].items()}
+        )
+    return proto
+
+
+def v2_record_batch_result(response) -> BatchResult:
+    """Parse a v2 ``ProximaRecordBatchResult`` proto into a ``BatchResult``."""
+    errors = [
+        f"{error.record_id or error.record_index}: {error.error_message}"
+        for error in response.errors
+    ]
+    return BatchResult(
+        total=int(response.total_processed),
+        success=int(response.success_count),
+        failed=int(response.failed_count),
+        errors=errors,
+        metrics=OperationMetrics(
+            total_processed=int(response.total_processed),
+            successful_count=int(response.success_count),
+            failed_count=int(response.failed_count),
+            processing_time_us=int(response.processing_time_us),
+        ),
+    )
+
+
+def search_results_from_proto(
+    response,
+    *,
+    include_vectors: bool,
+    include_metadata: bool,
+) -> list[SearchResult]:
+    """Parse a v2 Search response's results into SDK ``SearchResult`` rows.
+
+    Mirrors the per-result mapping in ``grpc_sync.search_vectors`` so both
+    transports return identical ``SearchResult`` shapes.
+    """
+    results: list[SearchResult] = []
+    for rank, result in enumerate(response.results):
+        metadata = None
+        if include_metadata:
+            metadata = {
+                key: v2_typed_value_to_python(value)
+                for key, value in result.props.items()
+            }
+        results.append(
+            SearchResult(
+                id=result.id,
+                score=result.score,
+                rank=rank,
+                vector=(
+                    list(result.vector) if include_vectors and result.vector else None
+                ),
+                metadata=metadata,
+                timestamp=(
+                    result.timestamp_ms if result.HasField("timestamp_ms") else None
+                ),
+                version=(result.version if result.HasField("version") else None),
+                source=(result.source if result.HasField("source") else None),
+            )
+        )
+    return results

--- a/clients/python/src/proximadb_sdk/protocols/grpc_async.py
+++ b/clients/python/src/proximadb_sdk/protocols/grpc_async.py
@@ -1,61 +1,357 @@
+"""ProximaDB native-async gRPC client (TD-126).
+
+A genuine ``grpc.aio`` client for the v2 ``ProximaRecordService``: it builds an
+``grpc.aio`` channel, instantiates the **existing generated**
+``proximadb.v2.record_pb2_grpc.ProximaRecordServiceStub`` on it (the generated
+stubs are channel-agnostic, so their RPC methods are awaitable on an aio
+channel — no stub/proto regeneration), and ``await``\\s each RPC. The proto
+build/parse logic is the transport-agnostic codec shared with the synchronous
+client (``protocols/_grpc_v2_codec``); it is not re-hand-rolled here.
+
+Covered v2 ``ProximaRecordService`` ops (all awaited over the aio channel):
+``insert_records``, ``upsert_records``, ``delete_vector``/``delete_vectors``,
+``search``, ``get_vector``. Collection ops are served by the same v2 service,
+but the async facade routes them over the generated async-REST transport
+(matching how the sync unified client keeps collections on its codegen path),
+so this client focuses on the record core ops.
+
+The ``grpc`` import is performed lazily inside ``connect``/methods so that
+``import proximadb_sdk`` stays grpc-free (lazy boundary, as today).
 """
-ProximaDB gRPC Async Client - DEPRECATED
 
-DEPRECATION NOTICE: This async gRPC client is deprecated and has been replaced by:
-- ProximaDBSyncGrpcClient (src/proximadb/protocols/grpc_sync.py) for synchronous gRPC
-- REST client (src/proximadb/protocols/rest_sync.py) for HTTP/JSON operations
+from __future__ import annotations
 
-This module now redirects to the synchronous gRPC client.
+import logging
+from typing import TYPE_CHECKING, Any
 
-Copyright 2025 ProximaDB
-"""
+from ..exceptions import ProximaDBError
+from ..models import SearchResult, VectorOperationResponse
+from . import _grpc_v2_codec as _codec
 
-import warnings
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..models import BatchResult
+    from ..models_v2 import ProximaRecord
 
-from .grpc_sync import ProximaDBSyncGrpcClient
-
-# Issue deprecation warning when module is imported
-warnings.warn(
-    "grpc_async.ProximaDBClient is deprecated. "
-    "Use grpc_sync.ProximaDBSyncGrpcClient instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
+logger = logging.getLogger(__name__)
 
 
-class ProximaDBClient(ProximaDBSyncGrpcClient):
+def _strip_scheme(endpoint: str) -> str:
+    """grpc.aio.insecure_channel expects a bare ``host:port`` target."""
+    return (
+        endpoint.replace("https://", "")
+        .replace("http://", "")
+        .replace("grpcs://", "")
+        .replace("grpc://", "")
+        .rstrip("/")
+    )
+
+
+class ProximaDBAsyncGrpcClient:
+    """Native-async gRPC client over a ``grpc.aio`` channel.
+
+    Usage::
+
+        client = ProximaDBAsyncGrpcClient("localhost:5679")
+        await client.connect()
+        try:
+            await client.insert_records("coll", records)
+        finally:
+            await client.close()
     """
-    DEPRECATED: Use grpc_sync.ProximaDBSyncGrpcClient instead.
 
-    This class now inherits from ProximaDBSyncGrpcClient for backward compatibility.
-    All async functionality has been removed during v1 proto migration.
+    def __init__(
+        self,
+        endpoint: str = "localhost:5679",
+        timeout: float = 60.0,
+        secure: bool = False,
+        max_message_size: int = 64 * 1024 * 1024,
+    ):
+        self.endpoint = endpoint
+        self.target = _strip_scheme(endpoint)
+        self.timeout = timeout
+        self.secure = secure
+        self.max_message_size = max_message_size
 
-    Migration guide:
-        # Old (deprecated):
-        from proximadb_sdk.protocols.grpc_async import ProximaDBClient
-        client = ProximaDBClient("localhost:5679")
+        self._channel = None  # grpc.aio.Channel
+        self._stub = None  # ProximaRecordServiceStub
+        self._pb2 = None  # proximadb.v2.record_pb2 module
 
-        # New (recommended):
-        from proximadb_sdk.protocols.grpc_sync import ProximaDBSyncGrpcClient
-        client = ProximaDBSyncGrpcClient("localhost:5679")
-    """
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    async def connect(self) -> "ProximaDBAsyncGrpcClient":
+        """Open the aio channel and bind the generated v2 record stub.
 
-    def __init__(self, endpoint: str = "localhost:5679", **kwargs):
+        grpc imported lazily here to preserve the SDK's grpc-free import.
         """
-        Initialize gRPC client (deprecated, redirects to sync client).
+        if self._channel is not None:
+            return self
 
-        Args:
-            endpoint: gRPC server endpoint (host:port)
-            **kwargs: Additional arguments passed to ProximaDBSyncGrpcClient
-        """
-        warnings.warn(
-            "grpc_async.ProximaDBClient is deprecated. "
-            "Use grpc_sync.ProximaDBSyncGrpcClient instead.",
-            DeprecationWarning,
-            stacklevel=2,
+        import grpc  # noqa: PLC0415 - lazy boundary
+
+        from proximadb.v2 import record_pb2 as v2_record_pb2  # noqa: PLC0415
+        from proximadb.v2 import record_pb2_grpc as v2_record_pb2_grpc  # noqa: PLC0415
+
+        options = [
+            ("grpc.max_send_message_length", self.max_message_size),
+            ("grpc.max_receive_message_length", self.max_message_size),
+        ]
+        if self.secure:
+            self._channel = grpc.aio.secure_channel(
+                self.target, grpc.ssl_channel_credentials(), options=options
+            )
+        else:
+            self._channel = grpc.aio.insecure_channel(self.target, options=options)
+
+        # The generated stub is channel-agnostic: on a grpc.aio channel its RPC
+        # methods return awaitables. No regeneration required.
+        self._stub = v2_record_pb2_grpc.ProximaRecordServiceStub(self._channel)
+        self._pb2 = v2_record_pb2
+        logger.info("Opened async gRPC channel to %s", self.target)
+        return self
+
+    async def close(self) -> None:
+        """Close the aio channel (awaitable, unlike the sync client)."""
+        if self._channel is not None:
+            await self._channel.close()
+            self._channel = None
+            self._stub = None
+            self._pb2 = None
+
+    async def __aenter__(self) -> "ProximaDBAsyncGrpcClient":
+        return await self.connect()
+
+    async def __aexit__(self, *exc) -> None:
+        await self.close()
+
+    def _require(self):
+        if self._stub is None or self._pb2 is None:
+            raise ProximaDBError("Async gRPC client not connected; call connect()")
+        return self._stub, self._pb2
+
+    async def _await_rpc(self, op: str, coro):
+        """Await an aio RPC, mapping grpc.aio errors to ProximaDBError."""
+        import grpc  # noqa: PLC0415 - lazy boundary
+
+        try:
+            return await coro
+        except grpc.aio.AioRpcError as e:  # pragma: no cover - exercised via mocks
+            details = e.details() or str(e)
+            logger.error("async gRPC %s failed: %s - %s", op, e.code(), details)
+            if e.code() == grpc.StatusCode.UNAVAILABLE or "connect" in details.lower():
+                raise ProximaDBError(f"{op} connection failed: {details}")
+            raise ProximaDBError(f"{op} RPC failed: {details}")
+
+    # ------------------------------------------------------------------
+    # Record core ops (awaited over the aio channel)
+    # ------------------------------------------------------------------
+    async def insert_records(
+        self,
+        collection_id: str,
+        records: list[ProximaRecord | dict[str, Any]],
+        **kwargs,
+    ) -> "BatchResult":
+        if bool(kwargs.pop("upsert", False)):
+            return await self.upsert_records(collection_id, records, **kwargs)
+
+        stub, pb2 = self._require()
+        request = pb2.ProximaRecordBatch(
+            collection_id=collection_id,
+            write_mode=pb2.INSERT,
+            validate_schema=bool(kwargs.get("validate_schema", True)),
+            return_ids=bool(kwargs.get("return_ids", True)),
+            return_errors=bool(kwargs.get("return_errors", True)),
         )
-        super().__init__(endpoint, **kwargs)
+        request.records.extend(
+            _codec.record_proto_for_grpc(pb2, record, index)
+            for index, record in enumerate(records)
+        )
+        if kwargs.get("schema_id"):
+            request.schema_id = str(kwargs["schema_id"])
+
+        response = await self._await_rpc(
+            "insert_records", stub.InsertRecords(request, timeout=self.timeout)
+        )
+        return _codec.v2_record_batch_result(response)
+
+    async def upsert_records(
+        self,
+        collection_id: str,
+        records: list[ProximaRecord | dict[str, Any]],
+        **kwargs,
+    ) -> "BatchResult":
+        kwargs.pop("upsert", None)
+        stub, pb2 = self._require()
+        request = pb2.ProximaRecordBatch(
+            collection_id=collection_id,
+            write_mode=pb2.UPSERT,
+            validate_schema=bool(kwargs.get("validate_schema", True)),
+            return_ids=bool(kwargs.get("return_ids", True)),
+            return_errors=bool(kwargs.get("return_errors", True)),
+        )
+        request.records.extend(
+            _codec.record_proto_for_grpc(pb2, record, index)
+            for index, record in enumerate(records)
+        )
+        if kwargs.get("schema_id"):
+            request.schema_id = str(kwargs["schema_id"])
+
+        response = await self._await_rpc(
+            "upsert_records", stub.UpsertRecords(request, timeout=self.timeout)
+        )
+        return _codec.v2_record_batch_result(response)
+
+    async def delete_vector(self, collection_id: str, vector_id: str) -> dict[str, Any]:
+        stub, pb2 = self._require()
+        request = pb2.ProximaRecordBatch(
+            collection_id=collection_id,
+            write_mode=pb2.DELETE,
+            return_ids=True,
+            return_errors=True,
+        )
+        request.records.append(pb2.ProximaRecord(id=vector_id))
+        response = await self._await_rpc(
+            "delete_vector", stub.DeleteRecords(request, timeout=self.timeout)
+        )
+        ok = response.failed_count == 0
+        return {
+            "status": "deleted" if ok else "failed",
+            "vector_id": vector_id,
+            "success": ok,
+        }
+
+    async def delete_vectors(
+        self, collection_id: str, vector_ids: list[str]
+    ) -> dict[str, Any]:
+        stub, pb2 = self._require()
+        request = pb2.ProximaRecordBatch(
+            collection_id=collection_id,
+            write_mode=pb2.DELETE,
+            return_ids=True,
+            return_errors=True,
+        )
+        for vector_id in vector_ids:
+            request.records.append(pb2.ProximaRecord(id=vector_id))
+        response = await self._await_rpc(
+            "delete_vectors", stub.DeleteRecords(request, timeout=self.timeout)
+        )
+        return {
+            "status": "completed",
+            "deleted_count": int(response.success_count),
+            "failed_count": int(response.failed_count),
+            "total_requested": len(vector_ids),
+        }
+
+    async def search(
+        self,
+        collection_id: str,
+        query_vector: list[float] | None = None,
+        query_vectors: list[list[float]] | None = None,
+        top_k: int = 10,
+        metadata_filters: dict[str, Any] | None = None,
+        include_vectors: bool = False,
+        include_metadata: bool = True,
+        search_hints: dict[str, Any] | None = None,
+    ) -> list[SearchResult]:
+        """Search via the v2 ``Search`` RPC, awaited over the aio channel."""
+        if query_vectors is None and query_vector is not None:
+            query_vectors = [query_vector]
+        elif query_vectors is None:
+            raise ValueError("Either query_vector or query_vectors must be provided")
+
+        stub, pb2 = self._require()
+        all_results: list[SearchResult] = []
+        for qv in query_vectors:
+            request = pb2.TypedSearchRequest(
+                collection_id=collection_id,
+                top_k=top_k,
+                include_vector=include_vectors,
+                include_text_fields=False,
+            )
+            request.query_vector.extend(float(value) for value in qv)
+            request.filter_logic = pb2.AND
+            if metadata_filters:
+                for key, value in metadata_filters.items():
+                    fc = request.filters.add()
+                    fc.field_name = str(key)
+                    fc.operator = pb2.EQ
+                    fc.value.CopyFrom(_codec.python_to_v2_typed_value(pb2, value))
+            if search_hints:
+                request.search_hints.update(
+                    {str(k): str(v) for k, v in search_hints.items()}
+                )
+
+            response = await self._await_rpc(
+                "search", stub.Search(request, timeout=self.timeout)
+            )
+            all_results.extend(
+                _codec.search_results_from_proto(
+                    response,
+                    include_vectors=include_vectors,
+                    include_metadata=include_metadata,
+                )
+            )
+        return all_results
+
+    async def get_vector(
+        self,
+        collection_id: str,
+        vector_id: str,
+        include_vector: bool = True,
+        include_metadata: bool = True,
+    ) -> dict[str, Any]:
+        """Get a single record via the v2 ``GetRecord`` RPC (aio)."""
+        stub, pb2 = self._require()
+        request = pb2.GetRecordRequest(
+            collection_id=collection_id,
+            id=vector_id,
+            include_vector=include_vector,
+        )
+        response = await self._await_rpc(
+            "get_vector", stub.GetRecord(request, timeout=self.timeout)
+        )
+        if not response.found or not response.HasField("record"):
+            raise ProximaDBError(f"Vector {vector_id} not found")
+        rec = response.record
+        result: dict[str, Any] = {"id": rec.id}
+        if include_vector and rec.vector:
+            result["vector"] = list(rec.vector)
+        if include_metadata and rec.props:
+            result["metadata"] = {
+                k: _codec.v2_typed_value_to_python(v) for k, v in rec.props.items()
+            }
+        return result
+
+    async def insert_vectors(
+        self,
+        collection_id: str,
+        vectors: list[dict[str, Any]],
+        upsert: bool = False,
+    ) -> VectorOperationResponse:
+        """Vector-alias insert/upsert over the v2 record surface (aio)."""
+        records = [
+            {
+                "id": v.get("id") or v.get("oid") or f"record_{i}",
+                "vector": v.get("vector"),
+                "props": v.get("props") or v.get("metadata") or {},
+            }
+            for i, v in enumerate(vectors)
+        ]
+        batch = (
+            await self.upsert_records(collection_id, records)
+            if upsert
+            else await self.insert_records(collection_id, records)
+        )
+        return VectorOperationResponse(
+            success=batch.failed == 0,
+            operation="UPSERT" if upsert else "INSERT",
+            metrics=batch.metrics,
+            vector_ids=[r["id"] for r in records],
+            error_message="; ".join(batch.errors) if batch.errors else None,
+        )
 
 
-# Alias for backward compatibility
-AsyncGrpcClient = ProximaDBClient
+# Backward-compatible aliases for the prior deprecated symbols. These now point
+# at the genuine async client (no longer a sync subclass).
+ProximaDBClient = ProximaDBAsyncGrpcClient
+AsyncGrpcClient = ProximaDBAsyncGrpcClient

--- a/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
@@ -8,7 +8,6 @@ Features:
 - Thread-safe concurrent operations
 """
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -16,11 +15,11 @@ from typing import Any
 from ..exceptions import ProximaDBError
 from ..models import (
     BatchResult,
-    OperationMetrics,
     SearchResult,
     VectorOperationResponse,
 )
 from ..models_v2 import ProximaRecord
+from . import _grpc_v2_codec as _codec
 from .connection_pools import GrpcChannelContext, GrpcConnectionPool
 
 
@@ -927,112 +926,16 @@ class ProximaDBSyncGrpcClient:
 
     # Record Operations - Unified Interface
     def _python_to_v2_typed_value(self, value: Any):
-        """Encode Python values into v2 ProximaValue/TypedValue protobufs."""
-        if v2_record_pb2 is None:
-            raise ProximaDBError("v2 record protobuf stubs not available")
+        """Encode Python values into v2 ProximaValue/TypedValue protobufs.
 
-        type_hint = None
-        if isinstance(value, dict) and set(value.keys()) == {"type", "value"}:
-            type_hint = str(value["type"]).lower()
-            value = value["value"]
-
-        tv = v2_record_pb2.TypedValue()
-        if value is None:
-            tv.declared_type = v2_record_pb2.COLUMN_TYPE_UNSPECIFIED
-            tv.is_null = True
-        elif isinstance(value, bool):
-            tv.declared_type = v2_record_pb2.BOOLEAN
-            tv.boolean_value = value
-        elif isinstance(value, int) and not isinstance(value, bool):
-            tv.declared_type = v2_record_pb2.INTEGER
-            tv.integer_value = value
-        elif isinstance(value, float):
-            tv.declared_type = (
-                v2_record_pb2.FLOAT32 if type_hint == "float32" else v2_record_pb2.FLOAT
-            )
-            if type_hint == "float32":
-                tv.float32_value = value
-            else:
-                tv.float_value = value
-        elif isinstance(value, (bytes, bytearray, memoryview)):
-            tv.declared_type = v2_record_pb2.BINARY
-            tv.binary_value = bytes(value)
-        elif isinstance(value, str):
-            tv.declared_type = (
-                v2_record_pb2.SYMBOL if type_hint == "symbol" else v2_record_pb2.TEXT
-            )
-            if type_hint == "symbol":
-                tv.symbol_value = value
-            else:
-                tv.text_value = value
-        elif isinstance(value, (list, tuple)):
-            tv.declared_type = v2_record_pb2.ARRAY_ANY
-            tv.array_value.values.extend(
-                self._python_to_v2_typed_value(item) for item in value
-            )
-        elif isinstance(value, dict):
-            tv.declared_type = v2_record_pb2.JSONB
-            tv.jsonb_value = json.dumps(value, separators=(",", ":")).encode("utf-8")
-        else:
-            tv.declared_type = v2_record_pb2.TEXT
-            tv.text_value = str(value)
-        return tv
+        Thin delegate to the transport-agnostic codec shared with the
+        native-async gRPC client (``protocols/_grpc_v2_codec``).
+        """
+        return _codec.python_to_v2_typed_value(v2_record_pb2, value)
 
     def _v2_typed_value_to_python(self, value: Any) -> Any:
-        """Decode v2 TypedValue protobufs into Python values."""
-        which = value.WhichOneof("value")
-        if which in (None, "is_null"):
-            return None
-        if which == "text_value":
-            return value.text_value
-        if which == "integer_value":
-            return value.integer_value
-        if which == "float_value":
-            return value.float_value
-        if which == "boolean_value":
-            return value.boolean_value
-        if which == "timestamp_value":
-            return value.timestamp_value
-        if which == "date_value":
-            return value.date_value
-        if which == "time_value":
-            return value.time_value
-        if which == "duration_value":
-            return value.duration_value
-        if which == "uuid_value":
-            return bytes(value.uuid_value).hex()
-        if which == "binary_value":
-            return bytes(value.binary_value)
-        if which == "json_value":
-            try:
-                return json.loads(value.json_value)
-            except json.JSONDecodeError:
-                return value.json_value
-        if which == "jsonb_value":
-            try:
-                return json.loads(bytes(value.jsonb_value).decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                return bytes(value.jsonb_value)
-        if which == "array_value":
-            return [
-                self._v2_typed_value_to_python(item)
-                for item in value.array_value.values
-            ]
-        if which == "map_value":
-            return {
-                key: self._v2_typed_value_to_python(item)
-                for key, item in value.map_value.entries.items()
-            }
-        if which == "struct_value":
-            return {
-                key: self._v2_typed_value_to_python(item)
-                for key, item in value.struct_value.entries.items()
-            }
-        if which == "float32_value":
-            return value.float32_value
-        if which.endswith("_array"):
-            return list(getattr(value, which).values)
-        return getattr(value, which)
+        """Decode v2 TypedValue protobufs into Python values (shared codec)."""
+        return _codec.v2_typed_value_to_python(value)
 
     def _normalize_vector_alias_records(
         self, vectors: list[dict[str, Any] | Any]
@@ -1087,107 +990,12 @@ class ProximaDBSyncGrpcClient:
     def _record_proto_for_grpc(
         self, record: ProximaRecord | dict[str, Any], index: int = 0
     ):
-        if v2_record_pb2 is None:
-            raise ProximaDBError("v2 record protobuf stubs not available")
-
-        if hasattr(record, "model_dump"):
-            record = record.model_dump(exclude_none=True)
-        elif hasattr(record, "dict"):
-            record = record.dict(exclude_none=True)
-        if not isinstance(record, dict):
-            raise TypeError(f"Unsupported record input: {type(record)!r}")
-
-        vector = record.get("vector")
-        if vector is None and record.get("embeddings"):
-            first_embedding = record["embeddings"][0]
-            vector = (
-                first_embedding.get("values")
-                if isinstance(first_embedding, dict)
-                else first_embedding
-            )
-        if vector is None:
-            raise ValueError("record is missing vector")
-
-        proto = v2_record_pb2.ProximaRecord()
-        proto.id = str(record.get("id") or record.get("oid") or f"record_{index}")
-        proto.vector.extend(float(v) for v in vector)
-        if record.get("vector_dimension") is not None:
-            proto.vector_dimension = int(record["vector_dimension"])
-
-        for source in ("props", "metadata", "flexible_fields"):
-            values = record.get(source)
-            if isinstance(values, dict):
-                for key, value in values.items():
-                    proto.props[str(key)].CopyFrom(
-                        self._python_to_v2_typed_value(value)
-                    )
-
-        typed_fields = record.get("typed_fields")
-        if isinstance(typed_fields, dict):
-            for key, value in typed_fields.items():
-                if hasattr(value, "model_dump"):
-                    value = value.model_dump(exclude_none=True)
-                if isinstance(value, dict) and "value" in value:
-                    value = {
-                        "type": value.get("value_type") or value.get("type"),
-                        "value": value["value"],
-                    }
-                proto.props[str(key)].CopyFrom(self._python_to_v2_typed_value(value))
-
-        for text_field in record.get("text_fields") or []:
-            if hasattr(text_field, "model_dump"):
-                text_field = text_field.model_dump(exclude_none=True)
-            if isinstance(text_field, dict):
-                proto.text_fields.add(
-                    name=str(text_field.get("name") or ""),
-                    content=str(text_field.get("content") or ""),
-                    storage_hint=str(text_field.get("storage_hint") or ""),
-                    chunk_count=int(text_field.get("chunk_count") or 0),
-                    chunk_reference=str(text_field.get("chunk_reference") or ""),
-                )
-
-        if record.get("timestamp_ms") is not None:
-            proto.timestamp_ms = int(record["timestamp_ms"])
-        for field in (
-            "updated_at_ms",
-            "expires_at_ms",
-            "version",
-            "source",
-            "source_type",
-            "schema_id",
-            "partition_key",
-            "created_by",
-            "updated_by",
-        ):
-            if record.get(field) is not None:
-                setattr(proto, field, record[field])
-        if isinstance(record.get("partition_values"), dict):
-            proto.partition_values.update(
-                {str(k): str(v) for k, v in record["partition_values"].items()}
-            )
-        if isinstance(record.get("custom_metadata"), dict):
-            proto.custom_metadata.update(
-                {str(k): str(v) for k, v in record["custom_metadata"].items()}
-            )
-        return proto
+        """Build a v2 ProximaRecord proto (shared transport-agnostic codec)."""
+        return _codec.record_proto_for_grpc(v2_record_pb2, record, index)
 
     def _v2_record_batch_result(self, response) -> BatchResult:
-        errors = [
-            f"{error.record_id or error.record_index}: {error.error_message}"
-            for error in response.errors
-        ]
-        return BatchResult(
-            total=int(response.total_processed),
-            success=int(response.success_count),
-            failed=int(response.failed_count),
-            errors=errors,
-            metrics=OperationMetrics(
-                total_processed=int(response.total_processed),
-                successful_count=int(response.success_count),
-                failed_count=int(response.failed_count),
-                processing_time_us=int(response.processing_time_us),
-            ),
-        )
+        """Parse a v2 batch result into a BatchResult (shared codec)."""
+        return _codec.v2_record_batch_result(response)
 
     def insert_records(
         self,

--- a/clients/python/src/proximadb_sdk/unified_client_async.py
+++ b/clients/python/src/proximadb_sdk/unified_client_async.py
@@ -11,6 +11,14 @@ The async ops mirror the sync facade (``unified_client.py`` /
 ``protocols/_rest_codegen``), which calls the generated ``asyncio_detailed``
 functions exactly as the sync path uses the generated ``sync``/``_get_kwargs``.
 
+When a gRPC endpoint is configured (``protocol=grpc`` or ``auto`` with grpc
+available), the record core ops (insert/upsert/delete/search/get_vector) are
+routed to the **native-async** ``grpc.aio`` client
+(``protocols/grpc_async.ProximaDBAsyncGrpcClient``) — mirroring how the sync
+``unified_client.py`` prefers gRPC over REST for these ops — otherwise they use
+the generated async-REST transport. Collection CRUD always uses the
+generated async-REST transport.
+
 Graph operations are NOT in the generated OpenAPI client; they stay on the
 hand-written ``rest_async.py`` httpx path (and async gRPC when available).
 """
@@ -39,13 +47,24 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 logger = logging.getLogger(__name__)
 
-try:
-    from .protocols.grpc_async import ProximaDBClient as GrpcAsyncClient  # type: ignore
-
-    GRPC_OK = True
-except Exception:
-    GRPC_OK = False
 from .protocols.rest_async import ProximaDBAsyncClient as RestAsyncClient
+
+
+def _grpc_available() -> bool:
+    """Lazily probe whether grpc.aio + generated v2 stubs are importable.
+
+    Kept out of module scope so ``import proximadb_sdk`` stays grpc-free (the
+    lazy gRPC boundary): the import only happens when the facade actually
+    considers the gRPC transport in ``astart``.
+    """
+    try:
+        import grpc.aio  # noqa: F401, PLC0415
+
+        from proximadb.v2 import record_pb2_grpc  # noqa: F401, PLC0415
+
+        return True
+    except Exception:
+        return False
 
 
 def _coalesce_name(raw_name: Any, collection_id: str) -> str:
@@ -89,6 +108,9 @@ class ProximaDBAsyncUnified:
 
         self._grpc = None
         self._rest = None
+        # True once the native-async gRPC channel is connected and core ops
+        # should route to it (set in astart).
+        self._use_grpc = False
         # Shared async transport for the generated REST client.
         self._async_http = None
         self._gen_client = None
@@ -109,26 +131,42 @@ class ProximaDBAsyncUnified:
             self._async_http
         )
 
-        # Graph ops: prefer async gRPC when available/selected, else async REST.
-        if self.protocol == Protocol.GRPC or (
-            self.protocol == Protocol.AUTO and GRPC_OK
-        ):
+        # Prefer the native-async gRPC channel for core record ops when grpc is
+        # selected (or auto + available) — mirrors the sync unified client's
+        # gRPC-over-REST preference. Falls back to async REST on failure.
+        want_grpc = self.protocol == Protocol.GRPC or (
+            self.protocol == Protocol.AUTO and _grpc_available()
+        )
+        if want_grpc:
             try:
-                self._grpc = GrpcAsyncClient(
+                from .protocols.grpc_async import ProximaDBAsyncGrpcClient
+
+                self._grpc = ProximaDBAsyncGrpcClient(
                     endpoint=self.grpc_endpoint, timeout=self.timeout
                 )
-                logger.info("Using async gRPC client for graph ops")
+                await self._grpc.connect()
+                self._use_grpc = True
+                logger.info("Using native-async gRPC client for core record ops")
             except Exception as e:
                 logger.warning(f"gRPC async init failed: {e}; falling back to REST")
-                self._rest = RestAsyncClient(url=self.rest_url, timeout=self.timeout)
-        else:
-            self._rest = RestAsyncClient(url=self.rest_url, timeout=self.timeout)
-            logger.info("Using async REST client for graph ops")
+                self._grpc = None
+                self._use_grpc = False
+
+        # Always stand up an async REST client too: it backs graph ops and is
+        # the fallback for core ops when gRPC is unavailable.
+        self._rest = RestAsyncClient(url=self.rest_url, timeout=self.timeout)
+        if not self._use_grpc:
+            logger.info("Using async REST client for core record ops")
         return self
 
     async def aclose(self):
+        if self._grpc is not None:
+            await self._grpc.close()
+            self._grpc = None
+            self._use_grpc = False
         if self._rest:
             await self._rest.aclose()
+            self._rest = None
         if self._async_http is not None:
             await self._async_http.aclose()
             self._async_http = None
@@ -334,7 +372,15 @@ class ProximaDBAsyncUnified:
         upsert: bool = False,
         validate_schema: bool = True,
     ) -> BatchResult:
-        """Insert records via the generated ``insert_records`` async op."""
+        """Insert records via gRPC-async when configured, else REST-async."""
+        if self._use_grpc and self._grpc is not None:
+            return await self._grpc.insert_records(
+                collection_id,
+                records,
+                upsert=upsert,
+                validate_schema=validate_schema,
+            )
+
         from .protocols import _rest_codegen_async as _gen_async
 
         body = {
@@ -386,7 +432,15 @@ class ProximaDBAsyncUnified:
         include_vector: bool = True,
         include_metadata: bool = True,
     ) -> dict[str, Any] | None:
-        """Get a single record via the generated ``get_record`` async op."""
+        """Get a single record via gRPC-async when configured, else REST-async."""
+        if self._use_grpc and self._grpc is not None:
+            return await self._grpc.get_vector(
+                collection_id,
+                vector_id,
+                include_vector=include_vector,
+                include_metadata=include_metadata,
+            )
+
         from .protocols import _rest_codegen_async as _gen_async
 
         resp = await _gen_async.get_record(
@@ -405,7 +459,16 @@ class ProximaDBAsyncUnified:
         return data
 
     async def delete_vector(self, collection_id: str, vector_id: str) -> DeleteResult:
-        """Delete a single record via the generated ``delete_record`` async op."""
+        """Delete a single record via gRPC-async when configured, else REST."""
+        if self._use_grpc and self._grpc is not None:
+            res = await self._grpc.delete_vector(collection_id, vector_id)
+            success = bool(res.get("success", False))
+            return DeleteResult(
+                success=success,
+                deleted_count=1 if success else 0,
+                errors=[],
+            )
+
         from .protocols import _rest_codegen_async as _gen_async
 
         resp = await _gen_async.delete_record(
@@ -422,7 +485,17 @@ class ProximaDBAsyncUnified:
     async def delete_vectors(
         self, collection_id: str, vector_ids: list[str]
     ) -> DeleteResult:
-        """Delete multiple records via the generated ``delete_record`` async op."""
+        """Delete multiple records: batched gRPC-async when configured, else REST."""
+        if self._use_grpc and self._grpc is not None:
+            res = await self._grpc.delete_vectors(collection_id, vector_ids)
+            deleted_count = int(res.get("deleted_count", 0))
+            failed_count = int(res.get("failed_count", 0))
+            return DeleteResult(
+                success=failed_count == 0,
+                deleted_count=deleted_count,
+                errors=([f"{failed_count} deletes failed"] if failed_count else []),
+            )
+
         deleted = 0
         errors: list[str] = []
         for vid in vector_ids:
@@ -452,9 +525,7 @@ class ProximaDBAsyncUnified:
         include_vectors: bool = False,
         include_metadata: bool = True,
     ) -> list[SearchResult]:
-        """Search via the generated ``search_records`` async op."""
-        from .protocols import _rest_codegen_async as _gen_async
-
+        """Search via gRPC-async when configured, else the REST-async op."""
         try:
             import numpy as _np
 
@@ -462,6 +533,18 @@ class ProximaDBAsyncUnified:
                 vector = vector.astype(_np.float32, copy=False).tolist()
         except Exception:
             pass
+
+        if self._use_grpc and self._grpc is not None:
+            return await self._grpc.search(
+                collection_id,
+                query_vector=list(vector),
+                top_k=top_k,
+                metadata_filters=metadata_filter,
+                include_vectors=include_vectors,
+                include_metadata=include_metadata,
+            )
+
+        from .protocols import _rest_codegen_async as _gen_async
 
         body: dict[str, Any] = {
             "vector": list(vector),

--- a/clients/python/tests/unit/test_grpc_async_native.py
+++ b/clients/python/tests/unit/test_grpc_async_native.py
@@ -1,0 +1,252 @@
+"""Native-async gRPC client tests (TD-126).
+
+These prove ``protocols/grpc_async.ProximaDBAsyncGrpcClient`` is a *genuine*
+``grpc.aio`` client (no longer a sync subclass):
+
+  * Each core op ``await``\\s the correct ``ProximaRecordServiceStub`` RPC.
+  * It builds the right v2 proto request (the shared transport-agnostic codec).
+  * It parses real v2 response protos into the SAME public return types the
+    sync client produces (BatchResult / list[SearchResult] / dict).
+  * Context-manager lifecycle: ``connect`` opens the aio channel + binds the
+    generated stub; ``close`` awaits ``channel.close()``.
+
+We mock only the stub: each RPC is an *async coroutine factory* (so the client
+must ``await`` it) that records the request proto and returns a real generated
+response proto. Real request-building and response-parsing run end to end.
+"""
+
+import pytest
+
+from proximadb.v2 import record_pb2 as pb
+from proximadb_sdk.models import BatchResult, SearchResult
+from proximadb_sdk.protocols.grpc_async import ProximaDBAsyncGrpcClient
+
+
+class _FakeUnaryCall:
+    """Awaitable returned by a fake RPC method (mimics aio MultiCallable())."""
+
+    def __init__(self, recorder, name, request, response):
+        recorder.append((name, request))
+        self._response = response
+
+    def __await__(self):
+        async def _coro():
+            return self._response
+
+        return _coro().__await__()
+
+
+class _FakeStub:
+    """Fake ProximaRecordServiceStub whose RPCs are awaitable + recorded."""
+
+    def __init__(self, responses):
+        self.calls = []  # list[(rpc_name, request_proto)]
+        self._responses = responses
+
+    def _make(self, name):
+        def _rpc(request, timeout=None):
+            return _FakeUnaryCall(self.calls, name, request, self._responses[name])
+
+        return _rpc
+
+    def __getattr__(self, name):
+        return self._make(name)
+
+
+def _batch_response(*, total, success, failed, errors=None):
+    resp = pb.ProximaRecordBatchResponse(
+        success=failed == 0,
+        total_processed=total,
+        success_count=success,
+        failed_count=failed,
+        processing_time_us=123,
+    )
+    for err in errors or []:
+        resp.errors.add(
+            record_id=err.get("record_id", ""),
+            record_index=err.get("record_index", 0),
+            error_message=err.get("error_message", ""),
+        )
+    return resp
+
+
+async def _connected_client(responses) -> ProximaDBAsyncGrpcClient:
+    """Build a client and inject a fake stub + pb2 (no real channel/grpc)."""
+    client = ProximaDBAsyncGrpcClient("localhost:5679")
+    client._stub = _FakeStub(responses)
+    client._pb2 = pb
+    # Mark connected without opening a socket.
+    client._channel = object()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_insert_records_awaits_InsertRecords_and_parses_batch():
+    stub_responses = {
+        "InsertRecords": _batch_response(total=2, success=2, failed=0),
+    }
+    client = await _connected_client(stub_responses)
+    records = [
+        {"id": "a", "vector": [1.0, 2.0], "metadata": {"k": "v"}},
+        {"id": "b", "vector": [3.0, 4.0]},
+    ]
+    result = await client.insert_records("coll", records)
+
+    # awaited the right RPC
+    assert [name for name, _ in client._stub.calls] == ["InsertRecords"]
+    _, req = client._stub.calls[0]
+    assert req.collection_id == "coll"
+    assert req.write_mode == pb.INSERT
+    assert [r.id for r in req.records] == ["a", "b"]
+    assert list(req.records[0].vector) == [1.0, 2.0]
+    # parsed to the sync return type
+    assert isinstance(result, BatchResult)
+    assert result.total == 2 and result.success == 2 and result.failed == 0
+
+
+@pytest.mark.asyncio
+async def test_upsert_records_awaits_UpsertRecords():
+    client = await _connected_client(
+        {"UpsertRecords": _batch_response(total=1, success=1, failed=0)}
+    )
+    result = await client.upsert_records("coll", [{"id": "x", "vector": [1.0]}])
+    assert [name for name, _ in client._stub.calls] == ["UpsertRecords"]
+    _, req = client._stub.calls[0]
+    assert req.write_mode == pb.UPSERT
+    assert isinstance(result, BatchResult)
+    assert result.success == 1
+
+
+@pytest.mark.asyncio
+async def test_insert_records_upsert_kwarg_routes_to_upsert():
+    client = await _connected_client(
+        {"UpsertRecords": _batch_response(total=1, success=1, failed=0)}
+    )
+    await client.insert_records("coll", [{"id": "x", "vector": [1.0]}], upsert=True)
+    assert [name for name, _ in client._stub.calls] == ["UpsertRecords"]
+
+
+@pytest.mark.asyncio
+async def test_delete_vector_awaits_DeleteRecords():
+    client = await _connected_client(
+        {"DeleteRecords": _batch_response(total=1, success=1, failed=0)}
+    )
+    res = await client.delete_vector("coll", "v1")
+    assert [name for name, _ in client._stub.calls] == ["DeleteRecords"]
+    _, req = client._stub.calls[0]
+    assert req.write_mode == pb.DELETE
+    assert [r.id for r in req.records] == ["v1"]
+    assert res["success"] is True and res["vector_id"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_delete_vectors_batch_awaits_DeleteRecords_once():
+    client = await _connected_client(
+        {"DeleteRecords": _batch_response(total=3, success=3, failed=0)}
+    )
+    res = await client.delete_vectors("coll", ["a", "b", "c"])
+    assert [name for name, _ in client._stub.calls] == ["DeleteRecords"]
+    _, req = client._stub.calls[0]
+    assert [r.id for r in req.records] == ["a", "b", "c"]
+    assert res["deleted_count"] == 3 and res["failed_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_search_awaits_Search_and_parses_results():
+    resp = pb.TypedSearchResponse()
+    item = resp.results.add()
+    item.id = "doc1"
+    item.score = 0.99
+    item.props["color"].text_value = "red"
+    item.props["color"].declared_type = pb.TEXT
+    client = await _connected_client({"Search": resp})
+
+    results = await client.search(
+        "coll",
+        query_vector=[0.1, 0.2],
+        top_k=5,
+        metadata_filters={"color": "red"},
+        include_metadata=True,
+    )
+    assert [name for name, _ in client._stub.calls] == ["Search"]
+    _, req = client._stub.calls[0]
+    assert req.collection_id == "coll"
+    assert req.top_k == 5
+    assert list(req.query_vector) == pytest.approx([0.1, 0.2])
+    assert req.filters[0].field_name == "color"
+    assert req.filters[0].operator == pb.EQ
+    # parsed
+    assert isinstance(results, list) and isinstance(results[0], SearchResult)
+    assert results[0].id == "doc1"
+    assert results[0].score == pytest.approx(0.99)
+    assert results[0].metadata == {"color": "red"}
+
+
+@pytest.mark.asyncio
+async def test_get_vector_awaits_GetRecord_and_parses_dict():
+    resp = pb.GetRecordResponse(found=True)
+    resp.record.id = "v1"
+    resp.record.vector.extend([1.0, 2.0, 3.0])
+    resp.record.props["n"].CopyFrom(pb.TypedValue(integer_value=7))
+    resp.record.props["n"].declared_type = pb.INTEGER
+    client = await _connected_client({"GetRecord": resp})
+
+    out = await client.get_vector("coll", "v1")
+    assert [name for name, _ in client._stub.calls] == ["GetRecord"]
+    _, req = client._stub.calls[0]
+    assert req.collection_id == "coll" and req.id == "v1"
+    assert out["id"] == "v1"
+    assert out["vector"] == [1.0, 2.0, 3.0]
+    assert out["metadata"] == {"n": 7}
+
+
+@pytest.mark.asyncio
+async def test_get_vector_not_found_raises():
+    from proximadb_sdk.exceptions import ProximaDBError
+
+    client = await _connected_client({"GetRecord": pb.GetRecordResponse(found=False)})
+    with pytest.raises(ProximaDBError):
+        await client.get_vector("coll", "missing")
+
+
+@pytest.mark.asyncio
+async def test_require_before_connect_raises():
+    from proximadb_sdk.exceptions import ProximaDBError
+
+    client = ProximaDBAsyncGrpcClient("localhost:5679")
+    with pytest.raises(ProximaDBError):
+        await client.insert_records("coll", [{"id": "x", "vector": [1.0]}])
+
+
+@pytest.mark.asyncio
+async def test_target_strips_scheme():
+    assert ProximaDBAsyncGrpcClient("http://h:5679").target == "h:5679"
+    assert ProximaDBAsyncGrpcClient("grpc://h:5679/").target == "h:5679"
+    assert ProximaDBAsyncGrpcClient("h:5679").target == "h:5679"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_connect_opens_channel_close_awaits():
+    """connect() builds a real grpc.aio channel + generated stub; close() awaits it."""
+    grpc_aio = pytest.importorskip("grpc.aio")
+    assert grpc_aio is not None
+
+    client = ProximaDBAsyncGrpcClient("localhost:5679")
+    assert client._channel is None
+    await client.connect()
+    import grpc.aio as _aio
+
+    assert isinstance(client._channel, _aio.Channel)
+    # generated stub bound on the aio channel; its RPCs are awaitable callables
+    assert client._stub is not None
+    assert isinstance(client._stub.InsertRecords, _aio.UnaryUnaryMultiCallable)
+    await client.close()
+    assert client._channel is None and client._stub is None
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_lifecycle():
+    async with ProximaDBAsyncGrpcClient("localhost:5679") as client:
+        assert client._channel is not None
+        assert client._stub is not None
+    assert client._channel is None

--- a/clients/python/tests/unit/test_unified_client_async.py
+++ b/clients/python/tests/unit/test_unified_client_async.py
@@ -2,19 +2,25 @@ import pytest
 
 
 class FakeGrpcAsync:
+    """Fake native-async gRPC client (records core-op + lifecycle calls).
+
+    Mirrors the post-TD-126 ``ProximaDBAsyncGrpcClient`` surface: it has
+    ``connect``/``close`` and the record core ops, but NO graph methods (graph
+    always goes REST in the new design).
+    """
+
     def __init__(self, endpoint: str, timeout: float = 60.0):
         self.endpoint = endpoint
         self.timeout = timeout
         self.calls = []
+        self.closed = False
 
-    def shortest_path(self, *args, **kwargs):
-        self.calls.append(("shortest_path", args, kwargs))
+    async def connect(self):
+        self.calls.append(("connect",))
+        return self
 
-        class R:
-            node_ids = ["n1", "n8"]
-            total_weight = 1.0
-
-        return R()
+    async def close(self):
+        self.closed = True
 
 
 class FakeRestAsync:
@@ -37,44 +43,54 @@ class FakeRestAsync:
 
 @pytest.mark.asyncio
 async def test_unified_async_uses_grpc_when_available(monkeypatch):
+    """auto + grpc available: native-async gRPC connected for core ops; graph=REST."""
+    import proximadb_sdk.protocols.grpc_async as ga
     import proximadb_sdk.unified_client_async as m
     from proximadb_sdk.unified_client_async import ProximaDBAsyncUnified
 
-    monkeypatch.setattr(m, "GRPC_OK", True)
-    monkeypatch.setattr(m, "GrpcAsyncClient", FakeGrpcAsync)
+    monkeypatch.setattr(m, "_grpc_available", lambda: True)
+    monkeypatch.setattr(ga, "ProximaDBAsyncGrpcClient", FakeGrpcAsync)
     monkeypatch.setattr(m, "RestAsyncClient", FakeRestAsync)
 
     client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="auto")
     await client.astart()
+    # Native-async gRPC connected and selected for core ops.
+    assert client._use_grpc is True
+    assert isinstance(client._grpc, FakeGrpcAsync)
+    assert ("connect",) in client._grpc.calls
+    # Graph ops always go over the async REST client (no graph on the new
+    # native-async gRPC client).
     resp_sp = await client.graph_shortest_path(
         "n1", "n8", enable_prefetch=True, prefetch_budget=3
     )
-    assert getattr(resp_sp, "node_ids", None) == ["n1", "n8"]
-    # Traversal goes REST; ensure _rest is available (inject if gRPC path selected)
-    if client._rest is None:
-        client._rest = FakeRestAsync(url="http://localhost:5678")
+    assert resp_sp["ok"] is True
     resp_tr = await client.graph_traverse(
         "n1", max_depth=2, enable_prefetch=True, prefetch_budget=3
     )
     assert resp_tr["ok"] is True
     await client.aclose()
+    assert client._grpc is None  # aclose awaited grpc.close()
 
 
 @pytest.mark.asyncio
 async def test_unified_async_fallback_to_rest_on_failure(monkeypatch):
+    """gRPC connect failure: facade falls back to REST core ops (no _use_grpc)."""
+    import proximadb_sdk.protocols.grpc_async as ga
     import proximadb_sdk.unified_client_async as m
     from proximadb_sdk.unified_client_async import ProximaDBAsyncUnified
 
     class FailingGrpc(FakeGrpcAsync):
-        def __init__(self, *a, **k):
-            raise RuntimeError("init failed")
+        async def connect(self):
+            raise RuntimeError("connect failed")
 
-    monkeypatch.setattr(m, "GRPC_OK", True)
-    monkeypatch.setattr(m, "GrpcAsyncClient", FailingGrpc)
+    monkeypatch.setattr(m, "_grpc_available", lambda: True)
+    monkeypatch.setattr(ga, "ProximaDBAsyncGrpcClient", FailingGrpc)
     monkeypatch.setattr(m, "RestAsyncClient", FakeRestAsync)
 
     client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="auto")
     await client.astart()
+    assert client._use_grpc is False  # fell back to REST
+    assert client._grpc is None
     resp_sp = await client.graph_shortest_path("n1", "n8")
     assert resp_sp["ok"] is True
     await client.aclose()

--- a/clients/python/tests/unit/test_unified_client_async_grpc_routing.py
+++ b/clients/python/tests/unit/test_unified_client_async_grpc_routing.py
@@ -1,0 +1,152 @@
+"""Facade routing tests: ProximaDBAsyncUnified routes core ops to gRPC-async.
+
+When a gRPC endpoint is configured, the async facade must dispatch core record
+ops (insert/upsert/delete/search/get_vector) to the native-async gRPC client
+(mirroring the sync unified client's gRPC-over-REST preference) and NOT to the
+generated async-REST path. We inject a fake async gRPC client (so no socket /
+event-loop-blocking call runs) and assert the right coroutine is awaited with
+the right arguments, and that the public return types match.
+"""
+
+import pytest
+
+from proximadb_sdk.models import (
+    BatchResult,
+    DeleteResult,
+    OperationMetrics,
+    SearchResult,
+)
+from proximadb_sdk.unified_client_async import ProximaDBAsyncUnified
+
+
+class _FakeAsyncGrpc:
+    """Records awaited core-op calls; returns sync-equivalent values."""
+
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    async def insert_records(self, collection_id, records, **kw):
+        self.calls.append(("insert_records", collection_id, records, kw))
+        return BatchResult(
+            total=len(records),
+            success=len(records),
+            failed=0,
+            errors=[],
+            metrics=OperationMetrics(
+                total_processed=len(records),
+                successful_count=len(records),
+                failed_count=0,
+            ),
+        )
+
+    async def upsert_records(self, collection_id, records, **kw):
+        self.calls.append(("upsert_records", collection_id, records, kw))
+        return BatchResult(total=1, success=1, failed=0, errors=[])
+
+    async def search(self, collection_id, **kw):
+        self.calls.append(("search", collection_id, kw))
+        return [SearchResult(id="x", score=1.0, rank=1)]
+
+    async def get_vector(self, collection_id, vector_id, **kw):
+        self.calls.append(("get_vector", collection_id, vector_id, kw))
+        return {"id": vector_id, "vector": [1.0]}
+
+    async def delete_vector(self, collection_id, vector_id):
+        self.calls.append(("delete_vector", collection_id, vector_id))
+        return {"status": "deleted", "vector_id": vector_id, "success": True}
+
+    async def delete_vectors(self, collection_id, vector_ids):
+        self.calls.append(("delete_vectors", collection_id, vector_ids))
+        return {
+            "status": "completed",
+            "deleted_count": len(vector_ids),
+            "failed_count": 0,
+            "total_requested": len(vector_ids),
+        }
+
+    async def close(self):
+        self.closed = True
+
+
+def _grpc_facade():
+    """Facade with a fake gRPC-async client wired in (no astart / no socket)."""
+    client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="grpc")
+    fake = _FakeAsyncGrpc()
+    client._grpc = fake
+    client._use_grpc = True
+    return client, fake
+
+
+@pytest.mark.asyncio
+async def test_insert_routes_to_grpc_async():
+    client, fake = _grpc_facade()
+    res = await client.insert_records("coll", [{"id": "a", "vector": [1.0]}])
+    assert fake.calls[0][0] == "insert_records"
+    assert isinstance(res, BatchResult) and res.success == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_routes_to_grpc_async_as_insert_upsert():
+    client, fake = _grpc_facade()
+    await client.upsert_records("coll", [{"id": "a", "vector": [1.0]}])
+    # upsert_records -> insert_records(upsert=True) -> grpc.insert_records(upsert=True)
+    assert fake.calls[0][0] == "insert_records"
+    assert fake.calls[0][3].get("upsert") is True
+
+
+@pytest.mark.asyncio
+async def test_search_routes_to_grpc_async():
+    client, fake = _grpc_facade()
+    res = await client.search("coll", [0.1, 0.2], top_k=3, metadata_filter={"k": "v"})
+    assert fake.calls[0][0] == "search"
+    kw = fake.calls[0][2]
+    assert kw["top_k"] == 3
+    assert kw["metadata_filters"] == {"k": "v"}
+    assert isinstance(res, list) and isinstance(res[0], SearchResult)
+
+
+@pytest.mark.asyncio
+async def test_get_vector_routes_to_grpc_async():
+    client, fake = _grpc_facade()
+    out = await client.get_vector("coll", "v1")
+    assert fake.calls[0][0] == "get_vector"
+    assert out["id"] == "v1"
+
+
+@pytest.mark.asyncio
+async def test_delete_vector_routes_to_grpc_async_returns_DeleteResult():
+    client, fake = _grpc_facade()
+    res = await client.delete_vector("coll", "v1")
+    assert fake.calls[0][0] == "delete_vector"
+    assert isinstance(res, DeleteResult) and res.success and res.deleted_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_vectors_routes_to_grpc_batch():
+    client, fake = _grpc_facade()
+    res = await client.delete_vectors("coll", ["a", "b"])
+    assert fake.calls[0][0] == "delete_vectors"
+    assert isinstance(res, DeleteResult) and res.deleted_count == 2 and res.success
+
+
+@pytest.mark.asyncio
+async def test_rest_path_used_when_grpc_disabled():
+    """When _use_grpc is False, core ops do NOT touch the gRPC client."""
+    client = ProximaDBAsyncUnified(url="http://localhost:5678", protocol="rest")
+    fake = _FakeAsyncGrpc()
+    client._grpc = fake
+    client._use_grpc = False
+    # require_gen_client guards: not started, so this raises (REST path taken,
+    # NOT the gRPC client) — proving routing keyed on _use_grpc.
+    with pytest.raises(RuntimeError):
+        await client.insert_records("coll", [{"id": "a", "vector": [1.0]}])
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_aclose_awaits_grpc_close():
+    client, fake = _grpc_facade()
+    await client.aclose()
+    assert fake.closed is True
+    assert client._grpc is None and client._use_grpc is False

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -12,9 +12,16 @@ Phase 3 done (Python `chunking`, `embeddings`, and `integrations`/`adapters` con
 opt-in + lazy behind extras — `import proximadb_sdk` pulls zero heavy deps; core =
 transport+facade+models); remaining-ops re-base done (2026-06-22 — graph/health/observability/meta
 ops routed through the generated client across Go/TS/Rust/Python, contract tests kept);
-Python native-async core ops done (2026-06-22 — `ProximaDBAsyncUnified` wires the generated
-`asyncio_detailed` for collections CRUD + records insert/upsert/get/delete + search behind a
-shared `httpx.AsyncClient`, drift-gated; async gRPC deferred); Phase 5 +
+Python native-async client done (2026-06-22 — `ProximaDBAsyncUnified` covers BOTH transports:
+the generated `asyncio_detailed` REST path for collections CRUD + records insert/upsert/get/delete
++ search behind a shared `httpx.AsyncClient`, AND a *genuine* `grpc.aio` client
+(`protocols/grpc_async.ProximaDBAsyncGrpcClient`) for the record core ops — the prior
+sync-subclass fake is gone. The async gRPC client reuses the EXISTING generated v2
+`ProximaRecordServiceStub` on a `grpc.aio` channel (channel-agnostic stubs → awaitable RPCs;
+no proto/stub regen) and the transport-agnostic proto codec now shared with the sync client
+(`protocols/_grpc_v2_codec`). The facade prefers gRPC-async for core ops when a gRPC endpoint is
+configured (mirroring the sync `unified_client`), else REST-async; `astart`/`aclose` manage both
+the httpx AsyncClient and the aio channel; lazy gRPC import boundary intact); Phase 5 +
 remaining Phase-4 languages (jvm) + generating the facades themselves open +
 Date: 2026-06-21 (updated 2026-06-22) +
 Owner: SDK / API surface


### PR DESCRIPTION
## Summary

Replaces the **fake** async gRPC client (`grpc_async.ProximaDBClient(ProximaDBSyncGrpcClient)` — a blocking sync subclass) with a **genuine `grpc.aio` client**, completing TD-126's native-async story: `ProximaDBAsyncUnified` now covers BOTH transports (async-REST from #240 + async-gRPC here).

## What changed

**`protocols/grpc_async.py` — real `grpc.aio` client (`ProximaDBAsyncGrpcClient`)**
- Builds a `grpc.aio.insecure_channel`/`secure_channel`, instantiates the **existing generated** `proximadb.v2.record_pb2_grpc.ProximaRecordServiceStub` on it, and `await`s each RPC. The generated stubs are channel-agnostic, so their RPC methods are awaitable on an aio channel — **no proto/stub regeneration**.
- Async record core ops over gRPC: `insert_records`, `upsert_records`, `delete_vector`/`delete_vectors`, `search`, `get_vector` (plus `insert_vectors` alias). Async `connect`/`close` lifecycle (`await channel.close()`) + async context manager.

**`protocols/_grpc_v2_codec.py` (new) — shared transport-agnostic proto codec**
- Extracted the pure proto build/parse converters (`record_proto_for_grpc`, `python_to_v2_typed_value`, `v2_typed_value_to_python`, `v2_record_batch_result`, `search_results_from_proto`) so the wire mapping is defined once. `grpc_sync.py` now delegates to it — no copy-pasted mapping, sync behavior unchanged (its converter-based tests still pass).

**`unified_client_async.py` — wire gRPC-async alongside async-REST**
- The facade prefers gRPC-async for core ops when a gRPC endpoint is configured (`protocol=grpc`, or `auto` + grpc available), mirroring the sync `unified_client`'s gRPC-over-REST preference; else REST-async. Collections + graph stay on the REST/codegen paths.
- `astart` opens BOTH the httpx `AsyncClient` (REST) and the aio channel (gRPC); `aclose` awaits both.

## Constraints honored
- No proto / `_generated/` / generated-stub edits (reused existing stubs over an aio channel).
- Lazy gRPC boundary intact: all `grpc`/proto imports in the new/changed async modules are function-local (the pre-existing package-level `import grpc` via `client_v1.py` is unchanged and not mine).
- Sync gRPC + REST paths untouched in behavior.

## Tests (mock-based, offline)
- `test_grpc_async_native.py` — each async op awaits the right `ProximaRecordServiceStub` RPC, builds the right v2 proto request, and parses real v2 response protos into the same return types as the sync path; aio channel lifecycle (connect opens / close awaits); not-connected guard.
- `test_unified_client_async_grpc_routing.py` — facade dispatches core ops to gRPC-async when `_use_grpc`, returns the public types, `aclose` awaits gRPC close; REST path when disabled.
- `test_unified_client_async.py` — updated the two pre-#240 graph tests to the new architecture (gRPC connected for core ops, graph over REST, fallback on connect failure).
- black/isort/ruff(E9,F63,F7)/py_compile clean. All other test failures in the gRPC/graph suites are **pre-existing on develop** (verified by running them against HEAD versions of the touched files — identical failure set).

Updates TD-126 (Python native-async client now covers both transports; genuine async gRPC done).