### PR TITLE
fix(collection,test): clear 15 of the advisory unit-test batch

### DIFF
--- a/src/query/semantic_analysis/analyzer.rs
+++ b/src/query/semantic_analysis/analyzer.rs
@@ -729,6 +729,12 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let storage_url = format!("file://{}", temp_dir.path().display());
+        // The catalog is file-backed (NativeCatalog persists table metadata JSON under
+        // storage_url), so the tempdir MUST outlive this fn. Without this, Drop deletes
+        // the catalog's storage the moment setup returns, and every later `get_collection`
+        // / `table_exists` misses — manifesting as "Table not found" across the whole
+        // analyzer suite. Mirrors the embedded parity test's `std::mem::forget(dir)`.
+        std::mem::forget(temp_dir);
 
         let catalog_manager = Arc::new(CatalogManager::new());
         catalog_manager

--- a/src/query/semantic_analysis/tests.rs
+++ b/src/query/semantic_analysis/tests.rs
@@ -216,6 +216,8 @@ async fn setup_analyzer_with_mock() -> Analyzer {
 
     let temp_dir = TempDir::new().unwrap();
     let storage_url = format!("file://{}", temp_dir.path().display());
+    // File-backed catalog: the tempdir MUST outlive this fn (see analyzer.rs setup).
+    std::mem::forget(temp_dir);
 
     let catalog_manager = Arc::new(CatalogManager::new());
     catalog_manager

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1911,6 +1911,9 @@ impl CollectionService {
             {
                 existing
                     .properties
+                    .insert("asset.kind".to_string(), "collection".to_string());
+                existing
+                    .properties
                     .insert("asset.capability.vector".to_string(), "true".to_string());
                 existing
                     .properties


### PR DESCRIPTION
## Summary
Shrinks the #372 advisory unit-test batch from 16 to 1 by fixing two distinct root causes, both surfaced by #365's feat→dev gate.

### Fix 1 — `asset.kind` marker in catalog-asset upsert update-path (1 test)
`upsert_collection_catalog_asset`'s **update-path** (an existing catalog row that isn't yet a collection asset — e.g. a SQL `CREATE TABLE` registered the row before the vector backing collection was ensured) added `collection.id/name`, `vector.dimension`, `asset.capability.vector` but **never `asset.kind = "collection"`** — the marker `collection_from_catalog_schema` requires. The fresh-create path sets it; only the update-path omitted it. Fixed the `test_embedded_execute_sql_lowers_agentic_ddl_to_catalog` failure ("Collection not found").

### Fix 2 — leak the test tempdir so the file-backed catalog survives setup (14 tests)
The catalog is file-backed (`NativeCatalog` persists table metadata JSON under `storage_url`). Both `semantic_analysis` test setups (`analyzer.rs` + `tests.rs`) created a `TempDir` and let it drop when `setup_analyzer_with_mock` returned — `Drop` deleted the catalog's storage, so every later `get_collection`/`table_exists` missed ("Table not found: products"). Leak it via `std::mem::forget` (mirrors the embedded parity test's `build_db`). Fixed the entire `query::semantic_analysis::analyzer` cluster (both modules). Surfaced by the "catalog-is-sole-store" refactor making the catalog file-backed.

## Verification (toolchain 1.95.0)
- `cargo test --lib -- test_analyze_ test_embedded_execute_sql_lowers_agentic_ddl_to_catalog` → **34 passed, 1 failed** (only `test_flushcoordinator_metrics_integration` remains).
- `cargo fmt --all -- --check`, `cargo check --workspace --lib --bins`, `cargo clippy --lib --bins -D warnings` → clean.
- Both root causes confirmed via instrumentation (debug reverted before commit).

## Not fixed here (the remaining 1)
`test_flushcoordinator_metrics_integration`: the flush succeeds and `record_flush` is called (`flush_coordinator.rs:579`), but `AsyncMetricsUpdater.record_flush` only `tx.try_send`s a `MetricsUpdate::Flush` to a background consumer — `total_flushes` stays 0 after the 300 ms wait. The async metrics pipeline (channel consumer → store) isn't recording — a separate metrics-wiring bug, out of scope for this catalog/test-hygiene PR.