### PR TITLE
fix(cluster): lease-on-write + DoExchange gate on the vector-record path (Scenario-1 routing)

### DIFF
--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -84,6 +84,13 @@ pub struct RecordOpsService {
     precision_resolver: std::sync::OnceLock<
         Arc<proximadb_catalog::canonical_precision::CanonicalPrecisionResolver>,
     >,
+    /// Durable partition-lease manager for lease-on-write (Scenario-1 routing
+    /// truth). When present, the record write path acquires/confirms this pod's
+    /// collection lease before writing, so the shared primary-pod registry that
+    /// the network gates consult is durably backed (not empty-after-restart).
+    /// Settable post-construction (thread-safe); absent in embedded/test builds.
+    lease_manager:
+        std::sync::RwLock<Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>>,
 }
 
 impl RecordOpsService {
@@ -99,6 +106,7 @@ impl RecordOpsService {
             dml_service: std::sync::RwLock::new(None),
             ddl_service: std::sync::RwLock::new(None),
             precision_resolver: std::sync::OnceLock::new(),
+            lease_manager: std::sync::RwLock::new(None),
         }
     }
 
@@ -112,6 +120,53 @@ impl RecordOpsService {
 
     pub(crate) fn get_dml_service(&self) -> Option<Arc<DmlService>> {
         self.dml_service.read().ok().and_then(|guard| guard.clone())
+    }
+
+    /// Wire the durable partition-lease manager for lease-on-write.
+    /// Callable post-initialization; thread-safe.
+    pub fn set_lease_manager(
+        &self,
+        manager: Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+    ) {
+        if let Ok(mut guard) = self.lease_manager.write() {
+            *guard = Some(manager);
+        }
+    }
+
+    /// Lease-on-write: make the shared primary-pod registry truthful for
+    /// `(tenant, collection)` by acquiring/confirming this pod's durable
+    /// collection lease before the write proceeds. Keyed by the collection NAME
+    /// (`request.collection_id`) and the transport tenant id — the exact pair the
+    /// network gates' `consult_for_write` uses — so the binding this populates is
+    /// the one the gates read. Idempotent + cheap after the first write (registry
+    /// fast-path; the renew loop keeps the lease warm). Fail-open: a missing
+    /// manager (embedded/tests) or a transient acquire error never blocks the
+    /// write — the network gate + the A6 storage fence are the enforcement points.
+    async fn ensure_collection_lease(&self, tenant_id: &str, collection_name: &str) {
+        let Some(manager) = self.lease_manager.read().ok().and_then(|g| g.clone()) else {
+            return;
+        };
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        match manager
+            .ensure_owned(tenant_id, collection_name, now_ms)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => tracing::warn!(
+                target = "proximadb.primary_pod.lease_on_write",
+                tenant_id = %tenant_id,
+                collection_id = %collection_name,
+                "lease-on-write: this pod is not the primary for the collection; \
+                 shared registry repointed to the owner (gate should now 421 subsequent writes)"
+            ),
+            Err(e) => tracing::warn!(
+                target = "proximadb.primary_pod.lease_on_write",
+                error = %e,
+                tenant_id = %tenant_id,
+                collection_id = %collection_name,
+                "lease-on-write acquire failed; proceeding fail-open"
+            ),
+        }
     }
 
     /// Wire a `DdlService` so gRPC `ExecuteQuery` can run relational DDL (TD-135).
@@ -289,6 +344,8 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
+        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await;
         let result = self
             .vector_operations_service
             .delete_records_with_tenant_context(
@@ -350,6 +407,8 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
+        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await;
 
         let mut records = request.records;
         self.coerce_records_to_canonical_precision(&mut records, &request.collection_id)
@@ -422,6 +481,8 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
+        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await;
         let mut records = request.records;
         self.coerce_records_to_canonical_precision(&mut records, &request.collection_id)
             .await;

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -2232,6 +2232,34 @@ impl PartitionLeaseManager {
         Ok(self.reconcile(tenant_id, collection_id, outcome))
     }
 
+    /// Ensure this pod owns `(tenant, collection)` with at most one object-store
+    /// round-trip per pod per collection (lease = latency optimization).
+    ///
+    /// Fast path: if the shared registry already binds the partition to this pod,
+    /// the renew loop keeps the durable lease warm, so return `true` without I/O.
+    /// Slow path (no binding, or a foreign owner): [`acquire`] (CAS) + reconcile,
+    /// which repoints the shared registry at the true owner so `consult_for_write`
+    /// is durably backed rather than empty-after-restart. Returns whether this pod
+    /// owns the partition. Callers fail-open on `Err` (transient object-store
+    /// blip), matching the lease stack's bootstrap posture; the storage-write
+    /// fence (A6) is the boundary backstop for the residual handoff race.
+    pub async fn ensure_owned(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        now_ms: i64,
+    ) -> Result<bool> {
+        if self
+            .registry
+            .lookup(tenant_id, collection_id)
+            .map(|binding| binding.pod == self.self_pod_id)
+            .unwrap_or(false)
+        {
+            return Ok(true);
+        }
+        self.acquire(tenant_id, collection_id, now_ms).await
+    }
+
     /// Acquire a lease for a resource identified by its ResourceKey.
     ///
     /// This is the multi-modality entry point that uses the registered strategy
@@ -3370,6 +3398,42 @@ mod tests {
             consult_for_write(&reg_a, "A", "t", "c"),
             WriteRoutingDecision::Misrouted {
                 target_pod: "B".to_string()
+            }
+        );
+        Ok(())
+    }
+
+    /// `ensure_owned` is the lease-on-write entry point: it acquires on a miss
+    /// (making the shared registry truthful), is idempotent on the fast-path when
+    /// already held, and steps a non-owner down to the true owner so the gate
+    /// Misroutes instead of admitting a split-brain write.
+    #[tokio::test]
+    async fn ensure_owned_idempotent_and_steps_down() -> Result<()> {
+        let backing = shared_backing();
+        let reg_a = Arc::new(PrimaryPodRegistry::new());
+        let reg_b = Arc::new(PrimaryPodRegistry::new());
+        let mgr_a =
+            PartitionLeaseManager::new(Arc::new(store(&backing)), reg_a.clone(), "A", LEASE_MS);
+        let mgr_b =
+            PartitionLeaseManager::new(Arc::new(store(&backing)), reg_b.clone(), "B", LEASE_MS);
+
+        // A's first write: ensure_owned acquires (registry miss) → A owns → Allow.
+        assert!(mgr_a.ensure_owned("t", "c", 0).await?);
+        assert_eq!(
+            consult_for_write(&reg_a, "A", "t", "c"),
+            WriteRoutingDecision::Allow
+        );
+        // A's subsequent write: fast-path (already bound to self) → still owns.
+        assert!(mgr_a.ensure_owned("t", "c", 1_000).await?);
+
+        // B's first write to the same collection: ensure_owned acquires → A holds
+        // the live lease → B does NOT own it, and B's shared registry is repointed
+        // to A so its gate Misroutes (no split brain).
+        assert!(!mgr_b.ensure_owned("t", "c", 2_000).await?);
+        assert_eq!(
+            consult_for_write(&reg_b, "B", "t", "c"),
+            WriteRoutingDecision::Misrouted {
+                target_pod: "A".to_string()
             }
         );
         Ok(())

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -2526,6 +2526,17 @@ impl ProximaFlightService {
         let mut insert_seen_ids = HashSet::new();
         Self::validate_flight_write_capability(capability.as_ref(), &collection_id, operation, 0)?;
 
+        // Primary-pod write-router gate. The DoExchange bulk write path
+        // (bulk_insert/upsert/delete) must gate symmetrically with do_put — a
+        // displaced pod streaming a bulk batch would otherwise land it in a
+        // memtable the new primary's reader never sees. Gate once for the whole
+        // exchange, after capability validation, before any storage work.
+        check_flight_primary_pod_gate(
+            &self.primary_pod_gate,
+            tenant_id.as_deref().unwrap_or(""),
+            &collection_id,
+        )?;
+
         // Resolve write lane once for the full exchange stream: DoExchange always
         // uses WAL durability because streaming batches require per-row ordering.
         let op_kind = crate::services::WriteOperationKind::from(operation);

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1828,7 +1828,7 @@ impl SharedServices {
         // `reconcile`→`assign` (step-down on lease loss) updated a registry
         // nobody read, and the assigned owner id never matched the gate's id —
         // a displaced pod kept seeing `Allow` and kept writing (split brain).
-        let dml_lock_service = {
+        let (dml_lock_service, lease_manager_for_writes) = {
             use crate::cluster::partition_lease::{
                 DmlLockService, PartitionLeaseManager, PartitionLeaseStore,
             };
@@ -1855,9 +1855,13 @@ impl SharedServices {
                     manager
                         .clone()
                         .spawn_renew_loop(std::time::Duration::from_millis(5_000));
-                    let lock_service = Arc::new(DmlLockService::new(manager, pod_id));
+                    let lock_service = Arc::new(DmlLockService::new(manager.clone(), pod_id));
                     let _ = lock_service.spawn_reconciliation_loop(5_000);
-                    Some(lock_service)
+                    // Surface the manager so RecordOpsService can lease-on-write:
+                    // acquire/confirm the collection lease before each vector-record
+                    // write so the shared primary-pod registry the gates consult is
+                    // durably backed (not empty-after-restart → wrong-pod write).
+                    (Some(lock_service), Some(manager))
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -1866,7 +1870,7 @@ impl SharedServices {
                         "DML lock service disabled (lease store unavailable); \
                          DML writes run lock-free (fail-open)"
                     );
-                    None
+                    (None, None)
                 }
             }
         };
@@ -1897,6 +1901,19 @@ impl SharedServices {
 
         request_handlers.set_dml_service(dml_service_for_grpc);
         debug!("✅ SharedServices::new - DmlService wired to UnifiedHandlers for EXPLAIN routing");
+
+        // Lease-on-write: give RecordOpsService the durable lease manager so the
+        // vector-record write path acquires/confirms the collection lease and the
+        // shared registry the network gates consult reflects ground truth after
+        // restart/partition (Scenario-1 routing truth). Absent → fail-open.
+        if let Some(lease_manager) = lease_manager_for_writes {
+            request_handlers
+                .record_ops()
+                .set_lease_manager(lease_manager);
+            debug!(
+                "✅ SharedServices::new - PartitionLeaseManager wired to RecordOpsService (lease-on-write)"
+            );
+        }
 
         // TD-135: wire a DdlService built from the SAME catalog_manager pgwire uses
         // (DdlService is a thin wrapper over the shared catalog), so relational


### PR DESCRIPTION
fix(cluster): lease-on-write + DoExchange gate on the vector-record path (Scenario-1 routing)

Closes the routing-layer half of the vector-record split-brain surfaced in the
lease/manifest/catalog re-review. (The A6 storage-write fence — the boundary
backstop for the residual stall-after-admission race — follows as its own gated
default-OFF PR, per the A6-enforcement TD.)

Two fixes:

- Lease-on-write (routing truth). RecordOpsService now acquires/confirms this
  pod's durable per-(tenant,collection) lease before each vector-record write
  (insert/upsert/delete), via PartitionLeaseManager::ensure_owned. ensure_owned
  is idempotent and cheap — a registry fast-path (already bound to self → no
  I/O; the renew loop keeps the lease warm) with a CAS-acquire only on a miss or
  foreign binding, which reconciles the SHARED primary-pod registry to the true
  owner. Previously the registry was populated only by the operator assign
  endpoint and the SQL-DML table path, so a restarted/partitioned pod consulted
  an empty registry → consult_for_write returned Allow → it wrote into its own
  memtable. Now the write path makes the registry the gates read durably backed.
  Keyed by the collection NAME + transport tenant id — the exact pair the gates'
  consult_for_write uses. Fail-open: a missing manager (embedded/tests) or a
  transient object-store blip never blocks the write (matches the lease stack's
  bootstrap posture); the A6 fence is the boundary backstop.

  Wiring: PartitionLeaseManager::ensure_owned (idempotent acquire);
  RecordOpsService gains a lease-manager handle (set_lease_manager) wired at
  SharedServices bootstrap from the same manager the renew loop drives and the
  same shared registry the gates consult.

- DoExchange gate coverage. The Arrow Flight bulk-write path
  (do_exchange → handle_bulk_write_exchange: bulk_insert/upsert/delete) was the
  one vector-write path with NO primary-pod gate — it bypassed even the advisory
  registry check that do_put and the gRPC/REST paths have. It now gates
  symmetrically with do_put (after capability validation, before storage work).

Tests: ensure_owned_idempotent_and_steps_down (acquire on miss → Allow;
fast-path idempotent; cross-pod → non-owner steps down → gate Misroutes).

Verified: cargo check --workspace --lib --bins (0 warnings); clippy --lib --bins
-D warnings; cargo fmt --check; nextest partition_lease; server binaries build.
