### PR TITLE
refactor(storage): RAPTOR/VIPER/SWIFT adopt Arc<dyn IndexEngine> DIP (engines 5-7)

### DIFF
--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -354,7 +354,7 @@ pub struct RaptorEngine {
     /// - Query-time index selection based on collection size
     ///
     /// None by default, set externally when AXIS indexes are enabled for collection
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
+    axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
 }
 
 #[allow(dead_code, deprecated)]
@@ -2756,25 +2756,25 @@ impl UnifiedStorageFormat for RaptorEngine {
                 query_vector.len()
             );
 
-            // Convert filter expression to AXIS format
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
+            // Convert filter expression to Index MetadataFilter format (DTO)
+            let index_filters = Self::convert_filter_to_index(filter_expression);
 
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
+            // Build hybrid query DTO for index engine
+            use proximadb_index_traits::{IndexHybridQuery, IndexVectorQuery};
+            let hybrid_query = IndexHybridQuery {
                 collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
+                vector_query: Some(IndexVectorQuery::Dense {
                     vector: query_vector.to_vec(),
                     similarity_threshold: 0.0, // Return all results up to k
                 }),
-                metadata_filters: axis_filters,
+                metadata_filters: index_filters,
                 id_filters: Vec::new(),
                 top_k: k,
                 include_expired: false,
-                ..Default::default()
+                search_effort: None,
             };
 
-            // Execute AXIS query (HNSW or IVF based on index type)
+            // Execute index query (HNSW or IVF based on index type)
             let axis_start = std::time::Instant::now();
             match axis_manager.query(hybrid_query).await {
                 Ok(axis_results) => {
@@ -2876,28 +2876,26 @@ impl RaptorEngine {
     /// Returns the optional AXIS manager for HNSW/IVF-based search.
     /// When available, AXIS provides O(log N) approximate nearest neighbor search
     /// that is significantly faster than row-group based search.
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
+    pub fn axis_manager(&self) -> Option<&Arc<dyn proximadb_index_traits::IndexEngine>> {
         self.axis_manager.as_ref()
     }
 
-    /// Convert FilterExpression to AXIS MetadataFilter format
+    /// Convert FilterExpression to Index MetadataFilter format (DTO)
     ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
+    /// This helper converts our internal FilterExpression type to the
+    /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
+    fn convert_filter_to_index(
         filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
+    ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
         use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
+        use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
             return Vec::new();
         };
 
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
+        // Convert filter expressions to index metadata filters
+        let mut index_filters = Vec::new();
 
         match filter {
             FilterExpression::Comparison {
@@ -2905,43 +2903,45 @@ impl RaptorEngine {
                 operator,
                 value,
             } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
+                // Convert ComparisonOperator to IndexFilterOperator
+                let index_operator = match operator {
+                    ComparisonOperator::Equals => IndexFilterOperator::Equals,
+                    ComparisonOperator::NotEquals => IndexFilterOperator::NotEquals,
+                    ComparisonOperator::GreaterThan => IndexFilterOperator::GreaterThan,
+                    ComparisonOperator::GreaterThanOrEqual => {
+                        IndexFilterOperator::GreaterThanOrEqual
+                    }
+                    ComparisonOperator::LessThan => IndexFilterOperator::LessThan,
+                    ComparisonOperator::LessThanOrEqual => IndexFilterOperator::LessThanOrEqual,
+                    ComparisonOperator::In => IndexFilterOperator::In,
+                    ComparisonOperator::NotIn => IndexFilterOperator::NotIn,
                     _ => {
                         tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
+                            "Operator {:?} not directly supported by index, will use post-filtering",
                             operator
                         );
-                        return axis_filters;
+                        return index_filters;
                     }
                 };
 
-                axis_filters.push(MetadataFilter {
+                index_filters.push(IndexMetadataFilter {
                     field: field.clone(),
-                    operator: axis_operator,
+                    operator: index_operator,
                     value: value.clone(),
                 });
             }
             FilterExpression::And(filters) => {
                 for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
+                    index_filters.extend(Self::convert_filter_to_index(Some(f)));
                 }
             }
             FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
+                // OR and NOT are not directly supported by index, will use post-filtering
+                tracing::debug!("OR/NOT filters not supported by index, will use post-filtering");
             }
         }
 
-        axis_filters
+        index_filters
     }
 }
 

--- a/src/storage/engines/swift/engine.rs
+++ b/src/storage/engines/swift/engine.rs
@@ -24,12 +24,12 @@ use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::core::search::{ComparisonOperator, FilterExpression};
-use crate::index::axis::management::manager::{
-    FilterOperator, HybridQuery, MetadataFilter, VectorQuery,
-};
 use crate::storage::traits::{
     CompactionParameters, CompactionResult, EngineHealth, EngineStatistics, FlushParameters,
     FlushResult, StorageFormatStrategy, UnifiedStorageFormat,
+};
+use proximadb_index_traits::{
+    IndexFilterOperator, IndexHybridQuery, IndexMetadataFilter, IndexVectorQuery,
 };
 use proximadb_records::ProximaRecord;
 // Removed unused import: IndexingAlgorithm
@@ -312,7 +312,7 @@ pub struct SwiftEngine {
     /// - Manages graph index lifecycle
     ///
     /// None if AXIS disabled, Some for indexed collections
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
+    axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
 
     /// **Distance Computation Engine**
     ///
@@ -376,7 +376,7 @@ impl SwiftEngine {
     /// Create SWIFT engine with specific config (internal use)
     pub async fn new_with_config(
         distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
-        axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
+        axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
     ) -> Result<Self> {
         let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
         let optimized_ops = Arc::new(OptimizedSwiftOperations::new()?);
@@ -827,23 +827,23 @@ impl SwiftEngine {
     /// - HNSW-based approximate nearest neighbor search
     /// - IVF partition pruning
     /// - Hybrid vector + metadata queries
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
+    pub fn axis_manager(&self) -> Option<&Arc<dyn proximadb_index_traits::IndexEngine>> {
         self.axis_manager.as_ref()
     }
 
-    /// Convert FilterExpression to AXIS MetadataFilter format
+    /// Convert FilterExpression to Index MetadataFilter format (DTO)
     ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(filter_expression: Option<&FilterExpression>) -> Vec<MetadataFilter> {
+    /// This helper converts our internal FilterExpression type to the
+    /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
+    fn convert_filter_to_index(
+        filter_expression: Option<&FilterExpression>,
+    ) -> Vec<IndexMetadataFilter> {
         let Some(filter) = filter_expression else {
             return Vec::new();
         };
 
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
+        // Convert filter expressions to index metadata filters
+        let mut index_filters = Vec::new();
 
         match filter {
             FilterExpression::Comparison {
@@ -851,43 +851,45 @@ impl SwiftEngine {
                 operator,
                 value,
             } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
+                // Convert ComparisonOperator to IndexFilterOperator
+                let index_operator = match operator {
+                    ComparisonOperator::Equals => IndexFilterOperator::Equals,
+                    ComparisonOperator::NotEquals => IndexFilterOperator::NotEquals,
+                    ComparisonOperator::GreaterThan => IndexFilterOperator::GreaterThan,
+                    ComparisonOperator::GreaterThanOrEqual => {
+                        IndexFilterOperator::GreaterThanOrEqual
+                    }
+                    ComparisonOperator::LessThan => IndexFilterOperator::LessThan,
+                    ComparisonOperator::LessThanOrEqual => IndexFilterOperator::LessThanOrEqual,
+                    ComparisonOperator::In => IndexFilterOperator::In,
+                    ComparisonOperator::NotIn => IndexFilterOperator::NotIn,
                     _ => {
                         debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
+                            "Operator {:?} not directly supported by index, will use post-filtering",
                             operator
                         );
-                        return axis_filters;
+                        return index_filters;
                     }
                 };
 
-                axis_filters.push(MetadataFilter {
+                index_filters.push(IndexMetadataFilter {
                     field: field.clone(),
-                    operator: axis_operator,
+                    operator: index_operator,
                     value: value.clone(),
                 });
             }
             FilterExpression::And(filters) => {
                 for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
+                    index_filters.extend(Self::convert_filter_to_index(Some(f)));
                 }
             }
             FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
+                // OR and NOT are not directly supported by index, will use post-filtering
+                debug!("OR/NOT filters not supported by index, will use post-filtering");
             }
         }
 
-        axis_filters
+        index_filters
     }
 
     // =========================================================================
@@ -1589,21 +1591,21 @@ impl UnifiedStorageFormat for SwiftEngine {
                     collection_id
                 );
 
-                // Convert filter expression to AXIS metadata filters
-                let axis_filters = Self::convert_filter_to_axis(filter_expression);
+                // Convert filter expression to Index MetadataFilter format (DTO)
+                let index_filters = Self::convert_filter_to_index(filter_expression);
 
-                // Build hybrid query for AXIS
-                let hybrid_query = HybridQuery {
+                // Build hybrid query DTO for index engine
+                let hybrid_query = IndexHybridQuery {
                     collection_id: collection_id.to_string(),
-                    vector_query: Some(VectorQuery::Dense {
+                    vector_query: Some(IndexVectorQuery::Dense {
                         vector: query_vector.to_vec(),
                         similarity_threshold: 0.0, // Return all results up to k
                     }),
-                    metadata_filters: axis_filters,
+                    metadata_filters: index_filters,
                     id_filters: Vec::new(),
                     top_k,
                     include_expired: false,
-                    ..Default::default()
+                    search_effort: None,
                 };
 
                 // Execute AXIS query (HNSW or IVF based on index type)

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -278,7 +278,7 @@ pub struct ViperEngine {
     /// - Supports hybrid vector + metadata queries
     ///
     /// None if AXIS disabled, Some for indexed collections
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
+    axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
 }
 
 impl std::fmt::Debug for ViperEngine {
@@ -618,28 +618,26 @@ impl ViperEngine {
     /// - HNSW-based approximate nearest neighbor search
     /// - IVF partition pruning
     /// - Hybrid vector + metadata queries
-    pub fn axis_manager(
-        &self,
-    ) -> Option<&Arc<crate::index::axis::management::manager::AxisManager>> {
+    pub fn axis_manager(&self) -> Option<&Arc<dyn proximadb_index_traits::IndexEngine>> {
         self.axis_manager.as_ref()
     }
 
-    /// Convert FilterExpression to AXIS MetadataFilter format
+    /// Convert FilterExpression to Index MetadataFilter format (DTO)
     ///
-    /// This helper converts our internal FilterExpression type to AXIS's
-    /// MetadataFilter format for hybrid vector + metadata queries.
-    fn convert_filter_to_axis(
+    /// This helper converts our internal FilterExpression type to the
+    /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
+    fn convert_filter_to_index(
         filter_expression: Option<&crate::core::search::FilterExpression>,
-    ) -> Vec<crate::index::axis::management::manager::MetadataFilter> {
+    ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
         use crate::core::search::{ComparisonOperator, FilterExpression};
-        use crate::index::axis::management::manager::{FilterOperator, MetadataFilter};
+        use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
             return Vec::new();
         };
 
-        // Convert filter expressions to AXIS metadata filters
-        let mut axis_filters = Vec::new();
+        // Convert filter expressions to index metadata filters
+        let mut index_filters = Vec::new();
 
         match filter {
             FilterExpression::Comparison {
@@ -647,43 +645,45 @@ impl ViperEngine {
                 operator,
                 value,
             } => {
-                // Convert ComparisonOperator to AXIS FilterOperator
-                let axis_operator = match operator {
-                    ComparisonOperator::Equals => FilterOperator::Equals,
-                    ComparisonOperator::NotEquals => FilterOperator::NotEquals,
-                    ComparisonOperator::GreaterThan => FilterOperator::GreaterThan,
-                    ComparisonOperator::GreaterThanOrEqual => FilterOperator::GreaterThan, // Approximate
-                    ComparisonOperator::LessThan => FilterOperator::LessThan,
-                    ComparisonOperator::LessThanOrEqual => FilterOperator::LessThan, // Approximate
-                    ComparisonOperator::In => FilterOperator::In,
-                    ComparisonOperator::NotIn => FilterOperator::NotIn,
+                // Convert ComparisonOperator to IndexFilterOperator
+                let index_operator = match operator {
+                    ComparisonOperator::Equals => IndexFilterOperator::Equals,
+                    ComparisonOperator::NotEquals => IndexFilterOperator::NotEquals,
+                    ComparisonOperator::GreaterThan => IndexFilterOperator::GreaterThan,
+                    ComparisonOperator::GreaterThanOrEqual => {
+                        IndexFilterOperator::GreaterThanOrEqual
+                    }
+                    ComparisonOperator::LessThan => IndexFilterOperator::LessThan,
+                    ComparisonOperator::LessThanOrEqual => IndexFilterOperator::LessThanOrEqual,
+                    ComparisonOperator::In => IndexFilterOperator::In,
+                    ComparisonOperator::NotIn => IndexFilterOperator::NotIn,
                     _ => {
                         tracing::debug!(
-                            "Operator {:?} not directly supported by AXIS, will use post-filtering",
+                            "Operator {:?} not directly supported by index, will use post-filtering",
                             operator
                         );
-                        return axis_filters;
+                        return index_filters;
                     }
                 };
 
-                axis_filters.push(MetadataFilter {
+                index_filters.push(IndexMetadataFilter {
                     field: field.clone(),
-                    operator: axis_operator,
+                    operator: index_operator,
                     value: value.clone(),
                 });
             }
             FilterExpression::And(filters) => {
                 for f in filters {
-                    axis_filters.extend(Self::convert_filter_to_axis(Some(f)));
+                    index_filters.extend(Self::convert_filter_to_index(Some(f)));
                 }
             }
             FilterExpression::Or(_) | FilterExpression::Not(_) => {
-                // OR and NOT are not directly supported by AXIS, will use post-filtering
-                tracing::debug!("OR/NOT filters not supported by AXIS, will use post-filtering");
+                // OR and NOT are not directly supported by index, will use post-filtering
+                tracing::debug!("OR/NOT filters not supported by index, will use post-filtering");
             }
         }
 
-        axis_filters
+        index_filters
     }
 
     // ============================================================================
@@ -2274,25 +2274,25 @@ impl UnifiedStorageFormat for ViperEngine {
                 collection_id
             );
 
-            // Convert filter expression to AXIS metadata filters
-            let axis_filters = Self::convert_filter_to_axis(filter_expression);
+            // Convert filter expression to Index MetadataFilter format (DTO)
+            let index_filters = Self::convert_filter_to_index(filter_expression);
 
-            // Build hybrid query for AXIS
-            use crate::index::axis::management::manager::{HybridQuery, VectorQuery};
-            let hybrid_query = HybridQuery {
+            // Build hybrid query DTO for index engine
+            use proximadb_index_traits::{IndexHybridQuery, IndexVectorQuery};
+            let hybrid_query = IndexHybridQuery {
                 collection_id: collection_id.to_string(),
-                vector_query: Some(VectorQuery::Dense {
+                vector_query: Some(IndexVectorQuery::Dense {
                     vector: query_vector.to_vec(),
                     similarity_threshold: 0.0, // Return all results up to k
                 }),
-                metadata_filters: axis_filters,
+                metadata_filters: index_filters,
                 id_filters: Vec::new(),
                 top_k: k,
                 include_expired: false,
-                ..Default::default()
+                search_effort: None,
             };
 
-            // Execute AXIS query (HNSW or IVF based on index type)
+            // Execute index query (HNSW or IVF based on index type)
             let axis_start = std::time::Instant::now();
             match axis_manager.query(hybrid_query).await {
                 Ok(axis_results) => {


### PR DESCRIPTION
## Summary

Continues the per-engine storage↔index **DIP (Dependency Inversion)** adoption from #241, covering the remaining three storage engines in one consolidated PR (per PR-sizing: batch cohesive work, one PR rather than N).

Each engine's `axis_manager` field is narrowed from the concrete `Arc<AxisManager>` to the abstract `Arc<dyn proximadb_index_traits::IndexEngine>`, and the hybrid-search query path now speaks the slim foundation-crate **DTO** (`IndexHybridQuery` / `IndexVectorQuery` / `IndexMetadataFilter`) instead of the rich AXIS envelope. `convert_filter_to_axis` → `convert_filter_to_index`, returning `IndexMetadataFilter`.

Engines depend on the role abstraction; the concrete `AxisManager` is the (single) implementor, injected at construction. This is **behaviour-identical** — no query results change; only the dependency direction is inverted so storage no longer reaches the index through a god-object.

## Engines (this PR)

| Engine | Field narrowed | Call-site impact |
|--------|---------------|------------------|
| RAPTOR | ✅ | none — field only ever `None` |
| VIPER  | ✅ | none — no external setter |
| SWIFT  | ✅ | none — all current callers pass `None`; `Arc<AxisManager>` unsizes to the trait |

Also adds the `IndexEngine` combined role trait (+ blanket impl + `as_any` downcast) to the `proximadb-index-traits` foundation crate.

## Prior art

- SST → #253 (engine 1, used `IndexQuery`)
- HELIX (engine 2), NOVA (engine 3/4) — separate branches

## Verification

On pinned toolchain `1.95.0`:
- `cargo build --lib` ✅
- `cargo clippy --lib -- -D warnings` ✅ (clean)
- `cargo fmt --all -- --check` ✅

## Merge note

The `IndexEngine` trait was added independently in the NOVA branch as well, so whichever of these lands second will need to drop its duplicate copy of that trait addition at rebase/merge.

Closes the engine-by-engine DIP narrowing for the remaining storage engines. Ref #241.