### PR TITLE
feat(catalog): sinval-style cross-pod cache coherence (system-catalog 6b)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -528,7 +528,7 @@ impl SharedServices {
                         format!("opening object-store catalog snapshot at {metadata_url}")
                     })?,
                 );
-                let system_catalog =
+                let system_catalog = Arc::new(
                     crate::services::system_catalog::SystemCatalog::open_with_snapshot_store(
                         "default",
                         &wal_path,
@@ -540,9 +540,31 @@ impl SharedServices {
                             "opening object-store SystemCatalog (WAL {})",
                             wal_path.display()
                         )
-                    })?;
+                    })?,
+                );
+                // Phase 6b: in a multi-pod deployment, tail the object-store
+                // snapshot so this pod's relcache stays coherent with DDL another
+                // pod commits (sinval-style lazy reload), and so a superseded
+                // owner steps down to read-only promptly. Inert by default
+                // (single-pod): gated behind `PROXIMADB_CATALOG_FOLLOWER_POLL_SECS`
+                // (> 0 to enable). The handle is detached — the loop is a
+                // cooperative tokio task that does no work when nothing changed.
+                if let Some(secs) = std::env::var("PROXIMADB_CATALOG_FOLLOWER_POLL_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .filter(|n| *n > 0)
+                {
+                    system_catalog
+                        .clone()
+                        .spawn_follower_poll(std::time::Duration::from_secs(secs));
+                    info!(
+                        "✅ SharedServices: catalog follower poll enabled (every {}s) — \
+                         tailing object-store snapshot for cross-pod coherence",
+                        secs
+                    );
+                }
                 catalog_manager
-                    .register(Arc::new(system_catalog))
+                    .register(system_catalog)
                     .await
                     .context("Failed to register object-store SystemCatalog backend")?;
                 info!(

--- a/src/services/canonical_wal.rs
+++ b/src/services/canonical_wal.rs
@@ -64,6 +64,22 @@ impl FramedTableWalAppender {
         &self.path
     }
 
+    /// Raise the next-assigned sequence floor so future appends never reuse a
+    /// sequence at or below `floor` (monotonic — a lower floor is ignored).
+    ///
+    /// `next_sequence` is otherwise derived from the on-disk WAL's highest frame.
+    /// That is correct only while the WAL still carries the full history; once a
+    /// snapshot watermark advances *past* the on-disk frames — the WAL was
+    /// compacted to empty (Phase 3), or this pod adopted a *peer's* snapshot
+    /// whose watermark lives in a different local sequence space (Phase 6b) — the
+    /// file-derived floor sits below the snapshot's `applied_seq`. A fresh append
+    /// would then land at a sequence the in-RAM authority has already applied and
+    /// be idempotently dropped on fold. Seeding the floor from the snapshot
+    /// watermark at open closes that gap.
+    pub fn advance_sequence_floor(&self, floor: u64) {
+        self.next_sequence.fetch_max(floor, Ordering::SeqCst);
+    }
+
     /// Read all complete entries currently present in the WAL.
     pub async fn read_entries(&self) -> Result<Vec<CanonicalWalEntry>> {
         read_entries_from_path(&self.path).await

--- a/src/services/catalog_snapshot_store.rs
+++ b/src/services/catalog_snapshot_store.rs
@@ -23,6 +23,35 @@ use tokio::io::AsyncWriteExt;
 use proximadb_iceberg_engine::manifest::{CommitOutcome, ManifestCommitter};
 use proximadb_object_store::ProximaObjectStore;
 
+/// A snapshot blob read back from the durable store, with the pointer metadata
+/// the Phase 6b cross-pod coherence protocol compares against.
+#[derive(Debug, Clone)]
+pub struct SnapshotRead {
+    /// Monotonic commit **version** of the snapshot pointer — it advances on
+    /// *every* publish, including same-owner re-checkpoints. This is the cheap
+    /// sinval staleness key a follower tails: a strictly higher version means
+    /// the published snapshot changed and the in-RAM cache must reload. `0` for
+    /// the unversioned local single-pod store.
+    pub version: u64,
+    /// Fencing **generation** the snapshot was committed under — it changes only
+    /// when a newer pod *takes the catalog over* (Phase 6a). A generation above
+    /// this pod's own write generation means it has been superseded. `0` for the
+    /// unfenced local store.
+    pub generation: u64,
+    /// The snapshot payload.
+    pub bytes: Vec<u8>,
+}
+
+/// Outcome of publishing a snapshot blob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotWrite {
+    /// The blob landed at this monotonic pointer `version`.
+    Published { version: u64 },
+    /// **Fenced** — a newer writer (higher generation) already owns the pointer,
+    /// so this stale writer must step down rather than overwrite it.
+    Fenced,
+}
+
 /// Durable, atomically-replaceable home for the catalog snapshot blob.
 ///
 /// `write_atomic` must guarantee a reader concurrent with the write observes
@@ -37,17 +66,25 @@ use proximadb_object_store::ProximaObjectStore;
 /// rejected instead of clobbering the newer pod's snapshot.
 #[async_trait]
 pub trait CatalogSnapshotStore: Send + Sync {
-    /// Read the current snapshot blob with its fencing generation, or `None` if
-    /// none has been written yet. Local (unfenced) stores report generation `0`.
-    async fn read(&self) -> Result<Option<(u64, Vec<u8>)>>;
+    /// Read the current snapshot blob with its pointer version + fencing
+    /// generation, or `None` if none has been written yet.
+    async fn read(&self) -> Result<Option<SnapshotRead>>;
 
-    /// Durably + atomically publish the snapshot blob stamped with `generation`.
-    ///
-    /// Returns `Ok(true)` when the write landed, `Ok(false)` when it was
-    /// **fenced** — a newer writer (higher generation) already owns the blob, so
-    /// this (stale) writer must step down rather than overwrite it. Local stores
-    /// never fence and always return `Ok(true)`.
-    async fn write_atomic(&self, generation: u64, bytes: &[u8]) -> Result<bool>;
+    /// Durably + atomically publish the snapshot blob stamped with `generation`,
+    /// returning the [`SnapshotWrite`] outcome (the new pointer version, or
+    /// `Fenced` when a newer generation already owns the pointer). Local stores
+    /// never fence and always [`Published`](SnapshotWrite::Published).
+    async fn write_atomic(&self, generation: u64, bytes: &[u8]) -> Result<SnapshotWrite>;
+
+    /// Cheap probe of the latest published pointer version **without** fetching
+    /// the (potentially large) snapshot payload — the Phase 6b sinval staleness
+    /// check polls this, and only fetches via [`read`](Self::read) on a version
+    /// advance. `None` when nothing has been published yet, or when the store
+    /// has no version concept (the local single-pod store, which followers never
+    /// tail). Default: `None`.
+    async fn latest_version(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
 
     /// Human-readable location, for logs and error context.
     fn describe(&self) -> String;
@@ -75,19 +112,23 @@ impl LocalSnapshotStore {
 
 #[async_trait]
 impl CatalogSnapshotStore for LocalSnapshotStore {
-    async fn read(&self) -> Result<Option<(u64, Vec<u8>)>> {
+    async fn read(&self) -> Result<Option<SnapshotRead>> {
         if tokio::fs::try_exists(&self.path).await.unwrap_or(false) {
             let bytes = tokio::fs::read(&self.path)
                 .await
                 .with_context(|| format!("reading catalog snapshot {}", self.path.display()))?;
-            // Local single-pod store is unfenced — generation is always 0.
-            Ok(Some((0, bytes)))
+            // Local single-pod store is unversioned + unfenced — (0, 0).
+            Ok(Some(SnapshotRead {
+                version: 0,
+                generation: 0,
+                bytes,
+            }))
         } else {
             Ok(None)
         }
     }
 
-    async fn write_atomic(&self, _generation: u64, bytes: &[u8]) -> Result<bool> {
+    async fn write_atomic(&self, _generation: u64, bytes: &[u8]) -> Result<SnapshotWrite> {
         let path = &self.path;
         let tmp = path.with_extension("snapshot-tmp");
         {
@@ -114,7 +155,8 @@ impl CatalogSnapshotStore for LocalSnapshotStore {
         {
             let _ = handle.sync_all();
         }
-        Ok(true)
+        // The local store is unversioned (single-pod, last-writer-wins).
+        Ok(SnapshotWrite::Published { version: 0 })
     }
 
     fn describe(&self) -> String {
@@ -169,7 +211,7 @@ impl ObjectStoreSnapshotStore {
 
 #[async_trait]
 impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
-    async fn read(&self) -> Result<Option<(u64, Vec<u8>)>> {
+    async fn read(&self) -> Result<Option<SnapshotRead>> {
         match self
             .committer
             .latest_version()
@@ -181,14 +223,18 @@ impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
                     self.committer.read_fenced(version).await.with_context(|| {
                         format!("reading catalog snapshot {}@{version}", self.label)
                     })?;
-                Ok(Some((generation, payload.to_vec())))
+                Ok(Some(SnapshotRead {
+                    version,
+                    generation,
+                    bytes: payload.to_vec(),
+                }))
             }
             // No manifest yet → empty-catalog boot; the caller replays the WAL.
             None => Ok(None),
         }
     }
 
-    async fn write_atomic(&self, generation: u64, bytes: &[u8]) -> Result<bool> {
+    async fn write_atomic(&self, generation: u64, bytes: &[u8]) -> Result<SnapshotWrite> {
         let parent = self
             .committer
             .latest_version()
@@ -200,11 +246,18 @@ impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
             .await
             .with_context(|| format!("committing catalog snapshot {}", self.label))?
         {
-            CommitOutcome::Committed(_) => Ok(true),
+            CommitOutcome::Committed(version) => Ok(SnapshotWrite::Published { version }),
             // Fenced (stale generation) or lost the version CAS race — either way
             // this writer did not publish; it must re-read and step down/retry.
-            CommitOutcome::Conflict { .. } => Ok(false),
+            CommitOutcome::Conflict { .. } => Ok(SnapshotWrite::Fenced),
         }
+    }
+
+    async fn latest_version(&self) -> Result<Option<u64>> {
+        self.committer
+            .latest_version()
+            .await
+            .with_context(|| format!("probing catalog snapshot version {}", self.label))
     }
 
     fn describe(&self) -> String {
@@ -216,8 +269,12 @@ impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
 mod tests {
     use super::*;
 
-    fn body(opt: Option<(u64, Vec<u8>)>) -> Option<Vec<u8>> {
-        opt.map(|(_gen, bytes)| bytes)
+    fn body(opt: Option<SnapshotRead>) -> Option<Vec<u8>> {
+        opt.map(|r| r.bytes)
+    }
+
+    fn published(w: SnapshotWrite) -> bool {
+        matches!(w, SnapshotWrite::Published { .. })
     }
 
     #[tokio::test]
@@ -226,17 +283,21 @@ mod tests {
         let path = dir.path().join("cat.snapshot");
         let store = LocalSnapshotStore::new(&path);
 
-        // Absent before any write.
+        // Absent before any write; local store exposes no version concept.
         assert!(store.read().await.unwrap().is_none());
+        assert!(store.latest_version().await.unwrap().is_none());
 
         // Local store is unfenced: it ignores the generation and never fences.
-        assert!(store.write_atomic(0, b"hello-catalog").await.unwrap());
-        let (generation, bytes) = store.read().await.unwrap().unwrap();
-        assert_eq!(generation, 0);
-        assert_eq!(bytes, b"hello-catalog");
+        assert!(published(
+            store.write_atomic(0, b"hello-catalog").await.unwrap()
+        ));
+        let read = store.read().await.unwrap().unwrap();
+        assert_eq!(read.version, 0);
+        assert_eq!(read.generation, 0);
+        assert_eq!(read.bytes, b"hello-catalog");
 
         // Atomic replace — even an "older" generation still writes locally.
-        assert!(store.write_atomic(0, b"v2").await.unwrap());
+        assert!(published(store.write_atomic(0, b"v2").await.unwrap()));
         assert_eq!(
             body(store.read().await.unwrap()).as_deref(),
             Some(&b"v2"[..])
@@ -252,18 +313,28 @@ mod tests {
                 .expect("memory store");
 
         assert!(store.read().await.unwrap().is_none());
+        assert!(store.latest_version().await.unwrap().is_none());
 
-        assert!(store.write_atomic(1, b"snap-bytes").await.unwrap());
-        let (generation, bytes) = store.read().await.unwrap().unwrap();
-        assert_eq!(generation, 1);
-        assert_eq!(bytes, b"snap-bytes");
+        assert_eq!(
+            store.write_atomic(1, b"snap-bytes").await.unwrap(),
+            SnapshotWrite::Published { version: 0 }
+        );
+        let read = store.read().await.unwrap().unwrap();
+        assert_eq!(read.version, 0);
+        assert_eq!(read.generation, 1);
+        assert_eq!(read.bytes, b"snap-bytes");
+        assert_eq!(store.latest_version().await.unwrap(), Some(0));
 
-        // A same-or-higher generation succeeds and supersedes.
-        assert!(store.write_atomic(1, b"snap-bytes-2").await.unwrap());
+        // A same-or-higher generation succeeds, advances the version, and supersedes.
+        assert_eq!(
+            store.write_atomic(1, b"snap-bytes-2").await.unwrap(),
+            SnapshotWrite::Published { version: 1 }
+        );
         assert_eq!(
             body(store.read().await.unwrap()).as_deref(),
             Some(&b"snap-bytes-2"[..])
         );
+        assert_eq!(store.latest_version().await.unwrap(), Some(1));
     }
 
     /// Phase 6a multi-instance fence: two stores over ONE shared backing object
@@ -291,23 +362,24 @@ mod tests {
         );
 
         // Pod A owns generation 1 and commits.
-        assert!(pod_a.write_atomic(1, b"from-A").await.unwrap());
+        assert!(published(pod_a.write_atomic(1, b"from-A").await.unwrap()));
 
         // Pod B takes over: it reads the current generation (1) and claims the
         // next one (2), then commits successfully (2 >= 1).
-        let (seen, _) = pod_b.read().await.unwrap().unwrap();
-        assert_eq!(seen, 1);
-        assert!(pod_b.write_atomic(2, b"from-B").await.unwrap());
+        let read = pod_b.read().await.unwrap().unwrap();
+        assert_eq!(read.generation, 1);
+        assert!(published(pod_b.write_atomic(2, b"from-B").await.unwrap()));
 
         // Pod A is now stale (generation 1 < 2). Its next commit is FENCED.
-        assert!(
-            !pod_a.write_atomic(1, b"from-A-again").await.unwrap(),
+        assert_eq!(
+            pod_a.write_atomic(1, b"from-A-again").await.unwrap(),
+            SnapshotWrite::Fenced,
             "stale generation-1 writer must be fenced once generation 2 owns the log"
         );
 
         // The newer pod's snapshot is intact — A did not clobber it.
-        let (generation, bytes) = pod_b.read().await.unwrap().unwrap();
-        assert_eq!(generation, 2);
-        assert_eq!(bytes, b"from-B");
+        let read = pod_b.read().await.unwrap().unwrap();
+        assert_eq!(read.generation, 2);
+        assert_eq!(read.bytes, b"from-B");
     }
 }

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -17,12 +17,15 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 
-use crate::services::catalog_snapshot_store::{CatalogSnapshotStore, LocalSnapshotStore};
+use crate::services::catalog_snapshot_store::{
+    CatalogSnapshotStore, LocalSnapshotStore, SnapshotWrite,
+};
 use proximadb_catalog::schema::{apply_evolution, validate_schema};
 use proximadb_catalog::{
     Catalog, CatalogIndex, CatalogNamespace, CatalogPrimaryPod, CatalogSchemaEvolution,
@@ -31,6 +34,13 @@ use proximadb_catalog::{
 
 use crate::services::record_store::TableWalAppender;
 use crate::services::system_catalog_state::{CatalogDelta, SystemCatalogState};
+
+/// Whether `candidate` is a strictly newer snapshot pointer version than the
+/// `loaded` one — treating the [`NO_VERSION`] sentinel ("nothing observed yet")
+/// as older than any real version. Monotonic: never reload an equal/older blob.
+fn version_is_newer(loaded: u64, candidate: u64) -> bool {
+    loaded == NO_VERSION || candidate > loaded
+}
 
 /// Current wall-clock milliseconds since the Unix epoch.
 fn now_millis() -> i64 {
@@ -44,6 +54,31 @@ fn now_millis() -> i64 {
 /// the legacy metastore's compaction threshold. Override with
 /// `PROXIMADB_CATALOG_SNAPSHOT_THRESHOLD`.
 const DEFAULT_SNAPSHOT_THRESHOLD: u64 = 1000;
+
+/// Sentinel for "no object-store snapshot version observed yet" — distinct from
+/// version `0`, the first real published version. Versions never reach `u64::MAX`.
+const NO_VERSION: u64 = u64::MAX;
+
+/// Outcome of a Phase 6b sinval staleness check ([`SystemCatalog::reload_if_stale`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadOutcome {
+    /// Coherence is not applicable — this catalog has no object-store snapshot
+    /// store (an injected-appender / local single-pod catalog never tails).
+    Disabled,
+    /// The in-RAM cache was already current with the published snapshot.
+    UpToDate,
+    /// The in-RAM authority was reloaded from a newer published snapshot.
+    Reloaded {
+        /// Pointer version adopted.
+        version: u64,
+        /// Fencing generation the adopted snapshot was committed under.
+        generation: u64,
+        /// Whether the adopted snapshot was published by a **newer** pod (its
+        /// generation outranks this pod's write generation), meaning this pod has
+        /// been superseded and has stepped down to read-only.
+        superseded: bool,
+    },
+}
 
 /// File locations + cadence for the snapshot/compaction machinery. Present only
 /// when the catalog owns an on-disk WAL (via [`SystemCatalog::open`]); the
@@ -83,6 +118,23 @@ pub struct SystemCatalog {
     /// commit is fenced on it. Single-pod / local: effectively inert (the local
     /// store never fences and each restart simply bumps it monotonically).
     generation: AtomicU64,
+    /// Pointer **version** of the object-store snapshot currently reflected in
+    /// [`state`](Self::state) (Phase 6b sinval key). [`NO_VERSION`] until the
+    /// first published snapshot is observed. The follower poll compares the
+    /// store's `latest_version()` against this to decide whether to reload; it is
+    /// advanced on every successful publish (our own) and every reload (a peer's).
+    loaded_version: AtomicU64,
+    /// Fencing generation of the snapshot currently reflected in `state`. Equal
+    /// to `generation` once we have published; raised to a peer's generation when
+    /// we adopt a newer snapshot. Informational for reads + the step-down check.
+    loaded_generation: AtomicU64,
+    /// Read-only mode (Phase 6b): a **follower** replica (opened via
+    /// [`open_follower`](Self::open_follower)) or an ex-owner that has been
+    /// **superseded** by a newer-generation pod. While set, DDL is rejected and
+    /// the in-RAM authority is driven solely by tailing the object-store
+    /// snapshot — the bounded-staleness read replica. The single-pod default
+    /// (an owner) leaves this `false`, so behaviour is unchanged.
+    read_only: AtomicBool,
 }
 
 impl SystemCatalog {
@@ -103,6 +155,9 @@ impl SystemCatalog {
             snapshot: None,
             commits_since_snapshot: AtomicU64::new(0),
             generation: AtomicU64::new(0),
+            loaded_version: AtomicU64::new(NO_VERSION),
+            loaded_generation: AtomicU64::new(0),
+            read_only: AtomicBool::new(false),
         }
     }
 
@@ -144,6 +199,40 @@ impl SystemCatalog {
         wal_path: impl Into<PathBuf>,
         snapshot_store: Arc<dyn CatalogSnapshotStore>,
     ) -> Result<Self> {
+        // An owner: claims the next generation and serves writes.
+        Self::open_inner(name, wal_path, snapshot_store, true).await
+    }
+
+    /// Open the catalog as a **read-only follower** (Phase 6b): seed the in-RAM
+    /// authority from the current object-store snapshot, but do **not** claim a
+    /// higher fencing generation (a follower never takes the catalog over) and
+    /// **reject DDL**. A follower tails the object-store snapshot — call
+    /// [`reload_if_stale`](Self::reload_if_stale) periodically (or
+    /// [`spawn_follower_poll`](Self::spawn_follower_poll)) to pull the owner's
+    /// published mutations into RAM within the poll interval (bounded staleness).
+    /// Reads are served from RAM exactly as on the owner; only writes differ.
+    pub async fn open_follower(
+        name: impl Into<String>,
+        wal_path: impl Into<PathBuf>,
+        snapshot_store: Arc<dyn CatalogSnapshotStore>,
+    ) -> Result<Self> {
+        // A follower: keeps the prior generation (no takeover) and is read-only.
+        Self::open_inner(name, wal_path, snapshot_store, false).await
+    }
+
+    /// Shared boot path for owner ([`open_with_snapshot_store`](Self::open_with_snapshot_store))
+    /// and follower ([`open_follower`](Self::open_follower)) catalogs.
+    ///
+    /// `claim_owner = true` makes this an owner: it claims `prior_generation + 1`
+    /// so its fenced snapshot commits outrank the pod it replaced, and it serves
+    /// writes. `claim_owner = false` makes this a read-only follower: it stays at
+    /// the prior generation and rejects DDL.
+    async fn open_inner(
+        name: impl Into<String>,
+        wal_path: impl Into<PathBuf>,
+        snapshot_store: Arc<dyn CatalogSnapshotStore>,
+        claim_owner: bool,
+    ) -> Result<Self> {
         let wal_path = wal_path.into();
         let appender = Arc::new(crate::services::FramedTableWalAppender::open(&wal_path).await?);
         let entries = appender.read_entries().await?;
@@ -151,23 +240,43 @@ impl SystemCatalog {
         // A snapshot that exists but fails to decode is **fatal**: after a
         // compaction the WAL alone no longer carries the pre-watermark history,
         // so silently falling back to a WAL-only replay would lose committed DDL.
-        // `read` also yields the snapshot's fencing generation (Phase 6a).
-        let (state, prior_generation) = match snapshot_store.read().await? {
-            Some((generation, bytes)) => {
-                let state = SystemCatalogState::from_snapshot_bytes(&bytes).with_context(|| {
-                    format!("decoding catalog snapshot {}", snapshot_store.describe())
-                })?;
+        // `read` also yields the snapshot's pointer version + fencing generation.
+        let (state, prior_version, prior_generation) = match snapshot_store.read().await? {
+            Some(read) => {
+                let state =
+                    SystemCatalogState::from_snapshot_bytes(&read.bytes).with_context(|| {
+                        format!("decoding catalog snapshot {}", snapshot_store.describe())
+                    })?;
+                // The local WAL tail (entries past the snapshot watermark) is a
+                // no-op for a follower (it never appends), and the owner's own
+                // post-snapshot durability for an owner.
                 state.replay(&entries)?;
-                (state, generation)
+                (state, read.version, read.generation)
             }
-            None => (SystemCatalogState::from_wal_entries(&entries)?, 0),
+            None => (
+                SystemCatalogState::from_wal_entries(&entries)?,
+                NO_VERSION,
+                0,
+            ),
         };
 
-        // Claim the next generation — a pod taking the catalog over outranks the
-        // one it replaced, so its first fenced commit fences any stale writer.
-        // For the local (unfenced) store this is inert: it monotonically bumps
-        // on each restart but the local store never rejects a write.
-        let generation = prior_generation + 1;
+        // Seed the appender's sequence floor from the snapshot watermark so a
+        // fresh local WAL (compacted-to-empty, or a peer's snapshot adopted into
+        // a different local sequence space) cannot mint a sequence the in-RAM
+        // authority has already applied (which `apply_committed` would drop). A
+        // no-op when the local WAL already carries the watermark.
+        appender.advance_sequence_floor(state.applied_seq());
+
+        // Owner claims the next generation — a pod taking the catalog over
+        // outranks the one it replaced, so its first fenced commit fences any
+        // stale writer. For the local (unfenced) store this is inert. A follower
+        // keeps the prior generation: it never publishes, so it must not outrank
+        // the owner whose snapshot it tails.
+        let generation = if claim_owner {
+            prior_generation + 1
+        } else {
+            prior_generation
+        };
 
         let threshold = std::env::var("PROXIMADB_CATALOG_SNAPSHOT_THRESHOLD")
             .ok()
@@ -188,6 +297,9 @@ impl SystemCatalog {
             }),
             commits_since_snapshot: AtomicU64::new(0),
             generation: AtomicU64::new(generation),
+            loaded_version: AtomicU64::new(prior_version),
+            loaded_generation: AtomicU64::new(prior_generation),
+            read_only: AtomicBool::new(!claim_owner),
         })
     }
 
@@ -195,6 +307,15 @@ impl SystemCatalog {
     /// authority — atomically with respect to other writers. Triggers an
     /// automatic checkpoint once enough mutations have accumulated.
     async fn commit_batch(&self, deltas: Vec<CatalogDelta>) -> Result<()> {
+        // Phase 6b: a follower replica / superseded ex-owner serves reads only;
+        // DDL must go to the owning pod. (Single-pod owner: never read-only.)
+        if self.read_only.load(Ordering::SeqCst) {
+            return Err(anyhow!(
+                "system catalog '{}' is read-only (a follower replica or superseded by a \
+                 newer pod); route DDL to the owning pod",
+                self.name
+            ));
+        }
         let _guard = self.write_lock.lock().await;
         let ops = deltas
             .iter()
@@ -223,8 +344,12 @@ impl SystemCatalog {
     }
 
     /// Force a snapshot + WAL compaction now. No-op for injected-appender
-    /// catalogs. Takes the write lock; callers must not already hold it.
+    /// catalogs and for read-only followers (they never publish). Takes the
+    /// write lock; callers must not already hold it.
     pub async fn checkpoint(&self) -> Result<()> {
+        if self.read_only.load(Ordering::SeqCst) {
+            return Ok(());
+        }
         if let Some(cfg) = &self.snapshot {
             let _guard = self.write_lock.lock().await;
             self.checkpoint_locked(cfg).await?;
@@ -254,21 +379,32 @@ impl SystemCatalog {
         //    a reader sees the old or new blob, never a torn one.
         let generation = self.generation.load(Ordering::SeqCst);
         let bytes = self.state.to_snapshot_bytes()?;
-        let published = cfg.store.write_atomic(generation, &bytes).await?;
-        if !published {
-            // Fenced (Phase 6a): a newer pod (higher generation) has taken the
-            // catalog over. We are now a stale writer — the snapshot we tried to
-            // publish did NOT land, so we MUST NOT compact our local WAL (doing so
-            // would drop history that is no longer covered by any durable
-            // snapshot we own). Surface it and leave the WAL intact; cross-pod
-            // reload / step-down is Phase 6b.
-            tracing::warn!(
-                catalog = %self.name,
-                generation,
-                store = %cfg.store.describe(),
-                "catalog snapshot checkpoint was fenced by a newer pod; skipping WAL compaction"
-            );
-            return Ok(());
+        match cfg.store.write_atomic(generation, &bytes).await? {
+            SnapshotWrite::Published { version } => {
+                // Our publish IS the latest snapshot now — record its version +
+                // generation so the sinval check does not mistake our own write
+                // for a peer's and reload it away (read-your-writes).
+                self.loaded_version.store(version, Ordering::SeqCst);
+                self.loaded_generation.store(generation, Ordering::SeqCst);
+            }
+            SnapshotWrite::Fenced => {
+                // Fenced (Phase 6a): a newer pod (higher generation) has taken
+                // the catalog over. We are a stale writer — the snapshot we tried
+                // to publish did NOT land, so we MUST NOT compact our local WAL.
+                // Phase 6b step-down: pull the newer pod's snapshot into RAM
+                // (discarding our now-doomed post-snapshot writes) and flip to
+                // read-only so we stop emitting writes the fence will reject. We
+                // already hold the write lock, so reload directly.
+                tracing::warn!(
+                    catalog = %self.name,
+                    generation,
+                    store = %cfg.store.describe(),
+                    "catalog snapshot checkpoint was fenced by a newer pod; \
+                     stepping down to read-only and reloading its snapshot"
+                );
+                self.reload_from_store_locked(cfg).await?;
+                return Ok(());
+            }
         }
 
         // 2. Compact the WAL: keep only entries the snapshot does not cover.
@@ -281,6 +417,152 @@ impl SystemCatalog {
             crate::services::canonical_wal::rewrite_canonical_wal(&cfg.wal_path, &kept).await?;
         }
         Ok(())
+    }
+
+    // ── Phase 6b: cross-pod cache coherence (sinval-style invalidation) ───────
+
+    /// **Sinval staleness check.** Compare this pod's cached snapshot version
+    /// against the object store's latest published version; if a newer snapshot
+    /// has been published (by the owner, or by a pod that took the catalog over),
+    /// lazily reload the in-RAM authority from it. This is the Postgres-`sinval`
+    /// analog: the published pointer's monotonic version is the invalidation
+    /// signal; a follower (or a superseded ex-owner) reloads on mismatch and is
+    /// thereafter consistent within the poll interval (bounded staleness).
+    ///
+    /// Cheap when nothing changed: a single object-store `list` probe
+    /// ([`CatalogSnapshotStore::latest_version`]) with no payload fetch. The
+    /// (larger) snapshot payload is read only on a version advance. Inert for the
+    /// local single-pod store (it reports no version) and for injected-appender
+    /// catalogs (no snapshot store).
+    pub async fn reload_if_stale(&self) -> Result<ReloadOutcome> {
+        let cfg = match &self.snapshot {
+            Some(cfg) => cfg,
+            None => return Ok(ReloadOutcome::Disabled),
+        };
+        // Cheap probe first — no payload fetch.
+        let latest = cfg.store.latest_version().await?;
+        let loaded = self.loaded_version.load(Ordering::SeqCst);
+        match latest {
+            Some(v) if version_is_newer(loaded, v) => {
+                // A newer snapshot exists — take the write lock so no DDL or
+                // checkpoint interleaves the state swap, then reload.
+                let _guard = self.write_lock.lock().await;
+                self.reload_from_store_locked(cfg).await
+            }
+            _ => Ok(ReloadOutcome::UpToDate),
+        }
+    }
+
+    /// Reload the in-RAM authority from the current object-store snapshot,
+    /// **assuming the write lock is held**. Used by [`reload_if_stale`] (after it
+    /// detects a version advance) and by the fenced-checkpoint step-down path.
+    /// Re-checks the version under the lock so two concurrent reloaders don't
+    /// double-apply, and never moves backward.
+    async fn reload_from_store_locked(&self, cfg: &SnapshotConfig) -> Result<ReloadOutcome> {
+        let read = match cfg.store.read().await? {
+            Some(read) => read,
+            // Nothing published (or it vanished) — nothing to adopt.
+            None => return Ok(ReloadOutcome::UpToDate),
+        };
+        let loaded = self.loaded_version.load(Ordering::SeqCst);
+        if !version_is_newer(loaded, read.version) {
+            // Another reload already pulled this version (or newer); never reload
+            // an older snapshot over a current one (monotonic reads).
+            return Ok(ReloadOutcome::UpToDate);
+        }
+
+        self.state
+            .load_from_snapshot_bytes(&read.bytes)
+            .with_context(|| {
+                format!(
+                    "reloading catalog '{}' from snapshot {}",
+                    self.name,
+                    cfg.store.describe()
+                )
+            })?;
+        self.loaded_version.store(read.version, Ordering::SeqCst);
+        self.loaded_generation
+            .store(read.generation, Ordering::SeqCst);
+
+        // Superseded: the adopted snapshot was committed under a generation that
+        // outranks this pod's write generation, i.e. a newer pod owns the
+        // catalog. Step down to read-only so we stop emitting writes the fence
+        // would reject (reacquiring write ownership is the Phase 7 lease).
+        let superseded = read.generation > self.generation.load(Ordering::SeqCst);
+        if superseded {
+            self.read_only.store(true, Ordering::SeqCst);
+        }
+        Ok(ReloadOutcome::Reloaded {
+            version: read.version,
+            generation: read.generation,
+            superseded,
+        })
+    }
+
+    /// Spawn a background task that tails the object-store snapshot, calling
+    /// [`reload_if_stale`](Self::reload_if_stale) every `interval`. This is the
+    /// **follower tailer** — it pulls the owner's published DDL into a follower's
+    /// (or a superseded ex-owner's) RAM within `interval` (bounded staleness).
+    ///
+    /// The returned [`JoinHandle`](tokio::task::JoinHandle) **owns the task**: the
+    /// caller must `abort()` it on shutdown (it is a cooperative tokio task, not
+    /// an OS thread, so it never blocks process exit, but a clean abort avoids a
+    /// stray reload firing during teardown). Inert for catalogs without a
+    /// snapshot store / version concept (each tick is a no-op `Disabled`).
+    pub fn spawn_follower_poll(self: Arc<Self>, interval: Duration) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // The first tick fires immediately; skip it so we honour `interval`.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                match self.reload_if_stale().await {
+                    Ok(ReloadOutcome::Reloaded {
+                        version,
+                        generation,
+                        superseded,
+                    }) => {
+                        tracing::info!(
+                            catalog = %self.name,
+                            version,
+                            generation,
+                            superseded,
+                            "catalog follower reloaded in-RAM authority from a newer \
+                             object-store snapshot"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            catalog = %self.name,
+                            error = %e,
+                            "catalog follower poll failed; will retry next interval"
+                        );
+                    }
+                }
+            }
+        })
+    }
+
+    /// The fencing generation this pod writes snapshots under (Phase 6a/6b).
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    /// The object-store snapshot pointer version currently reflected in RAM, or
+    /// `None` if no published snapshot has been observed yet.
+    pub fn loaded_version(&self) -> Option<u64> {
+        match self.loaded_version.load(Ordering::SeqCst) {
+            NO_VERSION => None,
+            v => Some(v),
+        }
+    }
+
+    /// Whether this catalog is a read-only replica — a follower, or an ex-owner
+    /// superseded by a newer-generation pod (Phase 6b).
+    pub fn is_read_only(&self) -> bool {
+        self.read_only.load(Ordering::SeqCst)
     }
 
     /// Load a table's current schema or fail (the catalog's "table not found").
@@ -1094,6 +1376,269 @@ mod tests {
         let reopened = catalog(dir.path()).await;
         let tables = reopened.list_tables(&nslevels(&["s"])).await?;
         assert_eq!(tables.len(), 15); // 20 created - 5 dropped
+        Ok(())
+    }
+
+    // ── Phase 6b: cross-pod cache coherence (sinval) — multi-instance harness ──
+    //
+    // Two (or more) in-process `SystemCatalog`s over ONE shared backing object
+    // store stand in for two pods. Each has its OWN local WAL; the object-store
+    // snapshot is the only shared artifact, so cross-pod visibility flows through
+    // it exactly as in a real deployment.
+
+    /// Open an owner catalog whose snapshot lives in the shared `backing` store.
+    async fn open_owner(
+        wal: &std::path::Path,
+        backing: &Arc<dyn object_store::ObjectStore>,
+    ) -> Result<SystemCatalog> {
+        let store = Arc::new(
+            crate::services::catalog_snapshot_store::ObjectStoreSnapshotStore::new(
+                proximadb_object_store::ProximaObjectStore::new(backing.clone()),
+                "memory:///",
+                "_operator/catalog/_manifests/",
+            ),
+        );
+        SystemCatalog::open_with_snapshot_store("default", wal, store).await
+    }
+
+    /// Open a read-only follower catalog over the shared `backing` store.
+    async fn open_follower(
+        wal: &std::path::Path,
+        backing: &Arc<dyn object_store::ObjectStore>,
+    ) -> Result<SystemCatalog> {
+        let store = Arc::new(
+            crate::services::catalog_snapshot_store::ObjectStoreSnapshotStore::new(
+                proximadb_object_store::ProximaObjectStore::new(backing.clone()),
+                "memory:///",
+                "_operator/catalog/_manifests/",
+            ),
+        );
+        SystemCatalog::open_follower("default", wal, store).await
+    }
+
+    fn tid(name: &str) -> TableIdentifier {
+        TableIdentifier::new(nslevels(&["s"]), name)
+    }
+
+    /// A read-only **follower** tails the owner's published snapshot: it sees the
+    /// owner's committed DDL after a `reload_if_stale`, within the staleness
+    /// bound, and rejects any DDL of its own (route writes to the owner).
+    #[tokio::test]
+    async fn follower_tails_owner_and_rejects_writes() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+
+        // Owner publishes a first snapshot (ns + t1).
+        let owner = open_owner(&dir.path().join("owner.wal"), &backing).await?;
+        owner
+            .create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        owner.create_table(&tid("t1"), vec_schema("t1")).await?;
+        owner.checkpoint().await?;
+
+        // Follower boots from that snapshot — read-only, already sees t1.
+        let follower = open_follower(&dir.path().join("follower.wal"), &backing).await?;
+        assert!(follower.is_read_only());
+        assert!(follower.table_exists(&tid("t1")).await?);
+        assert!(!follower.table_exists(&tid("t2")).await?);
+
+        // A follower must reject DDL — it has no write authority.
+        assert!(
+            follower
+                .create_table(&tid("nope"), vec_schema("nope"))
+                .await
+                .is_err(),
+            "follower must reject DDL"
+        );
+
+        // Owner commits more DDL and republishes. The follower is stale until it
+        // polls; a no-publish probe is cheap and a no-op.
+        owner.create_table(&tid("t2"), vec_schema("t2")).await?;
+        owner.checkpoint().await?;
+
+        // Sinval: the follower observes the newer pointer version and reloads.
+        match follower.reload_if_stale().await? {
+            ReloadOutcome::Reloaded { superseded, .. } => assert!(
+                !superseded,
+                "a same-generation owner republish is not a takeover"
+            ),
+            other => panic!("expected a reload, got {other:?}"),
+        }
+        assert!(follower.table_exists(&tid("t2")).await?);
+        // Polling again with nothing new is a no-op.
+        assert_eq!(follower.reload_if_stale().await?, ReloadOutcome::UpToDate);
+        Ok(())
+    }
+
+    /// **Read-your-writes** on the owner: an owner's own published snapshot must
+    /// not look "stale" to itself, and post-checkpoint writes that live only in
+    /// RAM + the local WAL survive a sinval poll (they are never reloaded away in
+    /// the absence of a newer pod).
+    #[tokio::test]
+    async fn owner_read_your_writes_survives_poll() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+
+        let owner = open_owner(&dir.path().join("owner.wal"), &backing).await?;
+        owner
+            .create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        owner.create_table(&tid("t1"), vec_schema("t1")).await?;
+        owner.checkpoint().await?; // publishes; loaded_version tracks our own write
+
+        // A post-checkpoint write lives only in RAM + the local WAL (unpublished).
+        owner.create_table(&tid("t2"), vec_schema("t2")).await?;
+
+        // Polling sees our own published version — no spurious reload.
+        assert_eq!(owner.reload_if_stale().await?, ReloadOutcome::UpToDate);
+        assert!(!owner.is_read_only());
+        // Read-your-writes: the unpublished t2 is still visible.
+        assert!(owner.table_exists(&tid("t2")).await?);
+        Ok(())
+    }
+
+    /// A **superseded** owner steps down: when a newer-generation pod has taken
+    /// the catalog over, a sinval poll on the old owner reloads the newer
+    /// snapshot, **discards** its own now-doomed unpublished writes, and flips to
+    /// read-only (no lost update — the fence + step-down converge to one writer).
+    #[tokio::test]
+    async fn superseded_owner_steps_down_via_poll() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+
+        // Pod A: first owner (generation 1), publishes ns + t1.
+        let pod_a = open_owner(&dir.path().join("a.wal"), &backing).await?;
+        pod_a
+            .create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        pod_a.create_table(&tid("t1"), vec_schema("t1")).await?;
+        pod_a.checkpoint().await?;
+        assert_eq!(pod_a.generation(), 1);
+
+        // Pod B: takes over (reads gen 1 → claims gen 2), publishes t2.
+        let pod_b = open_owner(&dir.path().join("b.wal"), &backing).await?;
+        assert_eq!(pod_b.generation(), 2);
+        pod_b.create_table(&tid("t2"), vec_schema("t2")).await?;
+        pod_b.checkpoint().await?;
+
+        // Pod A writes t3 locally — unaware it has been superseded; it is visible
+        // on A until the next poll.
+        pod_a.create_table(&tid("t3"), vec_schema("t3")).await?;
+        assert!(pod_a.table_exists(&tid("t3")).await?);
+
+        // Sinval poll on A: a higher generation owns the catalog → step down.
+        match pod_a.reload_if_stale().await? {
+            ReloadOutcome::Reloaded {
+                generation,
+                superseded,
+                ..
+            } => {
+                assert_eq!(generation, 2);
+                assert!(superseded, "a higher-generation snapshot is a takeover");
+            }
+            other => panic!("expected a superseding reload, got {other:?}"),
+        }
+        assert!(
+            pod_a.is_read_only(),
+            "superseded owner must step down to read-only"
+        );
+        // A converges to B's snapshot: sees t1 + t2, and its doomed t3 is gone.
+        assert!(pod_a.table_exists(&tid("t1")).await?);
+        assert!(pod_a.table_exists(&tid("t2")).await?);
+        assert!(
+            !pod_a.table_exists(&tid("t3")).await?,
+            "the superseded pod's unpublished write must be discarded (no lost update)"
+        );
+        // A can no longer write.
+        assert!(
+            pod_a
+                .create_table(&tid("t4"), vec_schema("t4"))
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
+
+    /// The fenced-checkpoint **self-heal** path: even without an explicit poll, an
+    /// owner that discovers it has been fenced *at checkpoint time* steps down and
+    /// reloads the newer snapshot in place (it does not silently keep serving its
+    /// doomed local state, and does not compact its WAL).
+    #[tokio::test]
+    async fn fenced_checkpoint_steps_down_and_reloads() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+
+        let pod_a = open_owner(&dir.path().join("a.wal"), &backing).await?;
+        pod_a
+            .create_namespace(&nslevels(&["s"]), HashMap::new())
+            .await?;
+        pod_a.create_table(&tid("t1"), vec_schema("t1")).await?;
+        pod_a.checkpoint().await?;
+
+        let pod_b = open_owner(&dir.path().join("b.wal"), &backing).await?;
+        pod_b.create_table(&tid("t2"), vec_schema("t2")).await?;
+        pod_b.checkpoint().await?;
+
+        // Pod A, still believing it owns the catalog, writes t3 then checkpoints —
+        // the publish is FENCED (gen 1 < 2), triggering the in-place step-down.
+        pod_a.create_table(&tid("t3"), vec_schema("t3")).await?;
+        pod_a.checkpoint().await?;
+
+        assert!(
+            pod_a.is_read_only(),
+            "a fenced owner steps down to read-only"
+        );
+        assert!(
+            pod_a.table_exists(&tid("t2")).await?,
+            "adopted B's snapshot"
+        );
+        assert!(
+            !pod_a.table_exists(&tid("t3")).await?,
+            "doomed unpublished write discarded on step-down"
+        );
+        Ok(())
+    }
+
+    /// Coherence is inert where it should be: an injected-appender catalog (no
+    /// snapshot store) reports `Disabled`, and a local single-pod owner — whose
+    /// store exposes no version — never spuriously reloads or steps down.
+    #[tokio::test]
+    async fn coherence_is_inert_for_local_and_injected() -> Result<()> {
+        // Injected-appender catalog: no snapshot store at all → Disabled.
+        let injected = SystemCatalog::new(
+            "x",
+            SystemCatalogState::new(),
+            Arc::new(crate::services::canonical_wal::MemoryTableWalAppender::new()),
+        );
+        assert_eq!(injected.reload_if_stale().await?, ReloadOutcome::Disabled);
+
+        // Local single-pod owner: the store has no version concept → the cheap
+        // probe returns None and the poll is always UpToDate, never read-only.
+        let dir = tempfile::tempdir()?;
+        {
+            let local = catalog(dir.path()).await;
+            local
+                .create_namespace(&nslevels(&["s"]), HashMap::new())
+                .await?;
+            local.create_table(&tid("t1"), vec_schema("t1")).await?;
+            local.checkpoint().await?; // snapshot watermark advances; WAL → empty
+            assert_eq!(wal_entry_count(dir.path()).await, 0);
+        }
+        // Reopen onto the empty (compacted) WAL + the snapshot: the appender's
+        // file-derived sequence floor is 0, below the snapshot watermark. Seeding
+        // the floor from the watermark means a fresh write still lands above it.
+        let local = catalog(dir.path()).await;
+        assert_eq!(local.reload_if_stale().await?, ReloadOutcome::UpToDate);
+        assert!(!local.is_read_only());
+        local.create_table(&tid("t2"), vec_schema("t2")).await?;
+        assert!(
+            local.table_exists(&tid("t2")).await?,
+            "a write after a compact-to-empty reopen must apply (sequence-floor seeded)"
+        );
         Ok(())
     }
 }

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -302,6 +302,30 @@ impl SystemCatalogState {
     /// Reconstruct state from a snapshot blob, rebuilding the `ns_children`
     /// secondary index.
     pub fn from_snapshot_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(Self {
+            inner: RwLock::new(Self::inner_from_snapshot_bytes(bytes)?),
+        })
+    }
+
+    /// **Replace** the entire in-RAM authority with the image decoded from a
+    /// snapshot blob, in place (the `Arc<SystemCatalogState>` identity is
+    /// preserved so all holders observe the swap). This is the Phase 6b
+    /// cross-pod **invalidation/reload** primitive: when a follower (or a
+    /// superseded ex-owner) observes a newer object-store snapshot, it adopts
+    /// that snapshot wholesale. The swap is atomic with respect to catalog reads
+    /// — a concurrent reader sees the entire old image or the entire new one,
+    /// never a partial blend — because it happens under the single write lock the
+    /// reads take in shared mode.
+    pub fn load_from_snapshot_bytes(&self, bytes: &[u8]) -> Result<()> {
+        let rebuilt = Self::inner_from_snapshot_bytes(bytes)?;
+        *self.inner.write() = rebuilt;
+        Ok(())
+    }
+
+    /// Decode a snapshot blob into a fully-indexed [`CatalogInner`], rebuilding
+    /// the `ns_children` secondary index (which the snapshot omits as a pure
+    /// derivation of `tables`).
+    fn inner_from_snapshot_bytes(bytes: &[u8]) -> Result<CatalogInner> {
         let snapshot: CatalogSnapshot =
             rmp_serde::from_slice(bytes).context("decoding catalog snapshot")?;
         let mut ns_children: HashMap<Vec<String>, HashSet<String>> = HashMap::new();
@@ -318,14 +342,12 @@ impl SystemCatalogState {
                 .insert(id.name.clone());
             tables.insert(id, Arc::new(schema));
         }
-        Ok(Self {
-            inner: RwLock::new(CatalogInner {
-                namespaces: snapshot.namespaces,
-                tables,
-                ns_children,
-                statistics: snapshot.statistics,
-                applied_seq: snapshot.applied_seq,
-            }),
+        Ok(CatalogInner {
+            namespaces: snapshot.namespaces,
+            tables,
+            ns_children,
+            statistics: snapshot.statistics,
+            applied_seq: snapshot.applied_seq,
         })
     }
 }


### PR DESCRIPTION
## Phase 6b — sinval-style cross-pod cache coherence

Builds directly on **6a** (PR #239, generation-fenced object-store snapshots). Closes the third multi-pod gap from the plan: *no cross-pod cache invalidation → a DDL on pod A leaves pod B's relcache stale*. Embedded relcaches now stay coherent across pods **without a master** — reads stay local, the object-store fence stays the write authority.

### What ships
- **Two monotonic keys, used correctly.** `ManifestCommitter` already gives a per-commit **version** (advances on *every* publish, incl. same-owner re-checkpoints) and a fencing **generation** (changes only on takeover). The follower staleness key is the **version** (so it picks up same-generation owner updates); a higher **generation** means takeover. The `CatalogSnapshotStore` trait now surfaces both: `read() -> SnapshotRead{version, generation, bytes}`, `write_atomic -> SnapshotWrite{Published{version} | Fenced}`, plus a cheap `latest_version()` LIST probe (`None` for the local single-pod store).
- **`SystemCatalog::reload_if_stale()`** — the sinval check. Cheap version probe; on advance, take the write lock and lazily reload the in-RAM authority **in place** (`SystemCatalogState::load_from_snapshot_bytes`, atomic vs. readers). A snapshot whose generation outranks this pod's = a takeover → **step down to read-only**.
- **Read-your-writes** on the owner (its own published version never looks stale, so its un-snapshotted RAM writes are never reloaded away); **bounded staleness** on followers via `spawn_follower_poll` (abortable tokio task; env-gated `PROXIMADB_CATALOG_FOLLOWER_POLL_SECS`, **off by default**).
- **`open_follower()`** — a read-only replica that tails the snapshot and rejects DDL.
- **Fenced checkpoint self-heals** (reload + step-down) instead of only warning (6a behaviour).
- **Latent WAL fix:** seed the appender's sequence floor from the snapshot watermark at open, so a write after a compact-to-empty reopen (or a pod adopting a *peer's* snapshot in a different local sequence space) is not idempotently dropped.

### Inert by default
Single-pod / local deployments have no version concept → `reload_if_stale` is always `UpToDate`, never read-only, no follower spawned. Behaviour is byte-identical to 6a.

### Verification — multi-instance harness (2+ catalogs over one shared object store)
- `follower_tails_owner_and_rejects_writes` — bounded-staleness tail + DDL rejection
- `owner_read_your_writes_survives_poll`
- `superseded_owner_steps_down_via_poll` — takeover → step-down, doomed local write discarded (no lost update)
- `fenced_checkpoint_steps_down_and_reloads`
- `coherence_is_inert_for_local_and_injected`
- 6a `fenced_commit_rejects_stale_writer` still green

**30/30** catalog tests pass; `cargo fmt` clean; `cargo clippy --lib --bins` clean; `cargo check --workspace --lib --bins --tests` (the hard merge gate) green.

### Scope / follow-ups
A stepped-down ex-owner's in-RAM state is correct (reload wins); reconciling its *local WAL* across per-pod sequence spaces on reboot is the deferred object-store-**native** WAL (the remaining Phase 6 work). Pure followers never write, so they have no such concern. Next: Phase 7 (partition lease via `consult_for_write`) + Phase 8 (system-schema + `CatalogTuning` levers).