### PR TITLE
fix(grpc): remove duplicate principal in entity_service (develop red — #317 regression)

### DIFF
--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -447,12 +447,9 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 grain: GraphGrain::Nodes,
                 // Entity search is metadata-only today (graph expand is a no-op); within-tenant
                 // `permitted_principals` RBAC is not threaded here. `None` ⇒ structural isolation.
+                // Threading the caller principal is a follow-up for entity RBAC.
                 principal: None,
                 policy: FusionPolicy::default(),
-                // Entity fusion search is vector-only (graph_weight 0), so no
-                // graph RBAC principal applies yet. Threading the caller
-                // principal here is a follow-up for entity RBAC.
-                principal: None,
             };
 
             let (items, _stats) = self


### PR DESCRIPTION
develop is **red** at compile. Root cause: #317 added a second `principal: None` to `entity_service.rs`'s `GraphFusionParams`, but #316 had already added one → `E0062: field specified more than once`. `entity_service.rs` is compiled by default (unconditional v2 mod), so this fails every tier — it's the cause of the develop→qa promotion (#321) Feature Matrix / Clippy / Connectors-flight failures too.

Fix: remove the duplicate (keep one, merge the comments). Verified: `cargo check --lib` (default) + `--features cloud-full` + `--features cluster` all pass.

This is the develop-first fix; once develop is green, #321 re-runs against it. (Separately, the qa-tier SDK Coverage Ratchet is unaffected — tracked separately.)