### PR TITLE
test(sst): mixed-format legacy+PAX coexistence gate + staged-rollout docs (Phase 2)

### DIFF
--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -151,8 +151,12 @@ impl SstEngine {
         let codec = FilenameCodec::new();
         let mut block_format = BlockFormat::parse_block_format(&self.config().block_format);
         // P3 Phase B: flag-gated PAX vector segments (default OFF). Reads stay
-        // mixed-format-safe (see `segment_format`), so flipping this on only changes
-        // newly written segments; existing ProximaBlocks segments still read back.
+        // mixed-format-safe — see
+        // `segment_format::mixed_format_legacy_and_pax_segments_coexist_and_read_back`
+        // — so flipping this on only changes newly written segments; existing
+        // ProximaBlocks segments still read back. STAGED ROLLOUT: default OFF in
+        // v0.2; the develop→qa recall ratchet (qa-gate `pax-recall-ratchet`,
+        // recall@10 >= 0.90 at N=100k) gates the v0.3 flip to default ON.
         if std::env::var("PROXIMADB_PAX_VECTOR_SEGMENTS")
             .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
             .unwrap_or(false)
@@ -433,6 +437,8 @@ impl SstEngine {
                 // P3 Phase D: vector quantization strategy. Deployment selector for now
                 // (`PROXIMADB_PAX_VECTOR_QUANT` = rabitq|sq8|auto); per-collection proto
                 // config is the productionization follow-up. `Auto` keeps the env default.
+                // STAGED ROLLOUT: only takes effect once PAX segments are enabled above
+                // (default OFF v0.2); the recall ratchet gates the v0.3 default-on flip.
                 let quant = match std::env::var("PROXIMADB_PAX_VECTOR_QUANT")
                     .unwrap_or_default()
                     .to_ascii_lowercase()

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -445,6 +445,75 @@ mod tests {
         assert_eq!(back.len(), records.len());
     }
 
+    /// Mixed-read-safe coexistence (storage-format mandate #8). A store rolling
+    /// PAX quantization on will have BOTH legacy `ProximaBlocks` segments (written
+    /// before the flip) and new PAX segments side by side. The magic-byte router
+    /// must read BOTH back through the single `read_segment_records` entry —
+    /// disjoint oids, no mis-route. This is the property that makes the staged
+    /// default-on flip safe (default OFF in v0.2, flip gated by the recall ratchet).
+    #[test]
+    fn mixed_format_legacy_and_pax_segments_coexist_and_read_back() {
+        let legacy_records = vec![
+            rec(
+                "legacy_a",
+                1_700_000_000_000_000_000,
+                vec![1.0, 2.0, 3.0, 4.0],
+            ),
+            rec(
+                "legacy_b",
+                1_700_000_000_000_000_001,
+                vec![5.0, 6.0, 7.0, 8.0],
+            ),
+        ];
+        let legacy_bytes = ProximaDataBlock::new(legacy_records, BlockCompressionConfig::default())
+            .serialize()
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let pax_path = dir.path().join("coexist.pax");
+        let pax_records = vec![
+            rec(
+                "pax_c",
+                1_700_000_000_000_000_002,
+                vec![9.0, 10.0, 11.0, 12.0],
+            ),
+            rec(
+                "pax_d",
+                1_700_000_000_000_000_003,
+                vec![13.0, 14.0, 15.0, 16.0],
+            ),
+        ];
+        write_pax_segment(&pax_path, &pax_records, "col", 1, VectorQuant::RaBitQ).unwrap();
+        let pax_bytes = std::fs::read(&pax_path).unwrap();
+
+        // The two segments are detected as DIFFERENT formats (never mis-routed).
+        assert_eq!(
+            SegmentFormat::detect(&legacy_bytes),
+            SegmentFormat::ProximaBlocks
+        );
+        assert_eq!(SegmentFormat::detect(&pax_bytes), SegmentFormat::Pax);
+
+        // ...and BOTH read back through the single mixed-format router.
+        let legacy_back = read_segment_records(&legacy_bytes, &[], &[], None).unwrap();
+        let pax_back = read_segment_records(&pax_bytes, &[], &[], None).unwrap();
+
+        let mut legacy_oids: Vec<&str> = legacy_back.iter().map(|r| r.oid.as_str()).collect();
+        legacy_oids.sort_unstable();
+        let mut pax_oids: Vec<&str> = pax_back.iter().map(|r| r.oid.as_str()).collect();
+        pax_oids.sort_unstable();
+
+        assert_eq!(
+            legacy_oids,
+            vec!["legacy_a", "legacy_b"],
+            "legacy segment oids"
+        );
+        assert_eq!(
+            pax_oids,
+            vec!["pax_c", "pax_d"],
+            "PAX segment oids (disjoint from legacy)"
+        );
+    }
+
     /// P3 C.2 cascade primitive — recall + trace gate. A real PAX+RaBitQ segment
     /// is cold-scanned via `rabitq_search_segment` (RaBitQ candidate prefilter →
     /// SQ8 rerank → top-k); recall@10 must hold ≥ 0.90 vs the exact-f32 baseline,


### PR DESCRIPTION
Staged prep for the PAX quant default-on flip — **no behavior change** (test + doc-comments only).

## What
- **mixed_format_legacy_and_pax_segments_coexist_and_read_back** — the storage-format mandate #8 mixed-read-safe proof: a store rolling PAX quant on has legacy ProximaBlocks + new PAX segments side by side; both read back through the single read_segment_records router (disjoint oids, no mis-route). Existing tests covered each format in isolation, not coexistence — this is the property the flip depends on.
- **Staged-rollout docs** at both gating sites in flush/mod.rs: PAX vector segments stay default-OFF in v0.2; the v0.3 flip is gated by the develop→qa recall ratchet (Phase 1, recall@10 ≥ 0.90 at N=100k).

## Why staged (per the approved plan)
Flipping a production write-path default is risky; this PR proves the flip is *safe* (mixed-read coexistence) and documents the staged plan, without flipping anything. Per-collection VectorQuant config (the named productionization follow-up) and the actual default-on flip remain deferred to later PRs.

## Verified
- New test passes (root-crate lib test, 0.02s).
- pinned-1.95.0 fmt clean on both files.
- No production-code change (test + comments) → clippy/build unaffected.

Phases: 1 = recall gate (PR #331) · **2 = this (staged prep)** · 3-5 = folds · 6 = retire SWIFT/RAPTOR.