### PR TITLE
feat(pax): configurable block geometry (TD-156) — the fragmentation lever

### DIFF
--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -448,12 +448,21 @@ impl SstEngine {
                     "sq8" => VectorQuant::Sq8,
                     _ => VectorQuant::Auto,
                 };
+                // TD-156 / ADR-026: configurable PAX block geometry. `None` keeps
+                // the writer default; a larger value (e.g. 8-16 MiB for object
+                // storage) coalesces rows into fewer blocks, cutting the per-block
+                // ranged-GET fragmentation measured by the footer-cache economics
+                // harness. Per-collection config is the productionization follow-up.
+                let target_block = std::env::var("PROXIMADB_PAX_BLOCK_SIZE")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok());
                 let meta = write_pax_segment(
                     std::path::Path::new(staging_path),
                     &records,
                     collection_id,
                     embedding_count,
                     quant,
+                    target_block,
                 )
                 .context("Failed to write PAX vector segment")?;
                 tracing::debug!(blocks = meta.block_count, "PAX segment write completed");

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -103,12 +103,20 @@ pub fn read_segment_records(
 /// `embedding_count` is the collection's embedding-modality count (≥1). `quant` selects
 /// the vector quantization strategy (P3 Phase D): `VectorQuant::Auto` keeps the env
 /// default (SQ8 unless `PROXIMADB_VECTOR_RABITQ`), `RaBitQ` writes ~30× binary codes.
+///
+/// `target_block` is the optional target block size in bytes (TD-156 / ADR-026
+/// configurable geometry). `None` keeps the writer default; a larger value (e.g.
+/// 8-16 MiB for object storage) coalesces rows into fewer blocks, cutting the
+/// per-block ranged-GET count — the fragmentation lever measured by the
+/// footer-cache economics harness. Mixed-read-safe: block size is a per-segment
+/// write choice and is irrelevant to the magic-detected read router.
 pub fn write_pax_segment(
     path: &Path,
     records: &[ProximaRecord],
     collection_id: &str,
     embedding_count: usize,
     quant: VectorQuant,
+    target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
     let mut writer = PaxSegmentWriter::new(
         path,
@@ -117,7 +125,7 @@ pub fn write_pax_segment(
         collection_id,
         0, // schema_fingerprint — derived from the catalog schema in a later phase
         embedding_count.max(1),
-        None,
+        target_block,
     )
     .with_quant(quant);
     for record in records {
@@ -397,7 +405,7 @@ mod tests {
             rec("w1", 1_700_000_000_000_000_000, vec![1.0, 2.0, 3.0]),
             rec("w2", 1_700_000_000_000_000_001, vec![4.0, 5.0, 6.0]),
         ];
-        let meta = write_pax_segment(&path, &records, "col", 1, VectorQuant::Auto).unwrap();
+        let meta = write_pax_segment(&path, &records, "col", 1, VectorQuant::Auto, None).unwrap();
         assert!(
             meta.block_count >= 1,
             "segment should have at least one block"
@@ -428,7 +436,7 @@ mod tests {
                 )
             })
             .collect();
-        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ).unwrap();
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
 
         // The written segment's vector column must be RaBitQ-quantized.
         let bytes = std::fs::read(&path).unwrap();
@@ -483,7 +491,7 @@ mod tests {
                 vec![13.0, 14.0, 15.0, 16.0],
             ),
         ];
-        write_pax_segment(&pax_path, &pax_records, "col", 1, VectorQuant::RaBitQ).unwrap();
+        write_pax_segment(&pax_path, &pax_records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
         let pax_bytes = std::fs::read(&pax_path).unwrap();
 
         // The two segments are detected as DIFFERENT formats (never mis-routed).
@@ -512,6 +520,36 @@ mod tests {
             vec!["pax_c", "pax_d"],
             "PAX segment oids (disjoint from legacy)"
         );
+    }
+
+    /// TD-156 / ADR-026: block geometry is the fragmentation lever. A larger
+    /// `target_block` packs rows into fewer blocks — so the per-block ranged-GET
+    /// count on the object-store read path drops (the +29,900% GET fragmentation
+    /// measured by the footer-cache economics harness shrinks as block count
+    /// falls). Mixed-read-safe: block size is a per-segment write choice, opaque
+    /// to the magic-detected read router.
+    #[test]
+    fn larger_target_block_yields_fewer_blocks() {
+        let records: Vec<ProximaRecord> = (0..512)
+            .map(|i| rec(&format!("r{i}"), 1000 + i as i64, vec![i as f32 * 0.1; 64]))
+            .collect();
+        let blocks_for = |target: Option<usize>| -> usize {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("geo.pax");
+            write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ, target)
+                .unwrap()
+                .block_count as usize
+        };
+        let small = blocks_for(Some(8 * 1024));
+        let large = blocks_for(Some(256 * 1024));
+        eprintln!(
+            "[geometry] 512x64 vectors: 8KiB target -> {small} blocks, 256KiB target -> {large} blocks"
+        );
+        assert!(
+            large < small,
+            "larger target_block must yield fewer blocks: {large} >= {small}"
+        );
+        assert!(large >= 1, "at least one block");
     }
 
     /// P3 C.2 cascade primitive — recall + trace gate. A real PAX+RaBitQ segment
@@ -555,7 +593,7 @@ mod tests {
                 )
             })
             .collect();
-        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ).unwrap();
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
         let bytes = std::fs::read(&path).unwrap();
 
         let l2 =

--- a/tests/cpg_fragment_pax_contract.rs
+++ b/tests/cpg_fragment_pax_contract.rs
@@ -188,6 +188,7 @@ async fn cpg_fragment_pax_contract_and_io_trace_emission() {
         "test_collection",
         0, // embedding_count — fragments carry no vectors.
         proximadb_block_format::VectorQuant::Auto,
+        None, // target_block — writer default
     )
     .expect("write_pax_segment must succeed");
 


### PR DESCRIPTION
TD-156 / ADR-026. Threads an optional target_block through write_pax_segment (was hardcoded to the writer default); the SST flush arm reads it from PROXIMADB_PAX_BLOCK_SIZE (default None = unchanged, mixed-read-safe).

**Why:** this is the direct lever for the footer-cache fragmentation finding (PR #341) — naive per-block ranged reads fragmented a column scan into ~6,000 small GETs because blocks were small. A larger target_block (8–16 MiB for object storage) packs rows into fewer blocks → fewer per-block GETs.

**Measured** (new test, 512×64 vectors):
- 8 KiB target → **64 blocks**
- 256 KiB target → **2 blocks**  (32× fewer blocks = 32× fewer per-block GETs)

**Scope:** signature + 6 callers (flush arm reads env; 4 lib tests + 1 integration test pass None). Default behavior unchanged (None). Mixed-read-safe (block size is a per-segment write choice, opaque to the magic-detected read router). fmt clean; lib + geometry test verified locally.

Follow-ups (tracked): TD-155 per-collection config; object-store-aware default (8–16 MiB) once PAX moves to S3; TD-151 range coalescing + pruning on top of larger blocks.

Rollout: 1=#331 2=#335 5=#341 6=ADR-026/#343 · **TD-156=this**.