### PR TITLE
fix(search): cache coherence on write + Strong-freshness bypass (read-after-write)

### DIFF
--- a/src/query/cache/invalidation_coordinator.rs
+++ b/src/query/cache/invalidation_coordinator.rs
@@ -295,9 +295,10 @@ mod tests {
         let s = InvalidationSummary {
             plan_cache_entries: 3,
             batch_groups_closed: 5,
+            query_cache_entries: 2,
             corpus_version_after: None,
         };
-        assert_eq!(s.total(), 8);
+        assert_eq!(s.total(), 10);
     }
 
     // Bind one cache key digest to a stable u64 so the coordinator tests

--- a/src/query/cache/invalidation_coordinator.rs
+++ b/src/query/cache/invalidation_coordinator.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use crate::query::cache::batch_group::BatchGroupCache;
 use crate::query::cache::plan_cache::PlanCache;
+use crate::storage::cache::specialized::query_cache::QueryCache;
 
 /// Per-call result — how many entries each cache dropped. Useful in
 /// observability dashboards and in tests that need to assert fan-out.
@@ -30,6 +31,7 @@ use crate::query::cache::plan_cache::PlanCache;
 pub struct InvalidationSummary {
     pub plan_cache_entries: u64,
     pub batch_groups_closed: u64,
+    pub query_cache_entries: u64,
     /// Corpus version after the bump that fired during this call —
     /// `None` only if the registry wasn't reachable. The observability
     /// dashboard reports this so an SRE can correlate "the version
@@ -39,7 +41,7 @@ pub struct InvalidationSummary {
 
 impl InvalidationSummary {
     pub fn total(&self) -> u64 {
-        self.plan_cache_entries + self.batch_groups_closed
+        self.plan_cache_entries + self.batch_groups_closed + self.query_cache_entries
     }
 }
 
@@ -49,6 +51,7 @@ impl InvalidationSummary {
 pub struct CacheInvalidationCoordinator {
     plan_cache: Option<Arc<PlanCache>>,
     batch_group: Option<Arc<BatchGroupCache>>,
+    query_cache: Option<Arc<QueryCache>>,
 }
 
 impl CacheInvalidationCoordinator {
@@ -59,6 +62,7 @@ impl CacheInvalidationCoordinator {
         Self {
             plan_cache: None,
             batch_group: None,
+            query_cache: None,
         }
     }
 
@@ -71,6 +75,12 @@ impl CacheInvalidationCoordinator {
     /// Attach the batch-group cache.
     pub fn with_batch_group(mut self, cache: Arc<BatchGroupCache>) -> Self {
         self.batch_group = Some(cache);
+        self
+    }
+
+    /// Attach the query-results cache.
+    pub fn with_query_cache(mut self, cache: Arc<QueryCache>) -> Self {
+        self.query_cache = Some(cache);
         self
     }
 
@@ -94,6 +104,10 @@ impl CacheInvalidationCoordinator {
 
         if let Some(cache) = &self.plan_cache {
             summary.plan_cache_entries = cache.invalidate_collection(tenant_id, collection).await;
+        }
+
+        if let Some(cache) = &self.query_cache {
+            summary.query_cache_entries = cache.invalidate_collection(collection).await as u64;
         }
 
         if let Some(cache) = &self.batch_group {

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2194,14 +2194,13 @@ impl VectorOperationsService {
         if !matches!(
             freshness_mode,
             crate::core::search::VectorFreshnessMode::Strong
-        ) {
-            if let Some(cached_v1) = self.query_cache.get_if_fresh_v1(&cache_key, 300).await {
-                // Phase 7.2: a process-local cache hit is the strongest
-                // possible signal that this node owns the warm path for
-                // the collection — record affinity here too.
-                self.record_search_affinity(collection_id);
-                return Ok((cached_v1, None));
-            }
+        ) && let Some(cached_v1) = self.query_cache.get_if_fresh_v1(&cache_key, 300).await
+        {
+            // Phase 7.2: a process-local cache hit is the strongest
+            // possible signal that this node owns the warm path for
+            // the collection — record affinity here too.
+            self.record_search_affinity(collection_id);
+            return Ok((cached_v1, None));
         }
 
         let progressive_enabled = config.as_ref().is_some_and(|c| c.progressive_search);

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -486,6 +486,21 @@ impl VectorOperationsService {
     pub fn invalidate_collection_cache(&self, collection_id: &str) {
         self.collection_resolver()
             .invalidate_collection_cache(collection_id);
+        // Read-after-write coherence: drop cached query results for this
+        // collection so the next search reflects the write. Fire-and-forget
+        // (async) — callers that need the invalidation guaranteed before a
+        // subsequent read call `invalidate_query_cache` and await it.
+        let query_cache = self.query_cache.clone();
+        let coll = collection_id.to_string();
+        tokio::spawn(async move {
+            query_cache.invalidate_collection(&coll).await;
+        });
+    }
+
+    /// Invalidate cached query results for a collection, awaited. Use this on
+    /// the write paths (insert/delete) where the next read must see the write.
+    pub async fn invalidate_query_cache(&self, collection_id: &str) {
+        self.query_cache.invalidate_collection(collection_id).await;
     }
 
     async fn validate_tenant_collection_access(
@@ -836,6 +851,9 @@ impl VectorOperationsService {
         if !result.success {
             return Ok(result);
         }
+        // Read-after-write coherence: a deleted record must not resurface
+        // from a stale cached query result. Await so the next search sees it.
+        self.invalidate_query_cache(collection_id).await;
         let total_processed = result.metrics.total_processed.max(0);
         let processing_time_us = start.elapsed().as_micros() as i64;
 
@@ -1762,9 +1780,16 @@ impl VectorOperationsService {
             return Err(anyhow::anyhow!(e));
         }
 
-        self.write_coordinator()
+        let result = self
+            .write_coordinator()
             .insert_batch_internal(collection_id, records)
-            .await
+            .await?;
+        // Read-after-write coherence: a freshly inserted record must be
+        // visible to the next search, not hidden behind a stale cached result.
+        if result.success {
+            self.invalidate_query_cache(collection_id).await;
+        }
+        Ok(result)
     }
 
     /// Alias kept for callers already using ProximaRecord envelopes.
@@ -2157,12 +2182,26 @@ impl VectorOperationsService {
             k as u32,
             filter_str.as_deref(),
         );
-        if let Some(cached_v1) = self.query_cache.get_if_fresh_v1(&cache_key, 300).await {
-            // Phase 7.2: a process-local cache hit is the strongest
-            // possible signal that this node owns the warm path for
-            // the collection — record affinity here too.
-            self.record_search_affinity(collection_id);
-            return Ok((cached_v1, None));
+        // Strong-freshness reads must NEVER be served from the query cache —
+        // a cached result could predate a concurrent write and violate
+        // read-after-write. Only non-Strong (StaleOk / BoundedStale) reads
+        // may use the cache. Extract freshness here (before the cache check)
+        // so the gate is correct.
+        let freshness_mode = config
+            .as_ref()
+            .and_then(|c| c.freshness_mode.clone())
+            .unwrap_or_default();
+        if !matches!(
+            freshness_mode,
+            crate::core::search::VectorFreshnessMode::Strong
+        ) {
+            if let Some(cached_v1) = self.query_cache.get_if_fresh_v1(&cache_key, 300).await {
+                // Phase 7.2: a process-local cache hit is the strongest
+                // possible signal that this node owns the warm path for
+                // the collection — record affinity here too.
+                self.record_search_affinity(collection_id);
+                return Ok((cached_v1, None));
+            }
         }
 
         let progressive_enabled = config.as_ref().is_some_and(|c| c.progressive_search);
@@ -2191,14 +2230,9 @@ impl VectorOperationsService {
             .map(|c| c.search_mode.clone())
             .unwrap_or_default();
 
-        // Phase 5: pull the request's freshness mode (default = Strong)
-        // so the v1 path applies the same delta-merge semantics as the
-        // legacy path. Keep clones of query_vector + filter for the
-        // delta scan since execute_unified_plan takes ownership.
-        let freshness_mode = config
-            .as_ref()
-            .and_then(|c| c.freshness_mode.clone())
-            .unwrap_or_default();
+        // freshness_mode was extracted above (before the cache check) so the
+        // Strong-bypass gate is correct. Keep clones of query_vector + filter
+        // for the delta scan since execute_unified_plan takes ownership.
         let delta_query_vector = query_vector.clone();
         let delta_filter = filter.clone();
 

--- a/src/storage/cache/backend/memory_tier.rs
+++ b/src/storage/cache/backend/memory_tier.rs
@@ -69,6 +69,31 @@ where
         }
     }
 
+    /// Remove every entry whose key matches `predicate`; returns the count
+    /// removed. Used by per-collection cache invalidation on writes.
+    pub async fn remove_where<F>(&self, predicate: F) -> usize
+    where
+        F: Fn(&K) -> bool,
+    {
+        // Collect matching keys first, then remove — avoids holding a shard
+        // guard across the remove call (DashMap re-entrancy).
+        let matching: Vec<K> = self
+            .storage
+            .iter()
+            .filter(|entry| predicate(entry.key()))
+            .map(|entry| entry.key().clone())
+            .collect();
+        let mut removed = 0usize;
+        for key in matching {
+            if let Some((_, value)) = self.storage.remove(&key) {
+                let entry_size = estimate_size(&value);
+                self.size_bytes.fetch_sub(entry_size, Ordering::Relaxed);
+                removed += 1;
+            }
+        }
+        removed
+    }
+
     /// Get memory usage in bytes
     pub async fn memory_usage(&self) -> usize {
         self.size_bytes.load(Ordering::Relaxed)

--- a/src/storage/cache/base.rs
+++ b/src/storage/cache/base.rs
@@ -157,6 +157,31 @@ where
         }
     }
 
+    /// Remove every L1 entry whose key matches `predicate`; returns the
+    /// count removed. Backs per-collection cache invalidation on writes.
+    pub async fn remove_where<F>(&self, predicate: F) -> usize
+    where
+        F: Fn(&K) -> bool,
+    {
+        let removed = self.l1_backend.remove_where(predicate).await;
+        if removed > 0 {
+            let metrics = self.metrics.clone();
+            tokio::spawn(async move {
+                for _ in 0..removed {
+                    metrics
+                        .record_operation(
+                            MetricsOperationType::Delete,
+                            true,
+                            0,
+                            std::time::Duration::from_secs(0),
+                        )
+                        .await;
+                }
+            });
+        }
+        removed
+    }
+
     /// Get current L1 memory usage in bytes
     pub async fn memory_usage(&self) -> usize {
         self.l1_backend.memory_usage().await

--- a/src/storage/cache/specialized/query_cache.rs
+++ b/src/storage/cache/specialized/query_cache.rs
@@ -173,6 +173,16 @@ impl QueryCache {
         false
     }
 
+    /// Invalidate ALL cached query results for a collection. Called on write
+    /// (insert/update/delete/DDL) via the CacheInvalidationCoordinator so a
+    /// write is immediately visible to subsequent reads (read-after-write).
+    /// Returns the number of entries evicted.
+    pub async fn invalidate_collection(&self, collection_id: &str) -> usize {
+        self.base
+            .remove_where(|k| k.collection_id == collection_id)
+            .await
+    }
+
     /// Resize the cache
     pub async fn resize(&self, _new_size_mb: usize) -> anyhow::Result<()> {
         // Deferred: Implement cache resizing


### PR DESCRIPTION
## Problem
Read-after-write was broken: the `QueryCache` (300s TTL) was never invalidated on writes, and a `Strong`-freshness read could be served a stale cached result that predated a concurrent write. (The same-query-stale-after-delete gap noted as a TD in #305.)

## Fixes
1. **`QueryCache::invalidate_collection`** via a new `BaseCacheImpl::remove_where` (`MemoryBackend` DashMap retain). The existing-but-**unwired** `CacheInvalidationCoordinator` gains a `query_cache` field + fan-out (`query_cache_entries` in `InvalidationSummary`).
2. **Write paths invalidate the query cache post-commit:** INSERT (`insert_batch_with_tenant_context`) + DELETE (`delete_records_with_tenant_context`) `await invalidate_query_cache`; `invalidate_collection_cache` (the DDL hook) spawns it. A freshly written record is now immediately visible to the next search.
3. **Strong-freshness reads bypass the query cache** (`unified_search_v1_inner`): the cache check is gated on `!Strong`, so a Strong read always computes fresh (delta-merge) — never a pre-write cached result.

## Verification
- ✅ `cargo clippy --lib --bins` clean (hard gate), `rustup run 1.95.0 cargo fmt --all` clean
- ✅ **E2E cache coherence:** `insert{a}` → search `[1,2,3]` (warms cache → `[a]`) → `insert{b}` → **SAME** search `[1,2,3]` → `[a,b]` (was `[a]` stale before the fix)

## Composes with #305
#305 (dead-record predicate) + this PR (cache coherence) together make **delete fully correct**: the tombstone is filtered AND the cache no longer serves a stale pre-delete result. Closes the same-query-stale-after-write TD noted in #305. (Independent PRs — zero file overlap on merge.)

## Files
- `src/storage/cache/backend/memory_tier.rs` + `base.rs` — `remove_where`
- `src/storage/cache/specialized/query_cache.rs` — `invalidate_collection`
- `src/query/cache/invalidation_coordinator.rs` — `query_cache` field + fan-out
- `src/services/operations/vectors/legacy.rs` — write-path invalidation (insert/delete) + `invalidate_collection_cache` spawn + Strong-bypass

## Scope note
The `CacheInvalidationCoordinator` fan-out to plan/batch caches is wired structurally (field + builder + summary), but the service currently invalidates `query_cache` directly (it holds it; plan/batch aren't plumbed into the service yet). Wiring plan/batch into the coordinator at service-build is a follow-up; the load-bearing read-after-write fix (query cache) is complete here.