### PR TITLE
fix(records): scan predicate filters dead records (tombstone + TTL-expired)

### DIFF
--- a/crates/foundation/proximadb-records/src/store.rs
+++ b/crates/foundation/proximadb-records/src/store.rs
@@ -123,6 +123,19 @@ impl RecordScanOptions {
     }
 
     pub fn matches_record(&self, record: &ProximaRecord) -> bool {
+        // Dead-record filter (defense-in-depth, applies to EVERY scan using
+        // RecordScanOptions): a tombstone (valid_to_ns == Some(0)) or
+        // TTL-expired (valid_to_ns in the past) record must never surface.
+        // Uses the canonical ProximaRecord::is_visible_at on valid_to_ns
+        // (ns) — never the unit-muddled expires_at.
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        if !record.is_visible_at(now_ns) {
+            return false;
+        }
+
         if let Some(label) = &self.required_label
             && !record.labels.contains(label)
         {
@@ -278,6 +291,41 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
     use std::sync::RwLock;
+
+    #[test]
+    fn matches_record_excludes_tombstone_and_expired() {
+        // A live record passes the unbounded scan filter.
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        let live = ProximaRecord {
+            oid: "alive".into(),
+            ..ProximaRecord::default()
+        };
+        assert!(
+            RecordScanOptions::unbounded().matches_record(&live),
+            "live record matches"
+        );
+
+        // A delete tombstone (valid_to_ns == 0) is excluded.
+        let tombstone = ProximaRecord::tombstone("dead", now_ns);
+        assert!(
+            !RecordScanOptions::unbounded().matches_record(&tombstone),
+            "tombstone excluded from scan"
+        );
+
+        // A TTL-expired record (valid_to_ns in the past) is excluded.
+        let expired = ProximaRecord {
+            oid: "stale".into(),
+            valid_to_ns: Some(now_ns - 1_000_000_000),
+            ..ProximaRecord::default()
+        };
+        assert!(
+            !RecordScanOptions::unbounded().matches_record(&expired),
+            "TTL-expired record excluded from scan"
+        );
+    }
 
     #[derive(Default)]
     struct MemoryRecordStore {


### PR DESCRIPTION
## Problem
The canonical scan predicate `RecordScanOptions::matches_record` matched on label/tenant/props but **never checked `valid_to_ns`**, so every scan routed through it leaked deleted (tombstone) and TTL-expired records. The P1 audit found SQL/pgwire, memtable scans, gRPC, and count/stats all leak.

## Fix
Add a dead-record check via the **existing** canonical `ProximaRecord::is_visible_at(now_ns)` (ns, MVCC-correct) at the top of `matches_record`. This is the shared predicate used by:
- the memtable scan (`record_memtable.rs` `scan_records_filtered`) → and SQL/pgwire reads that funnel through it
- the cedar engine scan (`cedar/mod.rs`)
- the records-crate `retain` (`store.rs`)

So the single change propagates to all those surfaces (defense-in-depth alongside the WAL/engine filters). Independent of #305 — uses `is_visible_at`, which is already on develop.

## Verified
- ✅ New unit test `matches_record_excludes_tombstone_and_expired` (tombstone + TTL-expired excluded; live passes)
- ✅ records crate 95 tests; `cargo clippy --lib --bins` clean; `rustup run 1.95.0 cargo fmt --all` clean

## Scope / follow-ups (from the P1 audit)
This fixes the scan-predicate leaks. Still open (separate PRs):
- **Collection stats** (`ViperEngine::collection_stats`) count raw atomic counters including dead records — needs a live-only count.
- **gRPC GetRecord/Scan** paths that don't funnel through `scan_records_filtered` — verify + add filter at emission.
- **Document store** `query_documents` — verify the delegated engine filters.
- Arrow Flight is currently a `UNIMPLEMENTED` placeholder (no leak yet).

Aligns with the Directive 16 mandate (#312): every read boundary filters dead records via the canonical predicate.