### PR TITLE
feat(metering): always-on per-tenant KRU billing observer on the I/O trace (ADR-030, TD-158)

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -128,6 +128,11 @@ impl ProximaDB {
         // measured cost of each (shape-class, backend). Observe-mode today —
         // routing is unchanged until a later flag-gated slice.
         crate::query::route_cost_model::install_route_cost_observer();
+        // ADR-030: wire the io_trace flush to the always-on per-tenant billing
+        // meters (KRU read-compute from the snapshot's per-engine compute_ms).
+        // Same snapshot as the route observer above — billed bytes/ms cannot
+        // diverge from the cost model's. Always-on (billing is never gated).
+        crate::metrics::consumption_metrics::install_billing_observer();
         // Co-design C5 (integration): register the tenant→tier Port to read the
         // header-fed tier registry (`X-Tenant-Tier` → `record_store::TENANT_TIERS`),
         // so the per-tenant tier the cache LimitsResolver already sees also drives

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -569,6 +569,26 @@ pub fn record_task_execution_time(tenant_id: Option<&str>, engine: &str, duratio
         .inc_by(duration_ms);
 }
 
+/// ADR-030: install the always-on **billing** observer on the per-query I/O trace.
+///
+/// At each query's trace flush this reads the *same* `IoTraceSnapshot` the perf
+/// observers read and emits the per-tenant **KRU** read-compute meter from the
+/// snapshot's per-engine `compute_ms` map — closing the verified-unwired
+/// `record_task_execution_time` gap. Always-on (never behind the perf `io-trace`
+/// feature gate; ADR-027 non-entanglement). Called once at startup, after the
+/// route-cost observer. Idempotent / replaceable in tests.
+pub fn install_billing_observer() {
+    crate::observability::io_trace::set_billing_observer(Some(Box::new(|snap, tenant_id| {
+        // KRU (read-compute): per-(tenant, engine), straight from the engine-keyed
+        // compute_ms map — no extra attribution needed.
+        for (engine, ms) in &snap.compute_ms {
+            if *ms > 0 {
+                record_task_execution_time(tenant_id, engine, *ms as f64);
+            }
+        }
+    })));
+}
+
 /// Record outgress bytes for one tenant — the single convergent **KOU** meter
 /// (Dimension 2). `direction` is `"read"` (object store → compute) or `"result"`
 /// (compute → client). It does two things at once so every boundary records

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -337,9 +337,18 @@ async fn execute_physical<F: ReaderFactory>(
     factory: &F,
     controls: ExecutionControls,
 ) -> Result<ExecutionPipelineResult, String> {
-    NativeVolcanoEngine::execute_physical(physical, factory, controls)
+    // ADR-030 / TD-158: feed the per-query I/O trace the native engine's compute
+    // time so the always-on billing observer can emit KRU(tenant, "native") at
+    // scope close. `record_compute_ms` no-ops outside an `io_trace` scope.
+    let started = std::time::Instant::now();
+    let result = NativeVolcanoEngine::execute_physical(physical, factory, controls)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string());
+    crate::observability::io_trace::record_compute_ms(
+        "native",
+        started.elapsed().as_millis() as u64,
+    );
+    result
 }
 
 /// Like [`execute_physical`] but meters every operator (EXPLAIN ANALYZE): returns the

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -522,6 +522,38 @@ fn notify_cache_observer(snap: &IoTraceSnapshot) {
     }
 }
 
+/// Observer invoked at trace flush with `snapshot` + `tenant_id` for **billing**
+/// (ADR-030). The metering layer registers a sink that emits the always-on
+/// per-tenant consumption meters (KRU read-compute, from `compute_ms`) from the
+/// same measured snapshot the perf observers read — so cost-model bytes and
+/// billed bytes cannot diverge. Dependency-inversion seam: io_trace feeds billing
+/// *without depending on it*.
+///
+/// Unlike the route/cache observers this is the **billing class** — always-on,
+/// never wrapped in the perf `io-trace` feature gate (ADR-027 non-entanglement;
+/// CI-guarded).
+type BillingObserver = dyn Fn(&IoTraceSnapshot, Option<&str>) + Send + Sync;
+
+static BILLING_OBSERVER: Mutex<Option<Box<BillingObserver>>> = Mutex::new(None);
+
+/// Install (or clear with `None`) the billing-trace observer. Called once at
+/// startup by the metering layer; replaceable in tests.
+pub fn set_billing_observer(observer: Option<Box<BillingObserver>>) {
+    *BILLING_OBSERVER.lock().unwrap_or_else(|p| p.into_inner()) = observer;
+}
+
+/// Feed the registered billing observer, if any, with a completed query's trace
+/// and the owning tenant. Called after the route + cache observers at scope close.
+fn notify_billing_observer(snap: &IoTraceSnapshot, tenant_id: Option<&str>) {
+    if let Some(obs) = BILLING_OBSERVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .as_ref()
+    {
+        obs(snap, tenant_id);
+    }
+}
+
 /// Bind a fresh [`IoTrace`] to `future` and await it. Lower-level than
 /// [`instrument`]; use when the caller wants to read the snapshot itself before
 /// the scope ends.
@@ -560,6 +592,12 @@ where
                 if !snap.is_empty() {
                     notify_cache_observer(&snap);
                 }
+                // ADR-030 billing fan-out (always-on): emit the per-tenant
+                // consumption meters (KRU) from the same snapshot. Tenant + the
+                // per-engine compute_ms are both in hand here.
+                if !snap.is_empty() {
+                    notify_billing_observer(&snap, tenant_id.as_deref());
+                }
             }
             out
         })
@@ -569,6 +607,40 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// ADR-030: the always-on billing observer fires at scope close with the
+    /// owning tenant and the same accumulated snapshot the perf observers see —
+    /// so KRU is emitted from `compute_ms` and cannot diverge from the cost
+    /// model's view. Drives the real `instrument` drain path end to end.
+    #[tokio::test]
+    async fn billing_observer_receives_tenant_and_accumulated_compute_ms() {
+        use std::sync::{Arc, Mutex};
+        let captured: Arc<Mutex<Option<(Option<String>, u64, u64)>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+        set_billing_observer(Some(Box::new(move |snap, tenant| {
+            *sink.lock().unwrap_or_else(|p| p.into_inner()) = Some((
+                tenant.map(String::from),
+                snap.total_compute_ms(),
+                snap.bytes_read,
+            ));
+        })));
+
+        instrument(Some("acme".to_string()), "test-route", async {
+            record_compute_ms("native", 4);
+            record_compute_ms("native", 3);
+            record_bytes_read(100);
+        })
+        .await;
+
+        set_billing_observer(None); // restore global state for other tests
+
+        let got = captured.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        assert_eq!(
+            got,
+            Some((Some("acme".to_string()), 7, 100)),
+            "billing observer must receive the tenant + summed compute_ms (4+3) + bytes_read from the same snapshot"
+        );
+    }
 
     #[test]
     fn classify_maps_known_verbs() {


### PR DESCRIPTION
## Summary
First implementation slice off **ADR-030** — closes the **verified-unwired KRU** read-compute meter (`record_task_execution_time` had zero live call-sites).

At the `io_trace` **scope-close drain** (where the tenant + the per-engine `compute_ms` are both in hand), a **new always-on billing observer** emits the per-tenant KRU meter from the **same `IoTraceSnapshot`** the route-cost + cache observers read — so billed compute cannot diverge from the cost model's view.

## Changes
- **`io_trace.rs`** — `BillingObserver` seam (`set_billing_observer` / `notify_billing_observer`) mirroring the route/cache observers; hooked in `instrument()` after them, passed the owning `tenant_id`.
- **`consumption_metrics.rs`** — `install_billing_observer` iterates `snap.compute_ms` (`BTreeMap<engine,u64>`) → `record_task_execution_time(tenant, engine, ms)`. **Always-on** — never behind the perf `io-trace` feature gate (ADR-027 non-entanglement).
- **`database.rs`** — installed at startup beside `install_route_cost_observer`.
- **`relational_pipeline.rs`** — time `NativeVolcanoEngine::execute_physical` → `record_compute_ms("native", ms)` so native SQL produces real KRU.

## Verification
- Deterministic test `billing_observer_receives_tenant_and_accumulated_compute_ms`: `instrument` + two `record_compute_ms("native", …)` calls (4 then 3) → observer receives `(tenant="acme", compute_ms=7, bytes_read=100)` from one snapshot. ✅
- `clippy --lib --bins -D warnings` (incl. `proximadb-server`) ✅; `fmt` ✅.

## Scope (per ADR-030 slicing)
Closes KRU for the **native path**. Explicitly **out** (separate slices): KSU (storage accrual = write/flush + periodic snapshot), the perf `io-trace` feature gate (Slice 0), the CI billing-never-gated guard (Slice 3), and feeding `compute_ms` on the DataFusion / SST-AXIS paths.

Additive + dependency-inverted (io_trace does not depend on the metering layer). Do **not** merge until reviewed.
