### PR TITLE
refactor(storage): Slice D / D0b — redirect hardware-caps + index-types edges (+ fix D0 gate)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
@@ -75,8 +75,10 @@ count dramatically before any inversion is attempted.
 | `crate::compute::distance_computation::*` (whole namespace: `DistanceMetric`, `engine`, `UnifiedDistanceCompute`, `quantized`, …) | `proximadb_distance_kernel::*` (the root path *is* `pub use proximadb_distance_kernel as distance_computation`) — done in D0
 | `crate::compute::quantization::types::*` | `proximadb_quantization_types::*`
 | `crate::core::search::FilterExpression` | `proximadb_filter_expression::*`
-| `crate::core::{config, hardware_capabilities}` | `proximadb_config` / `proximadb_hardware_caps`
-| `crate::index::axis::types` | `proximadb_index_types` / `proximadb_index_traits`
+| `crate::core::hardware_capabilities` | `proximadb_hardware_caps` (pure re-export, `hardware_capabilities.rs` = `pub use proximadb_hardware_caps::*`) — **done in D0b** (56 refs)
+| `crate::index::axis::types` | `proximadb_index_types` (pure re-export, `axis/types.rs` = `pub use proximadb_index_types::*`) — **done in D0b** (7 refs)
+| `crate::core::config` | ⚠️ **NOT a clean redirect** — `core::config` is a *real root module* (`pub mod config`), not a re-export of `proximadb-config` (divergent, like the `-distance-types` trap). Reconcile before redirecting.
+| `crate::compute::quantization::types` | `proximadb_quantization_types` — *unverified*; confirm it's a re-export before redirecting (the root `compute::quantization` is mostly orchestration, a Mechanism-B port).
 |===
 
 A few shared-type leaves are **not** yet crates and must be extracted down first (small,

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -247,14 +247,24 @@ _pkg_args() { local a=""; for p in $1; do a="$a -p $p"; done; printf '%s' "$a"; 
 cmd_check() {
   local pkgs; pkgs="$(_affected)"
   [ -n "$pkgs" ] || { printf 'worktree: no crate source changed vs %s — nothing to check\n' "$BASE_DEFAULT" >&2; return 0; }
-  # Match CI's compile+clippy gate AND compile #[cfg(test)] code. `--all-targets`
-  # is the fix for a real "green local, red CI" trap: a plain `cargo check`
-  # (or `clippy --lib --bins`) never compiles the test cfg, so a broken/changed
-  # import inside a `#[cfg(test)]` module sails through locally and only fails in
-  # the CI "Rust Tests" job. `-D warnings` matches the CI clippy gate.
-  printf 'worktree: cargo clippy --all-targets -D warnings%s (matches CI clippy + compiles tests)\n' "$(_pkg_args "$pkgs")" >&2
+  # Two complementary checks that together match CI without false reds:
+  #  1. `cargo check --tests` COMPILES the lib/bin `#[cfg(test)]` code + integration
+  #     tests — the "green local, red CI" trap fix: a plain `cargo check` or
+  #     `clippy --lib --bins` never compiles the test cfg, so a broken/changed
+  #     import inside a test module sails through locally and only fails in CI's
+  #     "Rust Tests" job. Scoped to `--tests` (NOT `--all-targets`): CI's Rust
+  #     Tests job runs `--lib` + doctests and never builds benches/examples, which
+  #     have bit-rotted on the root crate; `--all-targets` would flag that
+  #     pre-existing rot as a false red. (No `-D warnings` on test code — the root
+  #     crate's tests carry many pre-existing clippy warnings CI does not gate.)
+  #  2. `clippy --lib --bins -- -D warnings` lints exactly what CI's clippy gate
+  #     lints (lib+bins only), so the lint posture matches CI precisely.
+  printf 'worktree: cargo check --tests%s (compiles #[cfg(test)] — CI Rust Tests gap)\n' "$(_pkg_args "$pkgs")" >&2
   # shellcheck disable=SC2046
-  cargo clippy $(_pkg_args "$pkgs") --all-targets -- -D warnings
+  cargo check $(_pkg_args "$pkgs") --tests
+  printf 'worktree: cargo clippy --lib --bins -D warnings%s (matches CI clippy gate)\n' "$(_pkg_args "$pkgs")" >&2
+  # shellcheck disable=SC2046
+  cargo clippy $(_pkg_args "$pkgs") --lib --bins -- -D warnings
 }
 
 cmd_test() {

--- a/src/storage/engines/core/formats/columnar/batch_operations.rs
+++ b/src/storage/engines/core/formats/columnar/batch_operations.rs
@@ -32,7 +32,7 @@ impl ColumnarBatchOperations {
     /// Create new batch operations handler
     pub fn new(
         parquet_reader: Arc<UnifiedParquetReader>,
-        _hardware: Arc<crate::core::hardware_capabilities::HardwareCapabilities>,
+        _hardware: Arc<proximadb_hardware_caps::HardwareCapabilities>,
         memory_pool: Arc<VectorMemoryPool>,
         config: ColumnarConfig,
     ) -> Self {
@@ -502,7 +502,7 @@ mod tests {
             )
             .unwrap(),
         );
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let memory_pool = Arc::new(VectorMemoryPool::new());
         let config = ColumnarConfig::default();
 
@@ -580,7 +580,7 @@ mod tests {
                 )
                 .unwrap(),
             );
-            let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+            let hardware = proximadb_hardware_caps::get_hardware_capabilities();
             let memory_pool = Arc::new(VectorMemoryPool::new());
             let config = ColumnarConfig::default();
 

--- a/src/storage/engines/core/formats/columnar/examples_test.rs
+++ b/src/storage/engines/core/formats/columnar/examples_test.rs
@@ -12,9 +12,9 @@ use std::sync::Arc;
 use tempfile::tempdir;
 
 use super::*;
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_data_model::ProximaValue;
+use proximadb_hardware_caps::HardwareCapabilities;
 use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTreeNode};
 
 /// Example: VIPER engine using optimized columnar infrastructure

--- a/src/storage/engines/core/formats/columnar/mod.rs
+++ b/src/storage/engines/core/formats/columnar/mod.rs
@@ -851,7 +851,7 @@ impl ColumnarFactory {
     /// Create columnar optimizer with hardware-specific settings
     #[allow(clippy::todo)] // Deferred: Refactor to async and provide proper arguments (5 args required)
     pub fn create_optimizer(
-        _hardware: Arc<crate::core::hardware_capabilities::HardwareCapabilities>,
+        _hardware: Arc<proximadb_hardware_caps::HardwareCapabilities>,
         _config: ColumnarConfig,
     ) -> ColumnarOptimizer {
         let _distance_compute = Arc::new(

--- a/src/storage/engines/core/formats/columnar/utilities.rs
+++ b/src/storage/engines/core/formats/columnar/utilities.rs
@@ -53,7 +53,7 @@ impl ColumnarUtilities {
     /// Create new columnar utilities
     pub fn new(
         filesystem: Arc<FilesystemFactory>,
-        _hardware: Arc<crate::core::hardware_capabilities::HardwareCapabilities>,
+        _hardware: Arc<proximadb_hardware_caps::HardwareCapabilities>,
         config: ColumnarConfig,
     ) -> Self {
         Self {
@@ -606,7 +606,7 @@ mod tests {
                 .await
                 .unwrap(),
         );
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let config = ColumnarConfig::default();
 
         let utilities = ColumnarUtilities::new(filesystem, hardware, config);
@@ -642,7 +642,7 @@ mod tests {
                 .await
                 .unwrap()
         }));
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let config = ColumnarConfig::default();
 
         let utilities = ColumnarUtilities::new(filesystem, hardware, config);

--- a/src/storage/engines/core/formats/proximablocks/batch_operations.rs
+++ b/src/storage/engines/core/formats/proximablocks/batch_operations.rs
@@ -151,7 +151,7 @@ pub struct BatchOperationStats {
 impl RowBasedBatchOperations {
     /// Create new batch operations handler
     pub fn new(
-        _hardware: Arc<crate::core::hardware_capabilities::HardwareCapabilities>,
+        _hardware: Arc<proximadb_hardware_caps::HardwareCapabilities>,
         memory_pool: Arc<VectorMemoryPool>,
         config: BlockBatchConfig,
     ) -> Self {
@@ -771,7 +771,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_operations_creation() {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let memory_pool = Arc::new(VectorMemoryPool::new());
 
         let config = BlockBatchConfig::default();
@@ -783,7 +783,7 @@ mod tests {
 
     #[test]
     fn test_batch_size_calculation() {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let memory_pool = Arc::new(VectorMemoryPool::new());
 
         let config = BlockBatchConfig::default();
@@ -797,7 +797,7 @@ mod tests {
     // Deferred: Re-enable test after row_based module is implemented
     // #[test]
     // fn test_batch_splitting() {
-    //     let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+    //     let hardware = proximadb_hardware_caps::get_hardware_capabilities();
     //     let memory_pool = Arc::new(VectorMemoryPool::new(1024 * 1024 * 1024));
     //     let quantization_engine = Arc::new(
     //         crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(

--- a/src/storage/engines/core/formats/proximablocks/compression_config.rs
+++ b/src/storage/engines/core/formats/proximablocks/compression_config.rs
@@ -3,9 +3,9 @@
 
 use std::collections::HashMap;
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::CompressionConfig as ProtoCompressionConfig;
 use proximadb_compression::{CompressionAlgorithm, CompressionContext};
+use proximadb_hardware_caps::HardwareCapabilities;
 
 /// Row-based compression configuration
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/formats/proximablocks/utilities.rs
+++ b/src/storage/engines/core/formats/proximablocks/utilities.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use super::{ProximaDataBlock, RowBasedConfig};
-use crate::core::hardware_capabilities::HardwareCapabilities;
+use proximadb_hardware_caps::HardwareCapabilities;
 use proximadb_records::ProximaRecord;
 
 /// Row-based utilities collection

--- a/src/storage/engines/core/ops/compression_adapter.rs
+++ b/src/storage/engines/core/ops/compression_adapter.rs
@@ -5,7 +5,6 @@ use crate::storage::engines::core::ops::compression_common::CompressionStrategy;
 use anyhow::Result;
 use std::collections::HashMap;
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::metrics::compression::CompressionData;
 use crate::storage::engines::core::ops::compression_common::{
     AdaptiveCompressionSettings, ContextAwareCompressionConfig, UniversalCompressionConfig,
@@ -13,6 +12,7 @@ use crate::storage::engines::core::ops::compression_common::{
 use proximadb_compression::{
     CompressionAlgorithm, CompressionContext, CompressionProvider, StandardCompression,
 };
+use proximadb_hardware_caps::HardwareCapabilities;
 
 /// Compression adapter that bridges Universal config with Unified implementation
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/ops/compression_common.rs
+++ b/src/storage/engines/core/ops/compression_common.rs
@@ -3,9 +3,9 @@
 
 use std::collections::HashMap;
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::metrics::compression::CompressionData;
 use proximadb_compression::CompressionAlgorithm;
+use proximadb_hardware_caps::HardwareCapabilities;
 
 /// Universal compression configuration
 #[derive(Debug, Clone)]

--- a/src/storage/engines/core/ops/mod.rs
+++ b/src/storage/engines/core/ops/mod.rs
@@ -205,9 +205,9 @@ pub use crate::storage::engines::core::search::search_common::{
 use anyhow::Result;
 use std::collections::HashMap;
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::DistanceMetric;
+use proximadb_hardware_caps::HardwareCapabilities;
 
 // Temporary placeholder types until modules are created
 #[derive(Debug, Clone)]
@@ -959,7 +959,7 @@ mod tests {
 
     #[test]
     fn test_workload_specific_config() {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
 
         let high_throughput_config =
             create_config_for_workload(WorkloadType::HighThroughput, &hardware);

--- a/src/storage/engines/impls_tests/raptor/helpers.rs
+++ b/src/storage/engines/impls_tests/raptor/helpers.rs
@@ -415,14 +415,14 @@ pub fn create_pq8_quantization_config()
 // HARDWARE & COMPUTE HELPERS
 // ============================================================================
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
+use proximadb_hardware_caps::HardwareCapabilities;
 
 /// Initialize hardware capabilities for testing
 /// Source: Multiple test files
 #[allow(dead_code)]
 pub fn init_hardware_capabilities() -> Arc<HardwareCapabilities> {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
-    crate::core::hardware_capabilities::get_hardware_capabilities()
+    proximadb_hardware_caps::get_hardware_capabilities()
 }
 
 /// Create a UnifiedDistanceCompute instance for testing

--- a/src/storage/engines/impls_tests/raptor/matrix_tests.rs
+++ b/src/storage/engines/impls_tests/raptor/matrix_tests.rs
@@ -301,7 +301,7 @@ async fn test_p2_matrix_search_integration() -> Result<()> {
 fn test_phase1_boundary_detection_basic() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-    let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+    let hardware = proximadb_hardware_caps::get_hardware_capabilities();
     let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Euclidean));
     let builder = MatrixBuilder::new(
         distance_compute.clone(),
@@ -373,7 +373,7 @@ fn test_phase1_boundary_detection_basic() {
 fn test_phase2_spillover_detection() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-    let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+    let hardware = proximadb_hardware_caps::get_hardware_capabilities();
     let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
     let builder = MatrixBuilder::new(distance_compute.clone(), hardware, DistanceMetric::Cosine);
 
@@ -639,7 +639,7 @@ fn test_spillover_map_generation() {
 fn test_p2_matrix_building() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-    let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+    let hardware = proximadb_hardware_caps::get_hardware_capabilities();
     let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
 
     let builder = MatrixBuilder::new(distance_compute, hardware, DistanceMetric::Cosine);
@@ -660,7 +660,7 @@ fn test_p2_matrix_building() {
 fn test_k2_matrix_building() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-    let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+    let hardware = proximadb_hardware_caps::get_hardware_capabilities();
     let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
 
     let builder = MatrixBuilder::new(distance_compute, hardware, DistanceMetric::Euclidean);

--- a/src/storage/engines/impls_tests/swift/operations_tests.rs
+++ b/src/storage/engines/impls_tests/swift/operations_tests.rs
@@ -7,7 +7,7 @@
 //! - src/storage/engines/impls/swift/mod.rs
 
 use super::super::super::swift::*;
-use crate::core::hardware_capabilities;
+use proximadb_hardware_caps;
 use proximadb_runtime_common::pool::VectorMemoryPool;
 // TESTS FROM batch_operations.rs
 // =====================================================

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -32,7 +32,7 @@ use proximadb_distance_kernel::DistanceMetric;
 // Performance optimization handled internally
 // NOVA-specific optimization structures removed - now using universal module
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
+use proximadb_hardware_caps::HardwareCapabilities;
 
 /// NOVA Engine - Next-generation Optimized Vector Analytics
 ///
@@ -237,7 +237,7 @@ pub struct NovaEngine {
 impl NovaEngine {
     /// Create new NOVA engine instance
     pub async fn new() -> Result<Self> {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let optimized_ops = Arc::new(OptimizedNovaOperations::new()?);
 
         // Initialize filesystem factory

--- a/src/storage/engines/nova/optimized_operations.rs
+++ b/src/storage/engines/nova/optimized_operations.rs
@@ -5,9 +5,10 @@ use anyhow::{Result, anyhow};
 use arrow_array::RecordBatch;
 // Arrow compute not available, would need full arrow crate
 // use arrow::compute::kernels::aggregate;
-use crate::core::{hardware_capabilities::HardwareCapabilities, memory::pool::VectorMemoryPool};
+use crate::core::memory::pool::VectorMemoryPool;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
+use proximadb_hardware_caps::HardwareCapabilities;
 use std::sync::Arc;
 use tracing::info;
 // Memory-mapped Parquet operations would be imported here
@@ -73,7 +74,7 @@ pub struct OptimizedNovaOperations {
 impl OptimizedNovaOperations {
     /// Create new optimized operations
     pub fn new() -> Result<Self> {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let distance_compute = UnifiedDistanceCompute::default();
         let vector_pool = Arc::new(VectorMemoryPool::new());
         let mmap_pool = Arc::new(MmapPool::new(50));

--- a/src/storage/engines/raptor/common.rs
+++ b/src/storage/engines/raptor/common.rs
@@ -1187,7 +1187,7 @@ impl InterCentroidMatrix {
         use crate::compute::QuantizedVector;
         use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
         use crate::compute::quantization::types::UnifiedQuantizationLevel;
-        use crate::core::hardware_capabilities::get_hardware_capabilities;
+        use proximadb_hardware_caps::get_hardware_capabilities;
 
         let hw = get_hardware_capabilities();
 
@@ -1577,7 +1577,7 @@ impl VectorCentroidMatrix {
 
     /// Hardware-optimized batch distance retrieval using unified modules
     pub fn get_distances_batch_optimized(&self, queries: &[(usize, usize)]) -> Vec<f32> {
-        use crate::core::hardware_capabilities::get_hardware_capabilities;
+        use proximadb_hardware_caps::get_hardware_capabilities;
 
         match self.storage_strategy {
             VectorCentroidStorageStrategy::Full => {
@@ -1906,7 +1906,7 @@ impl RowGroupBloomFilter {
         footer: &RaptorFooter,
         vector_ids: &[String],
     ) -> Vec<Vec<u16>> {
-        use crate::core::hardware_capabilities::get_hardware_capabilities;
+        use proximadb_hardware_caps::get_hardware_capabilities;
 
         let hw = get_hardware_capabilities();
         let batch_size = if hw.has_avx512() {

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -16,7 +16,6 @@ use super::{
     RaptorConfig, RaptorWriter, RowGroups,
     consolidated_reader::{RaptorReader, ScanStrategy},
 };
-use crate::core::hardware_capabilities::get_hardware_capabilities;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
@@ -26,6 +25,7 @@ use crate::storage::traits::{
     UnifiedStorageFormat,
 };
 use proximadb_distance_kernel::{DistanceMetric, engine::UnifiedDistanceCompute};
+use proximadb_hardware_caps::get_hardware_capabilities;
 use proximadb_records::conversions::proxima_record_to_vector;
 // IvfManager removed - Matrix Trinity handles clustering
 use super::smart_rowgroup_sizing::SmartRowGroupSizer;
@@ -34,7 +34,7 @@ use super::smart_rowgroup_sizing::SmartRowGroupSizer;
 use crate::index::axis::clustering::{
     ClusterManager, ClusteringAlgorithm, ClusteringConfig, KMeansConfig,
 };
-use crate::index::axis::types::ClusterAssignment;
+use proximadb_index_types::ClusterAssignment;
 
 // Deep integration with filesystem API for cloud-aware I/O
 use crate::storage::persistence::filesystem::TierConfig;
@@ -43,10 +43,10 @@ use crate::storage::persistence::filesystem::{
 };
 
 // Universal performance optimization imports
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::storage::engines::core::ops::performance_optimization::{
     UniversalOptimizationStrategy, UniversalPerformanceOptimizer, UniversallyOptimized,
 };
+use proximadb_hardware_caps::HardwareCapabilities;
 // VectorMemoryPool now managed by universal optimizer
 
 // Unified metrics framework for AutoML integration

--- a/src/storage/engines/raptor/matrix_builder.rs
+++ b/src/storage/engines/raptor/matrix_builder.rs
@@ -18,14 +18,14 @@ use std::sync::Arc;
 use tracing::warn;
 use tracing::{debug, info};
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::storage::engines::core::ops::proximacodec::types::ProximaScheme;
 use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
+use proximadb_hardware_caps::HardwareCapabilities;
 
 #[cfg(feature = "gpu")]
 use crate::compute::gpu::distance::GpuDistanceCompute;
 #[cfg(feature = "gpu")]
-use crate::core::hardware_capabilities::GpuBackend;
+use proximadb_hardware_caps::GpuBackend;
 
 use super::common::{
     CompressionType, DeltaEntry, HierarchicalData, InterCentroidCompressionMetadata,
@@ -727,7 +727,7 @@ mod tests {
     fn test_p2_matrix_building() {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
 
         let builder = MatrixBuilder::new(distance_compute, hardware, DistanceMetric::Cosine);
@@ -748,7 +748,7 @@ mod tests {
     fn test_k2_matrix_building() {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
 
         let builder = MatrixBuilder::new(distance_compute, hardware, DistanceMetric::Euclidean);
@@ -792,7 +792,7 @@ mod tests {
 
     fn create_builder(metric: DistanceMetric) -> MatrixBuilder {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let distance_compute = Arc::new(UnifiedDistanceCompute::new(metric));
         MatrixBuilder::new(distance_compute, hardware, metric)
     }

--- a/src/storage/engines/raptor/tests.rs
+++ b/src/storage/engines/raptor/tests.rs
@@ -5,7 +5,7 @@ mod minimal_hnsw_tests {
     #[test]
     fn test_distance_aware_clustering() {
         // Create a minimal HNSW builder
-        let hw_caps = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
         let mut builder = IvfClusteringBuilder::new(3, hw_caps); // Small row groups for testing
 
         // Add nodes with predefined edges and distances
@@ -124,7 +124,7 @@ mod clustering_tests {
 
     #[test]
     fn test_uniqueness_guarantee() {
-        let hw_caps = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
         let mut builder = IvfClusteringBuilder::new(5, hw_caps);
 
         // Add 10 nodes

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -55,10 +55,10 @@ use tracing::debug;
 
 // Reuse existing platform capabilities
 use super::common::VectorStats;
-use crate::core::hardware_capabilities::get_hardware_capabilities;
 use proximadb_compression::{
     CompressionAlgorithm, CompressionContext, CompressionProvider, StandardCompression,
 };
+use proximadb_hardware_caps::get_hardware_capabilities;
 
 // Import bloom filter types from common
 use super::common::{
@@ -67,10 +67,10 @@ use super::common::{
 };
 use super::matrix_builder::MatrixBuilder;
 use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::DistanceMetric;
 use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_hardware_caps::HardwareCapabilities;
 use proximadb_runtime_common::pool::VectorMemoryPool;
 // ProximaCodec system for encoding/decoding
 use crate::storage::engines::core::ops::proximacodec::{
@@ -2391,7 +2391,7 @@ mod minimal_hnsw_tests {
     #[test]
     fn test_distance_aware_clustering() {
         // Create a minimal HNSW builder
-        let hw_caps = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
         let mut builder = IvfClusteringBuilder::new(3, hw_caps); // Small row groups for testing
 
         // Add nodes with predefined edges and distances
@@ -2506,7 +2506,7 @@ mod minimal_hnsw_tests {
 
 #[test]
 fn test_uniqueness_guarantee() {
-    let hw_caps = crate::core::hardware_capabilities::get_hardware_capabilities();
+    let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
     let mut builder = IvfClusteringBuilder::new(5, hw_caps);
 
     // Add 10 nodes

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -711,12 +711,12 @@ mod tests {
     #[tokio::test]
     async fn td112_live_flush_indexes_vectors_into_axis() {
         use crate::index::axis::management::manager::AxisManager;
-        use crate::index::axis::types::AxisConfig;
         use crate::proto::proximadb_v1::{
             Collection, CollectionConfig, StorageAssignment, StorageEngine,
         };
         use crate::storage::traits::UnifiedStorageEngine;
         use proximadb_distance_kernel::DistanceMetric;
+        use proximadb_index_types::AxisConfig;
 
         // Attach an AXIS manager (process-global OnceLock; a no-op if a prior test
         // already set one). We read the effective manager back from the engine so

--- a/src/storage/engines/sst/tests/test_sst1_validation.rs
+++ b/src/storage/engines/sst/tests/test_sst1_validation.rs
@@ -11,13 +11,13 @@ use std::sync::Arc;
 use tempfile::NamedTempFile;
 use tokio::fs;
 
-use crate::core::hardware_capabilities;
 use crate::core::search::SearchParams;
 use crate::storage::engines::sst::readers::sst_query_engine::{
     CollectionContext, UnifiedSstableReader,
 };
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
+use proximadb_hardware_caps;
 
 /// Helper to create a test reader
 async fn create_test_reader() -> Arc<UnifiedSstableReader> {

--- a/src/storage/engines/swift/engine.rs
+++ b/src/storage/engines/swift/engine.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn};
 // Universal performance optimization imports - UniversalIOConfig removed as unused
 // VectorMemoryPool now managed by universal optimizer
 // StorageTier already imported from crate::core::search
-use crate::core::hardware_capabilities::HardwareCapabilities;
+use proximadb_hardware_caps::HardwareCapabilities;
 
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
@@ -377,7 +377,7 @@ impl SwiftEngine {
         distance_engine: Arc<proximadb_distance_kernel::engine::UnifiedDistanceCompute>,
         axis_manager: Option<Arc<dyn proximadb_index_traits::IndexEngine>>,
     ) -> Result<Self> {
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
         let optimized_ops = Arc::new(OptimizedSwiftOperations::new()?);
 
         // Initialize filesystem factory

--- a/src/storage/engines/swift/mod.rs
+++ b/src/storage/engines/swift/mod.rs
@@ -1359,9 +1359,9 @@ impl SwiftFile {
     /// Uses columnar layout for maximum SIMD efficiency and optimized I/O
     #[allow(dead_code)]
     fn finalize_superblock_encoding(&mut self) {
-        // use crate::core::hardware_capabilities::HardwareCapabilities; // Unused import
+        // use proximadb_hardware_caps::HardwareCapabilities; // Unused import
 
-        let hw_caps = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
 
         for superblock in &mut self.superblocks {
             // Columnar analysis: transpose vectors to analyze dimension-wise

--- a/src/storage/engines/swift/optimized_operations.rs
+++ b/src/storage/engines/swift/optimized_operations.rs
@@ -5,16 +5,14 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
+use crate::core::memory::pool::VectorMemoryPool;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
-use crate::core::{
-    hardware_capabilities::{HardwareBackend, HardwareCapabilities},
-    memory::pool::VectorMemoryPool,
-};
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::engines::core::search::search_modes::{
     CandidateRecord, CandidateState, SearchCandidate,
 };
 use proximadb_distance_kernel::{DistanceMetric, DistanceMode, UnifiedDistanceCompute};
+use proximadb_hardware_caps::{HardwareBackend, HardwareCapabilities};
 // Memory-mapped file operations would be imported here
 // For now, we'll use placeholder types
 struct MmapFile;
@@ -72,7 +70,7 @@ impl OptimizedSwiftOperations {
     /// Create new optimized operations instance
     pub fn new() -> Result<Self> {
         // Get global hardware capabilities
-        let hardware = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let hardware = proximadb_hardware_caps::get_hardware_capabilities();
 
         // Create unified distance compute with hardware acceleration
         let distance_compute = UnifiedDistanceCompute::default();

--- a/src/storage/engines/universal/adapter.rs
+++ b/src/storage/engines/universal/adapter.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, trace};
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::{
     DistanceMetric, Int8VectorData, PQVectorData, QuantizedDistanceResult, QuantizedVectorData,
     SelectedFormat, SimilarityResult, UnifiedDistanceCompute,
 };
+use proximadb_hardware_caps::HardwareCapabilities;
 
 use super::{
     config::ProgressiveRefinementConfig as ConfigProgressiveRefinementConfig,

--- a/src/storage/engines/universal/quantized_calculator.rs
+++ b/src/storage/engines/universal/quantized_calculator.rs
@@ -7,11 +7,11 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, trace};
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use proximadb_distance_kernel::{
     ComputationMethod, DistanceMetric, DistanceMetrics, QuantizedDistanceResult,
     QuantizedVectorData, SelectedFormat, UnifiedDistanceCompute,
 };
+use proximadb_hardware_caps::HardwareCapabilities;
 
 use super::config::UniversalAdapterConfig;
 

--- a/src/storage/engines/universal/tests.rs
+++ b/src/storage/engines/universal/tests.rs
@@ -101,7 +101,7 @@ mod tests {
     async fn test_quantized_calculator() {
         use crate::storage::engines::universal::config::UniversalAdapterConfig;
         let config = UniversalAdapterConfig::default();
-        let capabilities = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let capabilities = proximadb_hardware_caps::get_hardware_capabilities();
 
         let calculator = UniversalQuantizedCalculator::new(&config, &capabilities).await;
         assert!(
@@ -113,7 +113,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_hardware_acceleration_manager() {
-        let capabilities = crate::core::hardware_capabilities::get_hardware_capabilities();
+        let capabilities = proximadb_hardware_caps::get_hardware_capabilities();
 
         let manager = HardwareAccelerationManager::new((*capabilities).clone());
         // Test the manager was created successfully

--- a/src/storage/persistence/write_ahead_log/compaction_axis_integration.rs
+++ b/src/storage/persistence/write_ahead_log/compaction_axis_integration.rs
@@ -242,7 +242,7 @@ impl CompactionAxisUpdater {
             let algorithm = index.algorithm();
             if matches!(
                 algorithm,
-                crate::index::axis::types::IndexAlgorithm::Annoy { .. }
+                proximadb_index_types::IndexAlgorithm::Annoy { .. }
             ) {
                 info!(
                     "🔨 AXIS Compaction: Rebuilding static index {} for collection {}",
@@ -294,14 +294,10 @@ impl CompactionAxisUpdater {
 
             // Count index types
             match index.algorithm() {
-                crate::index::axis::types::IndexAlgorithm::HNSW { .. } => {
-                    stats.dynamic_indexes += 1
-                }
-                crate::index::axis::types::IndexAlgorithm::IVF { .. } => stats.dynamic_indexes += 1,
-                crate::index::axis::types::IndexAlgorithm::LSH { .. } => stats.dynamic_indexes += 1,
-                crate::index::axis::types::IndexAlgorithm::Annoy { .. } => {
-                    stats.static_indexes += 1
-                }
+                proximadb_index_types::IndexAlgorithm::HNSW { .. } => stats.dynamic_indexes += 1,
+                proximadb_index_types::IndexAlgorithm::IVF { .. } => stats.dynamic_indexes += 1,
+                proximadb_index_types::IndexAlgorithm::LSH { .. } => stats.dynamic_indexes += 1,
+                proximadb_index_types::IndexAlgorithm::Annoy { .. } => stats.static_indexes += 1,
                 _ => {}
             }
         }

--- a/src/storage/persistence/write_ahead_log/parallel_search.rs
+++ b/src/storage/persistence/write_ahead_log/parallel_search.rs
@@ -11,12 +11,12 @@ use rayon::prelude::*;
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 
-use crate::core::hardware_capabilities::HardwareCapabilities;
 use crate::core::search::OptimizedSearchRecord;
 use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
 use proximadb_distance_kernel::DistanceMetric;
 use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_filter_expression::FilterExpression;
+use proximadb_hardware_caps::HardwareCapabilities;
 use proximadb_records::{ProximaRecord, ProximaTreeNode};
 
 /// Parallel WAL search coordinator
@@ -40,7 +40,7 @@ impl ParallelWALSearch {
     /// Create a new parallel WAL search coordinator
     pub fn new(distance_metric: DistanceMetric) -> Self {
         Self {
-            hardware: crate::core::hardware_capabilities::get_hardware_capabilities(),
+            hardware: proximadb_hardware_caps::get_hardware_capabilities(),
             distance_compute: Arc::new(UnifiedDistanceCompute::new(distance_metric)),
             parallel_batch_size: 4,            // Process 4 batches in parallel
             early_termination_multiplier: 3.0, // Stop when we have 3x candidates


### PR DESCRIPTION
## Summary

Continues the **Slice-D redirect-down** (Mechanism A) after D0 (distance+filter). Redirects the next two storage→up *type* edges to the foundation crates that already own them — both verified **pure re-exports** (identity-safe), both already root deps:

- `crate::core::hardware_capabilities` → `proximadb_hardware_caps` (56 refs / 28 files; `hardware_capabilities.rs` = `pub use proximadb_hardware_caps::*`)
- `crate::index::axis::types` → `proximadb_index_types` (7 refs / 3 files; `axis/types.rs` = `pub use proximadb_index_types::*`)

Two nested `use crate::core::{hardware_capabilities::.., memory::..}` imports (nova/swift) split so `memory` stays on `crate::core`.

**Skipped as not-clean** (flagged in the design doc): `crate::core::config` is a real root module (not a re-export — divergent, like the `-distance-types` trap), and `compute::quantization::types` is unverified.

## Also: fixes the D0 gate (from #370)

The `scripts/worktree.sh check` change shipped in #370 used `clippy --all-targets -- -D warnings`, which turned the root crate's **thousands of pre-existing test/bench clippy warnings** (and bit-rotted benches) into false reds. Corrected to:
- `cargo check --tests` — compiles `#[cfg(test)]` code (the actual D0 gap) without benches/examples
- `cargo clippy --lib --bins -- -D warnings` — lints exactly what CI's clippy gate lints

## Verification

- `cargo check --tests` (compiles lib test-cfg) — clean
- `cargo clippy --lib --bins -- -D warnings` — clean
- `proximadb-server` + `-bench` + `-migrate` build
- `scripts/check-layering.sh` — "No boundary findings"; `fmt --all` ✓ · no-agent-attribution ✓
- **Ratchet:** storage→`core::hardware_capabilities` and storage→`index::axis::types` edge counts now **0**

Behavior-neutral by re-export identity. Ref `ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26` (Slice D / D0b).