### PR TITLE
feat(cluster): spawn lease renew/reconcile loop in production (P1a)

### DIFF
--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -3063,6 +3063,49 @@ mod tests {
         Ok(())
     }
 
+    /// P1a: the background renew loop (spawned in production by SharedServices)
+    /// keeps a held lease alive past its TTL. Without it the lease would lapse
+    /// and the leaseholder model the write-gate (421) + DML locks rely on
+    /// silently degrades.
+    #[tokio::test]
+    async fn renew_loop_keeps_held_lease_past_ttl() -> Result<()> {
+        let backing = shared_backing();
+        let store_handle = Arc::new(store(&backing));
+        // Short TTL (100ms) so the test is fast.
+        let mgr = Arc::new(PartitionLeaseManager::new(
+            store_handle.clone(),
+            Arc::new(PrimaryPodRegistry::new()),
+            "pod-A",
+            100,
+        ));
+        let key = ResourceKey::legacy_collection("t1", "c1");
+        assert!(mgr.acquire_with_key(&key, now_millis()).await?);
+
+        // Renew every 40ms (≤ TTL/2), fire-and-forget like production.
+        let renew_handle = mgr.clone().spawn_renew_loop(Duration::from_millis(40));
+
+        // Sleep well past the TTL. Without renewal the lease would be expired;
+        // with the renew loop it must stay held by pod-A at the same generation.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let (_, lease) = store_handle
+            .read_key(&key)
+            .await?
+            .expect("lease still present");
+        assert_eq!(lease.holder_pod, "pod-A");
+        assert!(
+            !lease.is_expired(now_millis()),
+            "renewal must push expiry forward past now"
+        );
+        assert_eq!(
+            lease.generation, 1,
+            "renewal keeps generation (no takeover)"
+        );
+
+        renew_handle.abort();
+        Ok(())
+    }
+
     /// Owner death (lease expiry) → fenced handoff: a new pod takes over with a
     /// strictly-higher generation, and the dead owner's later renewal is rejected.
     #[tokio::test]

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1833,7 +1833,20 @@ impl SharedServices {
                         pod_id.clone(),
                         10_000,
                     ));
-                    Some(Arc::new(DmlLockService::new(manager, pod_id)))
+                    // P1a: keep held leases warm. Without this the renew loop
+                    // never runs in production (it was only spawned in tests),
+                    // so held leases lapse after the 10s TTL and the
+                    // leaseholder model the write-gate (421) + DML locks rely
+                    // on silently degrades. Fire-and-forget for the process
+                    // lifetime (matches SharedServices' existing background-task
+                    // pattern); interval ≤ lease_ms/2 so a lease never lapses
+                    // between renewals.
+                    let _ = manager
+                        .clone()
+                        .spawn_renew_loop(std::time::Duration::from_millis(5_000));
+                    let lock_service = Arc::new(DmlLockService::new(manager, pod_id));
+                    let _ = lock_service.spawn_reconciliation_loop(5_000);
+                    Some(lock_service)
                 }
                 Err(e) => {
                     tracing::warn!(


### PR DESCRIPTION
feat(cluster): spawn lease renew/reconcile loop in production (P1a)

The partition-lease + DML-lock foundation (#281/#288/#294) constructed
PartitionLeaseManager in SharedServices but never spawned its renew loop
(only tests did). Held leases therefore lapsed after the 10s TTL, silently
degrading the leaseholder model the write-gate (421) and DML locks rely on.
This completes the lease lifecycle.

- SharedServices: spawn PartitionLeaseManager::spawn_renew_loop (interval <=
  lease_ms/2) + DmlLockService::spawn_reconciliation_loop at bootstrap,
  fire-and-forget for the process lifetime (matches SharedServices' existing
  background-task pattern).
- Test: renew_loop_keeps_held_lease_past_ttl proves a held lease survives
  past its TTL with the loop running (stays held, same generation, not expired).

Phase 1a of the next architectural arc (complete the distributed-coordination
plane). Phase 1b (lease-aware read routing) deferred — it's a read-locality/
consistency optimization (reads from the shared object store are already
consistent; the write side is already 421-gated), not a correctness fix like
this one.

Arc (plan): P1a lifecycle -> [P1b read routing, deferred] -> P2 close the C0
cloud-I/O-trace gap -> P3 multi-modal fusion -> P4 serverless elasticity ->
P5 native OLAP.

Verified: cargo check --lib green; 4 lease tests pass incl. new renew-loop
test; fmt clean.
