### PR TITLE
docs(adr): ADR-025 — deletion vectors for cold-path deletes (layered over MVCC)

### DIFF
--- a/docs/12-design/adr/ADR-025-deletion-vectors-cold-path.adoc
+++ b/docs/12-design/adr/ADR-025-deletion-vectors-cold-path.adoc
@@ -1,0 +1,171 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-025: Deletion Vectors for Cold-Path Deletes (Layered over MVCC)
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-25
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-007 (Iceberg REST), ADR-010 (PAX Block Format), ADR-020 (Canonical WAL Authority), `FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc` (P4), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`
+|Supersedes|—
+|===
+
+== Context
+
+ProximaDB today represents **all** deletes — hot and cold — as per-record
+tombstones (`valid_to_ns == Some(0)`, `origin = "delete"`), filtered at read
+time by `ProximaRecord::is_visible_at` / the canonical `is_record_dead`
+predicate (ADR for the predicate shipped as PR #305). A first-principles
+correctness audit (PRs #305, #310, #312, #313) raised a deeper question:
+
+*Is MVCC + per-record-tombstone read-pruning the right durable delete
+mechanism for a performant cloud-native **serverless** store serving OLTP
+**and** OLAP **and** vector workloads — or should we move to redo/undo, or
+another mechanism?*
+
+The dominant cost for a cloud DB is **I/O round-trips + egress, not CPU**
+(the co-design cost spine). Judged against that term, the current model has
+three structural problems on the **flushed (cold)** data path:
+
+1. **Read amplification.** A scan must read *every* dead row then drop it.
+   Over object storage, dead bytes are extra GETs + egress — the exact cost
+   term we minimize. The 1-hour tombstone-retention window means scans
+   *degrade* between compactions (the classic LSM tombstone problem).
+2. **Correctness footgun.** Read-pruning distributes the "filter dead
+   records" responsibility across *every* read surface (vector search, scan,
+   get, SQL/pgwire, Arrow Flight, graph, document, count/stats). The audit
+   found most of them leak; the predicate (PR #305) + scan-predicate fix
+   (PR #313) patch the leaks, but the model is structurally leak-prone.
+3. **ANN-hostile.** HNSW/IVF cannot prune tombstones during traversal — a
+   deleted vector node is *visited then filtered*. That is wasted graph hops
+   and a recall hazard.
+
+Redo/undo (ARIES-style in-place pages) was evaluated and **rejected**:
+in-place page mutation over object storage is a read-modify-write of whole
+objects (the most expensive op in the cost spine); it is OLTP-native but
+OLAP-poor (row pages, not columnar); and it reverses the committed
+lakehouse / immutable-object-store-first direction (see
+`DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc`).
+
+The design doc `FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc` already
+commits to Iceberg v3-default, which includes **deletion vectors (Puffin)**
+for deletes — listed as P4 (planned, not yet implemented). This ADR makes
+that commitment concrete and scopes the architecture.
+
+== Decision
+
+Adopt a **layered hybrid** delete model keyed to data temperature, **not** a
+wholesale replacement of MVCC and **not** redo/undo:
+
+[cols="1,4,3"]
+|===
+|Tier |Mechanism |Rationale
+
+|**HOT** (unflushed, OLTP)
+|WAL/memtable delta + MVCC `valid_from_ns`/`valid_to_ns` on the live row; tombstone for the delete marker.
+|Small, in-RAM; read-time prune is cheap here. The current model is *correct* for hot data — the PR #305/#310/#313 fixes stand.
+
+|**COLD** (flushed, OLAP + vector)
+|Immutable Parquet/PAX files + **deletion vectors** (per-file Roaring bitmap) + Iceberg snapshot manifests.
+|Delete = set a DV bit (compact), *not* append a tombstone row. Scans apply the DV at the file/segment boundary — prune whole ranges before touching row data, minimizing bytes scanned/egressed.
+
+|**VECTOR** (ANN segments)
+|Deletion vector at the **index-segment** level.
+|Deleted vector sets a segment-DV bit; traversal skips it. The segment rebuilds when DV density exceeds a threshold (Pinot/ClickHouse style), avoiding the HNSW-traverses-deleted-nodes problem.
+|===
+
+**Transition rule (on flush):** a tombstone in the HOT delta is converted to a
+DV bit in the target COLD file's deletion vector. Compaction merges DVs
+across files and reclaims space; it no longer rewrites rows to drop tombstones
+on the cold path (it merges bitmaps instead).
+
+**Transaction layer (separate concern):** a short-lived *undo log in the
+TxnManager* (for ROLLBACK / snapshot / serializable isolation of in-flight
+transactions) is compatible with this model and is the right tool for txn
+abort/isolation. This is *not* a redo/undo durable storage mechanism — it
+lives only for the transaction's duration, in memory or WAL-local, layered
+above the immutable storage.
+
+=== Why this is the cloud-native serverless fit
+
+* **Minimizes the dominant cost.** DVs are tiny bitmaps applied once per file
+  during scan setup, not per row — dead bytes never leave object storage.
+* **Serverless-native.** Immutable files over S3; compaction is independently
+  scalable compute (scale-to-zero otherwise); snapshots are manifest
+  references (Iceberg infra already exists); per-tenant DV size meters cleanly
+  into the storage TAM surface.
+* **OLTP + OLAP + vector.** Delta/MVCC for recent OLTP writes; columnar base
+  + DV for OLAP scans; segment-level DV for vector ANN.
+* **Centralizes correctness.** Cold-path delete visibility is decided at one
+  boundary (the file/segment scan), not distributed across every read surface
+  — removing the structural leak the audit exposed.
+
+== Alternatives Considered
+
+* **Redo/undo (ARIES in-place pages) — REJECTED.** In-place mutation over
+  object store = read-modify-write of whole objects (costliest op). OLAP-poor.
+  Reverses the committed lakehouse direction.
+* **Pure tombstone read-prune for all data (status quo on cold path) —
+  REJECTED as the cold-path target.** Read-amplifying, correctness-leak-prone,
+  ANN-hostile. Retained only for the hot delta where prune cost is negligible.
+* **Wholesale DV replacement of MVCC — REJECTED.** Unnecessary and risky;
+  MVCC is correct for hot data. The win is at the cold/scan path — layer it.
+
+== Mixed-Read-Safe Migration (phased, default-OFF)
+
+Per the storage-format migration mandate (CLAUDE.md §8): version/magic-byte
+detection, old + new coexist, default-OFF until baked, readers default to
+legacy when the marker is absent. Template: `RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc`.
+
+* **N0 — DV primitive.** Per-file Roaring bitmap; Puffin sidecar writer/reader
+  (Iceberg-interop surface) and/or inline PAX/Parquet footer slot (vertical-
+  internal, one fewer RTT). Versioned magic. No behavior change.
+* **N1 — write path (default-OFF).** DELETE on a flushed file sets a DV bit
+  *in addition to* the tombstone (dual-write). Flush converts hot-delta
+  tombstones → target-file DV bits.
+* **N2 — read path.** OLAP/vector reads apply the DV at file/segment scan;
+  gate on the magic byte (absent marker → legacy tombstone-prune).
+* **N3 — compaction.** Merge DVs across files; ANN segment rebuild on a DV
+  density threshold.
+* **N4 — cutover.** Per-collection opt-in → default-on once recall@k and
+  TPC-H/TPC-DS ratchets hold. Tombstones retained only for the hot delta.
+
+Each phase gated by round-trip + recall/quality tests vs the f32 baseline.
+
+== Open Decisions (resolve before N0)
+
+1. **DV storage location** — Puffin sidecar (Iceberg-standard, interop) vs
+   inline PAX/Parquet footer (one fewer RTT). Recommendation: *inline* for the
+   vertical-internal PAX path, *Puffin* for the Iceberg-interop surface.
+2. **Update semantics** — confirm update = delete-old (DV the position) +
+   insert-new everywhere on the cold path; no in-place update leaks.
+3. **ANN rebuild threshold** — the DV density at which an HNSW segment
+   rebuilds vs continues skipping. Must be justified by a measured per-query
+   trace, not a static heuristic (co-design: trace before tune).
+4. **CDC / `changes_since`** — DVs are point-in-time delete markers; ensure
+   CDC still emits delete events from the DV transition (do not lose the
+   lineage the tombstone carried).
+5. **Txn-layer undo** — scope a separate ADR for the TxnManager undo log
+   (serializable isolation / abort).
+
+== Consequences
+
+* **Positive:** cold-path scan bytes drop sharply (dead ranges pruned at the
+  file boundary); delete correctness centralized (no distributed read-time
+  leaks); ANN no longer traverses deleted nodes; aligns with the committed
+  Iceberg v3 direction and the co-design cost spine.
+* **Negative / cost:** a new primitive (DV bitmap + reader/writer) and its
+  wiring across flush, scan, compaction, and ANN — a multi-phase effort.
+  Dual-write during N1 temporarily *adds* a tombstone + a DV bit (small write
+  amplification) until cutover.
+* **Neutral:** MVCC + tombstones are retained for the hot delta; the PR
+  #305–#313 correctness work remains valid and load-bearing for that tier.
+
+== References
+
+* `docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` — cost spine (I/O + egress dominate).
+* `docs/12-design/DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` — lakehouse pivot.
+* `docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc` — Iceberg v3 default; P4 deletion vectors.
+* `docs/12-design/RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc` — mixed-read-safe migration template.
+* Accuracy audit: PRs #305 (dead-record predicate), #310 (cache coherence), #312 (Directive 16 mandate), #313 (scan-predicate filter).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -71,6 +71,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | `PortUserContext` — Boundary Type for `SecurityPort` Authentication
 | Accepted
 | Lossy projection of root-crate `UnifiedUserContext` so `SecurityPort::authenticate` can exist at the runtime boundary without dragging the typed permission graph into the runtime crate
+
+| link:ADR-025-deletion-vectors-cold-path.adoc[ADR-025]
+| Deletion Vectors for Cold-Path Deletes (Layered over MVCC)
+| Proposed
+| Cold-path delete mechanism (DV bitmap + immutable files + Iceberg snapshots); rejects redo/undo; retains MVCC for the hot delta
 |===
 
 NOTE: ADR-010 through ADR-013 exist in this directory but are not yet


### PR DESCRIPTION
## What
Records the architecture decision for the durable **delete mechanism** on a performant cloud-native serverless store (OLTP + OLAP + vector). Design-only — no implementation.

## Decision (the TL;DR)
- **Reject redo/undo** — in-place pages over object store is the costliest op; OLAP-poor; reverses the lakehouse direction.
- **Keep MVCC + tombstones for the HOT (unflushed/OLTP) delta** — small, in-RAM, prune is cheap. The PR #305–#313 correctness work stands.
- **Adopt deletion vectors (per-file Roaring bitmap, Iceberg v3/Puffin) for the COLD (flushed) OLAP + vector path** — delete = set a bit; scans prune whole file/segment ranges before touching row data, minimizing the dominant cost (bytes scanned / egress). Segment-level DV for ANN. Makes concrete the P4 item in `FORMAT_STRATEGY_ICEBERG_DELTA_LANCE`.
- **Txn-layer undo** (for ROLLBACK / serializable isolation) is a separate, compatible concern — not a redo/undo durable storage mechanism.

## Why (first-principles, vs the co-design cost spine)
For a cloud DB the dominant cost is I/O round-trips + egress, not CPU. Per-record tombstone read-pruning on cold data is read-amplifying (scans read every dead row), correctness-leak-prone (the audit found 8/10 read surfaces leak), and ANN-hostile (HNSW traverses deleted nodes then filters). Deletion vectors applied at the file boundary are the lakehouse-industry-standard fix (Iceberg/Delta/Snowflake/Databricks) and the design docs already commit to it (P4). Most infra exists (immutable files, Iceberg snapshots, WAL delta, compaction) — the gap is the DV primitive itself.

## Contents
Context · Decision (layered hybrid table) · alternatives considered · mixed-read-safe N0–N4 migration (default-OFF) · open decisions (DV location, update semantics, ANN rebuild threshold, CDC lineage, txn-undo ADR) · consequences · references.

Doc-only (asciidoc) + an index entry in `adr/README.adoc`. Pairs with the in-flight accuracy PRs (#305, #310, #312, #313) — this ADR is the *strategic* counterpart to their *tactical* correctness fixes.