### PR TITLE
docs(td): TD-148 — collection stats over-count dead records

### DIFF
--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -380,6 +380,9 @@ PR #265). Moved to the closed archive.
 
 | TD-085 | Internal marketing-copy overclaims — product scrub | LOW | Partial | — | OE
 | *Engineering side resolved 2026-05-30:* `docs/_internal/{enterprise,business}` sealed with INTERNAL-ONLY banners + `make docs-claim-check` hard-fail on external references. Residual (product-owner scope): actually scrub "85-96% cost reduction" / "296% performance" claims or cite reproducible methodology before moving out of `_internal/`.
+
+| TD-148 | Collection stats over-count dead records | MED | Open | D1 | PERF
+| `collection_stats` (`ViperEngine` et al.) reports `row_count` from a raw atomic counter that increments on insert but never decrements on delete/tombstone, so the count includes deleted/expired records. The read-surface accuracy audit (PRs #305, #313, #317) confirmed every *record-returning* read path now filters dead records; `collection_stats` is the last over-count. *Do NOT build a throwaway per-engine tombstone counter* — it is partial work superseded by ADR-025 deletion vectors, where live count = total positions − deletion-vector bits (computed naturally in the N2/N3 DV phases). Until then, treat `row_count` as approximate (document this on the stats surface). See `docs/12-design/adr/ADR-025-deletion-vectors-cold-path.adoc`.
 |===
 
 == Summary (accurate as of 2026-06-24)


### PR DESCRIPTION
## What
Files **TD-148** in the technical-debt register: `collection_stats` (`ViperEngine` et al.) reports `row_count` from a raw atomic counter that increments on insert but never decrements on delete/tombstone → the count includes deleted/expired records.

## Why a TD, not a tactical fix
The read-surface accuracy audit (PRs #305, #313, #317) confirmed every **record-returning** read path now filters dead records — `collection_stats` is the last over-count. A per-engine tombstone counter would be **throwaway work**: it's superseded by **ADR-025 deletion vectors** (#314), where live count = total positions − deletion-vector bits (computed naturally in the N2/N3 DV phases). Building the counter now then ripping it out for DVs is wasted effort. Until the DV work lands, `row_count` should be documented as approximate.

## Doc-only
Single-row addition to `docs/10-quality/TECHNICAL_DEBT.adoc`. Cross-references ADR-025.

⚠️ Note: `develop` is currently red (the `GraphFusionParams.principal` E0063) until #317 merges, so this PR's CI build will be red on that pre-existing break — unrelated to this doc change. Goes green once #317 lands.