### PR TITLE
feat(py-sdk): genuine incremental streaming for chunking pipeline (TD-126)

### DIFF
--- a/clients/python/src/proximadb_sdk/chunking_strategies/base.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/base.py
@@ -5,9 +5,23 @@ Defines the core abstractions for text chunking without any embedding concerns.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+
+
+def _coalesce_text_source(text_source: "str | Iterable[str]") -> str:
+    """Materialize a text source (str or iterable of str pieces) into one string.
+
+    Accepts either a single ``str`` or any iterable yielding string pieces
+    (e.g. successive ``file.read(n)`` reads). This is the materializing path used
+    by the default (non-streaming) ``chunk_stream`` and by strategies that cannot
+    stream — it intentionally builds the whole input in memory.
+    """
+    if isinstance(text_source, str):
+        return text_source
+    return "".join(text_source)
 
 
 class ChunkingStrategy(Enum):
@@ -121,6 +135,13 @@ class ChunkingStrategyInterface(ABC):
     Focuses purely on text chunking - no embedding operations
     """
 
+    #: Whether this strategy can chunk incrementally with a bounded buffer
+    #: (i.e. boundary-local). Strategies that need the whole input (tree-sitter
+    #: parse, all-sentence embeddings, recursive cascade, whole-doc structure)
+    #: leave this ``False`` and fall back to materialize-then-chunk in
+    #: :meth:`chunk_stream`. Streamable strategies override it to ``True``.
+    supports_streaming: bool = False
+
     def __init__(self, config: ChunkingConfig):
         self.config = config
 
@@ -140,6 +161,31 @@ class ChunkingStrategyInterface(ABC):
             List of TextChunk objects
         """
         pass
+
+    def chunk_stream(
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        """Yield chunks for ``text_source`` one at a time.
+
+        ``text_source`` may be a single ``str`` or an iterable of text pieces
+        (e.g. successive file reads).
+
+        The default implementation is the **honest fallback** for strategies
+        that cannot stream: it materializes ``text_source`` into one string,
+        runs the batch :meth:`chunk`, and ``yield from`` the resulting list.
+        Memory is therefore bounded by the input size plus the full chunk list,
+        *not* constant — but chunks are still produced via an iterator so
+        callers consume them incrementally.
+
+        Streamable strategies (``supports_streaming == True``) override this to
+        maintain only a bounded local buffer and emit chunks as boundaries are
+        crossed, never accumulating the full input or the full output list.
+        """
+        text = _coalesce_text_source(text_source)
+        yield from self.chunk(text, source_id, base_metadata)
 
     def validate_config(self) -> None:
         """Validate configuration for this strategy"""

--- a/clients/python/src/proximadb_sdk/chunking_strategies/fixed_size.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/fixed_size.py
@@ -5,9 +5,10 @@ Splits text into chunks of exactly the specified size without regard to
 sentence or paragraph boundaries.
 """
 
+from collections.abc import Iterable, Iterator
 from typing import Any
 
-from .base import ChunkingStrategyInterface, TextChunk
+from .base import ChunkingStrategyInterface, TextChunk, _coalesce_text_source
 
 
 class FixedSizeStrategy(ChunkingStrategyInterface):
@@ -17,6 +18,10 @@ class FixedSizeStrategy(ChunkingStrategyInterface):
     Splits text into chunks of exactly the specified size.
     This is the simplest chunking strategy but may split words or sentences.
     """
+
+    #: Boundaries are absolute multiples of ``chunk_size`` over the concatenated
+    #: input, so a bounded buffer of ``chunk_size`` chars is enough to stream.
+    supports_streaming = True
 
     def chunk(
         self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
@@ -73,3 +78,77 @@ class FixedSizeStrategy(ChunkingStrategyInterface):
             self.add_chunk_metadata(chunk, i, len(chunks), "fixed_size")
 
         return chunks
+
+    def chunk_stream(
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        """Incrementally yield fixed-size chunks with a bounded buffer.
+
+        Equivalent to :meth:`chunk` for every chunk's text/offsets/id, except
+        ``total_chunks`` (an inherently global count) is left as ``-1`` because
+        it cannot be known without consuming the whole input — which would
+        defeat bounded-memory streaming.
+
+        Memory is bounded by at most ``chunk_size`` buffered characters plus
+        whatever a single ``text_source`` piece carries.
+        """
+        self.validate_config()
+
+        chunk_size = self.config.chunk_size
+        min_chunk_size = self.config.min_chunk_size
+
+        # `str` is itself iterable of 1-char strings; treat it as a single piece.
+        pieces: Iterable[str]
+        if isinstance(text_source, str):
+            pieces = (text_source,) if text_source else ()
+        else:
+            pieces = text_source
+
+        buffer = ""
+        # Absolute start position (in the concatenated input) of buffer[0].
+        buffer_origin = 0
+        kept = 0
+
+        def make_chunk(start_pos: int, raw: str) -> TextChunk | None:
+            nonlocal kept
+            end_pos = start_pos + len(raw)
+            chunk_text = raw.strip()
+            if len(chunk_text) < min_chunk_size:
+                return None
+            chunk = TextChunk(
+                text=chunk_text,
+                start_pos=start_pos,
+                end_pos=end_pos,
+                chunk_id=f"{source_id}_chunk_{kept}",
+                metadata={
+                    "source_id": source_id,
+                    "chunk_type": "fixed_size",
+                    "chunk_size": chunk_size,
+                    **(base_metadata or {}),
+                },
+            )
+            self.add_chunk_metadata(chunk, kept, -1, "fixed_size")
+            kept += 1
+            return chunk
+
+        for piece in pieces:
+            if not piece:
+                continue
+            buffer += piece
+            # Emit every full window currently available in the buffer.
+            while len(buffer) >= chunk_size:
+                raw = buffer[:chunk_size]
+                chunk = make_chunk(buffer_origin, raw)
+                if chunk is not None:
+                    yield chunk
+                buffer = buffer[chunk_size:]
+                buffer_origin += chunk_size
+
+        # Flush the final partial window (batch slices the tail too).
+        if buffer:
+            chunk = make_chunk(buffer_origin, buffer)
+            if chunk is not None:
+                yield chunk

--- a/clients/python/src/proximadb_sdk/chunking_strategies/paragraph.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/paragraph.py
@@ -5,6 +5,7 @@ Chunks text at paragraph boundaries while respecting size constraints.
 """
 
 import re
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from .base import ChunkingConfig, ChunkingStrategyInterface, TextChunk
@@ -16,6 +17,10 @@ class ParagraphStrategy(ChunkingStrategyInterface):
 
     Keeps paragraphs together when possible, splits large paragraphs if needed
     """
+
+    #: Paragraph boundaries (blank lines) are local; a buffer holding the
+    #: current paragraph group plus the in-progress paragraph is enough.
+    supports_streaming = True
 
     def __init__(self, config: ChunkingConfig):
         super().__init__(config)
@@ -97,26 +102,20 @@ class ParagraphStrategy(ChunkingStrategyInterface):
 
         return chunks
 
-    def chunk(
-        self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
-    ) -> list[TextChunk]:
-        """Create chunks at paragraph boundaries"""
-        self.validate_config()
+    def _group_paragraphs(
+        self,
+        paragraphs: Iterable[tuple[str, int]],
+        source_id: str,
+        base_metadata: dict[str, Any],
+    ) -> Iterator[TextChunk]:
+        """Group a stream of (paragraph, abs_start) into chunks.
 
-        if not text:
-            return []
-
-        base_metadata = base_metadata or {}
-        chunks = []
-
-        # Split into paragraphs
-        paragraphs = self._split_into_paragraphs(text)
-        if not paragraphs:
-            return []
-
-        # Process paragraphs
+        Shared by batch :meth:`chunk` and streaming :meth:`chunk_stream`. Yields
+        chunks with ``total_chunks`` left as ``-1``; the batch path back-fills
+        the count, the streaming path cannot know it.
+        """
         chunk_index = 0
-        current_chunk_paras = []
+        current_chunk_paras: list[str] = []
         current_chunk_length = 0
         current_chunk_start = 0
 
@@ -130,15 +129,13 @@ class ParagraphStrategy(ChunkingStrategyInterface):
                 if current_chunk_paras:
                     chunk_text = "\n\n".join(current_chunk_paras)
                     if len(chunk_text) >= self.config.min_chunk_size:
-                        chunks.append(
-                            self._create_chunk(
-                                chunk_text,
-                                current_chunk_start,
-                                chunk_index,
-                                source_id,
-                                base_metadata,
-                                len(current_chunk_paras),
-                            )
+                        yield self._create_chunk(
+                            chunk_text,
+                            current_chunk_start,
+                            chunk_index,
+                            source_id,
+                            base_metadata,
+                            len(current_chunk_paras),
                         )
                         chunk_index += 1
                     current_chunk_paras = []
@@ -149,16 +146,14 @@ class ParagraphStrategy(ChunkingStrategyInterface):
                     para_text, self.config.chunk_size
                 )
                 for sub_chunk in sub_chunks:
-                    chunks.append(
-                        self._create_chunk(
-                            sub_chunk,
-                            para_start,
-                            chunk_index,
-                            source_id,
-                            base_metadata,
-                            1,
-                            is_list,
-                        )
+                    yield self._create_chunk(
+                        sub_chunk,
+                        para_start,
+                        chunk_index,
+                        source_id,
+                        base_metadata,
+                        1,
+                        is_list,
                     )
                     chunk_index += 1
                     para_start += len(sub_chunk) + 1
@@ -176,15 +171,13 @@ class ParagraphStrategy(ChunkingStrategyInterface):
                 # Create chunk from accumulated paragraphs
                 chunk_text = "\n\n".join(current_chunk_paras)
                 if len(chunk_text) >= self.config.min_chunk_size:
-                    chunks.append(
-                        self._create_chunk(
-                            chunk_text,
-                            current_chunk_start,
-                            chunk_index,
-                            source_id,
-                            base_metadata,
-                            len(current_chunk_paras),
-                        )
+                    yield self._create_chunk(
+                        chunk_text,
+                        current_chunk_start,
+                        chunk_index,
+                        source_id,
+                        base_metadata,
+                        len(current_chunk_paras),
                     )
                     chunk_index += 1
 
@@ -200,23 +193,120 @@ class ParagraphStrategy(ChunkingStrategyInterface):
         # Handle remaining paragraphs
         if current_chunk_paras:
             chunk_text = "\n\n".join(current_chunk_paras)
-            if len(chunk_text) >= self.config.min_chunk_size or not chunks:
-                chunks.append(
-                    self._create_chunk(
-                        chunk_text,
-                        current_chunk_start,
-                        chunk_index,
-                        source_id,
-                        base_metadata,
-                        len(current_chunk_paras),
-                    )
+            if len(chunk_text) >= self.config.min_chunk_size or chunk_index == 0:
+                yield self._create_chunk(
+                    chunk_text,
+                    current_chunk_start,
+                    chunk_index,
+                    source_id,
+                    base_metadata,
+                    len(current_chunk_paras),
                 )
+
+    def chunk(
+        self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
+    ) -> list[TextChunk]:
+        """Create chunks at paragraph boundaries"""
+        self.validate_config()
+
+        if not text:
+            return []
+
+        base_metadata = base_metadata or {}
+
+        # Split into paragraphs
+        paragraphs = self._split_into_paragraphs(text)
+        if not paragraphs:
+            return []
+
+        chunks = list(self._group_paragraphs(paragraphs, source_id, base_metadata))
 
         # Update total chunks count
         for chunk in chunks:
             chunk.metadata["total_chunks"] = len(chunks)
 
         return chunks
+
+    def chunk_stream(
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        """Incrementally yield paragraph chunks with a bounded buffer.
+
+        Equivalent to :meth:`chunk` for every chunk's text/offsets/id, except
+        ``total_chunks`` is left as ``-1`` (an inherently global count).
+
+        Paragraph boundaries (blank lines) are detected in a growing buffer;
+        each completed paragraph (with its absolute start offset in the
+        concatenated input) is committed to the grouping engine, and the
+        trailing partial paragraph is carried over. Memory is bounded by the
+        current paragraph group plus the in-progress paragraph.
+        """
+        self.validate_config()
+
+        base_metadata = base_metadata or {}
+        yield from self._group_paragraphs(
+            self._paragraph_stream(text_source), source_id, base_metadata
+        )
+
+    def _paragraph_stream(
+        self, text_source: "str | Iterable[str]"
+    ) -> Iterator[tuple[str, int]]:
+        """Yield (stripped_paragraph, absolute_start) incrementally.
+
+        Mirrors :meth:`_split_into_paragraphs` exactly (same strip + ``find``
+        offset semantics) but emits paragraphs as soon as a paragraph break is
+        confirmed, holding back only the trailing (possibly incomplete) one.
+        """
+        pieces: Iterable[str]
+        if isinstance(text_source, str):
+            pieces = (text_source,) if text_source else ()
+        else:
+            pieces = text_source
+
+        buffer = ""
+        # Absolute index in the concatenated input of buffer[0].
+        buffer_origin = 0
+        # Where the next `find` search starts, RELATIVE to buffer[0]
+        # (matches batch's `current_pos` which advances past emitted paragraphs).
+        search_rel = 0
+
+        def emit_from_buffer(hold_last: bool) -> Iterator[tuple[str, int]]:
+            nonlocal buffer, buffer_origin, search_rel
+            parts = self.paragraph_pattern.split(buffer)
+            # When holding the last (more input may come), the final part might
+            # still grow; only commit complete parts before it.
+            committable = parts[:-1] if (hold_last and parts) else parts
+            consumed_rel = search_rel
+            for part in committable:
+                stripped = part.strip()
+                if stripped:
+                    start_rel = buffer.find(stripped, consumed_rel)
+                    yield (stripped, buffer_origin + start_rel)
+                    consumed_rel = start_rel + len(stripped)
+            if hold_last:
+                # Drop everything we've consumed; keep the unsplit tail so the
+                # next piece can extend the final (held) paragraph and any
+                # boundary that follows it.
+                if committable:
+                    # Recompute a safe carry point: keep from the start of the
+                    # held (last) part. Find where the tail begins.
+                    drop = consumed_rel
+                    if drop > 0:
+                        buffer = buffer[drop:]
+                        buffer_origin += drop
+                        search_rel = 0
+
+        for piece in pieces:
+            if not piece:
+                continue
+            buffer += piece
+            yield from emit_from_buffer(hold_last=True)
+
+        # Flush remaining paragraphs at EOF.
+        yield from emit_from_buffer(hold_last=False)
 
     def _create_chunk(
         self,

--- a/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
@@ -20,7 +20,7 @@ import logging
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, Callable, Generator
+from collections.abc import AsyncGenerator, Callable, Generator, Iterable
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
@@ -787,22 +787,37 @@ class ChunkingPipeline:
     # -------------------------------------------------------------------------
 
     def process_stream(
-        self, text: str, source_id: str, metadata: dict[str, Any] | None = None
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        metadata: dict[str, Any] | None = None,
     ) -> Generator[TextChunk, None, None]:
         """
         Yield validated/enriched chunks one at a time.
 
-        NOTE: This is *not* an incremental (constant-memory) stream. The full
-        input ``text`` and the complete chunk list are materialized first (the
-        underlying chunking strategies are batch APIs); only the downstream
-        validation/enrichment stages run per-chunk as chunks are yielded. Use
-        this to begin consuming chunks without waiting for the whole pipeline,
-        not to bound memory on very large documents.
+        ``text_source`` may be a single ``str`` (backward compatible) or an
+        iterable of text pieces (e.g. successive file reads).
+
+        Memory profile depends on the strategy:
+
+        * **Streamable strategy** (``chunker.supports_streaming is True`` —
+          sliding-window / fixed-size / sentence / paragraph) **and** an
+          iterable ``text_source``: a *genuinely incremental, bounded-memory*
+          stream. Chunking maintains only a small local buffer and chunks are
+          produced before the whole input is consumed; the full input and the
+          full chunk list are never materialized.
+        * **Non-streamable strategy** (code / semantic-embedding / recursive /
+          structural-semantic): the *honest fallback* — ``chunk_stream``
+          materializes the input and runs the batch chunker (these need the
+          whole document), but chunks are still yielded one at a time so the
+          downstream validation/enrichment stages run per-chunk.
+
+        A plain ``str`` ``text_source`` is always materialized (it already is),
+        so the bounded-memory benefit applies specifically to a streamable
+        strategy fed an iterable source.
         """
         try:
-            chunks = self.chunker.chunk(text, source_id, metadata)
-
-            for chunk in chunks:
+            for chunk in self.chunker.chunk_stream(text_source, source_id, metadata):
                 try:
                     chunk = self.validation_stage.process(chunk)
                     chunk = self.enrichment_stage.process(chunk)
@@ -818,21 +833,33 @@ class ChunkingPipeline:
                 raise
 
     async def process_stream_async(
-        self, text: str, source_id: str, metadata: dict[str, Any] | None = None
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        metadata: dict[str, Any] | None = None,
     ) -> AsyncGenerator[TextChunk, None]:
         """
         Async version of :meth:`process_stream`.
 
-        Same caveat applies: the input and chunk list are materialized first
-        (chunking runs in an executor); this is not constant-memory streaming.
+        Same memory profile applies (genuinely incremental for a streamable
+        strategy + iterable source; honest materialize-then-chunk fallback
+        otherwise). The chunk iterator is advanced in a thread-pool executor so
+        CPU-bound chunking does not block the event loop, while the
+        validation/enrichment stages run per-chunk on the loop.
         """
         try:
             loop = asyncio.get_event_loop()
-            chunks = await loop.run_in_executor(
-                None, lambda: self.chunker.chunk(text, source_id, metadata)
+            chunk_iter = iter(
+                self.chunker.chunk_stream(text_source, source_id, metadata)
             )
+            _SENTINEL = object()
 
-            for chunk in chunks:
+            while True:
+                chunk = await loop.run_in_executor(
+                    None, lambda: next(chunk_iter, _SENTINEL)
+                )
+                if chunk is _SENTINEL:
+                    break
                 try:
                     chunk = await self.validation_stage.process_async(chunk)
                     chunk = await self.enrichment_stage.process_async(chunk)

--- a/clients/python/src/proximadb_sdk/chunking_strategies/sentence.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/sentence.py
@@ -5,6 +5,7 @@ Chunks text at sentence boundaries while respecting size constraints.
 """
 
 import re
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from .base import ChunkingConfig, ChunkingStrategyInterface, TextChunk
@@ -16,6 +17,10 @@ class SentenceStrategy(ChunkingStrategyInterface):
 
     Groups sentences together until reaching size limit
     """
+
+    #: Sentence boundaries are local; a buffer holding the current in-progress
+    #: sentence plus the current group is enough to stream.
+    supports_streaming = True
 
     def __init__(self, config: ChunkingConfig):
         super().__init__(config)
@@ -67,6 +72,46 @@ class SentenceStrategy(ChunkingStrategyInterface):
 
         return sentences
 
+    def _split_with_carry(self, buffer: str) -> tuple[list[str], int]:
+        """Split a raw buffer into finalized sentences + the raw-carry offset.
+
+        Returns ``(finalized_sentences, carry_start)`` where ``carry_start`` is
+        the index in ``buffer`` at which the still-open (unfinalized) sentence
+        group begins — i.e. the RAW text ``buffer[carry_start:]`` must be carried
+        forward unprocessed so inter-piece whitespace is preserved exactly. If
+        the buffer ends on a finalized sentence boundary, ``carry_start`` is
+        ``len(buffer)``.
+
+        The finalization logic mirrors :meth:`_split_into_sentences` exactly; we
+        additionally track the raw span of each regex part so the carry is a
+        verbatim slice of ``buffer`` (not a normalized rejoin).
+        """
+        # Raw part spans: text between successive sentence-boundary matches.
+        spans: list[tuple[int, int]] = []
+        prev = 0
+        for m in self.sentence_pattern.finditer(buffer):
+            spans.append((prev, m.start()))
+            prev = m.end()
+        spans.append((prev, len(buffer)))
+
+        sentences: list[str] = []
+        current = ""
+        group_start: int | None = None  # raw start of the open group
+        for start, end in spans:
+            part = buffer[start:end].strip()
+            if not part:
+                continue
+            if group_start is None:
+                group_start = start
+            current += (" " if current else "") + part
+            if self._is_sentence_end(current):
+                sentences.append(current)
+                current = ""
+                group_start = None
+
+        carry_start = group_start if group_start is not None else len(buffer)
+        return sentences, carry_start
+
     def _is_sentence_end(self, text: str) -> bool:
         """Check if text ends with a sentence ending"""
         text = text.rstrip()
@@ -82,6 +127,66 @@ class SentenceStrategy(ChunkingStrategyInterface):
 
         return False
 
+    def _group_sentences(
+        self,
+        sentences: Iterable[str],
+        source_id: str,
+        base_metadata: dict[str, Any],
+    ) -> Iterator[TextChunk]:
+        """Group a stream of sentences into chunks (shared by batch + stream).
+
+        Yields chunks with ``total_chunks`` left as ``-1`` — the batch path
+        back-fills the real count, the streaming path cannot know it.
+        """
+        current_chunk: list[str] = []
+        current_length = 0
+        current_start = 0
+        chunk_index = 0
+
+        def build(
+            chunk_text: str, start: int, index: int, sentences_in_chunk: list[str]
+        ) -> TextChunk:
+            first = sentences_in_chunk[0]
+            chunk_metadata = {
+                **base_metadata,
+                "chunk_type": "sentence",
+                "sentence_count": len(sentences_in_chunk),
+                "first_sentence": (first[:50] + "..." if len(first) > 50 else first),
+            }
+            chunk = TextChunk(
+                text=chunk_text,
+                start_pos=start,
+                end_pos=start + len(chunk_text),
+                chunk_id=f"{source_id}_chunk_{index}",
+                metadata=chunk_metadata,
+            )
+            self.add_chunk_metadata(chunk, index, -1, "sentence")
+            return chunk
+
+        for sentence in sentences:
+            sentence_length = len(sentence)
+
+            if (
+                current_chunk
+                and current_length + sentence_length + 1 > self.config.chunk_size
+            ):
+                chunk_text = " ".join(current_chunk)
+                if len(chunk_text) >= self.config.min_chunk_size:
+                    yield build(chunk_text, current_start, chunk_index, current_chunk)
+                    chunk_index += 1
+
+                current_chunk = []
+                current_length = 0
+                current_start += len(chunk_text) + 1
+
+            current_chunk.append(sentence)
+            current_length += sentence_length + (1 if current_chunk else 0)
+
+        if current_chunk:
+            chunk_text = " ".join(current_chunk)
+            if len(chunk_text) >= self.config.min_chunk_size or chunk_index == 0:
+                yield build(chunk_text, current_start, chunk_index, current_chunk)
+
     def chunk(
         self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
     ) -> list[TextChunk]:
@@ -92,95 +197,62 @@ class SentenceStrategy(ChunkingStrategyInterface):
             return []
 
         base_metadata = base_metadata or {}
-        chunks = []
 
-        # Split into sentences
         sentences = self._split_into_sentences(text)
         if not sentences:
             return []
 
-        # Group sentences into chunks
-        current_chunk = []
-        current_length = 0
-        current_start = 0
-        chunk_index = 0
-
-        for i, sentence in enumerate(sentences):
-            sentence_length = len(sentence)
-
-            # Check if adding this sentence would exceed chunk size
-            if (
-                current_chunk
-                and current_length + sentence_length + 1 > self.config.chunk_size
-            ):
-                # Create chunk from current sentences
-                chunk_text = " ".join(current_chunk)
-
-                if len(chunk_text) >= self.config.min_chunk_size:
-                    chunk_metadata = {
-                        **base_metadata,
-                        "chunk_type": "sentence",
-                        "sentence_count": len(current_chunk),
-                        "first_sentence": (
-                            current_chunk[0][:50] + "..."
-                            if len(current_chunk[0]) > 50
-                            else current_chunk[0]
-                        ),
-                    }
-
-                    chunk = TextChunk(
-                        text=chunk_text,
-                        start_pos=current_start,
-                        end_pos=current_start + len(chunk_text),
-                        chunk_id=f"{source_id}_chunk_{chunk_index}",
-                        metadata=chunk_metadata,
-                    )
-
-                    self.add_chunk_metadata(chunk, chunk_index, -1, "sentence")
-                    chunks.append(chunk)
-                    chunk_index += 1
-
-                # Reset for next chunk
-                current_chunk = []
-                current_length = 0
-                current_start += len(chunk_text) + 1
-
-            # Add sentence to current chunk
-            current_chunk.append(sentence)
-            current_length += sentence_length + (1 if current_chunk else 0)
-
-        # Handle remaining sentences
-        if current_chunk:
-            chunk_text = " ".join(current_chunk)
-
-            if len(chunk_text) >= self.config.min_chunk_size or not chunks:
-                chunk_metadata = {
-                    **base_metadata,
-                    "chunk_type": "sentence",
-                    "sentence_count": len(current_chunk),
-                    "first_sentence": (
-                        current_chunk[0][:50] + "..."
-                        if len(current_chunk[0]) > 50
-                        else current_chunk[0]
-                    ),
-                }
-
-                chunk = TextChunk(
-                    text=chunk_text,
-                    start_pos=current_start,
-                    end_pos=current_start + len(chunk_text),
-                    chunk_id=f"{source_id}_chunk_{chunk_index}",
-                    metadata=chunk_metadata,
-                )
-
-                self.add_chunk_metadata(chunk, chunk_index, -1, "sentence")
-                chunks.append(chunk)
+        chunks = list(self._group_sentences(sentences, source_id, base_metadata))
 
         # Update total chunks count
         for chunk in chunks:
             chunk.metadata["total_chunks"] = len(chunks)
 
         return chunks
+
+    def chunk_stream(
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        """Incrementally yield sentence chunks with a bounded buffer.
+
+        Equivalent to :meth:`chunk` for every chunk's text/offsets/id, except
+        ``total_chunks`` is left as ``-1`` (an inherently global count).
+
+        The raw input buffer is split into sentences as text arrives; every
+        sentence except the last (which may still grow) is committed to the
+        grouping engine, and the trailing partial sentence is carried over to
+        the next ``text_source`` piece. Memory is bounded by the current group
+        plus the in-progress sentence.
+        """
+        self.validate_config()
+
+        base_metadata = base_metadata or {}
+
+        pieces: Iterable[str]
+        if isinstance(text_source, str):
+            pieces = (text_source,) if text_source else ()
+        else:
+            pieces = text_source
+
+        def sentence_stream() -> Iterator[str]:
+            buffer = ""
+            for piece in pieces:
+                if not piece:
+                    continue
+                buffer += piece
+                finalized, carry_start = self._split_with_carry(buffer)
+                yield from finalized
+                # Carry the RAW remainder verbatim so inter-piece whitespace is
+                # preserved exactly (matches feeding the whole text at once).
+                buffer = buffer[carry_start:]
+            # Flush the final carried fragment(s) at EOF (matches batch's
+            # trailing-`current` append for text that never closed a sentence).
+            yield from self._split_into_sentences(buffer)
+
+        yield from self._group_sentences(sentence_stream(), source_id, base_metadata)
 
     def __repr__(self) -> str:
         return f"SentenceStrategy(chunk_size={self.config.chunk_size})"

--- a/clients/python/src/proximadb_sdk/chunking_strategies/sliding_window.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/sliding_window.py
@@ -4,6 +4,7 @@ Sliding window chunking strategy
 Simple overlapping window approach for text chunking.
 """
 
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from .base import ChunkingStrategyInterface, TextChunk
@@ -15,6 +16,10 @@ class SlidingWindowStrategy(ChunkingStrategyInterface):
 
     Most basic strategy - creates fixed-size chunks with overlap
     """
+
+    #: Windows are boundary-local: a buffer holding the current window plus the
+    #: overlap carry-over (<= chunk_size chars) is enough to stream.
+    supports_streaming = True
 
     def chunk(
         self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
@@ -82,6 +87,117 @@ class SlidingWindowStrategy(ChunkingStrategyInterface):
             chunk.metadata["total_chunks"] = len(chunks)
 
         return chunks
+
+    def chunk_stream(
+        self,
+        text_source: "str | Iterable[str]",
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        """Incrementally yield sliding-window chunks with a bounded buffer.
+
+        Equivalent to :meth:`chunk` for every chunk's text/offsets/id/overlap
+        metadata, except ``total_chunks`` is left as ``-1`` (an inherently
+        global count that cannot be known without consuming the whole input).
+
+        Overlap carry-over: the buffer retains everything from the next window's
+        start position onward, so the ``chunk_overlap`` characters shared by
+        consecutive windows are preserved across ``text_source`` piece
+        boundaries. Memory is bounded by at most ``chunk_size`` buffered
+        characters plus a single piece.
+        """
+        self.validate_config()
+
+        base_metadata = base_metadata or {}
+        chunk_size = self.config.chunk_size
+        min_chunk_size = self.config.min_chunk_size
+        step_size = max(1, chunk_size - self.config.chunk_overlap)
+
+        pieces: Iterable[str]
+        if isinstance(text_source, str):
+            pieces = (text_source,) if text_source else ()
+        else:
+            pieces = text_source
+
+        # `buffer` holds text starting at absolute index `buffer_origin`.
+        buffer = ""
+        buffer_origin = 0
+        position = 0  # absolute start of the next window
+        chunk_index = 0
+        done = False
+
+        def build_chunk(start_pos: int, raw: str) -> TextChunk:
+            nonlocal chunk_index
+            chunk_metadata = {
+                **base_metadata,
+                "chunk_type": "sliding_window",
+                "has_overlap": chunk_index > 0 and self.config.chunk_overlap > 0,
+                "overlap_size": self.config.chunk_overlap if chunk_index > 0 else 0,
+            }
+            chunk = TextChunk(
+                text=raw,
+                start_pos=start_pos,
+                end_pos=start_pos + len(raw),
+                chunk_id=f"{source_id}_chunk_{chunk_index}",
+                metadata=chunk_metadata,
+            )
+            self.add_chunk_metadata(chunk, chunk_index, -1, "sliding_window")
+            chunk_index += 1
+            return chunk
+
+        def trim_to(pos: int) -> None:
+            """Discard buffer prefix before absolute index `pos`."""
+            nonlocal buffer, buffer_origin
+            drop = pos - buffer_origin
+            if drop > 0:
+                buffer = buffer[drop:]
+                buffer_origin += drop
+
+        def emit_ready(at_eof: bool) -> Iterator[TextChunk]:
+            """Emit every window whose full extent is available (or, at EOF, the tail).
+
+            Mirrors batch exactly: a window is *final* (loop break) when its end
+            reaches the end of input. At EOF the buffer end is the input end, so
+            ``position + chunk_size >= total`` marks the last window; before EOF
+            a full window can never be known-final, so we wait for more input
+            unless the window is already complete.
+            """
+            nonlocal position, done
+            total_so_far = buffer_origin + len(buffer)
+            while not done and position < total_so_far:
+                rel = position - buffer_origin
+                available = total_so_far - position  # chars from position to buffer end
+                # Pre-EOF we need strictly MORE than chunk_size available so we
+                # can prove this window is not the final one (batch breaks when a
+                # window reaches the input end). With exactly chunk_size and no
+                # EOF signal yet, the window might be the last — defer it.
+                if not at_eof and available <= chunk_size:
+                    break  # window not provably complete-and-non-final yet
+                raw = buffer[rel : rel + chunk_size]
+                # At EOF the buffer end is the true input end. A window is final
+                # when its (clamped) end reaches the input end.
+                is_final = at_eof and (position + chunk_size >= total_so_far)
+                if len(raw) < min_chunk_size and not is_final:
+                    position += step_size
+                    trim_to(position)
+                    continue
+                yield build_chunk(position, raw)
+                position += step_size
+                trim_to(position)
+                if is_final:
+                    done = True
+                    return
+
+        for piece in pieces:
+            if done:
+                break
+            if not piece:
+                continue
+            buffer += piece
+            yield from emit_ready(at_eof=False)
+
+        if not done:
+            yield from emit_ready(at_eof=True)
 
     def __repr__(self) -> str:
         return (

--- a/clients/python/tests/unit/test_chunking_pipeline_cov.py
+++ b/clients/python/tests/unit/test_chunking_pipeline_cov.py
@@ -586,7 +586,9 @@ def test_process_stream_chunker_exception_fail_fast(monkeypatch):
     def boom(*a, **k):
         raise RuntimeError("nope")
 
-    monkeypatch.setattr(p.chunker, "chunk", boom)
+    # process_stream routes through chunk_stream (genuine incremental path for
+    # streamable strategies like SENTENCE), so patch that.
+    monkeypatch.setattr(p.chunker, "chunk_stream", boom)
     with pytest.raises(RuntimeError):
         list(p.process_stream("text", "doc1"))
 
@@ -599,7 +601,7 @@ def test_process_stream_chunker_exception_collect(monkeypatch):
     def boom(*a, **k):
         raise RuntimeError("nope")
 
-    monkeypatch.setattr(p.chunker, "chunk", boom)
+    monkeypatch.setattr(p.chunker, "chunk_stream", boom)
     assert list(p.process_stream("text", "doc1")) == []
 
 
@@ -656,7 +658,7 @@ def test_process_stream_async_chunker_exception_fail_fast(monkeypatch):
     def boom(*a, **k):
         raise RuntimeError("nope")
 
-    monkeypatch.setattr(p.chunker, "chunk", boom)
+    monkeypatch.setattr(p.chunker, "chunk_stream", boom)
 
     async def collect():
         return [c async for c in p.process_stream_async("text", "doc1")]

--- a/clients/python/tests/unit/test_chunking_true_streaming.py
+++ b/clients/python/tests/unit/test_chunking_true_streaming.py
@@ -1,0 +1,369 @@
+"""Offline unit tests for genuine incremental streaming in the chunking pipeline.
+
+Covers the ``supports_streaming`` capability flag and the ``chunk_stream``
+contract added in the chunking true-streaming work (TD-126):
+
+* Equivalence: for the four streamable strategies (fixed-size, sliding-window,
+  sentence, paragraph), streaming a piece-split source yields the SAME chunks
+  (text / offsets / id, including sliding-window overlap) as the batch
+  ``chunk()`` of the joined input.
+* Bounded memory: a streamable strategy fed a generator yields its first chunk
+  BEFORE the generator is fully consumed (true streaming, not materialize-all).
+* Honest fallback: non-streamable strategies (recursive / structural-semantic /
+  semantic-embedding / code) report ``supports_streaming is False`` and their
+  ``chunk_stream`` materializes the input but still yields chunks incrementally
+  and equivalently to batch.
+* Backward compatibility: ``process_stream(str)`` keeps working for every
+  strategy.
+
+Fully offline: pure CPU text processing, no network, no embedding model.
+"""
+
+import asyncio
+
+import pytest
+
+from proximadb_sdk.chunking_strategies.base import (
+    ChunkingConfig,
+    ChunkingStrategy,
+)
+from proximadb_sdk.chunking_strategies.factory import ChunkingStrategyFactory
+from proximadb_sdk.chunking_strategies.pipeline import (
+    ChunkingPipeline,
+    PipelineConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+TEXTS = {
+    "lorem": "The quick brown fox jumps over the lazy dog. " * 20,
+    "sentences": (
+        "Hello world. This is a test. Dr. Smith went home. "
+        "Another sentence here! And a question? Final one."
+    ),
+    "paras": (
+        "First paragraph here with content.\n\n"
+        "Second paragraph also here.\n\n"
+        "Third one is a bit longer than the others to vary.\n\n"
+        "- item a\n- item b\n- item c"
+    ),
+    "short": "abc",
+    "unicode": "これはテストです。次の文も。English mixes in. Done.",
+    "abbrev": "I met Mr. Smith today. He works at Inc. Corp. nearby. Cool.",
+}
+
+# (strategy, config-kwargs) for the four streamable strategies, several configs.
+STREAMABLE = {
+    "fixed_size": (
+        ChunkingStrategy.FIXED_SIZE,
+        dict(chunk_size=40, chunk_overlap=0, min_chunk_size=5),
+    ),
+    "sliding_a": (
+        ChunkingStrategy.SLIDING_WINDOW,
+        dict(chunk_size=40, chunk_overlap=10, min_chunk_size=5),
+    ),
+    "sliding_b": (
+        ChunkingStrategy.SLIDING_WINDOW,
+        dict(chunk_size=30, chunk_overlap=7, min_chunk_size=1),
+    ),
+    "sliding_high_overlap": (
+        ChunkingStrategy.SLIDING_WINDOW,
+        dict(chunk_size=12, chunk_overlap=11, min_chunk_size=1),
+    ),
+    "sentence_a": (
+        ChunkingStrategy.SENTENCE,
+        dict(chunk_size=50, chunk_overlap=0, min_chunk_size=5),
+    ),
+    "sentence_b": (
+        ChunkingStrategy.SENTENCE,
+        dict(chunk_size=30, chunk_overlap=0, min_chunk_size=1),
+    ),
+    "paragraph_a": (
+        ChunkingStrategy.PARAGRAPH,
+        dict(chunk_size=80, chunk_overlap=0, min_chunk_size=5, max_chunk_size=120),
+    ),
+    "paragraph_b": (
+        ChunkingStrategy.PARAGRAPH,
+        dict(chunk_size=40, chunk_overlap=0, min_chunk_size=1, max_chunk_size=50),
+    ),
+}
+
+# Awkward piece splittings (1-char, mid-word, single huge piece, fibonacci, ...).
+PIECE_PLANS = [
+    [7],
+    [1, 1, 1, 1, 1],
+    [3, 13, 2, 40],
+    [100],
+    [13, 9, 21],
+    [2],
+    [1, 2, 3, 5, 8, 13],
+]
+
+
+def _make(strategy_key):
+    strat, cfg = STREAMABLE[strategy_key]
+    config = ChunkingConfig(strategy=strat, **cfg)
+    return ChunkingStrategyFactory.create_strategy(strat, config)
+
+
+def _split_pieces(text, sizes):
+    out = []
+    i = 0
+    for s in sizes:
+        out.append(text[i : i + s])
+        i += s
+    if i < len(text):
+        out.append(text[i:])
+    return out
+
+
+def _key(chunks):
+    """The streaming-stable identity of a chunk (excludes total_chunks, which is
+    inherently global and cannot be known without consuming the whole input)."""
+    return [(c.text, c.start_pos, c.end_pos, c.chunk_id) for c in chunks]
+
+
+# ---------------------------------------------------------------------------
+# Capability flag
+# ---------------------------------------------------------------------------
+
+
+def test_streamable_strategies_advertise_support():
+    for key in ("fixed_size", "sliding_a", "sentence_a", "paragraph_a"):
+        assert _make(key).supports_streaming is True, key
+
+
+def test_nonstreamable_strategies_do_not_advertise_support():
+    from proximadb_sdk.chunking_strategies.code import CodeChunkingStrategy
+    from proximadb_sdk.chunking_strategies.recursive import RecursiveStrategy
+    from proximadb_sdk.chunking_strategies.semantic import SemanticStrategy
+    from proximadb_sdk.chunking_strategies.semantic_embedding import (
+        SemanticEmbeddingStrategy,
+    )
+
+    assert RecursiveStrategy.supports_streaming is False
+    assert SemanticStrategy.supports_streaming is False
+    assert SemanticEmbeddingStrategy.supports_streaming is False
+    assert CodeChunkingStrategy.supports_streaming is False
+
+
+# ---------------------------------------------------------------------------
+# Equivalence: chunk_stream(pieces) == chunk("".join(pieces))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("strategy_key", list(STREAMABLE))
+@pytest.mark.parametrize("text_name", list(TEXTS))
+def test_str_source_matches_batch(strategy_key, text_name):
+    s = _make(strategy_key)
+    text = TEXTS[text_name]
+    assert _key(list(s.chunk_stream(text, "doc"))) == _key(s.chunk(text, "doc"))
+
+
+@pytest.mark.parametrize("strategy_key", list(STREAMABLE))
+@pytest.mark.parametrize("text_name", list(TEXTS))
+@pytest.mark.parametrize("plan", PIECE_PLANS)
+def test_piece_source_matches_batch(strategy_key, text_name, plan):
+    s = _make(strategy_key)
+    text = TEXTS[text_name]
+    pieces = _split_pieces(text, plan)
+    streamed = list(s.chunk_stream(iter(pieces), "doc"))
+    assert _key(streamed) == _key(s.chunk(text, "doc"))
+
+
+def test_sliding_window_overlap_preserved_across_piece_boundary():
+    """The tricky bit: overlap text shared by consecutive windows must survive
+    being split across input pieces."""
+    s = _make("sliding_a")
+    text = TEXTS["lorem"]
+    batch = s.chunk(text, "doc")
+    # Pieces that deliberately split inside the overlap region.
+    pieces = _split_pieces(text, [35, 4, 6, 1, 1, 1])
+    streamed = list(s.chunk_stream(iter(pieces), "doc"))
+    assert _key(streamed) == _key(batch)
+    # Sanity: there really is overlap to preserve.
+    assert any(c.metadata.get("has_overlap") for c in batch)
+
+
+def test_total_chunks_sentinel_in_stream():
+    """total_chunks is the one inherently-global field; streaming leaves it -1."""
+    s = _make("fixed_size")
+    streamed = list(s.chunk_stream(TEXTS["lorem"], "doc"))
+    assert streamed
+    assert all(c.metadata["total_chunks"] == -1 for c in streamed)
+    # ...while batch back-fills the real count.
+    batch = s.chunk(TEXTS["lorem"], "doc")
+    assert all(c.metadata["total_chunks"] == len(batch) for c in batch)
+
+
+# ---------------------------------------------------------------------------
+# Bounded memory / genuine streaming
+# ---------------------------------------------------------------------------
+
+
+def test_first_chunk_emitted_before_generator_exhausted():
+    s = _make("sliding_a")
+    state = {"advanced": 0}
+    n_pieces = 5000
+
+    def gen():
+        for i in range(n_pieces):
+            state["advanced"] = i + 1
+            yield "The quick brown fox jumps over the lazy dog. "
+
+    it = s.chunk_stream(gen(), "doc")
+    first = next(it)
+    assert first.chunk_id == "doc_chunk_0"
+    # True streaming: the first chunk is produced long before the whole
+    # generator is drained.
+    assert state["advanced"] < n_pieces
+    # In fact only a couple of pieces are needed to fill the first window.
+    assert state["advanced"] <= 3
+
+
+@pytest.mark.parametrize(
+    "strategy_key", ["fixed_size", "sliding_a", "sentence_a", "paragraph_a"]
+)
+def test_each_streamable_strategy_yields_before_exhaustion(strategy_key):
+    s = _make(strategy_key)
+    state = {"advanced": 0}
+    n_pieces = 2000
+    # A piece that contains a complete sentence + paragraph break so every
+    # strategy can find a boundary early.
+    piece = "This is a complete sentence here.\n\n"
+
+    def gen():
+        for i in range(n_pieces):
+            state["advanced"] = i + 1
+            yield piece
+
+    first = next(s.chunk_stream(gen(), "doc"))
+    assert first is not None
+    assert state["advanced"] < n_pieces, strategy_key
+
+
+# ---------------------------------------------------------------------------
+# Honest fallback for non-streamable strategies
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TEXT = (
+    "First paragraph here.\n\n"
+    "Second paragraph here with more.\n\n"
+    "Third block of content here too."
+)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [ChunkingStrategy.RECURSIVE, ChunkingStrategy.SEMANTIC],
+)
+def test_nonstreamable_fallback_matches_batch(strategy):
+    config = ChunkingConfig(
+        strategy=strategy, chunk_size=50, chunk_overlap=5, min_chunk_size=5
+    )
+    s = ChunkingStrategyFactory.create_strategy(strategy, config)
+    batch = s.chunk(_FALLBACK_TEXT, "doc")
+    # Default chunk_stream materializes then yields from chunk(): same result.
+    via_str = list(s.chunk_stream(_FALLBACK_TEXT, "doc"))
+    via_iter = list(
+        s.chunk_stream(
+            iter([_FALLBACK_TEXT[:20], _FALLBACK_TEXT[20:50], _FALLBACK_TEXT[50:]]),
+            "doc",
+        )
+    )
+    assert [c.text for c in via_str] == [c.text for c in batch]
+    assert [c.text for c in via_iter] == [c.text for c in batch]
+
+
+def test_pipeline_fallback_yields_correct_chunks_for_nonstreamable():
+    cfg = PipelineConfig(
+        chunking_strategy=ChunkingStrategy.RECURSIVE,
+        chunking_config=ChunkingConfig(
+            strategy=ChunkingStrategy.RECURSIVE,
+            chunk_size=50,
+            chunk_overlap=5,
+            min_chunk_size=5,
+        ),
+    )
+    p = ChunkingPipeline(cfg)
+    batch = p.chunker.chunk(_FALLBACK_TEXT, "doc")
+    streamed = list(
+        p.process_stream(iter([_FALLBACK_TEXT[:25], _FALLBACK_TEXT[25:]]), "doc")
+    )
+    assert [c.text for c in streamed] == [c.text for c in batch]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline backward compatibility + iterable sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        ChunkingStrategy.FIXED_SIZE,
+        ChunkingStrategy.SLIDING_WINDOW,
+        ChunkingStrategy.SENTENCE,
+        ChunkingStrategy.PARAGRAPH,
+        ChunkingStrategy.RECURSIVE,
+        ChunkingStrategy.SEMANTIC,
+    ],
+)
+def test_process_stream_str_backward_compatible(strategy):
+    cfg = PipelineConfig(
+        chunking_strategy=strategy,
+        chunking_config=ChunkingConfig(
+            strategy=strategy, chunk_size=40, chunk_overlap=5, min_chunk_size=3
+        ),
+    )
+    p = ChunkingPipeline(cfg)
+    chunks = list(p.process_stream(TEXTS["lorem"], "doc"))
+    assert all(c.text for c in chunks)
+
+
+def test_process_stream_iterable_source_streamable():
+    cfg = PipelineConfig(
+        chunking_strategy=ChunkingStrategy.FIXED_SIZE,
+        chunking_config=ChunkingConfig(
+            strategy=ChunkingStrategy.FIXED_SIZE,
+            chunk_size=30,
+            chunk_overlap=0,
+            min_chunk_size=3,
+        ),
+    )
+    p = ChunkingPipeline(cfg)
+    text = TEXTS["lorem"]
+    via_str = [c.text for c in p.process_stream(text, "doc")]
+    via_iter = [
+        c.text for c in p.process_stream(iter(_split_pieces(text, [7, 11, 3])), "doc")
+    ]
+    assert via_iter == via_str
+
+
+def test_process_stream_async_iterable_source():
+    cfg = PipelineConfig(
+        chunking_strategy=ChunkingStrategy.SENTENCE,
+        chunking_config=ChunkingConfig(
+            strategy=ChunkingStrategy.SENTENCE,
+            chunk_size=40,
+            chunk_overlap=0,
+            min_chunk_size=3,
+        ),
+    )
+    p = ChunkingPipeline(cfg)
+    text = TEXTS["sentences"]
+
+    async def collect_iter():
+        return [
+            c.text
+            async for c in p.process_stream_async(
+                iter(_split_pieces(text, [9, 5, 21])), "doc"
+            )
+        ]
+
+    async def collect_str():
+        return [c.text async for c in p.process_stream_async(text, "doc")]
+
+    assert asyncio.run(collect_iter()) == asyncio.run(collect_str())

--- a/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
+++ b/roadmap/techdebt/TD_126_SDK_SPEC_DRIVEN_MODULARIZATION_2026_06_21.adoc
@@ -731,11 +731,43 @@ not a rewrite. Landed as three sequenced PRs:
   `tree-sitter>=0.25` and `tree-sitter-language-pack>=1.0` (code uses Query-free node traversal,
   so it is 0.25-safe — verified no `Query()`/`captures()`/`QueryCursor` usage).
 
+*True incremental streaming — SHIPPED (2026-06-23).* `process_stream`/`process_stream_async`
+no longer materialize the full document + chunk list. A capability contract was added to
+`ChunkingStrategyInterface` (`base.py`): a `supports_streaming` flag (default `False`) plus a
+`chunk_stream(text_source, source_id, base_metadata) -> Iterator[TextChunk]` method, where
+`text_source` is a `str` (back-compat) OR an iterable of text pieces (e.g. successive file reads).
+
+* *Genuine incremental streaming (4 strategies, `supports_streaming = True`):* `FixedSizeStrategy`,
+  `SlidingWindowStrategy`, `SentenceStrategy`, `ParagraphStrategy` override `chunk_stream` to keep
+  only a BOUNDED local buffer (the pending unflushed window / in-progress sentence-or-paragraph)
+  and emit `TextChunk`s as boundaries are crossed — never accumulating the full input or the full
+  output list. Sliding-window preserves overlap carry-over by retaining the buffer from the next
+  window's start; sentence/paragraph carry the RAW (unstripped) buffer tail across piece boundaries
+  so inter-piece whitespace is preserved and the split is identical to feeding the whole text. The
+  streaming path produces chunks IDENTICAL to batch `chunk()` (text/offsets/id/overlap) — the only
+  difference is `total_chunks`, an inherently global count that streaming cannot know without
+  draining the input, so it is left as the existing `-1` sentinel (batch back-fills it).
+* *Honest fallback (non-streamable strategies):* `CodeChunkingStrategy` (tree-sitter parses the whole
+  file), `SemanticEmbeddingStrategy` (needs all sentence embeddings), `RecursiveStrategy` (cascade),
+  and structural `SemanticStrategy` (whole-doc structure) keep `supports_streaming = False` and use
+  the default `chunk_stream`, which materializes `text_source` and `yield from chunk()` — chunks are
+  still produced incrementally but memory is not constant. Docstrings state honestly which path
+  applies per strategy.
+* *Pipeline:* `process_stream`/`_async` accept `str` or an iterable/async source, route through
+  `strategy.chunk_stream(...)`, and run the per-chunk validation/enrichment/filter stages as before
+  (the `chunks = chunker.chunk(...)` full-materialization is gone). The async path advances the chunk
+  iterator in a thread-pool executor so CPU-bound chunking does not block the loop. Backward compat:
+  `process_stream(str_input)` works unchanged for every strategy.
+* *Tests* (`tests/unit/test_chunking_true_streaming.py`, 404 cases): (1) equivalence —
+  `chunk_stream(pieces) == chunk("".join(pieces))` for the 4 streamable strategies across awkward
+  piece boundaries (1-char, mid-word, single-piece, unicode, abbreviations) and high-overlap windows;
+  (2) bounded memory — a streamable strategy fed a generator yields its first chunk after consuming
+  only a couple of pieces (not all N), proving true streaming; (3) honest fallback — non-streamable
+  strategies via `process_stream` yield chunks equal to batch; (4) backward compat — `process_stream(str)`
+  for all strategies. `import proximadb_sdk` lazy boundary intact (no heavy deps pulled).
+
 *Deferred (follow-up):*
 
-* *True incremental streaming* — `process_stream`/`_async` still materialize the full document
-  and chunk list (every underlying strategy is a batch API). Real constant-memory streaming
-  requires an incremental contract across all strategies; out of scope for a cleanup pass.
 * *Embedding-based semantic chunking* — a percentile-breakpoint-over-sentence-embeddings mode
   alongside the structural `SemanticStrategy`. The SDK has embedding infra to support it, but it
   needs an embedding-provider injection seam, sentence splitting, and factory/config wiring +


### PR DESCRIPTION
## Summary

Makes `process_stream`/`process_stream_async` in the Python SDK chunking pipeline *actually stream* (TD-126 final backlog item). Previously they called `chunker.chunk(text)`, materializing the whole document AND the full chunk list before yielding (the "memory-efficient" claim was already downgraded to an honest docstring in #196).

## Contract

`ChunkingStrategyInterface` (`base.py`) gains:
- `supports_streaming` flag (default `False`)
- `chunk_stream(text_source, source_id, base_metadata) -> Iterator[TextChunk]`, where `text_source` is a `str` (backward compatible) OR an iterable of text pieces (e.g. successive file reads).

## Genuine incremental streaming (4 strategies)

`FixedSizeStrategy`, `SlidingWindowStrategy`, `SentenceStrategy`, `ParagraphStrategy` set `supports_streaming = True` and override `chunk_stream` to keep only a **bounded** local buffer (the pending window / in-progress sentence-or-paragraph), emitting chunks as boundaries are crossed — never accumulating the full input or output list.

- **Sliding-window overlap carry-over:** the buffer retains text from the next window's start, so the `chunk_overlap` chars shared by consecutive windows survive piece boundaries. A 1-char lookahead defers a full window until it is provably non-final, matching batch's `end >= len` break exactly.
- **Sentence/paragraph:** the **raw** (unstripped) buffer tail is carried across pieces so inter-piece whitespace and split points are identical to feeding the whole text.

Output is **identical to batch `chunk()`** (text / offsets / id / overlap metadata). The only difference is `total_chunks` — an inherently global count that streaming cannot know without draining the input — left as the existing `-1` sentinel (batch back-fills it).

## Honest fallback (non-streamable)

`CodeChunkingStrategy`, `SemanticEmbeddingStrategy`, `RecursiveStrategy`, structural `SemanticStrategy` keep `supports_streaming = False` and use the default `chunk_stream`: materialize the input, `yield from chunk()`. Chunks still flow incrementally; memory is not constant. Documented per strategy.

## Pipeline

`process_stream`/`_async` accept `str` or an iterable source and route through `chunk_stream`, dropping the full-materialization. The async path advances the chunk iterator in a thread-pool executor so CPU-bound chunking does not block the loop. `process_stream(str)` is unchanged for every strategy.

## Verification

- **Equivalence (404 test cases):** `chunk_stream(pieces) == chunk("".join(pieces))` for all 4 streamable strategies across awkward piece boundaries (1-char, mid-word, single-piece), unicode, abbreviations, and high-overlap windows.
- **Bounded memory:** a streamable strategy fed a 5000-piece generator yields its first chunk after consuming only ~2 pieces (proven via a generator that records how far it advanced).
- **Honest fallback + backward compat:** non-streamable strategies via `process_stream` yield chunks equal to batch; `process_stream(str)` works for all strategies; async iterable source verified.
- `import proximadb_sdk` lazy boundary intact (no heavy deps pulled).
- black/isort/ruff(E9,F63,F7) + py_compile clean. Full chunking suite green (the one red, `test_real_integration_rest_grpc_sql`, is a pre-existing server+HF-model integration failure — `unknown enum label ""` in `_grpc_v2_codec.py` — reproduced identically on develop, unrelated to this change).