### PR TITLE
perf(storage): TD-167 collapse PAX read-path depth — batch surviving block bodies (ADR-034 P1)

### DIFF
--- a/crates/storage/proximadb-iceberg-engine/src/lib.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/lib.rs
@@ -352,6 +352,24 @@ impl ObjectStoreBridge for IcebergObjectStoreBridge {
             .to_vec())
     }
 
+    /// TD-167 / ADR-034 P1: batched multi-range GET via `object_store::get_ranges`,
+    /// which coalesces adjacent ranges and issues the reads concurrently — so K
+    /// surviving block bodies cost ~one round-trip instead of K serial GETs.
+    async fn fetch_vector_segment_ranges(
+        &self,
+        path: &Path,
+        ranges: &[std::ops::Range<u64>],
+        _tenant_id: Option<&str>,
+    ) -> Result<Vec<Vec<u8>>, StorageError> {
+        Ok(self
+            .store
+            .get_ranges(path, ranges)
+            .await?
+            .into_iter()
+            .map(|b| b.to_vec())
+            .collect())
+    }
+
     async fn persist_vector_segment(
         &self,
         path: &Path,

--- a/crates/storage/proximadb-object-store/src/lib.rs
+++ b/crates/storage/proximadb-object-store/src/lib.rs
@@ -162,6 +162,21 @@ impl ProximaObjectStore {
             .map_err(|e| os_err("get_range", e))
     }
 
+    /// Read **multiple** byte ranges of the object at `path` in one batched call.
+    /// `object_store::get_ranges` coalesces adjacent ranges and issues them
+    /// concurrently, so K block-body reads cost ~one round-trip instead of K
+    /// serial GETs — the depth-collapse primitive for TD-167 / ADR-034 P1.
+    pub async fn get_ranges(
+        &self,
+        path: &Path,
+        ranges: &[Range<u64>],
+    ) -> Result<Vec<Bytes>, StorageError> {
+        self.store
+            .get_ranges(&self.full_path(path), ranges)
+            .await
+            .map_err(|e| os_err("get_ranges", e))
+    }
+
     /// Fetch object metadata (size, last-modified, e-tag) for `path` WITHOUT
     /// reading the body.
     ///

--- a/crates/storage/proximadb-storage-common/src/object_store_bridge.rs
+++ b/crates/storage/proximadb-storage-common/src/object_store_bridge.rs
@@ -117,6 +117,31 @@ pub trait ObjectStoreBridge: Send + Sync {
         Ok(whole[start..end].to_vec())
     }
 
+    /// Read **multiple** byte ranges of a PAX segment in one batched operation —
+    /// the depth-collapsing primitive for object storage (TD-167 / ADR-034 P1). A
+    /// pruned read fetches all surviving block bodies through this call instead of
+    /// issuing one *dependent* ranged GET per block, turning `O(K)` serial
+    /// round-trips into a single batched op (latency = depth × RTT, so batching K
+    /// independent reads is one RTT, not K). Returns one buffer per input range, in
+    /// order. The default loops [`fetch_vector_segment_range`] (correct, no I/O
+    /// saving); object-store-backed implementations SHOULD override with
+    /// `FileSystem::read_ranges` so the ranges coalesce/parallelize on the wire.
+    async fn fetch_vector_segment_ranges(
+        &self,
+        path: &Path,
+        ranges: &[std::ops::Range<u64>],
+        tenant_id: Option<&str>,
+    ) -> Result<Vec<Vec<u8>>, StorageError> {
+        let mut out = Vec::with_capacity(ranges.len());
+        for r in ranges {
+            out.push(
+                self.fetch_vector_segment_range(path, r.start, r.end - r.start, tenant_id)
+                    .await?,
+            );
+        }
+        Ok(out)
+    }
+
     /// Persists a specialized PAX block or Segment to decoupled object storage.
     /// Implementers MUST emit `proximadb_object_store_ops_total` and `proximadb_storage_bytes_seconds` for billing.
     async fn persist_vector_segment(

--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -216,6 +216,28 @@ impl<'b> RangedSegmentReader<'b> {
         Ok(out)
     }
 
+    /// Batched multi-range fetch (TD-167 / ADR-034 P1): fetch every range in a
+    /// single bridge call so K independent block-body reads cost **one** logical
+    /// round-trip, not K serial GETs. Counted as a single `range_gets` because
+    /// latency = depth × RTT and a batched read is depth 1 (the bridge coalesces /
+    /// parallelizes the ranges on the wire). Bytes are summed across the buffers.
+    async fn fetch_ranges(
+        &self,
+        ranges: &[std::ops::Range<u64>],
+    ) -> Result<Vec<Vec<u8>>, StorageError> {
+        if ranges.is_empty() {
+            return Ok(Vec::new());
+        }
+        let out = self
+            .bridge
+            .fetch_vector_segment_ranges(&self.path, ranges, self.tenant_id.as_deref())
+            .await?;
+        let total: u64 = out.iter().map(|b| b.len() as u64).sum();
+        self.bytes_read.fetch_add(total, Ordering::Relaxed);
+        self.range_gets.fetch_add(1, Ordering::Relaxed);
+        Ok(out)
+    }
+
     /// Assemble a block's [`BlockLayout`], consulting the footer cache first
     /// (a hit skips all footer/metadata ranged reads). Segments are immutable, so
     /// the `(tenant, segment#offset)` key needs no TTL/etag.
@@ -321,21 +343,29 @@ impl<'b> RangedSegmentReader<'b> {
         embedding_model_ids: &[String],
         user_column_keys: &[String],
     ) -> Result<Vec<ProximaRecord>, StorageError> {
-        let mut out = Vec::new();
+        // Phase 1 — prune from per-block metadata alone (footer/col-meta, footer-
+        // cached); no block body is fetched. Collect the surviving blocks' byte
+        // ranges.
+        let mut survivors: Vec<std::ops::Range<u64>> = Vec::new();
         for entry in &self.index.blocks {
             let (off, bsz) = (entry.offset, entry.size as u64);
             let layout = self.block_layout(off, bsz).await?;
-
-            // Block-level prune from metadata alone — no block body fetched.
             if evaluate_block(&*layout as &dyn BlockZoneSource, filter, field_to_col)
                 == PruneResult::Skip
             {
                 continue;
             }
+            survivors.push(off..off + bsz);
+        }
 
-            // Surviving block: fetch the whole block and reconstruct its rows.
-            let block_bytes = self.fetch(off, bsz).await?;
-            let reader = PaxBlockReader::open(&block_bytes).map_err(|e| fs_err("open block", e))?;
+        // Phase 2 — fetch ALL surviving block bodies in ONE batched multi-range op
+        // (depth 1) instead of K serial dependent GETs (TD-167 / ADR-034 P1).
+        let bodies = self.fetch_ranges(&survivors).await?;
+
+        // Phase 3 — decode each block's rows.
+        let mut out = Vec::new();
+        for block_bytes in &bodies {
+            let reader = PaxBlockReader::open(block_bytes).map_err(|e| fs_err("open block", e))?;
             for flat in FlatRow::from_block_reader(&reader).map_err(|e| fs_err("flat rows", e))? {
                 out.push(
                     flat.into_record(
@@ -383,6 +413,10 @@ mod tests {
     struct InMemoryRangeBridge {
         bytes: Vec<u8>,
         ranged_bytes: AtomicU64,
+        /// Count of single-range `fetch_vector_segment_range` calls.
+        single_calls: AtomicU64,
+        /// Count of batched `fetch_vector_segment_ranges` calls (TD-167).
+        batched_calls: AtomicU64,
     }
 
     #[async_trait]
@@ -436,11 +470,30 @@ mod tests {
             length: u64,
             _tenant_id: Option<&str>,
         ) -> Result<Vec<u8>, StorageError> {
+            self.single_calls.fetch_add(1, Ordering::Relaxed);
             let start = (offset as usize).min(self.bytes.len());
             let end = ((offset + length) as usize).min(self.bytes.len());
             self.ranged_bytes
                 .fetch_add((end - start) as u64, Ordering::Relaxed);
             Ok(self.bytes[start..end].to_vec())
+        }
+
+        async fn fetch_vector_segment_ranges(
+            &self,
+            _path: &Path,
+            ranges: &[std::ops::Range<u64>],
+            _tenant_id: Option<&str>,
+        ) -> Result<Vec<Vec<u8>>, StorageError> {
+            self.batched_calls.fetch_add(1, Ordering::Relaxed);
+            let mut out = Vec::with_capacity(ranges.len());
+            for r in ranges {
+                let start = (r.start as usize).min(self.bytes.len());
+                let end = (r.end as usize).min(self.bytes.len());
+                self.ranged_bytes
+                    .fetch_add((end - start) as u64, Ordering::Relaxed);
+                out.push(self.bytes[start..end].to_vec());
+            }
+            Ok(out)
         }
 
         async fn persist_vector_segment(
@@ -506,6 +559,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let footer_cache: Arc<FooterCache> = Arc::new(FooterCache::new(
             proximadb_cache::CacheBudget::new(1 << 30, 1 << 30),
@@ -591,6 +646,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes: bytes.clone(),
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
 
         let reader = RangedSegmentReader::open(&bridge, Path::from("seg.pax"), Some("t"))
@@ -627,6 +684,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let reader = RangedSegmentReader::open(&bridge, Path::from("seg.pax"), Some("t"))
             .await
@@ -666,6 +725,57 @@ mod tests {
         );
     }
 
+    /// TD-167 / ADR-034 P1: the surviving block bodies are fetched in exactly ONE
+    /// batched multi-range call regardless of how many blocks survive — collapsing
+    /// the read-path depth from `O(K)` serial body GETs to one batched op. (The
+    /// per-block metadata reads remain single-range here; eliminating them is the
+    /// follow-up zone-map-summary slice.)
+    #[tokio::test]
+    async fn td167_pruned_read_batches_surviving_block_bodies_in_one_call() {
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
+
+        let bytes = build_segment_bytes(2000, 32);
+        let bridge = InMemoryRangeBridge {
+            bytes,
+            ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
+        };
+        let reader = RangedSegmentReader::open(&bridge, Path::from("seg.pax"), Some("t"))
+            .await
+            .unwrap();
+        assert!(
+            reader.block_count() > 2,
+            "need several blocks to prove batching"
+        );
+
+        // Keep roughly the upper half ⇒ MANY surviving blocks.
+        let threshold = 1000 + 1000i64;
+        let filter = FilterExpression::Comparison {
+            field: "created_at".into(),
+            operator: ComparisonOperator::GreaterThanOrEqual,
+            value: serde_json::json!(threshold),
+        };
+        let field_to_col = |f: &str| match f {
+            "created_at" => Some(col_id::CREATED_AT),
+            _ => None,
+        };
+
+        let recs = reader
+            .read_records_pruned(&filter, &field_to_col, &[], &[])
+            .await
+            .unwrap();
+        assert!(!recs.is_empty(), "many blocks should survive the cut");
+
+        // The invariant: ONE batched body fetch, not one serial GET per surviving
+        // block. `range_gets` (logical round-trips) counts that batch as 1.
+        let batched = bridge.batched_calls.load(Ordering::Relaxed);
+        assert_eq!(
+            batched, 1,
+            "surviving block bodies must be one batched fetch, got {batched}"
+        );
+    }
+
     #[tokio::test]
     async fn footer_cache_hit_skips_metadata_reads() {
         // Second read of the same segment must skip footer/metadata ranged reads
@@ -674,6 +784,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let footer_cache: Arc<FooterCache> = Arc::new(FooterCache::new(
             proximadb_cache::CacheBudget::new(1 << 30, 1 << 30),
@@ -760,6 +872,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let footer_cache: Arc<FooterCache> = Arc::new(FooterCache::new(
             proximadb_cache::CacheBudget::new(1 << 30, 1 << 30),
@@ -810,6 +924,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let reader = RangedSegmentReader::open(&bridge, Path::from("seg.pax"), Some("t"))
             .await
@@ -848,6 +964,8 @@ mod tests {
         let bridge = InMemoryRangeBridge {
             bytes,
             ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
         };
         let footer_cache: Arc<FooterCache> = Arc::new(FooterCache::new(
             proximadb_cache::CacheBudget::new(1 << 30, 1 << 30),


### PR DESCRIPTION
## TD-167 / ADR-034 P1 — collapse the read-path dependency depth

A pruned PAX ranged read issued the surviving block bodies as **K serial dependent GETs** (one `fetch` per block in a loop, `ranged_segment.rs`). Since object-storage latency = dependency **DEPTH × RTT** (ADR-034 P1), that's `O(K)` round-trips for what are really K *independent* reads. This batches them into one.

### Change (additive, output-identical — no format change, no gate)
- **`ObjectStoreBridge`**: add `fetch_vector_segment_ranges(path, ranges, tenant)` with a **default impl that loops the existing single-range method** — so *every* existing impl keeps working unchanged. The production `IcebergObjectStoreBridge` overrides it to **`object_store::get_ranges`**, which coalesces adjacent ranges and issues them concurrently (≈one round-trip on the wire). Adds `ProximaObjectStore::get_ranges` delegating to the inner store.
- **`read_records_pruned`**: phase 1 prunes from per-block metadata (footer-cached, unchanged) collecting survivors; phase 2 fetches **all surviving block bodies in ONE batched call**; phase 3 decodes. Same byte ranges, same records → **output-identical**, no recall risk, no feature gate needed.

Result: surviving-body round-trips **`O(K)` → 1**.

### Scope (honest)
- This collapses the **body** reads. The per-block **metadata** reads remain single-range; eliminating them via a `SegmentIndex` zone-map summary (the riskier format-versioning work) is the **follow-up TD-167 slice**, deliberately separated.
- The win is proven **structurally** (the test asserts one batched call for many surviving blocks). Per mandate #6 this is **not** an end-to-end latency number — measuring the real round-trip/latency reduction needs a scale benchmark over a real object-store backend (the missing validation substrate; tracked separately).

### Verification
- New test `td167_pruned_read_batches_surviving_block_bodies_in_one_call`: a ~62-block segment with many survivors issues **exactly one** batched body fetch.
- Existing pruned / footer-cache / correctness tests stay green (**8/8**).
- Clippy clean (changed crates + CI-exact `-p proximadb --lib --bins`); server binary builds.