### PR TITLE
fix(cluster): silence clippy::let_underscore_future on lease-renew spawn (develop red)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1841,7 +1841,10 @@ impl SharedServices {
                     // lifetime (matches SharedServices' existing background-task
                     // pattern); interval ≤ lease_ms/2 so a lease never lapses
                     // between renewals.
-                    let _ = manager
+                    // `spawn_renew_loop` tokio::spawns the loop and returns its
+                    // JoinHandle; drop it as a temporary so the task runs detached
+                    // (fire-and-forget) without tripping clippy::let_underscore_future.
+                    manager
                         .clone()
                         .spawn_renew_loop(std::time::Duration::from_millis(5_000));
                     let lock_service = Arc::new(DmlLockService::new(manager, pod_id));


### PR DESCRIPTION
fix(cluster): silence clippy::let_underscore_future on lease-renew spawn (develop red)

The lease-renew/reconcile spawn added in #295 wrote
  let _ = manager.clone().spawn_renew_loop(...);
which trips clippy::let_underscore_future (-D warnings → Clippy red on
develop, inherited by every rebased PR).

spawn_renew_loop internally tokio::spawns the loop and returns its JoinHandle,
so the loop already runs detached; the `let _ =` merely discards the handle.
Drop the binding so the JoinHandle is a discarded temporary — identical
fire-and-forget behavior, no lint. No behavior change (the renew loop still
runs for the process lifetime).
