### PR TITLE
refactor(grpc): deprecate v1 ExecuteHybridQuery (TD-143)

### DIFF
--- a/crates/platform/proximadb-api/src/grpc/v1/graph.rs
+++ b/crates/platform/proximadb-api/src/grpc/v1/graph.rs
@@ -318,6 +318,8 @@ impl GraphServiceTrait for GraphServiceImpl {
 
     // ── Hybrid query ──────────────────────────────────────────────────────
 
+    /// DEPRECATED (TD-143): v1 entry — calls the deprecated `GraphPort::execute_hybrid_query`.
+    #[allow(deprecated)]
     async fn execute_hybrid_query(
         &self,
         request: Request<HybridSearchRequest>,

--- a/crates/platform/proximadb-runtime/src/graph_port.rs
+++ b/crates/platform/proximadb-runtime/src/graph_port.rs
@@ -87,6 +87,9 @@ pub trait GraphPort: Send + Sync {
 
     // ── Hybrid query (cross-modal) ────────────────────────────────────────
 
+    /// DEPRECATED (TD-143): v1 hybrid query — dormant (behind `enable_grpc_v1_compat`),
+    /// not tenant-scoped, owns its own ranking. Use v2 FusionSearch instead.
+    #[deprecated(note = "v1 ExecuteHybridQuery is deprecated; use v2 FusionSearch. See TD-143.")]
     async fn execute_hybrid_query(
         &self,
         request: HybridSearchRequest,

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -62,6 +62,9 @@ pub trait ApiHandlersPort: Send + Sync {
 
     // ── Hybrid ────────────────────────────────────────────────────────────────
 
+    /// DEPRECATED (TD-143): v1 hybrid query — dormant (behind `enable_grpc_v1_compat`),
+    /// not tenant-scoped, owns its own ranking. Use v2 FusionSearch instead.
+    #[deprecated(note = "v1 ExecuteHybridQuery is deprecated; use v2 FusionSearch. See TD-143.")]
     async fn execute_hybrid_query(
         &self,
         request: HybridSearchRequest,

--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -142,8 +142,8 @@ Phase 1+ of `CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` — one calibrated fuse-by
 | TD-140 | Edge-grain fusion | LOW | Open | D4 | PERF
 | Optional edge/relationship-grain fusion unit (edge-level carries 6–12% more signal than node-level). Differentiator; gate behind query class.
 
-| TD-143 | Retire weak proto fusion path | LOW | Open | D4 | OE
-| Retire `request_handlers.rs::execute_hybrid_query` (hardcoded graph, no tenant) once the seam covers gRPC; collapse the 12-strategy engine to D4. Cleanup after TD-136..138 land.
+| TD-143 | Retire weak proto fusion path | LOW | Deprecated | D4 | OE
+| Deprecated 2026-06-25: `#[deprecated]` + runtime `warn!` on the inherent `execute_hybrid_query` and both port traits (`ApiHandlersPort`/`GraphPort`); `#[allow(deprecated)]` at the three internal v1-compat forwarders (gRPC `GraphService`, the `ApiHandlersPort` impl, the platform `GraphPort` shim). Hard removal deferred — a faithful v2 *redirect* is impossible: (1) the path is dormant (only reachable via `enable_grpc_v1_compat`, default OFF; REST v1 surface is a mock); (2) semantically distinct from v2 — its `combination_strategy` is a sequential vector→graph pipeline, not the PIT-calibrated score-fusion of `graph_fusion_search`; (3) type-mismatched — v1 returns graph `nodes`/`edges`/`paths`, v2 returns fused `FusedItem`s, no 1:1 mapping; (4) not tenant-scoped. Redirect target: v2 `POST /api/v2/graphs/\{graph_id}/fusion-search` or gRPC `ProximaFusionService.FusionSearch`. Remove when the v1 compat surface sunsets; do not extend or add strategies.
 
 | TD-062 | Hybrid retrieval + reranking planner surface | HIGH | Open | D4 | PERF
 | Planner-level representation for lexical + dense + sparse + graph + doc-path + time + rerank stages; `EXPLAIN` shows fusion/rerank strategy + post-filter fallback. Move durable direction into shared algebra/catalog/projection metadata. Overhaul spec.

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -61,7 +61,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tracing::{debug, error, info, info_span};
+use tracing::{debug, error, info, info_span, warn};
 
 /// Global request counter for generating unique request IDs
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1413,12 +1413,41 @@ impl UnifiedHandlers {
         }
     }
 
-    /// Execute a hybrid vector-graph query
+    /// Execute a hybrid vector-graph query.
+    ///
+    /// # DEPRECATED (TD-143)
+    ///
+    /// This v1 `ExecuteHybridQuery` path is **dormant**: it is only reachable when
+    /// `enable_grpc_v1_compat` is enabled (default OFF; `PROXIMADB_GRPC_V1_COMPAT`),
+    /// and the REST v1 surface for it is a mock. It violates the one-fusion-engine
+    /// contract (#280) — it owns its own ranking via `combination_strategy`, which is a
+    /// sequential vector→graph / graph→vector *pipeline*, not the PIT-calibrated
+    /// score-fusion of v2 `graph_fusion_search`. It is also **not tenant-scoped**, and
+    /// its response shape (`nodes`/`edges`/`paths`/`vector_results`) has no 1:1 mapping
+    /// to v2 fused results (`FusedItem` + `FusionStats`).
+    ///
+    /// Use v2 **FusionSearch** instead — REST `POST /api/v2/graphs/{graph_id}/fusion-search`
+    /// (`GraphFusionParams`) or gRPC `ProximaFusionService.FusionSearch`. Hard removal is
+    /// deferred until the v1 compat surface itself sunsets; do not extend this path.
+    #[deprecated(
+        note = "v1 ExecuteHybridQuery is a dormant legacy path behind enable_grpc_v1_compat \
+                (default OFF). It owns its own combination_strategy ranking (sequential \
+                pipeline, not score-fusion) and is not tenant-scoped. Use v2 FusionSearch \
+                (POST /api/v2/graphs/{graph_id}/fusion-search, GraphFusionParams). See TD-143."
+    )]
     pub async fn execute_hybrid_query(
         &self,
         request: crate::proto::proximadb_v1::HybridSearchRequest,
     ) -> Result<crate::proto::proximadb_v1::HybridSearchResponse> {
         let start_time = std::time::Instant::now();
+        warn!(
+            target: "proximadb::deprecation",
+            "execute_hybrid_query (v1 ExecuteHybridQuery) is DEPRECATED — dormant behind \
+             enable_grpc_v1_compat (default OFF). It does its own combination_strategy ranking \
+             (sequential pipeline, not score-fusion) and is not tenant-scoped. Use v2 \
+             FusionSearch (POST /api/v2/graphs/{{graph_id}}/fusion-search, GraphFusionParams) \
+             or gRPC ProximaFusionService.FusionSearch. See TD-143."
+        );
         info!(
             "Executing hybrid query with strategy: {:?}",
             request.combination_strategy
@@ -3858,6 +3887,8 @@ impl proximadb_runtime::ApiHandlersPort for UnifiedHandlers {
         .await
     }
 
+    /// DEPRECATED (TD-143): forwards to the deprecated v1 inherent impl.
+    #[allow(deprecated)]
     async fn execute_hybrid_query(
         &self,
         request: crate::proto::proximadb_v1::HybridSearchRequest,

--- a/src/network/grpc/graph_service.rs
+++ b/src/network/grpc/graph_service.rs
@@ -1097,7 +1097,12 @@ impl GraphServiceImpl {
         }
     }
 
-    /// Execute hybrid vector-graph query
+    /// Execute hybrid vector-graph query.
+    ///
+    /// DEPRECATED (TD-143): v1 entry — delegates to the deprecated inherent impl,
+    /// reachable only when `enable_grpc_v1_compat` is on. Prefer v2
+    /// `ProximaFusionService.FusionSearch`.
+    #[allow(deprecated)]
     async fn execute_hybrid_query(
         &self,
         request: Request<HybridSearchRequest>,


### PR DESCRIPTION
## Summary

Deprecates the dormant v1 `ExecuteHybridQuery` path (TD-143) — the last search surface that owns its own ranking — completing the one-fusion-engine contract from #280 / #282 / #284. A faithful *redirect* to v2 FusionSearch is impossible (below), so this marks it deprecated and defers hard removal until the v1 compat surface itself sunsets.

## Why deprecate (not redirect)

v1 `execute_hybrid_query` is **dormant**: only reachable when `enable_grpc_v1_compat` is on (default OFF, `PROXIMADB_GRPC_V1_COMPAT`); the REST v1 surface is a mock. Four findings block a faithful v2 redirect:

1. **Dormant** — gated off by default.
2. **Semantically distinct** — its `combination_strategy` is a sequential vector→graph / graph→vector *pipeline*, whereas v2 `graph_fusion_search` does PIT-calibrated score-fusion (`GraphFusionParams`). Delegating would change semantics.
3. **Type-mismatch** — v1 returns graph structure (`nodes`/`edges`/`paths`/`vector_results`); v2 returns fused ranked `FusedItem`s. No 1:1 mapping.
4. **Not tenant-scoped** (existing TD-143 note).

## Changes

- `#[deprecated(note = ...)]` + runtime `warn!(target: "proximadb::deprecation", ...)` on `UnifiedHandlers::execute_hybrid_query` (the inherent impl holding the ranking logic).
- `#[deprecated]` on both port trait methods (`ApiHandlersPort`, `GraphPort`) — the seam.
- `#[allow(deprecated)]` at the three internal v1-compat forwarders (gRPC `GraphService`, the `ApiHandlersPort` impl, the platform `GraphPort` shim) so the dormant path still compiles under `-D warnings`.
- TD-143 register row: `Open → Deprecated`, recording the redirect-blocker findings + the deferral.

**Redirect target for callers:** v2 `POST /api/v2/graphs/{graph_id}/fusion-search` (`GraphFusionParams`) or gRPC `ProximaFusionService.FusionSearch`.

## Verification

- `cargo fmt --all -- --check` — clean (pinned 1.95.0)
- `cargo clippy --lib --bins -- -D warnings` — green (the authoritative lint gate; test/build jobs do not deny warnings, so deprecated calls in `#[cfg(test)]` mock code only warn)
- Matches the repo's existing note-only `#[deprecated]` convention (no `since` field — `clippy::deprecated_semver` rejects non-semver values)