### PR TITLE
feat(pgwire): ON CONFLICT DO UPDATE / DO NOTHING upsert (TD-129)

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -376,10 +376,10 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | pgwire — `ON CONFLICT DO UPDATE`
 | P2
 | MED
-| *Open*
-| `TableRecordMutationKind::Upsert` exists at the DML boundary but pgwire has no `INSERT ... ON CONFLICT DO UPDATE` surface; idempotent re-index must read-then-write. Wire the upsert mutation through the pgwire parser/planner.
-| 1 week
-| `src/network/postgres/` parser + `src/services/dml/`. Map conflict target (PK) to `Upsert`.
+| *Partial — implementation branch ready 2026-06-23*
+| `TableRecordMutationKind::Upsert` exists at the DML boundary; `feat/td-129-pgwire-upsert` wires `INSERT ... ON CONFLICT (pk) DO UPDATE / DO NOTHING` through `src/services/dml/mod.rs` and adds `tests/pgwire_upsert_on_conflict_e2e.rs`.
+| MVP merge gate
+| Rebase/merge the branch after `cargo test --test pgwire_upsert_on_conflict_e2e` passes on current `origin/develop`. Remaining post-MVP: non-PK/multi-column conflict targets and prior-version closure semantics in the table-record writer.
 
 | TD-130
 | Graph — edge bulk-load

--- a/docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc
+++ b/docs/12-design/CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc
@@ -217,8 +217,8 @@ incremental re-index: point upserts + small predicate scans (symbols-in-file, fi
 are by _name/file_, not PK oid; today only PK lookup exists → else full scan. *(TD-127, HIGH)*
 . *IN-list/range pushdown* (`WHERE file IN (...)`, `BETWEEN`) → multi-key point-batch; re-index touches
 a batch of files per debounce. Today: full scan + memory filter. *(TD-128, HIGH)*
-. *`ON CONFLICT DO UPDATE`* (upsert-by-PK) in pgwire for idempotent re-index. Mutation kind exists; the
-SQL surface does not. *(TD-129, MED)*
+. *`ON CONFLICT DO UPDATE`* (upsert-by-PK) in pgwire for idempotent re-index. Implementation branch
+`feat/td-129-pgwire-upsert` wires PK-targeted `DO UPDATE` / `DO NOTHING` and e2e coverage. *(TD-129, MED)*
 . MVCC/row-lock — *not needed* (single-writer-per-repo, last-write-wins fine). No TD.
 
 == Deployment
@@ -252,7 +252,7 @@ See `docs/10-quality/TECHNICAL_DEBT.adoc`:
 | TD | Item | Priority
 | TD-127 | OLTP secondary indexes (name/file) on native tables | HIGH
 | TD-128 | Volcano IN-list/range pushdown → multi-key point-batch | HIGH
-| TD-129 | pgwire `ON CONFLICT DO UPDATE` upsert | MED
+| TD-129 | pgwire `ON CONFLICT DO UPDATE` upsert — implementation branch ready | MED
 | TD-130 | Graph edge bulk-load (sorted LSM merge; kills per-edge uniqueness serialization) | MED
 | TD-131 | Graph on REST v2 + first-class co-planned hybrid endpoint (seed→expand→filter) | MED
 | TD-132 | Tier-B CPG-fragment PAX storage contract + per-query I/O trace emission | MED

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -2745,14 +2745,25 @@ impl DmlService {
         ))
     }
 
-    /// Execute UPSERT statement
+    /// Execute `INSERT ... ON CONFLICT` (TD-129).
+    ///
+    /// The conflict target must reference the table's PRIMARY KEY: the record `oid`
+    /// is PK-derived (`build_mutation_record` → `to_mutation_record`), so an
+    /// idempotent re-push of the same key resolves to the same `oid` and updates the
+    /// row in place rather than duplicating it. Each proposed row is probed by key
+    /// (point `get_by_key`, no scan) and routed:
+    ///   * conflict + `DO UPDATE` → apply the assignments onto the existing row,
+    ///     reusing the standalone UPDATE applier. `excluded.<col>` references are
+    ///     pre-resolved to the literal the INSERT proposed for `<col>`.
+    ///   * conflict + `DO NOTHING` (no assignments) → skip the row (no write).
+    ///   * no conflict → insert the proposed row.
     async fn execute_upsert(
         &self,
         table_name: &str,
         columns: &[String],
         values: Vec<Vec<SqlValueLiteral>>,
-        _conflict_columns: &[String],
-        _update_assignments: Vec<(String, SqlValueLiteral)>,
+        conflict_columns: &[String],
+        update_assignments: Vec<(String, SqlValueLiteral)>,
         tenant_context: Option<&TenantContext>,
     ) -> Result<DmlResult> {
         let (catalog, table_id) = self
@@ -2767,6 +2778,35 @@ impl DmlService {
 
         // Get table schema
         let table_schema = catalog.get_table(&table_id).await?;
+
+        // The OLTP fast-lane upsert key is the primary key — the `oid` is derived
+        // from it. Require a PK and, when an explicit conflict target is given,
+        // require it to name that PK column (single-column). Non-PK / multi-column
+        // conflict targets fail closed rather than silently upserting by the wrong key.
+        let pk_column = Self::primary_key_column(&table_schema).ok_or_else(|| {
+            anyhow!(
+                "INSERT ... ON CONFLICT requires a PRIMARY KEY on table '{}'",
+                table_schema.name
+            )
+        })?;
+        if !(conflict_columns.is_empty()
+            || (conflict_columns.len() == 1
+                && conflict_columns[0].eq_ignore_ascii_case(&pk_column)))
+        {
+            return Err(anyhow!(
+                "ON CONFLICT target ({}) must reference the primary key column '{}' of table '{}'",
+                conflict_columns.join(", "),
+                pk_column,
+                table_schema.name
+            ));
+        }
+
+        // `DO NOTHING` carries no assignments; `DO UPDATE` always has at least one.
+        let do_update = !update_assignments.is_empty();
+        if do_update {
+            Self::validate_update_assignments(&update_assignments, &table_schema)?;
+        }
+
         let (write_intent, write_lane_decision) = Self::route_row_dml_write_intent(
             &table_schema,
             WriteOperationKind::Upsert,
@@ -2774,53 +2814,170 @@ impl DmlService {
         );
         Self::trace_row_dml_write_lane(&write_intent, &write_lane_decision);
 
-        let mut records = Vec::new();
-        let mut inserted_ids = Vec::new();
+        let mut mutations = Vec::new();
+        let mut affected_ids = Vec::new();
+        let mut batch_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut inserted = 0usize;
+        let mut updated = 0usize;
+        let mut skipped = 0usize;
 
         for row in values {
-            let record = self.build_mutation_record(
+            // The proposed row carries the full INSERT values and the PK-derived oid.
+            let new_record = self.build_mutation_record(
                 columns,
                 &row,
                 &table_schema,
                 RelationalMutationKind::Upsert,
             )?;
-            inserted_ids.push(record.oid.clone());
-            records.push(record);
+            let key = new_record.oid.clone();
+
+            // A conflict key may affect at most one row per statement (Postgres:
+            // "ON CONFLICT ... cannot affect row a second time").
+            if !batch_keys.insert(key.clone()) {
+                return Err(anyhow!(
+                    "ON CONFLICT cannot affect row '{}' a second time on table '{}': the conflict key appears more than once in this statement",
+                    key,
+                    table_schema.name
+                ));
+            }
+
+            let existing = self
+                .record_store
+                .get_by_key(
+                    &table_schema,
+                    TableRecordGetRequest {
+                        table_id: table_id.name.clone(),
+                        key: key.clone(),
+                        include_vector: true,
+                        include_props: true,
+                    },
+                    tenant_context,
+                )
+                .await?;
+
+            match existing {
+                Some(existing) if do_update => {
+                    let resolved = self.resolve_conflict_assignments(
+                        &update_assignments,
+                        columns,
+                        &row,
+                        &table_schema,
+                    )?;
+                    let merged =
+                        self.build_updated_proxima_record(existing, &resolved, &table_schema)?;
+                    affected_ids.push(merged.oid.clone());
+                    mutations.push(TableRecordMutation::new(
+                        TableRecordMutationKind::Update,
+                        merged,
+                    ));
+                    updated += 1;
+                }
+                Some(_) => {
+                    // DO NOTHING on a conflicting row.
+                    skipped += 1;
+                }
+                None => {
+                    affected_ids.push(key);
+                    mutations.push(TableRecordMutation::new(
+                        TableRecordMutationKind::Upsert,
+                        new_record,
+                    ));
+                    inserted += 1;
+                }
+            }
         }
 
-        let num_records = records.len();
-        let mutations = records
-            .into_iter()
-            .map(|record| TableRecordMutation::new(TableRecordMutationKind::Upsert, record))
-            .collect::<Vec<_>>();
-        let batch_result = self
-            .record_store
-            .write_mutations(&table_schema, mutations, tenant_context)
-            .await?;
-        if !batch_result.success {
-            return Err(anyhow!(
-                "Upsert failed: {}",
-                batch_result
-                    .errors
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| "unknown error".to_string())
-            ));
+        if !mutations.is_empty() {
+            let batch_result = self
+                .record_store
+                .write_mutations(&table_schema, mutations, tenant_context)
+                .await?;
+            if !batch_result.success {
+                return Err(anyhow!(
+                    "Upsert failed: {}",
+                    batch_result
+                        .errors
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "unknown error".to_string())
+                ));
+            }
         }
 
         info!(
             table = %table_name,
-            rows = num_records,
+            inserted,
+            updated,
+            skipped,
             "Upserted rows"
         );
 
-        self.bump_row_count_stats(table_name, num_records as i64)
-            .await;
+        // Only freshly inserted rows change the row count; updates and skipped
+        // (DO NOTHING) conflicts do not.
+        if inserted > 0 {
+            self.bump_row_count_stats(table_name, inserted as i64).await;
+        }
 
+        // Affected = inserted + updated (Postgres does not count DO NOTHING skips).
+        let affected = (inserted + updated) as u64;
         Ok(
-            DmlResult::success(num_records as u64, format!("Upserted {} rows", num_records))
-                .with_inserted_ids(inserted_ids),
+            DmlResult::success(affected, format!("Upserted {} rows", affected))
+                .with_inserted_ids(affected_ids),
         )
+    }
+
+    /// Resolve an `ON CONFLICT DO UPDATE` assignment list for one inserted row by
+    /// substituting `excluded.<col>` references with the literal the INSERT proposed
+    /// for `<col>`. Plain literals, `DEFAULT`, `NULL`, functions, and bare references
+    /// to the existing row pass through unchanged so the shared UPDATE applier
+    /// (`build_updated_proxima_record`) handles them identically to a standalone
+    /// UPDATE. An `excluded.<col>` whose column the INSERT omitted falls back to
+    /// `DEFAULT` (filled by `CatalogRow::validate`).
+    fn resolve_conflict_assignments(
+        &self,
+        assignments: &[(String, SqlValueLiteral)],
+        insert_columns: &[String],
+        insert_row: &[SqlValueLiteral],
+        table_schema: &CatalogTableSchema,
+    ) -> Result<Vec<(String, SqlValueLiteral)>> {
+        // Synthesize the column list when the INSERT omitted it, mirroring
+        // `build_mutation_record`, so positional values map to columns identically.
+        let synthesized: Vec<String>;
+        let insert_columns: &[String] = if insert_columns.is_empty() && !insert_row.is_empty() {
+            synthesized = table_schema
+                .columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect();
+            &synthesized
+        } else {
+            insert_columns
+        };
+
+        let lookup_proposed = |col: &str| -> SqlValueLiteral {
+            insert_columns
+                .iter()
+                .zip(insert_row.iter())
+                .find(|(name, _)| name.eq_ignore_ascii_case(col))
+                .map(|(_, literal)| literal.clone())
+                .unwrap_or(SqlValueLiteral::Default)
+        };
+
+        Ok(assignments
+            .iter()
+            .map(|(target, value)| {
+                let resolved = match value {
+                    SqlValueLiteral::Column(reference) => match reference.split_once('.') {
+                        Some((qualifier, col)) if qualifier.eq_ignore_ascii_case("excluded") => {
+                            lookup_proposed(col)
+                        }
+                        _ => value.clone(),
+                    },
+                    _ => value.clone(),
+                };
+                (target.clone(), resolved)
+            })
+            .collect())
     }
 
     // ========================

--- a/tests/pgwire_upsert_on_conflict_e2e.rs
+++ b/tests/pgwire_upsert_on_conflict_e2e.rs
@@ -1,0 +1,241 @@
+//! TD-129 — pgwire `INSERT ... ON CONFLICT DO UPDATE` upsert, end-to-end.
+//!
+//! The code-graph re-index hot path re-pushes a file's symbol rows every time
+//! the watcher fires. Without `ON CONFLICT` the idempotent re-push had to
+//! read-then-write; this proves the SQL surface now does it in one statement and
+//! that a re-push **updates the row in place** rather than duplicating it.
+//!
+//! Coverage:
+//!  * `DO UPDATE SET col = excluded.col` — re-push with changed values leaves
+//!    exactly one row, carrying the new values.
+//!  * `DO NOTHING` — a conflicting re-push is skipped; the row is unchanged and
+//!    still single.
+//!  * the conflict key (PRIMARY KEY) drives identity, so no row is duplicated.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct PgwireTestServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl PgwireTestServer {
+    async fn start() -> anyhow::Result<Self> {
+        unsafe {
+            std::env::set_var("PROXIMADB_EMBED_PRECISION_SCHEMA_V2", "true");
+        }
+
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{}/health", rest_port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http_client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!(
+                            "REST server didn't become ready on port {} within 20s",
+                            rest_port
+                        );
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn pg_connection_string(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgwireTestServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Collect the data rows of a SELECT as strings (one inner `Vec` per row).
+async fn query_rows(client: &tokio_postgres::Client, sql: &str) -> Vec<Vec<Option<String>>> {
+    let messages = client.simple_query(sql).await.expect("pgwire query");
+    let mut rows = Vec::new();
+    for message in messages {
+        if let tokio_postgres::SimpleQueryMessage::Row(row) = message {
+            let mut values = Vec::with_capacity(row.columns().len());
+            for idx in 0..row.columns().len() {
+                values.push(row.get(idx).map(|s| s.to_string()));
+            }
+            rows.push(values);
+        }
+    }
+    rows
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pgwire_on_conflict_do_update_is_idempotent_and_in_place() {
+    let server = PgwireTestServer::start().await.expect("server start");
+
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+            .await
+            .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    let table = format!(
+        "pgw_upsert_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+
+    client
+        .simple_query(&format!(
+            "CREATE TABLE {table} (id VARCHAR PRIMARY KEY, title VARCHAR, hits BIGINT)"
+        ))
+        .await
+        .expect("CREATE TABLE");
+
+    // Initial push of the symbol row.
+    client
+        .simple_query(&format!(
+            "INSERT INTO {table} (id, title, hits) VALUES ('sym-1', 'first', 1)"
+        ))
+        .await
+        .expect("first INSERT");
+
+    // Idempotent re-push with changed payload via ON CONFLICT DO UPDATE.
+    client
+        .simple_query(&format!(
+            "INSERT INTO {table} (id, title, hits) VALUES ('sym-1', 'second', 5) \
+             ON CONFLICT (id) DO UPDATE SET title = excluded.title, hits = excluded.hits"
+        ))
+        .await
+        .expect("upsert DO UPDATE");
+
+    sleep(Duration::from_millis(300)).await;
+
+    // Exactly one row for the key, carrying the UPDATED values (not duplicated).
+    let rows = query_rows(
+        &client,
+        &format!("SELECT title, hits FROM {table} WHERE id = 'sym-1'"),
+    )
+    .await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "re-upsert must leave exactly one row for the key, got {rows:?}"
+    );
+    assert_eq!(
+        rows[0][0].as_deref(),
+        Some("second"),
+        "DO UPDATE must apply excluded.title; got {rows:?}"
+    );
+    assert_eq!(
+        rows[0][1].as_deref(),
+        Some("5"),
+        "DO UPDATE must apply excluded.hits; got {rows:?}"
+    );
+
+    let all = query_rows(&client, &format!("SELECT id FROM {table}")).await;
+    assert_eq!(all.len(), 1, "table must hold a single row, got {all:?}");
+
+    // DO NOTHING: a conflicting re-push is skipped, row stays as last updated.
+    client
+        .simple_query(&format!(
+            "INSERT INTO {table} (id, title, hits) VALUES ('sym-1', 'ignored', 999) \
+             ON CONFLICT (id) DO NOTHING"
+        ))
+        .await
+        .expect("upsert DO NOTHING");
+
+    sleep(Duration::from_millis(300)).await;
+
+    let rows = query_rows(
+        &client,
+        &format!("SELECT title, hits FROM {table} WHERE id = 'sym-1'"),
+    )
+    .await;
+    assert_eq!(rows.len(), 1, "DO NOTHING must not duplicate, got {rows:?}");
+    assert_eq!(
+        rows[0][0].as_deref(),
+        Some("second"),
+        "DO NOTHING must leave the row unchanged; got {rows:?}"
+    );
+
+    // A non-conflicting upsert inserts a brand-new row.
+    client
+        .simple_query(&format!(
+            "INSERT INTO {table} (id, title, hits) VALUES ('sym-2', 'fresh', 7) \
+             ON CONFLICT (id) DO UPDATE SET title = excluded.title"
+        ))
+        .await
+        .expect("upsert new key");
+
+    sleep(Duration::from_millis(300)).await;
+
+    let all = query_rows(&client, &format!("SELECT id FROM {table}")).await;
+    assert_eq!(
+        all.len(),
+        2,
+        "a non-conflicting upsert must insert a new row, got {all:?}"
+    );
+}


### PR DESCRIPTION
Idempotent re-push of a code-graph file batch must update a symbol row in
place, not duplicate it. The parser/AST/routing already carried the ON
CONFLICT clause; execute_upsert ignored it (unconditional upsert-by-oid).

**What changed**
- Wire the conflict clause through the DML boundary:
  - Conflict target must reference the single-column PRIMARY KEY (the record
    oid is PK-derived, so a re-push of the same key resolves to the same oid).
  - Per-row point-probe → DO UPDATE (reusing the UPDATE applier with
    excluded.* pre-resolved to the proposed INSERT literal) / DO NOTHING /
    insert.
  - Within-statement duplicate conflict keys rejected (Postgres
    "cannot affect row a second time").
  - Postgres-accurate affected count; only inserts bump row-count stats.
- Reuses build_updated_proxima_record + get_by_key; no new decoder.
- e2e test proves re-upsert leaves one row updated, DO NOTHING preserves it,
  new key inserts.

**Verification**
- `cargo nextest run pgwire_upsert_on_conflict_e2e` — green (1/1 passed)
- `cargo clippy -p proximadb --lib` — 1 style suggestion, no panic/unwrap hits
- fmt check passes on touched files

Refs TD-129.