### PR TITLE
ci(qa-gate): bump Rust Coverage Ratchet timeout 60m -> 90m so it can seed

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -132,10 +132,14 @@ jobs:
   rust-coverage-ratchet:
     name: Rust Coverage Ratchet
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    # FIRST CUT: cargo-llvm-cov over the full workspace is heavy and has OOM'd
-    # CI before; kept non-blocking until the baseline is seeded from a clean run
-    # and memory is tamed. Flip to required (remove this line) once stable.
+    timeout-minutes: 90
+    # FIRST CUT: cargo-llvm-cov over the full workspace is heavy. 60m was too
+    # tight — it timed out mid-lib-test-run (deep into the graph/index tests),
+    # so the seed artifact was never produced. 90m lets it complete + emit the
+    # seed (rust-coverage-seed.json), the prerequisite to baseline rust:* in
+    # COVERAGE_BASELINE.json. Still non-blocking (continue-on-error); flip to
+    # required (remove continue-on-error) only AFTER a clean run seeds the
+    # baseline AND it stays green.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What
Bump the `rust-coverage-ratchet` job `timeout-minutes` 60 → 90.

## Why
On the develop→qa run (#28217563472) the Rust Coverage Ratchet was **cancelled at exactly 60m** — `cargo-llvm-cov` was deep into the instrumented lib-test run (graph/index tests passing) when killed. It's a **timeout, not an OOM**, and it was close to finishing. 60m is too tight for the instrumented compile + full lib-test run on the current workspace size.

## Effect
90m lets it complete and emit the seed artifact (`rust-coverage-seed.json`) — the prerequisite to baseline `rust:*` entries in `COVERAGE_BASELINE.json` (right now the ratchet is a no-op: no rust baseline, so it only seeds, never checks). Still `continue-on-error` (advisory); it becomes a real gate only after a clean run seeds the baseline and it stays green.

actionlint clean.
