### PR TITLE
feat(metering): feed compute_ms on DataFusion + SST-AXIS paths (ADR-030, TD-158)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -293,11 +293,16 @@ pub async fn try_run_select(
             allow_engine_sql_fallback: true,
             controls: controls.clone(),
         };
-        return Some(
-            execute_sql_with_backend(decision.backend.clone(), sql, context)
-                .await
-                .map_err(|e| e.to_string()),
+        // ADR-030 / TD-158: time the DataFusion (engine-SQL fallback) execution so
+        // the always-on billing observer can attribute KRU to this engine at scope
+        // close. `record_compute_ms` no-ops outside an `io_trace` scope.
+        let started = std::time::Instant::now();
+        let engine_result = execute_sql_with_backend(decision.backend.clone(), sql, context).await;
+        crate::observability::io_trace::record_compute_ms(
+            &crate::query::compute_scheduler::backend_label(&decision.backend),
+            started.elapsed().as_millis() as u64,
         );
+        return Some(engine_result.map_err(|e| e.to_string()));
     }
 
     let snapshot = SnapshotCatalog {

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -90,6 +90,34 @@ fn try_begin_axis_rebuild(collection_id: &str) -> Option<AxisRebuildPermit> {
     })
 }
 
+/// ADR-030 / TD-158: attribute an SST vector-search query's compute time to KRU
+/// on **any** exit path (the search has several early returns — exact-scan,
+/// orchestrated, direct). On drop it records the elapsed millis to the active
+/// per-query I/O trace under the given engine label; `record_compute_ms` no-ops
+/// outside an `io_trace` scope, so internal/test callers are unaffected.
+struct ComputeMsGuard {
+    engine: &'static str,
+    started: std::time::Instant,
+}
+
+impl ComputeMsGuard {
+    fn new(engine: &'static str) -> Self {
+        Self {
+            engine,
+            started: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Drop for ComputeMsGuard {
+    fn drop(&mut self) {
+        crate::observability::io_trace::record_compute_ms(
+            self.engine,
+            self.started.elapsed().as_millis() as u64,
+        );
+    }
+}
+
 /// TD-165: the exact-vs-approximate route is a *cost* decision, and for a cloud DB
 /// the dominant term is bytes read from object storage, not vectors or CPU. An
 /// `Adaptive` search takes the exact brute-force segment scan when the whole scan
@@ -209,6 +237,9 @@ impl SstEngine {
         ctx: &StorageQueryContext,
     ) -> Result<Vec<OptimizedSearchRecord>> {
         let _search_start = std::time::Instant::now();
+        // ADR-030 / TD-158: attribute this query's SST compute to KRU on any exit
+        // path (records the elapsed time to the active io_trace on drop).
+        let _compute_guard = ComputeMsGuard::new("sst");
 
         // Track metadata access for cache optimization
         if let Some(orch) = self.orchestrator() {
@@ -1388,6 +1419,33 @@ mod tests {
     use proximadb_data_model::ProximaValue;
     use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
     use std::sync::Arc;
+
+    /// ADR-030 / TD-158: the SST `ComputeMsGuard` records elapsed compute to the
+    /// active per-query I/O trace on drop, under the engine label — so the
+    /// billing observer can attribute KRU to "sst". No-op outside a scope.
+    #[tokio::test]
+    async fn compute_ms_guard_records_to_active_io_trace() {
+        use crate::observability::io_trace;
+        let snap = io_trace::scope(async {
+            {
+                let _g = ComputeMsGuard::new("sst");
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            } // guard drops here → records elapsed into the active trace
+            io_trace::snapshot()
+        })
+        .await
+        .expect("snapshot inside an active io_trace scope");
+        assert!(
+            snap.compute_ms.contains_key("sst"),
+            "guard must record compute under the 'sst' engine label, got {:?}",
+            snap.compute_ms
+        );
+        assert!(
+            snap.total_compute_ms() >= 1,
+            "elapsed compute must be >= 1ms after a 2ms sleep, got {}",
+            snap.total_compute_ms()
+        );
+    }
 
     #[tokio::test]
     async fn test_parse_storage_url() {


### PR DESCRIPTION
## Summary
Second implementation slice off **ADR-030** — extends KRU read-compute attribution beyond the native path (#387) to the two engines that dominate the cost model: **DataFusion** (OLAP) and **SST-AXIS** (vector search). The always-on billing observer from #387 consumes these as per-`(tenant, engine)` KRU at scope close.

## Changes
- **`relational_pipeline.rs`** — time the engine-SQL fallback (`execute_sql_with_backend`) → `record_compute_ms(backend_label(decision.backend))`, labelled by the same backend the cost model uses.
- **`sst/search/mod.rs`** — a `ComputeMsGuard` (Drop) at the top of `search_vectors_unified` records elapsed compute under `"sst"` on **any** exit path (exact-scan / orchestrated / direct / error). `record_compute_ms` no-ops outside an `io_trace` scope.

## Verification
- Deterministic test `compute_ms_guard_records_to_active_io_trace`: within an `io_trace::scope`, the guard drop records `compute_ms["sst"]` with elapsed ≥ 1ms. ✅
- `clippy --lib --bins -D warnings` (incl. `proximadb-server`) ✅; `fmt` ✅.

## Relationship
Builds on **#387** (the billing observer that consumes `compute_ms`). Both additive; composes when both land. Out of scope (later slices): KSU write-path meter, the perf `io-trace` feature gate (Slice 0), the CI billing-never-gated guard (Slice 3).

Do **not** merge until reviewed.
