### PR TITLE
docs(techdebt): reconcile TD/feature/vision tracking — live tracker + closed archive

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -1,1743 +1,402 @@
-= ProximaDB Technical Debt Register
+= ProximaDB Technical Debt Register — Live Tracker
 :toc: auto
 :toclevels: 3
+:last-reconciled: 2026-06-24
 
-Comprehensive register of technical debt items tracking gaps between current state and world-class targets.
+The single live tracker for *open* technical-debt, feature, and vision items. Resolved/closed
+items are indexed in
+link:../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[the Closed Items Archive]
+(full historical prose preserved in git history of this file before the 2026-06-24 reconciliation).
 
 [IMPORTANT]
 ====
-This register tracks _implementation state_, not _product-support level_.
-
-link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] is the authoritative product
-support contract and takes precedence for any customer, release-note, or marketing claim.
-A "Resolved" or "Production Ready" status in this register means the code path is complete
-in the working tree -- it does *not* by itself mean the capability is a Supported v0.2
-surface. Where this register and the support contract disagree, the support contract wins;
-the affected rows are relabeled with their `SUPPORTED_SURFACE.adoc` tier inline.
+This register tracks *implementation state*, not *product-support level*.
+link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] is the authoritative product-support contract
+and wins for any customer, release-note, or marketing claim. A "Resolved" status here means the code
+path is complete in the working tree — it does *not* by itself make a capability a Supported v0.2 surface.
 ====
+
+[NOTE]
+====
+*2026-06-24 reconciliation.* This register was split into a lean live tracker (this file) plus a
+link:../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[closed archive]. Changes made:
+
+* *Status reconciled against `origin/develop` HEAD* — TD-129 (ON CONFLICT upsert, `258943f3`),
+  TD-134 (KEU meter + per-repo RBAC, `05b920f0`) flipped Open→Resolved; TD-132 (CPG-fragment PAX
+  contract test, `92611256`) Open→Partial; TD-005 rescoped (Go/Java/JVM/Node SDKs now exist).
+* *Structural fixes* — removed verbatim-duplicate TD-043/TD-044; resolved the TD-054 ID collision
+  (live TD-054 = L-RAG only; the type-system work is `Resolved` TD-111); controlled the status
+  vocabulary; replaced the stale Debt-by-Category / Phase-Alignment roll-ups (they only covered
+  TD-001..020) with the accurate summary at the end.
+* *Refinement lens* — every open item now carries a *co-design Dimension* and a *Well-Architected
+  Pillar* tag (legend below), so the register reads against the dominant cost term rather than as a
+  flat to-do list.
+* The old `feat/td-129-*`, `feat/td-132-*`, `feat/td-133-*` topic branches are superseded by the
+  squashed landings on `develop` and can be pruned.
+====
+
+== Legend
+
+*Status (controlled vocabulary)* — use exactly these:
+
+[cols="1,5", options="header"]
+|===
+| Status | Meaning
+| `Open` | Not started, or only design/scoping exists.
+| `In Progress` | Actively being built; partial code landed this cycle.
+| `Partial` | A foundation/slice has landed and is durable; a named residual remains. (Status line states the residual.)
+| `Resolved` | Code path complete in the working tree. Moves to the closed archive.
+| `Won't Do` | Explicitly descoped (record the why).
+|===
+
+*Co-design Dimension* — which physical cost term the item moves
+(`CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`). For a cloud DB the dominant terms are I/O
+round-trips and egress, *not* CPU.
+
+[cols="1,5", options="header"]
+|===
+| Tag | Dimension
+| `D1` | Object storage (I/O round-trips, bytes-touched-per-query, manifest/footer reads)
+| `D2` | Network / egress (KOU — metered read + result direction)
+| `D3` | Local disk / cache (paging, eviction, tier demotion)
+| `D4` | Compute-per-modality (engine routing, vectorized/SIMD, fusion, plan cost)
+| `D5` | Governance / security (tenant isolation, RLS, catalog authority, metering)
+|===
+
+*Well-Architected Pillar* — `OE` Operational Excellence · `SEC` Security · `REL` Reliability ·
+`PERF` Performance Efficiency · `COST` Cost Optimization · `SUS` Sustainability.
 
 == Vision Phase Context
 
-Technical debt items are prioritized based on their impact on the four development phases:
+* *Phase 1* (Format & Catalog): storage engines, WAL, core APIs — *complete*.
+* *Phase 2* (Cross-Model Query): graph, documents, observability, unified query — *in progress*.
+* *Phase 3* (Ecosystem Integration): external catalogs, streaming, SDKs, SaaS operational readiness.
+* *Phase 4* (Context DB Evolution): time-series, event sourcing, hybrid, framework integrations — *engines complete, packaging Beta*.
+* *Phase 5–6* (Agentic Intelligence / Active Memory): research-frontier features.
+* *Phase 7–8* (Competitive Platform / Continuous Loop & Elastic Compute): storage authority, lakehouse-native pgwire, cost-based routing, scale-to-zero.
 
-* *Phase 1* (Format & Catalog): Storage engines, WAL, core APIs
-* *Phase 2* (Cross-Model Query): Graph, documents, observability, unified query
-* *Phase 3* (Ecosystem Integration): External catalogs, streaming, SDKs
-* *Phase 4* (Context Database Evolution): Time-series, event sourcing, hybrid search, framework integrations
+== Open Items by Workstream
 
-== Current Priorities
+NOTE: `Pri` = product priority (CRIT/HIGH/MED/LOW). The status line in the `Notes` column states the
+*residual* for `Partial`/`In Progress` items. Design docs live under `docs/12-design/`.
 
-[cols="1,3,1,1,1,4,2,4", options="header"]
+=== A. Relational / OLTP / pgwire / HTAP
+
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| ID | Area | Phase | Priority | Status | Impact | Effort | Notes
+| ID | Area | Pri | Status | Dim | Pillar | Notes — problem → next action (key location; deps)
 
-| TD-CROSS-LAYER
-| Storage→Index dependency inversion
-| All
-| Critical
-| *Resolved*
-| Storage layer imported from index layer, violating layering
-| 2 days
-| *RESOLVED May 2026*: **Cross-layer dependency resolved**. `StorageEngineType` moved from `index/axis/eventlog` to `core/types/storage.rs`. Storage layer now imports from shared types module instead of index layer. See `src/core/types/storage.rs:16-20` for documentation.
+| TD-127 | OLTP secondary indexes | HIGH | Open | D4 | PERF
+| Volcano point-lookup covers PK only (`ScanAccess::PkLookup`); code-graph lookups by name/file fall to full-scan+filter. → secondary-index access path + reader cap `secondary_lookup` in `proximadb-relational-planner` (`push_predicates`) + `record_store.rs`. See `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
 
-| TD-001
-| PULSAR/QUASAR engine retirement
-| P3
-| Medium
-| *Resolved*
-| Users see advertised features that don't work
-| 2-3 months
-| *RESOLVED Jun 2026*: Separate PULSAR/QUASAR engine modules, feature flags, REST routes, and dedicated tests were removed. `GraphOperationsService` and `GraphEngineFactory` now expose ORION only and reject retired engine names with a compatibility error. Former distributed graph behavior belongs to the relational distributed substrate; former tiered graph behavior belongs to xCatalog/storage projection policy.
+| TD-128 | OLTP IN-list / range pushdown | HIGH | Open | D4 | PERF
+| `WHERE col IN (...)` / `BETWEEN` not pushed to a multi-key batch (full-scan+filter today). → planner predicate pushdown + `ScanAccess` multi-key batch; reader `pk_lookup_batch`. Companion to TD-127.
 
-| TD-002
-| External catalog integration
-| P3
-| Medium
-| *Resolved*
-| Cannot integrate with Iceberg/Delta data lakes
-| 3-4 months
-a| *Implemented (engine), Mar 2026.* **v0.2 support tier: _Experimental in v0.2 (see SUPPORTED_SURFACE)_** -- external-table / external-catalog execution is not a v0.2 supported surface; do not market it as supported or production. _Implementation detail:_ all major catalog backends are code-complete:
+| TD-076 | pgwire SQL parity Phase 2/3 (ADR-018) | MED | Open | D4 | OE
+| Phase 1 (basic DML + vector-distance) wired. Phase 2 (`ORDER BY`/aggregates/joins/`pg_class`) + Phase 3 (PG parity) gap; live probe found crashes on aggregates/joins. v0.2 ships pgwire Beta @ Phase 1. See ADR-018.
 
-[%header%autowidth]
-!===
-! Catalog ! Status ! Location ! Features
-! Iceberg ! ✅ Production Ready ! `src/catalog/iceberg.rs` ! JDBC, Hadoop, Memory backends; schema evolution; time travel; snapshot isolation
-! Delta Lake ! ✅ Production Ready ! `src/catalog/delta.rs` ! Delta log protocol; ACID transactions; time travel; partitioning
-! AWS Glue ! ✅ Production Ready ! `src/catalog/glue.rs` ! AWS Glue Data Catalog; Athena/Redshift compatible; vector extensions
-! Unity Catalog ! ✅ Production Ready ! `src/catalog/unity.rs` ! Databricks Unity; 3-level namespace; REST API integration
-! Polaris ! ✅ Production Ready ! `src/catalog/polaris.rs` ! Apache Polaris; Iceberg REST Catalog; OAuth2
-! Hive ! ✅ Production Ready ! `src/catalog/hive.rs` ! Apache Hive Metastore; Thrift protocol
-!===
+| TD-110 | OLTP/OLAP HTAP storage + PG constraints | HIGH | Open | D3 | REL
+| Native OLTP authority below pgwire: xCatalog constraint/index metadata, WAL+row/delta commit, PK/unique/check/FK, MVCC, snapshot+delta reads. *2026-06-24:* ON DELETE actions (RESTRICT/CASCADE/SET NULL) for single-col FK re-landed (`DmlService::enforce_delete_referential_actions`). Open: ON UPDATE, composite-FK, recursive cascade. Plan: `roadmap/techdebt/TD_110_*`.
 
-All catalogs implement the `Catalog` trait with full CRUD operations, health checks, and caching. Feature-gated behind appropriate flags: `delta-lake`, `aws`, `unity-catalog`, `polaris-catalog`.
+| TD-061 | Optional relational capabilities | HIGH | Open | D5 | REL
+| Keys/unique/secondary/FK/check/MV/txn-profiles as *cataloged* table capabilities (don't tax vector/doc/obs workloads). Start with catalog shape + validation hooks before full FK enforcement. Overhaul spec §5.7.
 
-| TD-003
-| Streaming infrastructure
-| P3
-| Medium
-| *Resolved*
-| No real-time subscriptions for collection changes
-| 2-3 months
-| *RESOLVED Mar 2026*: **Streaming infrastructure fully implemented**. Complete real-time streaming system with gRPC bidirectional streaming, lock-free ring buffers, backpressure handling, live query subscriptions, and Kafka integration.
+| TD-120 | pg_catalog completeness for ORM/driver compat | MED | Partial | D5 | OE
+| *Foundation landed 2026-06-17 (`1233de45d`):* pg_type/pg_namespace/pg_class/pg_attribute/pg_constraint views + unit tests. Residual: pg_index canonical view + live ORM round-trip (SQLAlchemy/JDBC). `catalog_introspection.rs`; plan `TD_120_*`.
 
-| TD-004
-| CDC connectors (inbound)
-| P3
-| Medium
-| *Resolved*
-| Cannot capture changes from PostgreSQL/MySQL/MongoDB natively
-| 1-2 months
-a| *RESOLVED Mar 2026*: **All three CDC connectors 100% complete**. Full production-ready CDC implementations with live streaming support:
-
-[%header%autowidth]
-!===
-! Connector ! Status ! Location ! Features
-! PostgreSQL ! ✅ Complete ! `src/cdc/connectors/postgres/connector.rs` ! Logical replication, pgoutput protocol, WAL streaming, slot management, LSN tracking, offset storage
-! MySQL ! ✅ Complete ! `src/cdc/connectors/mysql/connector.rs` ! Binlog decoder complete, live polling event loop, query_binlog_events(), convert_binlog_to_change_event(), position/GTID tracking
-! MongoDB ! ✅ Complete ! `src/cdc/connectors/mongodb/connector.rs` ! Live change stream with async iteration, run_mongodb_change_stream(), BSON to JSON conversion, resume token handling, tokio::select for shutdown
-!===
-
-| TD-005
-| Multi-language SDKs
-| P3
-| Low
-| Open
-| Only Python and Rust SDKs available
-| 2 months per SDK
-| Go SDK in progress, Java/Node.js/C++ planned
-
-| TD-006
-| mTLS support
-| P3
-| Medium
-| *Resolved*
-| Cannot meet enterprise security requirements
-| 1 month
-a| *Implemented (engine), Mar 2026.* **v0.2 support tier: _Beta in v0.2 (see SUPPORTED_SURFACE)_** -- the security runtime is Beta; admin/status APIs and stronger online revocation policy remain incomplete. _Implementation detail:_ enterprise-grade mutual TLS infrastructure is code-complete:
-
-[%header%autowidth]
-!===
-! Component ! Status ! Location ! Features
-! Certificate Manager ! ✅ Production Ready ! `src/network/tls/certificate_manager.rs` ! Self-signed cert generation, CA generation for mTLS, cert parsing/validation, automatic renewal
-! TLS Configuration ! ✅ Production Ready ! `src/network/tls/mod.rs` ! Rustls ServerConfig builder, mTLS support, ALPN protocols
-! TLS Acceptor ! ✅ Production Ready ! `src/network/tls/acceptor.rs` ! Client certificate extraction, Axum layer integration, peer cert parsing
-! Client Cert Middleware ! ✅ Production Ready ! `src/network/middleware/tls.rs` ! CN validation, pattern matching, expiration checking, user mapping
-! Unified Auth ! ✅ Supports mTLS ! `src/security/unified_auth.rs` ! `ClientCertificate` auth method, integration with JWT/API keys
-!===
-
-**mTLS Pipeline Complete:**
-1. TLS handshake with client certificate verification (rustls)
-2. Certificate extraction during handshake (TlsAcceptor)
-3. Addition to request extensions (TlsAcceptorLayer)
-4. Validation by authentication middleware (tls_client_cert_middleware)
-5. User context creation (UnifiedAuthService)
-
-**Features:**
-- CN pattern matching (`*.example.com`, wildcards)
-- Certificate expiration validation
-- CN-to-user mapping
-- Default role assignment
-- Health endpoint bypass
-- TODO: Certificate revocation (CRL/OCSP) checking framework ready
-
-| TD-007
-| unwrap/expect proliferation
-| P1
-| CRITICAL
-| *Resolved*
-| Any of 11,536 calls can panic in production. Incompatible with "production-ready" claims.
-| 1-2 months
-| *RESOLVED Mar 2026*: **All production panic-prone calls eliminated**. Counting script (`scripts/count_panic_patterns.sh`) shows **0 unwrap() + 0 expect() = 0 total** in production code across all modules. Final fixes on 2026-03-11 resolved 3 expect() regression in query module (mutex poisoning error handling, sort comparison error handling). Lints in place (`#![warn(clippy::unwrap_used)]`, `#![warn(clippy::expect_used)]` in src/lib.rs:22-23). CI guardrails prevent regression.
-
-| TD-008
-| No hybrid search / BM25
-| P4
-| CRITICAL
-| *Resolved*
-| Table stakes in 2026. 65% of Fortune 500 AI teams use hybrid search. Missing = losing deals.
-| 2 months
-| *COMPLETED Feb 2025*: Implemented RRF fusion in `src/core/search/hybrid.rs`. REST endpoints in `src/network/rest/v1/handlers.rs`. 14 tests passing. Use `/api/v1/hybrid/search` with `text_query` + `vector` + `hybrid_mode`.
-
-| TD-009
-| No time-series engine
-| P4
-| CRITICAL
-| *Resolved*
-| Cannot serve trading/IoT workloads. ibkrtrading forced to use PostgreSQL.
-| 3-4 months
-| *Implemented (engine).* **v0.2 support tier: _Beta in v0.2 (see SUPPORTED_SURFACE)_** -- time-series/event foundations are Beta; product packaging, API parity, and at-scale validation are still in progress. _Implementation detail:_ TST engine implemented in `src/storage/engines/impls/tst/` with time-partitioned storage (Arrow IPC I/O), OHLC downsampling with Gorilla compression, segment compaction. 6 integration tests passing. ASOF joins <1ms, >100K bars/second ingestion, >10:1 compression ratio.
-
-| TD-010
-| No event sourcing store
-| P4
-| CRITICAL
-| *Resolved*
-| Cannot provide immutable audit trails. ibkrtrading uses 119MB/day JSONL. MiFID II non-compliant.
-| 2-3 months
-| *Implemented (engine).* **v0.2 support tier: _Beta in v0.2 (see SUPPORTED_SURFACE)_** -- see TD-009; event sourcing shares the Beta time-series/event tier. _Implementation detail:_ EventLogEngine implemented in `src/storage/engines/impls/eventlog/` with append-only event log, indexed queries (by entity ID, event type, timestamp), temporal replay (point-in-time reconstruction), MiFID II compliance mode. JSON serialization for serde_json::Value compatibility. 7 integration tests passing. Monotonic sequence numbers, immutable audit trail, snapshot manager.
-
-| TD-011
-| No framework integrations
-| P4
-| HIGH
-| *Resolved*
-| Cannot be used with LangChain, LlamaIndex, Haystack, CrewAI without custom code. Every competitor has these.
-| 1-2 months
-a| *Implemented (SDK), Mar 2026.* **_Not a v0.2 supported surface (see SUPPORTED_SURFACE)_** -- framework integrations ship in the Python SDK but are not listed as a Supported v0.2 product surface; do not release-note them as production. _Implementation detail:_ 7 frameworks implemented:
-
-[%header%autowidth]
-!===
-! Framework ! Status ! Location ! Features
-! LangChain ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/langchain.py` ! VectorStore, from_texts/from_documents, similarity_search
-! LangGraph ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/langgraph.py` ! Retriever integration with LangGraph
-! LlamaIndex ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/llama_index.py` ! VectorStore, Retriever, Node with embeddings
-! Haystack ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/haystack.py` ! DocumentStore, Retriever, write_documents
-! CrewAI ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/crewai.py` ! SearchTool, KnowledgeSource
-! DSPy ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/dspy.py` ! RM (Retrieval Model) integration
-! AutoGen ! ✅ Complete ! `clients/python/src/proximadb_sdk/integrations/autogen.py` ! VectorDB adapter
-!===
-
-**Installation:**
-```bash
-# Core SDK
-pip install proximadb-python
-
-# With frameworks
-pip install proximadb-python[langchain,langgraph,crewai,dspy,autogen,llama_index,haystack]
-```
-
-| TD-012
-| API handler test coverage at 5%
-| P1
-| HIGH
-| *Resolved*
-| API handlers barely tested. Regressions likely on every change.
-| 2-3 months
-| *COMPLETED Mar 2025*: Created `tests/rest_api_handlers_test.rs` with 45 tests covering request parsing, validation, error handling, metadata filters, health checks, graph operations, batch operations, pagination, explain plans, document operations, collection configuration, response serialization. Created `tests/rest_api_load_test.rs` with 13 performance benchmarks for JSON parsing/serialization, bulk operations, concurrent parsing, memory efficiency, batch operations, error handling, validation performance, throughput, stress testing. All 58 tests passing.
-
-| TD-013
-| Python SDK mypy disabled
-| P1
-| MEDIUM
-| *Resolved*
-| Type errors exist. Strict mypy not enforced. Reduces developer trust.
-| 2 weeks
-| *Resolved*: py.typed marker added, mypy re-enabled in CI (commit `2410bde7`).
-
-| TD-014
-| No backup/restore
-| P2
-| HIGH
-| *Resolved*
-| Enterprise requirement. No mechanism for incremental backup or point-in-time recovery.
-| 1-2 months
-a| *RESOLVED Mar 2026*: **Backup/restore infrastructure fully implemented**. Complete enterprise-grade backup and restore system:
-
-[%header%autowidth]
-!===
-! Component ! Status ! Location ! Features
-! Backup Manager ! ✅ Production Ready ! `src/operations/backup/mod.rs` ! Incremental snapshots, S3/GCS/Azure targets, WAL checkpointing, compression, checksums
-! Restore Manager ! ✅ Production Ready ! `src/operations/restore/mod.rs` ! Manifest restore, checksum verification, WAL replay, dry-run mode, continue-on-error
-! CLI Scripts ! ✅ Production Ready ! `scripts/backup.sh`, `scripts/restore.sh` ! User-friendly CLI with incremental/full support, retention policy, verification
-!===
-
-**Features:**
-- RPO <1 minute (WAL checkpoint frequency)
-- RTO <10 minutes (restore time target)
-- Multi-cloud support (local, S3, GCS, Azure)
-- Automatic cleanup with retention policy
-- Checksum verification for data integrity
-
-| TD-015
-| No published benchmarks
-| P4
-| MEDIUM
-| *Resolved*
-| Cannot prove performance claims. No ANN-benchmark submission.
-| 2 weeks
-a| *RESOLVED Mar 2026*: **Comprehensive benchmark infrastructure complete**. All components implemented:
-
-[%header%autowidth]
-!===
-! Component ! Status ! Location ! Features
-! ANN-Benchmarks Adapter ! ✅ Complete ! `src/bench/ann_benchmarks/adapter.rs` ! HNSW, IVF, DiskANN, Annoy, LSH, PQ algorithms; SIFT/GIST/MNIST/DEEP1B datasets
-! Binary Runner ! ✅ Complete ! `apps/proximadb-ann-bench/src/main.rs` ! CLI runner with CSV/JSON export
-! VectorDBBench Comparison ! ✅ Complete ! `apps/proximadb-vectordb-compare/src/main.rs` ! Competitor comparison (Qdrant, Weaviate, Milvus, Pinecone)
-! Public Documentation ! ✅ Complete ! `docs/10-quality/benchmarks/PERFORMANCE.md` ! 271 lines with methodology, results, competitor comparisons
-! Python Benchmarks ! ✅ Complete ! `clients/python/tests/` ! 15+ benchmark scripts for SDK validation
-!===
-
-**ANN-Benchmarks Status:**
-- Infrastructure production-ready
-- Supports standard datasets: SIFT (1M, 128D), GIST (1M, 960D), DEEP1B (1B, 96D), MNIST (60K, 784D)
-- Export format compatible with ann-benchmarks.com submission
-- Comprehensive performance data published in PERFORMANCE.md
-
-| TD-016
-| Encryption at rest not implemented
-| P3
-| HIGH
-| *Resolved*
-| Data stored unencrypted on disk. Fails SOC 2 requirements.
-| 1-2 months
-a| *RESOLVED Mar 2026*: **Storage engine file encryption complete**. Integrated FileEncryptionLayer into LocalFileSystem with transparent AES-256-GCM encryption for all storage engines (SST, VIPER, NOVA, SWIFT, HELIX, RAPTOR). WAL encryption was previously complete. Key rotation support implemented.
-
-[%header%autowidth]
-!===
-! Component ! Status ! Location ! Features
-! WAL Encryption ! ✅ Complete ! `src/storage/persistence/write_ahead_log/encryption.rs` ! WALEncryptionLayer for transaction logs
-! File Encryption ! ✅ Complete ! `src/storage/persistence/filesystem/local.rs` ! FileEncryptionLayer for all storage files
-! Key Manager ! ✅ Complete ! `src/storage/encryption/key_manager.rs` ! KeyVersionManager with rotation support
-! Tests ! ✅ Complete ! `tests/storage_encryption_test.rs` ! 5 integration tests passing
-!===
-
-**Features:**
-- Transparent encryption/decryption at filesystem level
-- AES-256-GCM with hardware acceleration (AES-NI)
-- Per-file key derivation via HKDF
-- Chunked encryption (4KB blocks) for large files
-- Encrypted file detection via magic number ("PEDE")
-- Graceful fallback for unencrypted files
-- Key mismatch detection for security
-
-| TD-017
-| PULSAR/QUASAR advertised but incomplete
-| P3
-| MEDIUM
-| *Resolved*
-| Documentation and feature dashboard advertise these as available. Erodes trust when users try them.
-| 1 week
-| *Resolved Jun 2026*: Retired as graph engines. Feature flags, modules, REST routes, and dedicated tests removed; ORION is the graph runtime.
-
-| TD-018
-| OTLP trace ingestion incomplete
-| P2
-| HIGH
-| *Resolved*
-| Cannot receive OpenTelemetry traces. Incomplete observability story vs. Splunk/Datadog/Loki.
-| 3-4 weeks
-| *RESOLVED Mar 2026*: `src/observability/ingestion/adapters/otlp.rs` implements full OTLP HTTP/JSON trace ingestion (port 4318). All 8 integration tests passing. Supports resource spans, scope spans, span attributes, events, links, and status codes. gRPC transport (port 4317) not implemented - HTTP/JSON is the recommended OTLP transport. Trace storage in `src/observability/storage/traces.rs` functional. Removed from experimental features list.
-
-| TD-019
-| Cypher query language
-| P2
-| MEDIUM
-| *Resolved*
-| Parser exists (`src/graph/query/parser.rs`) but incomplete engine integration. Not production-ready vs. Neo4j openCypher.
-| 2-3 months
-a| *RESOLVED Mar 2026*: **Cypher query language fully implemented**. Complete OpenCypher-compatible query language:
-
-[%header%autowidth]
-!===
-! Component ! Status ! Location ! Features
-! Parser ! ✅ Complete ! `src/graph/query/parser.rs` ! MATCH, WHERE, RETURN, ORDER BY, SKIP, LIMIT, WITH, UNION
-! AST ! ✅ Complete ! `src/graph/query/ast.rs` ! ReturnSpec, WithClause, UnionClause with full support
-! Planner ! ✅ Complete ! `src/graph/query/planner.rs` ! Cost-based optimization, join ordering, index selection
-! Executor ! ✅ Complete ! `src/graph/query/pattern.rs` ! `apply_ordering_and_limits`, `apply_with_clauses`, `apply_union`
-! Distributed ! ✅ Complete ! `src/query/facade/strategies/distributed.rs` ! Distributed query execution, REST endpoint
-!===
-
-**Clauses Implemented:**
-- RETURN: Projections, variables, DISTINCT
-- ORDER BY: Multi-field ascending/descending
-- SKIP/LIMIT: Pagination support
-- WITH: Subquery result chaining, DISTINCT, ordering
-- UNION: UNION (distinct) and UNION ALL
-- Distributed query execution across clusters
-
-| TD-020
-| No ACID transactions across models
-| P2
-| HIGH
-| *Resolved*
-| Graph has WAL but no cross-model atomicity. Cannot guarantee consistency for vector+graph operations.
-| 4-6 weeks
-| *COMPLETED Feb 2025*: `CrossModelTransactionCoordinator` implemented in `src/transaction/` with two-phase commit protocol. TransactionParticipant implementations for VectorEngineParticipant, DocumentEngineParticipant, GraphEngineParticipant, TimeSeriesEngineParticipant in `src/transaction/participants.rs`. 6 integration tests passing. Cross-model ACID transactions with prepare/commit/rollback phases. WAL coordination across models.
-
-| TD-127
-| Relational/OLTP — secondary indexes
-| P2
-| HIGH
-| *Open*
-| Volcano OLTP point lookup only covers PRIMARY KEY (`ScanAccess::PkLookup`). Code-graph lookups are by `name`/`file`, not oid → fall back to full scan + memory filter. Blocks the re-index hot path (symbols-in-file, by-name resolution). See `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
-| 2-3 weeks
-| Add secondary-index support on native (LsmWriteOptimized) tables; planner emits an index-scan access path; reader capability `secondary_lookup`. Targets `crates/query/proximadb-relational-planner` (`push_predicates`) + `record_store.rs`.
-
-| TD-128
-| Relational/OLTP — IN-list / range pushdown
-| P2
-| HIGH
-| *Open*
-| `WHERE col IN (...)` / `BETWEEN` are not pushed to a multi-key point-batch; today full scan + in-memory filter. Incremental re-index touches a batch of files per debounce, so this is on the hot path.
-| 1-2 weeks
-| Extend planner predicate pushdown + `ScanAccess` with a multi-key batch lookup; reader `pk_lookup_batch`. Companion to TD-127.
-
-| TD-129
-| pgwire — `ON CONFLICT DO UPDATE`
-| P2
-| MED
-| *Open*
-| `TableRecordMutationKind::Upsert` exists at the DML boundary but pgwire has no `INSERT ... ON CONFLICT DO UPDATE` surface; idempotent re-index must read-then-write. Wire the upsert mutation through the pgwire parser/planner.
-| 1 week
-| `src/network/postgres/` parser + `src/services/dml/`. Map conflict target (PK) to `Upsert`.
-
-| TD-130
-| Graph — edge bulk-load
-| P3
-| MED
-| *Open*
-| `batch_create_edges` enforces per-edge composite uniqueness against a global in-memory index, serialized; bulk-loading large edge sets is minutes–hours. The code-graph Tier-A/B split avoids the worst case, but incremental re-index of a hot file still benefits.
-| 2-3 weeks
-| Add a sorted LSM-style bulk path (sort by `(from,to,type)`, single merge) mirroring the vector `BulkLoader`. `src/graph/service.rs`.
-
-| TD-131
-| Graph — REST v2 + co-planned hybrid endpoint
-| P3
-| MED
-| *Open*
-| Graph CRUD/traversal is REST v1 (legacy); v2 is vector-only. Hybrid (semantic-seed → k-hop expand → metadata filter) is clean only over gRPC `ExecuteHybridQuery`; REST `/api/v2/query` is rewrite-join, not co-planned.
-| 2-3 weeks
-| Promote graph routes to REST v2; add a first-class co-planned hybrid endpoint. `src/network/rest/v2/`.
-
-| TD-132
-| Storage — Tier-B CPG-fragment PAX + I/O trace
-| P3
-| MED
-| *Open*
-| Intra-procedural CPG (1.18M statements + 2.88M DDG/CFG/CDG edges; measured 100% intra-file) should be a per-function columnar PAX fragment, ranged-read on drill-down, NOT first-class graph elements. Needs a fragment storage contract + per-query I/O trace emission (co-design mandate).
-| 3-4 weeks
-| Define `cpg_fragment` layout + zone-map; emit query-scoped I/O trace so `ComputeScheduler` can cost it. See `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
-
-| TD-133
-| Cross-modal — transactional multi-modal write
-| P3
-| LOW
-| *Open*
-| Writing a symbol's node + embedding + edges is multiple record-store ops (no cross-modal atomicity for the code-graph collection). Acceptable today (idempotent single-writer re-index, eventual consistency), but an optional atomic multi-modal upsert would close gap G7.
-| 2-3 weeks
-| Optional; leverage `CrossModelTransactionCoordinator` (TD-020) for the code-graph collection.
-
-| TD-134
-| Metering/Governance — code-embedding KEU + per-repo RBAC
-| P2
-| MED
-| *Open*
-| Multi-tenant code-graph service needs a KEU meter variant for code embeddings and per-repo RBAC entitlement (tenant is atomic today). Mostly anvaiops-side; ProximaDB exposes the meter hook + field/row governance seam.
-| 2 weeks
-| KEU variant in the meter spine; per-repo `permitted_principals` scoping. See `../anvaiops` ADR.
-
-| TD-136
-| Fusion — neutral `Fuser` core + PIT calibration
-| P1
-| HIGH
-| *In progress*
-| One calibrated fuse-by-`oid` core for all modalities: PIT/percentile-rank calibration (cosine≈Gaussian vs graph/PPR≈power-law are incommensurable; naive weighted-sum + min-max both fail) + calibrated-linear + consensus boost + RRF fallback + skip-gates. Phase 1 of `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`.
-| 1 week
-| `src/core/search/fusion/`. Calibration is the load-bearing step; the operator is secondary (Calibrated-Fusion).
-| TD-137
-| Fusion — `GraphExpander` + REST v2 `fusion-search`
-| P1
-| HIGH
-| *In progress*
-| Graph modality as the first expander on the seam (oid-keyed percentile-rank graph candidates, bounded k-hop, retiring `1/(dist+1)`) + vector seed; `POST /api/v2/graphs/{graph_id}/fusion-search`, tenant-scoped. Subsumes the old TD-131 graph-on-REST-v2 goal.
-| 1 week
-| Reuse `HybridQueryEngine` internals + `VectorOperationsService`. Honor the request graph_id (not "default").
-| TD-138
-| Fusion — converge `DocumentExpander`
-| P2
-| MED
-| *Open*
-| Fold the 12-strategy `HybridFusionEngine` (vector+BM25, `doc_id`) onto the seam as the `DocumentExpander`, keyed by `oid`.
-| 1-2 weeks
-| Collapse the 12 strategies to D4 (calibrated-linear default, RRF fallback); keep exotics behind a flag.
-| TD-139
-| Fusion — `RelationalExpander` prefilter (semimask)
-| P2
-| MED
-| *Open*
-| Relational predicate as an `oid`-keyed membership mask (roaring bitset) passed by SIP into the seed — prefilter, not postfilter (NaviX: prefilter wins below 50% selectivity). Reuse TD-127/128.
-| 2 weeks
-| The mask is the universal expander→seed interface.
-| TD-140
-| Fusion — edge-grain fusion
-| P3
-| LOW
-| *Open*
-| Optional edge/relationship-grain fusion unit (HELIOS: edge-level carries 6–12% more signal than node-level) in addition to node/`oid`-keyed merge.
-| 2 weeks
-| Differentiator; gate behind query class.
-| TD-141
-| Fusion — `ComputeScheduler` cost-routed fusion
-| P2
-| MED
-| *Open*
-| Route the fused query from a measured per-query trace: invoke fusion only when multi-modal; cardinality-driven filter strategy (UNIFY); per-modality weight+selectivity-aware candidate budget + cheap local pre-probe (BoomHQ). Measured threshold router, not learned.
-| 3-4 weeks
-| Keep plan-construction cheap (Samyama: parse+plan was 98% of latency).
-| TD-142
-| Fusion — `oid` / entity alias resolution
-| P2
-| MED
-| *Open*
-| Cross-source consensus requires `oid`/entity alias resolution (synonym linking); else fusion silently loses the consensus boost (Calibrated-Fusion).
-| 2 weeks
-| Precondition for *true* cross-modal fusion across collections; within one collection `oid` is canonical.
-| TD-143
-| Fusion — retire weak proto path
-| P3
-| LOW
-| *Open*
-| Retire `request_handlers.rs` `execute_hybrid_query` (hardcoded graph, no tenant) once the seam covers gRPC; collapse the 12-strategy engine to D4.
-| 1 week
-| Cleanup after F-A..F-C land.
-| TD-144
-| Embedded — relocate composition root out of `network::*` (co-design Pillar A)
-| P2
-| MED
-| *Open*
-| The service composition root `SharedServices` lives in `src/network/shared_services.rs` and constructs network-layer types inline (`network::grpc::{ObservabilityServiceImpl,GraphServiceImpl}`, `network::rest::v1::rank::RankServices`, `network::hybrid_search::HybridFullTextIndexMap`), so the fused embedded core depends *up* on the network module. A clean relocation to a transport-neutral home first requires decoupling those in-process handler-impl/index types out of `network::` (they are handler logic, not listeners). Then `network::multi_server` and `embedded` both depend *down* onto the neutral root. Co-design tenet 4 (vertical inside / standard outside).
-| 1-2 weeks
-| Blocked discovery from the embedded co-design plan; mechanical but wide. ServiceProfile (Pillar B) already shipped #236.
-| TD-145
-| Embedded — Arrow-native ingestion (co-design Pillar C, redirected by measurement)
-| P2
-| MED
-| *Open*
-| MEASURED FINDING (`EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22`): swapping the pyarrow-IPC insert path for the zero-copy Arrow C Data Interface (`arrow::pyarrow` FFI, `insert_arrow_batches`) is **perf-neutral** — the FFI boundary serialize was never the dominant cost term. The ~95 ms (5000x128) insert is dominated by `ArrowProtoCodec::batches_to_proxima_records` (Arrow→ProximaRecord materialization) + `insert_batch` (WAL/storage). The zero-copy `insert_arrow_batches` seam is landed (correct, cross-language substrate, lighter memory) but NOT as a latency win. Remaining Pillar-C work, redirected to the real dominant term: make ingestion **Arrow-native** so the record-materialization + insert copy shrinks (columnar straight into the engine), and apply the same to the search-result return path (currently row-by-row Python objects).
-| 2-3 weeks
-| Co-design tenets 1 & 2 (trace before you tune): the boundary was not the bottleneck. Seam + measurement landed in the embedded-arrow-zerocopy PR.
-| TD-146
-| Fusion — `EntityService.SearchEntities` delegates to seam (no standalone retrieval)
-| P2
-| MED
-| *Open*
-| `EntityService.SearchEntities` (PR #278) must be a typed facade over the fusion seam, not a fourth retrieval engine (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`): `similar`→seam seed, `filters`→predicate mask (`oid` membership bitset), result→entity projection of `FusedItem`s. Resolves the `UNIMPLEMENTED` vector mode by delegation, not a new implementation. Forbids any bespoke vector-ANN/fusion path on the entity surface.
-| 1 week
-| Depends on TD-136/137; gRPC `FusionSearch` parity folds into TD-143.
-| TD-147
-| Index — IVF posting-list id compaction (`Vec<String>` → `Vec<u64>`)
-| P2
-| MED
-| *Open*
-| IVF `TieredPostingList.vector_ids` (`src/index/axis/indexes/dual_store_ivf.rs:470`) stores dense per-cluster member ids as `Vec<String>` (the external `oid`), the one dense in-memory structure that does NOT use a compact internal id — HNSW already maps to `Vec<usize>` via `ConcurrentIdMapping` (`src/index/axis/utils.rs:156`), and Orion graph CSR uses compact indices. Migrate IVF posting lists to `Vec<u64>` internal ids, translating at the insert/iterate boundaries (`:1475` push, `:1594/:2003/:2535/:2609` iterate) through the existing mapping. ~3–7× posting-list RAM shrink → less eviction to disk → fewer cold-load I/O round-trips (Dim 1, the dominant cloud-DB cost term). Co-design: compact id INSIDE dense structures, self-describing string `oid` only at the boundary (vertical inside / standard outside).
-| 1-2 weeks
-| Storage-format change (posting lists persist/evict to disk) → mixed-read-safe + default-OFF gate + round-trip/recall test (storage-format-migration mandate). Verify the eviction path persists `vector_ids` before scoping versioning. HNSW `ConcurrentIdMapping` is the reference pattern; do NOT touch the external record `oid` key. (Audit `2026-06-24`: only genuine dense/persistent string-id flag found.)
+| TD-115 | Cost-based multi-engine dispatch | HIGH | Open | D4 | PERF
+| `ComputeScheduler::route_select()` hardcodes Native(Volcano) for every SELECT; analytical scans/joins/aggregates over Parquet forced through row executor. → enrich `QueryShape` (cardinality/selectivity/partitions), `cost_model.rs` selectivity-crossover, set `parquet_backed`, `SET compute_engine` override. Depends on live DataFusion path. Plan `TD_115_*`.
 |===
 
-== Debt by Category
+=== B. Cross-Modal Fusion Seam
 
-[cols="2,3,3", options="header"]
+Phase 1+ of `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` — one calibrated fuse-by-`oid` core for all modalities.
+
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| Category | Items | Blocking Release?
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| Code Quality
-| ~TD-007~, ~TD-012~, ~TD-013~
-| No (All resolved: TD-007, TD-012, TD-013). Production code is panic-safe with proper error handling.
+| TD-136 | Neutral `Fuser` core + PIT calibration | HIGH | In Progress | D4 | PERF
+| Calibrated fuse-by-`oid` core: PIT/percentile-rank calibration (cosine≈Gaussian vs graph/PPR≈power-law are incommensurable) + calibrated-linear + consensus boost + RRF fallback + skip-gates. Calibration is the load-bearing step. `src/core/search/fusion/`.
 
-| Missing Critical Features
-| ~TD-008~, ~TD-009~, ~TD-010~, ~TD-011~, ~TD-018~, ~TD-019~, ~TD-020~
-| No (All resolved: TD-008, TD-009, TD-010, TD-011, TD-018, TD-019, TD-020)
+| TD-137 | `GraphExpander` + REST v2 `fusion-search` | HIGH | In Progress | D4 | PERF
+| Graph modality as first expander (oid-keyed percentile-rank, bounded k-hop, retire `1/(dist+1)`) + vector seed; `POST /api/v2/graphs/{graph_id}/fusion-search`, tenant-scoped. *Subsumes the old TD-131 goal.* Reuse `HybridQueryEngine` + `VectorOperationsService`; honor request graph_id.
 
-| Security
-| TD-006, TD-016
-| Yes (for enterprise customers)
+| TD-138 | Converge `DocumentExpander` | MED | Open | D4 | PERF
+| Fold the 12-strategy `HybridFusionEngine` (vector+BM25, `doc_id`) onto the seam, keyed by `oid`; collapse to D4 (calibrated-linear default, RRF fallback); exotics behind a flag.
 
-| Operations
-| ~TD-014~, ~TD-015~
-| No (All resolved: comprehensive backup/restore and benchmark infrastructure complete)
+| TD-139 | `RelationalExpander` prefilter (semimask) | MED | Open | D4 | PERF
+| Relational predicate as `oid`-keyed roaring-bitset membership mask via SIP into the seed — *prefilter, not postfilter* (NaviX: prefilter wins below 50% selectivity). The mask is the universal expander→seed interface. Reuse TD-127/128.
 
-| Ecosystem
-| TD-004, TD-005
-| No (TD-002, TD-003 resolved)
+| TD-141 | `ComputeScheduler` cost-routed fusion | MED | Open | D4 | PERF
+| Route fused query from a measured per-query trace: invoke fusion only when multi-modal; cardinality-driven filter strategy; per-modality weight+selectivity candidate budget + cheap pre-probe. Measured threshold router, not learned. Keep plan construction cheap.
 
-| Honesty/Trust
-| ~TD-001~, ~TD-017~
-| No (but erodes credibility). Both resolved.
-|===
+| TD-142 | `oid` / entity alias resolution | MED | Open | D4 | REL
+| Cross-source consensus needs `oid`/entity alias resolution (synonym linking); else fusion silently loses the consensus boost. Precondition for true cross-collection fusion; within one collection `oid` is canonical.
 
-== Priority Legend
+| TD-140 | Edge-grain fusion | LOW | Open | D4 | PERF
+| Optional edge/relationship-grain fusion unit (edge-level carries 6–12% more signal than node-level). Differentiator; gate behind query class.
 
-[cols="1,4", options="header"]
-|===
-| Priority | Meaning
+| TD-143 | Retire weak proto fusion path | LOW | Open | D4 | OE
+| Retire `request_handlers.rs::execute_hybrid_query` (hardcoded graph, no tenant) once the seam covers gRPC; collapse the 12-strategy engine to D4. Cleanup after TD-136..138 land.
 
-| CRITICAL
-| Blocking world-class status or losing deals. Fix in next quarter.
+| TD-062 | Hybrid retrieval + reranking planner surface | HIGH | Open | D4 | PERF
+| Planner-level representation for lexical + dense + sparse + graph + doc-path + time + rerank stages; `EXPLAIN` shows fusion/rerank strategy + post-filter fallback. Move durable direction into shared algebra/catalog/projection metadata. Overhaul spec.
 
-| HIGH
-| Significant gap. Fix within 6 months.
+| TD-092 | Hybrid BM25 auto-indexing on canonical insert path | MED | Open | D4 | OE
+| Two residual gaps (re-scoped 2026-05-28 after live audit; the dead `bm25_wrapper.rs` stub was removed): (1) hybrid BM25 index populated only via explicit `BM25IndexPort::index_documents`, *not on canonical INSERT* (collections with `enable_fulltext_index`); (2) `request_handlers.rs::execute_hybrid_search` has BM25 hardcoded-disabled. → auto-populate on INSERT; route/remove the duplicate hybrid path.
 
-| MEDIUM
-| Important but not blocking. Fix opportunistically.
+| TD-044 | Projection Fusion B5 — vector-space variant | MED | Partial | D4 | PERF
+| Score-level analog shipped (`fusion.rs`, REST, SDK, bench: RRF 248µs vs Projection 255µs). Residual: the paper's *vector-space* B5 (BGE-dense + Achlioptas-projected SPLADE → single 768d ANN) needs a sparse encoder + projection matrix + combined-vector index — a TD-051-class dependency. Plus a labeled-IR quality bench (nDCG/ILD).
 
-| LOW
-| Nice to have. Backlog.
+| TD-146 | `EntityService.SearchEntities` delegates to the seam (no standalone retrieval) | MED | Open | D4 | OE
+| `EntityService.SearchEntities` (PR #278) must be a *typed facade* over the fusion seam, not a fourth retrieval engine: `similar`→seam seed, `filters`→`oid`-membership predicate mask, result→entity projection of `FusedItem`s. Resolves the `UNIMPLEMENTED` vector mode by delegation (forbids any bespoke vector-ANN/fusion path on the entity surface). Depends on TD-136/137; gRPC `FusionSearch` parity folds into TD-143. `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`.
 |===
 
-== Phase Alignment
+=== C. Storage Spine / Lakehouse / Object Economy
 
-[cols="3,4,2", options="header"]
+Co-design D1/D3 work — the dominant cloud-DB cost term. See `PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md`, `VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc`.
+
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| Phase | Items | Total Effort
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| Phase 1 (Foundation)
-| ~TD-007~, ~TD-012~, ~TD-013~
-| *COMPLETED* (All resolved)
+| TD-060 | Storage Layout Authority + external-format semantics | CRIT | Partial | D1,D5 | REL
+| *Catalog + EXPLAIN hooks landed (May 2026):* `CatalogAuthorityMode`/layout/format/projection types persisted; `information_schema` introspection; EXPLAIN storage-authority section; `PlanContext.resolved_objects` carries authority. Residual: route SQL/federated planners through shared `PlanContext` end-to-end instead of resolving at the protocol boundary. Overhaul spec §5.6.
 
-| Phase 2 (Cross-Model)
-| ~TD-014~
-| *COMPLETED* (Backup/restore infrastructure complete)
+| TD-114 | Background L0→base compactor + merge-on-read deletion vectors | HIGH | Partial | D1,D3 | PERF
+| *Foundation landed 2026-06-17 (`71dbd3b17`):* tested PAX merge-on-read core (`compact_pax_segments`, drops tombstones) + flag-gated trigger (`PROXIMADB_L0_COMPACTION_ENABLED`, default OFF). Residual: live auto-invoke from flush, orchestrator integration, deletion-vector read-path overlay (wire dormant `enable_deletion_vectors`). Plan `TD_114_*`. Related: TD-112.
 
-| Phase 3 (Ecosystem)
-| TD-004, TD-005, TD-016
-| 6-10 months (TD-001, TD-002, TD-003, TD-006, TD-014, TD-017 resolved)
+| TD-119 | Promote v1 key-list manifest → real Iceberg snapshots | MED | Partial | D1 | OE
+| *Phase 1 landed 2026-06-18:* persisted versioned `metadata.json` + manifest-log snapshot history (parent chain, v2 seq, `refs.main`) + `MetadataCommitter` CAS + GET route. Residual (Phase 2): Avro manifest-list + per-file `DataFile` stats (so Spark/Trino scan data files); tenant-scope the Iceberg REST endpoints. Unblocks TD-117. Plan `TD_119_*`.
 
-| Phase 4 (Context DB)
-| ~TD-015~
-| *COMPLETED* (All Phase 4 items resolved)
-|===
+| TD-116 | WAL tiering + read-as-of-LSN time travel | MED | Open | D1 | REL
+| WAL is local-only (`WalEntryStatus::Archived` never set); no sealed-segment offload to object store; `time_travel()` stubs. → archival task (copy `Flushed` segments to object store, set Archived), archive read-back, `scan_records_at_lsn`, `SELECT … AS OF (LSN/TIMESTAMP/SNAPSHOT)`. *Unblocks* TD-117. Plan `TD_116_*`.
 
-== Recently Resolved (Phase 1 & Phase 2 Complete)
+| TD-118 | Unify paging/cache policy with tier policy | MED | Open | D3 | COST
+| Cache eviction (RAM/NVMe) and tier demotion (S3/Glacier) are one OS-paging decision governed by two unrelated components; no scan-ring, so a cold S3 scan can evict the OLTP working set. → extract `PagingCache` over `TenantCache`; one `HierarchyPolicy` for both; `BufferAccessStrategy`-style scan ring. Keep `FileSystem`/tier-engine as separate mechanism/policy seams. Plan `TD_118_*`.
 
-[cols="1,3,4,1", options="header"]
-|===
-| ID | Area | Resolution | Phase
+| TD-088 | Point-read I/O amplification (point-read-optimized lake layout) | MED | Open | D1 | PERF
+| Vector search returns IDs but apps need full records; a point read drags a whole PAX row-group/stripe (≈9.4 MB vs ≈0.07 MB for a point-read layout). → PAX row-aligned column-group mode; evaluate open Vortex format; one logical copy for point-read + scan. Pairs with TD-087/TD-086. Lakebase R3.
 
-| TD-R01
-| Unified query wiring
-| FederatedQueryContext fully implemented
-| P2
+| TD-087 | Scale-to-zero cold path — binary-first two-stage + IVF pruning | MED | Open | D1,D3 | COST
+| First cold query pulls pure object-store data; a full HNSW (~340 GB for 1B×768) takes minutes from S3. → cold-load ordering that pulls a compact binary/RaBitQ rep first (~1/30th), two-stage rerank, IVF-prune bytes-touched; recall envelope via `RecallProbeGate` + TD-064 disclosure. Lakebase R2.
 
-| TD-R02
-| Document engine persistence
-| WAL-backed with full read/write path
-| P2
+| TD-078 | External-table federated execution (Iceberg/Delta/Hudi as hot authority) | MED | Open | D1 | REL
+| Adapters exist as interop modes, not Proxima-owned hot authority with full ACID+ANN+RLS; several paths return "not yet supported". v0.2 = Experimental external-authority modes. Acceptance: authority-mode catalog field + federated route-health + EXPLAIN external-authority disclosure.
 
-| TD-R03
-| Graph metadata persistence
-| ORION WAL persistence complete
-| P2
+| TD-090 | External Collection — ProximaDB-owned indexes over external-resident data | MED | Open | D1 | COST
+| Build/maintain vector+inverted+JSON indexes over data left in place in an external lake ("one data, one index, no dual-write"). → authority sub-mode; index-staleness-vs-source-commit freshness; lets TD-086 cover lake-resident data. Gated for Lance by TD-091. Lakebase R5.
 
-| TD-R04
-| Observability log indexing
-| Full-text search via inverted index
-| P2
+| TD-091 | Lance format interoperability | LOW | Open | D1 | OE
+| Lance as a read/import/external-index substrate alongside Iceberg/Delta/Hudi/Parquet. Gates TD-090 for Lance corpora. Lakebase R6.
 
-| TD-R05
-| ORION update replay
-| WAL replay handles all operations
-| P2
+| TD-096 | Routing guidance: vector-locality workloads SST vs HELIX | HIGH | Open | D4,D1 | PERF
+| SST block-centroid pruning collapses to ~5% recall at 100K on diffuse data (records sorted by `oid` lexicographically before block write → centroids are mixtures). HELIX already sorts by PCA-Hilbert key at L0 flush ("80-90% block reduction"). → validate HELIX recall @10K/25K/100K, then *route* vector-locality → HELIX, OLTP/oid → SST (don't retrofit SST). `SearchMode::Exact` already bypasses pruning (`403fd1ba1`).
 
-| TD-R06
-| pgwire completeness
-| Prepared statements, DDL/DML complete
-| P2
+| TD-112 | ANN recall over flushed/compacted segments | MED | Partial | D1,D4 | PERF
+| *Fix landed 2026-06-16:* index-on-flush wired on live SST path (`handle_flushed_vectors`); recall-band e2e green (~0.95 top-k); local post-loss lazy rebuild-from-SST. Residual: real object-store (S3/ADLS/GCS) SST read-back coverage; boot-time AXIS prewarm not claimed; HELIX/NOVA flush-index paths. Recall-band track.
 
-| TD-R07
-| Cross-model joins
-| LATERAL joins across all models
-| P2
+| TD-147 | IVF posting-list id compaction (`Vec<String>` → `Vec<u64>`) | MED | Open | D3,D1 | COST
+| IVF `TieredPostingList.vector_ids` is the one dense in-memory structure storing external string `oid` (HNSW uses `ConcurrentIdMapping`, Orion CSR uses compact indices). → migrate to `Vec<u64>` internal ids; ~3–7× posting-list RAM shrink → less eviction → fewer cold-load round-trips. *Storage-format change* → mixed-read-safe + default-OFF + round-trip/recall test. `dual_store_ivf.rs`.
 
-| TD-R08
-| Extra metadata filtering
-| JSON/binary filtering in columnar strategy
-| P1
+| TD-132 | Tier-B CPG-fragment PAX + per-query I/O trace | MED | Partial | D1 | PERF
+| *Contract test landed (`92611256`, `tests/cpg_fragment_pax_contract.rs`).* Intra-procedural CPG (1.18M stmts + 2.88M edges, 100% intra-file) should be a per-function columnar PAX fragment, ranged-read on drill-down — not first-class graph elements. Residual: live `cpg_fragment` layout + zone-map + query-scoped I/O-trace emission so `ComputeScheduler` can cost it. `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
 
-| TD-R09
-| SST dual block types
-| Legacy types deprecated
-| P1
-
-| TD-R10
-| WAL wiring (REST/gRPC)
-| Document + observability wired
-| P1
-
-| TD-R11
-| Metric aggregation
-| Aggregation engine wired
-| P2
-
-| TD-R12
-| DataFusion integration
-| TableProvider, ScanExec, VectorRecordBridge
-| P2
-
-| TD-R13
-| SIMD decoders
-| AVX2, NEON, scalar backends complete
-| P1
-
-| TD-R14
-| Smart I/O layer
-| ParallelReader, IoMetrics complete
-| P1
-
-| TD-R15
-| CentroidTree
-| O(log n) vector pruning complete
-| P1
-
-| TD-R16
-| Framework integrations (TD-011)
-| LangChain, CrewAI, LangGraph, DSPy, AutoGen adapters shipped in Python SDK
-| P4
-
-| TD-R17
-| Python SDK mypy (TD-013)
-| py.typed marker added, mypy re-enabled in CI
-| P1
-
-| TD-R18
-| PULSAR/QUASAR engine retirement (TD-017)
-| Retired instead of feature-gated; behavior folded into relational/storage substrate requirements
-| P3
-
-| TD-R19
-| ORION-only graph service layer (TD-001)
-| `src/graph/service_engine_factory.rs` accepts ORION and rejects retired PULSAR/QUASAR names
-| P3
-
-| TD-R20
-| Backup/restore infrastructure (TD-014)
-| Complete backup/restore system in `src/operations/backup/` and `src/operations/restore/` with CLI scripts
-| P2
-
-| TD-R21
-| Streaming infrastructure (TD-003)
-| Complete real-time streaming system in `src/streaming/` with gRPC bidirectional streaming, subscriptions, Kafka integration
-| P3
-
-| TD-R22
-| Cypher query language (TD-019)
-| Full OpenCypher implementation with RETURN, ORDER BY, SKIP/LIMIT, WITH, UNION clauses in `src/graph/query/`
-| P2
-
-| TD-R23
-| Framework integrations (TD-011)
-| Complete Python SDK integrations for LangChain, LlamaIndex, Haystack, CrewAI, LangGraph, DSPy, AutoGen
-| P4
-
-| TD-R24
-| Published benchmarks (TD-015)
-| Complete benchmark infrastructure with ANN-benchmarks adapter, VectorDBBench comparison, comprehensive public documentation
-| P4
-
-| TD-R25
-| Type system unification — Phase A (TD-054)
-| `ProximaType`/`ProximaValue` extended with `to_arrow()`, `pgwire_oid()`, `type_of()`, `is_compatible_with()`; `CatalogDataType::to_proxima_type()` bridge added. 17 TDD tests in `proximadb-data-model`. Resolves the three-parallel-value-system problem (spec §4).
-| Phase A
-
-| TD-R26
-| Unified record envelope — Phase B (TD-054)
-| `proximadb_records::ProximaRecord` spec §3 envelope implemented with NF² props tree, RLS fields, per-modality embeddings, temporal ns fields, `LabelSet`. `From<&VectorRecord>`, `From<&Node>`, `From<&Edge>` conversions in `conversions.rs`. `RecordConverter::vector_to_envelope()` bridge added. 26 TDD tests.
-| Phase B
-
-| TD-R27
-| Engine-level RLS scaffold — Phase E (TD-054)
-| `RlsRecordPredicate` + optional `rls_record_filter()` hook added to `UnifiedStorageEngine` trait. SST and VIPER engines implement the override (extract `tenant_id`/principal from `StorageQueryContext`). Default returns `None` (no-op). Spec §8 proof-of-concept.
-| Phase E
+| TD-040 | Quantization-aware row group pruning | MED | Partial | D1 | PERF
+| Write-side stats added (`vector_norm_min/max/mean`, per-dim component bounds via `update_vector_bounds`). Residual: read-side integration (check bounds vs query-vector distance at query time).
 |===
 
-== New Gaps Identified (March 2026 Codebase Audit)
+=== D. Elastic Compute / Scale-to-Zero / Continuous Discovery
 
-The following items were identified during a comprehensive code review on March 15, 2026.
-They represent real implementation gaps discovered by reading the actual source code.
+`VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R1/R4 — "resources follow the data".
 
-[cols="1,3,1,1,1,4,2,4", options="header"]
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| ID | Area | Phase | Priority | Status | Impact | Effort | Notes
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| TD-021
-| Distributed writes return fake ACKs
-| P3
-| CRITICAL
-| *Resolved*
-| `distributed_ops.rs` local write path returns hardcoded `1` ack without persisting to storage engine. Distributed writes silently succeed without storing data.
-| 1-2 weeks
-| *RESOLVED Mar 2026*: Identified in codebase audit. Local shard writes/reads are coordinator stubs — by design, actual storage is handled by the engine layer beneath. The distributed coordinator fans out to remote nodes via RPC; local node operations delegate to the existing `UnifiedStorageEngine` trait through the service layer, not through the coordinator itself. Coordinator counts acks correctly. No data loss: WAL + engine writes occur at the service layer before coordinator replication.
+| TD-094 | Single-node scale-to-zero (collection suspend/resume) | MED | Open | D4 | COST
+| *Unblocked half split from TD-089.* Evict a collection's compute/index while keeping catalog metadata queryable; lazy-warm on first query via TD-087 cold path. Reuse `CollectionPinRegistry`, `DirectoryLoadStatus`, route-health, tiering engine. No dependency on TD-077. Sequence after TD-087.
 
-| TD-022
-| Raft snapshot mechanism not implemented
-| P3
-| HIGH
-| *Resolved*
-| `StateMachine::snapshot()` and `StateMachine::restore()` are trait definitions but never called. `install_snapshot` RPC handler is a no-op stub. Without snapshots, Raft log grows unbounded (mitigated by log compaction added in Phase 2 gap remediation, but not a complete solution for node recovery).
-| 2-3 weeks
-| *RESOLVED Mar 2026*: Full snapshot support implemented. `take_snapshot()` captures state machine state and updates `last_snapshot_index`/`last_snapshot_term`. `restore_snapshot()` restores state machine, updates volatile state, and discards covered log entries. `maybe_compact_log()` now triggers snapshot when `last_applied - last_snapshot_index >= snapshot_threshold`. Test verifies full snapshot/restore cycle across consensus instances.
+| TD-089 | Elastic compute modes (multi-node warm pool) | HIGH | Open | D4,D5 | COST
+| The *multi-node* half (minute-billed `OnDemand` pods + `OfflineBatch`); warm-pool scheduler attach-on-request/release-on-idle; metadata queryable with zero resident compute cluster-wide. *Blocked on TD-077* (distributed transport). Sequence after TD-087/088 + TD-077.
 
-| TD-023
-| Memory growth in long-running processes
-| P1
-| HIGH
-| *Resolved*
-| Multiple unbounded growth patterns cause OOM on Mac terminals: alert samples using O(n) Vec removal, AutoML trial history accumulation, document store without capacity limits, Raft log without compaction, TTL eviction spikes.
-| 1-2 weeks
-| *RESOLVED Mar 2026*: All memory growth issues addressed. (1) Alert samples: Vec→VecDeque with 64-cap. (2) AutoML trial cap + zero-copy TPE. (3) Document store: 100K/collection eviction. (4) Raft log compaction with snapshot trigger. (5) TTL eviction batching at 10K/tick. (6) Observability retention: `ObservabilityService::enforce_retention()` wired to metrics tiering (`apply_tiering_policy`), metrics compaction, and log partition pruning (`prune_partitions_before`). CRL parsing fix (DER-first).
-
-| TD-024
-| SWIFT engine incomplete (30+ TODOs)
-| P1
-| MEDIUM
-| Open
-| Engine header says `INCOMPLETE`. 30+ TODO items including: progressive search, file loading, batch ID tracking, vector counting (hardcoded 0), SST file loading, search optimizer integration.
-| 2-3 months
-| Feature-gated behind `experimental-engines`. Production users should use SST, VIPER, HELIX, or NOVA. Not blocking v1.0 unless engine is needed.
-
-| TD-025
-| RAPTOR engine experimental (35+ TODOs)
-| P1
-| MEDIUM
-| Open
-| Engine header says `EXPERIMENTAL`. 35+ TODOs including: bloom filter lookup, clustering, cohesion calculation, caching APIs, row group extraction.
-| 3-4 months
-| Feature-gated behind `experimental-engines`. Same guidance as TD-024.
-
-| TD-026
-| gRPC alert endpoints return unimplemented
-| P2
-| MEDIUM
-| *Resolved*
-| `list_alert_rules`, `create_alert`, `list_alerts` in `src/network/grpc/observability_service.rs` return `Status::unimplemented()`. Alert engine works internally but not exposed via gRPC API.
-| 1 week
-| *RESOLVED Mar 2026*: All three gRPC alert endpoints implemented. `upsert_alert_rule` converts proto AlertRule/ThresholdCondition to internal RuleCondition and registers via AlertEngine. `delete_alert_rule` unregisters by parsed rule ID. `list_alerts` evaluates all rules and filters by min_severity. Alert engine attached via `with_alert_engine()` builder (backward-compatible).
-
-| TD-027
-| UB in TST engine clone (std::mem::zeroed)
-| P1
-| CRITICAL
-| *Resolved*
-| `src/storage/engines/impls/tst/mod.rs:1648` used `unsafe { std::mem::zeroed() }` on `FilesystemFactory` which contains `Vec`, `HashMap`, `String` — creating null pointers that crash on any use. Undefined behavior.
-| 1 hour
-| *RESOLVED Mar 2026*: Replaced with safe `FilesystemFactory::new_empty()` constructor that creates valid empty maps. Compiler warning eliminated.
-
-| TD-028
-| Document status discrepancy across strategic docs
-| P4
-| HIGH
-| *Resolved*
-| VISION.adoc, PRD.adoc, Strategic Roadmap, and Master Feature Dashboard show Phase 4 features as "Planned" or "12% complete" while Technical Debt register shows them as "Resolved Feb 2025". Creates confusion about actual project status.
-| 1-2 days
-| *RESOLVED Mar 2026*: Strategic Roadmap updated with all Phase 4 completions (Hybrid Search, TST, Event Sourcing, 7 Framework Integrations). Master Feature Dashboard updated with corrected counts (79% total, Phase 4 at 100%). Catalog, Streaming/CDC, Security, and Cluster sections reconciled with Technical Debt resolutions. All documents now reference consistent status.
-
-| TD-029
-| Code coverage at 49% vs 80% target
-| P1
-| HIGH
-| *In Progress*
-| Overall coverage 49.3% (Jan 2026 report). Critical gaps: api_handlers 5.1%, network 30.2%, audit 28.0%. Target is 80% for core modules. CI threshold not enforced.
-| 2-3 months
-| *Progress Mar 2026*: +940 new unit tests (6435→7375), coverage 49.3%→54.9% (+5.6pp). Added across 30+ modules. CI coverage threshold enforcement implemented (50% min in tdd.yml and ci.yml with ratchet plan: 55% Q2, 60% Q3). Pure-logic test surface exhausted; further gains require integration test infrastructure (HTTP test clients, storage engine setup). Key improvements: audit 28%→92%, auth 42%→86%, api_handlers 5%→43%, embedded 30%→51%, network 30%→45%, compute 54%→61%, index 50%→57%, core 52%→58%.
-
-| TD-030
-| No integrated ibkrtrading validation
-| P4
-| HIGH
-| Open
-| VISION positions ibkrtrading as proof-of-production-readiness but no documented integration test results. TST engine, Event Store, and Document Store are ready but end-to-end trading validation not confirmed.
-| 2-4 weeks
-| Need: 30-day production run results, performance comparison vs 3-DB architecture, MiFID II compliance verification with real trading data.
+| TD-086 | Continuous Discovery surface + atomic snapshot republish | MED | Open | D4 | OE
+| No first-class *discovery* arm: read a pinned snapshot, run offline refinement (dedup/recluster/re-embed/drift), republish a new snapshot with an *atomic* serving switch. → `DiscoveryJob` catalog asset; routes through `compute_route` declaring authority/freshness SLA; explainable in unified EXPLAIN. Mostly composition over existing primitives; converts `src/automl/` into the offline arm. Lakebase R1.
 |===
 
-== Performance & Execution Layer Gaps (March 2026 Architectural Review)
+=== E. Graph & gRPC v1→v2
 
-The following items were identified during a comprehensive architectural review on March 21, 2026,
-comparing ProximaDB's foundational layers against DuckDB and Polars performance patterns.
-See `docs/_internal/roadmap/ARCHITECTURAL_REVIEW_2026_03_21.adoc` for full analysis.
-
-[cols="1,3,1,1,1,4,2,4", options="header"]
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| ID | Area | Phase | Priority | Status | Impact | Effort | Notes
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| TD-031
-| Columnar query engine lacks vectorized execution
-| P2.5
-| CRITICAL
-| Resolved Mar 2026
-| `columnar_query_engine/unified_reader.rs` processes Arrow batches row-at-a-time (`for record in batch_records { if matches_filter... }`). `filter_pushdown_engine.rs` returns `true` for all row groups (no actual pruning). `adaptive_filter_executor.rs` disabled ("temporarily disabled due to API changes"). No selection vector pattern -- copies filtered rows instead of maintaining bitmask. DuckDB uses 2048-value vectorized chunks with SIMD auto-vectorization; ProximaDB is 10-100x slower for analytical queries on same Parquet files.
-| 4-6 weeks
-| Resolved March 27, 2026. Pull-based pipeline engine implemented in `pipeline.rs` with 4 operators (ScanOperator, FilterOperator, ScoreOperator, TopKOperator). PipelineBuilder provides fluent API: `PipelineBuilder::new(batches).filter(conds).score(query, metric).top_k(k)`. 7 tests covering full pipeline, filter, score, empty input, min-score threshold.
+| TD-035 | Graph query executor mostly stubbed | MED | Open | D4 | PERF
+| `src/graph/query/executor.rs` implements `NodeScan` partially; Traverse/Filter/Project/Sort/Limit are TODOs. Queries bypass the executor via `GraphStrategy`→`GraphOperationsService`, skipping the planner (no graph query optimization). Required for graph query optimization + Arrow-native graph results.
 
-| TD-032
-| Cross-model LATERAL join JSON parsing overhead
-| P2.5
-| HIGH
-| Resolved May 2026
-| `DOCUMENT_QUERY` and `GRAPH_QUERY`/`GRAPH_TRAVERSAL` now materialize vector-bearing fields and properties as native Arrow `FixedSizeList<Float32>` or `List<Float32>` columns, including nested document paths and graph property vectors. `resolve_vector_from_outer_column()` reads those Arrow columns directly for correlated `LATERAL VECTOR_SEARCH(...)` execution and falls back to JSON parsing only for legacy string-only batches.
-| 3-4 weeks
-| Resolved May 1, 2026. Coverage includes nested document embeddings, graph property vectors, end-to-end correlated LATERAL joins, and root projection checks so internal Arrow vector columns do not leak into plain `DOCUMENT_QUERY` results.
+| TD-130 | Graph edge bulk-load | MED | Open | D4 | PERF
+| `batch_create_edges` enforces per-edge composite uniqueness against a global in-memory index, serialized → minutes–hours for large edge sets. → sorted LSM-style bulk path (sort by `(from,to,type)`, single merge) mirroring vector `BulkLoader`. `src/graph/service.rs`.
 
-| TD-033
-| Parquet row group statistics pruning incomplete
-| P2.5
-| HIGH
-| Resolved Mar 2026
-| `condition_matches_row_group()` in `filter_pushdown_engine.rs` now handles all numeric types (INT32, INT64, FLOAT, DOUBLE) via `extract_stats_min_max()` and `check_numeric_in_stats_range()`/`check_range_overlaps_stats()`. Both `search_vectors` path (via `select_row_groups_with_pruning`) and `read_file_with_optimization_and_filters` use these functions. Tests `test_numeric_equality_pruning` and `test_range_filter_pruning` verify correctness.
-| 1 week
-| Resolved. Numeric row group pruning functional for Equals, Range, In, IsNull, IsNotNull filter types.
+| TD-122 | gRPC v2 parity services (graph/document/entity) | HIGH | Partial | D4 | OE
+| *Graph done 2026-06-21* (`proximadb.v2.ProximaGraphService` + `src/network/grpc/v2/graph_service.rs`, registered + SDK-consumed). Residual: `DocumentServiceV2` + `EntityServiceV2` (still REST-v2-only). *Blocks* TD-121. Deferred RPCs → TD-124.
 
-| TD-034
-| No spill-to-disk for larger-than-memory queries
-| P2.5
-| HIGH
-| Resolved Mar 2026
-| L2 NvmeBackend was already implemented (DashMap-based with LRU eviction, shard directory structure). Fixed: `base.rs` now spills to L2 when L1 `CapacityExceeded` — both after orchestrator eviction failure and when no orchestrator is available. Previously would log error and drop the entry. Now gracefully degrades to L2 tier. External merge sort for ORDER BY remains a future optimization.
-| 3-4 weeks
-| Resolved March 27, 2026. L1→L2 spillover implemented. NvmeBackend functional with LRU eviction and capacity management.
+| TD-124 | Deferred RPCs on v2 ProximaGraphService | LOW | Open | D4 | OE
+| Deferred from the first v2 graph surface: `GetConnectedComponents`, `HasCycle`, `BatchCreate*`, `StreamTraverse`, unique-constraint DDL, `ExecuteQuery` (Cypher/Gremlin), `ExecuteHybridQuery`. Do NOT port PULSAR/QUASAR. Relates to TD-122 (parent), TD-121.
 
-| TD-035
-| Graph query executor mostly stubbed
-| P2.5
-| MEDIUM
-| Open
-| `src/graph/query/executor.rs` only implements `NodeScan` partially. Traverse, Filter, Project, Sort, Limit are all TODOs. Queries bypass the executor via `GraphStrategy` calling `GraphOperationsService` directly, skipping the query planner. Graph query optimization is not applied.
-| 3-4 weeks
-| Required for graph query optimization and Arrow-native graph results.
+| TD-123 | Full proximadb.v1→v2 message-type migration | MED | Open | D4 | OE
+| *Keystone STEP 1 done 2026-06-21 (graph):* transport-agnostic `src/graph/model.rs` + `proto_convert.rs`; `GraphOperationsService` speaks only the neutral model (was using v1 proto AS its domain type — a dependency inversion). Residual: same pattern for record/vector/collection services; typed `GraphRef{tenant,graph_id}` to replace `effective_graph_id` string-prefix isolation; `scripts/check_v1_proto_usage.py`. *Must precede* TD-121. Depends on TD-122.
 
-| TD-036
-| No per-segment adaptive codec selection
-| P3
-| MEDIUM
-| Resolved (was already implemented)
-| Codec selection was already fully adaptive. `analyze_and_choose_scheme_f32()` in `analysis.rs` runs on actual data patterns at 4 encoding call sites in `block_structures.rs`. Per-dimension parallel analysis with Rayon for transpose encoding. Lossy scheme override protection for f32 semantics. The March 21 review's characterization of "static selection" was incorrect.
-| N/A
-| Already resolved. No changes needed.
-
-| TD-037
-| Distance computation not truly multi-vector batched
-| P3
-| MEDIUM
-| Improved Mar 2026
-| Improved March 27, 2026: NEON batch unrolling increased from 2-way to 4-way. Software prefetch hints added to both AVX2 and NEON paths — `_mm_prefetch` (x86) and `__prefetch` (ARM) bring next batch into L1 cache while current batch computes. True matrix transposition for one-shot multi-vector SIMD remains a future optimization for an additional 2-4x gain.
-| 2 weeks
-| Improved. Prefetch + 4-way NEON unrolling added. Full matrix transposition deferred.
-
-| TD-038
-| Cross-modal transaction isolation not integrated
-| P2.5
-| HIGH
-| Resolved Mar 2026
-| All four participants (Vector, Document, Graph, TimeSeries) now support `with_durable_writer(DurableWriteFn)` for engine-backed durable commits. `EngineBackedParticipant` wrapper enables any participant to support durable commit via callback pattern. `supports_durable_commit()` returns true when writer is attached, unblocking the coordinator's `ensure_durable_participants()` check. Writer statistics now include vector norm bounds (TD-040: vector_norm_min/max/mean, vector_component_min/max).
-| 4-6 weeks
-| Resolved March 27, 2026. Participants wired for durable commits. Tests cover success and failure paths.
-
-| TD-039
-| No morsel-driven query parallelism
-| P2.5
-| HIGH
-| Resolved Mar 2026
-| `search_vectors()` now uses three-phase parallel execution: (1) concurrent I/O via `tokio::spawn` per file, (2) morsel-driven parallel scoring via `rayon::par_chunks(4)` with thread-local `BoundedPriorityQueue` per morsel, (3) merge phase combining thread-local queues. `BoundedPriorityQueue::merge()` added for combining results.
-| 3-4 weeks
-| Resolved March 27, 2026. Multi-core scoring via rayon morsel-driven parallelism.
-
-| TD-040
-| No quantization-aware row group pruning
-| P3
-| MEDIUM
-| Partial (Mar 2026)
-| `StreamingParquetWriterStats` now tracks vector norm bounds (vector_norm_min/max/mean) and per-dimension component bounds (vector_component_min/max) via `update_vector_bounds()`. Infrastructure for distance-based row group pruning is in place. Integration with the query-time pruning path (checking bounds against query vector distance) remains as future work.
-| 2-3 weeks
-| Partially resolved March 27, 2026. Write-side statistics added. Read-side pruning integration pending.
-
-| TD-041
-| Vectorized executor not wired into primary query path
-| P2.5
-| CRITICAL
-| Resolved Mar 2026
-| `search_vectors()` in `unified_reader.rs` now uses `read_file_batches_with_filters()` to return Arrow RecordBatches (row group pruning + vectorized metadata filtering applied without VectorRecord materialization), then `score_batch_with_simd()` computes batch SIMD distances via `UnifiedDistanceCompute::batch_distance_pooled_simd()`. Metadata materialization is lazy — only for records passing threshold/top-k. Shared helpers `select_row_groups_with_pruning()` and `build_projection_indices()` deduplicate logic with the original path.
-| 2-3 weeks
-| Resolved March 26, 2026. search_vectors() now uses batch SIMD distance, vectorized metadata filtering, and lazy materialization.
-
-| TD-042
-| Cache architecture over-engineering
-| P3
-| LOW
-| Open
-| 5 specialized cache types (VectorCache, MetadataStore, QueryCache, BitmapFilterCache, IndexNodeCache) coordinated by `CrossCacheOrchestrator` mixing 8 concerns. Memory split (40/30/15/10/5) is undocumented. Consolidating to 2-3 patterns would reduce cognitive load without sacrificing functionality.
-| 1-2 weeks
-| Maintainability improvement only.
+| TD-121 | Hard-delete gRPC v1 proto + compat adapters (post-Sunset) | HIGH | Open | D4 | OE
+| After Sunset 2026-06-30, remove `proto/proximadb/v1/` + `crates/platform/proximadb-api/src/grpc/v1/` + `enable_grpc_v1_compat`. *Gate: do NOT merge before 2026-07-01.* Unblocked by TD-122 (v2 parity) + TD-123 (callers migrated). Plan in item.
 |===
 
-== Phase 5: Agentic Intelligence & Research Frontier (2026 Strategic Alignment)
+=== F. Agent Memory & Branching
 
-The following items represent the frontier of AI database research, aligned with ProximaDB's mission to be the primary memory for agentic systems.
+`AGENT_MEMORY_LAYER_HLD_2026_05_30.adoc` / ADR-022; branching `PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md` §6.
 
-[cols="1,3,1,1,1,4,2,4", options="header"]
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| ID | Area | Phase | Priority | Status | Impact | Effort | Notes
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| TD-043
-| Semantic Disentanglement Pipeline (SDP) + Entanglement Index
-| P5
-| HIGH
-| *Closed April 27, 2026*
-| Multi-topic documents produce embeddings with cross-topic overlap, hurting Top-K precision (paper shows 32% precision under fixed-token chunking, 82% under SDP). Implement (a) Entanglement Index metric for measurement, (b) 4-stage preprocessing pipeline that restructures documents prior to embedding (arXiv:2604.17677, Loghmani 2026, *verified*).
-| Sub-1: closed April 26, 2026. Sub-2 + Sub-3: closed April 27, 2026.
-| **Verified**: April 25, 2026. **Sub-1 status (closed April 26, 2026)**: `src/analytics/entanglement.rs` ships the EI library function. **Sub-2 status (closed April 27, 2026)**: stateless `POST /api/v1/analytics/entanglement` and collection-aware `GET /api/v1/collections/{id}/entanglement` ship in `src/network/rest/v1/analytics.rs`. Collection-aware variant loads records via `VectorOperationsService` and extracts topics from metadata. **Sub-3 status (closed April 27, 2026)**: SDP implemented in `src/storage/document/sdp.rs` and integrated into `TextChunker` in `text_storage.rs`. Enabled via `ChunkingConfig.use_sdp`. **Acceptance**: EI computable for any collection; SDP reduces EI ≥30% on multi-topic test corpus. See `PROXIMADB_RECOMMENDATIONS.md` §1.1.
+| TD-101 | Agent memory write surface (extraction + consolidation) | MED | In Progress | D4 | OE
+| P2 of the agent-memory layer. *Slice 1 + embedder/route/e2e landed:* `MemoryWriteEngine.ingest` (extract→retrieve→consolidate→apply), `VectorMemoryStore`, `EmbeddingServiceEmbedder`, `POST /api/v1/memory/ingest` (501 guard w/o LLM). Residual: consolidation-decision EventLog audit persistence. `src/services/agent_memory.rs`.
 
-| TD-044
-| Projection Fusion (B5) — Speed/Diversity Tradeoff
-| P5
-| MEDIUM
-| *Score-level analog landed; vector-space B5 (paper's actual algorithm) NOT yet shipped*
-| **Paper re-read April 26, 2026**: paper's B5 is **vector-space pre-fusion** — BGE-dense (768d) + SPLADE-sparse (30522d) projected to 768d via Achlioptas sparse random projection R∈ℝ^768×30522 (density=1/3, ±√3 entries), L2-normalized, then `q = α_query·d̂ + (1−α_query)·p̂` followed by L2-normalize. α_query=0.95 (tuned), α_doc=0.50 (fixed). Single dot-product ANN against the resulting dense index. Paper's nDCG@10: B5=0.6779, RRF=0.8282 (RRF wins relevance by 0.15). ILD@10: B5=0.389, RRF=0.176 (B5 wins diversity 2.2×). What we shipped is a **score-level rank-fusion analog** with the same name (arXiv:2604.13728, Prajapati 2026, *verified*).
-| 1-2 weeks remaining (quality benchmark on labeled dataset)
-| **Paper re-read April 26, 2026 — important correction**: our shipped `FusionStrategy::Projection` is **NOT the same algorithm** as the paper's B5. Paper B5 operates in **vector space** (combines BGE-dense + projected-SPLADE into one 768d vector before ANN). Our impl operates on **post-retrieval scalar scores** via `score = bm25_norm·cos(theta) + vector_norm·sin(theta)` with min-max normalization. Same name, different layer of the stack. Score-level projection is a useful operator on its own and matches RRF's API surface (post-retrieval scalar fusion), but it is not what the paper's nDCG/ILD numbers measured. **Where shipped**: implementation `src/core/search/hybrid/fusion.rs:106-253`; REST parser `src/network/rest/v1/hybrid.rs::parse_fusion_strategy` (accepts `"projection"` and `"projection_b5"`, alpha=0.5); strategies-list endpoint advertises Projection with description noting RRF remains relevance default; Python SDK enum `clients/python/src/proximadb_sdk/hybrid.py::FusionStrategy::PROJECTION`; latency bench `benches/bench_21_hybrid_search_fusion.rs::bench_rrf_vs_projection` (results April 27: RRF 248µs vs Projection 255µs @ k=1000 — RRF is slightly faster in this impl); positioning guide `docs/05-concepts/hybrid-fusion.adoc` (updated April 27). **Remaining**: (1) quality benchmark on labeled IR dataset showing nDCG@10/MRR/ILD@10 tradeoff — gated on labeled dataset under `benches/data/`; (2) **vector-space B5** is a separate sub-deliverable — needs a sparse vector encoder integration (SPLADE or analog), the Achlioptas projection matrix, and a single combined-vector ANN index. That work is a TD-051 dependency since it needs a unified retrieval+compression embedding flow. **Acceptance for score-level path**: quality bench on labeled IR dataset. See `PROXIMADB_RECOMMENDATIONS.md` §1.2 and `docs/05-concepts/hybrid-fusion.adoc`.
+| TD-102 | mem0 / agentmemory framework adapters | LOW | Partial | D2 | OE
+| *Slice A landed 2026-05-31:* pgwire extended `$N` params + Describe columns + metadata filter pushdown (`67b1373e5`). Residual (Slice B): Python mem0 `VectorStoreBase` provider over the wire; mem0g graph-store mapping; binary param-format decode.
 
-| TD-043
-| Semantic Disentanglement Pipeline (SDP) + Entanglement Index
-| P5
-| HIGH
-| *Closed April 27, 2026*
-| Multi-topic documents produce embeddings with cross-topic overlap, hurting Top-K precision (paper shows 32% precision under fixed-token chunking, 82% under SDP). Implement (a) Entanglement Index metric for measurement, (b) 4-stage preprocessing pipeline that restructures documents prior to embedding (arXiv:2604.17677, Loghmani 2026, *verified*).
-| Sub-1: closed April 26, 2026. Sub-2 + Sub-3: closed April 27, 2026.
-| **Verified**: April 25, 2026. **Sub-1 status (closed April 26, 2026)**: `src/analytics/entanglement.rs` ships the EI library function. **Sub-2 status (closed April 27, 2026)**: stateless `POST /api/v1/analytics/entanglement` and collection-aware `GET /api/v1/collections/{id}/entanglement` ship in `src/network/rest/v1/analytics.rs`. Collection-aware variant loads records via `VectorOperationsService` and extracts topics from metadata. **Sub-3 status (closed April 27, 2026)**: SDP implemented in `src/storage/document/sdp.rs` and integrated into `TextChunker` in `text_storage.rs`. Enabled via `ChunkingConfig.use_sdp`. **Acceptance**: EI computable for any collection; SDP reduces EI ≥30% on multi-topic test corpus. See `PROXIMADB_RECOMMENDATIONS.md` §1.1.
+| TD-117 | Agent branching via object-store metadata (BranchRef, COW, writer fence) | HIGH | Partial | D1 | REL
+| *Foundation landed 2026-06-17 (`e4d9b05fb`):* `BranchRef` type + assembly, `DrPathBuilder::branches_subprefix`, `commit_fenced` generation writer-fence + unit tests. Residual: ancestor read fall-through, live CAS fencing on the write path, branch GC. The Neon/Lakebase headline capability. Depends on TD-116 (LSN history) + TD-119 (manifest refs).
 
-| TD-044
-| Projection Fusion (B5) — Speed/Diversity Tradeoff
-| P5
-| MEDIUM
-| *Score-level analog landed; vector-space B5 (paper's actual algorithm) NOT yet shipped*
-| **Paper re-read April 26, 2026**: paper's B5 is **vector-space pre-fusion** — BGE-dense (768d) + SPLADE-sparse (30522d) projected to 768d via Achlioptas sparse random projection R∈ℝ^768×30522 (density=1/3, ±√3 entries), L2-normalized, then `q = α_query·d̂ + (1−α_query)·p̂` followed by L2-normalize. α_query=0.95 (tuned), α_doc=0.50 (fixed). Single dot-product ANN against the resulting dense index. Paper's nDCG@10: B5=0.6779, RRF=0.8282 (RRF wins relevance by 0.15). ILD@10: B5=0.389, RRF=0.176 (B5 wins diversity 2.2×). What we shipped is a **score-level rank-fusion analog** with the same name (arXiv:2604.13728, Prajapati 2026, *verified*).
-| 1-2 weeks remaining (quality benchmark on labeled dataset)
-| **Paper re-read April 26, 2026 — important correction**: our shipped `FusionStrategy::Projection` is **NOT the same algorithm** as the paper's B5. Paper B5 operates in **vector space** (combines BGE-dense + projected-SPLADE into one 768d vector before ANN). Our impl operates on **post-retrieval scalar scores** via `score = bm25_norm·cos(theta) + vector_norm·sin(theta)` with min-max normalization. Same name, different layer of the stack. Score-level projection is a useful operator on its own and matches RRF's API surface (post-retrieval scalar fusion), but it is not what the paper's nDCG/ILD numbers measured. **Where shipped**: implementation `src/core/search/hybrid/fusion.rs:106-253`; REST parser `src/network/rest/v1/hybrid.rs::parse_fusion_strategy` (accepts `"projection"` and `"projection_b5"`, alpha=0.5); strategies-list endpoint advertises Projection with description noting RRF remains relevance default; Python SDK enum `clients/python/src/proximadb_sdk/hybrid.py::FusionStrategy::PROJECTION`; latency bench `benches/bench_21_hybrid_search_fusion.rs::bench_rrf_vs_projection` (results April 27: RRF 248µs vs Projection 255µs @ k=1000 — RRF is slightly faster in this impl); positioning guide `docs/05-concepts/hybrid-fusion.adoc` (updated April 27). **Remaining**: (1) quality benchmark on labeled IR dataset showing nDCG@10/MRR/ILD@10 tradeoff — gated on labeled dataset under `benches/data/`; (2) **vector-space B5** is a separate sub-deliverable — needs a sparse vector encoder integration (SPLADE or analog), the Achlioptas projection matrix, and a single combined-vector ANN index. That work is a TD-051 dependency since it needs a unified retrieval+compression embedding flow. **Acceptance for score-level path**: quality bench on labeled IR dataset. See `PROXIMADB_RECOMMENDATIONS.md` §1.2 and `docs/05-concepts/hybrid-fusion.adoc`.
+| TD-053 | True Memory Encoding Gates | CRIT | Open | D4 | OE
+| Three-layer Encoding Gate (Novelty/Salience/Prediction-Error) for verbatim event ingestion — shift from "extraction at ingest" to "retrieval-centered". → `EncodingGate` trait in document service. From arXiv:2605.04897.
 
-| TD-045
-| Modular Graph RAG (RGL)
-| P5
-| CRITICAL
-| *Closed April 27, 2026*
-| Modular framework spanning the full graph-RAG pipeline: indexing, dynamic node retrieval, subgraph construction, tokenization. Paper reports **143× speedup** over conventional methods, mainly through dynamic node filtering (arXiv:2503.19314, Li/Hu/Jiang/Liu/Hooi/He 2025, *verified — NUS authors*).
-| Sub-1, Sub-2, and Sub-3: closed April 27, 2026.
-| **Verified**: April 25, 2026. **Sub-1 status (closed April 26, 2026)**: trait surface and orchestrator ship in `src/graph/rag/mod.rs`. **Sub-2 status (closed April 27, 2026)**: `VectorNodeRetriever`, `KHopSubgraphBuilder`, and `LlmNodeFilter` ship in `src/graph/rag/engine_impls.rs`. **Sub-3 status (closed April 27, 2026)**: REST endpoint `POST /api/v1/graph/graphs/{id}/rag` ships in `src/network/rest/v1/graph.rs` with optional LLM filtering. Verified with integration test `tests/graph_rag_integration_test.rs`. **Acceptance**: RGL pipeline executes e2e; 2-hop construction over 1M node graph <10ms. See `PROXIMADB_RECOMMENDATIONS.md` §2.1.
+| TD-054 | Entropy-Based Lazy Loading (L-RAG) | HIGH | Open | D4 | PERF
+| Hierarchical context: expensive chunk retrieval triggered only when model predictive entropy exceeds a calibrated threshold. → entropy-threshold check in AQL `Find`. From arXiv:2601.06551. *(Sole owner of the TD-054 id; the former type-system "TD-054" is Resolved TD-111.)*
 
-| TD-046
-| Tool-Based Navigation (GraphWalk)
-| P5
-| HIGH
-| *Mostly closed — REST + agent-tool schema landed; gRPC parity gated on proto regen workflow*
-| Equip LLMs with **minimal graph operations** (move, look, remember) so they traverse arbitrarily large structures via tool calls. Gains "more pronounced as scale increases" (arXiv:2604.01610, Ghandi/Mahyar/Klaiman 2026, *verified*).
-| Proto/gRPC: blocked on regen workflow setup. SDK framework integration: 1 week.
-| **Verified**: April 25, 2026. **GraphWalkClient (closed April 26, 2026)**: framework-agnostic Python client at `clients/python/src/proximadb_sdk/integrations/graph_walk_client.py`. **Status as of April 26, 2026**: REST exposure landed for walk + step; agent-tool schema and renderer ship in the Python SDK. **Where**: service primitives in `src/graph/service_traversal_api.rs`; REST handlers `walk_graph` and `step_graph` in `src/network/rest/v1/graph.rs`; routes `POST /api/v1/graph/graphs/{graph_id}/walk` and `POST /api/v1/graph/graphs/{graph_id}/step`. Agent tools at `clients/python/src/proximadb_sdk/integrations/mcp_tools.py` expose `GRAPH_WALK_TOOL`, `GRAPH_STEP_TOOL`, `list_tools()`, and `render_invocation()`. **Remaining work**: (1) proto `WalkRequest`/`WalkStepRequest` in `proto/proximadb/v1/graph.proto` + regenerated gRPC handlers; (2) LangChain/CrewAI/LlamaIndex tool wrappers. **Acceptance**: agent walks 1M-node graph with ≤8K tokens/step. See `PROXIMADB_RECOMMENDATIONS.md` §2.2.
-
-| TD-047
-| Evolutionary Query Planning (DBPlanBench-style)
-| P5
-| MEDIUM
-| *Closed April 27, 2026*
-| Expose physical plans as compact serialized form; let an LLM propose **localized plan edits**; evolutionary search refines candidates. Up to **4.78× speedup** (arXiv:2602.10387, Erol/Hao/Bianchi/Greco/Tagliabue/Zou 2026, *verified*).
-| Sub A and Sub B: closed April 27, 2026.
-| **Verified**: April 25, 2026. **Sub A status (closed April 26, 2026)**: skeleton committed at `src/query/unified/evolutionary.rs`; `PlanExecutionCache` at `src/query/unified/plan_execution_cache.rs` records wall-time per `(shape, order)`. **Sub B status (closed April 27, 2026)**: `llm_mutate` operator implemented in `evolutionary.rs` using `LLMIntegrationEngine` to propose plan reorderings. Optimization stack migrated to `async` to support non-blocking LLM calls. Plumbed from `UnifiedQueryEngine` through `QueryOptimizer` to `EvolutionaryOptimizer`. **Acceptance**: Evolutionary planner executes e2e with optional LLM mutation; measured fitness converges to faster plans. See `PROXIMADB_RECOMMENDATIONS.md` §3.1.
-
-| TD-048
-| Agentic View Decomposition (AV-SQL) — 3-Agent Pipeline
-| P5
-| HIGH
-| *Closed April 27, 2026*
-| Decompose complex NL→SQL via **three specialized agents**: (1) rewriter compresses/clarifies the NL query; (2) view generator produces per-schema-chunk "agentic views"; (3) planner/generator/revisor composes views into final SQL. Reports **70.38% execution accuracy on Spider 2.0** (arXiv:2604.07041, Pham et al. 2026, *verified*).
-| Closed April 27, 2026.
-| **Verified**: April 25, 2026. **Status (closed April 27, 2026)**: `AvSqlEngine` and LLM-backed agent traits (`AgentRewriter`, `AgentViewGenerator`, `AgentComposer`) landed in `src/query/nl/mod.rs`. Wired into REST API at `POST /api/v1/nl/translate`. Supports multi-model view generation. Response includes normalized query and project views for traceability. **Acceptance**: end-to-end NL→federated-SQL test; response exposes intermediate views. See `PROXIMADB_RECOMMENDATIONS.md` §3.2.
-
-| TD-049
-| Block-Batched Semantic Joins
-| P5
-| HIGH
-| *Closed April 27, 2026*
-| **Block nested loops join** for semantic joins: pack batches of rows from *both* tables into a single LLM prompt, ask the model to identify all matching pairs in one shot (arXiv:2510.08489, Trummer 2025, *verified — Cornell*).
-| Closed April 27, 2026.
-| **Verified**: April 25, 2026. **Status (closed April 27, 2026)**: `execute_block_batch_semantic_join` implemented in `src/query/unified/executor.rs` with prompt packing and LLM integration via `LLMIntegrationEngine`. Plumbed through `ParallelExecutor` and `dispatch_semantic_join`. Feature-gated behind `llm-joins`. **Acceptance**: ≥10× LLM-call reduction vs nested-loop baseline at equal precision@10. See `PROXIMADB_RECOMMENDATIONS.md` §3.3.
-
-| TD-050
-| RUBICON-Style Auditable Query Layer (AQL)
-| P5
-| CRITICAL
-| *Closed April 27, 2026*
-| Replace opaque LLM agent chains with **explicit, auditable query plans**. Stonebraker et al. propose **RUBICON** architecture and **AQL (Agentic Query Language)** executed through source-specific wrappers (arXiv:2604.21413, Wenz/Treutwein/Arenja/Demiralp/Stonebraker 2026, *verified*).
-| Closed April 27, 2026.
-| **Verified**: April 25, 2026. **Status (closed April 27, 2026)**: AQL AST, structured Audit Trail (`AuditTrail`, `AuditFrame`), and `AqlExecutor` landed in `src/query/aql/`. Multi-model sources implemented: `VectorAqlSource`, `GraphAqlSource`, `DocumentAqlSource`, and `ObservabilityAqlSource`. Wired into REST API at `POST /api/v1/aql/execute` and `/api/v1/aql/audit/{id}`. Persistent audit log via `EventLogEngine` implemented. `EXPLAIN VERBOSE` mapped to AQL projection in `UnifiedQueryEngine`. **Acceptance**: `EXPLAIN VERBOSE` produces compliance-grade trace; end-to-end test showing AQL plan → audit trail. See `PROXIMADB_RECOMMENDATIONS.md` §4.1.
-
-| TD-051
-| Dual-Use Embedding Integration (Unified Retrieval + Compression)
-| P5
-| MEDIUM
-| *Closed April 27, 2026*
-| A unified model in which the **same** representation serves both retrieval kNN and as the compressed context fed to the LLM. Reports performance matching traditional RAG using ~**1/10 of the context** (arXiv:2604.14403, Killingback/Meshi/Li/Zamani/Karimzadehgan 2026, *verified — Google*).
-| Closed April 27, 2026.
-| **Verified**: April 25, 2026. **Status (closed April 27, 2026)**: `enable_dual_use_embeddings` flag added to `CollectionConfig` (proto tag 24) and propagated through server layers. Python SDK integration (`DualUseStore` + `DualUseModel` Protocol) shipped. **Acceptance**: Collection config flag honored end-to-end. See `PROXIMADB_RECOMMENDATIONS.md` §1.3.
-
-| TD-052
-| Proactive Agentic Memory Retrieval (Speculative — No Citation)
-| P5
-| LOW
-| Open — speculative
-| Don't wait for explicit retrieval calls. Use RL to predict when stored memory is relevant to the current intent and surface it proactively.
-| 6-8 weeks
-| **Verified**: April 25, 2026 — the "PASK" acronym used in earlier drafts has **NO paper backing**. Treating as future research direction, not a planned feature. **Wait for**: TD-050 audit substrate to land first (done). See `PROXIMADB_RECOMMENDATIONS.md` §4.2.
-
-| TD-053
-| True Memory Encoding Gates
-| P6
-| CRITICAL
-| Open
-| Implement a three-layer Encoding Gate (Novelty, Salience, Prediction Error) for verbatim event ingestion, shifting from "extraction at ingest" to "retrieval-centered architecture".
-| 4-6 weeks
-| **Verified**: May 9, 2026. From "Storage Is Not Memory" (arXiv:2605.04897). **Next step**: Implement `EncodingGate` trait in document service. See §5.1.
-
-| TD-054
-| Entropy-Based Lazy Loading (L-RAG)
-| P6
-| HIGH
-| Open
-| Implement hierarchical context management where expensive chunk retrieval is triggered only when model predictive entropy exceeds a calibrated threshold.
-| 2-3 weeks
-| **Verified**: May 9, 2026. From L-RAG (arXiv:2601.06551). **Next step**: Integrate entropy-threshold check into AQL `Find` operator. See §5.2.
-
-| TD-055
-| Memanto Typed Semantic Memory
-| P6
-| HIGH
-| *Closed May 9, 2026*
-| Implement the 13 predefined memory categories, conflict resolution, and temporal versioning for high-fidelity agent recall (arXiv:2604.22085).
-| Sub-1, Sub-2, and Sub-3: closed May 9, 2026.
-| **Verified**: May 9, 2026. **Implementation**: `MemoryType` enum in `proximadb-data-model`; `memory_type` field and `resolve_conflict` (LWW) in `proximadb-records`; `TypeMatch` predicate in AQL. **Verification**: `tests/typed_memory_test.rs`, including `test_aql_type_filtering_reduces_topic_bleed`. **Outcome**: Agents can perform high-precision retrieval by memory intent (e.g., `FIND * FROM mem WHERE type = "decision"`). See §5.3.
-
-| TD-056
-| Agentic Hybrid Reference Architecture
-| P6
-| HIGH
-| *Closed May 10, 2026*
-| Implement Plan-Retrieve-Evaluate loop and metadata pseudo-query augmentation for bounded, auditable dataset search.
-| 5-6 weeks
-| **Verified**: May 10, 2026. From March 2026 Reference Architecture (arXiv:2604.16394). **Implementation**: `PseudoQueryGenerator` in `VectorOperationsService` ingestion paths (`insert_batch_internal`, `insert_vectors_via_*`), storing auto-derived `proximadb.pseudo_query` metadata. **Tests**: `src/services/operations/vectors.rs` (`pseudo_query_tests`).
-
-| TD-117
-| Agent branching via object-store metadata (BranchRef, copy-on-write, writer fence)
-| P5
-| HIGH
-| *Foundation landed 2026-06-17* (`e4d9b05fb`) — BranchRef type + assembly, `DrPathBuilder::branches_subprefix`, and `ManifestCommitter::commit_fenced` generation writer-fence shipped + unit-tested; residual: ancestor read fall-through, live CAS fencing on the write path, branch GC
-| The two copy-on-write substrates exist but there is no branch primitive: `SnapshotPin` captures `(from_lsn,to_lsn,checkpoint_id)` (`src/services/snapshot/coordinator.rs:18`) with no parent/ancestor pointer, and `ManifestCommitter` writes immutable versioned `v{N}.manifest` under CAS (`crates/storage/proximadb-iceberg-engine/src/manifest.rs`) with no ref/branch layer and *no generation/epoch writer fence* (`DrPathBuilder` isolates paths but does not fence concurrent writers). There is no way for an agent to instantly fork an isolated read-write copy of a collection/table — the headline capability Neon/Lakebase have and Supabase lacks. (The graph branch/merge APIs are unrelated knowledge-graph features.)
-| 3-4 sprints
-| Deliverables: (1) `BranchRef` (new `src/services/snapshot/branch_ref.rs`): `{branch_id, parent, collections:{coll→fork_lsn}, tables:{tbl→manifest_version}, catalog_snapshot_id, generation, created_at_ns}` persisted as `_branches/{id}.json` under a new `DrPathBuilder::branches_subprefix()` (`src/storage/trait_components/path_resolver.rs` ~:474) and indexed in a new catalog `branches`/`snapshots` table (reuse the drop+create projection pattern); (2) ancestor fall-through — `SnapshotPublishCoordinator::create_branch()` + `resolve_snapshot_lineage()`; the tenant/collection-scoped read path recurses to the parent when the branch has no entry ≤ the requested version; (3) a generation-number writer fence on the `ManifestCommitter` CAS per `(tenant, branch)` (copies Neon's `index_part.json`+generation single-writer guarantee); (4) branch GC by reference-counting WAL layers/data files (Iceberg `expire_snapshots` semantics — safer than Delta shallow clone). *Acceptance:* O(1) branch create off a populated collection (no data copy); divergent writes leave the parent unchanged; unmodified reads fall through to the parent; a stale writer is fenced by generation. *Depends on* TD-116 (LSN history) and TD-119 (manifest refs). Design doc §6 (`docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md`); plan `roadmap/techdebt/TD_117_AGENT_BRANCHING_2026_06_17.adoc`.
+| TD-052 | Proactive agentic memory retrieval (speculative) | LOW | Open | D4 | OE
+| RL-predict when stored memory is relevant; surface proactively. *No paper backing* (the "PASK" acronym was unverified) — future research direction, not a planned feature. Builds on the TD-050 audit substrate (landed).
 |===
 
-== Phase 7: Competitive Platform Architecture And Storage Authority (2026+)
+=== G. Embedded / Co-Design Plumbing / Convergence
 
-The following items track the architecture gaps added by
-`docs/12-design/DATA_AI_PLATFORM_ARCHITECTURE_ANCHOR_2026_05_12.adoc`,
-`docs/12-design/RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc`,
-`roadmap/MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc`, and
-`roadmap/techdebt/WORKSPACE_REFACTOR_PLAN_2026_05_07.adoc`.
+`CONVERGENCE_AUDIT_2026_05_30.adoc`, `IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc`, ADR-024.
 
-These are not claims about the current supported surface. They are the next implementation seams
-that keep ProximaDB competitive while preserving the broader mandate: one semantic spine, many
-physical layouts.
-
-[cols="1,3,1,1,1,4,2,4", options="header"]
+[cols="1,3,1,1,1,1,5", options="header"]
 |===
-| ID | Area | Phase | Priority | Status | Impact | Effort | Notes
+| ID | Area | Pri | Status | Dim | Pillar | Notes
 
-| TD-060
-| Storage Layout Authority And External Format Semantics
-| P7
-| CRITICAL
-| Open - catalog + EXPLAIN hooks landed May 14, 2026
-| Without an explicit authority model, Arrow/Parquet/Iceberg/Delta/Hudi and internal engines can drift into hidden sources of truth with separate type, policy, freshness, and recovery semantics.
-| 4-6 weeks
-| **May 14, 2026**: contract skeleton added to `crates/control/proximadb-catalog/src/lib.rs`: `CatalogAuthorityMode`, `CatalogStorageLayoutKind`, `CatalogPhysicalFormat`, `CatalogWriteMode`, `ProjectionFreshness`, `CatalogProjectionKind`, `CatalogStorageLayout`, `CatalogProjection`, and `RelationalCapabilities`. `CatalogTableSchema` now persists `storage_layouts`, `projections`, and `relational_capabilities` with backward-compatible serde defaults. Internal `ObjectSchema` carries the same metadata, and `information_schema.storage_layouts`, `information_schema.projections`, and `information_schema.relational_capabilities` expose it for catalog introspection. `src/query/explain.rs` now has a nullable storage-authority section that can disclose layout authority, physical format, projection freshness/lossiness, policy enforcement, fallback behavior, and optional relational capabilities. `/api/v1/sql/explain` resolves the explicit collection or parsed `FROM` target through `CatalogManager`; `/api/v1/unified/explain` carries optional catalog context and resolves `VECTOR_SEARCH`, `DOCUMENT_QUERY`, `LOGS`, `METRICS`, and simple `FROM` targets when metadata is available. Tests cover default internal authority, external authoritative boundaries, rebuildable projection metadata, optional relational semantics, table-schema persistence, introspection, EXPLAIN metadata conversion, SQL EXPLAIN catalog resolution, and unified EXPLAIN target extraction. **May 15, 2026**: `PlanContext.resolved_objects` now carries planner-native authority/layout/projection metadata, and `UnifiedQueryRouter` resolves cataloged UQL sources through `CatalogManager` before lowering. **May 16, 2026**: `StorageAuthorityExplanation::from_plan_context()` lets EXPLAIN consume shared resolved object context directly, `UnifiedQueryPortImpl::explain_unified_query()` enriches port-backed SQL/unified EXPLAIN JSON with `storage_authority`, and `query::authority_context` centralizes catalog-to-plan authority conversion for router, port-backed EXPLAIN, and legacy root REST EXPLAIN callers. Verified with `cargo test -p proximadb-multimodel-plan plan_context --target-dir /private/tmp/proximadb-plan-target`; root router/EXPLAIN validation is tracked separately because full lib targets may compile unrelated dirty surfaces. Remaining: route SQL/federated planners through shared `PlanContext` end-to-end instead of resolving catalog metadata at the protocol boundary. See `MULTIMODAL_OVERHAUL_SPEC_2026_05_08.adoc` §5.6 and Phase B2.
+| TD-064 | Predicate-aware vector search correctness + fallback reporting | CRIT | In Progress | D5,D4 | SEC
+| Post-filtered ANN can return < top-k under tenant/RLS/time/branch/typed filters — a *correctness + security* surface. *Slices 1-5 landed (2026-05-27):* `FilterableHnswMetadata`, `search_with_predicate` on all 4 AXIS indexes, snapshot v2, ADR-011 routing-mode wiring, predicate-shortfall diagnostics + Prometheus counters. Residual: thread shortfall through service types; IVF inline pushdown (Phase 3); selectivity-source/projection-freshness/rejected-route diagnostics. `TD_064_*`.
 
-| TD-061
-| Optional Relational Capabilities
-| P7
-| HIGH
-| Open
-| PostgreSQL/Oracle adoption paths require keys, unique indexes, secondary indexes, FKs, checks, materialized views, transaction profiles, and stricter schema evolution, but forcing those costs onto every vector/document/observability workload would be wrong.
-| 6-8 weeks
-| Model relational rigor as cataloged table/profile capabilities. When enabled, constraints are durable semantics enforced below REST/gRPC/Arrow Flight/PostgreSQL wire handlers and recovered through WAL/log/manifest. Start with catalog shape and validation hooks before full FK enforcement. See overhaul spec §5.7.
+| TD-066 | ORION WAL as parallel durable graph truth | HIGH | Partial | D1 | REL
+| *Emission + production wiring + recovery read-side + Option E metrics landed (May 2026).* ORION WAL is a compatibility recovery buffer alongside canonical `RecordUpsert`; spec demotes it to a projection recovery path. Residual: Part 2 Option A (tag engine WAL frames w/ `canonical_emission_lsn` to scope replay) + engine WAL truncation tied to canonical checkpoint LSN. `TD_066_PART2_*`.
 
-| TD-062
-| Hybrid Retrieval And Reranking Planner Surface
-| P7
-| HIGH
-| Open
-| Competitive search/RAG systems increasingly combine BM25/full-text, dense vectors, sparse vectors, metadata filters, graph context, recency, and rerankers. Treating these as separate API paths leaves quality and explainability on the table.
-| 6-10 weeks
-| Add planner-level representation for lexical, dense, sparse, graph, document path, time, and rerank stages. `EXPLAIN` must show fusion/rerank strategy and any post-filter fallback. Reuse existing hybrid search work, but move the durable direction into shared algebra/catalog/projection metadata.
+| TD-144 | Relocate composition root out of `network::*` (co-design Pillar A) | MED | Open | D4 | OE
+| `SharedServices` (`src/network/shared_services.rs`) constructs network-layer types inline, so the fused embedded core depends *up* on `network::`. → decouple in-process handler-impl/index types out of `network::`, then `multi_server` and `embedded` both depend *down* onto a transport-neutral root. Mechanical but wide. ServiceProfile (Pillar B) shipped #236.
 
-| TD-063
-| Observability/SIEM Convergence
-| P7
-| HIGH
-| Open
-| Splunk, Datadog, Elastic, and OpenSearch compete on operational workflows: log search, metrics, traces, profiles, service maps, alerts, anomaly detection, retention tiers, and now LLM/agent observability.
-| 8-12 weeks
-| Normalize logs, metric samples, spans, profiles, alerts, anomalies, agent traces, prompts, tool calls, retrieval evidence, token/cost metrics, and eval events as `ProximaRecord` profiles plus cataloged projections. Rollups/anomalies/alerts become durable only when written as canonical derived records with provenance.
+| TD-145 | Arrow-native ingestion (co-design Pillar C, redirected by measurement) | MED | Open | D4 | PERF
+| *Measured (`EMBEDDED_ARROW_ZEROCOPY_BENCH_2026_06_22`):* zero-copy Arrow C-Data FFI is *perf-neutral* — the FFI boundary was never the dominant term. The ~95 ms insert is dominated by `batches_to_proxima_records` materialization + `insert_batch`. → make ingestion Arrow-native (columnar straight into the engine) + apply to the row-by-row search-return path. *Trace before you tune.*
 
-| TD-064
-| Predicate-Aware Vector Search Correctness And Fallback Reporting
-| P7
-| CRITICAL
-| In Progress (Foundation + AXIS wiring landed 2026-05-27)
-| Post-filtered ANN can return fewer than the requested matching top-k under tenant/RLS, time, branch, and typed metadata filters. This is a correctness and security surface, not just a latency issue.
-| 6-8 weeks
-| Active blueprint: `docs/12-design/TD_064_PREDICATE_AWARE_VECTOR_SEARCH_DESIGN_2026_05_27.adoc`. Extend ADR-011 `VectorTopK` planning to state PreFilter, Inline predicate-aware ANN, or PostFilter fallback. Push tenant/RLS and typed predicates into candidate generation where supported. `EXPLAIN` must disclose recall/failure risk for fallback plans. Coordinates with Phase C in the overhaul spec.
+| TD-104 | Complete Phase 9 handler/service extraction (seam S1) | MED | Open | D4 | OE
+| Real `UnifiedHandlers` (~250 methods) lives in the root crate; `proximadb-runtime/src/handlers.rs` is a stub. → migrate handler bodies endpoint-group at a time so the root crate composes ports only. `CONVERGENCE_AUDIT_2026_05_30.adoc` S1.
 
-**Status 2026-05-27 (slices 1-5 landed)**:
+| TD-106 | Migrate proto-v1 internal mirrors to canonical types (seam S3) | MED | Partial | D4 | OE
+| *Group A done 2026-06-03:* document compute VALUE path runs on `ProximaValue`; proto `SqlValue` confined to row-field edges; canonical `json_to_proxima` added. Residual: Group B (aggregation working set `Vec<SqlObject>`→`Vec<ProximaTree>`), Group C (dual-carry `props: ProximaTree` on `DocumentRecord`, drop `SqlObject`). `TD106_*`.
 
-* Foundation: `FilterableHnswMetadata` schema + shared `FilterableMetadataCache` helper in `src/index/axis/filterable_metadata.rs`. <50-byte per-record overhead target.
-* `AxisVectorIndex` trait extended with `add_with_metadata`, `search_with_predicate(tenant, time_range, rls_tags)`, `supports_predicate_search`, `configure_filterable_fields`. All four AXIS-native indexes (HNSW, IVF, Annoy, LSH) implement them — HNSW with native skip-through traversal, IVF/Annoy/LSH with oversample-and-postfilter.
-* Snapshot persistence v2 with v1 backward-compat decoder. Old HNSW snapshots upgrade to v2 in-memory with empty metadata.
-* `AxisManager` insert paths (HNSW direct, IVF trained-path, IVF cold-start bulk-add, HMGI partitions) all call `add_with_metadata` so cached metadata is populated as records flow in. IVF cold-start hydrates metadata from `collection_vectors` to close the gap.
-* `AxisManagerQueryResult.predicate_shortfall: Option<PredicateShortfall>` populated by inline path when post-filter trimming drops survivors below `top_k`. Prometheus counters `axis_predicate_shortfall_total` + `axis_predicate_shortfall_missing_sum` for operator dashboards.
-* `SearchPlanTrace.predicate_shortfall: Option<PredicateShortfall>` + `mark_predicate_shortfall(...)` helper. `TraceBuilderInputs.predicate_shortfall` carries it into the assembled trace; `failure_class = PermissionThin` set when populated.
-* Task-local `predicate_diagnostics` bus (`src/observability/predicate_diagnostics.rs`) — `scope`/`record_shortfall`/`take_shortfall`. REST + gRPC handlers wrap search in `scope`, read at trace-build / response-construction time. Lets AxisManager-deep shortfall reach the gateway without forcing intermediate service / proto types to carry the field.
-* ADR-011 `AnnFilteringPolicy::routing_mode()` wired into `AxisManager.query`. `AxisHybridQuery` carries optional `ann_filtering_policy` + `estimated_selectivity`; when both are present, the catalog policy decides PreFilter / Inline / PostFilter. `AxisManagerQueryResult.selected_filtering_mode` surfaces the chosen mode. PostFilter uses `policy.effective_top_k_for_post_filter()` for oversample sizing; shortfall is tagged with the effective mode label.
-* Non-AXIS orphan index modules (`src/index/{hnsw,ivf,diskann,sparse_hnsw}` + `tests/index/`) deleted — confirmed zero production users in the audit. ~4600 LOC removed.
+| TD-109 | Consolidate json↔proxima value converters | LOW | Open | D4 | OE
+| Three scattered private `json→ProximaValue` copies + a separate `proxima→json` pair. Canonical `json_to_proxima` now in `proximadb-records`. → converge the copies; relocate `proxima_value_to_json`/`proxima_tree_to_json_map` into the same crate. Surfaced during TD-106.
 
-**Remaining work**:
+| TD-111 | Unify data-type enums onto canonical ProximaType (ADR-024 / S8) | MED | Partial | D4 | REL
+| *Mostly done 2026-06-05:* three logical type enums + two schema structs collapsed onto `ProximaType` + `CatalogTableSchema` (`ProximaDataType`/`CatalogDataType`/`ProximaSchema` deleted with serde-compat shim). Residual (~1 day): `build_vector_column` honor non-f32 dense element width (latent); broader `SqlValue→ProximaValue` tracked under TD-106.
 
-* Plumb `AxisManagerQueryResult.predicate_shortfall` through `services/operations/vectors` and `RichSearchResponse` so REST/gRPC handlers can populate `TraceBuilderInputs.predicate_shortfall` (currently the task-local bus carries it; threading the field through service types is an alternative if the bus pattern becomes brittle).
-* IVF inline predicate pushdown (replace oversample-and-postfilter with nprobe-time predicate evaluation) — TD-064 Phase 3.
-* Selectivity source + projection-freshness + rejected-route-reason diagnostics on `AxisManagerQueryResult` — extends the route disclosure surface beyond just `selected_filtering_mode`.
+| TD-067 | Projection keys use facade document id instead of canonical OID | MED | Open | D4 | REL
+| JSON-path/full-text/columnar projection keys are the facade `document_id`, not `ProximaRecord::oid` → lookups join through the facade id→OID map; executor can't address canonical records directly. → once `plan_executor.rs` produces OID-addressed candidate sets, switch projection writes to `record.oid` + re-key migration.
 
-| TD-065
-| Document Service In-Memory Map As Temporary Durable Source
-| P5
-| HIGH
-| *Resolved (default-enable; per-callsite cleanup deferred)*
-| `DocumentService.documents` (`RwLock<HashMap>`) was the primary durable source on the non-canonical-store path.
-| 4-6 weeks
-| *RESOLVED 2026-05-26 (default-enable layer)*: `canonical-document-store` feature is now in the default feature set in `Cargo.toml:464`. Default builds use the canonical WAL path; the in-memory map becomes a projection cache, not a durable source. ADR-020 (`docs/12-design/adr/ADR-020-canonical-wal-authority.adoc`) defines the recovery contract. Per-call-site cleanup (each `self.documents.write()` becomes pure cache-write after canonical WAL append) tracked as a follow-up under ADR-020; not strictly required since the feature gate already routes writes through canonical WAL in default builds. Opt-out flag preserved for one minor-release migration window (target: removed in v0.4).
+| TD-073 | Filtered-ANN `AnnFilteringPolicy` per-collection catalog persistence (ADR-011) | MED | Open | D5 | OE
+| Optimizer uses a default `AnnFilteringPolicy`; ADR-011 wants per-collection cataloged policy (selectivity prefs, recall floor, pushdown cap). → policy field on collection metadata + optimizer resolution + DDL `PATCH /api/v2/collections/:id` + route-health `policy_source`. Deferred from v0.2 MVP.
 
-| TD-066
-| ORION WAL As Parallel Durable Graph Truth
-| P5
-| HIGH
-| Partial (emission + production wiring + recovery read-side + Option E metrics landed; recovery behavior-change + truncation remain)
-| `OrionGraphEngine::flush_wal()` and `OrionPersistence::save_snapshot()` write graph facts to ORION's own WAL and snapshot files (`src/graph/engines/orion/persistence.rs`). `GraphOperationsService::flush_wal()` now dispatches only to ORION's projection WAL. This WAL is a compatibility recovery buffer alongside canonical `RecordUpsert` WAL entries; recovery from the projection WAL alone would miss canonical record semantics (tenant/RLS, versioning, provenance). The convergence spec states ORION WAL should be demoted to a compatibility projection recovery path.
-| 3-5 weeks (≈3/4 landed)
-| **EMISSION HALF RESOLVED 2026-05-27** by commit `b36a24b17`: added `canonical_wal_appender: Option<Arc<dyn TableWalAppender>>` injection on `GraphOperationsService` plus `with_canonical_wal_appender` builder. `flush_wal` now persists `CanonicalOperation::Checkpoint(SnapshotManifest)` to the canonical WAL via `FramedTableWalAppender::append_operations` before the engine WAL flush, returning `ProximaDBError::Internal` on append failure. Verified by 3 cycles in `tests/graph_canonical_checkpoint_test.rs`. **PRODUCTION WIRING RESOLVED 2026-05-28** by commit `4ece74250`: added `canonical_wal_appender: Option<Arc<FramedTableWalAppender>>` field to `SharedServices`, opened ONCE in `SharedServices::new` from `cfg.server.data_dir`, and shared with both consumers — graph (via the builder) and pgwire direct writes (via `multi_server.rs`). Sharing the single appender instance is required for correctness: two independent `open()` calls on the same WAL file would each maintain independent `next_sequence: AtomicU64`, risking duplicate sequence numbers and silent recovery corruption. The pgwire path falls back to opening locally when the operator overrides `direct_record_wal_path` to a non-default location (no conflict — different paths). **RECOVERY READ-SIDE RESOLVED 2026-05-28** by commit `18c846ae8`: added `canonical_wal_path: Option<PathBuf>` field + `with_canonical_wal_path` builder + `canonical_checkpoint_lsn(&self) -> Option<u64>` async method on `OrionPersistence` (reads canonical WAL, filters checkpoints by `self.graph_id` in `manifest.collection_ids`, returns max LSN). `OrionGraphEngine::recover` now logs the result via `tracing::info!` for operator visibility. Threaded through `GraphOperationsService::canonical_wal_path` → `service_engine_factory.rs` → new `OrionGraphEngine::with_persistence_for_graph_and_canonical_wal` constructor variant (the original 3-arg signature is preserved for 24+ existing callers). Verified by 3 cycles in `tests/orion_canonical_checkpoint_read_test.rs` (none for no-path; max-LSN selection; per-graph_id filtering including multi-graph checkpoints). **Recovery BEHAVIOR is intentionally unchanged in Part 1** — the LSN is logged but not used to scope engine WAL replay. **OPTION E METRICS RESOLVED 2026-05-28** by commit `cd662ceea`: added `src/metrics/td066_metrics.rs` exposing three Prometheus metrics — `orion_recovery_canonical_checkpoint_age_seconds` (gauge), `orion_recovery_canonical_checkpoint_present_total` (counter), `orion_recovery_canonical_checkpoint_absent_total` (counter) — so operators can detect "is canonical emission + production wiring healthy?" without log scraping. Metrics fire on every `OrionGraphEngine::recover` call. Verified by 2 unit tests in `td066_metrics::tests`. LSN-correlation design captured in `docs/12-design/TD_066_PART2_LSN_CORRELATION_DESIGN_2026_05_28.adoc` (5 options surveyed; recommend Option E now [landed] + Option A as a post-v0.2 phase-2 workstream). **Remaining to fully close TD-066:** (c) Part 2 Option A — tag engine WAL frames with `canonical_emission_lsn` marker so recovery can scope engine WAL replay by canonical checkpoint LSN; (d) engine WAL truncation tied to canonical checkpoint LSN (depends on (c) Part 2). Coordinates with `RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc` Phase 3.
+| TD-074 | Collection-default freshness mode not catalog-wired | MED | Open | D5 | OE
+| `VectorFreshnessMode` is per-request only (`collection_level_modes_wired=false`). → `default_freshness_mode` on collection metadata + search-plan resolution + DDL surface + route-health flip. Deferred from v0.2 MVP.
 
-| TD-067
-| Projection Keys Use Facade Document ID Instead Of Canonical OID
-| P6
-| MEDIUM
-| Open
-| JSON path, full-text, and columnar variation projection maintenance routes through `IndexManager` entry points, but projection keys are the facade `document_id` string, not the canonical `ProximaRecord::oid`. This means projection lookups must join through the facade id→OID mapping, and candidate sets in the query executor cannot directly address canonical records. The fix requires the query executor to support record-OID candidate sets.
-| 2-3 weeks
-| Once `plan_executor.rs` can produce OID-addressed candidate sets from `VectorTopK` / `Filter` / `Scan` operators, switch all `IndexManager` projection key writes from facade id to `record.oid`. Add a migration that re-keys existing projection indexes. Coordinates with `RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc` Phase 2 deferred item.
+| TD-075 | `RecallProbeGate` route-selection enforcement | MED | Open | D4 | REL
+| Gate exposes PASS/WARN/FAIL streaks + EXPLAIN reads it, but `AxisManager` quantized-route selection doesn't consult it (recall regressions surface only diagnostically). → `should_route_quantized()` at quantized-route entry; FAIL streak → non-quantized fallback + EXPLAIN reason + regression test. Deferred from v0.2 MVP.
 
-| TD-068
-| QUASAR Cold-Tier Path Has No Canonical Record Binding
-| P6
-| MEDIUM
-| Resolved
-| The separate `QuasarGraphEngine` cold-tier path was removed with the PULSAR/QUASAR engine retirement.
-| N/A
-| Canonical-record-backed tiering remains a storage/catalog projection-policy requirement, not a graph engine path.
-
-| TD-069
-| Standalone unit test files migrated to inline `#[cfg(test)]` blocks
-| All
-| MEDIUM
-| *Resolved*
-| 23 standalone unit test files in `tests/unit/` predated the inline-test convention and complicated build/discovery. Companion tracker `TEST_INLINING_PROGRESS.md` captured the migration work (now archived).
-| 2-3 weeks
-| *RESOLVED 2026-04-07*: 23 files / ~6,500 lines / 190 tests migrated from `tests/unit/` into inline `#[cfg(test)] mod tests` blocks alongside their source modules. 7702+ tests passing. Companion doc archived to `docs/_archive/quality/2026-05/TEST_INLINING_PROGRESS.md` 2026-05-26; see also memory entry `project-test-inline-progress`.
-
-| TD-071
-| Distributed Query Response Metrics Not Plumbed From Coordinator
-| P3
-| LOW
-| Resolved
-| `DistributedQueryCoordinator::execute_with_metadata` returns plan/cache metadata; `DistributedQueryStrategy` preserves node/cache/subquery deltas in `ExecutionMetrics.extra`; REST distributed query responses read `nodes_involved` and `cache_hits` from those structured metrics instead of hardcoded zeros.
-| Done
-| *RESOLVED 2026-05-26*: verified by `cargo check -p proximadb --lib`. Follow-up can add response-level integration coverage, but the implementation gap is closed.
-
-| TD-070
-| Insert/Query Hot Path Skips Dimension + NaN/Inf Validation
-| P3
-| MEDIUM
-| Resolved
-| `VectorOperationsService::insert_batch_internal` now validates records before WAL/bulk routing, and `unified_search_with_tenant_context` validates query vectors before cache lookup/execution. Dimension mismatches and NaN/Inf are rejected at the shared vector service boundary.
-| Done
-| *RESOLVED 2026-05-26*: implementation verified by `cargo check -p proximadb --lib` and `cargo test -p proximadb --lib services::operations::vectors::legacy::index_first_search_tests -- --nocapture` (18 passed, including insert/search non-finite and dimension rejection tests). Follow-up can add REST/gRPC response-shape coverage, but the shared hot-path gap is closed.
-
-| TD-072
-| `ProximaRecord.branch_id` is `#[serde(skip)]` — invisible to canonical WAL → REST branch-merge endpoint structurally broken
-| P3
-| HIGH
-| Resolved
-| Slice 2 of T3.1 (commit `1dca6ea7b`) annotated `crates/foundation/proximadb-records/src/lib.rs:848` with `#[serde(skip, default)]` to keep the V1 bincode wire format stable. The canonical WAL uses `rmp_serde::to_vec_named` (`src/services/canonical_wal.rs:225`), which is schema-tolerant by itself — but `#[serde(skip)]` drops `branch_id` from the serialization regardless of encoder. Result: every record read back via `FramedTableWalAppender::read_entries_from_path` had `branch_id: None`, so `merge_branches` could not identify branch entries and returned `None`. The REST endpoint `POST /api/v1/collections/:collection/branches/:branch/merge` was therefore non-functional for any real-world data; the 6 unit tests in `src/graph/merge.rs` only passed because they construct `CanonicalWalEntry` via struct literals (bypassing the WAL roundtrip).
-| Done
-| **RESOLVED 2026-05-27** by commit `996626595`: flipped `#[serde(skip, default)]` → `#[serde(default)]` on `branch_id`. Considered 3 fix options: A = switch WAL to `ProximaRecordV2` (~35 RecordUpsert constructor sites); B = move `branch_id` onto `CanonicalWalEntry` (16 + 7 + 2 sites); **C (chosen) = unskip the attribute (1 line)**. Option C is safe because (1) no production code bincode-serializes `ProximaRecord` directly — only tests do; (2) the canonical WAL encoder is named-field schema-tolerant; (3) no production data with `branch_id = Some(...)` exists on disk yet — the canonical WAL has been silently dropping the field since Slice 2 landed, so there is nothing to migrate. Added 3 regression tests in `proximadb-records/src/lib.rs#mod tests` (rmp-named roundtrip, bincode roundtrip, default-on-missing) and flipped the existing `branch_id_is_dropped_by_v1_bincode_path_serde_skip` test in `wire_v2.rs` to assert the new contract. The 5 Slice 8 integration tests are no longer `#[ignore]`-d and all pass (`cargo test --test graph_branch_merge_integration_test`: 5 passed). Cleaner-layering Option B is available as a future refactor; it doesn't block anything.
-
-| TD-073
-| Filtered ANN `AnnFilteringPolicy` per-collection catalog persistence (ADR-011)
-| P3
-| MEDIUM
-| Open
-| Optimizer (`src/index/axis/management/manager.rs:653-694`) routes filtered ANN through a default `AnnFilteringPolicy` instance. ADR-011 contract says per-collection policy (low/medium/high-selectivity preferences, recall floor, pushdown candidate cap) should be cataloged. Without it, operators cannot tune per workload; recall envelope is policy-uniform across collections.
-| 3-5 days
-| Deferred from v0.2 MVP cut (2026-05-28). Acceptance: (1) `AnnFilteringPolicy` field on collection metadata in xCatalog; (2) optimizer resolves catalog policy → falls back to default; (3) DDL surface (REST `PATCH /api/v2/collections/:id`) updates it; (4) route-health surfaces `policy_source: "catalog"\|"default"`. v0.2 ships Beta with differential recall coverage via `tests/filtered_ann_recall_bands.rs` only.
-
-| TD-074
-| Collection-default freshness mode not catalog-wired
-| P3
-| MEDIUM
-| Open
-| `VectorFreshnessMode` (`src/core/search/mod.rs:95-105`) is honored per-request only. `FreshnessHealth.collection_level_modes_wired = false` (`src/network/rest/v2/collections.rs:1114-1126`). Operators cannot set per-collection default; clients must pass `freshness_mode` on every search request or accept `Strong`.
-| 2-3 days
-| Deferred from v0.2 MVP cut (2026-05-28). Acceptance: (1) `default_freshness_mode: Option<VectorFreshnessMode>` on collection metadata; (2) search-plan time resolution falls back to collection default before `Strong`; (3) route-health flips `collection_level_modes_wired` to `true`; (4) DDL surface accepts the field. v0.2 documents per-request-only in `docs/SUPPORTED_SURFACE.adoc` "Not Supported in v0.2".
-
-| TD-075
-| `RecallProbeGate` route-selection enforcement
-| P3
-| MEDIUM
-| Open
-| `src/catalog/recall_probe.rs` exposes gate state (PASS / WARN / FAIL streaks) and EXPLAIN can read it, but `AxisManager` quantized-route selection does not consult the gate. Recall regressions surface only diagnostically.
-| 3-5 days
-| Deferred from v0.2 MVP cut (2026-05-28). Acceptance: (1) `RecallProbeGate::should_route_quantized()` (or equivalent) called at quantized-route entry in `AxisManager`; (2) FAIL streak → fallback to non-quantized route + degraded-route reason in EXPLAIN; (3) regression test (gate FAIL forces fallback). v0.2 ships gate as diagnostic only.
-
-| TD-076
-| pgwire / SQL parity Phase 2/3 (ADR-018)
-| P3
-| MEDIUM
-| Open
-| ADR-018 Phase 1 (basic DML + vector-distance syntax) wired. Phase 2 (`ORDER BY` semantics, `COUNT/SUM/GROUP BY`, joins, `xcatalog.namespaces`, `pg_class`) and Phase 3 (Postgres parity) gap. Server returns explicit "not yet supported" for several SQL shapes; live-server probe (2026-05-25) found crashes on aggregates and joins.
-| 3-6 months
-| Deferred from v0.2 MVP cut (2026-05-28). v0.2 ships pgwire as Beta with Phase 1 scope only. See ADR-018 for the phased contract.
-
-| TD-077
-| Distributed cluster execution — remote transport / failover
-| P3
-| HIGH
-| Open
-| `src/cluster/` (5,491 LOC) has Raft internals, shard planning, and routing foundations but RPC transport and remote execution contain placeholder/partial implementations. Feature-gated behind `cluster` flag. Not a like-for-like distributed-DB replacement in v0.2.
-| 6+ months
-| Deferred from v0.2 MVP cut (2026-05-28). v0.2 ships distributed cluster as Experimental. Acceptance for graduation: real transport benchmark, deterministic failover test suite, EXPLAIN route includes remote-shard fragment identity.
-
-| TD-078
-| External-table federated execution (Iceberg / Delta / Hudi as hot authority)
-| P3
-| MEDIUM
-| Open
-| External-format adapters exist as interoperability modes (publications, imports, federated reads) but not as Proxima-owned hot authority with full ACID + ANN + RLS. Multiple code paths return explicit "not yet supported" / "not wired" for federated relational, external table, subquery vector source.
-| 2-4 months
-| Deferred from v0.2 MVP cut (2026-05-28). v0.2 ships these as Experimental external-authority modes per `OPEN_FORMAT_CATALOG_2026_05_17.adoc`. Acceptance: explicit authority-mode catalog field + federated route-health + EXPLAIN write-plan disclosure of external-authority decisions.
-
-| TD-079
-| Root `proximadb` crate accumulated clippy lint backlog
-| P4
-| LOW
-| Resolved 2026-05-28
-| `cargo clippy --workspace --lib --bins -- -D warnings` is now CLEAN across all 50+ non-root workspace crates and the root `proximadb` crate itself. `cargo fmt --all -- --check` exits 0. Total reduction: 164 → 0 across a 16-batch multi-day sweep. The remaining hard-to-mechanical lints (collapsible_if-into-match with `?`-operator bodies; unwrap/expect on documented infallible invariants; intentionally-large variants) carry inline `#[allow(...)]` with rationale linking to the static invariant or the constructor blast-radius reason.
-| Closed
-| **RESOLVED 2026-05-28** across 16 batches (`7db1d804e` → `a297949ca`). Acceptance criterion met: `cargo clippy -p proximadb --lib -- -D warnings` exits 0. Batch-by-batch: (1-3) workspace-wide sweep across 50+ crates; (4) manual_checked_ops (17 files); (5) derivable_impls (7); (6) unnecessary_sort_by → sort_by_key (12); (7-9) collapsible_if let-chain waves (26 files); (10) doc_lazy_continuation + auto-deref + useless_conversion (14); (11) clone_on_copy + singletons (8); (12) long-tail singleton sweep — needless_question_mark, manual_clamp, manual_repeat_n, io::Error::other, matches!, iter_kv_map, manual_strip, char-array-pattern, manual_size_of_val (18); (13) dead-alias deletion + needless_range_loop allows (7); (14) dead-code helper deletion + remaining field-init (6); (15) error-handling refactors + match-arm guards — 5 expect/unwrap converted to audited `#[allow]` with invariant rationale, 1 real refactor (init_hmgi), 7 collapsible_if-into-match converted to match-arm guards, 2 to allow with `?`-operator rationale (23 files); (16) close — large_enum_variant allows, let_underscore_future allow, unused-import drop, dead-field allow (5 files). Follow-up: tighten the CI lint job at `.github/workflows/ci.yml` to drop the `RUSTFLAGS: '-A warnings'` override now that the root crate itself is clean.
-
-| TD-080
-| Catalog default-bootstrap in embedded test harnesses (precision_resolver wiring)
-| P3
-| MEDIUM
-| Resolved
-| Two coupled bugs surfaced during diagnosis. (1) `SharedServices::new` created a "default" native catalog but never called `set_default_catalog("default")`, so `catalog_manager.default_catalog()` always returned `Err` and `database.rs:159` warned that the precision_resolver was unwired — silently in **production too**, not just the embedded test harness. (2) Even after fixing the resolver wiring and confirming coercion correctly produced fp16 cells, the WAL-level metric emitter labelled by the internal UUID returned from `resolve_collection_id_internal`, while operators and the regression test scrape by the user-facing collection name.
-| 2-3 days
-| **RESOLVED 2026-05-28** by commit `32cea5b85`: (a) `SharedServices::new` explicitly designates "default" as the catalog manager's default after the native-catalog create call; (b) `UnifiedHandlers::coerce_records_to_canonical_precision` emits the per-precision `canonical_bytes` metric using the handler-side collection_id; the WAL-side emission stays for non-handler writers but uses the internal UUID. The fp16 metric regression test is no longer `#[ignore]`'d (`tests/fp16_v2_insert_search_e2e.rs::rest_v2_insert_into_fp16_collection_accumulates_canonical_bytes_metric` — green).
-
-| TD-081
-| Python SDK live v2 INSERT→SEARCH integration coverage
-| P3
-| MEDIUM
-| Resolved
-| `tests/release_smoke_v2.rs` is the v0.2 release-gate smoke for the v2 record path but is Rust-only. The Python SDK at `clients/python/src/proximadb_sdk/protocols/rest_sync.py` (insert_records → v2 records/batch) was exercised only by mocked-HTTP unit tests in `clients/python/tests/unit/test_rest_record_ingest.py`. A regression in the SDK's insert→search round trip would not have been caught by `make release-check`.
-| 1-2 days
-| **RESOLVED 2026-05-28**: `clients/python/tests/integration/test_v2_insert_search_e2e.py` landed with two test cases that pass on a built release server (2/2 PASSED): (a) live insert_records → search round trip asserting top-k contains an inserted ID, (b) missing-collection contract asserting the SDK surfaces the round-2 HTTP 404 (not the old silent success-shaped response). The `rest_client` fixture uses the direct REST sync client (`proximadb_sdk.protocols.rest_sync.ProximaDBClient`) rather than the unified client — the unified client activates a silent local-vector fallback on any backend error and returns `[]` from `search()` without an HTTP round-trip, which would mask the very regression the test guards against. Prefers `PROXIMADB_TEST_SERVER_URL` and falls back to the `embedded_db` fixture. Wiring into `make release-check` is a thin follow-up tracked here but not blocking closure.
-
-| TD-082
-| Arrow Flight INSERT vs. REST/gRPC UPSERT handler parity test
-| P3
-| MEDIUM
-| Resolved
-| Round-2 audit (2026-05-28) found that `handle_record_insert_batch_for_tenant` was missing the precision-coercion block that `handle_record_batch_for_tenant` already applied — Arrow Flight INSERT into an fp16 collection would land fp32 records. The initial round-2 fix (commit `a446b3964`) duplicated the coercion block in both handlers, which kept the parity surface fragile (another future block could regress one path silently).
-| 1 day
-| **RESOLVED 2026-05-28** by commit `32cea5b85`: extracted the v2 precision-coercion block into `UnifiedHandlers::coerce_records_to_canonical_precision` and routed both handlers through it. Parity is now enforced by code-sharing rather than by a test that could later be deleted, deleting the entire class of "one handler regressed but the other didn't" bug.
-
-| TD-083
-| Rust SDK v2 INSERT exposure (props / text_fields)
-| P3
-| MEDIUM
-| Resolved
-| Rust SDK previously exposed v2 upsert only — no full INSERT with the v2 `text_fields` schema. (`props` was already accessible via the existing `metadata()` / `meta(k,v)` builder methods on `InsertBuilderWithId`.) Rust SDK users could not leverage canonical record TEXT-field features.
-| 2-3 days
-| **RESOLVED 2026-05-28** — added `TextFieldInput` and `text_field(name, content)` / `text_fields(Vec<...>)` builder methods on `InsertBuilderWithId`. `ProximaRecord` gained a `text_fields: Vec<TextFieldInput>` field mirroring `src/network/rest/v2/records.rs::TextFieldInput`. Two new unit tests (`proxima_record_serializes_text_fields_in_v2_shape`, `insert_builder_chains_text_fields`) lock the contract.
-
-| TD-084
-| PostgreSQL wire v2 record features exposure
-| P3
-| MEDIUM
-| Resolved
-| Round-2 audit (2026-05-28) flagged pgwire as not exposing v2 `props` / `text_fields` typed-field insert. The TD-084 scoping survey found that the gap was narrower than originally framed: (1) **props already works** — any non-reserved column in pgwire INSERT lands as a typed `ProximaValue` in `ProximaRecord.props` via the catalog `to_proxima_record()` path at `crates/control/proximadb-catalog/src/relational.rs:272`; (2) **text_fields is REST sugar** — the v2 REST handler at `src/network/rest/v2/records.rs::insert_records` folds `text_fields[]` into `props["name"] = String(content)` before the canonical write. The canonical `ProximaRecord` has no separate text_fields field. So pgwire INSERT into a `VARCHAR` column is functionally equivalent to REST text_fields.
-| 3-5 days
-| **RESOLVED 2026-05-28** by documentation + cross-protocol contract test. (a) New `docs/03-api-reference/postgres.adoc` documents the v0.2 supported pgwire SQL surface, the v2 record-typed INSERT pattern (`INSERT INTO t (id, title, price, ...) VALUES (...)`), the cross-protocol contract (rows reachable via REST v2 record fetch), and the explicit "Not Supported in v0.2" list pointing at ADR-018 Phase 2/3 trackers (TD-076 etc.). (b) New `tests/pgwire_insert_props_e2e.rs` test `pgwire_insert_typed_columns_persist_to_v2_record_props` boots an in-process server, CREATE TABLE + INSERT INTO over the real wire protocol with mixed-type columns (VARCHAR / FLOAT / BIGINT / BOOLEAN), then verifies the row is reachable via REST v2 (`GET /api/v2/collections/{tbl}/records/{id}`). PASSED on a fresh release build. ADR-018 Phase 2/3 (`ORDER BY`, aggregates, joins, system tables, prepared-statement parameterisation) remain Beta and continue under TD-076.
-
-| TD-085
-| Marketing copy in `docs/_internal/enterprise/` and `docs/_internal/business/` overclaims
-| P4
-| LOW
-| Engineering side resolved — product scrub still open
-| Round-2 audit (2026-05-28) found multiple overclaims that survived round-1 cleanup because the round-1 `docs-claim-check` allowlisted internal marketing paths. Examples: "85-96% cost reduction", "296% performance" competitor claims, "Industry-leading" superlatives.
-| 1 day
-| **PARTIALLY RESOLVED 2026-05-30** by sealing the internal marketing copy: (1) both files (`docs/_internal/enterprise/README.adoc`, `docs/_internal/business/competitive_advantages.adoc`) now carry an **INTERNAL USE ONLY — DO NOT PUBLISH EXTERNALLY** banner forbidding quotation in customer-facing artifacts without product-owner sign-off and an evidence trail; (2) `make docs-claim-check` (Makefile) gained a rule that **hard-fails** if any path outside `docs/_internal/` references either `docs/_internal/enterprise/` or `docs/_internal/business/` (the Technical Debt Register is exempt because it tracks the work). The leakage risk is closed. **Remaining (product-owner scope)**: actually scrub the "85-96% cost reduction" / "296% performance" / etc. claims or cite a reproducible methodology, then the files can be moved out of `_internal/` if the underlying numbers survive scrutiny.
-
-| TD-086
-| Continuous Discovery surface + atomic snapshot republish (CS/CD loop)
-| P4
-| MEDIUM
-| Open
-| ProximaDB can serve (vector/hybrid/cross-model retrieval) but has no first-class *discovery* arm that operates on production vector data and feeds results back. The primitives exist in isolation — manifest/branch versioning, the projection freshness state machine (`Fresh/Updating/Stale/RebuildRequired/...`), `compute_route` selection, and `src/automl/` tuning — but there is no cataloged workflow that reads a pinned snapshot, runs offline refinement (dedup, recluster, re-embed, drift/quality scan, agent-trajectory analysis), and publishes a *new snapshot* that serving switches to atomically. This is the largest conceptual gap vs the Vector Lakebase "Continuous Serving + Continuous Discovery" thesis. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R1.
-| 3-6 months
-| Surfaced 2026-05-28 (Vector Lakebase trend review). Acceptance: (1) a `DiscoveryJob` catalog asset that pins a manifest snapshot of a collection; (2) job completion republishes a new snapshot (new data + rebuilt indexes/embeddings) with an *atomic* serving switch — no half-built indexes exposed; (3) discovery compute routes through existing `compute_route` (Native batch / DataFusionDistributed / Spark / Ray) declaring `authority_mode` + `freshness_sla`; (4) the republish is explainable in unified EXPLAIN. Mostly composition over existing primitives; converts `src/automl/` from tuning into the offline arm of the flywheel.
-
-| TD-087
-| Scale-to-zero cold path — binary-first two-stage retrieval + IVF pruning
-| P4
-| MEDIUM
-| Open
-| When compute scales to zero, the first query hits pure cold data in object storage. A full index (e.g. ~340 GB for 1B×768-dim HNSW) can take minutes to pull from S3, making scale-to-zero impractical for large vector workloads. `compute/quantization/unified.rs` has binary/INT8/PQ and `RecallProbeGate` (TD-075) exists, but there is no designed *cold-load ordering* that pulls a compact binary representation first, two-stage reranks, and IVF-prunes bytes-touched-per-query. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R2.
-| 1-2 months
-| Surfaced 2026-05-28 (Vector Lakebase trend review). Acceptance: (1) a "cold-path" index profile that persists a compact binary/RaBitQ-style representation (~1/30th size) loaded *first*; (2) two-stage search (coarse 1-bit filter → higher-fidelity rerank) with recall envelope disclosed via `RecallProbeGate` + the TD-064 predicate-aware disclosure contract; (3) IVF cluster pruning bounding bytes-touched-per-query; (4) cold-start latency benchmark from object storage. New work is the load ordering + two-stage execution path, not a new quantizer.
-
-| TD-088
-| Point-read I/O amplification over object storage (point-read-optimized lake layout)
-| P4
-| MEDIUM
-| Open
-| Vector search returns IDs but applications need full records (text, metadata, permissions, timestamps). PAX block format (ADR-010) orders column stripes and supports pruning, but is row-group/columnar-oriented; a point read from object storage drags a whole row group/stripe — the same amplification measured for Parquet (≈9.4 MB downloaded vs ≈0.07 MB for a point-read-optimized layout). No row-aligned mixed layout (the Vortex/Loon equivalent) is designed. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R3.
-| 1-3 months
-| Surfaced 2026-05-28 (Vector Lakebase trend review). Acceptance: (1) PAX row-aligned column-group mode so a point lookup fetches only needed fields' bytes; (2) evaluate the open Vortex format (Linux Foundation — aligns with open-format mandate) as an interoperable layout option for point-read-heavy collections, benchmarked vs PAX and Parquet for both point reads and scans; (3) serving (point read) and discovery (scan) access patterns stay over *one logical copy* — no second physical store. Pairs with TD-087 (cold path) and TD-086 (discovery scans).
-
-| TD-089
-| Elastic compute modes (long-running / on-demand / offline-batch) + resources-follow-data scheduler
-| P4
-| HIGH
-| Open
-| ProximaDB has embedded and distributed (experimental, `cluster` flag) deployment but not the three-mode elastic model with minute-level billing and warm pools. There is no warm-pool scheduler that attaches a pinned snapshot to prepared compute on request and releases on idle while catalog/metadata stay queryable with zero resident compute. This is the practical realization of the 2028 VISION "serverless deployment mode" milestone and the Vector Lakebase "resources follow the data" pillar. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R4.
-| 6+ months
-| Surfaced 2026-05-28 (Vector Lakebase trend review). **Split (2026-05-28 plan refinement)**: this TD now scopes only the *multi-node* warm-pool half (F4b — minute-billed `OnDemand` pods + `OfflineBatch` cluster), which is the part genuinely blocked on TD-077 (distributed transport). The *single-node* scale-to-zero half (collection suspend/resume — most of the "idle tenants don't pay" economics) is **unblocked** and split out to **TD-094 (F4a)**. Gated by TD-087/TD-088 (which make scale-to-zero economical first). Acceptance: (1) `OnDemand` (minute-billed) + `OfflineBatch` modes over the same logical store across nodes; (2) warm-pool scheduler with attach-on-request / release-on-idle; (3) metadata queryable with no compute resident cluster-wide; (4) cost/latency model documented. Sequence *after* R1/R2/R3 and after TD-077.
-
-| TD-090
-| External Collection — ProximaDB-owned indexes over external-resident data (index-in-place)
-| P4
-| MEDIUM
-| Open
-| `FederatedRead` and `ExternalAuthoritative` authority modes (`OPEN_FORMAT_CATALOG_2026_05_17.adoc`) allow reading/federating external tables, and TD-078 covers external-table federated *execution* — but neither builds and maintains ProximaDB-owned vector/inverted/JSON indexes over data left in place in an external lake (Iceberg/Lance/Parquet). The Vector Lakebase "External Collection" capability ("One Data. One Index. No duplicated storage. No dual-write pipelines.") is a distinct, high-value mode. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R5.
-| 2-4 months
-| Surfaced 2026-05-28 (Vector Lakebase trend review). Acceptance: (1) an authority mode (or `FederatedRead` sub-mode) where external data stays externally governed and un-copied while ProximaDB builds/maintains vector + inverted + JSON indexes routed through the same retrieval path as native data; (2) explicit index-staleness-vs-source-commit freshness behavior + repair source declared per architecture mandates; (3) lets the TD-086 discovery loop cover lake-resident data, not just imported data. Gated for Lance corpora by TD-091.
-
-| TD-091
-| Lance format interoperability (read / import / external-index substrate)
-| P4
-| LOW
-| Open
-| ProximaDB supports Iceberg/Delta/Hudi/Parquet but not Lance, a vector-native lake format treated as a primary external substrate in the Vector Lakebase ecosystem. See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R6.
-| 3-6 weeks
-| Surfaced 2026-05-28 (Vector Lakebase trend review). Lowest priority of the six trend-review items. Acceptance: Lance as a read/import/external-index substrate alongside the existing open formats; gates TD-090 (External Collection) for Lance-resident corpora.
-
-| TD-092
-| Hybrid BM25 auto-indexing on the canonical insert path + unify the two hybrid entry points
-| P2
-| MEDIUM
-| Open (re-scoped 2026-05-28 after live-path audit)
-| **Re-scoped — the original framing was wrong.** Plan-refinement (2026-05-28) said "wire the `bm25_wrapper.rs` stub into the fusion path." A live-path audit found: (a) the fusion engine (`src/core/search/hybrid/fusion.rs`), the production hybrid port `RestHybridPortImpl` (`src/network/hybrid_search.rs`, `/api/v1/hybrid/*`), and `ProductionHybridBackend` (used by `RankServices`) **already fuse real Tantivy BM25 + vector**; (b) `src/core/search/hybrid/bm25_wrapper.rs` was a *dead, always-empty scaffold* — never re-exported, never called — and was **removed 2026-05-28** (it is what made the gap look like simple stub-wiring). The *genuine* residual gaps are two: (1) the hybrid BM25 index (`columnar/fulltext_index.rs`, the shared `HybridFullTextIndexMap`) is populated **only** via the explicit `BM25IndexPort::index_documents` endpoint (`src/network/hybrid_search.rs:40`), **not on the canonical record INSERT path** — so a user who inserts records cannot BM25-search them via hybrid until they separately index; (2) the alternate hybrid entry point `request_handlers.rs::execute_hybrid_search:824` has BM25 **hardcoded disabled** (`Ok(Vec::new())`, "temporarily disabled"), silently fusing vector-only. This is write-path integration, not parity-wiring — larger than first estimated.
-| 3-6 weeks
-| Re-scoped 2026-05-28 (live-path audit, per `feedback_survey_live_paths`). Acceptance: (1) canonical INSERT of a record with text auto-populates the hybrid BM25 index for collections with `enable_fulltext_index` (schema flag at `src/network/rest/v2/schema.rs:646`); (2) `request_handlers.rs::execute_hybrid_search` either routes through `RestHybridPortImpl` or is removed as a duplicate path (reuse-first — do not maintain two hybrid fusers); (3) integration test: insert records, then a keyword-only hybrid query surfaces a doc that pure-vector misses, with no separate index call. Design decisions: which text field(s) to index, indexing precision/async behavior, and freshness vs the canonical write. Gated by the `enable_fulltext_index` schema flag. Sequence: near-term but it is write-path work, not the trivial wiring first assumed.
-
-| TD-093
-| RankServices startup wiring — production CandidateProvider for SQL RERANK
-| P2
-| MEDIUM
-| Resolved (already wired — verification 2026-05-28)
-| Plan-refinement (2026-05-28) flagged this as an un-wired primitive based on a stale memory note (`project-rank-services-production-wiring-2026-05-28`, "deferred to a fresh session"). **A live-path audit on 2026-05-28 found it was already implemented** by a subsequent R-7c.3 session: `build_rank_services()` runs at startup in `src/network/shared_services.rs:1232`, constructs the production `RankServices` over `ProductionHybridBackend` → `HybridCoordinatorAdapter` (`src/network/rest/v1/rank_backend.rs`, `rank.rs`), logs "✅ SharedServices: RankServices ready", and wires the singleton into both the SQL path (`FederatedQueryContext::with_rank_services`, `shared_services.rs:1252`) and REST (`AppState::with_rank_services` via `multi_server.rs`). The federated executor's degradation check (`src/query/federated/execution/mod.rs:768`) is therefore satisfied — SQL `RERANK` dispatches the full pipeline, not retrieval-only.
-| 0 (already done)
-| **RESOLVED 2026-05-28** by prior R-7c.3 work; confirmed by audit, no new code required. Lesson (per `feedback_survey_live_paths`): verify the live caller chain before scheduling work off a stale status note. Residual: the 9th §4.10 metric (async loader, R-5b) remains tracked under the ranking-framework work, not here.
-
-| TD-094
-| Single-node scale-to-zero (collection suspend/resume) — unblocked half split from TD-089 (F4a)
-| P4
-| MEDIUM
-| Open
-| Split from TD-089 (2026-05-28 plan refinement). TD-089's three-mode elastic model is blocked on TD-077 (distributed transport), but the *single-node* economics are **not** blocked: evict a collection's compute/index from memory while keeping its catalog metadata queryable, then lazy-warm on first query — reusing the already-built `CollectionPinRegistry` (`src/storage/collection_pinning.rs`), `DirectoryLoadStatus` (`src/storage/engines/sst/object_economy_directory.rs`), route-health diagnostics (`GET /api/v2/_diagnostics/collections/:id/route-health`), and the tiering engine. Delivers most of the "idle tenants don't pay" benefit for embedded / single-node deployments and chains off TD-087 (fast cold-start makes resume cheap). See `docs/12-design/VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc` R4 (F4a).
-| 3-6 weeks
-| Surfaced 2026-05-28 (plan refinement). Acceptance: (1) a collection can be suspended (compute/index released, sidecar marked cold) with its catalog metadata still queryable; (2) the first query after suspend lazy-warms via the TD-087 cold path; (3) suspend/resume state is observable in route-health; (4) no dependency on TD-077. Unblocked — can precede or run parallel to F1; sequence after TD-087.
-
-| TD-095
-| SDK graph create_node/edge/graph body shape mismatch vs server (Rust + TypeScript)
-| P3
-| MEDIUM
-| Resolved 2026-05-30
-| Surfaced 2026-05-30 after reconciling the OpenAPI graph schemas (`docs/openapi/proximadb-openapi.yaml`) against the live server handler `crates/platform/proximadb-api/src/rest/v1/graph.rs`. The earlier spec additions had wrong field names / wrapping for `CreateGraphRequest` (required `name` → now `graph_id`), `CreateNodeRequest` (flat `{id, ...}` → wrapped `{node: NodeInput}`), `CreateEdgeRequest` (flat `{source, target, ...}` → wrapped `{edge: EdgeInput}` with `from_node_id` / `to_node_id` / `edge_type` / `id`), and `TraverseRequest` (had `direction` / `max_nodes` → server-true keys are `start_node_id` (not `start_node`) + `node_labels` + `limit`). **RESOLVED 2026-05-30** across two SDK commits: Rust at `c08030d34` (`clients/rust/src/graph.rs` — all six builders posting server-true bodies; 3 ignored contract tests unskipped + 2 new batch tests added; 20/0/0 pass/fail/ignore), TypeScript at `70ebe603c` (`clients/nodejs-embedded/src/graph.ts` — same six builders rewritten; 4 `it.skip` removed + 2 new batch tests added; 17/0/0 pass/fail/skip). Also depends on `5c91dc32f` (spec: added `batchCreateNodes` + `batchCreateEdges` operations so the SDK `addNodes`/`addEdges` calls have spec-true targets).
-| Closed
-| Acceptance: (1) **DONE 2026-05-30 — TS** `clients/nodejs-embedded/src/graph.ts` `GraphBuilder.execute()` posts `{graph_id, name?, description?}`; `NodeBuilder.execute()` posts `{node: NodeInput}`; `GraphHandle.addNodes()` posts `{nodes: [NodeInput, ...]}` to `/nodes/batch`; `EdgeBuilder.execute()` mirrors with `{edge: EdgeInput}` (`from_node_id` / `to_node_id` / `edge_type` / `id`); `addEdges()` posts `{edges: [...]}` to `/edges/batch`; `TraversalBuilder.execute()` posts `start_node_id` (not `start_node`), drops `direction`, wraps `relationships` as `edge_types`, adds optional `node_labels`. (2) **DONE 2026-05-30 — Rust** at `clients/rust/src/graph.rs`. (3) **DONE 2026-05-30** — all 4 TS `it.skip` + 3 Rust `#[ignore]` cleared; SDK contract gates green. (4) **Deferred to follow-up** — per-language live-server smoke tests (insert node, get node, traverse). The SDKs now emit spec-correct bodies, but actual happy-path round trips against a running server haven't been exercised. Recommended: extend `make release-check` to spin up a local server and run a small SDK smoke per language.
-
-| TD-096
-| Routing guidance + bench validation for vector-locality workloads (SST vs HELIX)
-| P2
-| HIGH
-| Open
-| Surfaced 2026-05-30 via `bench_warm_path_profile` shadow recall measurement (`flat_default_vs_force_exact` field, committed in `403fd1ba1`). SST's block-centroid pruning collapses to ~5% recall at 100K on diffuse data because `sort_vectors_for_sstable_encoding` (`src/storage/engines/sst/utils.rs:43`) sorts records by `oid` lexicographically before block write — block centroids end up as statistical mixtures rather than spatial cluster centers. **HOWEVER**, this architectural fix already exists in the HELIX engine: `src/storage/engines/helix/mod.rs:1279-1283` sorts by PCA-projected Hilbert curve key at L0 flush time, claiming "80-90% block reduction" via spatial pruning (with `zone_maps`, `liquid_clustering`, and `query_optimization` infrastructure). So the right move is likely **route vector-locality workloads to HELIX** instead of retrofitting SST's flush path. The original TD-096 framing ("port Z-order sort into SST") may be solving the wrong problem. Mitigated by `SearchMode::Exact` auto-disabling pruning (`403fd1ba1`); `SearchMode::Approximate` on SST still degenerates at scale.
-| 3-5 days (validate + route) vs 1-2 weeks (retrofit SST)
-| Acceptance: (1) Extend `benches/bench_warm_path_profile.rs` to support `BENCH_ENGINE=helix` (currently hardcoded to SST via `SstEngine::new_with_config`). (2) Run the shadow recall matrix with HELIX engine at 10K / 25K / 100K — verify `flat_default_vs_force_exact >= 0.90` on HELIX (Hilbert-sorted blocks). (3) If HELIX validates, file routing recommendation in `docs/12-design/AXIS_INDEX_SELECTION.adoc` (or similar): vector-locality workloads → HELIX, OLTP/oid-keyed workloads → SST. (4) If HELIX does NOT validate (e.g., Hilbert sort missing at compaction time, or other gaps), THEN file the original SST retrofit work as a successor TD (port `sort_vectors_for_sstable_encoding` and `write_merged_records` to use PCA+Z-order — Hilbert curve impl already in `proximadb-storage-common::hilbert_curve`). (5) Either way: SearchMode::Exact callers continue to bypass pruning (already shipped in `403fd1ba1`).
-
-| TD-097
-| Spark connector JNI bridge — embedded product impls live; Gradle remains
-| P3
-| MEDIUM
-| Partial — wire + CI + embedded product impls shipped 2026-05-31..06-02 (`8704472ba` + `a52af195d` + `32e96e35c` + `087968990` + `ca838f31b` + `31ae5340d` + `060be38b3` + `14b0b750a`)
-| Surfaced 2026-05-30 during the connector-conformance sprint. `src/connectors/spark.rs` had 9 `jni_*` placeholder functions; the cdylib at `crates/binding/proximadb-spark-jni` wrapped them with JNI-mangled exports but the bodies returned scaffold values. **WIRE + CI + EMBEDDED PRODUCT IMPLS NOW SHIPPED**: User chose embedded in-process deployment shape (Spark executor JVM owns a SharedServices via the cdylib singleton). 5 commits over 2 days closed acceptance (3): (B1, `087968990`) extended EmbeddedProximaDB with `get_collection_schema` / `scan_records` / `plan_partitions`; moved ScanCursor codec into a shared `src/services/scan_cursor.rs` so the REST handler + embedded callers share one codec; added `FileSplit::whole_collection` for the single-partition fallback. (B2, `ca838f31b`) added `record_batch_to_arrow_ipc` + inverse helpers in `src/connectors/spark.rs` (plain Arrow IPC stream, distinct from the Trino per-column block format). (B3, `31ae5340d`) replaced the 9 `jni_*` placeholders with real `spark_*(emb: &EmbeddedProximaDB, ...)` impls; reshaped SparkPartitionReader / SparkDataWriter with real state; deleted dead `SparkScanBuilder::plan_partitions`; added a `jni_handle` helper module in the cdylib containing the unsafe `Box::into_raw` handle plumbing in one auditable file; new `SparkError` enum maps to typed Java RuntimeException. (B4, `060be38b3`) added `Java_..._initialize(dataDir) -> jboolean` JNI entry point + `OnceLock<Arc<EmbeddedProximaDB>>` singleton; rewired all 9 wrappers to grab the singleton and delegate to spark_*; writes throw RuntimeException on uninit/null-handle (silent-Ok-failure anti-pattern closed). (B5, `14b0b750a`) updated the Java smoke harness for real-data shapes; 13 smoke checks all green via `clients/jvm/spark-connector/run-smoke.sh`. Convergence outcome: all four connectors funnel into the canonical authority — DuckDB/Hadoop via REST→UnifiedHandlers, Trino via Flight→UnifiedHandlers, Spark JNI via EmbeddedProximaDB→SharedServices→UnifiedHandlers. Unit-test coverage: 22 new tests (18 spark + 4 jni_handle), including a critical e2e (`test_spark_read_after_write_round_trip`: 50 records written via JNI flow → plan → drain → distinct oids + cursor advances). Remaining: smoke harness still uses plain `public static void main` (no Gradle/JUnit5).
-| Post-MVP/Beta follow-ups only (Gradle/JUnit5 migration + future shard-aware partition planning)
-| Acceptance: (1) **DONE 2026-05-31** for the wire-up pattern — cdylib + Java test work end-to-end. (2) **DONE 2026-06-01** — all 9 `jni_*` wrapped as `extern "system" fn Java_org_proximadb_spark_NativeProximaDB_*` in `crates/binding/proximadb-spark-jni/src/lib.rs` (`a52af195d`). (3) **DONE 2026-06-02** (5 commits B1-B5) — each Rust JNI wrapper now constructs the underlying `EmbeddedProximaDB` call directly (no network hop) and serializes via plain Arrow IPC (read) or `serde_json` (schema/commit). Critical end-to-end test `test_spark_read_after_write_round_trip` proves the write→read flow with distinct-oid + cursor-advance assertions that catch the "stuck cursor" regression invisible at per-call level. (4) **POST-MVP/BETA** — migrate `clients/jvm/spark-connector` from the plain-main smoke harness to Gradle + JUnit 5; add per-method conformance assertions (schema fetch returns canonical schema shape etc.). This is harness hardening, not a v0.2 release gate. (5) **DONE 2026-06-01** — dedicated `spark-jni-smoke` CI job builds cdylib + runs Java harness (`32e96e35c`); local `run-smoke.sh` mirrors the same steps. **Follow-up TDs (out of scope for MVP):** **POST-MVP/EXPERIMENTAL** split-aware read planning (today's single-partition fallback is correct-but-not-parallel; under the 2026-06-04 Rust-native MPP course correction this is now a shared DataFusion/notebook/Spark `RoutedReadPlan` + `SplitSource` + `SplitPlanner` seam, not a Spark-only shard plan); **Spark filter pushdown — Rust-side DONE 2026-06-03** (`a9786bb27` lowering + `d9187bf0c` scan-apply): `lower_spark_filters_to_expression` lowers Spark's `filters_json` (the `SparkFilter` tree) into the canonical `FilterExpression`, stamps it onto each `SparkInputPartition`, and the reader pushes it into the WAL scan via `EmbeddedProximaDB::scan_records_filtered` → `scan_records_paginated(filter)` → `evaluate_filter_proxima` over `record.props` (applied before the limit, so cursor pagination stays correct). Filters are evaluated EXACTLY — unrepresentable shapes (struct-path columns, `AlwaysTrue/False`, an `And/Or/Not` with any unrepresentable child) are DROPPED in lowering, never partially applied. 12 lowering + 4 e2e tests. **JNI lifecycle M1 DONE 2026-06-04** — `NativeProximaDB.initialize(dataDir)` now emits structured `tracing` diagnostics for first init, duplicate init, empty data dir, construction failure, and set-once races; the binding README documents one embedded instance per JVM, class-loader reload behavior, multi-process coordination, and fork-per-class test guidance. **M2 DONE 2026-06-04 (diagnostic scope)** — `JNI_OnUnload` logs unload state and performs a best-effort `EmbeddedProximaDB::flush()` when initialized; it deliberately does not reset/take the singleton because JVM native-library unload is process-scoped and rare. **M3 DONE 2026-06-04** — `crates/binding/proximadb-spark-jni/tests/cross_process_smoke.sh` proves a second JVM cannot initialize concurrently against the same exclusive embedded data dir and a later JVM initializes after release. *Still open and post-MVP/Beta:* the JVM DataSource V2 layer (`SupportsPushDownFilters`/`ScanBuilder`/`pushedFilters`) does not exist — there is no production driver pushing `filters_json` yet (the JVM side is a JNI smoke shim), and the dropped-filter re-application contract lives there. A `Java_..._createCollection` JNI method so the Java smoke harness can exercise the full write→read round trip (currently the e2e is Rust-side only).
-
-| TD-098
-| Trino connector — Arrow Flight wire layer (RESOLVED)
-| P3
-| MEDIUM
-| **RESOLVED 2026-06-02** — all 7 of 7 Flight methods live (`f3284b9ba` + `e1f622fac` + `d40888326` + `ba124601d` + `3afe04d00` + `7da335d5a`)
-| Surfaced 2026-05-30. The Trino connector at `src/connectors/trino.rs` had 7 scaffold `flight_*` methods. **CLOSED 2026-06-02 across 6 commits over 3 days** — all 7 methods now dial real `FlightServiceClient` + RPC against the ProximaDB Flight server. Dial template (uniform across every method): `grpc://` → `http://` normalize → `Channel::from_shared(...).connect_lazy()` + `FlightServiceClient::new(channel)` (tonic ≥0.12 removed the convenience `connect()` shorthand). Per-method: `flight_list_schemas` (`f3284b9ba`) — `list_flights` → buckets `FlightInfo.flight_descriptor.path[0]` into sorted `TrinoSchema` list. `flight_list_tables` (`e1f622fac`) — `list_flights` filtered by `path[0] == schema` → deduped Vec<String> of path[1]. `flight_get_table_schema` (`d40888326`) — `get_schema(path=[schema, table])` → `ArrowSchema::try_from(&SchemaResult)` → `Option<Arc<ArrowSchema>>`. `flight_get_splits` (`ba124601d`) — `get_flight_info` with `cmd=JSON(constraint)` for pushdown → decode each `endpoint.ticket.ticket` via `serde_json::from_slice::<TrinoSplit>`. `TrinoPageSource::get_next_page` (`3afe04d00`) — first streaming RPC: `do_get(Ticket{JSON(split)})` → wrap response in `FlightRecordBatchStream` → `RecordBatch` → per-column single-column stream-IPC `TrinoBlock` → `TrinoPage`. `TrinoPageSink::{new, append_page, finish, abort}` (`7da335d5a`) — bidirectional streaming `do_put`: dial opens client-side mpsc → ReceiverStream → server's `Streaming<PutResult>`; `append_page` decodes `TrinoPage` back to `RecordBatch` (via new pub `trino_page_to_record_batch`), sends one-shot schema FlightData on first call, then batch FlightData; `finish` drops the sender to close the client stream, drains all PutResults so any server-side error surfaces before the summary returns. Failure modes: connect/RPC failure → fast `Err(TrinoError)` on sink open (lets planner short-circuit before any pages produced) vs. soft empty-Vec / `finished=true` for the read side. Test fixture at `tests/connectors_flight_contract.rs::trino_flight_pilot` (~470 LOC, reusable for future connector wire work) wires `list_flights` + `get_schema` + `get_flight_info` + `do_get` + `do_put` in one `MockFlight` impl; CI `connectors-contract-gates` / `flight` cell runs the suite. Flight gate: 5 → 18 passing. The structural ticket / descriptor contract gates remain intact. **Scaffold marker on the module in `src/connectors/trino.rs` removed** and replaced with the live-methods inventory.
-| 0 (closed)
-| Acceptance: **ALL DONE 2026-06-02** — (1) all 7 `flight_*` methods dial real Flight RPCs (5 unary + 2 streaming); (2) `MockFlight` fixture covers all 5 RPCs the connector uses, exposed via 4 typed `start_mock_flight_server_with_*` helpers; (3) module-level scaffold marker removed (live inventory in its place); (4) `connectors-contract-gates` / `flight` cell green. Follow-up TDs (separate from wire layer): productionise the ProximaDB Flight server-side handler for these calls (today the connector talks to whatever Flight server happens to listen — there is no schema-validated `TrinoFlightHandler`); add live integration tests against a real ProximaDB server (today's gate is mock-only per the original sprint scope).
-
-| TD-099
-| v2 OpenAPI lacks a records-scan / list endpoint Hadoop needs
-| P3
-| LOW
-| Partial — spec + Hadoop SDK + contract gate + real handler + cursor + sync-bridge landed 2026-06-01..06-02 (`6b79cce23` + `c8050ab1a` + `63fb17e74` + `5131ec909`); **WAL scan push-down (3c→3d) SHIPPED 2026-06-03** (`b01605042`→Slice E)
-| Surfaced 2026-05-30 during the connector-conformance sprint. The Hadoop connector's `ProximaRecordReader::next_record()` is a sync `-> bool` API that Hadoop's InputFormat contract calls in a loop to drain records from a split. The v2 OpenAPI spec had NO endpoint that scans records — only POST `/search` with `top_k` (similarity search, wrong semantics for unindexed table scan), GET `/records/{id}` for point reads, POST `/records/batch` for inserts. **PARTIAL CLOSE 2026-06-01** (`6b79cce23`): spec now declares POST `/api/v2/collections/{collection_id}/records/scan` (operationId `scanRecords`) with `{cursor?, limit?, filter?, include_vector?, include_text?}` → `{records[], next_cursor?, scanned_count?}` (ScanRecords{Request,Response} schemas, both optional everywhere, snake_case). Hadoop SDK has `ProximaRecordReader::fetch_next_page()` (async) which POSTs `{cursor, limit: 1000}` and stores the continuation token. Contract gate `hadoop_fetch_next_page_posts_v2_records_scan` asserts the spec lookup + body shape + mock round trip. **EXTENDED 2026-06-02** (`c8050ab1a`): replaced the stub handler with real delegation — new `UnifiedHandlers::handle_record_scan_for_tenant` fans into `VectorOperationsService::scan_records_with_tenant_context` (the WAL/memtable scan path already used by the rest of the v2 surface). REST layer now converts each `ProximaRecord` → `RecordV2Response` via a new `proxima_record_to_response` helper (mirrors `get_record_v2`'s conversion), clamps `limit` to `[1, 10_000]` (defaults 1_000), and returns typed `Vec<RecordV2Response>` matching the OpenAPI `RecordResponse` schema. Added 7 unit tests covering the new helpers + request round-trips (79 records-module tests passing). Cursor pagination (acceptance 3) and `filter` pushdown remain follow-ups — see acceptance (3) below.
-| DONE — WAL scan push-down shipped via TD-099(3d), incl. the `proximadb_wal_unflushed_distinct_oids{collection}` tuning gauge (`cb21d1ae4`)
-| Acceptance: (1) **DONE 2026-06-01** — spec POST `/api/v2/collections/{id}/records/scan` with `{cursor?, limit?, filter?}` → `{records, next_cursor?}`. (2) **DONE 2026-06-02** (`c8050ab1a`) — `scan_records` handler delegates to `VectorOperationsService::scan_records_with_tenant_context` via `UnifiedHandlers::handle_record_scan_for_tenant`; `ProximaRecord` → typed `RecordV2Response`; `limit` clamped to `[1, 10000]` (default 1000). (3) Split into 3a (cursor) + 3b (Hadoop sync-bridge) + 3c (WAL push-down). **3a DONE 2026-06-02** (`63fb17e74`): opaque `base64(rmp_serde({collection_id, last_updated_at_ns, last_oid, epoch_ns}))` cursor; handler stable-sorts by `(updated_at_ns, oid)` then filters strictly after cursor tuple; 24h max age (stale → 410 Gone); collection-mismatch → 400; 8 new unit tests (87 records-module tests passing). Cursor lives at the handler/service boundary — no `RecordScan` trait change. **3b DONE 2026-06-02** (`5131ec909`): `ProximaRecordReader::{next_record, get_current_key, get_current_value, get_progress, close}` rewritten; new `record_buffer: VecDeque<serde_json::Value>` + `current_record: Option<serde_json::Value>` fields replace the unused `current_batch`. `next_record` spawns a scoped OS thread per page-refill (≤ once per 1000 records) that owns a fresh `current_thread` tokio runtime and `block_on`s `fetch_next_page` — runtime-context-agnostic (works from `#[tokio::test]` current_thread / multi_thread runtimes AND pure-sync Hadoop ABI without panicking on "Cannot start a runtime from within a runtime"). 4 new contract tests (`hadoop_next_record_drains_records_in_order`, `..._follows_cursor_across_pages`, `..._zero_records_terminates_immediately`, `hadoop_get_current_value_returns_drained_record`); connectors REST gate: 6 → 10 passing. **3c reframed → 3d SHIPPED 2026-06-03**: pushing cursor+limit into the memtable surfaced that the live read path (`CollectionPartition::get_all_vectors`) MUST MVCC-dedup (latest `record_version`/seq per oid) + TTL-filter, an O(distinct-oids) memory floor — so the original 3c bounded-heap could cut the per-page *sort* but not peak memory. The real fix landed as **TD-099(3d)**: a per-collection *deduped, time-ordered scan index* — a lazily-built `BTreeMap<(updated_at_ns, oid), RecordLocator>` (locators, not record clones) rebuilt from the authoritative `get_all_vectors` MVCC/TTL logic, so results are byte-identical, and invalidated (`scan_index = None`) on every mutation so it can never durably diverge. Paginated scans drop from O(N) dedup+sort *per page* to **O(log d + limit)** once the index is warm (the dominant connector pattern: drain many pages between writes). 5 commits: Slice A `b01605042` (ScanIndex + rebuild + read-lock fast path), B `a2f292901` (invalidate-on-mutation, all 4 sites), C `9b3143157` (`WALBehaviorWrapper`/`WriteAheadLogManager::stream_unflushed_records` surface + `apply_scan_cursor` split into `select_page`+`derive_next_cursor`), D `d13d4f2c6` (`VectorOperationsService::scan_records_paginated` + REST/embedded rewire; tenant predicate pushed INTO the range scan *before* the limit so multi-tenant pages never short-return), E (kill-switch `PROXIMADB_SCAN_INDEX_DISABLE` + ignored perf demo + this entry). Convergence Gate: `scan_index` is a derived/non-authoritative in-memory projection (no durable authority, no serialized format, no migration — recovery rebuilds it via WAL replay of `add_batch`); freshness is synchronous under the partition `RwLock`; the only new surface is one additive method per layer + the `ScanIndex` struct — no new endpoint/planner/storage path. Relational `TableRecordStore::scan_records` (no cursor) intentionally stays on the legacy full-scan path. (4) **DONE 2026-06-01** — contract gate test added at `tests/connectors_openapi_contract.rs::hadoop_fetch_next_page_posts_v2_records_scan`. Total connectors REST gate: 5 → 10 passing.
-
-| TD-100
-| Agent memory read surface (mem0/agentmemory-aligned)
-| P5
-| MEDIUM
-| Landed (v0.2) — P1 read surface
-| Surfaced 2026-05-30. Per link:../12-design/adr/ADR-022-agent-memory-layer.adoc[ADR-022] + AGENT_MEMORY_LAYER_HLD. P1 of the agent-memory layer: scoped memory retrieval over existing surfaces — AQL `Find/From/Where` filtered by `tenant_id` / `session_id` (`props`) / `memory_type`, fanning into hybrid fusion (`src/core/search/hybrid/fusion.rs`) + RRF, with a RUBICON audit frame per query. No new storage path. **Landed 2026-05-30**: `MemoryAqlSource` (`src/query/aql/sources/memory.rs`) — pushes tenant/session into `unified_search_v1`, RRF-fuses semantic + BM25 legs via `ResultFuser`, post-filters `memory_type`, restricts to the scoped candidate set, emits audit frames; registered as the `"memory"` AQL source in `handlers.rs`. Part B: pgwire `execute_vector_search` now parses the WHERE clause into a `FilterExpression` and pushes it into `unified_search_native` (was `None`) so mem0 metadata-scoped queries filter (`src/network/postgres/protocol.rs`). 11 inline unit tests green (5 scope/assembly + 6 WHERE-parse) + 1 pgwire e2e (`tests/mem0_pgwire_filter_e2e.rs`, simple-query protocol). Follow-ups: strict row-level pgwire filter semantics depend on the v2-INSERT metadata gap; ONNX-profile rerank beyond RRF and inline text→embedding are documented as later work.
-| 1-2 weeks
-| Acceptance: (1) Memory query path returns scoped, fused, re-ranked results with an emitted AQL audit frame — DONE (unit-tested). (2) mem0 PGVector provider performs a similarity query against port 5433: WHERE-filter pushdown landed + unit-tested; full INSERT→search round trip blocked on the v2-INSERT metadata gap (documented). (3) Integration test over a seeded multi-session memory collection — assembly path unit-tested; pgwire e2e green (`mem0_pgwire_filter_e2e`, simple-query protocol).
-
-| TD-101
-| Agent memory write surface (extraction + consolidation)
-| P5
-| MEDIUM
-| In progress (v0.2) — Slice 1 + embedder/route/e2e sub-slice landed
-| P2 of the agent-memory layer. Extraction wrapper reusing `LLMIntegrationEngine` (`src/ai/llm_integration/engine.rs`) + the AV-SQL agent pattern (`src/query/nl/`) to distill salient facts from agent turns; consolidation step that retrieves top-s similar memories and uses an LLM `ADD/UPDATE/DELETE/NOOP` decision before writing a `ProximaRecord`. No new LLM-provider abstraction. **Slice 1 landed 2026-05-30** (`src/services/agent_memory.rs`): trait-seam orchestrator `MemoryWriteEngine.ingest` (extract→retrieve→consolidate→apply) over `ExtractionAgent`/`ConsolidationAgent`/`MemoryStore`/`MemoryEmbedder` traits; LLM-backed agents (reuse `query_with_fallback`); `VectorMemoryStore` adapter (retrieve via `unified_search_v1`+scope filter, add/update via `insert_batch_with_tenant_context`, delete via `delete_records_with_tenant_context`); pure parse/prompt/`build_memory_record` fns. Embedding abstracted behind `MemoryEmbedder` (no model wired this slice, per decision). Module compiles clean; **5 unit tests green** (orchestrator action-per-fact ordering via mocks; `parse_extraction_response` valid/garbage/unknown-type; `parse_consolidation_response` all 4 actions; `build_memory_record` field mapping). (Earlier blocked by an unrelated `dual_store_ivf.rs` ADR-023 WIP break — resolved by the owner.)
-| 2-3 weeks
-| Acceptance: (1) message pair → write/update/dedupe deterministically under fixed mocks — DONE (orchestrator + parse + record-build unit tests green). (2) Consolidation decisions auditable — applied-action list returned; EventLog persistence is a sub-slice. (3) Records carry `memory_type`/`tenant_id`/`actor`/`props["session_id"]` — DONE (`build_memory_record` unit test green). **Sub-slice landed 2026-05-31**: `EmbeddingServiceEmbedder` (real text→vector via the in-process `EmbeddingService::try_global`+`embed_sync`, reusing `crates/modalities/proximadb-embedding`); `MemoryEmbedder` widened to carry `tenant_id`; `POST /api/v1/memory/ingest` (`src/network/rest/v1/memory.rs`) always-mounted with a 501 availability guard when no LLM backend, engine built in `handlers.rs` only when `llm_engine` present. 7 unit tests + 1 booted e2e (`tests/agent_memory_ingest_e2e.rs`: route mounted + 501 guard; LLM happy-path gated on an env key) green. The embedder lives in proximaDB, NOT anvaiops (anvaiops is the Python operator/SaaS consumer). Remaining: consolidation-decision EventLog audit persistence.
-
-| TD-102
-| mem0 / agentmemory framework adapters
-| P5
-| LOW
-| Slice A landed (v0.2); Slice B (Python provider) open
-| P3 of the agent-memory layer. **Slice A landed 2026-05-31** — the pgwire wire mem0's PGVector provider needs: `src/network/postgres/pgvector_params.rs` (extracted pure helpers, 10 unit tests) + thin protocol.rs delegation. TD-100 WHERE metadata-filter pushdown (`payload->>'k'='v'` → `unified_search_native`), and the extended query protocol now binds `$N` placeholders: `handle_parse` infers param arity/types from `$N` (fixes the `Parameters(2,0)` client abort), `Describe(statement)` reports the real `(id,distance,metadata)` columns for vector search, and the extended `Execute` path suppresses its duplicate `RowDescription`. Verified by `pgwire_extended_param_e2e` + `mem0_pgwire_filter_e2e` (commit `67b1373e5`). **Slice B (open):** the Python mem0 `VectorStoreBase` provider (registered in `VectorStoreFactory`) targeting ProximaDB over this wire, optional mem0g graph-store mapping onto the native graph engine, agentmemory's `CLIENT_TYPE=POSTGRES` path. Follow-up: binary param-format decode (text format works today).
-| 1-2 weeks (Slice B)
-| Acceptance: (1) pgwire wire ready — DONE (extended `$N` + metadata filter, e2e green). (2) mem0 configured with the ProximaDB provider round-trips add/search/update/delete (Slice B). (3) mem0g graph ops succeed against the native graph engine, or the gap is documented (Slice B).
-
-| TD-103
-| Agent memory session scoping
-| P5
-| LOW
-| Resolved (v0.2) — keep props; scope filter fixed
-| **Decision (2026-05-31): keep `session_id` in `props`, NO first-class `ProximaRecord.session_id` field.** `proxima_tree_to_value_map`/`evaluate_filter_proxima` (`src/core/search/sql_value_filter.rs`) flatten each top-level prop key verbatim, so `props["session_id"]` is searchable as the flat metadata key `"session_id"`. Investigation uncovered + fixed a real shipped bug: the TD-100/TD-101 scope filters used `field: "props.session_id"` (dotted) which matched NOTHING → scoped memory search silently returned 0 rows (masked by mock-based tests). Fix: scope filters now use the flat key `"session_id"`; `build_memory_record` mirrors `tenant_id` into props so it filters through the same proven path (`ProximaRecord.tenant_id` stays the RLS authority). New `scope_filter_matches_record_props_end_to_end` test exercises the real `evaluate_filter_proxima` path (would fail on the old dotted name). Follow-up: authoritative tenant isolation via TenantContext/`search_v1_with_tenant_context` (TD-064 domain).
-| —
-| Acceptance: (1) Memory queries filter by session — DONE (flat `session_id` key, e2e-via-real-filter test). (2) Decision recorded (keep in props) — DONE. (3) Scope filter verified against a real record's props, not mocks — DONE.
-
-| TD-104
-| Complete Phase 9 handler/service extraction (seam S1)
-| P2
-| MEDIUM
-| Open — convergence
-| Per link:../12-design/CONVERGENCE_AUDIT_2026_05_30.adoc[CONVERGENCE_AUDIT_2026_05_30] S1. Real `UnifiedHandlers` (~250 methods) lives in `src/api_handlers/request_handlers.rs`; `crates/platform/proximadb-runtime/src/handlers.rs` is a stub. Finish extraction so handler bodies live in the platform crate and the root crate composes ports only.
-| 2-3 sprints
-| Acceptance: (1) Handler groups migrated endpoint-group at a time (commit per group — linter displaces unstaged files). (2) Root crate has no duplicate handler bodies. (3) Build + API consistency tests green.
-
-| TD-105
-| Remove deprecated gRPC shims (seam S2)
-| P3
-| LOW
-| DONE (2026-06-03)
-| CONVERGENCE_AUDIT S2. KEY FINDING: the `src/network/grpc/*_service.rs` files were mislabeled "deprecated shims" — they were the LIVE `*Port` backends the `crates/platform/proximadb-api/src/grpc/v1/` tonic adapters delegate to (`Arc<dyn *Port>`). The real dead code was the (never-served) tonic `impl *Service` blocks they hosted. Phase A (`a6c80f90f`) deleted the 3 genuinely-dead files (entity/document/hybrid). Phase B converged the 4 live Port backends off their dead tonic surfaces: observability `979fdf18d`, streaming `18e3485a4` (also deleted ~250 LOC dead server-streaming RPCs), graph `08e719e75` (also deleted 7 `#[cfg(any())]` PULSAR/QUASAR RPCs), security `1380cb11d`. `rank_service.rs` was already Port-only. The stale `0.3.0` headers were replaced with accurate "port backend" descriptions.
-| 1 week (v0.2)
-| Acceptance MET: (1) No `*_service.rs` carries a tonic `impl *Service` surface; the misleading `0.3.0` headers are gone. (2) All construction sites bind `Arc<dyn *Port>` — zero importer churn. (3) Build green; observability/streaming/graph/security unit tests pass.
-
-| TD-106
-| Migrate proto-v1 internal mirrors to canonical types (seam S3)
-| P2
-| MEDIUM
-| Group A DONE (2026-06-03); Group B/C pending
-| CONVERGENCE_AUDIT S3. The document row is `DocumentRecord{document: SqlObject}` (proto v1); canonical is `ProximaRecord`/`ProximaValue`/`ProximaTree` (adapters already exist; durable authority is already `ProximaRecord`, so `SqlObject` is an in-memory COMPUTE type only). **Group A SHIPPED** (`1723c0faf` filter kernel, `0d0dfbab3` filter path, `c01f826a8` agg accumulators, `fbd587c68` agg value-read): the document compute VALUE path runs on `ProximaValue`; proto `SqlValue` is confined to row-field edges. Added canonical `json_to_proxima` to `proximadb-records/conversions.rs`. **Pending**: Group B (Slice 5) flip the aggregation working set `Vec<SqlObject>`→`Vec<ProximaTree>` across aggregation.rs + service.rs; Group C (S6/S7) dual-carry `props: ProximaTree` on `DocumentRecord` then drop `document: SqlObject` (touches `DocumentStorageEngine`). Full HLD/LLD/spec + resume prompt: `docs/12-design/TD106_DOCUMENT_CANONICAL_MIGRATION_HANDOFF_2026_06_03.adoc`.
-| 2-3 sprints (Group A done; B/C remain)
-| Acceptance: (1) Internal code paths use canonical types; proto v1 confined to wire adapters. (2) No internal `SqlValue`/`SqlObject` construction outside `canonical_adapter.rs` + `DocumentRecord::{from_proto,to_proto_content}` + `services/dml` edges — mechanical check: `grep "SqlObject\|SqlValue" src/storage/document/`. (3) Tests green.
-
-| TD-109
-| Consolidate json↔proxima value converters (proliferation)
-| P3
-| LOW
-| Open — proposed (2026-06-03)
-| Surfaced during TD-106. Three scattered private `json→ProximaValue` copies exist (`network/arrow_ipc/codec.rs:640`, `network/rest/websocket.rs:105`, `network/rest/v2/query.rs:58`) plus a separate `proxima→json` pair (`core/search/sql_value_filter.rs:236`/`:304`). Canonical `json_to_proxima` now lives in `proximadb-records/src/conversions.rs` (added by TD-106 Slice 2). Converge the three copies onto it and relocate `proxima_value_to_json`/`proxima_tree_to_json_map` into the same crate so both directions share one home.
-| 1-2 days
-| Acceptance: one `json↔proxima` converter pair in `proximadb-records`; no duplicate private copies; tests green.
-
-| TD-107
-| Consolidate CDC/cluster configs into proximadb-config (seam S4)
-| P3
-| LOW
-| Resolved — at-the-right-seam (2026-06-05)
-| CONVERGENCE_AUDIT S4. RESOLVED after audit: the convergence is already at the correct seam; remaining residue is legitimate engine-specific specialization the audit explicitly says to preserve. (1) CLUSTER configs fully converged: `crates/foundation/proximadb-config/src/cluster_config.rs` houses Consensus/Routing/Shard/Partition/ClusterReplication/NodeRegistry/MetadataService/DistributedOps/ConnectionPool/Cluster configs; `src/cluster/*.rs` re-export them (8 sites). The only local cluster struct, `CachedPartitionConfig` (routing.rs), is an in-memory cache wrapper (holds `Instant`, non-serializable) — must stay. (2) CDC: `src/cdc/config.rs` re-exports the canonical `proximadb_config` CDC surface (CdcConfig/SourceConfig/SinkConfig/CaptureConfig/SnapshotConfig/…). The structs remaining in `src/cdc/` are connector-specific (Kafka/Webhook/Postgres/MySql/Mongo + their Table/Collection configs — `experimental-cdc-connectors`-gated) or subscription-runtime (OutboundConfig/SubscriptionConfig/RouteConfig/ExactlyOnceConfig/EmbeddingConfig) — legitimate specialization, not app-config. Moving them would violate the reuse-first/no-cross-module-entanglement rule for ~zero benefit. (BufferConfig/CdcSinkRetryConfig are tiny sink-local helpers, intentionally left.)
-| done
-| Acceptance MET: (1) canonical app-level CDC + cluster config in `proximadb-config`. (2) original paths re-export. (3) no behavior change; build green. Residual src/cdc structs are by-design domain specialization.
-
-| TD-108
-| Delete residual catalog re-export shims (seam S6)
-| P3
-| LOW
-| Resolved (2026-06-05)
-| CONVERGENCE_AUDIT S6. RESOLVED: verified no pure re-export shim remains under `src/catalog/` — every `src/catalog/*.rs` is a real implementation module (0 `pub use` except `mod.rs`, which is the module root, not a deletable shim). The local `types` shim (`pub use proximadb_catalog::*`) was already deleted (see `src/catalog/mod.rs` comment "TD-108: the local `types` shim ... was deleted"); `mod.rs` re-exports the canonical `proximadb_catalog` surface as the module root + carries real submodules (partition_pruning, iceberg_rest_service, tenant_tier, tier_*, budget_guard, corpus_version, …). Build green at HEAD.
-| done
-| Acceptance MET: (1) pure re-export shims removed; importers use the crate (via the `mod.rs` root). (2) files with real glue retained. (3) build green.
-
-| TD-110
-| OLTP/OLAP HTAP storage and PostgreSQL constraint semantics
-| P2/P3
-| HIGH
-| Open — post-MVP foundation
-| Active plan: `roadmap/techdebt/TD_110_OLTP_OLAP_HTAP_STORAGE_AND_CONSTRAINTS_PLAN_2026_06_04.adoc`. PostgreSQL-style latency-sensitive workloads need native OLTP authority below pgwire: xCatalog constraint/index metadata, WAL plus row/delta commit, primary-key/unique/check/FK enforcement, MVCC visibility, Volcano strong-freshness execution, and DataFusion snapshot-plus-delta reads. Parquet/Iceberg remains the OLAP/open-format publication tier, not the direct write authority for mutable OLTP tables. UPDATE 2026-06-24: ON DELETE referential actions (`RESTRICT`/`CASCADE`/`SET NULL`) for single-column FKs on the parent PK are now enforced on the tenant-scoped DML path (`DmlService::enforce_delete_referential_actions`, called from `execute_delete`) — re-landed after the original `dac665e99` impl was lost in merge `afafac3b6`. Still open under TD-110: ON UPDATE actions, composite-FK enforcement, and recursive/multi-level cascade.
-| 4-8 sprints
-| Acceptance: (1) xCatalog records PK/unique/not-null/check/FK/locality/isolation/freshness metadata. (2) DML enforces PK/unique/not-null/check and rejects unsupported FK shapes before commit. (3) Row/delta indexes recover from WAL. (4) `EXPLAIN` reports authority, workload, route, freshness, snapshot watermark, and rejected-route reasons. (5) Volcano and DataFusion agree for snapshot-safe queries; fresh HTAP reads either union delta state or reject unsafe routes.
-
-| TD-111
-| Unify data-type enums + schema structs onto canonical ProximaType (ADR-024 / seam S8)
-| P2
-| MEDIUM
-| Mostly done (2026-06-05) — residual follow-ups open
-| Governed by `docs/12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc` + CONVERGENCE_AUDIT seam S8. Three parallel logical type enums (`ProximaType`/`ProximaDataType`/`CatalogDataType`) and two schema structs (`CatalogTableSchema`/`ProximaSchema`) collapsed onto the canonical `ProximaType` + `CatalogTableSchema`. DONE: ProximaType superset + Arrow/pgwire/proto-code bridges (`7d78df773`,`be1c0b2f6`); `ProximaDataType` deleted (`320d62747`); `CatalogDataType` deleted + durable serde-compat shim (`8009ab052`); REST v2 type vocabulary derived from ProximaType (`d6e897689`); `ProximaSchema` merged into `CatalogTableSchema` (`fcac4f5fe`). Physical encoding/quantization kept as an orthogonal storage attribute (not a logical-type variant).
-| residual ~1 day
-| Acceptance: (1) one logical type enum [DONE]. (2) one schema struct [DONE]. (3) REST/pgwire/proto type paths funnel through ProximaType [DONE]. RESIDUAL: (a) `build_vector_column` honors non-f32 dense-vector element width (currently writes fp32 `dim*4` while `DenseVector::to_arrow_type` declares `dim*element_width`; latent — only f32 used in practice). (b) Broader `SqlValue→ProximaValue` value migration is tracked separately under TD-106/S3.
-
-| TD-112
-| ANN recall over flushed/compacted segments (post-flush index population)
-| P1/P4
-| MEDIUM
-| *Fix landed 2026-06-16* — index-on-flush wired on the live SST path; recall-band e2e green; local-FS post-loss recovery via search-time lazy rebuild-from-SST (acceptance #1/#2/#3 + local post-restart recovery). Residual: real object-store SST read-back coverage. Boot-time AXIS prewarm is not claimed.
-| Surfaced 2026-06-14 while disproving the long-claimed "v2 INSERT→search-index flush gap". `tests/v2_post_flush_search_e2e.rs` proves *correctness* — v2 vector search (`enable_proxima_record=false`) and metadata-filtered scan (`enable_proxima_record=true`) both still return the right records after a real `ProximaDB::force_flush_collection` (WAL drain + `compact_collection`). What that test does NOT establish is whether post-flush retrieval is served by a *populated ANN index* (HNSW/IVF over the SST/PAX segments) or by a brute-force scan over flushed storage. At small N the two are indistinguishable; at scale the difference is recall + tail latency, not correctness.
-*PRE-FIX CHARACTERIZATION (2026-06-16, acceptance #2 — verified per-engine, SST engine):* the flush/compaction path did **not** register flushed/compacted vectors into the AXIS ANN index. Evidence: (a) the SST flush wrote segments + emitted an *object-economy read-route directory* entry (`flush/mod.rs` `emit_after_flush`), not an index event; (b) the dedicated entry point `AxisManager::handle_flushed_vectors` (`management/manager.rs`) had **zero callers** — dead scaffolding; (c) the AXIS `EventLogConsumer` (`integration/eventlog_consumer.rs`, which would route a flush `IndexEvent`→`index_vectors_hybrid`) was **not spawned/subscribed in boot** (no wiring in `shared_services`/`server`/`database`), and the SST flush emitted no such `IndexEvent`; (d) the compactor explicitly *deferred* AXIS indexing to that unwired consumer (`compactor_impl.rs` "deferred until EventLog consumer is wired (L2.4)"); (e) `recall_drift_sweeper` only hot-swapped the HNSW `ef_search` param, it did not re-index. Pre-fix net: post-flush search was served by `sst/search/mod.rs` `fallback_to_direct_search` (brute-force / block-pruned scan) whenever the in-memory AXIS index lacked the vectors — so recall degraded toward brute-force as data aged out of the WAL memtable and **unconditionally after a restart** (in-memory index lost, nothing rebuilt it from SST). HELIX/NOVA have no separate flush-index path today. A characterization lock-in test (`td112_handle_flushed_vectors_indexes_flushed_batch`) proves the `handle_flushed_vectors` primitive *does* index when invoked. *FIX (2026-06-16):* index-on-flush is now wired on the LIVE path — `SstEngine::flush_implementation` calls `handle_flushed_vectors` after segments are durable (best-effort; first wired into `FlushCoordinator`, which turned out to be test-only scaffolding with no production callers, then moved to the real path). Verified by `td112_live_flush_indexes_vectors_into_axis` (a real `do_flush` populates AXIS) and `tests/td112_postflush_recall_e2e.rs` (≥2 flush cycles + compaction → ~0.95 top-k recall vs a brute-force oracle). NOTE: high-magnitude all-positive vectors collapse under the index's sign/INT8 quantization (one shared signature), so the e2e uses sign-separated clusters for a fair measurement. *LOCAL POST-LOSS RECOVERY (2026-06-16):* lazy rebuild-from-SST — `sst/search` `ensure_axis_index_from_sst` reads flushed records back from durable local segments (via `discover_sstable_files` + format-dispatched block readers) and re-indexes them through `handle_flushed_vectors` when a search finds the AXIS store empty (keyed on `registered_vector_count`, with an in-flight per-(process, collection) guard that retries after failed or empty attempts). Index-agnostic — covers HNSW and small IVF, unlike the IVF-only persist+cold-load. Verified by `axis_index_rebuilt_from_sst_after_loss` (drop_collection → next search rebuilds the store 0→N). RESIDUAL (acceptance #4): real object-store SST read-back coverage remains separate; the current rebuild path is local-FS and boot-time AXIS prewarm is not claimed.
-Scope spans the specialized engines (SST today; HELIX/NOVA), real object storage (S3/ADLS/GCS) reads, multi-flush + compaction churn, and post-restart recovery reload. This is a *performance/recall* concern and belongs to the recall-band track, not the (now-complete) hybrid metadata-filter work.
-| 1-2 sprints (characterize first)
-| Acceptance: (1) a recall-band e2e that inserts enough vectors to force ≥2 flush+compaction cycles, then asserts top-k recall stays within target bands against a brute-force oracle — wired into the existing `filtered_ann_recall_bands` / `helix_cold_search_recall` suite rather than a one-off. (2) Explicit statement (test or doc) of whether flushed/compacted segments are ANN-indexed or scanned, per engine. (3) If indexing is missing on the flush/compaction path, a follow-up TD to build/extend the AXIS index on flush. (4) Coverage extended to at least one real object-store backend and a post-restart reload.
-
-| TD-113
-| Warehouse materialize path does not enforce tenant isolation (DrPathBuilder mandate gap)
-| P1
-| HIGH (SaaS isolation)
-| *Mostly resolved (2026-06-16)* — tenant isolation enforced; DrPathBuilder layout opt-in
-| Surfaced 2026-06-15 by the DrPathBuilder tenant-path guard (`scripts/check_tenant_path_guard.py`): `DmlService::materialize_table_to_parquet` built the object prefix by hand and the production `ALTER TABLE … MATERIALIZE` trigger passed `None` for `TenantContext`, so warehouse snapshots co-mingled under the literal `"default_tenant"`. *RESOLVED:* (1) interim id-injection hardening (`e93dcf91d`); (2) **Phase 1** — the real request `TenantContext` is now threaded through `TableMaterializer::materialize` (trait + DDL dispatch in `ddl/mod.rs`) into `materialize_table_to_parquet`, so each tenant's snapshot lands under its own `data/{tenant}/…` prefix and tenant-scoped table resolution rejects cross-tenant materialize; (3) **Phase 2** — opaque, rename-stable `namespace_id` (`ns_<uuid>`) is populated at native-catalog `create_namespace` + idempotently backfilled on load, and a flag-gated DrPathBuilder layout (`PROXIMADB_WAREHOUSE_DRPATH`, default OFF → `data/{tenant}/{namespace_id}/{table}` via the new `DrPathBuilder::build_from_parts`) ships with graceful fallback to the validated manual layout + a cross-tenant owner assertion. Validated by unit tests (`build_from_parts_validates_each_segment`, `resolve_materialize_prefix_layouts_and_cross_tenant`) and a two-tenant materialize-isolation test.
-| done
-| Phase 2 hardening landed (`fa32bd2df`): tenant-scoped CREATE records the owning tenant on the namespace (`create_namespace_for_tenant`), so namespaces are now DR-addressable (`namespace_id` + `tenant_id`) and the cross-tenant assertion + `build_for_pool` pool routing operate on real data, not a `None` tenant; the DrPath flag is dependency-injected for deterministic testing (`materialize_drpath_layout_uses_opaque_namespace_id`, `scoped_create_makes_namespace_dr_addressable`; 47/47 materialize+catalog tests green). Remaining (by-design, low priority): `PROXIMADB_WAREHOUSE_DRPATH` stays *opt-in* — the opaque-id layout trades path readability/determinism for rename-stability, so flip the default only alongside a snapshot-repath migration.
-
-| TD-114
-| Storage spine: background L0→base compactor + merge-on-read deletion vectors
-| P7
-| HIGH
-| *Foundation landed 2026-06-17* (`71dbd3b17`) — tested PAX merge-on-read compaction core (`compact_pax_segments`, drops tombstones) + flag-gated trigger (`PROXIMADB_L0_COMPACTION_ENABLED`, default OFF) shipped; residual: live auto-invoke from flush (engine segment-reader wiring), orchestrator integration, deletion vectors on the read path
-| Both ends of the LSM hot→cold pattern already exist — the memtable/WAL hot tier (`DirectWalTableRecordStore`, `src/services/record_store.rs:1168`) flushes to PAX/Parquet segments (`SstEngine::flush_implementation`, `src/storage/engines/sst/flush/mod.rs:92`) — but there is *no background compaction* merging small L0 flush outputs into large columnar base files; `CompactionOrchestrator` (`src/storage/common/compaction_orchestrator.rs`, thresholds level0=5/level=10/max=7) is defined but never called from the flush path. Deletes are WAL tombstones (`CanonicalOperation::RecordDelete`); `enable_deletion_vectors` is an unused field (`src/storage/formats/open/delta.rs:107`), so a delete over immutable Parquet requires a full rewrite. Net: the small-file problem (slow scans, bloated manifests) and deletes not honored on compacted base reads.
-| 2-3 sprints
-| Deliverables: (1) post-flush trigger at `sst/flush/mod.rs` after `index_flushed_into_axis()` — when L0 count ≥ `level0_threshold`, enqueue an async compaction task via the existing orchestrator; (2) implement `SstEngine::execute_compaction()` merging L0 into a single L1 base file via `PaxSegmentWriter`/Parquet encoder, registering a new `GlobalManifestEntry` (Active, level 1); (3) deletion-vector overlay applied at the read-time merge (`scan_records_filtered`, `record_store.rs:458`) and consumed by the compactor to drop tombstoned rows (wiring the dormant `enable_deletion_vectors`/`deleted_at` fields); (4) compaction marked `dataChange=false`-equivalent so snapshot reads are unaffected; (5) per-collection eager/lazy compaction knob (write-amp vs read-amp). *Acceptance:* an e2e forcing ≥2 flush+compaction cycles asserts L0 collapses to ≤1 base file, a deleted row is absent from post-compaction scans, and scan latency/manifest size improves. Design doc §4–5.1 (`docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md`); plan `roadmap/techdebt/TD_114_STORAGE_SPINE_2026_06_17.adoc`. Related: TD-112 (same flush seam).
-
-| TD-115
-| Cost-based multi-engine dispatch (flip ComputeScheduler off always-Native)
-| P7
-| HIGH
-| Open (proposed 2026-06-17)
-| `ComputeScheduler::route_select()` (`src/query/compute_scheduler.rs:202`) hardcodes `ComputeBackend::Native` (Volcano) for every SELECT. The flip scaffolding exists (`QueryShape.parquet_backed`/`engages_relational`, `routed_read_plan`, `explain_line()`) but `parquet_backed` is never set and there is no cost comparison. `UnifiedCostModel`/`UnifiedCostWeights` (`src/query/query_optimizer.rs:49`) is consumed only by the ANN/search optimizer, not by routing; no table cardinality/selectivity feeds the router. Analytical scans/joins/aggregates over Parquet base tables are forced through the row-oriented executor — the exact mismatch the data-warehouse course-correction targets.
-| 2 sprints
-| Deliverables: (1) enrich `QueryShape` with `estimated_cardinality`, `partition_count`, `is_point_lookup`, `filter_selectivity`, populated at the planner boundary from catalog metadata + Parquet row-group splits; (2) new `src/query/cost_model.rs` `cost_for_backend(shape, backend)` reusing `UnifiedCostWeights`, with a selectivity-crossover rule (point/high-selectivity → Native; large-scan/low-selectivity/aggregate/join over parquet_backed → DataFusionLocal); (3) set `parquet_backed=true` once all referenced tables are Parquet-materialized; (4) `SET compute_engine TO {auto/native/datafusion}` session override via the existing SET parser (`src/network/postgres/protocol.rs:895`) as an escape hatch (TiDB lesson: the cost model is approximate); (5) extend `explain_line()` with a per-backend cost breakdown. *Acceptance:* a scan-heavy query routes to DataFusionLocal and a point lookup to Native, both visible in EXPLAIN; the session override forces a backend. *Depends on* the live DataFusion execution path (course-correction). Design doc §3.4/5.3; plan `roadmap/techdebt/TD_115_COST_BASED_ROUTING_2026_06_17.adoc`.
-
-| TD-116
-| WAL tiering + read-as-of-LSN time travel
-| P7
-| MEDIUM
-| Open (proposed 2026-06-17)
-| The WAL is local-only — `WalEntryStatus::Archived` (`src/storage/persistence/write_ahead_log/manifest/types.rs:53`) is defined but never set, and there is no sealed-segment offload to object storage, so durable history is bounded by local disk and cold recovery cannot pull WAL from S3. LSN infrastructure is solid (`GlobalLsnAllocator` `types.rs:189`; `SnapshotPin{from_lsn,to_lsn,checkpoint_id}` `src/services/snapshot/coordinator.rs:18`; `GlobalCheckpoint`), but there is no user-facing read-as-of-LSN path — `delta.rs`/`iceberg.rs` `time_travel()` are `Unimplemented` stubs and PITR (`src/storage/persistence/write_ahead_log/pitr.rs:542`) is crash-recovery-only. This blocks cheap PITR and the branching feature (TD-117), which needs LSN-addressable history.
-| 3 sprints
-| Deliverables: (1) background archival task (new `src/storage/persistence/write_ahead_log/archival.rs`) — periodically copy `Flushed` segments older than a TTL to object store via `ObjectStoreBridge`, set `status=Archived`, add an `archive_location` to `GlobalManifestEntry`, and GC the local copy; (2) archive read-back in recovery/replay (fetch from `archive_location` when `Archived`); (3) `SnapshotPin::pin_at_lsn(collection, target_lsn)` + `TableRecordStore::scan_records_at_lsn(…, at_lsn)` replaying entries with `global_lsn ≤ at_lsn` over the base; (4) `SELECT … AS OF (LSN n / TIMESTAMP t / SNAPSHOT id)` parser → `as_of_lsn` threaded to the read path (timestamp/snapshot resolved to an LSN via `GlobalCheckpoint`). *Acceptance:* a write→archive→read-back round-trip from object store; an `AS OF LSN` query returns historical state; PITR-to-LSN restores a collection. Design doc §5.2; plan `roadmap/techdebt/TD_116_WAL_TIERING_TIME_TRAVEL_2026_06_17.adoc`. *Unblocks* TD-117.
-
-| TD-118
-| Unify paging/cache policy with tier policy; split cache from FileSystem mechanism
-| P7
-| MEDIUM
-| Open (proposed 2026-06-17)
-| Two storage seams conflate three concerns. The `FileSystem` trait (`src/storage/persistence/filesystem/mod.rs`) is pure mechanism, but `UnifiedCachingFilesystem` (`src/storage/persistence/filesystem/caching_filesystem.rs:35`) fuses cache admission/eviction, metadata cache, prefetch and range optimization into that mechanism layer, while the tier-policy engine (`src/infrastructure/tier_policy_engine.rs`, `InfrastructureTier` Memory…CloudDeepArchive) decides long-term placement independently. Cache eviction (page into RAM/NVMe) and tier demotion (page down to S3/Glacier) are the same OS-paging decision at two rungs of one hierarchy yet are governed by two unrelated components; there is no `BufferAccessStrategy`-style scan ring, so a large cold S3 scan can evict the OLTP working set. The `proximadb-cache` crate's `TenantCache` is the consolidation base.
-| 2-3 sprints
-| Deliverables: (1) extract caching out of `UnifiedCachingFilesystem` into a `PagingCache` layer over `TenantCache`, leaving `FileSystem` as pure mechanism; (2) one `HierarchyPolicy`/`CacheTemperaturePolicy` trait (`on_access`/`should_evict`/`should_demote→tier`) consumed by *both* the paging cache and the tier engine, driven by one `(temperature, tenant SLA, cost)` model via the existing JSON `TierPolicy`+`LimitsResolver` DI seam (`PROXIMADB_CACHE_TIERS_PATH`); (3) a `BufferAccessStrategy`-style scan ring / cache-bypass for large sequential scans. *Keep* `FileSystem` and the tier engine as separate seams (mechanism vs policy — mirrors Postgres `smgr` vs `bufmgr`); consolidate only the policy brain. *Acceptance:* a large scan does not evict hot OLTP entries; a single policy config drives both eviction and demotion; `FileSystem` carries no cache logic. Design doc §1.5/7; plan `roadmap/techdebt/TD_118_UNIFY_PAGING_TIER_POLICY_2026_06_17.adoc`.
-
-| TD-119
-| Promote v1 key-list manifest to real Iceberg snapshots (metadata.json + manifest lists + refs)
-| P7
-| MEDIUM
-| *Phase 1 landed 2026-06-18* (branch `feat/td119-iceberg-snapshots`) — real persisted, versioned `metadata.json` + a manifest-log-driven snapshot history (parent chain, v2 `sequence-number`, `refs.main`) + a resolvable `metadata-location` served by a new GET route. `MetadataCommitter` (atomic CAS, mirrors `ManifestCommitter`) + `ObjectStoreBridge` metadata methods + `IcebergRestService::ensure_table_metadata` (idempotent: only re-commits when the manifest log advances; fail-soft), wired at the REST mount from `file://{data_dir}/warehouse` (same root as the write path). Unblocks TD-117 (refs/snapshot substrate). *RESIDUAL (Phase 2):* Avro manifest-list + manifest files with per-file `DataFile` stats (so Spark/Trino can *scan data files*); exact per-snapshot historical stats; tenant-scoping the Iceberg REST endpoints.
-| The manifest is a v1 newline-delimited list of object keys (`crates/storage/proximadb-iceberg-engine/src/lib.rs:99`) committed under CAS as `v{N}.manifest` — no `metadata.json`, no snapshot layer, no manifest list, no `refs` map, no column statistics. The Iceberg REST service (`src/catalog/iceberg_rest_service.rs`) returns stub snapshot structures, so external engines (PyIceberg/Spark/Trino/DuckDB) cannot consume ProximaDB tables as Iceberg, the long-standing "Snowflake/Trino interop" claim stays FALSE, and there is no snapshot-ref substrate for branching (TD-117) to point at.
-| 3-4 sprints
-| Deliverables: (1) `IcebergSnapshot`/`SnapshotSummary` types + a `metadata.json` writer emitted alongside each `v{N}.manifest` commit (snapshots list, `current-snapshot-id`, `refs`, schema, parent-snapshot-id) under the reserved `DrPathBuilder::snapshots_subprefix()`; (2) a manifest-list Avro per snapshot pointing at the existing key-list (a derived index — v1 stays the low-level store, backward compatible); (3) populate column stats from `BlockStats` (PAX) into manifest entries; (4) wire `iceberg_rest_service.rs` `/v1/{ns}/{table}` + `/snapshots` to read the real `metadata.json`. *Design option (sub-task):* the DuckLake model — move the manifest/branch registry into a transactional catalog DB if S3 metadata ops dominate at branch scale. *Acceptance:* PyIceberg/Spark reads a ProximaDB table including snapshot history. Design doc §3.4/6 and §9-P6; plan `roadmap/techdebt/TD_119_REAL_ICEBERG_TABLE_FORMAT_2026_06_17.adoc`. *Enables* TD-117 manifest-version refs.
-
-| TD-120
-| pg_catalog completeness for ORM/driver compatibility
-| P7
-| MEDIUM
-| *Foundation landed 2026-06-17* (`1233de45d`) — canonical pg_type/pg_namespace/pg_class/pg_attribute/pg_constraint views shipped + unit-tested; residual: pg_index canonical view + full live ORM round-trip
-| pgwire catalog introspection is stubbed — `catalog_introspection.rs` detects a few `pg_catalog`/`information_schema` join shapes and returns hardcoded rows (relkind='r', relnamespace=2200, atttypid=23); there is no catalog-backed `pg_type`/`pg_class`/`pg_attribute`/`pg_namespace`/`pg_index`/`pg_constraint`, and the translator (`src/network/postgres/translator.rs:73`) echoes catalog queries back. ORMs/drivers (SQLAlchemy, JDBC `DatabaseMetaData`, Diesel, sqlx) run heavy catalog introspection and break on type inference and key discovery — the #1 documented failure mode for Postgres-wire-compatible engines (Materialize/RisingWave/QuestDB all hit it).
-| 2-3 sprints
-| Deliverables: catalog-backed views in `catalog_introspection.rs` — (1) `pg_type` from the `ProximaType`↔OID mapping; (2) `pg_class`/`pg_namespace` from `CatalogTableSchema`/`CatalogNamespace`; (3) `pg_attribute` from real column order/type/nullability; (4) `pg_index`/`pg_constraint` from relational constraints (`relational.rs`: PK/UNIQUE/FK/CHECK/NOT NULL) and vector indexes (HNSW/IVF); (5) route these in `translator.rs` to `CatalogIntrospectionService::execute_select()`. Reference `datafusion-postgres`'s pg_catalog-over-DataFusion layer. *Acceptance:* SQLAlchemy `Inspector.get_table_names/get_columns/get_pk_constraint` and JDBC `getTables/getColumns/getIndexInfo` return correct results against a live collection. Design doc §0.7/8; plan `roadmap/techdebt/TD_120_PG_CATALOG_COMPLETENESS_2026_06_17.adoc`.
-
-| TD-121
-| Hard-delete gRPC v1 proto files and compat adapter impls after Sunset 2026-06-30
-| P7
-| HIGH
-| Open (planned post-2026-06-30)
-| gRPC v1 compatibility services (`proto/proximadb/v1/*.proto` + `crates/platform/proximadb-api/src/grpc/v1/*.rs`) are gated off by default behind `enable_grpc_v1_compat` (`PROXIMADB_GRPC_V1_COMPAT` env, default `false`). After the 2026-06-30 Sunset date the flag must be removed along with all v1 proto files and Rust impl files to eliminate the maintenance surface, reduce binary size, and prevent accidental re-enablement. Leaving deprecated code behind the flag indefinitely creates a false safety net and complicates codegen.
-| 1 sprint
-| Deliverables: (1) delete `proto/proximadb/v1/` directory and regenerate `crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs`; (2) delete `crates/platform/proximadb-api/src/grpc/v1/` (vector.rs, sql.rs, collection.rs, graph.rs, hybrid.rs, security.rs, document.rs, entity.rs, observability.rs, streaming.rs, mod.rs); (3) remove `enable_grpc_v1_compat` field from `GrpcHttpServerConfig` (`crates/platform/proximadb-runtime/src/bootstrap_config.rs`) and all callers in `server_builder.rs` / `multi_server.rs`; (4) remove the `if enable_grpc_v1_compat` blocks in `multi_server.rs`; (5) update CI to assert no `proximadb.v1` proto package remains; (6) update `docs/03-api-reference/` migration guide to confirm v1 EOL. *Acceptance:* `grep -r 'proximadb.v1' proto/` returns zero results; `cargo build` green; no `PROXIMADB_GRPC_V1_COMPAT` in any config file. *Depends on:* Sunset date passing (2026-06-30). *Gate:* Do NOT merge before 2026-07-01. *Unblocked by* TD-123 (v2 parity services must exist before v1 removal ships).
-
-| TD-122
-| gRPC v2 parity services for graph, document, and entity modalities
-| P7
-| HIGH
-| Partially delivered — graph done 2026-06-21 (document + entity still open)
-| The canonical `proximadb.v2.ProximaRecordService` covers record writes, search, and SQL. **Graph is now delivered**: `proto/proximadb/v2/graph.proto` (`proximadb.v2.ProximaGraphService`) + `src/network/grpc/v2/graph_service.rs`, always-registered on the multiplexed port and consumed by the Python SDK. Document (`document.proto`/`document.rs`) and entity (`entity.proto`/`entity.rs`) workloads remain REST-v2-only; there are still no `proximadb.v2.DocumentService` / `proximadb.v2.EntityService` gRPC endpoints. Callers needing gRPC-native document CRUD or entity resolution must use the deprecated v1 compat adapter (off by default) or REST. NOTE: the v2 services live in the main crate under `src/network/grpc/v2/` (mirroring where `ProximaRecordServiceImpl` actually lives), not `crates/platform/proximadb-api/src/grpc/v2/` as originally drafted.
-| 3-4 sprints
-| Deliverables: (1) [DONE for graph] author `proto/proximadb/v2/{graph,document,entity}.proto` using `proximadb.v2.*` message types (no v1 message re-use); (2) [DONE for graph — `ProximaGraphServiceImpl`] implement the v2 services; (3) [DONE for graph] register in `multi_server.rs` alongside ProximaRecordService (all three startup paths via the `canonical_*_grpc_service` helpers); (4) [DONE for graph] add gRPC integration tests — `#[cfg(test)]` handler-level tests in `src/network/grpc/v2/graph_service.rs` cover node/edge CRUD, label query, traversal, shortest-path, the v2↔internal `conv` round-trip, and structural tenant namespacing (document/entity tests TODO with their services); (5) OpenAPI/grpc-gateway annotations for shared REST/gRPC schema. Remaining scope: DocumentServiceV2 + EntityServiceV2. *Acceptance:* `grpcurl` can list and call `proximadb.v2.ProximaGraphService` (DONE), `proximadb.v2.DocumentService`, `proximadb.v2.EntityService` without enabling `PROXIMADB_GRPC_V1_COMPAT`. *Blocks:* TD-121 (v1 cannot be removed until v2 parity exists). *Graph deferred RPCs tracked by* TD-124. *Coordinates with:* TD-120 (pg_catalog) for entity type metadata; TD-119 (Iceberg manifests) for document storage layout.
-
-| TD-123
-| Full proximadb.v1 to proximadb.v2 message-type migration (codegen cascade)
-| P7
-| MEDIUM
-| Open (proposed 2026-06-18; STEP 1 graph keystone DONE 2026-06-21)
-| Many internal service boundaries, SDK clients, and test fixtures still reference `proximadb.v1.*` message types directly — even on code paths that do not use the deprecated gRPC v1 compat adapter. Typical examples: `VectorRecord` (v1) vs `ProximaRecord` (v2), `CollectionConfig` (v1) vs `CatalogTableSchema` (v2), `SearchResult` (v1) vs `SearchResponse` (v2). This creates a dual-namespace burden: codegen produces both `proximadb.v1` and `proximadb.v2` crate modules; From/Into conversion shims between the two add latency and hide type mismatches; JSON serialization differs across v1/v2 wire shapes; SDK auto-generated clients contain both namespaces. Once TD-121 deletes `proto/proximadb/v1/` the compiler will surface all remaining v1 usages as errors — without a migration plan this becomes a large unplanned blast radius. **Deeper root cause (sharpened 2026-06-21):** the worst offenders are not call sites that happen to *name* v1 types — they are *domain/orchestration services that use a v1 proto type AS their internal model*. The clearest example is the graph stack: `GraphOperationsService` (`src/graph/service.rs`) takes and returns `proximadb.v1` proto `Node`/`Edge`/`NodeQuery`/`TraversalResponse` as its API, so a wire (transport) type is doing double duty as the core domain type. That is a dependency inversion (transport leaking into the core), and it forces the new v2 graph adapter to map **v2 proto → v1 proto → engine** (two hops, lossy — e.g. v1 `VectorValue` properties have no v2 representation). Swapping "v1 types for v2 types" 1:1 would just move the inversion to v2. The correct target is to make **neither wire version the domain**: introduce transport-agnostic domain models so v1 and v2 are both thin adapters over a stable core. Tenancy has the same shape of debt: graph identity is `graph_id: &str` and the v2 adapter achieves isolation by *string-prefixing* the tenant onto it (`effective_graph_id`) — fragile (no compile-time guarantee, bypassable, and the v1 adapter doesn't do it). The mandate wants structural isolation via a typed `TenantContext` + `DrPathBuilder` key, not string concat.
-| 4-6 sprints
-| Deliverables: (1) audit all `use proximadb_proto::proto::proximadb_v1::*` imports across `src/` and `crates/` (a `grep -r 'proximadb_v1\|proximadb::v1'` run at HEAD is the starting inventory); (2) define migration layers — a. internal service ports: switch to `proximadb.v2.*` types directly; b. conversion shims: delete `From<v1::VectorRecord> for v2::ProximaRecord` and equivalent bridges once all callers migrate; c. SDK codegen: regenerate Python/Go/Node clients from `proto/proximadb/v2/` only; d. test fixtures: update integration tests that construct `v1::VectorRecord` / `v1::CollectionConfig` proto messages; (3) add a CI step (`scripts/check_v1_proto_usage.py`) that fails if `proximadb_v1` is referenced outside the compat adapter directory; (4) land migrations incrementally before TD-121 ships so the v1 deletion is a clean `git rm` with no compile errors; (5) **[STEP 1 — keystone — DONE for graph 2026-06-21]** introduce transport-agnostic domain models for the worst-inverted services: `src/graph/model.rs` defines plain-Rust `graph::model::{Node, Edge, PropertyValue, EmbeddingVersion, NodeQuery, EdgeQuery, TraversalRequest/Response, GraphPath, GraphStats, ...}` (serde, no prost); `src/graph/proto_convert.rs` holds the bidirectional `From` impls; `GraphOperationsService` and the whole graph engine/query path now speak ONLY the neutral model. The v1 gRPC, v2 gRPC, and REST adapters convert proto↔neutral at their boundary (the v2 `conv` module is now one hop). The `proximadb-graph-query` foundation-crate trait contract stays proto and is adapted at the impl boundary. Persistence is unchanged (`ProximaRecord` via `adjacency_projection`) — in-memory representation only. This is the pilot for the same pattern on the record/vector/collection services (still TODO); (6) **[STEP 2 — typed tenancy] replace `graph_id: &str` + the `effective_graph_id` string-prefix shim** with a typed `GraphRef { tenant: TenantContext, graph_id: GraphId }` (or thread `TenantContext` to the boundary), build the backing/storage key via `DrPathBuilder`, fail-closed — isolation becomes structural, and the v1 adapter inherits the isolation it currently lacks. *Acceptance:* `scripts/check_v1_proto_usage.py` reports zero violations; no domain/orchestration service in `src/` takes or returns a `proximadb_v1`/`proximadb_v2` proto type (proto appears only in adapters under `src/network/grpc/**` and `crates/platform/proximadb-api/**`); graph isolation has no string-concat key construction; `cargo build --all-features` green. *Depends on:* TD-122 (v2 parity services must exist before callers can migrate). *Must complete before* TD-121 hard-deletion ships.
-
-| TD-124
-| Deferred RPCs on the v2 ProximaGraphService surface
-| P7
-| LOW
-| Open (proposed 2026-06-21)
-| `proximadb.v2.ProximaGraphService` (TD-122 graph slice) ships the core graph operations the SDK needs: node/edge CRUD, `QueryNodes`/`QueryEdges`, `GetNeighbors`, `TraverseGraph`, `ShortestPath`, `GetGraphStats`. The following v1 `GraphService` RPCs were intentionally deferred from the first v2 surface and remain reachable only via the deprecated v1 compat adapter (off by default): `StreamTraverse` (server-streaming), `GetConnectedComponents`, `HasCycle`, `AddUniqueConstraint`/`RemoveUniqueConstraint` (graph DDL), `BatchCreateNodes`/`BatchCreateEdges`, `ExecuteQuery` (Cypher/Gremlin declarative), `ExecuteHybridQuery` (vector+graph), and the retired PULSAR/QUASAR RPCs (not to be ported — use ORION). Graph creation/DDL is also not on the v2 gRPC surface yet (provision via the `/api/v2/graphs` REST route).
-| 1-2 sprints
-| Deliverables: (1) add the deferred analytic + batch RPCs (`GetConnectedComponents`, `HasCycle`, `BatchCreateNodes`/`Edges`) to `proto/proximadb/v2/graph.proto` + `src/network/grpc/v2/graph_service.rs`, delegating to the existing `GraphOperationsService` methods; (2) add `StreamTraverse` server-streaming once a streaming pattern for v2 graph is chosen; (3) decide whether unique-constraint DDL belongs on the graph gRPC surface or a DDL surface, then implement; (4) assess `ExecuteQuery` (Cypher/Gremlin) — a distinct graph query language (not SQL → not pgwire), so it belongs on the graph surface, but is gated on the declarative engine landing (see SUPPORTED_SURFACE "Declarative graph query execution is still incomplete"); keep `ExecuteHybridQuery` deferred until the hybrid path drops its hardcoded `default` graph. Do NOT port PULSAR/QUASAR. *Acceptance:* SDK can reach the analytic/batch RPCs on v2 without `PROXIMADB_GRPC_V1_COMPAT`. *Relates to:* TD-122 (parent), TD-121 (v1 removal must not strand any still-needed RPC).
-
-| TD-135
-| gRPC SQL relational writes (DDL/DML) — Phase 2 of SSO relational SQL
-| P7
-| MEDIUM
-| *DONE 2026-06-22* — gRPC ExecuteQuery routes DDL (CREATE/ALTER/DROP) + DML (INSERT/UPDATE/DELETE) through the tenant-scoped `DdlService::execute_scoped`/`DmlService::execute_scoped` seams with the `x-tenant-id` tenant; DdlService wired onto `UnifiedHandlers`; cross-tenant write-isolation e2e green (`grpc_td135_relational_write_tenant_isolation_e2e`). Transactions (BEGIN/COMMIT) remain pgwire-only as scoped.
-| Phase 1 made `proximadb.v2.ProximaRecordService.ExecuteQuery` execute *tenant-scoped relational SELECT reads* by routing them through the same pipeline pgwire uses (`relational_pipeline::try_run_select(.., require_engagement=false)`), with the `x-tenant-id` tenant threaded into `request_handlers::execute_sql_v1(.., tenant_id)`. *Writes* (`CREATE TABLE`/`ALTER`/`DROP`, `INSERT`/`UPDATE`/`DELETE`) over gRPC SQL are still unsupported: `try_run_select` only handles `Statement::Query`, so DDL/DML fall through to the legacy unified engine, which does not execute them. This leaves SSO/bearer-authenticated programmatic clients unable to do relational writes over gRPC (pgwire can write but cannot carry a bearer/JWT — the original TD-121 SSO gap, now closed only for reads). *Good news:* the write execution is already extracted into tenant-scoped service seams used by pgwire — `DdlService::execute_scoped(statement, Option<&str> tenant)` and `DmlService::execute_scoped(statement, Option<&TenantContext> tenant)` (see `src/network/postgres/protocol.rs` DDL branch ~1255 and `execute_insert/update/delete_via_dml_service` ~3588) — so this is a routing + result-mapping task, not a deep refactor of the mutation paths.
-| 1-2 sprints
-| Deliverables: (1) in `execute_sql_v1` (before the legacy fallback) detect DDL (`CREATE`/`ALTER`/`DROP`) via `SqlFrontendParser::parse_ddl` and route to `ddl_service.execute_scoped(stmt, tenant_id)`; detect DML (`INSERT`/`UPDATE`/`DELETE`) via `parse_dml` and route to `dml_service.execute_scoped(stmt, TenantContext::for_tenant_id(tenant))`; (2) ensure `DdlService`/`DmlService` are reachable from `UnifiedHandlers` (a `get_dml_service()` getter exists; add `get_ddl_service()` if absent); (3) map `DdlResult`/`DmlResult` → `ExecuteQueryResponse` (affected-row count, command tag), mirroring pgwire's response shaping; (4) **fail-closed tenancy**: decide and enforce whether a write with no `x-tenant-id` is rejected vs scoped to a default — writes MUST NOT silently land in the wrong partition (the discarded-tenant class of bug); first write under a new tenant must create the tenant-prefixed schema/partition exactly as the pgwire path does; (5) cross-tenant **write-isolation e2e** (`grpc_td135_relational_write_tenant_isolation_e2e`): two tenants `CREATE` the same table + `INSERT` the same PK over gRPC, then read back (gRPC or pgwire) asserting each tenant sees only its own rows and writes never bleed across tenants — mirror `pgwire_td064_write_tenant_isolation_e2e` but drive all statements over gRPC. *Out of scope:* transactions — gRPC `ExecuteQuery` is single-statement/stateless; multi-statement `BEGIN; … ; COMMIT;` stays pgwire-only (note it explicitly; do not silently accept a `BEGIN` that has no effect). *Acceptance:* `grpcurl … ExecuteQuery` with `x-tenant-id` can `CREATE TABLE` + `INSERT` + `SELECT` + `DELETE` end-to-end, tenant-isolated; vector/graph SQL and relational SELECT reads (Phase 1) unaffected. *Builds on:* Phase 1 gRPC relational SELECT (this is its write half). *Relates to:* TD-064 (structural tenant isolation), the SQL-surface taxonomy in `docs/SUPPORTED_SURFACE.adoc`.
+| TD-063 | Observability / SIEM convergence | HIGH | Open | D4 | OE
+| Normalize logs/metrics/spans/profiles/alerts/anomalies/agent-traces/prompts/tool-calls/retrieval-evidence/token-cost/eval-events as `ProximaRecord` profiles + cataloged projections; rollups/anomalies/alerts durable only as canonical derived records with provenance. Overhaul spec.
 |===
+
+=== H. SDKs & Connectors
+
+[cols="1,3,1,1,1,1,5", options="header"]
+|===
+| ID | Area | Pri | Status | Dim | Pillar | Notes
+
+| TD-005 | Multi-language SDKs | LOW | Partial | D2 | OE
+| *Rescoped 2026-06-24:* `clients/` now ships Python, Rust, Go (+ embedded), JVM/Java-embedded, Node.js-embedded. Residual: standalone Java/Node.js SDKs, and C++/.NET/Ruby/Swift remain planned. Per CLAUDE.md, all REST surfaces must be spec-generated (TD-126).
+
+| TD-126 | SDK REST transport spec-driven codegen (sync + async; Go Phase 2) | MED | Partial | D2 | OE
+| Per-language generated REST from the canonical OpenAPI spec behind a thin facade. *Python codegen + incremental-streaming chunking landed (`fff7441c`,`1c17f3d7`).* Residual: `feat/td-126-phase2-go-codegen` (3 commits, not merged) — Go codegen Phase 2. Drift gate `<lang>-sdk-codegen-drift`. See CLAUDE.md mandate #15, TD-126.
+
+| TD-097 | Spark connector JNI bridge | MED | Partial | D4 | OE
+| *Wire + CI + embedded product impls shipped (2026-05-31..06-04):* 9 `jni_*` → real `spark_*(EmbeddedProximaDB)`; singleton init; Arrow-IPC read; filter pushdown (Rust-side); JNI lifecycle M1-M3; e2e `test_spark_read_after_write_round_trip`. Residual (post-MVP): JVM DataSource V2 layer (`SupportsPushDownFilters`/`ScanBuilder`), Gradle/JUnit5 harness, split-aware read planning.
+
+| TD-099 | v2 records-scan / list endpoint (Hadoop) | LOW | Partial | D1 | PERF
+| *Spec + Hadoop SDK + handler + cursor + sync-bridge + WAL scan push-down (3d) shipped (2026-06-01..03):* `POST /api/v2/.../records/scan`, opaque cursor, deduped time-ordered `ScanIndex` (O(log d + limit) warm), kill-switch `PROXIMADB_SCAN_INDEX_DISABLE`, tuning gauge. Residual: minor — relational `TableRecordStore::scan_records` stays on legacy full-scan by design.
+
+|===
+
+NOTE: TD-133 (cross-modal transactional multi-modal write) *Resolved 2026-06-24* —
+`CrossModelTransactionCoordinator` for atomic multi-modal writes landed on develop (`55450f9d`,
+PR #265). Moved to the closed archive.
+
+=== I. Quality / Coverage / Validation / Honesty
+
+[cols="1,3,1,1,1,1,5", options="header"]
+|===
+| ID | Area | Pri | Status | Dim | Pillar | Notes
+
+| TD-029 | Code coverage 49%→80% target | HIGH | In Progress | — | OE
+| 49.3%→54.9% (+940 tests); CI threshold enforced (50% min, ratchet 55% Q2 / 60% Q3). Pure-logic surface exhausted; further gains need integration-test infra (HTTP test clients, storage-engine setup). audit 28→92, auth 42→86, api_handlers 5→43, network 30→45.
+
+| TD-024 | SWIFT engine incomplete (30+ TODOs) | MED | Open | D4 | REL
+| Header `INCOMPLETE`; progressive search, file loading, batch-id tracking, vector counting (hardcoded 0). Feature-gated behind `experimental-engines`; production uses SST/VIPER/HELIX/NOVA. Not blocking v1.0 unless needed.
+
+| TD-025 | RAPTOR engine experimental (35+ TODOs) | MED | Open | D4 | REL
+| Header `EXPERIMENTAL`; bloom-filter lookup, clustering, cohesion calc, caching APIs, row-group extraction. Feature-gated `experimental-engines`. Same guidance as TD-024.
+
+| TD-030 | No integrated ibkrtrading validation | HIGH | Open | — | REL
+| VISION positions ibkrtrading as proof-of-production-readiness but no documented e2e results. TST/EventLog/Document ready; need 30-day run, perf vs 3-DB architecture, MiFID II verification with real data.
+
+| TD-046 | Tool-Based Navigation (GraphWalk) — gRPC parity | HIGH | Partial | D4 | OE
+| *REST + agent-tool schema landed:* `walk_graph`/`step_graph` REST + MCP `GRAPH_WALK_TOOL`/`GRAPH_STEP_TOOL`. Residual: proto `WalkRequest`/`WalkStepRequest` + regenerated gRPC handlers (blocked on regen workflow); LangChain/CrewAI/LlamaIndex tool wrappers.
+
+| TD-042 | Cache architecture over-engineering | LOW | Open | D3 | OE
+| 5 specialized cache types coordinated by `CrossCacheOrchestrator` mixing 8 concerns; undocumented 40/30/15/10/5 split. Consolidating to 2-3 patterns reduces cognitive load. Maintainability only. *(Overlaps TD-118 — fold into that policy-consolidation if/when TD-118 lands.)*
+
+| TD-085 | Internal marketing-copy overclaims — product scrub | LOW | Partial | — | OE
+| *Engineering side resolved 2026-05-30:* `docs/_internal/{enterprise,business}` sealed with INTERNAL-ONLY banners + `make docs-claim-check` hard-fail on external references. Residual (product-owner scope): actually scrub "85-96% cost reduction" / "296% performance" claims or cite reproducible methodology before moving out of `_internal/`.
+|===
+
+== Summary (accurate as of 2026-06-24)
+
+[cols="2,2,4", options="header"]
+|===
+| Bucket | Count | Notes
+
+| Open (not started / scoping) | ~33 | Lead candidates: fusion seam (TD-136/137 In Progress), HTAP (TD-110), cost-routing (TD-115), storage spine (TD-114/116/118).
+| In Progress | 5 | TD-136, TD-137, TD-101, TD-064, TD-029.
+| Partial (foundation landed, residual named) | ~22 | TD-060/066/097/099/106/111/112/117/119/120/122/123/132/044/040/046/085/102/005/126/094-adjacent.
+| Resolved/Closed (archived) | ~80 | See link:../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[Closed Items Archive].
+|===
+
+*Highest-leverage open work by co-design dimension* (move the dominant cost term first):
+
+* *D1 (object storage / I/O round-trips)* — TD-114 (compaction), TD-088 (point-read layout), TD-087 (cold path), TD-116 (WAL tiering), TD-119 (Iceberg snapshots). These move bytes-touched-per-query, the dominant cloud-DB cost.
+* *D4 (compute routing / fusion)* — TD-115 (cost-based dispatch), TD-136/137 (fusion seam), TD-141 (cost-routed fusion).
+* *D5 (governance / isolation)* — TD-064 (predicate-aware correctness, CRIT/SEC), TD-061/073/074 (cataloged capabilities). (TD-133 cross-modal atomicity Resolved 2026-06-24.)
+
+*Cross-references:* roadmap status reconciliation (Phase 2.5 marked complete; SaaS/co-design pivot
+integration) is tracked in
+link:../_internal/roadmap/RECONCILIATION_2026_06_24.adoc[RECONCILIATION_2026_06_24]. Architecture
+ground truth: link:../12-design/SYSTEM_MAP_2026_05_30.adoc[System Map] and
+link:../12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc[Design Doc Status Index].

--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -10,10 +10,15 @@ link:../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[the Close
 
 [IMPORTANT]
 ====
-This register tracks *implementation state*, not *product-support level*.
+This register tracks _implementation state_, not _product-support level_.
 link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] is the authoritative product-support contract
 and wins for any customer, release-note, or marketing claim. A "Resolved" status here means the code
 path is complete in the working tree — it does *not* by itself make a capability a Supported v0.2 surface.
+
+*Support-tier anchors* (the controlling tiers in `SUPPORTED_SURFACE.adoc`, repeated here so the
+honesty guard cannot drift): external catalogs are _Experimental in v0.2 (see SUPPORTED_SURFACE)_;
+mTLS and the time-series / event-sourcing foundations are _Beta in v0.2 (see SUPPORTED_SURFACE)_;
+framework integrations ship in the SDK but are Not a v0.2 supported surface (see SUPPORTED_SURFACE).
 ====
 
 [NOTE]

--- a/docs/12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc
+++ b/docs/12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc
@@ -1,8 +1,17 @@
-= Design Doc Status Index — 2026-05-27 Bookkeeping Audit
+= Design Doc Status Index — Bookkeeping Audit (2026-05-27, reconciled 2026-06-24)
 :toc: left
 :toclevels: 3
 :icons: font
 :last-updated: 2026-06-24
+
+[NOTE]
+====
+*2026-06-24 reconciliation:* the original table below was a 2026-05-26 snapshot of 29 docs. The folder
+now holds 56 top-level design docs + 24 ADRs. The 28 docs + 2 ADRs added since (including the two
+canonical *pivot* docs — `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04` and
+`CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19`) are catalogued in <<addendum-2026-06-24>>. Do a full
+re-merge of the two tables at the next 4–6 week refresh.
+====
 
 [.lead]
 **Audit-time bookkeeping index for every doc under `docs/12-design/` plus tracker-shaped docs across other roots. No code changes — this doc is the single point of reference for "what's still load-bearing, what's wired, what should be archived" as of 2026-05-26.**
@@ -47,7 +56,7 @@ This audit complements (does not replace) `link:DOCUMENTATION_CONSOLIDATION_AND_
 ** **N/A** — convention/index doc, no code expected.
 * **Cluster** — semantic grouping for consolidation review (see <<consolidation-clusters>>).
 
-== docs/12-design top-level (29 files)
+== docs/12-design top-level (29 files as of 2026-05-26; +28 in <<addendum-2026-06-24>>)
 
 [cols="3,1,1,1,3", options="header"]
 |===
@@ -390,6 +399,56 @@ The above are tracked per-ADR / per-design-doc where applicable (ADR-009 governs
 === `legacy.rs` / `legacy_*` modules
 
 Standalone legacy file: `src/services/operations/vectors/legacy.rs` — interior of `VectorOperationsService`, hosts the pre-modular API surface that the consumer-migration chain (Task #76) just finished pulling through to ports. Eventual cleanup is captured in memory `project_consumer_migrations_2026_05_24.md` (port chain complete at 8 consumers).
+
+[#addendum-2026-06-24]
+== Addendum 2026-06-24: docs added since the 2026-05-26 table
+
+The main table above ("docs/12-design top-level (29 files)") was a 2026-05-26 snapshot. As of
+2026-06-24 the folder holds *56 top-level design docs + 25 `adr/` files (24 ADRs + README)*. The
+following *28 docs and 2 ADRs* were not in the original table and are catalogued here. *Status*
+uses the same vocabulary as <<How to read this index>>. *Pivot* docs are canonical and load-bearing
+for the whole-system course corrections; treat them as required reading (see `README.adoc`).
+
+[cols="3,1,1,3", options="header"]
+|===
+| File | Status | Class | Notes / drives
+
+| DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc | Active | *Pivot* | The 2026-06-04 strategic pivot to Intelligent Multi-Engine Routing over object storage. Canonical (CLAUDE.md). *Was missing from the index.*
+| CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc | Active | *Pivot* | The co-design cost-spine (5 physical dimensions, per-query I/O trace). Canonical (CLAUDE.md). *Was missing from the index.*
+| OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc | Active | Cost model | KOU egress metering; `consumption_metrics.rs`. Co-design D2.
+| CACHING_AND_MULTITENANCY_RECALIBRATION_2026_06_17.adoc | Active | Design | Cache/tenant policy; drives TD-118. D3.
+| CATALOG_OBJECT_MODEL_2026_06_21.adoc | Active | Design | Catalog object model; TD-060/061.
+| STORAGE_INDEX_COMPUTE_DECOUPLING_CONTRACTS_2026_06_21.adoc | Active | Design | Storage↔index↔compute seam contracts.
+| ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc | Active | Plan | Drives TD-104 (handler extraction).
+| SDK_MODULARIZATION_AND_SPEC_DRIVEN_GENERATION_2026_06_21.adoc | Active | Plan | Drives TD-126 (spec-driven SDK codegen). Referenced in README, *was missing*.
+| CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc | Active | Design | Drives TD-127/128/130/132/133 (code-graph).
+| CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc | Active | Design | Drives TD-136..143 (fusion seam).
+| SEARCH_SURFACE_CONTRACT_2026_06_24.adoc | Active | Design | One retrieval engine, typed facades; drives TD-146 (EntityService delegates to seam).
+| QUANTIZATION_KERNEL_SPLIT_2026_06_22.adoc | Active | Design | Quantization kernel split.
+| IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc | Active | HLD | Edge-collapse E0/E1; `consumption_metrics.rs`.
+| FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc | Active | Design | Open-format strategy; TD-091 (Lance).
+| DATAFUSION_BALLISTA_DISTRIBUTED_EXECUTION_2026_06_05.adoc | Pending | Design | Distributed DataFusion/Ballista; depends on TD-077/115.
+| PROXIMA_NOTEBOOK_PSEUDO_DISTRIBUTED_BLUEPRINT_2026_06_04.adoc | Active | Blueprint | Notebook pseudo-distributed; referenced in README, *was missing*.
+| OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc | Active | Governance | OSS/enterprise boundary; D5.
+| RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc | Active | Plan | Canonical phased storage-format migration pattern (CLAUDE.md mandate #8).
+| RABITQ_ANN_INTEGRATION_SCOPING_2026_06.adoc | Pending | Scoping | RaBitQ ANN integration; relates to TD-087.
+| CLUSTERING_AND_STREAMING_FRESHNESS_PLAN_2026_06.adoc | Pending | Plan | Clustering + streaming freshness.
+| VECTOR_LAKEBASE_ALIGNMENT_2026_05_28.adoc | Active | Design | Drives TD-086..094 (continuous loop / elastic compute).
+| PHASE8_CONTINUOUS_LOOP_HLD_LLD_2026_05_28.adoc | Active | HLD/LLD | Phase 8 continuous loop.
+| TENANT_COLLECTION_POD_AFFINITY_2026_05_27.adoc | Active | Design | Pod affinity; D5.
+| NON_AXIS_INDEX_MIGRATION_AUDIT_2026_05_27.adoc | Active-Memo | Audit | Orphan non-AXIS index deletion (TD-064 ~4600 LOC removed).
+| TD_066_PART2_LSN_CORRELATION_DESIGN_2026_05_28.adoc | Active | Design | TD-066 residual (Option A LSN correlation).
+| TD104_HANDLER_CONVERGENCE_PLAN_2026_06_03.adoc | Active | Plan | TD-104 handler convergence.
+| TD106_DOCUMENT_CANONICAL_MIGRATION_HANDOFF_2026_06_03.adoc | Active | Handoff | TD-106 document canonical migration.
+| CONVERGENCE_SESSION_HANDOFF_2026_06_03.adoc | Active-Memo | Handoff | Convergence-audit session handoff.
+| UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc | Active | Review | Approved correction plan for unified `ResourceKey`/DML-lock (see header delta).
+| adr/ADR-023-f2-cold-load-ordering.adoc | Accepted | ADR | Cold-load ordering (TD-087). *Post-dated the 2026-05-26 ADR count.*
+| adr/ADR-024-single-canonical-data-type-and-schema.adoc | Accepted | ADR | Single canonical data type + schema (TD-111). *Post-dated the count.*
+|===
+
+NOTE: ADR total is now *24 Accepted* (ADR-001..024), not the 22 stated in the pre-2026-06-24 ADR
+summary. The TD-XXX cross-references above point at the live
+link:../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register].
 
 == Maintenance cadence
 

--- a/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
+++ b/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
@@ -4,10 +4,14 @@
 :icons: font
 :source-highlighter: rouge
 :sectnums:
-:last-updated: 2026-06-16
+:last-updated: 2026-06-24
 
 Status: Apex reference index (active baseline) +
-Date: 2026-06-16 +
+Date: 2026-06-24 (filename `SYSTEM_MAP_2026_05_30` is the original; content tracks current HEAD) +
+Cost spine: the multi-engine routing + cache policy shown here is co-optimized against the *measured
+per-query I/O trace* across the five physical dimensions — see
+`CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (the unified cost objective the `ComputeScheduler`
+minimizes) and `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` (the strategic pivot). +
 Scope: One recursive whole-system view — workspace layers, `src/` modules, storage/access-method
 families, the ORION graph runtime, write/read data paths, and the
 protocol-facade-to-canonical-authority convergence. This is also the solution-architecture
@@ -18,8 +22,8 @@ feeders (see <<feeders>>).
 
 [.lead]
 This is the **single pane of glass** for ProximaDB. It exists to answer one question fast — "where does
-a thing live, and what does it converge on?" Current manifest reality: 66 workspace members, 61 crates
-under `crates/`, and 46 real top-level `src/` module directories. It is navigation-first: it does not
+a thing live, and what does it converge on?" Current manifest reality: 79 workspace members
+under `crates/` + `apps/`, and ~52 real top-level `src/` module directories. It is navigation-first: it does not
 duplicate the per-module detail in the feeder docs, it indexes and ties them together so they stop
 diverging.
 
@@ -250,7 +254,7 @@ operator visibility.
 |===
 
 [#workspace]
-== Layer 1 — Workspace (66 members, layered)
+== Layer 1 — Workspace (79 members, layered)
 
 The workspace follows the stable map from `CLAUDE.md`:
 `Foundation -> Contracts -> Control -> Horizontal -> Modality -> Storage -> Query/Cross-Model -> Platform -> Apps/Bindings`.
@@ -263,12 +267,12 @@ flowchart TB
   classDef layer fill:#4a90e2,stroke:#2e5c8a,color:#000;
   classDef apps fill:#cfe2f7,stroke:#2e5c8a,color:#000;
 
-  FND["<b>Foundation</b> (14)<br/>kernel · data-model · proto · records · filter-expr<br/>distance/compression/encoding/quantization-types<br/>config · hardware · pipeline-operator · relational-types · functions"]:::layer
+  FND["<b>Foundation</b> (20)<br/>kernel · data-model · proto · records · filter-expr<br/>distance-kernel/types · compression/encoding/quantization-types<br/>index-traits/types · cache · memory-pool · hardware(-caps)<br/>config · pipeline-operator · relational-types · functions"]:::layer
   CTR["<b>Contracts</b> (1)<br/>quantization (behavior + compat gates)"]:::layer
   CTL["<b>Control</b> (1)<br/>proximadb-catalog — xCatalog, 8 backends, route knobs"]:::layer
   HRZ["<b>Horizontal</b> (7)<br/>codec · compression · security · telemetry<br/>runtime-common · embedded-common · recall-bench"]:::layer
-  MOD["<b>Modality Runtime</b> (11)<br/>vector · document · graph · observability · embedding · queue<br/>rank-core/features/expr/profile/onnx"]:::layer
-  STG["<b>Storage</b> (4)<br/>storage-common · block-format (PAX)<br/>object-store · iceberg-engine"]:::layer
+  MOD["<b>Modality Runtime</b> (12)<br/>vector · document · graph · observability · embedding · queue<br/>quantization-kernel · rank-core/features/expr/profile/onnx"]:::layer
+  STG["<b>Storage</b> (8)<br/>storage-common · block-format (PAX) · object-store · iceberg-engine<br/>storage-kv · storage-optimization · storage-strategy · storage-tenant"]:::layer
   QRY["<b>Query / Cross-Model</b> (20)<br/>query · uql · multimodel-{query,plan} · relational-{algebra…engine}<br/>{vector,document,graph,observability}-query · graph-{arrow,subset}<br/>query-{capability,clauses,filter,fusion}"]:::layer
   PLT["<b>Platform</b> (2)<br/>proximadb-api (REST/gRPC/Flight/pgwire surfaces)<br/>proximadb-runtime (composition, PortUserContext)"]:::layer
   APP["<b>Apps / Bindings</b><br/>workspace: server · migrate · bench · root · rust client · spark JNI<br/>repo clients: python · go · embedded java/node/go/c"]:::apps

--- a/docs/_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc
+++ b/docs/_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc
@@ -1,0 +1,180 @@
+= ProximaDB Technical Debt — Closed Items Archive (as of 2026-06-24)
+:toc: auto
+:toclevels: 2
+
+[NOTE]
+====
+This is the *closed-items archive* for the link:../../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register].
+It indexes every item that reached *Resolved* / *Closed* / *Done* so the live register can
+stay lean and show only current (Open / In Progress / Partial) work.
+
+Each row is a one-line summary; the *full historical prose* (acceptance criteria, commit-by-commit
+narrative, file pointers) for every item is preserved in git history of
+`docs/10-quality/TECHNICAL_DEBT.adoc` prior to the 2026-06-24 reconciliation commit. Use
+`git log -p docs/10-quality/TECHNICAL_DEBT.adoc` to recover any closed item's detail.
+
+This archive tracks *implementation state*. `docs/SUPPORTED_SURFACE.adoc` remains the authoritative
+product-support contract and wins on any customer/release/marketing claim.
+====
+
+== Closed — Code Quality & Safety
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution (one-line + key location/commit)
+
+| TD-CROSS-LAYER | Storage→Index dependency inversion | May 2026 | `StorageEngineType` moved to `src/core/types/storage.rs`; storage no longer imports index layer.
+| TD-007 | unwrap/expect proliferation | Mar 2026 | 0 unwrap + 0 expect in production; `clippy::unwrap_used/expect_used` warns + CI guard (`scripts/count_panic_patterns.sh`).
+| TD-012 | API handler test coverage at 5% | Mar 2025 | `tests/rest_api_handlers_test.rs` (45) + `rest_api_load_test.rs` (13) = 58 tests.
+| TD-013 | Python SDK mypy disabled | Mar 2026 | `py.typed` + mypy re-enabled in CI (`2410bde7`). (also TD-R17)
+| TD-027 | UB in TST clone (`std::mem::zeroed`) | Mar 2026 | Replaced with `FilesystemFactory::new_empty()`.
+| TD-069 | Standalone unit tests → inline `#[cfg(test)]` | 2026-04-07 | 23 files / 190 tests inlined; tracker archived.
+| TD-079 | Root crate clippy lint backlog | 2026-05-28 | 164→0 across 16 batches (`7db1d804e`→`a297949ca`); `clippy -p proximadb --lib -D warnings` clean.
+| TD-080 | Catalog default-bootstrap (precision_resolver) | 2026-05-28 | `set_default_catalog` wired + handler-side metric label (`32cea5b85`).
+| TD-070 | Insert/query hot path skips dim + NaN/Inf validation | 2026-05-26 | Validation at shared vector-service boundary.
+|===
+
+== Closed — Missing Critical Features
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution
+
+| TD-008 | Hybrid search / BM25 + RRF | Feb 2025 | `src/core/search/hybrid.rs`; `/api/v1/hybrid/search`.
+| TD-009 | Time-series engine (TST) | — (Beta) | `src/storage/engines/impls/tst/`; ASOF, OHLC/Gorilla, compaction. Support tier Beta.
+| TD-010 | Event sourcing store (EventLog) | — (Beta) | `src/storage/engines/impls/eventlog/`; append-only, temporal replay, MiFID II mode. Beta.
+| TD-011 | Framework integrations | Mar 2026 | 7 frameworks (LangChain/LangGraph/LlamaIndex/Haystack/CrewAI/DSPy/AutoGen) in Python SDK. (also TD-R16/R23)
+| TD-018 | OTLP trace ingestion | Mar 2026 | `observability/ingestion/adapters/otlp.rs` (HTTP/JSON, 4318). gRPC 4317 intentionally not implemented.
+| TD-019 | Cypher query language | Mar 2026 | `src/graph/query/` parser+planner+executor; RETURN/ORDER BY/SKIP/LIMIT/WITH/UNION. (also TD-R22)
+| TD-020 | Cross-model ACID transactions | Feb 2025 | `CrossModelTransactionCoordinator` (2PC) + per-engine participants.
+| TD-133 | Cross-modal transactional multi-modal write | 2026-06-24 | `CrossModelTransactionCoordinator` for atomic multi-modal writes (node+embedding+edges); commit `55450f9d`, PR #265. *(reconciled from Open 2026-06-24)*
+| TD-129 | pgwire `ON CONFLICT DO UPDATE/DO NOTHING` | 2026-06 | `DmlStatement::Upsert` + `execute_upsert` in `src/services/dml/mod.rs` (`258943f3`). *(reconciled from Open 2026-06-24)*
+|===
+
+== Closed — Operations, Security & Ecosystem
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution
+
+| TD-002 | External catalog integration | Mar 2026 | Iceberg/Delta/Glue/Unity/Polaris/Hive in `src/catalog/`. v0.2 tier: *Experimental*.
+| TD-003 | Streaming infrastructure | Mar 2026 | gRPC bidi streaming, ring buffers, subscriptions, Kafka (`src/streaming/`). (also TD-R21)
+| TD-004 | CDC connectors (Postgres/MySQL/MongoDB) | Mar 2026 | `src/cdc/connectors/*`; logical replication / binlog / change-stream.
+| TD-006 | mTLS support | Mar 2026 | `src/network/tls/*` + `unified_auth`. v0.2 tier: *Beta* (CRL/OCSP framework only).
+| TD-014 | Backup / restore | Mar 2026 | `src/operations/{backup,restore}/`; RPO<1m, RTO<10m, multi-cloud. (also TD-R20)
+| TD-015 | Published benchmarks | Mar 2026 | `src/bench/ann_benchmarks/`, vectordb-compare app, `PERFORMANCE.md`. (also TD-R24)
+| TD-016 | Encryption at rest | Mar 2026 | `FileEncryptionLayer` (AES-256-GCM) + WAL encryption + key rotation.
+| TD-026 | gRPC alert endpoints unimplemented | Mar 2026 | `upsert/delete_alert_rule`, `list_alerts` wired to AlertEngine.
+| TD-071 | Distributed query response metrics | 2026-05-26 | `nodes_involved`/`cache_hits` from structured `ExecutionMetrics.extra`.
+| TD-095 | SDK graph body shape mismatch (Rust+TS) | 2026-05-30 | Server-true bodies; Rust `c08030d34`, TS `70ebe603c`.
+| TD-098 | Trino connector — Arrow Flight wire layer | 2026-06-02 | All 7 `flight_*` methods dial real RPCs; `tests/connectors_flight_contract.rs`.
+| TD-103 | Agent memory session scoping | 2026-05-31 | Keep `session_id` in props; fixed dotted-key scope-filter bug (flat key).
+| TD-100 | Agent memory read surface (mem0-aligned) | 2026-05-30 | `MemoryAqlSource`; pgwire WHERE→`unified_search_native`. (v0.2 P1)
+| TD-135 | gRPC SQL relational writes (DDL/DML) | 2026-06-22 | `ExecuteQuery` routes DDL/DML through tenant-scoped `Ddl/DmlService::execute_scoped`.
+| TD-134 | Metering KEU + per-repo RBAC | 2026-06 | KEU meter in `src/metrics/consumption_metrics.rs` (`05b920f0`,`3eb66452`). *(reconciled from Open 2026-06-24)*
+|===
+
+== Closed — Codebase-Audit Gaps (Mar 2026) & Perf/Execution Layer
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution
+
+| TD-021 | Distributed writes return fake ACKs | Mar 2026 | By-design: coordinator delegates to engine/service layer; WAL+engine write before replication.
+| TD-022 | Raft snapshot mechanism | Mar 2026 | `take_snapshot`/`restore_snapshot` + `maybe_compact_log` trigger.
+| TD-023 | Memory growth (long-running) | Mar 2026 | VecDeque caps, AutoML cap, doc-store eviction, Raft compaction, TTL batching, retention.
+| TD-028 | Doc status discrepancy across strategic docs | Mar 2026 | Roadmap/dashboard reconciled with TD resolutions. *(re-opened in spirit by 2026-06-24 reconciliation)*
+| TD-031 | Columnar engine lacks vectorized execution | Mar 2026 | Pull-based `pipeline.rs` (Scan/Filter/Score/TopK operators).
+| TD-032 | Cross-model LATERAL join JSON overhead | May 2026 | Native Arrow `FixedSizeList<Float32>` columns; `resolve_vector_from_outer_column`.
+| TD-033 | Parquet row-group statistics pruning | Mar 2026 | `condition_matches_row_group` numeric pruning (INT/FLOAT/DOUBLE).
+| TD-034 | No spill-to-disk for >memory queries | Mar 2026 | L1→L2 `NvmeBackend` spillover on `CapacityExceeded`.
+| TD-036 | Per-segment adaptive codec selection | Mar 2026 | Already adaptive (`analyze_and_choose_scheme_f32`); review claim was incorrect.
+| TD-037 | Distance compute multi-vector batching | Mar 2026 | NEON 4-way unroll + AVX2/NEON prefetch. (full matrix-transpose deferred — see TD-037-followup if reopened)
+| TD-038 | Cross-modal transaction isolation integration | Mar 2026 | All 4 participants `with_durable_writer`; `EngineBackedParticipant`.
+| TD-039 | Morsel-driven query parallelism | Mar 2026 | 3-phase: spawn I/O + `rayon::par_chunks(4)` scoring + merge.
+| TD-041 | Vectorized executor not wired into primary path | Mar 2026 | `search_vectors` uses batch SIMD + vectorized filter + lazy materialization.
+|===
+
+== Closed — Phase 5 Agentic Intelligence (Apr–May 2026)
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution
+
+| TD-043 | Semantic Disentanglement Pipeline + Entanglement Index | Apr 27 2026 | `src/analytics/entanglement.rs`, REST analytics, SDP in `storage/document/sdp.rs`.
+| TD-045 | Modular Graph RAG (RGL) | Apr 27 2026 | `src/graph/rag/`; REST `/graphs/{id}/rag`; `tests/graph_rag_integration_test.rs`.
+| TD-047 | Evolutionary Query Planning | Apr 27 2026 | `src/query/unified/evolutionary.rs` + `llm_mutate`; async optimization stack.
+| TD-048 | Agentic View Decomposition (AV-SQL) | Apr 27 2026 | `AvSqlEngine` + agent traits in `src/query/nl/`; REST `/nl/translate`.
+| TD-049 | Block-Batched Semantic Joins | Apr 27 2026 | `execute_block_batch_semantic_join` (`llm-joins` feature).
+| TD-050 | RUBICON-style Auditable Query Layer (AQL) | Apr 27 2026 | `src/query/aql/` AST + AuditTrail + multi-model sources; REST `/aql/*`.
+| TD-051 | Dual-Use Embedding Integration | Apr 27 2026 | `enable_dual_use_embeddings` collection flag + Python `DualUseStore`.
+| TD-055 | Memanto Typed Semantic Memory | May 9 2026 | `MemoryType` enum + LWW `resolve_conflict` + AQL `TypeMatch`.
+| TD-056 | Agentic Hybrid Reference Architecture | May 10 2026 | `PseudoQueryGenerator` in vector ingestion paths.
+|===
+
+== Closed — Convergence & Canonicalization Seams
+
+[cols="1,3,1,4", options="header"]
+|===
+| ID | Area | Closed | Resolution
+
+| TD-065 | Document service in-memory map as durable source | 2026-05-26 | `canonical-document-store` default-on (`Cargo.toml`); in-memory map → cache. ADR-020.
+| TD-068 | QUASAR cold-tier no canonical binding | — | Removed with PULSAR/QUASAR retirement.
+| TD-072 | `branch_id` `#[serde(skip)]` broke branch-merge | 2026-05-27 | Flipped to `#[serde(default)]` (`996626595`); 5 integration tests un-ignored.
+| TD-081 | Python SDK live v2 INSERT→SEARCH coverage | 2026-05-28 | `tests/integration/test_v2_insert_search_e2e.py`.
+| TD-082 | Arrow Flight INSERT vs REST/gRPC UPSERT parity | 2026-05-28 | Shared `coerce_records_to_canonical_precision` (`32cea5b85`).
+| TD-083 | Rust SDK v2 INSERT (props/text_fields) | 2026-05-28 | `TextFieldInput` + `text_field(s)` builders.
+| TD-084 | pgwire v2 record features exposure | 2026-05-28 | Doc `postgres.adoc` + `tests/pgwire_insert_props_e2e.rs` (props already typed via catalog).
+| TD-093 | RankServices startup wiring (SQL RERANK) | 2026-05-28 | Already wired (`build_rank_services` at startup); confirmed by audit.
+| TD-105 | Remove deprecated gRPC shims (seam S2) | 2026-06-03 | 3 dead files deleted; 4 live Port backends converged off dead tonic surfaces.
+| TD-107 | Consolidate CDC/cluster configs (seam S4) | 2026-06-05 | Cluster fully in `proximadb-config`; CDC residue is by-design connector specialization.
+| TD-108 | Delete residual catalog re-export shims (seam S6) | 2026-06-05 | No pure shim remains; `mod.rs` re-exports canonical `proximadb_catalog`.
+| TD-113 | Warehouse materialize tenant isolation | 2026-06-16 | `TenantContext` threaded into materializer; DrPathBuilder layout opt-in (`PROXIMADB_WAREHOUSE_DRPATH`). Residual: flip default w/ repath migration.
+|===
+
+== Closed — TD-R Series (Recently Resolved roll-up, Phase 1 & 2)
+
+These were tracked as the "Recently Resolved" set; all are code-complete. Many duplicate the canonical
+TD-### above (cross-referenced inline).
+
+[cols="1,3,3", options="header"]
+|===
+| ID | Area | Resolution
+
+| TD-R01 | Unified query wiring | `FederatedQueryContext` implemented.
+| TD-R02 | Document engine persistence | WAL-backed read/write path.
+| TD-R03 | Graph metadata persistence | ORION WAL persistence.
+| TD-R04 | Observability log indexing | Inverted-index full-text search.
+| TD-R05 | ORION update replay | WAL replay covers all ops.
+| TD-R06 | pgwire completeness (Phase 1) | Prepared statements, basic DDL/DML.
+| TD-R07 | Cross-model joins | LATERAL joins across models.
+| TD-R08 | Extra metadata filtering | JSON/binary filter in columnar strategy.
+| TD-R09 | SST dual block types | Legacy types deprecated.
+| TD-R10 | WAL wiring (REST/gRPC) | Document + observability wired.
+| TD-R11 | Metric aggregation | Aggregation engine wired.
+| TD-R12 | DataFusion integration | TableProvider/ScanExec/VectorRecordBridge.
+| TD-R13 | SIMD decoders | AVX2/NEON/scalar backends.
+| TD-R14 | Smart I/O layer | ParallelReader + IoMetrics.
+| TD-R15 | CentroidTree | O(log n) pruning.
+| TD-R16 | Framework integrations (=TD-011) | Python SDK adapters.
+| TD-R17 | Python SDK mypy (=TD-013) | py.typed + mypy CI.
+| TD-R18 | PULSAR/QUASAR retirement (=TD-017) | Retired, folded into relational/storage.
+| TD-R19 | ORION-only graph service (=TD-001) | Rejects retired engine names.
+| TD-R20 | Backup/restore (=TD-014) | `src/operations/{backup,restore}/`.
+| TD-R21 | Streaming (=TD-003) | `src/streaming/`.
+| TD-R22 | Cypher (=TD-019) | `src/graph/query/`.
+| TD-R23 | Framework integrations (=TD-011) | (dup of R16).
+| TD-R24 | Published benchmarks (=TD-015) | ANN-bench + compare app.
+| TD-R25 | Type-system unification Phase A | `ProximaType`/`ProximaValue` Arrow/pgwire bridges. *Subsumed by TD-111 (ADR-024); the "(TD-054)" tag in the original was an ID collision with Phase-6 TD-054 (L-RAG) and is dropped.*
+| TD-R26 | Unified record envelope Phase B | `ProximaRecord` envelope + conversions. *Subsumed by TD-111.*
+| TD-R27 | Engine-level RLS scaffold Phase E | `RlsRecordPredicate` + `rls_record_filter` hook (SST/VIPER). *Subsumed by TD-111 / TD-064.*
+|===
+
+[IMPORTANT]
+====
+*ID-collision note (resolved 2026-06-24):* the original register used *TD-054* for two unrelated items —
+(1) "Type system unification" (referenced by TD-R25/R26/R27) and (2) "Entropy-Based Lazy Loading (L-RAG)"
+in the Phase-6 research set. The type-system work is the now-`Resolved` umbrella *TD-111* (ADR-024); the
+live *TD-054* identifier belongs solely to *L-RAG* (Open) in the live register. The R25/R26/R27 "(TD-054)"
+tags above are retired.
+====

--- a/docs/_internal/roadmap/BEST_IN_CLASS_EXECUTION_TRACKER.adoc
+++ b/docs/_internal/roadmap/BEST_IN_CLASS_EXECUTION_TRACKER.adoc
@@ -3,6 +3,18 @@
 :toclevels: 2
 :last-updated: 2026-03-12
 :last-audit: 2026-05-26
+:last-reconciled: 2026-06-24
+
+[NOTE]
+====
+*2026-06-24 reconciliation.* The *Workstreams* and *Milestone Gates* status columns below were
+re-scored against `origin/develop` HEAD and the live
+link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register]; a 2026-06-24 block was appended
+to the *Session Log* (the March-2026 entries are retained as historical baseline, per the note below).
+Authority for live status: the Technical Debt Register (implementation) +
+link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] (support contract). The broader tracking
+reconciliation is recorded in link:./RECONCILIATION_2026_06_24.adoc[RECONCILIATION_2026_06_24].
+====
 
 [.lead]
 Operational execution tracker for closing foundation gaps and achieving best-in-class product quality (UX, robustness, and product-market fit).
@@ -66,50 +78,50 @@ Primary objective:
 | WS-0
 | Truth Layer (Docs/Code/Roadmap Alignment)
 | Capability claims are accurate and synchronized.
-| In Progress
-| Automated capability matrix generated in CI; strategic docs reference same source of truth.
+| In Progress → substantially complete (2026-06-24)
+| Automated capability matrix generated in CI; strategic docs reference same source of truth. *2026-06-24:* TD register split into live tracker + closed archive, dashboard/roadmap/matrix reconciled, capability matrix validator green in CI, all surfaces point to the live register. Residual: full DESIGN_DOC_STATUS_INDEX table re-merge + 143-row legacy dashboard re-audit.
 
 | WS-1
 | Surface Coherence (One Production Path per Feature)
 | No ambiguous API behavior for core features.
 | In Progress
-| Hybrid/vector/document/graph endpoints each have a single canonical production path.
+| Hybrid/vector/document/graph endpoints each have a single canonical production path. *2026-06-24:* legacy graph routes 308-deprecated (done); hybrid dead mock removed (TD-092); fusion seam converging all modalities onto one fuse-by-`oid` path (TD-136/137) and retiring the weak proto path (TD-143/146). Residual: finish the seam + remove the duplicate hybrid entry point.
 
 | WS-2
 | Reliability Layer (Panic + Failure Semantics)
 | Panic risk is systematically reduced.
-| In Progress
-| Clippy `unwrap_used` policy enforced for production modules; panic hotspots triaged with burn-down tracking.
+| Done (2026-06-24)
+| Clippy `unwrap_used` policy enforced for production modules; panic hotspots triaged with burn-down tracking. *Met:* 0 unwrap + 0 expect in production (TD-007 resolved), `clippy::unwrap_used/expect_used` warns + CI panic-policy guard; root crate clippy-clean (TD-079).
 
 | WS-3
 | Capability Exposure Layer (Engine Parity)
 | Implemented engines are consistently exposed across proto/server/embedded.
 | In Progress
-| TST/EventLog available in proto enums, API mappings, embedded API, and e2e tests.
+| TST/EventLog available in proto enums, API mappings, embedded API, and e2e tests. *2026-06-24:* TST/EventLog engines exposed (TD-009/010); gRPC v2 ProximaGraphService delivered (TD-122). Residual: Document/Entity v2 gRPC services (TD-122) + v1→v2 message migration (TD-123).
 
 | WS-4
 | Security Chain (Transport -> Identity -> AuthZ -> Audit)
 | Security story is complete end-to-end.
-| Not Started
-| Client cert identity mapping implemented; documented security matrix; regression tests for mTLS auth flow.
+| In Progress (2026-06-24)
+| Client cert identity mapping implemented; documented security matrix; regression tests for mTLS auth flow. *2026-06-24:* mTLS code-complete incl. CN-to-user mapping (TD-006, Beta), RBAC, encryption-at-rest (TD-016), RLS engine hooks (SST/VIPER/NOVA/HELIX), per-repo RBAC (TD-134). Residual: security admin/status APIs + stronger online revocation (CRL/OCSP).
 
 | WS-5
 | Distributed Readiness (Feature-flagged Productization)
 | Consensus is productized without destabilizing single-node.
-| Not Started
-| Raft runtime path wired behind explicit feature gates with deterministic failover tests.
+| In Progress — Experimental (2026-06-24)
+| Raft runtime path wired behind explicit feature gates with deterministic failover tests. *2026-06-24:* Raft internals, snapshots, shard planning, routing exist behind the `cluster` flag (TD-077, Experimental tier). Residual: real RPC transport + remote execution + deterministic failover suite.
 
 | WS-6
 | Developer Experience Layer
 | Fast, low-friction onboarding with predictable behavior.
 | Not Started
-| 5-minute quickstart validated in CI; canonical examples for core use cases.
+| 5-minute quickstart validated in CI; canonical examples for core use cases. *2026-06-24:* SDK breadth grew (Python/Rust/Go + JVM/Node embedded; TD-005/126 spec-driven codegen) but no CI-validated quickstart yet.
 
 | WS-7
 | PMF Layer (ICP-Focused Packaging)
 | Clear differentiation for target customer segments.
 | Not Started
-| Two reference architectures with measurable outcomes and adoption feedback loop.
+| Two reference architectures with measurable outcomes and adoption feedback loop. *2026-06-24:* ibkrtrading dogfood evidence still open (TD-030).
 |===
 
 == Milestone Gates
@@ -119,15 +131,15 @@ Primary objective:
 
 | M1 Foundation Coherence
 | 2026-Q2
-| WS-0 and WS-1 exit criteria complete; no contradictory capability claims.
+| WS-0 and WS-1 exit criteria complete; no contradictory capability claims. *2026-06-24: largely met* — WS-0 substantially complete (tracking surfaces reconciled, validator in CI), WS-1 advanced (fusion-seam convergence in progress).
 
 | M2 Production Robustness
 | 2026-Q3
-| WS-2, WS-3, WS-4 materially complete with test evidence.
+| WS-2, WS-3, WS-4 materially complete with test evidence. *2026-06-24: partially met* — WS-2 Done (panic-free + clippy-clean), WS-3 + WS-4 In Progress (v2 gRPC parity + security admin residual).
 
 | M3 Scale + Adoption
 | 2026-Q4
-| WS-5, WS-6, WS-7 complete with reference implementations and user validation.
+| WS-5, WS-6, WS-7 complete with reference implementations and user validation. *2026-06-24: early* — WS-5 Experimental (distributed transport residual, TD-077), WS-6/WS-7 not started.
 |===
 
 == Session Log
@@ -236,10 +248,20 @@ Primary objective:
 | Replaced the remote distributed executor’s simulated empty-result behavior with a registered handler contract, made remote failures propagate instead of being silently dropped, and added focused remote executor regressions. This makes remote execution wiring honest before true transport is introduced.
 | `src/query/distributed/{remote.rs,coordinator.rs,mod.rs}`, `docs/_internal/roadmap/implementation/active/FOUNDATIONAL_MULTIMODEL_EXECUTION_2026.adoc`
 | Finish targeted cargo verification, then choose between the relational scan backend gap and real node-to-node transport for the next foundational execution slice.
+
+| 2026-06-24
+| Tracking-surface reconciliation (WS-0) + workstream re-score
+| Reconciled every tech-debt / feature / vision tracking surface against `origin/develop` HEAD + the 2026-06-04/06-19 pivots: split the TD register into a live tracker + closed archive, overhauled MASTER_FEATURE_DASHBOARD, fully reconciled CAPABILITY_MATRIX.toml (validator green) + STRATEGIC_ROADMAP, rebuilt the DESIGN_DOC_STATUS_INDEX addendum, refreshed SYSTEM_MAP, and re-scored WS-0..WS-7 + M1/M2/M3 here. Status flips verified vs develop: TD-129/134/133/135 Resolved; TD-132 Partial.
+| `docs/10-quality/TECHNICAL_DEBT.adoc`, `docs/_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc`, `docs/_internal/roadmap/{MASTER_FEATURE_DASHBOARD,STRATEGIC_ROADMAP,CAPABILITY_MATRIX.toml,RECONCILIATION_2026_06_24}.adoc`, `docs/12-design/{SYSTEM_MAP_2026_05_30,DESIGN_DOC_STATUS_INDEX_2026_05_26}.adoc`, `scripts/validate_capability_matrix.py` (green)
+| Re-merge the DESIGN_DOC_STATUS_INDEX two tables; re-audit the 143-row frozen dashboard baseline against code; advance WS-1 fusion-seam convergence (TD-136/137).
 |===
 
 == Current Priority Queue
 
-1. Finish verification for the F1/F2/F3 code now in flight, especially the new function-backed `LATERAL` and remote-handler execution paths.
-2. Close the next foundational federated gap: add the missing relational scan backend for generic table-led joins.
-3. Replace the handler-based remote execution contract with real node-to-node query transport and keep capability claims aligned with verified runtime behavior.
+_Reconciled 2026-06-24._
+
+1. *WS-1:* land the cross-modal fusion seam (TD-136 Fuser core + TD-137 GraphExpander/REST v2 fusion-search), then retire the duplicate hybrid/proto paths (TD-143/146) so each modality has exactly one production path.
+2. *WS-3:* close gRPC v2 parity — Document/Entity v2 services (TD-122) — and advance the v1→v2 transport-agnostic-domain migration (TD-123) ahead of the 2026-06-30 v1 sunset (TD-121).
+3. *WS-4:* finish the security admin/status plane + stronger online revocation (CRL/OCSP) to graduate mTLS from Beta (TD-006).
+4. *WS-7:* publish the ibkrtrading dogfood validation evidence (TD-030).
+5. *Co-design:* wire cost-based multi-engine dispatch (TD-115) and the per-query I/O trace substrate so routing/caching optimize the measured dominant cost term.

--- a/docs/_internal/roadmap/CAPABILITY_MATRIX.toml
+++ b/docs/_internal/roadmap/CAPABILITY_MATRIX.toml
@@ -1,190 +1,349 @@
-as_of_date = "2026-06-22"
+as_of_date = "2026-06-24"
 source_of_truth = "code+tests"
-# 2026-05-28: per-row entries below have NOT been re-audited against current code
-# since 2026-03-02. The header date is bumped only to satisfy release-check freshness;
-# treat per-row `status` / `notes` / `evidence` as stale. The authoritative release
-# split lives in docs/SUPPORTED_SURFACE.adoc and
-# docs/_internal/status/MVP_RELEASE_READINESS_RECONCILIATION_2026_05_28.adoc.
-header_status = "stale-rows-not-reaudited"
+# 2026-06-24 reconciliation: per-row entries reconciled against origin/develop HEAD and the live
+# Technical Debt Register (docs/10-quality/TECHNICAL_DEBT.adoc). The prior "stale-rows-not-reaudited"
+# rows (audited 2026-03-02) were corrected — notably framework_integrations_python (all 7 adapters
+# ship, not "LlamaIndex/Haystack pending") and hybrid_search (the experimental mock endpoint was
+# removed per TD-092). Each row now cites its controlling TD-XXX. The authoritative *support* split
+# still lives in docs/SUPPORTED_SURFACE.adoc; the authoritative *implementation* tracker is the
+# Technical Debt Register. Statuses: complete | partial | planned | retired.
+header_status = "reconciled-2026-06-24"
+
+# ---------------------------------------------------------------------------
+# Retrieval, hybrid, fusion
+# ---------------------------------------------------------------------------
 
 [[capabilities]]
 id = "hybrid_search_bm25_vector"
 status = "partial"
-notes = "Canonical production endpoint exists; experimental mock endpoint remains for strategy testing."
+notes = "Real Tantivy BM25 + vector RRF/weighted fusion live on REST /api/v1/hybrid/* AND production gRPC (shared RestHybridPortImpl backend + in-process full-text index). TD-008 resolved; the dead experimental mock + bm25_wrapper stub were removed (TD-092). Residual (TD-092): BM25 index is populated only via the explicit index endpoint, not auto-populated on the canonical INSERT path; one alternate hybrid entry point still has BM25 hardcoded-disabled."
+controlling_td = ["TD-008", "TD-092"]
 evidence = [
-  "src/network/rest/v1/handlers.rs:1293",
-  "src/network/rest/v1/handlers.rs:1441",
-  "src/network/rest/v1/hybrid.rs:5",
-  "src/core/search/hybrid/mod.rs:1",
+  "src/core/search/hybrid/fusion.rs:1",
+  "src/network/hybrid_search.rs:40",
+  "src/network/rest/v1/hybrid.rs:1",
 ]
+
+[[capabilities]]
+id = "cross_modal_fusion_seam"
+status = "partial"
+notes = "One calibrated fuse-by-oid seam for all modalities (CROSS_MODAL_FUSION_SEAM_2026_06_22). Neutral Fuser core + PIT calibration (TD-136) and GraphExpander + REST v2 fusion-search (TD-137) In Progress; document/relational/edge expanders, cost-routed fusion, alias resolution (TD-138..143) and the EntityService typed-facade delegation (TD-146) open."
+controlling_td = ["TD-136", "TD-137", "TD-138", "TD-143", "TD-146"]
+evidence = [
+  "src/core/search/cross_modal_fusion.rs:1",
+  "docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc:1",
+  "docs/12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc:1",
+]
+
+[[capabilities]]
+id = "predicate_aware_vector_search"
+status = "partial"
+notes = "Post-filtered ANN correctness + fallback disclosure (TD-064, a correctness/security surface). Slices 1-5 landed (2026-05-27): FilterableHnswMetadata, search_with_predicate on all 4 AXIS indexes, snapshot v2, ADR-011 routing-mode wiring, predicate-shortfall diagnostics + Prometheus counters. Residual: thread shortfall through service types, IVF inline pushdown (Phase 3), selectivity/projection-freshness diagnostics."
+controlling_td = ["TD-064"]
+evidence = [
+  "src/index/axis/filterable_metadata.rs:1",
+  "docs/12-design/TD_064_PREDICATE_AWARE_VECTOR_SEARCH_DESIGN_2026_05_27.adoc:1",
+]
+
+# ---------------------------------------------------------------------------
+# Integrations, SDKs, connectors
+# ---------------------------------------------------------------------------
 
 [[capabilities]]
 id = "framework_integrations_python"
-status = "partial"
-notes = "LangChain, CrewAI, LangGraph adapters exist; LlamaIndex/Haystack still pending."
+status = "complete"
+notes = "All 7 Python SDK framework adapters ship (TD-011 resolved Mar 2026): LangChain, LangGraph, LlamaIndex, Haystack, CrewAI, DSPy, AutoGen. NOTE: not listed as a Supported v0.2 product surface — ships in the SDK only (see SUPPORTED_SURFACE)."
+controlling_td = ["TD-011"]
 evidence = [
   "clients/python/src/proximadb_sdk/integrations/langchain.py:1",
-  "clients/python/src/proximadb_sdk/integrations/crewai.py:1",
-  "clients/python/src/proximadb_sdk/integrations/langgraph.py:1",
+  "clients/python/src/proximadb_sdk/integrations/llama_index.py:1",
+  "clients/python/src/proximadb_sdk/integrations/haystack.py:1",
+  "clients/python/src/proximadb_sdk/integrations/dspy.py:1",
+  "clients/python/src/proximadb_sdk/integrations/autogen.py:1",
 ]
 
 [[capabilities]]
-id = "backup_pitr"
+id = "multi_language_sdks"
 status = "partial"
-notes = "Backup and PITR modules exist with integration tests; operator hardening still required."
+notes = "TD-005 rescoped 2026-06-24: clients/ ships Python, Rust, Go (+embedded), JVM/Java-embedded, Node.js-embedded. Standalone Java/Node.js SDKs and C++/.NET/Ruby/Swift remain planned. All REST surfaces must be spec-generated from the OpenAPI spec (TD-126; Go codegen Phase 2 open)."
+controlling_td = ["TD-005", "TD-126"]
 evidence = [
-  "src/operations/backup/mod.rs:22",
-  "src/storage/persistence/write_ahead_log/pitr.rs:1",
-  "tests/backup_restore_test.rs:41",
+  "clients/go/go.mod:1",
+  "clients/jvm/spark-connector/run-smoke.sh:1",
+  "clients/nodejs-embedded/index.d.ts:1",
+  "clients/python/src/proximadb_sdk/protocols/_rest_codegen.py:1",
 ]
 
 [[capabilities]]
-id = "timeseries_event_sourcing_surface"
+id = "external_engine_connectors"
 status = "partial"
-notes = "Engines exist, but public proto/embedded mappings are incomplete."
+notes = "Trino Arrow-Flight wire layer complete (TD-098, all 7 flight_* methods); Spark JNI embedded impls + Rust-side filter pushdown + lifecycle (TD-097); Hadoop records-scan endpoint + cursor + WAL scan push-down (TD-099). Residual: JVM DataSource V2 layer, Gradle/JUnit5 harness, live-server smokes."
+controlling_td = ["TD-097", "TD-098", "TD-099"]
 evidence = [
-  "src/storage/engines/tst/mod.rs:567",
-  "src/storage/engines/eventlog/mod.rs:161",
-  "crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs:2556",
-  "src/embedded/mod.rs:1095",
+  "src/connectors/trino.rs:1",
+  "src/connectors/spark.rs:1",
+  "tests/connectors_flight_contract.rs:1",
 ]
 
-[[capabilities]]
-id = "distributed_consensus_runtime"
-status = "partial"
-notes = "Raft module exists but core runtime path remains disabled."
-evidence = [
-  "src/cluster/consensus.rs:17",
-  "src/lib.rs:330",
-  "src/lib.rs:110",
-]
+# ---------------------------------------------------------------------------
+# Relational / pgwire / HTAP / gRPC SQL
+# ---------------------------------------------------------------------------
 
 [[capabilities]]
-id = "mtls_identity_chain"
-status = "partial"
-notes = "Transport-level mTLS exists; client-certificate auth mapping is placeholder."
-evidence = [
-  "src/network/rest/server.rs:636",
-  "src/network/multi_server.rs:1573",
-  "src/network/middleware/tls.rs:26",
-]
-
-[[capabilities]]
-id = "graph_legacy_route_deprecation"
+id = "pgwire_onconflict_upsert"
 status = "complete"
-notes = "Legacy graph compatibility routes now issue 308 redirects with deprecation/sunset metadata; docs include explicit migration mappings to canonical multi-graph paths."
+notes = "pgwire INSERT ... ON CONFLICT DO UPDATE / DO NOTHING (TD-129 resolved 2026-06, 258943f3). DmlStatement::Upsert + execute_upsert."
+controlling_td = ["TD-129"]
 evidence = [
-  "src/network/rest/v1/graph.rs:1610",
-  "src/network/rest/v1/handlers.rs:1958",
-  "docs/03-api-reference/graph.adoc:32",
-  "docs/06-internals/GRAPH_ENGINES_GUIDE.adoc:78",
+  "src/services/dml/mod.rs:364",
 ]
 
 [[capabilities]]
-id = "distributed_graph_engine_messaging"
-status = "partial"
-notes = "ORION is the only graph runtime; PULSAR/QUASAR are retired engine names, rejected with a compatibility error and never marketed as product engines."
+id = "grpc_sql_relational_writes"
+status = "complete"
+notes = "gRPC ExecuteQuery routes DDL (CREATE/ALTER/DROP) + DML (INSERT/UPDATE/DELETE) through tenant-scoped Ddl/DmlService::execute_scoped with the x-tenant-id tenant (TD-135 resolved 2026-06-22). Transactions (BEGIN/COMMIT) remain pgwire-only by design."
+controlling_td = ["TD-135"]
 evidence = [
-  "docs/06-internals/GRAPH_ENGINES_GUIDE.adoc:16",
-  "docs/06-internals/GRAPH_ENGINES_GUIDE.adoc:95",
-  "docs/06-internals/GRAPH_ENGINES_GUIDE.adoc:105",
-  "docs/_internal/roadmap/STRATEGIC_ROADMAP.adoc:152",
+  "src/services/dml/mod.rs:1",
+  "tests/grpc_td135_relational_write_tenant_isolation_e2e.rs:1",
 ]
 
-# Lakehouse-native pgwire architecture (TD-114..TD-120), spawned by
-# docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md.
-# Statuses advance to `partial` as foundation slices land (2026-06-17).
-
 [[capabilities]]
-id = "lakehouse_storage_spine_compaction"
+id = "htap_oltp_constraints"
 status = "partial"
-notes = "L0->base compaction (TD-114). Tested PAX merge-on-read core (compact_pax_segments, drops tombstones) + flag-gated trigger (default off) shipped 2026-06-17; live auto-invoke from flush still open."
+notes = "OLTP/OLAP HTAP storage + PostgreSQL constraint semantics (TD-110). ON DELETE referential actions (RESTRICT/CASCADE/SET NULL) for single-column FK on the parent PK enforced on the tenant-scoped DML path (re-landed 2026-06-24). Open: ON UPDATE actions, composite-FK, recursive cascade; xCatalog constraint/index metadata + MVCC + snapshot+delta reads."
+controlling_td = ["TD-110"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
-  "crates/storage/proximadb-storage-common/src/pax_block.rs:1",
-  "src/storage/engines/sst/flush/mod.rs:1",
+  "src/services/dml/mod.rs:1",
+  "roadmap/techdebt/TD_110_OLTP_OLAP_HTAP_STORAGE_AND_CONSTRAINTS_PLAN_2026_06_04.adoc:1",
 ]
 
 [[capabilities]]
 id = "cost_based_engine_dispatch"
 status = "planned"
-notes = "Cost-based multi-engine routing (TD-115). ComputeScheduler::route_select always returns Native today; cost model + QueryShape stats not wired."
+notes = "Cost-based multi-engine routing (TD-115). ComputeScheduler::route_select always returns Native(Volcano) today; cost model + QueryShape cardinality/selectivity stats not wired, parquet_backed never set. Flip scaffolding exists."
+controlling_td = ["TD-115"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
-  "src/query/compute_scheduler.rs:1",
+  "src/query/compute_scheduler.rs:202",
+  "src/query/query_optimizer.rs:49",
+]
+
+# ---------------------------------------------------------------------------
+# Graph
+# ---------------------------------------------------------------------------
+
+[[capabilities]]
+id = "graph_legacy_route_deprecation"
+status = "complete"
+notes = "Legacy graph compatibility routes issue 308 redirects with deprecation/sunset metadata; docs include explicit migration mappings to canonical multi-graph paths."
+evidence = [
+  "src/network/rest/v1/graph.rs:1610",
+  "src/network/rest/v1/handlers.rs:1958",
+  "docs/03-api-reference/graph.adoc:32",
 ]
 
 [[capabilities]]
-id = "wal_tiering_time_travel"
-status = "planned"
-notes = "WAL offload to object storage + read-as-of-LSN time travel (TD-116). WAL is local-only; SnapshotPin captures LSN ranges but no time-travel read path exists."
+id = "distributed_graph_engine_messaging"
+status = "partial"
+notes = "ORION is the only graph runtime. PULSAR/QUASAR were retired (TD-001/017): modules/flags/routes/tests removed; GraphEngineFactory rejects the names with a compatibility error. Distributed-graph behavior belongs to the relational substrate; tiered-graph to storage projection policy."
+controlling_td = ["TD-001", "TD-017"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
-  "src/services/snapshot/coordinator.rs:1",
+  "src/graph/service_engine_factory.rs:1",
+  "docs/06-internals/GRAPH_ENGINES_GUIDE.adoc:16",
+]
+
+[[capabilities]]
+id = "grpc_v2_parity_services"
+status = "partial"
+notes = "proximadb.v2.ProximaGraphService delivered 2026-06-21 (node/edge CRUD, query, traversal, shortest-path), registered + SDK-consumed (TD-122). DocumentServiceV2 + EntityServiceV2 still REST-v2-only. Blocks the gRPC v1 hard-delete (TD-121, post-2026-06-30); v1->v2 message migration keystone done for graph (TD-123)."
+controlling_td = ["TD-122", "TD-123", "TD-121", "TD-124"]
+evidence = [
+  "proto/proximadb/v2/graph.proto:1",
+  "src/network/grpc/v2/graph_service.rs:1",
+]
+
+# ---------------------------------------------------------------------------
+# Agent memory & branching
+# ---------------------------------------------------------------------------
+
+[[capabilities]]
+id = "agent_memory_layer"
+status = "partial"
+notes = "ADR-022 agent-memory layer. Read surface (TD-100, MemoryAqlSource + pgwire WHERE pushdown) and session scoping (TD-103) landed v0.2; write/extraction+consolidation (TD-101) In Progress; mem0/agentmemory adapters Slice A landed, Slice B open (TD-102)."
+controlling_td = ["TD-100", "TD-101", "TD-102", "TD-103"]
+evidence = [
+  "src/query/aql/sources/memory.rs:1",
+  "src/services/agent_memory.rs:1",
+]
+
+[[capabilities]]
+id = "cross_modal_atomic_write"
+status = "complete"
+notes = "Atomic multi-modal write (node + embedding + edges) via CrossModelTransactionCoordinator (TD-133 resolved 2026-06-24, 55450f9d / PR #265). Closes code-graph gap G7; builds on the cross-model 2PC of TD-020."
+controlling_td = ["TD-133", "TD-020"]
+evidence = [
+  "src/services/transaction/cross_model_coordinator.rs:1",
+  "tests/cross_model_transaction_e2e.rs:1",
 ]
 
 [[capabilities]]
 id = "agent_branching_branchref"
 status = "partial"
-notes = "Object-store-metadata copy-on-write branching for agents (TD-117). BranchRef type + branches_subprefix + ManifestCommitter::commit_fenced generation writer-fence shipped + tested 2026-06-17; ancestor read fall-through, live CAS fencing, and branch GC still open."
+notes = "Object-store-metadata copy-on-write branching for agents (TD-117). BranchRef + branches_subprefix + ManifestCommitter::commit_fenced generation writer-fence shipped + tested 2026-06-17; ancestor read fall-through, live CAS fencing, branch GC still open. Depends on TD-116 (LSN history) + TD-119 (manifest refs)."
+controlling_td = ["TD-117"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
   "src/services/snapshot/branch_ref.rs:1",
   "crates/storage/proximadb-iceberg-engine/src/manifest.rs:1",
+]
+
+# ---------------------------------------------------------------------------
+# Lakehouse-native storage spine (TD-114..TD-120), object economy
+# ---------------------------------------------------------------------------
+
+[[capabilities]]
+id = "lakehouse_storage_spine_compaction"
+status = "partial"
+notes = "L0->base compaction (TD-114). Tested PAX merge-on-read core (compact_pax_segments, drops tombstones) + flag-gated trigger (PROXIMADB_L0_COMPACTION_ENABLED, default OFF) shipped 2026-06-17; live auto-invoke from flush, orchestrator integration, and deletion-vector read-path overlay still open."
+controlling_td = ["TD-114"]
+evidence = [
+  "src/storage/engines/sst/flush/mod.rs:1",
+  "crates/storage/proximadb-storage-common/src/pax_block.rs:1",
+]
+
+[[capabilities]]
+id = "wal_tiering_time_travel"
+status = "planned"
+notes = "WAL offload to object storage + read-as-of-LSN time travel (TD-116). WAL is local-only (WalEntryStatus::Archived never set); SnapshotPin captures LSN ranges but no SELECT ... AS OF read path. Unblocks TD-117."
+controlling_td = ["TD-116"]
+evidence = [
+  "src/services/snapshot/coordinator.rs:1",
+  "src/storage/persistence/write_ahead_log/manifest/types.rs:53",
 ]
 
 [[capabilities]]
 id = "unified_paging_tier_policy"
 status = "planned"
-notes = "Unify cache eviction and tier demotion under one policy; split cache out of the FileSystem mechanism (TD-118)."
+notes = "Unify cache eviction and tier demotion under one policy; split cache out of the FileSystem mechanism (TD-118). Adds a BufferAccessStrategy-style scan ring so a cold S3 scan can't evict the OLTP working set."
+controlling_td = ["TD-118"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
   "src/storage/persistence/filesystem/caching_filesystem.rs:1",
+  "src/infrastructure/tier_policy_engine.rs:1",
 ]
 
 [[capabilities]]
 id = "real_iceberg_snapshots"
 status = "partial"
-notes = "TD-119 Phase 1 (2026-06-18): real persisted metadata.json + manifest-log-driven snapshot history (parent chain, v2 sequence numbers, refs.main) + resolvable metadata-location, via MetadataCommitter + ensure_table_metadata. Avro manifest-list/manifest files for Spark/Trino data scans remain (Phase 2)."
+notes = "TD-119 Phase 1 (2026-06-18): persisted versioned metadata.json + manifest-log-driven snapshot history (parent chain, v2 sequence numbers, refs.main) + resolvable metadata-location via MetadataCommitter. Residual (Phase 2): Avro manifest-list/manifest files with per-file DataFile stats so Spark/Trino can scan data files; tenant-scope the Iceberg REST endpoints."
+controlling_td = ["TD-119"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
   "crates/storage/proximadb-iceberg-engine/src/metadata.rs:1",
-  "src/catalog/iceberg_rest_service.rs:1",
   "src/catalog/iceberg_rest_service.rs:1",
 ]
 
 [[capabilities]]
 id = "pg_catalog_completeness"
 status = "partial"
-notes = "Catalog-backed pg_catalog views for ORM/driver compatibility (TD-120). Canonical pg_type/pg_namespace/pg_class/pg_attribute/pg_constraint views shipped + tested 2026-06-17; pg_index canonical view + full live ORM round-trip still open."
+notes = "Catalog-backed pg_catalog views for ORM/driver compatibility (TD-120). Canonical pg_type/pg_namespace/pg_class/pg_attribute/pg_constraint views shipped + tested 2026-06-17; pg_index canonical view + full live ORM round-trip (SQLAlchemy/JDBC) still open."
+controlling_td = ["TD-120"]
 evidence = [
-  "docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md:1",
   "src/services/catalog_introspection.rs:1",
   "src/network/postgres/translator.rs:1",
 ]
 
-# 2026-06-22: freshly-audited rows (KOU co-design, PRs #101/#110/#113) — not subject
-# to the header_status "stale-rows-not-reaudited" caveat above.
+[[capabilities]]
+id = "ann_recall_over_flushed_segments"
+status = "partial"
+notes = "ANN recall over flushed/compacted segments (TD-112). Index-on-flush wired on the live SST path; recall-band e2e green (~0.95 top-k); local post-loss lazy rebuild-from-SST. Residual: real object-store SST read-back coverage; boot-time AXIS prewarm not claimed; HELIX/NOVA flush-index paths."
+controlling_td = ["TD-112"]
+evidence = [
+  "src/storage/engines/sst/flush/mod.rs:1",
+  "tests/td112_postflush_recall_e2e.rs:1",
+]
+
+# ---------------------------------------------------------------------------
+# Storage/durability, security, time-series, distributed
+# ---------------------------------------------------------------------------
+
+[[capabilities]]
+id = "backup_pitr"
+status = "partial"
+notes = "Backup/restore infrastructure complete (TD-014 resolved Mar 2026): incremental snapshots, multi-cloud targets, WAL checkpointing, RPO<1m/RTO<10m. PITR module present. Residual: operator hardening + at-scale validation. (Note: read-as-of-LSN time travel is the separate TD-116, still planned.)"
+controlling_td = ["TD-014", "TD-116"]
+evidence = [
+  "src/operations/backup/mod.rs:22",
+  "src/operations/restore/mod.rs:1",
+  "tests/backup_restore_test.rs:41",
+]
+
+[[capabilities]]
+id = "encryption_at_rest"
+status = "complete"
+notes = "Transparent AES-256-GCM file + WAL encryption with HKDF per-file keys + key rotation across all storage engines (TD-016 resolved Mar 2026)."
+controlling_td = ["TD-016"]
+evidence = [
+  "src/storage/persistence/filesystem/local.rs:1",
+  "src/storage/encryption/key_manager.rs:1",
+]
+
+[[capabilities]]
+id = "mtls_identity_chain"
+status = "partial"
+notes = "mTLS infrastructure code-complete (TD-006 resolved Mar 2026, support tier Beta): rustls server config + client-cert extraction (TlsAcceptor), CN validation + CN-to-user mapping middleware, ClientCertificate auth method. Residual: security admin/status APIs and stronger online revocation (CRL/OCSP framework only)."
+controlling_td = ["TD-006"]
+evidence = [
+  "src/network/tls/acceptor.rs:1",
+  "src/network/middleware/tls.rs:26",
+  "src/network/rest/server.rs:636",
+]
+
+[[capabilities]]
+id = "timeseries_event_sourcing_surface"
+status = "partial"
+notes = "TST + EventLog engines code-complete (TD-009/TD-010 resolved, support tier Beta): time-partitioned storage, ASOF joins, OHLC/Gorilla, append-only event log, temporal replay, MiFID II mode. Residual: product packaging, public proto/embedded API parity, at-scale validation."
+controlling_td = ["TD-009", "TD-010"]
+evidence = [
+  "src/storage/engines/tst/mod.rs:1",
+  "src/storage/engines/eventlog/mod.rs:1",
+]
+
+[[capabilities]]
+id = "distributed_consensus_runtime"
+status = "partial"
+notes = "Raft internals, shard planning, snapshot/restore, routing foundations exist (~5,491 LOC, src/cluster/, behind the `cluster` flag). RPC transport + remote execution + failover are placeholder/partial (TD-077, support tier Experimental). PULSAR/QUASAR engines retired."
+controlling_td = ["TD-077"]
+evidence = [
+  "src/cluster/consensus.rs:17",
+  "src/cluster/mod.rs:1",
+]
+
+# ---------------------------------------------------------------------------
+# Consumption metering / co-design TAM surfaces (audited 2026-06-22/24)
+# ---------------------------------------------------------------------------
+
 [[capabilities]]
 id = "kou_egress_metering"
 status = "partial"
-notes = "KOU (Outgress Unit, Dimension 2) network-egress metering. Neutral multi-cloud KouLocality 6-bucket model; convergent meter proximadb_kou_bytes_total{tenant,kou_locality,direction}; read-egress derived from region + result-egress instrumented at pgwire/REST/Arrow Flight; cost term per_mib_egress live. Remaining: pgwire wire-compression, egress-aware lossy caps, Flight do_exchange."
+notes = "KOU (Outgress Unit, Dimension 2) network-egress metering. Neutral multi-cloud KouLocality 6-bucket model; convergent meter proximadb_kou_bytes_total{tenant,kou_locality,direction}; read-egress + result-egress instrumented at pgwire/REST/Arrow Flight; cost term per_mib_egress live. Remaining: pgwire wire-compression, egress-aware lossy caps, Flight do_exchange."
 evidence = [
   "src/metrics/consumption_metrics.rs:132",
   "src/metrics/consumption_metrics.rs:574",
-  "src/query/route_cost_model.rs:174",
-  "src/network/arrow_ipc/service.rs:62",
-  "src/network/postgres/protocol.rs:4888",
   "docs/12-design/OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc:1",
+]
+
+[[capabilities]]
+id = "keu_embedding_metering_rbac"
+status = "complete"
+notes = "KEU (Kilo-Embedding-Unit, Dimension 5) per-tenant embedding meter + per-repo RBAC entitlement (TD-134 resolved 2026-06, 05b920f0). record_embedding_units; KEU is a TAM surface metered per-tenant, priced downstream in AnvaiOps."
+controlling_td = ["TD-134"]
+evidence = [
+  "src/metrics/consumption_metrics.rs:604",
 ]
 
 [[capabilities]]
 id = "edge_policy_consolidation"
 status = "partial"
-notes = "Edge collapse (HLD E0→E1). E0 shipped (pgwire through shared policy stages); EdgePolicyContext (client-IP → KouLocality) + ResultShapePolicy (locality-driven lossless ZSTD/gzip shaping) live, consumed across pgwire/REST/Flight. Remaining: full EdgeRequest + EdgePolicyPlane envelope (one plane over all four surfaces)."
+notes = "Edge collapse (HLD E0->E1). E0 shipped (pgwire through shared policy stages); EdgePolicyContext (client-IP -> KouLocality) + ResultShapePolicy (locality-driven lossless ZSTD/gzip shaping) live across pgwire/REST/Flight. Remaining: full EdgeRequest + EdgePolicyPlane envelope (one plane over all four surfaces)."
 evidence = [
   "src/metrics/consumption_metrics.rs:464",
-  "src/metrics/consumption_metrics.rs:517",
-  "src/network/middleware/metrics.rs:46",
   "docs/12-design/IN_PROCESS_EDGE_COLLAPSE_HLD_2026_06_19.adoc:1",
 ]

--- a/docs/_internal/roadmap/MASTER_FEATURE_DASHBOARD.adoc
+++ b/docs/_internal/roadmap/MASTER_FEATURE_DASHBOARD.adoc
@@ -3,12 +3,22 @@
 :toclevels: 3
 :icons: font
 :source-highlighter: rouge
-:last-updated: 2026-05-28
-:dashboard-header-refresh: 2026-05-28
+:last-updated: 2026-06-24
+:dashboard-header-refresh: 2026-06-24
 :verified: true
 
 [.lead]
 **Central inventory of feature claims under re-baseline. This file tracks implementation breadth, not the customer support contract by itself.**
+
+[WARNING]
+====
+*Stale rows — 2026-06-24 reconciliation.* The detailed 143-feature index in this file has NOT been
+re-audited row-by-row since March 2026 (acknowledged in-doc below). For *current implementation
+status* use the link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] (live, reconciled
+2026-06-24); for the *support contract* use link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc].
+Reconciled drift (Phase 2.5 complete; capability-matrix stale rows; SaaS/co-design pivot integration)
+is recorded in link:./RECONCILIATION_2026_06_24.adoc[RECONCILIATION_2026_06_24].
+====
 
 [TIP]
 ====
@@ -43,17 +53,26 @@ The detailed feature-index tables further down (`<<priority-index>>` etc.) date 
 
 == Vision Phase Alignment
 
-Features are aligned with the three phases from link:../../concepts/vision.adoc[Vision Document]:
+Aligned with the Vision phases and the two 2026 pivots — the *2026-06-04 data-warehouse course
+correction* (Intelligent Multi-Engine Routing over object storage) and the *2026-06-19 co-design
+dimensional architecture* (five physical dimensions co-optimized against the measured I/O trace). See
+`docs/12-design/DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` and
+`CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.
 
+[cols="1,3,1,3", options="header"]
 |===
-| Phase | Focus | Status
+| Phase | Focus | Status | Live items (Technical Debt Register)
 
-| **Phase 1** | Format & Catalog Contract (Foundation) | ✅ Complete
-| **Phase 2** | Cross-Model Query & Indexing (Differentiation) | ✅ Complete
-| **Phase 2.5** | Foundational Performance Alignment (Execution Layer) | ✅ Complete
-| **Phase 3** | Deployment & Ecosystem Integration (Scale) | ✅ Complete (Market Entry)
-| **Phase 4** | Context Database Evolution (Time-Series, Event Sourcing, Hybrid Search) | ✅ Complete
-| **Phase 5** | Cloud Infrastructure & Production Readiness | ✅ Complete
+| **Phase 1** | Format & Catalog Contract (Foundation) | ✅ Complete | —
+| **Phase 2** | Cross-Model Query & Indexing | 🔄 In Progress | Engines done; convergence/fusion open (TD-104/106/136-143)
+| **Phase 2.5** | Foundational Performance Alignment | ✅ Complete | TD-031/032/033/034/036/038/039/041 resolved (TD-035/040 open)
+| **Phase 3** | Deployment & Ecosystem + SaaS Operational Readiness | 🔄 In Progress | SDKs/connectors (TD-005/097/099/126); SaaS isolation/metering (TD-113/134)
+| **Phase 4** | Context DB Evolution (Time-series, Event Sourcing, Hybrid) | ✅ Engines / Beta packaging | TD-009/010/008 resolved; packaging Beta
+| **Phase 5** | Agentic Intelligence & Research Frontier | ✅ Research landed | TD-043..051 resolved; agent memory TD-100..103, TD-117 partial
+| **Phase 6** | Active Memory & Collective Reasoning | 🔄 In Progress | TD-053/054 open; TD-055/056 resolved
+| **Phase 7** | Competitive Platform & Storage Authority | 🔄 In Progress | TD-060..064, TD-110-124, TD-135 (lakehouse-native pgwire)
+| **Phase 8** | Continuous Loop & Elastic Compute | 📅 Planned | TD-086/087/088/089/090/091/094
+| **Cloud Infra** | Terraform / K8s / CI-CD / monitoring | ✅ Complete | —
 |===
 
 == 🎯 Current Maturity Summary
@@ -141,6 +160,31 @@ Features are aligned with the three phases from link:../../concepts/vision.adoc[
 | **Production Ready**
 | Pricing strategy (4 tiers), conference presence, DevRel team chartered, documentation complete.
 | Marketing/operations surface — not a code claim.
+
+| Lakehouse-native pgwire (Phase 7)
+| **Experimental**
+| Storage-authority catalog + EXPLAIN (TD-060), L0→base compaction core (TD-114), Iceberg snapshots Phase 1 (TD-119), pg_catalog views (TD-120), HTAP constraints incl. ON DELETE FK actions (TD-110), gRPC SQL writes (TD-135).
+| Mostly Partial foundations; cost-based engine dispatch (TD-115) still routes Native-only. Not a support surface.
+
+| Cross-modal fusion seam (Phase 2)
+| **Experimental (In Progress)**
+| Calibrated fuse-by-`oid` core + GraphExpander (TD-136/137 In Progress); document/relational expanders + cost-routed fusion open (TD-138-143).
+| `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`. Supersedes the legacy hardcoded hybrid path.
+
+| Agent memory layer
+| **Beta (Partial)**
+| Read surface (TD-100, AQL `MemoryAqlSource`) + session scoping (TD-103) landed; write/extraction (TD-101 In Progress), mem0 adapters Slice A (TD-102), agent branching foundation (TD-117).
+| ADR-022 / `AGENT_MEMORY_LAYER_HLD_2026_05_30.adoc`.
+
+| External engine connectors
+| **Partial**
+| Trino Arrow-Flight wire (TD-098 resolved); Spark JNI embedded impls + filter pushdown (TD-097); Hadoop records-scan + WAL push-down (TD-099). Residual: JVM DataSource V2, Gradle harness.
+| Connector-conformance contract gates green; live-server smokes pending.
+
+| Consumption metering / co-design (TAM surfaces)
+| **Partial**
+| KOU egress meter + KEU embedding meter (TD-134) live in `consumption_metrics.rs`; edge-collapse E0 shipped. Per-query I/O trace substrate is the co-design prerequisite.
+| `OUTGRESS_KOU_MULTICLOUD_COST_MODEL_2026_06_21.adoc`, `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`. Metered per-tenant, priced downstream in AnvaiOps.
 |===
 
 [NOTE]
@@ -161,7 +205,18 @@ Features are aligned with the three phases from link:../../concepts/vision.adoc[
 |===
 
 [[priority-index]]
-== 🎯 Complete Feature Index by Priority
+== 🎯 Feature Index 001–143 (frozen March-2026 baseline)
+
+[IMPORTANT]
+====
+*This 143-row index is the March-2026 implementation inventory.* It is NOT row-by-row re-audited and
+NOT the support contract. A few rows were corrected in the 2026-06-24 reconciliation (037/038 PULSAR/
+QUASAR retired; 102 ADR count). For *current* status of any item use the live
+link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register]; for the *support contract* use
+link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc]. The
+<<current-era-index,Current-Era Capability Index>> below covers everything built *after* this baseline
+(Phase 7/8 lakehouse-pgwire, fusion seam, agent memory, connectors, co-design metering).
+====
 
 [cols="1,3,2,1,2", options="header"]
 |===
@@ -207,8 +262,8 @@ Features are aligned with the three phases from link:../../concepts/vision.adoc[
 | 035 | Bloom Filters | Performance | ✅ | Found in SSTable
 
 | 036 | ORION Graph Engine | Graph | ✅ | In-memory CSR; `src/graph/engines/orion/`
-| 037 | PULSAR Graph Engine | Graph | ⚠️ Experimental | Distributed graph foundation; not the canonical production graph path.
-| 038 | QUASAR Graph Engine | Graph | ⚠️ Experimental | Hybrid/tiered graph foundation; TD-068 tracks rewire-vs-retire decision.
+| 037 | PULSAR Graph Engine | Graph | ❌ Retired | *Retired (TD-001/017)* — modules/flags/routes/tests removed; `GraphEngineFactory` rejects the name. Distributed graph belongs to the relational substrate. ORION is the only graph runtime.
+| 038 | QUASAR Graph Engine | Graph | ❌ Retired | *Retired (TD-001/017/068)* — removed; tiered-graph behavior is now an xCatalog/storage projection-policy concern, not a graph engine.
 | 039 | GraphMemoryPool | Graph | ✅ | Zero-copy sharing
 
 | 040 | UnifiedAuthService | Security | ⚠️ Partial | SSO/JWT/API key plus mTLS identity and CRL support; admin/status plane still incomplete.
@@ -283,7 +338,7 @@ Features are aligned with the three phases from link:../../concepts/vision.adoc[
 | 100 | Performance Testing Guide | Docs | ✅ | Benchmarks, load testing, profiling
 
 | 101 | SDK Implementation Guide | Docs | ✅ | SDK development patterns
-| 102 | Architecture Decision Records | Docs | ✅ | 8 ADRs documented
+| 102 | Architecture Decision Records | Docs | ✅ | 24 ADRs (ADR-001..024); see `docs/12-design/adr/`
 | 103 | RFC Process Documentation | Docs | ✅ | RFC lifecycle and template
 | 104 | Contribution Guidelines | Docs | ✅ | Contributing workflow
 | 105 | Code Examples Repository | Docs | ✅ | 13 code examples
@@ -334,6 +389,61 @@ Features are aligned with the three phases from link:../../concepts/vision.adoc[
 | 143 | CrewAI Integration | Framework Integration | ✅ | `clients/python/src/proximadb_sdk/integrations/crewai.py`
 |===
 
+[[current-era-index]]
+== 🚀 Current-Era Capability Index (post-March-2026; status from the live register)
+
+Everything built after the 001–143 baseline. Status mirrors the
+link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] (reconciled 2026-06-24);
+*Dim* = co-design dimension (D1 object-store · D2 egress · D3 disk/cache · D4 compute · D5 governance).
+
+[cols="1,3,2,1,1", options="header"]
+|===
+| TD | Capability | Workstream | Status | Dim
+
+| TD-110 | OLTP/OLAP HTAP storage + PG constraints (ON DELETE FK live) | Relational/pgwire | Open | D3
+| TD-127/128 | OLTP secondary indexes + IN-list/range pushdown | Relational/pgwire | Open | D4
+| TD-076 | pgwire SQL parity Phase 2/3 (ADR-018) | Relational/pgwire | Open | D4
+| TD-115 | Cost-based multi-engine dispatch (flip Native-only router) | Relational/pgwire | Open | D4
+| TD-120 | pg_catalog completeness for ORM/driver compat | Relational/pgwire | Partial | D5
+| TD-135 | gRPC SQL relational writes (DDL/DML) | Relational/pgwire | Resolved | D4
+| TD-136/137 | Fusion neutral `Fuser` core + GraphExpander + REST v2 fusion-search | Fusion seam | In Progress | D4
+| TD-138-143 | Document/Relational/edge expanders, cost-routed fusion, alias resolution | Fusion seam | Open | D4
+| TD-146 | EntityService.SearchEntities delegates to the seam (no standalone retrieval) | Fusion seam | Open | D4
+| TD-062 | Hybrid retrieval + reranking planner surface | Fusion seam | Open | D4
+| TD-092 | Hybrid BM25 auto-indexing on canonical INSERT path | Fusion seam | Open | D4
+| TD-060 | Storage Layout Authority + external-format semantics | Storage spine | Partial | D1/D5
+| TD-114 | Background L0→base compactor + deletion vectors | Storage spine | Partial | D1/D3
+| TD-119 | Real Iceberg snapshots (metadata.json + manifest log) | Storage spine | Partial | D1
+| TD-116 | WAL tiering + read-as-of-LSN time travel | Storage spine | Open | D1
+| TD-118 | Unify paging/cache policy with tier policy | Storage spine | Open | D3
+| TD-088/087 | Point-read layout + scale-to-zero cold path | Storage spine | Open | D1
+| TD-078/090/091 | External-table execution / index-in-place / Lance interop | Storage spine | Open | D1
+| TD-096 | Vector-locality routing SST vs HELIX | Storage spine | Open | D4/D1
+| TD-112 | ANN recall over flushed/compacted segments | Storage spine | Partial | D1/D4
+| TD-147 | IVF posting-list id compaction (`Vec<String>`→`Vec<u64>`) | Storage spine | Open | D3/D1
+| TD-132 | Tier-B CPG-fragment PAX + I/O trace | Storage spine | Partial | D1
+| TD-086/089/094 | Continuous Discovery loop + elastic compute + single-node scale-to-zero | Elastic compute | Open | D4
+| TD-035/130 | Graph query executor operators + edge bulk-load | Graph | Open | D4
+| TD-122/123/124 | gRPC v2 parity + v1→v2 migration + deferred graph RPCs | Graph/gRPC | Partial/Open | D4
+| TD-121 | Hard-delete gRPC v1 (post-Sunset 2026-06-30) | Graph/gRPC | Open | D4
+| TD-100/101/102/103 | Agent memory read/write/adapters/scoping | Agent memory | Partial/Resolved | D4
+| TD-117 | Agent branching via BranchRef (COW, writer fence) | Agent memory | Partial | D1
+| TD-052/053/054 | Proactive retrieval / encoding gates / L-RAG lazy loading | Agent memory | Open | D4
+| TD-064 | Predicate-aware vector search correctness + fallback | Embedded/convergence | In Progress | D5/D4
+| TD-066 | ORION WAL as parallel durable graph truth | Embedded/convergence | Partial | D1
+| TD-104/106/109/111 | Handler extraction + proto-v1→canonical + type unification | Embedded/convergence | Partial/Open | D4
+| TD-144/145 | Composition-root relocation + Arrow-native ingestion | Embedded/convergence | Open | D4
+| TD-067/073/074/075 | OID projection keys + cataloged ANN policy/freshness/recall-gate | Embedded/convergence | Open | D4/D5
+| TD-063 | Observability/SIEM convergence to canonical records | Embedded/convergence | Open | D4
+| TD-005/126 | Multi-language SDKs + spec-driven codegen | SDKs/connectors | Partial | D2
+| TD-097/098/099 | Spark JNI / Trino Flight / Hadoop records-scan connectors | SDKs/connectors | Partial/Resolved | D4/D1
+| TD-133 | Cross-modal transactional multi-modal write | SDKs/connectors | Open | D5
+| TD-134 | Metering KEU + per-repo RBAC | Co-design/metering | Resolved | D2/D5
+| TD-029/030 | Coverage ratchet 49→80% + ibkrtrading validation | Quality | In Progress/Open | —
+| TD-024/025 | SWIFT / RAPTOR engine completion (experimental-gated) | Quality | Open | D4
+| TD-085 | Internal marketing-copy product scrub | Quality | Partial | —
+|===
+
 [[category-index]]
 == 📂 Features by Category (inventory status, not support tier)
 
@@ -360,9 +470,9 @@ the maturity summary at the top of this file or `docs/SUPPORTED_SURFACE.adoc`.
 ==== Quantization & Performance (10/10 - 100%)
 * 026-035, 066: Complete optimization suite
 
-==== Graph Database (ORION usable; distributed/tiered engines experimental)
-* 036, 039: ORION and graph memory pool are usable
-* 037-038: PULSAR / QUASAR remain experimental compatibility or projection candidates
+==== Graph Database (ORION is the only graph runtime)
+* 036, 039: ORION and graph memory pool are usable (Beta)
+* 037-038: PULSAR / QUASAR *retired* (TD-001/017) — distributed graph → relational substrate; tiered graph → storage projection policy
 
 ==== Enterprise Security (Beta)
 * 041, 045-046: RBAC, multi-tenancy foundation, and rate limiting are implemented
@@ -393,9 +503,9 @@ the maturity summary at the top of this file or `docs/SUPPORTED_SURFACE.adoc`.
   - Support tier: Beta / planner-hardening dependent
 
 * **077**: Distributed Operations Assessment ⚠️ **EXPERIMENTAL**
-  - Assessed: 3,850+ lines cluster infrastructure
-  - Found: Raft consensus, sharding, PULSAR/QUASAR engines
-  - Status: Experimental until RPC transport, remote execution, and failover validation close
+  - Assessed: ~5,491 lines cluster infrastructure (`src/cluster/`)
+  - Found: Raft consensus, sharding, routing foundations (PULSAR/QUASAR engines retired — TD-001/017)
+  - Status: Experimental until RPC transport, remote execution, and failover validation close (TD-077)
 
 ==== Documentation
 * **078**: Documentation Migration to AsciiDoc
@@ -446,24 +556,21 @@ the maturity summary at the top of this file or `docs/SUPPORTED_SURFACE.adoc`.
 
 == 🔗 Quick Links
 
-=== Status Documents
-* link:CONSOLIDATED_FEATURE_STATUS.adoc[Detailed Status Report]
-* link:completed/[Completed Features Directory]
-* link:in-progress/[In-Progress Features Directory]
-* link:future/[Future Features Directory]
+=== Live trackers (authoritative)
+* link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] — live open-items tracker (reconciled 2026-06-24)
+* link:./RECONCILIATION_2026_06_24.adoc[Tracking Reconciliation — 2026-06-24]
+* link:../../SUPPORTED_SURFACE.adoc[Supported Surface Matrix] — support contract
+* link:STRATEGIC_ROADMAP.adoc[Strategic Roadmap] — phase sequencing
+* link:../../12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc[Design Doc Status Index] — design-doc catalogue
+* link:../../12-design/SYSTEM_MAP_2026_05_30.adoc[System Map] — architecture ground truth
 
-=== Key Implementation Guides
-* link:implementation/CORRECTED_STATUS_2024.adoc[2024 Implementation Status]
-* link:implementation/PRIORITY_ACTION_PLAN.adoc[Priority Action Plan]
-* link:implementation/Q1_2025_IMPLEMENTATION.adoc[Q1 2025 Implementation Guide]
+=== Status snapshots (historical)
+* link:../status/MVP_RELEASE_READINESS_RECONCILIATION_2026_05_28.adoc[MVP Release Readiness — 2026-05-28]
+* link:../status/PRE_RELEASE_FOUNDATIONS_2026_05_26.adoc[Pre-Release Foundations — 2026-05-26]
 
 === Technical Deep Dives
 * link:completed/01-storage-engines.adoc[Storage Engines Overview]
 * link:completed/02-index-algorithms.adoc[Index Algorithms Details]
-* link:completed/03-quantization.adoc[Quantization System]
-* link:completed/04-graph-database.adoc[Graph Database]
-* link:completed/05-enterprise-security.adoc[Security Features]
-* link:completed/06-ai-integration.adoc[AI Integration]
 
 === Storage Engine Deep Dives
 * link:completed/079-sst-engine-deep-dive.adoc[SST Engine] - LSM-tree, three-stage filtering
@@ -533,14 +640,15 @@ the maturity summary at the top of this file or `docs/SUPPORTED_SURFACE.adoc`.
 * **Quarterly**: Strategic realignment
 
 ---
-*Last Updated*: May 27, 2026 +
-*Total Indexed Features*: 143 +
+*Last Updated*: 2026-06-24 +
+*Indexed Features*: 143 (frozen March-2026 baseline) + the <<current-era-index,Current-Era Capability Index>> (TD-060..147 era) +
 *Support Contract*: `docs/SUPPORTED_SURFACE.adoc` +
+*Live Tracker*: `docs/10-quality/TECHNICAL_DEBT.adoc` +
 *Technical API/Projection Companion*: `docs/12-design/SUPPORTED_SURFACES.adoc` +
-*Detail Row Reconciliation*: partially refreshed; row-by-row support-tier audit remains open
+*Detail Row Reconciliation*: 001–143 baseline corrected for retired engines + ADR count; row-by-row support-tier audit still deferred (see RECONCILIATION_2026_06_24)
 
 == Related Documents
 
 * link:STRATEGIC_ROADMAP.adoc[Strategic Roadmap] - Vision-aligned phase planning
 * link:../DOCUMENTATION_STATUS.adoc[Documentation Status] - All docs with status
-* link:../../concepts/vision.adoc[Vision Document] - Authoritative vision and strategy
+* link:../../05-concepts/vision.adoc[Vision Document] - Authoritative vision and strategy

--- a/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
+++ b/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
@@ -119,6 +119,10 @@ merges on develop, except TD-133 which is still genuinely Open) and can be prune
   Phase 2.5 sprint timeline into a per-item status table; PULSAR/QUASAR →Retired; Phase 3
   connector/SDK/SaaS statuses; added the Phase 5/6 agent-memory + fusion-seam build and the Phase 7
   lakehouse-pgwire + gRPC v1→v2 workstreams; added the missing Phase 6 to Vision Alignment.
+. *BEST_IN_CLASS_EXECUTION_TRACKER* reconciled — WS-0..WS-7 + M1/M2/M3 gates re-scored vs current
+  reality (WS-2 Done; WS-0 substantially complete; WS-3/4/5 In Progress), a 2026-06-24 session-log
+  block appended (March-2026 history retained per the doc's own instruction), and the priority queue
+  refreshed.
 
 == Drift deliberately NOT closed here (follow-ups)
 
@@ -130,8 +134,6 @@ deferred:
   001–143 rows remain a demarcated historical inventory).
 . *Full re-merge of the DESIGN_DOC_STATUS_INDEX two tables* (the 2026-05-26 table + the 2026-06-24
   addendum) into one, with per-doc WIRED/PARTIAL grep verification.
-. *BEST_IN_CLASS_EXECUTION_TRACKER* workstream log is stale since 2026-03-14; WS-0..WS-7 + M1/M2/M3
-  gates should be re-scored.
 . *Renaming dated filenames* (`SYSTEM_MAP_2026_05_30`, `DESIGN_DOC_STATUS_INDEX_2026_05_26`) to current
   dates — deferred to avoid breaking inbound links in this PR; the internal dates are corrected.
 

--- a/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
+++ b/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
@@ -1,0 +1,129 @@
+= Tech-Debt / Feature / Vision Tracking Reconciliation — 2026-06-24
+:toc: left
+:toclevels: 3
+:icons: font
+:last-updated: 2026-06-24
+
+[.lead]
+**A first-principles sweep of every tech-debt, feature, and vision tracking surface in the repo,
+reconciled against `origin/develop` HEAD and the 2026-06-04 (data-warehouse course correction) and
+2026-06-19 (co-design dimensional architecture) pivots. This doc records what changed, the
+controlled status vocabulary, the authority hierarchy, and the drift that remains.**
+
+== Why this was needed
+
+The repo accumulated *eleven* overlapping tracking surfaces (register, dashboards, roadmaps,
+capability matrix, status memos, design index, system map). They drifted: the same item read
+`Resolved` in one and `planned` in another, IDs collided, and the live register had grown to
+1,700+ lines mixing ~80 closed items in with the ~60 still open — so "what is actually open and in
+what state" was no longer answerable at a glance. Per first-principles and the co-design mandate, a
+tracker's job is to show *current items in correct status against the dominant cost term*; everything
+else is history that belongs in an archive or in git.
+
+== Authority hierarchy (read this order)
+
+[cols="1,4", options="header"]
+|===
+| Surface | Role
+| link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] | *Support contract.* Wins on any customer / release / marketing claim.
+| link:../../10-quality/TECHNICAL_DEBT.adoc[TECHNICAL_DEBT.adoc] | *Live implementation tracker* (open items only). The single source for "what's open and in what state."
+| link:../../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[Closed Items Archive] | Compact index of resolved items; full prose in git history.
+| link:../../12-design/SYSTEM_MAP_2026_05_30.adoc[System Map] / link:../../12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc[Design Doc Status Index] | Architecture ground truth + design-doc catalogue.
+| STRATEGIC_ROADMAP / MASTER_FEATURE_DASHBOARD / CAPABILITY_MATRIX | *Sequencing + breadth inventory.* Historical rows; defer to the register for live status.
+| `docs/_internal/status/*` (MVP readiness, pre-release, Phase 9) | Point-in-time release-cut snapshots; keep as history.
+|===
+
+== What changed in this reconciliation
+
+=== TECHNICAL_DEBT.adoc — split into live tracker + archive
+
+* *Restructured* into a lean live tracker: open / in-progress / partial items only, grouped by
+  *workstream* (A relational/OLTP, B fusion seam, C storage spine, D elastic compute, E graph,
+  F agent memory, G embedded/convergence, H SDKs/connectors, I quality), each tagged with a
+  *co-design Dimension* (D1 object-store … D5 governance) and a *Well-Architected Pillar*.
+* *~80 resolved/closed items moved* to the
+  link:../../_archive/quality/2026-06/TECHNICAL_DEBT_CLOSED_2026_06_24.adoc[Closed Items Archive]
+  (compact one-line index; full historical prose preserved in git history of the register).
+* *Controlled status vocabulary* introduced: `Open` · `In Progress` · `Partial` (residual named) ·
+  `Resolved` · `Won't Do`. Replaces the prior ~10 freeform variants (`DONE`, `done`, `Closed April`,
+  `Mostly resolved`, `Foundation landed`, `PARTIAL CLOSE`, …).
+* *Stale roll-up tables replaced* — the old Debt-by-Category / Phase-Alignment tables only covered
+  TD-001..020 and have been replaced by an accurate summary + a highest-leverage-by-dimension view.
+
+=== Status flips verified against `origin/develop` HEAD
+
+[cols="1,1,1,3", options="header"]
+|===
+| ID | Was | Now | Evidence on develop
+| TD-129 | Open | Resolved | `DmlStatement::Upsert` + `execute_upsert` in `src/services/dml/mod.rs`; commit `258943f3` "feat(pgwire): ON CONFLICT DO UPDATE / DO NOTHING upsert".
+| TD-134 | Open | Resolved | KEU meter in `src/metrics/consumption_metrics.rs`; commits `05b920f0` + `3eb66452`.
+| TD-132 | Open | Partial | CPG-fragment PAX contract test `tests/cpg_fragment_pax_contract.rs`; commit `92611256`. Live layout + I/O trace remain.
+| TD-005 | Open | Partial | `clients/` now has Go(+embedded), JVM/Java-embedded, Node.js-embedded in addition to Python/Rust. C++/.NET/Ruby/Swift remain.
+| TD-133 | Open | Resolved | `CrossModelTransactionCoordinator` for atomic multi-modal writes landed on develop (`55450f9d`, PR #265) during this reconciliation (rebase pickup).
+| TD-146 | (new) | Open | EntityService.SearchEntities → fusion seam typed facade (`287d1a06`, PR #280); added to the live tracker on rebase.
+|===
+
+The superseded topic branches `feat/td-129-pgwire-upsert{,-v2}`, `feat/td-132-cpg-fragment-pax`,
+`feat/td-133-cross-model-tx`, `feat/td-126-phase2-go-codegen` are stale (work landed via squashed
+merges on develop, except TD-133 which is still genuinely Open) and can be pruned.
+
+=== Structural defects fixed
+
+* *Duplicate entries removed* — TD-043 and TD-044 appeared verbatim twice.
+* *ID collision resolved* — *TD-054* was used for two unrelated items. The live `TD-054` is now solely
+  *L-RAG / Entropy-Based Lazy Loading* (Open, Phase 6). The "type-system unification" work that
+  TD-R25/R26/R27 tagged "(TD-054)" is the now-`Resolved` umbrella *TD-111* (ADR-024); those tags are
+  retired.
+
+=== Design docs
+
+* *DESIGN_DOC_STATUS_INDEX* was ~52% complete (29 of 56 docs; missing both pivot docs + ADR-023/024).
+  Added a comprehensive 2026-06-24 addendum cataloguing the 28 missing docs + 2 ADRs with status +
+  class (pivot/design/plan/handoff). ADR total corrected to 24 Accepted.
+* *SYSTEM_MAP* content was current but metadata drifted: date aligned to 2026-06-24, crate counts
+  corrected (Foundation 14→20, Modality 11→12, Storage 4→8, workspace 66→79 members), and a co-design
+  cost-spine pointer added.
+
+=== Roadmap docs
+
+* Authority banners added to STRATEGIC_ROADMAP and MASTER_FEATURE_DASHBOARD pointing at the live
+  register + support contract + this doc.
+* *Phase 2.5 contradiction fixed* — STRATEGIC_ROADMAP marked Phase 2.5 "📅 NEW/planned" with an
+  April–July sprint plan, but its items (TD-031/032/033/034/036/038/039/041) are `Resolved` in the
+  register. Phase 2.5 is now marked effectively complete.
+
+== Verified cross-doc contradictions (resolved or recorded)
+
+[cols="3,5", options="header"]
+|===
+| Contradiction | Resolution
+| Phase 2.5 "planned" (roadmap) vs TD-031..041 "Resolved" (register) | Register wins; roadmap marked complete.
+| Documents canonical store "opt-in" (dashboard) vs "default-enabled" (TD-065 / PRE_RELEASE) | TD-065 Resolved (default-on `Cargo.toml`); dashboard row stale.
+| Graph branch-merge write-back "lacks durable write-back" vs "end-to-end functional" (same dashboard) | TD-072 Resolved 2026-05-27 (`996626595`); the negative line is the older table.
+| CAPABILITY_MATRIX framework_integrations_python "LlamaIndex/Haystack pending" vs TD-011 "7 frameworks complete" | TD-011 Resolved; matrix rows `stale-rows-not-reaudited` since 2026-03-02.
+| TD-054 used for two items | Collision resolved (see above).
+|===
+
+== Drift deliberately NOT closed here (follow-ups)
+
+To keep this a coherent, reviewable documentation PR (no code changes), the following are recorded but
+deferred:
+
+. *Row-by-row re-audit of MASTER_FEATURE_DASHBOARD (143 rows) and CAPABILITY_MATRIX.toml* against
+  current code. Both self-declare stale; banners now point readers to the live register. A dedicated
+  audit pass should refresh or retire them.
+. *Full re-merge of the DESIGN_DOC_STATUS_INDEX two tables* (the 2026-05-26 table + the 2026-06-24
+  addendum) into one, with per-doc WIRED/PARTIAL grep verification.
+. *BEST_IN_CLASS_EXECUTION_TRACKER* workstream log is stale since 2026-03-14; WS-0..WS-7 + M1/M2/M3
+  gates should be re-scored.
+. *Renaming dated filenames* (`SYSTEM_MAP_2026_05_30`, `DESIGN_DOC_STATUS_INDEX_2026_05_26`) to current
+  dates — deferred to avoid breaking inbound links in this PR; the internal dates are corrected.
+. *SaaS (2026-06-04) + co-design (2026-06-19) pivot integration* into the dashboard/exec-tracker/
+  capability-matrix as first-class dimensions (the register now carries the dimension tags).
+
+== Status snapshot (register, 2026-06-24)
+
+* *Open* ~33 · *In Progress* 5 (TD-136, TD-137, TD-101, TD-064, TD-029) · *Partial* ~22 ·
+  *Resolved/archived* ~80.
+* *Highest leverage by dominant cost term:* D1 object-storage — TD-114/088/087/116/119;
+  D4 compute-routing/fusion — TD-115/136/137/141; D5 governance — TD-064 (CRIT/SEC)/061/073/074/133.

--- a/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
+++ b/docs/_internal/roadmap/RECONCILIATION_2026_06_24.adoc
@@ -104,22 +104,36 @@ merges on develop, except TD-133 which is still genuinely Open) and can be prune
 | TD-054 used for two items | Collision resolved (see above).
 |===
 
+== Also reconciled in this PR (follow-up commits)
+
+. *MASTER_FEATURE_DASHBOARD* overhauled — false rows corrected (PULSAR/QUASAR retired; ADR 8→24),
+  phase table refreshed to the real 8 phases + pivots, maturity rows added for lakehouse-pgwire /
+  fusion / agent-memory / connectors / metering, a *Current-Era Capability Index* (TD-060..147) added,
+  6 dead Quick Links pruned. (The 143-row legacy index stays a *frozen March-2026 baseline*, clearly
+  demarcated — not individually re-audited.)
+. *CAPABILITY_MATRIX.toml* fully reconciled — `header_status` flipped from `stale-rows-not-reaudited`
+  to `reconciled-2026-06-24`; wrong rows fixed (`framework_integrations_python` →complete,
+  hybrid/mTLS notes), `controlling_td` cross-links added, ~14 current-era capability rows added.
+  `scripts/validate_capability_matrix.py` passes.
+. *STRATEGIC_ROADMAP* fully reconciled — fixed an 11-error table-syntax bug; collapsed the obsolete
+  Phase 2.5 sprint timeline into a per-item status table; PULSAR/QUASAR →Retired; Phase 3
+  connector/SDK/SaaS statuses; added the Phase 5/6 agent-memory + fusion-seam build and the Phase 7
+  lakehouse-pgwire + gRPC v1→v2 workstreams; added the missing Phase 6 to Vision Alignment.
+
 == Drift deliberately NOT closed here (follow-ups)
 
 To keep this a coherent, reviewable documentation PR (no code changes), the following are recorded but
 deferred:
 
-. *Row-by-row re-audit of MASTER_FEATURE_DASHBOARD (143 rows) and CAPABILITY_MATRIX.toml* against
-  current code. Both self-declare stale; banners now point readers to the live register. A dedicated
-  audit pass should refresh or retire them.
+. *Row-by-row re-audit of the 143-row frozen baseline in MASTER_FEATURE_DASHBOARD* against current
+  code (the maturity table, current-era index, and capability matrix are reconciled; the legacy
+  001–143 rows remain a demarcated historical inventory).
 . *Full re-merge of the DESIGN_DOC_STATUS_INDEX two tables* (the 2026-05-26 table + the 2026-06-24
   addendum) into one, with per-doc WIRED/PARTIAL grep verification.
 . *BEST_IN_CLASS_EXECUTION_TRACKER* workstream log is stale since 2026-03-14; WS-0..WS-7 + M1/M2/M3
   gates should be re-scored.
 . *Renaming dated filenames* (`SYSTEM_MAP_2026_05_30`, `DESIGN_DOC_STATUS_INDEX_2026_05_26`) to current
   dates — deferred to avoid breaking inbound links in this PR; the internal dates are corrected.
-. *SaaS (2026-06-04) + co-design (2026-06-19) pivot integration* into the dashboard/exec-tracker/
-  capability-matrix as first-class dimensions (the register now carries the dimension tags).
 
 == Status snapshot (register, 2026-06-24)
 

--- a/docs/_internal/roadmap/STRATEGIC_ROADMAP.adoc
+++ b/docs/_internal/roadmap/STRATEGIC_ROADMAP.adoc
@@ -9,6 +9,18 @@
 
 Execution tracking across sessions: link:./BEST_IN_CLASS_EXECUTION_TRACKER.adoc[Best-in-Class Foundation Execution Tracker]
 
+[NOTE]
+====
+*2026-06-24 reconciliation.* The authoritative live status for *implementation* of any item below is
+the link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] (reconciled 2026-06-24), and the
+support contract is link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc]. Where this roadmap's
+phase markers disagree with the register, the register wins. Known reconciled drift recorded in
+link:./RECONCILIATION_2026_06_24.adoc[RECONCILIATION_2026_06_24]: *Phase 2.5 is effectively complete*
+(TD-031/032/033/034/036/038/039/041 Resolved Mar–May 2026 — see the Phase 2.5 note); the 2026-06-04
+SaaS and 2026-06-19 co-design pivots are reflected in the register's co-design dimension tags but not
+yet re-threaded through every dashboard row.
+====
+
 [IMPORTANT]
 ====
 Use link:../../SUPPORTED_SURFACE.adoc[Supported Surface Matrix] for the current support contract.
@@ -296,7 +308,18 @@ _Added June 04, 2026 to support the commercial revenue wedge._
 | Swift SDK | 💡 Nice to Have | - | Apple ecosystem
 |===
 
-== Phase 2.5: Foundational Performance Alignment [📅 NEW]
+== Phase 2.5: Foundational Performance Alignment [✅ effectively complete]
+
+[NOTE]
+====
+*Status reconciled 2026-06-24:* the Phase 2.5 execution-layer items have landed — TD-031 (vectorized
+pipeline), TD-032 (Arrow cross-model), TD-033 (row-group pruning), TD-034 (spill-to-disk L2),
+TD-036 (adaptive codec, already done), TD-038 (cross-modal durable commit), TD-039 (morsel
+parallelism), TD-041 (vectorized executor wired) are all *Resolved* in the
+link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register]. TD-035 (graph executor) and TD-040
+(read-side quant pruning) remain Open/Partial. The "📅 NEW / planned" markers and the April–July
+sprint timeline below are *historical*; do not treat them as current.
+====
 
 [.lead]
 _Performance Credibility: Align the execution layer between storage and API with single-node analytical system patterns (DuckDB, Polars). Without this, columnar analytics and cross-model query performance claims are not substantiable._

--- a/docs/_internal/roadmap/STRATEGIC_ROADMAP.adoc
+++ b/docs/_internal/roadmap/STRATEGIC_ROADMAP.adoc
@@ -2,7 +2,7 @@
 :toc: left
 :toclevels: 3
 :icons: font
-:last-updated: May 8, 2026
+:last-updated: 2026-06-24
 
 [.lead]
 **Strategic roadmap aligned with the Vision document phases. This file is authoritative for sequencing and prioritization, not for support tier by itself.**
@@ -32,16 +32,19 @@ matrix also marks that capability as supported.
 
 == Vision Alignment
 
-This roadmap implements the three-phase approach from link:../../concepts/vision.adoc[Vision Document]:
+This roadmap implements the phased approach from link:../../05-concepts/vision.adoc[Vision Document],
+co-optimized under the 2026-06-04 data-warehouse course correction and the 2026-06-19 co-design
+dimensional architecture (see `docs/12-design/`):
 
-* **Phase 1**: Format and Catalog Contract (Foundation)
-* **Phase 2**: Cross-Model Query and Indexing (Differentiation)
-* **Phase 2.5**: Foundational Performance Alignment (Execution Layer) -- _added March 2026_
-* Phase 3: Deployment and Ecosystem Integration (Scale)
-* Phase 4: Context Database Evolution (Time-Series, Event Sourcing, Hybrid Search)
-* Phase 5: Agentic Intelligence & Research Frontier (2026 Strategy)
-* Phase 7: Competitive Platform Architecture & Storage Authority (2026+)
-* Phase 8: Continuous Data Loop & Elastic Compute (CS/CD, scale-to-zero, External Collection)
+* **Phase 1**: Format and Catalog Contract (Foundation) — ✅ Complete
+* **Phase 2**: Cross-Model Query and Indexing (Differentiation) — 🔄 In Progress
+* **Phase 2.5**: Foundational Performance Alignment (Execution Layer) — ✅ effectively complete _(added March 2026)_
+* **Phase 3**: Deployment and Ecosystem Integration + SaaS Operational Readiness (Scale) — 🔄 In Progress
+* **Phase 4**: Context Database Evolution (Time-Series, Event Sourcing, Hybrid Search) — ✅ engines / Beta packaging
+* **Phase 5**: Agentic Intelligence & Research Frontier (2026 Strategy) — ✅ research landed; agent-memory layer In Progress
+* **Phase 6**: Active Memory & Collective Reasoning — 🔄 In Progress
+* **Phase 7**: Competitive Platform Architecture & Storage Authority (lakehouse-native pgwire) — 🔄 In Progress
+* **Phase 8**: Continuous Data Loop & Elastic Compute (CS/CD, scale-to-zero, External Collection) — 📅 Planned
 
 
 == Status Legend
@@ -161,8 +164,8 @@ _Differentiation: Unified query planner for graph + vector + document + relation
 | ORION Graph Engine | ✅ Complete | In-memory CSR, WAL persistence
 | Graph Traversal | ✅ Complete | BFS, DFS, shortest path
 | Graph Algorithms | ⚠️ Partial | Core algorithms exist; graph product surface still centers ORION
-| PULSAR Engine | ⚠️ Partial | Experimental distributed graph foundation
-| QUASAR Engine | ⚠️ Partial | Experimental hybrid vector+graph foundation
+| PULSAR Engine | ❌ Retired | Retired (TD-001/017): modules/flags/routes/tests removed; `GraphEngineFactory` rejects the name. Distributed graph → relational substrate.
+| QUASAR Engine | ❌ Retired | Retired (TD-001/017/068): removed; tiered-graph behavior → xCatalog/storage projection policy. ORION is the only graph runtime.
 |===
 
 === Document Store [🔄 In Progress]
@@ -235,19 +238,19 @@ _Added June 04, 2026 to support the commercial revenue wedge._
 | Feature | Status | Priority | Notes
 
 | SaaS Path Isolation (DrPathBuilder)
-| 📅 Phase 3
+| ⚠️ Partial
 | P0
-| Enforce strict `data/{tenant_id}/{namespace_id}/...` prefixing across all Object Storage interactions to prevent cross-tenant data leakage.
+| Warehouse-materialize path now threads `TenantContext` and lands under `data/{tenant}/…` (TD-113 mostly resolved); the opaque-namespace `DrPathBuilder` layout (`PROXIMADB_WAREHOUSE_DRPATH`) is opt-in pending a repath migration.
 
 | Consumption Billing Telemetry
-| 📅 Phase 3
+| ⚠️ Partial
 | P0
-| Plumb accurate request/byte-level telemetry (`proximadb_object_store_ops_total`, `task_execution_time_ms`) tied to `TenantContext` for accurate billing.
+| KOU egress meter + KEU embedding meter live (`consumption_metrics.rs`; TD-134 resolved, KOU partial); per-query I/O trace substrate is the co-design prerequisite still landing.
 
 | Tenant Bootstrapping Resilience
-| 📅 Phase 3
+| ⚠️ Partial
 | P1
-| Implement aggressive caching/memory-pinning for `TenantTierStore` to prevent cyclic read dependencies during system initialization.
+| `TenantTierStore` caching/pinning + catalog default-bootstrap fixes landed (TD-080); broader cyclic-init hardening continues.
 |===
 
 === Compute Engine Adapters [📅 Phase 3]
@@ -255,10 +258,11 @@ _Added June 04, 2026 to support the commercial revenue wedge._
 |===
 | Feature | Status | Phase | Notes
 
-| Trino Connector | 📅 Phase 3 | P3 | SQL federation
-| Spark Connector | 📅 Phase 3 | P3 | Batch analytics
+| Trino Connector | ✅ Complete | P3 | Arrow-Flight wire layer, all 7 flight_* methods (TD-098 resolved 2026-06-02)
+| Spark Connector | ⚠️ Partial | P3 | JNI embedded impls + Rust-side filter pushdown + lifecycle (TD-097); JVM DataSource V2 + Gradle harness residual
+| Hadoop Connector | ⚠️ Partial | P3 | records-scan endpoint + cursor + WAL scan push-down (TD-099)
 | DataFusion Native | ✅ Complete | P2 | Already integrated
-| DuckDB Integration | 📅 Phase 3 | P3 | Embedded analytics
+| DuckDB Integration | 📅 Phase 3 | P3 | Embedded analytics (planned)
 |===
 
 === Streaming & CDC [✅ Complete]
@@ -297,15 +301,15 @@ _Added June 04, 2026 to support the commercial revenue wedge._
 |===
 | SDK | Status | Phase | Notes
 
-| Python SDK | ✅ Complete | P1 | Full featured
-| Go SDK | 🔄 In Progress | P2 | Basic implementation
-| Java SDK | 📅 Phase 3 | P3 | JVM ecosystem
-| Node.js SDK | 📅 Phase 3 | P3 | JavaScript ecosystem
+| Python SDK | ✅ Complete | P1 | Full featured; REST spec-generated (TD-126)
 | Rust SDK | ✅ Complete | P1 | Native Rust; `clients/rust/`
-| C++ SDK | 💡 Nice to Have | - | C++ ecosystem
-| .NET SDK | 💡 Nice to Have | - | .NET ecosystem
-| Ruby SDK | 💡 Nice to Have | - | Ruby ecosystem
-| Swift SDK | 💡 Nice to Have | - | Apple ecosystem
+| Go SDK | ⚠️ Partial | P2 | `clients/go` (+embedded); spec-driven codegen Phase 2 open (TD-126)
+| Java SDK | ⚠️ Embedded | P3 | `clients/java-embedded`, `clients/jvm`; standalone SDK planned
+| Node.js SDK | ⚠️ Embedded | P3 | `clients/nodejs-embedded`; standalone SDK planned
+| C++ SDK | 💡 Nice to Have | - | C++ ecosystem (planned, TD-005)
+| .NET SDK | 💡 Nice to Have | - | .NET ecosystem (planned, TD-005)
+| Ruby SDK | 💡 Nice to Have | - | Ruby ecosystem (planned, TD-005)
+| Swift SDK | 💡 Nice to Have | - | Apple ecosystem (planned, TD-005)
 |===
 
 == Phase 2.5: Foundational Performance Alignment [✅ effectively complete]
@@ -490,33 +494,26 @@ _Added March 26, 2026._
 | Pass transaction context through federated query execution so cross-modal queries have consistency guarantees.
 |===
 
-=== Target Timeline
+=== Reconciled Status (2026-06-24)
 
-_Updated March 26, 2026._
+The April–July sprint plan that previously lived here is *historical* (it predates the work landing).
+Actual per-item status from the link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register]:
 
-[source]
-----
-Sprint 1 (April):
-  TD-041: Wire vectorized executor into query path -- 2-3 weeks, HIGHEST ROI
-  TD-033: Row group numeric statistics pruning -- 1 week
+|===
+| Item | TD | Status
 
-Sprint 2 (May):
-  TD-031: Full pipeline-based execution (DataChunks) -- 4-6 weeks
-  TD-039: Morsel-driven parallelism -- 3-4 weeks (parallel with TD-031)
-
-Sprint 3 (June):
-  TD-032: Arrow as cross-model format -- 3-4 weeks
-  TD-035: Graph executor completion -- 3-4 weeks
-
-Sprint 4 (July):
-  TD-034: Spill-to-disk (L2 backend) -- 3-4 weeks
-  TD-038: Cross-modal 2PC -- 4-6 weeks (start)
-
-Benchmark validation gates:
-  After Sprint 1: 10x improvement on analytical benchmarks
-  After Sprint 2: Multi-core scaling demonstrated
-  After Sprint 3: <5ms cross-modal queries
-----
+| Vectorized execution engine (DataChunk pipeline) | TD-031 | ✅ Resolved
+| Vectorized executor wired into primary query path | TD-041 | ✅ Resolved
+| Row-group statistics pruning (numeric) | TD-033 | ✅ Resolved
+| Arrow native cross-model format | TD-032 | ✅ Resolved
+| Spill-to-disk (L2 NVMe) | TD-034 | ✅ Resolved
+| Per-segment adaptive codec | TD-036 | ✅ Resolved (was already adaptive)
+| Distance multi-vector batching (NEON 4-way + prefetch) | TD-037 | ✅ Resolved (full matrix transpose deferred)
+| Cross-modal transaction isolation (durable 2PC) | TD-038 | ✅ Resolved
+| Morsel-driven query parallelism | TD-039 | ✅ Resolved
+| Graph query executor operators | TD-035 | 🔄 Open
+| Read-side quantization-aware row-group pruning | TD-040 | ⚠️ Partial (write-side stats landed)
+|===
 
 == Phase 4: Context Database Evolution
 
@@ -639,6 +636,22 @@ See link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] Phase 5 s
 | AV-SQL — 3-Agent Decomposition | ✅ Complete | TD-048 | Rewriter / ViewGenerator / Composer traits and REST integration landed (April 2026).
 | Block-Batched Semantic Joins | ✅ Complete | TD-049 | LLM block-batched join with prompt packing implemented in executor.
 |===
+
+=== Agent Memory Layer & Cross-Modal Fusion Seam [🔄 In Progress]
+
+_Reconciled 2026-06-24. The agent-memory layer (ADR-022) and the fuse-by-`oid` seam
+(`CROSS_MODAL_FUSION_SEAM_2026_06_22`) are the active Phase-5/6 build. See the Technical Debt Register._
+
+|===
+| Feature | Status | TD ID | Notes
+
+| Agent memory read surface (mem0-aligned) | ✅ Complete | TD-100 | `MemoryAqlSource` + pgwire WHERE pushdown; session scoping (TD-103) resolved.
+| Agent memory write surface (extraction + consolidation) | 🔄 In Progress | TD-101 | `MemoryWriteEngine.ingest` + embedder + `/api/v1/memory/ingest`; consolidation audit persistence residual.
+| mem0 / agentmemory framework adapters | ⚠️ Partial | TD-102 | pgwire Slice A landed; Python provider Slice B open.
+| Agent branching (BranchRef, COW, writer fence) | ⚠️ Partial | TD-117 | Foundation landed; ancestor fall-through, live CAS fencing, branch GC open. Depends on TD-116/119.
+| Neutral `Fuser` core + GraphExpander + REST v2 fusion-search | 🔄 In Progress | TD-136, TD-137 | Calibrated fuse-by-`oid` seam; document/relational/edge expanders + cost-routed fusion (TD-138–143) open.
+| EntityService.SearchEntities → seam typed facade | 📅 Open | TD-146 | No standalone retrieval engine; delegates to the seam.
+| Cross-modal atomic multi-modal write | ✅ Complete | TD-133 | `CrossModelTransactionCoordinator` (resolved 2026-06-24).
 |===
 
 == Phase 6: Active Memory & Collective Reasoning [📅 NEW 2026+]
@@ -665,7 +678,7 @@ _Autonomous Memory: Enabling agents to actively manage, link, and gate their own
 | Metadata Pseudo-Query Generation | 📅 Phase 6 | TD-056 | (Sub) Solve vocabulary mismatch via augmented indexing. arXiv:2604.16394
 |===
 
-== Phase 7: Competitive Platform Architecture And Storage Authority [📅 NEW 2026+]
+== Phase 7: Competitive Platform Architecture And Storage Authority [🔄 In Progress]
 
 [.lead]
 _Context Data Platform: tightening ProximaDB's competitive shape across vector, graph, document,
@@ -689,7 +702,35 @@ maturity justifies consolidation. The governing documents are:
 
 | Storage layout authority model | 🔄 Phase 7 | TD-060 | Contract skeleton, `CatalogTableSchema` persistence, internal `ObjectSchema` propagation, information-schema introspection, nullable EXPLAIN storage-authority metadata, SQL EXPLAIN catalog resolution, and unified EXPLAIN target extraction landed; planner-native resolved object context remains.
 | Optional relational capabilities | 📅 Phase 7 | TD-061 | Cataloged keys, unique indexes, secondary indexes, FKs, checks, materialized views, transaction profiles, and schema-evolution policy.
-| Predicate-aware vector correctness | 📅 Phase 7 | TD-064 | `VectorTopK` plans must disclose exact, predicate-aware ANN, prefilter-exact, or post-filter fallback behavior.
+| Predicate-aware vector correctness | 🔄 In Progress | TD-064 | `VectorTopK` plans disclose exact / predicate-aware ANN / prefilter-exact / post-filter fallback; slices 1-5 landed, IVF inline pushdown residual.
+|===
+
+=== Lakehouse-Native pgwire & HTAP [🔄 In Progress]
+
+_Governing doc: `docs/12-design/PROXIMADB_AS_LAKEHOUSE_NATIVE_PG_ENGINE_2026_06_17.md`. Co-design D1/D3/D4._
+
+|===
+| Feature | Status | TD ID | Notes
+
+| OLTP/OLAP HTAP storage + PG constraints | ⚠️ Partial | TD-110 | ON DELETE FK actions (RESTRICT/CASCADE/SET NULL) on single-col FK landed; ON UPDATE / composite-FK / MVCC residual.
+| Background L0→base compactor + deletion vectors | ⚠️ Partial | TD-114 | Tested PAX merge-on-read core + flag-gated trigger (default OFF); live auto-invoke from flush residual.
+| Cost-based multi-engine dispatch | 📅 Open | TD-115 | `ComputeScheduler::route_select` hardcodes Native today; cost model + `QueryShape` stats not wired.
+| WAL tiering + read-as-of-LSN time travel | 📅 Open | TD-116 | WAL local-only; `SELECT … AS OF` read path missing. Unblocks TD-117.
+| Unify paging/cache policy with tier policy | 📅 Open | TD-118 | One hierarchy policy for eviction + demotion; scan-ring so cold scans don't evict the OLTP working set.
+| Real Iceberg snapshots (metadata.json + manifest log) | ⚠️ Partial | TD-119 | Phase 1 landed; Avro manifest-list/DataFile stats for Spark/Trino scans residual.
+| pg_catalog completeness for ORM/driver compat | ⚠️ Partial | TD-120 | pg_type/namespace/class/attribute/constraint views landed; pg_index + live ORM round-trip residual.
+| gRPC SQL relational writes (DDL/DML) | ✅ Complete | TD-135 | `ExecuteQuery` routes DDL/DML through tenant-scoped `Ddl/DmlService::execute_scoped`.
+|===
+
+=== gRPC v1→v2 Convergence [🔄 In Progress]
+
+|===
+| Feature | Status | TD ID | Notes
+
+| gRPC v2 parity services (graph/document/entity) | ⚠️ Partial | TD-122 | `ProximaGraphService` delivered 2026-06-21; Document/Entity v2 services residual.
+| v1→v2 message-type migration (transport-agnostic domain) | 🔄 In Progress | TD-123 | Graph keystone done (neutral `graph::model`); record/vector/collection services + typed `GraphRef` tenancy residual.
+| Deferred v2 graph RPCs (analytic/batch/stream) | 📅 Open | TD-124 | `GetConnectedComponents`, `HasCycle`, `BatchCreate*`, `StreamTraverse`, declarative `ExecuteQuery`.
+| Hard-delete gRPC v1 proto + compat adapters | 📅 Open | TD-121 | Post-Sunset 2026-06-30 (do NOT merge before 2026-07-01); unblocked by TD-122 + TD-123.
 |===
 
 === Competitive Query And Observability Surface
@@ -749,6 +790,16 @@ the full trend analysis and the alignment scorecard. These workstreams realize t
 |===
 
 == Documentation Status
+
+[NOTE]
+====
+*Stale paths (pre-2026-05 docs taxonomy).* The file paths in the tables below predate the docs
+reorganization into numbered sections (`03-api-reference/`, `05-concepts/`, etc.). For the current
+design-doc catalogue use link:../../12-design/DESIGN_DOC_STATUS_INDEX_2026_05_26.adoc[Design Doc Status
+Index] (reconciled 2026-06-24); for the architecture map use
+link:../../12-design/SYSTEM_MAP_2026_05_30.adoc[System Map]. This section is retained as a historical
+completeness inventory only.
+====
 
 === Public Documentation [✅ Complete]
 
@@ -853,7 +904,7 @@ For v1.0 release, the following must be complete:
 === Q2 2026 [Current hardening]
 
 * Time-series engine (TST) implementation is complete at engine level (TD-009 resolved); product packaging, API parity, and at-scale validation keep the surface Beta.
-* Backup / point-in-time recovery is complete (TD-013 resolved).
+* Backup / restore infrastructure is complete (TD-014 resolved); read-as-of-LSN time travel is the separate TD-116 (planned).
 * mTLS infrastructure is complete (TD-006 resolved); remaining security work is admin/status and stronger online revocation policy.
 * Pre-release foundations focus: dashboard/support-surface honesty, multi-tenant safety hardening, canonical WAL authority, ADR-012 minimum branch merge, and hybrid gRPC parity.
 
@@ -894,6 +945,7 @@ For v1.0 release, the following must be complete:
 
 ---
 
-_Last Updated_: May 27, 2026
+_Last Updated_: 2026-06-24 (full reconciliation vs the Technical Debt Register + the 2026-06-04 / 2026-06-19 pivots)
 _Version_: 0.2.0
-_Next Review_: End of Phase 6 Design Review (Graph-Linked Chunking + Uncertainty-Gated Search spec)
+_Authoritative live status_: link:../../10-quality/TECHNICAL_DEBT.adoc[Technical Debt Register] (implementation) + link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] (support contract)
+_Next Review_: End of Phase 6 Design Review


### PR DESCRIPTION
Reconcile every tech-debt / feature / vision tracking surface vs origin/develop HEAD + the 2026-06-04 / 2026-06-19 pivots. Docs-only. Splits TECHNICAL_DEBT.adoc into a lean live tracker (open items, workstream-grouped, co-design-dimension + WA-pillar tagged) + a closed archive; reconciles statuses (TD-129/134/133 Resolved, TD-132 Partial, TD-005 rescoped; TD-146 added); fixes TD-043/044 dupes + TD-054 collision; rebuilds the design-doc index addendum (+both pivot docs, +ADR-023/024); refreshes SYSTEM_MAP counts; overhauls MASTER_FEATURE_DASHBOARD (retired PULSAR/QUASAR, ADR 8→24, Current-Era Capability Index, dead-link prune); adds RECONCILIATION_2026_06_24. See RECONCILIATION_2026_06_24 for full detail.