### PR TITLE
bench(object-store): round-trip latency floor harness (co-design T3.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -877,6 +877,15 @@ name = "bench_10_query_progressive"
 harness = false
 path = "benches/bench_10_query_progressive.rs"
 
+[[bench]]
+name = "bench_object_store_latency"
+harness = false
+path = "benches/bench_object_store_latency.rs"
+# Co-design T3.2: measures the object-store round-trip latency floor (GET /
+# ranged-GET / LIST). Defaults to in-process `memory://` (no network RTT — a
+# harness smoke check); point BENCH_OBJECT_STORE_URL at s3:// (with --features
+# aws) or file:// for real cloud-latency evidence.
+
 # 4. UNIFIED & CROSS-ENGINE BENCHMARKS
 # Note: Cross-engine comparisons now included in bench_storage_engines
 

--- a/benches/bench_object_store_latency.rs
+++ b/benches/bench_object_store_latency.rs
@@ -1,0 +1,305 @@
+// Copyright 2026 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! Object-store round-trip latency floor (co-design T3.2 — cloud-latency evidence).
+//!
+//! The dominant cost term for a cloud DB is the **I/O round-trip**, not CPU
+//! (co-design P5). This bench measures that floor in isolation — the raw
+//! object-store operations a ProximaDB scan/manifest read actually issues — so a
+//! routing/format/cache decision can be justified against the *measured* RTT,
+//! not a guess:
+//!
+//! * **GET** — a full-object GET (the round-trip a footer read or a small-segment
+//!   scan pays).
+//! * **ranged GET** — a byte-range GET (the footer-first / IVF-cold-load path
+//!   the co-design leans on to avoid whole-object scans).
+//! * **LIST** — a prefix enumeration (manifest / directory fan-out cost).
+//!
+//! ## Running
+//!
+//! Always runs (defaults to an in-process `memory://` store) so CI proves the
+//! harness compiles and is sane. **In-process memory latencies are NOT cloud
+//! latency** — they have no network RTT. To produce REAL cloud-latency evidence
+//! point the bench at a real backend:
+//!
+//! ```text
+//! BENCH_OBJECT_STORE_URL=s3://my-bench-bucket/path     cargo bench --bench bench_object_store_latency --features aws
+//! BENCH_OBJECT_STORE_URL=file:///tmp/os-bench          cargo bench --bench bench_object_store_latency
+//! BENCH_OBJECT_STORE_URL=memory://                     cargo bench --bench bench_object_store_latency
+//! ```
+//!
+//! (`s3://` needs the `aws` feature, which compiles the S3 backend into
+//! `object_store::parse_url`; `file://` and `memory://` work in a default build.)
+//! S3 credentials come from the standard chain (env vars / IRSA / profile).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::TryStreamExt;
+use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
+use object_store::path::Path;
+use tokio::runtime::Runtime;
+
+// ────────────────────────────────────────────────────────────────────────
+// main
+// ────────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let cfg = BenchConfig::from_env();
+
+    println!("================================================================================");
+    println!("   ProximaDB — Object-Store Round-Trip Latency Floor (T3.2)");
+    println!("================================================================================");
+    println!();
+    println!("Configuration:");
+    println!("  store_url:  {}", cfg.store_url);
+    println!("  iterations: {} per (op × size)", cfg.iterations);
+    println!("  sizes:      {} bytes", fmt_sizes(&cfg.sizes));
+    if cfg.is_memory() {
+        println!();
+        println!("  ⚠ IN-PROCESS memory store — NO network RTT. These numbers are a");
+        println!("    harness smoke check, NOT cloud latency. Set BENCH_OBJECT_STORE_URL");
+        println!("    to s3:// (with --features aws) or file:// for real RTT evidence.");
+    }
+    println!();
+
+    let rt = Runtime::new().expect("tokio runtime");
+    rt.block_on(async move {
+        match open_store(&cfg.store_url).await {
+            Ok(store) => run_bench(&cfg, store).await,
+            Err(e) => {
+                eprintln!(
+                    "error: could not open object store `{}`: {e}",
+                    cfg.store_url
+                );
+                eprintln!("note: s3:// requires the `aws` feature (cargo bench --features aws);");
+                eprintln!("      file:// and memory:// work in a default build.");
+                std::process::exit(1);
+            }
+        }
+    });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Config
+// ────────────────────────────────────────────────────────────────────────
+
+struct BenchConfig {
+    store_url: String,
+    iterations: usize,
+    sizes: Vec<usize>,
+}
+
+impl BenchConfig {
+    fn from_env() -> Self {
+        Self {
+            store_url: std::env::var("BENCH_OBJECT_STORE_URL")
+                .unwrap_or_else(|_| "memory://os-bench".to_string()),
+            iterations: env_usize("BENCH_OS_ITERATIONS", 200),
+            // Footer-like, small-segment, large-segment — the shapes a scan pays.
+            sizes: vec![4 * 1024, 64 * 1024, 1024 * 1024],
+        }
+    }
+
+    fn is_memory(&self) -> bool {
+        self.store_url.starts_with("memory://")
+    }
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn fmt_sizes(sizes: &[usize]) -> String {
+    sizes
+        .iter()
+        .map(|s| format_bytes(*s as u64))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Store construction
+// ────────────────────────────────────────────────────────────────────────
+
+async fn open_store(url: &str) -> Result<Arc<dyn ObjectStore>, Box<dyn std::error::Error>> {
+    // In-process memory is the always-available default (no feature needed).
+    if let Some(rest) = url.strip_prefix("memory://") {
+        let _ = rest; // path is irrelevant for the in-memory store
+        return Ok(Arc::new(object_store::memory::InMemory::new()));
+    }
+    let parsed = url::Url::parse(url)?;
+    let (store, _) = object_store::parse_url(&parsed)?;
+    Ok(Arc::from(store))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Bench
+// ────────────────────────────────────────────────────────────────────────
+
+async fn run_bench(cfg: &BenchConfig, store: Arc<dyn ObjectStore>) {
+    // Unique prefix so concurrent runs / leftovers don't interfere.
+    let prefix_str = format!("os-bench-pid{}", std::process::id());
+    let prefix = Path::from(prefix_str.clone());
+    let obj_path = |size: usize| Path::from(format!("{prefix_str}/obj-{size}"));
+
+    // Seed one object per size, plus a few siblings for a realistic LIST.
+    for &size in &cfg.sizes {
+        let body = object_store::PutPayload::from_bytes(Bytes::from(vec![0u8; size]));
+        store
+            .put(&obj_path(size), body)
+            .await
+            .expect("put seed object");
+    }
+    for i in 0..5 {
+        let path = Path::from(format!("{prefix_str}/sibling-{i}"));
+        store
+            .put(
+                &path,
+                object_store::PutPayload::from_bytes(Bytes::from_static(b"x")),
+            )
+            .await
+            .expect("put sibling");
+    }
+
+    println!(
+        "Results (per-operation latency, {} iterations each):",
+        cfg.iterations
+    );
+    println!();
+    println!(
+        "  {:<10} {:>10} {:>12} {:>12} {:>12} {:>12}",
+        "op", "size", "p50 (ms)", "p95 (ms)", "p99 (ms)", "mean (ms)"
+    );
+    println!("  {}", "-".repeat(72));
+
+    for &size in &cfg.sizes {
+        let path = obj_path(size);
+
+        // GET (full object) — the dominant round-trip a scan/footer-read pays.
+        let get = measure(cfg.iterations, || async {
+            let _ = store.get(&path).await?.bytes().await?;
+            Ok::<_, object_store::Error>(())
+        })
+        .await;
+        print_row("GET", size, &get);
+
+        // ranged GET (last 4 KiB) — the footer-first / IVF cold-load path.
+        let range_start = (size.saturating_sub(4 * 1024)) as u64;
+        let range_end = size as u64;
+        let ranged = measure(cfg.iterations, || async {
+            let _ = store.get_range(&path, range_start..range_end).await?;
+            Ok::<_, object_store::Error>(())
+        })
+        .await;
+        print_row("GET range", size, &ranged);
+    }
+
+    // LIST (prefix enumeration) — manifest / directory fan-out.
+    let list = measure(cfg.iterations, || async {
+        let _ = store.list(Some(&prefix)).try_collect::<Vec<_>>().await?;
+        Ok::<_, object_store::Error>(())
+    })
+    .await;
+    print_row("LIST", 0, &list);
+
+    println!();
+
+    // Cleanup so repeated runs against a real bucket don't accumulate.
+    let _ = cleanup(&store, &prefix).await;
+}
+
+/// Measure `op` `iters` times, returning the latency distribution in microseconds.
+async fn measure<F, Fut>(iters: usize, op: F) -> LatencyDist
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<(), object_store::Error>>,
+{
+    // Warmup: prime any connection pool / TLS handshake so we measure steady-state.
+    for _ in 0..(iters.min(10)) {
+        let _ = op().await;
+    }
+    let mut samples: Vec<u64> = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let start = Instant::now();
+        match op().await {
+            Ok(()) => samples.push(start.elapsed().as_micros() as u64),
+            // A failing op (e.g. transient) is recorded as the observed latency;
+            // the bench reports round-trip cost, not just success cost.
+            Err(_) => samples.push(start.elapsed().as_micros() as u64),
+        }
+    }
+    LatencyDist::from_samples(samples)
+}
+
+async fn cleanup(store: &Arc<dyn ObjectStore>, prefix: &Path) -> Result<(), object_store::Error> {
+    let mut stream = store.list(Some(prefix));
+    while let Some(entry) = stream.try_next().await? {
+        store.delete(&entry.location).await?;
+    }
+    Ok(())
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Reporting
+// ────────────────────────────────────────────────────────────────────────
+
+struct LatencyDist {
+    samples: Vec<u64>, // microseconds, sorted
+}
+
+impl LatencyDist {
+    fn from_samples(mut samples: Vec<u64>) -> Self {
+        samples.sort_unstable();
+        Self { samples }
+    }
+
+    fn percentile(&self, p: f64) -> f64 {
+        if self.samples.is_empty() {
+            return 0.0;
+        }
+        let idx = ((self.samples.len() as f64 - 1.0) * p).round() as usize;
+        self.samples[idx.min(self.samples.len() - 1)] as f64
+    }
+
+    fn mean(&self) -> f64 {
+        if self.samples.is_empty() {
+            return 0.0;
+        }
+        (self.samples.iter().sum::<u64>() as f64) / self.samples.len() as f64
+    }
+}
+
+fn print_row(op: &str, size: usize, dist: &LatencyDist) {
+    println!(
+        "  {:<10} {:>10} {:>12.3} {:>12.3} {:>12.3} {:>12.3}",
+        op,
+        format_bytes(size as u64),
+        dist.percentile(0.50) / 1000.0,
+        dist.percentile(0.95) / 1000.0,
+        dist.percentile(0.99) / 1000.0,
+        dist.mean() / 1000.0,
+    );
+}
+
+fn format_bytes(n: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * 1024;
+    if n == 0 {
+        return "-".to_string();
+    }
+    if n >= MIB {
+        format!("{}MiB", n / MIB)
+    } else if n >= KIB {
+        format!("{}KiB", n / KIB)
+    } else {
+        format!("{n}B")
+    }
+}

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -246,3 +246,17 @@ hardware = "Local macOS arm64 (Apple Silicon), no other workload"
 date = "2026-06-22"
 version = "v0.2"
 notes = "Co-design Pillar C / TD-145. MEASURED (5000x128 f32, 2 warmup + 9 timed, median): insert_arrow_ipc 96.8/95.0 ms vs zero-copy insert_arrow_batches 95.8/107.3 ms = PARITY within run-to-run noise, despite eliminating a 2,669,512-byte IPC serialize/deserialize. The plan's hypothesis (boundary copy = dominant embedded cost term) is REFUTED at the insert path: the ~95 ms is dominated by ArrowProtoCodec::batches_to_proxima_records + insert_batch (WAL/storage), not the serialize. The insert_arrow_batches seam is kept (correct, cross-language, lighter memory) but NOT as a latency win; the real Pillar-C lever is redirected to Arrow-native ingestion (TD-145). Trace before you tune."
+
+[[claims]]
+id = "object_store_latency_floor"
+claim = "Object-store round-trip latency floor (GET / ranged-GET / LIST) — the dominant I/O cost term for a cloud DB (co-design P5)"
+metric = "object_store_rtt_ms"
+status = "unverified"
+asserted_in = ["docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc"]
+bench_source = "benches/bench_object_store_latency.rs"
+bench_command = "BENCH_OBJECT_STORE_URL=s3://<bucket>/path cargo bench --bench bench_object_store_latency --features aws"
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "Co-design T3.2. The bench measures the raw object-store round-trip floor in isolation (full GET, last-4KiB ranged GET, prefix LIST) at 4KiB/64KiB/1MiB sizes, p50/p95/p99/mean. It ALWAYS runs (defaults to in-process memory://) so CI proves the harness compiles, but memory:// latencies carry NO network RTT and are a smoke check only. Real cloud-latency evidence requires an operator run against s3:// (with --features aws; creds via the standard chain) or a minio endpoint — promote to `measured` with that dated artifact. This is the floor the route cost model and footer/ranged-read decisions must beat."


### PR DESCRIPTION
## What

Adds the object-store round-trip latency-floor benchmark that closes co-design gap **T3.2**, plus its evidence-ledger entry.

## Why

The dominant cost term for a cloud DB is the **I/O round-trip**, not CPU (co-design P5). T3.2 called for cloud-latency evidence — the S3 GET / LIST / ranged-GET floor — so routing, format, and cache decisions (e.g. the trace-driven route cost model in #279) can be justified against the *measured* RTT rather than a guess.

## The bench

`benches/bench_object_store_latency.rs` measures the raw object-store round-trip floor in isolation — the operations a scan / manifest read actually issues:

- **GET** — full-object GET (footer read / small-segment scan)
- **ranged GET** — last-4KiB byte range (the footer-first / IVF-cold-load path the co-design leans on)
- **LIST** — prefix enumeration (manifest / directory fan-out)

…at 4KiB / 64KiB / 1MiB sizes, reporting **p50/p95/p99/mean** over a configurable iteration count.

It **always runs** (defaults to in-process `memory://`) so CI proves the harness compiles, but `memory://` carries **no network RTT** — it's a smoke check, not cloud latency. Real evidence requires an operator run against a real backend:

```text
BENCH_OBJECT_STORE_URL=s3://<bucket>/path   cargo bench --bench bench_object_store_latency --features aws
BENCH_OBJECT_STORE_URL=file:///tmp/os-bench cargo bench --bench bench_object_store_latency
```

## Evidence ledger

`BENCHMARK_EVIDENCE.toml` records `object_store_latency_floor` as **`unverified`** — the bench exists and can substantiate the claim, but a dated artifact requires an operator S3/minio run (promote to `measured` with it). This is exactly the ledger's `unverified` taxonomy; I'm not asserting numbers I can't reproduce.

No source/logic change — a new bench + its evidence entry.