### PR TITLE
ci(qa-gate): shared build + no cancel-in-progress + 45m TPC timeout

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -15,7 +15,13 @@ on:
 
 concurrency:
   group: qa-gate-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  # false (not true): a develop→qa promotion PR has head=develop, so every push
+  # to develop fires a `synchronize` event landing in the SAME per-PR group —
+  # with cancel-in-progress:true that killed the in-flight run before TPC-H/DS
+  # could finish (the promotion never completed during develop churn). false lets
+  # the in-flight run finish; GitHub still keeps only the newest *pending* run per
+  # group (older pendings are auto-dropped), so there is no runaway stacking.
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,10 +49,21 @@ jobs:
           fi
           echo "ok: main PR originates from qa"
 
-  tpch-pgwire:
-    name: TPC-H pgwire integration
+  # Build the workspace test artifacts ONCE. The pgwire + recall jobs below take
+  # `needs: [build]` and restore this same target/ via Swatinem/rust-cache
+  # (shared-key), so they skip recompiling the workspace — modeled on ci.yml's
+  # rust-build -> rust-test cache-sharing idiom (prefix v1-rust-nightly-dev +
+  # shared-key "build"). `--workspace --tests` compiles every member crate's lib
+  # (incl. proximadb-block-format), the root crate's [[test]] integration target,
+  # and all auto-discovered tests/*.rs integration bins (tpch_pgwire_e2e,
+  # tpcds_pgwire_e2e). It does NOT build benches/examples. (`--tests` is a
+  # superset of `--lib`, so pax-recall's `-p proximadb-block-format --lib` is
+  # covered.) The e2e tests embed the server via tokio::spawn, so they link the
+  # lib — a pre-built server binary cannot replace this; a shared target/ can.
+  build:
+    name: Rust Build (workspace tests)
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -56,14 +73,35 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-qa-tpch"
+          prefix-key: "v1-qa-build"
+          shared-key: "qa-tests"
+      - name: Build workspace test artifacts
+        run: cargo build --workspace --tests
+
+  tpch-pgwire:
+    name: TPC-H pgwire integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-qa-build"
+          shared-key: "qa-tests"
       - name: Run TPC-H over pgwire
         run: CARGO_BUILD_JOBS=2 cargo test --test tpch_pgwire_e2e -- --nocapture
 
   tpcds-pgwire:
     name: TPC-DS pgwire integration
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -73,7 +111,8 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-qa-tpcds"
+          prefix-key: "v1-qa-build"
+          shared-key: "qa-tests"
       - name: Run TPC-DS over pgwire
         run: CARGO_BUILD_JOBS=2 cargo test --test tpcds_pgwire_e2e -- --nocapture
 
@@ -86,6 +125,7 @@ jobs:
     name: ANN Recall Ratchet (PAX RaBitQ→SQ8)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -95,7 +135,8 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-qa-pax-recall"
+          prefix-key: "v1-qa-build"
+          shared-key: "qa-tests"
       - name: Run PAX recall ratchets
         run: cargo test -p proximadb-block-format --lib recall -- --nocapture
 


### PR DESCRIPTION
## What
Stop the develop→qa promotion's qa-gate from failing to complete. Three independent fixes in `qa-gate.yml`.

## Why (diagnosed from the cancelled promotion runs)
1. **Runs cancelled mid-flight** — `concurrency.cancel-in-progress: true` whose group keys on `github.ref` (= `refs/pull/<N>/merge`, stable per PR). A develop→qa promotion PR has `head=develop`, so **every push to develop fires a `synchronize` event in the same group** → the new run cancels the in-flight one before TPC-H/DS finish. (Verified: the cancelled run timestamps line up exactly with the develop direct-push commit times.) → **`cancel-in-progress: false`**; the in-flight run now completes, and GitHub still keeps only the newest *pending* run per group (older pendings auto-dropped — no runaway).
2. **TPC-DS timed out** — hit `timeout-minutes: 35` (ran 35m16s; TPC-H took 30m06s and passed). Not a query failure — a CI capacity ceiling. → **TPC-H + TPC-DS `35 → 45`**.
3. **3 redundant workspace compiles** — `tpch-pgwire`, `tpcds-pgwire`, `pax-recall-ratchet` each compiled the whole workspace with separate rust-cache prefix-keys. → **new `build` job** (`cargo build --workspace --tests`, prefix `v1-qa-build` + shared-key `qa-tests`); the three jobs become `needs: [build]` with the same key and **skip recompiling** (restore the shared `target/`; cargo up-to-date detection; `profile.test` mirrors `profile.dev`). Mirrors ci.yml's `rust-build → rust-test` idiom.

## Scope
- Only `qa-gate.yml` is changed.
- ci.yml's main test jobs **already share** a build (`rust-build` + shared-key `"build"`) — no change there. (A few ci.yml stragglers could later reuse it, but their path-filter gates differ — deferred.)
- `rust-coverage-ratchet` (instrumented `cargo llvm-cov`, own cache) and `sdk-coverage-ratchet` (Python) are **unchanged**.
- The e2e tests embed the server (`tokio::spawn`), so they link the lib — the lever is a shared compiled `target/`, not a pre-built binary.

## Verification
- `actionlint` clean on the edited workflow.
- End-to-end (qa-gate runs only on PR→qa/main, so confirmed after merge by re-running the develop→qa promotion): `build` compiles once; TPC-H/TPC-DS/PAX-recall show no recompilation; TPC-DS finishes <45m; a develop push mid-run does not cancel the in-flight run.

## Follow-up (GitHub side)
If `qa`/`main` branch protection lists required checks by name, add the new `Rust Build (workspace tests)` job there.
