### PR TITLE
feat(query): route SELECT on real shape signals — close co-design cost loop (T2.1/T3.3)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -232,11 +232,28 @@ pub async fn try_run_select(
     #[cfg(not(feature = "datafusion-integration"))]
     let parquet_backed = false;
 
+    // C4 Phase-2b: refine the shape-class with real fan-out / cardinality for
+    // hot Parquet-backed tables, peeked from the in-memory stat cache warmed by
+    // table opens (zero route-time I/O — a cold/never-scanned table stays
+    // `Unknown`, backward-compatible). Finer classes let the cost model
+    // discriminate within the OLAP-over-Parquet band where a Native↔DataFusion
+    // override is freshness-safe.
+    #[cfg(feature = "datafusion-integration")]
+    let (partition_fanout, cardinality) = if parquet_backed {
+        let locations: Vec<String> = parquet_loc_by_key.values().cloned().collect();
+        crate::query::route_cost_model::classify_table_shapes(&locations)
+    } else {
+        (Default::default(), Default::default())
+    };
+    #[cfg(not(feature = "datafusion-integration"))]
+    let (partition_fanout, cardinality) = (Default::default(), Default::default());
+
     let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
             parquet_backed,
-            ..Default::default()
+            partition_fanout,
+            cardinality,
         },
         // C4: observe-mode advisory from the trace-driven cost model — augments
         // the reason for telemetry/EXPLAIN, never changes the backend.
@@ -1023,8 +1040,10 @@ async fn parquet_split_summary(
     let (mut any_rows, mut any_bytes) = (false, false);
     for location in locations {
         let table = ObjectStoreParquetTable::open(location).await.ok()?;
-        partitions += table.split_count();
-        if let Some(r) = table.estimated_rows() {
+        let splits = table.split_count();
+        let est_rows = table.estimated_rows();
+        partitions += splits;
+        if let Some(r) = est_rows {
             rows = rows.saturating_add(r);
             any_rows = true;
         }
@@ -1032,6 +1051,10 @@ async fn parquet_split_summary(
             bytes = bytes.saturating_add(b);
             any_bytes = true;
         }
+        // EXPLAIN opens the footer anyway — warm the route-time shape cache so
+        // the next SELECT's route decision can classify this location's fan-out
+        // / cardinality without a cold read (co-design: zero extra I/O).
+        crate::query::route_cost_model::record_table_shape_stat(location, splits as u32, est_rows);
     }
     Some(crate::query::read_route::ReadSplitSummary::row_groups(
         partitions,

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -87,13 +87,23 @@ impl DataFusionLocalEngine {
         .map_err(|e| ExecutionError::Context(format!("session: {e}")))?;
 
         for (name, location) in &context.parquet_tables {
-            crate::datafusion::register_object_store_parquet_location(&ctx, name, location)
-                .await
-                .map_err(|e| {
-                    ExecutionError::Context(format!(
-                        "register object-store parquet table {name}: {e}"
-                    ))
-                })?;
+            let table =
+                crate::datafusion::register_object_store_parquet_location(&ctx, name, location)
+                    .await
+                    .map_err(|e| {
+                        ExecutionError::Context(format!(
+                            "register object-store parquet table {name}: {e}"
+                        ))
+                    })?;
+            // Warm the route-time shape cache for free — the footer is already
+            // read, so the next route decision can classify this location's
+            // fan-out / cardinality without a cold read (co-design: zero extra
+            // I/O on the route path).
+            crate::query::route_cost_model::record_table_shape_stat(
+                location,
+                table.split_count() as u32,
+                table.estimated_rows(),
+            );
         }
 
         context.controls.check_cancelled()?;

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -68,6 +68,90 @@ pub fn install_route_cost_observer() {
     GLOBAL_ROUTE_COST_MODEL.set_override_enabled(on);
 }
 
+// ── Per-Parquet-location shape stats (route-time classification) ────────────
+
+/// One Parquet table's physical shape, warmed for free wherever the table is
+/// opened and peeked at route time so the cost-model shape-class discriminates
+/// OLAP-over-Parquet queries by fan-out / cardinality WITHOUT a cold footer
+/// read on the route path (co-design P5: I/O round-trips, not CPU, dominate).
+#[derive(Clone, Copy, Debug)]
+pub struct TableShapeStat {
+    /// Row-group / split count — the GET-fan-out a scan of this table pays.
+    pub row_groups: u32,
+    /// Estimated row count from footer statistics, when the footer carries it.
+    pub rows: Option<u64>,
+}
+
+/// Process-global, bounded cache of per-Parquet-location [`TableShapeStat`]s.
+/// Warmed as a free side-effect of opening a table for execution/EXPLAIN (the
+/// opener already reads the footer) and consulted at the route decision so the
+/// scheduler's [`QueryShape`] carries real `partition_fanout` / `cardinality`
+/// for hot tables. A cold (never-scanned) table simply lacks an entry → the
+/// shape stays coarse (`Unknown`), so a fresh table changes nothing until its
+/// first scan warms the stat. Workload-adaptive, and adds zero I/O to routing.
+static GLOBAL_TABLE_SHAPE_STATS: LazyLock<Mutex<HashMap<String, TableShapeStat>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Soft cap on cached locations. Locations are catalog-bounded in practice; this
+/// only guards a runaway (e.g. a bug minting synthetic locations). Over-cap the
+/// cache clears wholesale — stat data is advisory and re-warms on the next scan.
+const TABLE_SHAPE_STAT_CAP: usize = 8192;
+
+/// Record (or refresh) a table's shape stat. Called by the Parquet opener after
+/// it has the footer, so this adds no I/O. Best-effort: a poisoned lock or an
+/// over-cap cache is silently dropped (classification then falls back coarse).
+pub fn record_table_shape_stat(location: &str, row_groups: u32, rows: Option<u64>) {
+    let mut guard = GLOBAL_TABLE_SHAPE_STATS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    if guard.len() >= TABLE_SHAPE_STAT_CAP {
+        guard.clear();
+    }
+    guard.insert(location.to_string(), TableShapeStat { row_groups, rows });
+}
+
+/// Aggregate the cached stats for `locations` into cost-model shape buckets.
+///
+/// Conservative: if *any* referenced location lacks a warmed stat, returns
+/// `(Unknown, Unknown)` — never half-classify a multi-table query from partial
+/// data, since an unknown table could dominate fan-out / cardinality. An empty
+/// slice also yields `Unknown`. Sums row-groups (total GET fan-out) and rows
+/// (total scan cardinality) across the tables, then buckets via the scheduler's
+/// [`PartitionFanout`] / [`CardinalityClass`].
+///
+/// [`PartitionFanout`]: crate::query::compute_scheduler::PartitionFanout
+/// [`CardinalityClass`]: crate::query::compute_scheduler::CardinalityClass
+pub fn classify_table_shapes(
+    locations: &[String],
+) -> (
+    crate::query::compute_scheduler::PartitionFanout,
+    crate::query::compute_scheduler::CardinalityClass,
+) {
+    use crate::query::compute_scheduler::{CardinalityClass, PartitionFanout};
+    if locations.is_empty() {
+        return (PartitionFanout::Unknown, CardinalityClass::Unknown);
+    }
+    let guard = GLOBAL_TABLE_SHAPE_STATS
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let mut total_row_groups = 0u32;
+    let mut total_rows: Option<u64> = Some(0);
+    for loc in locations {
+        let Some(stat) = guard.get(loc) else {
+            return (PartitionFanout::Unknown, CardinalityClass::Unknown);
+        };
+        total_row_groups = total_row_groups.saturating_add(stat.row_groups);
+        total_rows = match (total_rows, stat.rows) {
+            (Some(acc), Some(r)) => Some(acc.saturating_add(r)),
+            _ => None,
+        };
+    }
+    (
+        PartitionFanout::from_count(Some(total_row_groups)),
+        CardinalityClass::from_estimate(total_rows),
+    )
+}
+
 /// Per-tenant governance **tier-entitlement multiplier** resolver — the final
 /// term of the §3 `Cost(q)` objective (Dimension 5, C5). Maps a `tenant_id` to a
 /// neutral scalar applied to the *reported* cost.
@@ -981,6 +1065,136 @@ mod tests {
         assert!(
             m.exploration_choice("oltp/native", &[ComputeBackend::Native])
                 .is_none()
+        );
+    }
+
+    // ── C4 Phase-2b: route-time shape-stat cache (T2.1 wiring / T3.3 ratchet) ─
+
+    #[test]
+    fn classify_table_shapes_empty_and_missing_is_unknown() {
+        use crate::query::compute_scheduler::{CardinalityClass, PartitionFanout};
+        // Empty slice → Unknown.
+        let (pf, card) = classify_table_shapes(&[]);
+        assert_eq!(
+            (pf, card),
+            (PartitionFanout::Unknown, CardinalityClass::Unknown)
+        );
+        // A location with no warmed stat → Unknown (conservative: never
+        // half-classify — an unknown table could dominate fan-out/cardinality).
+        let (pf, card) = classify_table_shapes(&["test://route-shape/missing".to_string()]);
+        assert_eq!(
+            (pf, card),
+            (PartitionFanout::Unknown, CardinalityClass::Unknown)
+        );
+    }
+
+    #[test]
+    fn classify_table_shapes_buckets_and_sums_warmed_stats() {
+        use crate::query::compute_scheduler::{CardinalityClass, PartitionFanout};
+        // Small / single-row-group table.
+        record_table_shape_stat("test://route-shape/small", 1, Some(500));
+        let (pf, card) = classify_table_shapes(&["test://route-shape/small".to_string()]);
+        assert_eq!(pf, PartitionFanout::Single);
+        assert_eq!(card, CardinalityClass::Small);
+
+        // Large / many-row-group table.
+        record_table_shape_stat("test://route-shape/large", 5_000, Some(50_000_000));
+        let (pf, card) = classify_table_shapes(&["test://route-shape/large".to_string()]);
+        assert_eq!(pf, PartitionFanout::Many);
+        assert_eq!(card, CardinalityClass::Large);
+
+        // Two warmed tables: row-groups and rows SUM (total GET fan-out / scan
+        // cardinality). 12 row-groups → Many; 1.3M rows → Large.
+        record_table_shape_stat("test://route-shape/sum-a", 6, Some(600_000));
+        record_table_shape_stat("test://route-shape/sum-b", 6, Some(700_000));
+        let (pf, card) = classify_table_shapes(&[
+            "test://route-shape/sum-a".to_string(),
+            "test://route-shape/sum-b".to_string(),
+        ]);
+        assert_eq!(pf, PartitionFanout::Many);
+        assert_eq!(card, CardinalityClass::Large);
+
+        // Conservative: a cold location among warmed ones → Unknown.
+        let (pf, card) = classify_table_shapes(&[
+            "test://route-shape/sum-a".to_string(),
+            "test://route-shape/cold".to_string(),
+        ]);
+        assert_eq!(
+            (pf, card),
+            (PartitionFanout::Unknown, CardinalityClass::Unknown)
+        );
+    }
+
+    #[test]
+    fn shape_class_discriminates_fine_parquet_signals() {
+        use crate::query::compute_scheduler::{CardinalityClass, PartitionFanout, QueryShape};
+        // Coarse (no fine signals) — the backward-compatible 2-part key.
+        let coarse = shape_class(&QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            ..Default::default()
+        });
+        assert_eq!(coarse, "olap/parquet");
+        // Refined — distinct keys per fine signal, so the model accrues
+        // per-(cardinality, fan-out) cells instead of one noisy bucket.
+        let big = shape_class(&QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            cardinality: CardinalityClass::Large,
+            partition_fanout: PartitionFanout::Many,
+        });
+        let small = shape_class(&QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            cardinality: CardinalityClass::Small,
+            partition_fanout: PartitionFanout::Single,
+        });
+        assert_ne!(big, coarse);
+        assert_ne!(small, coarse);
+        assert_ne!(big, small);
+    }
+
+    #[test]
+    fn warmed_fine_class_lets_cost_override_flip_route() {
+        // T2.1 keystone (T3.3 ratchet): with real fine signals the model accrues
+        // trustworthy per-(cardinality, fan-out) cost; with override enabled it
+        // flips a freshness-safe OLAP-Parquet route to the confidently-cheaper
+        // backend. This is the co-design loop actually closing — observe-mode
+        // promoted to act-mode on reliable per-class evidence.
+        use crate::query::compute_scheduler::{
+            CardinalityClass, ComputeScheduler, PartitionFanout, QueryShape,
+        };
+        let m = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_min_advantage(0.1);
+        m.set_override_enabled(true);
+        let big = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            cardinality: CardinalityClass::Large,
+            partition_fanout: PartitionFanout::Many,
+        };
+        let class = shape_class(&big);
+        // Observe Native as confidently cheaper than DataFusion for THIS fine
+        // class (far fewer object-store round-trips). Both backends get ≥
+        // min_samples → exploration is satisfied (warm), so the exploit override
+        // runs deterministically rather than probing.
+        for _ in 0..3 {
+            m.observe(&class, &ComputeBackend::Native, &snap(2, 8192, 1));
+            m.observe(
+                &class,
+                &ComputeBackend::DataFusionLocal,
+                &snap(40, 1 << 20, 8),
+            );
+        }
+        let decision = ComputeScheduler::new().route_select_advised(big, Some(&m));
+        // Static rule picks DataFusion for OLAP-Parquet; the warmed model
+        // overrides to freshness-safe, cheaper Native.
+        assert_eq!(decision.backend, ComputeBackend::Native);
+        assert!(
+            decision.reason.contains("OVERRIDE"),
+            "expected override reason, got: {}",
+            decision.reason
         );
     }
 }


### PR DESCRIPTION
## What

Closes the co-design cost-loop gap (plan T2.1) and ships its validation ratchet (T3.3).

## Problem

The trace-driven `RouteCostModel` was **already consulted** on the production SELECT path (`ComputeScheduler::route_select_advised` at all 3 sites in `relational_pipeline.rs`). But `QueryShape`'s `cardinality` / `partition_fanout` were **always `Unknown`** (`..Default::default()`), so the model aggregated every query into one coarse bucket per workload (`olap/parquet`, `oltp/native`, …).

That left the OLAP-over-Parquet band — the *only* shape where a freshness-safe `Native ↔ DataFusion` override is permitted (`override_candidates`) — indistinguishable: a 10-row single-row-group scan and a 50M-row 5000-row-group scan landed in the same cell, so the per-class EWMA was noisy and the cost-driven override stayed untrustworthy / observe-only.

## Fix (T2.1)

A process-global, bounded in-memory `TableShapeStat` cache (`route_cost_model.rs`), warmed **for free** wherever a Parquet table is *already* opened — and peeked at route time to populate real `partition_fanout` / `cardinality`:

- **Warm** in `datafusion_engine::prepare_dataframe` (captures the table returned by `register_object_store_parquet_location`) and in `parquet_split_summary` (EXPLAIN). Both already read the footer, so **zero new I/O**.
- **Peek** at the route site (`try_run_select`) to fill `QueryShape`.
- Hot tables classify into per-`(cardinality, fan-out)` cost cells → the override becomes reliable enough to act on. Cold / never-scanned tables stay `Unknown` → backward-compatible (the coarse key is unchanged, warmed cells unaffected).
- Conservative aggregation: if *any* referenced location lacks a stat → `Unknown` (never half-classify a multi-table query).

No footer round-trips are added to the route path (co-design P5: I/O round-trips dominate, not CPU). This is the workload-adaptive answer — the more a table is scanned, the finer its routing.

## Validation (T3.3)

4 deterministic ratchets in `route_cost_model::tests`:
1. empty / missing-location → `Unknown` (conservative);
2. bucketing + multi-table summation (row-groups and rows sum; a cold location among warm ones → `Unknown`);
3. fine-class discrimination (`shape_class` produces distinct keys per `(cardinality, fan-out)`);
4. keystone — a warmed fine class lets the cost-model **override** a freshness-safe OLAP-Parquet route to the confidently-cheaper backend (observe-mode → act-mode on reliable per-class evidence).

## Local verification

- `cargo check --lib` ✅
- `cargo clippy --lib -- -D warnings` ✅
- `cargo test --lib route_cost_model::` could not complete locally — the root-crate test-binary compile repeatedly hit disk corruption (`No such file or directory` moving dep-graphs / writing fingerprints) under shared-disk pressure from concurrent builds; CI's isolated runner runs the test gate. Code paths and test logic mirror the existing `route_cost_model` suite.

Default-safe / mixed-read-safe: no on-disk format change; behavior under default config (override OFF) is unchanged except richer observe-mode advisory text and finer cost-model bucketing.