### PR TITLE
refactor(rest): relocate record-read methods to RecordOpsService (TD-104 REST phase 2)

### DIFF
--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -48,13 +48,18 @@ use std::sync::Arc;
 use tracing::debug;
 
 use crate::api_handlers::request_handlers::{CollectionIdCache, enforce_wal_lane_for_record_batch};
+use crate::core::search::FilterExpression;
 use crate::services::DmlService;
 use crate::services::WriteOperationKind;
 use crate::services::collection::manager::CollectionService;
 use crate::services::operations::BatchOperationResult;
 use crate::services::operations::vectors::{
-    RichRecordBatchRequest, RichRecordDeleteBatchRequest, VectorOperationsService,
+    RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest,
+    RichRecordGetResponse, RichSearchRequest, RichSearchResponse, VectorOperationsService,
 };
+use crate::services::record_store::ChangeRow;
+use crate::services::scan_cursor::ScanCursor;
+use proximadb_records::ProximaRecord;
 
 /// Canonical record-batch orchestration service.
 ///
@@ -448,6 +453,113 @@ impl RecordOpsService {
                     "RECORD_INSERT_FAILED".to_string(),
                 ))
             }
+        }
+    }
+
+    // ---- record READ path (TD-104 REST phase 2) -------------------------------
+    // Moved verbatim from ROOT `UnifiedHandlers` so the REST layer reaches these
+    // via `state.record_ops` instead of `state.request_handlers`. ROOT keeps thin
+    // delegating inherent wrappers for its gRPC callers (see request_handlers.rs).
+    // Behaviour-identical: the `self.<svc>` references resolve to the same Arcs
+    // ROOT held (collection_service / vector_operations_service / dml_service),
+    // and `resolve_collection_id_internal` is this service's own (ROOT already
+    // delegates the cache here — one logical owner).
+
+    /// Canonical rich-record search handler used by v2 REST/gRPC/internal callers.
+    pub async fn handle_record_search_for_tenant(
+        &self,
+        request: RichSearchRequest,
+        tenant_id: Option<&str>,
+    ) -> Result<RichSearchResponse> {
+        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
+        let request = RichSearchRequest {
+            collection_id: match self
+                .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
+                .await?
+            {
+                Some(id) => id,
+                None => {
+                    return Err(anyhow!("Collection '{}' not found", request.collection_id));
+                }
+            },
+            ..request
+        };
+
+        self.vector_operations_service
+            .search_records_with_tenant_context(request, tenant_context.as_ref())
+            .await
+    }
+
+    /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
+    pub async fn handle_record_get_for_tenant(
+        &self,
+        request: RichRecordGetRequest,
+        tenant_id: Option<&str>,
+    ) -> Result<RichRecordGetResponse> {
+        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
+        let request = RichRecordGetRequest {
+            collection_id: match self
+                .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
+                .await?
+            {
+                Some(id) => id,
+                None => {
+                    return Err(anyhow!("Collection '{}' not found", request.collection_id));
+                }
+            },
+            ..request
+        };
+
+        self.vector_operations_service
+            .get_record_with_tenant_context(request, tenant_context.as_ref())
+            .await
+    }
+
+    /// Paginated rich-record scan (TD-099(3d) push-down): resolves tenant +
+    /// collection id, then streams a single page from the deduped, time-ordered
+    /// scan index and returns `(page, next_cursor)`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn handle_record_scan_paginated_for_tenant(
+        &self,
+        collection_id: &str,
+        cursor: Option<&ScanCursor>,
+        limit: usize,
+        include_vector: bool,
+        include_props: bool,
+        tenant_id: Option<&str>,
+        filter: Option<&FilterExpression>,
+        now_ns: i64,
+    ) -> Result<(Vec<ProximaRecord>, Option<ScanCursor>)> {
+        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
+        let resolved_id = match self
+            .resolve_collection_id_internal(collection_id, tenant_context.as_ref())
+            .await?
+        {
+            Some(id) => id,
+            None => {
+                return Err(anyhow!("Collection '{}' not found", collection_id));
+            }
+        };
+
+        self.vector_operations_service
+            .scan_records_paginated(
+                &resolved_id,
+                cursor,
+                limit,
+                include_vector,
+                include_props,
+                tenant_context.as_ref(),
+                filter,
+                now_ns,
+            )
+            .await
+    }
+
+    /// Change feed: rows changed since `since_lsn` (delegates to the DML service).
+    pub async fn table_changes(&self, table: &str, since_lsn: u64) -> Result<Vec<ChangeRow>> {
+        match self.get_dml_service() {
+            Some(dml) => dml.changes_since(table, since_lsn).await,
+            None => Ok(Vec::new()),
         }
     }
 }

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -421,10 +421,7 @@ impl UnifiedHandlers {
         table: &str,
         since_lsn: u64,
     ) -> anyhow::Result<Vec<crate::services::record_store::ChangeRow>> {
-        match self.get_dml_service() {
-            Some(dml) => dml.changes_since(table, since_lsn).await,
-            None => Ok(Vec::new()),
-        }
+        self.record_ops.table_changes(table, since_lsn).await
     }
 
     /// Post-construction setter for the canonical-precision resolver.
@@ -851,47 +848,20 @@ impl UnifiedHandlers {
         request: RichSearchRequest,
         tenant_id: Option<&str>,
     ) -> Result<RichSearchResponse> {
-        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
-        let request = RichSearchRequest {
-            collection_id: match self
-                .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
-                .await?
-            {
-                Some(id) => id,
-                None => {
-                    return Err(anyhow!("Collection '{}' not found", request.collection_id));
-                }
-            },
-            ..request
-        };
-
-        self.vector_operations_service
-            .search_records_with_tenant_context(request, tenant_context.as_ref())
+        self.record_ops
+            .handle_record_search_for_tenant(request, tenant_id)
             .await
     }
 
     /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
+    /// Delegates to the shared `RecordOpsService` (TD-104 REST phase 2).
     pub async fn handle_record_get_for_tenant(
         &self,
         request: RichRecordGetRequest,
         tenant_id: Option<&str>,
     ) -> Result<RichRecordGetResponse> {
-        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
-        let request = RichRecordGetRequest {
-            collection_id: match self
-                .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
-                .await?
-            {
-                Some(id) => id,
-                None => {
-                    return Err(anyhow!("Collection '{}' not found", request.collection_id));
-                }
-            },
-            ..request
-        };
-
-        self.vector_operations_service
-            .get_record_with_tenant_context(request, tenant_context.as_ref())
+        self.record_ops
+            .handle_record_get_for_tenant(request, tenant_id)
             .await
     }
 
@@ -941,7 +911,6 @@ impl UnifiedHandlers {
     /// from the deduped, time-ordered scan index and returns `(page,
     /// next_cursor)`.
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub async fn handle_record_scan_paginated_for_tenant(
         &self,
         collection_id: &str,
@@ -956,25 +925,14 @@ impl UnifiedHandlers {
         Vec<proximadb_records::ProximaRecord>,
         Option<crate::services::scan_cursor::ScanCursor>,
     )> {
-        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
-        let resolved_id = match self
-            .resolve_collection_id_internal(collection_id, tenant_context.as_ref())
-            .await?
-        {
-            Some(id) => id,
-            None => {
-                return Err(anyhow!("Collection '{}' not found", collection_id));
-            }
-        };
-
-        self.vector_operations_service
-            .scan_records_paginated(
-                &resolved_id,
+        self.record_ops
+            .handle_record_scan_paginated_for_tenant(
+                collection_id,
                 cursor,
                 limit,
                 include_vector,
                 include_props,
-                tenant_context.as_ref(),
+                tenant_id,
                 filter,
                 now_ns,
             )

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -449,10 +449,6 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 // `permitted_principals` RBAC is not threaded here. `None` ⇒ structural isolation.
                 principal: None,
                 policy: FusionPolicy::default(),
-                // Entity fusion search is vector-only (graph_weight 0), so no
-                // graph RBAC principal applies yet. Threading the caller
-                // principal here is a follow-up for entity RBAC.
-                principal: None,
             };
 
             let (items, _stats) = self

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -36,7 +36,10 @@ use serde::{Deserialize, Serialize};
 /// Shared application state
 #[derive(Clone)]
 pub struct AppState {
-    /// Shared unified handlers for business logic delegation
+    /// Shared unified handlers — retained for the (deprecating) v1 REST graph
+    /// surface + v2 graph/entity field accesses (graph_operations_service /
+    /// graph_collection_service). Record/collection/vector reads are off this
+    /// field (TD-104 S5 / REST phases 1–2); it goes away when v1 graph is deleted.
     pub request_handlers: Arc<UnifiedHandlers>,
     /// Extracted graph execution capability for query planning/execution helpers
     pub graph_execution_service: Arc<dyn GraphExecutionService>,

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1620,7 +1620,7 @@ pub async fn search_with_typed_filters(
         "rest.v2.records.search",
         crate::observability::predicate_diagnostics::scope(async {
             let outcome = state
-                .request_handlers
+                .record_ops
                 .handle_record_search_for_tenant(search_request, Some(&tenant.tenant_id))
                 .await;
             let downgraded =
@@ -2008,7 +2008,7 @@ pub async fn get_record_v2(
     });
 
     match state
-        .request_handlers
+        .record_ops
         .handle_record_get_for_tenant(
             RichRecordGetRequest {
                 collection_id: collection_id.clone(),
@@ -2306,7 +2306,7 @@ pub async fn scan_records(
     // streaming layer; the handler returns a single ordered page plus the next
     // cursor (O(log d + limit) per page once the scan index is warm).
     let (page, next_cursor) = state
-        .request_handlers
+        .record_ops
         .handle_record_scan_paginated_for_tenant(
             &collection_id,
             inbound_cursor.as_ref(),
@@ -2433,7 +2433,7 @@ pub async fn get_changes(
     Query(q): Query<ChangesQuery>,
 ) -> ApiResult<Json<serde_json::Value>> {
     let changes = state
-        .request_handlers
+        .record_ops
         .table_changes(&collection_id, q.since_lsn)
         .await
         .map_err(|e| ApiError::Internal(format!("change-feed read failed: {e}")))?;


### PR DESCRIPTION
## Summary

TD-104 REST decoupling, **phase 2** (follows #315). `RecordOpsService` already owned the record **write** ops (S3-c); this moves the 4 record **read** methods into it so it becomes the single record authority (reads + writes), and the v2 REST record sites stop reaching through `AppState.request_handlers`.

### Changes (behavior-identical, verbatim move)
- **`record_ops_service.rs`** (+114): add the 4 read methods — `handle_record_search_for_tenant`, `handle_record_get_for_tenant`, `handle_record_scan_paginated_for_tenant`, `table_changes` — copied verbatim from ROOT. `self.collection_service` / `resolve_collection_id_internal` / `vector_operations_service` / `get_dml_service` resolve to the same Arcs `RecordOpsService` already holds (it owns the shared collection-id cache ROOT delegates to).
- **`request_handlers.rs`**: ROOT's 4 inherent methods become thin delegates to `self.record_ops.<method>` (gRPC callers unchanged — same S3-c pattern as the write methods).
- **`rest/v2/records.rs`**: the 4 record sites → `state.record_ops.<method>`.

### Scope note: the `AppState.request_handlers` field is **retained**
Removing it is **blocked by the deprecating v1 REST graph surface** + v2 graph/entity field accesses (`.graph_operations_service` / `.graph_collection_service` — ~29 sites, incl. `v1/graph.rs`'s 27). Per the v1→v2 deprecation steer, those are out of scope; the field goes away when v1 graph is deleted. (An explanatory comment is added to the field.) This PR still advances TD-104: the record path is now fully off ROOT's logic (all record ops centralized in `RecordOpsService`), and 4 more REST sites stop touching `request_handlers`.

## Verification (pinned 1.95.0)
- `cargo check --workspace --lib --bins` ✅ (CI command)
- `cargo fmt --all -- --check` ✅

(Rust Clippy shows red repo-wide from pre-existing #295 `let_underscore_future`; non-required.)

Ref TD-104. Plan: \`~/.claude/plans/generic-wishing-pudding.md\`.