### PR TITLE
docs(design): Slice D storage port-inversion plan (decomposition linchpin)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
@@ -138,7 +138,7 @@ the compute kernels by the distance/quant/bridge seam — not per file.
 | — | `proximadb-storage-formats` ← `src/storage/formats/` | ~5K | ~~Low~~ → High | 🚫 *Blocked.* Engine-bound: `adapters.rs` → all six engines (12 refs). Defer behind E. (Disproves the original "formats-first"; see #145.)
 | — | `proximadb-storage-cache` ← `src/storage/cache/` (wraps `proximadb-cache`) | ~11K | ~~Low~~ → High | 🚫 *Blocked.* 11/27 files depend on root-resident `storage::traits::UnifiedStorageFormat` (90 consumers) + root `metrics`/`observability`. Requires D.
 | C | Persistence: WAL + disk-manager port crates | ~? | Med | Pending (filesystem trait/types already extracted via #332)
-| D | *Enabler:* `IndexManager` (+ distance, metadata) **port crate(s)**; refactor engine/compaction to inject ports | n/a | Med-High | Linchpin (also unblocks cache's `storage::traits` dep)
+| D | *Enabler:* `IndexManager` (+ distance, metadata) **port crate(s)**; refactor engine/compaction to inject ports — **detailed plan: `ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc`** | n/a | Med-High | Linchpin (also unblocks cache's `storage::traits` dep)
 | E | Engines: `proximadb-{sst,nova,viper}-engine` (depend on ports from D) | large | High | Coordinated window
 | F | Multimodel / document / entity / transaction stores | large | High | Coordinated window
 |===

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
@@ -1,0 +1,188 @@
+= Root-Crate Decomposition — Slice D: Storage Port-Inversion Plan (2026-06-26)
+:toc: macro
+:icons: font
+
+[abstract]
+Slice D is the linchpin of the root-crate decomposition: it inverts the storage→up
+dependency edges so the large storage *engines* (Slices E/F — `sst`/`nova`/`viper`/… plus
+the multimodel/document/entity stores, ~245K LOC) can extract into crates. Engines cannot
+move while `src/storage` reaches *up* into `crate::index` / `crate::compute` /
+`crate::services` / `crate::core`. This plan is grounded in the **measured** coupling on
+`develop` (2026-06-26) and splits the work into two mechanisms — most edges *redirect down*
+to crates that already exist; only a thin orchestration surface needs true port inversion.
+
+toc::[]
+
+== Why Slice D, and why now
+
+The clean-leaf phase is complete (kv, transaction, encryption, operations, serialization,
+tls extracted; ~14.6K LOC). Every remaining *valuable* extraction — the storage engines and
+the modality stores — is blocked because `src/storage` is simultaneously a deep dependency
+(~51 root files `use crate::storage`) **and** deeply entangled *upward*. A crate may never
+depend on the root; so until storage depends *down* on traits/types instead of *up* on
+`crate::index`/`crate::compute`/`crate::services`, no engine can become a crate.
+
+== Measured coupling (develop, 2026-06-26)
+
+`grep` of `crate::{index,compute,services,query,core}::*` references under `src/storage`:
+
+[cols="2,1,3",options="header"]
+|===
+| Up-edge target | Refs | Nature
+| `crate::compute::distance_computation` | 403 | mostly the `DistanceMetric` **type** (207) + the distance `engine` (151)
+| `crate::core::search` | 450 | shared search **types**: results, `FilterExpression` (61), `SearchParams`, `BlockPruneConfig`, comparison ops, `bounded_queue`, `json_comparison`
+| `crate::compute::quantization` | 250 | the quantization `engine`/`storage_engine` (201) + `types` (19)
+| `crate::core::bloom` | 105 | bloom-filter utility
+| `crate::core::config` / `hardware_capabilities` | 114 | config + SIMD/GPU capability **types**
+| `crate::index::axis` | 41 | the ANN index: `AxisManager` (storage **constructs** + `.query()`s it), `eventlog`, `clustering`
+| `crate::services::collection` | 12 | `CollectionService` — metadata `.read`/`.collection`/`.write`
+| `crate::query::*`, misc | ~25 | optimizer/planner hints
+|===
+
+Heaviest injection points: `src/storage/engine.rs` (constructs `AxisManager::new(...)`,
+holds `Arc<AxisManager>`), `common/compaction_orchestrator.rs`, `background_flush_context.rs`,
+`engines/core/formats/columnar/*`, `memtable/*`.
+
+== The key insight: two mechanisms, not "three ports"
+
+The earlier plan framed Slice D as three port crates (IndexManager / distance / metadata).
+The measured data shows that is only *part* of it — **the majority of the edges are
+references to shared *types* and stable utilities, not calls into orchestration policy.**
+Critically, the foundation tier **already contains** the canonical type/kernel crates:
+
+  proximadb-distance-types · proximadb-distance-kernel · proximadb-filter-expression
+  proximadb-quantization-types · proximadb-index-types · proximadb-index-traits
+  proximadb-hardware-caps · proximadb-config · proximadb-data-model
+
+So `crate::compute::distance_computation::DistanceMetric` (×207) is storage referencing the
+*root re-export/parallel path* of a type that already lives in `proximadb-distance-types`.
+That edge dissolves by **redirecting the path**, not by inverting a dependency.
+
+=== Mechanism A — Redirect-down to existing/new type crates (≈80% of edges)
+
+Point storage at the leaf crate that owns the type, instead of the root module. This is a
+*pure path rewrite* — behavior-neutral, mechanically verifiable, and it collapses the edge
+count dramatically before any inversion is attempted.
+
+[cols="3,3",options="header"]
+|===
+| Storage references… | …should reference (crate, mostly already exists)
+| `crate::compute::distance_computation::DistanceMetric` | `proximadb_distance_types::DistanceMetric`
+| `crate::compute::distance_computation::{engine, Quantized*}` (kernel math) | `proximadb_distance_kernel::*`
+| `crate::compute::quantization::types::*` | `proximadb_quantization_types::*`
+| `crate::core::search::FilterExpression` | `proximadb_filter_expression::*`
+| `crate::core::{config, hardware_capabilities}` | `proximadb_config` / `proximadb_hardware_caps`
+| `crate::index::axis::types` | `proximadb_index_types` / `proximadb_index_traits`
+|===
+
+A few shared-type leaves are **not** yet crates and must be extracted down first (small,
+clean, foundation/contract tier — same recipe as the leaves already landed):
+
+* `proximadb-search-types` ← the non-`FilterExpression` half of `core::search`
+  (`SearchParams`, `SearchResult`/`results`, `BlockPruneConfig`/`Mode`, `ComparisonOperator`,
+  `SearchMode`, `bounded_queue`, `json_comparison`, `sql_value_filter`). ~450 edges collapse
+  to one crate dep.
+* `proximadb-bloom` ← `core::bloom` (105 edges; self-contained probabilistic structure).
+
+Precondition check per redirect: confirm the root path is a re-export/duplicate of the leaf
+type (identical definition), not a divergent root-only type. Where it diverges, treat it as
+Mechanism B (a port) or reconcile the duplication first (cf. the `StorageEngineType`
+shim/`core::types` finding).
+
+=== Mechanism B — Port-invert the genuine orchestration (the thin, real DIP work)
+
+What remains after Mechanism A is a *small* surface where storage **drives** a higher-level
+collaborator. Apply the Dependency-Inversion Principle: **storage (the high-level policy in
+engines/compaction) defines a narrow trait for what it needs; the concrete collaborator (up
+in index/compute/services) implements it; the composition root injects the impl.** Storage
+then depends *down* on the trait crate, never *up* on the implementor.
+
+[cols="1,2,3",options="header"]
+|===
+| Port (trait crate) | Inverts | Narrow surface storage actually uses
+| `IndexPort` | `crate::index::axis::AxisManager` | storage **constructs** `AxisManager::new` and `.query()`s it (7), drives `eventlog`/`clustering` during compaction. Trait: `query(...)`, index-maintenance hooks (insert/compact/eventlog-append). `AxisManager` (index tier) `impl IndexPort`.
+| `CollectionMetadataPort` | `crate::services::collection::CollectionService` | `.read` (4) / `.collection` (2) / `.write` (1). Trait: collection metadata read (+ the one write site). `CollectionService` (services) `impl`s it. (This is the `InternalCollectionProvider` the prior plan named — it does not yet exist as a trait; define it.)
+| `DistanceDispatchPort` *(conditional)* | `compute::distance_computation::engine` (151) | **Decision rule:** if the `engine` is pure kernel math → redirect to `proximadb-distance-kernel` (Mechanism A). If it performs *runtime policy* (format/quantized-vs-f32 selection, codebook registry lookup) above the kernel → invert as a port. Measure before deciding.
+| `QuantizationEnginePort` *(conditional)* | `compute::quantization::{quantization_engine, storage_engine}` (201) | Same decision rule: pure codec → use `proximadb-quantization-*` crates; orchestration/registry/global-cache → port. The `turboquant_store_registry`/`global_cache` references suggest a registry that should be injected, not reached up to.
+|===
+
+== Target architecture
+
+[source,text]
+----
+        ┌───────────────────────────────────────────────┐
+        │  composition root (apps/ + crates/platform)   │  ← wires concrete impls
+        │  AxisManager → IndexPort                       │     into storage at startup
+        │  CollectionService → CollectionMetadataPort    │
+        └───────────────┬───────────────────────────────┘
+                        │ injects Arc<dyn Port>
+        ┌───────────────▼───────────────┐   implements   ┌────────────────────────┐
+        │  storage engines (Slice E)    │◄───────────────│ index / compute / svc  │
+        │  depend DOWN on:              │                │ depend DOWN on the     │
+        │   • proximadb-*-types/kernel  │                │ same port trait crates │
+        │   • proximadb-storage-ports   │                └────────────────────────┘
+        └───────────────────────────────┘
+----
+
+* **Port trait crates** are trait-only, no behavior, `serde`-free where possible — placed in
+  a low tier so both storage *and* the implementors can depend down on them. Options:
+  one cohesive `proximadb-storage-ports` crate (foundation/contract tier) vs one crate per
+  port. Recommendation: **one `proximadb-storage-ports` crate** (the ports co-change as the
+  storage↔engine seam evolves; crate-per-trait is premature fragmentation here).
+* The concrete implementors (`AxisManager`, `CollectionService`) gain an `impl Port for …`
+  in their own crate/module — a downward dep on the port crate. No upward edge anywhere.
+* Injection happens at the **composition root** (the bootstrap in `apps/proximadb-server` /
+  `crates/platform/proximadb-runtime`), which already owns wiring.
+
+== Phasing (each phase behavior-neutral + layering-gated)
+
+[cols="1,4,1",options="header"]
+|===
+| Phase | Work | Risk
+| D0 | **Redirect-down (Mechanism A, existing crates).** Rewrite storage's `crate::compute::…DistanceMetric` / `crate::core::search::FilterExpression` / quant-types / config / hardware-caps / index-types references to the existing foundation crates. Pure path rewrites; verify each root path == leaf type. Several small mechanical PRs; collapses the edge count first. | Low
+| D1 | **Extract remaining shared-type leaves down.** `proximadb-search-types` (← `core::search` minus FilterExpression) and `proximadb-bloom` (← `core::bloom`). Same leaf recipe already proven. | Low
+| D2 | **Define `proximadb-storage-ports`** — the `IndexPort` + `CollectionMetadataPort` traits (and the conditional distance/quant dispatch ports if the decision rule says invert). Trait-only crate, no impls. | Low
+| D3 | **Refactor storage to consume injected ports.** `engine.rs`/compaction stop constructing `AxisManager` / calling `CollectionService` directly; take `Arc<dyn IndexPort>` / `Arc<dyn CollectionMetadataPort>` via constructor injection. Same concrete behavior, now behind the trait. **This is the hot, coordination-window phase.** | Med-High
+| D4 | **Implement ports + wire injection.** `impl IndexPort for AxisManager`, `impl CollectionMetadataPort for CollectionService`; the composition root injects them. | Med
+| D5 | **Gate to zero.** `scripts/check_workspace_boundaries.py` + a storage-up-edge ratchet asserting `crate::{index,compute,services,query}` references under `src/storage` == 0 (core type refs already redirected in D0/D1). Engines (Slice E) now unblocked. | Low
+|===
+
+D0 and D1 are opportunistic (mechanical, independent, no coordination needed) and should be
+done first — they shrink the surface and de-risk D3. D3/D4 touch `engine.rs`, the compaction
+orchestrator, and the composition root, so they need the **announced coordination window**
+(the storage hot-path is edited by multiple sessions) — not an opportunistic PR.
+
+== Verification & invariants
+
+* **Behavior-neutral:** D0–D2 are path/trait plumbing; D3/D4 are DIP wrapping around the
+  *same* concrete impls (`AxisManager`, `CollectionService`) — no algorithm changes. Gate on
+  the existing storage unit/integration suites + ANN recall ratchet (unchanged numbers).
+* **Layering:** every phase keeps `scripts/check-layering.sh` green; D5 adds the
+  storage-up-edge ratchet (count only goes down, terminal 0).
+* **No new upward edges:** the port crate sits below both storage and the implementors; the
+  layering validator already forbids storage→{modality,query,platform,app} — extend it to
+  forbid storage→{index,compute,services} once D3/D4 land.
+* **Mixed-read-safe / default-OFF** is N/A (no on-disk format change); this is a pure
+  in-process dependency-graph refactor.
+
+== Risks & coordination
+
+* **Hot files.** `engine.rs` + `compaction_orchestrator.rs` are edited concurrently; D3 must
+  land within its window to avoid divergence. Sequence D0/D1 first to minimize D3's diff.
+* **Type duplication.** Some root paths may be *divergent* parallel types rather than
+  re-exports (cf. `core::types` re-exporting `storage_common::StorageEngineType`, and
+  `storage::types` re-exporting the proto enum). Each redirect in D0 must verify identity
+  first; reconcile duplicates before redirecting.
+* **Distance/quant decision.** The conditional ports (B) hinge on whether the compute
+  `engine` submodules are kernel math or runtime policy — measure (call-site analysis) in D2
+  before committing to invert-vs-redirect.
+
+== Next action
+
+Execute **D0** as the first step: redirect storage's `DistanceMetric` / `FilterExpression`
+references to `proximadb-distance-types` / `proximadb-filter-expression` (the two largest,
+unambiguously-existing type crates), after confirming the root paths are re-exports. This is
+a low-risk mechanical PR that immediately drops the storage→compute/core edge count and
+proves the redirect-down mechanism before the coordinated D3/D4 inversion.
+
+Ref: `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc` (Slice D row), TD-104.

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
@@ -55,8 +55,13 @@ Critically, the foundation tier **already contains** the canonical type/kernel c
   proximadb-hardware-caps · proximadb-config · proximadb-data-model
 
 So `crate::compute::distance_computation::DistanceMetric` (×207) is storage referencing the
-*root re-export/parallel path* of a type that already lives in `proximadb-distance-types`.
-That edge dissolves by **redirecting the path**, not by inverting a dependency.
+*root alias path* of a type that already lives in `proximadb-distance-kernel` — the root
+module is literally `pub use proximadb_distance_kernel as distance_computation`
+(`src/compute/mod.rs:168`), so the *entire* `distance_computation` namespace is the kernel
+crate. That edge dissolves by **redirecting the path**, not by inverting a dependency.
+*(Caution: `proximadb-distance-types` is a **separate, divergent** 4-variant migration enum
+(L2/Cosine/InnerProduct/L1) — NOT the storage path, which is the 14-variant proto enum
+re-exported by the kernel. Do not target `-distance-types`.)*
 
 === Mechanism A — Redirect-down to existing/new type crates (≈80% of edges)
 
@@ -67,8 +72,7 @@ count dramatically before any inversion is attempted.
 [cols="3,3",options="header"]
 |===
 | Storage references… | …should reference (crate, mostly already exists)
-| `crate::compute::distance_computation::DistanceMetric` | `proximadb_distance_types::DistanceMetric`
-| `crate::compute::distance_computation::{engine, Quantized*}` (kernel math) | `proximadb_distance_kernel::*`
+| `crate::compute::distance_computation::*` (whole namespace: `DistanceMetric`, `engine`, `UnifiedDistanceCompute`, `quantized`, …) | `proximadb_distance_kernel::*` (the root path *is* `pub use proximadb_distance_kernel as distance_computation`) — done in D0
 | `crate::compute::quantization::types::*` | `proximadb_quantization_types::*`
 | `crate::core::search::FilterExpression` | `proximadb_filter_expression::*`
 | `crate::core::{config, hardware_capabilities}` | `proximadb_config` / `proximadb_hardware_caps`
@@ -179,10 +183,14 @@ orchestrator, and the composition root, so they need the **announced coordinatio
 
 == Next action
 
-Execute **D0** as the first step: redirect storage's `DistanceMetric` / `FilterExpression`
-references to `proximadb-distance-types` / `proximadb-filter-expression` (the two largest,
-unambiguously-existing type crates), after confirming the root paths are re-exports. This is
-a low-risk mechanical PR that immediately drops the storage→compute/core edge count and
-proves the redirect-down mechanism before the coordinated D3/D4 inversion.
+**D0 is implemented in this PR:** storage's `crate::compute::distance_computation::*`
+references are redirected to `proximadb-distance-kernel` (whole-namespace path rewrite, 403
+refs / 129 files) and `crate::core::search::{FilterExpression, ComparisonOperator}` to
+`proximadb-filter-expression` (61 refs / 31 files, grouped imports split so non-filter
+`core::search` symbols stay put). Both root paths were confirmed re-exports; both target
+crates were already root deps. Behaviour-neutral; the storage→`compute::distance_computation`
+and storage→`core::search::{FilterExpression,ComparisonOperator}` edge counts are now **0**
+(ratchet). The remaining redirects (quantization/config/hardware-caps/index-types), the
+`search-types`/`bloom` leaf extractions (D1), and the port inversions (D2–D5) follow.
 
 Ref: `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc` (Slice D row), TD-104.

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -247,17 +247,34 @@ _pkg_args() { local a=""; for p in $1; do a="$a -p $p"; done; printf '%s' "$a"; 
 cmd_check() {
   local pkgs; pkgs="$(_affected)"
   [ -n "$pkgs" ] || { printf 'worktree: no crate source changed vs %s — nothing to check\n' "$BASE_DEFAULT" >&2; return 0; }
-  printf 'worktree: cargo check%s\n' "$(_pkg_args "$pkgs")" >&2
+  # Match CI's compile+clippy gate AND compile #[cfg(test)] code. `--all-targets`
+  # is the fix for a real "green local, red CI" trap: a plain `cargo check`
+  # (or `clippy --lib --bins`) never compiles the test cfg, so a broken/changed
+  # import inside a `#[cfg(test)]` module sails through locally and only fails in
+  # the CI "Rust Tests" job. `-D warnings` matches the CI clippy gate.
+  printf 'worktree: cargo clippy --all-targets -D warnings%s (matches CI clippy + compiles tests)\n' "$(_pkg_args "$pkgs")" >&2
   # shellcheck disable=SC2046
-  cargo check $(_pkg_args "$pkgs")
+  cargo clippy $(_pkg_args "$pkgs") --all-targets -- -D warnings
 }
 
 cmd_test() {
   local pkgs; pkgs="$(_affected)"
   [ -n "$pkgs" ] || { printf 'worktree: no crate source changed vs %s — nothing to test\n' "$BASE_DEFAULT" >&2; return 0; }
-  printf 'worktree: cargo nextest run%s (affected crates)\n' "$(_pkg_args "$pkgs")" >&2
+  # Mirror CI's "Rust Tests" job EXACTLY so green-local == green-CI:
+  #   unit: cargo nextest run --lib --profile unit --test-threads=2
+  #   doc : cargo test --doc -- --test-threads=4
+  # `--test-threads` bounds the global-statics races the root suite is known to
+  # have (WAL registry / metadata provider / request-id counter) — running
+  # unbounded locally drifts from CI and hides (or invents) flakes. `--profile
+  # unit` applies the nextest retry/config CI uses. `--lib` scopes to unit tests
+  # like CI. (CARGO_BUILD_JOBS stays at the local default — JOBS=1 is a 16GB-CI
+  # OOM workaround, not needed on a dev box.)
+  printf 'worktree: cargo nextest run --lib --profile unit --test-threads=2%s (matches CI)\n' "$(_pkg_args "$pkgs")" >&2
   # shellcheck disable=SC2046
-  cargo nextest run $(_pkg_args "$pkgs") || cargo test $(_pkg_args "$pkgs")
+  cargo nextest run --lib --profile unit --test-threads=2 $(_pkg_args "$pkgs")
+  printf 'worktree: cargo test --doc --test-threads=4%s (matches CI doc tests)\n' "$(_pkg_args "$pkgs")" >&2
+  # shellcheck disable=SC2046
+  cargo test --doc $(_pkg_args "$pkgs") -- --test-threads=4
 }
 
 case "${1:-}" in

--- a/src/storage/background_flush_context.rs
+++ b/src/storage/background_flush_context.rs
@@ -12,9 +12,9 @@ use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::proto::proximadb_v1::FilterableColumnSpec;
 use crate::services::collection::manager::CollectionService;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Storage engine types supported by ProximaDB
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/storage/compute_bridge/global_cache.rs
+++ b/src/storage/compute_bridge/global_cache.rs
@@ -830,9 +830,7 @@ impl GlobalQuantizationCache {
         // This provides the unified interface expected by the engines
         Arc::new(
             crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(
-                Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-                ),
+                Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default()),
                 Self::global()
                     as Arc<dyn crate::compute::quantization::quantization_engine::CodebookStore>,
             ),

--- a/src/storage/document/storage/cold_tier.rs
+++ b/src/storage/document/storage/cold_tier.rs
@@ -11,10 +11,11 @@
 use anyhow::Result;
 use std::sync::Arc;
 
-use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+use crate::core::search::SearchParams;
 use crate::proto::proximadb_v1::Collection;
 use crate::storage::document::DocumentRecord;
 use crate::storage::traits::{StorageQueryContext, UnifiedStorageFormat};
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
 // =============================================================================
 // TRAIT: ColdTierRetriever (Dependency Inversion Principle)

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -31,7 +31,7 @@ pub struct StorageEngine {
     filesystem: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
 
     /// Shared distance computation engine for all storage operations
-    distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 
     /// A6 storage-write fence (default-OFF). Injected post-construction from the
     /// bootstrap (`database.rs`) once `SharedServices` — and thus the durable
@@ -162,7 +162,7 @@ impl StorageEngine {
             compaction_manager,
             filesystem,
             distance_compute: Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+                proximadb_distance_kernel::engine::UnifiedDistanceCompute::default(),
             ),
             storage_write_fence: None,
         })
@@ -929,7 +929,7 @@ impl StorageEngine {
     /// Get the shared distance computation engine
     pub fn distance_compute(
         &self,
-    ) -> &Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute> {
+    ) -> &Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute> {
         &self.distance_compute
     }
 
@@ -939,7 +939,7 @@ impl StorageEngine {
         &self,
         query: &[f32],
         vector: &[f32],
-        distance_metric: &crate::compute::distance_computation::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
     ) -> crate::storage::Result<f32> {
         // Use shared unified distance computation engine
         let result = self

--- a/src/storage/engines/core/filter_evaluator.rs
+++ b/src/storage/engines/core/filter_evaluator.rs
@@ -15,8 +15,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::core::search::FilterExpression;
 use crate::core::search::sql_value_filter::evaluate_filter_resolved;
+use proximadb_filter_expression::FilterExpression;
 
 /// Thread-safe filter evaluator that can be shared across async tasks.
 ///
@@ -85,7 +85,7 @@ fn strings_to_json_map(metadata: &HashMap<String, String>) -> HashMap<String, Va
 /// string into a JSON array (e.g. `"a, b"` → `["a","b"]`), preserving the prior
 /// `CompiledFilter` convenience. All other expressions pass through unchanged.
 fn normalize_in_values(expr: &FilterExpression) -> FilterExpression {
-    use crate::core::search::ComparisonOperator;
+    use proximadb_filter_expression::ComparisonOperator;
     match expr {
         FilterExpression::And(exprs) => {
             FilterExpression::And(exprs.iter().map(normalize_in_values).collect())
@@ -200,7 +200,7 @@ pub fn evaluate_filter_with_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::search::ComparisonOperator;
+    use proximadb_filter_expression::ComparisonOperator;
     use serde_json::json;
 
     #[test]

--- a/src/storage/engines/core/filter_evaluator_examples.rs
+++ b/src/storage/engines/core/filter_evaluator_examples.rs
@@ -3,7 +3,7 @@
 //! This file demonstrates how all storage engines can leverage the unified
 //! filter evaluator for consistent filtering behavior.
 
-use crate::core::search::{ComparisonOperator, FilterExpression};
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 use crate::storage::engines::core::filter_evaluator::*;
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/src/storage/engines/core/formats/columnar/columnar_compaction.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_compaction.rs
@@ -252,13 +252,13 @@ impl UnifiedColumnarCompaction {
         batch: &RecordBatch,
         collection_config: Option<&crate::proto::proximadb_v1::Collection>,
     ) -> Result<RecordBatch> {
-        use crate::compute::distance_computation::DistanceMetric;
         use crate::compute::quantization::storage_engine::{
             StorageQuantizationConfig, StorageQuantizationEngine,
         };
         use crate::storage::engines::core::formats::columnar::constants;
         use arrow::array::ArrayRef;
         use arrow_array::{FixedSizeListArray, Float32Array, builder::BinaryBuilder};
+        use proximadb_distance_kernel::DistanceMetric;
         use proximadb_runtime_common::pool::VectorMemoryPool;
         use std::sync::Arc;
 

--- a/src/storage/engines/core/formats/columnar/columnar_io.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_io.rs
@@ -269,7 +269,7 @@ impl UnifiedColumnarReader {
     async fn read_parquet_filtered(
         &self,
         file_path: &str,
-        _predicates: Option<&crate::core::search::FilterExpression>,
+        _predicates: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Box<dyn ScanIterator>> {
         let metadata = self.get_or_load_parquet_metadata(file_path).await?;
 
@@ -314,7 +314,7 @@ impl UnifiedColumnarReader {
     fn apply_predicate_pushdown(
         &self,
         metadata: &parquet::file::metadata::ParquetMetaData,
-        _predicate: &crate::core::search::FilterExpression,
+        _predicate: &proximadb_filter_expression::FilterExpression,
     ) -> Result<Vec<usize>> {
         let mut qualified = Vec::new();
 
@@ -341,7 +341,7 @@ impl UnifiedColumnarReader {
         _file_path: &str,
         _metadata: &parquet::file::metadata::ParquetMetaData,
         row_groups: Vec<usize>,
-        _predicates: Option<&crate::core::search::FilterExpression>,
+        _predicates: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<usize>> {
         // Deferred: Implement bloom filter checking
         // For now, return all row groups

--- a/src/storage/engines/core/formats/columnar/columnar_query_engine/columnar_query_reader.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_query_engine/columnar_query_reader.rs
@@ -3,8 +3,6 @@
 //! This module provides the UnifiedParquetReader that other parts of the
 //! codebase expect, delegating to the appropriate modular components.
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::search_interface::SearchPlan;
 use crate::proto::proximadb_v1::MetadataFilter;
@@ -13,6 +11,8 @@ use anyhow::Result;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use proximadb_data_model::ProximaValue;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTree, ProximaTreeNode};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -708,7 +708,7 @@ impl UnifiedParquetReader {
         file_path: &str,
         needs_vectors: bool,
         needs_metadata: bool,
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
         quantization_enabled: bool,
     ) -> Result<(Vec<ProximaRecord>, usize)> {
         use bytes::Bytes;
@@ -1114,7 +1114,7 @@ impl UnifiedParquetReader {
         file_path: &str,
         needs_vectors: bool,
         needs_metadata: bool,
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
         quantization_enabled: bool,
     ) -> Result<(Vec<arrow::record_batch::RecordBatch>, usize)> {
         use bytes::Bytes;
@@ -1468,7 +1468,7 @@ impl UnifiedParquetReader {
         &self,
         metadata: &parquet::file::metadata::ParquetMetaData,
         total_row_groups: usize,
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Vec<usize> {
         let filter_expr = match filter_expression {
             Some(fe) => fe,
@@ -2525,7 +2525,7 @@ impl UnifiedParquetReader {
     fn matches_filter_expression(
         &self,
         record: &ProximaRecord,
-        filter_expr: &crate::core::search::FilterExpression,
+        filter_expr: &proximadb_filter_expression::FilterExpression,
     ) -> bool {
         // Use centralized type-safe SqlValue filtering from core::search::sql_value_filter
         // ProximaRecord.metadata is map<string, SqlValue> per proto definition
@@ -2541,7 +2541,7 @@ impl UnifiedParquetReader {
     fn filter_batch_row_at_a_time(
         &self,
         batch: &arrow::record_batch::RecordBatch,
-        filter_expr: &crate::core::search::FilterExpression,
+        filter_expr: &proximadb_filter_expression::FilterExpression,
     ) -> Result<arrow::record_batch::RecordBatch> {
         let records = self.extract_records_from_batch(batch, false, true)?;
         let mask: arrow::array::BooleanArray = records
@@ -2566,8 +2566,8 @@ impl UnifiedParquetReader {
     fn convert_metadata_filter_to_expression(
         &self,
         filter: &MetadataFilter,
-    ) -> crate::core::search::FilterExpression {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+    ) -> proximadb_filter_expression::FilterExpression {
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
         if filter.clauses.is_empty() {
             // Empty filter matches everything - return a trivial true condition

--- a/src/storage/engines/core/formats/columnar/columnar_query_engine/pipeline.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_query_engine/pipeline.rs
@@ -25,11 +25,11 @@ use std::sync::Arc;
 use tracing::trace;
 
 use super::vectorized_executor::{DataChunk, vectorized_filter_batch};
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::storage::engines::core::formats::columnar::FilterCondition;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Default morsel size matching L2 cache line efficiency.
 /// DuckDB uses 2048; we match that for comparable behavior.

--- a/src/storage/engines/core/formats/columnar/columnar_query_engine/vectorized_executor.rs
+++ b/src/storage/engines/core/formats/columnar/columnar_query_engine/vectorized_executor.rs
@@ -355,10 +355,10 @@ fn evaluate_is_not_null(batch: &RecordBatch, col_name: &str) -> Result<BooleanAr
 fn evaluate_comparison_mask(
     batch: &RecordBatch,
     field: &str,
-    operator: &crate::core::search::ComparisonOperator,
+    operator: &proximadb_filter_expression::ComparisonOperator,
     value: &serde_json::Value,
 ) -> Result<BooleanArray> {
-    use crate::core::search::ComparisonOperator;
+    use proximadb_filter_expression::ComparisonOperator;
 
     match operator {
         ComparisonOperator::Equals => evaluate_equals(batch, field, value),
@@ -419,9 +419,9 @@ fn evaluate_comparison_mask(
 /// caller can fall back to the (correct, structure-preserving) row-at-a-time path.
 fn evaluate_filter_expression_mask(
     batch: &RecordBatch,
-    expr: &crate::core::search::FilterExpression,
+    expr: &proximadb_filter_expression::FilterExpression,
 ) -> Result<BooleanArray> {
-    use crate::core::search::FilterExpression;
+    use proximadb_filter_expression::FilterExpression;
 
     match expr {
         FilterExpression::Comparison {
@@ -463,7 +463,7 @@ fn evaluate_filter_expression_mask(
 /// which case the caller must fall back to row-at-a-time evaluation to stay correct.
 pub fn vectorized_filter_batch_expr(
     batch: RecordBatch,
-    expr: &crate::core::search::FilterExpression,
+    expr: &proximadb_filter_expression::FilterExpression,
 ) -> Result<Option<RecordBatch>> {
     let mask = match evaluate_filter_expression_mask(&batch, expr) {
         Ok(mask) => mask,

--- a/src/storage/engines/core/formats/columnar/common.rs
+++ b/src/storage/engines/core/formats/columnar/common.rs
@@ -198,7 +198,7 @@ pub struct ZeroCopyConfig {
 #[derive(Debug, Clone)]
 pub struct DistanceComputationConfig {
     /// Default distance metric
-    pub default_distance_metric: crate::compute::distance_computation::DistanceMetric,
+    pub default_distance_metric: proximadb_distance_kernel::DistanceMetric,
 
     /// Progressive search configuration
     pub progressive_search: ColumnarCommonProgressiveSearchConfig,
@@ -707,7 +707,7 @@ impl CommonColumnarOperations {
 
     // Distance computation methods removed - use compute module directly
     // Engines (NOVA, VIPER) should use:
-    // - crate::compute::distance_computation::engine::UnifiedDistanceCompute
+    // - proximadb_distance_kernel::engine::UnifiedDistanceCompute
     // - crate::compute::quantization::storage_engine::StorageQuantizationEngine
 
     // Batch distance computation removed - use compute module directly
@@ -822,7 +822,7 @@ impl CommonColumnarOperations {
         // For now, return placeholder data
         info!("File metadata loading from disk not fully implemented");
 
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
 
         let metadata = ColumnarFileMetadata {
             collection_id: "placeholder".to_string(),
@@ -953,31 +953,23 @@ impl SerializationOptimizationConfig {
 
 impl DistanceComputationConfig {
     #[allow(dead_code)]
-    fn to_simd_optimization(
-        &self,
-    ) -> crate::compute::distance_computation::quantized::SIMDOptimization {
-        crate::compute::distance_computation::quantized::SIMDOptimization::default()
+    fn to_simd_optimization(&self) -> proximadb_distance_kernel::quantized::SIMDOptimization {
+        proximadb_distance_kernel::quantized::SIMDOptimization::default()
     }
 
     #[allow(dead_code)]
-    fn to_cache_config(
-        &self,
-    ) -> crate::compute::distance_computation::quantized::DistanceCacheConfig {
-        crate::compute::distance_computation::quantized::DistanceCacheConfig::default()
+    fn to_cache_config(&self) -> proximadb_distance_kernel::quantized::DistanceCacheConfig {
+        proximadb_distance_kernel::quantized::DistanceCacheConfig::default()
     }
 
     #[allow(dead_code)]
-    fn to_approximation_config(
-        &self,
-    ) -> crate::compute::distance_computation::quantized::ApproximationConfig {
-        crate::compute::distance_computation::quantized::ApproximationConfig::default()
+    fn to_approximation_config(&self) -> proximadb_distance_kernel::quantized::ApproximationConfig {
+        proximadb_distance_kernel::quantized::ApproximationConfig::default()
     }
 
     #[allow(dead_code)]
-    fn to_hardware_preferences(
-        &self,
-    ) -> crate::compute::distance_computation::quantized::HardwarePreferences {
-        crate::compute::distance_computation::quantized::HardwarePreferences::default()
+    fn to_hardware_preferences(&self) -> proximadb_distance_kernel::quantized::HardwarePreferences {
+        proximadb_distance_kernel::quantized::HardwarePreferences::default()
     }
 }
 
@@ -1097,7 +1089,7 @@ impl Default for ZeroCopyConfig {
 impl Default for DistanceComputationConfig {
     fn default() -> Self {
         Self {
-            default_distance_metric: crate::compute::distance_computation::DistanceMetric::Cosine,
+            default_distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
             progressive_search: ColumnarCommonProgressiveSearchConfig::default(),
             distance_caching: DistanceCachingConfig::default(),
             hardware_acceleration: HardwareAccelerationConfig::default(),

--- a/src/storage/engines/core/formats/columnar/examples_test.rs
+++ b/src/storage/engines/core/formats/columnar/examples_test.rs
@@ -218,7 +218,7 @@ pub async fn viper_optimization_example() -> Result<()> {
                 &[file_path.to_str().unwrap().to_string()],
                 &query_vector,
                 10, // top-10
-                &crate::compute::distance_computation::DistanceMetric::Cosine,
+                &proximadb_distance_kernel::DistanceMetric::Cosine,
             )
             .await?;
         */

--- a/src/storage/engines/core/formats/columnar/mod.rs
+++ b/src/storage/engines/core/formats/columnar/mod.rs
@@ -112,7 +112,7 @@ pub mod columnar_compaction; // Unified Parquet compaction using StreamingParque
 pub mod common;
 pub mod schema;
 pub mod serialization;
-// NOTE: Distance computation has been moved to crate::compute::distance_computation::quantized
+// NOTE: Distance computation has been moved to proximadb_distance_kernel::quantized
 
 // TEXT column storage, filtering, and full-text search (Phase 3)
 pub mod fulltext_index;
@@ -228,9 +228,9 @@ pub use schema::{
 pub use serialization::{
     ColumnarSerializationConfig, ColumnarSerializer, FormatPreference, SerializationResult,
 };
-// NOTE: SelectedFormat and QuantizedVectorData have been moved to crate::compute::distance_computation::quantized
-// NOTE: Distance computation has been moved to crate::compute::distance_computation::quantized
-// Use: crate::compute::distance_computation::{QuantizedDistanceCalculator, QuantizedDistanceConfig, ...}
+// NOTE: SelectedFormat and QuantizedVectorData have been moved to proximadb_distance_kernel::quantized
+// NOTE: Distance computation has been moved to proximadb_distance_kernel::quantized
+// Use: proximadb_distance_kernel::{QuantizedDistanceCalculator, QuantizedDistanceConfig, ...}
 pub use common::{
     CommonColumnarConfig, CommonColumnarOperations, DistanceComputationConfig, OptimalBatchSizes,
     PerformanceMonitor, RowGroupSizeOptimization, SchemaGenerationConfig,
@@ -300,7 +300,7 @@ use parquet::file::metadata::RowGroupMetaData;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use proximadb_records::ProximaRecord;
 
 /// Common configuration for columnar operations
@@ -468,8 +468,10 @@ impl FilterCondition {
 impl ColumnarMetadataFilter {
     /// Convert from core::search::FilterExpression to columnar::ColumnarMetadataFilter
     /// This enables row group pruning using FilterExpression
-    pub fn from_filter_expression(expr: &crate::core::search::FilterExpression) -> Option<Self> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+    pub fn from_filter_expression(
+        expr: &proximadb_filter_expression::FilterExpression,
+    ) -> Option<Self> {
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
         fn convert_condition(expr: &FilterExpression) -> Option<FilterCondition> {
             match expr {
@@ -853,8 +855,8 @@ impl ColumnarFactory {
         _config: ColumnarConfig,
     ) -> ColumnarOptimizer {
         let _distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                proximadb_distance_kernel::engine::DistanceMetric::Cosine,
             ),
         );
         // Deferred: Fix this to be async and provide proper arguments

--- a/src/storage/engines/core/formats/columnar/optimization.rs
+++ b/src/storage/engines/core/formats/columnar/optimization.rs
@@ -6,7 +6,6 @@
 //! - Progressive search with quantization
 //! - Cost-based query optimization
 
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::storage::engines::core::formats::columnar::{
     ColumnarConfig, MetadataFilter, RowGroupStats, SearchCandidate,
 };
@@ -16,6 +15,7 @@ use arrow_array::RecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::bloom_filter::Sbbf as BloomFilter;
 use parquet::file::metadata::{ParquetMetaData, RowGroupMetaData};
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 use proximadb_records::{EmbeddingCell, ProximaRecord};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/storage/engines/core/formats/columnar/parquet_io_layer.rs
+++ b/src/storage/engines/core/formats/columnar/parquet_io_layer.rs
@@ -60,8 +60,8 @@ use tracing::{debug, info, warn};
 
 use crate::storage::persistence::filesystem::FilesystemFactory;
 // DEPRECATED: refined_integrated_cache replaced by zero_copy_io_system
-use crate::core::search::FilterExpression;
 use crate::storage::engines::core::io::zero_copy::ZeroCopyIOSystem;
+use proximadb_filter_expression::FilterExpression;
 use proximadb_kernel::error::{ProximaDBError, StorageError};
 
 const FOOTER_MAX_SIZE: usize = 8 * 1024 * 1024; // 8MB max footer size

--- a/src/storage/engines/core/formats/columnar/parquet_write_engine/streaming_writer.rs
+++ b/src/storage/engines/core/formats/columnar/parquet_write_engine/streaming_writer.rs
@@ -627,11 +627,11 @@ impl StreamingParquetWriter {
         arrays: &mut Vec<ArrayRef>,
         records: &[ProximaRecord],
     ) -> Result<()> {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::compute::quantization::quantization_engine::{
             InMemoryCodebookStore, UnifiedQuantizationEngine,
         };
         use arrow::array::BinaryBuilder;
+        use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
         // Create a quantization engine for this batch with in-memory codebook
         let distance_compute = Arc::new(UnifiedDistanceCompute::default());

--- a/src/storage/engines/core/formats/columnar/search.rs
+++ b/src/storage/engines/core/formats/columnar/search.rs
@@ -15,8 +15,9 @@ use std::sync::Arc;
 use tracing::{debug, info, trace};
 
 use proximadb_records::{EmbeddingCell, ProximaRecord};
-use crate::core::search::{SearchResult, FilterExpression};
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
+use crate::core::search::SearchResult;
+use proximadb_filter_expression::FilterExpression;
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::storage::engines::core::ops::crate::storage::engines::core::search::search_common::{SearchableFile, SearchableBlock, FileSearcher};
 
 /// Columnar search configuration

--- a/src/storage/engines/core/formats/columnar/serialization.rs
+++ b/src/storage/engines/core/formats/columnar/serialization.rs
@@ -14,11 +14,11 @@ use std::sync::Arc;
 use tracing::{info, trace, warn};
 
 use super::QuantizationConfig;
-use crate::compute::distance_computation::SelectedFormat;
 use crate::compute::quantization::storage_engine::{
     StorageQuantizationConfig, StorageQuantizationEngine, StorageQuantizedData,
 };
 use proximadb_compression::CompressionAlgorithm;
+use proximadb_distance_kernel::SelectedFormat;
 use proximadb_records::{EmbeddingCell, ProximaRecord};
 
 /// Serialization configuration for columnar storage
@@ -359,9 +359,8 @@ impl ColumnarSerializer {
     pub fn new(config: ColumnarSerializationConfig) -> Result<Self> {
         let quantization_engine = if config.quantization.is_some() {
             let quant_config = StorageQuantizationConfig::default(); // Deferred: Convert from QuantizationConfig
-            let distance_compute = Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-            );
+            let distance_compute =
+                Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
             let codebook_store = Arc::new(crate::compute::InMemoryCodebookStore::new());
             let unified_engine = Arc::new(
                 crate::compute::quantization::UnifiedQuantizationEngine::new(
@@ -1112,7 +1111,7 @@ impl From<FormatPreference> for SelectedFormat {
     }
 }
 
-// NOTE: SelectedFormat has been moved to crate::compute::distance_computation::quantized
+// NOTE: SelectedFormat has been moved to proximadb_distance_kernel::quantized
 // This eliminates code duplication and allows all engines to use the same format definitions
 
 #[cfg(test)]

--- a/src/storage/engines/core/formats/proximablocks/block_reader.rs
+++ b/src/storage/engines/core/formats/proximablocks/block_reader.rs
@@ -13,12 +13,12 @@
 use anyhow::Result;
 use std::sync::Arc;
 
-use crate::core::search::FilterExpression;
 use crate::storage::engines::core::formats::proximablocks::block_structures::{
     ProximaBlockMetadata, ProximaDataBlock,
 };
 use crate::storage::persistence::filesystem::FileSystem;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
+use proximadb_filter_expression::FilterExpression;
 
 /// ✅ Reading strategy for different access patterns
 #[derive(Debug, Clone)]
@@ -396,7 +396,7 @@ impl ProximaBlockReader {
         metadata: &ProximaBlockMetadata,
         filter: &Option<&FilterExpression>,
     ) -> bool {
-        use crate::core::search::ComparisonOperator;
+        use proximadb_filter_expression::ComparisonOperator;
 
         // If no filter, always check the block
         let Some(filter_expr) = filter else {

--- a/src/storage/engines/core/formats/proximablocks/header_metadata.rs
+++ b/src/storage/engines/core/formats/proximablocks/header_metadata.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use proximadb_kernel::uuid::Uuid;
 use std::collections::HashMap;
 
-use crate::compute::distance_computation::DistanceMetric;
 use proximadb_compression::CompressionAlgorithm;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Row-based file header structure
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/formats/proximablocks/mod.rs
+++ b/src/storage/engines/core/formats/proximablocks/mod.rs
@@ -294,8 +294,8 @@ pub use sst_metadata::{SstBlockHeader, SstGlobalHeader, SstMetadata, SstMetadata
 // NEW: Export Arrow reader for .sst files
 pub use arrow_reader::ProximaBlocksArrowReader;
 
-use crate::compute::distance_computation::DistanceMetric;
 use proximadb_compression::CompressionAlgorithm;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Common configuration for row-based storage engines
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/formats/proximablocks/spatial_pruning.rs
+++ b/src/storage/engines/core/formats/proximablocks/spatial_pruning.rs
@@ -27,7 +27,7 @@ use std::cmp::Ordering;
 
 use super::spatial_encoding::SpatialCode;
 use super::spatial_traits::CurveType;
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Pruning mode for block selection
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/storage/engines/core/formats/proximablocks/sst_io_layer.rs
+++ b/src/storage/engines/core/formats/proximablocks/sst_io_layer.rs
@@ -152,7 +152,7 @@ pub struct SharedSstFormatReader {
 
     /// ✅ Reusable distance compute engine - created once and passed to all search operations
     #[allow(dead_code)]
-    distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 }
 
 /// Shared SST format writer with compression and Proxima encoding
@@ -232,7 +232,7 @@ impl SharedSstFormatReader {
         caching_filesystem: Arc<UnifiedCachingFilesystem>,
         collection_id: String,
     ) -> Self {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+        use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
         Self {
             filesystem,
@@ -249,7 +249,7 @@ impl SharedSstFormatReader {
         &'a self,
         file_path: &'a str,
         strategy: &'a crate::storage::engines::sst::readers::sst_query_engine::SstableReadingStrategy,
-        _filter_expression: Option<&'a crate::core::search::FilterExpression>,
+        _filter_expression: Option<&'a proximadb_filter_expression::FilterExpression>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<crate::storage::engines::core::formats::proximablocks::block_structures::ProximaDataBlock>, ProximaDBError>> + Send + 'a>>{
         Box::pin(async move {
             use crate::storage::engines::sst::readers::sst_query_engine::SstableReadingStrategy;
@@ -404,7 +404,7 @@ impl SharedSstFormatReader {
         enable_bloom_filters: bool,
         enable_cache_lookup: bool,
         _enable_metadata_cache: bool,
-        _filter_expression: Option<&crate::core::search::FilterExpression>,
+        _filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<crate::storage::engines::core::formats::proximablocks::block_structures::ProximaDataBlock>, ProximaDBError>{
         // Use mmap-first reading for zero-copy performance
         let data = self
@@ -499,7 +499,7 @@ impl SharedSstFormatReader {
         file_path: &str,
         selected_blocks: &[u32],
         _skip_bloom_check: bool,
-        _filter_expression: Option<&crate::core::search::FilterExpression>,
+        _filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<crate::storage::engines::core::formats::proximablocks::block_structures::ProximaDataBlock>, ProximaDBError>{
         // Use mmap-first reading for zero-copy performance
         let data = self.read_with_mmap_fallback(file_path, true).await?;
@@ -554,10 +554,10 @@ impl SharedSstFormatReader {
         &self,
         blocks: &[crate::storage::engines::core::formats::proximablocks::block_structures::ProximaDataBlock],
         query_vector: &[f32],
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
-        distance_compute: &crate::compute::distance_computation::engine::UnifiedDistanceCompute, // ✅ Pass from caller for reuse
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
+        distance_compute: &proximadb_distance_kernel::engine::UnifiedDistanceCompute, // ✅ Pass from caller for reuse
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>, ProximaDBError> {
         let mut all_results = Vec::new();
 

--- a/src/storage/engines/core/ops/mod.rs
+++ b/src/storage/engines/core/ops/mod.rs
@@ -35,7 +35,7 @@ pub mod compression_common;
 pub mod performance_optimization;
 
 // Import common types used across the module
-use crate::core::search::FilterExpression;
+use proximadb_filter_expression::FilterExpression;
 
 /// Backwards-compat alias for [`CoreOpsFilterableColumn`].
 pub type FilterableColumn = CoreOpsFilterableColumn;
@@ -205,9 +205,9 @@ pub use crate::storage::engines::core::search::search_common::{
 use anyhow::Result;
 use std::collections::HashMap;
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::DistanceMetric;
 
 // Temporary placeholder types until modules are created
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/ops/performance_optimization.rs
+++ b/src/storage/engines/core/ops/performance_optimization.rs
@@ -17,9 +17,9 @@ use std::fs::File;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::storage::persistence::filesystem::{FileStorageTier, FilesystemFactory};
 use proximadb_compression::{CompressionAlgorithm, StandardCompression};
+use proximadb_distance_kernel::DistanceMetric;
 use proximadb_runtime_common::pool::VectorMemoryPool;
 
 /// Backwards-compat alias for [`GlobalMemoryPoolConfig`].

--- a/src/storage/engines/core/ops/performance_optimization_tests.rs
+++ b/src/storage/engines/core/ops/performance_optimization_tests.rs
@@ -186,7 +186,7 @@ mod tests {
         let distances = optimizer.compute_distances_accelerated(
             &query,
             &candidates,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
         ).await.unwrap();
         
         assert_eq!(distances.len(), 3);
@@ -198,7 +198,7 @@ mod tests {
         let cosine_distances = optimizer.compute_distances_accelerated(
             &query,
             &candidates,
-            crate::compute::distance_computation::DistanceMetric::Cosine,
+            proximadb_distance_kernel::DistanceMetric::Cosine,
         ).await.unwrap();
         
         assert_eq!(cosine_distances.len(), 3);

--- a/src/storage/engines/core/progressive/coordinator.rs
+++ b/src/storage/engines/core/progressive/coordinator.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use std::time::Instant;
 use tracing::{debug, info, trace};
 
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 
 use super::stage::{ProgressiveSearchStage, ScoredCandidate};
 

--- a/src/storage/engines/core/progressive/factory.rs
+++ b/src/storage/engines/core/progressive/factory.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use super::{ProgressiveSearchCoordinator, ProgressiveSearchStage};
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Engine type for progressive pipeline creation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -307,8 +307,8 @@ impl ProgressivePipelineFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::{CodebookStore, InMemoryCodebookStore};
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_factory() -> ProgressivePipelineFactory {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/core/progressive/stage.rs
+++ b/src/storage/engines/core/progressive/stage.rs
@@ -10,9 +10,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Quantization level identifier for stages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/storage/engines/core/read_strategy.rs
+++ b/src/storage/engines/core/read_strategy.rs
@@ -10,7 +10,7 @@
 //! - Full scans: Use direct reads to avoid cache pollution
 //! - Writes: Always use direct filesystem (no caching benefit)
 
-use crate::core::search::FilterExpression;
+use proximadb_filter_expression::FilterExpression;
 
 /// Unified read access strategy used across all storage engines
 ///

--- a/src/storage/engines/core/scan_implementation.rs
+++ b/src/storage/engines/core/scan_implementation.rs
@@ -172,7 +172,7 @@ impl UnifiedScanImpl {
         &self,
         engine: &dyn UnifiedStorageFormat,
         collection_id: &str,
-        predicates: Option<crate::core::search::FilterExpression>,
+        predicates: Option<proximadb_filter_expression::FilterExpression>,
         enable_pushdown: bool,
         collection_config: Option<&crate::proto::proximadb_v1::Collection>,
     ) -> Result<Box<dyn ScanIterator>> {
@@ -499,7 +499,7 @@ impl ArrowIpcFullScanIterator {
 /// Engine-specific filtered scan implementations
 async fn create_sst_filtered_scan(
     collection_id: &str,
-    predicates: Option<crate::core::search::FilterExpression>,
+    predicates: Option<proximadb_filter_expression::FilterExpression>,
 ) -> Result<Box<dyn ScanIterator>> {
     // SST uses bloom filters and block scanning
     Err(anyhow::anyhow!("SST filtered scan not implemented"))
@@ -507,7 +507,7 @@ async fn create_sst_filtered_scan(
 
 async fn create_viper_filtered_scan(
     collection_id: &str,
-    predicates: Option<crate::core::search::FilterExpression>,
+    predicates: Option<proximadb_filter_expression::FilterExpression>,
     enable_pushdown: bool,
 ) -> Result<Box<dyn ScanIterator>> {
     // VIPER uses columnar predicate pushdown
@@ -516,7 +516,7 @@ async fn create_viper_filtered_scan(
 
 async fn create_nova_filtered_scan(
     collection_id: &str,
-    predicates: Option<crate::core::search::FilterExpression>,
+    predicates: Option<proximadb_filter_expression::FilterExpression>,
     enable_pushdown: bool,
 ) -> Result<Box<dyn ScanIterator>> {
     // NOVA uses zone maps and statistics
@@ -525,7 +525,7 @@ async fn create_nova_filtered_scan(
 
 async fn create_raptor_filtered_scan(
     collection_id: &str,
-    predicates: Option<crate::core::search::FilterExpression>,
+    predicates: Option<proximadb_filter_expression::FilterExpression>,
 ) -> Result<Box<dyn ScanIterator>> {
     // RAPTOR uses tier-aware filtering
     Err(anyhow::anyhow!("RAPTOR filtered scan not implemented"))

--- a/src/storage/engines/core/search/progressive_search.rs
+++ b/src/storage/engines/core/search/progressive_search.rs
@@ -27,8 +27,6 @@ use std::sync::Arc;
 use tracing::{debug, trace};
 
 // Note: SearchResult is proto type, not in core::search anymore
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::{
     QuantizedVector, UnifiedQuantizationEngine,
 };
@@ -36,6 +34,8 @@ use crate::compute::quantization::storage_engine::StorageQuantizedData;
 use crate::core::search::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::traits::{QuantizationLevel, QuantizationType, StorageQueryContext};
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Progressive search executor that can be used by any storage engine
 pub struct ProgressiveSearchExecutor {

--- a/src/storage/engines/core/search/search_common.rs
+++ b/src/storage/engines/core/search/search_common.rs
@@ -9,10 +9,11 @@ use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
-use crate::core::search::{FilterExpression, OptimizedSearchRecord};
+use crate::core::search::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_filter_expression::FilterExpression;
 
 /// Backwards-compat alias for [`UniversalSearchConfig`].
 pub type SearchConfig = UniversalSearchConfig;
@@ -39,7 +40,7 @@ pub struct UniversalSearchConfig {
     pub enable_progressive_search: bool,
 
     /// Distance metric for similarity calculation
-    pub distance_metric: crate::compute::distance_computation::DistanceMetric,
+    pub distance_metric: proximadb_distance_kernel::DistanceMetric,
 }
 
 impl Default for UniversalSearchConfig {
@@ -51,7 +52,7 @@ impl Default for UniversalSearchConfig {
             enable_reranking: true,
             max_parallel_files: 4,
             enable_progressive_search: true,
-            distance_metric: crate::compute::distance_computation::DistanceMetric::default(),
+            distance_metric: proximadb_distance_kernel::DistanceMetric::default(),
         }
     }
 }
@@ -427,7 +428,7 @@ impl UniversalSearchPipeline {
             let similarity_result = self.distance_compute.as_ref().calculate_distance(
                 query_vector,
                 &record.vector,
-                &crate::compute::distance_computation::DistanceMetric::default(),
+                &proximadb_distance_kernel::DistanceMetric::default(),
             );
 
             // Convert metadata from Vec<MetadataItem> to HashMap<String, Value>

--- a/src/storage/engines/core/search/search_modes.rs
+++ b/src/storage/engines/core/search/search_modes.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Backwards-compat alias for [`SearchModeMetadataFilter`].
 pub type MetadataFilter = SearchModeMetadataFilter;

--- a/src/storage/engines/helix/benchmarks.rs
+++ b/src/storage/engines/helix/benchmarks.rs
@@ -10,7 +10,7 @@
 #[cfg(test)]
 mod benchmarks {
     use super::super::*;
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::VectorRecord;
     use crate::proto::proximadb_v1::{

--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -119,7 +119,6 @@ pub mod unified_metadata_serializer {
 pub mod proximablocks_strategy_reader;
 pub mod zone_maps;
 
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::core::search::SearchMode;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::proto::proximadb_v1::VectorRecord;
@@ -131,6 +130,7 @@ use crate::storage::traits::{
     CompactionParameters, CompactionResult, FlushParameters, FlushResult, StorageFormatStrategy,
     StorageQueryContext, UnifiedStorageFormat,
 };
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_records::conversions::proxima_record_to_vector;
 use proximadb_storage_common::storage_path::StoragePath;
 
@@ -314,7 +314,7 @@ pub struct HelixEngine {
     /// - Batch processing for throughput
     ///
     /// Shared singleton across all distance operations
-    distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 
     /// **Storage Quantization Engine** (Optional, Collection-Aware)
     ///
@@ -528,9 +528,9 @@ impl HelixEngine {
     /// This helper converts our internal FilterExpression type to the
     /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
     fn convert_filter_to_index(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
         use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
@@ -687,9 +687,7 @@ impl HelixEngine {
         let distance_compute = if let Some(compute) = distance_compute_override {
             compute
         } else {
-            Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-            )
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default())
         };
 
         // Initialize dual quantization architecture

--- a/src/storage/engines/helix/progressive_search.rs
+++ b/src/storage/engines/helix/progressive_search.rs
@@ -7,11 +7,11 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationLevel;
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 use super::clustering::HilbertKey;
 use super::{HelixConfig, SStableMetadata};

--- a/src/storage/engines/helix/progressive_stages.rs
+++ b/src/storage/engines/helix/progressive_stages.rs
@@ -13,11 +13,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// HELIX-specific Binary stage adapter
 ///
@@ -260,8 +260,8 @@ pub fn create_helix_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/helix/proxima.rs
+++ b/src/storage/engines/helix/proxima.rs
@@ -821,10 +821,10 @@ pub async fn search_helix_sstable(
     query_vector: &[f32],
     query_hilbert_key: Option<u64>,
     k: usize,
-    distance_metric: &crate::compute::distance_computation::DistanceMetric,
-    distance_compute: &Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_metric: &proximadb_distance_kernel::DistanceMetric,
+    distance_compute: &Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
     collection: Option<&crate::proto::proximadb_v1::Collection>,
-    filter_expression: Option<&crate::core::search::FilterExpression>,
+    filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     prune: &crate::core::search::BlockPruneConfig,
 ) -> Result<
     Vec<(
@@ -960,7 +960,7 @@ pub async fn search_helix_sstable(
 fn select_blocks_by_centroid(
     query_vector: &[f32],
     metas: &[HelixBlockMetadata],
-    metric: &crate::compute::distance_computation::DistanceMetric,
+    metric: &proximadb_distance_kernel::DistanceMetric,
     prune: &crate::core::search::BlockPruneConfig,
 ) -> Vec<usize> {
     use crate::storage::engines::core::formats::proximablocks::spatial_pruning::{
@@ -1107,10 +1107,9 @@ fn _l2_distance(a: &[f32], b: &[f32]) -> f32 {
 fn metric_distance(
     a: &[f32],
     b: &[f32],
-    metric: &crate::compute::distance_computation::DistanceMetric,
+    metric: &proximadb_distance_kernel::DistanceMetric,
 ) -> f32 {
-    let distance_compute =
-        crate::compute::distance_computation::engine::UnifiedDistanceCompute::default();
+    let distance_compute = proximadb_distance_kernel::engine::UnifiedDistanceCompute::default();
     distance_compute.distance_with_metric(a, b, metric)
 }
 
@@ -1155,7 +1154,7 @@ mod tests {
         let selected = select_blocks_by_centroid(
             &query,
             &metas,
-            &crate::compute::distance_computation::DistanceMetric::Euclidean,
+            &proximadb_distance_kernel::DistanceMetric::Euclidean,
             &crate::core::search::BlockPruneConfig::for_testing(),
         );
         // max(3, sqrt(4)) = 3 -> expect the three closest indices 0, 2, 1

--- a/src/storage/engines/helix/proximablocks_strategy_reader.rs
+++ b/src/storage/engines/helix/proximablocks_strategy_reader.rs
@@ -112,7 +112,7 @@ impl UnifiedHELIXReader {
     pub fn for_spatial_locality_query(
         filesystem_factory: Arc<FilesystemFactory>,
         collection_id: String,
-        filter: Option<crate::core::search::FilterExpression>,
+        filter: Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<Self> {
         Self::new(
             filesystem_factory,

--- a/src/storage/engines/helix/readers.rs
+++ b/src/storage/engines/helix/readers.rs
@@ -9,11 +9,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::persistence::filesystem::FileSystem;
+use proximadb_distance_kernel::DistanceMetric;
 
 use super::SStableMetadata;
 // Filter evaluator now uses unified module from core
@@ -68,8 +68,8 @@ pub async fn search_sstable(
     _query_hilbert_key: Option<u64>,
     k: usize,
     distance_metric: &DistanceMetric,
-    distance_compute: &Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
-    filter_expression: Option<&crate::core::search::FilterExpression>,
+    distance_compute: &Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
+    filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     candidate_ids: Option<&[String]>, // Optional IDs to check via bloom filter
     collection: Option<&crate::proto::proximadb_v1::Collection>,
     prune: &crate::core::search::BlockPruneConfig,
@@ -208,8 +208,8 @@ pub async fn parallel_search(
     query_hilbert_key: Option<u64>,
     k: usize,
     distance_metric: DistanceMetric,
-    distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
-    filter_expression: Option<crate::core::search::FilterExpression>,
+    distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
+    filter_expression: Option<proximadb_filter_expression::FilterExpression>,
     collection: Option<std::sync::Arc<crate::proto::proximadb_v1::Collection>>,
     block_prune: crate::core::search::BlockPruneConfig,
 ) -> Result<Vec<OptimizedSearchRecord>> {
@@ -328,7 +328,7 @@ pub async fn search_with_stats(
     query_hilbert_key: Option<u64>,
     k: usize,
     distance_metric: &DistanceMetric,
-    distance_compute: &Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_compute: &Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 ) -> Result<(Vec<OptimizedSearchRecord>, HelixReaderQueryStats)> {
     let mut stats = HelixReaderQueryStats::default();
     let mut priority_queue = BoundedPriorityQueue::new(k);

--- a/src/storage/engines/impls_tests/helix/core_tests.rs
+++ b/src/storage/engines/impls_tests/helix/core_tests.rs
@@ -18,7 +18,7 @@
 //! **Total Tests**: 22
 
 use super::helpers::*;
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::core::bloom::{BloomFilterConfig, factory::BloomFilterFactory};
 use crate::core::search::SearchParams;
 use crate::core::search::results::OptimizedSearchRecord;

--- a/src/storage/engines/impls_tests/helix/helpers.rs
+++ b/src/storage/engines/impls_tests/helix/helpers.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use crate::proto::proximadb_v1::{
     Collection, CollectionConfig, CollectionStats, DistanceMetric as ProtoDistanceMetric,
     StorageAssignment, StorageEngine, VectorRecord,

--- a/src/storage/engines/impls_tests/helix/integration_tests.rs
+++ b/src/storage/engines/impls_tests/helix/integration_tests.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use tempfile::{TempDir, tempdir};
 use tokio::sync::RwLock;
 
-use crate::compute::distance_computation::DistanceMetric as ComputeDistanceMetric;
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
+use proximadb_distance_kernel::DistanceMetric as ComputeDistanceMetric;
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::core::search::SearchParams;
 use crate::proto::proximadb_v1::Collection;
@@ -775,7 +775,7 @@ async fn test_flush_operation() {
             .unwrap(),
     );
     let distance_compute =
-        Arc::new(crate::compute::distance_computation::engine::UnifiedDistanceCompute::default());
+        Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
     let config = HelixConfig::default();
     let engine = HelixEngine::new_with_config(config, filesystem_factory, distance_compute)
@@ -848,7 +848,7 @@ async fn test_vector_search() {
             .unwrap(),
     );
     let distance_compute =
-        Arc::new(crate::compute::distance_computation::engine::UnifiedDistanceCompute::default());
+        Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
     let config = HelixConfig::default();
     let engine = HelixEngine::new_with_config(config, filesystem_factory, distance_compute)
@@ -949,7 +949,7 @@ async fn test_vector_by_id() {
             .unwrap(),
     );
     let distance_compute =
-        Arc::new(crate::compute::distance_computation::engine::UnifiedDistanceCompute::default());
+        Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
     let config = HelixConfig::default();
     let engine = HelixEngine::new_with_config(config, filesystem_factory, distance_compute)
@@ -1024,7 +1024,7 @@ async fn test_compaction() {
             .unwrap(),
     );
     let distance_compute =
-        Arc::new(crate::compute::distance_computation::engine::UnifiedDistanceCompute::default());
+        Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
     let mut config = HelixConfig::default();
     config.level0_file_num_compaction_trigger = 2;
@@ -1215,7 +1215,7 @@ async fn test_proxima_integration() {
     // Search SSTable
     let query = vec![0.5; 128];
     let distance_compute = Arc::new(
-        crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
+        proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
             ComputeDistanceMetric::Euclidean,
         ),
     );
@@ -1254,7 +1254,7 @@ async fn test_metrics_collection() {
             .unwrap(),
     );
     let distance_compute =
-        Arc::new(crate::compute::distance_computation::engine::UnifiedDistanceCompute::default());
+        Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
     let config = HelixConfig::default();
     let engine = HelixEngine::new_with_config(config, filesystem_factory, distance_compute)

--- a/src/storage/engines/impls_tests/nova/core_tests.rs
+++ b/src/storage/engines/impls_tests/nova/core_tests.rs
@@ -13,7 +13,7 @@
 //! Total: 11 tests
 
 use std::sync::Arc;
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::storage::engines::nova::*;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::traits::UnifiedStorageFormat;
@@ -30,10 +30,10 @@ async fn test_optimized_viper_operations() {
     // Test compute mode selection
     let small_vectors = vec![vec![0.0; 128]; 10];
     let mode = ops.select_compute_mode(&small_vectors);
-    assert_eq!(mode, crate::compute::distance_computation::DistanceMode::Normalized);
+    assert_eq!(mode, proximadb_distance_kernel::DistanceMode::Normalized);
     let large_vectors = vec![vec![0.0; 768]; 1000];
     let mode = ops.select_compute_mode(&large_vectors);
-    assert_eq!(mode, crate::compute::distance_computation::DistanceMode::Normalized);
+    assert_eq!(mode, proximadb_distance_kernel::DistanceMode::Normalized);
 }
 
 #[test]

--- a/src/storage/engines/impls_tests/nova/optimization_tests.rs
+++ b/src/storage/engines/impls_tests/nova/optimization_tests.rs
@@ -34,7 +34,7 @@ use crate::storage::engines::nova::{
     zone_maps::*,
     streaming_search::*,
 };
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 
 // ============================================================================
 // Hierarchical Statistics Tests (4 tests)

--- a/src/storage/engines/impls_tests/raptor/helpers.rs
+++ b/src/storage/engines/impls_tests/raptor/helpers.rs
@@ -17,7 +17,7 @@
 //! - Distance calculations
 //! - Matrix building and verification
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::storage::engines::core::ops::proximacodec::types::ProximaScheme;
 use std::sync::Arc;
 

--- a/src/storage/engines/impls_tests/raptor/integration_tests.rs
+++ b/src/storage/engines/impls_tests/raptor/integration_tests.rs
@@ -420,7 +420,7 @@ async fn test_clustering_integration() -> Result<()> {
         }),
         min_vectors_for_clustering: 3,
         max_clusters: 10,
-        distance_metric: crate::compute::distance_computation::DistanceMetric::Cosine,
+        distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
         adaptive_cluster_count: false,
         recompute_threshold: 100,
         enable_incremental: false,
@@ -749,7 +749,7 @@ async fn test_raptor_large_scale_search_benchmark() -> Result<()> {
     let search_params = Arc::new(crate::core::search::SearchParams {
         query_vectors: Some(vec![query_vector]),
         top_k: Some(10),
-        distance_metric: Some(crate::compute::distance_computation::DistanceMetric::Euclidean),
+        distance_metric: Some(proximadb_distance_kernel::DistanceMetric::Euclidean),
         ..Default::default()
     });
 
@@ -769,7 +769,7 @@ async fn test_raptor_large_scale_search_benchmark() -> Result<()> {
         use_axis_indexes: false,
         has_quantization: false,
         dimension,
-        distance_metric: crate::compute::distance_computation::DistanceMetric::Euclidean,
+        distance_metric: proximadb_distance_kernel::DistanceMetric::Euclidean,
         storage_strategy: crate::storage::traits::StorageFormatStrategy::Raptor,
         storage_path: storage_path.clone(), // CRITICAL: This tells RAPTOR where to find files
         quantization_config: None,

--- a/src/storage/engines/impls_tests/raptor/matrix_tests.rs
+++ b/src/storage/engines/impls_tests/raptor/matrix_tests.rs
@@ -24,7 +24,7 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::storage::engines::core::ops::proximacodec::types::ProximaScheme;
 use crate::storage::engines::raptor::common::VectorCentroidStorageStrategy;
@@ -120,7 +120,7 @@ async fn test_build_p2_matrix() -> Result<()> {
 
     // Compute upper triangle distances manually
     let distance_compute = UnifiedDistanceCompute::new(
-        crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+        proximadb_distance_kernel::engine::DistanceMetric::Cosine,
     );
     let mut distances = Vec::new();
 
@@ -166,7 +166,7 @@ async fn test_p2_matrix_proximaencoder() -> Result<()> {
 
     // Compute distances and quantize
     let distance_compute = UnifiedDistanceCompute::new(
-        crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+        proximadb_distance_kernel::engine::DistanceMetric::Cosine,
     );
     let mut distances = Vec::new();
 

--- a/src/storage/engines/impls_tests/sst/flush_tests.rs
+++ b/src/storage/engines/impls_tests/sst/flush_tests.rs
@@ -38,7 +38,7 @@ use crate::storage::engines::sst::{
 };
 use crate::core::SstConfig;
 use crate::storage::persistence::filesystem::{FilesystemFactory, FilesystemConfig};
-use crate::compute::distance_computation::{
+use proximadb_distance_kernel::{
     engine::UnifiedDistanceCompute,
     DistanceMetric,
 };

--- a/src/storage/engines/impls_tests/sst/helpers.rs
+++ b/src/storage/engines/impls_tests/sst/helpers.rs
@@ -22,8 +22,8 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::{InMemoryCodebookStore, UnifiedQuantizationEngine};
 use crate::core::SstConfig;
 use crate::core::search::results::OptimizedSearchRecord;

--- a/src/storage/engines/impls_tests/sst/search_tests.rs
+++ b/src/storage/engines/impls_tests/sst/search_tests.rs
@@ -32,8 +32,8 @@ use crate::storage::engines::sst::search::{SearchCoordinator, SearchOperations, 
 use crate::storage::engines::sst::search::coordinator::SearchStrategy;
 use crate::storage::engines::sst::search::optimizer::{OptimizationStrategy, OptimizationConfig};
 
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::compute::quantization::quantization_engine::{UnifiedQuantizationEngine, InMemoryCodebookStore};
 
 use crate::core::bloom::{BloomFilterConfig, BloomFilterStrategy, MetadataBloomFilter};
@@ -41,7 +41,8 @@ use crate::core::bloom::factory::BloomFilterFactory;
 use crate::core::bloom::strategies::composite::CompositeBloomFilterBuilder;
 use crate::core::bloom::{BloomFilterStats, SstableBloomFilter};
 
-use crate::core::search::{SearchParams, SearchPlan, FilterExpression, ComparisonOperator};
+use crate::core::search::{SearchParams, SearchPlan};
+use proximadb_filter_expression::{FilterExpression, ComparisonOperator};
 use crate::storage::engines::core::search::SearchResult;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::storage::traits::StorageQueryContext;

--- a/src/storage/engines/impls_tests/swift/core_tests.rs
+++ b/src/storage/engines/impls_tests/swift/core_tests.rs
@@ -27,8 +27,8 @@ async fn test_swift_engine_creation() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
     // Need to create distance engine and axis manager for new()
     let _distance_engine = Arc::new(
-        crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+        proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
         ),
     );
     let engine = crate::storage::engines::swift::SwiftEngine::new()
@@ -43,8 +43,8 @@ async fn test_swift_feature_support() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
     // Need to create distance engine and axis manager for new()
     let _distance_engine = Arc::new(
-        crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+        proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
         ),
     );
     let engine = crate::storage::engines::swift::SwiftEngine::new()

--- a/src/storage/engines/impls_tests/swift/helpers.rs
+++ b/src/storage/engines/impls_tests/swift/helpers.rs
@@ -18,8 +18,8 @@
 
 use std::sync::Arc;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use crate::proto::proximadb_v1::{MetadataItem, VectorRecord};
 #[allow(deprecated)]
 use crate::storage::engines::swift::{SwiftEngine, SwiftFile};

--- a/src/storage/engines/impls_tests/swift/reader_tests.rs
+++ b/src/storage/engines/impls_tests/swift/reader_tests.rs
@@ -13,7 +13,7 @@ use crate::storage::persistence::filesystem::{FilesystemFactory, FilesystemConfi
 use crate::storage::engines::core::read_strategy::ReadAccessStrategy;
 use std::sync::Arc;
 use std::collections::BinaryHeap;
-use crate::compute::distance_computation::{UnifiedDistanceCompute, DistanceMetric};
+use proximadb_distance_kernel::{UnifiedDistanceCompute, DistanceMetric};
 
 // =====================================================
 // TESTS FROM unified_reader.rs

--- a/src/storage/engines/impls_tests/viper/core_tests.rs
+++ b/src/storage/engines/impls_tests/viper/core_tests.rs
@@ -6,7 +6,7 @@
 
 #[tokio::test]
 async fn test_viper_predicate_pushdown() {
-    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use crate::storage::engines::viper::column_filter::VIPERColumnFilterEvaluator;
     use tracing::debug;
 
@@ -27,7 +27,7 @@ async fn test_viper_predicate_pushdown() {
 
 #[tokio::test]
 async fn test_parallel_column_evaluation() {
-    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use crate::storage::engines::viper::column_filter::VIPERColumnFilterEvaluator;
     use tracing::debug;
 

--- a/src/storage/engines/impls_tests/viper/engine_tests.rs
+++ b/src/storage/engines/impls_tests/viper/engine_tests.rs
@@ -136,7 +136,7 @@ async fn test_single_vector_operations() {
     let search_params = crate::core::search::SearchParams {
         vector: Some(vector.vector.clone()),
         top_k: Some(1),
-        distance_metric: Some(crate::compute::distance_computation::DistanceMetric::Cosine),
+        distance_metric: Some(proximadb_distance_kernel::DistanceMetric::Cosine),
         ..Default::default()
     };
     let collection = create_test_collection(collection_id, temp_dir.path().to_str().unwrap());

--- a/src/storage/engines/impls_tests/viper/helpers.rs
+++ b/src/storage/engines/impls_tests/viper/helpers.rs
@@ -418,7 +418,7 @@ pub fn convert_search_params_to_plan(
     params: &crate::core::search::SearchParams,
     collection_id: &str,
 ) -> crate::core::search::search_interface::SearchPlan {
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     use crate::core::search::search_interface::{CollectionConfig, SearchPlan, StorageInfo};
 
     SearchPlan {

--- a/src/storage/engines/impls_tests/viper/reader_tests.rs
+++ b/src/storage/engines/impls_tests/viper/reader_tests.rs
@@ -15,9 +15,10 @@ use tempfile::TempDir;
 use tracing::debug;
 
 // Core imports
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::core::search::search_interface::{CollectionConfig, SearchPlan, StorageInfo};
-use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+use crate::core::search::SearchParams;
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 use crate::proto::proximadb_v1::{SqlValue, VectorRecord, sql_value};
 use crate::storage::engines::core::formats::columnar::CollectionContext;
 use crate::storage::engines::core::formats::columnar::columnar_query_engine::columnar_query_reader::UnifiedParquetReader;

--- a/src/storage/engines/nova/columnar_integration.rs
+++ b/src/storage/engines/nova/columnar_integration.rs
@@ -4,16 +4,12 @@
 //! while maintaining NOVA-specific optimizations like hierarchical statistics,
 //! zone maps, and streaming processing.
 
-use crate::compute::distance_computation::DistanceMetric;
 use anyhow::Result;
+use proximadb_distance_kernel::DistanceMetric;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::{
-    Int8VectorData, QuantizedDistanceCalculator, QuantizedDistanceConfig, QuantizedVectorData,
-    SelectedFormat,
-};
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::engines::core::formats::columnar::common::{
     NovaOptimizations, StreamingProcessingConfig, ZoneMapOptimization,
@@ -22,6 +18,10 @@ use crate::storage::engines::core::formats::columnar::{
     ColumnarFilterableSpec, CommonColumnarConfig, CommonColumnarOperations, QuantizationConfig,
 };
 use crate::storage::persistence::filesystem::FilesystemFactory;
+use proximadb_distance_kernel::{
+    Int8VectorData, QuantizedDistanceCalculator, QuantizedDistanceConfig, QuantizedVectorData,
+    SelectedFormat,
+};
 
 /// NOVA engine wrapper using unified columnar infrastructure
 pub struct NovaUnifiedEngine {
@@ -44,7 +44,7 @@ pub struct NovaUnifiedEngine {
     collection_cache: Arc<tokio::sync::RwLock<HashMap<String, NovaCollectionMetadata>>>,
 
     /// Distance computation engine
-    distance_compute: Arc<crate::compute::distance_computation::UnifiedDistanceCompute>,
+    distance_compute: Arc<proximadb_distance_kernel::UnifiedDistanceCompute>,
 }
 
 /// NOVA-specific configuration
@@ -405,7 +405,7 @@ impl NovaUnifiedEngine {
 
         // Initialize distance compute engine
         let distance_compute =
-            Arc::new(crate::compute::distance_computation::UnifiedDistanceCompute::default());
+            Arc::new(proximadb_distance_kernel::UnifiedDistanceCompute::default());
 
         info!("NOVA engine initialized with unified infrastructure and hierarchical optimizations");
 
@@ -892,10 +892,10 @@ impl NovaUnifiedEngine {
     async fn compute_progressive_distances(
         &self,
         query_vector: &[f32],
-        quantized_vectors: &[crate::compute::distance_computation::QuantizedVectorData],
+        quantized_vectors: &[proximadb_distance_kernel::QuantizedVectorData],
         target_quality: f32,
         _top_k: usize,
-    ) -> Result<Vec<crate::compute::distance_computation::QuantizedDistanceResult>> {
+    ) -> Result<Vec<proximadb_distance_kernel::QuantizedDistanceResult>> {
         // Progressive distance computation using best available representation
         let mut results = Vec::new();
         let distance_metric = DistanceMetric::Cosine; // Get from collection config in production
@@ -924,14 +924,14 @@ impl NovaUnifiedEngine {
                 // Approximate: use binary hamming distance
                 let hamming_distance = compute_hamming_distance(query_vector, binary_vec);
                 let _normalized = 1.0 - (hamming_distance as f32 / (binary_vec.len() * 8) as f32);
-                let sim = crate::compute::distance_computation::engine::SimilarityResult::new(
+                let sim = proximadb_distance_kernel::engine::SimilarityResult::new(
                     hamming_distance as f32,
                     DistanceMetric::Hamming,
                 );
                 (sim, 0.60) // ~60% quality for binary
             } else {
                 // No data available
-                let sim = crate::compute::distance_computation::engine::SimilarityResult::new(
+                let sim = proximadb_distance_kernel::engine::SimilarityResult::new(
                     f32::MAX,
                     DistanceMetric::Cosine,
                 );
@@ -939,13 +939,11 @@ impl NovaUnifiedEngine {
             };
 
             // Create QuantizedDistanceResult
-            let result = crate::compute::distance_computation::quantized::QuantizedDistanceResult {
+            let result = proximadb_distance_kernel::quantized::QuantizedDistanceResult {
                 similarity: similarity.normalized_score,
                 quality_estimate,
-                method:
-                    crate::compute::distance_computation::quantized::ComputationMethod::ExactFP32,
-                metrics: crate::compute::distance_computation::quantized::DistanceMetrics::default(
-                ),
+                method: proximadb_distance_kernel::quantized::ComputationMethod::ExactFP32,
+                metrics: proximadb_distance_kernel::quantized::DistanceMetrics::default(),
             };
 
             results.push(result);
@@ -961,7 +959,7 @@ impl NovaUnifiedEngine {
 
     async fn rank_and_filter_results(
         &self,
-        mut distance_results: Vec<crate::compute::distance_computation::QuantizedDistanceResult>,
+        mut distance_results: Vec<proximadb_distance_kernel::QuantizedDistanceResult>,
         top_k: usize,
         _search_options: &AdvancedSearchOptions,
     ) -> Result<Vec<NovaSearchResult>> {
@@ -1035,7 +1033,7 @@ pub struct AdvancedSearchOptions {
     pub target_quality: f32,
     pub enable_progressive: bool,
     pub max_vectors_to_evaluate: Option<usize>,
-    pub format_preference: Option<crate::compute::distance_computation::SelectedFormat>,
+    pub format_preference: Option<proximadb_distance_kernel::SelectedFormat>,
     pub enable_hierarchical_pruning: bool,
     pub enable_zone_map_pruning: bool,
 }

--- a/src/storage/engines/nova/columnar_search.rs
+++ b/src/storage/engines/nova/columnar_search.rs
@@ -9,12 +9,12 @@ use std::sync::Arc;
 use tokio::sync::{Semaphore, mpsc};
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::engines::core::formats::columnar::{
     MetadataFilter, columnar_query_engine::columnar_query_reader::UnifiedParquetReader,
 };
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 
 use super::{
     NovaFile,
@@ -348,11 +348,10 @@ impl NovaColumnarSearch {
         while let Some(candidates) = rx.recv().await {
             for (record, distance) in candidates {
                 // Create SimilarityResult using constructor
-                let similarity_result =
-                    crate::compute::distance_computation::engine::SimilarityResult::new(
-                        distance,
-                        distance_metric,
-                    );
+                let similarity_result = proximadb_distance_kernel::engine::SimilarityResult::new(
+                    distance,
+                    distance_metric,
+                );
 
                 heap.push(SearchCandidate {
                     row_group_id: 0,
@@ -436,9 +435,7 @@ impl NovaColumnarSearch {
             for record in batch {
                 // Create distance compute instance and compute distance
                 let distance_compute =
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                        distance_metric,
-                    );
+                    proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric);
                 let distance_result = distance_compute.calculate_distance(
                     query_vector,
                     record
@@ -906,9 +903,7 @@ impl NovaColumnarSearch {
                     .collect();
 
                 let distance_compute =
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                        distance_metric,
-                    );
+                    proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric);
                 let distances = distance_compute.batch_distance_pooled_simd(
                     query_vector,
                     &batch_vectors,

--- a/src/storage/engines/nova/columnar_strategy_reader.rs
+++ b/src/storage/engines/nova/columnar_strategy_reader.rs
@@ -107,7 +107,7 @@ impl UnifiedNOVAReader {
     pub fn for_hierarchical_query(
         filesystem_factory: Arc<FilesystemFactory>,
         collection_id: String,
-        filter: Option<crate::core::search::FilterExpression>,
+        filter: Option<proximadb_filter_expression::FilterExpression>,
         dimension: u32,
     ) -> Result<Self> {
         Self::new(
@@ -201,7 +201,7 @@ impl UnifiedNOVAReader {
     /// Convert FilterExpression to MetadataFilter for columnar module
     fn convert_to_metadata_filter(
         &self,
-        _filter: &crate::core::search::FilterExpression,
+        _filter: &proximadb_filter_expression::FilterExpression,
     ) -> crate::storage::engines::core::formats::columnar::MetadataFilter {
         // Filter conversion: NOVA uses Parquet's built-in statistics and bloom filters.
         // Full FilterExpression → FilterConditions mapping requires expression visitor pattern.
@@ -220,7 +220,7 @@ impl UnifiedNOVAReader {
         &self,
         _metadata: &parquet::file::metadata::ParquetMetaData,
         _rg_idx: usize,
-        filter: &Option<crate::core::search::FilterExpression>,
+        filter: &Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<bool> {
         // If no filter, read all row groups
         if filter.is_none() {
@@ -237,7 +237,7 @@ impl UnifiedNOVAReader {
     #[allow(dead_code)]
     fn evaluate_filter(
         &self,
-        _filter: &crate::core::search::FilterExpression,
+        _filter: &proximadb_filter_expression::FilterExpression,
         _metadata: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<bool> {
         // Filter evaluation: accepts all records (conservative).

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -23,10 +23,10 @@ use tracing::{debug, info};
 // Health status handled internally
 use super::operations::{NovaCompactionOperations, NovaFlushOperations, NovaSearchOperations};
 use super::optimized_operations::OptimizedNovaOperations;
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::metrics::collectors::{EngineMetricsCollector, OperationTimer};
+use proximadb_distance_kernel::DistanceMetric;
 // Arrow schema handled by parquet reader
 
 // Performance optimization handled internally
@@ -209,7 +209,7 @@ pub struct NovaEngine {
     /// - Progressive refinement (coarse → fine distances)
     ///
     /// Shared singleton across all distance operations
-    _distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    _distance_engine: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 
     /// **Universal Performance Optimizer**
     ///
@@ -251,9 +251,8 @@ impl NovaEngine {
         // Initialize compression provider directly
         let compression_provider = StandardCompression;
         // Initialize unified quantization engine from compute module
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         let codebook_store = Arc::new(
             crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
         );
@@ -443,8 +442,7 @@ impl NovaEngine {
                             collection_id: collection_id.to_string(),
                             num_vectors: vectors.len() as u64,
                             dimension,
-                            distance_metric:
-                                crate::compute::distance_computation::DistanceMetric::Euclidean,
+                            distance_metric: proximadb_distance_kernel::DistanceMetric::Euclidean,
                             quantization: Default::default(),
                             column_stats: Default::default(),
                             version: 1,
@@ -1902,9 +1900,9 @@ impl NovaEngine {
     /// This helper converts our internal FilterExpression type to the
     /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
     fn convert_filter_to_index(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
         use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
@@ -1976,8 +1974,8 @@ impl NovaEngine {
         storage_path: &str,
         _query_vector: &[f32],
         top_k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
-        _filter_expression: Option<&crate::core::search::FilterExpression>,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
+        _filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         tracing::warn!("🔄 NOVA: Falling back to direct search implementation");
 
@@ -2005,10 +2003,8 @@ impl NovaEngine {
         // Insert all results into bounded queue
         for (record, distance) in all_results {
             // Use SimilarityResult for proper normalization
-            let similarity_result = crate::compute::distance_computation::SimilarityResult::new(
-                distance,
-                distance_metric,
-            );
+            let similarity_result =
+                proximadb_distance_kernel::SimilarityResult::new(distance, distance_metric);
 
             let search_record = OptimizedSearchRecord {
                 id: record.id.clone(),

--- a/src/storage/engines/nova/operations/search.rs
+++ b/src/storage/engines/nova/operations/search.rs
@@ -6,15 +6,15 @@ use proximadb_records::{ProximaRecord, conversions::proxima_tree_to_value_map};
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::storage::persistence::filesystem::FilesystemFactory;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Handles all search operations for NOVA engine
 pub struct NovaSearchOperations {
     filesystem: Arc<FilesystemFactory>,
-    distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_engine: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 }
 
 /// Operational kill-switch for TD-040 vector-bounds row-group pruning (shared
@@ -49,9 +49,7 @@ impl NovaSearchOperations {
         Self {
             filesystem,
             distance_engine: Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                    distance_metric,
-                ),
+                proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric),
             ),
         }
     }

--- a/src/storage/engines/nova/optimized_operations.rs
+++ b/src/storage/engines/nova/optimized_operations.rs
@@ -5,9 +5,9 @@ use anyhow::{Result, anyhow};
 use arrow_array::RecordBatch;
 // Arrow compute not available, would need full arrow crate
 // use arrow::compute::kernels::aggregate;
-use crate::compute::distance_computation::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
 use crate::core::{hardware_capabilities::HardwareCapabilities, memory::pool::VectorMemoryPool};
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
 use std::sync::Arc;
 use tracing::info;
 // Memory-mapped Parquet operations would be imported here

--- a/src/storage/engines/nova/progressive_search.rs
+++ b/src/storage/engines/nova/progressive_search.rs
@@ -6,11 +6,11 @@ use super::streaming_processor::{
     ProcessingStage, RowGroupProcessingResult, StreamingConfig, StreamingContext,
     StreamingRowGroupProcessor,
 };
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::proto::proximadb_v1::VectorRecord;
 use anyhow::Result;
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 use std::collections::BinaryHeap;
 use std::sync::Arc;
 use tracing::{debug, info, instrument};

--- a/src/storage/engines/nova/progressive_stages.rs
+++ b/src/storage/engines/nova/progressive_stages.rs
@@ -13,11 +13,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// NOVA-specific Binary stage adapter
 ///
@@ -228,8 +228,8 @@ pub fn create_nova_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/nova/streaming_search.rs
+++ b/src/storage/engines/nova/streaming_search.rs
@@ -17,8 +17,8 @@ use super::zone_maps::{
     AdvancedZoneMap, CostBasedOptimizer, OptimizationStrategy, PerformanceHistory, WorkloadStats,
     ZoneMapConfig,
 };
-use crate::compute::distance_computation::DistanceMetric;
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Unified streaming search engine for NOVA
 pub struct StreamingSearchEngine {
@@ -192,9 +192,8 @@ impl StreamingSearchEngine {
     /// Create new streaming search engine
     pub fn new(config: NovaStreamingSearchConfig) -> Self {
         // Create dependencies for progressive search
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         let quant_config =
             crate::compute::quantization::storage_engine::StorageQuantizationConfig::default();
         let unified_quantization_engine = Arc::new(

--- a/src/storage/engines/raptor/adaptive_pxk.rs
+++ b/src/storage/engines/raptor/adaptive_pxk.rs
@@ -7,10 +7,10 @@ use super::common::{
     VectorCentroidCompressionMetadata, VectorCentroidMatrix, VectorCentroidStorageStrategy,
 };
 use super::config::{CompressionStrategy, PxKStrategy};
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::proto::proximadb_v1::DistanceMetric;
 use anyhow::Result;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use std::collections::HashSet;
 
 /// Selection reason for sparse storage

--- a/src/storage/engines/raptor/common.rs
+++ b/src/storage/engines/raptor/common.rs
@@ -1192,10 +1192,10 @@ impl InterCentroidMatrix {
         let hw = get_hardware_capabilities();
 
         // Create required components for StorageQuantizationEngine
-        use crate::compute::distance_computation::DistanceMetric;
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
         use crate::compute::quantization::storage_engine::StorageQuantizationConfig;
+        use proximadb_distance_kernel::DistanceMetric;
+        use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
         use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
         let unified_engine = Arc::new(UnifiedQuantizationEngine::new(

--- a/src/storage/engines/raptor/consolidated_compactor.rs
+++ b/src/storage/engines/raptor/consolidated_compactor.rs
@@ -12,12 +12,12 @@ use super::common::{RaptorFileMetadata, RowGroup, RowGroupMetadata, SchemaDescri
 use super::config::RaptorConfig;
 use super::consolidated_reader::RaptorReader;
 use super::smart_rowgroup_sizing::BalancedMatrixTrinitySizing;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::index::axis::clustering::{
     AxisClusteringEngine as AxisClustering, ClusteringConfig as AxisClusteringConfig,
     ReusableClusteringEngine,
 };
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 // ProximaCodec is now used in writer.rs for encoding
 use crate::storage::persistence::filesystem::FileSystem;
 use crate::storage::transaction_coordinator::TransactionCoordinator;
@@ -310,7 +310,7 @@ impl RaptorCompactor {
         // This provides fast convergence for high-dimensional data
         // Deferred: Use AXIS clustering when available
         // use crate::index::axis::clustering::AxisClustering;
-        use crate::compute::distance_computation::engine::DistanceMetric;
+        use proximadb_distance_kernel::engine::DistanceMetric;
 
         // Convert VectorRecord to Vec<Vec<f32>> for AXIS clustering
         let vector_data: Vec<Vec<f32>> = vectors.iter().map(|v| v.vector.clone()).collect();

--- a/src/storage/engines/raptor/consolidated_reader.rs
+++ b/src/storage/engines/raptor/consolidated_reader.rs
@@ -16,11 +16,9 @@ use std::sync::Arc;
 use tracing::{debug, info, trace, warn};
 
 // Use unified components instead of custom implementations
-use crate::compute::distance_computation::engine::{
-    DistanceMetric, SimilarityResult, UnifiedDistanceCompute,
-};
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
+use proximadb_distance_kernel::engine::{DistanceMetric, SimilarityResult, UnifiedDistanceCompute};
 
 use crate::storage::cache::orchestrator::{CacheType, CrossCacheOrchestrator};
 use crate::storage::engines::core::ops::proximacodec::{ProximaCodec, types::ProximaScheme};
@@ -2789,7 +2787,7 @@ impl RaptorReader {
                     .calculate_distance(
                         &target_vector,
                         &centroid,
-                        &crate::compute::distance_computation::DistanceMetric::Cosine,
+                        &proximadb_distance_kernel::DistanceMetric::Cosine,
                     )
                     .raw_value;
                 cluster_distances.push((rg_id, distance));

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -16,7 +16,6 @@ use super::{
     RaptorConfig, RaptorWriter, RowGroups,
     consolidated_reader::{RaptorReader, ScanStrategy},
 };
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::core::hardware_capabilities::get_hardware_capabilities;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
@@ -26,6 +25,7 @@ use crate::storage::traits::{
     CompactionParameters, CompactionResult, FlushParameters, FlushResult, StorageQueryContext,
     UnifiedStorageFormat,
 };
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 use proximadb_records::conversions::proxima_record_to_vector;
 // IvfManager removed - Matrix Trinity handles clustering
 use super::smart_rowgroup_sizing::SmartRowGroupSizer;
@@ -441,9 +441,7 @@ impl RaptorEngine {
         );
         let fallback_quantization_engine = Arc::new(
             crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(
-                Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-                ),
+                Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default()),
                 Arc::new(
                     crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
                 ),
@@ -643,7 +641,7 @@ impl RaptorEngine {
             }),
             min_vectors_for_clustering: 100,
             max_clusters: 256,
-            distance_metric: crate::compute::distance_computation::DistanceMetric::Cosine,
+            distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
             adaptive_cluster_count: true,
             recompute_threshold: config.rowgroup_size / 2,
             enable_incremental: true,
@@ -895,7 +893,7 @@ impl RaptorEngine {
         query: &[f32],
         k: usize,
         filter: Option<HashMap<String, String>>,
-        distance_metric: &crate::compute::distance_computation::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
         storage_path: &str,
         collection_id: &str,
     ) -> Result<Vec<OptimizedSearchRecord>> {
@@ -990,7 +988,7 @@ impl RaptorEngine {
         query: &[f32],
         k: usize,
         filter: Option<HashMap<String, String>>,
-        distance_metric: &crate::compute::distance_computation::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
         storage_path: &str,
         collection_id: &str,
     ) -> Result<Vec<OptimizedSearchRecord>> {
@@ -1304,7 +1302,7 @@ impl RaptorEngine {
         query: &[f32],
         k: usize,
         selected_rowgroups: Vec<u32>,
-        distance_metric: &crate::compute::distance_computation::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
         storage_path: &str,
         collection_id: &str,
     ) -> Result<Vec<OptimizedSearchRecord>> {
@@ -1353,7 +1351,7 @@ impl RaptorEngine {
                 distances
                     .into_iter()
                     .map(|d| {
-                        crate::compute::distance_computation::engine::SimilarityResult::new(
+                        proximadb_distance_kernel::engine::SimilarityResult::new(
                             d,
                             *distance_metric,
                         )
@@ -1879,7 +1877,7 @@ impl RaptorEngine {
         &self,
         query: &[f32],
         k: usize,
-        distance_metric: &crate::compute::distance_computation::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
     ) -> Result<Vec<VectorSearchResult>> {
         let rowgroup_manager = self.rowgroup_manager.read().await;
         // For full scan, get all rowgroups
@@ -1917,7 +1915,7 @@ impl RaptorEngine {
                 distances
                     .into_iter()
                     .map(|d| {
-                        crate::compute::distance_computation::engine::SimilarityResult::new(
+                        proximadb_distance_kernel::engine::SimilarityResult::new(
                             d,
                             *distance_metric,
                         )
@@ -2885,9 +2883,9 @@ impl RaptorEngine {
     /// This helper converts our internal FilterExpression type to the
     /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
     fn convert_filter_to_index(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
         use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
@@ -3115,7 +3113,7 @@ impl UniversallyOptimized for RaptorEngine {
 #[cfg(test)]
 #[cfg(feature = "experimental-engines")]
 mod tests {
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     #[test]
     fn test_raptor_distance_computation_non_zero() {

--- a/src/storage/engines/raptor/matrix_builder.rs
+++ b/src/storage/engines/raptor/matrix_builder.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use tracing::warn;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::storage::engines::core::ops::proximacodec::types::ProximaScheme;
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 #[cfg(feature = "gpu")]
 use crate::compute::gpu::distance::GpuDistanceCompute;

--- a/src/storage/engines/raptor/progressive_stages.rs
+++ b/src/storage/engines/raptor/progressive_stages.rs
@@ -13,11 +13,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// RAPTOR-specific Binary stage adapter
 ///
@@ -301,8 +301,8 @@ pub fn create_raptor_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -66,11 +66,11 @@ use super::common::{
     RowGroupBloomFilter, RowGroupNeighbor,
 };
 use super::matrix_builder::MatrixBuilder;
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_runtime_common::pool::VectorMemoryPool;
 // ProximaCodec system for encoding/decoding
 use crate::storage::engines::core::ops::proximacodec::{
@@ -2597,7 +2597,7 @@ impl RaptorWriter {
 
         // Initialize unified distance compute first
         let distance_compute = Arc::new(UnifiedDistanceCompute::new(
-            crate::compute::distance_computation::DistanceMetric::Cosine,
+            proximadb_distance_kernel::DistanceMetric::Cosine,
         ));
 
         // Initialize codebook store for quantization
@@ -2621,7 +2621,7 @@ impl RaptorWriter {
         let quant_config =
             crate::compute::quantization::storage_engine::StorageQuantizationConfig {
                 enable_hardware_acceleration: config.enable_simd,
-                distance_metric: crate::compute::distance_computation::DistanceMetric::Cosine,
+                distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
                 ..Default::default() // INT8 by default, PQ requires explicit config
             };
 

--- a/src/storage/engines/sst/collections_tests.rs
+++ b/src/storage/engines/sst/collections_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::{SstConfig, SstEngine};
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -358,9 +358,8 @@ impl Compaction {
         // using the unified quantization engine
         if let Some(ref mut _compactor) = self.sst_compactor {
             // Create unified quantization engine for PQ-based sorting
-            let distance_compute = Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-            );
+            let distance_compute =
+                Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
             let codebook_store = Arc::new(
                 crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
             );
@@ -372,8 +371,8 @@ impl Compaction {
             );
             // Create distance compute engine
             let distance_compute = Arc::new(
-                crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                 ),
             );
             // Create quantization config

--- a/src/storage/engines/sst/compactor_impl.rs
+++ b/src/storage/engines/sst/compactor_impl.rs
@@ -1241,13 +1241,13 @@ struct WriterStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::compute::quantization::quantization_engine::{
         InMemoryCodebookStore, UnifiedQuantizationEngine,
     };
     use crate::compute::quantization::storage_engine::{
         StorageQuantizationConfig, StorageQuantizationEngine,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     // Note: Using StorageQuantizationConfig instead of removed SstQuantizationConfig
 
     #[tokio::test]
@@ -1299,9 +1299,8 @@ mod tests {
 
         // Note: Using StorageQuantizationConfig instead of undefined SstQuantizationConfig
         // Create storage quantization engine
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         let codebook_store = Arc::new(
             crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
         );
@@ -1324,7 +1323,7 @@ mod tests {
                     crate::compute::quantization::quantization_engine::UnifiedQuantizationLevel::int8(),
                 ),
                 distance_metric:
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                 enable_progressive: true,
                 filter_threshold: 100.0,
                 candidate_multiplier: 4,
@@ -1334,8 +1333,8 @@ mod tests {
             };
 
         let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                proximadb_distance_kernel::engine::DistanceMetric::Cosine,
             ),
         );
 

--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -27,7 +27,6 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::info;
 
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::{
     quantization_engine::{CodebookStore, InMemoryCodebookStore, UnifiedQuantizationEngine},
     storage_engine::StorageQuantizationEngine,
@@ -41,6 +40,7 @@ use crate::storage::engines::sst::{
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::{FileSystem, FilesystemFactory};
 use crate::storage::transaction_coordinator::TransactionCoordinator;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_records::ProximaRecord;
 
 // AXIS manager for HNSW/IVF index integration

--- a/src/storage/engines/sst/flush/coordinator.rs
+++ b/src/storage/engines/sst/flush/coordinator.rs
@@ -180,9 +180,9 @@ impl FlushCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     #[tokio::test]
     async fn test_flush_coordinator_validation() {

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -641,9 +641,9 @@ pub type SortStats = SortingStats;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     #[tokio::test]
     async fn test_sort_vectors_for_sstable_encoding() {
@@ -710,13 +710,13 @@ mod tests {
     /// real path exercised here.)
     #[tokio::test]
     async fn td112_live_flush_indexes_vectors_into_axis() {
-        use crate::compute::distance_computation::DistanceMetric;
         use crate::index::axis::management::manager::AxisManager;
         use crate::index::axis::types::AxisConfig;
         use crate::proto::proximadb_v1::{
             Collection, CollectionConfig, StorageAssignment, StorageEngine,
         };
         use crate::storage::traits::UnifiedStorageEngine;
+        use proximadb_distance_kernel::DistanceMetric;
 
         // Attach an AXIS manager (process-global OnceLock; a no-op if a prior test
         // already set one). We read the effective manager back from the engine so

--- a/src/storage/engines/sst/flush/operations.rs
+++ b/src/storage/engines/sst/flush/operations.rs
@@ -233,9 +233,9 @@ impl FlushOperations {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use proximadb_records::{EmbeddingCell, ProximaRecord};
     #[tokio::test]
     async fn test_validate_flush_preconditions() {

--- a/src/storage/engines/sst/multi_stage_filter.rs
+++ b/src/storage/engines/sst/multi_stage_filter.rs
@@ -16,11 +16,11 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use crate::core::bloom::SstableBloomFilter;
-use crate::core::search::{ComparisonOperator, FilterExpression};
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 use crate::storage::engines::sst::IndexEntry;
 use crate::storage::engines::sst::readers::sst_query_engine::ReadStrategy;
 use crate::storage::engines::sst::row_filter::{SSTBatchFilterEvaluator, SSTRowFilterEvaluator};
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
 /// Complete SST filtering pipeline with all three stages
 /// Uses immutable Arc types for optimal read performance
@@ -542,7 +542,7 @@ impl FilterStageStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use std::collections::HashMap;
 
     #[tokio::test]

--- a/src/storage/engines/sst/progressive_stages.rs
+++ b/src/storage/engines/sst/progressive_stages.rs
@@ -14,11 +14,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// SST-specific Binary stage adapter
 ///
@@ -232,8 +232,8 @@ pub fn create_sst_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/sst/readers/block_pruning.rs
+++ b/src/storage/engines/sst/readers/block_pruning.rs
@@ -1,7 +1,7 @@
-use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
 use crate::core::search::BlockPruneConfig;
 use crate::storage::engines::core::constants::pruning as pruning_constants;
 use crate::storage::engines::sst::IndexEntry;
+use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 use tracing::debug;
 
 /// Compute Z-Order code for a query vector using PCA transform.

--- a/src/storage/engines/sst/readers/sst_query_engine.rs
+++ b/src/storage/engines/sst/readers/sst_query_engine.rs
@@ -44,10 +44,9 @@ use tracing::{debug, error, info, trace, warn};
 // use std::hint::likely; // Unstable feature - removed for compilation
 
 use super::block_filter::{BlockFilter, IntelligentBlockFilter};
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::core::bloom::BloomFilterConfig;
 use crate::core::bloom::SstableBloomFilter;
-use crate::core::search::{FilterExpression, SearchParams};
+use crate::core::search::SearchParams;
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 use crate::storage::engines::core::formats::proximablocks::sst_io_layer::{
     SharedSstFormatReader, SstMmapStrategy, SstRegion,
@@ -55,6 +54,8 @@ use crate::storage::engines::core::formats::proximablocks::sst_io_layer::{
 use crate::storage::engines::sst::{IndexEntry, SstableHeader}; // OPTIMIZED: Removed SstRecord import
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use proximadb_compression::CompressionAlgorithm;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_filter_expression::FilterExpression;
 
 // Using UnifiedCachingFilesystem instead of ZeroCopyIOSystem
 use crate::storage::persistence::filesystem::FileSystem;
@@ -420,7 +421,7 @@ fn vector_bounds_prune_query(params: &SearchParams) -> Option<&[f32]> {
     }
     if !matches!(
         params.distance_metric,
-        Some(crate::compute::distance_computation::DistanceMetric::Euclidean)
+        Some(proximadb_distance_kernel::DistanceMetric::Euclidean)
     ) {
         return None;
     }
@@ -465,11 +466,9 @@ fn vector_bounds_provisional_threshold(
     if k == 0 {
         return None;
     }
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     let distance_compute =
-        crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-            DistanceMetric::Euclidean,
-        );
+        proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(DistanceMetric::Euclidean);
     let mut queue = BoundedPriorityQueue::new(k);
     for block in seed_blocks {
         for record in &block.records {
@@ -914,7 +913,7 @@ impl ModularBlockReader {
         query_vector: &[f32],
         k: usize,
         filter: Option<&FilterExpression>,
-        distance_metric: &crate::compute::distance_computation::engine::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::engine::DistanceMetric,
     ) -> Result<Vec<OptimizedSearchRecord>> {
         // Always use traditional search (quantization handled at a higher level)
         self.traditional_search(query_vector, k, filter, distance_metric)
@@ -930,7 +929,7 @@ impl ModularBlockReader {
         query_vector: &[f32],
         k: usize,
         _filter: Option<&FilterExpression>,
-        distance_metric: &crate::compute::distance_computation::engine::DistanceMetric,
+        distance_metric: &proximadb_distance_kernel::engine::DistanceMetric,
     ) -> Result<Vec<OptimizedSearchRecord>> {
         info!("📝 Fallback: Using traditional search (no quantization)");
 
@@ -945,11 +944,9 @@ impl ModularBlockReader {
         // Hoisted out of the per-record loop: instantiating UnifiedDistanceCompute
         // and dispatching SIMD once per vector was per-record overhead. With the
         // batch entry point we get one SIMD dispatch per block.
-        let distance_compute =
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default();
-        let mut distance_results: Vec<
-            crate::compute::distance_computation::engine::SimilarityResult,
-        > = Vec::new();
+        let distance_compute = proximadb_distance_kernel::engine::UnifiedDistanceCompute::default();
+        let mut distance_results: Vec<proximadb_distance_kernel::engine::SimilarityResult> =
+            Vec::new();
 
         // Scan all blocks and compute distances
         for (block_idx, _index_entry) in index_entries.iter().enumerate() {
@@ -1395,8 +1392,9 @@ impl ModularBlockReader {
 #[cfg(test)]
 mod vector_bounds_prune_tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
-    use crate::core::search::{BlockPruneConfig, FilterExpression};
+    use crate::core::search::BlockPruneConfig;
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_filter_expression::FilterExpression;
 
     fn euclidean_params(query: Vec<f32>) -> SearchParams {
         SearchParams {
@@ -2234,7 +2232,7 @@ impl UnifiedSstableReader {
         query_vector: &[f32],
         filter: Option<FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         collection: Option<&crate::proto::proximadb_v1::Collection>,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         // Delegate to the new version with default (sqrt) block pruning
@@ -2260,7 +2258,7 @@ impl UnifiedSstableReader {
         query_vector: &[f32],
         filter: Option<FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         collection: Option<&crate::proto::proximadb_v1::Collection>,
         block_prune: &crate::core::search::BlockPruneConfig,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
@@ -2323,9 +2321,7 @@ impl UnifiedSstableReader {
         // dropping from ~62 ms to ~10–20 ms range on aarch64/NEON.
         let mut priority_queue = BoundedPriorityQueue::new(k);
         let distance_compute =
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                distance_metric,
-            );
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric);
 
         for block in blocks {
             for record in block.records {
@@ -2398,7 +2394,7 @@ impl UnifiedSstableReader {
         query_vector: &[f32],
         filter: Option<FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         collection: Option<&crate::proto::proximadb_v1::Collection>,
         block_prune: &crate::core::search::BlockPruneConfig,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
@@ -2437,9 +2433,7 @@ impl UnifiedSstableReader {
 
         // Create distance compute engine
         let distance_compute =
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                distance_metric,
-            );
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric);
 
         // Process blocks with vectorized filtering + deferred
         // materialization (same optimization as the scalar path —
@@ -2524,7 +2518,7 @@ impl UnifiedSstableReader {
         query_vector: &[f32],
         filter: Option<FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         collection: Option<&crate::proto::proximadb_v1::Collection>,
         block_prune: &crate::core::search::BlockPruneConfig,
         max_workers: Option<usize>,
@@ -2619,9 +2613,7 @@ impl UnifiedSstableReader {
                 async move {
                     // Create distance compute for this morsel
                     let distance_compute =
-                        crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                            metric,
-                        );
+                        proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(metric);
 
                     // Process each record in the morsel
                     let mut results = Vec::new();
@@ -2694,7 +2686,7 @@ impl UnifiedSstableReader {
         query_vector: &[f32],
         filter: Option<FilterExpression>,
         k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         collection: Option<&crate::proto::proximadb_v1::Collection>,
         block_prune: &crate::core::search::BlockPruneConfig,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
@@ -2743,9 +2735,7 @@ impl UnifiedSstableReader {
         );
 
         let distance_compute =
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                distance_metric,
-            );
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric);
         let mut queue = BoundedPriorityQueue::new(k);
 
         for record in &all_records {
@@ -2839,8 +2829,8 @@ impl UnifiedSstableReader {
         &self,
         filter: &FilterExpression,
     ) -> Result<crate::storage::engines::core::formats::columnar::FilterCondition> {
-        use crate::core::search::ComparisonOperator;
         use crate::storage::engines::core::formats::columnar::FilterCondition;
+        use proximadb_filter_expression::ComparisonOperator;
 
         // Convert FilterExpression to FilterCondition for vectorized executor
         match filter {
@@ -3673,9 +3663,8 @@ impl UnifiedSstableReader {
                 }
 
                 // Calculate similarity using unified distance computation for semantic correctness
-                let metric = distance_metric.unwrap_or(
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
-                );
+                let metric = distance_metric
+                    .unwrap_or(proximadb_distance_kernel::engine::DistanceMetric::Cosine);
                 let similarity = distance_compute.calculate_distance(query_vector, vector, &metric);
 
                 // Use normalized_score for consistency across all engines
@@ -6129,7 +6118,7 @@ impl UnifiedSstableReader {
         survivors: &[usize],
         query: &[f32],
     ) -> Vec<usize> {
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
         let mut scored: Vec<(f32, usize)> = survivors
             .iter()
             .map(|&block_idx| {
@@ -6348,7 +6337,7 @@ impl UnifiedSstableReader {
         filter: &FilterExpression,
         conditions: &mut Vec<(String, serde_json::Value)>,
     ) {
-        use crate::core::search::ComparisonOperator;
+        use proximadb_filter_expression::ComparisonOperator;
 
         match filter {
             FilterExpression::Comparison {
@@ -6499,7 +6488,7 @@ impl UnifiedSstableReader {
         // Fallback: No spatial codes, use centroid-based pruning only
         let metric = _params
             .distance_metric
-            .unwrap_or(crate::compute::distance_computation::DistanceMetric::Cosine);
+            .unwrap_or(proximadb_distance_kernel::DistanceMetric::Cosine);
 
         select_blocks_by_centroid(query, _index_blocks, metric, &_params.block_prune)
     }

--- a/src/storage/engines/sst/readers/tests.rs
+++ b/src/storage/engines/sst/readers/tests.rs
@@ -94,7 +94,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &crate::core::search::BlockPruneConfig::for_testing(),
         );
         // sqrt(4) = 2 => expect the two closest blocks by centroid: block_ids 0 and 2.
@@ -162,7 +162,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
 
@@ -252,7 +252,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
 
@@ -363,7 +363,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
 
@@ -454,7 +454,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
 
@@ -507,7 +507,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
 
@@ -1083,7 +1083,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(selected.len(), 4, "None mode should return all 4 blocks");
@@ -1114,7 +1114,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1146,7 +1146,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1178,7 +1178,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1208,7 +1208,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1240,7 +1240,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1272,7 +1272,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         // Order: Fixed(1) -> max(1,5)=5 -> min(5,3)=3 -> clamp(3,1,5)=3
@@ -1299,7 +1299,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1324,7 +1324,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(selected.len(), 1, "Single block should always be selected");
@@ -1350,7 +1350,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::Euclidean,
             &prune_config,
         );
         assert_eq!(
@@ -1379,7 +1379,7 @@
         let selected = select_blocks_by_centroid(
             &query,
             &entries,
-            crate::compute::distance_computation::DistanceMetric::Cosine,
+            proximadb_distance_kernel::DistanceMetric::Cosine,
             &prune_config,
         );
         assert_eq!(selected.len(), 1, "Fixed(1) should return 1 block");

--- a/src/storage/engines/sst/row_filter.rs
+++ b/src/storage/engines/sst/row_filter.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
-use crate::core::search::FilterExpression;
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
+use proximadb_filter_expression::FilterExpression;
 use proximadb_records::ProximaRecord;
 
 /// Fast in-memory filter evaluator for row-oriented SST data

--- a/src/storage/engines/sst/row_filter_tests.rs
+++ b/src/storage/engines/sst/row_filter_tests.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use crate::core::search::{ComparisonOperator, FilterExpression};
     use crate::proto::proximadb_v1::VectorRecord;
     use crate::storage::engines::sst::row_filter::{
         SSTBatchFilterEvaluator, SSTRowFilterEvaluator,
     };
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use proximadb_records::ProximaRecord;
 
     #[tokio::test]

--- a/src/storage/engines/sst/search/coordinator.rs
+++ b/src/storage/engines/sst/search/coordinator.rs
@@ -306,11 +306,11 @@ pub struct SearchStatistics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::proto::proximadb_v1::DistanceMetric;
     use crate::query::query_optimizer::SearchParams;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     #[tokio::test]
     async fn test_search_strategy_selection() {

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -36,13 +36,13 @@ use anyhow::Result;
 use std::collections::HashMap;
 use tracing::{debug, info, trace, warn};
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
-use crate::core::search::{ComparisonOperator, FilterExpression};
 use crate::storage::engines::core::formats::arrow_block::ArrowBlockReader;
 use crate::storage::engines::sst::{SstEngine, SstError};
 use crate::storage::traits::StorageQueryContext;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 use proximadb_index_traits::{
     IndexFilterOperator, IndexHybridQuery, IndexMetadataFilter, IndexSearchEffort, IndexVectorQuery,
 };
@@ -799,7 +799,7 @@ impl SstEngine {
         &self,
         storage_url: &str,
         query_vector: &[f32],
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
         search_mode: &crate::core::search::SearchMode,
         prune_config: &crate::core::search::BlockPruneConfig, // [AGENT_FIX] New parameter
     ) -> Result<Vec<String>> {
@@ -963,9 +963,9 @@ impl SstEngine {
         &self,
         query: &[f32],
         centroid: &[f32],
-        metric: crate::compute::distance_computation::DistanceMetric,
+        metric: proximadb_distance_kernel::DistanceMetric,
     ) -> f32 {
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
 
         match metric {
             DistanceMetric::Euclidean => {
@@ -1142,9 +1142,7 @@ impl SstEngine {
         limit: usize,
         distance_metric: DistanceMetric,
     ) -> Result<Vec<OptimizedSearchRecord>> {
-        use crate::compute::distance_computation::engine::{
-            SimilarityResult, UnifiedDistanceCompute,
-        };
+        use proximadb_distance_kernel::engine::{SimilarityResult, UnifiedDistanceCompute};
         use std::sync::Arc;
 
         debug!("🏹 Searching Arrow file: {}", arrow_path);
@@ -1217,10 +1215,10 @@ impl SstEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
     use proximadb_data_model::ProximaValue;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/src/storage/engines/sst/search/operations.rs
+++ b/src/storage/engines/sst/search/operations.rs
@@ -23,11 +23,11 @@ use anyhow::{Context, Result};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::core::search::FilterExpression;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::storage::engines::sst::SstEngine;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_filter_expression::FilterExpression;
 
 /// Low-level search operations
 pub struct SearchOperations {
@@ -368,9 +368,9 @@ pub struct SearchOperationStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     #[tokio::test]
     async fn test_validate_search_params() {

--- a/src/storage/engines/sst/search/optimizer.rs
+++ b/src/storage/engines/sst/search/optimizer.rs
@@ -23,8 +23,8 @@ use anyhow::Result;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::core::search::FilterExpression;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_filter_expression::FilterExpression;
 
 /// Search optimization strategies
 #[derive(Debug, Clone)]

--- a/src/storage/engines/sst/sst_reader.rs
+++ b/src/storage/engines/sst/sst_reader.rs
@@ -122,7 +122,7 @@ impl UnifiedSSTReader {
     pub fn for_filtered_query(
         filesystem_factory: Arc<FilesystemFactory>,
         collection_id: String,
-        filter: Option<crate::core::search::FilterExpression>,
+        filter: Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<Self> {
         Self::new(
             filesystem_factory,

--- a/src/storage/engines/sst/tests/arrow_vs_proximablocks_benchmark.rs
+++ b/src/storage/engines/sst/tests/arrow_vs_proximablocks_benchmark.rs
@@ -23,7 +23,6 @@ mod tests {
     use std::time::Instant;
     use tempfile::TempDir;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::core::SstConfig;
     use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::{
@@ -34,6 +33,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     // Separator line constants for output formatting
     const SEPARATOR_DOUBLE: &str =

--- a/src/storage/engines/sst/tests/arrowblock_compaction_test.rs
+++ b/src/storage/engines/sst/tests/arrowblock_compaction_test.rs
@@ -45,7 +45,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::core::SstConfig;
     use crate::core::search::SearchParams;
     use crate::core::search::results::OptimizedSearchRecord;
@@ -60,6 +59,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use tracing::info;
 
     /// Create test vectors with predictable patterns for verification

--- a/src/storage/engines/sst/tests/arrowblock_full_lifecycle_test.rs
+++ b/src/storage/engines/sst/tests/arrowblock_full_lifecycle_test.rs
@@ -36,7 +36,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::core::SstConfig;
     use crate::core::search::SearchParams;
     use crate::core::search::results::OptimizedSearchRecord;
@@ -48,6 +47,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use tracing::info;
 
     /// Create test vectors with predictable patterns for verification

--- a/src/storage/engines/sst/tests/cross_format_interop_benchmark.rs
+++ b/src/storage/engines/sst/tests/cross_format_interop_benchmark.rs
@@ -27,7 +27,6 @@ mod tests {
     use std::time::Instant;
     use tempfile::TempDir;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::core::SstConfig;
     use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::{
@@ -40,6 +39,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     // Separator line constants for output formatting
     const SEPARATOR_DOUBLE: &str =
@@ -245,9 +245,9 @@ mod tests {
         let full_scan_time_ms = scan_start.elapsed().as_secs_f64() * 1000.0;
 
         // Benchmark filtered read (with predicate)
-        let filter_expr = crate::core::search::FilterExpression::Comparison {
+        let filter_expr = proximadb_filter_expression::FilterExpression::Comparison {
             field: "category".to_string(),
-            operator: crate::core::search::ComparisonOperator::Equals,
+            operator: proximadb_filter_expression::ComparisonOperator::Equals,
             value: serde_json::Value::String("cat_5".to_string()),
         };
 
@@ -354,9 +354,9 @@ mod tests {
         let full_scan_time_ms = scan_start.elapsed().as_secs_f64() * 1000.0;
 
         // Benchmark filtered read
-        let filter_expr = crate::core::search::FilterExpression::Comparison {
+        let filter_expr = proximadb_filter_expression::FilterExpression::Comparison {
             field: "category".to_string(),
-            operator: crate::core::search::ComparisonOperator::Equals,
+            operator: proximadb_filter_expression::ComparisonOperator::Equals,
             value: serde_json::Value::String("cat_5".to_string()),
         };
 
@@ -460,9 +460,9 @@ mod tests {
         let full_scan_time_ms = scan_start.elapsed().as_secs_f64() * 1000.0;
 
         // Benchmark filtered read
-        let filter_expr = crate::core::search::FilterExpression::Comparison {
+        let filter_expr = proximadb_filter_expression::FilterExpression::Comparison {
             field: "category".to_string(),
-            operator: crate::core::search::ComparisonOperator::Equals,
+            operator: proximadb_filter_expression::ComparisonOperator::Equals,
             value: serde_json::Value::String("cat_5".to_string()),
         };
 

--- a/src/storage/engines/sst/tests/end_to_end_test.rs
+++ b/src/storage/engines/sst/tests/end_to_end_test.rs
@@ -14,7 +14,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::{
         Collection, CollectionConfig, FilterableColumnSpec, FilterableDataType, SqlValue,
@@ -25,6 +24,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use tracing::info;
 
     #[tokio::test]

--- a/src/storage/engines/sst/tests/flush_recovery_tdd_test.rs
+++ b/src/storage/engines/sst/tests/flush_recovery_tdd_test.rs
@@ -20,7 +20,6 @@ mod tests {
     use tempfile::TempDir;
     use tracing::{debug, info, warn};
 
-    use crate::compute::distance_computation::{DistanceMetric, engine::UnifiedDistanceCompute};
     use crate::core::search::{SearchMode, SearchParams};
     use crate::proto::proximadb_v1::{
         Collection, CollectionConfig, FilterableColumnSpec, FilterableDataType, SqlValue,
@@ -31,6 +30,7 @@ mod tests {
     use crate::storage::traits::{
         FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageFormat,
     };
+    use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
 
     /// Helper to create test vectors with known patterns
     fn create_test_vectors(num_vectors: usize, dimension: usize) -> Vec<VectorRecord> {

--- a/src/storage/engines/sst/tests/modular_integration_test.rs
+++ b/src/storage/engines/sst/tests/modular_integration_test.rs
@@ -29,7 +29,6 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::Arc;
 
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::{
         SstConfig,
         blocks::SstRecord,
@@ -40,6 +39,7 @@ mod tests {
     };
     use crate::storage::persistence::filesystem::FilesystemFactory;
     use crate::storage::traits::{StorageQueryContext, UnifiedStorageFormat};
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use proximadb_records::{EmbeddingCell, ProximaRecord};
 
     /// Test that the core module properly initializes the engine

--- a/src/storage/engines/sst/tests/sst_compactor_tests.rs
+++ b/src/storage/engines/sst/tests/sst_compactor_tests.rs
@@ -22,8 +22,8 @@ mod tests {
     use std::collections::HashMap;
 
     // Import test utilities from sst_test_config
-    use crate::compute::distance_computation::DistanceMetric;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use proximadb_storage_common::storage_path::StoragePath;
     use std::path::Path;
     use std::sync::Arc;

--- a/src/storage/engines/sst/tests/sst_reader_edge_tests.rs
+++ b/src/storage/engines/sst/tests/sst_reader_edge_tests.rs
@@ -4,10 +4,9 @@
 
 #[cfg(test)]
 mod edge_tests {
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::core::bloom::BloomFilterConfig;
     use crate::core::config::SstConfig;
-    use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+    use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::{SqlValue, VectorRecord, sql_value};
     use crate::storage::engines::sst::readers::sst_query_engine::{
         CollectionContext, ReaderConfig, UnifiedSstableReader,
@@ -15,6 +14,8 @@ mod edge_tests {
     use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
     use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
     use chrono::Utc;
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/src/storage/engines/sst/tests/sst_reader_tests.rs
+++ b/src/storage/engines/sst/tests/sst_reader_tests.rs
@@ -9,8 +9,9 @@ mod tests {
         CollectionContext, UnifiedSstableReader,
     };
     // use crate::core::config::{BloomFilterConfig, SstConfig};
-    use crate::compute::distance_computation::DistanceMetric;
-    use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+    use crate::core::search::SearchParams;
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
     fn create_test_config() -> SstConfig {
         SstConfig {

--- a/src/storage/engines/sst/tests/test_metadata_filtering.rs
+++ b/src/storage/engines/sst/tests/test_metadata_filtering.rs
@@ -4,7 +4,6 @@
 //! the CompositeBloomFilter implementation which supports both key
 //! and metadata bloom filters.
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::SearchParams;
 use crate::proto::proximadb_v1::{SqlValue, VectorRecord, sql_value};
 use crate::storage::engines::sst::SstConfig;
@@ -12,6 +11,7 @@ use crate::storage::engines::sst::SstableWriter;
 use crate::storage::engines::sst::readers::{CollectionContext, UnifiedSstableReader};
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+use proximadb_distance_kernel::DistanceMetric;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tempfile::TempDir;

--- a/src/storage/engines/sst/text_column_support.rs
+++ b/src/storage/engines/sst/text_column_support.rs
@@ -397,9 +397,9 @@ impl SstTextFilterEvaluator {
 
     /// Convert a FilterExpression to TextComparisonOp if applicable
     pub fn convert_filter_expression(
-        expr: &crate::core::search::FilterExpression,
+        expr: &proximadb_filter_expression::FilterExpression,
     ) -> Option<(String, TextComparisonOp, String)> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
         match expr {
             FilterExpression::Comparison {
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_convert_filter_expression() {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
         let expr = FilterExpression::Comparison {
             field: "title".to_string(),

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -425,9 +425,9 @@ impl crate::storage::engines::core::ops::UniversallyOptimized for SstEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/src/storage/engines/sst/unified_search_engine/tests.rs
+++ b/src/storage/engines/sst/unified_search_engine/tests.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use chrono::Utc;
 
 use super::*;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::{UnifiedQuantizationEngine, InMemoryCodebookStore};
 use crate::core::search::{SearchParams, SearchPlan};
 
@@ -58,7 +58,7 @@ fn create_test_search_context() -> SearchPlan {
             },
         ],
         collection_config: Some(crate::core::search::CollectionConfig {
-            default_distance_metric: crate::compute::distance_computation::DistanceMetric::Cosine,
+            default_distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
             vector_dimension: 128,
             enable_quantization: false,
             enable_metadata_filtering: true,
@@ -74,7 +74,7 @@ fn create_test_search_params() -> SearchParams {
     SearchParams {
         query_vectors: Some(vec![vec![0.1; 128]]),
         top_k: Some(10),
-        distance_metric: Some(crate::compute::distance_computation::DistanceMetric::Cosine),
+        distance_metric: Some(proximadb_distance_kernel::DistanceMetric::Cosine),
         filters: None,
         filter_expression: None,
         accuracy_threshold: None,

--- a/src/storage/engines/sst/utils.rs
+++ b/src/storage/engines/sst/utils.rs
@@ -454,9 +454,9 @@ pub struct SstableFileInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
     use crate::storage::engines::sst::SstConfig;
     use crate::storage::persistence::filesystem::FilesystemFactory;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/src/storage/engines/sst/writer.rs
+++ b/src/storage/engines/sst/writer.rs
@@ -218,9 +218,8 @@ impl SstableWriter {
         let compression_provider = StandardCompression;
 
         // Initialize unified quantization engine from compute module
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         let codebook_store = Arc::new(
             crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
         );
@@ -246,17 +245,17 @@ impl SstableWriter {
                 distance_metric: if let Some(collection) = collection_config {
                     // Get distance metric from collection config
                     collection.config.as_ref()
-                    .map_or(crate::compute::distance_computation::engine::DistanceMetric::Cosine, |cfg| match cfg.distance_metric() {
+                    .map_or(proximadb_distance_kernel::engine::DistanceMetric::Cosine, |cfg| match cfg.distance_metric() {
                         crate::proto::proximadb_v1::DistanceMetric::Cosine =>
-                            crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                            proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                         crate::proto::proximadb_v1::DistanceMetric::Euclidean =>
-                            crate::compute::distance_computation::engine::DistanceMetric::Euclidean,
+                            proximadb_distance_kernel::engine::DistanceMetric::Euclidean,
                         crate::proto::proximadb_v1::DistanceMetric::DotProduct =>
-                            crate::compute::distance_computation::engine::DistanceMetric::DotProduct,
-                        _ => crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                            proximadb_distance_kernel::engine::DistanceMetric::DotProduct,
+                        _ => proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                     })
                 } else {
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine
                 },
                 enable_progressive: true,
                 filter_threshold: 100.0,
@@ -355,9 +354,8 @@ impl SstableWriter {
         let compression_provider = StandardCompression;
 
         // Initialize unified quantization engine from compute module
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         let codebook_store = Arc::new(
             crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
         );
@@ -381,7 +379,7 @@ impl SstableWriter {
                     crate::compute::quantization::quantization_engine::UnifiedQuantizationLevel::int8(),
                 ),
                 distance_metric:
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                 enable_progressive: true,
                 filter_threshold: 100.0,
                 candidate_multiplier: 10,

--- a/src/storage/engines/swift/engine.rs
+++ b/src/storage/engines/swift/engine.rs
@@ -20,14 +20,14 @@ use tracing::{debug, info, warn};
 // StorageTier already imported from crate::core::search
 use crate::core::hardware_capabilities::HardwareCapabilities;
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
-use crate::core::search::{ComparisonOperator, FilterExpression};
 use crate::storage::traits::{
     CompactionParameters, CompactionResult, EngineHealth, EngineStatistics, FlushParameters,
     FlushResult, StorageFormatStrategy, UnifiedStorageFormat,
 };
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 use proximadb_index_traits::{
     IndexFilterOperator, IndexHybridQuery, IndexMetadataFilter, IndexVectorQuery,
 };
@@ -323,7 +323,7 @@ pub struct SwiftEngine {
     /// - Batch processing for throughput
     ///
     /// Shared singleton across all distance operations
-    distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_engine: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
 
     /// **PCA Model Cache** (Per-Collection)
     ///
@@ -367,15 +367,14 @@ impl SwiftEngine {
              See /docs/storage/EXPERIMENTAL_ENGINES_STATUS.md for details."
         );
 
-        let distance_engine = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_engine =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
         Self::new_with_config(distance_engine, None).await
     }
 
     /// Create SWIFT engine with specific config (internal use)
     pub async fn new_with_config(
-        distance_engine: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+        distance_engine: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
         axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
     ) -> Result<Self> {
         let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
@@ -417,7 +416,7 @@ impl SwiftEngine {
                     crate::compute::quantization::quantization_engine::UnifiedQuantizationLevel::int8(),
                 ),
                 distance_metric:
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                 enable_progressive: true,
                 filter_threshold: 100.0,
                 candidate_multiplier: 10,
@@ -1973,8 +1972,8 @@ impl SwiftEngine {
         storage_path: &str,
         query_vector: &[f32],
         top_k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
-        _filter_expression: Option<&crate::core::search::FilterExpression>,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
+        _filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         // Debug level since this is expected behavior until orchestration is fully integrated
         tracing::debug!("🔍 SWIFT: Using direct search (orchestration pending integration)");
@@ -2065,8 +2064,8 @@ mod tests {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
         // Need to create distance engine and axis manager for new()
         let _distance_engine = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                proximadb_distance_kernel::DistanceMetric::Euclidean,
             ),
         );
         let engine = SwiftEngine::new().await.unwrap();
@@ -2079,8 +2078,8 @@ mod tests {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
         // Need to create distance engine and axis manager for new()
         let _distance_engine = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                crate::compute::distance_computation::DistanceMetric::Euclidean,
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                proximadb_distance_kernel::DistanceMetric::Euclidean,
             ),
         );
         let engine = SwiftEngine::new().await.unwrap();
@@ -2113,8 +2112,8 @@ mod tests {
     #[cfg(feature = "experimental-engines")]
     #[test]
     fn test_swift_filter_evaluation() {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
         use proximadb_data_model::ProximaValue;
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
         use proximadb_records::{ProximaTree, ProximaTreeNode};
 
         // Create test records with metadata

--- a/src/storage/engines/swift/optimized_operations.rs
+++ b/src/storage/engines/swift/optimized_operations.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::compute::distance_computation::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::{
     hardware_capabilities::{HardwareBackend, HardwareCapabilities},
@@ -15,6 +14,7 @@ use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::engines::core::search::search_modes::{
     CandidateRecord, CandidateState, SearchCandidate,
 };
+use proximadb_distance_kernel::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
 // Memory-mapped file operations would be imported here
 // For now, we'll use placeholder types
 struct MmapFile;

--- a/src/storage/engines/swift/progressive_search.rs
+++ b/src/storage/engines/swift/progressive_search.rs
@@ -866,8 +866,8 @@ fn condition_matches_record(
     }
 }
 
-fn parse_distance_metric(name: &str) -> crate::compute::distance_computation::DistanceMetric {
-    use crate::compute::distance_computation::DistanceMetric;
+fn parse_distance_metric(name: &str) -> proximadb_distance_kernel::DistanceMetric {
+    use proximadb_distance_kernel::DistanceMetric;
     match name.to_lowercase().as_str() {
         "cosine" => DistanceMetric::Cosine,
         "dot" | "dotproduct" => DistanceMetric::DotProduct,
@@ -881,9 +881,9 @@ fn parse_distance_metric(name: &str) -> crate::compute::distance_computation::Di
 fn compute_distance(
     a: &[f32],
     b: &[f32],
-    metric: &crate::compute::distance_computation::DistanceMetric,
+    metric: &proximadb_distance_kernel::DistanceMetric,
 ) -> f32 {
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
 
     match metric {
         DistanceMetric::Euclidean => a
@@ -1089,7 +1089,7 @@ fn filter_superblocks_by_adacurve(
 fn select_blocks_by_centroid(
     superblock: &super::SuperBlock,
     query: &[f32],
-    _metric: &crate::compute::distance_computation::DistanceMetric,
+    _metric: &proximadb_distance_kernel::DistanceMetric,
     prune: &crate::core::search::BlockPruneConfig,
 ) -> Vec<usize> {
     use crate::storage::engines::core::formats::proximablocks::spatial_encoding::SpatialCode;
@@ -1723,7 +1723,7 @@ mod tests {
 
     #[test]
     fn test_parse_distance_metric() {
-        use crate::compute::distance_computation::DistanceMetric as DM;
+        use proximadb_distance_kernel::DistanceMetric as DM;
         assert!(matches!(parse_distance_metric("cosine"), DM::Cosine));
         assert!(matches!(parse_distance_metric("dot"), DM::DotProduct));
         assert!(matches!(
@@ -1740,7 +1740,7 @@ mod tests {
 
     #[test]
     fn test_compute_distance_euclidean() {
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
         let a = vec![0.0, 0.0, 0.0];
         let b = vec![3.0, 4.0, 0.0];
         let dist = compute_distance(&a, &b, &DistanceMetric::Euclidean);
@@ -1749,7 +1749,7 @@ mod tests {
 
     #[test]
     fn test_compute_distance_cosine_parallel() {
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
         let a = vec![1.0, 0.0];
         let b = vec![1.0, 0.0];
         let dist = compute_distance(&a, &b, &DistanceMetric::Cosine);
@@ -1758,7 +1758,7 @@ mod tests {
 
     #[test]
     fn test_compute_distance_dot_product() {
-        use crate::compute::distance_computation::DistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric;
         let a = vec![1.0, 2.0, 3.0];
         let b = vec![4.0, 5.0, 6.0];
         let dist = compute_distance(&a, &b, &DistanceMetric::DotProduct);

--- a/src/storage/engines/swift/progressive_stages.rs
+++ b/src/storage/engines/swift/progressive_stages.rs
@@ -13,11 +13,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// SWIFT-specific Binary stage adapter
 ///
@@ -234,8 +234,8 @@ pub fn create_swift_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/swift/proximablocks_compact_strategy_reader.rs
+++ b/src/storage/engines/swift/proximablocks_compact_strategy_reader.rs
@@ -114,7 +114,7 @@ impl UnifiedSWIFTReader {
     pub fn for_filtered_query(
         filesystem_factory: Arc<FilesystemFactory>,
         collection_id: String,
-        filter: Option<crate::core::search::FilterExpression>,
+        filter: Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<Self> {
         let config = SwiftReaderConfig {
             enable_prefetch: false,
@@ -267,10 +267,14 @@ impl UnifiedSWIFTReader {
     fn check_bloom_filter(
         &self,
         bloom: &crate::core::bloom::SstableBloomFilter,
-        filter: &Option<crate::core::search::FilterExpression>,
+        filter: &Option<proximadb_filter_expression::FilterExpression>,
     ) -> bool {
         // Extract field name from filter for bloom filter check
-        if let Some(crate::core::search::FilterExpression::Comparison { field, value, .. }) = filter
+        if let Some(proximadb_filter_expression::FilterExpression::Comparison {
+            field,
+            value,
+            ..
+        }) = filter
         {
             // Build a MetadataItem from the filter value for bloom lookup
             let item = crate::proto::proximadb_v1::MetadataItem {
@@ -296,7 +300,7 @@ impl UnifiedSWIFTReader {
     fn apply_filter_to_block(
         &self,
         records: &[VectorRecord],
-        filter: &Option<crate::core::search::FilterExpression>,
+        filter: &Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<VectorRecord>> {
         let filter_expr = match filter {
             Some(expr) => expr,

--- a/src/storage/engines/swift/stages.rs
+++ b/src/storage/engines/swift/stages.rs
@@ -50,12 +50,12 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use tracing::debug;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 // ============================================================================
 // SWIFT Binary Stage

--- a/src/storage/engines/universal/adapter.rs
+++ b/src/storage/engines/universal/adapter.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, trace};
 
-use crate::compute::distance_computation::{
+use crate::core::hardware_capabilities::HardwareCapabilities;
+use crate::proto::proximadb_v1::VectorRecord;
+use proximadb_distance_kernel::{
     DistanceMetric, Int8VectorData, PQVectorData, QuantizedDistanceResult, QuantizedVectorData,
     SelectedFormat, SimilarityResult, UnifiedDistanceCompute,
 };
-use crate::core::hardware_capabilities::HardwareCapabilities;
-use crate::proto::proximadb_v1::VectorRecord;
 
 use super::{
     config::ProgressiveRefinementConfig as ConfigProgressiveRefinementConfig,

--- a/src/storage/engines/universal/distance_cache.rs
+++ b/src/storage/engines/universal/distance_cache.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use tracing::{debug, trace};
 
 use super::config::CacheConfig;
-use crate::compute::distance_computation::DistanceMetric;
 use crate::storage::cache::orchestrator::{CacheType, CrossCacheOrchestrator};
+use proximadb_distance_kernel::DistanceMetric;
 
 /// Cache key for distance tables
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]

--- a/src/storage/engines/universal/mod.rs
+++ b/src/storage/engines/universal/mod.rs
@@ -118,7 +118,7 @@ pub use progressive_refinement::{
 };
 
 // Quantized calculator exports removed - use compute module directly:
-// - crate::compute::distance_computation::engine::UnifiedDistanceCompute
+// - proximadb_distance_kernel::engine::UnifiedDistanceCompute
 // - crate::compute::quantization::storage_engine::StorageQuantizationEngine
 
 pub use storage_integration::{

--- a/src/storage/engines/universal/progressive_refinement.rs
+++ b/src/storage/engines/universal/progressive_refinement.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, trace};
 
-use crate::compute::distance_computation::{
+use proximadb_distance_kernel::{
     DistanceMetric, SelectedFormat, SimilarityResult, UnifiedDistanceCompute,
 };
 
@@ -646,8 +646,8 @@ impl ProgressiveRefinementPipeline {
     fn convert_to_quantized_int8(
         &self,
         data: &[u8],
-    ) -> AdapterResult<crate::compute::distance_computation::QuantizedVectorData> {
-        use crate::compute::distance_computation::{Int8VectorData, QuantizedVectorData};
+    ) -> AdapterResult<proximadb_distance_kernel::QuantizedVectorData> {
+        use proximadb_distance_kernel::{Int8VectorData, QuantizedVectorData};
 
         // Convert to INT8 format
         let int8_data: Vec<i8> = data.iter().map(|&b| b as i8).collect();
@@ -670,8 +670,8 @@ impl ProgressiveRefinementPipeline {
         data: &[u8],
         segments: usize,
         _bits: usize,
-    ) -> AdapterResult<crate::compute::distance_computation::QuantizedVectorData> {
-        use crate::compute::distance_computation::{PQVectorData, QuantizedVectorData};
+    ) -> AdapterResult<proximadb_distance_kernel::QuantizedVectorData> {
+        use proximadb_distance_kernel::{PQVectorData, QuantizedVectorData};
 
         // Convert to PQ format - simplified implementation
         let codes: Vec<u8> = data.iter().take(segments).copied().collect();

--- a/src/storage/engines/universal/quantized_calculator.rs
+++ b/src/storage/engines/universal/quantized_calculator.rs
@@ -7,11 +7,11 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, trace};
 
-use crate::compute::distance_computation::{
+use crate::core::hardware_capabilities::HardwareCapabilities;
+use proximadb_distance_kernel::{
     ComputationMethod, DistanceMetric, DistanceMetrics, QuantizedDistanceResult,
     QuantizedVectorData, SelectedFormat, UnifiedDistanceCompute,
 };
-use crate::core::hardware_capabilities::HardwareCapabilities;
 
 use super::config::UniversalAdapterConfig;
 

--- a/src/storage/engines/universal/tests.rs
+++ b/src/storage/engines/universal/tests.rs
@@ -2,7 +2,6 @@
 mod tests {
     use std::collections::HashMap;
 
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::storage::engines::universal::adapter::{
         CandidateVector, DistanceComputationRequest, HardwareAccelerationManager,
         UniversalDistanceAdapter,
@@ -13,6 +12,7 @@ mod tests {
     use crate::storage::engines::universal::storage_integration::{
         EngineType, NOVAAdapter, PRISMAdapter,
     };
+    use proximadb_distance_kernel::DistanceMetric;
     use proximadb_kernel::uuid::Uuid;
 
     #[tokio::test]
@@ -231,12 +231,12 @@ pub use crate::storage::engines::universal::storage_integration::{
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod test_utils {
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::storage::engines::universal::adapter::{
         CandidateVector, DistanceComputationRequest,
     };
     use crate::storage::engines::universal::conversion::StorageFormat;
     use crate::storage::engines::universal::storage_integration::EngineType;
+    use proximadb_distance_kernel::DistanceMetric;
     use proximadb_kernel::uuid::Uuid;
     use std::collections::HashMap;
 

--- a/src/storage/engines/viper/column_filter.rs
+++ b/src/storage/engines/viper/column_filter.rs
@@ -8,9 +8,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::core::search::{ComparisonOperator, FilterExpression};
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::persistence::filesystem::FilesystemFactory;
+use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
 /// Column-oriented filter evaluator with predicate pushdown
 ///
@@ -632,7 +632,7 @@ impl VIPERSelectiveReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
     #[tokio::test]
     async fn test_viper_predicate_pushdown() -> anyhow::Result<()> {

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -366,9 +366,8 @@ impl ViperEngine {
         let filesystem_config =
             crate::storage::persistence::filesystem::FilesystemConfig::default();
         let filesystem = Arc::new(FilesystemFactory::create(filesystem_config).await?);
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
         Self::new_with_config(core_config, filesystem, distance_compute).await
     }
@@ -377,9 +376,7 @@ impl ViperEngine {
     pub async fn new_with_config(
         core_config: crate::core::config::ViperConfig,
         filesystem: Arc<FilesystemFactory>,
-        _distance_compute: Arc<
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute,
-        >, // VIPER creates its own internally
+        _distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>, // VIPER creates its own internally
     ) -> Result<Self> {
         info!("🔧 Creating stateless VIPER engine");
 
@@ -411,7 +408,7 @@ impl ViperEngine {
         collection_id: String,
         core_config: crate::core::config::ViperConfig,
         filesystem: Arc<FilesystemFactory>,
-        distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+        distance_compute: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
         _base_location: String, // Ignored
     ) -> Result<Self> {
         // Just call the stateless new() method
@@ -446,9 +443,8 @@ impl ViperEngine {
         // Initialize unified quantization engine from compute module
         // This provides the core quantization algorithms (Binary, INT8, PQ)
         // that VIPER uses for its multi-stage compression pipeline
-        let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-        );
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
 
         // In-memory codebook store for PQ quantization
         // Codebooks are trained on sample data and cached for fast access
@@ -482,7 +478,7 @@ impl ViperEngine {
                 ),
                 // Cosine is default, but can be overridden per collection
                 distance_metric:
-                    crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                 // Enable Binary→INT8→PQ→FP32 progressive refinement
                 enable_progressive: true,
                 // Initial filter returns 100x final k for refinement
@@ -627,9 +623,9 @@ impl ViperEngine {
     /// This helper converts our internal FilterExpression type to the
     /// IndexMetadataFilter DTO format for hybrid vector + metadata queries.
     fn convert_filter_to_index(
-        filter_expression: Option<&crate::core::search::FilterExpression>,
+        filter_expression: Option<&proximadb_filter_expression::FilterExpression>,
     ) -> Vec<proximadb_index_traits::IndexMetadataFilter> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
         use proximadb_index_traits::{IndexFilterOperator, IndexMetadataFilter};
 
         let Some(filter) = filter_expression else {
@@ -860,7 +856,7 @@ impl ViperEngine {
         &self,
         query: &[f32],
         candidates: &[Vec<f32>],
-        metric: crate::compute::distance_computation::DistanceMetric,
+        metric: proximadb_distance_kernel::DistanceMetric,
     ) -> Result<Vec<f32>> {
         // Use universal optimizer's hardware-accelerated distance computation
         self.universal_optimizer
@@ -2707,9 +2703,7 @@ impl UnifiedStorageFormat for ViperEngine {
 
         // Get distance compute engine
         let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                distance_metric,
-            ),
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(distance_metric),
         );
 
         for record in read_results.results {

--- a/src/storage/engines/viper/flush.rs
+++ b/src/storage/engines/viper/flush.rs
@@ -92,7 +92,7 @@ impl Flush {
             crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
         );
         let distance_compute = Arc::new(
-            crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
+            proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
                 crate::proto::proximadb_v1::DistanceMetric::Cosine,
             ),
         );

--- a/src/storage/engines/viper/pipeline.rs
+++ b/src/storage/engines/viper/pipeline.rs
@@ -737,9 +737,8 @@ impl VectorRecordProcessor {
             schema_adapter,
             // ml_clustering, // Moved to AXIS
             quantization: {
-                let distance_compute = Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-                );
+                let distance_compute =
+                    Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
                 let codebook_store = Arc::new(
                     crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
                 );
@@ -751,8 +750,8 @@ impl VectorRecordProcessor {
                 );
                 // Create distance compute engine
                 let distance_compute = Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                        crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                        proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                     ),
                 );
                 // Create quantization config
@@ -3171,9 +3170,8 @@ impl CompactionEngine {
             schema_adapter,
             // ml_clustering: Arc::new(Mutex::new(MLClusteringEngine::new(KMeansConfig::default()))), // Moved to AXIS
             quantization: {
-                let distance_compute = Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
-                );
+                let distance_compute =
+                    Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
                 let codebook_store = Arc::new(
                     crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
                 );
@@ -3185,8 +3183,8 @@ impl CompactionEngine {
                 );
                 // Create distance compute engine
                 let distance_compute = Arc::new(
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::new(
-                        crate::compute::distance_computation::engine::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::engine::UnifiedDistanceCompute::new(
+                        proximadb_distance_kernel::engine::DistanceMetric::Cosine,
                     ),
                 );
                 // Create quantization config

--- a/src/storage/engines/viper/progressive_stages.rs
+++ b/src/storage/engines/viper/progressive_stages.rs
@@ -13,11 +13,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::engine::{DistanceMetric, UnifiedDistanceCompute};
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::storage::engines::core::progressive::{
     ProgressiveSearchStage, QuantizationLevel, ScoredCandidate,
 };
+use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
 
 /// VIPER-specific Binary stage adapter
 ///
@@ -229,8 +229,8 @@ pub fn create_viper_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::compute::quantization::quantization_engine::InMemoryCodebookStore;
+    use proximadb_distance_kernel::DistanceMetric;
 
     fn create_test_engines() -> (Arc<UnifiedQuantizationEngine>, Arc<UnifiedDistanceCompute>) {
         let dist_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));

--- a/src/storage/engines/viper/tests/engine_tests.rs
+++ b/src/storage/engines/viper/tests/engine_tests.rs
@@ -13,7 +13,6 @@ mod tests {
     use tempfile::TempDir;
     use tracing::debug;
 
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::core::search::search_interface::{CollectionConfig, SearchPlan, StorageInfo};
     use crate::storage::engines::core::formats::columnar::FIELD_ID;
     use crate::storage::engines::core::formats::columnar::FIELD_TIMESTAMP;
@@ -23,6 +22,7 @@ mod tests {
     use arrow_array::{Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use proximadb_data_model::ProximaValue;
+    use proximadb_distance_kernel::DistanceMetric;
     use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTree, ProximaTreeNode};
     use proximadb_storage_common::storage_path::StoragePath;
     use std::fs::File;
@@ -211,7 +211,7 @@ mod tests {
         query_vector: &[f32],
         top_k: usize,
         distance_metric: DistanceMetric,
-        filter_expression: Option<crate::core::search::FilterExpression>,
+        filter_expression: Option<proximadb_filter_expression::FilterExpression>,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>, anyhow::Error> {
         use crate::core::search::SearchParams;
         use crate::storage::traits::{StorageQueryContext, StorageQueryMetadata};
@@ -370,7 +370,7 @@ mod tests {
                     .unwrap_or_default(),
             ),
             top_k: Some(1),
-            distance_metric: Some(crate::compute::distance_computation::DistanceMetric::Cosine),
+            distance_metric: Some(proximadb_distance_kernel::DistanceMetric::Cosine),
             ..Default::default()
         };
         let collection = create_test_collection(collection_id, temp_dir.path().to_str().unwrap());
@@ -1179,9 +1179,9 @@ mod tests {
         assert_eq!(results[0].id, "vec1"); // Should be the exact match
 
         // Test that we can search with filters (even if filtering is not applied without config)
-        let filter_expr = crate::core::search::FilterExpression::Comparison {
+        let filter_expr = proximadb_filter_expression::FilterExpression::Comparison {
             field: "category".to_string(),
-            operator: crate::core::search::ComparisonOperator::Equals,
+            operator: proximadb_filter_expression::ComparisonOperator::Equals,
             value: serde_json::Value::String("A".to_string()),
         };
 

--- a/src/storage/engines/viper/tests/parquet_reader_edge_tests.rs
+++ b/src/storage/engines/viper/tests/parquet_reader_edge_tests.rs
@@ -4,8 +4,9 @@
 
 #[cfg(test)]
 mod edge_tests {
-    use crate::compute::distance_computation::DistanceMetric;
-    use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+    use proximadb_distance_kernel::DistanceMetric;
+    use crate::core::search::SearchParams;
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use crate::storage::engines::viper::readers::unified_parquet_reader::{
         CollectionContext, UnifiedParquetReader,
     };

--- a/src/storage/engines/viper/tests/parquet_reader_tests.rs
+++ b/src/storage/engines/viper/tests/parquet_reader_tests.rs
@@ -4,9 +4,10 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     use crate::core::search::search_interface::{CollectionConfig, SearchPlan, StorageInfo};
-    use crate::core::search::{ComparisonOperator, FilterExpression, SearchParams};
+    use crate::core::search::SearchParams;
+    use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
     use crate::proto::proximadb_v1::{SqlValue, VectorRecord, sql_value};
     use crate::storage::engines::core::formats::columnar::CollectionContext;
     use crate::storage::engines::core::formats::columnar::columnar_query_engine::columnar_query_reader::UnifiedParquetReader;

--- a/src/storage/engines/viper/tests/test_data_generator.rs
+++ b/src/storage/engines/viper/tests/test_data_generator.rs
@@ -4,13 +4,13 @@
 //! containing both FP32 and quantized vector data for testing the two-stage
 //! search functionality.
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use anyhow::Result;
 use arrow_array::builder::Float32Builder;
 use arrow_array::types::UInt8Type;
 use arrow_array::{ArrayRef, Float64Array, Int64Array, ListArray, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 // TODO: Refactor test code to use columnar module's exports
 // Currently using direct ArrowWriter for test data generation
 use parquet::arrow::ArrowWriter;

--- a/src/storage/entity_store_legacy.rs
+++ b/src/storage/entity_store_legacy.rs
@@ -1138,9 +1138,9 @@ impl ProximaEntityStore {
 
     fn convert_metadata_filter(
         filter: &Option<MetadataFilter>,
-    ) -> Option<crate::core::search::FilterExpression> {
-        use crate::core::search::{ComparisonOperator as Op, FilterExpression as FE};
+    ) -> Option<proximadb_filter_expression::FilterExpression> {
         use crate::proto::proximadb_v1::{ComparisonOp, LogicalOp, filter_clause};
+        use proximadb_filter_expression::{ComparisonOperator as Op, FilterExpression as FE};
         let f = filter.as_ref()?;
         let mut terms: Vec<FE> = Vec::new();
         for c in &f.clauses {

--- a/src/storage/memtable/implementations/global_partitioned.rs
+++ b/src/storage/memtable/implementations/global_partitioned.rs
@@ -78,8 +78,8 @@ use tokio::sync::RwLock;
 use tracing::debug;
 
 use super::super::core::MemtableMetrics;
-use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
-use crate::compute::distance_computation::engine::{
+use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
+use proximadb_distance_kernel::engine::{
     DistanceComputeProvider, SimilarityResult, UnifiedDistanceCompute,
 };
 use proximadb_records::ProximaRecord;
@@ -1601,9 +1601,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_global_partitioned_batch_operations() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
         use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
         use crate::storage::persistence::write_ahead_log::BatchId;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
         use std::sync::Arc;
 
         let memtable = GlobalPartitionedMemtable::new();
@@ -1642,9 +1642,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_global_partitioned_multi_collection() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
         use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
         use crate::storage::persistence::write_ahead_log::BatchId;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
         use std::sync::Arc;
 
         let memtable = GlobalPartitionedMemtable::new();
@@ -1705,9 +1705,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_mvcc_and_logical_deletes() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
         use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
         use crate::storage::persistence::write_ahead_log::BatchId;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
         use std::sync::Arc;
 
         let memtable = GlobalPartitionedMemtable::new();
@@ -1790,9 +1790,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_global_partitioned_deletion_via_expiry() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
         use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
         use crate::storage::persistence::write_ahead_log::BatchId;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
         use std::sync::Arc;
 
         let memtable = GlobalPartitionedMemtable::new();
@@ -2348,7 +2348,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_three_layer_search_consistency_basic() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
         let memtable = GlobalPartitionedMemtable::new();
         let collection_id = "1uctd3f";
@@ -2541,7 +2541,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_version_ordering_across_layers() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
         let memtable = GlobalPartitionedMemtable::new();
         let collection_id = "1uctd3h";
@@ -2586,7 +2586,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_expired_records_vs_active_records() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
         let memtable = GlobalPartitionedMemtable::new();
         let collection_id = "1uctd3i";
@@ -2641,7 +2641,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_id_different_vector_values() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
         let memtable = GlobalPartitionedMemtable::new();
         let collection_id = "1uctd3j";
@@ -2742,7 +2742,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_flush_compaction_atomic_consistency() {
-        use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
+        use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
         let memtable = GlobalPartitionedMemtable::new();
         let collection_id = "1uctd3k";

--- a/src/storage/memtable/specialized/wal_behavior.rs
+++ b/src/storage/memtable/specialized/wal_behavior.rs
@@ -14,12 +14,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
 use crate::core::bloom::strategies::composite::CompositeBloomFilter;
 use crate::core::bloom::{BloomFilterConfig, BloomFilterStrategy};
 use crate::storage::memtable::core::MemtableConfig;
 use crate::storage::memtable::implementations::global_partitioned::GlobalPartitionedMemtable;
 use crate::storage::persistence::write_ahead_log::{BatchId, WALOperation, WALStats};
+use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 use proximadb_records::ProximaRecord;
 
 /// Canonical key format for a metadata `field=value` entry in a batch's
@@ -531,8 +531,8 @@ impl WALBehaviorWrapper {
         collection_id: &str,
         query_vector: &[f32],
         top_k: usize,
-        distance_metric: crate::compute::distance_computation::DistanceMetric,
-        _metadata_filters: Option<&crate::core::search::FilterExpression>,
+        distance_metric: proximadb_distance_kernel::DistanceMetric,
+        _metadata_filters: Option<&proximadb_filter_expression::FilterExpression>,
         include_vectors: bool,
         include_metadata: bool,
     ) -> Result<Vec<crate::proto::proximadb_v1::SearchVectorRecord>> {
@@ -546,48 +546,20 @@ impl WALBehaviorWrapper {
         // Convert unified DistanceMetric to CoreDistanceMetric for now
         // Deferred: Update global partitioned memtable to accept unified DistanceMetric for all 13 metrics
         let core_metric = match distance_metric {
-            crate::compute::distance_computation::DistanceMetric::Unspecified => {
-                CoreDistanceMetric::Cosine
-            } // Default fallback
-            crate::compute::distance_computation::DistanceMetric::Cosine => {
-                CoreDistanceMetric::Cosine
-            }
-            crate::compute::distance_computation::DistanceMetric::Euclidean => {
-                CoreDistanceMetric::Euclidean
-            }
-            crate::compute::distance_computation::DistanceMetric::DotProduct => {
-                CoreDistanceMetric::DotProduct
-            }
-            crate::compute::distance_computation::DistanceMetric::Manhattan => {
-                CoreDistanceMetric::Manhattan
-            }
-            crate::compute::distance_computation::DistanceMetric::Hamming => {
-                CoreDistanceMetric::Hamming
-            }
-            crate::compute::distance_computation::DistanceMetric::Jaccard => {
-                CoreDistanceMetric::Jaccard
-            }
-            crate::compute::distance_computation::DistanceMetric::Chebyshev => {
-                CoreDistanceMetric::Chebyshev
-            }
-            crate::compute::distance_computation::DistanceMetric::Canberra => {
-                CoreDistanceMetric::Canberra
-            }
-            crate::compute::distance_computation::DistanceMetric::Minkowski => {
-                CoreDistanceMetric::Minkowski
-            }
-            crate::compute::distance_computation::DistanceMetric::Angular => {
-                CoreDistanceMetric::Angular
-            }
-            crate::compute::distance_computation::DistanceMetric::BrayCurtis => {
-                CoreDistanceMetric::BrayCurtis
-            }
-            crate::compute::distance_computation::DistanceMetric::Hellinger => {
-                CoreDistanceMetric::Hellinger
-            }
-            crate::compute::distance_computation::DistanceMetric::Custom => {
-                CoreDistanceMetric::Custom
-            }
+            proximadb_distance_kernel::DistanceMetric::Unspecified => CoreDistanceMetric::Cosine, // Default fallback
+            proximadb_distance_kernel::DistanceMetric::Cosine => CoreDistanceMetric::Cosine,
+            proximadb_distance_kernel::DistanceMetric::Euclidean => CoreDistanceMetric::Euclidean,
+            proximadb_distance_kernel::DistanceMetric::DotProduct => CoreDistanceMetric::DotProduct,
+            proximadb_distance_kernel::DistanceMetric::Manhattan => CoreDistanceMetric::Manhattan,
+            proximadb_distance_kernel::DistanceMetric::Hamming => CoreDistanceMetric::Hamming,
+            proximadb_distance_kernel::DistanceMetric::Jaccard => CoreDistanceMetric::Jaccard,
+            proximadb_distance_kernel::DistanceMetric::Chebyshev => CoreDistanceMetric::Chebyshev,
+            proximadb_distance_kernel::DistanceMetric::Canberra => CoreDistanceMetric::Canberra,
+            proximadb_distance_kernel::DistanceMetric::Minkowski => CoreDistanceMetric::Minkowski,
+            proximadb_distance_kernel::DistanceMetric::Angular => CoreDistanceMetric::Angular,
+            proximadb_distance_kernel::DistanceMetric::BrayCurtis => CoreDistanceMetric::BrayCurtis,
+            proximadb_distance_kernel::DistanceMetric::Hellinger => CoreDistanceMetric::Hellinger,
+            proximadb_distance_kernel::DistanceMetric::Custom => CoreDistanceMetric::Custom,
         };
 
         let raw_results = self

--- a/src/storage/persistence/write_ahead_log/avro_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/avro_serialization_strategy.rs
@@ -11,7 +11,6 @@ use tracing::{debug, info, warn};
 
 use super::batch_strategy::WALBatchStrategy;
 use super::{BatchId, FlushResult, WALConfig, WALStats};
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::write_ahead_log::{
@@ -19,6 +18,7 @@ use crate::storage::persistence::write_ahead_log::{
     serialization::{SerializationFormat, SerializerFactory, VectorBatchSerializer},
 };
 use crate::storage::traits::UnifiedStorageFormat;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Avro WAL batch strategy using serialization-first architecture
 pub struct AvroSerializationStrategy {
@@ -269,7 +269,7 @@ impl WALBatchStrategy for AvroSerializationStrategy {
         collection_id: &str,
         query_vector: &[f32],
         k: usize,
-        distance_metric: Option<crate::compute::distance_computation::DistanceMetric>,
+        distance_metric: Option<proximadb_distance_kernel::DistanceMetric>,
     ) -> Result<Vec<(String, f32, proximadb_records::ProximaRecord)>> {
         // For tests, we can do a simple search in memtable
         let vectors = self
@@ -285,8 +285,7 @@ impl WALBatchStrategy for AvroSerializationStrategy {
         let distance_compute = UnifiedDistanceCompute::default();
 
         // Use the unified distance compute to calculate distances
-        let metric =
-            distance_metric.unwrap_or(crate::compute::distance_computation::DistanceMetric::Cosine);
+        let metric = distance_metric.unwrap_or(proximadb_distance_kernel::DistanceMetric::Cosine);
         let mut results: Vec<(String, f32, proximadb_records::ProximaRecord)> = Vec::new();
 
         for vector in vectors {

--- a/src/storage/persistence/write_ahead_log/batch_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/batch_strategy.rs
@@ -11,11 +11,11 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::compute::distance_computation::DistanceMetric as CoreDistanceMetric;
 use crate::core::{String, VectorId};
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::traits::UnifiedStorageFormat;
+use proximadb_distance_kernel::DistanceMetric as CoreDistanceMetric;
 
 use super::{WALConfig, WALStats};
 use crate::storage::traits::FlushResult;
@@ -362,47 +362,35 @@ pub trait WALBatchStrategy: Send + Sync + std::fmt::Debug {
             // Convert CoreDistanceMetric to unified DistanceMetric (they're the same due to alias)
             let unified_metric = distance_metric.map(|m| match m {
                 CoreDistanceMetric::Unspecified => {
-                    crate::compute::distance_computation::DistanceMetric::Cosine
+                    proximadb_distance_kernel::DistanceMetric::Cosine
                 } // Default fallback
-                CoreDistanceMetric::Cosine => {
-                    crate::compute::distance_computation::DistanceMetric::Cosine
-                }
+                CoreDistanceMetric::Cosine => proximadb_distance_kernel::DistanceMetric::Cosine,
                 CoreDistanceMetric::Euclidean => {
-                    crate::compute::distance_computation::DistanceMetric::Euclidean
+                    proximadb_distance_kernel::DistanceMetric::Euclidean
                 }
                 CoreDistanceMetric::DotProduct => {
-                    crate::compute::distance_computation::DistanceMetric::DotProduct
+                    proximadb_distance_kernel::DistanceMetric::DotProduct
                 }
                 CoreDistanceMetric::Manhattan => {
-                    crate::compute::distance_computation::DistanceMetric::Manhattan
+                    proximadb_distance_kernel::DistanceMetric::Manhattan
                 }
-                CoreDistanceMetric::Hamming => {
-                    crate::compute::distance_computation::DistanceMetric::Hamming
-                }
-                CoreDistanceMetric::Jaccard => {
-                    crate::compute::distance_computation::DistanceMetric::Jaccard
-                }
+                CoreDistanceMetric::Hamming => proximadb_distance_kernel::DistanceMetric::Hamming,
+                CoreDistanceMetric::Jaccard => proximadb_distance_kernel::DistanceMetric::Jaccard,
                 CoreDistanceMetric::Chebyshev => {
-                    crate::compute::distance_computation::DistanceMetric::Chebyshev
+                    proximadb_distance_kernel::DistanceMetric::Chebyshev
                 }
-                CoreDistanceMetric::Canberra => {
-                    crate::compute::distance_computation::DistanceMetric::Canberra
-                }
+                CoreDistanceMetric::Canberra => proximadb_distance_kernel::DistanceMetric::Canberra,
                 CoreDistanceMetric::Minkowski => {
-                    crate::compute::distance_computation::DistanceMetric::Minkowski
+                    proximadb_distance_kernel::DistanceMetric::Minkowski
                 }
-                CoreDistanceMetric::Angular => {
-                    crate::compute::distance_computation::DistanceMetric::Angular
-                }
+                CoreDistanceMetric::Angular => proximadb_distance_kernel::DistanceMetric::Angular,
                 CoreDistanceMetric::BrayCurtis => {
-                    crate::compute::distance_computation::DistanceMetric::BrayCurtis
+                    proximadb_distance_kernel::DistanceMetric::BrayCurtis
                 }
                 CoreDistanceMetric::Hellinger => {
-                    crate::compute::distance_computation::DistanceMetric::Hellinger
+                    proximadb_distance_kernel::DistanceMetric::Hellinger
                 }
-                CoreDistanceMetric::Custom => {
-                    crate::compute::distance_computation::DistanceMetric::Custom
-                }
+                CoreDistanceMetric::Custom => proximadb_distance_kernel::DistanceMetric::Custom,
             });
 
             let results = wal_behavior
@@ -410,8 +398,7 @@ pub trait WALBatchStrategy: Send + Sync + std::fmt::Debug {
                     collection_id,
                     query_vector,
                     k,
-                    unified_metric
-                        .unwrap_or(crate::compute::distance_computation::DistanceMetric::Cosine),
+                    unified_metric.unwrap_or(proximadb_distance_kernel::DistanceMetric::Cosine),
                     None, // No metadata filters
                     true, // Include vectors
                     true, // Include metadata

--- a/src/storage/persistence/write_ahead_log/batch_strategy_tests.rs
+++ b/src/storage/persistence/write_ahead_log/batch_strategy_tests.rs
@@ -11,7 +11,6 @@
 #[cfg(test)]
 mod write_ahead_log_batch_strategy_tests {
     use super::super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
     use crate::storage::persistence::filesystem::FilesystemFactory;
     use crate::storage::persistence::write_ahead_log::BatchId;
@@ -19,6 +18,7 @@ mod write_ahead_log_batch_strategy_tests {
     use anyhow::Result;
     use async_trait::async_trait;
     use proximadb_data_model::ProximaValue;
+    use proximadb_distance_kernel::DistanceMetric;
     use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTree, ProximaTreeNode};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -31,7 +31,7 @@ mod write_ahead_log_batch_strategy_tests {
         filesystem: Option<Arc<FilesystemFactory>>,
         initialized: bool,
         wal_behavior: Option<MockWriteBufferBehavior>,
-        distance_compute: crate::compute::distance_computation::engine::UnifiedDistanceCompute,
+        distance_compute: proximadb_distance_kernel::engine::UnifiedDistanceCompute,
     }
 
     #[derive(Debug)]
@@ -107,18 +107,14 @@ mod write_ahead_log_batch_strategy_tests {
                 initialized: false,
                 wal_behavior: Some(MockWriteBufferBehavior::new()),
                 distance_compute:
-                    crate::compute::distance_computation::engine::UnifiedDistanceCompute::default(),
+                    proximadb_distance_kernel::engine::UnifiedDistanceCompute::default(),
             }
         }
     }
 
     #[async_trait]
-    impl crate::compute::distance_computation::engine::DistanceComputeProvider
-        for MockWALBatchStrategy
-    {
-        fn distance_compute(
-            &self,
-        ) -> &crate::compute::distance_computation::engine::UnifiedDistanceCompute {
+    impl proximadb_distance_kernel::engine::DistanceComputeProvider for MockWALBatchStrategy {
+        fn distance_compute(&self) -> &proximadb_distance_kernel::engine::UnifiedDistanceCompute {
             &self.distance_compute
         }
     }

--- a/src/storage/persistence/write_ahead_log/bincode_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/bincode_serialization_strategy.rs
@@ -13,7 +13,6 @@ use tracing::{debug, info, warn};
 
 use super::batch_strategy::WALBatchStrategy;
 use super::{BatchId, FlushResult, WALConfig, WALStats};
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::write_ahead_log::{
@@ -21,6 +20,7 @@ use crate::storage::persistence::write_ahead_log::{
     serialization::{SerializationFormat, SerializerFactory, VectorBatchSerializer},
 };
 use crate::storage::traits::UnifiedStorageFormat;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
 /// Bincode WAL batch strategy using serialization-first architecture
 pub struct BincodeSerializationStrategy {
@@ -332,7 +332,7 @@ impl WALBatchStrategy for BincodeSerializationStrategy {
         collection_id: &str,
         query_vector: &[f32],
         k: usize,
-        distance_metric: Option<crate::compute::distance_computation::DistanceMetric>,
+        distance_metric: Option<proximadb_distance_kernel::DistanceMetric>,
     ) -> Result<Vec<(String, f32, proximadb_records::ProximaRecord)>> {
         // For tests, we can do a simple search in memtable
         let vectors = self
@@ -348,8 +348,7 @@ impl WALBatchStrategy for BincodeSerializationStrategy {
         let distance_compute = UnifiedDistanceCompute::default();
 
         // Use the unified distance compute to calculate distances
-        let metric =
-            distance_metric.unwrap_or(crate::compute::distance_computation::DistanceMetric::Cosine);
+        let metric = distance_metric.unwrap_or(proximadb_distance_kernel::DistanceMetric::Cosine);
         let mut results: Vec<(String, f32, proximadb_records::ProximaRecord)> = Vec::new();
 
         for vector in vectors {

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -79,13 +79,11 @@ use tracing::{debug, info, trace, warn};
 
 use crate::core::bloom::BloomFilterStrategy;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::{
-    DistanceComputeProvider, UnifiedDistanceCompute,
-};
 use crate::core::{String, VectorId};
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::traits::{FlushResult, UnifiedStorageFormat};
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::{DistanceComputeProvider, UnifiedDistanceCompute};
 use proximadb_records::{
     EmbeddingCell, ProximaRecord, ProximaTreeNode, conversions::sql_value_to_proxima,
 };
@@ -2344,13 +2342,13 @@ impl WriteAheadLogManager {
         collection_id: &str,
         query_vector: &[f32],
         k: usize,
-        distance_metric: Option<crate::compute::distance_computation::DistanceMetric>,
+        distance_metric: Option<proximadb_distance_kernel::DistanceMetric>,
     ) -> Result<Vec<(VectorId, f32, ProximaRecord)>> {
         {
             let memtable_config = crate::storage::memtable::core::MemtableConfig::default();
             let wal_behavior = self.shared_wal_behavior.get_or_init(&memtable_config);
-            let metric = distance_metric
-                .unwrap_or(crate::compute::distance_computation::DistanceMetric::Cosine);
+            let metric =
+                distance_metric.unwrap_or(proximadb_distance_kernel::DistanceMetric::Cosine);
             let results = wal_behavior
                 .search_unflushed_vectors(
                     collection_id,
@@ -2401,11 +2399,11 @@ impl WriteAheadLogManager {
         query_vector: &[f32],
         top_k: usize,
         distance_metric: DistanceMetric,
-        metadata_filters: Option<&crate::core::search::FilterExpression>,
+        metadata_filters: Option<&proximadb_filter_expression::FilterExpression>,
         include_vectors: bool,
         include_metadata: bool,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
+        use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
         tracing::debug!(
             "🔍 WAL: Enhanced search for collection {} with top_k={}, metric={:?}, filters={}",
@@ -2593,7 +2591,7 @@ impl WriteAheadLogManager {
     async fn filter_batches_with_bloom(
         &self,
         batches: Vec<crate::storage::memtable::specialized::wal_behavior::WALVectorBatch>,
-        metadata_filters: &crate::core::search::FilterExpression,
+        metadata_filters: &proximadb_filter_expression::FilterExpression,
     ) -> Result<Vec<crate::storage::memtable::specialized::wal_behavior::WALVectorBatch>> {
         let mut filtered_batches = Vec::new();
         let mut bloom_hits = 0;
@@ -2668,9 +2666,9 @@ impl WriteAheadLogManager {
     /// must still satisfy those `Equals` legs.
     fn extract_filter_conditions(
         &self,
-        filter: &crate::core::search::FilterExpression,
+        filter: &proximadb_filter_expression::FilterExpression,
     ) -> Vec<(String, String)> {
-        use crate::core::search::{ComparisonOperator, FilterExpression};
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
 
         match filter {
             FilterExpression::Comparison {
@@ -3134,10 +3132,10 @@ impl std::fmt::Debug for WriteAheadLogManager {
 #[cfg(test)]
 mod simple_context_tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::storage::background_flush_context::{
         BackgroundFlushContext, CompressionConfig, OperationPriority, StorageEngineType,
     };
+    use proximadb_distance_kernel::DistanceMetric;
     use std::collections::HashMap;
 
     #[tokio::test]
@@ -3363,10 +3361,10 @@ mod wal_manager_infra_tests {
 #[cfg(test)]
 mod optimization_validation_tests {
     use super::*;
-    use crate::compute::distance_computation::DistanceMetric;
     use crate::storage::background_flush_context::{
         BackgroundFlushContext, CompressionConfig, OperationPriority, StorageEngineType,
     };
+    use proximadb_distance_kernel::DistanceMetric;
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/src/storage/persistence/write_ahead_log/parallel_search.rs
+++ b/src/storage/persistence/write_ahead_log/parallel_search.rs
@@ -11,11 +11,12 @@ use rayon::prelude::*;
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 
-use crate::compute::distance_computation::DistanceMetric;
-use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
 use crate::core::hardware_capabilities::HardwareCapabilities;
-use crate::core::search::{FilterExpression, OptimizedSearchRecord};
+use crate::core::search::OptimizedSearchRecord;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
+use proximadb_distance_kernel::DistanceMetric;
+use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_filter_expression::FilterExpression;
 use proximadb_records::{ProximaRecord, ProximaTreeNode};
 
 /// Parallel WAL search coordinator

--- a/src/storage/persistence/write_ahead_log/proto_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/proto_serialization_strategy.rs
@@ -11,9 +11,6 @@ use tracing::{debug, info, warn};
 
 use super::batch_strategy::WALBatchStrategy;
 use super::{BatchId, FlushResult, WALConfig, WALStats};
-use crate::compute::distance_computation::engine::{
-    DistanceComputeProvider, UnifiedDistanceCompute,
-};
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::write_ahead_log::{
@@ -21,6 +18,7 @@ use crate::storage::persistence::write_ahead_log::{
     serialization::{SerializationFormat, SerializerFactory, VectorBatchSerializer},
 };
 use crate::storage::traits::UnifiedStorageFormat;
+use proximadb_distance_kernel::engine::{DistanceComputeProvider, UnifiedDistanceCompute};
 
 /// Proto WAL batch strategy using serialization-first architecture
 pub struct ProtoSerializationStrategy {
@@ -268,7 +266,7 @@ impl WALBatchStrategy for ProtoSerializationStrategy {
         _collection_id: &str,
         _query_vector: &[f32],
         _k: usize,
-        _distance_metric: Option<crate::compute::distance_computation::DistanceMetric>,
+        _distance_metric: Option<proximadb_distance_kernel::DistanceMetric>,
     ) -> Result<Vec<(String, f32, proximadb_records::ProximaRecord)>> {
         // For now, similarity search is delegated to storage engine
         let engine = self.storage_engine.read().await;

--- a/src/storage/persistence/write_ahead_log/tests/avro_serialization_tests.rs
+++ b/src/storage/persistence/write_ahead_log/tests/avro_serialization_tests.rs
@@ -7,7 +7,7 @@
 //! - Recovery operations
 //! - Stats tracking
 
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::write_ahead_log::{

--- a/src/storage/persistence/write_ahead_log/tests/background_flush_optimization_tests.rs
+++ b/src/storage/persistence/write_ahead_log/tests/background_flush_optimization_tests.rs
@@ -9,7 +9,7 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::{Mutex, RwLock};
 
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     use crate::storage::background_flush_context::{
         BackgroundFlushContext, CompressionConfig, OperationPriority, StorageEngineType,
     };

--- a/src/storage/persistence/write_ahead_log/tests/batch_strategy_tests.rs
+++ b/src/storage/persistence/write_ahead_log/tests/batch_strategy_tests.rs
@@ -10,7 +10,7 @@ mod tests {
         AvroSerializationStrategy, BincodeSerializationStrategy, WALBatchStrategy,
     };
     // WalBatchStrategyExt removed - use write_native_batch directly
-    use crate::compute::distance_computation::DistanceMetric;
+    use proximadb_distance_kernel::DistanceMetric;
     use crate::storage::WALConfig;
     use proximadb_records::{EmbeddingCell, ProximaRecord};
 

--- a/src/storage/persistence/write_ahead_log/tests/bincode_serialization_tests.rs
+++ b/src/storage/persistence/write_ahead_log/tests/bincode_serialization_tests.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::compute::distance_computation::DistanceMetric;
+use proximadb_distance_kernel::DistanceMetric;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::write_ahead_log::{

--- a/src/storage/scan_strategy.rs
+++ b/src/storage/scan_strategy.rs
@@ -17,8 +17,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashSet;
 
-use crate::core::search::FilterExpression;
 use crate::proto::proximadb_v1::Collection;
+use proximadb_filter_expression::FilterExpression;
 use proximadb_records::ProximaRecord;
 
 /// Unified scan strategy based on RAPTOR's successful pattern

--- a/src/storage/tests/storage_engine_simple_tests.rs
+++ b/src/storage/tests/storage_engine_simple_tests.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 use tempfile::TempDir;
 
-use crate::compute::distance_computation::DistanceMetric;
 use crate::core::Config;
 use crate::storage::engine::StorageEngine;
 use proximadb_data_model::ProximaValue;
+use proximadb_distance_kernel::DistanceMetric;
 use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTreeNode};
 
 fn create_test_vector(id: &str, vector: Vec<f32>) -> ProximaRecord {

--- a/src/storage/traits/query.rs
+++ b/src/storage/traits/query.rs
@@ -106,7 +106,7 @@ pub struct StorageQueryMetadata {
     pub dimension: usize,
 
     /// Distance metric for the collection
-    pub distance_metric: crate::compute::distance_computation::DistanceMetric,
+    pub distance_metric: proximadb_distance_kernel::DistanceMetric,
 
     /// Storage engine strategy for this collection
     pub storage_strategy: StorageFormatStrategy,
@@ -314,47 +314,47 @@ impl StorageQueryContext {
                     crate::proto::proximadb_v1::DistanceMetric::try_from(metric).ok()
                 })
                 .map_or(
-                    crate::compute::distance_computation::DistanceMetric::Cosine,
+                    proximadb_distance_kernel::DistanceMetric::Cosine,
                     |metric| match metric {
                         crate::proto::proximadb_v1::DistanceMetric::Unspecified
                         | crate::proto::proximadb_v1::DistanceMetric::Cosine => {
-                            crate::compute::distance_computation::DistanceMetric::Cosine
+                            proximadb_distance_kernel::DistanceMetric::Cosine
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Euclidean => {
-                            crate::compute::distance_computation::DistanceMetric::Euclidean
+                            proximadb_distance_kernel::DistanceMetric::Euclidean
                         }
                         crate::proto::proximadb_v1::DistanceMetric::DotProduct => {
-                            crate::compute::distance_computation::DistanceMetric::DotProduct
+                            proximadb_distance_kernel::DistanceMetric::DotProduct
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Hamming => {
-                            crate::compute::distance_computation::DistanceMetric::Hamming
+                            proximadb_distance_kernel::DistanceMetric::Hamming
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Manhattan => {
-                            crate::compute::distance_computation::DistanceMetric::Manhattan
+                            proximadb_distance_kernel::DistanceMetric::Manhattan
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Jaccard => {
-                            crate::compute::distance_computation::DistanceMetric::Jaccard
+                            proximadb_distance_kernel::DistanceMetric::Jaccard
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Angular => {
-                            crate::compute::distance_computation::DistanceMetric::Angular
+                            proximadb_distance_kernel::DistanceMetric::Angular
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Chebyshev => {
-                            crate::compute::distance_computation::DistanceMetric::Chebyshev
+                            proximadb_distance_kernel::DistanceMetric::Chebyshev
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Canberra => {
-                            crate::compute::distance_computation::DistanceMetric::Canberra
+                            proximadb_distance_kernel::DistanceMetric::Canberra
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Minkowski => {
-                            crate::compute::distance_computation::DistanceMetric::Minkowski
+                            proximadb_distance_kernel::DistanceMetric::Minkowski
                         }
                         crate::proto::proximadb_v1::DistanceMetric::BrayCurtis => {
-                            crate::compute::distance_computation::DistanceMetric::BrayCurtis
+                            proximadb_distance_kernel::DistanceMetric::BrayCurtis
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Hellinger => {
-                            crate::compute::distance_computation::DistanceMetric::Hellinger
+                            proximadb_distance_kernel::DistanceMetric::Hellinger
                         }
                         crate::proto::proximadb_v1::DistanceMetric::Custom => {
-                            crate::compute::distance_computation::DistanceMetric::Custom
+                            proximadb_distance_kernel::DistanceMetric::Custom
                         }
                     },
                 ),
@@ -405,7 +405,7 @@ impl StorageQueryContext {
     }
 
     /// Get distance metric (pre-computed from collection config).
-    pub fn distance_metric(&self) -> crate::compute::distance_computation::DistanceMetric {
+    pub fn distance_metric(&self) -> proximadb_distance_kernel::DistanceMetric {
         self.search_params
             .distance_metric
             .unwrap_or(self.metadata.distance_metric)


### PR DESCRIPTION
## Summary

A detailed, **measurement-grounded** plan for **Slice D** — the linchpin of the root-crate decomposition that inverts the storage→up dependency edges so the storage engines (Slices E/F, ~245K LOC) can extract into crates.

Docs only (no code). For review — **do not merge until approved.**

## Key reframe vs. the original "three ports" sketch

Grounded in the measured coupling on `develop` (storage → `index`/`compute`/`services`/`core`), the plan splits Slice D into **two mechanisms**:

- **Mechanism A — redirect-down (~80% of edges, mechanical):** most edges are storage referencing *root paths* of shared **types** that already live in foundation crates (`DistanceMetric`×207 → `proximadb-distance-types`; `FilterExpression`×61 → `proximadb-filter-expression`; quant/index types; config/hardware-caps). These dissolve by rewriting the path — **not** by inverting a dependency. Plus two small new type-leaf extractions (`search-types`, `bloom`).
- **Mechanism B — true port inversion (thin surface):** only where storage *drives* a collaborator — `AxisManager` (storage constructs + `.query()`s it) → `IndexPort`; `CollectionService` (`.read`/`.collection`/`.write`) → `CollectionMetadataPort`; plus conditional distance/quant *dispatch* ports decided by a measure-first rule (kernel→redirect, policy→invert). Concrete impls inject at the composition root.

## Phasing (D0–D5)

Behavior-neutral + layering-gated throughout; redirect-down (D0/D1) is opportunistic and done first to shrink the surface and de-risk the hot injection phase (D3/D4), which needs the announced coordination window. Terminates in a storage-up-edge ratchet to zero, unblocking Slice E.

## Files
- `docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc` (new)
- cross-referenced from the Slice D row of `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`

Ref ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21, TD-104.