### PR TITLE
fix(ui): restore CRA entry assets so the operator console builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,6 +369,9 @@ reports/
 !crates/platform/proximadb-admin-ui/assets/*.html
 !target/criterion/**/*.html
 !src/network/rest/dashboard.html
+# CRA operator console entry assets are source, not generated reports.
+!ui/public/index.html
+!ui/public/manifest.json
 
 # Generated configuration files (but keep examples)
 #*_config.toml

--- a/ui/README.adoc
+++ b/ui/README.adoc
@@ -16,9 +16,9 @@ is the heavier *full operator console* counterpart to the lightweight, read-only
 dashboard the server now serves at `GET /admin` (see
 `docs/04-operations/admin-dashboard.adoc` / `crates/platform/proximadb-admin-ui`).
 
-*Known gap:* `public/index.html` (and `public/manifest.json`) are absent, so a
-`react-scripts build` will fail until they are restored. Treat this as a work-in-progress
-operator UI, not a shipping artifact.
+The CRA `public/` entry assets (`index.html`, `manifest.json`) are present, so the app
+builds with `npm install && npm run build`. It remains a developer/operator app that is
+not gated by CI, so verify a build before relying on it.
 ====
 
 == Stack
@@ -33,7 +33,7 @@ operator UI, not a shipping artifact.
 $ cd ui
 $ npm install
 $ npm start      # dev server on :3000, proxies API calls to :5678
-$ npm run build  # production bundle (requires public/index.html — see Status note)
+$ npm run build  # production bundle into build/
 ----
 
 == Layout

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0f1320" />
+    <meta
+      name="description"
+      content="ProximaDB web operator console — admin and monitoring for a running ProximaDB server."
+    />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>ProximaDB Operator Console</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run the ProximaDB operator console.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/ui/public/manifest.json
+++ b/ui/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "ProximaDB",
+  "name": "ProximaDB Operator Console",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#0f1320",
+  "background_color": "#0f1320"
+}


### PR DESCRIPTION
## What

Fixes the `ui/` build gap flagged in #322: `public/index.html` and `public/manifest.json` were absent, so `react-scripts build` failed before compiling anything. Restores them.

- **`public/index.html`** — standard CRA template, ProximaDB-branded, with the `#root` mount target `src/index.tsx` renders into, plus favicon + manifest links and theme-color.
- **`public/manifest.json`** — minimal, references the existing `favicon.ico` only (the default PWA logos `logo192/512.png` were intentionally removed in #322, so they're not referenced).
- **`.gitignore`** — the repo-wide `*.html` and `*.json` rules were swallowing the new (untracked) entry files; added explicit negations so they're tracked (otherwise a fresh clone would lack them and the build would fail again).
- **README** — dropped the "missing index.html" caveat.

## Verification

- Static checks (offline): `manifest.json` is valid JSON; `index.html` has `id="root"` and references only assets that exist; **all relative imports under `src/` resolve**; no `PUBLIC_URL`/`react-router` build dependency is missing.
- **Not** build-verified here: this sandbox has no npm-registry egress (`npm install` can't run), and `ui/` isn't gated by CI. A green `npm install && npm run build` should be confirmed on a networked machine. The structural blocker (missing entry HTML) is removed; any remaining issues would be component-level TS, which can't be checked offline.