### PR TITLE
fix(search): deleted records reappear until WAL flush (tombstone in same delta)

### DIFF
--- a/src/core/search/merge.rs
+++ b/src/core/search/merge.rs
@@ -74,10 +74,22 @@ pub fn merge_delta_with_directory_results(
     // Pass 2: build the merged map. Insert delta records first so the
     // "delta wins" rule is enforced by the subsequent directory pass
     // skipping any OIDs already seen.
+    //
+    // A tombstone in the delta suppresses *every* copy of that OID — not
+    // just the flushed/directory copy but also the live copy that may sit
+    // beside it in the same unflushed WAL (insert-then-delete before any
+    // flush). Without this check the live WAL record survives because it is
+    // itself not a tombstone, so `is_wal_tombstone` returns false and it
+    // gets inserted here while the tombstone is silently dropped.
     let mut by_oid: HashMap<String, OptimizedSearchRecord> = HashMap::new();
     for record in delta_results {
         if is_wal_tombstone(&record) {
             // Tombstones never appear in the output set.
+            continue;
+        }
+        if tombstone_ids.contains_key(&record.id) {
+            // A tombstone for this OID exists in the same delta — the
+            // delete supersedes this live copy.
             continue;
         }
         by_oid.insert(record.id.clone(), record);
@@ -180,6 +192,28 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].id, "b", "tombstoned OID removed from output");
+    }
+
+    #[test]
+    fn tombstone_in_delta_suppresses_live_copy_in_same_delta() {
+        // Insert-then-delete before any flush: both the live record and its
+        // tombstone are unflushed, so both surface in the WAL delta. The
+        // tombstone must suppress the live copy sitting beside it in the
+        // same delta — not just the flushed/directory copy.
+        let directory: Vec<OptimizedSearchRecord> = vec![];
+        let delta = vec![
+            live("a", 0.9), // live copy, inserted
+            tombstone("a"), // tombstone, same OID, newer
+            live("b", 0.8),
+        ];
+        let merged = merge_delta_with_directory_results(delta, directory, 10);
+
+        assert_eq!(
+            merged.len(),
+            1,
+            "live + tombstone for the same OID in the delta collapses to nothing"
+        );
+        assert_eq!(merged[0].id, "b");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A deleted record reappeared in search results until the WAL flushed. Repro: insert records, delete one, search → the deleted id is still present.

## Root cause

Delete writes a tombstone (`valid_to_ns = 0`, empty embeddings) to the WAL. In the common **insert-then-delete-before-flush** case, a record's *live* copy and its *tombstone* are both unflushed, so the WAL delta search returns both.

`merge_delta_with_directory_results` handled tombstones in two of three places:
- **Pass 1** — collected tombstone OIDs into a set ✓
- **Pass 3** (directory) — skipped records whose OID is tombstoned ✓
- **Pass 2** (delta) — inserted the live WAL copy beside its **own** tombstone ✗

Because the live copy is not itself a tombstone, `is_wal_tombstone(record)` returned `false`, so Pass 2 inserted it while the tombstone was silently dropped. The deleted record survived into the merged output.

## Fix

In Pass 2, also skip any delta record whose OID has a tombstone in the same delta — the delete supersedes the live copy regardless of which WAL batch it sits in.

```rust
for record in delta_results {
    if is_wal_tombstone(&record) { continue; }
    if tombstone_ids.contains_key(&record.id) { continue; }  // <-- NEW
    by_oid.insert(record.id.clone(), record);
}
```

## Verification

- ✅ New unit test `tombstone_in_delta_suppresses_live_copy_in_same_delta` (live + tombstone for the same OID in the delta collapses to nothing); full `core::search::merge` suite green (9/9).
- ✅ End-to-end on a clean `origin/develop` build: insert `{a, b}` → delete `a` → search (cache-miss) → `[b]` only.
- ✅ `cargo clippy --lib --bins` clean (no new warnings).

## Scope

Single-file change (`src/core/search/merge.rs`) + one test. Conflict-free against `develop` (this file is untouched by recent merges).

## Known follow-up (separate concern, not introduced here)

The **query-results cache** (`QueryCache`) has no per-collection invalidation, so the *exact same* query repeated within its 300s TTL after *any* write (insert/update/delete) returns stale cached results. This is a pre-existing cache-coherence-on-write limitation affecting all writes; cache-miss / differently-shaped queries are correct. Filed as a separate TD — it needs a new `invalidate_by_collection` spanning the L1/L2/L3 cache tiers and wire-up across all write paths, which is out of scope for this delete-correctness fix.