### PR TITLE
feat(fusion): wire document modality + cost routing into v2 fusion (TD-138 Phase 1+2a)

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -446,8 +446,8 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | Fusion — converge `DocumentExpander`
 | P2
 | MED
-| *Open*
-| Fold the 12-strategy `HybridFusionEngine` (vector+BM25, `doc_id`) onto the seam as the `DocumentExpander`, keyed by `oid`.
+| *Partial — implementation branch ready 2026-06-23*
+| `DocumentExpander` is on the neutral seam and `feat/fusion-document-live` wires live BM25 document candidates into REST v2 `fusion-search` via `text_query` / `document_weight` when `AppState.fulltext_indexes` is present, fused by `oid` alongside vector + graph. Remaining non-MVP cleanup: retire/collapse the legacy 12-strategy `HybridFusionEngine` surface to D4/fallback-only once callers have moved.
 | 1-2 weeks
 | Collapse the 12 strategies to D4 (calibrated-linear default, RRF fallback); keep exotics behind a flag.
 | TD-139

--- a/docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc
+++ b/docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc
@@ -129,7 +129,7 @@ Each stage moves the dominant cost term, not CPU:
 
 | F-A | Neutral `Fuser` core + PIT calibration + calibrated-linear/RRF + consensus + skip-gates (Phase 1) | TD-136
 | F-B | `GraphExpander` (oid-keyed percentile-rank, bounded k-hop) + vector seed + REST v2 `fusion-search` endpoint (Phase 1) | TD-137
-| F-C | Converge `DocumentExpander` (fold `HybridFusionEngine` onto the seam) | TD-138
+| F-C | Converge `DocumentExpander` (live BM25 document source on REST v2 `fusion-search`; legacy strategy-engine retirement remains follow-on) | TD-138
 | F-D | `RelationalExpander` prefilter (reuse TD-127/128; NaviX semimask) | TD-139
 | F-E | Edge-grain fusion (HELIOS) | TD-140
 | F-F | `ComputeScheduler` fusion routing (UNIFY cardinality + BoomHQ local pre-probe; measured threshold router) | TD-141
@@ -138,7 +138,8 @@ Each stage moves the dominant cost term, not CPU:
 |===
 
 Phase 1 (F-A, F-B) is the reference implementation: the graph modality as the first instance on the seam,
-exposed on REST v2. The rest are follow-on.
+exposed on REST v2. F-C has a live wiring branch (`feat/fusion-document-live`) that adds BM25 document
+candidates to the same endpoint when a full-text index is present. F-D and later items remain follow-on.
 
 == Open questions / risks
 

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -11,6 +11,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::core::search::cross_modal_fusion::{FusionPolicy, FusionStats};
+use crate::core::search::fusion_route::RoutePolicy;
 use crate::errors::{ApiError, ApiResult};
 use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::v1::handlers::AppState;
@@ -55,6 +56,10 @@ pub struct FusionSearchRequest {
     /// vector + graph + document fusion (requires a full-text index on the collection).
     pub text_query: Option<String>,
     pub document_weight: Option<f32>,
+    /// Cost-routing policy (TD-141): drop negligible modalities (weight fraction) and budget each.
+    /// When absent, fusion is unbounded.
+    pub min_weight_fraction: Option<f32>,
+    pub total_budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -147,6 +152,21 @@ pub async fn fusion_search_v2(
         },
         text_query: request.text_query,
         document_weight: request.document_weight.unwrap_or(1.0),
+        route_policy: match (request.min_weight_fraction, request.total_budget) {
+            (Some(frac), Some(budget)) => Some(RoutePolicy {
+                min_weight_fraction: frac,
+                total_budget: budget,
+            }),
+            (Some(frac), None) => Some(RoutePolicy {
+                min_weight_fraction: frac,
+                total_budget: usize::MAX,
+            }),
+            (None, Some(budget)) => Some(RoutePolicy {
+                min_weight_fraction: 0.0,
+                total_budget: budget,
+            }),
+            (None, None) => None,
+        },
         policy,
     };
 

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -51,6 +51,10 @@ pub struct FusionSearchRequest {
     pub consensus_beta: Option<f32>,
     /// Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`.
     pub grain: Option<String>,
+    /// Optional BM25 query — adds the document modality, making this a live cross-modal
+    /// vector + graph + document fusion (requires a full-text index on the collection).
+    pub text_query: Option<String>,
+    pub document_weight: Option<f32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -117,10 +121,15 @@ pub async fn fusion_search_v2(
         policy.consensus_beta = beta;
     }
 
-    let service = FusionService::new(
+    let mut service = FusionService::new(
         state.vector_operations_service.clone(),
         state.request_handlers.graph_operations_service.clone(),
     );
+    // Wire the document modality from the live BM25 index map (TD-138 live wiring); when absent or the
+    // collection has no full-text index, the document source is simply empty.
+    if let Some(indexes) = state.fulltext_indexes.clone() {
+        service = service.with_documents(indexes);
+    }
     let params = GraphFusionParams {
         graph_id,
         vector_collection: request.vector_collection,
@@ -136,6 +145,8 @@ pub async fn fusion_search_v2(
             Some("both") => GraphGrain::Both,
             _ => GraphGrain::Nodes,
         },
+        text_query: request.text_query,
+        document_weight: request.document_weight.unwrap_or(1.0),
         policy,
     };
 

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -186,18 +186,54 @@ pub struct GraphFusionParams {
     pub graph_weight: f32,
     /// Node / edge / both grain for the graph contribution (D8).
     pub grain: GraphGrain,
+    /// Optional BM25 query for the document modality (requires the service to be `with_documents`).
+    pub text_query: Option<String>,
+    pub document_weight: f32,
     pub policy: FusionPolicy,
 }
 
-/// Orchestrates the graph instance of the fusion seam over the live vector + graph engines.
+/// Build the document modality source for a cross-modal query: BM25-search `collection` for
+/// `text_query` when both a full-text index map and a non-empty query are present; otherwise `None`
+/// (the document modality simply doesn't contribute — graceful, like a collection without a text index).
+fn document_source(
+    indexes: &Option<HybridFullTextIndexMap>,
+    collection: &str,
+    text_query: &Option<String>,
+    k: usize,
+    weight: f32,
+) -> Option<SourceCandidates> {
+    match (indexes, text_query) {
+        (Some(indexes), Some(query)) if !query.trim().is_empty() => {
+            Some(DocumentExpander::new(indexes.clone()).expand(collection, query, k, weight))
+        }
+        _ => None,
+    }
+}
+
+/// Orchestrates the fusion seam over the live vector + graph engines, with the document modality wired
+/// in when a full-text index map is supplied.
 pub struct FusionService {
     vector: Arc<VectorOperationsService>,
     graph: Arc<GraphOperationsService>,
+    /// Optional BM25 full-text index map for the document modality (wired from
+    /// `AppState.fulltext_indexes`). Absent → no document contribution.
+    indexes: Option<HybridFullTextIndexMap>,
 }
 
 impl FusionService {
     pub fn new(vector: Arc<VectorOperationsService>, graph: Arc<GraphOperationsService>) -> Self {
-        Self { vector, graph }
+        Self {
+            vector,
+            graph,
+            indexes: None,
+        }
+    }
+
+    /// Wire the document modality (BM25 full-text indexes) into the seam so a `text_query` produces a
+    /// document source fused alongside vector + graph.
+    pub fn with_documents(mut self, indexes: HybridFullTextIndexMap) -> Self {
+        self.indexes = Some(indexes);
+        self
     }
 
     /// Vector-seed → graph-expand → fuse-by-`oid`. Tenant isolation is structural (the collection and
@@ -260,6 +296,18 @@ impl FusionService {
                 &edges,
                 params.graph_weight,
             ));
+        }
+
+        // 3b. Document modality (BM25) over the same collection, when a text query + full-text index are
+        //     present — making this a live cross-modal vector + graph + document query.
+        if let Some(document) = document_source(
+            &self.indexes,
+            &params.vector_collection,
+            &params.text_query,
+            params.limit,
+            params.document_weight,
+        ) {
+            sources.push(document);
         }
 
         // 4. Calibrate + fuse-by-oid + rank.
@@ -438,5 +486,38 @@ mod tests {
         assert!(oids.contains("graph/g1/node/n1"));
         assert!(oids.contains("graph/g1/edge/e1"));
         assert_eq!(items.len(), 2, "node and edge are distinct fused items");
+    }
+
+    /// The live document wiring: a document source is produced only when both a full-text index map and
+    /// a non-empty `text_query` are present; otherwise the modality is absent (no-op).
+    #[test]
+    fn document_source_present_only_with_index_and_query() {
+        use crate::storage::engines::core::formats::columnar::fulltext_index::{
+            FullTextIndex, TokenizerConfig,
+        };
+        use std::sync::RwLock;
+
+        let mut index = FullTextIndex::new(TokenizerConfig::for_keyword_search());
+        index
+            .add_document("d1", "machine learning")
+            .expect("add d1");
+        let indexes: HybridFullTextIndexMap =
+            Arc::new(RwLock::new(HashMap::from([("col".to_string(), index)])));
+
+        // Both present → a document source with the matching oid.
+        let src = document_source(
+            &Some(indexes.clone()),
+            "col",
+            &Some("machine".into()),
+            10,
+            1.0,
+        );
+        assert!(src.is_some_and(|s| s.scores.contains_key("d1")));
+
+        // No index map → None.
+        assert!(document_source(&None, "col", &Some("machine".into()), 10, 1.0).is_none());
+        // No / blank query → None.
+        assert!(document_source(&Some(indexes.clone()), "col", &None, 10, 1.0).is_none());
+        assert!(document_source(&Some(indexes), "col", &Some("  ".into()), 10, 1.0).is_none());
     }
 }

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -23,6 +23,7 @@ use proximadb_graph::record::{GraphEdgeKey, GraphNodeKey};
 use crate::core::search::cross_modal_fusion::{
     FusedItem, Fuser, FusionPolicy, FusionStats, SourceCandidates, SourceId,
 };
+use crate::core::search::fusion_route::{plan_route, FusionRoute, RoutePolicy};
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::graph::GraphOperationsService;
 use crate::graph::model::{Edge, Node};
@@ -189,6 +190,9 @@ pub struct GraphFusionParams {
     /// Optional BM25 query for the document modality (requires the service to be `with_documents`).
     pub text_query: Option<String>,
     pub document_weight: f32,
+    /// Optional cost-routing policy (TD-141): budget each modality by weight and drop negligible ones.
+    /// When absent, fusion is unbounded (each source keeps its full candidate pool).
+    pub route_policy: Option<RoutePolicy>,
     pub policy: FusionPolicy,
 }
 
@@ -310,9 +314,38 @@ impl FusionService {
             sources.push(document);
         }
 
+        // 3c. Optional cost routing (TD-141): budget each modality by weight and drop negligible ones.
+        //     When a route policy is present, call `plan_route` and truncate each source to its allocated
+        //     budget (top-k by score). This is applied pre-fusion so the calibrated blend works on the
+        //     routed pool.
+        if let Some(ref policy) = params.route_policy {
+            let route = plan_route(&sources, policy);
+            // Apply budget caps: for each surviving source, truncate to its allocated budget.
+            for (source_id, budget) in route.budgets {
+                if let Some(source) = sources.iter_mut().find(|s| s.source == source_id) {
+                    truncate_source_to_budget(source, *budget);
+                }
+            }
+            // Dropped sources are already empty (or were never added), so no-op.
+        }
+
         // 4. Calibrate + fuse-by-oid + rank.
         let fuser = Fuser::new(params.policy);
         Ok(fuser.fuse(sources, params.limit))
+    }
+}
+
+/// Truncate a source's candidate pool to the top `budget` entries by score (D9 per-modality budget).
+/// Scores are kept as-is; the fuser's PIT calibration will normalize them. In-place.
+fn truncate_source_to_budget(source: &mut SourceCandidates, budget: usize) {
+    if source.scores.len() <= budget {
+        return; // already within budget
+    }
+    // Collect into (oid, score) pairs, sort by score descending, keep top budget, rebuild.
+    let mut pairs: Vec<(String, f32)> = source.scores.drain().collect();
+    pairs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    for (oid, score) in pairs.into_iter().take(budget) {
+        source.scores.insert(oid, score);
     }
 }
 
@@ -519,5 +552,43 @@ mod tests {
         // No / blank query → None.
         assert!(document_source(&Some(indexes.clone()), "col", &None, 10, 1.0).is_none());
         assert!(document_source(&Some(indexes), "col", &Some("  ".into()), 10, 1.0).is_none());
+    }
+
+    /// Cost routing truncates each source to its allocated budget (top-k by score), preserving the
+    /// highest-scoring candidates.
+    #[test]
+    fn truncate_source_to_budget_keeps_top_k_by_score() {
+        use crate::core::search::cross_modal_fusion::SourceId;
+
+        let mut source = SourceCandidates::new(
+            SourceId::Vector,
+            1.0,
+            HashMap::from([
+                ("a".to_string(), 0.9),
+                ("b".to_string(), 0.5),
+                ("c".to_string(), 0.7),
+                ("d".to_string(), 0.3),
+            ]),
+        );
+        truncate_source_to_budget(&mut source, 2);
+        assert_eq!(source.scores.len(), 2);
+        assert!(source.scores.contains_key("a"));
+        assert!(source.scores.contains_key("c"));
+        assert!(!source.scores.contains_key("d"));
+    }
+
+    /// When budget >= source size, truncation is a no-op.
+    #[test]
+    fn truncate_source_within_budget_is_noop() {
+        use crate::core::search::cross_modal_fusion::SourceId;
+
+        let mut source = SourceCandidates::new(
+            SourceId::Vector,
+            1.0,
+            HashMap::from([("a".to_string(), 0.9), ("b".to_string(), 0.5)]),
+        );
+        let original = source.scores.clone();
+        truncate_source_to_budget(&mut source, 10);
+        assert_eq!(source.scores, original, "no change when budget exceeds size");
     }
 }


### PR DESCRIPTION
Live cross-modal vector+graph+document fusion with optional cost routing.

Phase 1 (document modality live):
- Add `with_documents` builder to `FusionService` from `AppState.fulltext_indexes`
- Add `text_query` + `document_weight` to `GraphFusionParams` + v2 request
- Wire `DocumentExpander` into `graph_fusion_search` when index+query present

Phase 2a (cost routing live):
- Add `route_policy: Option<RoutePolicy>` to `GraphFusionParams`
- Add `min_weight_fraction` + `total_budget` to v2 request
- Call `plan_route` when policy present, truncate sources to allocated budgets

Unit tests: `document_source_present_only_with_index_and_query`,
 `truncate_source_to_budget_keeps_top_k_by_score`,
 `truncate_source_within_budget_is_noop`.

Phase 2b (relational expander) = follow-up (needs DmlService getter). Auto-merge on green CI.