### PR TITLE
ci(qa-gate): bump build parallelism CARGO_BUILD_JOBS 2 -> 4

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -56,7 +56,7 @@ jobs:
   # which compiles every workspace test target and both fails (some targets don't
   # compile in CI) and OOMs (no job cap). `cargo test ... --no-run` matches each
   # consumer's compile step exactly, so its `cargo test --test X` is a cache hit.
-  # CARGO_BUILD_JOBS=2 bounds link-phase memory like the TPC jobs do. The e2e
+  # CARGO_BUILD_JOBS=4 keeps the shared build well under the 45m timeout (JOBS=2 was too slow). The e2e
   # tests embed the server (tokio::spawn), so they link the lib — a shared
   # compiled target/ is the lever, not a pre-built server binary.
   build:
@@ -76,7 +76,7 @@ jobs:
           shared-key: "qa-tests"
       - name: Build the pgwire + recall test binaries
         env:
-          CARGO_BUILD_JOBS: "2"
+          CARGO_BUILD_JOBS: "4"
         run: |
           cargo test --test tpch_pgwire_e2e --test tpcds_pgwire_e2e --no-run
           cargo test -p proximadb-block-format --lib --no-run
@@ -98,7 +98,7 @@ jobs:
           prefix-key: "v1-qa-build"
           shared-key: "qa-tests"
       - name: Run TPC-H over pgwire
-        run: CARGO_BUILD_JOBS=2 cargo test --test tpch_pgwire_e2e -- --nocapture
+        run: CARGO_BUILD_JOBS=4 cargo test --test tpch_pgwire_e2e -- --nocapture
 
   tpcds-pgwire:
     name: TPC-DS pgwire integration
@@ -117,7 +117,7 @@ jobs:
           prefix-key: "v1-qa-build"
           shared-key: "qa-tests"
       - name: Run TPC-DS over pgwire
-        run: CARGO_BUILD_JOBS=2 cargo test --test tpcds_pgwire_e2e -- --nocapture
+        run: CARGO_BUILD_JOBS=4 cargo test --test tpcds_pgwire_e2e -- --nocapture
 
   # PAX stacked-quantization recall gate. Storage-format mandate (#8): any
   # quantization / block / segment change is gated on recall@k vs the exact-f32


### PR DESCRIPTION
## What
Bump the qa-gate build parallelism `CARGO_BUILD_JOBS` 2 → 4 (build job + the two TPC jobs). JOBS=2 made the shared build slow enough to approach the 45m timeout on a cold cache.

## Status — HOLD merge (do not merge yet)
The in-progress develop→qa run (#28220321549, JOBS=2) already has **build + SDK + ANN green** with TPC-H/TPC-DS running — it's on track to complete green on its own. Merging this now would advance develop and make that run's result stale (the auto-merge watch keys on the latest develop HEAD), forcing a wasteful restart. **Merge this AFTER PR #355 (develop→qa) completes**, as a speedup for future qa-gate runs.

## Change
- `build` job env: `CARGO_BUILD_JOBS: "2"` → `"4"`
- `tpch-pgwire` / `tpcds-pgwire` inline: `CARGO_BUILD_JOBS=2` → `=4` (they reuse the shared target/ via rust-cache, so this mainly matters for the build job + any cache-miss recompile)
- `rust-coverage-ratchet` stays at `JOBS=1` (coverage instrumentation is memory-sensitive)

actionlint clean.
