### PR TITLE
ci(T4.2): pre-install toolchain components to fix rustup rustfmt-preview conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          # Match rust-toolchain.toml's declared components + target so `cargo
+          # check` doesn't trigger a rustup re-sync that collides installing
+          # rustfmt-preview on the runner's existing bin/cargo-fmt (T4.2 red).
+          components: rustfmt, clippy
+          targets: x86_64-unknown-linux-gnu
       - name: Install System Dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
ci(T4.2): pre-install toolchain components to dodge rustup rustfmt-preview conflict

The Proto Compatibility (T4.2) job was a pre-existing red: `make proto-check`
(cargo check + Python drift/contract tests) passes cleanly, but `cargo check`
triggered a rustup re-sync (rust-toolchain.toml declares components
rustfmt+clippy + the linux target) that collided installing rustfmt-preview on
the runner's existing bin/cargo-fmt:
  error: failed to install component: 'rustfmt-preview-x86_64-unknown-linux-gnu',
         detected conflict: 'bin/cargo-fmt'

Fix: have the T4.2 job's dtolnay/rust-toolchain step pre-install exactly the
components + target rust-toolchain.toml declares, so cargo's verification is a
no-op and no re-sync is triggered — matching the pattern already used by the
passing fmt/clippy jobs (components: rustfmt, clippy).

Verified locally: `make proto-check` is green (cargo check + 11 Python tests,
zero generated-source drift). The change is CI-infra only; no code/proto delta.
