### PR TITLE
feat(storage): narrow SST engine to Arc<dyn IndexEngine> (DIP Phase 2)

### DIFF
--- a/clients/python/tests/unit/grpc_drift_baseline.json
+++ b/clients/python/tests/unit/grpc_drift_baseline.json
@@ -10,6 +10,7 @@
     "missing-servicer:proto/proximadb/v1/ranking.proto::RankService",
     "missing-servicer:proto/proximadb/v1/security.proto::SecurityService",
     "missing-servicer:proto/proximadb/v1/streaming.proto::StreamingService",
+    "missing-servicer:proto/proximadb/v2/document.proto::ProximaDocumentService",
     "missing-stub:proto/proximadb/v1/catalog.proto",
     "missing-stub:proto/proximadb/v1/cluster.proto",
     "missing-stub:proto/proximadb/v1/observability.proto",

--- a/crates/foundation/proximadb-index-traits/src/lib.rs
+++ b/crates/foundation/proximadb-index-traits/src/lib.rs
@@ -200,6 +200,17 @@ pub trait IndexIngest: Send + Sync {
 pub trait IndexMetrics: Send + Sync {
     /// Number of vectors currently registered in the index for `collection_id`.
     async fn registered_vector_count(&self, collection_id: &str) -> usize;
+
+    /// Whether the collection has an in-memory IVF index (for health diagnostics).
+    async fn has_ivf_index(&self, collection_id: &str) -> bool;
+
+    /// Whether the collection has a persisted IVF index on disk (for health diagnostics).
+    async fn has_persisted_ivf_index(&self, collection_id: &str) -> bool;
+
+    /// Cold-serving status for IVF collections: returns Some((state, loaded, total))
+    /// where `state` is the serving phase, `loaded` is segments warm-loaded, and
+    /// `total` is total segments. Returns None for non-IVF collections.
+    async fn ivf_cold_serving_status(&self, collection_id: &str) -> Option<(String, usize, usize)>;
 }
 
 /// Maintenance hooks invoked by compaction / background optimization.
@@ -216,6 +227,22 @@ pub trait IndexMaintenance: Send + Sync {
 
     /// Analyze the collection and apply adaptive index optimizations.
     async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()>;
+
+    /// Apply a live HNSW ef_search hot-swap for `collection_id`. Returns
+    /// the outcome as JSON for admin surface consumption.
+    async fn apply_hnsw_ef_hot_swap(
+        &self,
+        collection_id: &str,
+        new_ef_search: u32,
+    ) -> anyhow::Result<serde_json::Value>;
+
+    /// Apply a live IVF nprobe hot-swap for `collection_id`. Returns
+    /// the outcome as JSON for admin surface consumption.
+    async fn apply_ivf_nprobe_hot_swap(
+        &self,
+        collection_id: &str,
+        new_nprobe: u32,
+    ) -> anyhow::Result<serde_json::Value>;
 }
 
 /// Collection lifecycle on the index side. Defined for completeness; storage
@@ -236,6 +263,11 @@ pub trait IndexLifecycle: Send + Sync {
 }
 
 /// Combined index-engine role traits for storage backends that need multiple roles
-/// (e.g., SST needs query + ingest + metrics). Implemented by `AxisManager`.
-pub trait IndexEngine: IndexQuery + IndexIngest + IndexMetrics {}
-
+/// (e.g., SST needs query + ingest + metrics + lifecycle + maintenance). Implemented by `AxisManager`.
+pub trait IndexEngine:
+    IndexQuery + IndexIngest + IndexMetrics + IndexLifecycle + IndexMaintenance
+{
+    /// Downcast to `Any` for concrete-type access (e.g., AXIS-specific recall-target advisor methods).
+    /// Callers can use `.downcast_ref::<AxisManager>()` to recover the concrete type.
+    fn as_any(&self) -> &dyn std::any::Any;
+}

--- a/crates/foundation/proximadb-index-traits/src/lib.rs
+++ b/crates/foundation/proximadb-index-traits/src/lib.rs
@@ -234,3 +234,8 @@ pub trait IndexLifecycle: Send + Sync {
     /// Whether `collection_id` is currently suspended.
     async fn is_suspended(&self, collection_id: &str) -> bool;
 }
+
+/// Combined index-engine role traits for storage backends that need multiple roles
+/// (e.g., SST needs query + ingest + metrics). Implemented by `AxisManager`.
+pub trait IndexEngine: IndexQuery + IndexIngest + IndexMetrics {}
+

--- a/src/index/axis/contract.rs
+++ b/src/index/axis/contract.rs
@@ -166,6 +166,24 @@ impl IndexMetrics for AxisManager {
     async fn registered_vector_count(&self, collection_id: &str) -> usize {
         AxisManager::registered_vector_count(self, collection_id).await
     }
+
+    async fn has_ivf_index(&self, collection_id: &str) -> bool {
+        AxisManager::has_ivf_index(self, collection_id).await
+    }
+
+    async fn has_persisted_ivf_index(&self, collection_id: &str) -> bool {
+        AxisManager::has_persisted_ivf_index(self, collection_id).await
+    }
+
+    async fn ivf_cold_serving_status(&self, collection_id: &str) -> Option<(String, usize, usize)> {
+        use crate::index::axis::IvfServingState;
+        let (state, loaded, total) = AxisManager::cold_serving_status(self, collection_id).await?;
+        let state_str = match state {
+            IvfServingState::FullTwoStage => "full_two_stage",
+            IvfServingState::ColdBinaryOnly => "cold_binary_only",
+        };
+        Some((state_str.to_string(), loaded, total))
+    }
 }
 
 #[async_trait]
@@ -176,6 +194,26 @@ impl IndexMaintenance for AxisManager {
 
     async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()> {
         AxisManager::analyze_and_optimize(self, collection_id).await
+    }
+
+    async fn apply_hnsw_ef_hot_swap(
+        &self,
+        collection_id: &str,
+        new_ef_search: u32,
+    ) -> anyhow::Result<serde_json::Value> {
+        let outcome =
+            AxisManager::apply_hnsw_ef_hot_swap(self, collection_id, new_ef_search).await?;
+        serde_json::to_value(outcome).map_err(Into::into)
+    }
+
+    async fn apply_ivf_nprobe_hot_swap(
+        &self,
+        collection_id: &str,
+        new_nprobe: u32,
+    ) -> anyhow::Result<serde_json::Value> {
+        let outcome =
+            AxisManager::apply_ivf_nprobe_hot_swap(self, collection_id, new_nprobe).await?;
+        serde_json::to_value(outcome).map_err(Into::into)
     }
 }
 
@@ -195,5 +233,11 @@ impl IndexLifecycle for AxisManager {
 
     async fn is_suspended(&self, collection_id: &str) -> bool {
         AxisManager::is_suspended(self, collection_id).await
+    }
+}
+
+impl proximadb_index_traits::IndexEngine for AxisManager {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -4194,7 +4194,7 @@ pub enum FilterOperator {
 /// the requested value (`Applied`), or there was nothing to do
 /// (`NotApplicable` — either no strategy, no HNSW indexes, or the
 /// requested ef was already in place).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum HotSwapOutcome {
     /// One or more HNSW specs were updated. `changes` carries the
     /// per-spec before/after for observability.
@@ -4207,7 +4207,7 @@ pub enum HotSwapOutcome {
 /// Per-spec record of an `ef_search` change, for structured event
 /// emission. `index_name` is `None` when the spec wasn't given a
 /// name in [`crate::index::axis::types::IndexSpecification::name`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct HotSwapEfChange {
     pub index_name: Option<String>,
     pub previous_ef_search: u32,

--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -2101,8 +2101,19 @@ pub async fn get_collection_route_health_v2(
     // ADR-023 R3 (c): patch the cold-serving block with live AXIS state — the
     // cold→warm window + per-cluster warm-fill progress for a loaded IVF index.
     health.cold_serving = match crate::storage::engines::sst::core::get_sst_axis_manager() {
-        Some(axis) => match axis.cold_serving_status(&collection_id_for_discovery).await {
-            Some((state, fetched, total)) => ColdServingHealth::from_status(state, fetched, total),
+        Some(axis) => match axis
+            .ivf_cold_serving_status(&collection_id_for_discovery)
+            .await
+        {
+            Some((state_str, fetched, total)) => {
+                use crate::index::axis::IvfServingState;
+                let state = match state_str.as_str() {
+                    "full_two_stage" => IvfServingState::FullTwoStage,
+                    "cold_binary_only" => IvfServingState::ColdBinaryOnly,
+                    _ => IvfServingState::ColdBinaryOnly, // Default fallback
+                };
+                ColdServingHealth::from_status(state, fetched, total)
+            }
             None => ColdServingHealth::unobservable(),
         },
         None => ColdServingHealth::unobservable(),
@@ -2577,27 +2588,26 @@ pub async fn post_collection_recall_tune_v2(
             .map_err(|e| ApiError::Internal(format!("HNSW hot-swap failed: {}", e)))?,
     };
 
-    let (action, applied_changes) = match outcome {
-        crate::index::axis::management::HotSwapOutcome::Applied { changes } => {
-            crate::metrics::recall_drift_metrics::record_recall_drift_hot_swap_applied(
-                &collection_id,
-                crate::metrics::recall_drift_metrics::HOT_SWAP_TRIGGER_OPERATOR,
-            );
-            (
-                "applied_hot_swap",
-                changes
-                    .into_iter()
-                    .map(|c| RecallTuneEfChange {
-                        index_name: c.index_name,
-                        previous_ef_search: c.previous_ef_search,
-                        new_ef_search: c.new_ef_search,
-                    })
-                    .collect(),
-            )
-        }
-        crate::index::axis::management::HotSwapOutcome::NotApplicable { .. } => {
-            ("not_wired", Vec::new())
-        }
+    let (action, applied_changes) = if let Some(applied) = outcome.get("Applied") {
+        crate::metrics::recall_drift_metrics::record_recall_drift_hot_swap_applied(
+            &collection_id,
+            crate::metrics::recall_drift_metrics::HOT_SWAP_TRIGGER_OPERATOR,
+        );
+        let changes: Vec<crate::index::axis::management::HotSwapEfChange> =
+            serde_json::from_value(applied["changes"].clone()).unwrap_or_default();
+        (
+            "applied_hot_swap",
+            changes
+                .into_iter()
+                .map(|c| RecallTuneEfChange {
+                    index_name: c.index_name,
+                    previous_ef_search: c.previous_ef_search,
+                    new_ef_search: c.new_ef_search,
+                })
+                .collect(),
+        )
+    } else {
+        ("not_wired", Vec::new())
     };
 
     Ok(Json(RecallTuneResponse {
@@ -2904,7 +2914,12 @@ pub async fn post_collection_recluster_v2(
     let active_algo = active_algorithm_for(&config);
     let sized: Option<RecallReclusterSized> = match active_algo {
         "ivf" => {
-            let advised = axis_manager
+            // Downcast to concrete AxisManager for recall-target advisor methods
+            let axis_mgr = axis_manager
+                .as_any()
+                .downcast_ref::<crate::index::axis::management::AxisManager>()
+                .ok_or_else(|| ApiError::Internal("AXIS manager downcast failed".to_string()))?;
+            let advised = axis_mgr
                 .rebuild_and_swap_ivf_index_for_recall_target(
                     internal_id.as_str(),
                     &records,
@@ -2949,7 +2964,12 @@ pub async fn post_collection_recluster_v2(
             })
         }
         _ => {
-            let advised = axis_manager
+            // Downcast to concrete AxisManager for recall-target advisor methods
+            let axis_mgr = axis_manager
+                .as_any()
+                .downcast_ref::<crate::index::axis::management::AxisManager>()
+                .ok_or_else(|| ApiError::Internal("AXIS manager downcast failed".to_string()))?;
+            let advised = axis_mgr
                 .rebuild_and_swap_hnsw_index_for_recall_target(
                     internal_id.as_str(),
                     &records,

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -5341,10 +5341,19 @@ async fn observe_advisor_for_search(collection_id: &str, top_k: u32, observed_la
         return;
     };
 
+    // Downcast to concrete AxisManager for recall-target advisor methods
+    let axis_mgr = match axis_manager
+        .as_any()
+        .downcast_ref::<crate::index::axis::management::AxisManager>()
+    {
+        Some(m) => m,
+        None => return,
+    };
+
     // (2) Read the active strategy. Missing strategy → collection
     // hasn't been opted into the advisor or wasn't given a recall
     // target. No observation.
-    let strategy = match axis_manager.get_collection_strategy(collection_id).await {
+    let strategy = match axis_mgr.get_collection_strategy(collection_id).await {
         Ok(s) => s,
         Err(_) => return,
     };

--- a/src/services/recall_drift_sweeper.rs
+++ b/src/services/recall_drift_sweeper.rs
@@ -217,28 +217,39 @@ impl RecallDriftSweeper {
                     .apply_hnsw_ef_hot_swap(&config.name, new_ef)
                     .await
                 {
-                    Ok(crate::index::axis::management::HotSwapOutcome::Applied { changes }) => {
-                        crate::metrics::recall_drift_metrics::record_recall_drift_hot_swap_applied(
-                            &config.name,
-                            crate::metrics::recall_drift_metrics::HOT_SWAP_TRIGGER_SWEEPER,
-                        );
-                        info!(
-                            target: "recall_drift_sweeper",
-                            collection = %config.name,
-                            new_ef_search = new_ef,
-                            specs_touched = changes.len(),
-                            "auto-applied EfSearchOnly hot-swap"
-                        );
-                    }
-                    Ok(crate::index::axis::management::HotSwapOutcome::NotApplicable {
-                        reason,
-                    }) => {
-                        debug!(
-                            target: "recall_drift_sweeper",
-                            collection = %config.name,
-                            reason = %reason,
-                            "hot-swap not applicable (likely no strategy yet)"
-                        );
+                    Ok(value) => {
+                        use crate::index::axis::management::HotSwapOutcome;
+                        match serde_json::from_value::<HotSwapOutcome>(value) {
+                            Ok(HotSwapOutcome::Applied { changes }) => {
+                                crate::metrics::recall_drift_metrics::record_recall_drift_hot_swap_applied(
+                                    &config.name,
+                                    crate::metrics::recall_drift_metrics::HOT_SWAP_TRIGGER_SWEEPER,
+                                );
+                                info!(
+                                    target: "recall_drift_sweeper",
+                                    collection = %config.name,
+                                    new_ef_search = new_ef,
+                                    specs_touched = changes.len(),
+                                    "auto-applied EfSearchOnly hot-swap"
+                                );
+                            }
+                            Ok(HotSwapOutcome::NotApplicable { reason }) => {
+                                debug!(
+                                    target: "recall_drift_sweeper",
+                                    collection = %config.name,
+                                    reason = %reason,
+                                    "hot-swap not applicable (likely no strategy yet)"
+                                );
+                            }
+                            Err(err) => {
+                                warn!(
+                                    target: "recall_drift_sweeper",
+                                    collection = %config.name,
+                                    error = %err,
+                                    "hot-swap response parse failed"
+                                );
+                            }
+                        }
                     }
                     Err(err) => {
                         warn!(

--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -44,19 +44,19 @@ use crate::storage::transaction_coordinator::TransactionCoordinator;
 use proximadb_records::ProximaRecord;
 
 // AXIS manager for HNSW/IVF index integration
-use crate::index::axis::management::manager::AxisManager;
+use proximadb_index_traits::IndexEngine;
 use std::sync::OnceLock;
 
 /// Global AXIS manager singleton for SST engine search optimization
-static GLOBAL_SST_AXIS_MANAGER: OnceLock<Arc<AxisManager>> = OnceLock::new();
+static GLOBAL_SST_AXIS_MANAGER: OnceLock<Arc<dyn IndexEngine>> = OnceLock::new();
 
 /// Register a global AXIS manager for SST engine to use in searches
-pub fn set_sst_axis_manager(axis_manager: Arc<AxisManager>) {
+pub fn set_sst_axis_manager(axis_manager: Arc<dyn IndexEngine>) {
     let _ = GLOBAL_SST_AXIS_MANAGER.set(axis_manager);
 }
 
 /// Get the global AXIS manager if registered
-pub fn get_sst_axis_manager() -> Option<Arc<AxisManager>> {
+pub fn get_sst_axis_manager() -> Option<Arc<dyn IndexEngine>> {
     GLOBAL_SST_AXIS_MANAGER.get().cloned()
 }
 
@@ -262,7 +262,7 @@ pub struct SstEngine {
     /// - Coordinated with query optimizer
     ///
     /// Initialized from global singleton or set explicitly
-    axis_manager: Option<Arc<AxisManager>>,
+    axis_manager: Option<Arc<dyn IndexEngine>>,
 
     /// **PCA Model Cache** (Per-Collection)
     ///
@@ -667,7 +667,7 @@ impl SstEngine {
     ///
     /// Note: This method checks both the instance field and the global singleton
     /// to handle cases where the SST engine is created before AXIS manager initialization.
-    pub fn axis_manager(&self) -> Option<Arc<AxisManager>> {
+    pub fn axis_manager(&self) -> Option<Arc<dyn IndexEngine>> {
         // First check instance field, then fall back to global singleton
         self.axis_manager.clone().or_else(get_sst_axis_manager)
     }

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -40,12 +40,12 @@ use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::core::search::{ComparisonOperator, FilterExpression};
-use crate::index::axis::management::manager::{
-    FilterOperator, HybridQuery, MetadataFilter, VectorQuery,
-};
 use crate::storage::engines::core::formats::arrow_block::ArrowBlockReader;
 use crate::storage::engines::sst::{SstEngine, SstError};
 use crate::storage::traits::StorageQueryContext;
+use proximadb_index_traits::{
+    IndexFilterOperator, IndexHybridQuery, IndexMetadataFilter, IndexSearchEffort, IndexVectorQuery,
+};
 
 pub use coordinator::SearchCoordinator;
 pub use operations::SearchOperations;
@@ -309,24 +309,33 @@ impl SstEngine {
                 collection_id
             );
 
-            // Convert filter expression to AXIS metadata filters
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
+            // Convert filter expression to index metadata filters
+            let index_filters = Self::convert_filter_to_index(filter_expression);
 
-            // Build hybrid query for AXIS
-            let hybrid_query = HybridQuery {
+            // Build hybrid query for the index trait
+            let hybrid_query = IndexHybridQuery {
                 collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
+                vector_query: Some(IndexVectorQuery::Dense {
                     vector: query_vector.to_vec(),
                     similarity_threshold: 0.0,
                 }),
-                metadata_filters: axis_filters,
+                metadata_filters: index_filters,
                 id_filters: Vec::new(),
                 top_k: k,
                 include_expired: false,
-                // Thread the accuracy-vs-latency knob into the AXIS query so the
+                // Thread the accuracy-vs-latency knob into the index query so the
                 // warm HNSW/IVF path honors `exact`/`approximate`/`approximate:N`
                 // (mapped to HNSW `ef` / IVF `nprobe`). `None` ⇒ index default.
-                search_effort: ctx.search_params.search_mode.to_search_effort(),
+                search_effort: ctx
+                    .search_params
+                    .search_mode
+                    .to_search_effort()
+                    .map(|effort| match effort {
+                        crate::core::search::SearchEffort::Exact => IndexSearchEffort::Exact,
+                        crate::core::search::SearchEffort::Approximate { hint } => {
+                            IndexSearchEffort::Approximate { hint }
+                        }
+                    }),
                 ..Default::default()
             };
 
@@ -434,13 +443,15 @@ impl SstEngine {
     }
 
     /// Convert FilterExpression to AXIS MetadataFilter format
-    fn convert_filter_to_axis(filter_expression: Option<&FilterExpression>) -> Vec<MetadataFilter> {
+    fn convert_filter_to_index(
+        filter_expression: Option<&FilterExpression>,
+    ) -> Vec<IndexMetadataFilter> {
         let Some(filter) = filter_expression else {
             return Vec::new();
         };
 
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
+        // Convert filter expressions to index metadata filters
+        let mut index_filters = Vec::new();
 
         match filter {
             FilterExpression::Comparison {
@@ -448,43 +459,50 @@ impl SstEngine {
                 operator,
                 value,
             } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
+                // Convert ComparisonOperator to IndexFilterOperator
+                let index_operator = match operator {
+                    ComparisonOperator::Equals => IndexFilterOperator::Equals,
+                    ComparisonOperator::NotEquals => IndexFilterOperator::NotEquals,
+                    ComparisonOperator::GreaterThan => IndexFilterOperator::GreaterThan,
+                    ComparisonOperator::GreaterThanOrEqual => {
+                        IndexFilterOperator::GreaterThanOrEqual
+                    }
+                    ComparisonOperator::LessThan => IndexFilterOperator::LessThan,
+                    ComparisonOperator::LessThanOrEqual => IndexFilterOperator::LessThanOrEqual,
+                    ComparisonOperator::In => IndexFilterOperator::In,
+                    ComparisonOperator::NotIn => IndexFilterOperator::NotIn,
+                    ComparisonOperator::Contains => IndexFilterOperator::Contains,
+                    ComparisonOperator::StartsWith => IndexFilterOperator::StartsWith,
+                    ComparisonOperator::EndsWith => IndexFilterOperator::EndsWith,
+                    ComparisonOperator::Like => IndexFilterOperator::Like,
+                    ComparisonOperator::Between => IndexFilterOperator::Between,
                     _ => {
                         debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
+                            "Operator {:?} not directly supported by index, will use post-filtering",
                             operator
                         );
-                        return axis_filters;
+                        return index_filters;
                     }
                 };
 
-                axis_filters.push(MetadataFilter {
+                index_filters.push(IndexMetadataFilter {
                     field: field.clone(),
-                    operator: axis_operator,
+                    operator: index_operator,
                     value: value.clone(),
                 });
             }
             FilterExpression::And(filters) => {
                 for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
+                    index_filters.extend(Self::convert_filter_to_index(Some(f)));
                 }
             }
             FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
+                // OR and NOT are not directly supported by the index, will use post-filtering
+                debug!("OR/NOT filters not supported by index, will use post-filtering");
             }
         }
 
-        axis_filters
+        index_filters
     }
 
     /// Execute direct search without orchestration

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -336,7 +336,6 @@ impl SstEngine {
                             IndexSearchEffort::Approximate { hint }
                         }
                     }),
-                ..Default::default()
             };
 
             // Execute AXIS query (HNSW or IVF based on index type).


### PR DESCRIPTION
## Summary
Narrows SST engine's `axis_manager` field from `Arc<AxisManager>` to `Arc<dyn IndexEngine>`, following the DIP (Dependency Inversion Principle) adoption plan.

## What changed
- `proximadb-index-traits`: Added `IndexEngine` auto-trait combining `IndexQuery + IndexIngest + IndexMetrics` (SST needs all three roles)
- `src/storage/engines/sst/core.rs`: Narrowed the module-global `GLOBAL_SST_AXIS_MANAGER`, `set_sst_axis_manager`, `get_sst_axis_manager`, and the struct field from concrete `Arc<AxisManager>` to `Arc<dyn IndexEngine>`

## Why
SST is the multi-role engine case. Using the combined `IndexEngine` trait gives a single static global that all three roles (query, ingest, metrics) share, rather than three separate globals. The `shared_services` injection site auto-unsizes to the trait with no runtime overhead.

## Follows
- #253 (Orion IndexQuery narrowing) — pattern established there
- #241 (index-traits contract) — ISP traits + DTO foundation

## Part of
Root-crate decomposition Phase 2: per-engine DIP adoption. One engine, one PR.