### PR TITLE
docs(surface): document v2 entity/fusion boundary + REST v2 routes

### DIFF
--- a/docs/03-api-reference/rest.adoc
+++ b/docs/03-api-reference/rest.adoc
@@ -48,6 +48,9 @@ ProximaDB's multi-model query engine enables cross-model joins that are impossib
 | Record fetch | GET | `/api/v2/collections/:collection/records/:record` | Canonical ProximaRecord fetch
 | Record delete | DELETE | `/api/v2/collections/:collection/records/:record` | Canonical ProximaRecord delete
 | Record/vector search | POST | `/api/v2/collections/:collection/search` | Canonical record search
+| Document collections | Various | `/api/v2/document-collections/*` | Beta document convenience surface
+| Graphs | Various | `/api/v2/graphs/*` | Beta graph topology surface
+| Graph fusion | POST | `/api/v2/graphs/:graph/fusion-search` | Beta vector-seed -> graph-expand fusion seam
 | Query facade | POST | `/api/v2/query` | Shared query facade
 | REST v1 compatibility | Various | `/api/v1/*` | Deprecated compatibility facades; new clients should avoid these
 |===
@@ -213,20 +216,23 @@ curl -X POST http://localhost:5678/api/v1/search \
 
 == Documents (Beta)
 
-=== POST /api/v1/documents/collections
+Document routes are mounted under `/api/v2/document-collections`. The older
+`/api/v1/documents/*` paths are compatibility facades only.
+
+=== POST /api/v2/document-collections
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/documents/collections \
+curl -X POST http://localhost:5678/api/v2/document-collections \
   -H "Content-Type: application/json" \
   -d '{"name": "events"}'
 ----
 
-=== POST /api/v1/documents/collections/:collection/documents
+=== POST /api/v2/document-collections/:collection/documents
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/documents/collections/events/documents \
+curl -X POST http://localhost:5678/api/v2/document-collections/events/documents \
   -H "Content-Type: application/json" \
   -d '{"document": {"service": "api", "status": "warn"}}'
 ----
@@ -235,22 +241,43 @@ curl -X POST http://localhost:5678/api/v1/documents/collections/events/documents
 
 == Graphs (Beta)
 
-=== POST /api/v1/graph/graphs
+Graph routes are mounted under `/api/v2/graphs`. Legacy `/api/v1/graph/*`
+routes redirect or carry deprecation metadata.
+
+=== POST /api/v2/graphs
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/graph/graphs \
+curl -X POST http://localhost:5678/api/v2/graphs \
   -H "Content-Type: application/json" \
   -d '{"graph_id": "topology"}'
 ----
 
-=== POST /api/v1/graph/graphs/:graph_id/traverse
+=== POST /api/v2/graphs/:graph_id/traverse
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/graph/graphs/topology/traverse \
+curl -X POST http://localhost:5678/api/v2/graphs/topology/traverse \
   -H "Content-Type: application/json" \
   -d '{"start_node_id": "service-api", "max_depth": 2}'
+----
+
+=== POST /api/v2/graphs/:graph_id/fusion-search
+
+Vector-seed -> bounded graph-expand -> calibrated fuse-by-`oid`. This is the
+v2 REST instance of the shared cross-modal fusion seam; it is not the deprecated
+v1 `GraphService.ExecuteHybridQuery` RPC.
+
+[source,bash]
+----
+curl -X POST http://localhost:5678/api/v2/graphs/topology/fusion-search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector_collection": "services",
+    "query_vector": [0.1, 0.2],
+    "limit": 10,
+    "max_depth": 1
+  }'
 ----
 
 ---
@@ -290,13 +317,15 @@ curl -X POST http://localhost:5678/api/v1/observability/namespaces/prod/metrics/
 
 ProximaDB's multi-model query engine is the key differentiator vs single-model databases (Pinecone, Weaviate, Milvus). It enables cross-model joins in a single SQL query.
 
-=== POST /api/v1/unified/federated
+=== POST /api/v2/query
 
-**Federated SQL query with multi-model extensions.** This is the primary endpoint for cross-model queries.
+**Shared query facade.** Use this for UQL/AQL/federated non-pgwire flows. For
+plain SQL, prefer pgwire; for token-authenticated SQL over gRPC, use
+`proximadb.v2.ProximaRecordService.ExecuteQuery`.
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/unified/federated \
+curl -X POST http://localhost:5678/api/v2/query \
   -H "Content-Type: application/json" \
   -d '{"query": "SELECT * FROM VECTOR_SEARCH('products', '[0.1, 0.2, 0.3]', 10)"}'
 ----
@@ -373,13 +402,18 @@ WHERE l.timestamp > now() - interval '5m';
 }
 ----
 
-=== POST /api/v1/unified/execute
+=== Deprecated REST v1 Unified Routes
 
-**Auto-routing unified query.** Automatically detects multi-model extensions and routes to federated engine.
+`/api/v1/unified/federated`, `/api/v1/unified/execute`,
+`/api/v1/unified/multi-model`, and `/api/v1/unified/explain` are deprecated
+compatibility facades. New work should target `/api/v2/query`, pgwire,
+`ProximaRecordService.ExecuteQuery`, or a dedicated v2 modality/fusion endpoint.
+
+The old `multi-model` route accepted explicit components like:
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/unified/execute \
+curl -X POST http://localhost:5678/api/v1/unified/multi-model \
   -H "Content-Type: application/json" \
   -d '{
     "query": "SELECT * FROM products WHERE $.category = 'electronics' AND VECTOR_SIMILAR(embedding, ?, 0.8)",
@@ -400,54 +434,13 @@ curl -X POST http://localhost:5678/api/v1/unified/execute \
 | `ranked` | Custom weights per model
 |===
 
-=== POST /api/v1/unified/multi-model
-
-**Programmatic multi-model query.** Use when you need explicit control over each model's parameters.
-
-[source,bash]
-----
-curl -X POST http://localhost:5678/api/v1/unified/multi-model \
-  -H "Content-Type: application/json" \
-  -d '{
-    "components": [
-      {
-        "component_type": "vector",
-        "config": {
-          "collection": "products",
-          "query_vector": [0.1, 0.2, 0.3],
-          "top_k": 10,
-          "threshold": 0.8
-        }
-      },
-      {
-        "component_type": "document",
-        "config": {
-          "collection": "products",
-          "filter": "$.category = 'electronics'"
-        }
-      },
-      {
-        "component_type": "graph",
-        "config": {
-          "graph": "product_categories",
-          "start_node": "electronics",
-          "edge_type": "CONTAINS",
-          "max_depth": 2
-        }
-      }
-    ],
-    "fusion_strategy": "rrf",
-    "limit": 100
-  }'
-----
-
-=== POST /api/v1/unified/explain
+=== POST /api/v2/query/explain
 
 **Explain query execution plan.** Shows how a query will be decomposed and executed.
 
 [source,bash]
 ----
-curl -X POST http://localhost:5678/api/v1/unified/explain \
+curl -X POST http://localhost:5678/api/v2/query/explain \
   -H "Content-Type: application/json" \
   -d '{"query": "SELECT * FROM VECTOR_SEARCH('products', '[0.1,0.2]', 10) v JOIN GRAPH_QUERY('...') g ON v.id = g.id"}'
 ----

--- a/docs/11-usecases/AGENTIC_AI_API_CONTRACTS_V2_2026_05_12.md
+++ b/docs/11-usecases/AGENTIC_AI_API_CONTRACTS_V2_2026_05_12.md
@@ -35,6 +35,33 @@ the supported-surface docs and durability tests say otherwise.
 | Events | append-only stream, expected version, replay, snapshots | event API and `EVENTS` logical operator |
 | Observability | logs, metrics, traces, span lookup | existing observability API and logical operators |
 
+## Entity And Fusion Boundary
+
+The SKS/entity shape is a convenience contract, not a new storage lane. An
+entity spans existing primitives:
+
+| Entity concern | Backing primitive | API owner |
+| --- | --- | --- |
+| Stable semantic identity and typed fields | `ProximaRecord` id + `props` | record/collection APIs |
+| Current topology and explicit relations | graph node + graph edges | graph APIs and `GRAPH_QUERY` |
+| One or more embeddings | vector-bearing records / embedding cells | record/vector APIs and `VECTOR_SEARCH` |
+| Source chunks and evidence | document records / text fields | document APIs and `DOCUMENT_QUERY` |
+| Provenance, temporal validity, replay | event/history records | event/logical query path |
+| Cross-modal ranking | `oid`-keyed fusion seam | query/fusion layer |
+
+Do not introduce a v2 entity store with its own WAL, path layout, or recovery
+rules. If a v2 `EntityService` is exposed, it should be an orchestration facade:
+
+- `UpsertEntity`: write/update the graph node, vector-bearing records, document
+  provenance, and optional temporal/event records through their owning services.
+- `GetEntity`: assemble the view from graph + record/vector + document/event
+  lookups.
+- `SearchEntities`: seed from vector search, apply record/document predicates,
+  optionally expand through graph, then fuse/rank via the shared `oid` seam.
+
+This avoids the wrong seam: separate "entity storage" that duplicates graph
+nodes, vector records, document metadata, and temporal state.
+
 ## Server API V2
 
 The v2 server surface should be additive and map to the existing service layer:

--- a/docs/11-usecases/AGENTIC_AI_BACKING_STORE_MVP_2026_05_12.md
+++ b/docs/11-usecases/AGENTIC_AI_BACKING_STORE_MVP_2026_05_12.md
@@ -38,6 +38,7 @@ An agentic AI backing store should cover these lanes:
 | Long-term memory | namespaced JSON KV, prefix namespace listing, filters, semantic search, per-item timestamps | Mostly covered by document + vector engines; needs BaseStore-compatible wrapper |
 | Semantic memory/RAG | dense/sparse vectors, metadata filters, batch upsert/search, hybrid lexical/vector | Covered by vector engines; embedded API covers vector MVP |
 | Project/code graph | nodes, edges, labels, properties, traversal, callers/callees, impact analysis | Embedded Python exposes graph CRUD/traversal; Victor provider already uses server SDK |
+| Entity memory / SKS | semantic units with embeddings, relations, provenance, and temporal memory | Compose records/vectors + graph + documents + events; do not add a separate entity store |
 | Documents | JSON document CRUD/query, schema-free records, indexed paths | Embedded API exposes document CRUD/query; engine is still experimental/in-memory per supported surface |
 | Relational metadata | typed rows, joins, ordering, pagination, SQL-ish access | Server has experimental SEQUOIA; embedded `execute_sql` exists but needs ORM-like mapper tests |
 | Event log/audit | append-only events, stream version, causation/correlation, replay, snapshots | EventLog exists experimentally; needs Python-facing event-store adapter |
@@ -70,6 +71,9 @@ Main gaps before claiming full agentic backing-store coverage:
   in-memory in `docs/SUPPORTED_SURFACE.adoc`; MVP claims must be local/experimental until durability
   tests prove otherwise.
 - Cross-modal embedded tests need to prove one real flow, not only parser/fusion units.
+- Entity-shaped helpers need to assemble graph/vector/document/event state through
+  existing APIs. They must not target the legacy split `ProximaEntityStore` as a
+  new durable backend.
 
 ## MVP Shape
 
@@ -104,6 +108,8 @@ Build embedded-first adapters in this order:
      Victor code symbols, graph edges, events, logs, and vectors.
    - It then runs semantic search, graph traversal, checkpoint replay lookup, event replay,
      and one cross-modal query through `execute_unified_query` or equivalent adapter calls.
+   - Any entity/SKS helper in that proof must be an orchestration wrapper over
+     record/vector + graph + document/event calls, not a second store.
 
 ## Acceptance Criteria
 

--- a/docs/12-design/SUPPORTED_SURFACES.adoc
+++ b/docs/12-design/SUPPORTED_SURFACES.adoc
@@ -69,7 +69,7 @@ Current relational/pgwire DML and compute-routing implementation tracker:
 | Path expansion (k-hop) | ✅ | ✅ | — | ✅
 | Cypher query | ✅ | ✅ | — | ✅ (PGQ extension)
 | PageRank / centrality | ✅ (async) | ✅ (async) | — | —
-| Mixed vector + graph hybrid | ✅ | ✅ | ✅ | —
+| Mixed vector + graph hybrid | ✅ (`/api/v2/graphs/{id}/fusion-search`) | ⚠️ v1 compat/deferred | — | —
 |===
 
 === Physical Projection Status
@@ -97,7 +97,7 @@ Current relational/pgwire DML and compute-routing implementation tracker:
 | ANN / top-K search | ✅ | ✅ | ✅ | ✅
 | Filtered vector search | ✅ | ✅ | ✅ | ✅
 | Hybrid BM25 + dense | ✅ | ✅ | — | —
-| Vector + graph hybrid | ✅ | ✅ | ✅ | —
+| Vector + graph hybrid | ✅ (`/api/v2/graphs/{id}/fusion-search`) | ⚠️ v1 compat/deferred | — | —
 |===
 
 === Physical Projection Status
@@ -108,6 +108,34 @@ Current relational/pgwire DML and compute-routing implementation tracker:
 | HNSW index | ✅ Retained (rebuildable) | `ProjectionDirective::HnswIndex`. Rebuilt from canonical `ProximaRecord::embeddings` fields. Predicate-aware ACORN construction per spec §6.1.
 | IVF / PQ quantized index | ✅ Retained (rebuildable) | Quantization lives in `proximadb-vector` modality crate. Foundation types from `proximadb-quantization-types`.
 | Storage engine vector layouts (SST/HELIX/VIPER/NOVA/SWIFT) | ✅ Retained (canonical record layouts/access methods) | Flush, compaction, ProximaBlocks/columnar serialization, filtering, and search result shaping are migrating to `ProximaRecord::embeddings` + `props`. Legacy `VectorRecord` is allowed only in explicit v1 compatibility helpers while client/proto migration completes.
+|===
+
+---
+
+== Entity / Semantic Knowledge Store
+
+=== API Support
+
+[cols="2,1,1,1,1", options="header"]
+|===
+| Operation | REST | gRPC | Arrow Flight | pgwire
+| Upsert entity-shaped view | ⚠️ v1 compat only | ⚠️ v1 compat only (`proximadb.v1.EntityService`) | — | —
+| Get entity-shaped view | ⚠️ v1 compat only | ⚠️ v1 compat only (`proximadb.v1.EntityService`) | — | —
+| Delete entity-shaped view | ⚠️ v1 compat only | ⚠️ v1 compat only (`proximadb.v1.EntityService`) | — | —
+| Search entity-shaped view | ⚠️ v1 compat only | ⚠️ v1 compat only (`proximadb.v1.EntityService`) | — | Use vector/document/graph SQL extensions instead
+| v2 entity orchestration facade | Planned | Planned | — | —
+|===
+
+=== Physical Projection Status
+
+[cols="2,1,3", options="header"]
+|===
+| Projection / Engine | Status | Notes
+| No standalone v2 entity store | ✅ Required architecture | SKS/entity is a composed view over record/vector, graph, document/provenance, and event/temporal history. It must not introduce a separate WAL, path namespace, recovery loop, or billing boundary.
+| Legacy `ProximaEntityStore` / split relations stores | ⚠️ Compatibility / transition only | Useful for old v1 handlers and migration tests, but not a target for new v2 work. New entity-shaped helpers should orchestrate existing services.
+| Entity graph/topology view | ✅ Retained (rebuildable) | Backed by graph nodes/edges and ORION/CSR projections.
+| Entity embedding view | ✅ Retained (rebuildable) | Backed by vector-bearing `ProximaRecord` rows / embedding cells and ANN projections.
+| Entity provenance / evidence view | ✅ Retained (rebuildable or canonical by policy) | Backed by document/text records and event/history records with explicit provenance.
 |===
 
 ---

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -139,6 +139,51 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
   independent of query language — never as a per-language interface.
 ====
 
+=== Endpoint And Composition Ownership
+
+The same domain objects appear through record, document, graph, hybrid, and
+entity-shaped APIs. Treat this table as the guardrail against adding another
+storage path when the requirement is really orchestration over existing
+primitives.
+
+[cols="1,2,2,2", options="header"]
+|===
+| Shape | Existing reachable surface | Owns today | Proposal / rule
+
+| Record / vector
+| REST `/api/v2/collections/{id}/records/*`, REST `/api/v2/collections/{id}/search`, gRPC `proximadb.v2.ProximaRecordService`
+| Canonical vector-bearing records, typed props, collection/schema lifecycle, ANN/vector search, SQL-over-gRPC
+| Keep as the durable authority for embeddings and typed metadata. Multi-version embeddings are modeled as records/embedding cells or derived history, not as a separate entity store.
+
+| Document
+| REST `/api/v2/document-collections/*`, REST `/api/v2/collections/{id}/documents` text ingest, gRPC `proximadb.v2.ProximaDocumentService` CRUD
+| JSON/document body, evidence chunks, document query/aggregate compatibility path
+| Keep as beta document convenience and provenance/evidence lane. Durable convergence remains `ProximaRecord` + `props`; do not duplicate entity metadata here and in an entity store.
+
+| Graph
+| REST `/api/v2/graphs/*`, gRPC `proximadb.v2.ProximaGraphService`
+| Nodes, edges, labels, properties, traversal, graph stats, Cypher subset
+| Keep topology and relationship traversal here. ORION/CSR is a rebuildable projection over canonical records; graph node embeddings are a convenience for single-vector nodes, not the place to own multi-version semantic embeddings.
+
+| Hybrid / fusion
+| REST `/api/v2/collections/{id}/search` for dense+BM25 hybrid; REST `/api/v2/graphs/{graph_id}/fusion-search` for the TD-137 vector-seed -> graph-expand fusion instance
+| Candidate-set fusion and calibrated ranking across existing modalities
+| Converge every cross-modal blend on the `oid`-keyed fusion seam (`seed -> expand -> calibrate -> fuse-by-oid -> rank`). Do not add one-off entity/vector/document/graph join handlers.
+
+| Entity / SKS
+| Deprecated gRPC v1 `proximadb.v1.EntityService` when `enable_grpc_v1_compat=true`; legacy REST v1 entity routes and split `ProximaEntityStore` exist as compatibility/transition code
+| Semantic convenience shape: entity id, metadata, embeddings, provenance, relations, temporal fields
+| Do not create v2 entity storage. A future v2 entity surface, if exposed, must be an orchestration facade over record/vector + graph + document/provenance + event/temporal history, with `TenantContext` and structural tenant paths at every I/O boundary.
+|===
+
+[NOTE]
+====
+An entity is a projection/composition of existing primitives: a graph node for
+topology, one or more vector-bearing records for embeddings, document records
+for evidence/provenance, and event/history records for temporal state. The v1
+`EntityService` proto shape is not authority to add a fourth durable substrate.
+====
+
 == Status Tiers
 
 |===
@@ -198,8 +243,8 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 
 | Hybrid retrieval
 | Beta
-| tantivy BM25 integration, RRF/weighted fusion, and canonical REST `/api/v2/collections/{id}/search` hybrid path (TD-008 resolved). The former `/api/v1/hybrid/search` facade is a deprecated compat alias only. Request `filters` are enforced on both fusion legs: the vector candidates are filtered server-side, and the text (BM25) candidates are gated to that filtered id set so a scoped filter cannot leak through the text leg.
-| Backend integration improved; REST v1 hybrid alias is a deprecated compatibility surface (see Canonical API Surface above) and gRPC path parity is still in progress. A BM25-only match that passes the filter but falls outside the vector leg's `top_k` (or a hybrid request with no query vector) is dropped rather than risk a leak — safe, but it can under-return; keeping that tail needs a resolving metadata fetch (follow-up). Projection Fusion is a shared planner contract only until runtime implementation, explain output, and benchmarks are complete.
+| tantivy BM25 integration, RRF/weighted fusion, and canonical REST `/api/v2/collections/{id}/search` hybrid path (TD-008 resolved). REST `/api/v2/graphs/{graph_id}/fusion-search` is the first vector+graph instance of the shared cross-modal fusion seam (TD-137). The former `/api/v1/hybrid/search` facade is a deprecated compat alias only. Request `filters` are enforced on both dense/BM25 legs: the vector candidates are filtered server-side, and the text candidates are gated to that filtered id set so a scoped filter cannot leak through the text leg.
+| Backend integration improved; REST v1 hybrid alias is a deprecated compatibility surface (see Canonical API Surface above) and gRPC path parity is still in progress. v1 `GraphService.ExecuteHybridQuery` remains deferred; use the v2 REST fusion route for vector-seed -> graph-expand experiments. A BM25-only match that passes the filter but falls outside the vector leg's `top_k` (or a hybrid request with no query vector) is dropped rather than risk a leak — safe, but it can under-return; keeping that tail needs a resolving metadata fetch (follow-up). Wider Projection Fusion remains a shared planner contract until runtime implementation, explain output, and benchmarks are complete.
 
 | PULSAR and QUASAR graph engine names
 | Retired / Not supported


### PR DESCRIPTION
Documents the v2 REST surface and the entity/SKS architectural boundary.

**Changes:**
- `rest.adoc`: v2 `document-collections`, `graphs`, `graphs/{id}/fusion-search`, and `query` routes; v1 `unified/*` routes marked deprecated.
- **Entity/SKS boundary** (AGENTIC_AI contracts + backing-store MVP): an entity is an **orchestration facade** over record/vector + graph + document/provenance + event/temporal primitives — explicitly **not** a fourth durable substrate (no separate WAL/path/recovery).
- `SUPPORTED_SURFACES` / `SUPPORTED_SURFACE`: fusion-search endpoint refs (TD-137) + an endpoint/composition-ownership table guarding against reintroducing a split entity store.

Docs-only; no code change.