### PR TITLE
perf(storage): TD-167 follow-up — v2 zone-map SegmentIndex (prune with no per-block metadata GETs)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -37,11 +37,12 @@
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use anyhow::{Result, bail};
 use proximadb_block_format::{
-    BlockCompression, BlockMode, BlockStats, FlatRow, PaxBlockReader, PaxBlockWriter, VectorQuant,
-    header::fnv1a_hash,
+    BlockCompression, BlockMode, BlockStats, BlockZoneSource, ColumnMeta, FlatRow, PaxBlockReader,
+    PaxBlockWriter, RowGroupBlock, VectorQuant, col_id, header::fnv1a_hash,
 };
 use proximadb_records::ProximaRecord;
 use serde::{Deserialize, Serialize};
@@ -56,6 +57,223 @@ pub const SEGMENT_MAGIC: &[u8; 8] = b"PAXSEG01";
 
 // ── Segment index ─────────────────────────────────────────────────────────────
 
+/// Trailer marker for a **v2** segment index carrying per-block zone-map
+/// summaries (TD-167 follow-up / ADR-034 P1). v1 indexes lack it, so the reader
+/// detects the format by whether the bytes before [`SEGMENT_MAGIC`] end with this
+/// marker — keeping v1 byte-identical (old readers/segments unaffected).
+pub const ZONE_INDEX_MARKER: &[u8; 4] = b"PAXZ";
+
+// Bit positions in [`BlockZoneSummary::present`] — only the numeric canonical
+// columns predicate pushdown prunes on without decoding rows.
+const ZONE_CREATED_AT: u8 = 1 << 0;
+const ZONE_UPDATED_AT: u8 = 1 << 1;
+const ZONE_VALID_FROM: u8 = 1 << 2;
+const ZONE_VALID_TO: u8 = 1 << 3;
+const ZONE_EDGE_WEIGHT: u8 = 1 << 4;
+
+/// Serialized fixed width of a [`BlockZoneSummary`]: row_count(4) + present(1) +
+/// 4×(i64,i64)=64 + (f64,f64)=16.
+const ZONE_SUMMARY_BYTES: usize = 4 + 1 + 64 + 16;
+/// v2 per-block index entry width: offset(8) + size(4) + zone summary.
+const V2_ENTRY_BYTES: usize = 8 + 4 + ZONE_SUMMARY_BYTES;
+
+/// Fixed-width per-block zone-map summary embedded in a v2 segment index, so the
+/// reader can prune a block from the *cached index* with **zero** per-block
+/// footer/metadata GETs (cold-path depth 4→2). min/max are copied verbatim from
+/// the block's `ColumnMeta` (the same bounds the full-layout prune uses), so v2
+/// pruning is byte-for-byte identical to v1 for these predicates; columns absent
+/// from the summary fall through to "may match" (conservative — never skips a
+/// block wrongly).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BlockZoneSummary {
+    pub row_count: u32,
+    /// Bitmask of which canonical columns carry valid bounds.
+    pub present: u8,
+    pub created_at: (i64, i64),
+    pub updated_at: (i64, i64),
+    pub valid_from: (i64, i64),
+    pub valid_to: (i64, i64),
+    pub edge_weight: (f64, f64),
+}
+
+impl BlockZoneSummary {
+    /// An empty summary (no bounds) — used for blocks whose zone is unknown when
+    /// a v2 index is written.
+    pub fn empty(row_count: u32) -> Self {
+        Self {
+            row_count,
+            present: 0,
+            created_at: (0, 0),
+            updated_at: (0, 0),
+            valid_from: (0, 0),
+            valid_to: (0, 0),
+            edge_weight: (0.0, 0.0),
+        }
+    }
+
+    /// Extract the canonical-column bounds from a flushed block's column metadata.
+    /// A column with `distinct_hint == 0` (no usable bounds) is left out of
+    /// `present`.
+    pub fn from_column_metas(row_count: u32, metas: &[ColumnMeta]) -> Self {
+        let mut s = Self::empty(row_count);
+        for m in metas {
+            if m.distinct_hint == 0 {
+                continue;
+            }
+            let i64_lo = i64::from_le_bytes(m.min_val[0..8].try_into().unwrap_or([0; 8]));
+            let i64_hi = i64::from_le_bytes(m.max_val[0..8].try_into().unwrap_or([0; 8]));
+            match m.column_id {
+                col_id::CREATED_AT => {
+                    s.created_at = (i64_lo, i64_hi);
+                    s.present |= ZONE_CREATED_AT;
+                }
+                col_id::UPDATED_AT => {
+                    s.updated_at = (i64_lo, i64_hi);
+                    s.present |= ZONE_UPDATED_AT;
+                }
+                col_id::VALID_FROM => {
+                    s.valid_from = (i64_lo, i64_hi);
+                    s.present |= ZONE_VALID_FROM;
+                }
+                col_id::VALID_TO => {
+                    s.valid_to = (i64_lo, i64_hi);
+                    s.present |= ZONE_VALID_TO;
+                }
+                col_id::EDGE_WEIGHT => {
+                    s.edge_weight = (
+                        f64::from_le_bytes(m.min_val[0..8].try_into().unwrap_or([0; 8])),
+                        f64::from_le_bytes(m.max_val[0..8].try_into().unwrap_or([0; 8])),
+                    );
+                    s.present |= ZONE_EDGE_WEIGHT;
+                }
+                _ => {}
+            }
+        }
+        s
+    }
+
+    fn write_to(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.row_count.to_le_bytes());
+        buf.push(self.present);
+        for (lo, hi) in [
+            self.created_at,
+            self.updated_at,
+            self.valid_from,
+            self.valid_to,
+        ] {
+            buf.extend_from_slice(&lo.to_le_bytes());
+            buf.extend_from_slice(&hi.to_le_bytes());
+        }
+        buf.extend_from_slice(&self.edge_weight.0.to_le_bytes());
+        buf.extend_from_slice(&self.edge_weight.1.to_le_bytes());
+    }
+
+    fn read_from(data: &[u8]) -> Result<Self> {
+        if data.len() < ZONE_SUMMARY_BYTES {
+            bail!("zone summary truncated");
+        }
+        let row_count = u32::from_le_bytes(data[0..4].try_into()?);
+        let present = data[4];
+        let rd = |off: usize| -> Result<(i64, i64)> {
+            Ok((
+                i64::from_le_bytes(data[off..off + 8].try_into()?),
+                i64::from_le_bytes(data[off + 8..off + 16].try_into()?),
+            ))
+        };
+        let created_at = rd(5)?;
+        let updated_at = rd(21)?;
+        let valid_from = rd(37)?;
+        let valid_to = rd(53)?;
+        let edge_weight = (
+            f64::from_le_bytes(data[69..77].try_into()?),
+            f64::from_le_bytes(data[77..85].try_into()?),
+        );
+        Ok(Self {
+            row_count,
+            present,
+            created_at,
+            updated_at,
+            valid_from,
+            valid_to,
+            edge_weight,
+        })
+    }
+
+    fn i64_bounds(&self, column_id: i32) -> Option<(i64, i64)> {
+        match column_id {
+            col_id::CREATED_AT if self.present & ZONE_CREATED_AT != 0 => Some(self.created_at),
+            col_id::UPDATED_AT if self.present & ZONE_UPDATED_AT != 0 => Some(self.updated_at),
+            col_id::VALID_FROM if self.present & ZONE_VALID_FROM != 0 => Some(self.valid_from),
+            col_id::VALID_TO if self.present & ZONE_VALID_TO != 0 => Some(self.valid_to),
+            _ => None,
+        }
+    }
+
+    fn f64_bounds(&self, column_id: i32) -> Option<(f64, f64)> {
+        match column_id {
+            col_id::EDGE_WEIGHT if self.present & ZONE_EDGE_WEIGHT != 0 => Some(self.edge_weight),
+            _ => None,
+        }
+    }
+}
+
+/// Shared empty row-group sub-index for summary-based pruning (the summary is
+/// block-level only — no per-row-group bounds).
+static EMPTY_ROW_GROUP: LazyLock<RowGroupBlock> = LazyLock::new(RowGroupBlock::default);
+
+// block-format wire `data_type_id`s (private in prune.rs) — stable on-disk codec
+// markers, mirrored here so the summary can advertise the right predicate path.
+const DT_I64: u8 = 0x03;
+const DT_F64: u8 = 0x07;
+
+/// Prune a block from its compact zone-map summary alone — the reader path that
+/// needs NO per-block footer/metadata GET. Soundness matches the full-layout
+/// prune: bounds are copied verbatim from the block's `ColumnMeta`, and any column
+/// not in the summary advertises `None` (→ `evaluate_leaf` returns `MayMatch`), so
+/// a block is skipped only when provably empty for the summarized predicate.
+impl BlockZoneSource for BlockZoneSummary {
+    fn column_meta_type(&self, column_id: i32) -> Option<u8> {
+        if self.i64_bounds(column_id).is_some() {
+            Some(DT_I64)
+        } else if self.f64_bounds(column_id).is_some() {
+            Some(DT_F64)
+        } else {
+            None
+        }
+    }
+
+    fn may_contain_i64(&self, column_id: i32, value: i64) -> bool {
+        self.i64_bounds(column_id)
+            .is_none_or(|(lo, hi)| value >= lo && value <= hi)
+    }
+
+    fn range_overlaps_i64(&self, column_id: i32, lo: i64, hi: i64) -> bool {
+        self.i64_bounds(column_id)
+            .is_none_or(|(min, max)| lo <= max && hi >= min)
+    }
+
+    fn range_overlaps_f64(&self, column_id: i32, lo: f64, hi: f64) -> bool {
+        self.f64_bounds(column_id).is_none_or(|(min, max)| {
+            if min.is_nan() || max.is_nan() {
+                return true;
+            }
+            lo <= max && hi >= min
+        })
+    }
+
+    fn may_contain_str(&self, _column_id: i32, _value: &str) -> bool {
+        true // the summary carries no string bounds; unreachable (column_meta_type → None)
+    }
+
+    fn row_group_index(&self) -> &RowGroupBlock {
+        &EMPTY_ROW_GROUP
+    }
+
+    fn row_count_hint(&self) -> u32 {
+        self.row_count
+    }
+}
+
 /// Per-block entry in the segment index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockIndexEntry {
@@ -63,6 +281,10 @@ pub struct BlockIndexEntry {
     pub offset: u64,
     /// Block byte length (matches the block's header + body + footer).
     pub size: u32,
+    /// v2 zone-map summary (`None` in a legacy v1 index — prune falls back to a
+    /// per-block metadata read).
+    #[serde(default)]
+    pub zone: Option<BlockZoneSummary>,
 }
 
 /// Index appended at the tail of a segment file.
@@ -72,8 +294,19 @@ pub struct SegmentIndex {
 }
 
 impl SegmentIndex {
-    /// Serialise to bytes: `[block_count u32] [offset u64, size u32] × n [crc32 u32]`.
+    /// Serialise to bytes. v1 (no zone summaries): `[n u32] [offset u64, size u32]
+    /// × n [crc32 u32]`. When any block carries a zone summary, emit v2 instead:
+    /// `[n u32] [offset, size, zone(85B)] × n [crc32 u32] [body_len u32] [PAXZ]`.
+    /// The trailing `PAXZ` marker lets the reader detect v2 without disturbing v1.
     pub fn to_bytes(&self) -> Vec<u8> {
+        if self.blocks.iter().any(|b| b.zone.is_some()) {
+            self.to_bytes_v2()
+        } else {
+            self.to_bytes_v1()
+        }
+    }
+
+    fn to_bytes_v1(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(4 + self.blocks.len() * 12 + 4);
         buf.extend_from_slice(&(self.blocks.len() as u32).to_le_bytes());
         for e in &self.blocks {
@@ -85,7 +318,27 @@ impl SegmentIndex {
         buf
     }
 
-    /// Deserialise from the last N bytes of a segment file.
+    fn to_bytes_v2(&self) -> Vec<u8> {
+        let mut body = Vec::with_capacity(4 + self.blocks.len() * V2_ENTRY_BYTES + 12);
+        body.extend_from_slice(&(self.blocks.len() as u32).to_le_bytes());
+        for e in &self.blocks {
+            body.extend_from_slice(&e.offset.to_le_bytes());
+            body.extend_from_slice(&e.size.to_le_bytes());
+            e.zone
+                .clone()
+                .unwrap_or_else(|| BlockZoneSummary::empty(0))
+                .write_to(&mut body);
+        }
+        let crc = crc32fast::hash(&body);
+        body.extend_from_slice(&crc.to_le_bytes());
+        // Self-describing trailer so the reader needs no brute-force for v2.
+        let body_len = body.len() as u32;
+        body.extend_from_slice(&body_len.to_le_bytes());
+        body.extend_from_slice(ZONE_INDEX_MARKER);
+        body
+    }
+
+    /// Deserialise a **v1** index from the last N bytes of a segment file.
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
         if data.len() < 8 {
             bail!("segment index too small");
@@ -105,20 +358,66 @@ impl SegmentIndex {
             let off = 4 + i * 12;
             let offset = u64::from_le_bytes(data[off..off + 8].try_into()?);
             let size = u32::from_le_bytes(data[off + 8..off + 12].try_into()?);
-            blocks.push(BlockIndexEntry { offset, size });
+            blocks.push(BlockIndexEntry {
+                offset,
+                size,
+                zone: None,
+            });
         }
         Ok(Self { blocks })
     }
 
-    /// Locate and parse the index at the tail of `before_magic` (the segment
-    /// bytes with the trailing [`SEGMENT_MAGIC`] removed). The index length is
-    /// not stored explicitly, so candidate counts are tried until the embedded
-    /// count + CRC validate. Shared by the whole-file scanner and the ranged
-    /// reader.
+    /// Deserialise a **v2** index body (`[n][offset,size,zone]×n[crc]`, without the
+    /// `[body_len][PAXZ]` trailer).
+    fn from_bytes_v2(body: &[u8]) -> Result<Self> {
+        if body.len() < 8 {
+            bail!("v2 segment index too small");
+        }
+        let n = u32::from_le_bytes(body[0..4].try_into()?) as usize;
+        let crc_pos = 4 + n * V2_ENTRY_BYTES;
+        if body.len() < crc_pos + 4 {
+            bail!("v2 segment index truncated");
+        }
+        let stored_crc = u32::from_le_bytes(body[crc_pos..crc_pos + 4].try_into()?);
+        if crc32fast::hash(&body[..crc_pos]) != stored_crc {
+            bail!("v2 segment index CRC mismatch");
+        }
+        let mut blocks = Vec::with_capacity(n);
+        for i in 0..n {
+            let off = 4 + i * V2_ENTRY_BYTES;
+            let offset = u64::from_le_bytes(body[off..off + 8].try_into()?);
+            let size = u32::from_le_bytes(body[off + 8..off + 12].try_into()?);
+            let zone = BlockZoneSummary::read_from(&body[off + 12..off + 12 + ZONE_SUMMARY_BYTES])?;
+            blocks.push(BlockIndexEntry {
+                offset,
+                size,
+                zone: Some(zone),
+            });
+        }
+        Ok(Self { blocks })
+    }
+
+    /// Locate and parse the index at the tail of `before_magic` (the segment bytes
+    /// with the trailing [`SEGMENT_MAGIC`] removed). v2 is found directly via the
+    /// self-describing `[body_len][PAXZ]` trailer; v1's length is not stored, so
+    /// candidate counts are tried until the embedded count + CRC validate. Shared
+    /// by the whole-file scanner and the ranged reader.
     pub fn locate(before_magic: &[u8]) -> Result<Self> {
         if before_magic.len() < 8 {
             bail!("no room for segment index");
         }
+        // v2: trailing [body_len u32][PAXZ].
+        if &before_magic[before_magic.len() - 4..] == ZONE_INDEX_MARKER {
+            let blen_pos = before_magic.len() - 8;
+            let body_len =
+                u32::from_le_bytes(before_magic[blen_pos..blen_pos + 4].try_into()?) as usize;
+            if before_magic.len() < 8 + body_len {
+                bail!("v2 index marker present but body does not fit");
+            }
+            let body = &before_magic[before_magic.len() - 8 - body_len..before_magic.len() - 8];
+            return Self::from_bytes_v2(body);
+        }
+        // v1 brute-force.
         for candidate_n in 0usize..=(before_magic.len().saturating_sub(8) / 12) {
             let index_len = 4 + candidate_n * 12 + 4;
             if index_len > before_magic.len() {
@@ -142,16 +441,23 @@ impl SegmentIndex {
     /// Locate and parse the index from a file **suffix** that must contain the
     /// trailing [`SEGMENT_MAGIC`] and the full index. Returns `Ok(None)` when the
     /// suffix is too small to hold the whole index (the caller should re-read a
-    /// larger suffix), and `Err` only on a corrupt/invalid tail. This is the
-    /// footer-first entry point for object-storage ranged reads.
+    /// larger suffix), and `Err` only on a corrupt/invalid tail.
     pub fn locate_in_suffix(suffix: &[u8]) -> Result<Option<Self>> {
         if suffix.len() < 8 || &suffix[suffix.len() - 8..] != SEGMENT_MAGIC {
             bail!("segment suffix missing magic (not a PAX segment tail)");
         }
         let before_magic = &suffix[..suffix.len() - 8];
+        // A v2 index needs its whole body in the suffix; signal a re-read otherwise.
+        if before_magic.len() >= 8 && &before_magic[before_magic.len() - 4..] == ZONE_INDEX_MARKER {
+            let blen_pos = before_magic.len() - 8;
+            let body_len =
+                u32::from_le_bytes(before_magic[blen_pos..blen_pos + 4].try_into()?) as usize;
+            if before_magic.len() < 8 + body_len {
+                return Ok(None);
+            }
+        }
         match Self::locate(before_magic) {
             Ok(idx) => Ok(Some(idx)),
-            // The index may simply not fit in this suffix yet — signal a re-read.
             Err(_) => Ok(None),
         }
     }
@@ -194,6 +500,9 @@ pub struct PaxSegmentWriter {
     block_stats: Vec<BlockStats>,
     file_buf: Vec<u8>,
     row_count: u64,
+    /// Emit a v2 zone-map segment index (per-block bounds for index-only pruning).
+    /// Gated default-OFF by `PROXIMADB_PAX_INDEX_ZONEMAP`; mixed-read-safe.
+    zonemap: bool,
 }
 
 impl PaxSegmentWriter {
@@ -237,7 +546,18 @@ impl PaxSegmentWriter {
             block_stats: Vec::new(),
             file_buf: Vec::new(),
             row_count: 0,
+            zonemap: std::env::var("PROXIMADB_PAX_INDEX_ZONEMAP")
+                .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+                .unwrap_or(false),
         }
+    }
+
+    /// Force the v2 zone-map segment index on/off for this writer, overriding the
+    /// `PROXIMADB_PAX_INDEX_ZONEMAP` env default. Builder form (deterministic for
+    /// tests, which must not depend on a process-global env var).
+    pub fn with_zonemap(mut self, on: bool) -> Self {
+        self.zonemap = on;
+        self
     }
 
     /// Set the vector quantization strategy for this segment (P3 Phase D). Builder form
@@ -290,9 +610,17 @@ impl PaxSegmentWriter {
         let stats =
             BlockStats::from_metas(row_count, block_size, min_ts, max_ts, reader.column_metas());
 
+        // TD-167 follow-up: when the v2 zone-map index is enabled, capture each
+        // block's canonical-column bounds (already in hand via the just-opened
+        // reader) into the index, so the reader can prune from the cached index
+        // with no per-block metadata GET. Gated default-OFF (mixed-read-safe).
+        let zone = self
+            .zonemap
+            .then(|| BlockZoneSummary::from_column_metas(row_count, reader.column_metas()));
         self.index.blocks.push(BlockIndexEntry {
             offset,
             size: block_size,
+            zone,
         });
         self.file_buf.extend_from_slice(&block_bytes);
         self.block_stats.push(stats);
@@ -610,10 +938,12 @@ mod tests {
                 BlockIndexEntry {
                     offset: 0,
                     size: 4096,
+                    zone: None,
                 },
                 BlockIndexEntry {
                     offset: 4096,
                     size: 8192,
+                    zone: None,
                 },
             ],
         };
@@ -622,6 +952,44 @@ mod tests {
         assert_eq!(idx2.blocks.len(), 2);
         assert_eq!(idx2.blocks[0].size, 4096);
         assert_eq!(idx2.blocks[1].offset, 4096);
+    }
+
+    #[test]
+    fn segment_index_v2_zonemap_round_trips_and_detects_via_locate() {
+        let mut zone = BlockZoneSummary::empty(10);
+        zone.created_at = (1000, 2000);
+        zone.valid_to = (0, 5000);
+        zone.present = ZONE_CREATED_AT | ZONE_VALID_TO;
+        let idx = SegmentIndex {
+            blocks: vec![
+                BlockIndexEntry {
+                    offset: 0,
+                    size: 4096,
+                    zone: Some(zone.clone()),
+                },
+                BlockIndexEntry {
+                    offset: 4096,
+                    size: 8192,
+                    zone: Some(BlockZoneSummary::empty(3)),
+                },
+            ],
+        };
+        // to_bytes picks v2 (a zone is present) and appends the PAXZ trailer.
+        let mut bytes = idx.to_bytes();
+        assert_eq!(
+            &bytes[bytes.len() - 4..],
+            ZONE_INDEX_MARKER,
+            "v2 trailer marker"
+        );
+        // The reader path strips SEGMENT_MAGIC, then locate() detects v2 by PAXZ.
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        let located = SegmentIndex::locate(&bytes[..bytes.len() - 8]).unwrap();
+        assert_eq!(located.blocks.len(), 2);
+        let z0 = located.blocks[0].zone.as_ref().expect("v2 zone preserved");
+        assert_eq!(z0.created_at, (1000, 2000));
+        assert_eq!(z0.valid_to, (0, 5000));
+        assert_eq!(z0.present, ZONE_CREATED_AT | ZONE_VALID_TO);
+        assert_eq!(located.blocks[1].size, 8192);
     }
 
     #[test]

--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -343,16 +343,26 @@ impl<'b> RangedSegmentReader<'b> {
         embedding_model_ids: &[String],
         user_column_keys: &[String],
     ) -> Result<Vec<ProximaRecord>, StorageError> {
-        // Phase 1 — prune from per-block metadata alone (footer/col-meta, footer-
-        // cached); no block body is fetched. Collect the surviving blocks' byte
-        // ranges.
+        // Phase 1 — prune each block; no block body is fetched. A **v2** index
+        // carries the block's zone-map summary inline, so we prune from the cached
+        // index with ZERO per-block metadata GETs (cold-path depth 4→2, TD-167
+        // follow-up). A **v1** index falls back to a per-block footer/col-meta read
+        // (footer-cached). Collect the surviving blocks' byte ranges.
         let mut survivors: Vec<std::ops::Range<u64>> = Vec::new();
         for entry in &self.index.blocks {
             let (off, bsz) = (entry.offset, entry.size as u64);
-            let layout = self.block_layout(off, bsz).await?;
-            if evaluate_block(&*layout as &dyn BlockZoneSource, filter, field_to_col)
-                == PruneResult::Skip
-            {
+            let skip = match &entry.zone {
+                Some(zone) => {
+                    evaluate_block(zone as &dyn BlockZoneSource, filter, field_to_col)
+                        == PruneResult::Skip
+                }
+                None => {
+                    let layout = self.block_layout(off, bsz).await?;
+                    evaluate_block(&*layout as &dyn BlockZoneSource, filter, field_to_col)
+                        == PruneResult::Skip
+                }
+            };
+            if skip {
                 continue;
             }
             survivors.push(off..off + bsz);
@@ -525,6 +535,11 @@ mod tests {
     }
 
     fn build_segment_bytes(n: usize, dim: usize) -> Vec<u8> {
+        build_segment_bytes_z(n, dim, false)
+    }
+
+    /// Like [`build_segment_bytes`] but `zonemap` selects the v2 zone-map index.
+    fn build_segment_bytes_z(n: usize, dim: usize, zonemap: bool) -> Vec<u8> {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seg.pax");
         let mut w = PaxSegmentWriter::new(
@@ -535,7 +550,8 @@ mod tests {
             0,
             1,
             Some(16 * 1024),
-        );
+        )
+        .with_zonemap(zonemap);
         for i in 0..n {
             let v: Vec<f32> = (0..dim).map(|d| (i * dim + d) as f32 * 0.001).collect();
             w.add_record(&rec(&format!("r{i}"), 1000 + i as i64, v))
@@ -773,6 +789,77 @@ mod tests {
         assert_eq!(
             batched, 1,
             "surviving block bodies must be one batched fetch, got {batched}"
+        );
+    }
+
+    /// TD-167 follow-up: a **v2 zone-map index** lets the reader prune from the
+    /// cached index alone — issuing ZERO per-block metadata GETs (cold-path depth
+    /// 4→2) — while returning records identical to the v1 (per-block-metadata)
+    /// path. Mixed-read-safe: v1 segments still read via the legacy path.
+    #[tokio::test]
+    async fn td167b_v2_zonemap_prunes_with_no_per_block_metadata_gets() {
+        use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
+
+        let threshold = 1000 + 1500i64;
+        let filter = FilterExpression::Comparison {
+            field: "created_at".into(),
+            operator: ComparisonOperator::GreaterThanOrEqual,
+            value: serde_json::json!(threshold),
+        };
+        let field_to_col = |f: &str| match f {
+            "created_at" => Some(col_id::CREATED_AT),
+            _ => None,
+        };
+
+        // v1 reference path (per-block footer/col-meta reads to prune).
+        let v1 = InMemoryRangeBridge {
+            bytes: build_segment_bytes(2000, 32),
+            ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
+        };
+        let v1r = RangedSegmentReader::open(&v1, Path::from("seg.pax"), Some("t"))
+            .await
+            .unwrap();
+        let mut v1_recs = v1r
+            .read_records_pruned(&filter, &field_to_col, &[], &[])
+            .await
+            .unwrap();
+        let v1_single = v1.single_calls.load(Ordering::Relaxed);
+
+        // v2 zone-map index path (prune from the cached index — no metadata GET).
+        let v2 = InMemoryRangeBridge {
+            bytes: build_segment_bytes_z(2000, 32, true),
+            ranged_bytes: AtomicU64::new(0),
+            single_calls: AtomicU64::new(0),
+            batched_calls: AtomicU64::new(0),
+        };
+        let v2r = RangedSegmentReader::open(&v2, Path::from("seg.pax"), Some("t"))
+            .await
+            .unwrap();
+        let mut v2_recs = v2r
+            .read_records_pruned(&filter, &field_to_col, &[], &[])
+            .await
+            .unwrap();
+        let v2_single = v2.single_calls.load(Ordering::Relaxed);
+
+        // Correctness: identical records (order-independent).
+        assert!(!v2_recs.is_empty());
+        v1_recs.sort_by(|a, b| a.oid.cmp(&b.oid));
+        v2_recs.sort_by(|a, b| a.oid.cmp(&b.oid));
+        let v1_oids: Vec<_> = v1_recs.iter().map(|r| r.oid.clone()).collect();
+        let v2_oids: Vec<_> = v2_recs.iter().map(|r| r.oid.clone()).collect();
+        assert_eq!(v1_oids, v2_oids, "v2 zone-map prune must match v1 records");
+
+        // The depth win: v1 pays per-block footer+col-meta single-range GETs to
+        // prune; v2 pays only the one index suffix read, then the batched bodies.
+        assert!(
+            v1_single > 10,
+            "v1 should issue many per-block metadata GETs, got {v1_single}"
+        );
+        assert!(
+            v2_single <= 2,
+            "v2 should prune from the index with ~no per-block metadata GETs, got {v2_single}"
         );
     }
 


### PR DESCRIPTION
## TD-167 follow-up — collapse the cold-path metadata reads too (depth 4→2)

> **Depends on #419** (TD-167 body-batching). This branch currently includes #419's commit; once #419 merges I'll rebase onto develop and the diff reduces to just this slice (`pax_block.rs` + `ranged_segment.rs`).

#419 batched the surviving *bodies* (`O(K)`→1); a pruned read still paid a per-block footer+col-meta GET to decide which blocks survive. This carries each block's canonical min/max **in the segment index**, so the reader prunes from the single cached index read with **zero per-block metadata GETs**.

### Format (mixed-read-safe, additive)
Versioned `SegmentIndex`: **v1 byte-identical**; **v2** appends a fixed-width per-block zone summary (`created_at/updated_at/valid_from/valid_to` i64 + `edge_weight` f64 + present bitmask) + a self-describing `[body_len][PAXZ]` trailer. Reader detects v2 by the trailing **`PAXZ`** marker before `SEGMENT_MAGIC`; absent → legacy v1 brute-force. **Old segments + old readers unaffected.**

### Writer (gated default-OFF)
`PaxSegmentWriter` captures each block's bounds from the just-opened reader's `column_metas` at flush time, emitting v2 when `PROXIMADB_PAX_INDEX_ZONEMAP` is set (or via `with_zonemap` for deterministic tests).

### Reader (depth 4→2)
`BlockZoneSummary` implements `BlockZoneSource`; `read_records_pruned` prunes from it when present (no `block_layout` fetch). Bounds copied **verbatim** from `ColumnMeta` → byte-identical to v1 for summarized i64/f64 predicates; non-summarized columns advertise `None` (`evaluate_leaf` → `MayMatch`) — a block is skipped only when **provably empty**.

### Verification
- v2 index round-trip + PAXZ detection; a v2 pruned read returns records **identical** to v1 while issuing **≤2** single-range GETs (the index suffix) vs v1's **>10** per-block metadata GETs.
- All **399** storage-common tests green; changed-crate + CI-exact clippy clean; server binary builds.

(Structural/round-trip win by GET-count; wall-clock latency needs the TD-172 scale harness — mandate #6.)