### PR TITLE
docs(adr): ADR-032 durable, tenant-prefixed object-store catalog

### DIFF
--- a/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
+++ b/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
@@ -1,0 +1,85 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-032: Durable, Tenant-Prefixed Object-Store Catalog (make the catalog the serverless shared truth; structural isolation, not a per-query predicate)
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-26
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-027 (Unified Storage + Metering substrate — PAX + coalesced writer + `_metering/_trace` system subtrees; "OSS=mechanism, $=AnvaiOps policy"), `CATALOG_OBJECT_MODEL_2026_06_21.adoc` (account=tenant=catalog / schema=namespace; "isolation is structural, addressing is catalog-resolved"; gap G2 = "addressing is convention/env-derived, not catalog-resolved"), `COLLECTION_DR_CRR_ENGINE_CONTRACT.adoc` (physical path contract: `data/{tenant_id}/{namespace_id}/{collection_id}/` and the Phase-5 `accounts/{account_id}/…` two-tier render; `DrPathBuilder` the single validated emitter), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (treat the I/O boundary as the contract; isolation structural not per-query), `OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc` (operator catalog + billing live in AnvaiOps; OSS emits neutral telemetry)
+|Supersedes|—
+|Tracked under|TD-113 (SaaS path isolation — opaque-namespace DrPathBuilder layout), TD-119 (tenant-scope Iceberg REST), TD-164 (reserved system-segment denylist — landed for the physical path resolver), plus new TD-CAT-1 (object-store catalog persistence), TD-CAT-2 (tenant-prefixed catalog paths + tenant-recording upsert), TD-CAT-3 (edge fail-closed deployment mode). Prior art shipped: PR #410 (cloud-URL fail-closed + reserved-`_`-tenant guard at the logical resolution boundary).
+|===
+
+== Context
+
+A multi-agent audit (2026-06-26) of the catalog/tenancy stack found the **documented design intent already matches the serverless target** — one shared control-plane catalog, tenant-tagged, with structural per-tenant path isolation via `DrPathBuilder`, an immutable system catalog under `_operator/`, and the operator/billing catalog externalized to AnvaiOps. The intent is right. The **runtime does not yet realize it**, and three findings together block a robust serverless foundation:
+
+* **F1 — the catalog is not durable on object storage.** `NativeCatalog::parse_storage_url` historically redirected `s3://`/`gs://`/`az://` to a process-local `std::env::temp_dir()` cache and did all I/O with `tokio::fs`. In a serverless deployment (ephemeral, stateless pods, storage decoupled to object store) this is fatal: each pod gets its own throwaway catalog, so there is no shared truth. PR #410 made this **fail closed** (refuse rather than silently cache to `/tmp`); this ADR makes it **work** (persist to object storage).
+
+* **F2 — catalog metadata bypasses the tenant prefix.** `NativeCatalog` persists flat `base_path/metadata/tables/<namespace>/<table>.json` with no `{tenant_id}` segment, and `upsert_collection_catalog_asset` calls the tenant-less `create_namespace`, so the persisted `CatalogNamespace.tenant_id` is `None`. The `DrPathBuilder` prefix (`data/{tenant_id}/{namespace_id}/…`, and the Phase-5 `accounts/{account_id}/…`) is built and used by the **engine/WAL/segment** paths but **not** by the catalog layer. So the catalog — the metadata authority — is the one place tenant data is *not* path-isolated.
+
+* **F3 — service-layer tenant isolation is inert in production and is the wrong mechanism.** `CollectionService`/`VectorOperationsService` guard tenant access with `tenant_context.filter(|_| self.tenant_manager.is_some())`, but **no production code calls `with_tenant_manager`** — `tenant_manager` is always `None` outside tests, so every request falls through to the unscoped path and the per-query ownership predicate never runs. This is doubly wrong: it is dead in production, and per the co-design mandate isolation must be **structural** (path-derived, fail-closed), *never a per-query predicate*. The reachable isolation boundaries today are the **network edge** (`TenantExtractor`, which defaults to permissive single-tenant) and the **catalog path** (F2, not yet prefixed).
+
+The throughline: in a serverless DB, **compute is ephemeral and the catalog is the only durable shared truth**. Until the catalog is durable on object storage and tenant-prefixed, isolation cannot be structural, and the per-query predicate that pretends to provide it is inert. This ADR makes the catalog that surface.
+
+This is a change to where on-disk/object-store catalog metadata lives and how it is addressed — an on-disk/location format change — so per the storage-format-migration mandate it requires this ADR, must be **mixed-read-safe**, and must ship **default-OFF** until baked.
+
+== Decision
+
+Make the native catalog a **durable, object-store-backed, tenant-prefixed, fail-closed** control surface, and move tenant isolation from the inert per-query predicate to the structural path + the network edge.
+
+=== D1 — Persist the catalog through `FilesystemFactory` (object-store durable)
+
+Inject `Arc<FilesystemFactory>` into `NativeCatalog` and route all metadata/data I/O (`save_table`/`save_namespaces`/`load_namespaces`/path helpers) through `factory.get_filesystem(url)?` → `write_atomic()/read()/list()/delete()`, replacing the direct `tokio::fs` calls. This is a **wiring job, not a new client**: the `FileSystem` cloud backends already implement real writes (`aws_s3.rs::write` → `object_store::put`; S3/GCS/Azure registered in `FilesystemFactory`), and the SST manifest path is the established pattern (`get_filesystem` → `write_atomic`). Reuse the existing `CatalogCache` (+ `TenantCache` for footers) so cold-start pod reads hit cache before object storage. `TenantContext` is plumbed to these boundaries for billing (KSU/KRU) and post-write cache invalidation (read/write invariant #16b).
+
+=== D2 — Address catalog assets through `DrPathBuilder` (tenant-prefixed)
+
+Catalog metadata and data path construction goes through `DrPathBuilder` so assets land under the documented prefix: `data/{tenant_id}/{namespace_id}/{collection_id}/` (legacy flat render) and `accounts/{account_id}/{tenant_id}/{namespace_id}/{collection_id}/` when an account is provisioned (Phase-5, inert until then). `upsert_collection_catalog_asset` records the tenant via `create_namespace_for_tenant(ns, props, Self::collection_tenant_id(collection).as_deref())` so the persisted namespace carries `tenant_id` — which in turn lets `DrPathBuilder` resolve instead of failing closed on `MissingTenantId`. Isolation becomes **structural**: per-tenant lifecycle is a prefix operation (drop = delete subtree), CRR and billing key off the prefix, and `_operator/`/`_metering/`/`_trace/` system subtrees are lexically separate (the reserved-segment denylist already guards them in `validate_id`, TD-164, and at the logical resolution boundary, PR #410).
+
+=== D3 — Isolation at the edge + the path; retire the inert service predicate
+
+Tenant isolation is enforced **structurally**:
+
+* **Network edge, fail-closed by explicit mode.** Replace the silent permissive default with an explicit `DeploymentMode::{SingleTenant{default_tenant}, MultiTenant}` resolved from config (TOML/`ServerConfig`). `MultiTenant` requires a tenant on every request (`require_tenant=true`, `validate_tenant=true` — the existing `RestServerSecurityConfig::multi_tenant()` path) and the same resolution at pgwire/gRPC/Flight edges (which already extract a tenant). `SingleTenant` injects the configured default tenant (back-compat — existing single-tenant deployments keep working by naming the mode). An ambiguous/unconfigured deployment denies. The point: a deployment that *intends* multi-tenant can no longer silently run permissive.
+* **Path, fail-closed by construction.** `DrPathBuilder` already refuses to build a path without `tenant_id`/`namespace_id` and rejects reserved/cross-pool targets. Once D2 routes catalog I/O through it, every catalog write is structurally tenant-scoped or it fails.
+* **Retire the per-query predicate.** The `tenant_context.filter(|_| tenant_manager.is_some())` service-layer checks are inert and are the wrong layer; they are replaced by the structural mechanism above (kept only as defense-in-depth where a `TenantContext` is genuinely threaded, never as the primary boundary).
+
+The **operator catalog stays in AnvaiOps** (per `OSS_ENTERPRISE_BOUNDARY`); this ADR only hardens the `_operator/` seam and the per-tenant `_metering/` sink that AnvaiOps consumes. A separate object-store **IAM** policy (bucket/credential isolation per `StoragePoolClass`/account, defense-in-depth *below* structural path isolation) is acknowledged as future work and out of scope here.
+
+=== D4 — Mixed-read-safe migration, default-OFF
+
+* A version/marker on the catalog root distinguishes the new object-store/tenant-prefixed layout from the legacy flat `file://` layout. Readers **default to the legacy layout when the marker is absent** — never assume the new format.
+* Ship **default-OFF** behind a per-collection opt-in / env gate (mirror `PROXIMADB_INDEX_CATALOG_PATHS`) until baked. New writes adopt the new layout only when the gate is on.
+* Provide a one-shot repath/migration that re-emits existing flat catalog assets under their tenant-prefixed paths and stamps the marker.
+* Gate promotion on round-trip + cross-read tests (legacy flat and new prefixed coexist), not just compile.
+
+== Consequences
+
+*Positive.* The catalog becomes durable and shared, so stateless pods can serve any tenant after a cold start (the serverless unlock). Isolation is structural and fail-closed, so it holds for every workload class — agent (many tiny bursty tenants), data-engineering (Iceberg/Parquet, TD-119 tenant-scoped REST), OLTP/pgwire, graph, docs — with no per-modality isolation code. Per-tenant lifecycle, CRR, and billing become prefix operations. The misconfiguration footgun (intended multi-tenant silently permissive) is closed.
+
+*Negative / cost.* Catalog reads/writes now cross the object-store boundary (mitigated by `CatalogCache`/footer cache and atomic single-PUT object writes). The `DeploymentMode` flip is a behavior change for deployments that relied on the implicit permissive default (mitigated by back-compat single-tenant mode + a release note). The migration adds a marker + repath step. Object-store IAM isolation is *not* delivered here (structural path isolation only).
+
+== Alternatives considered
+
+* **Keep the catalog on local disk / `tokio::fs`.** Rejected: incompatible with serverless (no shared state across ephemeral pods) — the root cause of F1.
+* **Build a new object-store client (`proximadb-object-store`) for the catalog.** Rejected: the `FileSystem` cloud backends already write; reusing `FilesystemFactory` avoids a second, divergent object-store path. (`proximadb-object-store` remains the warehouse/Iceberg-tier wrapper.)
+* **Harden the per-query service predicate (wire `tenant_manager` everywhere) instead of structural paths.** Rejected: it is the wrong mechanism per the co-design mandate (per-query predicate, not structural), and would require threading a tenant manager through every construction site to revive dead code rather than fixing the boundary.
+* **Tenant as a row column only (no path prefix).** Rejected: defeats per-tenant lifecycle/CRR/billing-by-prefix and leaves the catalog as the one non-isolated surface (F2).
+
+== Rollout (phased; one PR per slice, CLAUDE.md #7/#8)
+
+. **Shipped — PR #410:** cloud-URL fail-closed + reserved-`_`-tenant guard at the logical resolution boundary.
+. **TD-CAT-1 (D1):** inject `FilesystemFactory`, object-store persistence, behind the gate; `file://` unchanged. Round-trip tests on `file://` + a mock/object-store backend.
+. **TD-CAT-2 (D2):** route catalog paths through `DrPathBuilder`; tenant-recording `upsert`; marker + mixed-read fallback + migration. Cross-read tests.
+. **TD-CAT-3 (D3):** `DeploymentMode` + edge fail-closed; retire the inert service predicate. Cross-tenant-denied + single-tenant-still-works tests.
+. **TD-119:** tenant-scope the Iceberg REST endpoints on the same `TenantContext`.
+
+== Testing & gating
+
+* Round-trip catalog create→read against `file://` (temp) **and** a mock/object-store backend; cold read hits `CatalogCache`.
+* Mixed-read: a legacy flat catalog and a new tenant-prefixed catalog coexist; readers pick the right layout by marker.
+* Structural isolation: two tenants' assets land under distinct `…/{tenant}/…` prefixes; a tenant cannot read another tenant's collection; DDL/DML cannot target `_operator`/`system`.
+* Serverless: server restart re-reads the catalog from object storage (not `/tmp`); collections survive the restart.
+* Promotion is gated on these tests green with the gate ON, while the gate-OFF (legacy) path stays green — the migration mandate's round-trip requirement.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -101,6 +101,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Unified Hot-Path Trace+Meter Emission Seam (one I/O boundary, two structurally-separate sinks)
 | Proposed
 | Implements ADR-027's two-class trace via the per-query `tokio::task_local!` `IO_TRACE` accumulator: it is fed at the `read_range` GET boundary (no tenant needed), drained ONCE at scope-close (where tenant+engine are known), and fans the same snapshot to THREE observers — route-cost + cache (gateable perf, → `avg_get_size` for the cost model + adaptive engine, TD-158) and a NEW billing observer (always-on) that closes the verified **KRU** read-meter (`record_task_execution_time`) gap. **KSU** (storage accrual) is explicitly scoped out as the sibling write-path/periodic gap. Same measured snapshot ⇒ cost-model bytes == billing bytes (no divergence). Honors ADR-027 non-entanglement (separate sinks; billing never gated; CI guard) and the open-core boundary (OSS emits neutral units; AnvaiOps prices them). Closes the cost model's INPUT side only — routing-loop closure is a separate ADR. Tracked: TD-158 + KRU; prereq TD-160
+
+| link:ADR-032-durable-tenant-prefixed-object-store-catalog.adoc[ADR-032]
+| Durable, Tenant-Prefixed Object-Store Catalog (the catalog as the serverless shared truth; structural isolation, not a per-query predicate)
+| Proposed
+| An audit found the catalog is not yet durable on object storage (cloud URLs cached to `/tmp`; now fail-closed via PR #410), its metadata bypasses the `DrPathBuilder` tenant prefix (the one non-isolated surface), and the service-layer per-query tenant predicate is inert in production (no `with_tenant_manager` caller) and is the wrong mechanism. Decision: persist `NativeCatalog` through the existing `FilesystemFactory` (cloud backends already write — a wiring job, not a new client), address catalog assets through `DrPathBuilder` (`data/{tenant}/{ns}/…`, Phase-5 `accounts/{account}/…`), record tenant via `create_namespace_for_tenant`, and move isolation to the network edge (explicit fail-closed `DeploymentMode`) + the path — retiring the inert predicate. Mixed-read-safe, marker-detected, default-OFF, migration tool. Operator catalog stays in AnvaiOps; object-store IAM is future work. Tracked: TD-CAT-1/2/3, TD-113, TD-119, TD-164
 |===
 
 NOTE: ADR-010 through ADR-013 exist in this directory but are not yet


### PR DESCRIPTION
## Summary
ADR for **Phase 1** of the audit-driven catalog/tenant-isolation hardening program: make the native catalog a **durable, object-store-backed, tenant-prefixed, fail-closed** control surface — the single shared truth a serverless deployment needs — and move tenant isolation from the **inert per-query service predicate** to the **structural path + network edge**.

## Why now
A multi-agent audit found:
- **F1** the catalog isn't durable on object storage (cloud URLs were cached to `/tmp`; PR #410 made that fail-closed, this makes it *work*);
- **F2** catalog metadata bypasses the `DrPathBuilder` tenant prefix — the one surface where tenant data isn't path-isolated;
- **F3** the `tenant_context.filter(|_| tenant_manager.is_some())` service-layer check is **inert in production** (no `with_tenant_manager` caller) *and* is the wrong mechanism per the co-design mandate (isolation must be structural, not a per-query predicate).

## Decision (4 parts)
- **D1** persist `NativeCatalog` through the existing `FilesystemFactory` (cloud backends already write — wiring, not a new client);
- **D2** address catalog assets through `DrPathBuilder` (`data/{tenant}/{ns}/…`, Phase-5 `accounts/{account}/…`) + record tenant via `create_namespace_for_tenant`;
- **D3** explicit fail-closed `DeploymentMode` at the edge; retire the inert predicate;
- **D4** mixed-read-safe, marker-detected, default-OFF, with a migration tool.

Operator catalog stays externalized to AnvaiOps; a separate object-store IAM policy is acknowledged as future work.

## Scope
Doc-only. Implementation lands as separate gated PRs (TD-CAT-1/2/3) per the rollout section. Renders clean under `asciidoctor`; indexed in the ADR README.