### PR TITLE
refactor(grpc): decouple v2 entity + fusion services off ROOT UnifiedHandlers (TD-104)

### DIFF
--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, warn};
 
-use crate::api_handlers::UnifiedHandlers;
 use crate::core::search::cross_modal_fusion::FusionPolicy;
 use crate::graph::{
     Edge, GraphOperationsService, Node, NodeId, NodeQuery, PropertyFilter, PropertyValue,
@@ -58,17 +57,19 @@ pub struct ProximaEntityServiceImpl {
 }
 
 impl ProximaEntityServiceImpl {
-    /// Create a new service from the shared unified request handlers.
-    pub fn new(request_handlers: Arc<UnifiedHandlers>) -> Self {
-        let graph = request_handlers.graph_operations_service.clone();
-        let vector = request_handlers.vector_operations_service.clone();
+    /// Create a new service from its concrete backing services (production wiring).
+    /// The fusion port is built once here from the vector + graph services
+    /// (mirrors the REST AppState pattern, PR #282).
+    pub fn new(
+        graph: Arc<GraphOperationsService>,
+        vector: Arc<VectorOperationsService>,
+        document: Arc<DocumentService>,
+    ) -> Self {
         Self {
             graph_service: graph.clone(),
             vector_service: vector.clone(),
-            // The fusion port is built once at boot from the vector + graph
-            // services (mirrors the REST AppState pattern, PR #282).
             fusion_service: Arc::new(FusionService::new(vector, graph)),
-            document_service: request_handlers.document_service.clone(),
+            document_service: document,
         }
     }
 

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tracing::debug;
 
-use crate::api_handlers::UnifiedHandlers;
 use crate::core::search::cross_modal_fusion::FusionPolicy;
 use crate::network::grpc::auth as grpc_auth;
 use crate::proto::proximadb_v2 as pv2;
@@ -38,15 +37,15 @@ pub struct ProximaFusionServiceImpl {
 }
 
 impl ProximaFusionServiceImpl {
-    /// Build from the shared unified request handlers. The `FusionService` port
-    /// is constructed once at boot (from the vector + graph services) and shared
+    /// Build from the concrete vector + graph backing services. The `FusionService`
+    /// port is constructed once here (from the vector + graph services) and shared
     /// across requests — never per-RPC.
-    pub fn new(request_handlers: Arc<UnifiedHandlers>) -> Self {
+    pub fn new(
+        vector: Arc<crate::services::VectorOperationsService>,
+        graph: Arc<crate::graph::GraphOperationsService>,
+    ) -> Self {
         Self {
-            fusion: Arc::new(FusionService::new(
-                request_handlers.vector_operations_service.clone(),
-                request_handlers.graph_operations_service.clone(),
-            )),
+            fusion: Arc::new(FusionService::new(vector, graph)),
         }
     }
 

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -201,8 +201,11 @@ impl MultiServer {
     ) -> crate::proto::proximadb_v2::proxima_fusion_service_server::ProximaFusionServiceServer<
         crate::network::grpc::v2::ProximaFusionServiceImpl,
     > {
-        crate::network::grpc::v2::ProximaFusionServiceImpl::new(services.request_handlers.clone())
-            .into_server()
+        crate::network::grpc::v2::ProximaFusionServiceImpl::new(
+            services.vector_operations_service.clone(),
+            services.request_handlers.graph_operations_service.clone(),
+        )
+        .into_server()
     }
 
     /// Build the canonical v2 entity gRPC service.
@@ -214,8 +217,12 @@ impl MultiServer {
     ) -> crate::proto::proximadb_v2::proxima_entity_service_server::ProximaEntityServiceServer<
         crate::network::grpc::v2::ProximaEntityServiceImpl,
     > {
-        crate::network::grpc::v2::ProximaEntityServiceImpl::new(services.request_handlers.clone())
-            .into_server()
+        crate::network::grpc::v2::ProximaEntityServiceImpl::new(
+            services.request_handlers.graph_operations_service.clone(),
+            services.vector_operations_service.clone(),
+            services.document_service.clone(),
+        )
+        .into_server()
     }
 
     /// Create new multi-server instance (orchestrator only)


### PR DESCRIPTION
## Summary

TD-104. The last two v2 gRPC services holding `Arc<UnifiedHandlers>` — `ProximaEntityServiceImpl` and `ProximaFusionServiceImpl` — now take their concrete backing services directly. Neither struct stored ROOT (they already held the extracted services); only the constructors reached through ROOT to extract them.

### Changes (3 files, behavior-identical)
- **`entity_service.rs`**: `new(graph, vector, document)` — builds its `FusionService` from vector+graph (as before). Drops the `UnifiedHandlers` import.
- **`fusion_service.rs`**: `new(vector, graph)` — builds its `FusionService` from vector+graph (as before). Drops the `UnifiedHandlers` import.
- **`multi_server`** (2 construction sites): passes `services.vector_operations_service` + `services.document_service` + `services.request_handlers.graph_operations_service`.

With #292 (doc/graph), #338 (record), and this PR (entity/fusion), **every v2 gRPC service is now off the ROOT god-object** (no `UnifiedHandlers` import in any v2 service module).

## Verification (pinned 1.95.0)
- `cargo check --workspace --lib --bins` ✅
- `cargo fmt --all -- --check` ✅

(Rust Clippy red repo-wide from pre-existing #295 `let_underscore_future`; non-required.)

Ref TD-104.