### PR TITLE
feat(grpc): proximadb.v2.ProximaDocumentService — document CRUD on the neutral model (TD-122)

### DIFF
--- a/crates/foundation/proximadb-proto/build.rs
+++ b/crates/foundation/proximadb-proto/build.rs
@@ -28,19 +28,21 @@ fn main() {
     // single generated `proximadb.v2.rs`.
     let record_proto = repo_root.join("proto/proximadb/v2/record.proto");
     let graph_proto = repo_root.join("proto/proximadb/v2/graph.proto");
+    let document_proto = repo_root.join("proto/proximadb/v2/document.proto");
     let include = repo_root.join("proto");
     let out_dir = manifest_dir.join("src/proto");
 
     println!(
-        "cargo:warning=regenerating {} + {} -> {}",
+        "cargo:warning=regenerating {} + {} + {} -> {}",
         record_proto.display(),
         graph_proto.display(),
+        document_proto.display(),
         out_dir.display()
     );
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .out_dir(&out_dir)
-        .compile_protos(&[record_proto, graph_proto], &[include])
+        .compile_protos(&[record_proto, graph_proto, document_proto], &[include])
         .expect("v2 proto codegen failed");
 }

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -5840,3 +5840,541 @@ pub mod proxima_graph_service_server {
         const NAME: &'static str = SERVICE_NAME;
     }
 }
+/// A document: a collection-scoped, versioned bag of ProximaValue-typed fields.
+/// `props` is the document body; each value is a `TypedValue` (nested objects use
+/// the `TypedValueMap`/`array_value` variants), so the full ProximaValue type
+/// system round-trips without loss.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Document {
+    #[prost(string, tag = "1")]
+    pub collection_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(map = "string, message", tag = "3")]
+    pub props: ::std::collections::HashMap<::prost::alloc::string::String, TypedValue>,
+    #[prost(uint64, tag = "4")]
+    pub version: u64,
+    #[prost(string, optional, tag = "5")]
+    pub schema_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "6")]
+    pub document_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int64, tag = "7")]
+    pub updated_at_ms: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateDocumentRequest {
+    #[prost(string, tag = "1")]
+    pub collection_id: ::prost::alloc::string::String,
+    /// Optional client-supplied id; the server generates a UUID when empty.
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(map = "string, message", tag = "3")]
+    pub props: ::std::collections::HashMap<::prost::alloc::string::String, TypedValue>,
+    #[prost(string, optional, tag = "4")]
+    pub schema_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "5")]
+    pub document_type: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DocumentResponse {
+    #[prost(message, optional, tag = "1")]
+    pub document: ::core::option::Option<Document>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetDocumentRequest {
+    #[prost(string, tag = "1")]
+    pub collection_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DeleteDocumentRequest {
+    #[prost(string, tag = "1")]
+    pub collection_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DeleteDocumentResponse {
+    #[prost(bool, tag = "1")]
+    pub deleted: bool,
+}
+/// Generated client implementations.
+pub mod proxima_document_service_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct ProximaDocumentServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProximaDocumentServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProximaDocumentServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProximaDocumentServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            ProximaDocumentServiceClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Document CRUD (first slice). Query/update/aggregate are deferred follow-ups,
+        /// mirroring how the graph service staged its advanced RPCs (TD-124).
+        pub async fn create_document(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DocumentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaDocumentService/CreateDocument",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "proximadb.v2.ProximaDocumentService",
+                        "CreateDocument",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_document(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DocumentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaDocumentService/GetDocument",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("proximadb.v2.ProximaDocumentService", "GetDocument"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn delete_document(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteDocumentResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaDocumentService/DeleteDocument",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "proximadb.v2.ProximaDocumentService",
+                        "DeleteDocument",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod proxima_document_service_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ProximaDocumentServiceServer.
+    #[async_trait]
+    pub trait ProximaDocumentService: std::marker::Send + std::marker::Sync + 'static {
+        /// Document CRUD (first slice). Query/update/aggregate are deferred follow-ups,
+        /// mirroring how the graph service staged its advanced RPCs (TD-124).
+        async fn create_document(
+            &self,
+            request: tonic::Request<super::CreateDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DocumentResponse>,
+            tonic::Status,
+        >;
+        async fn get_document(
+            &self,
+            request: tonic::Request<super::GetDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DocumentResponse>,
+            tonic::Status,
+        >;
+        async fn delete_document(
+            &self,
+            request: tonic::Request<super::DeleteDocumentRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::DeleteDocumentResponse>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct ProximaDocumentServiceServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> ProximaDocumentServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for ProximaDocumentServiceServer<T>
+    where
+        T: ProximaDocumentService,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/proximadb.v2.ProximaDocumentService/CreateDocument" => {
+                    #[allow(non_camel_case_types)]
+                    struct CreateDocumentSvc<T: ProximaDocumentService>(pub Arc<T>);
+                    impl<
+                        T: ProximaDocumentService,
+                    > tonic::server::UnaryService<super::CreateDocumentRequest>
+                    for CreateDocumentSvc<T> {
+                        type Response = super::DocumentResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CreateDocumentRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaDocumentService>::create_document(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = CreateDocumentSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaDocumentService/GetDocument" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetDocumentSvc<T: ProximaDocumentService>(pub Arc<T>);
+                    impl<
+                        T: ProximaDocumentService,
+                    > tonic::server::UnaryService<super::GetDocumentRequest>
+                    for GetDocumentSvc<T> {
+                        type Response = super::DocumentResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetDocumentRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaDocumentService>::get_document(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetDocumentSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaDocumentService/DeleteDocument" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteDocumentSvc<T: ProximaDocumentService>(pub Arc<T>);
+                    impl<
+                        T: ProximaDocumentService,
+                    > tonic::server::UnaryService<super::DeleteDocumentRequest>
+                    for DeleteDocumentSvc<T> {
+                        type Response = super::DeleteDocumentResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteDocumentRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaDocumentService>::delete_document(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DeleteDocumentSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for ProximaDocumentServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "proximadb.v2.ProximaDocumentService";
+    impl<T> tonic::server::NamedService for ProximaDocumentServiceServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}

--- a/proto/proximadb/v2/document.proto
+++ b/proto/proximadb/v2/document.proto
@@ -1,0 +1,68 @@
+// ProximaDB v2 Document service.
+//
+// Self-contained `proximadb.v2` surface for the document modality, mirroring the
+// graph (`graph.proto`) and record (`record.proto`) v2 services. The document
+// body is carried as the canonical v2 `TypedValue` (full ProximaValue coverage)
+// — NOT the legacy v1 `SqlValue` — so decimals, timestamps, UUIDs, and vectors
+// survive losslessly. The server maps these messages to the neutral, ProximaTree
+// -native `DocumentRecord` only at the handler boundary; the engine never sees a
+// wire type. Tenant isolation is structural (the `x-tenant-id` header namespaces
+// the collection), never a per-request predicate.
+//
+// To regenerate the committed stubs after editing this file:
+//   PROXIMADB_REGEN_PROTO=1 cargo build -p proximadb-proto
+
+syntax = "proto3";
+
+package proximadb.v2;
+
+import "proximadb/v2/record.proto"; // TypedValue — the canonical v2 value type
+
+// A document: a collection-scoped, versioned bag of ProximaValue-typed fields.
+// `props` is the document body; each value is a `TypedValue` (nested objects use
+// the `TypedValueMap`/`array_value` variants), so the full ProximaValue type
+// system round-trips without loss.
+message Document {
+  string collection_id = 1;
+  string id = 2;
+  map<string, TypedValue> props = 3;
+  uint64 version = 4;
+  optional string schema_id = 5;
+  optional string document_type = 6;
+  int64 updated_at_ms = 7;
+}
+
+message CreateDocumentRequest {
+  string collection_id = 1;
+  // Optional client-supplied id; the server generates a UUID when empty.
+  string id = 2;
+  map<string, TypedValue> props = 3;
+  optional string schema_id = 4;
+  optional string document_type = 5;
+}
+
+message DocumentResponse {
+  Document document = 1;
+}
+
+message GetDocumentRequest {
+  string collection_id = 1;
+  string id = 2;
+}
+
+message DeleteDocumentRequest {
+  string collection_id = 1;
+  string id = 2;
+}
+
+message DeleteDocumentResponse {
+  bool deleted = 1;
+}
+
+service ProximaDocumentService {
+  // Document CRUD (first slice). Query/update/aggregate are deferred follow-ups,
+  // mirroring how the graph service staged its advanced RPCs (TD-124).
+  rpc CreateDocument(CreateDocumentRequest) returns (DocumentResponse);
+  rpc GetDocument(GetDocumentRequest) returns (DocumentResponse);
+  rpc DeleteDocument(DeleteDocumentRequest) returns (DeleteDocumentResponse);
+}

--- a/src/network/grpc/v2/document_service.rs
+++ b/src/network/grpc/v2/document_service.rs
@@ -1,0 +1,284 @@
+// Copyright 2025 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! gRPC V2 native document service implementation.
+//!
+//! Canonical `proximadb.v2.ProximaDocumentService` surface, mirroring the graph
+//! (`graph_service.rs`) and record (`record_service.rs`) v2 services.
+//!
+//! ## Design
+//!
+//! - **ProximaValue-native wire, never `SqlValue`.** The document body is carried
+//!   as the canonical v2 [`pv2::TypedValue`] (full ProximaValue coverage), so the
+//!   rich type system — decimals, timestamps, UUIDs, vectors — round-trips
+//!   losslessly. The v1 `SqlValue` envelope (and its lossy conversions) never
+//!   appears on this path. See the design note in
+//!   `neutral_type_and_map_policy` and the `conv` helpers below.
+//! - **Neutral internal model.** Handlers map v2 messages to the neutral,
+//!   ProximaTree-native [`DocumentRecord`] at the boundary only, then call the
+//!   shared [`DocumentService`] via its `DocumentRecord`-native entry point
+//!   (`insert_document_record`) — the engine never sees a wire type. This is the
+//!   document analog of the graph neutral model.
+//! - **Structural tenant isolation.** Each handler folds the request tenant
+//!   (`x-tenant-id` / auth context) into the backing collection key via
+//!   [`grpc_auth::tenant_id`]; isolation is a namespace on the storage key, never
+//!   a per-request predicate.
+//!
+//! ## Deferred RPCs
+//!
+//! The first surface ships document CRUD (create / get / delete). Query, update,
+//! and aggregate are deferred follow-ups, mirroring how the graph service staged
+//! its advanced RPCs (TD-124).
+
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+use tracing::{debug, error};
+
+use crate::api_handlers::UnifiedHandlers;
+use crate::network::grpc::auth as grpc_auth;
+use crate::proto::proximadb_v2 as pv2;
+use crate::proto::proximadb_v2::proxima_document_service_server::{
+    ProximaDocumentService, ProximaDocumentServiceServer,
+};
+use crate::storage::document::{DocumentRecord, DocumentService};
+
+/// gRPC V2 native document service.
+pub struct ProximaDocumentServiceImpl {
+    /// The shared document backing service — held directly (rather than the whole
+    /// `UnifiedHandlers`) so the service is constructible in tests from a
+    /// standalone `DocumentService`.
+    documents: Arc<DocumentService>,
+}
+
+impl ProximaDocumentServiceImpl {
+    /// Create a new service over the shared unified handlers (production wiring).
+    pub fn new(request_handlers: Arc<UnifiedHandlers>) -> Self {
+        Self {
+            documents: request_handlers.document_service.clone(),
+        }
+    }
+
+    /// Convert to a tonic server.
+    pub fn into_server(self) -> ProximaDocumentServiceServer<Self> {
+        ProximaDocumentServiceServer::new(self)
+    }
+
+    /// Derive the effective backing collection namespace from the request tenant.
+    ///
+    /// Isolation is structural: the tenant is folded into the storage key, never
+    /// applied as a per-query predicate. Embedded / unauthenticated calls (no
+    /// tenant) fall back to the raw `collection_id`.
+    fn effective_collection_id<T>(request: &Request<T>, collection_id: &str) -> String {
+        match grpc_auth::tenant_id(request) {
+            Some(tenant) if !tenant.is_empty() => format!("{tenant}::{collection_id}"),
+            _ => collection_id.to_string(),
+        }
+    }
+}
+
+// ============================================================================
+// v2 <-> neutral type mapping — handler boundary only. ProximaValue-native; the
+// legacy v1 `SqlValue` is never touched on this path.
+// ============================================================================
+mod conv {
+    use super::pv2;
+    use std::collections::HashMap;
+    use tonic::Status;
+
+    use proximadb_records::proto_v2::{proxima_value_to_typed_value, typed_value_to_proxima};
+    use proximadb_records::{ProximaTree, ProximaTreeNode};
+
+    use crate::core::search::sql_value_filter::proxima_tree_to_value_map;
+    use crate::storage::document::DocumentRecord;
+
+    /// v2 wire props (`TypedValue` map) -> neutral [`ProximaTree`]. Each field
+    /// becomes a `Value` node; nested objects ride inside the `ProximaValue`
+    /// (`TypedValueMap` -> `ProximaValue::Map`/`Struct`), matching the record
+    /// service convention. Lossless — never detours through v1 `SqlValue`.
+    pub fn props_to_tree(props: &HashMap<String, pv2::TypedValue>) -> Result<ProximaTree, Status> {
+        props
+            .iter()
+            .map(|(k, tv)| {
+                typed_value_to_proxima(tv)
+                    .map(|pv| (k.clone(), ProximaTreeNode::Value(pv)))
+                    .map_err(|e| Status::invalid_argument(format!("field '{k}': {e}")))
+            })
+            .collect()
+    }
+
+    /// neutral [`ProximaTree`] -> v2 wire props (`TypedValue` map). Nested objects
+    /// are preserved as `ProximaValue::Struct` by `proxima_tree_to_value_map`.
+    pub fn tree_to_props(tree: &ProximaTree) -> HashMap<String, pv2::TypedValue> {
+        proxima_tree_to_value_map(tree)
+            .iter()
+            .map(|(k, pv)| (k.clone(), proxima_value_to_typed_value(pv)))
+            .collect()
+    }
+
+    /// neutral [`DocumentRecord`] -> v2 `Document` wire message.
+    pub fn record_to_v2(record: &DocumentRecord) -> pv2::Document {
+        pv2::Document {
+            collection_id: record.collection_id.clone(),
+            id: record.id.clone(),
+            props: tree_to_props(&record.props),
+            version: record.version,
+            schema_id: record.schema_id.clone(),
+            document_type: record.document_type.clone(),
+            updated_at_ms: record.updated_at_ns / 1_000_000,
+        }
+    }
+}
+
+/// Map a backing-service error onto a gRPC status, inferring the code from the
+/// error message (mirrors the graph service's `graph_status`).
+fn doc_status(operation: &str, err: impl std::fmt::Display) -> Status {
+    let message = err.to_string();
+    let lower = message.to_lowercase();
+    if lower.contains("not found") {
+        Status::not_found(message)
+    } else if lower.contains("already exists") {
+        Status::already_exists(message)
+    } else if lower.contains("invalid") || lower.contains("required") {
+        Status::invalid_argument(message)
+    } else {
+        Status::internal(format!("{operation}: {message}"))
+    }
+}
+
+#[tonic::async_trait]
+impl ProximaDocumentService for ProximaDocumentServiceImpl {
+    async fn create_document(
+        &self,
+        request: Request<pv2::CreateDocumentRequest>,
+    ) -> Result<Response<pv2::DocumentResponse>, Status> {
+        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let req = request.into_inner();
+        debug!("v2 gRPC CreateDocument collection={collection}");
+
+        let props = conv::props_to_tree(&req.props)?;
+        let id = if req.id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            req.id
+        };
+        let record = DocumentRecord::from_tree(
+            id,
+            props,
+            collection.clone(),
+            req.schema_id,
+            req.document_type,
+        );
+
+        match self
+            .documents
+            .insert_document_record(&collection, record)
+            .await
+        {
+            Ok(stored) => Ok(Response::new(pv2::DocumentResponse {
+                document: Some(conv::record_to_v2(&stored)),
+            })),
+            Err(e) => {
+                error!("v2 gRPC CreateDocument failed: {e}");
+                Err(doc_status("create document", e))
+            }
+        }
+    }
+
+    async fn get_document(
+        &self,
+        request: Request<pv2::GetDocumentRequest>,
+    ) -> Result<Response<pv2::DocumentResponse>, Status> {
+        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let req = request.into_inner();
+        debug!("v2 gRPC GetDocument collection={collection} id={}", req.id);
+
+        match self
+            .documents
+            .get_document(&collection, &req.id, None)
+            .await
+        {
+            Ok(Some(record)) => Ok(Response::new(pv2::DocumentResponse {
+                document: Some(conv::record_to_v2(&record)),
+            })),
+            Ok(None) => Err(Status::not_found(format!(
+                "document '{}' not found in collection '{collection}'",
+                req.id
+            ))),
+            Err(e) => {
+                error!("v2 gRPC GetDocument failed: {e}");
+                Err(doc_status("get document", e))
+            }
+        }
+    }
+
+    async fn delete_document(
+        &self,
+        request: Request<pv2::DeleteDocumentRequest>,
+    ) -> Result<Response<pv2::DeleteDocumentResponse>, Status> {
+        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let req = request.into_inner();
+        debug!(
+            "v2 gRPC DeleteDocument collection={collection} id={}",
+            req.id
+        );
+
+        match self.documents.delete_document(&collection, &req.id).await {
+            Ok(deleted) => Ok(Response::new(pv2::DeleteDocumentResponse { deleted })),
+            Err(e) => {
+                error!("v2 gRPC DeleteDocument failed: {e}");
+                Err(doc_status("delete document", e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{conv, pv2};
+    use proximadb_records::ProximaTreeNode;
+    use std::collections::HashMap;
+
+    fn tv(value: pv2::typed_value::Value) -> pv2::TypedValue {
+        pv2::TypedValue {
+            declared_type: 0,
+            value: Some(value),
+        }
+    }
+
+    /// The v2 document wire carries the rich `ProximaValue` type system — notably
+    /// a native UUID, which the legacy v1 `SqlValue` envelope cannot represent.
+    /// Prove the `TypedValue` <-> neutral `ProximaTree` round-trip preserves the
+    /// values losslessly (the whole reason v2 must not route through `SqlValue`).
+    #[test]
+    fn typed_value_props_round_trip_is_lossless() {
+        use pv2::typed_value::Value;
+
+        let mut props = HashMap::new();
+        props.insert(
+            "name".to_string(),
+            tv(Value::TextValue("doc-1".to_string())),
+        );
+        props.insert("count".to_string(), tv(Value::IntegerValue(42)));
+        props.insert("uid".to_string(), tv(Value::UuidValue(vec![7u8; 16])));
+
+        // v2 wire props -> neutral ProximaTree -> v2 wire props -> neutral tree.
+        let tree1 = conv::props_to_tree(&props).expect("props -> tree");
+        assert_eq!(tree1.len(), 3, "all three fields decoded");
+        let props2 = conv::tree_to_props(&tree1);
+        let tree2 = conv::props_to_tree(&props2).expect("re-encode round-trips");
+
+        // The neutral representation is stable across the wire round-trip — the
+        // UUID survives, which is impossible through the v1 SqlValue path.
+        assert_eq!(
+            tree1, tree2,
+            "ProximaValue types preserved across the v2 round-trip"
+        );
+        assert!(
+            matches!(tree1.get("uid"), Some(ProximaTreeNode::Value(_))),
+            "native UUID round-trips as a value node"
+        );
+    }
+}

--- a/src/network/grpc/v2/mod.rs
+++ b/src/network/grpc/v2/mod.rs
@@ -29,8 +29,10 @@
 //! - `ListSchemas` - List all schemas for a collection
 //! - `EvolveSchema` - Evolve schema with compatibility checks
 
+pub mod document_service;
 pub mod graph_service;
 pub mod record_service;
 
+pub use document_service::ProximaDocumentServiceImpl;
 pub use graph_service::ProximaGraphServiceImpl;
 pub use record_service::ProximaRecordServiceImpl;

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -176,6 +176,17 @@ impl MultiServer {
             .into_server()
     }
 
+    /// Build the canonical v2 document gRPC service. Mirrors
+    /// [`Self::canonical_graph_grpc_service`].
+    fn canonical_document_grpc_service(
+        services: &SharedServices,
+    ) -> crate::proto::proximadb_v2::proxima_document_service_server::ProximaDocumentServiceServer<
+        crate::network::grpc::v2::ProximaDocumentServiceImpl,
+    >{
+        crate::network::grpc::v2::ProximaDocumentServiceImpl::new(services.request_handlers.clone())
+            .into_server()
+    }
+
     /// Create new multi-server instance (orchestrator only)
     /// MultiServer focuses on network orchestration, SharedServices handles business logic
     pub fn new(
@@ -584,6 +595,7 @@ impl MultiServer {
             let mut server = server_builder
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
+                .add_service(Self::canonical_document_grpc_service(&services))
                 .add_service(standard_health_server);
 
             // Deprecated gRPC v1 compatibility adapters are gated behind
@@ -1088,6 +1100,7 @@ impl MultiServer {
             let mut server = server_builder
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
+                .add_service(Self::canonical_document_grpc_service(&services))
                 .add_service(flight_server)
                 .add_service(standard_health_server);
 
@@ -1466,6 +1479,7 @@ impl MultiServer {
             let mut server = server_builder
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
+                .add_service(Self::canonical_document_grpc_service(&services))
                 .add_service(standard_health_server);
 
             // Deprecated gRPC v1 compatibility adapters are gated behind

--- a/src/storage/document/mod.rs
+++ b/src/storage/document/mod.rs
@@ -148,6 +148,27 @@ impl DocumentRecord {
         }
     }
 
+    /// Build a record directly from a neutral [`ProximaTree`] body — the v2
+    /// (ProximaValue-native) path, with no v1 `SqlObject` detour. Mirrors
+    /// [`Self::new`]'s version/timestamp convention.
+    pub fn from_tree(
+        id: String,
+        props: ProximaTree,
+        collection_id: String,
+        schema_id: Option<String>,
+        document_type: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            props,
+            version: 1,
+            collection_id,
+            updated_at_ns: chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+            schema_id,
+            document_type,
+        }
+    }
+
     /// Create from proto DocumentContent
     pub fn from_proto(id: String, content: DocumentContent, collection_id: String) -> Result<Self> {
         let props = sql_object_to_proxima_tree(&content.document.unwrap_or_default());

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -868,8 +868,31 @@ impl DocumentService {
         id: Option<&str>,
         document: SqlObject,
     ) -> Result<DocumentRecord> {
+        // The legacy v1 `SqlObject` is converted into the neutral, ProximaTree-
+        // native `DocumentRecord` here at the wire edge; all durability flows
+        // through the `DocumentRecord`-native path below.
+        let doc_id = id.map_or_else(|| uuid::Uuid::new_v4().to_string(), |s| s.to_string());
+        let record = DocumentRecord::new(doc_id, document, collection.to_string());
+        self.insert_document_record(collection, record).await
+    }
+
+    /// Insert a pre-built [`DocumentRecord`] — the ProximaTree-native (v2) write
+    /// path that never touches the legacy v1 `SqlObject`. Same durability
+    /// (WAL → canonical record store → indexes → hot cache → stats) as
+    /// [`insert_document`], which now converts `SqlObject` → `DocumentRecord` at
+    /// the wire edge and delegates here. The record's `id` is used verbatim
+    /// (callers generate/normalize it).
+    pub async fn insert_document_record(
+        &self,
+        collection: &str,
+        record: DocumentRecord,
+    ) -> Result<DocumentRecord> {
         let start = std::time::Instant::now();
-        debug!("Inserting document into collection: {}", collection);
+        let doc_id = record.id.clone();
+        debug!(
+            "Inserting document {} into collection: {}",
+            doc_id, collection
+        );
 
         // Verify collection exists
         let _collection_meta = match self
@@ -883,12 +906,6 @@ impl DocumentService {
                 return Err(e);
             }
         };
-
-        // Generate ID if not provided
-        let doc_id = id.map_or_else(|| uuid::Uuid::new_v4().to_string(), |s| s.to_string());
-
-        // Create document record
-        let record = DocumentRecord::new(doc_id.clone(), document, collection.to_string());
 
         // Write to WAL first (durability before in-memory update)
         if let Err(e) = self.write_document_upsert_to_wal(collection, &record).await {


### PR DESCRIPTION
## Summary

Adds the **v2 gRPC document surface** (`proximadb.v2.ProximaDocumentService`) — the document analog of `ProximaGraphService` — closing part of **TD-122**'s remaining scope (the v2 parity that **TD-121** requires before v1 gRPC can be removed). First slice: `CreateDocument` / `GetDocument` / `DeleteDocument`.

## Co-design alignment

This was designed against the locked co-design conclusion (`neutral_type_and_map_policy`, backed by a deep-research pass + two internal traces):

- **ProximaValue-native wire, never v1 `SqlValue`.** The document body is carried as the canonical v2 **`TypedValue`** (full ProximaValue coverage), reusing `record.proto`'s value type. Decimals / timestamps / **UUIDs** / vectors round-trip **losslessly** — the v1 `SqlValue` envelope (which structurally cannot represent them — protobuf has no native UUID type) never appears on this path.
- **Neutral internal model.** Handlers map v2 messages to the neutral, `ProximaTree`-native `DocumentRecord` at the boundary only, via the same lossless `typed_value_to_proxima` / `proxima_value_to_typed_value` conversion the record service uses. A new **`DocumentService::insert_document_record`** (`DocumentRecord`-native entry) lets the v2 path bypass `SqlObject` entirely; `insert_document` now converts `SqlObject` → `DocumentRecord` at the v1 wire edge and delegates to it. Per the research, the per-request conversion is ~0.1% of the I/O-bound latency budget — negligible, and correctness-forced.
- **Structural tenant isolation** via `effective_collection_id` (mirrors graph v2).

## What's included

- `proto/proximadb/v2/document.proto` (reuses `TypedValue`) + `build.rs` wiring + regenerated stubs.
- `src/network/grpc/v2/document_service.rs` — `ProximaDocumentServiceImpl` (conv + handlers + tenant namespacing + error mapping).
- `DocumentService::insert_document_record` native entry (`insert_document` delegates).
- `DocumentRecord::from_tree` (ProximaTree-native constructor).
- Registered in all three `multi_server` startup paths alongside record/graph.

## Verification

- `cargo check -p proximadb --lib` — green
- `cargo test -p proximadb --lib document_service` — `typed_value_props_round_trip_is_lossless` passes (a native UUID survives the `TypedValue` ↔ `ProximaTree` round-trip — impossible through v1 `SqlValue`)
- `cargo fmt --all --check` + `cargo clippy -p proximadb --lib -- -D warnings` on pinned **1.95.0** — clean

## Deferred (follow-ups)

`QueryDocuments` / `UpdateDocument` / `AggregateDocuments` (mirrors how graph staged its advanced RPCs to TD-124), then `EntityService` v2. Two optimization findings from the research are filed separately (Flight props native-Arrow zero-copy; per-collection `DashMap` for the doc store).