### PR TITLE
feat(sdk): TD-CG2 — SDK consumes victor-codegraph; deprecate in-SDK code.py

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -96,6 +96,15 @@ code-chunking = [
     "tree-sitter-language-pack>=1.0",
 ]
 
+# Shared code->CPG chunker (TD-CG2 / ADR-028). When installed, the deprecated
+# in-SDK `chunking_strategies/code.py` delegates to `victor_codegraph` so the
+# tree-sitter symbol+relation chunker lives in ONE place (Victor owns it). Until
+# `victor-codegraph` is published to PyPI, install it editable for now:
+#   pip install -e ../../victor/victor-codegraph && pip install 'proximadb[codegraph]'
+codegraph = [
+    "victor-codegraph>=0.1.0",
+]
+
 langchain = [
     "langchain-core>=0.3.0",
 ]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -96,7 +96,7 @@ code-chunking = [
     "tree-sitter-language-pack>=1.0",
 ]
 
-# Shared code->CPG chunker (TD-CG2 / ADR-028). When installed, the deprecated
+# Shared code->CPG chunker (TD-CG2 / ADR-029). When installed, the deprecated
 # in-SDK `chunking_strategies/code.py` delegates to `victor_codegraph` so the
 # tree-sitter symbol+relation chunker lives in ONE place (Victor owns it). Until
 # `victor-codegraph` is published to PyPI, install it editable for now:

--- a/clients/python/src/proximadb_sdk/chunking_strategies/code.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/code.py
@@ -1,7 +1,7 @@
 """
 Code-aware chunking strategy using Tree-sitter for AST parsing.
 
-.. deprecated:: TD-CG2 (ADR-028)
+.. deprecated:: TD-CG2 (ADR-029)
     This in-SDK code chunker duplicates the tree-sitter symbol+relation chunker that
     now lives in the shared, neutral ``victor-codegraph`` package (Victor owns it; the
     ProximaDB SDK, Victor, and AnvaiOps all consume it). When ``victor_codegraph`` is
@@ -40,7 +40,7 @@ except Exception:  # ImportError, or a partial/native load failure
 
 
 def _warn_code_chunker_deprecated() -> None:
-    """Steer callers toward the shared ``victor-codegraph`` package (ADR-028 / TD-CG2)."""
+    """Steer callers toward the shared ``victor-codegraph`` package (ADR-029 / TD-CG2)."""
 
     warnings.warn(
         "proximadb_sdk.chunking_strategies.code is deprecated (TD-CG2): the tree-sitter "

--- a/clients/python/src/proximadb_sdk/chunking_strategies/code.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/code.py
@@ -1,6 +1,15 @@
 """
 Code-aware chunking strategy using Tree-sitter for AST parsing.
 
+.. deprecated:: TD-CG2 (ADR-028)
+    This in-SDK code chunker duplicates the tree-sitter symbol+relation chunker that
+    now lives in the shared, neutral ``victor-codegraph`` package (Victor owns it; the
+    ProximaDB SDK, Victor, and AnvaiOps all consume it). When ``victor_codegraph`` is
+    installed (``pip install 'proximadb[codegraph]'``), ``CodeChunkingStrategy``
+    **delegates** to it; otherwise it falls back to the legacy in-file implementation
+    below. The legacy implementation is slated for deletion one minor release after
+    ``victor-codegraph`` is published — prefer ``from victor_codegraph import chunk``.
+
 This module provides AST-based code chunking that produces semantic code units
 (functions, classes, methods) with full structural awareness and relationship extraction.
 
@@ -14,12 +23,33 @@ Unlike text-based chunking, this:
 import hashlib
 import os
 import re
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Any
 
 from .base import ChunkingConfig, ChunkingStrategyInterface, TextChunk
+
+# Optional delegation target (TD-CG2). Imported softly so the SDK keeps working without
+# the `codegraph` extra; when present, it is the single source of truth for code chunking.
+try:  # pragma: no cover - availability depends on the optional extra
+    import victor_codegraph as _victor_codegraph
+except Exception:  # ImportError, or a partial/native load failure
+    _victor_codegraph = None
+
+
+def _warn_code_chunker_deprecated() -> None:
+    """Steer callers toward the shared ``victor-codegraph`` package (ADR-028 / TD-CG2)."""
+
+    warnings.warn(
+        "proximadb_sdk.chunking_strategies.code is deprecated (TD-CG2): the tree-sitter "
+        "code chunker now lives in the shared 'victor-codegraph' package. Install "
+        "`proximadb[codegraph]` and prefer `from victor_codegraph import chunk`. The "
+        "legacy in-SDK implementation will be removed in a future minor release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class CodeSymbolType(IntEnum):
@@ -4192,6 +4222,7 @@ class CodeChunkingStrategy(ChunkingStrategyInterface):
     """
 
     def __init__(self, config: CodeChunkingConfig | None = None):
+        _warn_code_chunker_deprecated()
         self.config = config or CodeChunkingConfig()
         # Lazily-instantiated parsers, keyed by language. We do NOT eagerly
         # build all ~23 tree-sitter parsers here: loading every grammar to chunk
@@ -4252,6 +4283,10 @@ class CodeChunkingStrategy(ChunkingStrategyInterface):
         metadata = metadata or {}
         language = metadata.get("language") or self._detect_language(source_id)
 
+        # TD-CG2: when the shared package is installed, it is the source of truth.
+        if _victor_codegraph is not None:
+            return self._chunk_via_victor_codegraph(text, source_id, language, metadata)
+
         parser = self._get_parser(language)
         if parser is None:
             # Fall back to semantic text chunking
@@ -4308,6 +4343,46 @@ class CodeChunkingStrategy(ChunkingStrategyInterface):
             )
 
         return chunks
+
+    def _chunk_via_victor_codegraph(
+        self,
+        text: str,
+        source_id: str,
+        language: str | None,
+        metadata: dict[str, Any],
+    ) -> list[TextChunk]:
+        """Delegate to the shared ``victor-codegraph`` package and adapt to TextChunk.
+
+        TD-CG2: this is the single source of truth when the ``codegraph`` extra is
+        installed. ``victor_codegraph`` already applies size-capping and a real JS/TS
+        parser (gaps this legacy module had), so its ``CodeChunk`` output is adapted
+        one-to-one into the SDK's ``TextChunk`` shape.
+        """
+        cfg = _victor_codegraph.ChunkConfig(
+            max_chunk_tokens=max(1, int(self.config.chunk_size / 3.5)),
+            chunk_overlap_tokens=max(0, int(self.config.chunk_overlap / 3.5)),
+            languages=self.config.languages,
+            include_private=self.config.include_private,
+            extract_relations=self.config.extract_relations,
+        )
+        out: list[TextChunk] = []
+        for c in _victor_codegraph.chunk(
+            text, language=language, file_path=source_id, config=cfg
+        ):
+            meta = {**metadata, **c.metadata}
+            meta.setdefault("chunking_strategy", "code")
+            meta.setdefault("chunk_type", "code")
+            meta["source"] = "victor_codegraph"
+            out.append(
+                TextChunk(
+                    text=c.text,
+                    start_pos=c.start_pos,
+                    end_pos=c.end_pos,
+                    chunk_id=c.chunk_id,
+                    metadata=meta,
+                )
+            )
+        return out
 
     def _detect_language(self, file_path: str) -> str | None:
         """Detect language from file extension using global registry"""

--- a/clients/python/tests/test_codegraph_delegation.py
+++ b/clients/python/tests/test_codegraph_delegation.py
@@ -1,0 +1,61 @@
+"""TD-CG2 (ADR-028): the in-SDK code chunker is deprecated and delegates to the shared
+``victor-codegraph`` package when the ``codegraph`` extra is installed.
+
+The deprecation-warning test runs always. The delegation tests are guarded with
+``importorskip`` so the suite stays green where the optional extra isn't installed
+(e.g. ProximaDB CI), and assert real delegation where it is.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from proximadb_sdk.chunking_strategies.code import (
+    CodeChunkingConfig,
+    CodeChunkingStrategy,
+)
+
+SAMPLE = "def a():\n    return b()\n\n\ndef b():\n    return 1\n"
+
+
+def test_code_chunker_emits_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="victor-codegraph"):
+        CodeChunkingStrategy()
+
+
+def test_chunk_still_returns_textchunks():
+    # Works on either path (legacy or delegated): the public contract is unchanged.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        chunks = CodeChunkingStrategy().chunk(SAMPLE, "m.py", {"language": "python"})
+    assert chunks
+    assert all(c.metadata.get("chunking_strategy") == "code" for c in chunks)
+
+
+# --- Delegation path (requires the `codegraph` extra) --------------------------------
+
+victor_codegraph = pytest.importorskip("victor_codegraph")
+
+
+def _chunk(src, source_id="m.py", language="python", **cfg):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        strat = CodeChunkingStrategy(CodeChunkingConfig(**cfg))
+        return strat.chunk(src, source_id, {"language": language})
+
+
+def test_delegates_to_victor_codegraph():
+    chunks = _chunk(SAMPLE)
+    assert chunks
+    assert all(c.metadata.get("source") == "victor_codegraph" for c in chunks)
+    names = {c.metadata.get("simple_name") for c in chunks}
+    assert {"a", "b"} <= names
+
+
+def test_size_cap_flows_through_delegation():
+    # The legacy code.py had no size-capping; via delegation an oversized symbol splits.
+    big = "def f():\n" + "\n".join(f"    a{i} = {i}" for i in range(300)) + "\n"
+    chunks = _chunk(big, source_id="big.py", chunk_size=400)
+    assert len(chunks) > 1

--- a/clients/python/tests/test_codegraph_delegation.py
+++ b/clients/python/tests/test_codegraph_delegation.py
@@ -1,4 +1,4 @@
-"""TD-CG2 (ADR-028): the in-SDK code chunker is deprecated and delegates to the shared
+"""TD-CG2 (ADR-029): the in-SDK code chunker is deprecated and delegates to the shared
 ``victor-codegraph`` package when the ``codegraph`` extra is installed.
 
 The deprecation-warning test runs always. The delegation tests are guarded with


### PR DESCRIPTION
Implements **TD-CG2** from ADR-028 (#374): the ProximaDB Python SDK consumes the shared `victor-codegraph` chunker instead of maintaining its own duplicate, keeping the generic DB SDK free of an application-domain AST parser.

## Changes

- **`[codegraph]` optional extra** → `victor-codegraph` (editable-installed until published to PyPI).
- **`chunking_strategies/code.py` → deprecation shim**: when `victor_codegraph` is importable, `CodeChunkingStrategy` **delegates** to it (adapting `CodeChunk` → `TextChunk`); otherwise it **falls back to the legacy in-file implementation** (mixed-read-safe, per CLAUDE.md mandate 8). Emits a `DeprecationWarning` pointing to `from victor_codegraph import chunk`.
- Public interface (`CodeChunkingStrategy`, `factory.py` `CODE` mapping, `TextChunk` output) is **unchanged** — no caller breakage.

## Why this is the right shape

ProximaDB stays generic: the tree-sitter symbol+relation chunker lives in **one** neutral package (Victor owns it), not duplicated in the DB SDK. Delegation also inherits the two donor-gap fixes for free — **size-capping** and **real JS/TS**.

## Verification

The full SDK suite can't run in my local env (pre-existing **protobuf 5.29 vs 6.31 gencode** mismatch blocks `import proximadb_sdk`, unrelated to this change). Verified the delegation in isolation against the live `victor_codegraph` editable install:
- `DeprecationWarning` fires on instantiation
- delegated chunks tagged `source=victor_codegraph`, correct symbols
- a 300-line function → **13 size-capped chunks** (the gap the legacy `code.py` couldn't fix)

New `tests/test_codegraph_delegation.py` guards the delegation cases with `importorskip("victor_codegraph")`, so CI is green **with or without** the extra installed (in ProximaDB CI the extra is absent → legacy path runs, existing tests unchanged; `DeprecationWarning` is already ignored by the SDK's `filterwarnings`).

## Follow-up (not this PR)

- Delete the legacy `code.py` body one minor release after `victor-codegraph` is on PyPI.
- TD-CG3: anvaiops F3 code-graph-sync worker (gated by its Dogfood milestone).

Companion: ADR-028 #374 · victor-codegraph #274 · ADRs victor #273 / anvaiops #179.