### PR TITLE
feat(observability): TD-160 io-trace perf-emission feature gate + billing-never-gated guard (ADR-030 Slice 0+3)

### DIFF
--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -70,6 +70,13 @@ jobs:
     - name: Run OSS/enterprise boundary guard
       run: python3 scripts/check_oss_boundary.py
 
+    # Billing-never-gated: the perf io-trace emission is gateable (TD-160) but the
+    # per-tenant billing meters + observer must stay always-on (ADR-027/ADR-030
+    # non-entanglement). Fails if any consumption_metrics symbol or the billing
+    # observer is wrapped in cfg(feature = "io-trace").
+    - name: Run billing-never-gated guard
+      run: python3 scripts/check_billing_never_gated.py
+
     - name: Report violations
       if: failure()
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -594,6 +594,13 @@ licensing_surface = []
 experimental-engines = []
 # Experimental SIMD path; not enabled by default
 simd-experimental = []
+# TD-160 / ADR-027 / ADR-030: gate the PERF-CLASS I/O-trace *emission* (the
+# per-query structured `tracing` event in `io_trace::IoTrace::emit`). Default OFF
+# → zero perf-emission cost in normal operation. The cheap core counters
+# (range_gets/bytes_read/compute_ms) and ALL observers (route-cost, cache, and
+# the always-on BILLING observer) stay live regardless — billing is never gated
+# (ADR-027 non-entanglement; enforced by scripts/check_billing_never_gated.py).
+io-trace = []
 # TurboQuant data-oblivious quantizer + in-kernel allowlist (ADR-021).
 # Gates the QuantizationLevel::TurboQuant variant in proximadb-vector + the
 # TurboQuantVectorData struct in src/compute/distance_computation/quantized.rs.

--- a/scripts/check_billing_never_gated.py
+++ b/scripts/check_billing_never_gated.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Guard: per-tenant BILLING meters are NEVER behind the perf ``io-trace`` gate.
+
+ADR-027 / ADR-030 keep the two I/O-trace classes structurally separate:
+
+* the **perf emission** (the structured ``tracing`` event in
+  ``io_trace::IoTrace::emit``) is gateable behind the ``io-trace`` cargo feature
+  (default off, zero cost in normal operation), but
+* the per-tenant **billing** meters (KSU/KRU/KIU/KOU/KEU) and the always-on
+  billing observer must **never** be gated — turning the perf gate off must not
+  silence billing (the chargeback source of truth).
+
+If any ``consumption_metrics`` symbol — or the billing observer — were wrapped in
+``cfg(feature = "io-trace")``, the default (feature-off) build would stop
+metering revenue. This lightweight fence (in the spirit of
+``check_oss_boundary.py`` / ``check_tenant_path_guard.py``) fails the build if
+that ever happens. The perf ``emit`` gate in ``io_trace.rs`` is *expected* and is
+not flagged, because it sits next to perf fields, not billing symbols.
+
+Exit status:
+* 0 - no billing symbol is behind the io-trace gate.
+* 1 - a billing meter / observer is gated by ``io-trace`` (ERROR).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# consumption_metrics.rs is billing in its entirety: ANY io-trace gate there is a
+# violation. io_trace.rs legitimately gates the perf emission, so it is only a
+# violation when the gate sits next to a billing symbol (the billing observer).
+CONSUMPTION = ROOT / "src" / "metrics" / "consumption_metrics.rs"
+IO_TRACE = ROOT / "src" / "observability" / "io_trace.rs"
+
+CFG_IO_TRACE = re.compile(r'cfg\s*\(\s*[^)]*feature\s*=\s*"io-trace"')
+BILLING_HINTS = (
+    "billing_observer",
+    "record_task_execution_time",
+    "record_storage_bytes",
+    "record_storage_snapshot",
+    "record_kou_bytes",
+    "record_keu_units",
+    "TASK_EXECUTION_TIME_MS",
+    "STORAGE_BYTES_SECONDS",
+    "KOU_BYTES_TOTAL",
+)
+
+
+def scan() -> list[str]:
+    violations: list[str] = []
+
+    if CONSUMPTION.exists():
+        for i, line in enumerate(CONSUMPTION.read_text().splitlines(), start=1):
+            if CFG_IO_TRACE.search(line):
+                violations.append(
+                    f"{CONSUMPTION.relative_to(ROOT)}:{i}: "
+                    "billing meters must never be behind the io-trace perf gate"
+                )
+
+    if IO_TRACE.exists():
+        lines = IO_TRACE.read_text().splitlines()
+        for i, line in enumerate(lines, start=1):
+            if not CFG_IO_TRACE.search(line):
+                continue
+            window = "\n".join(lines[max(0, i - 4) : i + 3])
+            if any(h in window for h in BILLING_HINTS):
+                violations.append(
+                    f"{IO_TRACE.relative_to(ROOT)}:{i}: "
+                    "the billing observer must stay always-on, not behind the io-trace gate"
+                )
+    return violations
+
+
+def main() -> int:
+    violations = scan()
+    if violations:
+        print(
+            "ERROR: billing/consumption meters must never be gated by the perf "
+            "`io-trace` feature (ADR-027 / ADR-030 non-entanglement):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print("  " + v, file=sys.stderr)
+        return 1
+    print("OK: no billing meter or observer is behind the io-trace perf gate")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -360,10 +360,18 @@ impl IoTraceSnapshot {
     /// Emit this snapshot as a structured `tracing` event under [`TARGET`].
     /// No-op when empty. `tenant_id` and `route` label the query; all physical
     /// quantities become event fields the OTLP layer (§4.4) maps to a span.
+    /// Emit the per-query I/O trace as a structured `tracing` event.
+    ///
+    /// TD-160: this is the **perf-class emission** — gated behind the `io-trace`
+    /// cargo feature (default OFF) so it costs nothing in normal operation. When
+    /// the feature is off this is a near-no-op; the cheap core counters and the
+    /// route/cache/**billing** observers in [`instrument`] are unaffected and stay
+    /// always-on (billing is never gated — ADR-027 non-entanglement).
     pub fn emit(&self, tenant_id: Option<&str>, route: &str) {
         if self.is_empty() {
             return;
         }
+        #[cfg(feature = "io-trace")]
         tracing::info!(
             target: TARGET,
             tenant_id = tenant_id.unwrap_or("default"),
@@ -388,6 +396,10 @@ impl IoTraceSnapshot {
             compute_ms_by_engine = ?self.compute_ms,
             "per-query I/O trace"
         );
+        // Perf emission compiled out (default): consume the args so the signature
+        // is stable and no unused-var warning fires in the feature-off build.
+        #[cfg(not(feature = "io-trace"))]
+        let _ = (tenant_id, route);
     }
 }
 


### PR DESCRIPTION
## Summary
Final ADR-030 slices (**0 + 3**) — the perf/billing **gate boundary** and its guardrail.

**Slice 0 (TD-160):** gate the perf-class I/O-trace **emission** (the per-query structured `tracing` event in `IoTrace::emit`) behind a new `io-trace` cargo feature, **default OFF** → zero perf-emission cost in normal operation.

**Slice 3:** a CI guard enforcing that billing is never silenced by that gate.

Per ADR-030's refinement of ADR-027's "gate wholesale", the gate covers **only the emission** — the cheap **core counters** (`range_gets`/`bytes_read`/`compute_ms`) and **all observers** (route-cost, cache, and the always-on **billing** observer from #387) stay live regardless. Billing is never gated.

## Changes
- **`Cargo.toml`** — `io-trace = []` feature (default off).
- **`io_trace::IoTrace::emit`** — the `tracing` event is behind `cfg(feature = "io-trace")`; the feature-off branch consumes the args (stable signature, no unused-var warning).
- **`scripts/check_billing_never_gated.py`** + a `layering-check` CI step — fails if any `consumption_metrics` symbol or the billing observer is wrapped in `cfg(feature = "io-trace")` (ADR-027 non-entanglement). The legitimate perf `emit` gate is not flagged (it sits next to perf fields, not billing symbols).

## Verification
- Builds in **both** feature states: default OFF (incl. `proximadb-server`) ✅ and `--features io-trace` ON ✅ (#11).
- `clippy --lib --bins -D warnings` clean; `fmt` clean; guard script passes locally.

Closes the ADR-030 implementation arc: metering (KRU #387/#389, KSU #391) + the gate boundary (this PR). Do **not** merge until reviewed.
