### PR TITLE
docs(adr): ADR-030 — unified hot-path trace+meter emission seam (TD-158 + KRU)

### DIFF
--- a/docs/12-design/adr/ADR-030-unified-hotpath-trace-meter-seam.adoc
+++ b/docs/12-design/adr/ADR-030-unified-hotpath-trace-meter-seam.adoc
@@ -1,0 +1,198 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-030: Unified Hot-Path Trace+Meter Emission Seam (one I/O boundary, two structurally-separate sinks)
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-26
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-027 (Unified Storage + Metering — the two-class trace decision this *implements*), ADR-026 (PAX canonical vector path), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (dominant cost term = I/O round-trips + egress; meter every dimension), `EXACT_VS_ANN_ROUTING_COST_MODEL_2026_06_26.adoc` (cost-from-measured-quantities)
+|Supersedes|—
+|Tracked under|TD-158 (emit perf/geometry trace on the live AXIS/SST read path) + the **KRU read-meter** wiring (KSU is the sibling write-path/periodic gap, scoped out); TD-160 (compile-time gate) is a prerequisite
+|===
+
+== Context
+
+ADR-027 already decided the *strategy*: a **two-class trace** — billing meters (KEU/KOU/KRU/KIU) that are **always-on, full-fidelity, per-tenant** and **never gated**, structurally separate from the **perf/geometry trace** (GET-count, bytes/block, route) which is **zero-cost-when-off** behind a compile-time gate. ADR-027 is explicit that the two classes must **not** be entangled into one counter set, and it sequenced TD-160 (gate) → TD-158 (emit perf trace on the live read path) → TD-161 (coalesced durable writer).
+
+What ADR-027 did **not** settle is the *implementation seam*, and a runtime audit (2026-06-26) shows **two concrete gaps that share a single root cause**:
+
+. **The perf/geometry trace is blind where the dominant cost term is incurred.** `io_trace.rs` has the primitives — `record_range_gets` (`:194`), `record_bytes_read` (`:189`), `IoTraceSnapshot.avg_get_size` (`:333`) — and the query-entry boundary instruments them (pgwire/REST), but **the hot AXIS/SST ranged-read path does not call them**. So `route_cost_model.rs` (which prices `per_get = 20`) and the adaptive engine (TD-157/159) cannot see the per-block GET count / block size where the I/O is actually paid. This *is* TD-158.
+
+. **Two of the five billing meters are defined but unwired.** `consumption_metrics.rs` defines `record_task_execution_time` (KRU read-compute, `:565`) and `record_storage_bytes` (KSU storage, `:557`), but they have **zero live call-sites** (verified). Only KOU (`record_kou_bytes:586`), KEU (`record_keu_units:618`), and object-store ops (`record_object_store_op:549`) fire — at `services/record_store.rs` `fetch_pax`/`fetch_pax_ranged`. Result: per-tenant **cost-to-serve for read-compute and storage is uncaptured**, so the durable-metering differentiator (ADR-027) and the unit-economics thesis (CODESIGN §6) are currently unfalsifiable. The two meters have **different correct homes**: KRU is a *per-read* event (this seam); KSU is a *storage accrual* (write/flush + periodic snapshot) — ADR-030 closes KRU and scopes KSU out explicitly so they are not conflated.
+
+**First principles:** both gaps need the *same raw quantities* — bytes read, GETs issued, engine-milliseconds — at the *same place*: where the hot read path issues a ranged GET against the `FileSystem`. Instrumenting that twice (once for perf, once for billing) duplicates the call-site and lets the two diverge — the geometry signal the cost model tunes against would no longer equal the bytes the billing meter charges for.
+
+== Decision
+
+The per-query trace is already a **`tokio::task_local!` accumulator** (`IO_TRACE`,
+`io_trace.rs:70`), set up once per query by `instrument(...)` (`io_trace.rs:532`) at the pgwire
+(`protocol.rs:970`) and REST (`records.rs:1618`) entry points — **where the `TenantContext` is
+in scope** — and **drained once at scope close** by `emit(tenant_id, route)` (`io_trace.rs:363`),
+which already fans the captured snapshot to a **route-cost observer** (`route_cost_model.rs:59`,
+`observe_by_label`) and a **cache observer** (`io_trace.rs:515` — "both observers can be active
+simultaneously"). ADR-030 **reuses this exact machinery** rather than adding a parallel path. The
+seam is therefore *not* a single `read_range` call-site — it is **one accumulator, fed at the GET
+boundary, drained once, fanning to three observers**:
+
+. **Feed the accumulator from the hot read path (TD-158).** Instrument the AXIS/SST ranged read
+  so every GET calls the task-local `io_trace::record_range_gets(1)` + `record_bytes_read(bytes)`
+  (`io_trace.rs:194/189`), and each engine's execution calls `record_compute_ms(engine, ms)`
+  (`io_trace.rs:439`) — which the snapshot already keeps **per-engine** as a
+  `BTreeMap<engine, u64>` (`io_trace.rs:303`). All are task-local, so they need **no tenant in
+  scope** — which dissolves the call-site tension: the universal `read_range`/engine boundaries
+  feed the accumulator cheaply, and the perf `route` is stamped once via `record_route(shape,
+  backend)` (`io_trace.rs:446`). Gated by the TD-160 `io-trace` feature (no-op when off).
+
+. **Add a third observer at scope close — the billing fan-out (NEW).** Alongside the existing
+  route + cache observers, at the **one point where the accumulated snapshot *and* `tenant_id`
+  are both in hand**, emit the always-on **read** meters keyed by `TenantContext` (fail-closed →
+  `"unknown"`, never dropped): iterate `snap.compute_ms` (`BTreeMap<engine, u64>`) and call
+  `record_task_execution_time(tenant, engine, ms)` per engine (`consumption_metrics.rs:565`) —
+  per-`(tenant, engine)` **KRU** *for free*, since the map is already engine-keyed — plus the
+  read-unit dimension from `snap.bytes_read`. This is the meter that genuinely belongs at the
+  read drain. KOU/KEU already fire at `record_store.rs` and are unchanged.
+
+NOTE: **KSU is *not* metered here.** KSU = storage units = *resident bytes · time* — an
+accrual, not a per-read event; metering it at the read drain would wrongly charge storage on
+every query. KSU (`record_storage_bytes`, `:557` — also verified-unwired) is the **sibling
+gap**, metered on the **write/flush + compaction path** (bytes resident after flush) plus a
+**periodic per-tenant resident-bytes snapshot**, and is closed *there* (TD-161-adjacent), not
+at this seam. ADR-030 deliberately scopes itself to the read meter (KRU) so the two are not
+conflated.
+
+Because all three observers read the **same** snapshot, the geometry the cost model prices
+(`avg_get_size = bytes_read / range_gets`, `io_trace.rs:333`) and the bytes the billing meter
+charges are **the same measured quantity by construction** — they cannot diverge.
+
+[.text-center]
+....
+        AXIS/SST hot read path
+   FileSystem::read_range ──(per GET: +1 range_get, +bytes)──┐
+   footer / index ranged reads ──────────────────────────────┤
+                                                              ▼
+                    IO_TRACE  — tokio task-local accumulator (one per query)
+                    range_gets · bytes_read · compute_ms{engine→ms} · route(shape,backend)
+                                                              │
+                 scope close  →  instrument() → emit(tenant_id, route)
+                 (the ONE drain point — tenant + engine both known here)
+            ┌─────────────────────────────┼──────────────────────────────┐
+            ▼                             ▼                               ▼
+   route-cost observer            cache observer               BILLING observer  (NEW)
+   observe_by_label(shape,        record_cache_tenant_stats    record_task_execution_time → KRU (compute_ms)
+     backend, snap)                                            snap.bytes_read            → KRU (read-units)
+   ── PERF class, gateable        ── PERF, gateable            ── BILLING class, ALWAYS-ON, fail-closed
+            │                                                               │
+   route_cost_model EWMA                                        consumption_metrics (Prometheus)
+   (neutral weights → routing,                                  + durable  data/{tenant}/_metering/
+    TD-157/159 geometry)                                          (TD-161)  ──►  AnvaiOps prices it
+
+   KSU (resident bytes·time) is NOT here — metered on the write/flush+compaction path
+   + periodic resident snapshot (sibling gap; out of scope for this read seam).
+....
+
+**Invariant (from ADR-027, preserved):** the three observers write **separate** sinks — the
+gateable perf snapshot vs the always-on `consumption_metrics` counters. ADR-030 does **not**
+"split `IoTrace` into billing/perf" and does **not** wrap any `consumption_metrics` symbol in
+`cfg(feature = "io-trace")`; a CI guard asserts billing-is-never-gated. The *accumulator* is
+shared; the *sinks* are not.
+
+**Gate boundary (refines ADR-027's "gate wholesale").** For the billing observer to be
+always-on while the perf class is gateable, the `io-trace` feature (TD-160) must gate the
+**perf *emission*** — the structured `tracing` event, per-block detail, any sampling — and
+**not** the three *cheap core counters* (`record_range_gets`/`record_bytes_read`/
+`record_compute_ms` = a handful of atomic/map increments per query). Those stay **always-on**
+so the billing observer reads real values at drain even when the perf class is compiled out.
+This is the precise reading of ADR-027's intent (zero *perf-emission* cost when off **and**
+billing-never-silenced); the ~free accumulator core was never the cost ADR-027 set out to
+eliminate. ADR-030 **refines** ADR-027 here rather than contradicting it.
+
+== Open-core boundary: what stays OSS (proximaDB) vs moves to AnvaiOps
+
+This ADR sits exactly on the open-core seam, so the split is explicit (consistent with
+ADR-027 "OSS = mechanism; the $ rate card is AnvaiOps policy"):
+
+[cols="1,2,2",options="header"]
+|===
+| Concern | Home | Why
+| **Metering mechanism** — the hot-path seam; per-tenant *neutral unit* counters (KSU/KRU/KIU/KOU/KEU); the gateable `io_trace` perf class | **proximaDB (OSS)** | You can only measure I/O where the I/O is issued — the seam is physically the engine's `FileSystem` ranged-read boundary. It emits **units**, never dollars.
+| **Routing cost model** (`route_cost_model.rs`) — neutral weights (`per_get`, `per_mib_egress` …) used to *pick a backend* | **proximaDB (OSS)** | Routing is a runtime *engine* decision; the weights are public cost-curve *ratios*, not the rate card. It is an optimizer, not an invoice.
+| **Durable per-tenant sink** under `DrPathBuilder` (`data/{tenant}/_metering/…`) + the OTLP/Prometheus push (TD-161) | **proximaDB (OSS)** emits; **AnvaiOps** consumes | The engine writes tenant-owned, structurally-isolated meter records (the differentiator); AnvaiOps reads them.
+| **Pricing / policy** — the `$` rate card (`anvaiops/pricing/ln/tiers.json`), units→dollars, tier-entitlement source-of-truth, aggregation/invoicing, dashboards, egress backstop | **AnvaiOps** | Already built and already flows *into* the engine via `anvaiops/scripts/sync_pricing_to_proximadb.sh` → `proximaDB/config/ln.json` (engine reads entitlement; AnvaiOps owns the number).
+|===
+
+**Net:** ADR-030 keeps *mechanism* in OSS (it has nowhere else to live — it is bound to the
+I/O boundary) and emits **neutral metered units**; turning those units into a bill — and the
+"cost-to-serve in `$`" view — is AnvaiOps reading the OSS sink and applying its rate card. The
+CI billing-never-gated guard and `TenantContext` fail-closed stamping are what make the OSS
+units *trustworthy enough* for AnvaiOps to price.
+
+== Consequences
+
+* **Closes the cost model's *input* side.** The model can finally see the dominant cost term (GET count × block size) on the live path. The *output* side — flipping `PROXIMADB_ROUTE_COST_OVERRIDE` from advisory to gated-auto routing — is a **separate decision, out of scope here**.
+* **Closes the KRU read-meter gap** (KOU/KEU already live; KRU now joins them at the read drain). Combined with the sibling KSU write-path meter (out of scope here) and KIU, per-tenant *units* become captured across all five dimensions, making the durable per-tenant metering real. The unit-economics view (`$/query`) is then computable **by AnvaiOps** applying its rate card to those units — so a measured PAX-quant / range-coalescing change can be shown to move real cost, not just latency. (Pricing stays AnvaiOps policy — see the open-core boundary above.)
+* **One seam, two consumers** — the co-design pattern: instrument at the boundary once; optimization and monetization both read it. Mirrors the "vertical inside" co-optimization across the storage↔compute boundary.
+* **Cost:** perf class is zero-cost-off (TD-160); billing is always-on but compact counter increments. Per ADR-027 the perf `route`/`compute_ms` `String` fields should become int enums. Verify the server binary builds in **both** feature states (#11).
+
+== Phasing
+
+* **This ADR (TD-158 + KRU):** the read-path accumulator feeder + the perf and KRU billing fan-outs; perf-gate default-OFF, billing always-on; the CI billing-never-gated guard.
+* **Sibling (KSU):** wire `record_storage_bytes` on the flush/compaction write path + a periodic per-tenant resident-bytes snapshot. Same `consumption_metrics` sink, different trigger — explicitly *not* this seam.
+* **Prerequisite:** TD-160 — add the `io-trace` cargo feature so the perf class is gateable (none exists today).
+* **Follow-ups (out of scope):** TD-161 (coalesced durable per-tenant `_metering`/`_trace` writer + periodic OTLP push); TD-157/159 (adaptive engine consumes the now-live trace); routing-loop closure (advisory → gated bandit, its own ADR); real-S3 cold-cliff measurement against the now-emitted `avg_get_size`.
+
+== Implementation slices
+
+Each slice is independently shippable and verifiable; default behaviour is unchanged until the
+billing observer is installed (Slice 2). Slices 0–3 are this ADR; Slice 4 is the sibling PR.
+
+. **Slice 0 — `io-trace` feature, scoped to the *emission* (TD-160).** Add the `io-trace` cargo
+  feature (default off). Gate the **perf emission** — `emit`'s structured `tracing` event,
+  per-block detail, sampling — to a no-op when off; **leave the core counters
+  (`record_range_gets`/`record_bytes_read`/`record_compute_ms`) always-on** (Gate-boundary note
+  above). Convert the perf `route` `String` to an int enum (ADR-027). *Files:* `Cargo.toml`,
+  `src/observability/io_trace.rs`. *Verify:* server binary builds with the feature on **and** off
+  (#11).
+
+. **Slice 1 — feed the accumulator on the hot read path (TD-158 core).** At the ranged-GET
+  boundary call `record_range_gets(1)` + `record_bytes_read(bytes)`; around each engine's
+  execution call `record_compute_ms(engine, ms)`. Lowest universal point for GETs is the
+  `FileSystem::read_range` impls (local now, S3 later); compute_ms is stamped at the
+  per-engine entry (Volcano / DataFusion / SST-AXIS). *Files:* `src/storage/persistence/
+  filesystem/*`, the SST/AXIS ranged reader, engine entry points. *Verify:* extend a cold
+  recall/round-trip test (e.g. `embedded_flush_recovery`) to assert `snapshot.range_gets > 0`
+  and a populated `avg_get_size`.
+
+. **Slice 2 — the billing observer (KRU), always-on (NEW).** Add `set_billing_observer` +
+  `notify_billing_observer(snap, tenant_id)` mirroring the route/cache observers
+  (`io_trace.rs:485/490/509/515`); call it inside `emit` after the route + cache observers.
+  Install at startup (mirror `install_route_cost_observer`): iterate `snap.compute_ms`
+  (`BTreeMap<engine,u64>`) → `record_task_execution_time(tenant, engine, ms)` per engine + the
+  read-unit dimension from `snap.bytes_read`. **Not** behind `cfg(feature = "io-trace")`. *Files:*
+  `src/observability/io_trace.rs`, a billing observer in `src/metrics/`, server startup wiring.
+  *Verify:* the **same-snapshot test** — one live pgwire/REST read emits KRU(`tenant`,`engine`)
+  with read-bytes == `snap.bytes_read`.
+
+. **Slice 3 — CI billing-never-gated guard.** A guard (script or `#[test]`) asserting no
+  `cfg(feature = "io-trace")` wraps any `consumption_metrics` symbol or the billing observer —
+  mirroring the panic-policy / layering guards; wired into the feat→develop LIGHT tier. *Files:*
+  `scripts/check_*.py` or a guard test + `.github/workflows`.
+
+. **Slice 4 — KSU on the write path (sibling, separate PR).** Wire `record_storage_bytes` at
+  flush/compaction (resident bytes) + a periodic per-tenant resident-bytes snapshot. Same
+  `consumption_metrics` sink, different trigger — explicitly *not* this seam.
+
+== Alternatives considered
+
+* **Two separate instrumentation passes** (perf counted in the segment reader, billing re-counted in `record_store`). *Rejected:* duplicate counters diverge — the `avg_get_size` the cost model prices would not equal the bytes the billing meter charges. The single task-local accumulator drained once is precisely the fix: one measurement, three readers.
+* **Pass `TenantContext` down to `read_range` so billing can fire at the GET site.** *Rejected:* pollutes the low-level `FileSystem` trait with tenant/engine plumbing and fires N times per query; the accumulator already lets the GET site stay context-free and the drain point (which *has* tenant + engine) do the per-query billing fan-out once.
+* **Merge billing + perf into one counter set.** *Rejected:* violates ADR-027's non-entanglement invariant — billing must be ungateable, full-fidelity, per-tenant; perf may be sampled or compiled out.
+* **Instrument only at query entry (where the trace already fires).** *Rejected:* the query-entry trace cannot see per-block `range_gets`; the dominant cost term is incurred at the GET boundary, so the seam must live there.
+
+== Verification
+
+* **One live read proves it (same-snapshot test):** a single pgwire/REST read drains one `IO_TRACE` scope that emits, for that query/tenant — an `IoTraceSnapshot` with `range_gets > 0` and a populated `avg_get_size`, **and**, from the *same* snapshot, non-zero `consumption_metrics` KRU(`tenant`,`engine`) read-units + KOU. Assert the KRU read-bytes equals `snap.bytes_read` (no divergence). KSU is *not* expected on a pure read — a separate flush/compaction test covers it.
+* **CI guard:** no `cfg(feature = "io-trace")` wraps any symbol in `consumption_metrics.rs` (billing-never-gated, per ADR-027).
+* **Build matrix:** server binary builds with the `io-trace` feature on and off (#11); both link `consumption_metrics` unchanged.
+* **Out of scope (do not gate on here):** real-S3 latency numbers, routing-loop closure, the adaptive engine actually consuming the trace.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -96,6 +96,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Shared Code→CPG Chunker Package (`victor-codegraph`) — one chunker, three consumers, zero duplication
 | Proposed
 | The tree-sitter code→symbol+relation chunker is duplicated across ProximaDB SDK (`code.py`) and Victor (`victor-coding`); extract it into one neutral Apache-2.0 PyPI package (`victor-codegraph`, deps = `victor-contracts` + tree-sitter) consumed by Victor (owner), ProximaDB SDK (optional extra, retires `code.py` to stay generic), and anvaiops (SaaS code-graph vertical, ADR-0017 F3). Adopts LlamaIndex `CodeSplitter` size-discipline + Victor fallback chain + ProximaDB taxonomy; emits the substrate-keystone `ProximaRecord` shape. Boundary-safe (policy-free). Tracked: TD-CG1..CG3
+
+| link:ADR-030-unified-hotpath-trace-meter-seam.adoc[ADR-030]
+| Unified Hot-Path Trace+Meter Emission Seam (one I/O boundary, two structurally-separate sinks)
+| Proposed
+| Implements ADR-027's two-class trace via the per-query `tokio::task_local!` `IO_TRACE` accumulator: it is fed at the `read_range` GET boundary (no tenant needed), drained ONCE at scope-close (where tenant+engine are known), and fans the same snapshot to THREE observers — route-cost + cache (gateable perf, → `avg_get_size` for the cost model + adaptive engine, TD-158) and a NEW billing observer (always-on) that closes the verified **KRU** read-meter (`record_task_execution_time`) gap. **KSU** (storage accrual) is explicitly scoped out as the sibling write-path/periodic gap. Same measured snapshot ⇒ cost-model bytes == billing bytes (no divergence). Honors ADR-027 non-entanglement (separate sinks; billing never gated; CI guard) and the open-core boundary (OSS emits neutral units; AnvaiOps prices them). Closes the cost model's INPUT side only — routing-loop closure is a separate ADR. Tracked: TD-158 + KRU; prereq TD-160
 |===
 
 NOTE: ADR-010 through ADR-013 exist in this directory but are not yet


### PR DESCRIPTION
## Summary
Implementation-design ADR that operationalizes **ADR-027**'s two-class trace and closes the verified-unwired **KRU** read meter — grounded in real symbols (no invented APIs).

**Mechanism:** one `tokio::task_local!` `IO_TRACE` accumulator, fed at the `read_range` GET boundary (no tenant needed), **drained once at scope-close** (`emit(tenant, route)`), fanning the *same* snapshot to **three observers**:
- route-cost (`route_cost_model.rs:59`) + cache — gateable **perf** class (`avg_get_size` for the cost model + adaptive engine, **TD-158**)
- a **NEW always-on billing observer** — iterates `snap.compute_ms` (`BTreeMap<engine,u64>`) → `record_task_execution_time(tenant, engine, ms)` per-engine **KRU**, closing the gap (`consumption_metrics.rs:565`, verified zero live call-sites).

Same snapshot ⇒ **cost-model bytes == billing bytes by construction** (no divergence).

**Decisions / corrections baked in:**
- **Honors ADR-027 non-entanglement** (separate sinks; CI billing-never-gated guard) and **refines its gate boundary**: the `io-trace` feature gates the perf *emission*, not the cheap core counters, so billing-at-drain is always-on.
- **Open-core boundary explicit**: OSS emits *neutral units* (mechanism, bound to the I/O boundary); **AnvaiOps prices them** (`pricing/ln/tiers.json` → `config/ln.json`). Routing cost-model = optimizer (neutral weights), also OSS.
- **KSU scoped OUT**: storage accrual = *resident bytes·time*, metered on the write/flush + periodic-snapshot path — sibling gap, **not** this read seam.

**Closes the cost model's INPUT side only** — routing-loop closure (advisory → gated bandit) is a separate ADR.

Includes a fan-out ASCII diagram + **implementation slices 0–4** (feature gate → read-path feeders → billing observer → CI guard → KSU sibling) + a same-snapshot verification test.

Docs-only. Next ADR number (ADR-029 = codegraph chunker; branch name says `adr029` but the file is correctly **ADR-030**).