### PR TITLE
fix(metrics): clear the last advisory unit failure — flushcoordinator

### DIFF
--- a/src/metrics/tests/integration_tests.rs
+++ b/src/metrics/tests/integration_tests.rs
@@ -165,14 +165,29 @@ mod tests {
     }
 
     async fn create_test_metrics_components_with_cleanup(
-        cleanup: bool,
+        _cleanup: bool,
+    ) -> Result<(Arc<MetricsUpdateService>, Arc<MetricsPersistenceLayer>)> {
+        // Unique tempdir per call so tests don't collide on a shared path — the
+        // file-backed MetricsPersistenceLayer accumulates state across runs,
+        // making total_flushes assertions flaky. (Tests that need a SHARED path
+        // across "restarts" use `create_test_metrics_components_at` directly.)
+        let temp_dir = tempfile::TempDir::new()?;
+        let storage_path = format!("file://{}", temp_dir.path().display());
+        std::mem::forget(temp_dir);
+        create_test_metrics_components_at(storage_path).await
+    }
+
+    /// Create test metrics components at an explicit storage path — for tests
+    /// that need a SHARED path across "restarts" (e.g. persistence-across-restarts).
+    async fn create_test_metrics_components_at(
+        storage_path: String,
     ) -> Result<(Arc<MetricsUpdateService>, Arc<MetricsPersistenceLayer>)> {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
         let config = MetricsConfig {
             enabled: true,
             collection_partitions: 4,
-            storage_path: "file:///tmp/proximadb_integration_metrics_test".to_string(),
+            storage_path,
             flush_interval_seconds: 30,
             retention_days: 7,
             parallel_scan_threshold: 10,
@@ -181,11 +196,6 @@ mod tests {
             snapshot_interval_seconds: 60,
             max_memory_mb: 512,
         };
-
-        // Clean up test directory only if requested
-        if cleanup {
-            let _ = tokio::fs::remove_dir_all("/tmp/proximadb_integration_metrics_test").await;
-        }
 
         let filesystem_config = Default::default();
         let filesystem_factory = Arc::new(FilesystemFactory::create(filesystem_config).await?);
@@ -776,9 +786,16 @@ mod tests {
 
         let collection_id = "persistence_test_collection";
 
+        // Shared storage path across both phases so Phase 2 reads what Phase 1
+        // persisted (simulates a restart on the same disk). Leaked (forget) so it
+        // outlives both component instances.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage_path = format!("file://{}", temp_dir.path().display());
+        std::mem::forget(temp_dir);
+
         // Phase 1: Create initial metrics store and record data
         {
-            let (metrics_updater, _) = create_test_metrics_components_with_cleanup(true)
+            let (metrics_updater, _) = create_test_metrics_components_at(storage_path.clone())
                 .await
                 .unwrap();
 
@@ -800,7 +817,9 @@ mod tests {
 
         // Phase 2: Create new metrics store (simulating restart) and verify persistence
         {
-            let (_, metrics_store) = create_test_metrics_components().await.unwrap();
+            let (_, metrics_store) = create_test_metrics_components_at(storage_path.clone())
+                .await
+                .unwrap();
 
             let stored_metrics = metrics_store
                 .collection_metrics(collection_id)

--- a/src/storage/traits/mod.rs
+++ b/src/storage/traits/mod.rs
@@ -1201,8 +1201,15 @@ pub trait UnifiedStorageFormat: Send + Sync {
         // Delegate to engine-specific implementation
         let mut result = self.do_flush(&params).await?;
 
-        // Common post-flush processing
-        result.duration_ms = Some(start_time.elapsed().as_millis() as u64);
+        // Common post-flush processing.
+        // Prefer the engine's self-reported duration (do_flush knows its own work);
+        // only fall back to the funnel's wall-clock measurement when the engine
+        // didn't report one. Previously this unconditionally overwrote the engine's
+        // value, so a fast engine (e.g. the test mock, or any sub-millisecond
+        // flush) recorded duration_ms=0 even when do_flush reported a real value.
+        result.duration_ms = result
+            .duration_ms
+            .or_else(|| Some(start_time.elapsed().as_millis() as u64));
         result.completed_at = Utc::now();
 
         // Log operation completion


### PR DESCRIPTION
Clears the final 1/16 of the #372 advisory unit batch. Two root causes (both confirmed via instrumentation, debug reverted): (1) shared `/tmp` test path → flaky total_flushes (unique tempdir per call); (2) the `UnifiedStorageFormat::flush` funnel overwrote `do_flush`'s reported duration with wall-clock elapsed (0 for a fast engine) → last_flush_duration_ms=0 (prefer engine-reported, fallback to measured). Verified: test passes 3× deterministically; fmt+check+clippy clean. 16/16 advisory green → gate can be re-tightened in a follow-up.