### PR TITLE
docs(design): search-surface contract — one retrieval engine, typed facades (TD-146)

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -506,6 +506,14 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | MEASURED FINDING (`EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22`): swapping the pyarrow-IPC insert path for the zero-copy Arrow C Data Interface (`arrow::pyarrow` FFI, `insert_arrow_batches`) is **perf-neutral** — the FFI boundary serialize was never the dominant cost term. The ~95 ms (5000x128) insert is dominated by `ArrowProtoCodec::batches_to_proxima_records` (Arrow→ProximaRecord materialization) + `insert_batch` (WAL/storage). The zero-copy `insert_arrow_batches` seam is landed (correct, cross-language substrate, lighter memory) but NOT as a latency win. Remaining Pillar-C work, redirected to the real dominant term: make ingestion **Arrow-native** so the record-materialization + insert copy shrinks (columnar straight into the engine), and apply the same to the search-result return path (currently row-by-row Python objects).
 | 2-3 weeks
 | Co-design tenets 1 & 2 (trace before you tune): the boundary was not the bottleneck. Seam + measurement landed in the embedded-arrow-zerocopy PR.
+| TD-146
+| Fusion — `EntityService.SearchEntities` delegates to seam (no standalone retrieval)
+| P2
+| MED
+| *Open*
+| `EntityService.SearchEntities` (PR #278) must be a typed facade over the fusion seam, not a fourth retrieval engine (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`): `similar`→seam seed, `filters`→predicate mask (`oid` membership bitset), result→entity projection of `FusedItem`s. Resolves the `UNIMPLEMENTED` vector mode by delegation, not a new implementation. Forbids any bespoke vector-ANN/fusion path on the entity surface.
+| 1 week
+| Depends on TD-136/137; gRPC `FusionSearch` parity folds into TD-143.
 | TD-147
 | Index — IVF posting-list id compaction (`Vec<String>` → `Vec<u64>`)
 | P2

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -149,6 +149,15 @@ Read these in order for future-shaping architecture work:
    storage-visible fencing. Read before changing `src/cluster/partition_lease.rs` or wiring locks
    into `DmlService`/protocol handlers.
 
+23. `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc` +
+   Surface-level companion to #22: pins the *endpoint* contract on top of the seam. One retrieval
+   engine (the seam); every search surface (`fusion_search_v2`, `hybrid/search`, `RecordService.Search`,
+   `EntityService.SearchEntities`, future gRPC `FusionSearch`) is a **thin facade** varying only in
+   seed/expander defaults + result projection — none owns retrieval/ranking. Decisive argument:
+   per-surface fusion is *incorrect by construction* (cosine≈Gaussian vs graph≈power-law need PIT
+   calibration only the shared `Fuser` provides). Resolves where `EntityService.SearchEntities` (PR
+   #278) fits: entity-typed view over the seam, no standalone vector-ANN. Adds TD-146.
+
 == Stable Reference Docs
 
 * `ARCHITECTURE_ATLAS_2026_05_22.adoc` - top-down OSS/SaaS architecture map, workspace map, and

--- a/docs/12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc
+++ b/docs/12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc
@@ -1,0 +1,183 @@
+= Search & Retrieval Surface Contract — One Retrieval Engine, Typed Facades
+:toc: macro
+:sectnums:
+:icons: font
+
+Status: Draft (decision record) +
+Date: 2026-06-24 +
+Owner: Query / Search +
+Related: `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` (authority for the retrieval engine), `SUPPORTED_SURFACES.adoc` (apex surface authority), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`, `TD_064_PREDICATE_AWARE_VECTOR_SEARCH_DESIGN_2026_05_27.adoc`, PR #278 (ProximaEntityService v2)
+
+toc::[]
+
+== Why this document exists
+
+`CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` already specifies the *internal* retrieval engine
+(`seed → expand → calibrate → fuse-by-oid → rank`, neutral `FusionQuery`/`FusionResult`,
+pluggable `ModalityExpander`). That is the canonical design and is **not** re-derived here.
+
+This document fills the gap the seam doc leaves open: the **surface-level contract** — i.e. which
+*endpoints/RPCs* should exist, what each one is *for*, and which must *not* grow its own retrieval
+logic. It was triggered by the `ProximaEntityService` (PR #278) whose `SearchEntities` RPC, if
+implemented naively, would become a **fourth** overlapping retrieval path alongside the three the
+seam is already converging. The decision below prevents that.
+
+== Problem: retrieval surfaces are proliferating
+
+ProximaDB exposes several "find things" surfaces, each historically rolling its own fuse-by-key:
+
+[cols="2,4,2,3", options="header"]
+|===
+| Surface | What it fuses / does | Key | Status
+
+| `POST /api/v2/hybrid/search` + gRPC `HybridSearchService.HybridSearch` (v1)
+| vector + BM25 (12-strategy `HybridFusionEngine`)
+| `doc_id`
+| Legacy; converging to seam (TD-138)
+
+| `POST /api/v2/graphs/{id}/fusion-search` (`fusion_search_v2`)
+| vector seed → graph expansion → calibrated fuse
+| `oid`
+| Canonical seam facade (TD-137)
+
+| `execute_hybrid_query` (`request_handlers.rs`)
+| proto vector→graph, hardcoded graph, no tenant
+| implicit
+| To retire (TD-143)
+
+| `GraphService.ExecuteHybridQuery` (v1) / `HybridQueryEngine`
+| vector + graph traversal, `1/(dist+1)`
+| `NodeId`
+| Internal; converging to seam
+
+| `EntityService.SearchEntities` (v2, PR #278)
+| today: metadata-only; **risk**: standalone vector-ANN
+| `entity:{coll}:{id}`
+| *This decision: facade over seam, no standalone engine*
+|===
+
+The risk is not hypothetical: the seam doc opens by naming exactly this class of failure —
+"three overlapping 'hybrid' implementations, each re-solving fuse-by-key on a different key space
+with no shared contract." A standalone `SearchEntities` vector path would be the fourth.
+
+== Decision: one retrieval engine, typed facades
+
+Retrieval is **one engine** — the fusion seam (`FusionService` + the `seed→expand→calibrate→fuse→rank`
+pipeline, correlated by canonical `oid`). Every "search" endpoint is a **thin facade** over it and may
+vary only along two axes:
+
+1. **Default seed + expander set** (which modalities to consult), and
+2. **Result projection** (the typed shape returned: record / graph-node / entity / fused-hit).
+
+No endpoint owns retrieval or fusion logic. Concretely:
+
+[cols="3,4,4", options="header"]
+|===
+| Surface | Role (target) | Disposition
+
+| `fusion_search_v2` (`POST /api/v2/graphs/{id}/fusion-search`)
+| Canonical seam facade (graph + vector)
+| **Canonical** (TD-137)
+
+| `POST /api/v2/hybrid/search`
+| Seam facade defaulting to the `DocumentExpander` (BM25) + vector seed
+| Facade once TD-138 lands; legacy until then
+
+| `RecordService.Search` (v2)
+| Degenerate seam: seed-only (vector), no expanders
+| Facade (already routes through vector search)
+
+| `EntityService.SearchEntities` (v2)
+| Seam facade scoped to entity-labeled nodes + entity projection
+| **Facade (this decision — see below)**; never a standalone engine
+
+| gRPC `FusionSearch` (new)
+| gRPC parity for the seam (REST-only today)
+| Add (fold into TD-143 "once seam covers gRPC")
+|===
+
+Write/lifecycle surfaces are orthogonal and unaffected — they are not retrieval:
+
+* Per-modality CRUD: `ProximaRecordService`, `ProximaGraphService`, `ProximaDocumentService`.
+* Multi-modal object lifecycle: `ProximaEntityService` *Upsert/Get/Delete* (an orchestration facade
+  that writes one object across graph+vector+document — convenience, not a new store).
+
+=== Resolution for `EntityService.SearchEntities`
+
+`SearchEntities` becomes a **typed view** over the seam, not a retrieval engine:
+
+* `similar` (vector / text) → the seam **seed**.
+* `filters` (metadata predicates) → a **predicate mask** (relational expander / `oid` membership
+  bitset, TD-139) scoped to `label = entity`.
+* result → **entity projection** of `FusedItem`s (resolve `oid` → entity node + its embeddings/provenance).
+* It therefore adds **zero** retrieval logic of its own. The `UNIMPLEMENTED` vector mode in PR #278
+  is resolved *by delegation*, not by a new implementation.
+
+This keeps an ergonomic, typed entity-retrieval RPC (good for the document/graph "entity" mental
+model) while guaranteeing no fourth fusion path.
+
+== Why one engine is superior (the load-bearing argument)
+
+The case for one shared calibrated seam over per-surface fusion is not tidiness — it is correctness
+and cost, in this order:
+
+. **Calibration correctness (decisive).** Heterogeneous sources are *incommensurable*: cosine
+  similarity is ≈ Gaussian, graph/PPR scores are ≈ power-law. Naive weighted-sum, min-max, and plain
+  RRF across modalities are mathematically wrong (the seam doc grounds this in HELIOS /
+  Calibrated-Fusion). PIT / percentile-rank calibration — mapping each source's per-query scores
+  through its empirical CDF to `[0,1]` — is *required* for cross-modal correctness. **A per-endpoint
+  fusion (hybrid vs fusion vs entity each rolling its own ranker) cannot be correct by construction**;
+  only the shared calibrated `Fuser` (TD-136) can. This single argument subsumes the rest: any surface
+  that wants cross-modal ranking *must* go through the seam or be wrong.
+
+. **Composability beats combinatorial explosion.** N modalities compose as N `ModalityExpander`s
+  (`Vector | Graph | Document | Relational`). Hardcoding modality combinations as endpoints
+  (vec+BM25, vec+graph, vec+graph+BM25, vec+doc, …) is `2^N` endpoints for N modalities. The seam is
+  `N` expanders.
+
+. **One canonical key + one durable authority.** Fuse-by-`oid` over canonical `ProximaRecord`
+  (= relational row + ORION node + HNSW vector), one result envelope (`FusedItem{oid, score,
+  per_source, payload, path?}`), rebuildable projections. This is exactly the API-support vs
+  physical-projection separation `SUPPORTED_SURFACES.adoc` prescribes.
+
+. **Drift minimization.** Under the spec-driven SDK mandate (TD-126), every canonical endpoint is
+  regenerated across N languages and the OpenAPI spec. Fewer canonical endpoints = smaller drift
+  surface. The current `openapi-spec-drift` advisory (where `fusion_search_v2` is not utoipa-specified)
+  is a symptom of surface sprawl; consolidation shrinks it.
+
+. **Cost co-design.** The seam late-materializes payload + full-f32 rerank only for the final top-k
+  and pool-caps each expander — co-designed against the dominant cloud-DB cost term (I/O round-trips +
+  bytes moved, not CPU). A sprawl of bespoke retrievals cannot enforce this uniformly.
+
+The corollary: **typed facades are not proliferation** as long as they are stateless delegations
+differing only in seed/expander defaults and projection. Proliferation begins the moment a facade
+grows its own ranking.
+
+== Tech-debt deltas
+
+This decision adds one TD and confirms the in-flight fusion TDs already do the convergence work:
+
+* **TD-146 (new, this doc)** — `EntityService.SearchEntities` delegates to the fusion seam; no
+  standalone vector-ANN path. The `similar` field maps to the seam seed, `filters` to a predicate
+  mask, result to an entity projection. P2 / MED.
+* **TD-136 / TD-137 / TD-138 / TD-139 / TD-143** — already converge the three legacy hybrid impls
+  onto the seam (`Fuser` core, `GraphExpander`, `DocumentExpander`, `RelationalExpander`, retire
+  `execute_hybrid_query`). This decision depends on them, does not replace them.
+* **gRPC fusion parity** — the seam is REST-only today; add a v2 gRPC `FusionSearch` (fold into
+  TD-143's "once the seam covers gRPC") so gRPC clients get the canonical surface instead of the
+  legacy `execute_hybrid_query`.
+
+== Sequencing
+
+. Land TD-136 (calibrated `Fuser`) + TD-137 (`GraphExpander` + `fusion_search_v2`) — in progress.
+. Land TD-138 (`DocumentExpander`); `POST /api/v2/hybrid/search` becomes its facade.
+. When EntityService vector search is needed (PR #278 follow-up), implement it **only** as
+  TD-146 delegation — never a bespoke path.
+. Add gRPC `FusionSearch`; retire `execute_hybrid_query` (TD-143).
+
+== Non-goals
+
+* Not redesigning the fusion algorithm — that is `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`.
+* Not removing typed facades (entity / hybrid / record search) — only forbidding them from owning
+  retrieval/ranking logic.
+* Not changing write/lifecycle surfaces (EntityService CRUD, per-modality services).


### PR DESCRIPTION
## Summary

Surface-level design companion to `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`, triggered by the `EntityService.SearchEntities` RPC in #278 which — if built naively — would become a **fourth** overlapping retrieval path alongside the three the seam is already converging.

**Decision: one retrieval engine, typed facades.** The fusion seam is the only retrieval/fusion logic. Every search surface (`fusion_search_v2`, `hybrid/search`, `RecordService.Search`, `EntityService.SearchEntities`, future gRPC `FusionSearch`) is a thin facade that may vary only in (a) seed/expander defaults and (b) result projection. None owns ranking.

## Why one engine is superior (the load-bearing argument)
1. **Correctness (decisive).** Per-surface fusion is *incorrect by construction*: cosine≈Gaussian vs graph/PPR≈power-law are incommensurable; only the shared PIT/percentile-rank-calibrated `Fuser` (TD-136) makes cross-modal scores comparable. Any surface wanting cross-modal ranking *must* go through the seam or be wrong.
2. **Composability** — N modalities = N `ModalityExpander`s, not `2^N` hardcoded endpoints.
3. **One canonical key/authority** — fuse-by-`oid` over `ProximaRecord`; rebuildable projections (the SUPPORTED_SURFACES principle).
4. **Drift minimization** — fewer canonical endpoints → smaller OpenAPI/SDK drift surface (TD-126).
5. **Cost** — late-materialize + pool-capped expanders, co-designed against I/O.

## Resolution for `EntityService.SearchEntities`
It becomes an **entity-typed view** over the seam — `similar`→seed, `filters`→predicate mask, result→entity projection — adding **zero** retrieval logic. The `UNIMPLEMENTED` vector mode in #278 is resolved by delegation, not a new implementation. (Alternative considered: drop `SearchEntities` retrieval entirely — rejected to keep an ergonomic typed entity-retrieval RPC; happy to revisit in review.)

## Changes
- `docs/12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc` (new) — the decision record
- `docs/12-design/README.adoc` — index entry #23
- `docs/10-quality/TECHNICAL_DEBT.adoc` — **TD-146** (EntityService.SearchEntities delegates to seam); confirms TD-136..143 do the convergence

## Review focus
The one judgment call: keep `SearchEntities` as a delegating facade (recommended) vs. remove its retrieval mode in favor of bare `fusion-search` + entity projection. The calibration-correctness argument is the part I'd most like validated.
