### PR TITLE
fix(search): canonical dead-record predicate + tombstone suppression (delete correctness)

### DIFF
--- a/crates/foundation/proximadb-records/src/lib.rs
+++ b/crates/foundation/proximadb-records/src/lib.rs
@@ -909,6 +909,24 @@ impl Default for ProximaRecord {
     }
 }
 
+/// Canonical "is this record dead" rule on `valid_to_ns` (nanoseconds) —
+/// the single source of truth for dead-record filtering. Operates on ns
+/// directly so it is immune to the `expires_at` unit confusion (ms on the
+/// proto wire vs secs in the WAL path). Used by types that carry only
+/// `valid_to_ns` (e.g. `OptimizedSearchRecord`); `ProximaRecord` prefers
+/// the richer [`ProximaRecord::is_dead`] (which also honors `valid_from`).
+///
+/// * `Some(0)` → tombstone (delete marker).
+/// * `Some(v)` where `0 < v < now_ns` → TTL-expired.
+/// * `None` or `v >= now_ns` → alive.
+pub fn is_record_dead(valid_to_ns: Option<i64>, now_ns: i64) -> bool {
+    match valid_to_ns {
+        Some(0) => true,
+        Some(v) if v > 0 && v < now_ns => true,
+        _ => false,
+    }
+}
+
 impl ProximaRecord {
     /// Returns true when this record is a tombstone marker at `snapshot_time_ns`.
     ///
@@ -939,6 +957,14 @@ impl ProximaRecord {
             .valid_to_ns
             .is_none_or(|valid_to_ns| snapshot_time_ns < valid_to_ns);
         valid_from_ok && valid_to_ok
+    }
+
+    /// Returns true when this record must NOT appear in a read at `now_ns`
+    /// — i.e. it is deleted (tombstone) or TTL-expired or not-yet-valid.
+    /// Convenience inverse of [`Self::is_visible_at`]; the single source of
+    /// truth for read-path dead-record filtering on `ProximaRecord`.
+    pub fn is_dead(&self, now_ns: i64) -> bool {
+        !self.is_visible_at(now_ns)
     }
 
     /// Construct a canonical tombstone marker for a logical record id.
@@ -1122,6 +1148,22 @@ mod tests {
         assert_eq!(r.oid, "row-1");
         assert!(r.is_tombstone_at(500));
         assert!(!r.is_visible_at(500));
+        assert!(r.is_dead(500), "tombstone is_dead");
+    }
+
+    #[test]
+    fn test_is_record_dead_canonical_rule() {
+        let now = 1_000_000_000i64;
+        // Tombstone marker.
+        assert!(is_record_dead(Some(0), now));
+        // TTL-expired (valid_to in the past).
+        assert!(is_record_dead(Some(999_999_999), now));
+        // Alive: no expiry.
+        assert!(!is_record_dead(None, now));
+        // Alive: expiry in the future.
+        assert!(!is_record_dead(Some(now + 1_000_000_000), now));
+        // Boundary: valid_to == now is exclusive (still alive at exactly now).
+        assert!(!is_record_dead(Some(now), now));
     }
 
     #[test]

--- a/src/core/search/merge.rs
+++ b/src/core/search/merge.rs
@@ -45,7 +45,12 @@ use crate::core::search::results::OptimizedSearchRecord;
 /// the combined check is the right distinguishing signal for the
 /// merge step.
 fn is_wal_tombstone(record: &OptimizedSearchRecord) -> bool {
-    record.vector.is_none() && record.expires_at.is_some()
+    // Canonical tombstone marker: valid_to_ns == Some(0). (The earlier
+    // `vector.is_none() && expires_at.is_some()` heuristic broke under
+    // `include_vectors=false`, where every delta record has vector == None,
+    // and relied on the unit-muddled expires_at.) valid_to_ns is the
+    // ns-accurate source of truth.
+    record.valid_to_ns == Some(0)
 }
 
 /// Merge WAL/memtable delta candidates with directory-routed candidates
@@ -74,10 +79,22 @@ pub fn merge_delta_with_directory_results(
     // Pass 2: build the merged map. Insert delta records first so the
     // "delta wins" rule is enforced by the subsequent directory pass
     // skipping any OIDs already seen.
+    //
+    // A tombstone in the delta suppresses *every* copy of that OID — not
+    // just the flushed/directory copy but also the live copy that may sit
+    // beside it in the same unflushed WAL (insert-then-delete before any
+    // flush). Without this guard the live WAL record survives into the
+    // output because it is itself not a tombstone, so `is_wal_tombstone`
+    // returns false and it gets inserted here while the tombstone is dropped.
     let mut by_oid: HashMap<String, OptimizedSearchRecord> = HashMap::new();
     for record in delta_results {
         if is_wal_tombstone(&record) {
             // Tombstones never appear in the output set.
+            continue;
+        }
+        if tombstone_ids.contains_key(&record.id) {
+            // A tombstone for this OID exists in the same delta — the
+            // delete supersedes this live copy.
             continue;
         }
         by_oid.insert(record.id.clone(), record);
@@ -125,8 +142,9 @@ mod tests {
             score: 0.0,
             similarity: Some(0.0),
             vector: None,
-            // WAL marks tombstones with a set expires_at; the value
-            // itself is irrelevant for the merge contract.
+            // Canonical tombstone marker (valid_to_ns == Some(0)); expires_at
+            // is display-only.
+            valid_to_ns: Some(0),
             expires_at: Some(0),
             ..Default::default()
         }
@@ -180,6 +198,28 @@ mod tests {
 
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].id, "b", "tombstoned OID removed from output");
+    }
+
+    #[test]
+    fn tombstone_in_delta_suppresses_live_copy_in_same_delta() {
+        // Insert-then-delete before any flush: both the live record and its
+        // tombstone are unflushed, so both surface in the WAL delta. The
+        // tombstone must suppress the live copy sitting beside it in the
+        // same delta — not just the flushed/directory copy.
+        let directory: Vec<OptimizedSearchRecord> = vec![];
+        let delta = vec![
+            live("a", 0.9), // live copy, inserted
+            tombstone("a"), // tombstone, same OID, newer
+            live("b", 0.8),
+        ];
+        let merged = merge_delta_with_directory_results(delta, directory, 10);
+
+        assert_eq!(
+            merged.len(),
+            1,
+            "live + tombstone for the same OID in the delta collapses to nothing"
+        );
+        assert_eq!(merged[0].id, "b");
     }
 
     #[test]

--- a/src/core/search/results.rs
+++ b/src/core/search/results.rs
@@ -3,6 +3,7 @@
 use crate::compute::distance_computation::engine::SimilarityResult;
 use crate::proto::proximadb_v1::SourceContent;
 use proximadb_data_model::ProximaValue;
+pub use proximadb_records::is_record_dead;
 // Canonical ranking score types — see roadmap/RANKING_FRAMEWORK_SPEC_2026_05_23.md (R-0).
 pub use proximadb_kernel::{PhaseId, ScoreComponent, ScoreVector};
 use std::collections::HashMap;
@@ -282,8 +283,15 @@ pub struct OptimizedSearchRecord {
     pub timestamp: Option<i64>,
     /// Last-update timestamp (ms since epoch)
     pub updated_at: Option<i64>,
-    /// TTL expiration timestamp (ms since epoch)
+    /// TTL expiration timestamp (ms since epoch). DISPLAY ONLY — unit-muddled
+    /// (ms on the proto wire, secs when derived in the WAL path). Correctness
+    /// (dead-record filtering) MUST use [`Self::valid_to_ns`] via
+    /// [`Self::is_dead`], never this field.
     pub expires_at: Option<i64>,
+    /// Validity end in nanoseconds (mirrors `ProximaRecord.valid_to_ns`).
+    /// `Some(0)` = tombstone; `Some(v)` in the past = TTL-expired. This is
+    /// the canonical field for dead-record filtering.
+    pub valid_to_ns: Option<i64>,
 
     // --- Source / context ---
     /// Original source content (skipped from serde — too large for wire)
@@ -313,6 +321,14 @@ impl OptimizedSearchRecord {
             score,
             ..Default::default()
         }
+    }
+
+    /// Returns true when this record must NOT appear in a read at `now_ns`
+    /// (tombstone `valid_to_ns == Some(0)` or TTL-expired). Uses the
+    /// canonical [`is_record_dead`] on `valid_to_ns` (ns) — never the
+    /// unit-muddled `expires_at`.
+    pub fn is_dead(&self, now_ns: i64) -> bool {
+        is_record_dead(self.valid_to_ns, now_ns)
     }
 
     /// Standardized distance-to-similarity conversion for consistent ranking across all metrics

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -630,6 +630,15 @@ impl VectorOperationsService {
                 record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
             });
         }
+        // Defense-in-depth: drop dead records (tombstone / TTL-expired) using
+        // the canonical ProximaRecord::is_dead on valid_to_ns (ns). The WAL
+        // memtable already filters these, but this guarantees no scan ever
+        // leaks a deleted/expired row regardless of the upstream path.
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        records.retain(|record| !record.is_dead(now_ns));
         if !include_vector {
             for record in &mut records {
                 record.embeddings.clear();
@@ -3214,19 +3223,32 @@ impl VectorOperationsService {
         // This is critical for delete/update operations where WAL contains tombstones
         use std::collections::HashMap;
 
-        // Get current time for tombstone detection
-        let current_time_secs = std::time::SystemTime::now()
+        // Current time in nanoseconds for canonical dead-record detection
+        // (see OptimizedSearchRecord::is_dead / proximadb_records::is_record_dead).
+        let now_ns = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
+            .map(|d| d.as_nanos() as i64)
             .unwrap_or(0);
 
         // Build map from results with priority: WAL > AXIS > Storage
         let mut id_to_result: HashMap<String, crate::core::search::results::OptimizedSearchRecord> =
             HashMap::new();
 
-        // WAL results have highest priority (fresher data)
+        // WAL results have highest priority (fresher data). A dead record
+        // (tombstone/expired) wins over a live one for the same OID: in the
+        // insert-then-delete-before-flush case both copies are unflushed in
+        // the same WAL delta, and the tombstone must survive so the dead-record
+        // filter below removes the OID. Never let a live copy overwrite a dead
+        // record. Uses the canonical is_dead(valid_to_ns) — not expires_at.
         for result in wal_optimized_results {
-            id_to_result.insert(result.id.clone(), result);
+            id_to_result
+                .entry(result.id.clone())
+                .and_modify(|existing| {
+                    if !existing.is_dead(now_ns) && result.is_dead(now_ns) {
+                        *existing = result.clone();
+                    }
+                })
+                .or_insert(result);
         }
 
         // AXIS HNSW results second priority (fast indexed search)
@@ -3239,25 +3261,18 @@ impl VectorOperationsService {
             id_to_result.entry(result.id.clone()).or_insert(result);
         }
 
-        // Filter out tombstones and collect final results
-        // Tombstone design: empty vector (Some(vec![])) + expires_at in past (including 0)
-        // NOTE: A record with vector=None is NOT a tombstone - it just means the vector wasn't
-        // returned in the optimized search (common for storage engines that return only IDs/scores)
+        // Filter out dead records (tombstone valid_to_ns==Some(0) OR TTL-expired)
+        // using the canonical predicate on valid_to_ns (ns) — immune to the
+        // expires_at unit confusion and to vector==None (engines returning only
+        // id/score). Defense-in-depth alongside the WAL delta merge.
         let mut all_results: Vec<crate::core::search::results::OptimizedSearchRecord> =
             id_to_result
                 .into_values()
                 .filter(|r| {
-                    // Check if this is a tombstone
-                    // Tombstone: vector is explicitly empty (Some(vec![])) AND expired
-                    // A record with vector=None is NOT a tombstone - it's just missing vector data
-                    let is_explicit_empty_vector = r.vector.as_ref().is_some_and(|v| v.is_empty());
-                    let is_expired = r.expires_at.is_some_and(|e| e <= current_time_secs);
-                    let is_tombstone = is_explicit_empty_vector && is_expired;
-
-                    if is_tombstone {
+                    if r.is_dead(now_ns) {
                         debug!(
-                            "🗑️ Filtering tombstone from two-stage search results: {}",
-                            r.id
+                            "🗑️ Filtering dead record from two-stage search results: {} (valid_to_ns={:?})",
+                            r.id, r.valid_to_ns
                         );
                         false
                     } else {

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -2494,6 +2494,7 @@ impl WriteAheadLogManager {
                         timestamp: Some(vector_record.created_at_ns / 1_000_000),
                         updated_at: Some(vector_record.updated_at_ns / 1_000_000),
                         expires_at: expires_at_secs,
+                        valid_to_ns: vector_record.valid_to_ns,
                         ..Default::default()
                     };
                     all_results.push(tombstone_result);
@@ -2557,6 +2558,7 @@ impl WriteAheadLogManager {
                     timestamp: Some(vector_record.created_at_ns / 1_000_000),
                     updated_at: Some(vector_record.updated_at_ns / 1_000_000),
                     expires_at: expires_at_secs,
+                    valid_to_ns: vector_record.valid_to_ns,
                     source: None,
                     semantic_similarity: Some(similarity_result.clone()),
                     ..Default::default()


### PR DESCRIPTION
## Problem
Deleted/TTL-expired records could reappear in search results. A first-principles audit found three compounding root causes.

## Root causes & fixes

**1. TTL/expiry unit bug.** `expires_at` was derived from `valid_to_ns` with **inconsistent divisors** — ms on the proto wire (`conversions.rs`), secs in the WAL path (`mod.rs`), ns in the memtable. Expiry comparisons that crossed units leaked expired records indefinitely. **Fix:** correctness now operates on `valid_to_ns` (ns) directly via a single canonical `is_record_dead(valid_to_ns, now_ns)` in the records crate + a new `OptimizedSearchRecord.valid_to_ns` field + `is_dead(now_ns)`. `expires_at` becomes display-only.

**2. Tombstone not suppressed in WAL-delta merge.** When a record's live copy and its tombstone were both unflushed (insert-then-delete-before-flush), `merge_delta_with_directory_results` Pass-2 inserted the live copy beside its own tombstone. **Fix:** Pass-2 skips any delta record whose OID has a tombstone in the same delta. `is_wal_tombstone` now uses the canonical `valid_to_ns == Some(0)` (the old `vector.is_none() && expires_at.is_some()` heuristic misfired under `include_vectors=false`, where every delta record has `vector==None`).

**3. Two-stage filter + scan.** The two-stage tombstone filter missed records with `vector==None` and used unit-muddled `expires_at`; replaced with `is_dead(now_ns)`. WAL dedup is now **tombstone-priority** (a dead record wins over a live copy for the same OID). Scan gets a defense-in-depth `retain` via `ProximaRecord::is_dead` (reusing the existing `is_visible_at` MVCC predicate).

## Verification
- ✅ New unit tests: `is_record_dead` (4 cases — tombstone / expired / alive-no-ttl / future) + `tombstone_in_delta_suppresses_live_copy_in_same_delta`
- ✅ records crate 95 tests; merge suite 9 tests
- ✅ `cargo clippy --lib --bins` clean (hard gate)
- ✅ **E2E on clean `origin/develop`**: insert `{a,b}` → delete `a` → cache-miss search → **`[b]` only**

## Scope
- `crates/foundation/proximadb-records/src/lib.rs` — canonical `is_record_dead` + `ProximaRecord::is_dead`
- `src/core/search/results.rs` — `OptimizedSearchRecord.valid_to_ns` + `is_dead`
- `src/core/search/merge.rs` — `is_wal_tombstone` canonical + Pass-2 guard + test
- `src/storage/persistence/write_ahead_log/mod.rs` — populate `valid_to_ns` (2 sites)
- `src/services/operations/vectors/legacy.rs` — two-stage dedup (tombstone-priority) + `is_dead` filter + scan `retain`

## Supersedes #297
#297 carried only the merge Pass-2 guard with the older `is_wal_tombstone` heuristic. This PR folds that in **and** fixes the unit bug at the root **and** adds the canonical predicate + defense-in-depth. **#297 should be closed.**

## Note (separate, follow-up P0b)
Query-cache staleness on the *exact same* query after a write (`QueryCache` has no per-collection invalidation) is a separate cache-coherence fix — the `CacheInvalidationCoordinator` exists but is unwired. Cache-miss / differently-shaped queries are now correct.

## Audit caveat
The audit flagged the Orion graph engine as leaking tombstoned nodes — **verified false**: Orion uses hard-delete (`memory_pool.remove_node` + index removal), so deleted nodes are gone from the pool and cannot leak. (The graph `Node` has no validity field because it doesn't use tombstones.)