### PR TITLE
bench(ranged-segment): footer-cache vs whole-byte cloud-economics measurement (Phase 5)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -826,4 +826,101 @@ mod tests {
             "scalar-only ranged fetched {fetched} not << segment {total}"
         );
     }
+
+    /// Footer-cache + ranged-read cloud-economics measurement (co-design C0;
+    /// "measure, don't assert"). Quantifies the byte/request savings of a
+    /// footer-cached vector-column projection read vs a whole-byte read across a
+    /// steady-state run of queries over one warm segment. The `InMemoryRangeBridge`
+    /// stands in for S3 ranged GETs, so bytes_read / range_gets / footer hit-ratio
+    /// directly proxy S3 egress + per-request-fee + cache effectiveness — the
+    /// evidence that justifies wiring the ranged reader into the live object-store
+    /// read path. Reports the numbers; asserts only the clear wins (hit ratio +
+    /// bytes), leaving GET-count as an honest reported metric (per-block column
+    /// scans can fragment into more, smaller GETs — the co-design §2.1 signal).
+    #[tokio::test]
+    async fn footer_cache_ranged_read_economics_vs_whole_byte() {
+        const N: usize = 4_000;
+        const DIM: usize = 128;
+        const Q: usize = 20; // steady-state queries over one warm segment
+
+        let bytes = build_segment_bytes(N, DIM);
+        let whole_segment_bytes = bytes.len() as u64;
+        let bridge = InMemoryRangeBridge {
+            bytes,
+            ranged_bytes: AtomicU64::new(0),
+        };
+        let footer_cache: Arc<FooterCache> = Arc::new(FooterCache::new(
+            proximadb_cache::CacheBudget::new(1 << 30, 1 << 30),
+        ));
+
+        // Steady state: Q vector-column projection reads sharing one tenant
+        // footer cache. Pass 1 warms the cache (footer+metadata fetched); passes
+        // 2..Q hit (only the vector stripes are fetched).
+        let mut ranged_bytes_total = 0u64;
+        let mut range_gets_total = 0u64;
+        let mut footer_hits = 0u64;
+        let mut footer_misses = 0u64;
+        for _ in 0..Q {
+            let r = RangedSegmentReader::open_with_cache(
+                &bridge,
+                Path::from("seg.pax"),
+                Some("t"),
+                Some(footer_cache.clone()),
+                None,
+            )
+            .await
+            .unwrap();
+            let vecs = r.read_f32_vec_column(col_id::EMBED_BASE).await.unwrap();
+            assert_eq!(vecs.len(), N, "vector column decodes all rows");
+            let s = r.read_stats();
+            ranged_bytes_total += s.bytes_read;
+            range_gets_total += s.range_gets;
+            footer_hits += s.footer_hits;
+            footer_misses += s.footer_misses;
+        }
+
+        // Whole-byte baseline (the current live read path): each query GETs the
+        // entire segment — no caching, no projection.
+        let whole_bytes_total = whole_segment_bytes * Q as u64;
+        let whole_gets_total = Q as u64;
+
+        let decisions = (footer_hits + footer_misses).max(1);
+        let hit_ratio = footer_hits as f64 / decisions as f64;
+        let byte_reduction = 100.0 * (1.0 - ranged_bytes_total as f64 / whole_bytes_total as f64);
+        let get_delta_pct = 100.0 * (range_gets_total as f64 / whole_gets_total as f64 - 1.0);
+
+        // Cloud-economics projection (S3 Standard, us-east-1 list): GET
+        // $0.00045/1k requests; egress $0.09/GB. Per-query figures in parens.
+        let bytes_saved = whole_bytes_total.saturating_sub(ranged_bytes_total);
+        let egress_usd = bytes_saved as f64 / (1024.0 * 1024.0 * 1024.0) * 0.09;
+        let gets_delta = range_gets_total as i64 - whole_gets_total as i64;
+        let get_fee_delta_usd = gets_delta as f64 * 0.00045 / 1000.0;
+
+        eprintln!("[footer-cache-bench] segment={whole_segment_bytes}B N={N} DIM={DIM} Q={Q}");
+        eprintln!(
+            "[footer-cache-bench] whole-byte  : {whole_bytes_total}B / {whole_gets_total} GETs"
+        );
+        eprintln!(
+            "[footer-cache-bench] ranged+cache: {ranged_bytes_total}B / {range_gets_total} GETs | footer hit-ratio={hit_ratio:.3}"
+        );
+        eprintln!(
+            "[footer-cache-bench] bytes -{byte_reduction:.1}% (egress saves ${egress_usd:.5} over {Q}q, ${:.7}/q)",
+            egress_usd / Q as f64
+        );
+        eprintln!(
+            "[footer-cache-bench] GETs {get_delta_pct:+.1}% vs whole ({gets_delta:+} reqs, ${get_fee_delta_usd:+.6} fee) — fragmentation signal"
+        );
+
+        // Ratchet: footer cache hits in steady state, and the projection reads
+        // strictly fewer bytes than whole-byte (the egress win). GET count is a
+        // reported signal, not a ratchet — per-block column scans can fragment.
+        assert!(
+            hit_ratio >= 0.9,
+            "footer cache should hit >=90% in steady state, got {hit_ratio:.3}"
+        );
+        assert!(
+            ranged_bytes_total < whole_bytes_total,
+            "ranged+cached ({ranged_bytes_total}B) must read less than whole-byte ({whole_bytes_total}B)"
+        );
+    }
 }

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -145,6 +145,20 @@ date = "2026-06-25"
 version = "v0.2"
 notes = "qa-gate ratchet (develop→qa promotion). Deterministic seeded LCG corpus (DIM=64). N=1000 REFINE=100 mean recall@10 = 0.9340; N=100000 REFINE=1000 mean recall@10 = 0.9320. Both >= 0.90 ratchet (only goes up, #10). Proves the RaBitQ->SQ8 cascade (stage-1 binary rank -> stage-2 SQ8 rerank, no f32 GET) holds recall at production scale -- the prerequisite for flipping PAX quant default-on (rollout Phase 2). NOTE: REFINE=200 at N=100k gave 0.708; a 1000-wide stage-1 pool (1% of corpus) recovers to 0.932. Indicative local run, not an SLA."
 
+[[claims]]
+id = "pax_footer_cache_ranged_read_economics"
+claim = "PAX footer-cache + ranged-read cloud-economics vs whole-byte (local S3-proxy measurement)"
+metric = "object_store_read_economics"
+status = "measured"
+asserted_in = ["crates/storage/proximadb-storage-common/src/ranged_segment.rs"]
+bench_source = "crates/storage/proximadb-storage-common/src/ranged_segment.rs"
+bench_command = "cargo test -p proximadb-storage-common --lib footer_cache_ranged_read_economics_vs_whole_byte -- --nocapture"
+artifact = "docs/_internal/status/PAX_FOOTER_CACHE_ECONOMICS_2026_06_25.adoc"
+hardware = "Apple M1 Max, 64 GB, macOS 26.2 (shared dev machine — indicative, not an SLA)"
+date = "2026-06-25"
+version = "v0.2"
+notes = "Local measurement (InMemoryRangeBridge = S3 ranged-GET proxy). 4000x128 PAX segment, Q=20 steady-state vector-column reads. RESULT: footer hit-ratio 0.950; ranged+cache 10.5MB/6000 GETs vs whole-byte 24.6MB/20 GETs -> bytes -57.1% (egress saves $0.0012) BUT GETs +29,900% (+$0.0027 fee). FINDING: naive per-block ranged reads are FEE-DOMINATED (GET fee > egress saving) -> naively wiring RAISES cloud cost. Real Phase 5 win = range coalescing (~8-16MiB GETs) + block pruning, not naive ranged reads. The harness is the ratchet for future coalescing work. Indicative, not an SLA."
+
 # ---------------------------------------------------------------------------
 # ASPIRATIONAL — target / acceptance-criterion only; no benchmark yet.
 # ---------------------------------------------------------------------------

--- a/docs/_internal/status/PAX_FOOTER_CACHE_ECONOMICS_2026_06_25.adoc
+++ b/docs/_internal/status/PAX_FOOTER_CACHE_ECONOMICS_2026_06_25.adoc
@@ -1,0 +1,46 @@
+= PAX Footer-Cache + Ranged-Read Economics — Measured 2026-06-25
+
+== Why measured
+Phase 5 ("footer-first ranged reads via the existing footer cache") looked like a
+straightforward reuse. Per the co-design "measure, don't assert" mandate, this
+harness quantifies the footer-cache + ranged-read economics *locally* before
+wiring it into the live object-store read path — the `InMemoryRangeBridge` stands
+in for S3 ranged GETs, so `bytes_read` / `range_gets` / footer hit-ratio directly
+proxy S3 egress + per-request fee + cache effectiveness.
+
+== Run
+- **Date:** 2026-06-25
+- **Hardware:** Apple M1 Max, 64 GB, macOS 26.2 (shared dev machine — indicative, *not* an SLA)
+- **Toolchain:** `rust-toolchain.toml` pinned 1.95.0
+- **Command:** `cargo test -p proximadb-storage-common --lib footer_cache_ranged_read_economics_vs_whole_byte -- --nocapture`
+- **Source:** `crates/storage/proximadb-storage-common/src/ranged_segment.rs` — `footer_cache_ranged_read_economics_vs_whole_byte`
+- **Scenario:** Q=20 steady-state vector-column projection reads over one warm 4000×128 PAX segment, sharing one tenant footer cache; compared to a whole-byte read (one full-segment GET per query).
+
+== Result
+[cols="1,2,1", options="header"]
+|===
+| Metric | Whole-byte (live path today) | Ranged + footer cache
+| Bytes fetched (20 q) | 24,563,120 B | 10,532,000 B
+| GET requests (20 q) | 20 | 6,000
+| Footer hit-ratio | n/a | 0.950
+| Egress @ $0.09/GB | — | saves $0.0012 (−57.1% bytes)
+| GET fee @ $0.00045/1k | — | +$0.0027 (+29,900% GETs)
+|===
+
+== Finding — the naive ranged read is fee-dominated
+Footer caching **works** (95% hit; 57% fewer bytes/egress). But a per-block
+column scan **fragments into thousands of small GETs** (6,000 vs 20) — exactly the
+co-design §2.1 "fragmented into many small, per-request-fee-dominated GETs" failure
+mode. At S3 prices the GET-fee increase (+$0.0027) *outweighs* the egress saving
+($0.0012) for this workload, so **naively wiring the ranged reader would *raise*
+cloud cost**, not lower it.
+
+== Implication (reframes Phase 5)
+The real Phase 5 win is **not** "wire ranged reads" — it is **range coalescing**
+(fetch contiguous column stripes / whole blocks in fewer, larger GETs toward the
+~8–16 MiB S3 cost-throughput optimum) **+ block pruning** (skip excluded blocks
+entirely, which cuts both bytes *and* GETs). The footer cache is necessary but not
+sufficient. The harness becomes the ratchet that proves any future coalescing
+change actually moves GET count down without losing the byte win.
+
+*Indicative local measurement, NOT an SLA.*


### PR DESCRIPTION
Phase 5 done as a **measurement**, not a wiring — and the measurement changed the conclusion. Test-only addition; no production-code change.

## What
`footer_cache_ranged_read_economics_vs_whole_byte` — steady-state (Q=20) vector-column projection reads over a warm 4000×128 PAX segment, footer-cache+ranged vs whole-byte, via the `InMemoryRangeBridge` S3-GET proxy. Reports bytes/GETs/hit-ratio + an S3 \$ projection; asserts only the clear wins (hit-ratio ≥ 0.90, bytes < whole-byte); GET-count is an honest *reported* metric.

## Measured (M1 Max, 1.95.0)
| | whole-byte (live path) | ranged + footer cache |
|---|---|---|
| bytes / 20q | 24.6 MB | 10.5 MB |
| GETs / 20q | 20 | 6,000 |
| footer hit-ratio | — | 0.950 |
| egress @ \$0.09/GB | — | −\$0.0012 (−57%) |
| GET fee @ \$0.00045/1k | — | **+\$0.0027 (+29,900%)** |

## Finding — the naive ranged read is fee-dominated
Footer caching works (95% hit, 57% fewer bytes). But per-block column scans **fragment into thousands of small GETs** — the co-design §2.1 failure mode. At S3 prices the GET-fee increase **outweighs** the egress saving, so **naively wiring the ranged reader would *raise* cloud cost.** Recorded `measured` in `BENCHMARK_EVIDENCE.toml` + dated artifact.

## Implication (reframes Phase 5)
The real win is **range coalescing** (~8–16 MiB GETs) **+ block pruning** (cuts both bytes and GETs), not naive ranged reads. This harness becomes the ratchet that proves a future coalescing change moves GETs down without losing the byte win.

Verified: test passes, pinned-1.95.0 fmt clean, evidence ledger validates, no production-code change.

Rollout: 1=recall gate (#331) · 2=staged prep (#335) · **5=this (measurement)** · 3/4=folds · 6=v1.0.