### PR TITLE
ci: include crates/** and apps/** in the rust paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,21 @@ jobs:
           filters: |
             rust:
               - 'src/**'
+              # Workspace members that `cargo` compiles, lints, and tests but that
+              # the filter previously omitted — a crate-only or app-only change
+              # therefore skipped rust-clippy/rust-test/rust-format/feature-matrix
+              # etc. and was caught only by the always-required rust-compile gate.
+              - 'crates/**'
+              - 'apps/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
               - 'tests/**'
               - 'benches/**'
+              # Toolchain pin + cargo config (rustflags) change lint/test outcomes
+              # workspace-wide, so a bump must re-run the Rust suite.
+              - 'rust-toolchain*'
+              - '.cargo/**'
             # `compile` gates the rust-compile hard gate. It is a deliberate
             # SUPERSET of every path that can affect `cargo check --workspace`:
             # the root `src/**`, every workspace member under `crates/**` and


### PR DESCRIPTION
## Follow-up to #299

#299 noted that the `rust` paths-filter omits `crates/**` and `apps/**` even though the workspace compiles, lints, and tests them. This closes that gap.

## Problem

`rust-clippy`, `rust-format`, `rust-test`, `feature-matrix`, `hygiene`, `rust-build`, etc. all gate on `needs.changes.outputs.rust == 'true'`. But the `rust` filter was:

```
rust:  src/**, Cargo.toml, Cargo.lock, build.rs, tests/**, benches/**
```

No `crates/**`, no `apps/**`. So a **crate-only or app-only PR** skipped the entire Rust lint/test suite and was caught only by the always-required `rust-compile` gate — which runs `cargo check` (no clippy, no tests). A clippy violation or a failing unit test in `crates/**` could merge without a required job ever flagging it.

## Fix

Extend `rust` to cover the whole workspace:

```
+ crates/**
+ apps/**
+ rust-toolchain*     # toolchain bump → re-run lint/test workspace-wide
+ .cargo/**           # rustflags / cargo config change → same
```

## Trade-off

Crate-only / app-only PRs now run the full Rust suite — **correct** behavior (they should be linted and tested), at slightly more runner minutes on those PRs. They already paid the `rust-compile` gate, so the net-new cost is the lint/test jobs that *should* have been running all along. Docs-only PRs are unaffected (none of these paths match).

## Note (not addressed here)

The granular targeted-test filters (`query_changes`, `storage_changes`, `graph_changes`, `core_changes`, `network_changes`) are still `src/...`-only, so a change under e.g. `crates/query/**` won't trigger the *targeted* integration suite via those filters (it will run via the broader `rust`/`test_tier` gating). Tightening those to mirror their crate locations is a separate, optional refinement.

## Validation

YAML parses; the `rust` filter now covers `crates/**` + `apps/**` + `rust-toolchain*` + `.cargo/**`; the `compile` superset from #299 is unchanged. (This PR touches only `.github/`, so its own run skips the Rust suite + `rust-compile` and `CI Success` reports green.)