### PR TITLE
feat(py-sdk): real vector-free metadata scan + Haystack filter_documents (TD-126)

### DIFF
--- a/clients/python/src/proximadb_sdk/integrations/haystack.py
+++ b/clients/python/src/proximadb_sdk/integrations/haystack.py
@@ -61,6 +61,134 @@ _HAYSTACK_OP_TO_PROXIMA = {
     "not in": "$nin",
 }
 
+# Mapping from Haystack 2.x comparison operators to the typed ops accepted by the
+# ProximaDB ``/records/scan`` filter surface (the ``[{field,op,value}]`` form).
+# Note the scan surface combines a flat list as a logical AND only and does not
+# offer a "not in" op — operators absent here (and any OR/NOT logical nesting)
+# cannot be pushed down and are evaluated client-side instead.
+_HAYSTACK_OP_TO_SCAN = {
+    None: "eq",
+    "==": "eq",
+    "eq": "eq",
+    "!=": "neq",
+    ">": "gt",
+    ">=": "gte",
+    "<": "lt",
+    "<=": "lte",
+    "in": "in",
+}
+
+
+def _strip_meta_prefix(field: str) -> str:
+    """Drop Haystack's ``meta.`` prefix from a metadata field name."""
+    return field[len("meta.") :] if field.startswith("meta.") else field
+
+
+def _haystack_filters_to_scan_filter(
+    filters: dict[str, Any] | None,
+) -> list[dict[str, Any]] | None:
+    """Flatten a Haystack 2.x filter tree into the scan endpoint's typed form.
+
+    Returns a ``[{"field","op","value"}]`` list suitable for the
+    ``/records/scan`` ``filter`` (an implicit logical AND that ProximaDB pushes
+    into the scan predicate server-side), or ``None`` when nothing can be pushed
+    down. Only the AND-combinable comparison subset is lowered: ``OR``/``NOT``
+    logical nodes and operators the scan surface lacks (e.g. ``not in``) are
+    skipped here and enforced client-side by :func:`_haystack_filter_matches`,
+    so the pushed-down predicate is always a *sound* over-approximation (it never
+    drops a matching document — it can only return a superset that the
+    client-side check then narrows).
+    """
+    if not filters:
+        return None
+    conditions: list[dict[str, Any]] = []
+    _collect_and_conditions(filters, conditions)
+    return conditions or None
+
+
+def _collect_and_conditions(node: dict[str, Any], out: list[dict[str, Any]]) -> None:
+    """Recurse only through AND nodes, collecting pushdown-safe comparisons.
+
+    Anything under an OR/NOT (or an unsupported operator) is intentionally not
+    collected: dropping it from the *pushdown* set keeps the server-side result a
+    superset of the true match set, which the client-side matcher then filters.
+    """
+    operator = node.get("operator")
+    if "conditions" in node:
+        if str(operator).upper() == "AND":
+            for child in node["conditions"]:
+                if isinstance(child, dict):
+                    _collect_and_conditions(child, out)
+        # OR / NOT cannot be expressed in the flat scan filter — skip (the
+        # client-side matcher enforces them).
+        return
+    scan_op = _HAYSTACK_OP_TO_SCAN.get(
+        operator if operator in _HAYSTACK_OP_TO_SCAN else str(operator)
+    )
+    if scan_op is None:
+        return
+    field = _strip_meta_prefix(node.get("field", ""))
+    if not field:
+        return
+    out.append({"field": field, "op": scan_op, "value": node.get("value")})
+
+
+def _haystack_filter_matches(
+    meta: dict[str, Any], filters: dict[str, Any] | None
+) -> bool:
+    """Evaluate a full Haystack 2.x filter tree against a document's metadata.
+
+    This is the authoritative correctness check applied client-side to every
+    scanned record. It supports the full logical tree (``AND``/``OR``/``NOT``)
+    and every comparison operator — including the ones the scan endpoint cannot
+    push down (``not in``) — so the returned set is exactly the documents the
+    caller's filter selects, regardless of what was pushed down server-side.
+    """
+    if not filters:
+        return True
+    operator = filters.get("operator")
+    if "conditions" in filters:
+        children = [c for c in filters["conditions"] if isinstance(c, dict)]
+        op = str(operator).upper()
+        if op == "OR":
+            return any(_haystack_filter_matches(meta, c) for c in children)
+        if op == "NOT":
+            return not all(_haystack_filter_matches(meta, c) for c in children)
+        # Default / AND.
+        return all(_haystack_filter_matches(meta, c) for c in children)
+
+    field = _strip_meta_prefix(filters.get("field", ""))
+    expected = filters.get("value")
+    actual = meta.get(field)
+    return _compare(actual, operator, expected)
+
+
+def _compare(actual: Any, operator: Any, expected: Any) -> bool:
+    """Apply a single Haystack comparison operator to a metadata value."""
+    if operator in (None, "==", "eq"):
+        return actual == expected
+    if operator == "!=":
+        return actual != expected
+    if operator == "in":
+        return expected is not None and actual in expected
+    if operator == "not in":
+        return expected is None or actual not in expected
+    if actual is None or expected is None:
+        return False
+    try:
+        if operator == ">":
+            return actual > expected
+        if operator == ">=":
+            return actual >= expected
+        if operator == "<":
+            return actual < expected
+        if operator == "<=":
+            return actual <= expected
+    except TypeError:
+        return False
+    # Unknown operator: fall back to equality (mirrors the lenient conversion).
+    return actual == expected
+
 
 def _convert_haystack_filters(filters: dict[str, Any] | None) -> dict[str, Any] | None:
     """Convert a Haystack 2.x filter tree into ProximaDB's filter dict format.
@@ -117,6 +245,12 @@ class ProximaDBDocumentStore:
         text_key: Metadata key used to store the original document text.
             Defaults to ``"content"``.
         namespace: Optional namespace prefix for document IDs.
+        max_filter_window: Safety cap on the total number of rows
+            :meth:`filter_documents` will accumulate across scan pages before
+            stopping. This is a guardrail against unbounded client memory use on
+            a huge collection, not an ANN window — ``filter_documents`` performs
+            a real cursor-paginated metadata scan, so within this cap it returns
+            every matching document.
     """
 
     def __init__(
@@ -154,32 +288,40 @@ class ProximaDBDocumentStore:
         self,
         filters: dict[str, Any] | None = None,
     ) -> list[Document]:
-        """Return documents whose metadata matches ``filters``.
+        """Return ALL documents whose metadata matches ``filters``.
 
         ``filters`` accepts the Haystack 2.x filter syntax (logical ``AND``/
-        ``OR``/``NOT`` over comparison nodes); it is converted to ProximaDB's
-        metadata-filter format and pushed down as a server-side predicate, so the
-        result is a true metadata filter rather than a similarity ranking.
+        ``OR``/``NOT`` over comparison nodes). The AND-combinable comparison
+        subset is converted to the SDK's vector-free metadata-scan filter and
+        pushed down as a server-side predicate; the scan is then paginated via
+        cursor until exhausted, so the result is the *complete* matching set —
+        not a similarity ranking and not a bounded ANN window.
 
-        Note: the SDK does not expose a pure metadata scan, so the predicate is
-        evaluated over a bounded retrieval window (``max_filter_window``). For an
-        unfiltered call (``filters is None``) every stored document up to that
-        window is returned. This is a deliberate cap, not an ANN ordering — the
-        ordering of the returned set is unspecified.
+        The scan endpoint's flat filter cannot express ``OR``/``NOT`` (or a
+        ``not in`` comparison), so the full Haystack tree is additionally
+        evaluated client-side over every scanned record. That keeps results
+        exactly correct while still using server-side pushdown to reduce the
+        scanned/egressed set whenever possible. For an unfiltered call
+        (``filters is None``) every stored document is returned (up to the
+        configurable ``max_filter_window`` total-row safety cap).
         """
-        metadata_filter = _convert_haystack_filters(filters)
+        scan_filter = _haystack_filters_to_scan_filter(filters)
 
-        # No similarity intent here: a constant probe vector is only the
-        # mechanism to enumerate the collection; the metadata predicate does the
-        # actual filtering server-side.
-        probe_vector = [0.0] * self._embedding_dim
-        search_results = self._client.search(
+        # Real vector-free metadata scan + cursor pagination over the whole
+        # matching set (no dummy probe vector, no ANN ordering, no top_k cap):
+        # the AND-combinable predicate is pushed down server-side, and the full
+        # Haystack tree is enforced client-side for OR/NOT/not-in correctness.
+        records = self._client.scan(
             self._collection_name,
-            vector=probe_vector,
-            top_k=self._max_filter_window,
-            metadata_filter=metadata_filter,
+            filter=scan_filter,
+            max_rows=self._max_filter_window,
+            include_vectors=True,
         )
-        return [self._result_to_document(r) for r in search_results]
+        return [
+            self._result_to_document(r)
+            for r in records
+            if _haystack_filter_matches(dict(r.metadata or {}), filters)
+        ]
 
     def write_documents(
         self,

--- a/clients/python/src/proximadb_sdk/protocols/_rest_codegen.py
+++ b/clients/python/src/proximadb_sdk/protocols/_rest_codegen.py
@@ -56,6 +56,7 @@ from .._generated.rest.api.query import execute_query as _gen_execute_query
 from .._generated.rest.api.query import explain_query as _gen_explain_query
 from .._generated.rest.api.records import get_record as _gen_get_record
 from .._generated.rest.api.records import insert_records as _gen_insert_records
+from .._generated.rest.api.records import scan_records as _gen_scan_records
 from .._generated.rest.api.search import search_records as _gen_search_records
 from .._generated.rest.models.create_collection_v2_request import (
     CreateCollectionV2Request,
@@ -66,6 +67,7 @@ from .._generated.rest.models.create_node_request import CreateNodeRequest
 from .._generated.rest.models.explain_query_request import ExplainQueryRequest
 from .._generated.rest.models.insert_records_request import InsertRecordsRequest
 from .._generated.rest.models.query_request import QueryRequest
+from .._generated.rest.models.scan_records_request import ScanRecordsRequest
 from .._generated.rest.models.traverse_request import TraverseRequest
 from .._generated.rest.models.typed_search_request import TypedSearchRequest
 from .._generated.rest.types import UNSET
@@ -161,6 +163,20 @@ def get_record(
             include_vector=UNSET if include_vector is None else include_vector,
             include_text=UNSET if include_text is None else include_text,
         )
+    )
+
+
+def scan_records(collection_id: str, body: dict[str, Any]) -> RestCall:
+    """Vector-free, metadata-filtered, cursor-paginated record scan.
+
+    The body mirrors the OpenAPI ``ScanRecordsRequest`` (``filter`` / ``limit`` /
+    ``cursor`` / ``include_text`` / ``include_vector``); all fields are optional,
+    so ``{}`` returns the first page. The metadata ``filter`` is pushed into the
+    scan predicate server-side (applied before the limit).
+    """
+    model = _from_dict(ScanRecordsRequest, body)
+    return _normalize(
+        _gen_scan_records._get_kwargs(collection_id=collection_id, body=model)
     )
 
 

--- a/clients/python/src/proximadb_sdk/protocols/_rest_codegen_async.py
+++ b/clients/python/src/proximadb_sdk/protocols/_rest_codegen_async.py
@@ -38,12 +38,14 @@ from .._generated.rest.api.collections import list_collections as _gen_list_coll
 from .._generated.rest.api.records import delete_record as _gen_delete_record
 from .._generated.rest.api.records import get_record as _gen_get_record
 from .._generated.rest.api.records import insert_records as _gen_insert_records
+from .._generated.rest.api.records import scan_records as _gen_scan_records
 from .._generated.rest.api.search import search_records as _gen_search_records
 from .._generated.rest.client import AuthenticatedClient, Client
 from .._generated.rest.models.create_collection_v2_request import (
     CreateCollectionV2Request,
 )
 from .._generated.rest.models.insert_records_request import InsertRecordsRequest
+from .._generated.rest.models.scan_records_request import ScanRecordsRequest
 from .._generated.rest.models.typed_search_request import TypedSearchRequest
 from .._generated.rest.types import UNSET, Response
 from ._rest_codegen import _from_dict
@@ -120,6 +122,21 @@ async def delete_record(
 ) -> Response[Any]:
     return await _gen_delete_record.asyncio_detailed(
         collection_id=collection_id, record_id=record_id, client=client
+    )
+
+
+async def scan_records(
+    client: GenClient, collection_id: str, body: dict[str, Any]
+) -> Response[Any]:
+    """Vector-free, metadata-filtered, cursor-paginated record scan (async).
+
+    Mirrors the sync :func:`_rest_codegen.scan_records`: the body is the OpenAPI
+    ``ScanRecordsRequest`` (``filter`` / ``limit`` / ``cursor`` / ``include_*``);
+    the metadata ``filter`` is pushed into the scan predicate server-side.
+    """
+    model = _from_dict(ScanRecordsRequest, body)
+    return await _gen_scan_records.asyncio_detailed(
+        collection_id=collection_id, client=client, body=model
     )
 
 

--- a/clients/python/src/proximadb_sdk/protocols/rest_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/rest_sync.py
@@ -2142,6 +2142,79 @@ class ProximaDBClient:
 
         return data
 
+    def scan_records(
+        self,
+        collection_id: str,
+        *,
+        filter: list[dict[str, Any]] | dict[str, Any] | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_vector: bool = False,
+        include_text: bool = False,
+    ) -> tuple[list[SearchResult], str | None]:
+        """Vector-free metadata scan of one page of records (TD-099/TD-126).
+
+        Wires the generated ``scan_records`` operation (method/URL/body shape
+        sourced from the OpenAPI spec) through ``_make_request``. Returns the
+        page of records mapped to :class:`SearchResult` plus the server's
+        ``next_cursor`` (``None`` at end-of-scan).
+
+        ``filter`` accepts the scan endpoint's metadata-filter shapes: the typed
+        list form ``[{"field", "op", "value"}]`` or a simple equality map
+        ``{field: value}``; it is pushed into the scan predicate (applied before
+        the limit). This is a true metadata scan, not an ANN ranking.
+        """
+        body: dict[str, Any] = {
+            "include_vector": include_vector,
+            "include_text": include_text,
+        }
+        if filter:
+            body["filter"] = filter
+        if limit is not None:
+            body["limit"] = limit
+        if cursor:
+            body["cursor"] = cursor
+
+        call = _gen.scan_records(collection_id, body)
+        response = self._make_request(call.method, call.endpoint, json=call.json)
+        response_data = response.json()
+
+        if isinstance(response_data, dict) and response_data.get("error_message"):
+            error_msg = response_data.get("error_message")
+            if isinstance(error_msg, str) and "not found" in error_msg.lower():
+                return [], None
+            raise ProximaDBError(f"Scan failed: {error_msg}")
+        if not isinstance(response_data, dict):
+            logger.warning(
+                f"Expected dict scan response, got {type(response_data)}: "
+                f"{response_data}"
+            )
+            return [], None
+
+        records_data = response_data.get("records") or []
+        results: list[SearchResult] = []
+        for rank, record in enumerate(records_data, start=1):
+            if not isinstance(record, dict):
+                continue
+            metadata = record.get("props", record.get("metadata", {})) or {}
+            results.append(
+                SearchResult(
+                    id=str(record.get("id", "")),
+                    score=0.0,
+                    rank=rank,
+                    vector=(record.get("vector") if include_vector else None),
+                    metadata=metadata,
+                    version=record.get("version"),
+                    timestamp=record.get("timestamp"),
+                    source=record.get("source"),
+                )
+            )
+
+        next_cursor = response_data.get("next_cursor")
+        if not next_cursor:
+            next_cursor = None
+        return results, next_cursor
+
     def upsert_vectors(
         self,
         collection_id: str,

--- a/clients/python/src/proximadb_sdk/unified_client.py
+++ b/clients/python/src/proximadb_sdk/unified_client.py
@@ -3060,6 +3060,112 @@ class ProximaDBClient:
 
     # The generic search method is defined above and forwards to search_single
 
+    #: Server-enforced upper bound on a single scan page (SCAN_RECORDS_MAX_PAGE).
+    SCAN_MAX_PAGE = 10_000
+    #: Default safety bound on the total rows ``scan`` will accumulate across
+    #: pages before stopping, so an unbounded scan can't exhaust client memory.
+    SCAN_DEFAULT_MAX_ROWS = 1_000_000
+
+    def scan_page(
+        self,
+        collection_id: str,
+        *,
+        filter: list[dict[str, Any]] | dict[str, Any] | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_vectors: bool = False,
+        include_text: bool = False,
+    ) -> tuple[list[SearchResult], str | None]:
+        """Scan a single page of records via the vector-free metadata-scan endpoint.
+
+        Returns ``(records, next_cursor)``. ``next_cursor`` is ``None`` at
+        end-of-scan. ``filter`` is the scan endpoint's metadata-filter shape:
+        the typed list ``[{"field", "op", "value"}]`` or an equality map
+        ``{field: value}``; it is pushed into the scan predicate server-side
+        (applied before the limit). Unlike :meth:`search`, this is a true
+        metadata scan with no ANN ordering or similarity cap.
+
+        Requires the REST transport (the scan endpoint is REST-only).
+        """
+        target = self._rest_client or (
+            self._client if hasattr(self._client, "scan_records") else None
+        )
+        if target is None or not hasattr(target, "scan_records"):
+            # Stand up a REST client on demand (the scan endpoint is REST-only).
+            if self._rest_client is None:
+                self._rest_client = self._create_rest_client()
+            target = self._rest_client
+        return target.scan_records(
+            collection_id,
+            filter=filter,
+            limit=limit,
+            cursor=cursor,
+            include_vector=include_vectors,
+            include_text=include_text,
+        )
+
+    def scan(
+        self,
+        collection_id: str,
+        *,
+        filter: list[dict[str, Any]] | dict[str, Any] | None = None,
+        page_size: int | None = None,
+        max_rows: int | None = None,
+        include_vectors: bool = False,
+        include_text: bool = False,
+    ) -> list[SearchResult]:
+        """Scan ALL records matching ``filter`` via cursor pagination.
+
+        Repeatedly calls :meth:`scan_page`, following the returned ``next_cursor``
+        until the server reports end-of-scan (``None``). This returns the full
+        matching set — not a bounded ANN window.
+
+        Args:
+            filter: Scan-endpoint metadata filter (typed list ``[{field,op,value}]``
+                or equality map ``{field: value}``), pushed down server-side.
+            page_size: Rows per page request (clamped to ``SCAN_MAX_PAGE``).
+            max_rows: Safety bound on total accumulated rows. Defaults to
+                :attr:`SCAN_DEFAULT_MAX_ROWS`; the loop stops once it is reached
+                even if the server has more pages.
+            include_vectors: Include vector embeddings in each record.
+            include_text: Include TEXT fields in each record.
+        """
+        cap = self.SCAN_DEFAULT_MAX_ROWS if max_rows is None else max_rows
+        per_page = self.SCAN_MAX_PAGE if page_size is None else page_size
+        per_page = max(1, min(per_page, self.SCAN_MAX_PAGE))
+
+        out: list[SearchResult] = []
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while len(out) < cap:
+            remaining = cap - len(out)
+            page_limit = min(per_page, remaining)
+            records, cursor = self.scan_page(
+                collection_id,
+                filter=filter,
+                limit=page_limit,
+                cursor=cursor,
+                include_vectors=include_vectors,
+                include_text=include_text,
+            )
+            out.extend(records)
+            if not cursor:
+                break
+            # Defensive: a server that echoes the same cursor would loop forever.
+            if cursor in seen_cursors:
+                logger.warning(
+                    "scan: repeated cursor %s for %s; stopping to avoid a loop",
+                    cursor,
+                    collection_id,
+                )
+                break
+            seen_cursors.add(cursor)
+            # A page that returned nothing but still handed back a cursor would
+            # otherwise spin; stop on an empty page too.
+            if not records:
+                break
+        return out[:cap]
+
     def search_batch(
         self,
         collection_id: str,

--- a/clients/python/src/proximadb_sdk/unified_client_async.py
+++ b/clients/python/src/proximadb_sdk/unified_client_async.py
@@ -587,6 +587,127 @@ class ProximaDBAsyncUnified:
         return results
 
     # ------------------------------------------------------------------
+    # Metadata scan (generated-async transport, REST-only)
+    # ------------------------------------------------------------------
+    #: Server-enforced upper bound on a single scan page (SCAN_RECORDS_MAX_PAGE).
+    SCAN_MAX_PAGE = 10_000
+    #: Default safety bound on the total rows ``scan`` accumulates across pages.
+    SCAN_DEFAULT_MAX_ROWS = 1_000_000
+
+    async def scan_page(
+        self,
+        collection_id: str,
+        *,
+        filter: list[dict[str, Any]] | dict[str, Any] | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_vectors: bool = False,
+        include_text: bool = False,
+    ) -> tuple[list[SearchResult], str | None]:
+        """Scan a single page of records via the vector-free metadata-scan op.
+
+        Wires the generated async ``scan_records`` op. Returns
+        ``(records, next_cursor)`` (``next_cursor`` is ``None`` at end-of-scan).
+        ``filter`` is the scan endpoint's metadata-filter shape (typed list
+        ``[{field,op,value}]`` or equality map ``{field: value}``), pushed into
+        the scan predicate server-side. This is a true metadata scan with no ANN
+        ordering. The scan endpoint is REST-only (no gRPC scan surface).
+        """
+        from .protocols import _rest_codegen_async as _gen_async
+
+        body: dict[str, Any] = {
+            "include_vector": include_vectors,
+            "include_text": include_text,
+        }
+        if filter:
+            body["filter"] = filter
+        if limit is not None:
+            body["limit"] = limit
+        if cursor:
+            body["cursor"] = cursor
+
+        resp = await _gen_async.scan_records(
+            self._require_gen_client(), collection_id, body
+        )
+        parsed = resp.parsed
+        if parsed is None:
+            return [], None
+        data = parsed.to_dict()
+        if data.get("error") or data.get("error_message"):
+            err = data.get("error") or data.get("error_message")
+            if isinstance(err, str) and "not found" in err.lower():
+                return [], None
+            raise ProximaDBError(f"Scan failed: {err}")
+
+        results: list[SearchResult] = []
+        for rank, record in enumerate(data.get("records", []) or [], start=1):
+            if not isinstance(record, dict):
+                continue
+            props = record.get("props") if isinstance(record.get("props"), dict) else {}
+            results.append(
+                SearchResult(
+                    id=str(record.get("id", "")),
+                    score=0.0,
+                    rank=rank,
+                    vector=record.get("vector") if include_vectors else None,
+                    metadata=props,
+                    version=record.get("version"),
+                    timestamp=record.get("timestamp"),
+                    source=record.get("source"),
+                )
+            )
+        next_cursor = data.get("next_cursor") or None
+        return results, next_cursor
+
+    async def scan(
+        self,
+        collection_id: str,
+        *,
+        filter: list[dict[str, Any]] | dict[str, Any] | None = None,
+        page_size: int | None = None,
+        max_rows: int | None = None,
+        include_vectors: bool = False,
+        include_text: bool = False,
+    ) -> list[SearchResult]:
+        """Scan ALL records matching ``filter`` via cursor pagination (async).
+
+        Follows ``next_cursor`` page-to-page until end-of-scan, returning the
+        full matching set (not a bounded ANN window). ``max_rows`` (default
+        :attr:`SCAN_DEFAULT_MAX_ROWS`) bounds total accumulated rows.
+        """
+        cap = self.SCAN_DEFAULT_MAX_ROWS if max_rows is None else max_rows
+        per_page = self.SCAN_MAX_PAGE if page_size is None else page_size
+        per_page = max(1, min(per_page, self.SCAN_MAX_PAGE))
+
+        out: list[SearchResult] = []
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while len(out) < cap:
+            page_limit = min(per_page, cap - len(out))
+            records, cursor = await self.scan_page(
+                collection_id,
+                filter=filter,
+                limit=page_limit,
+                cursor=cursor,
+                include_vectors=include_vectors,
+                include_text=include_text,
+            )
+            out.extend(records)
+            if not cursor:
+                break
+            if cursor in seen_cursors:
+                logger.warning(
+                    "scan: repeated cursor %s for %s; stopping to avoid a loop",
+                    cursor,
+                    collection_id,
+                )
+                break
+            seen_cursors.add(cursor)
+            if not records:
+                break
+        return out[:cap]
+
+    # ------------------------------------------------------------------
     # Graph operations (hand-written async REST/gRPC — not in OpenAPI spec)
     # ------------------------------------------------------------------
     async def graph_shortest_path(

--- a/clients/python/tests/unit/test_haystack_integration.py
+++ b/clients/python/tests/unit/test_haystack_integration.py
@@ -1,0 +1,279 @@
+"""Unit tests for the Haystack DocumentStore integration.
+
+Two concerns are covered:
+
+  * the Haystack 2.x filter-tree -> ProximaDB conversions (#204's
+    ``_convert_haystack_filters`` for the search path, plus the new
+    ``_haystack_filters_to_scan_filter`` / client-side ``_haystack_filter_matches``
+    that back the metadata scan), and
+  * ``filter_documents`` now performing a REAL vector-free metadata scan
+    (``client.scan`` with cursor pagination) instead of the old dummy zero-vector
+    ANN window — returning ALL matching documents, not an ANN-ordered/capped set.
+
+Haystack is an optional dep, so its modules are stubbed into ``sys.modules``
+before importing the integration (mirroring the offline framework-stub pattern
+used by the other integration cov tests).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+from proximadb_sdk.models import SearchResult
+
+
+def _install_haystack_stubs() -> None:
+    """Install minimal stubs for the haystack symbols the integration imports."""
+    hs = types.ModuleType("haystack")
+    hs.__spec__ = types.SimpleNamespace(name="haystack")
+
+    def component(cls):  # @component decorator passthrough
+        return cls
+
+    def _output_types(**_kw):
+        def deco(fn):
+            return fn
+
+        return deco
+
+    component.output_types = _output_types  # type: ignore[attr-defined]
+    hs.component = component
+    hs.default_from_dict = lambda cls, data: cls(**data.get("init_parameters", {}))
+    hs.default_to_dict = lambda obj, **kw: {"init_parameters": kw}
+
+    dc = types.ModuleType("haystack.dataclasses")
+
+    class Document:
+        def __init__(self, id=None, content=None, meta=None, embedding=None):
+            self.id = id
+            self.content = content
+            self.meta = meta or {}
+            self.embedding = embedding
+
+        def with_id(self, doc_id):
+            self.id = doc_id
+            return self
+
+    dc.Document = Document
+
+    ds = types.ModuleType("haystack.document_stores")
+    ds_types = types.ModuleType("haystack.document_stores.types")
+
+    class DuplicatePolicy:
+        FAIL = "fail"
+        OVERWRITE = "overwrite"
+        SKIP = "skip"
+
+    ds_types.DuplicatePolicy = DuplicatePolicy
+
+    sys.modules["haystack"] = hs
+    sys.modules["haystack.dataclasses"] = dc
+    sys.modules["haystack.document_stores"] = ds
+    sys.modules["haystack.document_stores.types"] = ds_types
+
+
+_install_haystack_stubs()
+
+# Evict any cached copy so the import binds against the stubs above.
+sys.modules.pop("proximadb_sdk.integrations.haystack", None)
+from proximadb_sdk.integrations import haystack as hs_mod  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# #204 search-path conversion (kept intact)
+# ---------------------------------------------------------------------------
+
+
+def test_convert_haystack_filters_equality_and_ops():
+    assert hs_mod._convert_haystack_filters(None) is None
+    # bare equality -> {field: value}
+    assert hs_mod._convert_haystack_filters(
+        {"field": "meta.author", "operator": "==", "value": "x"}
+    ) == {"author": "x"}
+    # comparison -> $-prefixed op
+    assert hs_mod._convert_haystack_filters(
+        {"field": "age", "operator": ">", "value": 30}
+    ) == {"age": {"$gt": 30}}
+    # logical AND tree
+    assert hs_mod._convert_haystack_filters(
+        {
+            "operator": "AND",
+            "conditions": [
+                {"field": "a", "operator": "==", "value": 1},
+                {"field": "b", "operator": ">=", "value": 2},
+            ],
+        }
+    ) == {"and": [{"a": 1}, {"b": {"$gte": 2}}]}
+
+
+# ---------------------------------------------------------------------------
+# scan-filter conversion (pushdown subset) + client-side matcher (full tree)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_filter_flattens_and_of_comparisons():
+    flt = hs_mod._haystack_filters_to_scan_filter(
+        {
+            "operator": "AND",
+            "conditions": [
+                {"field": "meta.author", "operator": "==", "value": "ann"},
+                {"field": "year", "operator": ">", "value": 2020},
+                {"field": "tag", "operator": "in", "value": ["a", "b"]},
+            ],
+        }
+    )
+    assert flt == [
+        {"field": "author", "op": "eq", "value": "ann"},
+        {"field": "year", "op": "gt", "value": 2020},
+        {"field": "tag", "op": "in", "value": ["a", "b"]},
+    ]
+
+
+def test_scan_filter_bare_comparison():
+    assert hs_mod._haystack_filters_to_scan_filter(
+        {"field": "k", "operator": "==", "value": "v"}
+    ) == [{"field": "k", "op": "eq", "value": "v"}]
+
+
+def test_scan_filter_skips_or_not_and_unsupported_ops_for_pushdown():
+    # OR cannot be pushed down to the flat scan filter -> nothing pushed.
+    assert (
+        hs_mod._haystack_filters_to_scan_filter(
+            {
+                "operator": "OR",
+                "conditions": [
+                    {"field": "a", "operator": "==", "value": 1},
+                    {"field": "b", "operator": "==", "value": 2},
+                ],
+            }
+        )
+        is None
+    )
+    # "not in" has no scan op -> skipped from pushdown.
+    assert (
+        hs_mod._haystack_filters_to_scan_filter(
+            {"field": "a", "operator": "not in", "value": [1, 2]}
+        )
+        is None
+    )
+
+
+def test_client_side_matcher_full_tree():
+    m = hs_mod._haystack_filter_matches
+    # AND
+    f = {
+        "operator": "AND",
+        "conditions": [
+            {"field": "a", "operator": "==", "value": 1},
+            {"field": "b", "operator": ">", "value": 5},
+        ],
+    }
+    assert m({"a": 1, "b": 6}, f) is True
+    assert m({"a": 1, "b": 5}, f) is False
+    # OR
+    f_or = {
+        "operator": "OR",
+        "conditions": [
+            {"field": "a", "operator": "==", "value": 1},
+            {"field": "a", "operator": "==", "value": 2},
+        ],
+    }
+    assert m({"a": 2}, f_or) is True
+    assert m({"a": 3}, f_or) is False
+    # NOT
+    f_not = {
+        "operator": "NOT",
+        "conditions": [{"field": "a", "operator": "==", "value": 1}],
+    }
+    assert m({"a": 1}, f_not) is False
+    assert m({"a": 2}, f_not) is True
+    # not in (the op the scan endpoint cannot push down)
+    f_nin = {"field": "a", "operator": "not in", "value": [1, 2]}
+    assert m({"a": 3}, f_nin) is True
+    assert m({"a": 1}, f_nin) is False
+    # None filter matches everything
+    assert m({"a": 1}, None) is True
+
+
+# ---------------------------------------------------------------------------
+# filter_documents — real scan + pagination, returns ALL matches
+# ---------------------------------------------------------------------------
+
+
+def _store(client):
+    return hs_mod.ProximaDBDocumentStore(
+        client=client, collection_name="docs", embedding_dim=4
+    )
+
+
+def _result(rid, meta):
+    return SearchResult(id=rid, score=0.0, metadata=meta, source=None)
+
+
+def test_filter_documents_uses_scan_not_search():
+    client = MagicMock()
+    # ALL docs returned by the scan (no top_k cap, no ANN ordering).
+    client.scan = MagicMock(
+        return_value=[
+            _result("1", {"author": "ann", "content": "doc one"}),
+            _result("2", {"author": "ann", "content": "doc two"}),
+        ]
+    )
+    # search must NOT be called anymore (no dummy-vector ANN path).
+    client.search = MagicMock(side_effect=AssertionError("search must not be used"))
+
+    store = _store(client)
+    docs = store.filter_documents(
+        {"field": "meta.author", "operator": "==", "value": "ann"}
+    )
+
+    assert [d.id for d in docs] == ["1", "2"]
+    assert [d.content for d in docs] == ["doc one", "doc two"]
+    # scan was invoked with the pushed-down AND-flattened filter.
+    client.scan.assert_called_once()
+    _, kwargs = client.scan.call_args
+    assert kwargs["filter"] == [{"field": "author", "op": "eq", "value": "ann"}]
+    assert kwargs["max_rows"] == store._max_filter_window
+    client.search.assert_not_called()
+
+
+def test_filter_documents_client_side_narrows_or_tree():
+    # Server cannot push down OR, so scan returns the unfiltered superset; the
+    # client-side matcher must narrow it to the true match set.
+    client = MagicMock()
+    client.scan = MagicMock(
+        return_value=[
+            _result("1", {"tier": "gold"}),
+            _result("2", {"tier": "silver"}),
+            _result("3", {"tier": "bronze"}),
+        ]
+    )
+    store = _store(client)
+
+    docs = store.filter_documents(
+        {
+            "operator": "OR",
+            "conditions": [
+                {"field": "tier", "operator": "==", "value": "gold"},
+                {"field": "tier", "operator": "==", "value": "bronze"},
+            ],
+        }
+    )
+
+    assert sorted(d.id for d in docs) == ["1", "3"]
+    # OR isn't pushable -> no server-side filter sent.
+    _, kwargs = client.scan.call_args
+    assert kwargs["filter"] is None
+
+
+def test_filter_documents_unfiltered_returns_all():
+    client = MagicMock()
+    client.scan = MagicMock(
+        return_value=[_result(str(i), {"content": f"d{i}"}) for i in range(5)]
+    )
+    store = _store(client)
+    docs = store.filter_documents(None)
+    assert len(docs) == 5
+    _, kwargs = client.scan.call_args
+    assert kwargs["filter"] is None

--- a/clients/python/tests/unit/test_scan_records.py
+++ b/clients/python/tests/unit/test_scan_records.py
@@ -1,0 +1,201 @@
+"""Unit tests for the spec-driven vector-free metadata-scan surface.
+
+The scan method (sync ``ProximaDBClient.scan``/``scan_page`` and async
+``ProximaDBAsyncUnified.scan``/``scan_page``) wires the GENERATED ``scan_records``
+endpoint (``sync``/``asyncio_detailed``) through the existing facade plumbing
+(``_rest_codegen`` / ``_rest_codegen_async``). These tests mock only the HTTP
+transport so the real generated request-building runs end to end, and assert:
+
+  * ``scan`` builds the right request body (filter + limit + cursor) on the wire.
+  * cursor pagination loops until ``next_cursor`` is exhausted.
+  * empty results are handled.
+  * records are mapped into the public ``SearchResult`` type.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from proximadb_sdk.models import SearchResult
+from proximadb_sdk.unified_client import ProximaDBClient
+from proximadb_sdk.unified_client_async import ProximaDBAsyncUnified
+
+SCAN_PATH = "/api/v2/collections/docs/records/scan"
+
+
+def _record(rid: str, props: dict) -> dict:
+    return {"id": rid, "props": props, "version": 1, "timestamp": 123}
+
+
+class _ScanRecorder:
+    """Serves canned scan pages keyed by the request's cursor, records bodies."""
+
+    def __init__(self, pages: list[dict]):
+        # pages: list of response bodies served in order, indexed by call count.
+        self.pages = pages
+        self.bodies: list[dict] = []
+        self.calls = 0
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        if request.url.path != SCAN_PATH or request.method != "POST":
+            return httpx.Response(404, json={"error": "no mock route"})
+        self.bodies.append(json.loads(request.content.decode() or "{}"))
+        body = self.pages[min(self.calls, len(self.pages) - 1)]
+        self.calls += 1
+        return httpx.Response(200, json=body)
+
+
+# ---------------------------------------------------------------------------
+# Sync facade — mocks the generated ``scan_records.sync`` transport.
+# ---------------------------------------------------------------------------
+
+
+def _sync_client(rec: _ScanRecorder) -> ProximaDBClient:
+    c = ProximaDBClient(url="http://testserver", protocol="rest")
+    rest = c._create_rest_client()
+    rest._http_client = httpx.Client(
+        base_url="http://testserver",
+        transport=httpx.MockTransport(rec.handler),
+    )
+    c._rest_client = rest
+    c._client = rest
+    return c
+
+
+def test_sync_scan_page_builds_filter_and_maps_results():
+    rec = _ScanRecorder([{"records": [_record("a", {"k": "v"})], "next_cursor": None}])
+    c = _sync_client(rec)
+
+    records, cursor = c.scan_page(
+        "docs",
+        filter=[{"field": "k", "op": "eq", "value": "v"}],
+        limit=50,
+    )
+
+    assert cursor is None
+    assert len(records) == 1
+    assert isinstance(records[0], SearchResult)
+    assert records[0].id == "a"
+    assert records[0].metadata == {"k": "v"}
+    # The generated request body carried the filter + limit on the wire.
+    sent = rec.bodies[0]
+    assert sent["filter"] == [{"field": "k", "op": "eq", "value": "v"}]
+    assert sent["limit"] == 50
+
+
+def test_sync_scan_paginates_until_cursor_exhausted():
+    rec = _ScanRecorder(
+        [
+            {"records": [_record("a", {})], "next_cursor": "c1"},
+            {"records": [_record("b", {})], "next_cursor": "c2"},
+            {"records": [_record("c", {})], "next_cursor": None},
+        ]
+    )
+    c = _sync_client(rec)
+
+    records = c.scan("docs", filter={"tenant": "t1"}, page_size=1)
+
+    assert [r.id for r in records] == ["a", "b", "c"]
+    assert rec.calls == 3
+    # First page sends no cursor; subsequent pages echo the prior next_cursor.
+    assert "cursor" not in rec.bodies[0]
+    assert rec.bodies[1]["cursor"] == "c1"
+    assert rec.bodies[2]["cursor"] == "c2"
+    # Equality-map filter forwarded verbatim each page.
+    assert all(b["filter"] == {"tenant": "t1"} for b in rec.bodies)
+
+
+def test_sync_scan_empty():
+    rec = _ScanRecorder([{"records": [], "next_cursor": None}])
+    c = _sync_client(rec)
+    records = c.scan("docs")
+    assert records == []
+    assert rec.calls == 1
+
+
+def test_sync_scan_respects_max_rows():
+    rec = _ScanRecorder(
+        [
+            {"records": [_record("a", {}), _record("b", {})], "next_cursor": "c1"},
+            {"records": [_record("c", {})], "next_cursor": None},
+        ]
+    )
+    c = _sync_client(rec)
+    records = c.scan("docs", page_size=2, max_rows=2)
+    # Stops at the cap without fetching the second page.
+    assert [r.id for r in records] == ["a", "b"]
+    assert rec.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Async facade — mocks the generated ``scan_records.asyncio_detailed`` transport.
+# ---------------------------------------------------------------------------
+
+
+async def _async_client(rec: _ScanRecorder) -> ProximaDBAsyncUnified:
+    client = ProximaDBAsyncUnified(url="http://testserver", protocol="rest")
+    await client.astart()
+    mock = httpx.AsyncClient(
+        base_url="http://testserver",
+        transport=httpx.MockTransport(rec.handler),
+    )
+    client._async_http = mock
+    client._gen_client.set_async_httpx_client(mock)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_async_scan_page_builds_filter_and_maps_results():
+    rec = _ScanRecorder([{"records": [_record("a", {"k": "v"})], "next_cursor": None}])
+    client = await _async_client(rec)
+    try:
+        records, cursor = await client.scan_page(
+            "docs",
+            filter=[{"field": "k", "op": "eq", "value": "v"}],
+            limit=25,
+        )
+    finally:
+        await client.aclose()
+
+    assert cursor is None
+    assert len(records) == 1
+    assert isinstance(records[0], SearchResult)
+    assert records[0].id == "a"
+    assert records[0].metadata == {"k": "v"}
+    assert rec.bodies[0]["filter"] == [{"field": "k", "op": "eq", "value": "v"}]
+    assert rec.bodies[0]["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_async_scan_paginates_until_cursor_exhausted():
+    rec = _ScanRecorder(
+        [
+            {"records": [_record("a", {})], "next_cursor": "c1"},
+            {"records": [_record("b", {})], "next_cursor": None},
+        ]
+    )
+    client = await _async_client(rec)
+    try:
+        records = await client.scan("docs", filter={"x": 1}, page_size=1)
+    finally:
+        await client.aclose()
+
+    assert [r.id for r in records] == ["a", "b"]
+    assert rec.calls == 2
+    assert "cursor" not in rec.bodies[0]
+    assert rec.bodies[1]["cursor"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_async_scan_empty():
+    rec = _ScanRecorder([{"records": [], "next_cursor": None}])
+    client = await _async_client(rec)
+    try:
+        records = await client.scan("docs")
+    finally:
+        await client.aclose()
+    assert records == []
+    assert rec.calls == 1

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -792,11 +792,32 @@ DSPy adapters.
 
 *Deferred (follow-up):*
 
-* *Pure metadata scan for Haystack `filter_documents`* — the SDK has no
-  vector-free scan endpoint, so the filter predicate is evaluated over a bounded
-  retrieval window (`max_filter_window`, default 10000) using a constant probe
-  vector. A true unbounded metadata-only scan needs a server-side scan API
-  (out of scope for an integration cleanup).
+* *Pure metadata scan for Haystack `filter_documents`* — SHIPPED (2026-06-22).
+  The server-side vector-free scan (`POST /api/v2/collections/{id}/records/scan`,
+  metadata-filtered + cursor-paginated) was already published in the OpenAPI spec
+  and the generated client (`_generated/rest/api/records/scan_records.py`), so this
+  was SDK wiring only — no spec/`_generated`/Rust edits (codegen-drift gate stays
+  green). Added a spec-driven `scan` surface that wires the GENERATED
+  `scan_records` (`sync`/`asyncio_detailed`) through the existing facade plumbing
+  (`protocols/_rest_codegen.scan_records` for sync, `_rest_codegen_async.scan_records`
+  for async): `ProximaDBClient.scan_page`/`scan` (sync) and
+  `ProximaDBAsyncUnified.scan_page`/`scan` (async). `scan_page` returns one page
+  `(records, next_cursor)`; `scan` follows the cursor page-to-page until exhausted
+  with a configurable `page_size` (clamped to `SCAN_MAX_PAGE` = 10000) and total-row
+  safety bound (`max_rows`, default `SCAN_DEFAULT_MAX_ROWS`). `rest_sync.scan_records`
+  maps each `RecordV2Response` into the public `SearchResult` type. Haystack
+  `filter_documents` was repointed off the dummy zero-vector ANN window onto the
+  real `scan`: it flattens the AND-combinable comparison subset of the Haystack 2.x
+  filter tree into the scan endpoint's typed `[{field,op,value}]` pushdown filter
+  (`_haystack_filters_to_scan_filter`) — the scan filter is a flat AND and lacks
+  OR/NOT/`not in`, so the full tree is additionally enforced client-side
+  (`_haystack_filter_matches`) over every scanned record for exact correctness.
+  Result: ALL matching documents are returned via cursor pagination (no ANN
+  ordering, no `top_k` cap); `max_filter_window` is now a total-row safety cap, not
+  an ANN window. `_convert_haystack_filters` (the #204 search-path conversion) is
+  unchanged. Unit tests: `tests/unit/test_scan_records.py` (sync+async filter build,
+  multi-page pagination, empty, max-rows) and `tests/unit/test_haystack_integration.py`
+  (filter conversions + `filter_documents` scans/paginates/narrows, not ANN).
 * *Native async SDK client (REST core ops)* — SHIPPED (2026-06-22). The
   spec-driven mandate now applies to async as well as sync (CLAUDE.md Core
   Directive #15 / GEMINI.md #29). `ProximaDBAsyncUnified` (`unified_client_async.py`)


### PR DESCRIPTION
## Summary

Replaces the Haystack `filter_documents` dummy zero-vector ANN workaround with a REAL vector-free metadata scan, and adds a spec-driven `scan` surface to the SDK. **SDK wiring only** — no spec / `_generated/` / Rust edits (the server-side scan endpoint and generated client already exist), so the `python-sdk-codegen-drift` gate stays green.

## New SDK scan surface (spec-driven)

Wires the GENERATED `scan_records` endpoint functions (`sync`/`asyncio_detailed`) through the existing facade plumbing — `protocols/_rest_codegen.scan_records` (sync) and `protocols/_rest_codegen_async.scan_records` (async). No hand-rolled httpx.

- `ProximaDBClient.scan_page(...)` / `ProximaDBAsyncUnified.scan_page(...)` — one page, returns `(records, next_cursor)`.
- `ProximaDBClient.scan(...)` / `ProximaDBAsyncUnified.scan(...)` — cursor-pagination loop until `next_cursor` is exhausted, with `page_size` (clamped to `SCAN_MAX_PAGE`=10000) and a `max_rows` total-row safety bound (default `SCAN_DEFAULT_MAX_ROWS`).
- `rest_sync.scan_records` maps each `RecordV2Response` into the public `SearchResult` type.
- `filter` accepts the scan endpoint's metadata-filter shapes (typed list `[{field,op,value}]` or equality map `{field: value}`), pushed into the scan predicate server-side.

## Haystack `filter_documents`

- Dropped the `probe_vector = [0.0]*dim` + `top_k=_max_filter_window` ANN call. Now uses the real `scan` with cursor pagination → returns **ALL** matching documents (no ANN ordering, no `top_k` cap).
- Reuses #204's `_convert_haystack_filters` (search path, unchanged). Adds `_haystack_filters_to_scan_filter` (flattens the AND-combinable comparison subset to the scan pushdown filter) + `_haystack_filter_matches` (full-tree client-side check). The scan filter is a flat AND and lacks OR/NOT/`not in`, so the full Haystack tree is enforced client-side for exact correctness; pushdown is a sound over-approximation.
- `max_filter_window` is now documented as a total-row safety cap, not an ANN window. Misleading "the SDK does not expose a pure metadata scan" docstring updated.

## Tests
- `tests/unit/test_scan_records.py` — mocks the generated transport; asserts `scan` builds the right filter + paginates via cursor until exhausted + maps return types; covers filter, multi-page, empty, max-rows (sync + async).
- `tests/unit/test_haystack_integration.py` — filter-tree conversions (search + scan + client-side matcher) and `filter_documents` scans/paginates/narrows (not ANN); haystack stubbed in `sys.modules` (optional dep).

## Verification
- codegen-drift gate green (0 spec/`_generated` edits).
- `import proximadb_sdk` lazy boundary intact (haystack not imported on bare import).
- black/isort/ruff(E9,F63,F7)+py_compile clean; 15 new tests pass; pre-existing unrelated failures unchanged.

Closes the TD-126 "pure metadata scan for Haystack" backlog item.