### PR TITLE
feat(catalog): consult_for_write_leased integration (Phase 7b)

### DIFF
--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -88,9 +88,12 @@ pub use metadata_service::{ClusterMetadata, MetadataService, MetadataServiceConf
 pub use node_registry::{
     NodeHealth, NodeInfo, NodeRegistry, NodeRegistryConfig, NodeRole, NodeStatus,
 };
+pub use partition_lease::{
+    LeaseOutcome, PartitionLease, PartitionLeaseManager, PartitionLeaseStore,
+};
 pub use primary_pod_registry::{
     AssignmentReason, PrimaryPod, PrimaryPodRegistry, WriteRoutingDecision, consult_for_write,
-    resolve_self_pod_id,
+    consult_for_write_leased, resolve_self_pod_id,
 };
 pub use replication::{
     EngineReplication, ReplicaState, ReplicationAck, ReplicationConfig, ReplicationEntry,

--- a/src/cluster/primary_pod_registry.rs
+++ b/src/cluster/primary_pod_registry.rs
@@ -72,6 +72,7 @@
 //!   empty registry with a warning. Operators re-apply via the
 //!   future REST endpoint.
 
+use anyhow::Context;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -531,6 +532,82 @@ pub fn consult_for_write(
             target_pod: binding.pod,
         },
     }
+}
+
+/// Lease-aware write consultation. Tries to acquire/renew a partition
+/// lease before consulting the in-memory registry.
+///
+/// ## Semantics
+///
+/// | Lease manager state | Outcome |
+/// |---|---|
+/// | `None` (single-pod) | Falls back to `consult_for_write` |
+/// | Acquire succeeds | `Allow` (we hold the lease) |
+/// | Acquire fails | `Misrouted { target_pod }` (another pod holds it) |
+///
+/// The caller (REST/gRPC/pgwire/Flight handler) should:
+/// * Proceed with the write if `is_allowed()`
+/// * Respond 421 Misdirected Request with the `target_pod` if `Misrouted`
+///
+/// ## Split-brain safety
+///
+/// Even if a pod bypasses this check (e.g., local single-pod deployment),
+/// the object-store fence in `SystemCatalog` still enforces generation fencing
+/// on every DDL commit. The lease is a latency optimization; the fence is
+/// the correctness authority.
+///
+/// ## Usage
+///
+/// ```rust,ignore
+/// use crate::cluster::primary_pod_registry::consult_for_write_leased;
+/// use std::time::{SystemTime, UNIX_EPOCH};
+///
+/// let decision = consult_for_write_leased(
+///     &registry,
+///     lease_manager.as_deref(),  // Option<&PartitionLeaseManager>
+///     "pod-1",
+///     "acme",
+///     "widgets",
+///     SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64,
+/// ).await?;
+/// if !decision.is_allowed() {
+///     return Err(Error::Misrouted { target_pod: decision.target_pod() });
+/// }
+/// ```
+pub async fn consult_for_write_leased(
+    registry: &PrimaryPodRegistry,
+    lease_manager: Option<&crate::cluster::partition_lease::PartitionLeaseManager>,
+    self_pod_id: &str,
+    tenant_id: &str,
+    collection_id: &str,
+    now_ms: i64,
+) -> Result<WriteRoutingDecision, anyhow::Error> {
+    if let Some(manager) = lease_manager {
+        // Try to acquire/renew the lease
+        let got_lease = manager
+            .acquire(tenant_id, collection_id, now_ms)
+            .await
+            .with_context(|| {
+                format!("lease acquisition for {tenant_id}/{collection_id} on pod {self_pod_id}")
+            })?;
+
+        if got_lease {
+            // We hold the lease → allow the write
+            return Ok(WriteRoutingDecision::Allow);
+        }
+
+        // Another pod holds the lease. The manager has already updated
+        // the in-memory registry (via `reconcile`), so we can safely
+        // consult it for the target pod.
+    }
+
+    // Fall back to in-memory lookup (single-pod or lease manager unavailable)
+    Ok(consult_for_write(
+        registry,
+        self_pod_id,
+        tenant_id,
+        collection_id,
+    ))
 }
 
 /// Resolve the current pod's identity. Order of precedence:


### PR DESCRIPTION
Lease-aware write consultation for protocol handler integration.

## Overview
Phase 7b of the system-catalog redesign: wires \`PartitionLeaseManager\` into protocol handlers (REST/gRPC/pgwire/Flight) via \`consult_for_write_leased\`.

## What Changed
- \`consult_for_write_leased\` in \`primary_pod_registry.rs\`
  - Tries to acquire/renew lease via \`PartitionLeaseManager\`
  - Returns \`Allow\` if we hold the lease, \`Misrouted\` if another pod holds it
  - Falls back to in-memory \`PrimaryPodRegistry\` lookup if manager is None
- Re-exports \`PartitionLeaseManager\` and related types from \`cluster::mod.rs\`

## Design
- Lease is a latency optimization; object-store fence is the correctness authority
- Single-pod deployments skip lease manager (None) → pure in-memory lookup
- Split-brain safety: stale writers rejected via \`commit_fenced\` even if lease check bypassed

## Next Phase
Wire \`consult_for_write_leased\` into the 4 protocol handlers (REST/gRPC/pgwire/Flight) on the DDL write path.

## Conformance
- ✅ rust lib compiles
- ✅ clippy (lib+bins) clean

Refs: system-catalog redesign Phase 7b