### PR TITLE
feat(grpc): ProximaFusionService v2 — cross-modal fusion over gRPC (search-surface alignment, step 2)

### DIFF
--- a/clients/python/tests/unit/grpc_drift_baseline.json
+++ b/clients/python/tests/unit/grpc_drift_baseline.json
@@ -11,6 +11,8 @@
     "missing-servicer:proto/proximadb/v1/security.proto::SecurityService",
     "missing-servicer:proto/proximadb/v1/streaming.proto::StreamingService",
     "missing-servicer:proto/proximadb/v2/document.proto::ProximaDocumentService",
+    "missing-servicer:proto/proximadb/v2/fusion.proto::ProximaFusionService",
+    "missing-stub:proto/proximadb/v2/fusion.proto",
     "missing-stub:proto/proximadb/v1/catalog.proto",
     "missing-stub:proto/proximadb/v1/cluster.proto",
     "missing-stub:proto/proximadb/v1/observability.proto",

--- a/crates/foundation/proximadb-proto/build.rs
+++ b/crates/foundation/proximadb-proto/build.rs
@@ -29,20 +29,25 @@ fn main() {
     let record_proto = repo_root.join("proto/proximadb/v2/record.proto");
     let graph_proto = repo_root.join("proto/proximadb/v2/graph.proto");
     let document_proto = repo_root.join("proto/proximadb/v2/document.proto");
+    let fusion_proto = repo_root.join("proto/proximadb/v2/fusion.proto");
     let include = repo_root.join("proto");
     let out_dir = manifest_dir.join("src/proto");
 
     println!(
-        "cargo:warning=regenerating {} + {} + {} -> {}",
+        "cargo:warning=regenerating {} + {} + {} + {} -> {}",
         record_proto.display(),
         graph_proto.display(),
         document_proto.display(),
+        fusion_proto.display(),
         out_dir.display()
     );
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .out_dir(&out_dir)
-        .compile_protos(&[record_proto, graph_proto, document_proto], &[include])
+        .compile_protos(
+            &[record_proto, graph_proto, document_proto, fusion_proto],
+            &[include],
+        )
         .expect("v2 proto codegen failed");
 }

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -6378,3 +6378,408 @@ pub mod proxima_document_service_server {
         const NAME: &'static str = SERVICE_NAME;
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FusionSearchRequest {
+    /// Graph to traverse for expansion (required).
+    #[prost(string, tag = "1")]
+    pub graph_id: ::prost::alloc::string::String,
+    /// Vector collection to seed from (its records co-indexed with this graph by `oid`).
+    #[prost(string, tag = "2")]
+    pub vector_collection: ::prost::alloc::string::String,
+    /// Query embedding for the ANN seed (required, non-empty).
+    #[prost(float, repeated, tag = "3")]
+    pub query_vector: ::prost::alloc::vec::Vec<f32>,
+    /// Max results to return (0 → server default).
+    #[prost(uint32, tag = "4")]
+    pub limit: u32,
+    /// k-hop expansion depth (bounded; default 1).
+    #[prost(uint32, tag = "5")]
+    pub max_depth: u32,
+    /// Edge types to traverse during expansion (empty = all).
+    #[prost(string, repeated, tag = "6")]
+    pub edge_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// How many of the top vector seeds to expand from (0 → server default).
+    #[prost(uint32, tag = "7")]
+    pub max_seeds: u32,
+    /// Optional per-source weights (presence carried via proto3 `optional`).
+    #[prost(float, optional, tag = "8")]
+    pub vector_weight: ::core::option::Option<f32>,
+    #[prost(float, optional, tag = "9")]
+    pub graph_weight: ::core::option::Option<f32>,
+    /// Use the rank-based RRF fallback instead of PIT-calibrated linear.
+    #[prost(bool, tag = "10")]
+    pub rrf: bool,
+    /// Consensus boost added to any `oid` present in >=2 sources.
+    #[prost(float, optional, tag = "11")]
+    pub consensus_beta: ::core::option::Option<f32>,
+    /// Graph contribution grain (default NODES).
+    #[prost(enumeration = "FusionGrain", tag = "12")]
+    pub grain: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FusionHit {
+    #[prost(string, tag = "1")]
+    pub oid: ::prost::alloc::string::String,
+    #[prost(float, tag = "2")]
+    pub score: f32,
+    #[prost(uint32, tag = "3")]
+    pub source_count: u32,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FusionStats {
+    #[prost(uint32, tag = "1")]
+    pub sources_fused: u32,
+    #[prost(uint32, tag = "2")]
+    pub sources_skipped: u32,
+    #[prost(uint32, tag = "3")]
+    pub candidates_in: u32,
+    #[prost(uint32, tag = "4")]
+    pub items_out: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FusionSearchResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub results: ::prost::alloc::vec::Vec<FusionHit>,
+    #[prost(message, optional, tag = "2")]
+    pub stats: ::core::option::Option<FusionStats>,
+}
+/// Graph-contribution grain (prefixed to avoid collisions with other v2 enums).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FusionGrain {
+    Unspecified = 0,
+    Nodes = 1,
+    Edges = 2,
+    Both = 3,
+}
+impl FusionGrain {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "FUSION_GRAIN_UNSPECIFIED",
+            Self::Nodes => "FUSION_GRAIN_NODES",
+            Self::Edges => "FUSION_GRAIN_EDGES",
+            Self::Both => "FUSION_GRAIN_BOTH",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FUSION_GRAIN_UNSPECIFIED" => Some(Self::Unspecified),
+            "FUSION_GRAIN_NODES" => Some(Self::Nodes),
+            "FUSION_GRAIN_EDGES" => Some(Self::Edges),
+            "FUSION_GRAIN_BOTH" => Some(Self::Both),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+pub mod proxima_fusion_service_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// Cross-modal fusion search service. One retrieval engine; this RPC is a thin
+    /// facade over `FusionService` (the shared port), varying only in projection.
+    #[derive(Debug, Clone)]
+    pub struct ProximaFusionServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProximaFusionServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProximaFusionServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProximaFusionServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            ProximaFusionServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn fusion_search(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FusionSearchRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FusionSearchResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaFusionService/FusionSearch",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("proximadb.v2.ProximaFusionService", "FusionSearch"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod proxima_fusion_service_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ProximaFusionServiceServer.
+    #[async_trait]
+    pub trait ProximaFusionService: std::marker::Send + std::marker::Sync + 'static {
+        async fn fusion_search(
+            &self,
+            request: tonic::Request<super::FusionSearchRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::FusionSearchResponse>,
+            tonic::Status,
+        >;
+    }
+    /// Cross-modal fusion search service. One retrieval engine; this RPC is a thin
+    /// facade over `FusionService` (the shared port), varying only in projection.
+    #[derive(Debug)]
+    pub struct ProximaFusionServiceServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> ProximaFusionServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for ProximaFusionServiceServer<T>
+    where
+        T: ProximaFusionService,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/proximadb.v2.ProximaFusionService/FusionSearch" => {
+                    #[allow(non_camel_case_types)]
+                    struct FusionSearchSvc<T: ProximaFusionService>(pub Arc<T>);
+                    impl<
+                        T: ProximaFusionService,
+                    > tonic::server::UnaryService<super::FusionSearchRequest>
+                    for FusionSearchSvc<T> {
+                        type Response = super::FusionSearchResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FusionSearchRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaFusionService>::fusion_search(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = FusionSearchSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for ProximaFusionServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "proximadb.v2.ProximaFusionService";
+    impl<T> tonic::server::NamedService for ProximaFusionServiceServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}

--- a/proto/proximadb/v2/fusion.proto
+++ b/proto/proximadb/v2/fusion.proto
@@ -1,0 +1,77 @@
+// ProximaDB v2 Fusion service.
+//
+// gRPC surface for the cross-modal fusion seam — the single retrieval engine per
+// `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc` (`seed → expand → calibrate →
+// fuse-by-oid → rank`). Mirrors the REST `POST /api/v2/graphs/{id}/fusion-search`:
+// vector seed → graph expansion → PIT-calibrated fuse-by-`oid`. The server
+// delegates to the shared `FusionService` port and owns NO retrieval/ranking
+// logic. Tenant isolation is structural (the `x-tenant-id` header namespaces the
+// backing collections), never a per-request predicate.
+//
+// To regenerate the committed stubs after editing this file:
+//   PROXIMADB_REGEN_PROTO=1 cargo build -p proximadb-proto
+
+syntax = "proto3";
+
+package proximadb.v2;
+
+option java_package = "com.proximadb.v2.fusion";
+option go_package = "proximadb/v2;proximadbpb";
+
+// Graph-contribution grain (prefixed to avoid collisions with other v2 enums).
+enum FusionGrain {
+  FUSION_GRAIN_UNSPECIFIED = 0;
+  FUSION_GRAIN_NODES = 1;
+  FUSION_GRAIN_EDGES = 2;
+  FUSION_GRAIN_BOTH = 3;
+}
+
+message FusionSearchRequest {
+  // Graph to traverse for expansion (required).
+  string graph_id = 1;
+  // Vector collection to seed from (its records co-indexed with this graph by `oid`).
+  string vector_collection = 2;
+  // Query embedding for the ANN seed (required, non-empty).
+  repeated float query_vector = 3;
+  // Max results to return (0 → server default).
+  uint32 limit = 4;
+  // k-hop expansion depth (bounded; default 1).
+  uint32 max_depth = 5;
+  // Edge types to traverse during expansion (empty = all).
+  repeated string edge_types = 6;
+  // How many of the top vector seeds to expand from (0 → server default).
+  uint32 max_seeds = 7;
+  // Optional per-source weights (presence carried via proto3 `optional`).
+  optional float vector_weight = 8;
+  optional float graph_weight = 9;
+  // Use the rank-based RRF fallback instead of PIT-calibrated linear.
+  bool rrf = 10;
+  // Consensus boost added to any `oid` present in >=2 sources.
+  optional float consensus_beta = 11;
+  // Graph contribution grain (default NODES).
+  FusionGrain grain = 12;
+}
+
+message FusionHit {
+  string oid = 1;
+  float score = 2;
+  uint32 source_count = 3;
+}
+
+message FusionStats {
+  uint32 sources_fused = 1;
+  uint32 sources_skipped = 2;
+  uint32 candidates_in = 3;
+  uint32 items_out = 4;
+}
+
+message FusionSearchResponse {
+  repeated FusionHit results = 1;
+  FusionStats stats = 2;
+}
+
+// Cross-modal fusion search service. One retrieval engine; this RPC is a thin
+// facade over `FusionService` (the shared port), varying only in projection.
+service ProximaFusionService {
+  rpc FusionSearch(FusionSearchRequest) returns (FusionSearchResponse);
+}

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -1,0 +1,154 @@
+// Copyright 2025 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! gRPC V2 fusion service — a thin facade over the shared `FusionService` port.
+//!
+//! This is the canonical cross-modal retrieval surface over gRPC
+//! (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`): `seed → expand → calibrate →
+//! fuse-by-oid → rank`. It mirrors the REST `POST /api/v2/graphs/{id}/fusion-search`
+//! and owns **no** retrieval/ranking logic — it delegates to `FusionService`,
+//! the single internal fusion port (vector seed + graph expansion + PIT-calibrated
+//! fuse-by-`oid`). Tenant isolation is structural: the backing collections are
+//! tenant-namespaced via `x-tenant-id`, never a per-query predicate.
+
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+use tracing::debug;
+
+use crate::api_handlers::UnifiedHandlers;
+use crate::core::search::cross_modal_fusion::FusionPolicy;
+use crate::network::grpc::auth as grpc_auth;
+use crate::proto::proximadb_v2 as pv2;
+use crate::proto::proximadb_v2::proxima_fusion_service_server::{
+    ProximaFusionService, ProximaFusionServiceServer,
+};
+use crate::services::fusion_service::{FusionService, GraphFusionParams, GraphGrain};
+
+/// Defaults shared with the REST handler (`src/network/rest/v2/graphs.rs`).
+const DEFAULT_LIMIT: usize = 10;
+const DEFAULT_DEPTH: u32 = 1;
+const DEFAULT_MAX_SEEDS: usize = 5;
+
+/// gRPC V2 fusion service — thin delegating facade over `FusionService`.
+pub struct ProximaFusionServiceImpl {
+    fusion: Arc<FusionService>,
+}
+
+impl ProximaFusionServiceImpl {
+    /// Build from the shared unified request handlers. The `FusionService` port
+    /// is constructed once at boot (from the vector + graph services) and shared
+    /// across requests — never per-RPC.
+    pub fn new(request_handlers: Arc<UnifiedHandlers>) -> Self {
+        Self {
+            fusion: Arc::new(FusionService::new(
+                request_handlers.vector_operations_service.clone(),
+                request_handlers.graph_operations_service.clone(),
+            )),
+        }
+    }
+
+    /// Convert to a tonic server.
+    pub fn into_server(self) -> ProximaFusionServiceServer<Self> {
+        ProximaFusionServiceServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl ProximaFusionService for ProximaFusionServiceImpl {
+    async fn fusion_search(
+        &self,
+        request: Request<pv2::FusionSearchRequest>,
+    ) -> Result<Response<pv2::FusionSearchResponse>, Status> {
+        // Tenant isolation is structural: the backing vector/graph collections are
+        // tenant-namespaced via `x-tenant-id`. We read it here only for logging.
+        let tenant_id = grpc_auth::tenant_id(&request);
+        let req = request.into_inner();
+
+        if req.query_vector.is_empty() {
+            return Err(Status::invalid_argument("query_vector must not be empty"));
+        }
+        if req.graph_id.trim().is_empty() {
+            return Err(Status::invalid_argument("graph_id is required"));
+        }
+        if req.vector_collection.trim().is_empty() {
+            return Err(Status::invalid_argument("vector_collection is required"));
+        }
+
+        debug!(
+            tenant_id = ?tenant_id,
+            graph_id = %req.graph_id,
+            vector_collection = %req.vector_collection,
+            "v2 gRPC FusionSearch"
+        );
+
+        // Fusion policy: PIT-calibrated linear (default) or rank-based RRF fallback.
+        let mut policy = if req.rrf {
+            FusionPolicy::rrf()
+        } else {
+            FusionPolicy::default()
+        };
+        if let Some(beta) = req.consensus_beta {
+            policy.consensus_beta = beta;
+        }
+
+        let grain = match req.grain {
+            2 => GraphGrain::Edges,
+            3 => GraphGrain::Both,
+            _ => GraphGrain::Nodes, // UNSPECIFIED (0) and NODES (1)
+        };
+
+        let params = GraphFusionParams {
+            graph_id: req.graph_id.clone(),
+            vector_collection: req.vector_collection.clone(),
+            query_vector: req.query_vector.clone(),
+            max_depth: if req.max_depth == 0 {
+                DEFAULT_DEPTH
+            } else {
+                req.max_depth
+            },
+            edge_types: req.edge_types.clone(),
+            max_seeds: if req.max_seeds == 0 {
+                DEFAULT_MAX_SEEDS
+            } else {
+                req.max_seeds as usize
+            },
+            limit: if req.limit == 0 {
+                DEFAULT_LIMIT
+            } else {
+                req.limit as usize
+            },
+            vector_weight: req.vector_weight.unwrap_or(1.0),
+            graph_weight: req.graph_weight.unwrap_or(1.0),
+            grain,
+            policy,
+        };
+
+        let (items, stats) = self
+            .fusion
+            .graph_fusion_search(params)
+            .await
+            .map_err(|e| Status::internal(format!("fusion search failed: {e}")))?;
+
+        let results = items
+            .into_iter()
+            .map(|item| pv2::FusionHit {
+                oid: item.oid,
+                score: item.score,
+                source_count: item.source_count as u32,
+            })
+            .collect();
+
+        Ok(Response::new(pv2::FusionSearchResponse {
+            results,
+            stats: Some(pv2::FusionStats {
+                sources_fused: stats.sources_fused as u32,
+                sources_skipped: stats.sources_skipped as u32,
+                candidates_in: stats.candidates_in as u32,
+                items_out: stats.items_out as u32,
+            }),
+        }))
+    }
+}

--- a/src/network/grpc/v2/mod.rs
+++ b/src/network/grpc/v2/mod.rs
@@ -30,9 +30,11 @@
 //! - `EvolveSchema` - Evolve schema with compatibility checks
 
 pub mod document_service;
+pub mod fusion_service;
 pub mod graph_service;
 pub mod record_service;
 
 pub use document_service::ProximaDocumentServiceImpl;
+pub use fusion_service::ProximaFusionServiceImpl;
 pub use graph_service::ProximaGraphServiceImpl;
 pub use record_service::ProximaRecordServiceImpl;

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -190,6 +190,18 @@ impl MultiServer {
             .into_server()
     }
 
+    /// Build the canonical v2 fusion gRPC service — the cross-modal retrieval
+    /// surface over gRPC (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`). A thin
+    /// facade over the shared `FusionService` port; owns no ranking logic.
+    fn canonical_fusion_grpc_service(
+        services: &SharedServices,
+    ) -> crate::proto::proximadb_v2::proxima_fusion_service_server::ProximaFusionServiceServer<
+        crate::network::grpc::v2::ProximaFusionServiceImpl,
+    > {
+        crate::network::grpc::v2::ProximaFusionServiceImpl::new(services.request_handlers.clone())
+            .into_server()
+    }
+
     /// Create new multi-server instance (orchestrator only)
     /// MultiServer focuses on network orchestration, SharedServices handles business logic
     pub fn new(
@@ -599,6 +611,7 @@ impl MultiServer {
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
                 .add_service(Self::canonical_document_grpc_service(&services))
+                .add_service(Self::canonical_fusion_grpc_service(&services))
                 .add_service(standard_health_server);
 
             // Deprecated gRPC v1 compatibility adapters are gated behind
@@ -1133,6 +1146,7 @@ impl MultiServer {
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
                 .add_service(Self::canonical_document_grpc_service(&services))
+                .add_service(Self::canonical_fusion_grpc_service(&services))
                 .add_service(flight_server)
                 .add_service(standard_health_server);
 
@@ -1512,6 +1526,7 @@ impl MultiServer {
                 .add_service(Self::canonical_record_grpc_service(&services))
                 .add_service(Self::canonical_graph_grpc_service(&services))
                 .add_service(Self::canonical_document_grpc_service(&services))
+                .add_service(Self::canonical_fusion_grpc_service(&services))
                 .add_service(standard_health_server);
 
             // Deprecated gRPC v1 compatibility adapters are gated behind


### PR DESCRIPTION
## Summary
Step 2 of the search-surface alignment (contract: PR #280). Adds the **canonical cross-modal retrieval surface over gRPC** — `proximadb.v2.ProximaFusionService.FusionSearch`, the gRPC peer to the REST `POST /api/v2/graphs/{id}/fusion-search`.

It is a **thin facade over the shared `FusionService` port** (vector seed → graph expand → PIT-calibrated fuse-by-`oid` → rank) and owns no retrieval/ranking logic — exactly the contract's "one engine, typed facades" rule.

This fills the gRPC gap: until now the seam was REST-only, so gRPC clients had only the legacy `execute_hybrid_query` path (hardcoded graph, no tenant — TD-143).

## Changes
- **`proto/proximadb/v2/fusion.proto`** (new) — `FusionSearchRequest` (graph_id, vector_collection, query_vector, limit, max_depth, edge_types, max_seeds, optional weights, rrf, consensus_beta, grain), `FusionHit`, `FusionStats`, `FusionSearchResponse`, `ProximaFusionService.FusionSearch`. Self-contained (no TypedValue import).
- **`build.rs`** — include `fusion_proto` in the `PROXIMADB_REGEN_PROTO` regeneration.
- **`src/proto/proximadb.v2.rs`** — regenerated (+405 lines).
- **`src/network/grpc/v2/fusion_service.rs`** (new) — `ProximaFusionServiceImpl` builds `FusionService` once at boot from `request_handlers` (vector + graph) and delegates; maps `FusedItem`→`FusionHit`, `FusionStats`→proto.
- **`multi_server.rs`** — `canonical_fusion_grpc_service` registered in all 3 startup modes.
- **`grpc_drift_baseline.json`** — accept fusion missing-stub/servicer (Python SDK fusion client is a follow-up, same treatment as document v2).

## Verified
- `cargo check --lib` clean (toolchain pinned 1.95.0); `cargo fmt` clean.
- Proto regenerated via `PROXIMADB_REGEN_PROTO=1 cargo build -p proximadb-proto`.
- Python `test_grpc_proto_drift.py` passes (3 tests).

## Relationship to other PRs
- Builds on the contract (#280) and complements the shared-port refactor (#282); independent of the entity surface (#278).
- Follow-ups (separate): Python SDK fusion client; retire `execute_hybrid_query` once clients migrate (TD-143); EntityService delegation (TD-146, blocked on key-correlation TD-142).
