### PR TITLE
refactor(storage): Orion depends on Arc<dyn IndexQuery>, not concrete AxisManager (index DIP, engine 1)

### DIFF
--- a/src/storage/entity_store/orion_backend.rs
+++ b/src/storage/entity_store/orion_backend.rs
@@ -61,7 +61,9 @@ use crate::graph::{
 use crate::proto::proximadb_v1::{
     ComparisonOp, Entity, LogicalOp, MetadataFilter, Relation, filter_clause,
 };
-use crate::{core::VectorId, index::AxisManager};
+use proximadb_index_traits::{
+    IndexFilterOperator, IndexHybridQuery, IndexMetadataFilter, IndexQuery, IndexVectorQuery,
+};
 
 /// Orion-backed entity store using graph-first architecture
 pub struct OrionBackedEntityStore {
@@ -78,13 +80,13 @@ pub struct OrionBackedEntityStore {
     relation_mapper: RelationEdgeMapper,
 
     /// Optional AXIS manager for hybrid vector + metadata search
-    axis_manager: Option<Arc<AxisManager>>,
+    axis_manager: Option<Arc<dyn IndexQuery>>,
 }
 
-static GLOBAL_AXIS_MANAGER: OnceLock<Arc<AxisManager>> = OnceLock::new();
+static GLOBAL_AXIS_MANAGER: OnceLock<Arc<dyn IndexQuery>> = OnceLock::new();
 
 /// Register a global AXIS manager so new stores can default to it.
-pub fn set_global_axis_manager(axis_manager: Arc<AxisManager>) {
+pub fn set_global_axis_manager(axis_manager: Arc<dyn IndexQuery>) {
     let _ = GLOBAL_AXIS_MANAGER.set(axis_manager);
 }
 
@@ -115,7 +117,7 @@ impl OrionBackedEntityStore {
     }
 
     /// Attach an AXIS manager for hybrid search; returns self for chaining.
-    pub fn with_axis_manager(mut self, axis_manager: Arc<AxisManager>) -> Self {
+    pub fn with_axis_manager(mut self, axis_manager: Arc<dyn IndexQuery>) -> Self {
         self.axis_manager = Some(axis_manager);
         self
     }
@@ -313,16 +315,14 @@ impl EntityStore for OrionBackedEntityStore {
             // Convert metadata filters (AND semantics; OR not yet supported in AXIS)
             let axis_filters = Self::convert_metadata_filters(metadata_filter.as_ref());
 
-            let hybrid_query = crate::index::axis::management::manager::HybridQuery {
+            let hybrid_query = IndexHybridQuery {
                 collection_id: collection_id.to_string(),
-                vector_query: Some(
-                    crate::index::axis::management::manager::VectorQuery::Dense {
-                        vector: vec.clone(),
-                        similarity_threshold: 0.0,
-                    },
-                ),
+                vector_query: Some(IndexVectorQuery::Dense {
+                    vector: vec.clone(),
+                    similarity_threshold: 0.0,
+                }),
                 metadata_filters: axis_filters,
-                id_filters: Vec::<VectorId>::new(),
+                id_filters: Vec::<String>::new(),
                 top_k,
                 include_expired: false,
                 ..Default::default()
@@ -731,9 +731,7 @@ impl OrionBackedEntityStore {
     }
 
     /// Convert proto metadata filters to AXIS metadata filters (best-effort).
-    fn convert_metadata_filters(
-        filter: Option<&MetadataFilter>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
+    fn convert_metadata_filters(filter: Option<&MetadataFilter>) -> Vec<IndexMetadataFilter> {
         let Some(filter) = filter else {
             return Vec::new();
         };
@@ -743,18 +741,10 @@ impl OrionBackedEntityStore {
             .iter()
             .filter_map(|clause| {
                 let operator = match ComparisonOp::try_from(clause.op).ok() {
-                    Some(ComparisonOp::Eq) => {
-                        crate::index::axis::management::manager::FilterOperator::Equals
-                    }
-                    Some(ComparisonOp::Ne) => {
-                        crate::index::axis::management::manager::FilterOperator::NotEquals
-                    }
-                    Some(ComparisonOp::Gt) => {
-                        crate::index::axis::management::manager::FilterOperator::GreaterThan
-                    }
-                    Some(ComparisonOp::Lt) => {
-                        crate::index::axis::management::manager::FilterOperator::LessThan
-                    }
+                    Some(ComparisonOp::Eq) => IndexFilterOperator::Equals,
+                    Some(ComparisonOp::Ne) => IndexFilterOperator::NotEquals,
+                    Some(ComparisonOp::Gt) => IndexFilterOperator::GreaterThan,
+                    Some(ComparisonOp::Lt) => IndexFilterOperator::LessThan,
                     _ => return None,
                 };
 
@@ -770,7 +760,7 @@ impl OrionBackedEntityStore {
                     None => return None,
                 };
 
-                Some(crate::index::axis::management::manager::MetadataFilter {
+                Some(IndexMetadataFilter {
                     field: clause.field.clone(),
                     operator,
                     value,


### PR DESCRIPTION
## What

First **per-engine adoption** of the storage↔index DIP contract (#241): `OrionBackedEntityStore` now depends on **`Arc<dyn IndexQuery>`** instead of the concrete `AxisManager`.

This is Phase 2 of the index-traits step, done per the plan's protocol: **one engine per PR, mechanical type-narrowing, behaviour-identical.**

## Why Orion first

A measured survey of the storage→AXIS seam showed most engines (nova/raptor/swift/helix/viper) hold `axis_manager: None` with **no setter** — their AXIS query path is vestigial. **Orion is the cleanest *live* target**: a single-trait (`IndexQuery`) consumer whose manager is genuinely injected via `set_global_axis_manager`, called from `src/network/shared_services.rs`.

## Change

- `axis_manager` field, the `GLOBAL_AXIS_MANAGER` static, and the `set_global_axis_manager` / `with_axis_manager` setters: `Arc<AxisManager>` → `Arc<dyn IndexQuery>`.
- The hybrid search path builds the slim **`IndexHybridQuery`** DTO; `convert_metadata_filters` now returns `Vec<IndexMetadataFilter>`.
- Result consumption is unchanged — `IndexScoredResult` carries the same `vector_id` / `similarity` fields.
- **Injection site untouched**: `Arc<AxisManager>` unsizes to `Arc<dyn IndexQuery>` automatically at the call boundary (the `impl IndexQuery for AxisManager` from #241).

No other engine is touched. No behavioural change.

## Verification (pinned 1.95.0)

- `cargo build --lib` — clean
- `cargo clippy --lib -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean (exit 0)

## Next (gated)

Remaining per-engine adoption — SST (the multi-trait + module-global case: `IndexQuery` + `IndexIngest` + `IndexMetrics`) and the deferred compaction-reader (`get_collection_indexes` + `IndexReader`). The dead `axis_manager` fields on nova/raptor/swift/helix/viper are a separate cleanup decision (narrow-for-hygiene vs remove-the-vestigial-path).
