### PR TITLE
fix(test): switch volcano streaming tests to current_thread runtime (hang flake)

### DIFF
--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -387,6 +387,7 @@ mod tests {
     use proximadb_relational_planner::PhysicalPlan;
     use proximadb_relational_reader::RelationalReader;
     use proximadb_relational_types::{ColumnInfo, Expr};
+    use std::time::Duration;
 
     struct EmptyReaderFactory;
 
@@ -551,14 +552,25 @@ mod tests {
         );
     }
 
+    // The `native_volcano_stream_*` tests have an intermittent hang in
+    // `execute_physical_stream` (the `.await` never resolves under certain CI
+    // scheduling conditions). Wrapping the call in a `tokio::time::timeout`
+    // turns the indeterminate hang into a fast, deterministic failure (10s) —
+    // preserving coverage when the flake doesn't trigger. Root cause TBD (the
+    // code path is sequential: `stream::try_unfold` + `next_row`, no
+    // spawn/channel/task — needs a deterministic repro).
     #[tokio::test]
     async fn native_volcano_stream_yields_rows_incrementally() {
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            ExecutionControls::default(),
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                ExecutionControls::default(),
+            ),
         )
         .await
+        .expect("streaming test timed out — investigate execute_physical_stream")
         .expect("values plan should open for streaming");
 
         // Schema is available before draining any row.
@@ -579,12 +591,16 @@ mod tests {
             cancellation_flag: Some(flag.clone()),
             ..Default::default()
         };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            ),
         )
         .await
+        .expect("streaming test timed out — investigate execute_physical_stream")
         .expect("values plan should open for streaming");
 
         let mut rows = result.rows;
@@ -608,12 +624,16 @@ mod tests {
             max_rows: Some(1),
             ..Default::default()
         };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            ),
         )
         .await
+        .expect("streaming test timed out — investigate execute_physical_stream")
         .expect("values plan should open for streaming");
 
         let mut rows = result.rows;
@@ -640,12 +660,16 @@ mod tests {
             row_limit_mode: RowLimitMode::Truncate,
             ..Default::default()
         };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            ),
         )
         .await
+        .expect("streaming test timed out — investigate execute_physical_stream")
         .expect("values plan should open for streaming");
 
         let mut rows = result.rows;


### PR DESCRIPTION
## Problem

The `native_volcano_stream_*` tests intermittently hung in CI until the 240s nextest TMT timeout (3 retries × 240s ≈ 12min wasted per CI run). The code path is sequential (`stream::try_unfold` + `next_row`, no spawn/channel/task) — root cause unclear, likely CI scheduling.

## Previous attempt (reverted)

`#[tokio::test(flavor = "current_thread")]` — **counterproductive**: the single-threaded runtime's drop blocks on the hung test's pending tasks → process-level hang → the job took **1h20m** (worse than the original ~1hr). Reverted.

## Fix

Wrap `execute_physical_stream` in `tokio::time::timeout(Duration::from_secs(10))`. If the streaming path hangs, the test **fails fast** (10s) instead of blocking for 240s × 3 retries. Preserves `#[tokio::test]` (multi-threaded, original behavior). Root cause TBD — needs a deterministic repro.

## Verification

The CI run will show whether `Rust Tests (unit)` completes faster (~30-40min, no hang) vs the previous ~1hr+. No production code changed.