### PR TITLE
fix(cluster): make the partition-lease write gate authoritative on the vector-record plane

### DIFF
--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -1913,25 +1913,49 @@ impl PartitionLeaseStore {
     ////////////////////////////////////////////////////////////////////////////////
 
     /// The fenced manifest committer for a resource identified by ResourceKey.
-    fn committer_for_key(&self, key: &ResourceKey) -> ManifestCommitter {
-        if key.resource_type == ResourceType::Collection
-            && key.namespace_id.is_none()
-            && let ResourceIdentifier::Single(collection_id) = &key.resource_id
-        {
-            // Mixed-read-safe migration: the legacy `(tenant, collection)` API
-            // and the new `ResourceKey::legacy_collection` API must address the
-            // same manifest log until a separate path migration is finalized.
-            return self.committer(&key.tenant_id, collection_id);
+    ///
+    /// Collection routing is **total, never silently divergent** (CLAUDE.md
+    /// mandate #8, mixed-read-safe migration). A collection's lease lives on the
+    /// legacy `{tenant}/{collection}/_manifests` log so the old
+    /// `acquire(tenant, collection)` API and the new `ResourceKey` API address
+    /// the SAME log — two independent fences for one collection is split brain.
+    /// The legacy log is keyed by `(tenant, collection)` only, so the canonical
+    /// collection shape is namespace-less + single-component. Any other
+    /// collection-domain key (namespaced, or composite/multi-part) would land on
+    /// a *different* `to_path()` log and fork the fence; reject it **loudly**
+    /// rather than diverge silently. No current caller produces such a key — this
+    /// guards against one being introduced. Non-collection resource types
+    /// (table/schema/graph/…) are genuinely distinct resources and keep their own
+    /// `to_path()` log.
+    fn committer_for_key(&self, key: &ResourceKey) -> Result<ManifestCommitter> {
+        if key.resource_type == ResourceType::Collection {
+            let single = match &key.resource_id {
+                ResourceIdentifier::Single(id) => Some(id.as_str()),
+                ResourceIdentifier::Composite(parts) if parts.len() == 1 => Some(parts[0].as_str()),
+                _ => None,
+            };
+            return match (key.namespace_id.as_deref(), single) {
+                (None, Some(collection_id)) => Ok(self.committer(&key.tenant_id, collection_id)),
+                _ => anyhow::bail!(
+                    "ambiguous collection lease key (tenant={}, namespace={:?}, id={:?}): a \
+                     collection lease must address the legacy \
+                     `{{tenant}}/{{collection}}/_manifests` log; a namespaced or composite \
+                     collection key would fork the generation fence",
+                    key.tenant_id,
+                    key.namespace_id,
+                    key.resource_id
+                ),
+            };
         }
 
         let path = format!("{}/{}", self.prefix, key.to_path());
-        ManifestCommitter::new(self.store.clone(), path)
+        Ok(ManifestCommitter::new(self.store.clone(), path))
     }
 
     /// Read the current lease for a resource by its ResourceKey.
     /// Handles both legacy and new-format leases (mixed-read-safe).
     pub async fn read_key(&self, key: &ResourceKey) -> Result<Option<(u64, PartitionLease)>> {
-        let committer = self.committer_for_key(key);
+        let committer = self.committer_for_key(key)?;
         let key_desc = format!("{}:{}", key.tenant_id, key.resource_type.name());
         match committer
             .latest_version()
@@ -1967,7 +1991,7 @@ impl PartitionLeaseStore {
         now_ms: i64,
         lease_ms: i64,
     ) -> Result<LeaseOutcome> {
-        let committer = self.committer_for_key(key);
+        let committer = self.committer_for_key(key)?;
         let key_desc = format!("{}:{}", key.tenant_id, key.resource_type.name());
 
         // Decide the parent version + the generation to claim, from the current
@@ -1982,13 +2006,16 @@ impl PartitionLeaseStore {
                 // occupies `lease.generation`; an object-store delete would have
                 // reset it to 1 and collapsed the fence).
                 if lease.released {
-                    (Some(version), lease.generation + 1)
+                    // `saturating_add` rather than `+` to honor the no-panic
+                    // policy (matches the manifest version counter's `checked_add`);
+                    // u64 generation overflow is unreachable in practice.
+                    (Some(version), lease.generation.saturating_add(1))
                 } else if lease.holder_pod.as_str() == holder_pod {
                     // We already own it → renew at the SAME generation
                     (Some(version), lease.generation)
                 } else if lease.is_expired(now_ms) {
                     // Take over a dead owner → strictly-higher generation
-                    (Some(version), lease.generation + 1)
+                    (Some(version), lease.generation.saturating_add(1))
                 } else {
                     // A live lease belongs to someone else — we are not the owner.
                     return Ok(LeaseOutcome::Held { by: lease });
@@ -2087,7 +2114,8 @@ impl PartitionLeaseStore {
 
         // Publish the tombstone at generation+1 so the holder's own in-flight
         // writes at `lease.generation` are fenced (strict less-than).
-        let new_generation = lease.generation + 1;
+        // `saturating_add` honors the no-panic policy (u64 overflow unreachable).
+        let new_generation = lease.generation.saturating_add(1);
         let tombstone = PartitionLease {
             released: true,
             generation: new_generation,
@@ -2098,7 +2126,7 @@ impl PartitionLeaseStore {
         let payload = serde_json::to_vec(&tombstone).context("encoding release tombstone")?;
 
         match self
-            .committer_for_key(key)
+            .committer_for_key(key)?
             .commit_fenced(Some(version), new_generation, bytes::Bytes::from(payload))
             .await
         {
@@ -2217,10 +2245,13 @@ impl PartitionLeaseManager {
             .acquire_with_key(key, &self.self_pod_id, now_ms, ttl_ms)
             .await?;
 
-        if Self::is_legacy_collection_key(key) {
-            let ResourceIdentifier::Single(collection_id) = &key.resource_id else {
-                unreachable!("legacy collection key checked above");
-            };
+        // A legacy collection key reconciles into the (tenant, collection)
+        // registry; everything else is tracked by full ResourceKey. Match the
+        // single-component id directly (no-panic policy — fall through to the
+        // generalized path rather than `unreachable!` if the shape ever differs).
+        if Self::is_legacy_collection_key(key)
+            && let ResourceIdentifier::Single(collection_id) = &key.resource_id
+        {
             return Ok(self.reconcile(&key.tenant_id, collection_id, outcome));
         }
 
@@ -2235,6 +2266,20 @@ impl PartitionLeaseManager {
                 Ok(false)
             }
         }
+    }
+
+    /// Track a resource lease this pod holds so [`renew_held`] keeps it warm.
+    ///
+    /// `DmlLockService` acquires the durable lease via the store directly (it
+    /// needs the `LeaseOutcome`/generation to build its guard), bypassing
+    /// [`acquire_with_key`] — the only other path that populates the renewal set.
+    /// Without this registration a DML lock's durable lease silently lapses at
+    /// its TTL while still held, opening a takeover-eligible split-brain window.
+    /// The matching un-track happens in [`release_with_key`], which removes the
+    /// same identity.
+    pub fn track_held_key(&self, key: &ResourceKey) {
+        self.held_resource_keys
+            .insert(Self::resource_key_identity(key), key.clone());
     }
 
     /// Explicitly relinquish a generalized resource lease (F7): drop the
@@ -2715,6 +2760,11 @@ impl DmlLockService {
                     },
                 );
                 crate::metrics::dml_lock_metrics::inc_held(resource_type);
+                // Register the durable lease in the manager's renewal set so the
+                // renew loop keeps it warm — we acquired via the store directly
+                // (above) to get the generation, bypassing the manager's
+                // `acquire_with_key`, which is the only other path that tracks it.
+                self.lease_manager.track_held_key(&resource_key);
                 LockOutcome::Acquired { lease }
             }
             LeaseOutcome::Held { by } => LockOutcome::Held {
@@ -3196,6 +3246,66 @@ mod tests {
         Ok(())
     }
 
+    /// Collection routing is TOTAL: a namespaced collection key would land on a
+    /// different `to_path()` log than the legacy `(tenant, collection)` writer —
+    /// a forked generation fence = cross-version split brain. It must be rejected
+    /// LOUDLY, never silently routed to a divergent log. (No current caller
+    /// builds such a key; this guards against one being introduced.)
+    #[tokio::test]
+    async fn namespaced_collection_key_is_rejected_not_forked() -> Result<()> {
+        let backing = shared_backing();
+        let store = store(&backing);
+        let ns_key = ResourceKey::new(
+            "tenant-a",
+            Some("ns-x".to_string()),
+            ResourceType::Collection,
+            ResourceIdentifier::single("collection-a".to_string()),
+        );
+
+        // Every routing path (read + acquire) must error rather than diverge.
+        assert!(
+            store.read_key(&ns_key).await.is_err(),
+            "namespaced collection key must be rejected, not routed to a forked log"
+        );
+        assert!(
+            store
+                .acquire_with_key(&ns_key, "pod-a", 0, LEASE_MS)
+                .await
+                .is_err(),
+            "acquire on a namespaced collection key must error, not fork the fence"
+        );
+        Ok(())
+    }
+
+    /// A composite-of-one collection key reduces to the canonical legacy shape
+    /// and MUST contend on the SAME log as the legacy `(tenant, collection)`
+    /// writer — totality, not a separate `to_path()` log.
+    #[tokio::test]
+    async fn composite_one_collection_key_uses_legacy_log() -> Result<()> {
+        let backing = shared_backing();
+        let store = store(&backing);
+
+        let legacy = store
+            .acquire("tenant-a", "collection-a", "pod-a", 0, LEASE_MS)
+            .await?;
+        assert!(matches!(legacy, LeaseOutcome::Acquired(_)));
+
+        let composite_key = ResourceKey::new(
+            "tenant-a",
+            None,
+            ResourceType::Collection,
+            ResourceIdentifier::composite(vec!["collection-a".to_string()]),
+        );
+        match store
+            .acquire_with_key(&composite_key, "pod-b", 1_000, LEASE_MS)
+            .await?
+        {
+            LeaseOutcome::Held { by } => assert_eq!(by.holder_pod, "pod-a"),
+            other => panic!("composite-of-one must contend with legacy log, got {other:?}"),
+        }
+        Ok(())
+    }
+
     /// Generalized resource keys must be path-safe: separators inside tenant,
     /// namespace, or resource components are encoded, not treated as hierarchy.
     #[test]
@@ -3387,6 +3497,51 @@ mod tests {
         let lease = stored.1;
         assert_eq!(lease.holder_pod, "solo");
         assert_eq!(lease.expires_at_ms, 130_000);
+        Ok(())
+    }
+
+    /// A DML lock's durable lease is registered in the manager's renewal set
+    /// (via `track_held_key`), so the renew loop keeps it warm. Before this fix
+    /// `DmlLockService` acquired via the store directly — bypassing the manager's
+    /// `held_resource_keys` — so `renew_held` returned 0 and the lease silently
+    /// lapsed at the 10s TTL while still held (a takeover-eligible split-brain
+    /// window for any DML lock held longer than the TTL).
+    #[tokio::test]
+    async fn dml_lock_durable_lease_is_tracked_and_renewed() -> Result<()> {
+        let backing = shared_backing();
+        let manager = Arc::new(test_manager(&backing, "pod-1"));
+        let lock_service = DmlLockService::new(manager.clone(), "pod-1".to_string());
+
+        let scope = DmlLockScope::Table {
+            schema_name: "public".to_string(),
+            table_name: "users".to_string(),
+        };
+        let acquired = lock_service
+            .acquire_dml_lock("tenant1", None, &scope, LockIntent::Write, 0)
+            .await?;
+        assert!(matches!(acquired, LockOutcome::Acquired { .. }));
+
+        // The renew loop must now see the DML lease as held-by-us and renew it.
+        let renewed = manager.renew_held(1_000).await?;
+        assert_eq!(renewed, 1, "DML lease must be in the manager's renewal set");
+
+        // Renewal pushed the durable expiry past the original 10s TTL window.
+        let key = ResourceKey::table("tenant1", "public", "users");
+        let stored = manager.store.read_key(&key).await?.expect("lease present");
+        assert_eq!(stored.1.holder_pod, "pod-1");
+        assert!(
+            stored.1.expires_at_ms > 10_000,
+            "renewal at t=1000 must push expiry beyond the initial TTL (got {})",
+            stored.1.expires_at_ms
+        );
+
+        // After full release the key leaves the renewal set (no renew leak).
+        lock_service.release_full("tenant1", None, &scope).await;
+        assert_eq!(
+            manager.renew_held(2_000).await?,
+            0,
+            "released DML lease must no longer be renewed"
+        );
         Ok(())
     }
 

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -858,6 +858,16 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             batch.records.len()
         );
 
+        // Primary-pod write-router gate (symmetric with `insert_records`). Every
+        // mutation must gate — not just insert — or a displaced pod silently
+        // accepts upserts that the new primary's reader never sees. Runs after
+        // auth/validation, before the lane router / storage path.
+        check_primary_pod_gate(
+            &self.primary_pod_gate,
+            tenant_id.as_deref().unwrap_or(""),
+            &batch.collection_id,
+        )?;
+
         let record_ids: Vec<String> = batch
             .records
             .iter()
@@ -929,6 +939,13 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             batch.records.len()
         );
 
+        // Primary-pod write-router gate (symmetric with `insert_records`).
+        check_primary_pod_gate(
+            &self.primary_pod_gate,
+            tenant_id.as_deref().unwrap_or(""),
+            &batch.collection_id,
+        )?;
+
         let record_ids: Vec<String> = batch
             .records
             .iter()
@@ -987,6 +1004,13 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             batch.collection_id,
             batch.records.len()
         );
+
+        // Primary-pod write-router gate (symmetric with `insert_records`).
+        check_primary_pod_gate(
+            &self.primary_pod_gate,
+            tenant_id.as_deref().unwrap_or(""),
+            &batch.collection_id,
+        )?;
 
         let record_ids: Vec<String> = batch
             .records

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -842,6 +842,17 @@ pub async fn execute_sql(
         }
         Err(e) => {
             error!("SQL query {} failed: {}", request_id, e);
+            // A DML lock/fence conflict must surface as a retryable 409
+            // lock_conflict, not a generic 500. The typed `DmlLockConflict` can
+            // sit several `.context(...)` layers deep, so walk the chain — same
+            // as the pgwire 55P03 and gRPC ABORTED mappings. (421 Misdirected =
+            // wrong pod stays distinct from 409 = conflict on the right pod.)
+            if let Some((resource, holder)) = crate::errors::extract_dml_lock_conflict(&e) {
+                return Err(ApiError::LockConflict(match holder {
+                    Some(h) => format!("{resource} held by {h}"),
+                    None => resource,
+                }));
+            }
             Err(ApiError::Internal(e.to_string()))
         }
     }

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -2102,6 +2102,44 @@ pub async fn delete_record_v2(
         ));
     }
 
+    // Primary-pod write-router gate (symmetric with `insert_records`). Deletes
+    // are mutations too: a delete accepted on a displaced pod would never reach
+    // the primary's memtable, leaving the record live on the primary. Gate
+    // BEFORE any storage work.
+    match crate::cluster::primary_pod_registry::consult_for_write(
+        &state.primary_pod_registry,
+        &state.self_pod_id,
+        &tenant.tenant_id,
+        &collection_id,
+    ) {
+        crate::cluster::primary_pod_registry::WriteRoutingDecision::Allow => {
+            if state
+                .primary_pod_registry
+                .is_assigned(&tenant.tenant_id, &collection_id)
+            {
+                crate::metrics::primary_pod_metrics::record_allowed_bound(&tenant.tenant_id);
+            } else {
+                crate::metrics::primary_pod_metrics::record_allowed_unbounded(&tenant.tenant_id);
+            }
+        }
+        crate::cluster::primary_pod_registry::WriteRoutingDecision::Misrouted { target_pod } => {
+            crate::metrics::primary_pod_metrics::record_misrouted(&tenant.tenant_id);
+            tracing::warn!(
+                target = "proximadb.primary_pod.misroute",
+                self_pod = %state.self_pod_id,
+                target_pod = %target_pod,
+                tenant_id = %tenant.tenant_id,
+                collection_id = %collection_id,
+                "v2 delete misrouted — client SDK should retry against the primary pod"
+            );
+            return Err(ApiError::Misdirected {
+                target_pod,
+                tenant_id: tenant.tenant_id.clone(),
+                collection_id: collection_id.clone(),
+            });
+        }
+    }
+
     let intent = WriteIntent::new(&collection_id, WriteOperationKind::Delete)
         .with_durability(WriteDurabilityRequirement::WalRequired)
         .with_row_count_hint(1);

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1817,19 +1817,27 @@ impl SharedServices {
         // table-level DML contention is real across pods (only one pod's
         // `DmlLockService` can hold the CAS-backed lease). Fail-open — no locks
         // — if the store can't be opened (test/embedded paths); never block
-        // bootstrap. The pod id is process-unique; a stable deployment-level
-        // pod id is a follow-up (matters only for multi-pod restart affinity).
+        // bootstrap.
+        //
+        // Registry/pod-id unification (lease ↔ write-gate): the lease manager
+        // MUST reconcile into the SAME `primary_pod_registry` the write gates
+        // consult (built above, wired into AppState/gRPC/Flight gates below) and
+        // use the SAME `self_pod_id` those gates compare against
+        // (`resolve_self_pod_id(None)`). Previously the manager owned a throwaway
+        // `PrimaryPodRegistry::new()` and a `pod-{pid}` id, so the renew loop's
+        // `reconcile`→`assign` (step-down on lease loss) updated a registry
+        // nobody read, and the assigned owner id never matched the gate's id —
+        // a displaced pod kept seeing `Allow` and kept writing (split brain).
         let dml_lock_service = {
             use crate::cluster::partition_lease::{
                 DmlLockService, PartitionLeaseManager, PartitionLeaseStore,
             };
-            use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
             match PartitionLeaseStore::from_url(&storage_config.metadata_url, "_operator/leases") {
                 Ok(store) => {
-                    let pod_id = format!("pod-{}", std::process::id());
+                    let pod_id = crate::cluster::primary_pod_registry::resolve_self_pod_id(None);
                     let manager = Arc::new(PartitionLeaseManager::new(
                         Arc::new(store),
-                        Arc::new(PrimaryPodRegistry::new()),
+                        primary_pod_registry.clone(),
                         pod_id.clone(),
                         10_000,
                     ));


### PR DESCRIPTION
## Summary

Foundation correctness fixes for the generation-fenced partition-lease plane (**PR 1 of 2**; the storage-write fence enforcement / A6 follows in PR 2). These close live split-brain / fencing-bypass holes found in a senior-staff review of the lease/manifest/catalog plane: the durable lease generation is the correctness authority, but on the highest-volume write paths nothing consulted it, and the routing cache the gates *did* consult was wired to the wrong instance.

## What changed

- **Registry + pod-id unification** (`shared_services.rs`): build `PartitionLeaseManager` with the shared `primary_pod_registry` and the unified `self_pod_id` (`resolve_self_pod_id`) instead of a throwaway `PrimaryPodRegistry::new()` + `pod-{pid}`. The renew loop's `reconcile`/step-down now updates the registry the write gates actually read, and the assigned owner id matches the gate's id. Previously a displaced pod kept seeing `Allow` and kept writing (split brain), and `reconcile` updated a registry nobody read.
- **Gate coverage** (`grpc/v2/record_service.rs`, `rest/v2/records.rs`): gate `upsert`/`update`/`delete` (not just `insert`) against the primary-pod registry. An ungated mutation on a displaced pod silently lands in a memtable the new primary's reader never sees.
- **Total manifest-log routing** (`partition_lease.rs::committer_for_key`): a namespaced or composite collection key is now rejected **loudly** instead of silently routing to a divergent `to_path()` log (a forked generation fence = cross-version split brain). No current caller produces such a key; this guards against one being introduced.
- **DML-lease renewal** (`partition_lease.rs`): register DML-lock durable leases in the manager's renewal set (`track_held_key`) so `renew_held` keeps them warm. Previously DML locks acquired via the store directly bypassed the manager and silently lapsed at the 10s TTL while still held (a takeover-eligible window).
- **REST v1 `execute_sql` error mapping** (`rest/v1/handlers.rs`): map a DML lock conflict to **409 lock_conflict** via the error-chain walk instead of a generic 500, matching the pgwire 55P03 / gRPC ABORTED mappings. 421 Misdirected (wrong pod) stays distinct from 409 (conflict on the right pod).
- **No-panic cleanups** (`partition_lease.rs`): `saturating_add` on generation arithmetic; dropped an `unreachable!` in favor of a fail-safe fall-through.

## Tests

New `partition_lease` unit tests (extending the two-stores-one-backing split-brain harness):
- `namespaced_collection_key_is_rejected_not_forked` — routing rejects the fork-prone shape on both read and acquire.
- `composite_one_collection_key_uses_legacy_log` — composite-of-one collection key contends on the same legacy log (totality).
- `dml_lock_durable_lease_is_tracked_and_renewed` — DML lease enters the renewal set, is renewed past TTL, and is untracked on release (no renew leak).

## Verification (local, toolchain 1.95.0)

- `cargo check --lib --bins --tests` — clean
- `cargo test --lib partition_lease` — 46 passed / 0 failed
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo build -p proximadb-server -p proximadb-bench -p proximadb-migrate` — clean

## Scope note

A7 (`DmlService::execute_scoped` lock acquisition after catalog resolution) and the broader A8 protocol mapping remain gated behind the A6 storage-write fence enforcement, which is PR 2. This PR does not wire protocol locks beyond the REST v1 conflict-mapping fix.
