### PR TITLE
fix(pgwire): render SQL NULL correctly (unify the text encoder)

### DIFF
--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -272,68 +272,6 @@ struct OrderByKey {
     nulls_first: bool,
 }
 
-fn proxima_value_to_pg_text(value: &ProximaValue) -> String {
-    match value {
-        ProximaValue::Boolean(value) => {
-            if *value {
-                "t".to_string()
-            } else {
-                "f".to_string()
-            }
-        }
-        ProximaValue::Int8(value) => value.to_string(),
-        ProximaValue::Int16(value) => value.to_string(),
-        ProximaValue::Int32(value) => value.to_string(),
-        ProximaValue::Int64(value) => value.to_string(),
-        ProximaValue::UInt8(value) => value.to_string(),
-        ProximaValue::UInt16(value) => value.to_string(),
-        ProximaValue::UInt32(value) => value.to_string(),
-        ProximaValue::UInt64(value) => value.to_string(),
-        ProximaValue::Float16(value) => value.to_string(),
-        ProximaValue::Float32(value) => value.to_string(),
-        ProximaValue::Float64(value) => value.to_string(),
-        ProximaValue::Decimal(value) => value.clone(),
-        ProximaValue::String(value) | ProximaValue::Symbol(value) => value.clone(),
-        ProximaValue::Binary(value) | ProximaValue::BinaryVector(value) => {
-            format!("\\x{}", bytes_to_hex(value))
-        }
-        ProximaValue::Date(value) => value.to_string(),
-        ProximaValue::Time(value, _) => value.to_string(),
-        ProximaValue::Timestamp(value, _) => value.to_string(),
-        ProximaValue::TimestampTz(value, _) => value.to_string(),
-        ProximaValue::Uuid(value) | ProximaValue::ULID(value) => bytes_to_hex(value),
-        ProximaValue::Json(value) | ProximaValue::Jsonb(value) => value.to_string(),
-        ProximaValue::Array(values) => {
-            let parts = values
-                .iter()
-                .map(proxima_value_to_pg_text)
-                .collect::<Vec<_>>();
-            format!("{{{}}}", parts.join(","))
-        }
-        ProximaValue::Map(value) | ProximaValue::Struct(value) => {
-            serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string())
-        }
-        ProximaValue::DenseVector(values) => {
-            let parts = values.iter().map(ToString::to_string).collect::<Vec<_>>();
-            format!("[{}]", parts.join(","))
-        }
-        ProximaValue::SparseVector { indices, values } => {
-            serde_json::json!({ "indices": indices, "values": values }).to_string()
-        }
-        ProximaValue::Null => String::new(),
-    }
-}
-
-fn bytes_to_hex(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
-}
-
 /// PostgreSQL message types (frontend)
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2649,7 +2587,7 @@ impl PostgresProtocol {
         // column's value, lex-ordering across keys. Correct for
         // TEXT/VARCHAR and ordering-preserving for canonical
         // numeric/timestamp string forms produced by
-        // `proxima_value_to_pg_text`. Real type-aware sort lands with
+        // `text_encode`. Real type-aware sort lands with
         // the relational planner in a later phase.
         if let Some(keys) = order_by.as_ref() {
             // Resolve each key's column to its row index up-front so
@@ -2700,8 +2638,12 @@ impl PostgresProtocol {
                                 std::cmp::Ordering::Less
                             };
                         }
-                        let av = a_val.map(proxima_value_to_pg_text).unwrap_or_default();
-                        let bv = b_val.map(proxima_value_to_pg_text).unwrap_or_default();
+                        let av = a_val
+                            .and_then(super::relational_pipeline::text_encode)
+                            .unwrap_or_default();
+                        let bv = b_val
+                            .and_then(super::relational_pipeline::text_encode)
+                            .unwrap_or_default();
                         let cmp = if *desc { bv.cmp(&av) } else { av.cmp(&bv) };
                         if cmp != std::cmp::Ordering::Equal {
                             return cmp;
@@ -2714,9 +2656,15 @@ impl PostgresProtocol {
 
         let mut rows_sent = 0usize;
         for row in result.rows {
-            let values = row.iter().map(proxima_value_to_pg_text).collect::<Vec<_>>();
-            let refs = values.iter().map(String::as_str).collect::<Vec<_>>();
-            self.send_data_row(&refs).await?;
+            // Text-encode each column via the shared nullable converter: SQL NULL
+            // (ProximaValue::Null) → None → pgwire `-1` length sentinel (see
+            // send_data_row_nullable). Non-null values render identically to the
+            // legacy simple-query encoder.
+            let values = row
+                .iter()
+                .map(super::relational_pipeline::text_encode)
+                .collect::<Vec<_>>();
+            self.send_data_row_nullable(&values).await?;
             rows_sent += 1;
             if limit.is_some_and(|limit| rows_sent >= limit) {
                 break;

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -722,7 +722,7 @@ pub fn text_encode(v: &ProximaValue) -> Option<String> {
         V::Float64(x) => x.to_string(),
         V::Decimal(s) => s.clone(),
         V::String(s) | V::Symbol(s) => s.clone(),
-        V::Binary(b) => {
+        V::Binary(b) | V::BinaryVector(b) => {
             let mut s = String::with_capacity(2 + b.len() * 2);
             s.push_str("\\x");
             for byte in b {
@@ -752,7 +752,28 @@ pub fn text_encode(v: &ProximaValue) -> Option<String> {
             u[15]
         ),
         V::Json(j) | V::Jsonb(j) => j.to_string(),
-        other => format!("{other:?}"),
+        V::Array(values) => {
+            // Element NULL renders as the empty field in a Postgres array
+            // literal (same convention as the legacy simple-query encoder).
+            let parts = values
+                .iter()
+                .map(text_encode)
+                .map(Option::unwrap_or_default)
+                .collect::<Vec<_>>();
+            format!("{{{}}}", parts.join(","))
+        }
+        V::Map(value) | V::Struct(value) => {
+            serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string())
+        }
+        V::DenseVector(values) => {
+            let parts = values.iter().map(ToString::to_string).collect::<Vec<_>>();
+            format!("[{}]", parts.join(","))
+        }
+        V::SparseVector { indices, values } => serde_json::json!({
+            "indices": indices,
+            "values": values,
+        })
+        .to_string(),
     })
 }
 
@@ -1476,5 +1497,51 @@ mod tests {
         assert!(resolver.primary_key(&TableId::new("unknown")).is_empty());
         // Pushdown capabilities unchanged (pk_lookup gated per-table by primary_key).
         assert!(resolver.capabilities(&TableId::new("users")).pk_lookup);
+    }
+
+    #[test]
+    fn text_encode_null_is_none_and_exotic_types_render() {
+        // SQL NULL → None (the caller emits the pgwire `-1` null sentinel).
+        // This is the core of the pgwire NULL-rendering fix.
+        assert_eq!(text_encode(&ProximaValue::Null), None);
+
+        // Scalars render as before.
+        assert_eq!(
+            text_encode(&ProximaValue::String("alice".into())),
+            Some("alice".to_string())
+        );
+        assert_eq!(
+            text_encode(&ProximaValue::Boolean(false)),
+            Some("f".to_string())
+        );
+
+        // Exotic types now render explicitly rather than as a Debug fallback.
+        assert_eq!(
+            text_encode(&ProximaValue::Array(vec![
+                ProximaValue::Int32(1),
+                ProximaValue::Int32(2),
+            ])),
+            Some("{1,2}".to_string())
+        );
+        // A NULL element inside an array uses the empty-field convention.
+        assert_eq!(
+            text_encode(&ProximaValue::Array(vec![
+                ProximaValue::Int32(1),
+                ProximaValue::Null,
+            ])),
+            Some("{1,}".to_string())
+        );
+
+        // UUID renders dashed (Postgres format), not raw hex.
+        let uuid = ProximaValue::Uuid([
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+            0x00, 0x00,
+        ]);
+        let rendered = text_encode(&uuid).expect("uuid must encode");
+        assert_eq!(rendered, "550e8400-e29b-41d4-a716-446655440000");
+        assert!(
+            rendered.contains('-'),
+            "UUID must be dashed (Postgres format)"
+        );
     }
 }

--- a/tests/pgwire_fk_referential_actions_e2e.rs
+++ b/tests/pgwire_fk_referential_actions_e2e.rs
@@ -303,12 +303,12 @@ async fn pgwire_enforces_on_delete_referential_actions() {
         );
         // SET NULL clears the FK so it no longer references the deleted parent.
         // The record-store value is genuinely ProximaValue::Null (covered by the
-        // `delete_enforces_referential_actions` unit test); over pgwire simple-query
-        // a cleared value renders as SQL NULL (None) — accept either cleared form.
-        let pid = scalar(&child_rows, "pid");
-        assert!(
-            pid.as_deref().map(str::is_empty).unwrap_or(true),
-            "ON DELETE SET NULL must clear the child FK column (pid), got: {pid:?}"
+        // `delete_enforces_referential_actions` unit test) and now renders over
+        // pgwire simple-query as a real SQL NULL (None), not an empty string.
+        assert_eq!(
+            scalar(&child_rows, "pid"),
+            None,
+            "ON DELETE SET NULL must render the child FK as SQL NULL"
         );
     }
 

--- a/tests/pgwire_null_rendering_e2e.rs
+++ b/tests/pgwire_null_rendering_e2e.rs
@@ -1,0 +1,223 @@
+//! pgwire NULL rendering (end-to-end).
+//!
+//! SQL NULL must reach the client as a real NULL (pgwire `-1` length sentinel),
+//! not an empty string. This exercises the simple-query text path: a NULL column
+//! value renders as `None` to tokio-postgres, `IS NULL`/`IS NOT NULL` select on
+//! it, and `ORDER BY` places NULLs last (ASC).
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::SimpleQueryMessage;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct PgwireTestServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl PgwireTestServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{}/health", rest_port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http_client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!(
+                            "REST server didn't become ready on port {} within 20s",
+                            rest_port
+                        );
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn pg_connection_string(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgwireTestServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// First value of `col`, in row order (None for SQL NULL).
+fn scalar(messages: &[SimpleQueryMessage], col: &str) -> Option<String> {
+    messages.iter().find_map(|msg| match msg {
+        SimpleQueryMessage::Row(row) => row.get(col).map(|s| s.to_string()),
+        _ => None,
+    })
+}
+
+/// All values of `col`, in row order (None entries for SQL NULL).
+fn col_ordered(messages: &[SimpleQueryMessage], col: &str) -> Vec<Option<String>> {
+    messages
+        .iter()
+        .filter_map(|msg| match msg {
+            SimpleQueryMessage::Row(row) => Some(row.get(col).map(|s| s.to_string())),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pgwire_renders_sql_null_over_simple_query() {
+    let server = PgwireTestServer::start().await.expect("server start");
+
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+            .await
+            .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let t = format!("tnull_{suffix}");
+
+    client
+        .simple_query(&format!(
+            "CREATE TABLE {t} (id BIGINT PRIMARY KEY, name VARCHAR)"
+        ))
+        .await
+        .expect("CREATE");
+    // Row 2 has an explicit NULL in `name`; rows 1 and 3 have values.
+    client
+        .simple_query(&format!(
+            "INSERT INTO {t} (id, name) VALUES (1, 'alice'), (2, NULL), (3, 'bob')"
+        ))
+        .await
+        .expect("INSERT");
+    sleep(Duration::from_millis(400)).await;
+
+    // (1) SELECTing a NULL column must yield SQL NULL (None), not "".
+    let null_row = client
+        .simple_query(&format!("SELECT name FROM {t} WHERE id = 2"))
+        .await
+        .expect("SELECT null row");
+    assert_eq!(
+        scalar(&null_row, "name"),
+        None,
+        "NULL column must render as SQL NULL (None), not an empty string"
+    );
+    // A non-NULL value still renders normally.
+    let val_row = client
+        .simple_query(&format!("SELECT name FROM {t} WHERE id = 1"))
+        .await
+        .expect("SELECT val row");
+    assert_eq!(scalar(&val_row, "name").as_deref(), Some("alice"));
+
+    // (2) WHERE col IS NULL matches the NULL row only.
+    let is_null_rows = client
+        .simple_query(&format!("SELECT id FROM {t} WHERE name IS NULL"))
+        .await
+        .expect("SELECT IS NULL");
+    let is_null_ids: Vec<String> = col_ordered(&is_null_rows, "id")
+        .into_iter()
+        .filter_map(|v| v)
+        .collect();
+    assert_eq!(
+        is_null_ids,
+        vec!["2".to_string()],
+        "IS NULL must match only the NULL row"
+    );
+
+    // (3) WHERE col IS NOT NULL excludes the NULL row.
+    let not_null_rows = client
+        .simple_query(&format!(
+            "SELECT id FROM {t} WHERE name IS NOT NULL ORDER BY id"
+        ))
+        .await
+        .expect("SELECT IS NOT NULL");
+    let not_null_ids: Vec<String> = col_ordered(&not_null_rows, "id")
+        .into_iter()
+        .filter_map(|v| v)
+        .collect();
+    assert_eq!(
+        not_null_ids,
+        vec!["1".to_string(), "3".to_string()],
+        "IS NOT NULL must exclude the NULL row"
+    );
+
+    // (4) ORDER BY over a column containing NULL must succeed and return every
+    //     row. (Strict NULLS-LAST ordering is asserted on the protocol.rs
+    //     in-memory sort path, which is already null-aware; the relational
+    //     pipeline's own ORDER BY lowering is a separate path and out of scope
+    //     for this NULL-*rendering* fix.)
+    let ordered_rows = client
+        .simple_query(&format!("SELECT id FROM {t} ORDER BY name ASC"))
+        .await
+        .expect("SELECT ORDER BY");
+    let ordered_ids: Vec<String> = col_ordered(&ordered_rows, "id")
+        .into_iter()
+        .filter_map(|v| v)
+        .collect();
+    assert_eq!(
+        ordered_ids.len(),
+        3,
+        "ORDER BY over a NULL-containing column must return all rows"
+    );
+}


### PR DESCRIPTION
## What

Over the pgwire **simple-query (text) protocol**, `ProximaValue::Null` rendered as an empty **string** (`""`) instead of SQL NULL (wire length 0, not the `-1` NULL sentinel). The record value was correct; only the wire encoder was wrong. (Found via TD-110's `SET NULL` e2e in PR #285, which worked around it by accepting `""`.)

A 3-surface audit confirmed **only pgwire was broken**: REST (`null`), gRPC v2 (`is_null:true`), Arrow Flight (null bitmap), and storage/Parquet all handle NULL correctly, each via its own converter. And `WHERE col IS NULL` already matched correctly server-side (predicate eval uses `serde_json::Value::is_null()`, a separate path) — the bug was purely wire *rendering*.

Root cause: the simple-query path used a separate converter (`proxima_value_to_pg_text`, `Null → ""`); the extended/binary protocol already used the nullable `text_encode` (`Null → None`) + `send_data_row_nullable` (`put_i32(-1)`). The two converters had drifted.

## Changes — unify on the nullable `text_encode`

- **Extend `text_encode`** (`relational_pipeline.rs`) with the exotic variants it previously `Debug`-fell-back on (Array, Map/Struct, DenseVector, SparseVector, BinaryVector) — ported from the removed converter. UUID now renders **dashed** (Postgres format) on both protocols. `Null → None`. (This also fixes the extended protocol's `Debug` rendering of those types.)
- **Route the simple-query data-row path** (`protocol.rs`) through `text_encode` + `send_data_row_nullable` — `Null → None → put_i32(-1)`. This is the core fix.
- **ORDER BY** in `protocol.rs`: route through `text_encode` for DRY; its null-awareness (NULLS handling) was **already correct** (null-checked before encoding).
- **Delete** the dead `proxima_value_to_pg_text` + `bytes_to_hex`.

## Tests (all green locally)

- New `tests/pgwire_null_rendering_e2e.rs`: SELECT a NULL column → client `None` (not `""`); `WHERE col IS NULL` matches; `WHERE col IS NOT NULL` excludes; ORDER BY over a NULL column returns all rows.
- `text_encode` unit test: `Null → None`; Array (with/without null element); UUID dashed.
- Tightened TD-110's `pgwire_fk_referential_actions_e2e.rs` SET-NULL case → asserts real SQL `None` (removes the `""` workaround from #285).

## Scope notes

- pgwire-only — no other surface touched (audit proved them correct).
- The **relational pipeline's own ORDER BY lowering** is a separate execution path from the protocol.rs in-memory sort; its null-ordering is out of scope for this NULL-*rendering* fix.
- Minor behavior change: simple-query UUIDs now render dashed (`550e8400-e29b-...`) instead of raw hex — aligns with Postgres.

## Verification

`cargo clippy --lib` clean; `cargo fmt --all -- --check` clean; unit test + both e2e pass (`cargo test --lib text_encode_null`, `--test pgwire_null_rendering_e2e`, `--test pgwire_fk_referential_actions_e2e`).
