### PR TITLE
docs(debt): TD-147 — IVF posting-list id compaction (Vec<String> → Vec<u64>)

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -506,6 +506,14 @@ a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete Op
 | MEASURED FINDING (`EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22`): swapping the pyarrow-IPC insert path for the zero-copy Arrow C Data Interface (`arrow::pyarrow` FFI, `insert_arrow_batches`) is **perf-neutral** — the FFI boundary serialize was never the dominant cost term. The ~95 ms (5000x128) insert is dominated by `ArrowProtoCodec::batches_to_proxima_records` (Arrow→ProximaRecord materialization) + `insert_batch` (WAL/storage). The zero-copy `insert_arrow_batches` seam is landed (correct, cross-language substrate, lighter memory) but NOT as a latency win. Remaining Pillar-C work, redirected to the real dominant term: make ingestion **Arrow-native** so the record-materialization + insert copy shrinks (columnar straight into the engine), and apply the same to the search-result return path (currently row-by-row Python objects).
 | 2-3 weeks
 | Co-design tenets 1 & 2 (trace before you tune): the boundary was not the bottleneck. Seam + measurement landed in the embedded-arrow-zerocopy PR.
+| TD-147
+| Index — IVF posting-list id compaction (`Vec<String>` → `Vec<u64>`)
+| P2
+| MED
+| *Open*
+| IVF `TieredPostingList.vector_ids` (`src/index/axis/indexes/dual_store_ivf.rs:470`) stores dense per-cluster member ids as `Vec<String>` (the external `oid`), the one dense in-memory structure that does NOT use a compact internal id — HNSW already maps to `Vec<usize>` via `ConcurrentIdMapping` (`src/index/axis/utils.rs:156`), and Orion graph CSR uses compact indices. Migrate IVF posting lists to `Vec<u64>` internal ids, translating at the insert/iterate boundaries (`:1475` push, `:1594/:2003/:2535/:2609` iterate) through the existing mapping. ~3–7× posting-list RAM shrink → less eviction to disk → fewer cold-load I/O round-trips (Dim 1, the dominant cloud-DB cost term). Co-design: compact id INSIDE dense structures, self-describing string `oid` only at the boundary (vertical inside / standard outside).
+| 1-2 weeks
+| Storage-format change (posting lists persist/evict to disk) → mixed-read-safe + default-OFF gate + round-trip/recall test (storage-format-migration mandate). Verify the eviction path persists `vector_ids` before scoping versioning. HNSW `ConcurrentIdMapping` is the reference pattern; do NOT touch the external record `oid` key. (Audit `2026-06-24`: only genuine dense/persistent string-id flag found.)
 |===
 
 == Debt by Category


### PR DESCRIPTION
docs(debt): TD-147 — IVF posting-list id compaction (Vec<String> → Vec<u64>)

Files the one dense string-id flag from the 2026-06-24 audit: IVF
`TieredPostingList.vector_ids` (`src/index/axis/indexes/dual_store_ivf.rs:470`)
stores per-cluster member ids as `Vec<String>` (the external oid), the only
dense in-memory structure not using a compact internal id. HNSW already maps to
`Vec<usize>` via `ConcurrentIdMapping`; Orion graph CSR uses compact indices.

Migrating IVF posting lists to `Vec<u64>` internal ids (translating at the
insert/iterate boundaries through the existing mapping) is a ~3–7× posting-list
RAM shrink → less eviction to disk → fewer cold-load I/O round-trips (Dim 1, the
dominant cloud-DB cost term). Co-design: compact id INSIDE dense structures,
self-describing string oid only at the boundary.

Storage-format change (posting lists persist/evict) → mixed-read-safe +
default-OFF gate + round-trip/recall test, per the storage-format-migration
mandate. The external record `oid` key is unchanged.
