### PR TITLE
test(proto): add ProximaDocumentService to Python gRPC drift baseline

### DIFF
--- a/clients/python/tests/unit/grpc_drift_baseline.json
+++ b/clients/python/tests/unit/grpc_drift_baseline.json
@@ -10,6 +10,7 @@
     "missing-servicer:proto/proximadb/v1/ranking.proto::RankService",
     "missing-servicer:proto/proximadb/v1/security.proto::SecurityService",
     "missing-servicer:proto/proximadb/v1/streaming.proto::StreamingService",
+    "missing-servicer:proto/proximadb/v2/document.proto::ProximaDocumentService",
     "missing-stub:proto/proximadb/v1/catalog.proto",
     "missing-stub:proto/proximadb/v1/cluster.proto",
     "missing-stub:proto/proximadb/v1/observability.proto",


### PR DESCRIPTION
Pre-existing drift: v2 ProximaDocumentService proto exists but Python gRPC stubs are not generated (only v1 stubs). Add to accepted_drift baseline to unblock CI.