### PR TITLE
fix: unblock develop (GraphFusionParams.principal) + get-by-id filters dead records

### DIFF
--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -446,6 +446,10 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 graph_weight: 0.0,
                 grain: GraphGrain::Nodes,
                 policy: FusionPolicy::default(),
+                // Entity fusion search is vector-only (graph_weight 0), so no
+                // graph RBAC principal applies yet. Threading the caller
+                // principal here is a follow-up for entity RBAC.
+                principal: None,
             };
 
             let (items, _stats) = self

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -603,7 +603,17 @@ impl VectorOperationsService {
             request.include_props,
         )
         .await
-        .map(|record| record.map(vector_record_to_rich_result))
+        .map(|record| {
+            // Defense-in-depth: never return a dead (tombstone / TTL-expired)
+            // record from get-by-id, regardless of which backing store (WAL
+            // or SST point-lookup) produced it. The WAL memtable filters on
+            // its own, but the SST point-lookup path does not. Use the
+            // canonical is_visible_at(now_ns) on valid_to_ns.
+            let now_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+            record
+                .filter(|r| r.is_visible_at(now_ns))
+                .map(vector_record_to_rich_result)
+        })
     }
 
     /// Scan current visible canonical records from the VectorOps-backed WAL/memtable path.


### PR DESCRIPTION
## ⚠️ Includes an urgent develop-unblock

**Commit 1 — `fix(entity): unblock develop — GraphFusionParams needs principal`.** `develop` is currently **red** (won't compile): `GraphFusionParams` gained a `principal: Option<String>` field (RBAC on the fusion seam) but the `search_entities` construction site (`entity_service.rs:437`) was missed → `E0063: missing field principal`. This blocks **every** PR. The entity fusion search is vector-only (`graph_weight: 0.0`, `max_depth: 0` — graph expand is a no-op), so `principal: None` is the safe minimal unblock; threading the caller principal is a follow-up for entity RBAC.

**Commit 2 — `fix(search): get-by-id filters dead records` (P1 follow-up).** `get_record_with_tenant_context` returned whatever the backing store produced with no dead-record check. The WAL memtable path filters on its own, but the **SST point-lookup path does not** — so a tombstoned / TTL-expired record in SST was returned by get-by-id (REST v2 `GET /records/{id}` **and** gRPC `GetRecord`, both via `handle_record_get_for_tenant`). Added a defense-in-depth `is_visible_at(now_ns)` filter on the final result at the service boundary (canonical MVCC predicate on `valid_to_ns`).

## Why bundled
The P1 fix can't build green on red `develop` without commit 1, so they ship together (two clearly-separated, independently-revertible commits). Once this merges, develop is green again **and** the get-by-id leak is closed.

## Verified
- ✅ `cargo clippy --lib --bins` clean (hard gate); `rustup run 1.95.0 cargo fmt --all` clean.

## P1 follow-ups still open (separate PRs; from the read-surface audit)
- **Collection stats** (`ViperEngine::collection_stats`) count raw atomic counters including dead records → needs live-only count accounting (write-path decrement or scan-based).
- **Document store** `query_documents` delegates to `DocumentService` — needs a trace to confirm whether `DocumentRecord` carries `valid_to_ns` (may already be covered by #313's `matches_record` scan filter).

Aligns with Directive 16 (#312): every read boundary filters dead records via the canonical predicate.