### PR TITLE
feat(catalog): ADR-031 stable u64 object_id physical key — spec + O0 IdAllocator

### DIFF
--- a/crates/control/proximadb-catalog/src/id_allocator.rs
+++ b/crates/control/proximadb-catalog/src/id_allocator.rs
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Monotonic per-type id allocator for stable catalog object ids (ADR-031).
+//!
+//! Design tenet (ADR-031): internal stable ids are compact `u64`, allocated **per
+//! object type** (tenant, namespace, table/collection, …) by a **global monotonic
+//! allocator**, **unique across all tenants within their type**, and **never
+//! reused**. One [`IdAllocator`] instance owns one type's id space.
+//!
+//! Mirrors the WAL `GlobalLsnAllocator` (lock-free `AtomicU64`). Durability is by
+//! **recovery, not a separate persisted counter**: at startup the owner calls
+//! [`IdAllocator::raise_floor`] with `max(existing object_id) + 1`, so a restart can
+//! never hand out an id already on disk. `0` is reserved as "unset" (so
+//! `Option<u64>::None` / `0` both mean "no id yet"); the first real id is `1`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Lock-free monotonic allocator for one object-type's stable `u64` id space.
+#[derive(Debug)]
+pub struct IdAllocator {
+    next: AtomicU64,
+}
+
+impl IdAllocator {
+    /// New allocator whose first allocation is `start` (clamped to ≥ 1, since `0`
+    /// is the reserved "unset" sentinel).
+    pub fn new(start: u64) -> Self {
+        Self {
+            next: AtomicU64::new(start.max(1)),
+        }
+    }
+
+    /// Allocate the next id (lock-free; strictly increasing; never reused).
+    pub fn allocate(&self) -> u64 {
+        self.next.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// The id the next [`allocate`](Self::allocate) would return, without consuming it.
+    pub fn peek(&self) -> u64 {
+        self.next.load(Ordering::Relaxed)
+    }
+
+    /// Recovery hook: ensure the next allocation is **at least** `floor` (monotone —
+    /// never lowers the counter). Call at startup with `max(existing id) + 1` so a
+    /// restart never reuses an id already persisted.
+    pub fn raise_floor(&self, floor: u64) {
+        self.next.fetch_max(floor, Ordering::Relaxed);
+    }
+}
+
+impl Default for IdAllocator {
+    fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocates_monotonic_distinct_ids_from_one() {
+        let a = IdAllocator::default();
+        assert_eq!(a.peek(), 1);
+        assert_eq!(a.allocate(), 1);
+        assert_eq!(a.allocate(), 2);
+        assert_eq!(a.allocate(), 3);
+        assert_eq!(a.peek(), 4, "peek does not consume");
+    }
+
+    #[test]
+    fn zero_start_is_clamped_to_one() {
+        // 0 is the reserved "unset" sentinel; allocation never returns it.
+        let a = IdAllocator::new(0);
+        assert_eq!(a.allocate(), 1);
+    }
+
+    #[test]
+    fn raise_floor_recovers_high_water_and_is_monotone() {
+        let a = IdAllocator::new(1);
+        assert_eq!(a.allocate(), 1);
+        assert_eq!(a.allocate(), 2);
+        // Recovery: existing max id on disk is 7 → next must be 8.
+        a.raise_floor(8);
+        assert_eq!(
+            a.allocate(),
+            8,
+            "never reuses ids below the recovered floor"
+        );
+        // A lower floor must never roll the counter backwards.
+        a.raise_floor(3);
+        assert_eq!(a.allocate(), 9);
+    }
+
+    #[test]
+    fn per_type_spaces_are_independent() {
+        // Two types (e.g. table vs namespace) each own their own space; the same
+        // number can appear in both — they are never compared across types.
+        let tables = IdAllocator::default();
+        let namespaces = IdAllocator::default();
+        assert_eq!(tables.allocate(), 1);
+        assert_eq!(tables.allocate(), 2);
+        assert_eq!(namespaces.allocate(), 1, "independent type space");
+    }
+}

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -544,6 +544,15 @@ pub struct CatalogStorageConfig {
 pub struct CatalogTableSchema {
     /// Table name
     pub name: String,
+    /// ADR-031 stable, immutable internal object id (per-type `u64`, globally unique
+    /// across tenants, never reused) — the rename-safe physical key for the WAL
+    /// `collection_id`, memtable partition, and object-store paths. `None` = legacy /
+    /// not-yet-allocated; `create_table` assigns it, `rename_table` preserves it.
+    /// Additive + `#[serde(default)]` so old persisted schemas deserialize to `None`
+    /// (mixed-read-safe). Physical layers still key on `name` until the migration
+    /// cuts over (ADR-031 O2).
+    #[serde(default)]
+    pub object_id: Option<u64>,
     /// Table columns
     pub columns: Vec<CatalogColumn>,
     /// Primary key columns (by name)
@@ -701,6 +710,7 @@ impl Default for CatalogTableSchema {
 
         Self {
             name: String::new(),
+            object_id: None,
             columns: Vec::new(),
             primary_key: Vec::new(),
             indexes: Vec::new(),

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -39,6 +39,7 @@ pub mod embedding_precision_policy;
 pub mod glue;
 pub mod hive;
 pub mod iceberg;
+pub mod id_allocator;
 pub mod native;
 pub mod oltp;
 #[cfg(feature = "polaris-catalog")]

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4367,6 +4367,20 @@ pub trait Catalog: Send + Sync {
     async fn list_tables(&self, namespace: &[String]) -> anyhow::Result<Vec<TableIdentifier>>;
     async fn table_exists(&self, identifier: &TableIdentifier) -> anyhow::Result<bool>;
     async fn get_table(&self, identifier: &TableIdentifier) -> anyhow::Result<CatalogTableSchema>;
+
+    /// ADR-031 O1 (dual-read): resolve a table by its stable `object_id` — the
+    /// inverse of `get_table(...).object_id`. Returns `None` when no table carries
+    /// that id, or when the backend does not allocate object_ids (external
+    /// catalogs). Lets `dyn Catalog` consumers (change-feed, recovery, planner)
+    /// key on the global id rather than the mutable name. Default: `None`.
+    async fn get_table_by_object_id(
+        &self,
+        object_id: u64,
+    ) -> anyhow::Result<Option<TableIdentifier>> {
+        let _ = object_id;
+        Ok(None)
+    }
+
     async fn rename_table(
         &self,
         from: &TableIdentifier,

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -103,6 +103,11 @@ pub struct NativeCatalog {
     /// load; eager startup recovery / persisted high-water is an O2 hardening
     /// (object_id is not yet load-bearing in O0).
     object_id_allocator: crate::id_allocator::IdAllocator,
+    /// ADR-031 O1 (dual-read): reverse index `object_id → TableIdentifier`, the
+    /// inverse of the name-keyed `tables` cache. Maintained on
+    /// create/load/rename/drop; populated lazily as tables load (eager build at
+    /// startup is the O2 recovery hardening).
+    object_id_index: RwLock<HashMap<u64, TableIdentifier>>,
 }
 
 /// Table metadata stored in storage
@@ -160,6 +165,7 @@ impl NativeCatalog {
             tables: RwLock::new(HashMap::new()),
             cache,
             object_id_allocator: crate::id_allocator::IdAllocator::default(),
+            object_id_index: RwLock::new(HashMap::new()),
         };
 
         // Load existing namespaces
@@ -275,10 +281,15 @@ impl NativeCatalog {
 
         let meta: TableMetadata = serde_json::from_slice(&data)?;
 
-        // ADR-031 O0: recover the allocator floor from persisted ids so a restart
-        // never reuses an object_id (best-effort as tables load on demand).
+        // ADR-031 O0/O1: recover the allocator floor + the reverse object_id index
+        // from persisted ids so a restart never reuses an id and object_id → table
+        // resolution survives (best-effort as tables load on demand).
         if let Some(id) = meta.schema.object_id {
             self.object_id_allocator.raise_floor(id + 1);
+            self.object_id_index
+                .write()
+                .await
+                .insert(id, identifier.clone());
         }
 
         // Cache in memory
@@ -556,6 +567,13 @@ impl Catalog for NativeCatalog {
         };
 
         self.save_table(&meta).await?;
+        // ADR-031 O1: maintain the reverse object_id → identifier index.
+        if let Some(oid) = schema.object_id {
+            self.object_id_index
+                .write()
+                .await
+                .insert(oid, identifier.clone());
+        }
         info!("Created table: {}", identifier);
 
         Ok(schema)
@@ -570,6 +588,13 @@ impl Catalog for NativeCatalog {
         if removed {
             // Remove from in-memory cache
             self.tables.write().await.remove(&identifier.to_fqn());
+
+            // ADR-031 O1: drop the reverse object_id index entry for this table.
+            let dropped_fqn = identifier.to_fqn();
+            self.object_id_index
+                .write()
+                .await
+                .retain(|_, id| id.to_fqn() != dropped_fqn);
 
             // Purge data files if requested
             if purge {
@@ -633,6 +658,13 @@ impl Catalog for NativeCatalog {
         Ok(meta.schema)
     }
 
+    async fn get_table_by_object_id(&self, object_id: u64) -> Result<Option<TableIdentifier>> {
+        // Reverse index is populated lazily as tables load (and on create); a fresh
+        // process resolves an id only after its table has been loaded by name.
+        // Eager startup index build is the O2 recovery hardening.
+        Ok(self.object_id_index.read().await.get(&object_id).cloned())
+    }
+
     async fn rename_table(&self, from: &TableIdentifier, to: &TableIdentifier) -> Result<()> {
         // Load existing table
         let mut meta = self.load_table(from).await?;
@@ -649,6 +681,12 @@ impl Catalog for NativeCatalog {
 
         // Save to new location
         self.save_table(&meta).await?;
+
+        // ADR-031 O1: object_id is preserved across rename (metadata-only); repoint
+        // the reverse index to the new identifier.
+        if let Some(oid) = meta.schema.object_id {
+            self.object_id_index.write().await.insert(oid, to.clone());
+        }
 
         // Delete old location
         let old_path = self.table_metadata_path(from);
@@ -1217,6 +1255,116 @@ mod tests {
         assert!(
             next.object_id.unwrap() > existing,
             "reload recovered the floor; no id reuse"
+        );
+    }
+
+    // ── ADR-031 O1: reverse object_id → table resolution ─────────────
+
+    #[tokio::test]
+    async fn reverse_resolver_round_trips_object_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let id = TableIdentifier::new(ns.clone(), "tbl");
+        let oid = cat
+            .create_table(&id, schema_with_id_col("tbl"))
+            .await
+            .unwrap()
+            .object_id
+            .expect("object_id");
+
+        assert_eq!(
+            cat.get_table_by_object_id(oid)
+                .await
+                .unwrap()
+                .map(|r| r.to_fqn()),
+            Some(id.to_fqn()),
+            "object_id resolves back to its table"
+        );
+        assert!(
+            cat.get_table_by_object_id(999_999).await.unwrap().is_none(),
+            "unknown id resolves to None"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_resolver_follows_rename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let from = TableIdentifier::new(ns.clone(), "old");
+        let oid = cat
+            .create_table(&from, schema_with_id_col("old"))
+            .await
+            .unwrap()
+            .object_id
+            .unwrap();
+        let to = TableIdentifier::new(ns.clone(), "new");
+        cat.rename_table(&from, &to).await.unwrap();
+
+        assert_eq!(
+            cat.get_table_by_object_id(oid)
+                .await
+                .unwrap()
+                .map(|r| r.to_fqn()),
+            Some(to.to_fqn()),
+            "object_id is stable across rename; reverse index repoints to the new name"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_resolver_cleared_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let id = TableIdentifier::new(ns.clone(), "tbl");
+        let oid = cat
+            .create_table(&id, schema_with_id_col("tbl"))
+            .await
+            .unwrap()
+            .object_id
+            .unwrap();
+
+        assert!(cat.drop_table(&id, false).await.unwrap());
+        assert!(
+            cat.get_table_by_object_id(oid).await.unwrap().is_none(),
+            "dropped table's id no longer resolves"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_resolver_recovers_on_reload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = vec!["t".to_string()];
+        let (oid, fqn) = {
+            let cat = fresh_catalog(&tmp).await;
+            cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+            let id = TableIdentifier::new(ns.clone(), "tbl");
+            let oid = cat
+                .create_table(&id, schema_with_id_col("tbl"))
+                .await
+                .unwrap()
+                .object_id
+                .unwrap();
+            (oid, id.to_fqn())
+        };
+
+        let cat2 = fresh_catalog(&tmp).await;
+        // Lazy index: resolves only after the table is loaded by name.
+        let _ = cat2
+            .get_table(&TableIdentifier::new(ns.clone(), "tbl"))
+            .await
+            .unwrap();
+        assert_eq!(
+            cat2.get_table_by_object_id(oid)
+                .await
+                .unwrap()
+                .map(|r| r.to_fqn()),
+            Some(fqn),
+            "reload repopulates the reverse index on load"
         );
     }
 

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -98,6 +98,11 @@ pub struct NativeCatalog {
     tables: RwLock<HashMap<String, TableMetadata>>,
     /// Catalog-level cache
     cache: Arc<CatalogCache>,
+    /// ADR-031 O0: monotonic allocator for table `object_id`s (per-type, globally
+    /// unique, never reused). Recovered best-effort via `raise_floor` as tables
+    /// load; eager startup recovery / persisted high-water is an O2 hardening
+    /// (object_id is not yet load-bearing in O0).
+    object_id_allocator: crate::id_allocator::IdAllocator,
 }
 
 /// Table metadata stored in storage
@@ -154,6 +159,7 @@ impl NativeCatalog {
             namespaces: RwLock::new(HashMap::new()),
             tables: RwLock::new(HashMap::new()),
             cache,
+            object_id_allocator: crate::id_allocator::IdAllocator::default(),
         };
 
         // Load existing namespaces
@@ -268,6 +274,12 @@ impl NativeCatalog {
             .map_err(|_| anyhow!("Table '{}' not found", identifier))?;
 
         let meta: TableMetadata = serde_json::from_slice(&data)?;
+
+        // ADR-031 O0: recover the allocator floor from persisted ids so a restart
+        // never reuses an object_id (best-effort as tables load on demand).
+        if let Some(id) = meta.schema.object_id {
+            self.object_id_allocator.raise_floor(id + 1);
+        }
 
         // Cache in memory
         self.tables.write().await.insert(key, meta.clone());
@@ -506,6 +518,14 @@ impl Catalog for NativeCatalog {
     ) -> Result<CatalogTableSchema> {
         // Validate schema
         validate_schema(&schema)?;
+
+        // ADR-031 O0: assign the stable object_id if unset; if the caller supplied
+        // one (import/migration), never reuse it (raise the allocator floor).
+        let mut schema = schema;
+        match schema.object_id {
+            None => schema.object_id = Some(self.object_id_allocator.allocate()),
+            Some(id) => self.object_id_allocator.raise_floor(id + 1),
+        }
 
         // Check namespace exists
         if !self.namespace_exists(&identifier.namespace).await? {
@@ -1071,6 +1091,133 @@ mod tests {
             read.primary_pod.as_ref().unwrap().reason,
             crate::CatalogPrimaryPodReason::Rebalance
         ));
+    }
+
+    // ── ADR-031 O0: stable object_id allocation ──────────────────────
+
+    fn schema_with_id_col(name: &str) -> crate::CatalogTableSchema {
+        crate::CatalogTableSchema::new(name).with_column(crate::CatalogColumn::new(
+            1,
+            "id",
+            proximadb_data_model::ProximaType::Int64,
+        ))
+    }
+
+    #[tokio::test]
+    async fn create_table_assigns_distinct_monotonic_object_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+
+        let a = cat
+            .create_table(
+                &TableIdentifier::new(ns.clone(), "a"),
+                schema_with_id_col("a"),
+            )
+            .await
+            .unwrap();
+        let b = cat
+            .create_table(
+                &TableIdentifier::new(ns.clone(), "b"),
+                schema_with_id_col("b"),
+            )
+            .await
+            .unwrap();
+
+        let ida = a.object_id.expect("a got an object_id");
+        let idb = b.object_id.expect("b got an object_id");
+        assert!(ida >= 1, "ids start at 1, got {ida}");
+        assert!(idb > ida, "monotonic + distinct: {idb} > {ida}");
+    }
+
+    #[tokio::test]
+    async fn rename_table_preserves_object_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let from = TableIdentifier::new(ns.clone(), "old");
+        let oid = cat
+            .create_table(&from, schema_with_id_col("old"))
+            .await
+            .unwrap()
+            .object_id
+            .expect("object_id assigned");
+
+        let to = TableIdentifier::new(ns.clone(), "new");
+        cat.rename_table(&from, &to).await.expect("rename");
+
+        let after = cat.get_table(&to).await.expect("read renamed");
+        assert_eq!(
+            after.object_id,
+            Some(oid),
+            "rename is metadata-only; object_id is preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_table_with_caller_object_id_raises_allocator_floor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+
+        // Import a table with a caller-supplied id; the allocator must not reuse it.
+        let mut imported = schema_with_id_col("imported");
+        imported.object_id = Some(100);
+        cat.create_table(&TableIdentifier::new(ns.clone(), "imported"), imported)
+            .await
+            .unwrap();
+
+        let next = cat
+            .create_table(
+                &TableIdentifier::new(ns.clone(), "fresh"),
+                schema_with_id_col("fresh"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            next.object_id.unwrap() > 100,
+            "allocator floor raised above the imported id"
+        );
+    }
+
+    #[tokio::test]
+    async fn object_id_recovered_on_reload_prevents_reuse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = vec!["t".to_string()];
+        let existing = {
+            let cat = fresh_catalog(&tmp).await;
+            cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+            cat.create_table(
+                &TableIdentifier::new(ns.clone(), "first"),
+                schema_with_id_col("first"),
+            )
+            .await
+            .unwrap()
+            .object_id
+            .unwrap()
+        };
+
+        // Fresh catalog (cold allocator). Loading the existing table recovers the
+        // floor (load_table raise_floor); a new table must not reuse the id.
+        let cat2 = fresh_catalog(&tmp).await;
+        let _ = cat2
+            .get_table(&TableIdentifier::new(ns.clone(), "first"))
+            .await
+            .unwrap();
+        let next = cat2
+            .create_table(
+                &TableIdentifier::new(ns.clone(), "second"),
+                schema_with_id_col("second"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            next.object_id.unwrap() > existing,
+            "reload recovered the floor; no id reuse"
+        );
     }
 
     // ── P3.1: set_storage_layouts (NativeCatalog override) ───────────

--- a/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
+++ b/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
@@ -1,0 +1,162 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-031: Stable object_id as the Physical Collection Key (name is metadata)
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-26
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-020 (Canonical WAL Authority), ADR-025 (Deletion Vectors), ADR-010 (PAX Block Format), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (structural isolation)
+|Supersedes|—
+|===
+
+== Context
+
+The canonical record path keys physical state on the **user-facing table name**,
+not a stable internal id:
+
+* `write_mutations` writes the WAL operation's `collection_id = table_schema.name`
+  (`src/services/record_store.rs`); the same is true of every other modality that
+  appends `CanonicalOperation::RecordUpsert`/`RecordDelete` (REST vector/document
+  `src/network/rest/v1/handlers.rs`, graph `src/graph/merge.rs`).
+* The relational memtable partition key is `(tenant_id, name)`
+  (`DirectWalTableRecordStore::partition`).
+* `materialize_table_to_parquet` builds the object path from `&schema.name`.
+* The canonical WAL is a **single shared file** `data_dir/pgwire/canonical-records.wal`
+  (`src/network/shared_services.rs`) — all tenants, all collections, all modalities,
+  each entry tagged with `collection_id` (the name) + `tenant_id`.
+
+This is a design smell, and it is **inconsistent with the rest of the system**,
+which already keys on stable ids: columns carry `id` "stable across renames"
+(`CatalogColumn`), namespaces carry a rename-stable `namespace_id` that "drives
+physical paths", and the object-store path scheme is
+`accounts/{account_id}/{tenant_id}/{namespace_id}/{object_id}/`. SST/HELIX engines
+already use internal ids.
+
+Two concrete defects follow from name-as-key:
+
+1. **Rename-unsafety.** `rename_table` exists, so the name is mutable. Keying the
+   WAL `collection_id`, the data path, and the memtable partition by the name means
+   a `RENAME` would orphan the WAL stream, the materialized data dir, and the
+   partition. A rename must be a *metadata-only* operation.
+2. **Tenant non-uniqueness → feed leak.** Because `collection_id` is the bare name
+   (not tenant-unique), two tenants that both `CREATE TABLE orders` write entries
+   with the same `collection_id="orders"` into the one shared WAL, distinguished
+   only by `tenant_id`. Normal reads are isolated by the `(tenant, name)` partition,
+   but the WAL **change-feed** (`read_changes_since`) bypasses the partition and
+   reads the raw shared WAL, so it must filter on `tenant_id` to isolate tenants
+   (ADR-025 added `read_changes_since_scoped` as the stopgap). Per
+   `CODESIGN_DIMENSIONAL_ARCHITECTURE` §"structural isolation", isolation should be
+   **structural, never a per-query predicate** — the predicate is a stopgap.
+
+== Design tenet (mandate): per-type, globally-unique-across-tenants compact ids
+
+[IMPORTANT]
+====
+**Stable internal ids are compact `u64`, allocated per object *type* by a global
+monotonic allocator, and are unique across *all tenants* within their type.**
+
+* **Compact `u64`, not UUID/ULID.** 8 bytes (vs 16–26), integer equality (vs string
+  compare) on every collection-route / feed / partition lookup, cache-friendly,
+  and `u64` covers ~1.8×10^19 objects/deployment — far beyond any real ceiling. This
+  directly serves the co-design cost spine (smaller WAL/index bytes, cheaper compare).
+* **Per-type id space, globally unique across tenants.** Each object *type* (tenant,
+  namespace, table/collection, …) has its **own** monotonic id space, allocated
+  **globally** (across all tenants). So no two *tables* across all tenants share an
+  `object_id`; `collection_id` is therefore tenant-unique by construction. Numbers
+  **may** repeat *across types* (a `tenant_id` and an `object_id` can both be `5`) —
+  that is harmless because they are distinct type spaces, never compared to each other.
+* **Allocator.** A durable global-monotonic allocator per type (mirror the existing
+  `GlobalLsnAllocator`): never reuses an id, recoverable across restart, no per-tenant
+  partitioning of the id space.
+
+This is a load-bearing design tenet: it is *what* makes collection-routing
+structurally tenant-isolated (no per-query `tenant_id` predicate) and rename-safe.
+====
+
+== Decision
+
+Introduce a **stable, immutable internal `object_id: u64`** for every catalog table
+(allocated per the tenet above) and make it the **physical key** across the record
+path: the WAL `collection_id`, the memtable partition key, and the object-store
+data/WAL/SST paths. The user-facing `name` becomes pure metadata in the catalog
+(a `name → object_id` mapping). `RENAME` mutates only that mapping.
+
+Consequences once cutover completes:
+
+* **Rename-safe.** `RENAME TABLE` is a metadata-only catalog op; no physical bytes move.
+* **Structurally tenant-isolated.** `object_id` is globally unique, so `collection_id`
+  in the WAL is tenant-unique by construction; the change-feed (and every other
+  collection-routed reader) is isolated by the id alone. The ADR-025
+  `read_changes_since_scoped` `tenant_id` predicate becomes redundant and is removed
+  (structural isolation, no wasted compare).
+* **Consistent with the rest of the system** (column ids, `namespace_id`, the
+  `{object_id}` path slot, SST/HELIX engine ids).
+
+== Mixed-read-safe migration (phased, default-OFF) — mandate §8
+
+The WAL `collection_id` is an on-disk/wire field shared by all modalities, so this
+MUST be mixed-read-safe (old name-keyed and new id-keyed entries coexist, detected,
+never a flag-day) and roll out default-OFF until baked. The single shared WAL means
+**all modalities migrate together**; a partial (relational-only) cutover would put
+mixed name/id semantics in one file and is rejected.
+
+* **O0 — additive id (no behavior change).** `CatalogTableSchema` gains
+  `object_id: Option<u64>` (`#[serde(default)]`, back-compat). `create_table`
+  allocates the next id from the global per-type table allocator; `rename_table`
+  preserves it; `get_table` backfills a stable id for legacy rows on first read
+  (monotonic, recorded). Nothing physical uses it yet. **(This is the only phase
+  safe to land independently.)** Encoding on the wire: the WAL `collection_id`
+  String field carries the decimal `object_id` once O2 cuts over (resolver accepts
+  both the legacy name and the decimal-id forms); a typed `u64` field is an optional
+  later compaction.
+* **O1 — resolution + dual-read.** A `name ⇄ object_id` resolver in the catalog;
+  readers (change-feed, partition lookup, path resolution) accept **either** key and
+  prefer `object_id` when present. The change-feed matches an entry if its
+  `collection_id` equals the table's `object_id` **or** (legacy) its `name`.
+* **O2 — dual-write (gated).** Behind a default-OFF gate, every
+  `RecordUpsert`/`RecordDelete` writer stamps `collection_id = object_id` (all
+  modalities, in lock-step). Memtable partition + materialize/WAL/SST paths key on
+  `object_id`. Recovery replays both name- and id-keyed entries via the resolver.
+* **O3 — cutover.** Per-deployment opt-in → default-on once recovery + the
+  multi-modal regression suites (TPC-H/DS, document, events, vector recall, graph)
+  hold. Legacy name-keyed entries remain readable (the resolver never drops the
+  legacy arm).
+* **O4 — simplify.** Once cutover is baked, delete the ADR-025
+  `read_changes_since_scoped` `tenant_id` predicate (now redundant) and make
+  `RENAME` metadata-only end-to-end with a rename-survival test.
+
+Each phase gated by recovery round-trip + the modality regression ratchets.
+
+== Alternatives considered
+
+* **Keep the `tenant_id` feed predicate only (status quo after ADR-025) — REJECTED
+  as the end-state.** Correct for tenant isolation but does not fix rename-unsafety,
+  and is the per-query predicate the structural-isolation mandate frowns on. Retained
+  only as the stopgap until O3.
+* **Tenant-qualify the name (`{tenant}/{name}`) as `collection_id` — REJECTED.**
+  Makes it tenant-unique but is still name-derived (rename-unsafe) and churns the
+  same surface as the id without the rename win.
+* **Per-(tenant,collection) physical WAL files — COMPLEMENTARY, not a substitute.**
+  Worth doing for I/O scaling/structural isolation, but the *path* must be keyed by
+  `object_id` for rename-safety, so it still depends on this ADR.
+* **Relational-only cutover — REJECTED.** The shared WAL would carry mixed name/id
+  semantics; all modalities must move together.
+
+== Consequences
+
+* **Positive:** rename-safe; structural tenant isolation (drop the predicate);
+  consistent id model; foundation for per-collection WAL/path partitioning.
+* **Cost:** a cross-modality, mixed-read-safe migration of the canonical WAL
+  (ADR-020) touching every `RecordUpsert`/`RecordDelete` writer, recovery, paths, and
+  the catalog data model — multi-phase, gated.
+* **Neutral:** ADR-025's read-merge is unaffected by which key the feed uses; it
+  swaps `name` for `object_id` at the feed lookup and inherits rename-safety.
+
+== References
+
+* ADR-020 (canonical WAL authority) · ADR-025 (deletion vectors) · ADR-010 (PAX).
+* `src/services/record_store.rs` (`write_mutations`, `read_changes_since*`),
+  `src/network/shared_services.rs` (single shared WAL),
+  `crates/control/proximadb-catalog/src/lib.rs` (`create_table`/`rename_table`/`CatalogTableSchema`).

--- a/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
+++ b/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
@@ -61,12 +61,51 @@ monotonic allocator, and are unique across *all tenants* within their type.**
   compare) on every collection-route / feed / partition lookup, cache-friendly,
   and `u64` covers ~1.8×10^19 objects/deployment — far beyond any real ceiling. This
   directly serves the co-design cost spine (smaller WAL/index bytes, cheaper compare).
+  *Why `u64` over `u32`:* the allocator **never reuses** ids, so the space is consumed
+  by **cumulative lifetime allocations** (including ephemeral CTAS/materialize/temp
+  objects), not the live-object count. `u32`'s 4.29e9 ceiling is reachable for a
+  large, long-lived, high-churn multi-tenant deployment, and exhausting a
+  never-reuse *foundational* id is catastrophic — and re-widening it later is itself a
+  migration. `u64`'s headroom removes that risk for 4 extra bytes, and paths stay
+  short regardless (base62-7 already covers 3.5e12 allocations in 7 chars). `u32` is
+  acceptable only for bounded, low-cardinality types; we use uniform `u64` to avoid
+  per-type width bookkeeping and any exhaustion cliff.
 * **Per-type id space, globally unique across tenants.** Each object *type* (tenant,
   namespace, table/collection, …) has its **own** monotonic id space, allocated
   **globally** (across all tenants). So no two *tables* across all tenants share an
   `object_id`; `collection_id` is therefore tenant-unique by construction. Numbers
   **may** repeat *across types* (a `tenant_id` and an `object_id` can both be `5`) —
   that is harmless because they are distinct type spaces, never compared to each other.
+* **Per-type integer width (tuned, not uniform).** Width is chosen per type by
+  cardinality × churn × ubiquity:
+  ** `tenant_id`, `account_id` → `u32`. Low cardinality (no deployment approaches
+     4.29e9 tenants/accounts), and these appear in **every** WAL entry and path
+     segment, so the 4-byte saving is multiplied across the whole corpus (co-design:
+     fewer bytes on the dominant term). Even a churny tenant lifecycle stays far under
+     the ceiling.
+  ** `namespace_id` (schema/database), `object_id` (table/collection) → `u64`.
+     Higher cardinality and **never-reuse** churn (CTAS/MATERIALIZE/temp objects
+     consume cumulative allocations, not live count); `u64` removes the exhaustion
+     cliff that `u32` could hit on a large, long-lived deployment, for a few bytes that
+     base62 paths absorb (base62-7 covers 3.5e12 ids in 7 chars).
+* **Column ids stay table-scoped/composite, NOT global; keep `i32` (not `u16`).** A
+  column is always accessed in its table's context, so its key is
+  `(object_id, column_id)` where `column_id` is the **existing per-table stable id**
+  (`CatalogColumn.id`, "stable across renames" — the Iceberg field-id model, `i32`).
+  Global column ids would be wasteful and non-idiomatic. We keep `i32` rather than
+  shrink to `u16` because: (a) ids are stable/never-reused, so schema evolution —
+  notably `PropsAutoPromotion` promoting props keys to typed columns over a table's
+  life — consumes *cumulative* column-ids, which can reach `u16`'s 65 536 on a
+  high-churn document/feature table; (b) Iceberg/Parquet field-ids are `int` and
+  `CatalogColumn.id` maps straight to them (ADR-010); (c) column ids are schema
+  metadata (one per column, **low ubiquity**), so `u16` saves essentially nothing —
+  the width principle (cardinality × churn × ubiquity) points to `i32` here.
+* **Representation per layer; `object_id`-first keys.** In memory, ids are the **raw
+  integer** (fast compare, compact); on object-store paths they are **base62**; both
+  derive from the same value. Memtable/index keys put the globally-unique `object_id`
+  **first**, so a collection scan is a prefix range scan and `tenant_id` needs no
+  compare on the scan path — it rides along for billing attribution + defense-in-depth
+  and, at `u32`, saves memory on shared multi-tenant pods (many tenants' keys resident).
 * **Allocator.** A durable global-monotonic allocator per type (mirror the existing
   `GlobalLsnAllocator`): never reuses an id, recoverable across restart, no per-tenant
   partitioning of the id space.
@@ -74,6 +113,35 @@ monotonic allocator, and are unique across *all tenants* within their type.**
 This is a load-bearing design tenet: it is *what* makes collection-routing
 structurally tenant-isolated (no per-query `tenant_id` predicate) and rename-safe.
 ====
+
+== Path encoding & reserved namespace
+
+The same `u64` ids encode compactly into object-store paths, collapsing path
+verbosity for `account / tenant / namespace / object`:
+
+* **base62 for id path segments** — reuse the existing `collection_path::base62_7`
+  (`[0-9A-Za-z]`, zero-padded fixed-width; extend to the width the per-type id space
+  needs — 62^7≈3.5e12, 62^11 covers full `u64`). Fixed-width ⇒ predictable path
+  length **and** lexicographic sort == allocation order (useful for `LIST`/range).
+  Path becomes `data/{acct62}/{tenant62}/{ns62}/{obj62}/…`. base62 is POSIX/S3/URL
+  safe (no `/`, `+`, `=`), unlike standard base64.
+  - *Caveat:* base62 is case-sensitive, so on a case-**insensitive** local FS
+    (macOS/Windows dev) two ids differing only by case could collide. Harmless on
+    object stores and case-sensitive Linux (the production targets); for belt-and-
+    suspenders on local disk, base36 (`[0-9a-z]`) trades ~2 chars for case-safety.
+    We keep base62 for consistency with the existing convention and flag the edge.
+* **`_`-prefix reserved for system/temp/manifests** — already the convention
+  (TD-164: `<tenant_root>_metering/`, `_trace/`, guarded by
+  `DrPathBuilder::validate_id` + `RESERVED_SYSTEM_SEGMENTS`). Because base62 excludes
+  `_`, a `_`-prefixed segment can **never** collide with a base62 id — so
+  `_tmp`/`_staging`/`_manifests`/`_SUCCESS`-style markers are unambiguously not data.
+  This is the Hadoop-output-committer `_temporary`/`_SUCCESS` hygiene, applied here.
+* **Commit protocol = Iceberg atomic CAS, not rename.** For atomic publication prefer
+  Iceberg's atomic metadata-swap commit (already wired via `publish_iceberg_snapshot`)
+  over the Hadoop `FileOutputCommitter` rename model — object stores lack atomic
+  rename (S3/ADLS "rename" = copy+delete, slow + non-atomic on failure), the exact
+  hazard the Hadoop v1 committer hits. `_`-staging dirs hold in-progress writes;
+  the CAS manifest swap is the commit point.
 
 == Decision
 

--- a/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
+++ b/docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc
@@ -76,6 +76,20 @@ monotonic allocator, and are unique across *all tenants* within their type.**
   `object_id`; `collection_id` is therefore tenant-unique by construction. Numbers
   **may** repeat *across types* (a `tenant_id` and an `object_id` can both be `5`) —
   that is harmless because they are distinct type spaces, never compared to each other.
+* **Identity is a single global id, NEVER a composite `(account_id, object_id)`.**
+  Because each type's id is globally unique, the lookup/identity key is the lone
+  `object_id`. `account_id`/`tenant_id`/`namespace_id` are functionally determined by
+  `object_id` (the object knows its owner) — by 3NF a composite key would be
+  denormalized redundancy. **Performance:** one `u64` equality (a single instruction)
+  beats a composite's two-field compare (`u32 && u64`, two loads + a branch) on
+  *every* hot path these ids touch — catalog/schema/stats lookup, the route/plan-cache
+  key, query-planner predicate threading, WAL `collection_id` match, and hash/btree
+  index keys (one compact `u64` key, one hash, no tuple). Since the ids are used
+  extensively in planning + metadata ops, the single-scalar win compounds.
+  `account_id`/`tenant_id` still appear in the *path* (structural isolation +
+  locality) and as billing attributes, but **never in the identity/lookup key**;
+  list-by-account is a rare admin op served by the path hierarchy or a small secondary
+  index, not the hot path.
 * **Per-type integer width (tuned, not uniform).** Width is chosen per type by
   cardinality × churn × ubiquity:
   ** `tenant_id`, `account_id` → `u32`. Low cardinality (no deployment approaches


### PR DESCRIPTION
## What

Proposes **ADR-031: stable `object_id` as the physical collection key** and lands its
first, self-contained unit — the **`IdAllocator`** (phase O0). Spec + foundation only;
no behavior change yet.

## Why

The relational record path keys physical state on the **user-facing table name**: the
canonical WAL `collection_id = table_schema.name`, the memtable partition key
`(tenant, name)`, and the materialize path are all name-derived. Two defects follow:

1. **Rename-unsafe** — `rename_table` exists, so the name is mutable; keying the WAL /
   path / partition by it means a `RENAME` would orphan them. Rename must be
   metadata-only.
2. **Not tenant-unique** — the canonical WAL is a *single shared file*
   (`canonical-records.wal`) and `collection_id` is the bare name, so two tenants that
   both `CREATE TABLE orders` collide; only the per-entry `tenant_id` distinguishes
   them. The change-feed (which bypasses the tenant-keyed memtable partition) needed a
   `tenant_id` predicate as a stopgap (#405) — a per-query predicate, which the
   structural-isolation mandate says to avoid.

This is inconsistent with the rest of the system, which already keys on stable ids
(column `id` "stable across renames", rename-stable `namespace_id`, the `{object_id}`
path slot, SST/HELIX engine ids).

## Decision (design tenet)

Stable internal ids are **compact integers, per object type, globally unique across
tenants, never reused**, with width tuned by cardinality × churn × ubiquity:
`tenant_id`/`account_id` → **u32**, `namespace_id`/`object_id` → **u64**, `column_id`
→ **i32** (table-scoped composite, Iceberg field-id). Paths encode ids in **base62**;
`_`-prefixed segments stay reserved for system/temp/manifests (TD-164); atomic
publication uses **Iceberg-CAS**, not Hadoop rename. In memory ids are raw integers;
`object_id`-first keys make collection scans prefix scans, so the tenant compare drops
out (structural isolation) and `RENAME` becomes metadata-only.

## This PR

- `docs/12-design/adr/ADR-031-*.adoc` — the full spec + phased mixed-read-safe
  migration (O0 additive id → O1 dual-read → O2 dual-write all-modality → O3 cutover →
  O4 drop the tenant predicate).
- `proximadb-catalog::id_allocator::IdAllocator` (O0 unit 1) — lock-free `AtomicU64`
  monotonic allocator (mirrors `GlobalLsnAllocator`); `0` reserved as unset;
  `raise_floor` for recovery-by-max-existing-id; per-type independent spaces. 4 unit
  tests. **Not yet wired into `create_table`** — that and the rest of the migration are
  the follow-up phases scoped in the ADR.

## Tests

`cargo test -p proximadb-catalog id_allocator` (4/4). Additive + unused → no behavior
change; full regression unaffected.

Refs ADR-020, ADR-025 (the stopgap tenant predicate this supersedes at O4), ADR-010.
