### PR TITLE
feat(olap): ADR-025 WAL-first deletion vectors over pgwire (relational cold path)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,5 +59,23 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'test(/_e2e$/) | test(/_integration_test$/) | binary(integration)'
 test-group = 'serial-network'
 
+# Heavy DataFusion / Volcano execution tests each spin up an all-core DataFusion
+# runtime. Running several at once oversubscribes the constrained CI runner
+# (--test-threads=2), starving them — and the lightweight tests scheduled beside
+# them — past the slow-timeout kill (240s). That is the root cause of the
+# intermittent 240s timeouts on `datafusion::*`, `datafusion_engine::tests`, and
+# `query::execution::engine::tests::native_volcano_*` (CLAUDE.md §11's known
+# `native_volcano_stream_*` flake). Serialize them so at most one runs at a time;
+# the other test-thread keeps draining fast tests, so wall-clock barely changes
+# while the oversubscription (and the flake) is eliminated.
+[[profile.default.overrides]]
+filter = 'test(/datafusion/) | test(/native_volcano/)'
+test-group = 'datafusion-heavy'
+
+[[profile.unit.overrides]]
+filter = 'test(/datafusion/) | test(/native_volcano/)'
+test-group = 'datafusion-heavy'
+
 [test-groups]
 serial-network = { max-threads = 1 }
+datafusion-heavy = { max-threads = 1 }

--- a/crates/storage/proximadb-storage-common/src/deletion_vector.rs
+++ b/crates/storage/proximadb-storage-common/src/deletion_vector.rs
@@ -1,0 +1,132 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! ADR-025 deletion vector — the N0 primitive.
+//!
+//! A compact, **position-indexed** set of deleted rows within one cold file or
+//! index segment, backed by the in-repo Roaring bitmap (no `roaring` crate
+//! dependency — the offline build cannot fetch new crates). Versioned magic
+//! makes it mixed-read-safe per CLAUDE.md §8: a reader that sees an absent or
+//! unknown magic errors out and falls back to a legacy full scan rather than
+//! misreading bytes as positions.
+//!
+//! This is the shared primitive for the **position-based persistent** DV path —
+//! PAX segments (which carry a sorted row directory) and ANN index segments
+//! (skip deleted nodes during traversal). The relational OLAP read-merge instead
+//! uses an oid-keyed suppress-set (Parquet has no row directory), so the two
+//! representations are complementary: positions here, oids there.
+
+use crate::bitmap::{BitmapError, RoaringBitmap};
+
+/// Versioned magic prefix for a serialized deletion vector.
+const DV_MAGIC: &[u8; 4] = b"PDV1";
+
+/// A set of deleted row positions within a single cold file / index segment.
+#[derive(Debug, Clone, Default)]
+pub struct DeletionVector {
+    deleted: RoaringBitmap,
+}
+
+impl DeletionVector {
+    /// An empty deletion vector (nothing deleted).
+    pub fn new() -> Self {
+        Self {
+            deleted: RoaringBitmap::new(),
+        }
+    }
+
+    /// Mark the row at `position` deleted. Returns `true` if newly marked.
+    pub fn mark_deleted(&mut self, position: u32) -> bool {
+        self.deleted.insert(position)
+    }
+
+    /// Whether the row at `position` is deleted.
+    pub fn is_deleted(&self, position: u32) -> bool {
+        self.deleted.contains(position)
+    }
+
+    /// Number of deleted positions.
+    pub fn deleted_count(&self) -> u64 {
+        self.deleted.cardinality()
+    }
+
+    /// Whether no row is deleted.
+    pub fn is_empty(&self) -> bool {
+        self.deleted.is_empty()
+    }
+
+    /// The deleted positions, ascending.
+    pub fn deleted_positions(&self) -> Vec<u32> {
+        self.deleted.to_vec()
+    }
+
+    /// Live-row count for a file/segment of `total` rows (saturating).
+    pub fn live_count(&self, total: u64) -> u64 {
+        total.saturating_sub(self.deleted_count())
+    }
+
+    /// Serialize as `[DV_MAGIC | roaring-bitmap-bytes]`.
+    pub fn serialize(&self) -> Result<Vec<u8>, BitmapError> {
+        let body = self.deleted.serialize()?;
+        let mut out = Vec::with_capacity(DV_MAGIC.len() + body.len());
+        out.extend_from_slice(DV_MAGIC);
+        out.extend_from_slice(&body);
+        Ok(out)
+    }
+
+    /// Deserialize, rejecting an absent/unknown magic so callers can fall back to
+    /// the legacy (no-DV) path instead of misreading the bytes.
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, BitmapError> {
+        if bytes.len() < DV_MAGIC.len() || &bytes[..DV_MAGIC.len()] != DV_MAGIC {
+            return Err(BitmapError::SerializationError(
+                "deletion vector: missing or unknown magic".to_string(),
+            ));
+        }
+        let deleted = RoaringBitmap::deserialize(&bytes[DV_MAGIC.len()..])?;
+        Ok(Self { deleted })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deletion_vector_roundtrip_and_versioned_magic() {
+        let mut dv = DeletionVector::new();
+        assert!(dv.is_empty());
+        assert!(dv.mark_deleted(2));
+        assert!(dv.mark_deleted(5));
+        assert!(dv.mark_deleted(100_000));
+        assert!(!dv.mark_deleted(5)); // idempotent — already marked
+        assert_eq!(dv.deleted_count(), 3);
+        assert!(dv.is_deleted(5));
+        assert!(!dv.is_deleted(6));
+        assert_eq!(dv.live_count(10), 7);
+
+        let bytes = dv.serialize().expect("serialize");
+        assert_eq!(&bytes[..4], DV_MAGIC, "magic prefix");
+        let back = DeletionVector::deserialize(&bytes).expect("deserialize");
+        assert_eq!(back.deleted_positions(), vec![2, 5, 100_000]);
+        assert_eq!(back.deleted_count(), 3);
+        assert!(back.is_deleted(100_000));
+    }
+
+    #[test]
+    fn deletion_vector_rejects_unknown_or_missing_magic() {
+        assert!(DeletionVector::deserialize(&[]).is_err());
+        assert!(DeletionVector::deserialize(b"PD").is_err());
+        // A legacy/foreign blob must error (so the reader falls back to legacy),
+        // never be silently interpreted as positions.
+        assert!(DeletionVector::deserialize(b"XXXXdeadbeef").is_err());
+    }
+
+    #[test]
+    fn empty_deletion_vector_roundtrips() {
+        let dv = DeletionVector::new();
+        let bytes = dv.serialize().expect("serialize empty");
+        let back = DeletionVector::deserialize(&bytes).expect("deserialize empty");
+        assert!(back.is_empty());
+        assert_eq!(back.deleted_count(), 0);
+        assert!(back.deleted_positions().is_empty());
+    }
+}

--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cache_config;
 pub mod collection_path;
 pub mod column_projector;
 pub mod columnar_constants;
+pub mod deletion_vector;
 pub mod delta_simd;
 pub mod engine_constants;
 pub mod engine_profile;

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -198,6 +198,13 @@ pub async fn try_run_select(
     // (nor advertised) when the build can't honor it.
     #[cfg(feature = "datafusion-integration")]
     let mut parquet_loc_by_key: HashMap<String, String> = HashMap::new();
+    // ADR-025: per-table OLAP read-merge params (snapshot_lsn + PK column) for the
+    // opted-in parquet-backed tables; empty ⇒ all reads stay on the bare Parquet path.
+    #[cfg(feature = "datafusion-integration")]
+    let mut olap_delta_tables: HashMap<
+        String,
+        crate::query::execution::olap_delta_merge::OlapDeltaTable,
+    > = HashMap::new();
     for raw in &names {
         let key = normalize_table_key(raw);
         if tables.contains_key(&key) {
@@ -208,6 +215,9 @@ pub async fn try_run_select(
                 #[cfg(feature = "datafusion-integration")]
                 if let Some(location) = catalog_table_is_parquet_backed(&catalog_schema) {
                     parquet_loc_by_key.insert(key.clone(), location);
+                    if let Some(params) = olap_delta_table_params(&catalog_schema) {
+                        olap_delta_tables.insert(key.clone(), params);
+                    }
                 }
                 tables.insert(key, PreparedTable::from_catalog(raw, &catalog_schema));
             }
@@ -284,6 +294,17 @@ pub async fn try_run_select(
             parquet_tables,
             vector_ops,
             tenant_id: tenant.map(str::to_string),
+            // ADR-025: reconcile opted-in parquet-backed tables with their
+            // post-snapshot WAL delta at scan time. `None` (no opted-in table)
+            // keeps the legacy bare-Parquet read (default-OFF).
+            olap_delta: if olap_delta_tables.is_empty() {
+                None
+            } else {
+                Some(crate::query::execution::olap_delta_merge::OlapDeltaConfig {
+                    source: dml.clone(),
+                    tables: olap_delta_tables,
+                })
+            },
             // Full ANSI SQL over pgwire: when the shared relational frontend can't
             // yet lower a query (e.g. typed DATE literals, certain subquery/window
             // shapes), execute it through DataFusion's own ANSI SQL planner over the
@@ -429,6 +450,59 @@ fn catalog_table_is_parquet_backed(
         } else {
             None
         }
+    })
+}
+
+/// Global master switch for the ADR-025 OLAP read-merge (default-OFF). A table is
+/// merged only when this is on OR the table carries an `olap_delta_merge` opt-in
+/// property — honoring the staged, per-collection-opt-in rollout mandate.
+#[cfg(feature = "datafusion-integration")]
+fn olap_delta_merge_enabled() -> bool {
+    std::env::var("PROXIMADB_OLAP_DELTA_MERGE")
+        .ok()
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+}
+
+/// Resolve the ADR-025 read-merge parameters for a parquet-backed table, or `None`
+/// when it is ineligible (no single-column PK, no recorded `snapshot_lsn`, or not
+/// opted in). Ineligible tables fall back to the bare Parquet read.
+#[cfg(feature = "datafusion-integration")]
+fn olap_delta_table_params(
+    schema: &proximadb_catalog::CatalogTableSchema,
+) -> Option<crate::query::execution::olap_delta_merge::OlapDeltaTable> {
+    use proximadb_catalog::{CatalogAuthorityMode, CatalogPhysicalFormat};
+    // Single-column PK required: the merge recomputes each base row's canonical oid
+    // from its PK column. Keyless heaps fall back to the bare Parquet read.
+    let pk_column = match schema.primary_key.as_slice() {
+        [pk] => pk.clone(),
+        _ => return None,
+    };
+    let layout = schema.storage_layouts.iter().find(|l| {
+        matches!(l.physical_format, CatalogPhysicalFormat::Parquet)
+            && matches!(
+                l.authority,
+                CatalogAuthorityMode::FederatedRead
+                    | CatalogAuthorityMode::ExternalAuthoritative
+                    | CatalogAuthorityMode::ImportedSnapshot
+                    | CatalogAuthorityMode::ExportedPublication
+                    | CatalogAuthorityMode::ProjectionPublication
+            )
+    })?;
+    let opted_in = olap_delta_merge_enabled()
+        || matches!(
+            layout
+                .properties
+                .get("olap_delta_merge")
+                .map(String::as_str),
+            Some("1" | "true" | "on" | "yes")
+        );
+    if !opted_in {
+        return None;
+    }
+    let snapshot_lsn: u64 = layout.properties.get("snapshot_lsn")?.parse().ok()?;
+    Some(crate::query::execution::olap_delta_merge::OlapDeltaTable {
+        snapshot_lsn,
+        pk_column,
     })
 }
 

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -93,19 +93,19 @@ impl DataFusionLocalEngine {
             // keyed by canonical oid. Non-opt-in tables fall through to the bare
             // Parquet read below (default-OFF), so the OLAP ratchet tables are
             // untouched.
-            if let Some(cfg) = &context.olap_delta {
-                if let Some(tbl) = cfg.tables.get(&normalize_table_key(name)) {
-                    register_merged_olap_table(
-                        &ctx,
-                        name,
-                        location,
-                        tbl,
-                        cfg.source.as_ref(),
-                        context.tenant_id.as_deref(),
-                    )
-                    .await?;
-                    continue;
-                }
+            if let Some(cfg) = &context.olap_delta
+                && let Some(tbl) = cfg.tables.get(&normalize_table_key(name))
+            {
+                register_merged_olap_table(
+                    &ctx,
+                    name,
+                    location,
+                    tbl,
+                    cfg.source.as_ref(),
+                    context.tenant_id.as_deref(),
+                )
+                .await?;
+                continue;
             }
             let table =
                 crate::datafusion::register_object_store_parquet_location(&ctx, name, location)
@@ -615,7 +615,26 @@ async fn register_merged_olap_table(
     use std::collections::HashSet;
     use std::sync::Arc;
 
-    // 1. Read the cold Parquet base in an isolated session so the hidden base
+    // 1. Suppress-set = oids changed since the snapshot (tenant-scoped WAL feed).
+    //    Computed first and cheaply: if NOTHING changed since the snapshot, the
+    //    cold base is already current — register it bare (full Parquet pushdown,
+    //    no MemTable, no base read). Correctness-neutral fast path for the common
+    //    OLAP case (read-mostly tables).
+    let changed = source
+        .changed_oids_since(name, table.snapshot_lsn, tenant)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge delta {name}: {e}")))?;
+    if changed.is_empty() {
+        crate::datafusion::register_object_store_parquet_location(ctx, name, location)
+            .await
+            .map_err(|e| {
+                ExecutionError::Context(format!("olap-merge bare register {name}: {e}"))
+            })?;
+        return Ok(());
+    }
+    let suppress: HashSet<String> = changed.iter().cloned().collect();
+
+    // 2. Read the cold Parquet base in an isolated session so the hidden base
     //    registration never leaks into the query's table namespace.
     let base_ctx = crate::datafusion::create_session_context()
         .map_err(|e| ExecutionError::Context(format!("olap-merge base session: {e}")))?;
@@ -634,13 +653,6 @@ async fn register_merged_olap_table(
         .collect()
         .await
         .map_err(|e| ExecutionError::Context(format!("olap-merge base collect {name}: {e}")))?;
-
-    // 2. Suppress-set = oids changed since the snapshot (canonical WAL change-feed).
-    let changed = source
-        .changed_oids_since(name, table.snapshot_lsn, tenant)
-        .await
-        .map_err(|e| ExecutionError::Context(format!("olap-merge delta {name}: {e}")))?;
-    let suppress: HashSet<String> = changed.iter().cloned().collect();
 
     // 3. Keep base rows whose recomputed oid is not suppressed. (TTL on the base
     //    is eventual-until-rematerialize — the snapshot carries no valid_to_ns,

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -87,6 +87,26 @@ impl DataFusionLocalEngine {
         .map_err(|e| ExecutionError::Context(format!("session: {e}")))?;
 
         for (name, location) in &context.parquet_tables {
+            // ADR-025 (relational cold path): an opt-in table reads its cold
+            // Parquet base reconciled with the authoritative post-snapshot WAL
+            // delta (deletes/updates/inserts after the `MATERIALIZE` snapshot),
+            // keyed by canonical oid. Non-opt-in tables fall through to the bare
+            // Parquet read below (default-OFF), so the OLAP ratchet tables are
+            // untouched.
+            if let Some(cfg) = &context.olap_delta {
+                if let Some(tbl) = cfg.tables.get(&normalize_table_key(name)) {
+                    register_merged_olap_table(
+                        &ctx,
+                        name,
+                        location,
+                        tbl,
+                        cfg.source.as_ref(),
+                        context.tenant_id.as_deref(),
+                    )
+                    .await?;
+                    continue;
+                }
+            }
             let table =
                 crate::datafusion::register_object_store_parquet_location(&ctx, name, location)
                     .await
@@ -567,6 +587,113 @@ mod tests {
 }
 
 // Helpers copied from relational_pipeline.rs or shared utilities
+
+/// ADR-025 relational cold-path read-merge. Registers `name` as an in-memory
+/// table whose rows are the materialized Parquet base reconciled with the
+/// authoritative post-snapshot WAL delta: base rows whose canonical oid (the PK
+/// value, recomputed from the base PK column) changed since `snapshot_lsn` are
+/// dropped, and the current live row for every changed oid is appended. The
+/// suppress-set is a rebuildable projection of the canonical WAL (ADR-020), so no
+/// new durable state is introduced. MemTable-backed (whole base in memory) —
+/// acceptable for the opt-in foundation; a streaming provider is future work.
+#[cfg(feature = "datafusion-integration")]
+async fn register_merged_olap_table(
+    ctx: &datafusion::prelude::SessionContext,
+    name: &str,
+    location: &str,
+    table: &crate::query::execution::olap_delta_merge::OlapDeltaTable,
+    source: &dyn crate::query::execution::olap_delta_merge::OlapDeltaSource,
+    tenant: Option<&str>,
+) -> Result<(), ExecutionError> {
+    use crate::services::record_store::proxima_value_to_unique_text;
+    use datafusion::arrow::array::BooleanArray;
+    use datafusion::arrow::compute::filter_record_batch;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use proximadb_storage_common::proxima_arrow::{
+        arrow_cell_to_proxima_value, proxima_records_to_record_batch,
+    };
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    // 1. Read the cold Parquet base in an isolated session so the hidden base
+    //    registration never leaks into the query's table namespace.
+    let base_ctx = crate::datafusion::create_session_context()
+        .map_err(|e| ExecutionError::Context(format!("olap-merge base session: {e}")))?;
+    crate::datafusion::register_object_store_parquet_location(&base_ctx, name, location)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge base register {name}: {e}")))?;
+    let base_schema = base_ctx
+        .table_provider(name)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge base provider {name}: {e}")))?
+        .schema();
+    let base_batches = base_ctx
+        .table(name)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge base table {name}: {e}")))?
+        .collect()
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge base collect {name}: {e}")))?;
+
+    // 2. Suppress-set = oids changed since the snapshot (canonical WAL change-feed).
+    let changed = source
+        .changed_oids_since(name, table.snapshot_lsn, tenant)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge delta {name}: {e}")))?;
+    let suppress: HashSet<String> = changed.iter().cloned().collect();
+
+    // 3. Keep base rows whose recomputed oid is not suppressed. (TTL on the base
+    //    is eventual-until-rematerialize — the snapshot carries no valid_to_ns,
+    //    a documented first-cut limitation; explicit deletes are always caught by
+    //    the suppress-set.)
+    let pk_idx = base_schema
+        .index_of(table.pk_column.as_str())
+        .map_err(|e| {
+            ExecutionError::Context(format!(
+                "olap-merge pk column `{}` not in base {name}: {e}",
+                table.pk_column
+            ))
+        })?;
+    let mut batches: Vec<RecordBatch> = Vec::with_capacity(base_batches.len() + 1);
+    for batch in &base_batches {
+        let pk_array = batch.column(pk_idx);
+        let keep: BooleanArray = (0..batch.num_rows())
+            .map(|row| {
+                let oid = arrow_cell_to_proxima_value(pk_array, row)
+                    .map(|v| proxima_value_to_unique_text(&v))
+                    .unwrap_or_default();
+                Some(!suppress.contains(&oid))
+            })
+            .collect();
+        let kept = filter_record_batch(batch, &keep)
+            .map_err(|e| ExecutionError::Context(format!("olap-merge filter {name}: {e}")))?;
+        batches.push(kept);
+    }
+
+    // 4. Append the current live rows for the changed oids, encoded with the same
+    //    catalog schema the base was written with and normalized onto the base
+    //    schema so every MemTable partition batch shares one schema.
+    let (schema, append_records) = source
+        .current_records(name, &changed, tenant)
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge appends {name}: {e}")))?;
+    if !append_records.is_empty() {
+        let append_batch = proxima_records_to_record_batch(&append_records, &schema)
+            .map_err(|e| ExecutionError::Context(format!("olap-merge append batch {name}: {e}")))?;
+        let normalized = RecordBatch::try_new(base_schema.clone(), append_batch.columns().to_vec())
+            .map_err(|e| {
+                ExecutionError::Context(format!("olap-merge append schema {name}: {e}"))
+            })?;
+        batches.push(normalized);
+    }
+
+    // 5. Register the reconciled rows as the table the query reads.
+    let mem = datafusion::datasource::MemTable::try_new(base_schema, vec![batches])
+        .map_err(|e| ExecutionError::Context(format!("olap-merge memtable {name}: {e}")))?;
+    ctx.register_table(name, Arc::new(mem))
+        .map_err(|e| ExecutionError::Context(format!("olap-merge register {name}: {e}")))?;
+    Ok(())
+}
 
 #[cfg(feature = "datafusion-integration")]
 fn arrow_type_to_proxima(dt: &arrow_schema::DataType) -> proximadb_data_model::ProximaType {

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -163,6 +163,12 @@ pub struct QueryExecutionContext {
     /// Optional request tenant for engines that need tenant-scoped I/O, metrics,
     /// or billing attribution.
     pub tenant_id: Option<String>,
+    /// ADR-025 OLAP read-merge (relational cold path): when set, parquet-backed
+    /// tables listed here are reconciled at scan time against the authoritative
+    /// post-snapshot WAL delta (deletes/updates/inserts that landed after the
+    /// `MATERIALIZE` snapshot), keyed by canonical `oid`. `None` ⇒ legacy bare
+    /// Parquet reads (default-OFF). See [`super::olap_delta_merge`].
+    pub olap_delta: Option<super::olap_delta_merge::OlapDeltaConfig>,
     /// Escape hatch for SQL dialect gaps while the shared relational lowering
     /// catches up. Keep false for production routes that require one logical
     /// plane across Volcano and DataFusion.

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -10,6 +10,7 @@ pub mod datafusion_engine;
 pub mod engine;
 pub mod executor;
 pub mod low_latency_executor;
+pub mod olap_delta_merge;
 pub mod plan_cache;
 pub mod planner;
 pub mod set_operations;

--- a/src/query/execution/olap_delta_merge.rs
+++ b/src/query/execution/olap_delta_merge.rs
@@ -1,0 +1,191 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! OLAP read-time delta merge (ADR-025, relational cold path).
+//!
+//! `ALTER TABLE … MATERIALIZE` writes an atomic, already-dead-filtered Parquet
+//! snapshot of a table at a point in time (`snapshot_lsn`). Any `DELETE` /
+//! `UPDATE` / `INSERT` that lands **after** that snapshot stays in the
+//! authoritative record store (memtable + canonical WAL + PAX) and is *not*
+//! reflected in the cold Parquet base. Without reconciliation an OLAP `SELECT`
+//! routed to DataFusion over the Parquet base returns stale rows — the gap this
+//! module closes.
+//!
+//! The reconciliation is a **read-time merge** keyed by the canonical `oid`:
+//!
+//! * `suppress` — the set of oids that changed since `snapshot_lsn`, taken from
+//!   the canonical-WAL change-feed (`TableRecordStore::read_changes_since`).
+//!   Deletes, updates, and post-snapshot inserts all land here.
+//! * `appends` — the **current live** row for each changed oid, read back from
+//!   the record store (already dead-record-filtered). A deleted/expired oid has
+//!   no live row, so it simply does not appear in `appends`.
+//!
+//! The merged result is every base row whose oid is **not** suppressed and which
+//! is not itself TTL-dead, followed by the appends. This is the in-memory
+//! deletion vector of ADR-025 done WAL-first: the suppress-set is, by
+//! construction, a rebuildable projection of the canonical WAL (ADR-020 — never a
+//! parallel durable authority), and re-`MATERIALIZE` plays the role of the N3
+//! compaction that physically drops the dead rows.
+//!
+//! This module is the pure, I/O-free core (so it unit-tests without the
+//! `datafusion-integration` feature). The Arrow/Parquet wiring that feeds it the
+//! base rows, suppress-set, and append rows lives in
+//! [`crate::query::execution::datafusion_engine`].
+
+use std::collections::HashSet;
+
+use proximadb_records::is_record_dead;
+
+/// One row of the cold Parquet base snapshot, tagged with the identity and
+/// liveness metadata the merge needs. `payload` is the opaque per-row value the
+/// caller carries through unchanged (e.g. an Arrow row index, or — in tests — a
+/// scalar). `valid_to_ns` is the row's MVCC upper bound when known (PR4+ sidecar
+/// lineage); `None` means "unknown", which the canonical predicate treats as
+/// live (passive-TTL is then eventual-until-rematerialize — a documented
+/// first-cut limitation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseRow<R> {
+    /// Canonical record identity. For the relational path this is the
+    /// PK-derived oid (recomputed from the base row's primary-key column via the
+    /// same canonicalization the writer used), so it matches the change-feed key.
+    pub oid: String,
+    /// MVCC upper bound, if the base carries it. `None` = unknown (treated live).
+    pub valid_to_ns: Option<i64>,
+    /// Opaque row payload carried through the merge unchanged.
+    pub payload: R,
+}
+
+impl<R> BaseRow<R> {
+    /// Construct a base row.
+    pub fn new(oid: impl Into<String>, valid_to_ns: Option<i64>, payload: R) -> Self {
+        Self {
+            oid: oid.into(),
+            valid_to_ns,
+            payload,
+        }
+    }
+}
+
+/// Merge a cold OLAP base snapshot with the authoritative post-snapshot delta.
+///
+/// * `base` — rows read from the materialized Parquet snapshot, each tagged with
+///   its canonical `oid` and (optionally) `valid_to_ns`.
+/// * `suppress` — oids that changed since the snapshot (deletes + updates + new
+///   inserts); their base copies are stale and must be dropped.
+/// * `appends` — the current live row for each changed oid (already
+///   dead-filtered by the record store). Deleted/expired oids contribute none.
+/// * `now_ns` — wall clock for the canonical dead-record predicate.
+///
+/// A base row survives iff its oid is **not** suppressed and it is not TTL-dead.
+/// Output order is the surviving base rows (in their original order) followed by
+/// the appends — deterministic, which keeps merge-on/merge-off result sets
+/// comparable in tests.
+///
+/// This resolves every cross-boundary case with one rule: base-row delete
+/// (suppressed, no append → gone); base-row update incl. PK change (old oid
+/// suppressed, new oid appended); post-snapshot insert (suppressed since it is a
+/// new upsert, appended as live); insert-then-delete after snapshot (suppressed,
+/// no live append → gone, the OLAP analog of invariant 16d); re-insert of a
+/// deleted PK (base suppressed, current appended).
+pub fn merge_base_with_delta<R>(
+    base: Vec<BaseRow<R>>,
+    suppress: &HashSet<String>,
+    appends: Vec<R>,
+    now_ns: i64,
+) -> Vec<R> {
+    let mut out = Vec::with_capacity(base.len() + appends.len());
+    for row in base {
+        if suppress.contains(&row.oid) {
+            continue;
+        }
+        if is_record_dead(row.valid_to_ns, now_ns) {
+            continue;
+        }
+        out.push(row.payload);
+    }
+    out.extend(appends);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn suppress(oids: &[&str]) -> HashSet<String> {
+        oids.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// A1: base {1,2,3} merged with delta {delete 2, update 3→3', insert 4}.
+    /// suppress = {2,3,4} (every changed oid); appends = current live = {3',4}.
+    /// Expect {1, 3', 4} — locks delete/update/insert and ordering.
+    #[test]
+    fn merge_parquet_base_with_delta_pure() {
+        let base = vec![
+            BaseRow::new("1", None, "1"),
+            BaseRow::new("2", None, "2"),
+            BaseRow::new("3", None, "3"),
+        ];
+        let merged = merge_base_with_delta(
+            base,
+            &suppress(&["2", "3", "4"]),
+            vec!["3'", "4"],
+            1_000,
+        );
+        assert_eq!(merged, vec!["1", "3'", "4"]);
+    }
+
+    /// A2 core: COUNT is the merged cardinality, never the base footer count.
+    /// base has 3 rows; after delete 2 + insert 4 the live count is 3, not 4.
+    #[test]
+    fn merged_count_excludes_deleted_includes_inserted() {
+        let base = vec![
+            BaseRow::new("1", None, 10),
+            BaseRow::new("2", None, 20),
+            BaseRow::new("3", None, 30),
+        ];
+        let merged = merge_base_with_delta(base, &suppress(&["2", "4"]), vec![40], 1_000);
+        assert_eq!(merged.len(), 3); // {1, 3, 4}
+        assert_eq!(merged, vec![10, 30, 40]);
+    }
+
+    /// UPDATE that changes the primary key: old oid suppressed, new oid appended.
+    #[test]
+    fn update_changing_pk_suppresses_old_appends_new() {
+        let base = vec![BaseRow::new("old", None, "old-row")];
+        // PK change emits delete(old) + insert(new) in the WAL → both oids change.
+        let merged =
+            merge_base_with_delta(base, &suppress(&["old", "new"]), vec!["new-row"], 1_000);
+        assert_eq!(merged, vec!["new-row"]);
+    }
+
+    /// Insert-then-delete after the snapshot: oid is suppressed (it changed) but
+    /// has no live append → it must be absent. OLAP analog of invariant 16d.
+    #[test]
+    fn insert_then_delete_after_materialize_absent() {
+        let base = vec![BaseRow::new("a", None, "a")];
+        // "b" was inserted then deleted post-snapshot: suppressed, no live append.
+        let merged = merge_base_with_delta(base, &suppress(&["b"]), vec![], 1_000);
+        assert_eq!(merged, vec!["a"]);
+    }
+
+    /// Passive TTL on a base row that carries its `valid_to_ns` (PR4+ lineage):
+    /// expired rows drop even with no WAL op, via the canonical predicate.
+    #[test]
+    fn ttl_expired_base_row_dropped_when_valid_to_ns_known() {
+        let base = vec![
+            BaseRow::new("live", Some(0), "x"), // tombstone marker → dead
+            BaseRow::new("expired", Some(500), "y"), // valid_to < now → dead
+            BaseRow::new("ok", Some(5_000), "z"), // valid_to > now → live
+            BaseRow::new("unknown", None, "w"), // unknown → treated live
+        ];
+        let merged = merge_base_with_delta(base, &HashSet::new(), vec![], 1_000);
+        assert_eq!(merged, vec!["z", "w"]);
+    }
+
+    /// Empty delta (nothing changed since the snapshot) returns the base intact.
+    #[test]
+    fn empty_delta_returns_base() {
+        let base = vec![BaseRow::new("1", None, 1), BaseRow::new("2", None, 2)];
+        let merged = merge_base_with_delta(base, &HashSet::new(), vec![], 1_000);
+        assert_eq!(merged, vec![1, 2]);
+    }
+}

--- a/src/query/execution/olap_delta_merge.rs
+++ b/src/query/execution/olap_delta_merge.rs
@@ -31,9 +31,13 @@
 //! base rows, suppress-set, and append rows lives in
 //! [`crate::query::execution::datafusion_engine`].
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 
-use proximadb_records::is_record_dead;
+use async_trait::async_trait;
+use proximadb_catalog::CatalogTableSchema;
+use proximadb_records::{ProximaRecord, is_record_dead};
 
 /// One row of the cold Parquet base snapshot, tagged with the identity and
 /// liveness metadata the merge needs. `payload` is the opaque per-row value the
@@ -106,6 +110,62 @@ pub fn merge_base_with_delta<R>(
     out
 }
 
+/// Authoritative post-snapshot delta source for the OLAP read-merge.
+///
+/// Implemented by `DmlService` over the canonical WAL + record store. Kept as a
+/// narrow, Arrow-free trait so the query-execution layer carries it on
+/// [`QueryExecutionContext`](super::engine::QueryExecutionContext) without
+/// depending on the services layer or on `datafusion-integration`.
+#[async_trait]
+pub trait OlapDeltaSource: Send + Sync {
+    /// Canonical oids that changed (upsert OR delete) for `table` strictly after
+    /// `snapshot_lsn`, from the canonical-WAL change-feed. Order is irrelevant;
+    /// the merge dedups into a set.
+    async fn changed_oids_since(
+        &self,
+        table: &str,
+        snapshot_lsn: u64,
+        tenant: Option<&str>,
+    ) -> anyhow::Result<Vec<String>>;
+
+    /// The table's catalog schema plus the **current live** records for `oids`,
+    /// each built with every column materialized in `props` (the exact shape the
+    /// warehouse materializer writes), so the caller can feed them straight to
+    /// `proxima_records_to_record_batch`. Deleted/expired/absent oids contribute
+    /// no record (the record store applies the canonical dead-record predicate).
+    async fn current_records(
+        &self,
+        table: &str,
+        oids: &[String],
+        tenant: Option<&str>,
+    ) -> anyhow::Result<(CatalogTableSchema, Vec<ProximaRecord>)>;
+}
+
+/// Per-table OLAP delta-merge parameters resolved from the catalog at query time.
+#[derive(Clone, Debug)]
+pub struct OlapDeltaTable {
+    /// WAL high-water LSN the cold Parquet base was snapshotted at (recorded in
+    /// the storage layout `properties` by `MATERIALIZE`).
+    pub snapshot_lsn: u64,
+    /// Primary-key column whose value canonicalizes to the record `oid`; used to
+    /// recompute each base row's oid for suppress-set membership. Tables without
+    /// a single-column PK are not eligible (keyless heaps fall back to the bare
+    /// Parquet read — a documented first-cut limitation).
+    pub pk_column: String,
+}
+
+/// Per-query wiring for the OLAP read-merge: the authoritative delta source plus
+/// the per-table parameters for every parquet-backed table that opted in. Absent
+/// (`QueryExecutionContext::olap_delta == None`) ⇒ legacy bare-Parquet reads.
+#[derive(Clone)]
+pub struct OlapDeltaConfig {
+    /// Authoritative post-snapshot delta source (the `DmlService`).
+    pub source: Arc<dyn OlapDeltaSource>,
+    /// Eligible tables keyed by normalized table key (see
+    /// [`normalize_table_key`](super::engine::normalize_table_key)).
+    pub tables: HashMap<String, OlapDeltaTable>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,12 +184,8 @@ mod tests {
             BaseRow::new("2", None, "2"),
             BaseRow::new("3", None, "3"),
         ];
-        let merged = merge_base_with_delta(
-            base,
-            &suppress(&["2", "3", "4"]),
-            vec!["3'", "4"],
-            1_000,
-        );
+        let merged =
+            merge_base_with_delta(base, &suppress(&["2", "3", "4"]), vec!["3'", "4"], 1_000);
         assert_eq!(merged, vec!["1", "3'", "4"]);
     }
 
@@ -172,10 +228,10 @@ mod tests {
     #[test]
     fn ttl_expired_base_row_dropped_when_valid_to_ns_known() {
         let base = vec![
-            BaseRow::new("live", Some(0), "x"), // tombstone marker → dead
+            BaseRow::new("live", Some(0), "x"),      // tombstone marker → dead
             BaseRow::new("expired", Some(500), "y"), // valid_to < now → dead
-            BaseRow::new("ok", Some(5_000), "z"), // valid_to > now → live
-            BaseRow::new("unknown", None, "w"), // unknown → treated live
+            BaseRow::new("ok", Some(5_000), "z"),    // valid_to > now → live
+            BaseRow::new("unknown", None, "w"),      // unknown → treated live
         ];
         let merged = merge_base_with_delta(base, &HashSet::new(), vec![], 1_000);
         assert_eq!(merged, vec!["z", "w"]);

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -670,15 +670,16 @@ impl crate::query::execution::olap_delta_merge::OlapDeltaSource for DmlService {
         &self,
         table: &str,
         snapshot_lsn: u64,
-        _tenant: Option<&str>,
+        tenant: Option<&str>,
     ) -> anyhow::Result<Vec<String>> {
-        // Canonical-WAL change-feed for this table after the snapshot LSN; the key
-        // is the canonical oid (= PK text). Tenant scoping rides the record store's
-        // collection partitioning; per-tenant isolation of the merge feed is a
-        // documented follow-up (default-OFF, opt-in foundation).
+        // Tenant-isolated canonical-WAL change-feed for this table after the
+        // snapshot LSN; the key is the canonical oid (= PK text). The feed is
+        // scoped by tenant_id because the WAL collection_id is the bare table name
+        // (not tenant-unique), so two tenants sharing a table name must not share
+        // the merge delta.
         let changes = self
             .record_store
-            .read_changes_since(table, snapshot_lsn)
+            .read_changes_since_scoped(table, tenant, snapshot_lsn)
             .await?;
         Ok(changes.into_iter().map(|c| c.key).collect())
     }

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -660,6 +660,53 @@ pub struct DmlService {
     dml_lock_service: Option<Arc<DmlLockService>>,
 }
 
+/// ADR-025: `DmlService` is the authoritative post-snapshot delta source for the
+/// OLAP read-merge — it owns both the canonical-WAL change-feed and the live
+/// point-read path, so the merge reconciles the cold Parquet base against exactly
+/// the state any pgwire write produced.
+#[async_trait::async_trait]
+impl crate::query::execution::olap_delta_merge::OlapDeltaSource for DmlService {
+    async fn changed_oids_since(
+        &self,
+        table: &str,
+        snapshot_lsn: u64,
+        _tenant: Option<&str>,
+    ) -> anyhow::Result<Vec<String>> {
+        // Canonical-WAL change-feed for this table after the snapshot LSN; the key
+        // is the canonical oid (= PK text). Tenant scoping rides the record store's
+        // collection partitioning; per-tenant isolation of the merge feed is a
+        // documented follow-up (default-OFF, opt-in foundation).
+        let changes = self
+            .record_store
+            .read_changes_since(table, snapshot_lsn)
+            .await?;
+        Ok(changes.into_iter().map(|c| c.key).collect())
+    }
+
+    async fn current_records(
+        &self,
+        table: &str,
+        oids: &[String],
+        tenant: Option<&str>,
+    ) -> anyhow::Result<(CatalogTableSchema, Vec<ProximaRecord>)> {
+        let tenant_ctx = tenant.map(TenantContext::for_tenant_id);
+        let (schema, _table_id) = self.resolve_select_table(table, tenant).await?;
+        let col_names: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+        let mut records = Vec::with_capacity(oids.len());
+        for oid in oids {
+            // get_by_key applies the canonical dead-record predicate, so a deleted
+            // or TTL-expired oid yields None and contributes no append.
+            if let Some(row) = self
+                .point_lookup_relational(table, oid, tenant_ctx.as_ref())
+                .await?
+            {
+                records.push(Self::value_row_to_relational_record(oid, &col_names, row));
+            }
+        }
+        Ok((schema, records))
+    }
+}
+
 impl DmlService {
     /// Create a new DML service
     pub fn new(catalog_manager: Arc<CatalogManager>, vector_ops: Arc<VectorOps>) -> Self {
@@ -1200,6 +1247,29 @@ impl DmlService {
     /// snapshot), schema inferred from the rows. Incremental/atomic manifest
     /// publication (`IcebergObjectStoreBridge::publish_snapshot`) and the
     /// catalog-authoritative write schema are follow-ups.
+    /// Build a relational `ProximaRecord` from a full column-ordered value row:
+    /// every non-NULL column lands in `props` keyed by name (the warehouse
+    /// materializer's record shape). Shared by `MATERIALIZE` (cold base) and the
+    /// ADR-025 OLAP read-merge (live appends) so both encode identically through
+    /// `proxima_records_to_record_batch`.
+    pub(crate) fn value_row_to_relational_record(
+        oid: &str,
+        col_names: &[String],
+        row: Vec<ProximaValue>,
+    ) -> ProximaRecord {
+        let mut rec = ProximaRecord {
+            oid: oid.to_string(),
+            ..Default::default()
+        };
+        for (name, value) in col_names.iter().zip(row) {
+            if !matches!(value, ProximaValue::Null) {
+                rec.props
+                    .insert(name.clone(), ProximaTreeNode::Value(value));
+            }
+        }
+        rec
+    }
+
     pub async fn materialize_table_to_parquet(
         &self,
         bridge: &dyn ObjectStoreBridge,
@@ -1207,6 +1277,18 @@ impl DmlService {
         table_name: &str,
         tenant_context: Option<&TenantContext>,
     ) -> Result<String> {
+        // ADR-025: capture this table's WAL high-water LSN BEFORE snapshotting, so any
+        // write landing during/after the scan has a strictly greater LSN and is caught
+        // by the OLAP read-merge delta (`read_changes_since(.., snapshot_lsn)`). Sequence
+        // numbers are globally monotonic, so the table's own latest change LSN is a safe
+        // floor; a table with no changes yet snapshots at 0.
+        let snapshot_lsn = self
+            .record_store
+            .read_changes_since(table_name, 0)
+            .await
+            .map(|changes| changes.iter().map(|c| c.lsn).max().unwrap_or(0))
+            .unwrap_or(0);
+
         // 1. Snapshot the table's current rows (all columns, no predicate/limit).
         let (schema, rows) = self
             .scan_table_relational(table_name, None, None, None, tenant_context)
@@ -1214,24 +1296,14 @@ impl DmlService {
 
         // 2. Column-order ProximaValue rows → ProximaRecord envelopes (props keyed by
         //    column name; relational tables carry no vectors). NULLs are omitted —
-        //    the schema-driven Arrow mapping null-fills any absent column.
+        //    the schema-driven Arrow mapping null-fills any absent column. Reuses the
+        //    SAME builder as the OLAP read-merge appends so the cold base and the live
+        //    append rows encode identically (ADR-025).
         let col_names: Vec<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
         let records: Vec<ProximaRecord> = rows
             .into_iter()
             .enumerate()
-            .map(|(i, row)| {
-                let mut rec = ProximaRecord {
-                    oid: i.to_string(),
-                    ..Default::default()
-                };
-                for (name, value) in col_names.iter().zip(row) {
-                    if !matches!(value, ProximaValue::Null) {
-                        rec.props
-                            .insert(name.clone(), ProximaTreeNode::Value(value));
-                    }
-                }
-                rec
-            })
+            .map(|(i, row)| Self::value_row_to_relational_record(&i.to_string(), &col_names, row))
             .collect();
 
         // 3. Tenant-isolated object prefix (DrPathBuilder mandate: data/{tenant}/{ns}/{table}).
@@ -1291,6 +1363,12 @@ impl DmlService {
             authority: proximadb_catalog::CatalogAuthorityMode::ProjectionPublication,
             physical_format: proximadb_catalog::CatalogPhysicalFormat::Parquet,
             location: Some(location.clone()),
+            // ADR-025: record the snapshot LSN so the OLAP read-merge can reconcile
+            // this cold base against post-snapshot writes (`read_changes_since`).
+            properties: std::collections::HashMap::from([(
+                "snapshot_lsn".to_string(),
+                snapshot_lsn.to_string(),
+            )]),
             ..Default::default()
         };
         catalog.set_storage_layouts(&table_id, vec![layout]).await?;

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -443,6 +443,40 @@ pub struct ChangeRow {
     pub props: Option<serde_json::Value>,
 }
 
+/// Build a [`ChangeRow`] for `collection_id` from a canonical WAL entry, or `None`
+/// if the entry is not an upsert/delete for that collection. Shared by the
+/// tenant-agnostic and tenant-scoped change-feeds so they stay in lock-step.
+fn change_row_from_entry(
+    entry: &proximadb_storage_common::wal_entry::CanonicalWalEntry,
+    collection_id: &str,
+) -> Option<ChangeRow> {
+    match &entry.operation {
+        CanonicalOperation::RecordUpsert {
+            collection_id: c,
+            record,
+            ..
+        } if c == collection_id => Some(ChangeRow {
+            lsn: entry.sequence_number,
+            op: "upsert".to_string(),
+            collection: c.clone(),
+            key: record.oid.clone(),
+            props: serde_json::to_value(&record.props).ok(),
+        }),
+        CanonicalOperation::RecordDelete {
+            collection_id: c,
+            oid,
+            ..
+        } if c == collection_id => Some(ChangeRow {
+            lsn: entry.sequence_number,
+            op: "delete".to_string(),
+            collection: c.clone(),
+            key: oid.clone(),
+            props: None,
+        }),
+        _ => None,
+    }
+}
+
 #[async_trait]
 pub trait TableRecordStore: Send + Sync {
     /// Write catalog-validated record mutations.
@@ -600,6 +634,23 @@ pub trait TableRecordStore: Send + Sync {
     ) -> Result<Vec<ChangeRow>> {
         let _ = (collection_id, since_lsn);
         Ok(Vec::new())
+    }
+
+    /// Tenant-scoped CDC change-feed: like [`read_changes_since`] but returns only
+    /// changes belonging to `tenant` (matched against the WAL entry's `tenant_id`,
+    /// with `None`/empty treated as the unscoped/default tenant). Required for the
+    /// OLAP read-merge because the WAL `collection_id` is the bare table name (not
+    /// tenant-unique), so two tenants sharing a table name would otherwise share
+    /// the feed. The default delegates to the tenant-agnostic [`read_changes_since`];
+    /// the WAL-backed store overrides it to enforce isolation.
+    async fn read_changes_since_scoped(
+        &self,
+        collection_id: &str,
+        tenant: Option<&str>,
+        since_lsn: u64,
+    ) -> Result<Vec<ChangeRow>> {
+        let _ = tenant;
+        self.read_changes_since(collection_id, since_lsn).await
     }
 }
 
@@ -1611,47 +1662,41 @@ impl DirectWalTableRecordStore {
 impl TableRecordStore for DirectWalTableRecordStore {
     /// CDC change-feed over the canonical WAL: surface every RecordUpsert/RecordDelete for
     /// `collection_id` (the table name) with sequence number > `since_lsn`, oldest first.
+    /// Tenant-agnostic (all tenants) — see [`read_changes_since_scoped`] for the
+    /// tenant-isolated feed the OLAP read-merge uses.
     async fn read_changes_since(
         &self,
         collection_id: &str,
         since_lsn: u64,
     ) -> Result<Vec<ChangeRow>> {
         let entries = self.wal_appender.read_all_entries().await?;
-        let mut out = Vec::new();
-        for e in entries {
-            if e.sequence_number <= since_lsn {
-                continue;
-            }
-            match e.operation {
-                CanonicalOperation::RecordUpsert {
-                    collection_id: c,
-                    record,
-                    ..
-                } if c == collection_id => {
-                    out.push(ChangeRow {
-                        lsn: e.sequence_number,
-                        op: "upsert".to_string(),
-                        collection: c,
-                        key: record.oid.clone(),
-                        props: serde_json::to_value(&record.props).ok(),
-                    });
-                }
-                CanonicalOperation::RecordDelete {
-                    collection_id: c,
-                    oid,
-                    ..
-                } if c == collection_id => {
-                    out.push(ChangeRow {
-                        lsn: e.sequence_number,
-                        op: "delete".to_string(),
-                        collection: c,
-                        key: oid,
-                        props: None,
-                    });
-                }
-                _ => {}
-            }
-        }
+        let mut out: Vec<ChangeRow> = entries
+            .iter()
+            .filter(|e| e.sequence_number > since_lsn)
+            .filter_map(|e| change_row_from_entry(e, collection_id))
+            .collect();
+        out.sort_by_key(|r| r.lsn);
+        Ok(out)
+    }
+
+    /// Tenant-isolated change-feed: like [`read_changes_since`] but keeps only
+    /// entries whose `tenant_id` matches `tenant` (None/"" = the unscoped tenant).
+    /// The WAL `collection_id` is the bare table name (not tenant-unique), so this
+    /// match is what isolates two tenants that share a table name.
+    async fn read_changes_since_scoped(
+        &self,
+        collection_id: &str,
+        tenant: Option<&str>,
+        since_lsn: u64,
+    ) -> Result<Vec<ChangeRow>> {
+        let entries = self.wal_appender.read_all_entries().await?;
+        let want = tenant.filter(|t| !t.is_empty());
+        let mut out: Vec<ChangeRow> = entries
+            .iter()
+            .filter(|e| e.sequence_number > since_lsn)
+            .filter(|e| e.tenant_id.as_deref().filter(|t| !t.is_empty()) == want)
+            .filter_map(|e| change_row_from_entry(e, collection_id))
+            .collect();
         out.sort_by_key(|r| r.lsn);
         Ok(out)
     }

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -1,0 +1,229 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! ADR-025 OLAP read-merge (relational cold path) — pgwire e2e.
+//!
+//! Proves the central correctness property: after `ALTER TABLE … MATERIALIZE`
+//! freezes a cold Parquet snapshot, subsequent `DELETE` / `UPDATE` / `INSERT`
+//! over pgwire are reflected in OLAP `SELECT`s that route to the DataFusion
+//! engine — and that the behavior is genuinely gated (default-OFF serves the
+//! stale snapshot; opt-in reconciles it).
+//!
+//! Gated on `datafusion-integration`: the read-merge lives on the DataFusion
+//! OLAP route, and the gate-OFF assertion (stale snapshot) is only meaningful
+//! there — without the feature, parquet-backed tables route to the native
+//! engine, which always reads live record state. Run with:
+//!   cargo test --features datafusion-integration --test pgwire_olap_delta_merge_e2e -- --nocapture
+#![cfg(feature = "datafusion-integration")]
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+/// Run a 2-column query and parse the rows into `(i64, i64)` pairs (pgwire simple
+/// query renders every cell as text).
+async fn pairs(client: &tokio_postgres::Client, sql: &str) -> Vec<(i64, i64)> {
+    client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)))
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some((
+                r.get(0).unwrap_or_default().parse().unwrap_or(i64::MIN),
+                r.get(1).unwrap_or_default().parse().unwrap_or(i64::MIN),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Run a single-cell aggregate query and parse the first column as `i64`.
+async fn one_i64(client: &tokio_postgres::Client, sql: &str) -> i64 {
+    client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)))
+        .into_iter()
+        .find_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => {
+                r.get(0).and_then(|s| s.parse::<i64>().ok())
+            }
+            _ => None,
+        })
+        .unwrap_or(i64::MIN)
+}
+
+/// A3 + A4: after MATERIALIZE, a `DELETE`/`UPDATE`/`INSERT` is invisible to the
+/// DataFusion OLAP route with the merge OFF (stale snapshot), and fully reflected
+/// with it ON — keyed by canonical oid, with `COUNT(*)` taking the merged
+/// cardinality (not the Parquet footer count).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn olap_delta_merge_gate_off_stale_then_on_corrects() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Schema: single-column INT PK (oid = PK text) + a value column.
+    client.simple_query("DROP TABLE IF EXISTS dvm").await.ok();
+    client
+        .simple_query("CREATE TABLE dvm (id INT PRIMARY KEY, v INT)")
+        .await
+        .unwrap_or_else(|e| panic!("create: {}", explain_err(&e)));
+    for sql in [
+        "INSERT INTO dvm (id, v) VALUES (1, 10)",
+        "INSERT INTO dvm (id, v) VALUES (2, 20)",
+        "INSERT INTO dvm (id, v) VALUES (3, 30)",
+    ] {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("insert `{sql}`: {}", explain_err(&e)));
+    }
+
+    // Freeze the cold Parquet snapshot at this LSN, then route SELECTs to OLAP.
+    client
+        .simple_query("ALTER TABLE dvm MATERIALIZE")
+        .await
+        .unwrap_or_else(|e| panic!("materialize: {}", explain_err(&e)));
+
+    // Post-snapshot mutations: delete a row, update another, insert a new one.
+    client
+        .simple_query("DELETE FROM dvm WHERE id = 2")
+        .await
+        .unwrap_or_else(|e| panic!("delete: {}", explain_err(&e)));
+    client
+        .simple_query("UPDATE dvm SET v = 99 WHERE id = 3")
+        .await
+        .unwrap_or_else(|e| panic!("update: {}", explain_err(&e)));
+    client
+        .simple_query("INSERT INTO dvm (id, v) VALUES (4, 40)")
+        .await
+        .unwrap_or_else(|e| panic!("insert4: {}", explain_err(&e)));
+
+    // GROUP BY / aggregate engages the relational engine → DataFusion over the
+    // materialized Parquet base (never the legacy single-table path).
+    let q_rows = "SELECT id, v FROM dvm GROUP BY id, v ORDER BY id";
+    let q_count = "SELECT COUNT(*) AS c FROM dvm";
+
+    // Gate OFF (default): the DataFusion route serves the STALE snapshot — this
+    // proves the merge is genuinely gated and the legacy behavior is preserved.
+    // SAFETY: toggled only between awaited queries — no request is in flight, so
+    // no server thread reads this env var concurrently (Rust 2024 marks env
+    // mutation unsafe for the general concurrent case). Tests run under nextest
+    // process isolation (CLAUDE.md §11).
+    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+    assert_eq!(
+        pairs(&client, q_rows).await,
+        vec![(1, 10), (2, 20), (3, 30)],
+        "gate-off must serve the stale materialized snapshot"
+    );
+
+    // Gate ON: the read-merge reconciles delete(2) / update(3→99) / insert(4).
+    // SAFETY: see the note above — no in-flight request, nextest-isolated.
+    unsafe { std::env::set_var("PROXIMADB_OLAP_DELTA_MERGE", "1") };
+    assert_eq!(
+        pairs(&client, q_rows).await,
+        vec![(1, 10), (3, 99), (4, 40)],
+        "gate-on must reflect post-snapshot delete/update/insert keyed by oid"
+    );
+    assert_eq!(
+        one_i64(&client, q_count).await,
+        3,
+        "COUNT(*) must be the merged cardinality, not the Parquet footer count"
+    );
+
+    // SAFETY: toggled only between awaited queries — no request is in flight, so
+    // no server thread reads this env var concurrently (Rust 2024 marks env
+    // mutation unsafe for the general concurrent case). Tests run under nextest
+    // process isolation (CLAUDE.md §11).
+    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+}

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -79,8 +79,12 @@ impl PgServer {
         })
     }
     fn conn_str(&self) -> String {
+        self.conn_str_for("proximadb")
+    }
+    /// Connection string scoped to a tenant (the startup `dbname` = tenant/catalog).
+    fn conn_str_for(&self, dbname: &str) -> String {
         format!(
-            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            "host=127.0.0.1 port={} user=postgres dbname={dbname} sslmode=disable",
             self.pg_port
         )
     }
@@ -136,6 +140,18 @@ async fn one_i64(client: &tokio_postgres::Client, sql: &str) -> i64 {
             _ => None,
         })
         .unwrap_or(i64::MIN)
+}
+
+/// Connect a client scoped to a tenant (startup `dbname` = tenant/catalog).
+async fn connect(server: &PgServer, dbname: &str) -> tokio_postgres::Client {
+    let (client, conn) =
+        tokio_postgres::connect(&server.conn_str_for(dbname), tokio_postgres::NoTls)
+            .await
+            .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
 }
 
 /// A3 + A4: after MATERIALIZE, a `DELETE`/`UPDATE`/`INSERT` is invisible to the
@@ -225,5 +241,64 @@ async fn olap_delta_merge_gate_off_stale_then_on_corrects() {
     // no server thread reads this env var concurrently (Rust 2024 marks env
     // mutation unsafe for the general concurrent case). Tests run under nextest
     // process isolation (CLAUDE.md §11).
+    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+}
+
+/// Tenant isolation of the read-merge (and the empty-delta fast path). Two
+/// tenants share a table name; tenant A mutates after MATERIALIZE, tenant B does
+/// not. A's OLAP read reflects A's delete/update; B's is UNAFFECTED — B's feed is
+/// tenant-scoped (empty), so the fast path serves B's pristine snapshot. A cross-
+/// tenant feed leak would surface A's delete/update in B's result.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn olap_delta_merge_is_tenant_isolated() {
+    // SAFETY: set before the server starts; never mutated while a request is in
+    // flight. nextest process isolation (CLAUDE.md §11).
+    unsafe { std::env::set_var("PROXIMADB_OLAP_DELTA_MERGE", "1") };
+    let server = PgServer::start().await.expect("server start");
+    let tenant_a = format!("tenant_a_{}", server.pg_port);
+    let tenant_b = format!("tenant_b_{}", server.pg_port);
+    let a = connect(&server, &tenant_a).await;
+    let b = connect(&server, &tenant_b).await;
+
+    // Both tenants: identical table name + data, each materialized to its own
+    // tenant-isolated Parquet snapshot.
+    for c in [&a, &b] {
+        c.simple_query("CREATE TABLE shared (id INT PRIMARY KEY, v INT)")
+            .await
+            .unwrap_or_else(|e| panic!("create: {}", explain_err(&e)));
+        for sql in [
+            "INSERT INTO shared (id, v) VALUES (1, 10)",
+            "INSERT INTO shared (id, v) VALUES (2, 20)",
+            "INSERT INTO shared (id, v) VALUES (3, 30)",
+        ] {
+            c.simple_query(sql)
+                .await
+                .unwrap_or_else(|e| panic!("insert `{sql}`: {}", explain_err(&e)));
+        }
+        c.simple_query("ALTER TABLE shared MATERIALIZE")
+            .await
+            .unwrap_or_else(|e| panic!("materialize: {}", explain_err(&e)));
+    }
+
+    // Only tenant A mutates after its snapshot.
+    a.simple_query("DELETE FROM shared WHERE id = 2")
+        .await
+        .unwrap_or_else(|e| panic!("A delete: {}", explain_err(&e)));
+    a.simple_query("UPDATE shared SET v = 99 WHERE id = 3")
+        .await
+        .unwrap_or_else(|e| panic!("A update: {}", explain_err(&e)));
+
+    let q = "SELECT id, v FROM shared GROUP BY id, v ORDER BY id";
+    assert_eq!(
+        pairs(&a, q).await,
+        vec![(1, 10), (3, 99)],
+        "tenant A must see its own post-snapshot delete(2)/update(3→99)"
+    );
+    assert_eq!(
+        pairs(&b, q).await,
+        vec![(1, 10), (2, 20), (3, 30)],
+        "tenant B must NOT see tenant A's changes (feed is tenant-isolated)"
+    );
+
     unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
 }


### PR DESCRIPTION
## What

Make OLTP `DELETE`/`UPDATE`/`INSERT` issued over pgwire visible to OLAP `SELECT`s
that route to the DataFusion engine, using **ADR-025 deletion vectors built
WAL-first** for the relational cold path.

After `ALTER TABLE … MATERIALIZE` freezes an atomic, already-dead-filtered Parquet
snapshot, subsequent DML stays in the authoritative record store (memtable +
canonical WAL + PAX) and was previously invisible to the DataFusion route
(`FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06` P4, planned). This reconciles the
snapshot with the post-snapshot WAL delta at scan time, keyed by canonical `oid`.

## Why this is ADR-025, WAL-first

The in-memory suppress-set the merge computes **is** the deletion vector, and it is
a rebuildable projection of the canonical WAL (ADR-020) — so no new durable state
is introduced and re-`MATERIALIZE` plays the role of the N3 compaction that drops
dead rows. The persistent on-disk DV (RoaringBitmap primitive, `PAXSEG02` inline +
Parquet sidecar, ANN-segment DV) is deferred to follow-ups where the vector/graph
modalities plug in.

## How

- `OlapDeltaSource` seam (impl on `DmlService`): `changed_oids_since` (canonical-WAL
  change-feed) + `current_records` (live, dead-filtered point-reads).
- `MATERIALIZE` records `snapshot_lsn` (captured pre-scan) in the storage-layout
  properties; base-row `oid` is recomputed from the PK column via
  `proxima_value_to_unique_text` (matches the WAL key across Parquet type-widening —
  no Parquet schema change).
- DataFusion engine registers a merged MemTable (base minus suppressed oids, plus
  live appends) for opted-in tables; bare Parquet otherwise.
- **Gated default-OFF.** Per-collection opt-in via the `olap_delta_merge` layout
  property or the `PROXIMADB_OLAP_DELTA_MERGE` master switch. Non-opt-in tables
  (TPC-H/DS) are untouched.

## Identity semantics

`DELETE`/`UPDATE` over an arbitrary `WHERE` require no user key (set-based,
scan-resolved). The internal `oid` is the stable identity — PK-derived when a PK
exists, surrogate otherwise. The merge keys on `oid`.

## Tests

- Pure merge-core unit tests: delete/update/insert, PK-change, insert-then-delete
  (invariant 16d analog), passive TTL, empty delta.
- pgwire e2e (`pgwire_olap_delta_merge_e2e`, feature-gated): gate-OFF serves the
  stale snapshot → gate-ON reflects delete(2)/update(3→99)/insert(4); `COUNT(*)` is
  the merged cardinality, not the Parquet footer count.
- Regression: TPC-H 22/22, TPC-DS pass (no OLAP-route change for non-opt-in tables);
  clippy clean on the changed files.

## First-cut limitations (tracked, deferred)

- Single-column PK only (composite → bare Parquet read).
- Passive TTL eventual-until-rematerialize (base carries no `valid_to_ns`).
- Whole-base MemTable (no Parquet pushdown yet) — streaming provider + persistent DV
  are follow-ups.
- Per-tenant merge-feed scoping is a follow-up.

Refs ADR-025 (N0/N2), ADR-020.
