### PR TITLE
refactor(rest): migrate AppState ROOT reads to ports/fields (TD-104 REST Phase 1)

### DIFF
--- a/src/network/rest/progressive_search_handler.rs
+++ b/src/network/rest/progressive_search_handler.rs
@@ -41,7 +41,7 @@ pub async fn progressive_search_handler(
 
     // Delegate directly to unified v1 handler
     let resp = state
-        .request_handlers
+        .api_handlers
         .handle_vector_search_v1_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -48,6 +48,12 @@ pub struct AppState {
     /// Document service, extracted at boot (TD-104 S5). Feeds the document AQL
     /// source; same `Arc` as the root handler.
     pub document_service: Arc<crate::storage::document::DocumentService>,
+    /// Collection service, extracted at boot (TD-104 S5). Feeds the health
+    /// endpoint's collection-count probe; same `Arc` as the root handler.
+    pub collection_service: Arc<crate::services::CollectionService>,
+    /// Record write-path service (TD-104 S5). Owns record-batch insert/delete
+    /// orchestration; same `Arc` the root handler's `record_ops()` returns.
+    pub record_ops: Arc<crate::api_handlers::record_ops_service::RecordOpsService>,
     /// Cross-modal fusion service — the single retrieval port every search
     /// surface delegates to (`SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`).
     /// Constructed once at boot from the vector + graph services (mirrors the
@@ -186,6 +192,8 @@ impl AppState {
         // Mirrors how `graph_execution_service` is already threaded.
         let vector_operations_service = request_handlers.vector_operations_service.clone();
         let document_service = request_handlers.document_service.clone();
+        let collection_service = request_handlers.collection_service.clone();
+        let record_ops = request_handlers.record_ops();
         let observability_service = request_handlers.observability_service.clone();
         let event_log = request_handlers.event_log.clone();
         // Cross-modal fusion port — built once at boot from the vector + graph
@@ -207,6 +215,8 @@ impl AppState {
             graph_execution_service,
             vector_operations_service,
             document_service,
+            collection_service,
+            record_ops,
             fusion_service,
             observability_service,
             event_log,
@@ -421,7 +431,7 @@ impl AppState {
     pub fn health_state(&self) -> health::HealthState {
         health::HealthState::new(
             self.vector_operations_service.clone(),
-            self.request_handlers.collection_service.clone(),
+            self.collection_service.clone(),
             self.graph_execution_service.clone(),
         )
     }
@@ -1259,10 +1269,7 @@ pub fn create_router(state: AppState) -> axum::Router {
             CsrRelationsStore, InMemoryProvenanceRegistry, ProximaEntityStore,
         };
 
-        let engine = state
-            .request_handlers
-            .vector_operations_service
-            .unified_engine();
+        let engine = state.vector_operations_service.unified_engine();
         let legacy_store = ProximaEntityStore::with_vector_service(
             engine,
             Arc::new(CsrRelationsStore::new()),

--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -650,7 +650,7 @@ pub async fn create_collection_v2(
 
     // Create collection via unified handlers
     match state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
         .await
     {
@@ -851,7 +851,7 @@ pub async fn get_collection_v2(
     };
 
     match state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
     {
@@ -1114,7 +1114,7 @@ pub async fn list_collections_v2(
     };
 
     match state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
     {
@@ -1214,7 +1214,7 @@ pub async fn delete_collection_v2(
     };
 
     state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -2049,7 +2049,7 @@ pub async fn get_collection_route_health_v2(
     };
 
     let resp = state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -2068,7 +2068,6 @@ pub async fn get_collection_route_health_v2(
     let distance_metric_str = collection_distance_metric_label(config.distance_metric).to_string();
     let cached_object_economy_status = if engine_str == "sst" {
         state
-            .request_handlers
             .vector_operations_service
             .cached_object_economy_directory_status(&collection_id)
             .as_ref()
@@ -2402,7 +2401,7 @@ pub async fn post_collection_recall_tune_v2(
     };
 
     let resp = state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -2732,7 +2731,7 @@ async fn ensure_collection_exists(
         migration_config: Default::default(),
     };
     state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -2867,7 +2866,7 @@ pub async fn post_collection_recluster_v2(
         migration_config: Default::default(),
     };
     let resp = state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1287,7 +1287,7 @@ pub async fn insert_records(
     );
 
     match state
-        .request_handlers
+        .record_ops
         .handle_record_batch_for_tenant(batch_request, Some(&tenant.tenant_id))
         .await
     {
@@ -2114,7 +2114,7 @@ pub async fn delete_record_v2(
     );
 
     match state
-        .request_handlers
+        .record_ops
         .handle_record_delete_batch_for_tenant(
             RichRecordDeleteBatchRequest {
                 collection_id: collection_id.clone(),

--- a/src/network/rest/v2/schema.rs
+++ b/src/network/rest/v2/schema.rs
@@ -119,7 +119,7 @@ pub async fn get_schema(
     };
 
     let collection_response = state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -479,7 +479,7 @@ pub async fn update_schema(
     };
 
     let collection_response = state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
@@ -658,7 +658,7 @@ pub async fn update_schema(
     };
 
     state
-        .request_handlers
+        .api_handlers
         .handle_collection_operation_for_tenant(update_request, Some(&tenant.tenant_id))
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to update collection schema: {}", e)))?;

--- a/src/network/rest/v3/documents.rs
+++ b/src/network/rest/v3/documents.rs
@@ -342,7 +342,7 @@ async fn ingest_documents_inner(
     };
 
     match state
-        .request_handlers
+        .record_ops
         .handle_record_batch_for_tenant(batch_request, Some(&tenant_id))
         .await
     {


### PR DESCRIPTION
## Summary

TD-104 REST decoupling, **phase 1 of 2**. `AppState` (`rest/v1/handlers.rs`) holds the ROOT `UnifiedHandlers`; this migrates the mechanical read sites to existing ports / extracted fields so `AppState` stops reaching through `request_handlers` for them. (The actual holder field stays for phase 2 — see below.)

### Changes (6 files, behavior-identical)
- `handle_collection_operation_for_tenant` ×11 (v2/collections ×8, v2/schema ×3) and `handle_vector_search_v1_for_tenant` ×1 (progressive_search) → `state.api_handlers` (`ApiHandlersPort` already provides both).
- `handle_record_batch_for_tenant` ×2 (v2/records, v3/documents) and `handle_record_delete_batch_for_tenant` ×1 (v2/records) → `state.record_ops` (new `AppState` field; `RecordOpsService` owns these write ops).
- `.vector_operations_service.{unified_engine,cached_object_economy_directory_status}` ×2 → `state.vector_operations_service` (field already present).
- `.collection_service.clone()` ×1 (health) → `state.collection_service` (new field).

### Scope / phasing
Investigation found `AppState.request_handlers` read at **49 sites**. This PR migrates the ~18 "mechanical" LIVE sites (no port changes needed). Two categories are deliberately **not** in this PR:
- **4 ROOT-only record-read sites** in `v2/records.rs` (`handle_record_search_for_tenant`, `handle_record_get_for_tenant`, `handle_record_scan_paginated_for_tenant`, `table_changes`) — no port/service exposes these yet. **Phase 2** will extend `ApiHandlersPort` (ROOT impls delegate to inherent methods), migrate these 4, then **remove the `AppState.request_handlers` field**.
- **27 sites in `rest/v1/graph.rs`** — **out of scope**; that surface is deprecating (308 redirects to canonical multi-graph routes; v1 → v2).

After phase 1: `AppState.request_handlers` reads drop from ~49 to ~5 (4 record-read + the `AppState::new` wiring).

## Verification (pinned 1.95.0)
- `cargo build --lib --bins` ✅ (the compiler is the oracle — the field/method swaps surface any missed site)
- `cargo fmt --all -- --check` ✅

(Rust Clippy will show red repo-wide from pre-existing #295 `let_underscore_future` in `shared_services.rs`; clippy is non-required — #295 merged with it red.)

Ref TD-104. Plan: \`~/.claude/plans/generic-wishing-pudding.md\`.