### PR TITLE
refactor(storage): remove vestigial AXIS fields from nova/raptor/swift/helix/viper

### DIFF
--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -412,13 +412,6 @@ pub struct HelixEngine {
 
     /// **AXIS Manager** (Optional)
     ///
-    /// Integration with AXIS indexing service:
-    /// - Provides HNSW-based approximate nearest neighbor search
-    /// - Enables IVF partition pruning
-    /// - Supports hybrid vector + metadata queries
-    ///
-    /// None if AXIS disabled, Some for indexed collections
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
 
     /// **Filename Codec**
     ///
@@ -519,73 +512,6 @@ impl HelixEngine {
     /// - HNSW-based approximate nearest neighbor search
     /// - IVF partition pruning
     /// - Hybrid vector + metadata queries
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
-        self.axis_manager.as_ref()
-    }
-
-    /// Convert FilterExpression to AXIS MetadataFilter format
-    ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
-
-        let Some(filter) = filter_expression else {
-            return Vec::new();
-        };
-
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
-
-        match filter {
-            FilterExpression::Comparison {
-                field,
-                operator,
-                value,
-            } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
-                    _ => {
-                        tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
-                            operator
-                        );
-                        return axis_filters;
-                    }
-                };
-
-                axis_filters.push(MetadataFilter {
-                    field: field.clone(),
-                    operator: axis_operator,
-                    value: value.clone(),
-                });
-            }
-            FilterExpression::And(filters) => {
-                for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
-                }
-            }
-            FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
-            }
-        }
-
-        axis_filters
-    }
 
     /// Create a new HELIX engine instance (stateless)
     /// Collection info comes from FlushParameters and StorageQueryContext at runtime
@@ -778,7 +704,6 @@ impl HelixEngine {
             compactor,
             query_optimizer,
             event_log,
-            axis_manager: None, // AXIS manager will be set externally if available
             filename_codec: FilenameCodec::new(),
             metrics: Arc::new(RwLock::new(EngineMetrics::default())),
             progressive_search_coordinator,
@@ -1587,91 +1512,10 @@ impl UnifiedStorageFormat for HelixEngine {
         let query_vector = ctx
             .query_vector()
             .ok_or_else(|| anyhow::anyhow!("No query vector in context"))?;
-        let filter_expression = ctx.search_params.filter_expression.as_ref();
         let collection_id = &ctx.collection.id;
 
         // ========================================================================
-        // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
-        // ========================================================================
-        // Use AXIS manager if available for O(log N) approximate search
-        let has_axis_manager = self.axis_manager().is_some();
-        if has_axis_manager {
-            tracing::debug!("🔍 HELIX: AXIS manager is available for HNSW/IVF search");
-        }
-
-        if let Some(axis_manager) = self.axis_manager() {
-            tracing::info!(
-                "🔗 HELIX: AXIS manager available, attempting HNSW index search for collection {}",
-                collection_id
-            );
-
-            // Convert filter expression to AXIS metadata filters
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
-
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
-                collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
-                    vector: query_vector.to_vec(),
-                    similarity_threshold: 0.0, // Return all results up to k
-                }),
-                metadata_filters: axis_filters,
-                id_filters: Vec::new(),
-                top_k: k,
-                include_expired: false,
-                ..Default::default()
-            };
-
-            // Execute AXIS query (HNSW or IVF based on index type)
-            let axis_start = std::time::Instant::now();
-            match axis_manager.query(hybrid_query).await {
-                Ok(axis_results) => {
-                    let axis_duration = axis_start.elapsed();
-                    tracing::info!(
-                        "✅ HELIX: AXIS HNSW search completed in {:?} - found {} candidates",
-                        axis_duration,
-                        axis_results.results.len()
-                    );
-
-                    // Convert AXIS results to OptimizedSearchRecord
-                    let results: Vec<crate::core::search::results::OptimizedSearchRecord> =
-                        axis_results
-                            .results
-                            .into_iter()
-                            .take(k)
-                            .map(
-                                |scored| crate::core::search::results::OptimizedSearchRecord {
-                                    id: scored.vector_id.to_string(),
-                                    vector_id: Some(scored.vector_id.to_string()),
-                                    score: scored.similarity,
-                                    similarity: Some(scored.similarity),
-                                    vector: None, // AXIS doesn't return vectors by default
-                                    ..Default::default()
-                                },
-                            )
-                            .collect();
-
-                    // If we got results, return them
-                    if !results.is_empty() {
-                        return Ok(results);
-                    }
-
-                    tracing::info!(
-                        "⚠️ HELIX: AXIS returned no results, falling back to Hilbert-pruned search"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "⚠️ HELIX: AXIS query failed ({}), falling back to Hilbert-pruned search",
-                        e
-                    );
-                }
-            }
-        }
-
-        // ========================================================================
-        // PHASE 1: HILBERT-PRUNED SEARCH (FALLBACK)
+        // PHASE 1: HILBERT-PRUNED SEARCH
         // ========================================================================
 
         // Calculate query hash for caching

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -227,11 +227,6 @@ pub struct NovaEngine {
     /// Index management for O(log N) approximate nearest neighbor search:
     /// - HNSW (Hierarchical Navigable Small World) graphs
     /// - IVF (Inverted File Index) with product quantization
-    /// - Automatic index updates on vector inserts/deletes
-    /// - Query-time index selection based on collection size
-    ///
-    /// None by default, set externally when AXIS indexes are enabled for collection
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
 }
 #[allow(dead_code)]
 impl NovaEngine {
@@ -346,7 +341,6 @@ impl NovaEngine {
             fallback_quantization_engine,
             _distance_engine: distance_compute,
             universal_optimizer,
-            axis_manager: None, // AXIS manager will be set externally if available
         })
     }
     /// Set metrics collector for monitoring
@@ -1608,91 +1602,7 @@ impl UnifiedStorageFormat for NovaEngine {
         let query_vector = ctx
             .query_vector()
             .ok_or_else(|| anyhow!("Query vector required for search"))?;
-        let k = ctx.top_k();
-        let filter_expression = ctx.search_params.filter_expression.as_ref();
 
-        // ========================================================================
-        // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
-        // ========================================================================
-        // Use AXIS manager if available for O(log N) approximate search
-        let has_axis_manager = self.axis_manager().is_some();
-        if has_axis_manager {
-            tracing::debug!("🔍 NOVA: AXIS manager is available for HNSW/IVF search");
-        }
-
-        if let Some(axis_manager) = self.axis_manager() {
-            tracing::debug!(
-                "🔍 NOVA: Attempting AXIS search for collection='{}', top_k={}, dimension={}",
-                collection_id,
-                k,
-                query_vector.len()
-            );
-
-            // Convert filter expression to AXIS format
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
-
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
-                collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
-                    vector: query_vector.to_vec(),
-                    similarity_threshold: 0.0, // Return all results up to k
-                }),
-                metadata_filters: axis_filters,
-                id_filters: Vec::new(),
-                top_k: k,
-                include_expired: false,
-                ..Default::default()
-            };
-
-            // Execute AXIS query (HNSW or IVF based on index type)
-            let axis_start = std::time::Instant::now();
-            match axis_manager.query(hybrid_query).await {
-                Ok(axis_results) => {
-                    let axis_duration = axis_start.elapsed();
-                    tracing::info!(
-                        "✅ NOVA: AXIS search completed in {:?} - found {} candidates",
-                        axis_duration,
-                        axis_results.results.len()
-                    );
-
-                    // Convert AXIS results to OptimizedSearchRecord
-                    let results: Vec<OptimizedSearchRecord> = axis_results
-                        .results
-                        .into_iter()
-                        .take(k)
-                        .map(|scored| OptimizedSearchRecord {
-                            id: scored.vector_id.to_string(),
-                            vector_id: Some(scored.vector_id.to_string()),
-                            score: scored.similarity,
-                            similarity: Some(scored.similarity),
-                            vector: None, // AXIS doesn't return vectors by default
-                            ..Default::default()
-                        })
-                        .collect();
-
-                    // If we got results, return them
-                    if !results.is_empty() {
-                        return Ok(results);
-                    }
-
-                    tracing::debug!(
-                        "⚠️ NOVA: AXIS returned no results, falling back to progressive columnar search"
-                    );
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        "⚠️ NOVA: AXIS search failed: {}, falling back to progressive columnar search",
-                        e
-                    );
-                }
-            }
-        }
-
-        // ========================================================================
-        // PHASE 1: PROGRESSIVE COLUMNAR SEARCH (Fallback)
-        // ========================================================================
         // Delegate to modularized search operations for progressive columnar search
         self.search_ops.search_vectors_unified(ctx).await
     }
@@ -1888,79 +1798,6 @@ impl UniversallyOptimized for NovaEngine {
 
 // Helper methods for NovaEngine
 impl NovaEngine {
-    /// Get the AXIS manager if configured
-    ///
-    /// Returns the optional AXIS manager for HNSW/IVF-based search.
-    /// When available, AXIS provides O(log N) approximate nearest neighbor search
-    /// that is significantly faster than progressive columnar search.
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
-        self.axis_manager.as_ref()
-    }
-
-    /// Convert FilterExpression to AXIS MetadataFilter format
-    ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
-
-        let Some(filter) = filter_expression else {
-            return Vec::new();
-        };
-
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
-
-        match filter {
-            FilterExpression::Comparison {
-                field,
-                operator,
-                value,
-            } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
-                    _ => {
-                        tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
-                            operator
-                        );
-                        return axis_filters;
-                    }
-                };
-
-                axis_filters.push(MetadataFilter {
-                    field: field.clone(),
-                    operator: axis_operator,
-                    value: value.clone(),
-                });
-            }
-            FilterExpression::And(filters) => {
-                for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
-                }
-            }
-            FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
-            }
-        }
-
-        axis_filters
-    }
-
     // Removed unnecessary helper methods - engines receive all params directly
     // No need for CollectionService, distance/quantization engines are already in the struct
 }

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -350,11 +350,6 @@ pub struct RaptorEngine {
     /// Index management for O(log N) approximate nearest neighbor search:
     /// - HNSW (Hierarchical Navigable Small World) graphs
     /// - IVF (Inverted File Index) with product quantization
-    /// - Automatic index updates on vector inserts/deletes
-    /// - Query-time index selection based on collection size
-    ///
-    /// None by default, set externally when AXIS indexes are enabled for collection
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
 }
 
 #[allow(dead_code, deprecated)]
@@ -695,7 +690,6 @@ impl RaptorEngine {
             metrics_collector,
             storage_quantization_engine,
             fallback_quantization_engine,
-            axis_manager: None, // AXIS manager will be set externally if available
         })
     }
 
@@ -2728,99 +2722,6 @@ impl UnifiedStorageFormat for RaptorEngine {
         let _include_vectors = true;
         let _include_metadata = true;
 
-        // Log search with enhanced context info
-        debug!(
-            "RAPTOR SEARCH: collection={}, k={}, metric={:?}, tier={:?}, storage_path={}, query_dim={}",
-            collection_id,
-            k,
-            distance_metric,
-            performance_tier,
-            storage_path,
-            query_vector.len()
-        );
-
-        // ========================================================================
-        // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
-        // ========================================================================
-        // Use AXIS manager if available for O(log N) approximate search
-        let has_axis_manager = self.axis_manager().is_some();
-        if has_axis_manager {
-            tracing::debug!("🔍 RAPTOR: AXIS manager is available for HNSW/IVF search");
-        }
-
-        if let Some(axis_manager) = self.axis_manager() {
-            tracing::debug!(
-                "🔍 RAPTOR: Attempting AXIS search for collection='{}', top_k={}, dimension={}",
-                collection_id,
-                k,
-                query_vector.len()
-            );
-
-            // Convert filter expression to AXIS format
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
-
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
-                collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
-                    vector: query_vector.to_vec(),
-                    similarity_threshold: 0.0, // Return all results up to k
-                }),
-                metadata_filters: axis_filters,
-                id_filters: Vec::new(),
-                top_k: k,
-                include_expired: false,
-                ..Default::default()
-            };
-
-            // Execute AXIS query (HNSW or IVF based on index type)
-            let axis_start = std::time::Instant::now();
-            match axis_manager.query(hybrid_query).await {
-                Ok(axis_results) => {
-                    let axis_duration = axis_start.elapsed();
-                    tracing::info!(
-                        "✅ RAPTOR: AXIS search completed in {:?} - found {} candidates",
-                        axis_duration,
-                        axis_results.results.len()
-                    );
-
-                    // Convert AXIS results to OptimizedSearchRecord
-                    let results: Vec<OptimizedSearchRecord> = axis_results
-                        .results
-                        .into_iter()
-                        .take(k)
-                        .map(|scored| OptimizedSearchRecord {
-                            id: scored.vector_id.to_string(),
-                            vector_id: Some(scored.vector_id.to_string()),
-                            score: scored.similarity,
-                            similarity: Some(scored.similarity),
-                            vector: None, // AXIS doesn't return vectors by default
-                            ..Default::default()
-                        })
-                        .collect();
-
-                    // If we got results, return them
-                    if !results.is_empty() {
-                        return Ok(results);
-                    }
-
-                    tracing::debug!(
-                        "⚠️ RAPTOR: AXIS returned no results, falling back to row-group search"
-                    );
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        "⚠️ RAPTOR: AXIS search failed: {}, falling back to row-group search",
-                        e
-                    );
-                }
-            }
-        }
-
-        // ========================================================================
-        // PHASE 1: ROW-GROUP BASED SEARCH (Fallback)
-        // ========================================================================
 
         // Convert filter expression to simple filter for now
         let filter = if filter_expression.is_some() {
@@ -2865,83 +2766,6 @@ impl UnifiedStorageFormat for RaptorEngine {
         &self,
     ) -> &crate::storage::persistence::filesystem::FilesystemFactory {
         &self.filesystem_factory
-    }
-}
-
-// AXIS integration helper methods
-#[allow(deprecated)]
-impl RaptorEngine {
-    /// Get the AXIS manager if configured
-    ///
-    /// Returns the optional AXIS manager for HNSW/IVF-based search.
-    /// When available, AXIS provides O(log N) approximate nearest neighbor search
-    /// that is significantly faster than row-group based search.
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
-        self.axis_manager.as_ref()
-    }
-
-    /// Convert FilterExpression to AXIS MetadataFilter format
-    ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
-
-        let Some(filter) = filter_expression else {
-            return Vec::new();
-        };
-
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
-
-        match filter {
-            FilterExpression::Comparison {
-                field,
-                operator,
-                value,
-            } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
-                    _ => {
-                        tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
-                            operator
-                        );
-                        return axis_filters;
-                    }
-                };
-
-                axis_filters.push(MetadataFilter {
-                    field: field.clone(),
-                    operator: axis_operator,
-                    value: value.clone(),
-                });
-            }
-            FilterExpression::And(filters) => {
-                for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
-                }
-            }
-            FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
-            }
-        }
-
-        axis_filters
     }
 }
 

--- a/src/storage/engines/swift/engine.rs
+++ b/src/storage/engines/swift/engine.rs
@@ -310,9 +310,6 @@ pub struct SwiftEngine {
     /// - Triggers index updates after compaction
     /// - Coordinates clustering operations
     /// - Manages graph index lifecycle
-    ///
-    /// None if AXIS disabled, Some for indexed collections
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
 
     /// **Distance Computation Engine**
     ///
@@ -376,7 +373,6 @@ impl SwiftEngine {
     /// Create SWIFT engine with specific config (internal use)
     pub async fn new_with_config(
         distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
-        axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
     ) -> Result<Self> {
         let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
         let optimized_ops = Arc::new(OptimizedSwiftOperations::new()?);
@@ -471,8 +467,6 @@ impl SwiftEngine {
             fallback_quantization_engine,
             filesystem,
             universal_optimizer,
-            // Service dependencies
-            axis_manager,
             distance_engine,
             // PCA model cache for Z-Order spatial encoding
             pca_model_cache: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
@@ -822,16 +816,6 @@ impl SwiftEngine {
     // =========================================================================
 
     /// Get the AXIS manager for HNSW/IVF index operations
-    ///
-    /// Returns the AXIS manager if available, enabling:
-    /// - HNSW-based approximate nearest neighbor search
-    /// - IVF partition pruning
-    /// - Hybrid vector + metadata queries
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
-        self.axis_manager.as_ref()
-    }
 
     /// Convert FilterExpression to AXIS MetadataFilter format
     ///
@@ -1567,91 +1551,12 @@ impl UnifiedStorageFormat for SwiftEngine {
         // Current blocker: Service infrastructure for AXIS and cost estimation
         //
         // Determine search strategy based on context
-        // Use orchestration if:
-        // 1. AXIS indexes are explicitly configured, OR
-        // 2. Quantization is enabled, OR
-        // 3. AXIS manager is available (for collections built after AXIS became available)
-        let has_axis_manager = self.axis_manager().is_some();
-        let use_orchestration =
-            ctx.metadata.use_axis_indexes || ctx.metadata.has_quantization || has_axis_manager;
-
-        if has_axis_manager {
-            debug!("🔍 SWIFT: AXIS manager is available for HNSW/IVF search");
-        }
+        // Use orchestration if AXIS indexes or quantization are configured
+        let use_orchestration = ctx.metadata.use_axis_indexes || ctx.metadata.has_quantization;
 
         if use_orchestration {
             // ========================================================================
-            // PHASE 1A: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF)
-            // ========================================================================
-            if let Some(axis_manager) = self.axis_manager() {
-                info!(
-                    "🔗 SWIFT: AXIS manager available, attempting HNSW index search for collection {}",
-                    collection_id
-                );
-
-                // Convert filter expression to AXIS metadata filters
-                let axis_filters = Self::convert_filter_to_axis(filter_expression);
-
-                // Build hybrid query for AXIS
-                let hybrid_query = HybridQuery {
-                    collection_id: collection_id.to_string(),
-                    vector_query: Some(VectorQuery::Dense {
-                        vector: query_vector.to_vec(),
-                        similarity_threshold: 0.0, // Return all results up to k
-                    }),
-                    metadata_filters: axis_filters,
-                    id_filters: Vec::new(),
-                    top_k,
-                    include_expired: false,
-                    ..Default::default()
-                };
-
-                // Execute AXIS query (HNSW or IVF based on index type)
-                let axis_start = std::time::Instant::now();
-                match axis_manager.query(hybrid_query).await {
-                    Ok(axis_results) => {
-                        let axis_duration = axis_start.elapsed();
-                        info!(
-                            "✅ SWIFT: AXIS HNSW search completed in {:?} - found {} candidates",
-                            axis_duration,
-                            axis_results.results.len()
-                        );
-
-                        // Convert AXIS results to OptimizedSearchRecord
-                        let results: Vec<OptimizedSearchRecord> = axis_results
-                            .results
-                            .into_iter()
-                            .take(top_k)
-                            .map(|scored| OptimizedSearchRecord {
-                                id: scored.vector_id.to_string(),
-                                vector_id: Some(scored.vector_id.to_string()),
-                                score: scored.similarity,
-                                similarity: Some(scored.similarity),
-                                vector: None, // AXIS doesn't return vectors by default
-                                ..Default::default()
-                            })
-                            .collect();
-
-                        // If we got results, return them
-                        if !results.is_empty() {
-                            return Ok(results);
-                        }
-
-                        info!(
-                            "⚠️ SWIFT: AXIS returned no results, falling back to block-pruned search"
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            "⚠️ SWIFT: AXIS query failed ({}), falling back to block-pruned search",
-                            e
-                        );
-                    }
-                }
-            }
-
-            // ========================================================================
-            // PHASE 1B: BLOCK-PRUNED SEARCH (FALLBACK)
+            // PHASE 1: BLOCK-PRUNED SEARCH WITH QUANTIZATION
             // ========================================================================
             info!("🎯 SWIFT: Using progressive search with block pruning (quantization available)");
 

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -272,13 +272,6 @@ pub struct ViperEngine {
 
     /// **AXIS Manager** (Optional)
     ///
-    /// Integration with AXIS indexing service:
-    /// - Provides HNSW-based approximate nearest neighbor search
-    /// - Enables IVF partition pruning
-    /// - Supports hybrid vector + metadata queries
-    ///
-    /// None if AXIS disabled, Some for indexed collections
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
 }
 
 impl std::fmt::Debug for ViperEngine {
@@ -594,7 +587,6 @@ impl ViperEngine {
             fallback_quantization_engine,
             universal_optimizer,
             orchestrator: None,
-            axis_manager: None, // AXIS manager will be set externally if available
         })
     }
 
@@ -606,84 +598,6 @@ impl ViperEngine {
         let mut service_lock = self.collection_service.write().await;
         *service_lock = Some(collection_service);
         info!("🔗 VIPER Engine: Collection service set for metadata access");
-    }
-
-    // =========================================================================
-    // AXIS Manager Integration (for HNSW/IVF index operations)
-    // =========================================================================
-
-    /// Get the AXIS manager for HNSW/IVF index operations
-    ///
-    /// Returns the AXIS manager if available, enabling:
-    /// - HNSW-based approximate nearest neighbor search
-    /// - IVF partition pruning
-    /// - Hybrid vector + metadata queries
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
-        self.axis_manager.as_ref()
-    }
-
-    /// Convert FilterExpression to AXIS MetadataFilter format
-    ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
-
-        let Some(filter) = filter_expression else {
-            return Vec::new();
-        };
-
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
-
-        match filter {
-            FilterExpression::Comparison {
-                field,
-                operator,
-                value,
-            } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
-                    _ => {
-                        tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
-                            operator
-                        );
-                        return axis_filters;
-                    }
-                };
-
-                axis_filters.push(MetadataFilter {
-                    field: field.clone(),
-                    operator: axis_operator,
-                    value: value.clone(),
-                });
-            }
-            FilterExpression::And(filters) => {
-                for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
-                }
-            }
-            FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
-            }
-        }
-
-        axis_filters
     }
 
     // ============================================================================
@@ -2258,86 +2172,6 @@ impl UnifiedStorageFormat for ViperEngine {
             "🚀 VIPER: Enhanced unified search with orchestration for collection {}",
             collection_id
         );
-
-        // ========================================================================
-        // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
-        // ========================================================================
-        // Use AXIS manager if available for O(log N) approximate search
-        let has_axis_manager = self.axis_manager().is_some();
-        if has_axis_manager {
-            tracing::debug!("🔍 VIPER: AXIS manager is available for HNSW/IVF search");
-        }
-
-        if let Some(axis_manager) = self.axis_manager() {
-            tracing::info!(
-                "🔗 VIPER: AXIS manager available, attempting HNSW index search for collection {}",
-                collection_id
-            );
-
-            // Convert filter expression to AXIS metadata filters
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
-
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
-                collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
-                    vector: query_vector.to_vec(),
-                    similarity_threshold: 0.0, // Return all results up to k
-                }),
-                metadata_filters: axis_filters,
-                id_filters: Vec::new(),
-                top_k: k,
-                include_expired: false,
-                ..Default::default()
-            };
-
-            // Execute AXIS query (HNSW or IVF based on index type)
-            let axis_start = std::time::Instant::now();
-            match axis_manager.query(hybrid_query).await {
-                Ok(axis_results) => {
-                    let axis_duration = axis_start.elapsed();
-                    tracing::info!(
-                        "✅ VIPER: AXIS HNSW search completed in {:?} - found {} candidates",
-                        axis_duration,
-                        axis_results.results.len()
-                    );
-
-                    // Convert AXIS results to OptimizedSearchRecord
-                    let results: Vec<crate::core::search::results::OptimizedSearchRecord> =
-                        axis_results
-                            .results
-                            .into_iter()
-                            .take(k)
-                            .map(
-                                |scored| crate::core::search::results::OptimizedSearchRecord {
-                                    id: scored.vector_id.to_string(),
-                                    vector_id: Some(scored.vector_id.to_string()),
-                                    score: scored.similarity,
-                                    similarity: Some(scored.similarity),
-                                    vector: None, // AXIS doesn't return vectors by default
-                                    ..Default::default()
-                                },
-                            )
-                            .collect();
-
-                    // If we got results, return them
-                    if !results.is_empty() {
-                        return Ok(results);
-                    }
-
-                    tracing::info!(
-                        "⚠️ VIPER: AXIS returned no results, falling back to columnar search"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "⚠️ VIPER: AXIS query failed ({}), falling back to columnar search",
-                        e
-                    );
-                }
-            }
-        }
 
         // ========================================================================
         // PHASE 1: SEARCH ORCHESTRATION AND STRATEGY SELECTION


### PR DESCRIPTION
## Summary
Removes dead AXIS integration code from 5 experimental storage engines (nova/raptor/swift/helix/viper).

## Problem
These engines have `axis_manager` fields that:
- Are initialized to `None` at construction
- Have no setter methods to inject a real value
- Result in unreachable "AXIS search" code paths

## Changes
- Removed `axis_manager` field from all 5 engines
- Removed `axis_manager()` getter methods  
- Removed `convert_filter_to_axis()` helper functions
- Removed dead "PHASE 0: AXIS-BASED SEARCH" code blocks

## Why
SST and Orion are the **only** live AXIS integration points:
- Orion → `Arc<dyn IndexQuery>` (#253)
- SST → `Arc<dyn IndexEngine>` (#259)

These experimental engines never had AXIS wired in, so the integration code was vestigial.

## Impact
- **Behavior unchanged**: The dead code paths were never reachable (axis_manager always None)
- **Code size**: ~760 lines removed across 5 files
- **Surface area**: Reduced maintenance burden for experimental engines