### PR TITLE
feat(embedded): Arrow C Data Interface insert seam + measured finding (co-design Pillar C)

### DIFF
--- a/clients/python-embedded/benches/bench_arrow_zerocopy.py
+++ b/clients/python-embedded/benches/bench_arrow_zerocopy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Co-design Pillar C microbench: Arrow IPC path vs zero-copy Arrow C Data Interface.
+
+Measures end-to-end embedded insert latency for the same data via:
+  (A) insert_arrow_ipc   — Python serializes the Table to Arrow IPC bytes, Rust
+                           deserializes them (the legacy path / baseline);
+  (B) insert_arrow_batches — pyarrow RecordBatches cross the FFI boundary zero-copy
+                           via the Arrow C Data Interface (no IPC serialize/deserialize).
+
+Both paths share the same downstream Arrow->ProximaRecord conversion + insert, so the
+delta isolates the boundary cost the zero-copy change removes. Also reports the IPC
+payload size (bytes copied at the boundary for path A; ~0 for path B).
+
+Run after `maturin develop` in the project venv:
+    python clients/python-embedded/benches/bench_arrow_zerocopy.py
+"""
+
+import statistics
+import tempfile
+import time
+
+import numpy as np
+import pyarrow as pa
+
+import proximadb_embedded as pdb
+from proximadb_embedded import _arrow_source_to_ipc_bytes
+
+N = 5000
+DIM = 128
+REPEATS = 9
+WARMUP = 2
+
+
+def build_table(n: int, dim: int) -> pa.Table:
+    vecs = np.random.rand(n, dim).astype(np.float32)
+    return pa.table(
+        {
+            "id": [f"v{i}" for i in range(n)],
+            "vector": pa.array(list(vecs), type=pa.list_(pa.float32())),
+            "tenant_id": ["bench"] * n,
+        }
+    )
+
+
+def time_path(make_db, do_insert) -> float:
+    samples = []
+    for i in range(REPEATS + WARMUP):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = make_db(tmp)
+            db.create_collection("bench", dimension=DIM)
+            t0 = time.perf_counter()
+            do_insert(db)
+            elapsed = (time.perf_counter() - t0) * 1000.0
+            if i >= WARMUP:  # discard warmup iterations
+                samples.append(elapsed)
+    return statistics.median(samples)
+
+
+def main() -> None:
+    table = build_table(N, DIM)
+    ipc_bytes = _arrow_source_to_ipc_bytes(table)
+    batches = table.to_batches()
+
+    ipc_p50 = time_path(
+        lambda tmp: pdb.ProximaDB(data_dirs=tmp),
+        lambda db: db.insert_arrow_ipc("bench", ipc_bytes, "insert", None),
+    )
+    zc_p50 = time_path(
+        lambda tmp: pdb.ProximaDB(data_dirs=tmp),
+        lambda db: db.insert_arrow_batches("bench", batches, "insert", None),
+    )
+
+    speedup = ipc_p50 / zc_p50 if zc_p50 else float("nan")
+    print(f"records={N} dim={DIM} repeats={REPEATS}")
+    print(f"IPC payload bytes copied at boundary (path A): {len(ipc_bytes):,}")
+    print(f"(A) insert_arrow_ipc       p50 = {ipc_p50:8.2f} ms")
+    print(f"(B) insert_arrow_batches   p50 = {zc_p50:8.2f} ms   (zero-copy C Data Interface)")
+    print(f"speedup (A/B)              = {speedup:6.2f}x   boundary bytes copied B ~= 0")
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python-embedded/src/proximadb_embedded/__init__.py
+++ b/clients/python-embedded/src/proximadb_embedded/__init__.py
@@ -198,6 +198,35 @@ def _arrow_source_to_ipc_bytes(source) -> bytes:
     return sink.getvalue().to_pybytes()
 
 
+def _arrow_source_to_batches(source):
+    """Convert a pyarrow Table/RecordBatch or pandas DataFrame to a list of pyarrow
+    RecordBatches for the **zero-copy** Arrow C Data Interface hand-off. Returns
+    ``None`` for already-serialized inputs (raw IPC bytes), which must take the IPC
+    path because their buffers are not live Arrow arrays."""
+    if isinstance(source, (bytes, bytearray, memoryview)):
+        return None
+
+    try:
+        import pyarrow as pa
+    except ImportError as exc:
+        raise ImportError(
+            "insert_arrow/insert_pandas require pyarrow. Install with "
+            "`pip install proximadb_embedded[arrow]` or pass Arrow IPC bytes."
+        ) from exc
+
+    if isinstance(source, pa.RecordBatch):
+        return [source]
+    if isinstance(source, pa.Table):
+        return source.to_batches()
+    try:
+        return pa.Table.from_pandas(source, preserve_index=False).to_batches()
+    except Exception as exc:
+        raise TypeError(
+            "Expected pyarrow.Table, pyarrow.RecordBatch, pandas.DataFrame, "
+            "or Arrow IPC bytes"
+        ) from exc
+
+
 def insert_arrow(
     db: ProximaDB,
     collection: str,
@@ -206,13 +235,20 @@ def insert_arrow(
     mode: str = "insert",
     tenant_id=None,
 ) -> int:
-    """Insert/upsert a pyarrow Table/RecordBatch, pandas DataFrame, or IPC bytes."""
-    return db.insert_arrow_ipc(
-        collection,
-        _arrow_source_to_ipc_bytes(source),
-        mode,
-        tenant_id,
-    )
+    """Insert/upsert a pyarrow Table/RecordBatch, pandas DataFrame, or IPC bytes.
+
+    Live Arrow inputs cross the FFI boundary zero-copy via the Arrow C Data
+    Interface (``insert_arrow_batches``); only pre-serialized IPC bytes take the
+    legacy IPC path (``insert_arrow_ipc``)."""
+    batches = _arrow_source_to_batches(source)
+    if batches is None:
+        return db.insert_arrow_ipc(
+            collection,
+            _arrow_source_to_ipc_bytes(source),
+            mode,
+            tenant_id,
+        )
+    return db.insert_arrow_batches(collection, batches, mode, tenant_id)
 
 
 def upsert_arrow(
@@ -222,12 +258,16 @@ def upsert_arrow(
     *,
     tenant_id=None,
 ) -> int:
-    """Upsert a pyarrow Table/RecordBatch, pandas DataFrame, or IPC bytes."""
-    return db.upsert_arrow_ipc(
-        collection,
-        _arrow_source_to_ipc_bytes(source),
-        tenant_id,
-    )
+    """Upsert a pyarrow Table/RecordBatch, pandas DataFrame, or IPC bytes (zero-copy
+    Arrow C Data Interface for live Arrow inputs)."""
+    batches = _arrow_source_to_batches(source)
+    if batches is None:
+        return db.upsert_arrow_ipc(
+            collection,
+            _arrow_source_to_ipc_bytes(source),
+            tenant_id,
+        )
+    return db.insert_arrow_batches(collection, batches, "upsert", tenant_id)
 
 
 def insert_pandas(

--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -499,13 +499,13 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | 1-2 weeks
 | Blocked discovery from the embedded co-design plan; mechanical but wide. ServiceProfile (Pillar B) already shipped #236.
 | TD-145
-| Embedded — zero-copy Arrow C Data Interface boundary (co-design Pillar C)
+| Embedded — Arrow-native ingestion (co-design Pillar C, redirected by measurement)
 | P2
 | MED
 | *Open*
-| The Python↔Rust embedded boundary copies on the hot path: numpy is read zero-copy then `.to_vec()`-d into `Vec<Vec<f32>>` on insert, the Arrow path serializes via pyarrow IPC (`_arrow_source_to_ipc_bytes`), and results are rebuilt row-by-row into Python objects. Replace with the Arrow C Data Interface (`arrow::pyarrow` FFI) so columnar batches cross zero-copy — the dominant cost term of the boundary that *replaces* the deleted network dimension. Same seam serves Node.js. Baseline (FFI copy bytes, insert/search p50) recorded in `BENCHMARK_EVIDENCE.toml` (`embedded_ffi_boundary_zero_copy`), ratcheted on landing.
+| MEASURED FINDING (`EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22`): swapping the pyarrow-IPC insert path for the zero-copy Arrow C Data Interface (`arrow::pyarrow` FFI, `insert_arrow_batches`) is **perf-neutral** — the FFI boundary serialize was never the dominant cost term. The ~95 ms (5000x128) insert is dominated by `ArrowProtoCodec::batches_to_proxima_records` (Arrow→ProximaRecord materialization) + `insert_batch` (WAL/storage). The zero-copy `insert_arrow_batches` seam is landed (correct, cross-language substrate, lighter memory) but NOT as a latency win. Remaining Pillar-C work, redirected to the real dominant term: make ingestion **Arrow-native** so the record-materialization + insert copy shrinks (columnar straight into the engine), and apply the same to the search-result return path (currently row-by-row Python objects).
 | 2-3 weeks
-| Co-design tenets 1 & 4; gate on the recorded baseline. Port-free verification (Pillar F) shipped alongside #236.
+| Co-design tenets 1 & 2 (trace before you tune): the boundary was not the bottleneck. Seam + measurement landed in the embedded-arrow-zerocopy PR.
 |===
 
 == Debt by Category

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -235,14 +235,14 @@ notes = "Design is literature-grounded (Calibrated-Fusion: post-PIT the operator
 
 [[claims]]
 id = "embedded_ffi_boundary_zero_copy"
-claim = "Embedded Python<->Rust boundary is zero-copy on the insert/search hot path (Arrow C Data Interface), eliminating the numpy->Vec<Vec<f32>> copy and the pyarrow-IPC serialize"
-metric = "ffi_copy_bytes_and_p50_ms"
-status = "aspirational"
-asserted_in = ["docs/10-quality/TECHNICAL_DEBT.adoc:501"]
-bench_source = ""
-bench_command = ""
-artifact = ""
-hardware = ""
-date = ""
-version = ""
-notes = "Co-design Pillar C / TD-145. BASELINE (pre-change, current develop): insert reads numpy zero-copy then `.to_vec()` into Vec<Vec<f32>> (one full copy of every vector), the Arrow path serializes via pyarrow IPC (`_arrow_source_to_ipc_bytes`), and search results are rebuilt row-by-row into Python objects. The fused path is already PORT-FREE (verified: tests/embedded_port_free.rs). To promote: add a maturin-built Python microbench (numpy insert + search p50, bytes copied at the boundary), record the baseline number, switch to `arrow::pyarrow` C Data Interface, and ratchet copy_bytes->~0 + p50 improvement in a dated artifact. The same seam serves a future Node.js (napi) binding."
+claim = "Embedded Arrow insert: the FFI boundary serialize is NOT the dominant cost term — swapping pyarrow-IPC for the zero-copy Arrow C Data Interface is perf-neutral; the dominant term is the Arrow->ProximaRecord conversion + insert_batch"
+metric = "insert_p50_ms"
+status = "measured"
+asserted_in = ["docs/_internal/status/EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22.adoc:1"]
+bench_source = "clients/python-embedded/benches/bench_arrow_zerocopy.py"
+bench_command = "python clients/python-embedded/benches/bench_arrow_zerocopy.py"
+artifact = "docs/_internal/status/EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), no other workload"
+date = "2026-06-22"
+version = "v0.2"
+notes = "Co-design Pillar C / TD-145. MEASURED (5000x128 f32, 2 warmup + 9 timed, median): insert_arrow_ipc 96.8/95.0 ms vs zero-copy insert_arrow_batches 95.8/107.3 ms = PARITY within run-to-run noise, despite eliminating a 2,669,512-byte IPC serialize/deserialize. The plan's hypothesis (boundary copy = dominant embedded cost term) is REFUTED at the insert path: the ~95 ms is dominated by ArrowProtoCodec::batches_to_proxima_records + insert_batch (WAL/storage), not the serialize. The insert_arrow_batches seam is kept (correct, cross-language, lighter memory) but NOT as a latency win; the real Pillar-C lever is redirected to Arrow-native ingestion (TD-145). Trace before you tune."

--- a/docs/_internal/status/EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22.adoc
+++ b/docs/_internal/status/EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22.adoc
@@ -1,0 +1,61 @@
+= Embedded Arrow boundary: IPC vs zero-copy C Data Interface (measured)
+:toc:
+:date: 2026-06-22
+
+Co-design Pillar C / TD-145. Measures whether replacing the Python<->Rust embedded
+Arrow insert path's IPC serialize/deserialize with the **Arrow C Data Interface**
+(zero-copy) moves the embedded insert cost.
+
+== Hypothesis (from the embedded co-design plan)
+
+Embedding deletes Dimension 2 (network), so the dominant cost term was expected to
+invert to the **FFI boundary crossing** — i.e. the pyarrow-IPC serialize (Python) +
+IPC deserialize (Rust). Pillar C swaps that for the Arrow C Data Interface
+(`arrow::pyarrow::PyArrowType<RecordBatch>`), which hands Arrow buffers across the
+boundary without serializing.
+
+== Method
+
+`clients/python-embedded/benches/bench_arrow_zerocopy.py`. 5000 records x 128-dim
+f32 vectors, one collection per iteration, 2 warmup + 9 timed iterations, median.
+Both paths share the same downstream Arrow->ProximaRecord conversion + `insert_batch`,
+so the delta isolates the boundary cost.
+
+* Path A — `insert_arrow_ipc`: Python serializes the Table to Arrow IPC bytes
+  (2,669,512 bytes copied at the boundary), Rust deserializes via `StreamReader`.
+* Path B — `insert_arrow_batches`: pyarrow `RecordBatch`es cross zero-copy via the
+  Arrow C Data Interface (~0 bytes copied at the boundary).
+
+Hardware: local macOS arm64 (Apple Silicon), no other workload.
+
+== Result — perf-neutral; the boundary serialize is NOT the dominant cost term
+
+[cols="2,1,1,1",options="header"]
+|===
+| Run | A `insert_arrow_ipc` p50 | B `insert_arrow_batches` p50 | A/B
+| 1 | 96.80 ms | 95.79 ms | 1.01x
+| 2 | 94.99 ms | 107.33 ms | 0.88x
+|===
+
+The two paths are at **parity within run-to-run noise** (~95-107 ms; the cross-run
+variance exceeds the A-vs-B difference). Eliminating the 2.67 MB IPC serialize +
+deserialize did **not** measurably reduce insert latency.
+
+== Interpretation (co-design tenets 1 & 2)
+
+At the insert path the FFI boundary serialize is **not** the dominant cost term — it
+is a few ms against a ~95 ms end-to-end insert that is dominated by the
+**Arrow->ProximaRecord model conversion (`ArrowProtoCodec::batches_to_proxima_records`)
++ `insert_batch` (WAL/storage)**. This is the "a 4x codec is irrelevant if you still
+pay N round-trips" lesson, measured: a zero-copy boundary is irrelevant while the
+record-materialization + insert dominate.
+
+== Decision
+
+* The `insert_arrow_batches` Rust + PyO3 **seam is kept** — it is correct
+  (data-integrity verified), avoids the 2.67 MB intermediate serialize buffer, and is
+  the language-neutral substrate a future Node.js (napi) binding and the real
+  Pillar-C work will build on. It is **not** shipped as a latency win.
+* The real Pillar-C lever is redirected (TD-145): make **ingestion Arrow-native** so
+  the dominant `batches_to_proxima_records` + `insert_batch` copy is what shrinks —
+  the boundary was never the bottleneck. Trace before you tune.

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -4261,9 +4261,10 @@ impl EmbeddedProximaDB {
     /// Insert or upsert Arrow IPC stream bytes through the embedded vector batch path.
     ///
     /// This is the in-process equivalent of Arrow Flight vector bulk_insert/bulk_upsert:
-    /// Arrow IPC stream bytes are decoded to RecordBatches, converted to ProximaRecord
-    /// batches with the shared Arrow codec, and routed directly to the embedded
-    /// vector service without binding ports or starting a Flight server.
+    /// Arrow IPC stream bytes are decoded to RecordBatches and delegated to
+    /// [`Self::insert_arrow_batches`]. This entry point exists for byte-stream
+    /// sources; in-process callers should prefer the batch path (Arrow C Data
+    /// Interface) which avoids the IPC serialize/deserialize round-trip.
     pub fn insert_arrow_ipc(
         &self,
         collection: &str,
@@ -4271,9 +4272,6 @@ impl EmbeddedProximaDB {
         insert_only: bool,
         tenant_id: Option<&str>,
     ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-        self.check_write_access()?;
-
-        let start = std::time::Instant::now();
         let cursor = std::io::Cursor::new(ipc_stream);
         let reader = arrow_ipc::reader::StreamReader::try_new(cursor, None).map_err(
             |e| -> Box<dyn std::error::Error + Send + Sync> {
@@ -4295,6 +4293,27 @@ impl EmbeddedProximaDB {
                 })?,
             );
         }
+
+        self.insert_arrow_batches(collection, batches, insert_only, tenant_id)
+    }
+
+    /// Zero-copy sibling of [`Self::insert_arrow_ipc`]: ingest already-decoded
+    /// Arrow `RecordBatch`es. The Python embedding hands these across the FFI
+    /// boundary via the **Arrow C Data Interface** (`arrow::pyarrow`), so there is
+    /// no IPC serialize on the Python side and no IPC deserialize here — only the
+    /// unavoidable Arrow→ProximaRecord model conversion remains. Co-design Pillar C
+    /// (move the dominant cost term of the boundary that replaced the deleted
+    /// network dimension). Routed to the same embedded vector service; no ports.
+    pub fn insert_arrow_batches(
+        &self,
+        collection: &str,
+        batches: Vec<arrow::record_batch::RecordBatch>,
+        insert_only: bool,
+        tenant_id: Option<&str>,
+    ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
+        self.check_write_access()?;
+
+        let start = std::time::Instant::now();
 
         let mut records =
             crate::network::arrow_ipc::codec::ArrowProtoCodec::batches_to_proxima_records(batches)

--- a/src/embedded/python.rs
+++ b/src/embedded/python.rs
@@ -3611,6 +3611,41 @@ impl PyProximaDB {
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to upsert Arrow batch: {}", e)))
     }
 
+    /// Zero-copy Arrow insert via the **Arrow C Data Interface**. Accepts a list of
+    /// pyarrow `RecordBatch`es whose buffers are shared (not serialized) across the
+    /// FFI boundary, and routes them straight into the embedded vector service —
+    /// the zero-copy replacement for the pyarrow-IPC serialize/deserialize
+    /// round-trip of `insert_arrow_ipc`. Co-design Pillar C: this is the dominant
+    /// cost term of the boundary that replaced the deleted network dimension.
+    #[pyo3(signature = (collection, batches, mode="insert", tenant_id=None))]
+    fn insert_arrow_batches(
+        &self,
+        py: Python<'_>,
+        collection: &str,
+        batches: Vec<arrow::pyarrow::PyArrowType<arrow::record_batch::RecordBatch>>,
+        mode: &str,
+        tenant_id: Option<&str>,
+    ) -> PyResult<u64> {
+        let insert_only = match mode.to_ascii_lowercase().as_str() {
+            "insert" | "bulk_insert" | "batch_insert" => true,
+            "upsert" | "bulk_upsert" | "batch_upsert" => false,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Invalid Arrow write mode '{}'. Use 'insert' or 'upsert'",
+                    other
+                )));
+            }
+        };
+        // The Arrow C Data Interface import happens during argument extraction
+        // (GIL held); the batches are then owned Rust RecordBatches, so the GIL is
+        // released for the actual ingest.
+        let batches: Vec<arrow::record_batch::RecordBatch> =
+            batches.into_iter().map(|b| b.0).collect();
+        let inner = self.db()?;
+        py.detach(move || inner.insert_arrow_batches(collection, batches, insert_only, tenant_id))
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to insert Arrow batch: {}", e)))
+    }
+
     /// Execute a unified multi-model query
     ///
     /// This executes a SQL-like query that can span multiple data models


### PR DESCRIPTION
## What

**Pillar C** of the embedded co-design plan — implemented **and measured**. The measurement refutes the plan's hypothesis, so this lands the zero-copy seam **honestly, not as a perf win**.

## Code
- **`mod.rs`**: extract `insert_arrow_batches(Vec<RecordBatch>, ..)` from `insert_arrow_ipc` (the post-decode sink); `insert_arrow_ipc` now decodes IPC then delegates.
- **`python.rs`**: new `insert_arrow_batches` PyO3 method taking pyarrow `RecordBatch`es via the **Arrow C Data Interface** (`arrow::pyarrow::PyArrowType`) — buffers shared, no IPC serialize/deserialize; GIL released for the ingest.
- **`__init__.py`**: `insert_arrow`/`upsert_arrow` route live Arrow/pandas through the zero-copy batch path; raw IPC bytes keep the legacy path.

## Measurement (the point of this PR)

`clients/python-embedded/benches/bench_arrow_zerocopy.py` — 5000×128 f32, 2 warmup + 9 timed, median:

| Run | A `insert_arrow_ipc` | B zero-copy `insert_arrow_batches` | A/B |
|-----|------|------|-----|
| 1 | 96.80 ms | 95.79 ms | 1.01× |
| 2 | 94.99 ms | 107.33 ms | 0.88× |

**Parity within noise**, despite eliminating a **2.67 MB** IPC serialize/deserialize. The FFI boundary serialize is **not** the dominant cost term at the insert path — the ~95 ms is dominated by `ArrowProtoCodec::batches_to_proxima_records` (Arrow→ProximaRecord) + `insert_batch` (WAL/storage). This is "trace before you tune" (co-design tenets 1 & 2) doing its job.

## Outcome (honest)
- The `insert_arrow_batches` seam is **kept** — correct (data-integrity verified), the cross-language substrate for a future Node.js (napi) binding, lighter memory (no 2.67 MB intermediate) — but **explicitly not a latency win**.
- `BENCHMARK_EVIDENCE.toml` `embedded_ffi_boundary_zero_copy` promoted to **`measured`** with the real result.
- **TD-145 redirected**: the real Pillar-C lever is **Arrow-native ingestion** (shrink the record-materialization + insert copy that actually dominates), not the boundary.
- Evidence artifact: `docs/_internal/status/EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22.adoc`.

## Verified
`cargo build` (lib + `--features python,pylib`), `cargo fmt --check` 0 diffs, clippy clean for changed lines, ledger validator passes, existing arrow pytest passes, zero-copy read-back correctness confirmed.