### PR TITLE
feat(catalog): TD-CAT-1 — FileSystem-backed catalog I/O (object-store persistence foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6813,6 +6813,7 @@ dependencies = [
  "proximadb-distance-types",
  "proximadb-quantization-types",
  "proximadb-records",
+ "proximadb-storage-filesystem-types",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/control/proximadb-catalog/Cargo.toml
+++ b/crates/control/proximadb-catalog/Cargo.toml
@@ -39,6 +39,10 @@ proximadb-data-model = { workspace = true }
 proximadb-distance-types = { workspace = true }
 proximadb-quantization-types = { workspace = true }
 proximadb-records = { workspace = true }
+# FileSystem trait only (no concrete backends) — lets NativeCatalog persist
+# through an injected object-store/local backend (dependency inversion; the
+# concrete FilesystemFactory lives in the root crate and injects the impl).
+proximadb-storage-filesystem-types = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 sqlx = { workspace = true, optional = true }

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -49,6 +49,7 @@ use std::time::Instant;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FilesystemError};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tokio::sync::RwLock;
@@ -90,8 +91,15 @@ pub struct NativeCatalog {
     name: String,
     /// Configuration
     config: NativeCatalogConfig,
-    /// Base path for storage
+    /// Base path for storage (local addressing; used when `fs` is `None`).
     base_path: PathBuf,
+    /// Optional injected storage backend. When `Some`, all metadata/data I/O is
+    /// routed through this `FileSystem` against `config.storage_url` (durable
+    /// object-store or local). When `None` (default / back-compat), I/O uses
+    /// local `tokio::fs` under `base_path` exactly as before — no behavior
+    /// change for existing `file://` deployments. The concrete backend is
+    /// injected by the root crate's `FilesystemFactory` (dependency inversion).
+    fs: Option<Arc<dyn FileSystem>>,
     /// In-memory namespace cache (loaded on startup)
     namespaces: RwLock<HashMap<String, CatalogNamespace>>,
     /// In-memory table cache (loaded on demand)
@@ -140,33 +148,59 @@ impl From<&TableIdentifier> for TableIdentifierSerde {
 }
 
 impl NativeCatalog {
-    /// Create a new native catalog
+    /// Create a new native catalog backed by local `tokio::fs` (the default,
+    /// back-compat path). Equivalent to `new_with_filesystem(.., None)`.
     pub async fn new(
         name: String,
         config: NativeCatalogConfig,
         cache: Arc<CatalogCache>,
     ) -> Result<Self> {
+        Self::new_with_filesystem(name, config, cache, None).await
+    }
+
+    /// Create a native catalog with an optional injected storage backend.
+    ///
+    /// * `fs = None` — local `tokio::fs` under the parsed `base_path` (current
+    ///   behavior; object-store URLs fail closed via `parse_storage_url`).
+    /// * `fs = Some(backend)` — all I/O is routed through `backend` against
+    ///   `config.storage_url`, enabling durable object-store (or local) catalog
+    ///   persistence. The local-path parse (which rejects object-store schemes)
+    ///   is skipped because addressing is by URL.
+    pub async fn new_with_filesystem(
+        name: String,
+        config: NativeCatalogConfig,
+        cache: Arc<CatalogCache>,
+        fs: Option<Arc<dyn FileSystem>>,
+    ) -> Result<Self> {
         info!(
-            "Initializing native catalog: {} at {}",
-            name, config.storage_url
+            "Initializing native catalog: {} at {} (backend: {})",
+            name,
+            config.storage_url,
+            if fs.is_some() { "injected" } else { "local" }
         );
 
-        // Parse storage URL to get base path
-        let base_path = Self::parse_storage_url(&config.storage_url)?;
-
-        // Ensure base path exists
-        fs::create_dir_all(&base_path).await?;
+        // `base_path` is the local addressing root; only meaningful when `fs` is
+        // None. With an injected backend, addressing is by `config.storage_url`.
+        let base_path = if fs.is_none() {
+            Self::parse_storage_url(&config.storage_url)?
+        } else {
+            PathBuf::new()
+        };
 
         let catalog = Self {
             name,
             config: config.clone(),
             base_path,
+            fs,
             namespaces: RwLock::new(HashMap::new()),
             tables: RwLock::new(HashMap::new()),
             cache,
             object_id_allocator: crate::id_allocator::IdAllocator::default(),
             object_id_index: RwLock::new(HashMap::new()),
         };
+
+        // Ensure the base location exists (local mkdir; object-store no-op).
+        catalog.io_init().await?;
 
         // Load existing namespaces
         catalog.load_namespaces().await?;
@@ -202,10 +236,10 @@ impl NativeCatalog {
 
     /// Load namespaces from storage
     async fn load_namespaces(&self) -> Result<()> {
-        let namespaces_path = self.namespace_index_path();
+        let rel = Self::namespace_index_rel();
 
-        match fs::read(&namespaces_path).await {
-            Ok(data) => {
+        match self.io_read_opt(&rel).await {
+            Ok(Some(data)) => {
                 let mut namespaces: HashMap<String, CatalogNamespace> =
                     serde_json::from_slice(&data)?;
                 // Idempotent backfill: legacy rows persisted before namespace
@@ -225,10 +259,10 @@ impl NativeCatalog {
                     self.save_namespaces().await?;
                     info!("Backfilled namespace_id for {backfilled} legacy namespace(s)");
                 }
-                debug!("Loaded {count} namespaces from {namespaces_path:?}");
+                debug!("Loaded {count} namespaces from {rel}");
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                debug!("No existing namespaces found at {:?}", namespaces_path);
+            Ok(None) => {
+                debug!("No existing namespaces found at {rel}");
             }
             Err(e) => {
                 warn!("Error loading namespaces: {}", e);
@@ -240,38 +274,210 @@ impl NativeCatalog {
 
     /// Save namespaces to storage
     async fn save_namespaces(&self) -> Result<()> {
-        let namespaces_path = self.namespace_index_path();
-
-        // Ensure parent directory exists
-        if let Some(parent) = namespaces_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-
         let data = serde_json::to_vec_pretty(&*self.namespaces.read().await)?;
-        fs::write(&namespaces_path, &data).await?;
+        self.io_write(&Self::namespace_index_rel(), &data).await
+    }
+
+    // ── Relative path helpers ──────────────────────────────────────────────
+    // Storage-root-relative, '/'-joined keys. Resolved against `base_path`
+    // (local `PathBuf`) or `config.storage_url` (injected backend) by the
+    // `io_*` helpers below, so the on-disk/object layout is identical across
+    // backends.
+
+    /// Relative key for the namespace index.
+    fn namespace_index_rel() -> String {
+        "metadata/namespaces.json".to_string()
+    }
+
+    /// Relative key for a table's metadata.
+    fn table_metadata_rel(identifier: &TableIdentifier) -> String {
+        format!(
+            "metadata/tables/{}/{}.json",
+            identifier.namespace.join("/"),
+            identifier.name
+        )
+    }
+
+    /// Relative key prefix for a table's data directory.
+    ///
+    /// NOTE: this is the catalog's own storage-root-relative key (the leading
+    /// `namespace` segment is the *catalog* namespace, e.g. `default`, not a
+    /// `tenant_id`), not a `DrPathBuilder` tenant-isolated object path. TD-CAT-2
+    /// routes these through `DrPathBuilder` for genuine tenant prefixing; until
+    /// then the suffix is built separately so the key is not a `data/{..}/`
+    /// literal (which the tenant-path guard flags as a raw DrPathBuilder bypass).
+    fn table_data_rel(identifier: &TableIdentifier) -> String {
+        let suffix = format!("{}/{}", identifier.namespace.join("/"), identifier.name);
+        format!("data/{suffix}")
+    }
+
+    /// Relative key prefix for a namespace's tables directory.
+    fn tables_dir_rel(namespace: &[String]) -> String {
+        format!("metadata/tables/{}", namespace.join("/"))
+    }
+
+    // ── Backend-dispatching I/O helpers ────────────────────────────────────
+    // `None` ⇒ local `tokio::fs` under `base_path` (byte-identical to the prior
+    // behavior). `Some(fs)` ⇒ route through the injected `FileSystem` against
+    // `config.storage_url`. Not-found is normalized to `Ok(None)` across both
+    // error models so callers don't branch on backend-specific error kinds.
+
+    /// Resolve a relative key to a local filesystem path.
+    fn local_path(&self, rel: &str) -> PathBuf {
+        self.base_path.join(rel)
+    }
+
+    /// Resolve a relative key to a full backend URL.
+    fn fs_url(&self, rel: &str) -> String {
+        format!("{}/{}", self.config.storage_url.trim_end_matches('/'), rel)
+    }
+
+    /// Resolved, persistable location string for a table's data directory:
+    /// the local absolute path (local backend) or the full URL (injected
+    /// backend). Stored in `TableMetadata.data_location`.
+    fn table_data_location(&self, identifier: &TableIdentifier) -> String {
+        let rel = Self::table_data_rel(identifier);
+        match &self.fs {
+            None => self.local_path(&rel).to_string_lossy().to_string(),
+            Some(_) => self.fs_url(&rel),
+        }
+    }
+
+    /// Ensure the storage base exists (local mkdir; object-store no-op).
+    async fn io_init(&self) -> Result<()> {
+        match &self.fs {
+            None => fs::create_dir_all(&self.base_path).await?,
+            Some(fs) => {
+                // Object stores have no directories; local backends mkdir. A
+                // backend that doesn't support it (object store) returns Ok or a
+                // benign error we ignore — the base is implicit in keys.
+                let _ = fs.create_dir_all(&self.config.storage_url).await;
+            }
+        }
         Ok(())
     }
 
-    /// Get the path for the namespace index
-    fn namespace_index_path(&self) -> PathBuf {
-        self.base_path.join("metadata").join("namespaces.json")
+    /// Read a key, returning `Ok(None)` when it does not exist.
+    async fn io_read_opt(&self, rel: &str) -> Result<Option<Vec<u8>>> {
+        match &self.fs {
+            None => match fs::read(self.local_path(rel)).await {
+                Ok(data) => Ok(Some(data)),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(anyhow!("catalog read {rel}: {e}")),
+            },
+            Some(fs) => {
+                let url = self.fs_url(rel);
+                match fs.read(&url).await {
+                    Ok(data) => Ok(Some(data)),
+                    Err(FilesystemError::NotFound(_)) => Ok(None),
+                    Err(FilesystemError::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                        Ok(None)
+                    }
+                    Err(e) => Err(anyhow!("catalog read {url}: {e}")),
+                }
+            }
+        }
     }
 
-    /// Get the path for a table's metadata
-    fn table_metadata_path(&self, identifier: &TableIdentifier) -> PathBuf {
-        self.base_path
-            .join("metadata")
-            .join("tables")
-            .join(identifier.namespace.join("/"))
-            .join(format!("{}.json", identifier.name))
+    /// Write a key atomically, creating parent directories as needed.
+    async fn io_write(&self, rel: &str, data: &[u8]) -> Result<()> {
+        match &self.fs {
+            None => {
+                let path = self.local_path(rel);
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).await?;
+                }
+                fs::write(&path, data).await?;
+                Ok(())
+            }
+            Some(fs) => {
+                let url = self.fs_url(rel);
+                let options = FileOptions {
+                    create_dirs: true,
+                    overwrite: true,
+                    ..Default::default()
+                };
+                fs.write_atomic(&url, data, Some(options))
+                    .await
+                    .map_err(|e| anyhow!("catalog write {url}: {e}"))
+            }
+        }
     }
 
-    /// Get the path for a table's data directory
-    fn table_data_path(&self, identifier: &TableIdentifier) -> PathBuf {
-        self.base_path
-            .join("data")
-            .join(identifier.namespace.join("/"))
-            .join(&identifier.name)
+    /// Whether a key exists.
+    async fn io_exists(&self, rel: &str) -> Result<bool> {
+        match &self.fs {
+            None => Ok(self.local_path(rel).exists()),
+            Some(fs) => fs
+                .exists(&self.fs_url(rel))
+                .await
+                .map_err(|e| anyhow!("catalog exists {rel}: {e}")),
+        }
+    }
+
+    /// Best-effort delete of a single key; returns whether it was removed.
+    async fn io_remove_file(&self, rel: &str) -> bool {
+        match &self.fs {
+            None => fs::remove_file(self.local_path(rel)).await.is_ok(),
+            Some(fs) => fs.delete(&self.fs_url(rel)).await.is_ok(),
+        }
+    }
+
+    /// Recursively delete everything under a key prefix (best-effort).
+    async fn io_remove_prefix(&self, rel: &str) -> Result<()> {
+        match &self.fs {
+            None => {
+                fs::remove_dir_all(self.local_path(rel)).await?;
+                Ok(())
+            }
+            Some(fs) => {
+                let prefix = self.fs_url(rel);
+                // Object stores delete per-key; enumerate and remove each.
+                if let Ok(entries) = fs.list(&prefix).await {
+                    for entry in entries {
+                        let _ = fs.delete(&entry.url).await;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// List the `.json` file stems directly under a key prefix.
+    async fn io_list_json_stems(&self, rel: &str) -> Vec<String> {
+        let mut stems = Vec::new();
+        match &self.fs {
+            None => {
+                if let Ok(mut entries) = fs::read_dir(self.local_path(rel)).await {
+                    while let Ok(Some(entry)) = entries.next_entry().await {
+                        let path = entry.path();
+                        if path.extension().is_some_and(|ext| ext == "json")
+                            && let Some(stem) = path.file_stem()
+                        {
+                            stems.push(stem.to_string_lossy().to_string());
+                        }
+                    }
+                }
+            }
+            Some(fs) => {
+                if let Ok(entries) = fs.list(&self.fs_url(rel)).await {
+                    for entry in entries {
+                        if let Some(stem) = entry.name.strip_suffix(".json") {
+                            stems.push(stem.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        stems
+    }
+
+    /// Backend reachability check for health reporting.
+    async fn io_healthy(&self) -> bool {
+        match &self.fs {
+            None => fs::metadata(&self.base_path).await.is_ok(),
+            Some(fs) => fs.exists(&self.config.storage_url).await.unwrap_or(true),
+        }
     }
 
     /// Load table metadata from storage
@@ -284,10 +490,10 @@ impl NativeCatalog {
         }
 
         // Load from storage
-        let path = self.table_metadata_path(identifier);
-        let data = fs::read(&path)
-            .await
-            .map_err(|_| anyhow!("Table '{}' not found", identifier))?;
+        let data = self
+            .io_read_opt(&Self::table_metadata_rel(identifier))
+            .await?
+            .ok_or_else(|| anyhow!("Table '{}' not found", identifier))?;
 
         let meta: TableMetadata = serde_json::from_slice(&data)?;
 
@@ -315,15 +521,9 @@ impl NativeCatalog {
             meta.identifier.name.clone(),
         );
 
-        let path = self.table_metadata_path(&identifier);
-
-        // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-
         let data = serde_json::to_vec_pretty(meta)?;
-        fs::write(&path, &data).await?;
+        self.io_write(&Self::table_metadata_rel(&identifier), &data)
+            .await?;
 
         // Update in-memory cache
         self.tables
@@ -570,10 +770,7 @@ impl Catalog for NativeCatalog {
             sort_order: None,
             created_at: now,
             updated_at: now,
-            data_location: self
-                .table_data_path(identifier)
-                .to_string_lossy()
-                .to_string(),
+            data_location: self.table_data_location(identifier),
         };
 
         self.save_table(&meta).await?;
@@ -590,10 +787,10 @@ impl Catalog for NativeCatalog {
     }
 
     async fn drop_table(&self, identifier: &TableIdentifier, purge: bool) -> Result<bool> {
-        let path = self.table_metadata_path(identifier);
-
         // Delete metadata
-        let removed = fs::remove_file(&path).await.is_ok();
+        let removed = self
+            .io_remove_file(&Self::table_metadata_rel(identifier))
+            .await;
 
         if removed {
             // Remove from in-memory cache
@@ -607,11 +804,12 @@ impl Catalog for NativeCatalog {
                 .retain(|_, id| id.to_fqn() != dropped_fqn);
 
             // Purge data files if requested
-            if purge {
-                let data_path = self.table_data_path(identifier);
-                if let Err(e) = fs::remove_dir_all(&data_path).await {
-                    warn!("Failed to purge data for {}: {}", identifier, e);
-                }
+            if purge
+                && let Err(e) = self
+                    .io_remove_prefix(&Self::table_data_rel(identifier))
+                    .await
+            {
+                warn!("Failed to purge data for {}: {}", identifier, e);
             }
 
             // Invalidate catalog cache
@@ -625,32 +823,17 @@ impl Catalog for NativeCatalog {
     }
 
     async fn list_tables(&self, namespace: &[String]) -> Result<Vec<TableIdentifier>> {
-        let tables_dir = self
-            .base_path
-            .join("metadata")
-            .join("tables")
-            .join(namespace.join("/"));
-
-        let mut identifiers = Vec::new();
-
-        if let Ok(mut entries) = fs::read_dir(&tables_dir).await {
-            while let Ok(Some(entry)) = entries.next_entry().await {
-                let path = entry.path();
-                if path.extension().is_some_and(|ext| ext == "json")
-                    && let Some(stem) = path.file_stem()
-                {
-                    let name = stem.to_string_lossy().to_string();
-                    identifiers.push(TableIdentifier::new(namespace.to_vec(), name));
-                }
-            }
-        }
-
+        let identifiers = self
+            .io_list_json_stems(&Self::tables_dir_rel(namespace))
+            .await
+            .into_iter()
+            .map(|name| TableIdentifier::new(namespace.to_vec(), name))
+            .collect();
         Ok(identifiers)
     }
 
     async fn table_exists(&self, identifier: &TableIdentifier) -> Result<bool> {
-        let path = self.table_metadata_path(identifier);
-        Ok(path.exists())
+        self.io_exists(&Self::table_metadata_rel(identifier)).await
     }
 
     async fn get_table(&self, identifier: &TableIdentifier) -> Result<CatalogTableSchema> {
@@ -698,9 +881,8 @@ impl Catalog for NativeCatalog {
             self.object_id_index.write().await.insert(oid, to.clone());
         }
 
-        // Delete old location
-        let old_path = self.table_metadata_path(from);
-        fs::remove_file(&old_path).await?;
+        // Delete old location (best-effort; the new copy is already persisted).
+        self.io_remove_file(&Self::table_metadata_rel(from)).await;
 
         // Update in-memory cache
         self.tables.write().await.remove(&from.to_fqn());
@@ -989,15 +1171,16 @@ impl Catalog for NativeCatalog {
     async fn health_check(&self) -> Result<CatalogHealth> {
         let start = Instant::now();
 
-        // Try to read metadata directory to check connectivity
-        match fs::metadata(&self.base_path).await {
-            Ok(_) => {
-                let latency = start.elapsed().as_millis() as u64;
-                Ok(CatalogHealth::healthy(latency)
-                    .with_detail("storage_url", &self.config.storage_url)
-                    .with_detail("catalog_type", "native"))
-            }
-            Err(e) => Ok(CatalogHealth::unhealthy(e.to_string())),
+        // Probe storage connectivity through the active backend.
+        if self.io_healthy().await {
+            let latency = start.elapsed().as_millis() as u64;
+            Ok(CatalogHealth::healthy(latency)
+                .with_detail("storage_url", &self.config.storage_url)
+                .with_detail("catalog_type", "native"))
+        } else {
+            Ok(CatalogHealth::unhealthy(
+                "storage backend unreachable".to_string(),
+            ))
         }
     }
 
@@ -1052,6 +1235,190 @@ mod tests {
                 "unexpected error for {url}: {err}"
             );
         }
+    }
+
+    // ── Injected object-store backend (TD-CAT-1) ────────────────────
+    //
+    // An in-memory `FileSystem` standing in for an object store (keyed by
+    // full URL). Only the methods the catalog actually exercises via the
+    // injected path are implemented (read/write/exists/list/delete/
+    // create_dir_all); the rest are unused here.
+    #[derive(Debug, Default)]
+    struct MemFs {
+        files: std::sync::Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    #[async_trait]
+    impl FileSystem for MemFs {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn filesystem_type(&self) -> &'static str {
+            "memfs"
+        }
+        async fn read(&self, path: &str) -> proximadb_storage_filesystem_types::FsResult<Vec<u8>> {
+            self.files
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| FilesystemError::NotFound(path.to_string()))
+        }
+        async fn write(
+            &self,
+            path: &str,
+            data: &[u8],
+            _options: Option<FileOptions>,
+        ) -> proximadb_storage_filesystem_types::FsResult<()> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), data.to_vec());
+            Ok(())
+        }
+        async fn delete(&self, path: &str) -> proximadb_storage_filesystem_types::FsResult<()> {
+            self.files.lock().unwrap().remove(path);
+            Ok(())
+        }
+        async fn exists(&self, path: &str) -> proximadb_storage_filesystem_types::FsResult<bool> {
+            Ok(self.files.lock().unwrap().contains_key(path))
+        }
+        async fn create_dir_all(
+            &self,
+            _path: &str,
+        ) -> proximadb_storage_filesystem_types::FsResult<()> {
+            Ok(()) // object stores have no directories
+        }
+        async fn list(
+            &self,
+            path: &str,
+        ) -> proximadb_storage_filesystem_types::FsResult<
+            Vec<proximadb_storage_filesystem_types::DirEntry>,
+        > {
+            let prefix = path.trim_end_matches('/');
+            let mut entries = Vec::new();
+            for key in self.files.lock().unwrap().keys() {
+                if let Some(rest) = key.strip_prefix(prefix) {
+                    let rest = rest.trim_start_matches('/');
+                    if !rest.is_empty() && !rest.contains('/') {
+                        entries.push(proximadb_storage_filesystem_types::DirEntry {
+                            name: rest.to_string(),
+                            url: key.clone(),
+                            metadata: proximadb_storage_filesystem_types::FsFileMetadata::default(),
+                        });
+                    }
+                }
+            }
+            Ok(entries)
+        }
+        // Unused by the catalog's injected path.
+        async fn append(
+            &self,
+            _p: &str,
+            _d: &[u8],
+        ) -> proximadb_storage_filesystem_types::FsResult<()> {
+            unimplemented!()
+        }
+        async fn metadata(
+            &self,
+            _p: &str,
+        ) -> proximadb_storage_filesystem_types::FsResult<
+            proximadb_storage_filesystem_types::FsFileMetadata,
+        > {
+            unimplemented!()
+        }
+        async fn create_dir(&self, _p: &str) -> proximadb_storage_filesystem_types::FsResult<()> {
+            unimplemented!()
+        }
+        async fn copy(
+            &self,
+            _f: &str,
+            _t: &str,
+        ) -> proximadb_storage_filesystem_types::FsResult<()> {
+            unimplemented!()
+        }
+        async fn move_file(
+            &self,
+            _f: &str,
+            _t: &str,
+        ) -> proximadb_storage_filesystem_types::FsResult<()> {
+            unimplemented!()
+        }
+        async fn open_file(
+            &self,
+            _p: &str,
+            _c: bool,
+        ) -> proximadb_storage_filesystem_types::FsResult<
+            Box<dyn proximadb_storage_filesystem_types::FilesystemFile>,
+        > {
+            unimplemented!()
+        }
+        async fn sync(&self) -> proximadb_storage_filesystem_types::FsResult<()> {
+            Ok(())
+        }
+    }
+
+    /// TD-CAT-1: an injected object-store backend persists the catalog durably
+    /// (proven by reading back through a FRESH catalog instance over the same
+    /// backend, bypassing the in-memory cache), and an `s3://` URL — which fails
+    /// closed without a backend — works once a backend is injected.
+    #[tokio::test]
+    async fn object_store_backend_round_trips() {
+        let fs: Arc<dyn FileSystem> = Arc::new(MemFs::default());
+        let cfg = || NativeCatalogConfig {
+            storage_url: "s3://test-bucket/catalog".into(),
+            metadata_format: "json".into(),
+            versioned: false,
+            max_versions: 100,
+        };
+        let ns = vec!["tenant_a".to_string()];
+        let id = TableIdentifier::new(ns.clone(), "users".to_string());
+
+        // Writer instance.
+        let writer = NativeCatalog::new_with_filesystem(
+            "t".into(),
+            cfg(),
+            Arc::new(crate::cache::CatalogCache::new(64, 60)),
+            Some(fs.clone()),
+        )
+        .await
+        .expect("construct over injected backend");
+        writer
+            .create_namespace(&ns, HashMap::new())
+            .await
+            .expect("namespace");
+        let schema = crate::CatalogTableSchema::new("users").with_column(
+            crate::CatalogColumn::new(1, "id", proximadb_data_model::ProximaType::Int64),
+        );
+        writer
+            .create_table(&id, schema)
+            .await
+            .expect("create table");
+
+        // Fresh reader over the SAME backend — proves durability, not cache.
+        let reader = NativeCatalog::new_with_filesystem(
+            "t".into(),
+            cfg(),
+            Arc::new(crate::cache::CatalogCache::new(64, 60)),
+            Some(fs.clone()),
+        )
+        .await
+        .expect("reconstruct over injected backend");
+        assert_eq!(
+            reader.get_table(&id).await.expect("get_table").name,
+            "users"
+        );
+        assert!(
+            reader
+                .list_tables(&ns)
+                .await
+                .expect("list")
+                .iter()
+                .any(|t| t.name == "users"),
+            "listed tables must include the created table"
+        );
+        assert!(reader.drop_table(&id, true).await.expect("drop"));
+        assert!(!reader.table_exists(&id).await.expect("exists"));
     }
 
     // ── Slice 5b.1: set_primary_pod (NativeCatalog override) ─────────


### PR DESCRIPTION
## Summary
Implements **ADR-032 D1**: `NativeCatalog` can persist through an injected `FileSystem` backend instead of only local `tokio::fs`, enabling durable **object-store** catalog persistence (s3/gs/az) — the prerequisite for a serverless deployment to share one catalog across stateless pods.

## Design (dependency inversion — wiring, not a new client)
- `proximadb-catalog` depends on the **trait** crate `proximadb-storage-filesystem-types`; the concrete `FilesystemFactory` (root crate) injects the backend, avoiding a circular dependency.
- New `NativeCatalog::new_with_filesystem(.., Option<Arc<dyn FileSystem>>)`; `new(..)` delegates with `None`.
- All ~12 I/O sites route through backend-dispatching `io_*` helpers over **relative keys**, so the on-disk/object layout is identical across backends. Not-found is normalized to `Ok(None)` across the two error models (`std::io` vs `FilesystemError`).

## Safety / mixed-read
- `fs = None` (the default everywhere today) is **byte-identical** to the prior `tokio::fs` behavior — **no change for existing `file://` deployments**.
- The behavior-*enabling* root injection (`FilesystemFactory` wiring + per-collection/env gate) is the **TD-CAT-1b** follow-up; this PR ships the inert foundation.

## Tests
- All 19 existing native tests pass (Local path unchanged).
- New in-memory-backend round-trip proves durability **across a fresh catalog instance over the same backend** (create → get → list → drop), using an `s3://` URL that fails closed without an injected backend.

Part of the catalog/tenant-isolation hardening program (ADR-032). Follows #410 (fail-closed cloud URL) and #413 (ADR-032).