### PR TITLE
test(sdk): classify live/integration tests + filter qa-gate coverage ratchet

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -101,9 +101,12 @@ jobs:
           # Coverage needs a single aggregating process; tolerate the known
           # _cov sys.modules-leak failures (the ratchet measures coverage, not
           # pass/fail — the per-file isolation gate in ci.yml owns correctness).
+          # Run OFFLINE unit tests only: filter out `integration` (needs a running
+          # server) and `live` (needs an external dependency / network, e.g. the
+          # `victor` package). The victor test self-skips via importorskip + `live`.
           pytest tests/unit/ -q -p no:cacheprovider --timeout=120 \
             --cov=proximadb_sdk --cov-report=json:/tmp/sdk-cov.json \
-            --ignore=tests/unit/test_integrations_victor_cov.py \
+            -m "not integration and not live" \
             --ignore=tests/unit/test_chunking_code_cov.py \
             --continue-on-collection-errors || true
           test -f /tmp/sdk-cov.json

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -268,8 +268,9 @@ markers = [
     "integration: marks tests as integration tests (may require running server)",
     "performance: marks tests as performance tests (may take longer to run)",
     "large_scale: marks tests as large-scale tests with significant data volumes",
-    "grpc: marks tests as gRPC-specific tests", 
+    "grpc: marks tests as gRPC-specific tests",
     "rest: marks tests as REST-specific tests",
+    "live: marks tests that require an external dependency or live service (e.g. the `victor` package, a real model download, network) — excluded from the offline SDK coverage ratchet",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/clients/python/tests/unit/test_integrations_victor_cov.py
+++ b/clients/python/tests/unit/test_integrations_victor_cov.py
@@ -14,7 +14,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import proximadb_sdk.integrations.victor as victor_mod
+# This module exercises the SDK's adapter for the external `victor` (victor-ai)
+# package, so importing it requires `victor` installed (../victor editable, or
+# PyPI `victor-ai`). Skip cleanly when absent, and tag `live` so the offline SDK
+# coverage ratchet filters it out (run it explicitly in an env that has victor).
+pytest.importorskip("victor")
+pytestmark = pytest.mark.live
+
+import proximadb_sdk.integrations.victor as victor_mod  # noqa: E402
 
 
 def _cfg(**over):


### PR DESCRIPTION
Classification foundation for the qa-gate SDK Coverage Ratchet (the brittle path-`--ignore` approach blew up collection on the victor test and ran live/integration tests against the offline ratchet).

## Changes
- **Register `live` marker** (`clients/python/pyproject.toml`) — needs an external dependency/network/real model — alongside the existing `integration` (needs a running server). `--strict-markers` is on, so it's registered.
- **`test_integrations_victor_cov.py`**: self-skip via `pytest.importorskip("victor")` (the external victor-ai package: `../victor` editable or PyPI `victor-ai`) + `pytestmark = pytest.mark.live`. Replaces the brittle qa-gate `--ignore`.
- **`qa-gate.yml`** SDK-ratchet pytest now runs `-m "not integration and not live"` (offline unit only); removed the victor `--ignore`. (`test_chunking_code_cov.py` `--ignore` kept — to be classified during the rework.)

## Verified locally
`pytest tests/unit/ -m "not integration and not live" --co` → **4496 collected, 2 deselected (victor), zero collection errors** (previously the victor import aborted collection).

## Scope note
This is the **classification framework only**. The ~60 stale *offline unit* tests (gRPC-client + embedding-provider refactor drift) still fail the ratchet — they're reworked in a dedicated session (per-test mock/assertion updates to the current SDK API), not weakened here. After that rework, the ratchet goes green and PR #321 (develop→qa) can promote.