### PR TITLE
fix(ci): clear develop red — doctest + feature-gate + graph test isolation

### DIFF
--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -1640,6 +1640,10 @@ impl MultiServer {
             // `ArrowFlightServer::new` signature.
             let arrow_bind_target =
                 BindTarget::Tcp(self.config.arrow_ipc_config.active_bind_address());
+            // Capture the debug form before `arrow_bind_target` is moved into the
+            // `tokio::spawn` below — mirrors the single-node start path's
+            // `arrow_target_log` (the value has no `Display` impl).
+            let arrow_target_log = format!("{arrow_bind_target:?}");
             let request_handlers = services.request_handlers.clone();
             let catalog_manager = services.catalog_manager.clone();
             let security_coordinator = if self.rest_auth_enabled {
@@ -1676,7 +1680,7 @@ impl MultiServer {
             });
 
             handles.push(arrow_handle);
-            info!("Arrow IPC Server started on {}", arrow_bind_addr);
+            info!("Arrow IPC Server started on {}", arrow_target_log);
         }
 
         // Start REST server on port 5678 if configured

--- a/src/services/transaction/cross_model_coordinator.rs
+++ b/src/services/transaction/cross_model_coordinator.rs
@@ -203,7 +203,7 @@ impl CrossModelTransactionCoordinator {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// # use proximadb::services::transaction::CrossModelTransactionCoordinator;
     /// # use std::sync::Arc;
     /// # async fn example(coordinator: &CrossModelTransactionCoordinator) -> anyhow::Result<()> {

--- a/tests/embedded_code_graph_parity_e2e.rs
+++ b/tests/embedded_code_graph_parity_e2e.rs
@@ -14,6 +14,13 @@
 //! same core correctly and is deterministic — together they clear the "parity-tested embedded path"
 //! gate. (A cross-process embedded-vs-networked-server comparison is deferred: the data-loading
 //! asymmetry makes it flaky-prone, and structural parity + dual correctness is the robust proof.)
+//!
+//! ## Test isolation
+//! `GraphCollectionService` persists graph metadata to a process-shared path, so multiple
+//! `EmbeddedProximaDB` instances in one test process share graph state. Each test therefore builds
+//! its DB under a UNIQUE graph id (threaded through `build_db`/`fixture`/`canonical_oid`) so the
+//! three `#[test]`s — which share one process under `--test-threads=1` — never collide on a graph
+//! that "already exists".
 
 use std::collections::HashSet;
 
@@ -21,11 +28,10 @@ use proximadb::embedded::{
     EmbeddedConfig, EmbeddedGraphEdge, EmbeddedGraphNode, EmbeddedProximaDB,
 };
 
-const GRAPH_ID: &str = "codegraph";
 const VEC_COLLECTION: &str = "code_vecs";
 
-fn canonical_oid(node_id: &str) -> String {
-    format!("graph/{GRAPH_ID}/node/{node_id}")
+fn canonical_oid(graph_id: &str, node_id: &str) -> String {
+    format!("graph/{graph_id}/node/{node_id}")
 }
 
 /// main --CALLS--> parse --CALLS--> validate
@@ -39,8 +45,8 @@ struct Fixture {
     embeddings: Vec<(String, Vec<f32>)>,
 }
 
-fn fixture() -> Fixture {
-    let emb = |id: &str, v: Vec<f32>| (canonical_oid(id), v);
+fn fixture(graph_id: &str) -> Fixture {
+    let emb = |id: &str, v: Vec<f32>| (canonical_oid(graph_id, id), v);
     Fixture {
         node_ids: &["main", "parse", "validate", "io", "util"],
         edges: &[
@@ -59,7 +65,11 @@ fn fixture() -> Fixture {
     }
 }
 
-fn build_db() -> EmbeddedProximaDB {
+/// Build an embedded DB seeded with the code-graph fixture under `graph_id`.
+///
+/// `graph_id` MUST be unique per test (see the module-level isolation note) —
+/// `GraphCollectionService` shares graph metadata across in-process instances.
+fn build_db(graph_id: &str) -> EmbeddedProximaDB {
     let dir = tempfile::tempdir().expect("tempdir");
     let data_path = dir.path().join("data");
     std::fs::create_dir_all(&data_path).expect("create data dir");
@@ -70,7 +80,7 @@ fn build_db() -> EmbeddedProximaDB {
     config.enable_wal = true;
     let db = EmbeddedProximaDB::new(config).expect("create embedded db");
 
-    let fx = fixture();
+    let fx = fixture(graph_id);
 
     // Co-indexed vector collection: record id == canonical graph node oid.
     db.create_collection(VEC_COLLECTION, 4, Some("sst"))
@@ -81,20 +91,20 @@ fn build_db() -> EmbeddedProximaDB {
         .expect("insert co-indexed vectors");
 
     // Graph: nodes + edges.
-    db.create_graph(GRAPH_ID, None).expect("create graph");
+    db.create_graph(graph_id, None).expect("create graph");
     let nodes: Vec<EmbeddedGraphNode> = fx
         .node_ids
         .iter()
         .map(|id| EmbeddedGraphNode::new(*id).with_label("Symbol"))
         .collect();
-    db.create_nodes(GRAPH_ID, nodes).expect("create nodes");
+    db.create_nodes(graph_id, nodes).expect("create nodes");
     let edges: Vec<EmbeddedGraphEdge> = fx
         .edges
         .iter()
         .enumerate()
         .map(|(i, (from, to, et))| EmbeddedGraphEdge::new(*from, *to, *et).with_id(format!("e{i}")))
         .collect();
-    db.create_edges(GRAPH_ID, edges).expect("create edges");
+    db.create_edges(graph_id, edges).expect("create edges");
 
     db
 }
@@ -103,11 +113,12 @@ fn build_db() -> EmbeddedProximaDB {
 /// parse + io. Fused oids = {main, parse, io}.
 #[test]
 fn embedded_fusion_search_seeds_and_expands() {
-    let db = build_db();
+    let graph_id = "codegraph_fusion";
+    let db = build_db(graph_id);
 
     let (items, stats) = db
         .fusion_search(
-            GRAPH_ID,
+            graph_id,
             VEC_COLLECTION,
             vec![1.0, 0.0, 0.0, 0.0], // == main's embedding → top seed
             1,                        // max_depth
@@ -124,11 +135,12 @@ fn embedded_fusion_search_seeds_and_expands() {
     let oids: HashSet<String> = items.into_iter().map(|i| i.oid).collect();
     assert!(stats.items_out > 0, "fusion must return candidates");
     assert!(
-        oids.contains(&canonical_oid("main")),
+        oids.contains(&canonical_oid(graph_id, "main")),
         "seed oid present: {oids:?}"
     );
     assert!(
-        oids.contains(&canonical_oid("parse")) && oids.contains(&canonical_oid("io")),
+        oids.contains(&canonical_oid(graph_id, "parse"))
+            && oids.contains(&canonical_oid(graph_id, "io")),
         "1-hop expand reaches parse + io: {oids:?}"
     );
 }
@@ -136,10 +148,11 @@ fn embedded_fusion_search_seeds_and_expands() {
 /// Forward blast radius from main (CALLS, depth 2): parse + io (d1), validate (d2).
 #[test]
 fn embedded_impact_analysis_forward() {
-    let db = build_db();
+    let graph_id = "codegraph_fwd";
+    let db = build_db(graph_id);
     let result = db
         .impact_analysis(
-            GRAPH_ID,
+            graph_id,
             "main",
             "forward",
             Some(vec!["CALLS".to_string()]),
@@ -160,10 +173,11 @@ fn embedded_impact_analysis_forward() {
 /// Backward blast radius to validate (CALLS, depth 2): parse (d1), main (d2). util/io must NOT appear.
 #[test]
 fn embedded_impact_analysis_backward() {
-    let db = build_db();
+    let graph_id = "codegraph_bwd";
+    let db = build_db(graph_id);
     let result = db
         .impact_analysis(
-            GRAPH_ID,
+            graph_id,
             "validate",
             "backward",
             Some(vec!["CALLS".to_string()]),


### PR DESCRIPTION
## Summary

`develop` is RED — 3 checks fail on the `#355 promote: develop → qa` PR, blocking promotion. They slipped through because feat→develop is LIGHT: the heavy jobs (doc tests, feature-matrix, integration tests) only run at develop→qa, so a broken doctest / feature-gating gap / test-isolation bug merges green and surfaces later. This PR fixes all three so `develop` goes green and #355 can promote. (A follow-up PR will move these checks to the feat→develop boundary so future latents surface on the introducing PR.)

## The 3 fixes

1. **`Rust Tests (doc)`** — `src/services/transaction/cross_model_coordinator.rs`: the `write_symbol_atomically` doctest was `no_run` (must compile) but referenced undefined locals (`node`/`embedding`/`edges`/`tenant_ctx`) and an unimported `TransactionOutcome`. It never could compile. Marked `ignore` (illustrative pseudo-code).

2. **`Feature Matrix (cluster)`** — `src/network/multi_server.rs`: logged an undefined `arrow_bind_addr` in the **cluster-gated** Arrow start path (only compiled under `--features cluster`, hence invisible to the default build). Captured `arrow_target_log` before the bind target is moved into the `tokio::spawn` (mirrors the single-node start path at line ~710), and log that.

3. **`Rust Integration Tests (graph)`** — `tests/embedded_code_graph_parity_e2e.rs`: the three tests collided on the fixed `GRAPH_ID = "codegraph"` via `GraphCollectionService`'s process-shared persistence path, so the 2nd/3rd tests hit `Graph collection 'codegraph' already exists` under `--test-threads=1`. Threaded a unique `graph_id` per test through `build_db`/`fixture`/`canonical_oid`.

## Verification (toolchain 1.95.0)
- `cargo test --doc -p proximadb` → **7 passed, 0 failed** (was 1 failed)
- `cargo check -p proximadb --features cluster` (the exposing combo) → clean
- `cargo test --test embedded_code_graph_parity_e2e -- --test-threads=1` → **3 passed**
- `cargo check --workspace --lib --bins`, `cargo clippy --lib --bins -- -D warnings`, `cargo fmt --all -- --check` → clean

## Follow-up (separate TD, not this PR)
`GraphCollectionService` hardcodes `/tmp/proximadb/metadata/...` instead of honoring the configured `data_dir` — a latent embedded-correctness bug where multiple in-process instances share graph state. The test-side isolation here works around it; the production fix is its own TD.