### PR TITLE
feat(cluster): activate cross-pod DML locking in production (A7)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1812,13 +1812,51 @@ impl SharedServices {
         // Use the SHARED canonical store so REST/gRPC relational DML/reads/EXPLAIN and the
         // CDC change-feed operate on the SAME state pgwire writes to. Fall back to the
         // vector-compatibility store only when no canonical store exists (test paths).
-        let dml_service_for_grpc = Arc::new(match canonical_record_store.clone() {
+        // A7: activate cross-pod DML locking. The durable lease lives on the
+        // SAME object store as the catalog (`storage_config.metadata_url`), so
+        // table-level DML contention is real across pods (only one pod's
+        // `DmlLockService` can hold the CAS-backed lease). Fail-open — no locks
+        // — if the store can't be opened (test/embedded paths); never block
+        // bootstrap. The pod id is process-unique; a stable deployment-level
+        // pod id is a follow-up (matters only for multi-pod restart affinity).
+        let dml_lock_service = {
+            use crate::cluster::partition_lease::{
+                DmlLockService, PartitionLeaseManager, PartitionLeaseStore,
+            };
+            use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
+            match PartitionLeaseStore::from_url(&storage_config.metadata_url, "_operator/leases") {
+                Ok(store) => {
+                    let pod_id = format!("pod-{}", std::process::id());
+                    let manager = Arc::new(PartitionLeaseManager::new(
+                        Arc::new(store),
+                        Arc::new(PrimaryPodRegistry::new()),
+                        pod_id.clone(),
+                        10_000,
+                    ));
+                    Some(Arc::new(DmlLockService::new(manager, pod_id)))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        url = %storage_config.metadata_url,
+                        "DML lock service disabled (lease store unavailable); \
+                         DML writes run lock-free (fail-open)"
+                    );
+                    None
+                }
+            }
+        };
+        let base_dml = match canonical_record_store.clone() {
             Some(store) => DmlService::with_direct_record_storage(
                 catalog_manager.clone(),
                 vector_operations_service.clone(),
                 store,
             ),
             None => DmlService::new(catalog_manager.clone(), vector_operations_service.clone()),
+        };
+        let dml_service_for_grpc = Arc::new(match dml_lock_service {
+            Some(lock_service) => base_dml.with_dml_lock_service(lock_service),
+            None => base_dml,
         });
 
         // Wire QueryFacadeAdapter to UnifiedHandlers for unified SQL routing.

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -4891,6 +4891,40 @@ mod tests {
             .with_primary_key(vec!["record_id".to_string()])
     }
 
+    /// A7: the production wiring (SharedServices) builds the lease stack from an
+    /// object-store URL via `PartitionLeaseStore::from_url` — the same path used
+    /// with `storage_config.metadata_url`. Verify that construction path yields a
+    /// working DmlLockService wired into DmlService (cross-pod coordination on).
+    #[tokio::test]
+    async fn dml_lock_service_buildable_from_url_like_production() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let url = format!("file://{}", dir.path().display());
+        let store = PartitionLeaseStore::from_url(&url, "_operator/leases")?;
+        let lease_manager = Arc::new(PartitionLeaseManager::new(
+            Arc::new(store),
+            Arc::new(PrimaryPodRegistry::new()),
+            "pod-prod",
+            10_000,
+        ));
+        let lock_service = Arc::new(DmlLockService::new(lease_manager, "pod-prod"));
+        let dml = DmlService::with_record_store_and_table_write_executor(
+            Arc::new(CatalogManager::new()),
+            Arc::new(ExplainOnlyRecordStore),
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        )
+        .with_dml_lock_service(lock_service);
+        let tenant = TenantContext::for_tenant_id("tenant_a");
+        let table_id =
+            TableIdentifier::new(vec!["tenant_a".to_string(), "default".to_string()], "users");
+        let guard = dml
+            .acquire_table_dml_lock(&table_id, Some(&tenant), LockIntent::Write)
+            .await?
+            .expect("wired DmlService should acquire the table lock");
+        assert_eq!(guard.lease_generation(), 1);
+        guard.release().await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn dml_service_table_lock_uses_resolved_tenant_namespace() -> Result<()> {
         let backing: Arc<dyn object_store::ObjectStore> =


### PR DESCRIPTION
feat(cluster): activate cross-pod DML locking in production (A7)

PR #281 shipped the DmlLockService foundation but left it inert in production
— SharedServices built DmlService WITHOUT a lock service, so table-level DML
never contended. This wires it up.

- SharedServices: build the lease stack via PartitionLeaseStore::from_url on
  storage_config.metadata_url (the SAME object store as the catalog, so
  contention is real across pods) -> PartitionLeaseManager -> DmlLockService,
  and .with_dml_lock_service on the production DmlService. Fail-open (no locks)
  if the store can't open (test/embedded) — never block bootstrap.
- Pod id is process-unique; a stable deployment pod id is a TD (matters only
  for multi-pod restart affinity).

Effect: relational DML (INSERT/UPDATE/DELETE/UPSERT) now acquires a table-level,
cross-pod lock via the durable object-store lease; conflicts block the second
writer (currently surfaced as a generic error).

Complementary to — NOT consolidated with — CrossModelTransactionCoordinator
(TD-133), which provides atomicity (saga/compensate, no locking);
DmlLockService provides isolation/mutual-exclusion. Different ACID concerns.

Deferred follow-up TDs:
- A8: map DML lock conflicts to protocol codes (REST 409 / gRPC ABORTED /
  pgwire SQLSTATE 55P03) — needs downcasts at the SQL-DML handler sites
  (no anyhow->ApiError bridge today).
- A6-enforcement: thread WriteIntent.fencing_generation through the WAL to the
  storage writer + validate_fencing at commit (defense-in-depth).

Verified: cargo check --lib green; 15 dml_lock tests pass incl. new
from_url-construction test; fmt clean.
