### PR TITLE
refactor(api): decouple ArrowFlightServer off ROOT UnifiedHandlers (TD-104 step 2)

### DIFF
--- a/src/network/arrow_ipc/server.rs
+++ b/src/network/arrow_ipc/server.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use tonic::transport::Server;
 use tracing::info;
 
-use crate::api_handlers::request_handlers::UnifiedHandlers;
 use crate::catalog::CatalogManager;
 use crate::security::SecurityCoordinator;
 use proximadb_runtime::bootstrap_config::BindTarget;
@@ -23,7 +22,7 @@ use super::service::ProximaFlightService;
 /// Arrow Flight server for ProximaDB
 pub struct ArrowFlightServer {
     bind_target: BindTarget,
-    request_handlers: Arc<UnifiedHandlers>,
+    flight_service: ProximaFlightService,
     security_coordinator: Option<Arc<SecurityCoordinator>>,
     catalog_manager: Option<Arc<CatalogManager>>,
     max_message_size: usize,
@@ -40,10 +39,10 @@ impl ArrowFlightServer {
     ///
     /// `bind_target` is either a TCP [`SocketAddr`](std::net::SocketAddr)
     /// (server mode) or a Unix-domain socket path (portless embedded mode).
-    pub fn new(bind_target: BindTarget, request_handlers: Arc<UnifiedHandlers>) -> Self {
+    pub fn new(bind_target: BindTarget, flight_service: ProximaFlightService) -> Self {
         Self {
             bind_target,
-            request_handlers,
+            flight_service,
             security_coordinator: None,
             catalog_manager: None,
             max_message_size: 512 * 1024 * 1024, // 512MB default
@@ -99,11 +98,12 @@ impl ArrowFlightServer {
             "Starting Arrow Flight server"
         );
 
-        // Create Flight service
-        let mut flight_service =
-            ProximaFlightService::from_unified_handlers(self.request_handlers.clone())
-                .with_security_coordinator(self.security_coordinator.clone())
-                .with_catalog_manager(self.catalog_manager.clone());
+        // Apply the outer-wrapper options (security/catalog) onto the injected
+        // Flight service (built from ports at the wiring layer).
+        let mut flight_service = self
+            .flight_service
+            .with_security_coordinator(self.security_coordinator.clone())
+            .with_catalog_manager(self.catalog_manager.clone());
 
         // Slice 6.2: only wire the gate when BOTH the registry and
         // the pod identity are present. Partial wiring would silently

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -686,9 +686,10 @@ impl MultiServer {
             let self_pod_id = services.self_pod_id.clone();
 
             let arrow_handle = tokio::spawn(async move {
-                use crate::network::arrow_ipc::ArrowFlightServer;
+                use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
-                match ArrowFlightServer::new(arrow_bind_target, request_handlers)
+                let flight_service = ProximaFlightService::from_unified_handlers(request_handlers);
+                match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
                     .with_max_message_size(max_message_size)
@@ -1610,9 +1611,10 @@ impl MultiServer {
             let self_pod_id = services.self_pod_id.clone();
 
             let arrow_handle = tokio::spawn(async move {
-                use crate::network::arrow_ipc::ArrowFlightServer;
+                use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
-                match ArrowFlightServer::new(arrow_bind_target, request_handlers)
+                let flight_service = ProximaFlightService::from_unified_handlers(request_handlers);
+                match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
                     .with_max_message_size(max_message_size)


### PR DESCRIPTION
## Summary

TD-104 ROOT \`UnifiedHandlers\` convergence, **step 2** (follows #292). Removes the \`ArrowFlightServer\` \`Arc<UnifiedHandlers>\` struct holder — Arrow Flight no longer knows about the ROOT god-object.

### Change
- \`ArrowFlightServer::new(bind_target, flight_service: ProximaFlightService)\` — takes a **pre-built** \`ProximaFlightService\` instead of \`Arc<UnifiedHandlers>\`.
- \`arrow_ipc/server.rs\` drops the \`UnifiedHandlers\` import + struct field; \`start()\` applies the outer-wrapper options (security/catalog/primary-pod-gate) onto the injected service.
- \`multi_server\` (2 construction sites) builds the \`ProximaFlightService\` via the existing \`from_unified_handlers\` boot adapter and passes it in.

\`ProximaFlightService\` was already fully port-based (\`ApiHandlersPort\` + \`RecordOpsPort\` + concrete services) from the earlier S3-c work; \`from_unified_handlers\` is the intentional ROOT→pieces wiring converter, now called only at the wiring layer. The Flight write path still routes through \`RecordOpsService\` exactly as before.

**Net:** one fewer live \`Arc<UnifiedHandlers>\` holder.

## Verification (pinned 1.95.0)
- \`cargo build --lib --bins\` ✅ (lib + server binary)
- \`cargo fmt --all -- --check\` ✅
- My files clippy-clean.

## Note on Rust Clippy (non-blocking)
\`Rust Clippy\` will show red, but it's **pre-existing and non-required**: #295's lease renew-loop wiring in \`shared_services.rs\` uses an intentional fire-and-forget \`let _ = manager.clone().spawn_renew_loop(...)\` (\`spawn_renew_loop\` does \`tokio::spawn\` internally and returns a \`JoinHandle\`, so the renew loop *does* run detached) which trips \`clippy::let_underscore_future\`. #295 merged with clippy red (CI Success green); develop CI Success is green. Clippy is informational, not gated.

## Remaining TD-104
Live holders left: \`rest/server.rs\` (5 ctors), \`rest/v1/handlers.rs\`, v2 \`grpc/record_service.rs\`, \`multiplex/handlers/rest.rs\` (RestHandlerConfig), then the S3-f endgame (collapse construction + migrate ~103 tests + delete \`request_handlers.rs\`). v1 gRPC holders are **out of scope** (v1 is being deprecated for v2).

Ref TD-104.