### PR TITLE
fix(catalog): harden system-catalog isolation — fail-closed cloud URL + reserved-tenant guard

### DIFF
--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -162,18 +162,28 @@ impl NativeCatalog {
         Ok(catalog)
     }
 
-    /// Parse storage URL to get local path
+    /// Parse storage URL to get local path.
+    ///
+    /// Only `file://` (and bare local paths) are durable today. Object-store
+    /// catalog persistence is a separate, gated change (inject `FilesystemFactory`
+    /// and route I/O through it). Until that lands we **fail closed** for
+    /// `s3://`/`gs://`/`az://`: the previous behaviour silently redirected cloud
+    /// catalog URLs to a process-local `std::env::temp_dir()` cache, so catalog
+    /// metadata was non-durable, non-isolated, and unshared across pods — a
+    /// silent data-loss footgun in any serverless/cloud deployment. Refusing to
+    /// start is strictly safer than persisting the control-plane catalog to /tmp.
     fn parse_storage_url(url: &str) -> Result<PathBuf> {
-        // Support file:// URLs and plain paths
         if let Some(path) = url.strip_prefix("file://") {
             Ok(PathBuf::from(path))
         } else if url.starts_with("s3://") || url.starts_with("gs://") || url.starts_with("az://") {
-            // Cloud storage - use local cache path
-            // In a real implementation, we'd use an object store client
-            let cache_dir = std::env::temp_dir().join("proximadb_catalog_cache");
-            Ok(cache_dir)
+            anyhow::bail!(
+                "object-store catalog URL '{url}' is not yet supported: the native catalog \
+                 only persists durably to file:// today. Configure a file:// metadata_url, \
+                 or wait for object-store catalog persistence (FilesystemFactory wiring). \
+                 Refusing to silently cache the control-plane catalog under a local temp dir."
+            )
         } else {
-            // Assume plain path
+            // Assume plain local path.
             Ok(PathBuf::from(url))
         }
     }
@@ -966,6 +976,24 @@ mod tests {
     fn test_parse_storage_url_plain_path() {
         let path = NativeCatalog::parse_storage_url("/tmp/catalog").unwrap();
         assert_eq!(path, PathBuf::from("/tmp/catalog"));
+    }
+
+    #[test]
+    fn test_parse_storage_url_object_store_fails_closed() {
+        // Object-store catalog URLs must fail closed (not silently redirect to a
+        // process-local temp dir) until durable object-store persistence is wired.
+        for url in [
+            "s3://bucket/catalog",
+            "gs://bucket/catalog",
+            "az://acct/catalog",
+        ] {
+            let err = NativeCatalog::parse_storage_url(url)
+                .expect_err("object-store catalog URL must be rejected, not temp-cached");
+            assert!(
+                err.to_string().contains("not yet supported"),
+                "unexpected error for {url}: {err}"
+            );
+        }
     }
 
     // ── Slice 5b.1: set_primary_pod (NativeCatalog override) ─────────

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -628,6 +628,22 @@ impl CatalogManager {
         fqn: &str,
         tenant: Option<&str>,
     ) -> Result<(Arc<dyn Catalog>, TableIdentifier)> {
+        // Structural system-catalog isolation (validate input first): the tenant
+        // id becomes `namespace[0]`, so a tenant must never shadow a reserved
+        // control-plane / per-tenant system subtree. Those are the
+        // underscore-prefixed segments (`_operator`, `_metering`, `_trace`,
+        // `_branches`, `_manifests` — see `DrPathBuilder::RESERVED_SYSTEM_SEGMENTS`).
+        // The physical path resolver already rejects them via `validate_id`;
+        // mirror that at the logical catalog-resolution boundary so DDL/DML cannot
+        // address the system catalog by passing a `_`-prefixed tenant.
+        if let Some(tenant) = tenant.filter(|tenant| !tenant.is_empty())
+            && tenant.starts_with('_')
+        {
+            anyhow::bail!(
+                "tenant '{tenant}' is invalid: tenant identifiers must not begin with '_' \
+                 (reserved for system/control-plane catalog subtrees)"
+            );
+        }
         let (catalog, id) = self.resolve_table(fqn).await?;
         match tenant {
             Some(tenant) if !tenant.is_empty() => {
@@ -802,6 +818,36 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().expect("Expected error result");
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn resolve_table_scoped_rejects_reserved_underscore_tenant() {
+        // A tenant id becomes namespace[0]; a `_`-prefixed tenant would shadow a
+        // reserved control-plane/system subtree. The guard validates the tenant
+        // BEFORE catalog lookup, so the reserved-tenant error fires regardless of
+        // whether the table exists (here: no catalog registered).
+        let manager = CatalogManager::new();
+        for tenant in [
+            "_operator",
+            "_metering",
+            "_trace",
+            "_branches",
+            "_manifests",
+        ] {
+            // `(Arc<dyn Catalog>, TableIdentifier)` isn't `Debug`, so match rather
+            // than `expect_err`.
+            let err = match manager
+                .resolve_table_scoped("some_table", Some(tenant))
+                .await
+            {
+                Ok(_) => panic!("reserved underscore tenant {tenant} must be rejected"),
+                Err(e) => e,
+            };
+            assert!(
+                err.to_string().contains("must not begin with '_'"),
+                "unexpected error for tenant {tenant}: {err}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Phase 0 of an audit-driven catalog/tenant-isolation hardening program. Two small, isolated, **structural-isolation** fixes — no on-disk format change.

1. **Cloud catalog URLs fail closed.** `NativeCatalog::parse_storage_url` previously redirected `s3://`/`gs://`/`az://` to a process-local `std::env::temp_dir()` cache (`crates/control/proximadb-catalog/src/native.rs`), so the control-plane catalog was **non-durable, non-isolated, and unshared across pods** — a silent data-loss footgun in any cloud/serverless deployment. It now returns an error until durable object-store persistence is wired (`FilesystemFactory`). Refusing to start beats persisting the catalog to `/tmp`.

2. **Reserved-tenant guard in `resolve_table_scoped`** (`src/catalog/mod.rs`). A tenant id becomes `namespace[0]`, so a `_`-prefixed tenant could shadow a reserved control-plane/system subtree (`_operator`/`_metering`/`_trace`/`_branches`/`_manifests` = `DrPathBuilder::RESERVED_SYSTEM_SEGMENTS`). The physical path resolver already rejects these via `validate_id`; this mirrors the guard at the **logical** catalog-resolution boundary (validated before lookup) so DDL/DML cannot address the system catalog by passing a `_`-prefixed tenant.

## Context
From a multi-agent audit of catalog tenancy/isolation. This is the small, safe, no-format-change slice; the larger fail-closed deployment-mode change (flipping tenant-isolation defaults) and durable object-store + tenant-prefixed catalog (its own ADR, mixed-read-safe) follow as separate PRs.

## Verification
- New unit tests: object-store URL rejection (3 schemes); reserved-tenant rejection (all 5 reserved segments).
- `clippy --lib` clean (both crates); `catalog::` + `services::dml::` suites green (261 passed).