### PR TITLE
refactor(rest): extract graph_operations_service onto AppState (TD-104 S5)

### DIFF
--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -36,10 +36,11 @@ use serde::{Deserialize, Serialize};
 /// Shared application state
 #[derive(Clone)]
 pub struct AppState {
-    /// Shared unified handlers — retained for the (deprecating) v1 REST graph
-    /// surface + v2 graph/entity field accesses (graph_operations_service /
-    /// graph_collection_service). Record/collection/vector reads are off this
-    /// field (TD-104 S5 / REST phases 1–2); it goes away when v1 graph is deleted.
+    /// Shared unified handlers — retained ONLY for the (deprecating) v1 REST
+    /// graph surface (`rest/v1/graph.rs`, ~27 sites). All v2/canonical reads
+    /// — record, collection, vector, graph-ops — are off this field (TD-104
+    /// S5 / REST phases 1–2 + graph-field extraction); it goes away when v1
+    /// graph is deleted.
     pub request_handlers: Arc<UnifiedHandlers>,
     /// Extracted graph execution capability for query planning/execution helpers
     pub graph_execution_service: Arc<dyn GraphExecutionService>,
@@ -54,6 +55,11 @@ pub struct AppState {
     /// Collection service, extracted at boot (TD-104 S5). Feeds the health
     /// endpoint's collection-count probe; same `Arc` as the root handler.
     pub collection_service: Arc<crate::services::CollectionService>,
+    /// Graph operations service, extracted at boot (TD-104 S5). Feeds the v2
+    /// graph fusion-search + impact-analysis handlers and the entity
+    /// orchestrator; same `Arc` as the root handler. Replaces per-request
+    /// `state.request_handlers.graph_operations_service` reads.
+    pub graph_operations_service: Arc<crate::graph::GraphOperationsService>,
     /// Record write-path service (TD-104 S5). Owns record-batch insert/delete
     /// orchestration; same `Arc` the root handler's `record_ops()` returns.
     pub record_ops: Arc<crate::api_handlers::record_ops_service::RecordOpsService>,
@@ -196,6 +202,7 @@ impl AppState {
         let vector_operations_service = request_handlers.vector_operations_service.clone();
         let document_service = request_handlers.document_service.clone();
         let collection_service = request_handlers.collection_service.clone();
+        let graph_operations_service = request_handlers.graph_operations_service.clone();
         let record_ops = request_handlers.record_ops();
         let observability_service = request_handlers.observability_service.clone();
         let event_log = request_handlers.event_log.clone();
@@ -203,8 +210,8 @@ impl AppState {
         // services (search-surface contract: one retrieval engine, shared port).
         let fusion_service =
             std::sync::Arc::new(crate::services::fusion_service::FusionService::new(
-                request_handlers.vector_operations_service.clone(),
-                request_handlers.graph_operations_service.clone(),
+                vector_operations_service.clone(),
+                graph_operations_service.clone(),
             ));
         // TD-104 2(b): default `api_handlers` to the root handler cast to its
         // `ApiHandlersPort` impl. Production overrides via `with_api_handlers`
@@ -219,6 +226,7 @@ impl AppState {
             vector_operations_service,
             document_service,
             collection_service,
+            graph_operations_service,
             record_ops,
             fusion_service,
             observability_service,

--- a/src/network/rest/v2/entities.rs
+++ b/src/network/rest/v2/entities.rs
@@ -156,7 +156,7 @@ fn property_value_to_json(pv: &PropertyValue) -> Value {
 /// Build an orchestrator from the app state's backing services (cheap Arc clones).
 fn orchestrator(state: &AppState) -> EntityOrchestrator {
     EntityOrchestrator::new(
-        state.request_handlers.graph_operations_service.clone(),
+        state.graph_operations_service.clone(),
         state.vector_operations_service.clone(),
         state.fusion_service.clone(),
         state.document_service.clone(),

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -243,7 +243,6 @@ pub async fn impact_analysis_v2(
     );
 
     let response = state
-        .request_handlers
         .graph_operations_service
         .impact_analysis(
             &graph_id,


### PR DESCRIPTION
## Summary

Continues TD-104 (delete the ROOT `UnifiedHandlers` god-object). The main thread — dropping `AppState.request_handlers` + the S3-f construction endgame — is blocked on v1-graph deletion (#345 only soft-deprecated `ExecuteHybridQuery`; v1 gRPC `graph_service` + v1 REST graph are still live). This is the unblocked additive slice: extract `graph_operations_service` as an `AppState` field so the v2 REST graph/entity handlers no longer reach into the root god-object for it, mirroring the S5 boot-extraction already used for `vector_operations_service` / `document_service` / `collection_service` / `record_ops`.

## Changes

- **Extract `graph_operations_service: Arc<GraphOperationsService>` onto `AppState`** (`AppState::new` clones it once at boot, same `Arc` as the root handler).
- **Migrate the two v2 `request_handlers.graph_operations_service` reads** to `state.graph_operations_service`:
  - `rest/v2/graphs.rs` — impact-analysis handler (multi-line `.request_handlers` chain).
  - `rest/v2/entities.rs` — the `orchestrator()` helper.
- **Tidy `AppState::new`'s `fusion_service` ctor** to reuse the just-extracted locals instead of redundantly re-cloning off `request_handlers`.
- **Narrow the `request_handlers` field** doc comment: it is now read only by the deprecating v1 REST graph surface (~27 sites) plus the boot adapter; every v2/canonical read is off it.

## Behavior

Behavior-preserving — pure accessor migration (same `Arc`, same methods). `graph_collection_service` is not accessed anywhere in v2 REST, so it was intentionally not extracted (no dead field). The `request_handlers` field is retained until v1 graph is deleted; this narrows its consumers as a step toward the S3-f endgame.

Out of scope (correctly): the v1 REST graph (deprecating/foreign WIP) and the `multi_server.rs` `services.request_handlers.graph_operations_service` reads (SharedServices → v2 gRPC ctor wiring, part of the S3-f endgame).

## Verification

- `cargo check --workspace --lib --bins` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --bins -- -D warnings` — clean
- Toolchain 1.95.0; rebased on latest `origin/develop`.