### PR TITLE
ci(qa-gate): fix build job — narrow to pgwire+recall test targets (#363 follow-up)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -49,19 +49,18 @@ jobs:
           fi
           echo "ok: main PR originates from qa"
 
-  # Build the workspace test artifacts ONCE. The pgwire + recall jobs below take
-  # `needs: [build]` and restore this same target/ via Swatinem/rust-cache
-  # (shared-key), so they skip recompiling the workspace — modeled on ci.yml's
-  # rust-build -> rust-test cache-sharing idiom (prefix v1-rust-nightly-dev +
-  # shared-key "build"). `--workspace --tests` compiles every member crate's lib
-  # (incl. proximadb-block-format), the root crate's [[test]] integration target,
-  # and all auto-discovered tests/*.rs integration bins (tpch_pgwire_e2e,
-  # tpcds_pgwire_e2e). It does NOT build benches/examples. (`--tests` is a
-  # superset of `--lib`, so pax-recall's `-p proximadb-block-format --lib` is
-  # covered.) The e2e tests embed the server via tokio::spawn, so they link the
-  # lib — a pre-built server binary cannot replace this; a shared target/ can.
+  # Compile the test binaries the downstream jobs run, ONCE, so tpch/tpcds/pax
+  # (`needs: [build]`) restore this target/ via Swatinem/rust-cache (shared-key)
+  # and skip recompiling. Modeled on ci.yml's rust-build -> rust-test idiom.
+  # IMPORTANT: build ONLY the targets the consumers run — NOT `--workspace --tests`,
+  # which compiles every workspace test target and both fails (some targets don't
+  # compile in CI) and OOMs (no job cap). `cargo test ... --no-run` matches each
+  # consumer's compile step exactly, so its `cargo test --test X` is a cache hit.
+  # CARGO_BUILD_JOBS=2 bounds link-phase memory like the TPC jobs do. The e2e
+  # tests embed the server (tokio::spawn), so they link the lib — a shared
+  # compiled target/ is the lever, not a pre-built server binary.
   build:
-    name: Rust Build (workspace tests)
+    name: Rust Build (pgwire + recall tests)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -75,8 +74,12 @@ jobs:
         with:
           prefix-key: "v1-qa-build"
           shared-key: "qa-tests"
-      - name: Build workspace test artifacts
-        run: cargo build --workspace --tests
+      - name: Build the pgwire + recall test binaries
+        env:
+          CARGO_BUILD_JOBS: "2"
+        run: |
+          cargo test --test tpch_pgwire_e2e --test tpcds_pgwire_e2e --no-run
+          cargo test -p proximadb-block-format --lib --no-run
 
   tpch-pgwire:
     name: TPC-H pgwire integration


### PR DESCRIPTION
## What
Fix the `build` job introduced in #363 — it **failed in CI**, which skipped TPC-H/TPC-DS/PAX-recall (they `needs: [build]`) and **blocked the entire qa-gate** (worse than before #363).

## Root cause
#363's build job ran `cargo build --workspace --tests`. That:
- compiles **every** workspace test target (80+ crates) — some don't compile in the CI env, so it fails; and
- with no `CARGO_BUILD_JOBS` cap, it can **OOM** linking them all in parallel.

Observed on run #28217593199: `Rust Build (workspace tests)` = **failure** → TPC-H/TPC-DS/PAX-recall = **skipped**.

## Fix
Narrow the build to **exactly** the test binaries the downstream jobs run, with `--no-run` (matches each consumer's compile step, so its `cargo test --test X` is a cache hit — no recompile) and `CARGO_BUILD_JOBS=2` (bounds link-phase memory, like the TPC jobs):
```
cargo test --test tpch_pgwire_e2e --test tpcds_pgwire_e2e --no-run
cargo test -p proximadb-block-format --lib --no-run
```
tpch/tpcds/pax-recall still `needs: [build]` and reuse the shared `target/` (Swatinem/rust-cache `v1-qa-build` / `qa-tests`). The other #363 changes (cancel-in-progress:false, 45m TPC timeout) are unchanged.

## Verification
- `actionlint` clean.
- End-to-end (qa-gate runs only on PR→qa/main): after merge, the develop→qa promotion's `Rust Build (pgwire + recall tests)` job passes; TPC-H/TPC-DS/PAX-recall run (not skipped) and reuse the build; TPC-DS finishes <45m; runs survive develop pushes (cancel-in-progress:false).
