### PR TITLE
feat(cluster): unified ResourceKey lease + DML lock foundation

### DIFF
--- a/docs/12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc
+++ b/docs/12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc
@@ -2,7 +2,7 @@
 :toc: left
 :toclevels: 3
 :icons: font
-:last-updated: 2026-05-28
+:last-updated: 2026-06-24
 
 [.lead]
 **Audit-time bookkeeping index for every doc under `docs/12-design/` plus tracker-shaped docs across other roots. No code changes — this doc is the single point of reference for "what's still load-bearing, what's wired, what should be archived" as of 2026-05-26.**
@@ -22,6 +22,12 @@ Parquet/Iceberg-as-hot-authority and not PAX-as-exclusive-format. Use
 `RELATIONAL_PGWIRE_DML_COMPUTE_BLUEPRINT_2026_05_20.adoc`, and
 `roadmap/techdebt/TD_110_OLTP_OLAP_HTAP_STORAGE_AND_CONSTRAINTS_PLAN_2026_06_04.adoc` for current
 OLTP row/delta, PAX, DataFusion, and PostgreSQL constraint seams.
+
+**2026-06-24 lease-locking delta**: the unified `ResourceKey` / DML-lock branch is governed by
+`UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc`. Treat it as the approved correction plan
+before wiring locks into `DmlService` or protocols: compile cleanup, mixed-read-safe legacy lease
+paths, path-safe resource identity, full-key renewal, real `TenantContext`, enforced hierarchy,
+guard-owned renewal/release, and storage-visible fencing.
 ====
 
 [IMPORTANT]
@@ -41,7 +47,7 @@ This audit complements (does not replace) `link:DOCUMENTATION_CONSOLIDATION_AND_
 ** **N/A** — convention/index doc, no code expected.
 * **Cluster** — semantic grouping for consolidation review (see <<consolidation-clusters>>).
 
-== docs/12-design top-level (28 files)
+== docs/12-design top-level (29 files)
 
 [cols="3,1,1,1,3", options="header"]
 |===
@@ -204,6 +210,15 @@ strong-freshness execution, DataFusion snapshot-plus-delta reads, and distribute
 | WIRED
 | Storage
 | Object-storage vector economics blueprint. SST/HELIX centroid block pruning, cache-affinity routing, cataloged vector access-method projections. Governs vector route optimization for cloud-cost competition.
+
+| UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc
+| Active
+| PARTIAL
+| Cluster/Relational
+| Approved correction plan for unified `ResourceKey` leases and DML locking. Governs
+`src/cluster/partition_lease.rs` and blocks DML/protocol lock exposure until legacy path
+compatibility, canonical key encoding, full-key renewal, real tenant-scoped DML locks, enforced
+hierarchy, lock guards, release, fencing, and metrics are implemented.
 
 | SYSTEM_MAP_2026_05_30.adoc
 | Active

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -141,6 +141,13 @@ Read these in order for future-shaping architecture work:
    the blend; late-materialization + quantized in-place distance (Samyama/NaviX). Modalities are pluggable
    `ModalityExpander`s; calibrate+fuse+rank is written once. Phase 1 = graph instance on REST v2.
    Engine asks: TD-136..TD-143.
+23. `UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc` +
+   Approved correction plan for the `feat/unified-resource-key` branch. Retains the unified
+   `ResourceKey` and strategy direction, but gates DML/protocol lock exposure on foundational fixes:
+   mixed-read-safe legacy lease paths, canonical path-safe resource identity, full-key renewal,
+   real `TenantContext` for DML locks, enforced hierarchy, guard-owned renewal/release, and
+   storage-visible fencing. Read before changing `src/cluster/partition_lease.rs` or wiring locks
+   into `DmlService`/protocol handlers.
 
 == Stable Reference Docs
 

--- a/docs/12-design/TENANT_COLLECTION_POD_AFFINITY_2026_05_27.adoc
+++ b/docs/12-design/TENANT_COLLECTION_POD_AFFINITY_2026_05_27.adoc
@@ -12,6 +12,13 @@
   generation-fenced partition lease primitive over object-store manifests.
   It is covered by focused unit tests for contention, renewal, expiry takeover,
   and split-brain-safe registry step-down.
+* 2026-06-24: The unified multi-resource lease/DML-lock expansion was reviewed
+  and approved as a correction plan in
+  `UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc`. That review is now
+  the gate before DML/protocol lock exposure: fix legacy path compatibility,
+  canonical `ResourceKey` encoding, full-key renewal, real `TenantContext`
+  lock keys, enforced hierarchy, guard-owned renewal/release, and
+  storage-visible fencing first.
 * Still open for MVP wiring: bootstrap a `PartitionLeaseManager` from the
   operator control-plane prefix, run its renewal task, and call `acquire`
   before accepting writes for a `(tenant_id, collection_id)`.

--- a/docs/12-design/UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc
+++ b/docs/12-design/UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc
@@ -1,0 +1,398 @@
+= Unified Resource Lease And DML Locking Review
+:toc: left
+:toclevels: 3
+:icons: font
+:date: 2026-06-24
+:status: Approved correction plan
+
+== Status
+
+Approved on 2026-06-24 as the tracking snapshot for the `feat/unified-resource-key`
+branch.
+
+This document governs the follow-up implementation for
+`src/cluster/partition_lease.rs` and the planned DML/protocol lock wiring. It is
+intentionally correction-first: the unified `ResourceKey` direction is retained,
+but the lock semantics and object-store path contracts must be tightened before
+the feature is exposed through `DmlService` or protocol handlers.
+
+[IMPORTANT]
+====
+Do not wire DML locks into REST, gRPC, pgwire, or Arrow Flight until the
+foundation gates in <<approved-foundation-gates>> are complete. A protocol-level
+lock that is not tenant-correct, path-compatible, hierarchically enforced, and
+fenced at the storage writer is only advisory and can create split-brain writes.
+====
+
+== First-principles position
+
+Object-store CAS is a strong primitive for coarse ownership, manifest publication,
+and generation fencing. It is not, by itself, a high-frequency distributed lock
+manager.
+
+Use object-store CAS for:
+
+* resource ownership and leaseholder election;
+* fenced manifest and metadata commits;
+* WAL/table-shard authority handoff;
+* durable operation epochs where the write path validates the epoch.
+
+Do not use object-store CAS as the hot path for every row-level DML lock unless
+the write is low-frequency and the storage layer validates the acquired fencing
+token before committing.
+
+The target shape is:
+
+* `ResourceKey` is the canonical identity for all lease-protected resources.
+* Every durable lease path is tenant-isolated and path-safe.
+* Legacy collection leases remain mixed-read-safe during migration.
+* DML lock guards are scoped to real tenant/schema/table identity.
+* Locks that claim hierarchy enforce ancestor and descendant conflicts.
+* A writer carries a fencing generation or operation epoch into the storage layer.
+* Protocol handlers map lock outcomes, but do not become the source of
+  correctness.
+
+== Approved findings
+
+[cols="1,1,3,4,3", options="header"]
+|===
+| ID | Priority | Finding | Impact | Approved correction
+
+| F1
+| P0
+| `std::sync::RwLock` was imported while the code awaits lock operations.
+| The branch does not compile; all later design work is untestable.
+| Use `tokio::sync::RwLock` for async DML lock registry operations, or make the
+section synchronous. Prefer `tokio::sync::RwLock`.
+
+| F2
+| P0
+| Legacy collection leases and new `ResourceKey::legacy_collection` leases use
+different object-store paths.
+| Mixed-read-safe migration is not actually safe: old and new pods can create
+independent leases for the same collection.
+| Define a compatibility path policy. Legacy collection keys must read/write the
+old `{prefix}/{tenant}/{collection}/_manifests` path until a separate migration
+finalizes the new layout.
+
+| F3
+| P0
+| DML lock keys use pod id as `tenant_id`.
+| Different pods do not contend for the same durable lock, defeating the lock.
+| DML acquisition must receive the real `TenantContext` and resolved table
+identity. Pod id is only the holder, never the tenant.
+
+| F4
+| P0
+| The durable lease primitive is single-holder but the API advertises shared
+read locks.
+| Cross-pod `Read + Read` cannot work with the current durable state. Same-pod
+read locks also collapse into one `HashMap` entry without ref counting.
+| Choose explicit semantics before wiring: either exclusive-only DML locks for
+MVP, or implement a true multi-holder durable read lock record.
+
+| F5
+| P0
+| ~~Hierarchical locking is declared but not enforced.~~ **FIXED**: enforced.
+| ~~A schema lock does not block table/partition/record locks. Tests currently
+allow the unsafe behavior.~~ Now blocked: schema/table lock fences descendants.
+| ~~Enforce ancestor and descendant compatibility checks.~~ **DONE**:
+`DmlLockScope::is_ancestor_of`/`is_descendant_of` wired into `acquire_dml_lock`
+ahead of the intent check; verified by `dml_lock_hierarchy`.
+
+| F6
+| P0
+| DML lock TTL can expire while the mutation continues.
+| A stale writer can keep writing after another pod takes the lock.
+| ~~Return an RAII guard + pass the fencing generation into the storage write
+path.~~ **SEAM DONE (staged)**: guard carries `lease_generation()`; the request
+carries it on `WriteIntent::fencing_generation`; the storage writer contract is
+the pure, unit-tested `validate_fencing`. Engine-level enforcement (threading
+the token to the flush boundary + calling `validate_fencing`) is the follow-up
+TD — see <<phase-2-gated>>. (`FlushParameters` deliberately NOT extended: ~150
+test construction sites make a required field break the test build for a field
+with zero current consumers.)
+
+| F7
+| P1
+| ~~Release only clears local memory and waits for durable TTL expiry.~~ **FIXED**.
+| ~~Elastic handoff and conflict recovery are delayed by TTL.~~
+| ~~Add fenced durable release/tombstone.~~ **DONE**:
+`PartitionLeaseStore::release_with_key` publishes a **released tombstone at
+generation+1** (preserves the monotonic fence; object-store *delete* was
+rejected — it would reset generation to 1). `DmlLockGuard` releases durably
+via `DmlLockService::release_full`. TTL stays the crash fallback. Verified by
+`release_publishes_higher_generation_tombstone`,
+`acquire_after_release_keeps_monotonic_generation`,
+`release_by_non_holder_is_noop`.
+
+| F8
+| P1
+| `ResourceKey` path encoding joins raw strings with `/`.
+| Tenant, namespace, and resource identifiers can collide or escape path
+boundaries.
+| Route through `DrPathBuilder` where applicable and encode every component with
+a canonical path-safe encoder.
+
+| F9
+| P1
+| Key-based leases are not renewed by full `ResourceKey`.
+| Non-collection resources lose type/namespace identity during renewal.
+| Track held leases by canonical `ResourceKey`; renew by key.
+
+| F10
+| P1
+| Registry reconciliation flattens keys to tenant plus resource id.
+| Different resource types and namespaces can collide in the routing registry.
+| Registry bindings for generalized resources must include full canonical
+`ResourceKey` identity.
+
+| F11
+| P1
+| CAS per DML lock is expensive for hot serverless paths.
+| High-frequency DML can become object-store metadata-bound.
+| Keep object-store CAS for coarse ownership and fencing. Co-design hot DML
+around WAL shard leases, storage-level conflict checks, idempotent writes, and
+batching.
+
+| F12
+| P2
+| ~~Design text says 12 resource types while code has 13.~~ **FIXED**: Documentation now correctly reflects 13 types.
+| Reviewers and future implementers will reason from stale counts.
+| ~~Fix documentation and separate resource domain from granularity where useful.~~ **COMPLETED**: Count corrected.
+|===
+
+== Approved foundation gates
+
+[cols="1,1,5,3", options="header"]
+|===
+| Gate | Priority | Required outcome | Blocks
+
+| A1
+| P0
+| Branch compiles and focused lease tests use the current constructor/API shape.
+| All later work.
+
+| A2
+| P0
+| Legacy collection lease path compatibility is explicit and tested.
+| DML/collection protocol wiring.
+
+| A3
+| P0
+| `ResourceKey` path encoding is canonical, path-safe, and tenant-isolated.
+| Generalized resource leases.
+
+| A4
+| P1
+| `PartitionLeaseManager` renews and reconciles generalized leases by full
+`ResourceKey` identity.
+| Background renewal for non-collection resources.
+
+| A5
+| P0
+| DML lock semantics are explicit. MVP uses exclusive write/schema locks unless
+true multi-reader durable state is implemented.
+| `DmlService` integration.
+
+| A6
+| P0
+| DML lock acquisition returns a guard that owns renewal/release and carries the
+fencing generation to the writer.
+| Protocol exposure.
+
+| A7
+| P1
+| `DmlService::execute_scoped` acquires locks after catalog resolution, using
+real tenant/schema/table identity.
+| REST/gRPC/pgwire/Flight wiring.
+
+| A8
+| P1
+| Protocol handlers map lock outcomes consistently.
+| User-visible protocol behavior.
+
+| A9
+| P1
+| Prometheus metrics expose lock contention, wait/fail counts, renewal failures,
+and object-store CAS volume.
+| Production tuning and billing.
+|===
+
+== DML lock semantic decision
+
+MVP DML locking should start with exclusive write/schema locks. Shared read
+locks should not be exposed until the durable representation supports multiple
+holders and release/reference semantics.
+
+Rationale:
+
+* Most DML mutations need write exclusion, not read locks.
+* A single-owner lease maps cleanly to object-store CAS.
+* Claiming shared reads on top of a single-holder lease misleads protocol
+  integrations.
+* Read consistency should primarily come from MVCC/WAL snapshot semantics and
+  storage-level visibility, not a distributed read lock on every select.
+
+If shared read locks are required later, introduce a separate durable lock record
+shape with:
+
+* holder ids and per-holder expirations;
+* monotonically fenced write epoch;
+* compare-and-swap update of the holder set;
+* bounded holder cardinality or sharded reader tickets;
+* explicit garbage collection of expired holders.
+
+== DML integration rules
+
+`DmlService` integration must happen below protocol handlers and above
+`TableRecordStore::write_mutations`, after catalog resolution:
+
+1. Resolve tenant/table with `resolve_table_scoped`.
+2. Build a DML lock scope from the resolved table identity, not from raw SQL
+   text alone.
+3. Acquire a write lock guard for INSERT/UPDATE/DELETE/UPSERT and table-write
+   plans.
+4. Pass the guard fencing generation into the write request once the storage
+   trait supports it.
+5. Release/complete the guard after success or failure; natural TTL expiry is
+   only for crash recovery.
+
+For statement shapes:
+
+* INSERT/UPSERT: table-level write lock for MVP; later row/partition locks only
+  after key extraction and deadlock ordering are defined.
+* UPDATE/DELETE: table-level write lock for MVP. Row locks can follow once
+  predicate-to-key extraction is complete and ordered.
+* INSERT SELECT / INSERT OVERWRITE: table-level write lock on the target; source
+  reads rely on snapshot semantics.
+
+== Protocol mapping
+
+Protocol handlers should not acquire their own independent locks once
+`DmlService` owns lock acquisition. They should only translate lock errors:
+
+[cols="1,3", options="header"]
+|===
+| Surface | Conflict mapping
+
+| REST
+| `409 Conflict` for fail-fast conflict, or `423 Locked` if the API surface
+documents lock semantics.
+
+| gRPC
+| Prefer `ABORTED` for concurrency conflicts. Use `FAILED_PRECONDITION` when
+the request cannot proceed because a prerequisite lock state is absent.
+
+| pgwire
+| SQLSTATE `55P03` (`lock_not_available`) for fail-fast lock acquisition.
+
+| Arrow Flight
+| Return a structured Flight error that maps to concurrency conflict and carries
+retry-after metadata when available.
+|===
+
+== Tracking checklist
+
+[cols="1,1,4,2", options="header"]
+|===
+| Item | Status | Work | Notes
+
+| A1
+| ✅ Complete
+| Compile and focused test cleanup.
+| Branch compiles successfully.
+
+| A2
+| ✅ Complete
+| Legacy path compatibility.
+| Mixed-read-safe migration implemented via `committer_for_key()`.
+
+| A3
+| ✅ Complete
+| Canonical path encoding.
+| `encode_path_component()` URL-encodes all path components.
+
+| A4
+| ✅ Complete
+| Full-key held lease renewal.
+| `held_resource_keys: DashMap<String, ResourceKey>` stores full keys.
+
+| A5
+| ✅ Complete
+| Enforced DML hierarchy and explicit exclusive-MVP semantics.
+| `is_ancestor_of()`/`is_descendant_of()` implemented and wired into acquisition.
+
+| A6
+| ⚠️ Staged
+| Guard, renewal, release, fencing token.
+| Guard carries `lease_generation()`; request carries it on
+`WriteIntent::fencing_generation`; writer contract is the unit-tested
+`validate_fencing`. Engine-level enforcement + `FlushParameters` threading =
+follow-up TD (see <<phase-2-gated>>). F7 durable release also done.
+
+| A7
+| Pending (gated)
+| `DmlService` integration.
+| After the A6-enforcement TD; see <<phase-2-gated>>.
+
+| A8
+| Pending (gated)
+| Protocol mapping.
+| Should not duplicate lock acquisition.
+
+| A9
+| ✅ Complete
+| Metrics and object-store operation accounting.
+| `src/metrics/dml_lock_metrics.rs`: acquisitions_total{outcome,resource_type,tenant_id}
++ duration histogram + held_current gauge + renewal_failures counter; wired into
+`acquire_dml_lock` / `release_full` / `renew_held`.
+|===
+
+[[phase-2-gated]]
+== Phase 2 (gated) — not in this branch
+
+The foundation gates A1-A5 + A9 are complete; A6 is landed as the non-breaking
+seam + contract; F7 durable release is done. The remaining work is **gated**
+behind the A6-enforcement TD and must NOT be wired into protocol handlers until
+it lands (a protocol-level lock that is not fenced at the storage writer is only
+advisory — see the IMPORTANT block at the top):
+
+* **A6-enforcement TD:** thread the fencing token from `WriteIntent` through the
+  WAL intermediate to the flush boundary, and have each storage engine call
+  `validate_fencing(write_gen, current_durable_gen)` before committing. This is
+  the split-brain defense that makes DML locks non-advisory. (`FlushParameters`
+  was deliberately NOT extended with the field: ~150 test construction sites are
+  full literals, so a required field would break the test build for a field with
+  zero current consumers — the enforcement TD will thread via `..Default::default()`
+  or a dedicated write context.)
+* **A7:** `DmlService::execute_scoped` acquires locks after catalog resolution,
+  using real tenant/schema/table identity.
+* **A8:** protocol error mapping (REST 409/423, gRPC ABORTED, pgwire
+  SQLSTATE 55P03, Arrow Flight structured conflict).
+
+Round-2 verification: `cargo check --lib` green; 46 `partition_lease` +
+`dml_lock_metrics` + `validate_fencing` nextest cases pass (F5 hierarchy, F7
+tombstone, A6 validator, A9 metrics — no regressions).
+
+== Code anchors
+
+* `src/cluster/partition_lease.rs` - unified resource leases and DML lock service.
+* `src/cluster/primary_pod_registry.rs` - current collection write-routing registry.
+* `src/services/dml/mod.rs` - DML execution boundary where locks should be acquired.
+* `src/services/record_store/` - canonical record mutation boundary that must eventually validate fencing.
+
+== Relationship to existing docs
+
+This document refines and constrains:
+
+* `TENANT_COLLECTION_POD_AFFINITY_2026_05_27.adoc`
+* `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`
+* `CATALOG_OBJECT_MODEL_2026_06_21.adoc`
+* `RELATIONAL_PGWIRE_DML_COMPUTE_BLUEPRINT_2026_05_20.adoc`
+* `roadmap/techdebt/TD_110_OLTP_OLAP_HTAP_STORAGE_AND_CONSTRAINTS_PLAN_2026_06_04.adoc`
+
+The design remains aligned with the SaaS mandate: tenant isolation must flow
+through real `TenantContext`, and control-plane/object-store paths must be
+constructed through approved path builders or canonical encoders rather than raw
+string joins.

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -42,10 +42,16 @@
 //! a few seconds of clock skew only shifts handoff timing, never correctness
 //! (the fence, not the clock, guarantees single-ownership).
 
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::RwLock;
 
 use proximadb_iceberg_engine::manifest::{CommitOutcome, ManifestCommitter};
 use proximadb_object_store::ProximaObjectStore;
@@ -53,6 +59,1472 @@ use proximadb_object_store::ProximaObjectStore;
 use crate::cluster::primary_pod_registry::{
     AssignmentReason, PrimaryPodRegistry, WriteRoutingDecision, consult_for_write,
 };
+
+////////////////////////////////////////////////////////////////////////////////
+/// Unified Resource Key (Type-Agnostic Core)
+////////////////////////////////////////////////////////////////////////////////
+
+/// Resource type discriminator — enables routing to correct strategy
+/// and determines how `resource_id` is interpreted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ResourceType {
+    /// Vector collections (HNSW/IVF indexes)
+    Collection,
+    /// Relational tables (warehouse DataFusion/Polars)
+    Table,
+    /// Relational schemas (DDL namespace)
+    Schema,
+    /// Graph databases
+    Graph,
+    /// Graph nodes (individual vertex locks)
+    GraphNode,
+    /// Graph edges (individual edge locks)
+    GraphEdge,
+    /// Document collections
+    Document,
+    /// Document (individual document locks)
+    Doc,
+    /// ML models
+    Model,
+    /// Specific model versions
+    ModelVersion,
+    /// ML experiments
+    Experiment,
+    /// ML experiment runs
+    ExperimentRun,
+    /// Feature sets
+    FeatureSet,
+}
+
+impl ResourceType {
+    /// Legacy collection type (for backward compatibility)
+    pub const LEGACY_COLLECTION: &'static str = "collection";
+
+    /// Human-readable name for logging
+    pub fn name(&self) -> &str {
+        match self {
+            ResourceType::Collection => "collection",
+            ResourceType::Table => "table",
+            ResourceType::Schema => "schema",
+            ResourceType::Graph => "graph",
+            ResourceType::GraphNode => "graph_node",
+            ResourceType::GraphEdge => "graph_edge",
+            ResourceType::Document => "document",
+            ResourceType::Doc => "doc",
+            ResourceType::Model => "model",
+            ResourceType::ModelVersion => "model_version",
+            ResourceType::Experiment => "experiment",
+            ResourceType::ExperimentRun => "experiment_run",
+            ResourceType::FeatureSet => "feature_set",
+        }
+    }
+}
+
+/// Resource identifier — interpretation varies by ResourceType
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ResourceIdentifier {
+    /// Single identifier (collection_id, table_name, model_id, etc.)
+    Single(String),
+
+    /// Composite identifier (schema.table, graph:node, model:version, etc.)
+    Composite(Vec<String>),
+
+    /// Hierarchical identifier (for nested resources like schema.table.partition)
+    Hierarchical { parent: String, child: String },
+}
+
+impl ResourceIdentifier {
+    /// Create a single identifier
+    pub fn single(id: impl Into<String>) -> Self {
+        ResourceIdentifier::Single(id.into())
+    }
+
+    /// Create a composite identifier from parts
+    pub fn composite(parts: Vec<String>) -> Self {
+        ResourceIdentifier::Composite(parts)
+    }
+
+    /// Create a hierarchical identifier
+    pub fn hierarchical(parent: impl Into<String>, child: impl Into<String>) -> Self {
+        ResourceIdentifier::Hierarchical {
+            parent: parent.into(),
+            child: child.into(),
+        }
+    }
+
+    /// Flatten to a string path for manifest storage
+    pub fn to_path(&self) -> String {
+        match self {
+            ResourceIdentifier::Single(s) => encode_path_component(s),
+            ResourceIdentifier::Composite(parts) => parts
+                .iter()
+                .map(|part| encode_path_component(part))
+                .collect::<Vec<_>>()
+                .join("/"),
+            ResourceIdentifier::Hierarchical { parent, child } => {
+                format!(
+                    "{}/{}",
+                    encode_path_component(parent),
+                    encode_path_component(child)
+                )
+            }
+        }
+    }
+}
+
+fn encode_path_component(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    out
+}
+
+fn decode_path_component(input: &str) -> Option<String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if bytes[idx] == b'%' {
+            let hi = *bytes.get(idx + 1)?;
+            let lo = *bytes.get(idx + 2)?;
+            let hex = [hi, lo];
+            let hex = std::str::from_utf8(&hex).ok()?;
+            out.push(u8::from_str_radix(hex, 16).ok()?);
+            idx += 3;
+        } else {
+            out.push(bytes[idx]);
+            idx += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+/// Unified key for all lease-protected resources across all modalities.
+///
+/// This key structure is type-agnostic at the lease layer but enables
+/// type-specific routing via `resource_type`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ResourceKey {
+    /// Tenant owning the resource.
+    pub tenant_id: String,
+
+    /// Namespace (optional — None for global resources)
+    pub namespace_id: Option<String>,
+
+    /// Resource type discriminator.
+    pub resource_type: ResourceType,
+
+    /// Resource identifier.
+    pub resource_id: ResourceIdentifier,
+}
+
+impl ResourceKey {
+    /// Create a new resource key.
+    pub fn new(
+        tenant_id: impl Into<String>,
+        namespace_id: Option<String>,
+        resource_type: ResourceType,
+        resource_id: ResourceIdentifier,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id,
+            resource_type,
+            resource_id,
+        }
+    }
+
+    /// Create a legacy collection key (for backward compatibility).
+    pub fn legacy_collection(
+        tenant_id: impl Into<String>,
+        collection_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Collection,
+            resource_id: ResourceIdentifier::single(collection_id),
+        }
+    }
+
+    /// Create a table key (schema.table).
+    pub fn table(
+        tenant_id: impl Into<String>,
+        schema_name: impl Into<String>,
+        table_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Table,
+            resource_id: ResourceIdentifier::composite(vec![schema_name.into(), table_name.into()]),
+        }
+    }
+
+    /// Create a schema key.
+    pub fn schema(tenant_id: impl Into<String>, schema_name: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Schema,
+            resource_id: ResourceIdentifier::single(schema_name),
+        }
+    }
+
+    /// Create a graph key.
+    pub fn graph(tenant_id: impl Into<String>, graph_id: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Graph,
+            resource_id: ResourceIdentifier::single(graph_id),
+        }
+    }
+
+    /// Create a model key.
+    pub fn model(tenant_id: impl Into<String>, model_name: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Model,
+            resource_id: ResourceIdentifier::single(model_name),
+        }
+    }
+
+    /// Create an experiment key.
+    pub fn experiment(tenant_id: impl Into<String>, experiment_name: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace_id: None,
+            resource_type: ResourceType::Experiment,
+            resource_id: ResourceIdentifier::single(experiment_name),
+        }
+    }
+
+    /// Flatten to a path string for manifest storage.
+    /// Format: `{tenant_id}/{resource_type}/{resource_path}` or `{tenant_id}/{namespace}/{resource_type}/{resource_path}`
+    pub fn to_path(&self) -> String {
+        let tenant = encode_path_component(&self.tenant_id);
+        if let Some(ns) = &self.namespace_id {
+            format!(
+                "{}/{}/{}/{}",
+                tenant,
+                encode_path_component(ns),
+                self.resource_type.name(),
+                self.resource_id.to_path()
+            )
+        } else {
+            format!(
+                "{}/{}/{}",
+                tenant,
+                self.resource_type.name(),
+                self.resource_id.to_path()
+            )
+        }
+    }
+
+    /// Parse a path string back into a ResourceKey (for migration).
+    /// Handles both formats: {tenant_id}/{resource_type}/{resource_path} and
+    /// {tenant_id}/{namespace}/{resource_type}/{resource_path}.
+    pub fn from_path(path: &str) -> Option<Self> {
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() < 3 {
+            return None;
+        }
+
+        // Try to detect format by checking if the second part is a known resource type
+        let (tenant_id, namespace_id, resource_type_idx) = match parts.get(1) {
+            Some(
+                &("collection" | "table" | "schema" | "graph" | "graph_node" | "graph_edge"
+                | "document" | "doc" | "model" | "model_version" | "experiment"
+                | "experiment_run" | "feature_set"),
+            ) => {
+                // Format: {tenant_id}/{resource_type}/{resource_path}
+                (parts.first()?, None, 1)
+            }
+            Some(&ns) => {
+                // Format: {tenant_id}/{namespace}/{resource_type}/{resource_path}
+                (parts.first()?, Some(decode_path_component(ns)?), 2)
+            }
+            None => return None,
+        };
+
+        let resource_type = match parts.get(resource_type_idx)? {
+            &"collection" => ResourceType::Collection,
+            &"table" => ResourceType::Table,
+            &"schema" => ResourceType::Schema,
+            &"graph" => ResourceType::Graph,
+            &"graph_node" => ResourceType::GraphNode,
+            &"graph_edge" => ResourceType::GraphEdge,
+            &"document" => ResourceType::Document,
+            &"doc" => ResourceType::Doc,
+            &"model" => ResourceType::Model,
+            &"model_version" => ResourceType::ModelVersion,
+            &"experiment" => ResourceType::Experiment,
+            &"experiment_run" => ResourceType::ExperimentRun,
+            &"feature_set" => ResourceType::FeatureSet,
+            _ => return None,
+        };
+
+        // Remaining parts form the resource_id
+        let resource_parts: Vec<String> = parts
+            .iter()
+            .skip(resource_type_idx + 1)
+            .map(|s| decode_path_component(s))
+            .collect::<Option<Vec<_>>>()?;
+        let resource_id = if resource_parts.len() == 1 {
+            ResourceIdentifier::single(resource_parts.into_iter().next()?)
+        } else {
+            ResourceIdentifier::composite(resource_parts)
+        };
+
+        Some(ResourceKey {
+            tenant_id: decode_path_component(tenant_id)?,
+            namespace_id,
+            resource_type,
+            resource_id,
+        })
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Resource Strategy Pattern (Type-Specific Behavior)
+////////////////////////////////////////////////////////////////////////////////
+
+/// Strategy for handling a specific resource type.
+///
+/// This trait enables type-specific behavior while keeping the lease mechanism
+/// type-agnostic. Different resource types have different:
+/// - Lease TTL requirements (latency vs safety tradeoffs)
+/// - Partitioning strategies (how to subdivide resources)
+/// - Conflict resolution (fencing vs optimistic concurrency)
+pub trait ResourceStrategy: Send + Sync {
+    /// Strategy name for telemetry/debugging.
+    fn name(&self) -> &str;
+
+    /// The resource type this strategy handles.
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Collection // Default
+    }
+
+    /// Lease TTL for this resource type (in seconds).
+    ///
+    /// Different workloads have different latency requirements:
+    /// - Vector collections: 60s (frequent writes, low latency)
+    /// - Relational tables: 120s (DDL is less frequent, longer TTL reduces overhead)
+    /// - ML models: 300s (model updates are rare, longer TTL is acceptable)
+    fn lease_ttl_secs(&self) -> u64 {
+        60 // Default: 60 seconds
+    }
+
+    /// Whether this resource type supports partitioning.
+    ///
+    /// Resources that support partitioning can be subdivided for parallel writes:
+    /// - Collections: partition by shard ID
+    /// - Tables: partition by partition ID
+    /// - Graphs: partition by split
+    fn supports_partitioning(&self) -> bool {
+        false
+    }
+
+    /// Generate a resource-specific key from generic components.
+    ///
+    /// This method interprets the `components` slice based on the resource type:
+    /// - Collection: [collection_id]
+    /// - Table: [schema_name, table_name]
+    /// - Graph: [graph_id]
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey;
+
+    /// Validate that an operation is allowed on this resource type.
+    ///
+    /// This enables type-specific validation logic.
+    fn validate_operation(&self, _operation: &ResourceOperation) -> Result<(), LeaseError> {
+        Ok(()) // Default: no validation
+    }
+
+    /// Whether this resource type supports hierarchical locking.
+    ///
+    /// Hierarchical locking enables locking at different levels:
+    /// - Schema → Table → Partition → Record
+    fn supports_hierarchical_locking(&self) -> bool {
+        false
+    }
+
+    /// Get the parent key for hierarchical locking (if supported).
+    fn parent_key(&self, _key: &ResourceKey) -> Option<ResourceKey> {
+        None
+    }
+}
+
+/// Standard resource operations for validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResourceOperation {
+    // DDL operations
+    Create,
+    Drop,
+    Alter,
+    // DML operations
+    Read,
+    Write,
+    // Schema-level operations
+    SchemaChange,
+    // Admin operations
+    Admin,
+    // ML-specific operations
+    ModelRegister,
+    ModelDeploy,
+    ExperimentLog,
+    MetricWrite,
+    FeatureWrite,
+    TrainingRun,
+    Inference,
+}
+
+/// Lease strategy errors.
+#[derive(Debug, thiserror::Error)]
+pub enum LeaseError {
+    #[error("Operation {operation:?} not allowed on resource type {resource_type}")]
+    InvalidOperation {
+        resource_type: String,
+        operation: String,
+    },
+    #[error("Invalid key for resource type: {reason}")]
+    InvalidKey { reason: String },
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Built-in Strategy Implementations
+////////////////////////////////////////////////////////////////////////////////
+
+/// Strategy for vector collections.
+#[derive(Debug, Clone)]
+pub struct CollectionStrategy;
+
+impl ResourceStrategy for CollectionStrategy {
+    fn name(&self) -> &str {
+        "collection"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Collection
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        60 // Vector workloads have frequent writes
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        true // Collections can be sharded
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Collection key requires at least collection_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Collection,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            ResourceOperation::SchemaChange => Err(LeaseError::InvalidOperation {
+                resource_type: "collection".to_string(),
+                operation: "SchemaChange".to_string(),
+            }),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Strategy for relational tables.
+#[derive(Debug, Clone)]
+pub struct TableStrategy;
+
+impl ResourceStrategy for TableStrategy {
+    fn name(&self) -> &str {
+        "table"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Table
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        120 // DDL is less frequent, can afford longer TTL
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        true // Tables can be partitioned
+    }
+
+    fn supports_hierarchical_locking(&self) -> bool {
+        true // Schema → Table → Partition hierarchy
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.len() < 2 {
+            panic!("Table key requires schema_name and table_name");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Table,
+            resource_id: ResourceIdentifier::composite(vec![
+                components[0].clone(),
+                components[1].clone(),
+            ]),
+        }
+    }
+
+    fn parent_key(&self, key: &ResourceKey) -> Option<ResourceKey> {
+        // Parent of a table is its schema
+        match &key.resource_id {
+            ResourceIdentifier::Composite(parts) if parts.len() >= 1 => Some(ResourceKey {
+                tenant_id: key.tenant_id.clone(),
+                namespace_id: key.namespace_id.clone(),
+                resource_type: ResourceType::Schema,
+                resource_id: ResourceIdentifier::single(parts[0].clone()),
+            }),
+            _ => None,
+        }
+    }
+
+    fn validate_operation(&self, _operation: &ResourceOperation) -> Result<(), LeaseError> {
+        // All operations are valid on tables
+        Ok(())
+    }
+}
+
+/// Strategy for relational schemas.
+#[derive(Debug, Clone)]
+pub struct SchemaStrategy;
+
+impl ResourceStrategy for SchemaStrategy {
+    fn name(&self) -> &str {
+        "schema"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Schema
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        300 // Schema changes are rare, use longer TTL
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Schemas are not partitioned
+    }
+
+    fn supports_hierarchical_locking(&self) -> bool {
+        true // Schema is the root of the hierarchy
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Schema key requires at least schema_name");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Schema,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            ResourceOperation::Write | ResourceOperation::Read => {
+                Err(LeaseError::InvalidOperation {
+                    resource_type: "schema".to_string(),
+                    operation: format!("{:?}", operation),
+                })
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Strategy for graph databases.
+#[derive(Debug, Clone)]
+pub struct GraphStrategy;
+
+impl ResourceStrategy for GraphStrategy {
+    fn name(&self) -> &str {
+        "graph"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Graph
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        60 // Graph workloads have frequent writes
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        true // Graphs can be split
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Graph key requires at least graph_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Graph,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn validate_operation(&self, _operation: &ResourceOperation) -> Result<(), LeaseError> {
+        // All operations are valid on graphs
+        Ok(())
+    }
+}
+
+/// Strategy for individual graph nodes (for DML-level locking).
+#[derive(Debug, Clone)]
+pub struct GraphNodeStrategy;
+
+impl ResourceStrategy for GraphNodeStrategy {
+    fn name(&self) -> &str {
+        "graph_node"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::GraphNode
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        10 // Node locks are short-lived
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Individual nodes are not partitioned
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.len() < 2 {
+            panic!("GraphNode key requires graph_id and node_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::GraphNode,
+            resource_id: ResourceIdentifier::composite(vec![
+                components[0].clone(),
+                components[1].clone(),
+            ]),
+        }
+    }
+}
+
+/// Strategy for individual graph edges (for DML-level locking).
+#[derive(Debug, Clone)]
+pub struct GraphEdgeStrategy;
+
+impl ResourceStrategy for GraphEdgeStrategy {
+    fn name(&self) -> &str {
+        "graph_edge"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::GraphEdge
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        10 // Edge locks are short-lived
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Individual edges are not partitioned
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.len() < 2 {
+            panic!("GraphEdge key requires graph_id and edge_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::GraphEdge,
+            resource_id: ResourceIdentifier::composite(vec![
+                components[0].clone(),
+                components[1].clone(),
+            ]),
+        }
+    }
+}
+
+/// Strategy for document collections.
+#[derive(Debug, Clone)]
+pub struct DocumentStrategy;
+
+impl ResourceStrategy for DocumentStrategy {
+    fn name(&self) -> &str {
+        "document"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Document
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        60 // Document workloads have frequent writes
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        true // Document collections can be sharded
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Document key requires at least collection_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Document,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+}
+
+/// Strategy for ML models.
+#[derive(Debug, Clone)]
+pub struct ModelStrategy;
+
+impl ResourceStrategy for ModelStrategy {
+    fn name(&self) -> &str {
+        "model"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Model
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        300 // Model updates are rare
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Models are not partitioned
+    }
+
+    fn supports_hierarchical_locking(&self) -> bool {
+        true // Model → ModelVersion hierarchy
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Model key requires at least model_name");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Model,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn parent_key(&self, key: &ResourceKey) -> Option<ResourceKey> {
+        // ModelVersion parent is the Model
+        if key.resource_type == ResourceType::ModelVersion {
+            match &key.resource_id {
+                ResourceIdentifier::Composite(parts) if parts.len() >= 1 => {
+                    return Some(ResourceKey {
+                        tenant_id: key.tenant_id.clone(),
+                        namespace_id: key.namespace_id.clone(),
+                        resource_type: ResourceType::Model,
+                        resource_id: ResourceIdentifier::single(parts[0].clone()),
+                    });
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            // ML-specific operations valid on models
+            ResourceOperation::ModelRegister | ResourceOperation::ModelDeploy => Ok(()),
+            // DDL-like operations
+            ResourceOperation::Create | ResourceOperation::Drop | ResourceOperation::Admin => {
+                Ok(())
+            }
+            // Read operations for model metadata
+            ResourceOperation::Read => Ok(()),
+            // Other operations not valid on models
+            _ => Err(LeaseError::InvalidOperation {
+                resource_type: "model".to_string(),
+                operation: format!("{:?}", operation),
+            }),
+        }
+    }
+}
+
+/// Strategy for ML model versions.
+#[derive(Debug, Clone)]
+pub struct ModelVersionStrategy;
+
+impl ResourceStrategy for ModelVersionStrategy {
+    fn name(&self) -> &str {
+        "model_version"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::ModelVersion
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        300 // Model version updates are rare
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Model versions are not partitioned
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.len() < 2 {
+            panic!("ModelVersion key requires model_name and version");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::ModelVersion,
+            resource_id: ResourceIdentifier::composite(vec![
+                components[0].clone(),
+                components[1].clone(),
+            ]),
+        }
+    }
+
+    fn parent_key(&self, key: &ResourceKey) -> Option<ResourceKey> {
+        // Parent of a model version is its model
+        match &key.resource_id {
+            ResourceIdentifier::Composite(parts) if parts.len() >= 1 => Some(ResourceKey {
+                tenant_id: key.tenant_id.clone(),
+                namespace_id: key.namespace_id.clone(),
+                resource_type: ResourceType::Model,
+                resource_id: ResourceIdentifier::single(parts[0].clone()),
+            }),
+            _ => None,
+        }
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            // Model-specific operations
+            ResourceOperation::ModelDeploy | ResourceOperation::Inference => Ok(()),
+            // Read operations
+            ResourceOperation::Read => Ok(()),
+            // Admin operations
+            ResourceOperation::Admin => Ok(()),
+            // Other operations not valid on model versions
+            _ => Err(LeaseError::InvalidOperation {
+                resource_type: "model_version".to_string(),
+                operation: format!("{:?}", operation),
+            }),
+        }
+    }
+}
+
+/// Strategy for ML experiments.
+#[derive(Debug, Clone)]
+pub struct ExperimentStrategy;
+
+impl ResourceStrategy for ExperimentStrategy {
+    fn name(&self) -> &str {
+        "experiment"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Experiment
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        120 // Experiment updates are moderately frequent
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Experiments are not partitioned
+    }
+
+    fn supports_hierarchical_locking(&self) -> bool {
+        true // Experiment → ExperimentRun hierarchy
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("Experiment key requires at least experiment_name");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::Experiment,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn parent_key(&self, key: &ResourceKey) -> Option<ResourceKey> {
+        // ExperimentRun parent is the Experiment
+        if key.resource_type == ResourceType::ExperimentRun {
+            match &key.resource_id {
+                ResourceIdentifier::Composite(parts) if parts.len() >= 1 => {
+                    return Some(ResourceKey {
+                        tenant_id: key.tenant_id.clone(),
+                        namespace_id: key.namespace_id.clone(),
+                        resource_type: ResourceType::Experiment,
+                        resource_id: ResourceIdentifier::single(parts[0].clone()),
+                    });
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            // ML-specific operations valid on experiments
+            ResourceOperation::ExperimentLog | ResourceOperation::MetricWrite => Ok(()),
+            // DDL-like operations
+            ResourceOperation::Create | ResourceOperation::Drop | ResourceOperation::Admin => {
+                Ok(())
+            }
+            // Read operations
+            ResourceOperation::Read => Ok(()),
+            // Other operations not valid on experiments
+            _ => Err(LeaseError::InvalidOperation {
+                resource_type: "experiment".to_string(),
+                operation: format!("{:?}", operation),
+            }),
+        }
+    }
+}
+
+/// Strategy for ML experiment runs.
+#[derive(Debug, Clone)]
+pub struct ExperimentRunStrategy;
+
+impl ResourceStrategy for ExperimentRunStrategy {
+    fn name(&self) -> &str {
+        "experiment_run"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::ExperimentRun
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        60 // Experiment run updates are frequent
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Experiment runs are not partitioned
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.len() < 2 {
+            panic!("ExperimentRun key requires experiment_name and run_id");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::ExperimentRun,
+            resource_id: ResourceIdentifier::composite(vec![
+                components[0].clone(),
+                components[1].clone(),
+            ]),
+        }
+    }
+
+    fn parent_key(&self, key: &ResourceKey) -> Option<ResourceKey> {
+        // Parent of an experiment run is its experiment
+        match &key.resource_id {
+            ResourceIdentifier::Composite(parts) if parts.len() >= 1 => Some(ResourceKey {
+                tenant_id: key.tenant_id.clone(),
+                namespace_id: key.namespace_id.clone(),
+                resource_type: ResourceType::Experiment,
+                resource_id: ResourceIdentifier::single(parts[0].clone()),
+            }),
+            _ => None,
+        }
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            // ML-specific operations valid on experiment runs
+            ResourceOperation::TrainingRun | ResourceOperation::MetricWrite => Ok(()),
+            // Write operations for logging
+            ResourceOperation::Write => Ok(()),
+            // Read operations
+            ResourceOperation::Read => Ok(()),
+            // Other operations not valid on experiment runs
+            _ => Err(LeaseError::InvalidOperation {
+                resource_type: "experiment_run".to_string(),
+                operation: format!("{:?}", operation),
+            }),
+        }
+    }
+}
+
+/// Strategy for feature sets.
+#[derive(Debug, Clone)]
+pub struct FeatureSetStrategy;
+
+impl ResourceStrategy for FeatureSetStrategy {
+    fn name(&self) -> &str {
+        "feature_set"
+    }
+
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::FeatureSet
+    }
+
+    fn lease_ttl_secs(&self) -> u64 {
+        120 // Feature set updates are moderately frequent
+    }
+
+    fn supports_partitioning(&self) -> bool {
+        false // Feature sets are not partitioned
+    }
+
+    fn make_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        components: &[String],
+    ) -> ResourceKey {
+        if components.is_empty() {
+            panic!("FeatureSet key requires at least feature_set_name");
+        }
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(|s| s.to_string()),
+            resource_type: ResourceType::FeatureSet,
+            resource_id: ResourceIdentifier::single(components[0].clone()),
+        }
+    }
+
+    fn validate_operation(&self, operation: &ResourceOperation) -> Result<(), LeaseError> {
+        match operation {
+            // ML-specific operations valid on feature sets
+            ResourceOperation::FeatureWrite => Ok(()),
+            // DDL-like operations
+            ResourceOperation::Create
+            | ResourceOperation::Alter
+            | ResourceOperation::Drop
+            | ResourceOperation::Admin => Ok(()),
+            // Read operations
+            ResourceOperation::Read => Ok(()),
+            // Other operations not valid on feature sets
+            _ => Err(LeaseError::InvalidOperation {
+                resource_type: "feature_set".to_string(),
+                operation: format!("{:?}", operation),
+            }),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// DML-Level Locking (Hierarchical & Coordinator-Driven)
+////////////////////////////////////////////////////////////////////////////////
+
+/// Lock levels (hierarchical): Schema → Table → Partition → Record
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LockLevel {
+    /// Schema-level lock (for DDL operations on schemas)
+    Schema,
+    /// Table-level lock (for bulk operations like TRUNCATE, bulk load)
+    Table,
+    /// Partition-level lock (for partition-specific operations)
+    Partition,
+    /// Record-level lock (for individual row/document operations)
+    Record,
+}
+
+impl LockLevel {
+    /// Human-readable name
+    pub fn name(&self) -> &str {
+        match self {
+            LockLevel::Schema => "schema",
+            LockLevel::Table => "table",
+            LockLevel::Partition => "partition",
+            LockLevel::Record => "record",
+        }
+    }
+
+    /// Whether this level can lock a parent level (for hierarchical locking)
+    pub fn can_lock_parent(&self) -> bool {
+        matches!(
+            self,
+            LockLevel::Table | LockLevel::Partition | LockLevel::Record
+        )
+    }
+
+    /// Whether this level can lock a child level
+    pub fn can_lock_child(&self) -> bool {
+        matches!(
+            self,
+            LockLevel::Schema | LockLevel::Table | LockLevel::Partition
+        )
+    }
+
+    /// Get the parent level (if any)
+    pub fn parent(&self) -> Option<LockLevel> {
+        match self {
+            LockLevel::Schema => None,
+            LockLevel::Table => Some(LockLevel::Schema),
+            LockLevel::Partition => Some(LockLevel::Table),
+            LockLevel::Record => Some(LockLevel::Partition),
+        }
+    }
+}
+
+/// Lock intent for compatibility checking.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LockIntent {
+    /// Shared read lock (multiple readers can hold)
+    Read,
+    /// Exclusive write lock (only one holder)
+    Write,
+    /// DDL/schema change lock (exclusive, blocks all others)
+    Schema,
+}
+
+impl LockIntent {
+    /// Human-readable name
+    pub fn name(&self) -> &str {
+        match self {
+            LockIntent::Read => "read",
+            LockIntent::Write => "write",
+            LockIntent::Schema => "schema",
+        }
+    }
+
+    /// Whether this intent is compatible with another intent.
+    ///
+    /// MVP DML locking uses the existing single-holder object-store lease, so
+    /// every durable DML lock is exclusive. Shared read locks need a separate
+    /// multi-holder durable record and are intentionally not claimed here.
+    pub fn is_compatible_with(&self, _other: &LockIntent) -> bool {
+        false
+    }
+}
+
+/// Scope of a DML lock (what is being locked).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DmlLockScope {
+    /// Schema-level lock
+    Schema { schema_name: String },
+    /// Table-level lock
+    Table {
+        schema_name: String,
+        table_name: String,
+    },
+    /// Partition-level lock
+    Partition {
+        schema_name: String,
+        table_name: String,
+        partition_id: String,
+    },
+    /// Record-level lock
+    Record {
+        schema_name: String,
+        table_name: String,
+        key: String,
+    },
+}
+
+impl DmlLockScope {
+    /// Get the lock level for this scope
+    pub fn level(&self) -> LockLevel {
+        match self {
+            DmlLockScope::Schema { .. } => LockLevel::Schema,
+            DmlLockScope::Table { .. } => LockLevel::Table,
+            DmlLockScope::Partition { .. } => LockLevel::Partition,
+            DmlLockScope::Record { .. } => LockLevel::Record,
+        }
+    }
+
+    /// Get the parent scope (if any)
+    pub fn parent(&self) -> Option<DmlLockScope> {
+        match self {
+            DmlLockScope::Schema { .. } => None,
+            DmlLockScope::Table { schema_name, .. } => Some(DmlLockScope::Schema {
+                schema_name: schema_name.clone(),
+            }),
+            DmlLockScope::Partition {
+                schema_name,
+                table_name,
+                ..
+            } => Some(DmlLockScope::Table {
+                schema_name: schema_name.clone(),
+                table_name: table_name.clone(),
+            }),
+            DmlLockScope::Record {
+                schema_name,
+                table_name,
+                ..
+            } => Some(DmlLockScope::Table {
+                schema_name: schema_name.clone(),
+                table_name: table_name.clone(),
+            }),
+        }
+    }
+
+    /// Check if this scope is an ancestor of another scope in the hierarchy.
+    ///
+    /// Hierarchy: Schema → Table → Partition → Record
+    ///
+    /// A Schema is an ancestor of Table/Partition/Record in the same schema.
+    /// A Table is an ancestor of Partition/Record in the same table.
+    /// A Partition is an ancestor of Records in the same partition (conceptually).
+    pub fn is_ancestor_of(&self, other: &DmlLockScope) -> bool {
+        // Same schema is the base requirement for any ancestor relationship
+        if self.schema_name() != other.schema_name() {
+            return false;
+        }
+
+        match (self, other) {
+            // Schema is ancestor of all non-schema scopes in the same schema
+            (DmlLockScope::Schema { .. }, DmlLockScope::Table { .. }) => true,
+            (DmlLockScope::Schema { .. }, DmlLockScope::Partition { .. }) => true,
+            (DmlLockScope::Schema { .. }, DmlLockScope::Record { .. }) => true,
+
+            // Table is ancestor of partition/record in the same table
+            (
+                DmlLockScope::Table {
+                    schema_name: s1,
+                    table_name: t1,
+                },
+                DmlLockScope::Partition {
+                    schema_name: s2,
+                    table_name: t2,
+                    ..
+                },
+            ) => s1 == s2 && t1 == t2,
+            (
+                DmlLockScope::Table {
+                    schema_name: s1,
+                    table_name: t1,
+                },
+                DmlLockScope::Record {
+                    schema_name: s2,
+                    table_name: t2,
+                    ..
+                },
+            ) => s1 == s2 && t1 == t2,
+
+            // Partition is ancestor of records in the same partition
+            // (Note: Record scope doesn't carry partition_id, so we treat Table as the direct parent)
+            (DmlLockScope::Partition { .. }, DmlLockScope::Record { .. }) => false,
+
+            // Same scope is not ancestor of itself
+            _ => false,
+        }
+    }
+
+    /// Check if this scope is a descendant of another scope in the hierarchy.
+    ///
+    /// This is the inverse of `is_ancestor_of`.
+    pub fn is_descendant_of(&self, other: &DmlLockScope) -> bool {
+        other.is_ancestor_of(self)
+    }
+
+    /// Get the schema name (if applicable)
+    pub fn schema_name(&self) -> Option<&str> {
+        match self {
+            DmlLockScope::Schema { schema_name }
+            | DmlLockScope::Table { schema_name, .. }
+            | DmlLockScope::Partition { schema_name, .. }
+            | DmlLockScope::Record { schema_name, .. } => Some(schema_name),
+        }
+    }
+
+    /// Get the table name (if applicable)
+    pub fn table_name(&self) -> Option<&str> {
+        match self {
+            DmlLockScope::Table { table_name, .. }
+            | DmlLockScope::Partition { table_name, .. }
+            | DmlLockScope::Record { table_name, .. } => Some(table_name),
+            DmlLockScope::Schema { .. } => None,
+        }
+    }
+
+    /// Convert to a string key for in-memory lock registry
+    pub fn to_key(&self) -> String {
+        match self {
+            DmlLockScope::Schema { schema_name } => {
+                format!("schema:{}", encode_path_component(schema_name))
+            }
+            DmlLockScope::Table {
+                schema_name,
+                table_name,
+            } => format!(
+                "table:{}.{}",
+                encode_path_component(schema_name),
+                encode_path_component(table_name)
+            ),
+            DmlLockScope::Partition {
+                schema_name,
+                table_name,
+                partition_id,
+            } => format!(
+                "partition:{}.{}.{}",
+                encode_path_component(schema_name),
+                encode_path_component(table_name),
+                encode_path_component(partition_id)
+            ),
+            DmlLockScope::Record {
+                schema_name,
+                table_name,
+                key,
+            } => format!(
+                "record:{}.{}.{}",
+                encode_path_component(schema_name),
+                encode_path_component(table_name),
+                encode_path_component(key)
+            ),
+        }
+    }
+
+    fn overlaps(&self, other: &DmlLockScope) -> bool {
+        let same_schema = self.schema_name() == other.schema_name();
+        if !same_schema {
+            return false;
+        }
+
+        match (self.table_name(), other.table_name()) {
+            (None, _) | (_, None) => true,
+            (Some(left_table), Some(right_table)) if left_table != right_table => false,
+            (Some(_), Some(_)) => match (self, other) {
+                (DmlLockScope::Table { .. }, _) | (_, DmlLockScope::Table { .. }) => true,
+                (
+                    DmlLockScope::Partition {
+                        partition_id: left, ..
+                    },
+                    DmlLockScope::Partition {
+                        partition_id: right,
+                        ..
+                    },
+                ) => left == right,
+                (
+                    DmlLockScope::Record { key: left, .. },
+                    DmlLockScope::Record { key: right, .. },
+                ) => left == right,
+                // Record scopes do not currently carry partition identity, so a
+                // partition-vs-record overlap is conservatively treated as a table conflict.
+                _ => true,
+            },
+        }
+    }
+}
+
+/// Outcome of a DML lock acquisition attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LockOutcome {
+    /// Lock was acquired successfully
+    Acquired { lease: PartitionLease },
+    /// Lock is held by another pod
+    Held { holder: String, expires_at: i64 },
+    /// Lock request conflicted with existing lock
+    Conflict,
+    /// This pod was fenced (newer generation owns the lock)
+    Fenced { latest: PartitionLease },
+}
+
+/// Prometheus label for a [`LockOutcome`] (A9). Kept low-cardinality:
+/// `acquired` / `conflict` / `held` / `fenced`.
+fn dml_lock_outcome_label(outcome: &LockOutcome) -> &'static str {
+    match outcome {
+        LockOutcome::Acquired { .. } => "acquired",
+        LockOutcome::Conflict => "conflict",
+        LockOutcome::Held { .. } => "held",
+        LockOutcome::Fenced { .. } => "fenced",
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Lease Types
+////////////////////////////////////////////////////////////////////////////////
 
 /// Current wall-clock milliseconds since the Unix epoch.
 fn now_millis() -> i64 {
@@ -62,27 +1534,225 @@ fn now_millis() -> i64 {
         .as_millis() as i64
 }
 
-/// A durable lease granting **one** pod write authority over a single partition
-/// (a collection within a tenant) until `expires_at_ms`.
+/// Error returned by [`validate_fencing`] when a write carries a fencing
+/// generation older than the current durable lease generation.
+///
+/// This is the storage-boundary split-brain defense (A6): a writer that
+/// acquired a lease at `write_generation` but has since been displaced (a
+/// takeover committed a strictly-higher generation) must be rejected
+/// *before* it commits, so two pods can never both believe they own a
+/// resource.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(
+    "stale fencing generation: write generation {write_generation} is older than current durable generation {current_generation}"
+)]
+pub struct FencingError {
+    /// Generation the writer is carrying (from the DML lock guard /
+    /// `FlushParameters::fencing_generation`).
+    pub write_generation: u64,
+    /// Generation currently published on the durable lease log for the
+    /// resource.
+    pub current_generation: u64,
+}
+
+/// Validate a write's fencing generation against the current durable lease
+/// generation (A6 boundary contract).
+///
+/// The DML write request carries the guard's generation on
+/// `WriteIntent::fencing_generation` (populated via
+/// `DmlLockGuard::lease_generation()`). A storage writer that consumes it
+/// MUST call this before committing the mutation:
+///
+/// - `write_generation = None` → legacy / unfenced write: **allowed**
+///   (`Ok`). The fence is opt-in per write so non-DML writes are
+///   unaffected.
+/// - `write_generation = Some(g)` with `g >= current_generation` → the
+///   write's lease is current or newer: **allowed** (`Ok`).
+/// - `write_generation = Some(g)` with `g < current_generation` → a
+///   takeover has displaced this writer: **rejected** (`Err`).
+///
+/// `current_generation` is the generation read from the durable lease log
+/// for the resource at commit time. Wiring that read into each storage
+/// engine's flush path (and threading the token from `WriteIntent` through
+/// the WAL intermediate to the writer) is the follow-up enforcement TD;
+/// this function is the pure, unit-tested contract they call.
+pub fn validate_fencing(
+    write_generation: Option<u64>,
+    current_generation: u64,
+) -> std::result::Result<(), FencingError> {
+    match write_generation {
+        None => Ok(()),
+        Some(g) if g < current_generation => Err(FencingError {
+            write_generation: g,
+            current_generation,
+        }),
+        Some(_) => Ok(()),
+    }
+}
+
+/// A durable lease granting **one** pod write authority over a single resource
+/// until `expires_at_ms`.
+///
+/// **Mixed-read-safe migration**: Old-format leases (with `tenant_id` and
+/// `collection_id` only) are automatically migrated to the new `resource_key`
+/// format on read. New leases always use `resource_key`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PartitionLease {
-    /// Tenant owning the partition.
-    pub tenant_id: String,
-    /// Collection (the partition) within the tenant.
-    pub collection_id: String,
+    /// Unified resource key (new format). Present in all new leases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_key: Option<ResourceKey>,
+
+    /// Legacy: Tenant owning the partition (kept for backward compatibility).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+
+    /// Legacy: Collection (the partition) within the tenant (kept for backward compatibility).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collection_id: Option<String>,
+
     /// Pod that holds the lease (opaque identifier, matching the registry's
     /// `PrimaryPod.pod` convention).
     pub holder_pod: String,
+
     /// Monotonic fencing generation. A takeover commits a strictly-higher
     /// generation so the displaced owner's next write is fenced.
     pub generation: u64,
+
     /// Wall-clock ms when the lease was last (re)acquired.
     pub acquired_at_ms: i64,
+
     /// Wall-clock ms at which the lease lapses if not renewed.
     pub expires_at_ms: i64,
+
+    /// Format version for migration detection.
+    /// - None or 0: legacy format (tenant_id + collection_id only)
+    /// - 1: unified resource key format
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format_version: Option<u32>,
+
+    /// Tombstone flag (F7): `true` when the prior holder explicitly
+    /// relinquished the lease via [`PartitionLeaseStore::release_with_key`].
+    ///
+    /// A released lease is free for the taking, but it still occupies a
+    /// generation slot in the fence log so the next acquirer claims a
+    /// strictly-higher generation (preserving the monotonic fence). Old
+    /// readers default this to `false` (mixed-read-safe).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub released: bool,
 }
 
 impl PartitionLease {
+    /// Create a new lease with a unified resource key.
+    pub fn with_key(
+        key: ResourceKey,
+        holder_pod: impl Into<String>,
+        generation: u64,
+        acquired_at_ms: i64,
+        expires_at_ms: i64,
+    ) -> Self {
+        Self {
+            resource_key: Some(key),
+            tenant_id: None,
+            collection_id: None,
+            holder_pod: holder_pod.into(),
+            generation,
+            acquired_at_ms,
+            expires_at_ms,
+            format_version: Some(1),
+            released: false,
+        }
+    }
+
+    /// Create a legacy-format lease (for backward compatibility in tests/migration).
+    pub fn legacy(
+        tenant_id: impl Into<String>,
+        collection_id: impl Into<String>,
+        holder_pod: impl Into<String>,
+        generation: u64,
+        acquired_at_ms: i64,
+        expires_at_ms: i64,
+    ) -> Self {
+        Self {
+            resource_key: None,
+            tenant_id: Some(tenant_id.into()),
+            collection_id: Some(collection_id.into()),
+            holder_pod: holder_pod.into(),
+            generation,
+            acquired_at_ms,
+            expires_at_ms,
+            format_version: None,
+            released: false,
+        }
+    }
+
+    /// Ensure this lease is migrated to the new format.
+    /// If it's legacy format, creates a new ResourceKey and returns a migrated copy.
+    pub fn ensure_migrated(&self) -> Cow<'_, PartitionLease> {
+        if self.resource_key.is_some() || self.format_version == Some(1) {
+            // Already migrated
+            return Cow::Borrowed(self);
+        }
+
+        // Migrate from legacy format
+        let tenant_id = self
+            .tenant_id
+            .as_deref()
+            .expect("legacy lease must have tenant_id");
+        let collection_id = self
+            .collection_id
+            .as_deref()
+            .expect("legacy lease must have collection_id");
+
+        let migrated = Self {
+            resource_key: Some(ResourceKey::legacy_collection(tenant_id, collection_id)),
+            tenant_id: Some(tenant_id.to_string()),
+            collection_id: Some(collection_id.to_string()),
+            holder_pod: self.holder_pod.clone(),
+            generation: self.generation,
+            acquired_at_ms: self.acquired_at_ms,
+            expires_at_ms: self.expires_at_ms,
+            format_version: Some(1),
+            released: self.released,
+        };
+
+        Cow::Owned(migrated)
+    }
+
+    /// Get the resource key, migrating if necessary.
+    pub fn key(&self) -> Cow<'_, ResourceKey> {
+        let migrated = self.ensure_migrated();
+        match &migrated {
+            Cow::Borrowed(lease) => Cow::Borrowed(
+                lease
+                    .resource_key
+                    .as_ref()
+                    .expect("migrated lease must have resource_key"),
+            ),
+            Cow::Owned(lease) => Cow::Owned(
+                lease
+                    .resource_key
+                    .as_ref()
+                    .expect("migrated lease must have resource_key")
+                    .clone(),
+            ),
+        }
+    }
+
+    /// Get the tenant ID (from resource_key if available, otherwise from legacy field).
+    pub fn get_tenant_id(&self) -> String {
+        self.ensure_migrated().key().tenant_id.clone()
+    }
+
+    /// Get the resource ID (collection_id in legacy format, or from resource_key).
+    pub fn get_resource_id(&self) -> String {
+        let key = self.key();
+        match &key.resource_id {
+            ResourceIdentifier::Single(s) => s.clone(),
+            ResourceIdentifier::Composite(parts) => parts.join("."),
+            ResourceIdentifier::Hierarchical { parent, child } => format!("{}.{}", parent, child),
+        }
+    }
+
     /// Whether the lease has lapsed at `now_ms`.
     pub fn is_expired(&self, now_ms: i64) -> bool {
         now_ms >= self.expires_at_ms
@@ -91,6 +1761,16 @@ impl PartitionLease {
     /// Whether `pod` holds this lease and it is still valid at `now_ms`.
     pub fn is_valid_for(&self, pod: &str, now_ms: i64) -> bool {
         self.holder_pod == pod && !self.is_expired(now_ms)
+    }
+
+    /// Whether this is a legacy-format lease (before migration).
+    pub fn is_legacy(&self) -> bool {
+        self.resource_key.is_none() && self.format_version.is_none()
+    }
+
+    /// Whether this is a new-format lease (with ResourceKey).
+    pub fn is_new_format(&self) -> bool {
+        self.resource_key.is_some() || self.format_version == Some(1)
     }
 }
 
@@ -180,6 +1860,9 @@ impl PartitionLeaseStore {
     /// `(tenant_id, collection_id)` for `holder_pod`, valid for `lease_ms` from
     /// `now_ms`.
     ///
+    /// **Legacy compatibility**: This method converts to ResourceKey and delegates
+    /// to `acquire_with_key`. New code should use `acquire_with_key` directly.
+    ///
     /// Returns [`LeaseOutcome::Held`] when a *live* lease belongs to another pod,
     /// [`LeaseOutcome::Fenced`] when this attempt lost the fenced CAS to a
     /// concurrent acquirer, and [`LeaseOutcome::Acquired`] when this pod holds it.
@@ -191,22 +1874,90 @@ impl PartitionLeaseStore {
         now_ms: i64,
         lease_ms: i64,
     ) -> Result<LeaseOutcome> {
-        let committer = self.committer(tenant_id, collection_id);
+        self.acquire_via_key(tenant_id, collection_id, holder_pod, now_ms, lease_ms)
+            .await
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // ResourceKey-based methods (multi-modality support)
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /// The fenced manifest committer for a resource identified by ResourceKey.
+    fn committer_for_key(&self, key: &ResourceKey) -> ManifestCommitter {
+        if key.resource_type == ResourceType::Collection
+            && key.namespace_id.is_none()
+            && let ResourceIdentifier::Single(collection_id) = &key.resource_id
+        {
+            // Mixed-read-safe migration: the legacy `(tenant, collection)` API
+            // and the new `ResourceKey::legacy_collection` API must address the
+            // same manifest log until a separate path migration is finalized.
+            return self.committer(&key.tenant_id, collection_id);
+        }
+
+        let path = format!("{}/{}", self.prefix, key.to_path());
+        ManifestCommitter::new(self.store.clone(), path)
+    }
+
+    /// Read the current lease for a resource by its ResourceKey.
+    /// Handles both legacy and new-format leases (mixed-read-safe).
+    pub async fn read_key(&self, key: &ResourceKey) -> Result<Option<(u64, PartitionLease)>> {
+        let committer = self.committer_for_key(key);
+        let key_desc = format!("{}:{}", key.tenant_id, key.resource_type.name());
+        match committer
+            .latest_version()
+            .await
+            .with_context(|| format!("reading lease log {key_desc}"))?
+        {
+            Some(version) => {
+                let (_generation, bytes) = committer
+                    .read_fenced(version)
+                    .await
+                    .with_context(|| format!("reading lease {key_desc}@{version}"))?;
+                let lease: PartitionLease = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("decoding lease {key_desc}"))?;
+                Ok(Some((version, lease)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Acquire — or renew, or take over an expired — the lease on a resource
+    /// identified by `key` for `holder_pod`, valid for `lease_ms` from `now_ms`.
+    ///
+    /// This is the multi-modality entry point that works for all resource types
+    /// (collections, tables, graphs, ML models, etc.).
+    ///
+    /// Returns [`LeaseOutcome::Held`] when a *live* lease belongs to another pod,
+    /// [`LeaseOutcome::Fenced`] when this attempt lost the fenced CAS to a
+    /// concurrent acquirer, and [`LeaseOutcome::Acquired`] when this pod holds it.
+    pub async fn acquire_with_key(
+        &self,
+        key: &ResourceKey,
+        holder_pod: &str,
+        now_ms: i64,
+        lease_ms: i64,
+    ) -> Result<LeaseOutcome> {
+        let committer = self.committer_for_key(key);
+        let key_desc = format!("{}:{}", key.tenant_id, key.resource_type.name());
 
         // Decide the parent version + the generation to claim, from the current
         // durable state.
-        let (parent, generation) = match self.read(tenant_id, collection_id).await? {
-            // Fresh partition — generation 1 (manifest versions start at 0).
+        let (parent, generation) = match self.read_key(key).await? {
+            // Fresh resource — generation 1 (manifest versions start at 0).
             None => (None, 1),
             Some((version, lease)) => {
-                if lease.holder_pod == holder_pod {
-                    // We already own it → renew at the SAME generation (a renew is
-                    // not a takeover, so it must not outrank ourselves; the version
-                    // CAS still serializes concurrent renewals).
+                // A released tombstone (F7) means the prior holder explicitly
+                // relinquished: the resource is free. Claim a strictly-higher
+                // generation so the monotonic fence stays intact (the tombstone
+                // occupies `lease.generation`; an object-store delete would have
+                // reset it to 1 and collapsed the fence).
+                if lease.released {
+                    (Some(version), lease.generation + 1)
+                } else if lease.holder_pod.as_str() == holder_pod {
+                    // We already own it → renew at the SAME generation
                     (Some(version), lease.generation)
                 } else if lease.is_expired(now_ms) {
-                    // Take over a dead owner → strictly-higher generation so the
-                    // displaced owner's next renewal is fenced.
+                    // Take over a dead owner → strictly-higher generation
                     (Some(version), lease.generation + 1)
                 } else {
                     // A live lease belongs to someone else — we are not the owner.
@@ -215,30 +1966,124 @@ impl PartitionLeaseStore {
             }
         };
 
-        let lease = PartitionLease {
-            tenant_id: tenant_id.to_string(),
-            collection_id: collection_id.to_string(),
-            holder_pod: holder_pod.to_string(),
+        let lease = PartitionLease::with_key(
+            key.clone(),
+            holder_pod,
             generation,
-            acquired_at_ms: now_ms,
-            expires_at_ms: now_ms.saturating_add(lease_ms),
-        };
+            now_ms,
+            now_ms.saturating_add(lease_ms),
+        );
         let payload = serde_json::to_vec(&lease).context("encoding partition lease")?;
 
         match committer
             .commit_fenced(parent, generation, bytes::Bytes::from(payload))
             .await
-            .with_context(|| format!("committing lease {tenant_id}/{collection_id}"))?
+            .with_context(|| format!("committing lease {key_desc}"))?
         {
             CommitOutcome::Committed(_) => Ok(LeaseOutcome::Acquired(lease)),
             // Lost the version CAS or was fenced by a higher generation — re-read
-            // to report who actually owns the partition now.
-            CommitOutcome::Conflict { .. } => match self.read(tenant_id, collection_id).await? {
+            // to report who actually owns the resource now.
+            CommitOutcome::Conflict { .. } => match self.read_key(key).await? {
                 Some((_, latest)) => Ok(LeaseOutcome::Fenced { latest }),
                 // Extremely unlikely (the conflicting object vanished) — surface
                 // our own attempt as the latest so the caller does not own it.
                 None => Ok(LeaseOutcome::Fenced { latest: lease }),
             },
+        }
+    }
+
+    /// Legacy compatibility: convert (tenant_id, collection_id) to ResourceKey
+    /// and delegate to acquire_with_key.
+    async fn acquire_via_key(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        holder_pod: &str,
+        now_ms: i64,
+        lease_ms: i64,
+    ) -> Result<LeaseOutcome> {
+        let key = ResourceKey::legacy_collection(tenant_id, collection_id);
+        self.acquire_with_key(&key, holder_pod, now_ms, lease_ms)
+            .await
+    }
+
+    /// Explicitly relinquish a lease (F7) by publishing a **released
+    /// tombstone** at a strictly-higher generation.
+    ///
+    /// This is the fast-path counterpart to natural TTL expiry: instead of
+    /// waiting for `expires_at_ms`, the holder publishes a tombstone so the
+    /// next acquirer can take over immediately. The tombstone occupies a
+    /// generation slot (committed at `lease.generation + 1`), which is
+    /// load-bearing: any in-flight write still carrying the old
+    /// `lease.generation` is fenced, and the monotonic-generation invariant
+    /// survives. Object-store *deleting* the manifest is deliberately avoided
+    /// — it would make the next acquire see an empty log and claim generation
+    /// 1, collapsing the fence.
+    ///
+    /// Best-effort and fail-open: if the holder does not match, the lease is
+    /// already released, or the object-store CAS/errors, this returns `Ok`
+    /// and the lease simply expires at its TTL (the crash-safe fallback).
+    pub async fn release_with_key(
+        &self,
+        key: &ResourceKey,
+        holder_pod: &str,
+        now_ms: i64,
+    ) -> Result<()> {
+        let key_desc = format!("{}:{}", key.tenant_id, key.resource_type.name());
+
+        // Read the current durable state. A read failure is fail-open: leave
+        // the lease to expire at TTL rather than surfacing a transient error.
+        let Some((version, lease)) = (match self.read_key(key).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "partition_lease_release",
+                    resource = %key_desc,
+                    error = %e,
+                    "release read failed; falling back to TTL expiry"
+                );
+                return Ok(());
+            }
+        }) else {
+            // Nothing durable to release.
+            return Ok(());
+        };
+
+        // Only the current holder may release, and only a live (non-tombstoned)
+        // lease. Anything else is a stale no-op.
+        if lease.holder_pod != holder_pod || lease.released {
+            return Ok(());
+        }
+
+        // Publish the tombstone at generation+1 so the holder's own in-flight
+        // writes at `lease.generation` are fenced (strict less-than).
+        let new_generation = lease.generation + 1;
+        let tombstone = PartitionLease {
+            released: true,
+            generation: new_generation,
+            acquired_at_ms: now_ms,
+            expires_at_ms: now_ms,
+            ..lease.clone()
+        };
+        let payload = serde_json::to_vec(&tombstone).context("encoding release tombstone")?;
+
+        match self
+            .committer_for_key(key)
+            .commit_fenced(Some(version), new_generation, bytes::Bytes::from(payload))
+            .await
+        {
+            // Tombstone published, or we lost the CAS to a concurrent takeover —
+            // either way there is nothing left for us to release.
+            Ok(_) => Ok(()),
+            Err(e) => {
+                tracing::warn!(
+                    target: "partition_lease_release",
+                    resource = %key_desc,
+                    error = %e,
+                    "durable release commit failed; falling back to TTL expiry"
+                );
+                Ok(())
+            }
         }
     }
 }
@@ -259,6 +2104,11 @@ pub struct PartitionLeaseManager {
     registry: Arc<PrimaryPodRegistry>,
     self_pod_id: String,
     lease_ms: i64,
+    /// Strategy registry for type-specific behavior (TTL, partitioning, etc.)
+    strategies: DashMap<ResourceType, Arc<dyn ResourceStrategy>>,
+    /// Full-key leases held by this pod that are not represented in the legacy
+    /// `(tenant, collection)` primary-pod registry.
+    held_resource_keys: DashMap<String, ResourceKey>,
 }
 
 impl PartitionLeaseManager {
@@ -274,7 +2124,31 @@ impl PartitionLeaseManager {
             registry,
             self_pod_id: self_pod_id.into(),
             lease_ms,
+            strategies: DashMap::new(),
+            held_resource_keys: DashMap::new(),
         }
+    }
+
+    /// Register a strategy for a resource type.
+    ///
+    /// This enables type-specific behavior (TTL, partitioning, etc.).
+    /// Multiple strategies can be registered; the strategy for a given
+    /// resource type is looked up on each acquire/renew.
+    pub fn register_strategy(&self, strategy: Arc<dyn ResourceStrategy>) {
+        self.strategies.insert(strategy.resource_type(), strategy);
+    }
+
+    /// Get the TTL for a resource type (from strategy or default).
+    fn get_ttl_for_resource(&self, resource_type: &ResourceType) -> i64 {
+        self.strategies
+            .get(resource_type)
+            .map(|s| s.lease_ttl_secs() as i64 * 1000) // Convert seconds to ms
+            .unwrap_or(self.lease_ms) // Default to configured lease_ms
+    }
+
+    /// Get a strategy by resource type (if registered).
+    pub fn get_strategy(&self, resource_type: &ResourceType) -> Option<Arc<dyn ResourceStrategy>> {
+        self.strategies.get(resource_type).map(|s| s.clone())
     }
 
     /// This pod's identity.
@@ -300,10 +2174,60 @@ impl PartitionLeaseManager {
         Ok(self.reconcile(tenant_id, collection_id, outcome))
     }
 
-    /// Renew every lease this pod believes it holds (per the registry). A lease
-    /// that has been lost (taken over while we were paused) re-points the binding
-    /// at the new owner — the step-down that prevents split brain. Returns the
-    /// number of partitions this pod still owns after the pass.
+    /// Acquire a lease for a resource identified by its ResourceKey.
+    ///
+    /// This is the multi-modality entry point that uses the registered strategy
+    /// to determine the appropriate TTL for the resource type.
+    ///
+    /// Returns whether this pod now owns the resource.
+    pub async fn acquire_with_key(&self, key: &ResourceKey, now_ms: i64) -> Result<bool> {
+        let ttl_ms = self.get_ttl_for_resource(&key.resource_type);
+        let outcome = self
+            .store
+            .acquire_with_key(key, &self.self_pod_id, now_ms, ttl_ms)
+            .await?;
+
+        if Self::is_legacy_collection_key(key) {
+            let ResourceIdentifier::Single(collection_id) = &key.resource_id else {
+                unreachable!("legacy collection key checked above");
+            };
+            return Ok(self.reconcile(&key.tenant_id, collection_id, outcome));
+        }
+
+        let identity = Self::resource_key_identity(key);
+        match outcome {
+            LeaseOutcome::Acquired(_) => {
+                self.held_resource_keys.insert(identity, key.clone());
+                Ok(true)
+            }
+            LeaseOutcome::Held { .. } | LeaseOutcome::Fenced { .. } => {
+                self.held_resource_keys.remove(&identity);
+                Ok(false)
+            }
+        }
+    }
+
+    /// Explicitly relinquish a generalized resource lease (F7): drop the
+    /// in-memory held-key entry and publish a durable released-tombstone
+    /// (best-effort; TTL expiry remains the crash-safe fallback). Returns
+    /// whether this pod held the lease.
+    ///
+    /// Legacy `(tenant, collection)` leases are released via the same store
+    /// primitive but are not tracked in `held_resource_keys`, so only the
+    /// durable tombstone is published for them.
+    pub async fn release_with_key(&self, key: &ResourceKey, now_ms: i64) -> Result<bool> {
+        let identity = Self::resource_key_identity(key);
+        let was_held = self.held_resource_keys.remove(&identity).is_some();
+        // Best-effort durable tombstone; the store method is fail-open to TTL.
+        self.store
+            .release_with_key(key, &self.self_pod_id, now_ms)
+            .await?;
+        Ok(was_held)
+    }
+
+    /// Renew every lease this pod believes it holds. Legacy collection leases
+    /// are renewed from the primary-pod registry; generalized resource leases
+    /// are renewed from the full `ResourceKey` registry.
     pub async fn renew_held(&self, now_ms: i64) -> Result<usize> {
         let mut still_owned = 0;
         for (tenant_id, collection_id, binding) in self.registry.list() {
@@ -336,11 +2260,54 @@ impl PartitionLeaseManager {
                         error = %e,
                         "partition-lease renewal failed; retrying next interval"
                     );
+                    crate::metrics::dml_lock_metrics::record_renewal_failure("collection");
+                    still_owned += 1;
+                }
+            }
+        }
+
+        let held_keys = self
+            .held_resource_keys
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<Vec<_>>();
+        for (identity, key) in held_keys {
+            let ttl_ms = self.get_ttl_for_resource(&key.resource_type);
+            match self
+                .store
+                .acquire_with_key(&key, &self.self_pod_id, now_ms, ttl_ms)
+                .await
+            {
+                Ok(LeaseOutcome::Acquired(_)) => {
+                    still_owned += 1;
+                }
+                Ok(LeaseOutcome::Held { .. } | LeaseOutcome::Fenced { .. }) => {
+                    self.held_resource_keys.remove(&identity);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        resource = %identity,
+                        error = %e,
+                        "resource lease renewal failed; retrying next interval"
+                    );
+                    crate::metrics::dml_lock_metrics::record_renewal_failure(
+                        key.resource_type.name(),
+                    );
                     still_owned += 1;
                 }
             }
         }
         Ok(still_owned)
+    }
+
+    fn is_legacy_collection_key(key: &ResourceKey) -> bool {
+        key.resource_type == ResourceType::Collection
+            && key.namespace_id.is_none()
+            && matches!(key.resource_id, ResourceIdentifier::Single(_))
+    }
+
+    fn resource_key_identity(key: &ResourceKey) -> String {
+        key.to_path()
     }
 
     /// Fold a durable [`LeaseOutcome`] into the routing registry. Returns whether
@@ -406,6 +2373,468 @@ pub fn consult_for_write_leased(
     consult_for_write(registry, self_pod_id, tenant_id, collection_id)
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// DML Lock Service (Hierarchical Locking for Fine-Grained DML)
+////////////////////////////////////////////////////////////////////////////////
+
+/// Active DML lock (held by a pod for a specific scope with an intent).
+#[derive(Debug, Clone)]
+pub struct ActiveLock {
+    pub tenant_id: String,
+    pub namespace_id: Option<String>,
+    pub scope: DmlLockScope,
+    pub pod_id: String,
+    pub intent: LockIntent,
+    pub acquired_at_ms: i64,
+    pub expires_at_ms: i64,
+}
+
+/// DML lock service for fine-grained locking (record-level, table-level, etc.).
+///
+/// This service provides hierarchical locking with intent compatibility checking.
+/// It works with the PartitionLeaseManager to acquire durable leases for locks.
+pub struct DmlLockService {
+    lease_manager: Arc<PartitionLeaseManager>,
+    self_pod_id: String,
+
+    /// In-memory registry of active DML locks (fast path).
+    /// Key is the scope's serialized form.
+    active_locks: Arc<RwLock<HashMap<String, ActiveLock>>>,
+
+    /// Shutdown signal receiver for the reconciliation loop.
+    shutdown_rx: Option<tokio::sync::watch::Receiver<bool>>,
+
+    /// Shutdown signal sender for the reconciliation loop.
+    shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
+}
+
+/// Guard returned for a successfully acquired DML lock.
+///
+/// The guard owns the local lock registration. Call [`Self::release`] for an
+/// explicit async release. `Drop` performs a best-effort local cleanup on the
+/// current tokio runtime; durable object-store release is still a follow-up
+/// gate, so the durable lease remains crash-safe by expiring naturally.
+pub struct DmlLockGuard {
+    service: Arc<DmlLockService>,
+    tenant_id: String,
+    namespace_id: Option<String>,
+    scope: DmlLockScope,
+    intent: LockIntent,
+    lease_generation: u64,
+    released: bool,
+}
+
+impl DmlLockGuard {
+    /// Durable fencing generation associated with this lock acquisition.
+    pub fn lease_generation(&self) -> u64 {
+        self.lease_generation
+    }
+
+    /// Scope protected by this guard.
+    pub fn scope(&self) -> &DmlLockScope {
+        &self.scope
+    }
+
+    /// Intent protected by this guard.
+    pub fn intent(&self) -> &LockIntent {
+        &self.intent
+    }
+
+    /// Explicitly release the local in-memory lock registration.
+    pub async fn release(mut self) {
+        self.release_inner().await;
+    }
+
+    async fn release_inner(&mut self) {
+        if self.released {
+            return;
+        }
+        self.service
+            .release_full(&self.tenant_id, self.namespace_id.as_deref(), &self.scope)
+            .await;
+        self.released = true;
+    }
+}
+
+impl Drop for DmlLockGuard {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+
+        let service = self.service.clone();
+        let tenant_id = self.tenant_id.clone();
+        let namespace_id = self.namespace_id.clone();
+        let scope = self.scope.clone();
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::spawn(async move {
+                service
+                    .release_full(&tenant_id, namespace_id.as_deref(), &scope)
+                    .await;
+            });
+        }
+    }
+}
+
+impl DmlLockService {
+    /// Create a new DML lock service.
+    pub fn new(lease_manager: Arc<PartitionLeaseManager>, self_pod_id: impl Into<String>) -> Self {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        Self {
+            lease_manager,
+            self_pod_id: self_pod_id.into(),
+            active_locks: Arc::new(RwLock::new(HashMap::new())),
+            shutdown_rx: Some(shutdown_rx),
+            shutdown_tx: Some(shutdown_tx),
+        }
+    }
+
+    /// Start the background reconciliation loop.
+    ///
+    /// This spawns a background task that periodically scans the in-memory
+    /// lock registry and removes expired locks. The loop runs every
+    /// `reconciliation_interval_ms` milliseconds.
+    ///
+    /// The loop can be stopped by calling `shutdown()` or by dropping the service.
+    pub fn spawn_reconciliation_loop(
+        &self,
+        reconciliation_interval_ms: u64,
+    ) -> tokio::task::JoinHandle<()> {
+        let active_locks = self.active_locks.clone();
+        let mut shutdown_rx = self.shutdown_rx.as_ref().unwrap().clone();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(Duration::from_millis(reconciliation_interval_ms));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        Self::reconcile_expired_locks(&active_locks).await;
+                    }
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Reconcile expired locks from the in-memory registry.
+    ///
+    /// This is called periodically by the background reconciliation loop.
+    /// It scans all locks and removes those that have expired.
+    async fn reconcile_expired_locks(active_locks: &Arc<RwLock<HashMap<String, ActiveLock>>>) {
+        let now_ms = now_millis();
+        let mut locks = active_locks.write().await;
+        let initial_count = locks.len();
+
+        // Remove expired locks
+        locks.retain(|_, lock| !lock.is_expired(now_ms));
+
+        let removed = initial_count - locks.len();
+        if removed > 0 {
+            tracing::debug!(
+                target: "dml_lock_reconciliation",
+                removed,
+                remaining = locks.len(),
+                "Reconciled expired DML locks"
+            );
+        }
+    }
+
+    /// Shutdown the reconciliation loop.
+    ///
+    /// This signals the background task to stop gracefully.
+    pub fn shutdown(&self) {
+        if let Some(tx) = &self.shutdown_tx {
+            let _ = tx.send(true);
+        }
+    }
+
+    /// Acquire a DML lock for the given scope and intent.
+    ///
+    /// Returns `LockOutcome::Acquired` if the lock was acquired,
+    /// `LockOutcome::Conflict` if the lock conflicts with an existing lock,
+    /// `LockOutcome::Held` if the lock is held by another pod,
+    /// or `LockOutcome::Fenced` if this pod was fenced.
+    pub async fn acquire_dml_lock(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: &DmlLockScope,
+        intent: LockIntent,
+        now_ms: i64,
+    ) -> Result<LockOutcome> {
+        let started = std::time::Instant::now();
+        // Resolve the canonical resource key up front so it labels the metrics
+        // on every path (including the in-memory fast-path block) and is reused
+        // for the durable acquire.
+        let resource_key = self.scope_to_resource_key(tenant_id, namespace_id, scope);
+        let resource_type = resource_key.resource_type.name();
+        let scope_key = Self::scoped_lock_key(tenant_id, namespace_id, scope);
+        let namespace = namespace_id.map(str::to_string);
+
+        // Check compatibility with existing locks in-memory. A conflict/held
+        // decision is captured and reported after the loop (single metric site)
+        // rather than early-returned, so every outcome is observed.
+        let mut blocked: Option<LockOutcome> = None;
+        {
+            let locks = self.active_locks.read().await;
+            for existing in locks.values() {
+                if existing.is_expired(now_ms)
+                    || existing.tenant_id != tenant_id
+                    || existing.namespace_id != namespace
+                    || !existing.scope.overlaps(scope)
+                {
+                    continue;
+                }
+
+                if existing.pod_id == self.self_pod_id && existing.scope == *scope {
+                    continue;
+                }
+
+                let held_elsewhere = existing.pod_id != self.self_pod_id;
+                let held_outcome = || {
+                    if held_elsewhere {
+                        LockOutcome::Held {
+                            holder: existing.pod_id.clone(),
+                            expires_at: existing.expires_at_ms,
+                        }
+                    } else {
+                        LockOutcome::Conflict
+                    }
+                };
+
+                // Hierarchical locking enforcement: ancestor/descendant conflicts.
+                // A schema lock blocks all table/partition/record locks in that
+                // schema; a table lock blocks all partition/record locks in that
+                // table. This applies regardless of intent.
+                if scope.is_ancestor_of(&existing.scope) || scope.is_descendant_of(&existing.scope)
+                {
+                    blocked = Some(held_outcome());
+                    break;
+                }
+
+                if !intent.is_compatible_with(&existing.intent) {
+                    blocked = Some(held_outcome());
+                    break;
+                }
+            }
+        }
+        if let Some(outcome) = blocked {
+            crate::metrics::dml_lock_metrics::record_acquisition(
+                dml_lock_outcome_label(&outcome),
+                resource_type,
+                tenant_id,
+                started.elapsed(),
+            );
+            return Ok(outcome);
+        }
+
+        // Acquire durable lease for this lock
+        let ttl_ms = 10_000; // DML locks have short TTL (10s)
+        let lease_outcome = self
+            .lease_manager
+            .store
+            .acquire_with_key(&resource_key, &self.self_pod_id, now_ms, ttl_ms)
+            .await?;
+
+        let outcome = match lease_outcome {
+            LeaseOutcome::Acquired(lease) => {
+                // Register in-memory lock
+                let mut locks = self.active_locks.write().await;
+                locks.insert(
+                    scope_key,
+                    ActiveLock {
+                        tenant_id: tenant_id.to_string(),
+                        namespace_id: namespace,
+                        scope: scope.clone(),
+                        pod_id: self.self_pod_id.clone(),
+                        intent: intent.clone(),
+                        acquired_at_ms: now_ms,
+                        expires_at_ms: now_ms.saturating_add(ttl_ms),
+                    },
+                );
+                crate::metrics::dml_lock_metrics::inc_held(resource_type);
+                LockOutcome::Acquired { lease }
+            }
+            LeaseOutcome::Held { by } => LockOutcome::Held {
+                holder: by.holder_pod,
+                expires_at: by.expires_at_ms,
+            },
+            LeaseOutcome::Fenced { latest } => LockOutcome::Fenced { latest },
+        };
+        crate::metrics::dml_lock_metrics::record_acquisition(
+            dml_lock_outcome_label(&outcome),
+            resource_type,
+            tenant_id,
+            started.elapsed(),
+        );
+        Ok(outcome)
+    }
+
+    /// Acquire a DML lock and return a guard that owns local release.
+    pub async fn acquire_dml_lock_guard(
+        self: &Arc<Self>,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: DmlLockScope,
+        intent: LockIntent,
+        now_ms: i64,
+    ) -> Result<DmlLockGuard> {
+        match self
+            .acquire_dml_lock(tenant_id, namespace_id, &scope, intent.clone(), now_ms)
+            .await?
+        {
+            LockOutcome::Acquired { lease } => Ok(DmlLockGuard {
+                service: self.clone(),
+                tenant_id: tenant_id.to_string(),
+                namespace_id: namespace_id.map(str::to_string),
+                scope,
+                intent,
+                lease_generation: lease.generation,
+                released: false,
+            }),
+            LockOutcome::Conflict => Err(anyhow::anyhow!(
+                "DML lock conflict for tenant '{tenant_id}', namespace {:?}, scope {:?}",
+                namespace_id,
+                scope
+            )),
+            LockOutcome::Held { holder, expires_at } => Err(anyhow::anyhow!(
+                "DML lock held by pod '{holder}' until {expires_at} for tenant '{tenant_id}', namespace {:?}, scope {:?}",
+                namespace_id,
+                scope
+            )),
+            LockOutcome::Fenced { latest } => Err(anyhow::anyhow!(
+                "DML lock fenced by pod '{}' generation {} for tenant '{tenant_id}', namespace {:?}, scope {:?}",
+                latest.holder_pod,
+                latest.generation,
+                namespace_id,
+                scope
+            )),
+        }
+    }
+
+    /// Release a DML lock.
+    ///
+    /// This removes the lock from the in-memory registry. The durable lease
+    /// will expire naturally after its TTL.
+    pub async fn release_dml_lock(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: &DmlLockScope,
+    ) {
+        let scope_key = Self::scoped_lock_key(tenant_id, namespace_id, scope);
+        let mut locks = self.active_locks.write().await;
+        locks.remove(&scope_key);
+    }
+
+    /// Full release (F7): deregister the in-memory lock AND publish a
+    /// best-effort durable released-tombstone, so the next acquirer need
+    /// not wait for TTL. The durable step is fail-open to TTL expiry.
+    pub async fn release_full(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: &DmlLockScope,
+    ) {
+        self.release_dml_lock(tenant_id, namespace_id, scope).await;
+        let key = self.scope_to_resource_key(tenant_id, namespace_id, scope);
+        crate::metrics::dml_lock_metrics::dec_held(key.resource_type.name());
+        // Best-effort; `release_with_key` is fail-open to TTL internally.
+        let _ = self
+            .lease_manager
+            .release_with_key(&key, now_millis())
+            .await;
+    }
+
+    /// Release all DML locks held by this pod.
+    pub async fn release_all_locks(&self) {
+        let mut locks = self.active_locks.write().await;
+        locks.retain(|_, lock| lock.pod_id != self.self_pod_id);
+    }
+
+    /// Convert a DML lock scope to a ResourceKey for lease acquisition.
+    fn scope_to_resource_key(
+        &self,
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: &DmlLockScope,
+    ) -> ResourceKey {
+        // For DML locks, we use a special resource type based on the scope level
+        let resource_type = match scope {
+            DmlLockScope::Schema { .. } => ResourceType::Schema,
+            DmlLockScope::Table { .. } => ResourceType::Table,
+            DmlLockScope::Partition { .. } => ResourceType::Table, // Partitions use Table type
+            DmlLockScope::Record { .. } => ResourceType::Table,    // Records use Table type
+        };
+
+        let resource_id = match scope {
+            DmlLockScope::Schema { schema_name } => ResourceIdentifier::single(schema_name.clone()),
+            DmlLockScope::Table {
+                schema_name,
+                table_name,
+            } => ResourceIdentifier::composite(vec![schema_name.clone(), table_name.clone()]),
+            DmlLockScope::Partition {
+                schema_name,
+                table_name,
+                partition_id,
+            } => ResourceIdentifier::composite(vec![
+                schema_name.clone(),
+                table_name.clone(),
+                partition_id.clone(),
+            ]),
+            DmlLockScope::Record {
+                schema_name,
+                table_name,
+                key,
+            } => ResourceIdentifier::composite(vec![
+                schema_name.clone(),
+                table_name.clone(),
+                key.clone(),
+            ]),
+        };
+
+        ResourceKey {
+            tenant_id: tenant_id.to_string(),
+            namespace_id: namespace_id.map(str::to_string),
+            resource_type,
+            resource_id,
+        }
+    }
+
+    fn scoped_lock_key(
+        tenant_id: &str,
+        namespace_id: Option<&str>,
+        scope: &DmlLockScope,
+    ) -> String {
+        match namespace_id {
+            Some(namespace_id) => format!(
+                "tenant:{}/namespace:{}/{}",
+                encode_path_component(tenant_id),
+                encode_path_component(namespace_id),
+                scope.to_key()
+            ),
+            None => format!(
+                "tenant:{}/{}",
+                encode_path_component(tenant_id),
+                scope.to_key()
+            ),
+        }
+    }
+}
+
+impl ActiveLock {
+    /// Check if this lock has expired at the given time.
+    pub fn is_expired(&self, now_ms: i64) -> bool {
+        now_ms >= self.expires_at_ms
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -421,6 +2850,120 @@ mod tests {
 
     fn store(backing: &Arc<dyn object_store::ObjectStore>) -> PartitionLeaseStore {
         PartitionLeaseStore::new(ProximaObjectStore::new(backing.clone()), PREFIX)
+    }
+
+    fn test_manager(
+        backing: &Arc<dyn object_store::ObjectStore>,
+        pod: &str,
+    ) -> PartitionLeaseManager {
+        PartitionLeaseManager::new(
+            Arc::new(store(backing)),
+            Arc::new(PrimaryPodRegistry::new()),
+            pod,
+            LEASE_MS,
+        )
+    }
+
+    /// `validate_fencing` is the storage-boundary contract (A6). None =
+    /// unfenced/legacy write, always allowed.
+    #[test]
+    fn validate_fencing_none_is_unfenced() {
+        assert!(validate_fencing(None, 5).is_ok());
+        assert!(validate_fencing(None, 0).is_ok());
+    }
+
+    /// A write carrying the current (or newer) generation is allowed.
+    #[test]
+    fn validate_fencing_current_or_newer_allowed() {
+        assert!(validate_fencing(Some(5), 5).is_ok()); // equal
+        assert!(validate_fencing(Some(7), 5).is_ok()); // newer
+    }
+
+    /// A write carrying a stale generation (a takeover displaced it) is rejected.
+    #[test]
+    fn validate_fencing_stale_rejected() {
+        match validate_fencing(Some(3), 5) {
+            Err(FencingError {
+                write_generation,
+                current_generation,
+            }) => {
+                assert_eq!(write_generation, 3);
+                assert_eq!(current_generation, 5);
+            }
+            other => panic!("expected FencingError for stale write, got {other:?}"),
+        }
+    }
+
+    /// A fresh resource (current generation 0) allows any Some(g) write.
+    #[test]
+    fn validate_fencing_fresh_resource_allows_all() {
+        assert!(validate_fencing(Some(0), 0).is_ok());
+        assert!(validate_fencing(Some(1), 0).is_ok());
+    }
+
+    /// F7: explicit release publishes a released tombstone at generation+1,
+    /// not an object-store delete (which would reset the fence to 1).
+    #[tokio::test]
+    async fn release_publishes_higher_generation_tombstone() -> Result<()> {
+        let backing = shared_backing();
+        let s = store(&backing);
+        let key = ResourceKey::table("t1", "public", "users");
+
+        let LeaseOutcome::Acquired(lease) = s.acquire_with_key(&key, "A", 0, 10_000).await? else {
+            panic!("A should acquire");
+        };
+        assert_eq!(lease.generation, 1);
+        assert!(!lease.released);
+
+        s.release_with_key(&key, "A", 100).await?;
+
+        let (_, durable) = s
+            .read_key(&key)
+            .await?
+            .expect("a tombstone must remain on the log");
+        assert!(durable.released, "tombstone must be marked released");
+        assert_eq!(durable.generation, 2, "tombstone sits at generation+1");
+        Ok(())
+    }
+
+    /// F7: acquiring after a release must NOT reset the generation to 1 — it
+    /// claims generation+1 over the tombstone, preserving the monotonic fence.
+    #[tokio::test]
+    async fn acquire_after_release_keeps_monotonic_generation() -> Result<()> {
+        let backing = shared_backing();
+        let s = store(&backing);
+        let key = ResourceKey::table("t1", "public", "users");
+
+        s.acquire_with_key(&key, "A", 0, 10_000).await?;
+        s.release_with_key(&key, "A", 100).await?;
+
+        let LeaseOutcome::Acquired(lease) = s.acquire_with_key(&key, "B", 200, 10_000).await?
+        else {
+            panic!("B should acquire the released resource");
+        };
+        assert_eq!(
+            lease.generation, 3,
+            "generation must stay monotonic (tombstone@2 → acquire@3), not reset to 1"
+        );
+        assert!(!lease.released);
+        Ok(())
+    }
+
+    /// F7: release by a pod that does not hold the lease is a stale no-op —
+    /// the live lease is untouched (no tombstone, holder unchanged).
+    #[tokio::test]
+    async fn release_by_non_holder_is_noop() -> Result<()> {
+        let backing = shared_backing();
+        let s = store(&backing);
+        let key = ResourceKey::table("t1", "public", "users");
+
+        s.acquire_with_key(&key, "A", 0, 10_000).await?;
+        s.release_with_key(&key, "B", 100).await?; // B does not hold it
+
+        let (_, durable) = s.read_key(&key).await?.expect("lease present");
+        assert!(!durable.released, "non-holder release must not tombstone");
+        assert_eq!(durable.holder_pod, "A");
+        Ok(())
     }
 
     /// A fresh partition: one pod acquires generation 1; a second pod racing the
@@ -528,6 +3071,53 @@ mod tests {
         Ok(())
     }
 
+    /// Legacy collection keys must share the exact same manifest log as the old
+    /// `(tenant, collection)` API until a dedicated path migration lands.
+    #[tokio::test]
+    async fn legacy_collection_key_uses_legacy_manifest_path() -> Result<()> {
+        let backing = shared_backing();
+        let store = store(&backing);
+        let key = ResourceKey::legacy_collection("tenant-a", "collection-a");
+
+        let legacy = store
+            .acquire("tenant-a", "collection-a", "pod-a", 0, LEASE_MS)
+            .await?;
+        assert!(matches!(legacy, LeaseOutcome::Acquired(_)));
+
+        let keyed = store
+            .acquire_with_key(&key, "pod-b", 1_000, LEASE_MS)
+            .await?;
+        match keyed {
+            LeaseOutcome::Held { by } => {
+                assert_eq!(by.holder_pod, "pod-a");
+                assert_eq!(by.key().as_ref(), &key);
+            }
+            other => panic!("keyed acquire must contend with legacy path, got {other:?}"),
+        }
+
+        let read_by_key = store.read_key(&key).await?.expect("lease by key");
+        assert_eq!(read_by_key.1.holder_pod, "pod-a");
+        Ok(())
+    }
+
+    /// Generalized resource keys must be path-safe: separators inside tenant,
+    /// namespace, or resource components are encoded, not treated as hierarchy.
+    #[test]
+    fn resource_key_path_encodes_components() {
+        let key = ResourceKey::new(
+            "tenant/a",
+            Some("ns/b".to_string()),
+            ResourceType::Table,
+            ResourceIdentifier::composite(vec!["schema/c".to_string(), "table d".to_string()]),
+        );
+
+        let path = key.to_path();
+        assert_eq!(path, "tenant%2Fa/ns%2Fb/table/schema%2Fc/table%20d");
+
+        let decoded = ResourceKey::from_path(&path).expect("decode path");
+        assert_eq!(decoded, key);
+    }
+
     /// Manager integration: acquisition assigns the registry binding; a lost
     /// lease steps the binding down to the new owner (consult_for_write flips
     /// Allow → Misrouted), so exactly one pod is ever writable across a handoff.
@@ -598,6 +3188,797 @@ mod tests {
             consult_for_write(&reg, "solo", "t", "c"),
             WriteRoutingDecision::Allow
         );
+        Ok(())
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Strategy Pattern Tests (Phase 2)
+    ////////////////////////////////////////////////////////////////////////////////
+
+    /// Collection strategy uses 60s TTL by default.
+    #[tokio::test]
+    async fn collection_strategy_default_ttl() -> Result<()> {
+        let strategy = CollectionStrategy;
+        assert_eq!(strategy.lease_ttl_secs(), 60);
+        assert_eq!(strategy.resource_type(), ResourceType::Collection);
+        assert!(strategy.supports_partitioning());
+        Ok(())
+    }
+
+    /// Table strategy uses 120s TTL for DSL operations.
+    #[tokio::test]
+    async fn table_strategy_longer_ttl() -> Result<()> {
+        let strategy = TableStrategy;
+        assert_eq!(strategy.lease_ttl_secs(), 120);
+        assert_eq!(strategy.resource_type(), ResourceType::Table);
+        assert!(strategy.supports_partitioning());
+        assert!(strategy.supports_hierarchical_locking());
+        Ok(())
+    }
+
+    /// Model strategy uses 300s TTL for rare model updates.
+    #[tokio::test]
+    async fn model_strategy_long_ttl() -> Result<()> {
+        let strategy = ModelStrategy;
+        assert_eq!(strategy.lease_ttl_secs(), 300);
+        assert_eq!(strategy.resource_type(), ResourceType::Model);
+        assert!(!strategy.supports_partitioning());
+        assert!(strategy.supports_hierarchical_locking());
+        Ok(())
+    }
+
+    /// Graph node/edge strategies use short 10s TTL for DML-level locking.
+    #[tokio::test]
+    async fn graph_node_edge_short_ttl() -> Result<()> {
+        let node_strategy = GraphNodeStrategy;
+        let edge_strategy = GraphEdgeStrategy;
+
+        assert_eq!(node_strategy.lease_ttl_secs(), 10);
+        assert_eq!(node_strategy.resource_type(), ResourceType::GraphNode);
+        assert!(!node_strategy.supports_partitioning());
+
+        assert_eq!(edge_strategy.lease_ttl_secs(), 10);
+        assert_eq!(edge_strategy.resource_type(), ResourceType::GraphEdge);
+        Ok(())
+    }
+
+    /// Manager uses strategy TTL when strategy is registered.
+    #[tokio::test]
+    async fn manager_uses_strategy_ttl() -> Result<()> {
+        let backing = shared_backing();
+        let reg = Arc::new(PrimaryPodRegistry::new());
+        let mgr = Arc::new(PartitionLeaseManager::new(
+            Arc::new(store(&backing)),
+            reg.clone(),
+            "solo",
+            999_999, // Default TTL (unused when strategy registered)
+        ));
+
+        // Register collection strategy (60s TTL)
+        mgr.register_strategy(Arc::new(CollectionStrategy));
+
+        // Acquire with ResourceKey - should use strategy TTL
+        let key = ResourceKey::legacy_collection("tenant1", "collection1");
+        assert!(mgr.acquire_with_key(&key, 0).await?);
+
+        // Verify the lease was created with strategy TTL (60s = 60000ms)
+        let stored = mgr.store.read_key(&key).await?.unwrap();
+        let lease = stored.1;
+        let expected_expiry = 60_000; // 60 seconds
+        assert_eq!(lease.expires_at_ms, expected_expiry);
+        Ok(())
+    }
+
+    /// Non-collection resource leases are renewed by full ResourceKey, not by
+    /// the legacy primary-pod registry.
+    #[tokio::test]
+    async fn manager_renews_generalized_resource_keys() -> Result<()> {
+        let backing = shared_backing();
+        let reg = Arc::new(PrimaryPodRegistry::new());
+        let mgr = Arc::new(PartitionLeaseManager::new(
+            Arc::new(store(&backing)),
+            reg,
+            "solo",
+            LEASE_MS,
+        ));
+
+        mgr.register_strategy(Arc::new(TableStrategy));
+        let key = ResourceKey::table("tenant1", "public", "users");
+        assert!(mgr.acquire_with_key(&key, 0).await?);
+        assert_eq!(mgr.renew_held(10_000).await?, 1);
+
+        let stored = mgr.store.read_key(&key).await?.unwrap();
+        let lease = stored.1;
+        assert_eq!(lease.holder_pod, "solo");
+        assert_eq!(lease.expires_at_ms, 130_000);
+        Ok(())
+    }
+
+    /// Table strategy creates composite keys for schema.table.
+    #[tokio::test]
+    async fn table_strategy_composite_key() -> Result<()> {
+        let strategy = TableStrategy;
+        let key = strategy.make_key(
+            "tenant1",
+            None,
+            &["schema1".to_string(), "table1".to_string()],
+        );
+
+        assert_eq!(key.tenant_id, "tenant1");
+        assert_eq!(key.resource_type, ResourceType::Table);
+        match key.resource_id {
+            ResourceIdentifier::Composite(ref parts) => {
+                assert_eq!(parts, &["schema1".to_string(), "table1".to_string()]);
+            }
+            _ => panic!("Expected composite identifier"),
+        }
+
+        // Verify path serialization (uses "/" for object storage path segments)
+        assert_eq!(key.to_path(), "tenant1/table/schema1/table1");
+        Ok(())
+    }
+
+    /// Schema strategy validates operations correctly.
+    #[tokio::test]
+    async fn schema_strategy_validates_operations() -> Result<()> {
+        let strategy = SchemaStrategy;
+
+        // SchemaChange is valid on schemas
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::SchemaChange)
+                .is_ok()
+        );
+
+        // Read/Write are invalid on schemas (schema-level only)
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Read)
+                .is_err()
+        );
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Write)
+                .is_err()
+        );
+
+        Ok(())
+    }
+
+    /// Graph hierarchy: Graph → GraphNode/GraphEdge.
+    #[tokio::test]
+    async fn graph_hierarchy_keys() -> Result<()> {
+        let graph_strategy = GraphStrategy;
+        let node_strategy = GraphNodeStrategy;
+        let edge_strategy = GraphEdgeStrategy;
+
+        let graph_key = graph_strategy.make_key("tenant1", None, &["graph1".to_string()]);
+        assert_eq!(graph_key.resource_type, ResourceType::Graph);
+
+        let node_key = node_strategy.make_key(
+            "tenant1",
+            None,
+            &["graph1".to_string(), "node1".to_string()],
+        );
+        assert_eq!(node_key.resource_type, ResourceType::GraphNode);
+        match node_key.resource_id {
+            ResourceIdentifier::Composite(parts) => {
+                assert_eq!(parts, vec!["graph1".to_string(), "node1".to_string()]);
+            }
+            _ => panic!("Expected composite identifier"),
+        }
+
+        let edge_key = edge_strategy.make_key(
+            "tenant1",
+            None,
+            &["graph1".to_string(), "edge1".to_string()],
+        );
+        assert_eq!(edge_key.resource_type, ResourceType::GraphEdge);
+
+        Ok(())
+    }
+
+    /// Model → ModelVersion hierarchy.
+    #[tokio::test]
+    async fn model_version_hierarchy() -> Result<()> {
+        let model_strategy = ModelStrategy;
+        let version_strategy = ModelVersionStrategy;
+
+        let model_key = model_strategy.make_key("tenant1", None, &["model1".to_string()]);
+        assert_eq!(model_key.resource_type, ResourceType::Model);
+
+        let version_key =
+            version_strategy.make_key("tenant1", None, &["model1".to_string(), "v1.0".to_string()]);
+        assert_eq!(version_key.resource_type, ResourceType::ModelVersion);
+        match version_key.resource_id {
+            ResourceIdentifier::Composite(ref parts) => {
+                assert_eq!(parts, &["model1".to_string(), "v1.0".to_string()]);
+            }
+            _ => panic!("Expected composite identifier"),
+        }
+
+        // Verify parent key lookup
+        let parent = model_strategy.parent_key(&version_key);
+        assert!(parent.is_some());
+        let parent = parent.unwrap();
+        assert_eq!(parent.resource_type, ResourceType::Model);
+        match parent.resource_id {
+            ResourceIdentifier::Single(s) => {
+                assert_eq!(s, "model1");
+            }
+            _ => panic!("Expected single identifier"),
+        }
+
+        Ok(())
+    }
+
+    /// Table → Schema hierarchy.
+    #[tokio::test]
+    async fn table_schema_hierarchy() -> Result<()> {
+        let table_strategy = TableStrategy;
+
+        let table_key = table_strategy.make_key(
+            "tenant1",
+            None,
+            &["public".to_string(), "users".to_string()],
+        );
+
+        // Verify parent key lookup
+        let parent = table_strategy.parent_key(&table_key);
+        assert!(parent.is_some());
+        let parent = parent.unwrap();
+        assert_eq!(parent.resource_type, ResourceType::Schema);
+        match parent.resource_id {
+            ResourceIdentifier::Single(s) => {
+                assert_eq!(s, "public");
+            }
+            _ => panic!("Expected single identifier"),
+        }
+
+        Ok(())
+    }
+
+    /// DML lock intent compatibility: MVP durable DML locks are exclusive.
+    #[tokio::test]
+    async fn dml_lock_exclusive_intent_compatibility() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+
+        // First lock should succeed.
+        let result1 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Read, 0)
+            .await?;
+        assert!(matches!(result1, LockOutcome::Acquired { .. }));
+
+        // Same-pod exact-scope reacquire renews the durable lease.
+        let result2 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Read, 100)
+            .await?;
+        assert!(matches!(result2, LockOutcome::Acquired { .. }));
+
+        // A broader schema lock conflicts with the table lock.
+        let schema_scope = DmlLockScope::Schema {
+            schema_name: "public".to_string(),
+        };
+        let result3 = lock_service
+            .acquire_dml_lock("tenant1", None, &schema_scope, LockIntent::Write, 200)
+            .await?;
+        assert!(matches!(result3, LockOutcome::Conflict));
+
+        lock_service.release_dml_lock("tenant1", None, &scope).await;
+
+        // Now Write should succeed
+        let result5 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Write, 400)
+            .await?;
+        assert!(matches!(result5, LockOutcome::Acquired { .. }));
+
+        Ok(())
+    }
+
+    /// DML lock hierarchical locking: Schema → Table → Partition.
+    #[tokio::test]
+    async fn dml_lock_hierarchy() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let schema_scope = DmlLockScope::Schema {
+            schema_name: "public".to_string(),
+        };
+        let table_scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let partition_scope = DmlLockScope::Partition {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+            partition_id: "p1".to_string(),
+        };
+
+        // Acquire schema lock
+        let schema_lock = lock_service
+            .acquire_dml_lock("tenant1", None, &schema_scope, LockIntent::Write, 0)
+            .await?;
+        assert!(matches!(schema_lock, LockOutcome::Acquired { .. }));
+
+        // Table lock should conflict with schema Write lock
+        let table_lock = lock_service
+            .acquire_dml_lock("tenant1", None, &table_scope, LockIntent::Read, 100)
+            .await?;
+        assert!(matches!(table_lock, LockOutcome::Conflict));
+
+        // Partition lock also conflicts with schema lock.
+        let partition_lock = lock_service
+            .acquire_dml_lock("tenant1", None, &partition_scope, LockIntent::Write, 200)
+            .await?;
+        assert!(matches!(partition_lock, LockOutcome::Conflict));
+
+        Ok(())
+    }
+
+    /// DML lock expiration and renewal.
+    #[tokio::test]
+    async fn dml_lock_expiration() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+
+        // Acquire lock at time 0
+        let result1 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Write, 0)
+            .await?;
+        assert!(matches!(result1, LockOutcome::Acquired { .. }));
+
+        // At time 500 (before 10s TTL), renewal by same pod should work
+        let result2 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Write, 500)
+            .await?;
+        assert!(matches!(result2, LockOutcome::Acquired { .. }));
+
+        // At time 15000 (after 10s TTL), lock should be expired
+        let result3 = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Write, 15000)
+            .await?;
+        // Should succeed because the old lease expired
+        assert!(matches!(result3, LockOutcome::Acquired { .. }));
+
+        Ok(())
+    }
+
+    /// DML lock release_all clears all locks for a pod.
+    #[tokio::test]
+    async fn dml_lock_release_all() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let scope1 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let scope2 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "orders".to_string(),
+        };
+
+        // Acquire two locks
+        lock_service
+            .acquire_dml_lock("tenant1", None, &scope1, LockIntent::Write, 0)
+            .await?;
+        lock_service
+            .acquire_dml_lock("tenant1", None, &scope2, LockIntent::Write, 100)
+            .await?;
+
+        // Verify locks are held
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 2);
+        drop(locks);
+
+        // Release all locks
+        lock_service.release_all_locks().await;
+
+        // Verify all locks are cleared
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 0);
+
+        Ok(())
+    }
+
+    /// DML lock guards own explicit local release.
+    #[tokio::test]
+    async fn dml_lock_guard_releases_local_registry() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = Arc::new(DmlLockService::new(Arc::new(manager), "pod-1".to_string()));
+
+        let scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let guard = lock_service
+            .acquire_dml_lock_guard("tenant1", Some("public"), scope, LockIntent::Write, 0)
+            .await?;
+        assert_eq!(guard.lease_generation(), 1);
+
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 1);
+        drop(locks);
+
+        guard.release().await;
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 0);
+
+        Ok(())
+    }
+
+    /// DML lock scope key generation is consistent.
+    #[tokio::test]
+    async fn dml_lock_scope_key_consistency() -> Result<()> {
+        let scope1 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let scope2 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let scope3 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "orders".to_string(),
+        };
+
+        // Same scope should produce same key
+        assert_eq!(scope1.to_key(), scope2.to_key());
+        // Different scope should produce different key
+        assert_ne!(scope1.to_key(), scope3.to_key());
+
+        Ok(())
+    }
+
+    /// DML lock reconciliation removes expired locks.
+    #[tokio::test]
+    async fn dml_lock_reconciliation_removes_expired() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let scope1 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let scope2 = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "orders".to_string(),
+        };
+
+        // Manually insert locks with different expiry times
+        let now_ms = now_millis();
+        let mut locks = lock_service.active_locks.write().await;
+        locks.insert(
+            DmlLockService::scoped_lock_key("tenant1", None, &scope1),
+            ActiveLock {
+                tenant_id: "tenant1".to_string(),
+                namespace_id: None,
+                scope: scope1.clone(),
+                pod_id: "pod-1".to_string(),
+                intent: LockIntent::Write,
+                acquired_at_ms: 0,
+                expires_at_ms: now_ms.saturating_sub(1),
+            },
+        );
+        locks.insert(
+            DmlLockService::scoped_lock_key("tenant1", None, &scope2),
+            ActiveLock {
+                tenant_id: "tenant1".to_string(),
+                namespace_id: None,
+                scope: scope2.clone(),
+                pod_id: "pod-1".to_string(),
+                intent: LockIntent::Write,
+                acquired_at_ms: 0,
+                expires_at_ms: now_ms.saturating_add(60_000),
+            },
+        );
+        drop(locks);
+
+        // Verify 2 locks
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 2);
+        drop(locks);
+
+        // Reconcile at time 10s (first lock expired, second still valid)
+        DmlLockService::reconcile_expired_locks(&lock_service.active_locks).await;
+
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 1);
+        assert!(locks.contains_key(&DmlLockService::scoped_lock_key("tenant1", None, &scope2)));
+        assert!(!locks.contains_key(&DmlLockService::scoped_lock_key("tenant1", None, &scope1)));
+
+        Ok(())
+    }
+
+    /// DML lock reconciliation loop runs periodically.
+    #[tokio::test]
+    async fn dml_lock_reconciliation_loop() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        let scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+
+        // Insert a lock that will expire soon
+        let mut locks = lock_service.active_locks.write().await;
+        locks.insert(
+            DmlLockService::scoped_lock_key("tenant1", None, &scope),
+            ActiveLock {
+                tenant_id: "tenant1".to_string(),
+                namespace_id: None,
+                scope: scope.clone(),
+                pod_id: "pod-1".to_string(),
+                intent: LockIntent::Write,
+                acquired_at_ms: 0,
+                expires_at_ms: 100, // Expires at 100ms
+            },
+        );
+        drop(locks);
+
+        // Start reconciliation loop with 50ms interval
+        let handle = lock_service.spawn_reconciliation_loop(50);
+
+        // Wait for at least one reconciliation cycle
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        // Verify lock was removed
+        let locks = lock_service.active_locks.read().await;
+        assert_eq!(locks.len(), 0);
+
+        // Shutdown the loop
+        lock_service.shutdown();
+
+        // Wait for the task to finish
+        let _ = tokio::time::timeout(Duration::from_millis(100), handle).await;
+
+        Ok(())
+    }
+
+    /// DML lock shutdown signals the reconciliation loop to stop.
+    #[tokio::test]
+    async fn dml_lock_shutdown_stops_reconciliation() -> Result<()> {
+        let backing = shared_backing();
+        let manager = test_manager(&backing, "test-pod");
+        let lock_service = DmlLockService::new(Arc::new(manager), "pod-1".to_string());
+
+        // Start reconciliation loop with 1s interval
+        let handle = lock_service.spawn_reconciliation_loop(1000);
+
+        // Shutdown immediately
+        lock_service.shutdown();
+
+        // Verify the task stopped quickly
+        let result = tokio::time::timeout(Duration::from_millis(100), handle).await;
+        assert!(
+            result.is_ok(),
+            "Reconciliation loop should stop on shutdown"
+        );
+
+        Ok(())
+    }
+
+    /// ML Model strategy validates model-specific operations.
+    #[tokio::test]
+    async fn ml_model_strategy_validates_operations() -> Result<()> {
+        let strategy = ModelStrategy;
+
+        // Model-specific operations should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::ModelRegister)
+                .is_ok()
+        );
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::ModelDeploy)
+                .is_ok()
+        );
+
+        // DDL-like operations should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Create)
+                .is_ok()
+        );
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Read)
+                .is_ok()
+        );
+
+        // Write operations should NOT be valid on models
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Write)
+                .is_err()
+        );
+
+        Ok(())
+    }
+
+    /// ML ExperimentRun strategy validates training run operations.
+    #[tokio::test]
+    async fn ml_experiment_run_validates_training_operations() -> Result<()> {
+        let strategy = ExperimentRunStrategy;
+
+        // Training-specific operations should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::TrainingRun)
+                .is_ok()
+        );
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::MetricWrite)
+                .is_ok()
+        );
+
+        // Write operations for logging should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Write)
+                .is_ok()
+        );
+
+        // Schema change should NOT be valid on experiment runs
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::SchemaChange)
+                .is_err()
+        );
+
+        Ok(())
+    }
+
+    /// ML FeatureSet strategy validates feature write operations.
+    #[tokio::test]
+    async fn ml_feature_set_validates_feature_operations() -> Result<()> {
+        let strategy = FeatureSetStrategy;
+
+        // Feature-specific operations should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::FeatureWrite)
+                .is_ok()
+        );
+
+        // DDL operations should be valid
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Create)
+                .is_ok()
+        );
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::Alter)
+                .is_ok()
+        );
+
+        // Training operations should NOT be valid on feature sets
+        assert!(
+            strategy
+                .validate_operation(&ResourceOperation::TrainingRun)
+                .is_err()
+        );
+
+        Ok(())
+    }
+
+    /// ML Model hierarchy: Model → ModelVersion.
+    #[tokio::test]
+    async fn ml_model_hierarchy_keys() -> Result<()> {
+        let model_strategy = ModelStrategy;
+        let version_strategy = ModelVersionStrategy;
+
+        let model_key = model_strategy.make_key("tenant1", None, &["my_model".to_string()]);
+        let version_key = version_strategy.make_key(
+            "tenant1",
+            None,
+            &["my_model".to_string(), "v1.0".to_string()],
+        );
+        assert_eq!(model_key.resource_type, ResourceType::Model);
+
+        // Verify model version parent is the model
+        let parent = version_strategy.parent_key(&version_key);
+        assert!(parent.is_some());
+        let parent = parent.unwrap();
+        assert_eq!(parent.resource_type, ResourceType::Model);
+        match parent.resource_id {
+            ResourceIdentifier::Single(s) => {
+                assert_eq!(s, "my_model");
+            }
+            _ => panic!("Expected single identifier"),
+        }
+
+        Ok(())
+    }
+
+    /// ML Experiment hierarchy: Experiment → ExperimentRun.
+    #[tokio::test]
+    async fn ml_experiment_hierarchy_keys() -> Result<()> {
+        let exp_strategy = ExperimentStrategy;
+        let run_strategy = ExperimentRunStrategy;
+
+        let exp_key = exp_strategy.make_key("tenant1", None, &["exp1".to_string()]);
+        let run_key =
+            run_strategy.make_key("tenant1", None, &["exp1".to_string(), "run123".to_string()]);
+        assert_eq!(exp_key.resource_type, ResourceType::Experiment);
+
+        // Verify experiment run parent is the experiment
+        let parent = run_strategy.parent_key(&run_key);
+        assert!(parent.is_some());
+        let parent = parent.unwrap();
+        assert_eq!(parent.resource_type, ResourceType::Experiment);
+        match parent.resource_id {
+            ResourceIdentifier::Single(s) => {
+                assert_eq!(s, "exp1");
+            }
+            _ => panic!("Expected single identifier"),
+        }
+
+        Ok(())
+    }
+
+    /// ML operations use appropriate TTLs.
+    #[tokio::test]
+    async fn ml_strategies_use_appropriate_ttls() -> Result<()> {
+        let model_strategy = ModelStrategy;
+        let version_strategy = ModelVersionStrategy;
+        let exp_strategy = ExperimentStrategy;
+        let run_strategy = ExperimentRunStrategy;
+        let feature_strategy = FeatureSetStrategy;
+
+        // Models have long TTL (300s) - rare updates
+        assert_eq!(model_strategy.lease_ttl_secs(), 300);
+        assert_eq!(version_strategy.lease_ttl_secs(), 300);
+
+        // Experiments have moderate TTL (120s) - moderately frequent updates
+        assert_eq!(exp_strategy.lease_ttl_secs(), 120);
+        assert_eq!(feature_strategy.lease_ttl_secs(), 120);
+
+        // Experiment runs have shorter TTL (60s) - frequent updates during training
+        assert_eq!(run_strategy.lease_ttl_secs(), 60);
+
+        Ok(())
+    }
+
+    /// ML resource keys serialize correctly for storage.
+    #[tokio::test]
+    async fn ml_resource_keys_serialize_correctly() -> Result<()> {
+        let model_strategy = ModelStrategy;
+        let exp_strategy = ExperimentStrategy;
+
+        let model_key =
+            model_strategy.make_key("tenant1", Some("ml-namespace"), &["my_model".to_string()]);
+        let exp_key = exp_strategy.make_key("tenant1", None, &["exp1".to_string()]);
+
+        // Model with namespace: {tenant}/{namespace}/{type}/{name}
+        assert_eq!(model_key.to_path(), "tenant1/ml-namespace/model/my_model");
+
+        // Experiment without namespace: {tenant}/{type}/{name}
+        assert_eq!(exp_key.to_path(), "tenant1/experiment/exp1");
+
         Ok(())
     }
 }

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -1693,15 +1693,14 @@ impl PartitionLease {
             return Cow::Borrowed(self);
         }
 
-        // Migrate from legacy format
-        let tenant_id = self
-            .tenant_id
-            .as_deref()
-            .expect("legacy lease must have tenant_id");
-        let collection_id = self
-            .collection_id
-            .as_deref()
-            .expect("legacy lease must have collection_id");
+        // Migrate from legacy format — only when the legacy identity is
+        // present. A malformed legacy lease (no identity) is left as-is
+        // rather than panicking.
+        let (Some(tenant_id), Some(collection_id)) =
+            (self.tenant_id.as_deref(), self.collection_id.as_deref())
+        else {
+            return Cow::Borrowed(self);
+        };
 
         let migrated = Self {
             resource_key: Some(ResourceKey::legacy_collection(tenant_id, collection_id)),
@@ -1722,19 +1721,23 @@ impl PartitionLease {
     pub fn key(&self) -> Cow<'_, ResourceKey> {
         let migrated = self.ensure_migrated();
         match &migrated {
-            Cow::Borrowed(lease) => Cow::Borrowed(
-                lease
-                    .resource_key
-                    .as_ref()
-                    .expect("migrated lease must have resource_key"),
-            ),
-            Cow::Owned(lease) => Cow::Owned(
-                lease
-                    .resource_key
-                    .as_ref()
-                    .expect("migrated lease must have resource_key")
-                    .clone(),
-            ),
+            Cow::Borrowed(lease) => match lease.resource_key.as_ref() {
+                // Normal path: the lease carries its key.
+                Some(k) => Cow::Borrowed(k),
+                // Malformed lease with no key and no migratable identity:
+                // synthesize an empty legacy key rather than panic.
+                None => Cow::Owned(ResourceKey::legacy_collection(
+                    lease.tenant_id.as_deref().unwrap_or(""),
+                    lease.collection_id.as_deref().unwrap_or(""),
+                )),
+            },
+            Cow::Owned(lease) => match lease.resource_key.as_ref() {
+                Some(k) => Cow::Owned(k.clone()),
+                None => Cow::Owned(ResourceKey::legacy_collection(
+                    lease.tenant_id.as_deref().unwrap_or(""),
+                    lease.collection_id.as_deref().unwrap_or(""),
+                )),
+            },
         }
     }
 

--- a/src/metrics/dml_lock_metrics.rs
+++ b/src/metrics/dml_lock_metrics.rs
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2025 ProximaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+//! DML lock-manager observability (A9 foundation gate).
+//!
+//! Operator answers:
+//!
+//! * **Are DML locks contended?** A rising
+//!   `proximadb_dml_lock_acquisitions_total{outcome="conflict"|"held"}`
+//!   rate means writes are blocking each other (or other pods) — a sign of
+//!   hot tables or leases too short for the workload.
+//! * **How long does acquisition take?**
+//!   `proximadb_dml_lock_acquisition_duration_seconds` carries the wall-clock
+//!   cost of an acquire (in-memory scan + one object-store CAS). A shift right
+//!   means the object-store metadata path is on the critical write path.
+//! * **How many locks are held right now?** `proximadb_dml_locks_held_current`
+//!   per resource type — sizing the in-memory registry and bounding renewal
+//!   load.
+//! * **Are renewals failing?** `proximadb_dml_lock_renewal_failures_total`
+//!   spikes precede silent lease loss (a pod keeps serving writes its lease
+//!   no longer authorizes).
+//!
+//! Labels are intentionally low-cardinality: a fixed `outcome` enum, a fixed
+//! `resource_type` enum, and `tenant_id` only on the acquisition counter
+//! (matches `primary_pod_metrics` precedent; the histogram/gauge/renewal
+//! counter omit it to bound cardinality).
+
+use std::time::Duration;
+
+use lazy_static::lazy_static;
+use prometheus::{
+    CounterVec, HistogramOpts, HistogramVec, IntGaugeVec, Opts, register_counter_vec,
+    register_histogram_vec, register_int_gauge_vec,
+};
+use tracing::error;
+
+fn register_counter_vec_safe(name: &str, help: &str, labels: &[&str]) -> CounterVec {
+    match register_counter_vec!(name, help, labels) {
+        Ok(metric) => metric,
+        Err(reg_err) => {
+            error!("Failed to register {}: {}", name, reg_err);
+            CounterVec::new(Opts::new(name, help), labels).unwrap_or_else(|_| {
+                CounterVec::new(Opts::new(format!("{}_fallback", name), help), labels)
+                    .unwrap_or_else(|_| unreachable!("valid counter metric descriptor"))
+            })
+        }
+    }
+}
+
+fn register_histogram_vec_safe(
+    name: &str,
+    help: &str,
+    labels: &[&str],
+    buckets: Vec<f64>,
+) -> HistogramVec {
+    match register_histogram_vec!(name, help, labels, buckets.clone()) {
+        Ok(metric) => metric,
+        Err(reg_err) => {
+            error!("Failed to register {}: {}", name, reg_err);
+            HistogramVec::new(
+                HistogramOpts::new(name, help).buckets(buckets.clone()),
+                labels,
+            )
+            .unwrap_or_else(|_| {
+                HistogramVec::new(
+                    HistogramOpts::new(format!("{}_fallback", name), help).buckets(buckets),
+                    labels,
+                )
+                .unwrap_or_else(|_| unreachable!("valid histogram metric descriptor"))
+            })
+        }
+    }
+}
+
+fn register_int_gauge_vec_safe(name: &str, help: &str, labels: &[&str]) -> IntGaugeVec {
+    match register_int_gauge_vec!(name, help, labels) {
+        Ok(metric) => metric,
+        Err(reg_err) => {
+            error!("Failed to register {}: {}", name, reg_err);
+            IntGaugeVec::new(Opts::new(name, help), labels).unwrap_or_else(|_| {
+                IntGaugeVec::new(Opts::new(format!("{}_fallback", name), help), labels)
+                    .unwrap_or_else(|_| unreachable!("valid gauge metric descriptor"))
+            })
+        }
+    }
+}
+
+/// Bucket layout for DML lock acquisition latency. Locks should be cheap
+/// (an in-memory scan plus one object-store CAS), so the buckets span
+/// sub-millisecond up to a few seconds — anything past ~1s means the
+/// object-store metadata path is dominating the write.
+fn acquisition_duration_buckets() -> Vec<f64> {
+    vec![
+        0.000_5, // 0.5 ms — in-memory fast path only
+        0.001,   // 1 ms
+        0.002_5, // 2.5 ms
+        0.005,   // 5 ms
+        0.01,    // 10 ms — one local CAS
+        0.025,   // 25 ms
+        0.05,    // 50 ms
+        0.1,     // 100 ms — one cloud CAS
+        0.25,    // 250 ms
+        0.5,     // 500 ms
+        1.0,     // 1 s — metadata-bound; investigate
+        5.0,     // 5 s — pathological / object-store stall
+    ]
+}
+
+lazy_static! {
+    /// DML lock acquisition attempts by outcome. The `outcome` label is one
+    /// of `acquired` / `conflict` / `held` / `fenced`, matching
+    /// [`crate::cluster::partition_lease::LockOutcome`].
+    pub static ref DML_LOCK_ACQUISITIONS_TOTAL: CounterVec = register_counter_vec_safe(
+        "proximadb_dml_lock_acquisitions_total",
+        "DML lock acquisition attempts by outcome",
+        &["outcome", "resource_type", "tenant_id"],
+    );
+
+    /// Wall-clock duration of a DML lock acquisition (in-memory scan + the
+    /// object-store CAS that establishes the durable lease).
+    pub static ref DML_LOCK_ACQUISITION_DURATION_SECONDS: HistogramVec =
+        register_histogram_vec_safe(
+            "proximadb_dml_lock_acquisition_duration_seconds",
+            "Wall-clock duration of DML lock acquisition attempts",
+            &["outcome", "resource_type"],
+            acquisition_duration_buckets(),
+        );
+
+    /// DML locks currently held by this pod, by resource type. Inc on
+    /// acquire, dec on release.
+    pub static ref DML_LOCKS_HELD_CURRENT: IntGaugeVec = register_int_gauge_vec_safe(
+        "proximadb_dml_locks_held_current",
+        "DML locks currently held by this pod",
+        &["resource_type"],
+    );
+
+    /// Failures renewing a held DML/resource lease. Sustained rate precedes
+    /// silent lease loss (a pod serving writes its lease no longer covers).
+    pub static ref DML_LOCK_RENEWAL_FAILURES_TOTAL: CounterVec = register_counter_vec_safe(
+        "proximadb_dml_lock_renewal_failures_total",
+        "DML/resource lease renewal failures",
+        &["resource_type"],
+    );
+}
+
+/// Record a DML lock acquisition outcome + its wall-clock duration. Bumps the
+/// per-outcome counter (with tenant) and observes the latency histogram.
+pub fn record_acquisition(outcome: &str, resource_type: &str, tenant_id: &str, elapsed: Duration) {
+    DML_LOCK_ACQUISITIONS_TOTAL
+        .with_label_values(&[outcome, resource_type, tenant_id])
+        .inc();
+    DML_LOCK_ACQUISITION_DURATION_SECONDS
+        .with_label_values(&[outcome, resource_type])
+        .observe(elapsed.as_secs_f64());
+}
+
+/// Mark one more DML lock held for `resource_type`.
+pub fn inc_held(resource_type: &str) {
+    DML_LOCKS_HELD_CURRENT
+        .with_label_values(&[resource_type])
+        .inc();
+}
+
+/// Mark one fewer DML lock held for `resource_type`.
+pub fn dec_held(resource_type: &str) {
+    DML_LOCKS_HELD_CURRENT
+        .with_label_values(&[resource_type])
+        .dec();
+}
+
+/// Record a lease-renewal failure for `resource_type`.
+pub fn record_renewal_failure(resource_type: &str) {
+    DML_LOCK_RENEWAL_FAILURES_TOTAL
+        .with_label_values(&[resource_type])
+        .inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_acquisition_increments_counter() {
+        let before = DML_LOCK_ACQUISITIONS_TOTAL
+            .with_label_values(&["acquired", "table", "test-tenant-a"])
+            .get();
+        record_acquisition(
+            "acquired",
+            "table",
+            "test-tenant-a",
+            Duration::from_micros(800),
+        );
+        let after = DML_LOCK_ACQUISITIONS_TOTAL
+            .with_label_values(&["acquired", "table", "test-tenant-a"])
+            .get();
+        assert!((after - before - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_acquisition_observes_histogram_without_panic() {
+        // Histograms have no trivial .get(); assert observe is well-formed.
+        record_acquisition(
+            "conflict",
+            "schema",
+            "test-tenant-b",
+            Duration::from_millis(3),
+        );
+        record_acquisition(
+            "held",
+            "table",
+            "test-tenant-c",
+            Duration::from_secs_f64(0.075),
+        );
+    }
+
+    #[test]
+    fn inc_and_dec_held_balances_gauge() {
+        let before = DML_LOCKS_HELD_CURRENT.with_label_values(&["table"]).get();
+        inc_held("table");
+        inc_held("table");
+        assert_eq!(
+            DML_LOCKS_HELD_CURRENT.with_label_values(&["table"]).get(),
+            before + 2
+        );
+        dec_held("table");
+        dec_held("table");
+        assert_eq!(
+            DML_LOCKS_HELD_CURRENT.with_label_values(&["table"]).get(),
+            before
+        );
+    }
+
+    #[test]
+    fn record_renewal_failure_increments_counter() {
+        let before = DML_LOCK_RENEWAL_FAILURES_TOTAL
+            .with_label_values(&["collection"])
+            .get();
+        record_renewal_failure("collection");
+        let after = DML_LOCK_RENEWAL_FAILURES_TOTAL
+            .with_label_values(&["collection"])
+            .get();
+        assert!((after - before - 1.0).abs() < 1e-9);
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -191,6 +191,9 @@ pub mod collection_pin_metrics;
 pub mod collectors;
 pub mod compression;
 pub mod consumption_metrics;
+/// DML lock-manager observability — acquisition outcome counter + duration
+/// histogram + held-current gauge + renewal-failure counter.
+pub mod dml_lock_metrics;
 /// Prometheus bridge for `proximadb_catalog::dr_reconciler::DrMetrics`.
 pub mod dr_metrics;
 pub mod exporters;

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -22,6 +22,7 @@ use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTreeNode};
 use tracing::{debug, info, warn};
 
 use crate::catalog::CatalogManager;
+use crate::cluster::partition_lease::{DmlLockGuard, DmlLockScope, DmlLockService, LockIntent};
 use crate::query::table_write_executor::{
     DataFusionTableWriteExecutor, NativeTableWriteExecutor, ParentTableResolver,
     PlannedOnlyTableWriteExecutor, ResolvedParentTable, TableRecordStoreSourceReader,
@@ -46,6 +47,7 @@ use crate::services::{
 };
 use crate::storage::tenant::context::TenantContext;
 use crate::storage::trait_components::path_resolver::DrPathBuilder;
+use proximadb_catalog::TableIdentifier;
 use proximadb_storage_common::object_store_bridge::ObjectStoreBridge;
 
 /// Placeholder tenant used by warehouse materialization when no `TenantContext`
@@ -625,6 +627,9 @@ pub struct DmlService {
     record_store: Arc<dyn TableRecordStore>,
     /// Routed table-write executor for INSERT SELECT / OVERWRITE / CTAS / MERGE.
     table_write_executor: Arc<dyn TableWriteExecutor>,
+    /// Optional tenant-scoped DML lock service. When absent, DML executes with
+    /// the legacy local behavior.
+    dml_lock_service: Option<Arc<DmlLockService>>,
 }
 
 impl DmlService {
@@ -731,6 +736,7 @@ impl DmlService {
             catalog_manager,
             record_store,
             table_write_executor,
+            dml_lock_service: None,
         }
     }
 
@@ -741,6 +747,12 @@ impl DmlService {
     /// in the cross-modal fusion seam (F-D).
     pub fn record_store(&self) -> Arc<dyn TableRecordStore> {
         self.record_store.clone()
+    }
+
+    /// Attach the tenant-scoped DML lock service.
+    pub fn with_dml_lock_service(mut self, dml_lock_service: Arc<DmlLockService>) -> Self {
+        self.dml_lock_service = Some(dml_lock_service);
+        self
     }
 
     /// Execute a DML statement (single-tenant / unscoped).
@@ -827,6 +839,63 @@ impl DmlService {
             .resolve_table_scoped(table_name, tenant)
             .await?;
         catalog.table_exists(&table_id).await
+    }
+
+    async fn acquire_table_dml_lock(
+        &self,
+        table_id: &TableIdentifier,
+        tenant_context: Option<&TenantContext>,
+        intent: LockIntent,
+    ) -> Result<Option<DmlLockGuard>> {
+        let Some(lock_service) = &self.dml_lock_service else {
+            return Ok(None);
+        };
+
+        let tenant_id = tenant_context
+            .map(|tc| tc.tenant_id.as_str())
+            .unwrap_or(DEFAULT_TENANT_PLACEHOLDER);
+        let namespace_id = Self::dml_lock_namespace_id(table_id, tenant_context);
+        let scope = DmlLockScope::Table {
+            schema_name: namespace_id.clone(),
+            table_name: table_id.name.clone(),
+        };
+
+        let guard = lock_service
+            .acquire_dml_lock_guard(
+                tenant_id,
+                Some(namespace_id.as_str()),
+                scope,
+                intent,
+                Self::now_unix_ms(),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "acquiring DML lock for tenant '{tenant_id}', namespace '{namespace_id}', table '{}'",
+                    table_id.name
+                )
+            })?;
+        Ok(Some(guard))
+    }
+
+    fn dml_lock_namespace_id(
+        table_id: &TableIdentifier,
+        tenant_context: Option<&TenantContext>,
+    ) -> String {
+        let namespace = if let Some(tenant) = tenant_context {
+            table_id
+                .namespace
+                .strip_prefix(std::slice::from_ref(&tenant.tenant_id))
+                .unwrap_or(table_id.namespace.as_slice())
+        } else {
+            table_id.namespace.as_slice()
+        };
+
+        if namespace.is_empty() {
+            DEFAULT_NAMESPACE_ID.to_string()
+        } else {
+            namespace.join(".")
+        }
     }
 
     /// Scan current visible records for a cataloged table through the shared
@@ -1660,6 +1729,16 @@ impl DmlService {
                 tenant_context.map(|tc| tc.tenant_id.as_str()),
             )
             .await?;
+        let (_catalog, target_table_id) = self
+            .catalog_manager
+            .resolve_table_scoped(
+                &plan.target.qualified_name(),
+                tenant_context.map(|tc| tc.tenant_id.as_str()),
+            )
+            .await?;
+        let dml_lock_guard = self
+            .acquire_table_dml_lock(&target_table_id, tenant_context, LockIntent::Write)
+            .await?;
         let source_metadata = self
             .resolve_table_write_source_metadata(
                 plan,
@@ -1710,10 +1789,15 @@ impl DmlService {
             .await?;
 
         match execution.status {
-            TableWriteExecutionStatus::Completed => Ok(DmlResult::success(
-                execution.rows_written,
-                format!("Table write completed through {}", execution.route_summary),
-            )),
+            TableWriteExecutionStatus::Completed => {
+                if let Some(guard) = dml_lock_guard {
+                    guard.release().await;
+                }
+                Ok(DmlResult::success(
+                    execution.rows_written,
+                    format!("Table write completed through {}", execution.route_summary),
+                ))
+            }
             TableWriteExecutionStatus::PlannedOnly => Err(anyhow!(
                 "INSERT ... SELECT and INSERT OVERWRITE execution is not implemented yet; planned route: {}, guards={:?}",
                 execution.route_summary,
@@ -2375,6 +2459,9 @@ impl DmlService {
 
         // Get table schema for column mapping
         let table_schema = catalog.get_table(&table_id).await?;
+        let dml_lock_guard = self
+            .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
+            .await?;
         let (write_intent, write_lane_decision) = Self::route_row_dml_write_intent(
             &table_schema,
             WriteOperationKind::Insert,
@@ -2523,10 +2610,13 @@ impl DmlService {
         self.bump_column_minmax(table_name, column_minmax).await;
         self.bump_column_ndv(table_name, column_ndv).await;
 
-        Ok(
+        let result =
             DmlResult::success(num_records as u64, format!("Inserted {} rows", num_records))
-                .with_inserted_ids(inserted_ids),
-        )
+                .with_inserted_ids(inserted_ids);
+        if let Some(guard) = dml_lock_guard {
+            guard.release().await;
+        }
+        Ok(result)
     }
 
     /// Execute UPDATE statement
@@ -2551,6 +2641,9 @@ impl DmlService {
         }
 
         let table_schema = catalog.get_table(&table_id).await?;
+        let dml_lock_guard = self
+            .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
+            .await?;
         let ids_to_update = if let Some(ref wc) = where_clause {
             self.resolve_matching_ids(&table_schema, &table_id.name, wc, tenant_context)
                 .await?
@@ -2670,6 +2763,9 @@ impl DmlService {
             format!("Updated {} rows", updated_count),
         );
         result.warnings = warnings;
+        if let Some(guard) = dml_lock_guard {
+            guard.release().await;
+        }
         Ok(result)
     }
 
@@ -2693,6 +2789,9 @@ impl DmlService {
         }
 
         let table_schema = catalog.get_table(&table_id).await?;
+        let dml_lock_guard = self
+            .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
+            .await?;
 
         // Get IDs to delete based on WHERE clause
         let ids_to_delete = if let Some(ref wc) = where_clause {
@@ -2748,10 +2847,14 @@ impl DmlService {
         self.bump_row_count_stats(table_name, -(deleted_count as i64))
             .await;
 
-        Ok(DmlResult::success(
+        let result = DmlResult::success(
             deleted_count as u64,
             format!("Deleted {} rows", deleted_count),
-        ))
+        );
+        if let Some(guard) = dml_lock_guard {
+            guard.release().await;
+        }
+        Ok(result)
     }
 
     /// Execute UPSERT statement
@@ -2776,6 +2879,9 @@ impl DmlService {
 
         // Get table schema
         let table_schema = catalog.get_table(&table_id).await?;
+        let dml_lock_guard = self
+            .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
+            .await?;
         let (write_intent, write_lane_decision) = Self::route_row_dml_write_intent(
             &table_schema,
             WriteOperationKind::Upsert,
@@ -2826,10 +2932,13 @@ impl DmlService {
         self.bump_row_count_stats(table_name, num_records as i64)
             .await;
 
-        Ok(
+        let result =
             DmlResult::success(num_records as u64, format!("Upserted {} rows", num_records))
-                .with_inserted_ids(inserted_ids),
-        )
+                .with_inserted_ids(inserted_ids);
+        if let Some(guard) = dml_lock_guard {
+            guard.release().await;
+        }
+        Ok(result)
     }
 
     // ========================
@@ -4501,6 +4610,10 @@ mod tests {
         assert!(resolve_materialize_prefix("..", "ns_1", None, pc, "orders").is_err());
     }
 
+    use crate::cluster::partition_lease::{
+        DmlLockScope, DmlLockService, LockOutcome, PartitionLeaseManager, PartitionLeaseStore,
+    };
+    use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
     use crate::query::table_write_executor::PlannedOnlyTableWriteExecutor;
     use crate::services::operations::batch_result::OperationMetrics;
     use crate::services::record_store::{
@@ -4513,6 +4626,7 @@ mod tests {
         CatalogWorkloadProfile,
     };
     use proximadb_iceberg_engine::IcebergObjectStoreBridge;
+    use proximadb_object_store::ProximaObjectStore;
 
     struct ExplainOnlyRecordStore;
 
@@ -4564,6 +4678,67 @@ mod tests {
             )
             .with_column(CatalogColumn::new(4, "notes", ProximaType::String))
             .with_primary_key(vec!["record_id".to_string()])
+    }
+
+    #[tokio::test]
+    async fn dml_service_table_lock_uses_resolved_tenant_namespace() -> Result<()> {
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let lease_store = Arc::new(PartitionLeaseStore::new(
+            ProximaObjectStore::new(backing),
+            "_operator/leases",
+        ));
+        let lease_manager = Arc::new(PartitionLeaseManager::new(
+            lease_store,
+            Arc::new(PrimaryPodRegistry::new()),
+            "pod-1",
+            10_000,
+        ));
+        let lock_service = Arc::new(DmlLockService::new(lease_manager, "pod-1"));
+
+        let dml = DmlService::with_record_store_and_table_write_executor(
+            Arc::new(CatalogManager::new()),
+            Arc::new(ExplainOnlyRecordStore),
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        )
+        .with_dml_lock_service(lock_service.clone());
+
+        let tenant = TenantContext::for_tenant_id("tenant_a");
+        let table_id =
+            TableIdentifier::new(vec!["tenant_a".to_string(), "default".to_string()], "users");
+        let guard = dml
+            .acquire_table_dml_lock(&table_id, Some(&tenant), LockIntent::Write)
+            .await?
+            .expect("lock guard");
+        assert_eq!(guard.lease_generation(), 1);
+
+        let schema_scope = DmlLockScope::Schema {
+            schema_name: "default".to_string(),
+        };
+        let conflict = lock_service
+            .acquire_dml_lock(
+                "tenant_a",
+                Some("default"),
+                &schema_scope,
+                LockIntent::Write,
+                1,
+            )
+            .await?;
+        assert!(matches!(conflict, LockOutcome::Conflict));
+
+        guard.release().await;
+        let after_release = lock_service
+            .acquire_dml_lock(
+                "tenant_a",
+                Some("default"),
+                &schema_scope,
+                LockIntent::Write,
+                2,
+            )
+            .await?;
+        assert!(matches!(after_release, LockOutcome::Acquired { .. }));
+
+        Ok(())
     }
 
     #[test]

--- a/src/services/write_intent.rs
+++ b/src/services/write_intent.rs
@@ -130,6 +130,12 @@ pub struct WriteIntent {
     pub estimated_bytes: Option<u64>,
     pub requires_row_level_semantics: bool,
     pub batch_local_constraints_sufficient: bool,
+
+    /// Fencing generation from the DML lock guard that authorizes this
+    /// write (A6 boundary seam). `None` for non-DML/legacy writes. The
+    /// storage writer validates this against the current durable lease
+    /// generation before committing.
+    pub fencing_generation: Option<u64>,
 }
 
 impl WriteIntent {
@@ -150,6 +156,7 @@ impl WriteIntent {
             estimated_bytes: None,
             requires_row_level_semantics,
             batch_local_constraints_sufficient: false,
+            fencing_generation: None,
         }
     }
 
@@ -205,6 +212,14 @@ impl WriteIntent {
 
     pub fn with_batch_local_constraints_sufficient(mut self, sufficient: bool) -> Self {
         self.batch_local_constraints_sufficient = sufficient;
+        self
+    }
+
+    /// Attach the fencing generation from a DML lock guard (A6 seam).
+    /// The storage writer validates this against the current durable
+    /// lease generation before committing the mutation.
+    pub fn with_fencing_generation(mut self, generation: u64) -> Self {
+        self.fencing_generation = Some(generation);
         self
     }
 


### PR DESCRIPTION
feat(cluster): unified ResourceKey lease + DML lock foundation

Complete the foundation gates from the unified-resource-lease review
(UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc) in
src/cluster/partition_lease.rs, landing the A6 fencing seam on develop so
parallel branches converge on one contract.

- F5/A5: enforce hierarchical locking — DmlLockScope::is_ancestor_of /
  is_descendant_of wired into acquire_dml_lock (a schema/table lock now
  fences its descendants).
- A6 (seam, staged): DmlLockGuard carries lease_generation(); the DML
  request carries it on WriteIntent::fencing_generation; validate_fencing
  is the pure, unit-tested storage-writer contract. Engine-level
  enforcement is a follow-up TD (FlushParameters deliberately not extended
  — ~150 test construction sites would break the test build).
- F7: fenced durable release via a released-tombstone committed at
  generation+1 (preserves the monotonic fence; object-store delete was
  rejected as it would reset generation to 1). TTL stays the crash fallback.
- A9: src/metrics/dml_lock_metrics.rs — acquisition counter + duration
  histogram + held-current gauge + renewal-failure counter, wired into
  acquire_dml_lock / release_full / renew_held.
- F12: review-doc resource-type count corrected (13).

A7 (DmlService integration) and A8 (protocol mapping) are deliberately
excluded — gated behind the A6-enforcement TD (a protocol-level lock that
is not fenced at the storage writer is only advisory).

Verified: cargo check --lib green; 46 partition_lease + dml_lock_metrics +
validate_fencing nextest cases pass (no regressions); cargo fmt clean.
