### PR TITLE
refactor(rest): hoist FusionService to a shared boot port (search-surface alignment, step 1)

### DIFF
--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -48,6 +48,11 @@ pub struct AppState {
     /// Document service, extracted at boot (TD-104 S5). Feeds the document AQL
     /// source; same `Arc` as the root handler.
     pub document_service: Arc<crate::storage::document::DocumentService>,
+    /// Cross-modal fusion service — the single retrieval port every search
+    /// surface delegates to (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`).
+    /// Constructed once at boot from the vector + graph services (mirrors the
+    /// TD-104 S5 extraction pattern) instead of per-request in each handler.
+    pub fusion_service: Arc<crate::services::fusion_service::FusionService>,
     /// Observability service, extracted at boot (TD-104 S5). Feeds the
     /// observability AQL source; same `Arc` as the root handler.
     pub observability_service: Arc<crate::observability::ObservabilityService>,
@@ -183,6 +188,13 @@ impl AppState {
         let document_service = request_handlers.document_service.clone();
         let observability_service = request_handlers.observability_service.clone();
         let event_log = request_handlers.event_log.clone();
+        // Cross-modal fusion port — built once at boot from the vector + graph
+        // services (search-surface contract: one retrieval engine, shared port).
+        let fusion_service =
+            std::sync::Arc::new(crate::services::fusion_service::FusionService::new(
+                request_handlers.vector_operations_service.clone(),
+                request_handlers.graph_operations_service.clone(),
+            ));
         // TD-104 2(b): default `api_handlers` to the root handler cast to its
         // `ApiHandlersPort` impl. Production overrides via `with_api_handlers`
         // with the runtime port-based handler; legacy/dev/test paths that never
@@ -195,6 +207,7 @@ impl AppState {
             graph_execution_service,
             vector_operations_service,
             document_service,
+            fusion_service,
             observability_service,
             event_log,
             security_coordinator,

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -16,7 +16,7 @@ use crate::errors::{ApiError, ApiResult};
 use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::openapi::ErrorResponse;
 use crate::network::rest::v1::handlers::AppState;
-use crate::services::fusion_service::{FusionService, GraphFusionParams, GraphGrain};
+use crate::services::fusion_service::{GraphFusionParams, GraphGrain};
 
 fn default_limit() -> usize {
     10
@@ -138,10 +138,9 @@ pub async fn fusion_search_v2(
         policy.consensus_beta = beta;
     }
 
-    let service = FusionService::new(
-        state.vector_operations_service.clone(),
-        state.request_handlers.graph_operations_service.clone(),
-    );
+    // Use the shared fusion port constructed once at boot (AppState::fusion_service),
+    // per the search-surface contract — one retrieval engine, no per-handler construction.
+    let service = state.fusion_service.clone();
     let params = GraphFusionParams {
         graph_id,
         vector_collection: request.vector_collection,


### PR DESCRIPTION
## Summary
First implementation step aligning the code to the search-surface contract (PR #280 / `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`): **make `FusionService` a real shared port** instead of an ad-hoc per-request construction.

Today `fusion_search_v2` builds `FusionService::new(vector, graph)` on every request. That contradicts the contract's assertion that `FusionService` is *the* internal retrieval port every surface delegates to — and it's why `EntityService` (no handle) and gRPC (no surface) currently can't reach the seam.

## Change (behavior-preserving)
- Construct `FusionService` once at boot in `AppState::new` from the existing `request_handlers` vector + graph services (same TD-104 S5 extraction pattern already used for `vector_operations_service`/`document_service`).
- `fusion_search_v2` now consumes `state.fusion_service` (Arc clone) instead of calling `FusionService::new`.

Same `FusionService`, same `graph_fusion_search` call — just built once and shared. `fusion_service.rs` logic and its 9 unit tests are untouched.

## Why this is step 1
It unblocks the rest of the alignment without touching the in-progress fusion *algorithm* (TD-136/137):
- **gRPC `FusionSearch`** (TD-143) can now reach the port via state instead of the legacy `execute_hybrid_query`.
- **`EntityService.SearchEntities`** (TD-146) can delegate once key-correlation (TD-142, entity node id vs vector oid) is resolved.

## Verified
- `cargo check --lib` clean (toolchain pinned 1.95.0); `cargo fmt` clean.
- Diff: 2 files, +18/-5.

## Out of scope (follow-up PRs)
- gRPC fusion surface (TD-143), EntityService delegation (TD-146), converging `hybrid/search` onto the `DocumentExpander` (TD-138).
