### PR TITLE
fix(test): bound all native_volcano_stream tests with 10s timeout (CI hang flake) — supersedes #402/#403

### DIFF
--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -553,107 +553,139 @@ mod tests {
 
     #[tokio::test]
     async fn native_volcano_stream_yields_rows_incrementally() {
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            ExecutionControls::default(),
-        )
+        // Wrap in a timeout — see native_volcano_stream_truncates_without_error
+        // (CLAUDE.md #11): the streaming path intermittently hangs, so bound it.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let result = NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                ExecutionControls::default(),
+            )
+            .await
+            .expect("values plan should open for streaming");
+
+            // Schema is available before draining any row.
+            assert_eq!(result.schema.columns[0].name, "id");
+
+            let mut rows = result.rows;
+            let first = rows.next().await.expect("first row").expect("row ok");
+            assert_eq!(first, vec![ProximaValue::Int64(1)]);
+            let second = rows.next().await.expect("second row").expect("row ok");
+            assert_eq!(second, vec![ProximaValue::Int64(2)]);
+            assert!(rows.next().await.is_none());
+        })
         .await
-        .expect("values plan should open for streaming");
-
-        // Schema is available before draining any row.
-        assert_eq!(result.schema.columns[0].name, "id");
-
-        let mut rows = result.rows;
-        let first = rows.next().await.expect("first row").expect("row ok");
-        assert_eq!(first, vec![ProximaValue::Int64(1)]);
-        let second = rows.next().await.expect("second row").expect("row ok");
-        assert_eq!(second, vec![ProximaValue::Int64(2)]);
-        assert!(rows.next().await.is_none());
+        .expect(
+            "volcano stream timed out >10s — investigate execute_physical_stream (CLAUDE.md #11)",
+        );
     }
 
     #[tokio::test]
     async fn native_volcano_stream_honors_mid_stream_cancellation() {
-        let flag = Arc::new(AtomicBool::new(false));
-        let controls = ExecutionControls {
-            cancellation_flag: Some(flag.clone()),
-            ..Default::default()
-        };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
-        )
-        .await
-        .expect("values plan should open for streaming");
-
-        let mut rows = result.rows;
-        let first = rows.next().await.expect("first row").expect("row ok");
-        assert_eq!(first, vec![ProximaValue::Int64(1)]);
-
-        // Cancel after the first row; the next pull must surface Cancelled rather
-        // than continuing to drain the plan.
-        flag.store(true, Ordering::Relaxed);
-        let err = rows
-            .next()
+        // Wrap in a timeout — see native_volcano_stream_truncates_without_error
+        // (CLAUDE.md #11): the streaming path intermittently hangs, so bound it.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let flag = Arc::new(AtomicBool::new(false));
+            let controls = ExecutionControls {
+                cancellation_flag: Some(flag.clone()),
+                ..Default::default()
+            };
+            let result = NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            )
             .await
-            .expect("a stream item")
-            .expect_err("cancelled mid-stream");
-        assert!(matches!(err, ExecutionError::Cancelled));
+            .expect("values plan should open for streaming");
+
+            let mut rows = result.rows;
+            let first = rows.next().await.expect("first row").expect("row ok");
+            assert_eq!(first, vec![ProximaValue::Int64(1)]);
+
+            // Cancel after the first row; the next pull must surface Cancelled rather
+            // than continuing to drain the plan.
+            flag.store(true, Ordering::Relaxed);
+            let err = rows
+                .next()
+                .await
+                .expect("a stream item")
+                .expect_err("cancelled mid-stream");
+            assert!(matches!(err, ExecutionError::Cancelled));
+        })
+        .await
+        .expect(
+            "volcano stream timed out >10s — investigate execute_physical_stream (CLAUDE.md #11)",
+        );
     }
 
     #[tokio::test]
     async fn native_volcano_stream_enforces_row_limit() {
-        let controls = ExecutionControls {
-            max_rows: Some(1),
-            ..Default::default()
-        };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
-        )
-        .await
-        .expect("values plan should open for streaming");
-
-        let mut rows = result.rows;
-        let first = rows.next().await.expect("first row").expect("row ok");
-        assert_eq!(first, vec![ProximaValue::Int64(1)]);
-        let err = rows
-            .next()
+        // Wrap in a timeout — see native_volcano_stream_truncates_without_error
+        // (CLAUDE.md #11): the streaming path intermittently hangs, so bound it.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let controls = ExecutionControls {
+                max_rows: Some(1),
+                ..Default::default()
+            };
+            let result = NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            )
             .await
-            .expect("a stream item")
-            .expect_err("row limit should reject the overflow row");
-        assert!(matches!(
-            err,
-            ExecutionError::RowLimitExceeded {
-                limit: 1,
-                actual: 2
-            }
-        ));
+            .expect("values plan should open for streaming");
+
+            let mut rows = result.rows;
+            let first = rows.next().await.expect("first row").expect("row ok");
+            assert_eq!(first, vec![ProximaValue::Int64(1)]);
+            let err = rows
+                .next()
+                .await
+                .expect("a stream item")
+                .expect_err("row limit should reject the overflow row");
+            assert!(matches!(
+                err,
+                ExecutionError::RowLimitExceeded {
+                    limit: 1,
+                    actual: 2
+                }
+            ));
+        })
+        .await
+        .expect(
+            "volcano stream timed out >10s — investigate execute_physical_stream (CLAUDE.md #11)",
+        );
     }
 
     #[tokio::test]
     async fn native_volcano_stream_truncates_without_error() {
-        let controls = ExecutionControls {
-            max_rows: Some(1),
-            row_limit_mode: RowLimitMode::Truncate,
-            ..Default::default()
-        };
-        let result = NativeVolcanoEngine::execute_physical_stream(
-            values_plan(),
-            &EmptyReaderFactory,
-            controls,
-        )
-        .await
-        .expect("values plan should open for streaming");
+        // Wrap in a timeout to convert the known streaming hang (CLAUDE.md #11:
+        // Limit executor race) into a deterministic, bounded failure instead of
+        // an indefinite CI runner block. If this times out, the root cause is
+        // the Limit executor's stream-termination race — not the test logic.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let controls = ExecutionControls {
+                max_rows: Some(1),
+                row_limit_mode: RowLimitMode::Truncate,
+                ..Default::default()
+            };
+            let result = NativeVolcanoEngine::execute_physical_stream(
+                values_plan(),
+                &EmptyReaderFactory,
+                controls,
+            )
+            .await
+            .expect("values plan should open for streaming");
 
-        let mut rows = result.rows;
-        let first = rows.next().await.expect("first row").expect("row ok");
-        assert_eq!(first, vec![ProximaValue::Int64(1)]);
-        // Truncate mode stops at the cap with no overflow error: the second row
-        // of the values plan is never produced.
-        assert!(rows.next().await.is_none());
+            let mut rows = result.rows;
+            let first = rows.next().await.expect("first row").expect("row ok");
+            assert_eq!(first, vec![ProximaValue::Int64(1)]);
+            // Truncate mode stops at the cap with no overflow error: the second row
+            // of the values plan is never produced.
+            assert!(rows.next().await.is_none());
+        })
+        .await
+        .expect("stream truncated within 10s — if timed out, the Limit executor race is the root cause (CLAUDE.md #11)");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Bounds **all four** `native_volcano_stream_*` tests with a 10s `tokio::time::timeout` so the known streaming-hang flake (CLAUDE.md #11) fails fast instead of stalling the CI runner. Now that `Rust Tests (unit)` is required again (#400), an unguarded hang burns the full ~180s nextest TMT per attempt and can fail the gate.

## Why this supersedes #402 and #403

I reproduced the flake locally (`cargo nextest run -p proximadb --lib native_volcano_stream`): `native_volcano_stream_enforces_row_limit` hung for 180s on try 1, passed in 30ms on try 2. That exposed that both open PRs miss the mark:

- **#403** wraps only `native_volcano_stream_truncates_without_error` — but the test that actually hangs is `native_volcano_stream_enforces_row_limit` (wrong target).
- **#402** wraps `execute_physical_stream(...)` (the *open*) only — but the hang lives in the `rows.next()` *drain*, which #402 leaves unguarded. It also tried the `current_thread` flavor, which makes the drop block on the hung future's pending tasks (worse).

This PR wraps the **whole body** (open **and** `rows.next()` drain) of **all four** streaming tests. Verified locally: all 4 pass in ~30ms, no hang.

## Approach

`tokio::time::timeout(10s, async { <existing body> }).await.expect("…")` around each test body. Default `#[tokio::test]` runtime supports timers; the tests are sequential (no spawned tasks), so dropping a timed-out future won't block. This is the accepted stance for this flake (mandate #11: "re-run, don't chase") — make it fail-fast + let nextest retries recover, rather than chase the root cause of the Limit-executor race.

Not a behavior change to production code — test-only.

## Verification

- `cargo nextest run -p proximadb --lib native_volcano_stream` → 4/4 pass (~30ms each, no hang; previously `enforces_row_limit` hung 180s).
- `cargo fmt --all -- --check` clean.
