### PR TITLE
feat(cluster): map DML lock conflicts to protocol codes (A8)

### DIFF
--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -2133,10 +2133,13 @@ impl UnifiedHandlers {
                 if is_write {
                     let tenant_ctx = tenant_id
                         .map(crate::storage::tenant::context::TenantContext::for_tenant_id);
+                    // Use `.context` (NOT `anyhow!("DML failed: {e}")`) so a typed
+                    // ProximaDBError::DmlLockConflict in the chain survives for the
+                    // protocol layer (gRPC/pgwire) to downcast + map to ABORTED/55P03.
                     let result = dml
                         .execute_scoped(statement, tenant_ctx.as_ref())
                         .await
-                        .map_err(|e| anyhow::anyhow!("DML failed: {e}"))?;
+                        .context("DML failed")?;
                     return Ok(crate::proto::proximadb_v1::ExecuteQueryResponse {
                         rows: vec![],
                         rows_scanned: 0,

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -2380,6 +2380,32 @@ pub fn consult_for_write_leased(
 /// DML Lock Service (Hierarchical Locking for Fine-Grained DML)
 ////////////////////////////////////////////////////////////////////////////////
 
+/// Cluster-local typed error: a DML lock could not be acquired (conflict /
+/// held / fenced). Kept cluster-local (no `core::errors` dependency — layering)
+/// and mapped to `ProximaDBError::DmlLockConflict` at the services layer so
+/// protocol handlers can recover it uniformly via an anyhow chain-walk.
+#[derive(Debug, thiserror::Error)]
+pub enum DmlLockAcquireError {
+    #[error("DML lock conflict on {resource}")]
+    Conflict { resource: String },
+    #[error("DML lock held by {holder} on {resource}")]
+    Held { resource: String, holder: String },
+    #[error("DML lock fenced by {holder} on {resource}")]
+    Fenced { resource: String, holder: String },
+}
+
+impl DmlLockAcquireError {
+    /// `(resource, holder?)` for mapping into a typed protocol error.
+    pub fn resource_holder(&self) -> (String, Option<String>) {
+        match self {
+            Self::Conflict { resource } => (resource.clone(), None),
+            Self::Held { resource, holder } | Self::Fenced { resource, holder } => {
+                (resource.clone(), Some(holder.clone()))
+            }
+        }
+    }
+}
+
 /// Active DML lock (held by a pod for a specific scope with an intent).
 #[derive(Debug, Clone)]
 pub struct ActiveLock {
@@ -2688,6 +2714,9 @@ impl DmlLockService {
         intent: LockIntent,
         now_ms: i64,
     ) -> Result<DmlLockGuard> {
+        // Compute the resource label up front so the error arms can use it
+        // without moving `scope` (which the Acquired arm consumes).
+        let resource = scope.to_key();
         match self
             .acquire_dml_lock(tenant_id, namespace_id, &scope, intent.clone(), now_ms)
             .await?
@@ -2701,23 +2730,17 @@ impl DmlLockService {
                 lease_generation: lease.generation,
                 released: false,
             }),
-            LockOutcome::Conflict => Err(anyhow::anyhow!(
-                "DML lock conflict for tenant '{tenant_id}', namespace {:?}, scope {:?}",
-                namespace_id,
-                scope
-            )),
-            LockOutcome::Held { holder, expires_at } => Err(anyhow::anyhow!(
-                "DML lock held by pod '{holder}' until {expires_at} for tenant '{tenant_id}', namespace {:?}, scope {:?}",
-                namespace_id,
-                scope
-            )),
-            LockOutcome::Fenced { latest } => Err(anyhow::anyhow!(
-                "DML lock fenced by pod '{}' generation {} for tenant '{tenant_id}', namespace {:?}, scope {:?}",
-                latest.holder_pod,
-                latest.generation,
-                namespace_id,
-                scope
-            )),
+            // Typed conflict errors (wrapped in anyhow) — mapped to
+            // ProximaDBError::DmlLockConflict at the services layer.
+            LockOutcome::Conflict => Err(DmlLockAcquireError::Conflict { resource }.into()),
+            LockOutcome::Held { holder, .. } => {
+                Err(DmlLockAcquireError::Held { resource, holder }.into())
+            }
+            LockOutcome::Fenced { latest } => Err(DmlLockAcquireError::Fenced {
+                resource,
+                holder: latest.holder_pod,
+            }
+            .into()),
         }
     }
 

--- a/src/core/errors/core_error.rs
+++ b/src/core/errors/core_error.rs
@@ -230,6 +230,17 @@ pub enum ProximaDBError {
         /// Savepoint name
         name: String,
     },
+
+    /// DML write-lock conflict — another writer holds the table/schema lease.
+    /// Surfaces as pgwire SQLSTATE 55P03 (lock_not_available) / gRPC ABORTED /
+    /// REST 409.
+    #[error("DML lock conflict on {resource}")]
+    DmlLockConflict {
+        /// Locked resource description (e.g. "schema.table").
+        resource: String,
+        /// Pod holding the conflicting lease, if known.
+        holder: Option<String>,
+    },
 }
 
 // Custom implementation for io::Error conversion since it's not Clone/Serialize

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -73,6 +73,11 @@ pub enum ApiError {
     #[error("Conflict: {0}")]
     Conflict(String),
 
+    /// DML write-lock conflict — another writer holds the table/schema lease.
+    /// REST 409 / gRPC ABORTED / pgwire SQLSTATE 55P03.
+    #[error("DML lock conflict: {0}")]
+    LockConflict(String),
+
     /// Capability not supported by storage engine
     #[error("Capability not supported: {0}")]
     UnsupportedCapability(String),
@@ -128,6 +133,9 @@ impl From<ApiError> for tonic::Status {
                 tonic::Status::invalid_argument(format!("Invalid vector: {}", msg))
             }
             ApiError::Conflict(msg) => tonic::Status::aborted(msg),
+            ApiError::LockConflict(msg) => tonic::Status::aborted(format!(
+                "DML lock conflict: {msg}. Retry the write once the holder releases."
+            )),
             ApiError::UnsupportedCapability(msg) => tonic::Status::invalid_argument(format!(
                 "Capability not supported: {}. Please check storage engine capabilities.",
                 msg
@@ -189,6 +197,7 @@ impl IntoResponse for ApiError {
             ApiError::DimensionMismatch { .. } => (StatusCode::BAD_REQUEST, "dimension_mismatch"),
             ApiError::InvalidVector(_) => (StatusCode::BAD_REQUEST, "invalid_vector"),
             ApiError::Conflict(_) => (StatusCode::CONFLICT, "conflict"),
+            ApiError::LockConflict(_) => (StatusCode::CONFLICT, "lock_conflict"),
             ApiError::UnsupportedCapability(_) => {
                 (StatusCode::BAD_REQUEST, "unsupported_capability")
             }
@@ -399,9 +408,31 @@ impl From<crate::core::errors::ProximaDBError> for ApiError {
                 "{} conflicts with {}",
                 transaction, conflicting_with
             )),
+            E::DmlLockConflict { resource, holder } => ApiError::LockConflict(match holder {
+                Some(h) => format!("{resource} held by {h}"),
+                None => resource,
+            }),
             other => ApiError::Internal(other.to_string()),
         }
     }
+}
+
+/// Walk an `anyhow::Error` chain looking for a DML lock conflict
+/// (`ProximaDBError::DmlLockConflict`). Returns `(resource, holder?)` so
+/// protocol boundaries that receive a raw `anyhow::Error` (pgwire, gRPC) can
+/// detect a lock conflict and map it to the right code (SQLSTATE 55P03 /
+/// `tonic::ABORTED`) without each reimplementing the chain walk. Anyhow's
+/// `downcast_ref` only inspects the top error, so we iterate `.chain()` to see
+/// through `.context(...)` wrappers added along the way.
+pub fn extract_dml_lock_conflict(err: &anyhow::Error) -> Option<(String, Option<String>)> {
+    use crate::core::errors::ProximaDBError as E;
+    err.chain()
+        .find_map(|source| match source.downcast_ref::<E>() {
+            Some(E::DmlLockConflict { resource, holder }) => {
+                Some((resource.clone(), holder.clone()))
+            }
+            _ => None,
+        })
 }
 
 /// Helper function to convert Result<T, ApiError> to Response
@@ -424,6 +455,54 @@ mod tests {
         let err = ApiError::CollectionNotFound("test_collection".to_string());
         let status: tonic::Status = err.into();
         assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    #[test]
+    fn dml_lock_conflict_maps_to_conflict_status_and_http() {
+        use crate::core::errors::ProximaDBError;
+        let mk = || {
+            ApiError::from(ProximaDBError::DmlLockConflict {
+                resource: "public.users".into(),
+                holder: Some("pod-7".into()),
+            })
+        };
+        // Variant + gRPC → ABORTED (retryable).
+        let api = mk();
+        assert!(matches!(api, ApiError::LockConflict(_)));
+        let status: tonic::Status = api.into();
+        assert_eq!(status.code(), tonic::Code::Aborted);
+        // REST → 409 Conflict (ApiError isn't Clone, so rebuild).
+        let resp = mk().into_response();
+        assert_eq!(resp.status().as_u16(), 409);
+    }
+
+    #[test]
+    fn extract_dml_lock_conflict_walks_anyhow_chain() {
+        use crate::core::errors::ProximaDBError;
+        // Plain (no context wrapper).
+        let e: anyhow::Error = ProximaDBError::DmlLockConflict {
+            resource: "public.t".into(),
+            holder: None,
+        }
+        .into();
+        let (resource, holder) = extract_dml_lock_conflict(&e).expect("should find the conflict");
+        assert_eq!(resource, "public.t");
+        assert!(holder.is_none());
+
+        // Through a .context(...) wrapper (the real DmlService path).
+        let wrapped: anyhow::Error = anyhow::Error::new(ProximaDBError::DmlLockConflict {
+            resource: "s.t".into(),
+            holder: Some("pod-1".into()),
+        })
+        .context("DML failed");
+        let (resource, holder) =
+            extract_dml_lock_conflict(&wrapped).expect("should see through context");
+        assert_eq!(resource, "s.t");
+        assert_eq!(holder.as_deref(), Some("pod-1"));
+
+        // Unrelated error → None.
+        let other: anyhow::Error = ProximaDBError::InvalidInput("boom".into()).into();
+        assert!(extract_dml_lock_conflict(&other).is_none());
     }
 
     #[test]

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1902,7 +1902,18 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             .request_handlers
             .execute_sql_v1(q.query, None, collection, tenant_id.as_deref())
             .await
-            .map_err(|e| Status::internal(format!("ExecuteQuery failed: {e}")))?;
+            .map_err(|e| {
+                // A DML lock conflict → ABORTED (retryable); other errors → INTERNAL.
+                if let Some((resource, holder)) = crate::errors::extract_dml_lock_conflict(&e) {
+                    let msg = match holder {
+                        Some(h) => format!("DML lock conflict on {resource} held by {h}"),
+                        None => format!("DML lock conflict on {resource}"),
+                    };
+                    Status::aborted(msg)
+                } else {
+                    Status::internal(format!("ExecuteQuery failed: {e}"))
+                }
+            })?;
         let rows = resp
             .rows
             .into_iter()

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -3654,6 +3654,18 @@ impl PostgresProtocol {
                             .await
                     }
                     Err(e) => {
+                        if let Some((resource, holder)) =
+                            crate::errors::extract_dml_lock_conflict(&e)
+                        {
+                            let msg = match holder {
+                                Some(h) => {
+                                    format!("lock not available on {resource} (held by {h})")
+                                }
+                                None => format!("lock not available on {resource}"),
+                            };
+                            warn!("DmlService INSERT blocked by DML lock: {msg}");
+                            return self.send_error("ERROR", "55P03", &msg).await;
+                        }
                         warn!("DmlService INSERT failed: {}", e);
                         self.send_error("ERROR", "42P01", &format!("Insert failed: {}", e))
                             .await
@@ -3757,6 +3769,18 @@ impl PostgresProtocol {
                             .await
                     }
                     Err(e) => {
+                        if let Some((resource, holder)) =
+                            crate::errors::extract_dml_lock_conflict(&e)
+                        {
+                            let msg = match holder {
+                                Some(h) => {
+                                    format!("lock not available on {resource} (held by {h})")
+                                }
+                                None => format!("lock not available on {resource}"),
+                            };
+                            warn!("DmlService DELETE blocked by DML lock: {msg}");
+                            return self.send_error("ERROR", "55P03", &msg).await;
+                        }
                         warn!("DmlService DELETE failed: {}", e);
                         self.send_error("ERROR", "42P01", &format!("Delete failed: {}", e))
                             .await
@@ -3854,6 +3878,18 @@ impl PostgresProtocol {
                             .await
                     }
                     Err(e) => {
+                        if let Some((resource, holder)) =
+                            crate::errors::extract_dml_lock_conflict(&e)
+                        {
+                            let msg = match holder {
+                                Some(h) => {
+                                    format!("lock not available on {resource} (held by {h})")
+                                }
+                                None => format!("lock not available on {resource}"),
+                            };
+                            warn!("DmlService UPDATE blocked by DML lock: {msg}");
+                            return self.send_error("ERROR", "55P03", &msg).await;
+                        }
                         // DmlService UPDATE returns error for not-implemented
                         // This is expected - UPDATE requires delete + insert pattern
                         warn!("DmlService UPDATE: {}", e);

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -868,14 +868,35 @@ impl DmlService {
                 intent,
                 Self::now_unix_ms(),
             )
-            .await
-            .with_context(|| {
-                format!(
-                    "acquiring DML lock for tenant '{tenant_id}', namespace '{namespace_id}', table '{}'",
-                    table_id.name
-                )
-            })?;
-        Ok(Some(guard))
+            .await;
+        match guard {
+            Ok(g) => Ok(Some(g)),
+            Err(e) => {
+                // A lock conflict → typed ProximaDBError so protocol layers can
+                // map it (pgwire SQLSTATE 55P03 / gRPC ABORTED). Walk the chain
+                // (anyhow downcast_ref only sees the top error) to find the
+                // cluster-local conflict detail.
+                use crate::cluster::partition_lease::DmlLockAcquireError;
+                if let Some(conflict) = e
+                    .chain()
+                    .find_map(|s| s.downcast_ref::<DmlLockAcquireError>())
+                {
+                    let (resource, holder) = conflict.resource_holder();
+                    return Err(crate::core::errors::ProximaDBError::DmlLockConflict {
+                        resource,
+                        holder,
+                    }
+                    .into());
+                }
+                // Non-conflict failure — propagate with context.
+                Err(e).with_context(|| {
+                    format!(
+                        "acquiring DML lock for tenant '{tenant_id}', namespace '{namespace_id}', table '{}'",
+                        table_id.name
+                    )
+                })
+            }
+        }
     }
 
     fn dml_lock_namespace_id(


### PR DESCRIPTION
feat(cluster): map DML lock conflicts to protocol codes (A8)

DML lock conflicts (PR #281/#288) blocked the second writer but surfaced as a
generic error. Now they map to the right protocol code so clients retry
correctly.

- ProximaDBError::DmlLockConflict { resource, holder } (core_error.rs).
- partition_lease.rs: cluster-local DmlLockAcquireError (Conflict/Held/Fenced)
  returned by acquire_dml_lock_guard — kept cluster-local (no core::errors dep;
  layering) and mapped to ProximaDBError in dml/mod.rs acquire_table_dml_lock.
- request_handlers.rs: execute_scoped error now uses .context (not anyhow!("..{e}"))
  so the typed error survives the chain (anyhow!("..{e}") was stringifying it).
- pgwire (protocol.rs INSERT/DELETE/UPDATE): anyhow chain-walk -> SQLSTATE 55P03
  (lock_not_available).
- gRPC (record_service.rs execute_sql_v1): chain-walk -> tonic::ABORTED.
- errors/mod.rs: ApiError::LockConflict + From<ProximaDBError> + REST 409 +
  tonic ABORTED + extract_dml_lock_conflict() chain-walk helper.

REST has no SQL-DML path through DmlService (vector records only), so the 409
mapping is for completeness/future. Flight inherits the gRPC tonic map.

Remaining TD: A6-enforcement (storage-level validate_fencing — defense-in-depth).

Verified: cargo check --lib green; 5 mapping/lock tests pass; fmt clean.
