### PR TITLE
fix(tests): add timeout wrapper for external commands to prevent test hang

### DIFF
--- a/src/deployment/discovery/environment_detector.rs
+++ b/src/deployment/discovery/environment_detector.rs
@@ -491,13 +491,13 @@ impl EnvironmentDetector {
         debug!("🔍 Checking Kubernetes availability...");
 
         // Check for kubectl command
-        match run_command_with_timeout("kubectl", ["cluster-info"], 5).await {
+        match run_command_with_timeout("kubectl", &["cluster-info"], 5).await {
             Ok(output) => {
                 if output.status.success() {
                     debug!("✅ kubectl cluster-info successful");
 
                     // Additional check: verify we can list nodes
-                    match run_command_with_timeout("kubectl", ["get", "nodes"], 5).await {
+                    match run_command_with_timeout("kubectl", &["get", "nodes"], 5).await {
                         Ok(nodes_output) => {
                             let success = nodes_output.status.success();
                             debug!(
@@ -626,7 +626,7 @@ impl EnvironmentDetector {
     async fn is_docker_available(&self) -> Result<bool> {
         debug!("🔍 Checking Docker availability...");
 
-        match run_command_with_timeout("docker", ["version"], 5).await {
+        match run_command_with_timeout("docker", &["version"], 5).await {
             Ok(output) => {
                 let available = output.status.success();
                 debug!(
@@ -691,7 +691,7 @@ impl EnvironmentDetector {
     /// Detect number of CPU cores
     async fn detect_cpu_cores(&self) -> Result<u32> {
         // Try multiple methods to detect CPU cores
-        if let Ok(output) = run_command_with_timeout("nproc", [], 2).await
+        if let Ok(output) = run_command_with_timeout("nproc", &[], 2).await
             && let Ok(cores_str) = String::from_utf8(output.stdout)
             && let Ok(cores) = cores_str.trim().parse::<u32>()
         {
@@ -724,7 +724,7 @@ impl EnvironmentDetector {
     /// Detect available storage in GB
     async fn detect_storage_gb(&self) -> Result<u64> {
         // Try using df command to check available disk space
-        match run_command_with_timeout("df", ["-BG", "/"], 2).await {
+        match run_command_with_timeout("df", &["-BG", "/"], 2).await {
             Ok(output) => {
                 if let Ok(df_output) = String::from_utf8(output.stdout) {
                     // Parse df output for available space
@@ -985,7 +985,7 @@ impl PlatformAnalyzer for KubernetesAnalyzer {
         ];
 
         // Check for additional Kubernetes features
-        if let Ok(output) = run_command_with_timeout("kubectl", ["get", "storageclass"], 5).await {
+        if let Ok(output) = run_command_with_timeout("kubectl", &["get", "storageclass"], 5).await {
             if output.status.success() {
                 capabilities.push("Dynamic volume provisioning".to_string());
             } else {
@@ -1145,12 +1145,21 @@ async fn run_command_with_timeout(
     args: &[&str],
     timeout_secs: u64,
 ) -> Result<std::process::Output> {
-    use tokio::time::{timeout, Duration};
+    use tokio::time::{Duration, timeout};
 
     let duration = Duration::from_secs(timeout_secs);
-    let output = timeout(duration, tokio::process::Command::new(program).args(args).output())
-        .await
-        .map_err(|_| anyhow!("Command '{}' timed out after {} seconds", program, timeout_secs))??;
+    let output = timeout(
+        duration,
+        tokio::process::Command::new(program).args(args).output(),
+    )
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "Command '{}' timed out after {} seconds",
+            program,
+            timeout_secs
+        )
+    })??;
 
     Ok(output)
 }

--- a/src/deployment/discovery/environment_detector.rs
+++ b/src/deployment/discovery/environment_detector.rs
@@ -491,21 +491,13 @@ impl EnvironmentDetector {
         debug!("🔍 Checking Kubernetes availability...");
 
         // Check for kubectl command
-        match tokio::process::Command::new("kubectl")
-            .args(["cluster-info"])
-            .output()
-            .await
-        {
+        match run_command_with_timeout("kubectl", ["cluster-info"], 5).await {
             Ok(output) => {
                 if output.status.success() {
                     debug!("✅ kubectl cluster-info successful");
 
                     // Additional check: verify we can list nodes
-                    match tokio::process::Command::new("kubectl")
-                        .args(["get", "nodes"])
-                        .output()
-                        .await
-                    {
+                    match run_command_with_timeout("kubectl", ["get", "nodes"], 5).await {
                         Ok(nodes_output) => {
                             let success = nodes_output.status.success();
                             debug!(
@@ -634,11 +626,7 @@ impl EnvironmentDetector {
     async fn is_docker_available(&self) -> Result<bool> {
         debug!("🔍 Checking Docker availability...");
 
-        match tokio::process::Command::new("docker")
-            .args(["version"])
-            .output()
-            .await
-        {
+        match run_command_with_timeout("docker", ["version"], 5).await {
             Ok(output) => {
                 let available = output.status.success();
                 debug!(
@@ -703,7 +691,7 @@ impl EnvironmentDetector {
     /// Detect number of CPU cores
     async fn detect_cpu_cores(&self) -> Result<u32> {
         // Try multiple methods to detect CPU cores
-        if let Ok(output) = tokio::process::Command::new("nproc").output().await
+        if let Ok(output) = run_command_with_timeout("nproc", [], 2).await
             && let Ok(cores_str) = String::from_utf8(output.stdout)
             && let Ok(cores) = cores_str.trim().parse::<u32>()
         {
@@ -736,11 +724,7 @@ impl EnvironmentDetector {
     /// Detect available storage in GB
     async fn detect_storage_gb(&self) -> Result<u64> {
         // Try using df command to check available disk space
-        match tokio::process::Command::new("df")
-            .args(["-BG", "/"])
-            .output()
-            .await
-        {
+        match run_command_with_timeout("df", ["-BG", "/"], 2).await {
             Ok(output) => {
                 if let Ok(df_output) = String::from_utf8(output.stdout) {
                     // Parse df output for available space
@@ -1001,11 +985,7 @@ impl PlatformAnalyzer for KubernetesAnalyzer {
         ];
 
         // Check for additional Kubernetes features
-        if let Ok(output) = tokio::process::Command::new("kubectl")
-            .args(["get", "storageclass"])
-            .output()
-            .await
-        {
+        if let Ok(output) = run_command_with_timeout("kubectl", ["get", "storageclass"], 5).await {
             if output.status.success() {
                 capabilities.push("Dynamic volume provisioning".to_string());
             } else {
@@ -1158,6 +1138,22 @@ impl Default for DetectionConfig {
 // Removed duplicate structs - using original definitions above
 
 // Removed duplicate DiscoveryNetworkConfiguration struct - use DiscoveryNetworkConfig instead
+
+/// Helper function to run a command with a timeout to prevent hanging
+async fn run_command_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout_secs: u64,
+) -> Result<std::process::Output> {
+    use tokio::time::{timeout, Duration};
+
+    let duration = Duration::from_secs(timeout_secs);
+    let output = timeout(duration, tokio::process::Command::new(program).args(args).output())
+        .await
+        .map_err(|_| anyhow!("Command '{}' timed out after {} seconds", program, timeout_secs))??;
+
+    Ok(output)
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Fix hanging `test_platform_detection` by adding timeout wrappers to all external command execution in `environment_detector.rs`.

## Problem

The test was hanging indefinitely when kubectl or docker commands were configured but their servers were unreachable, because `tokio::process::Command` calls had no timeout mechanism.

## Root Cause

- `is_kubernetes_available()`: `kubectl cluster-info` and `kubectl get nodes` had no timeout
- `is_docker_available()`: `docker version` had no timeout
- `detect_cpu_cores()`: `nproc` had no timeout
- `detect_storage_gb()`: `df -BG /` had no timeout
- `KubernetesAnalyzer::analyze_platform()`: `kubectl get storageclass` had no timeout

## Solution

Created `run_command_with_timeout()` helper function that wraps all external command execution with `tokio::time::timeout`:
- kubectl commands: 5 second timeout
- docker commands: 5 second timeout
- system commands (nproc, df): 2 second timeout

## Changes

- **`src/deployment/discovery/environment_detector.rs`**: 
  - Added `run_command_with_timeout` helper function
  - Updated all 6 external command calls to use the timeout wrapper

## Test Plan

- ✅ Code compiles without errors
- 🔄 CI will run `test_platform_detection` and verify it completes within ~10 seconds instead of hanging indefinitely

## Checklist

- [x] Code compiles (`cargo check --all`)
- [x] Formatting applied (`cargo fmt --all`)
- [ ] CI passes (awaiting results)
- [x] Follows workspace isolation rules (worktree-based development)