### PR TITLE
refactor(storage): invert compaction→AXIS coupling behind IndexMaintenance (Slice D / IndexPort)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7102,6 +7102,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "proximadb-index-types",
  "proximadb-records",
  "serde",
  "serde_json",

--- a/crates/foundation/proximadb-index-traits/Cargo.toml
+++ b/crates/foundation/proximadb-index-traits/Cargo.toml
@@ -20,3 +20,4 @@ chrono.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 proximadb-records.workspace = true
+proximadb-index-types.workspace = true

--- a/crates/foundation/proximadb-index-traits/src/lib.rs
+++ b/crates/foundation/proximadb-index-traits/src/lib.rs
@@ -167,6 +167,26 @@ pub struct IndexScoredResult {
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// A slim, read-only snapshot of one index for a collection — the foundation-only
+/// stand-in for a live `Arc<dyn AxisVectorIndex>` reader handle.
+///
+/// Compaction only *aggregates* per-index stats; it never holds the reader. So the
+/// boundary exposes exactly those three quantities (and the algorithm, to classify
+/// dynamic vs static indexes) rather than the concrete index trait — keeping
+/// `src/storage` free of any `crate::index` type. The concrete `AxisVectorIndex`
+/// → snapshot conversion lives in the AXIS adapter (`src/index/axis/contract.rs`).
+#[derive(Debug, Clone)]
+pub struct IndexReaderSnapshot {
+    /// Index name (e.g. the primary/global-id/metadata/vector index identifier).
+    pub name: String,
+    /// Number of vectors currently held by this index.
+    pub vector_count: usize,
+    /// Approximate memory consumption of this index in bytes.
+    pub memory_usage_bytes: usize,
+    /// The index algorithm (used to classify dynamic vs static indexes).
+    pub algorithm: proximadb_index_types::IndexAlgorithm,
+}
+
 // ---------------------------------------------------------------------------
 // Segregated role traits (ISP) — engines depend only on the role they use
 // ---------------------------------------------------------------------------
@@ -214,16 +234,38 @@ pub trait IndexMetrics: Send + Sync {
 }
 
 /// Maintenance hooks invoked by compaction / background optimization.
-///
-/// `get_collection_indexes` (returning per-index reader handles) is intentionally
-/// *not* part of this contract yet: on `develop` it is a stub returning an empty
-/// vec, and its return type (`Arc<dyn AxisVectorIndex>`) would force a shared
-/// reader trait + supertrait wiring across the concrete index impls. It lands
-/// with the compaction-reader follow-up, once compaction actually consumes it.
 #[async_trait]
 pub trait IndexMaintenance: Send + Sync {
     /// Rebuild a single named index for `collection_id`.
     async fn rebuild_index(&self, collection_id: &str, index_name: &str) -> anyhow::Result<()>;
+
+    /// Reconcile the collection's indexes after a storage compaction:
+    /// apply `deleted_vector_ids` removals, re-index `merged_vectors`, and rebuild
+    /// any static indexes that can't mutate in place.
+    ///
+    /// This is the **intent**, not the mechanism: the index side owns *how* it
+    /// updates its readers, so the concrete `Arc<dyn AxisVectorIndex>` handles
+    /// never cross into storage. Storage just announces "compaction happened,
+    /// here is what changed."
+    async fn update_indexes_after_compaction(
+        &self,
+        collection_id: &str,
+        deleted_vector_ids: &[String],
+        merged_vectors: &[ProximaRecord],
+    ) -> anyhow::Result<()>;
+
+    /// Slim per-index stat snapshots for `collection_id` (empty when the collection
+    /// has no active indexes), for compaction stats aggregation.
+    ///
+    /// Returns [`IndexReaderSnapshot`]s rather than live `Arc<dyn AxisVectorIndex>`
+    /// reader handles: storage only sums per-index stats, so the boundary need not
+    /// expose the concrete reader trait (which would force shared-reader supertrait
+    /// wiring and re-leak a `crate::index` type into storage). The concrete-reader
+    /// → snapshot conversion is the adapter's job (`src/index/axis/contract.rs`).
+    async fn collection_index_stats(
+        &self,
+        collection_id: &str,
+    ) -> anyhow::Result<Vec<IndexReaderSnapshot>>;
 
     /// Analyze the collection and apply adaptive index optimizations.
     async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()>;

--- a/src/index/axis/compaction_update.rs
+++ b/src/index/axis/compaction_update.rs
@@ -1,0 +1,237 @@
+// Copyright 2025 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! Post-compaction index reconciliation (AXIS side).
+//!
+//! When storage finishes a compaction it announces the change via the
+//! `IndexMaintenance::update_indexes_after_compaction` port; the *mechanism*
+//! lives here, inside AXIS, so the concrete `Arc<dyn AxisVectorIndex>` reader
+//! handles never cross into `src/storage`. Moved verbatim from the former
+//! `storage::…::CompactionAxisUpdater` (behaviour-neutral) as part of the
+//! storage→index dependency inversion (Slice D / IndexPort).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::{debug, info, warn};
+
+use crate::index::axis::{AxisManager, AxisVectorIndex};
+use proximadb_records::ProximaRecord;
+
+impl AxisManager {
+    /// Reconcile this collection's indexes after a storage compaction: apply
+    /// `deleted_vector_ids` removals, re-index `merged_vectors`, and rebuild any
+    /// static index that can't mutate in place. AXIS owns its readers throughout.
+    pub async fn update_indexes_after_compaction(
+        &self,
+        collection_id: &str,
+        deleted_vector_ids: &[String],
+        merged_vectors: &[ProximaRecord],
+    ) -> Result<()> {
+        let indexes = self.get_collection_indexes(collection_id).await?;
+        if indexes.is_empty() {
+            debug!(
+                "No indexes found for collection {}, skipping",
+                collection_id
+            );
+            return Ok(());
+        }
+
+        info!(
+            "🔄 AXIS Compaction: Updating {} indexes for collection {}",
+            indexes.len(),
+            collection_id
+        );
+
+        if !deleted_vector_ids.is_empty() {
+            remove_deleted_vectors_from_indexes(&indexes, deleted_vector_ids, collection_id)
+                .await?;
+        }
+
+        if !merged_vectors.is_empty() {
+            update_merged_vectors_in_indexes(&indexes, merged_vectors, collection_id).await?;
+        }
+
+        rebuild_static_indexes_if_needed(self, collection_id, &indexes).await?;
+
+        info!(
+            "✅ AXIS Compaction: Successfully updated {} indexes for collection {}",
+            indexes.len(),
+            collection_id
+        );
+
+        Ok(())
+    }
+}
+
+/// Remove deleted vectors from all indexes
+async fn remove_deleted_vectors_from_indexes(
+    indexes: &[(String, Arc<dyn AxisVectorIndex>)],
+    deleted_vector_ids: &[String],
+    collection_id: &str,
+) -> Result<()> {
+    info!(
+        "🗑️ AXIS Compaction: Removing {} deleted vectors from indexes for {}",
+        deleted_vector_ids.len(),
+        collection_id
+    );
+
+    let _deleted_set: HashSet<&str> = deleted_vector_ids.iter().map(|s| s.as_str()).collect();
+    let mut removal_errors = Vec::new();
+
+    for (index_name, index) in indexes {
+        debug!(
+            "Removing deleted vectors from index {} for collection {}",
+            index_name, collection_id
+        );
+
+        for vector_id in deleted_vector_ids {
+            match index.remove(vector_id).await {
+                Ok(_) => {
+                    debug!("Removed vector {} from index {}", vector_id, index_name);
+                }
+                Err(e) => {
+                    // Some indexes (like Annoy) don't support removal
+                    if e.to_string().contains("does not support removal") {
+                        debug!(
+                            "Index {} is static and doesn't support removal, will need rebuild",
+                            index_name
+                        );
+                        break; // No point trying more removals on this index
+                    } else {
+                        warn!(
+                            "Failed to remove vector {} from index {}: {}",
+                            vector_id, index_name, e
+                        );
+                        removal_errors.push((vector_id.clone(), index_name.clone(), e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Log removal statistics
+    if !removal_errors.is_empty() {
+        warn!(
+            "⚠️ AXIS Compaction: {} removal errors occurred during compaction_info",
+            removal_errors.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Update merged vectors in all indexes
+async fn update_merged_vectors_in_indexes(
+    indexes: &[(String, Arc<dyn AxisVectorIndex>)],
+    merged_vectors: &[ProximaRecord],
+    collection_id: &str,
+) -> Result<()> {
+    info!(
+        "🔄 AXIS Compaction: Updating {} merged vectors in indexes for {}",
+        merged_vectors.len(),
+        collection_id
+    );
+
+    let mut update_errors = Vec::new();
+
+    for (index_name, index) in indexes {
+        debug!(
+            "Updating merged vectors in index {} for collection {}",
+            index_name, collection_id
+        );
+
+        for vector in merged_vectors {
+            let vector_id = &vector.oid;
+            let Some(embedding) = vector.embeddings.first() else {
+                debug!(
+                    "Skipping merged record {} with no embedding for index {}",
+                    vector_id, index_name
+                );
+                continue;
+            };
+
+            // Remove old version first (if it exists)
+            let _ = index.remove(vector_id).await; // Ignore errors as it might not exist
+
+            // Add updated version
+            match index
+                .add(vector_id.clone(), embedding.values.to_fp32_owned())
+                .await
+            {
+                Ok(_) => {
+                    debug!("Updated vector {} in index {}", vector_id, index_name);
+                }
+                Err(e) => {
+                    // Some indexes (like Annoy) don't support dynamic updates
+                    if e.to_string().contains("cannot be modified") {
+                        debug!(
+                            "Index {} is static and doesn't support updates, will need rebuild",
+                            index_name
+                        );
+                        break; // No point trying more updates on this index
+                    } else {
+                        warn!(
+                            "Failed to update vector {} in index {}: {}",
+                            vector_id, index_name, e
+                        );
+                        update_errors.push((vector_id.clone(), index_name.clone(), e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Log update statistics
+    if !update_errors.is_empty() {
+        warn!(
+            "⚠️ AXIS Compaction: {} update errors occurred during compaction_info",
+            update_errors.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Rebuild static indexes that don't support dynamic updates
+async fn rebuild_static_indexes_if_needed(
+    axis: &AxisManager,
+    collection_id: &str,
+    indexes: &[(String, Arc<dyn AxisVectorIndex>)],
+) -> Result<()> {
+    for (index_name, index) in indexes {
+        // Check if this is a static index (like Annoy)
+        let algorithm = index.algorithm();
+        if matches!(
+            algorithm,
+            proximadb_index_types::IndexAlgorithm::Annoy { .. }
+        ) {
+            info!(
+                "🔨 AXIS Compaction: Rebuilding static index {} for collection {}",
+                index_name, collection_id
+            );
+
+            // Trigger a full rebuild through AXIS manager
+            match axis.rebuild_index(collection_id, index_name).await {
+                Ok(_) => {
+                    info!(
+                        "✅ Successfully rebuilt static index {} for collection {}",
+                        index_name, collection_id
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "❌ Failed to rebuild static index {} for collection {}: {}",
+                        index_name, collection_id, e
+                    );
+                    // Continue with other indexes even if one fails
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/index/axis/contract.rs
+++ b/src/index/axis/contract.rs
@@ -17,8 +17,8 @@ use async_trait::async_trait;
 
 use proximadb_index_traits::{
     IndexFilterOperator, IndexHybridQuery, IndexIngest, IndexLifecycle, IndexMaintenance,
-    IndexMetadataFilter, IndexMetrics, IndexQuery, IndexQueryResult, IndexScoredResult,
-    IndexSearchEffort, IndexVectorQuery,
+    IndexMetadataFilter, IndexMetrics, IndexQuery, IndexQueryResult, IndexReaderSnapshot,
+    IndexScoredResult, IndexSearchEffort, IndexVectorQuery,
 };
 use proximadb_records::ProximaRecord;
 
@@ -190,6 +190,46 @@ impl IndexMetrics for AxisManager {
 impl IndexMaintenance for AxisManager {
     async fn rebuild_index(&self, collection_id: &str, index_name: &str) -> anyhow::Result<()> {
         AxisManager::rebuild_index(self, collection_id, index_name).await
+    }
+
+    async fn update_indexes_after_compaction(
+        &self,
+        collection_id: &str,
+        deleted_vector_ids: &[String],
+        merged_vectors: &[ProximaRecord],
+    ) -> anyhow::Result<()> {
+        // The index side owns the mechanism: AxisManager reconciles its own live
+        // readers (remove/add/rebuild). Storage never sees `AxisVectorIndex`.
+        AxisManager::update_indexes_after_compaction(
+            self,
+            collection_id,
+            deleted_vector_ids,
+            merged_vectors,
+        )
+        .await
+    }
+
+    async fn collection_index_stats(
+        &self,
+        collection_id: &str,
+    ) -> anyhow::Result<Vec<IndexReaderSnapshot>> {
+        // Anti-corruption boundary: the concrete `Arc<dyn AxisVectorIndex>` readers
+        // never escape `src/index` — we project each one to a slim foundation
+        // snapshot here. (`get_collection_indexes` is a stub returning empty today,
+        // so this maps empty→empty; the conversion is ready for when it is filled.)
+        let readers = AxisManager::get_collection_indexes(self, collection_id).await?;
+        Ok(readers
+            .into_iter()
+            .map(|(name, index)| {
+                let stats = index.stats();
+                IndexReaderSnapshot {
+                    name,
+                    vector_count: stats.vector_count,
+                    memory_usage_bytes: stats.memory_usage_bytes,
+                    algorithm: index.algorithm().clone(),
+                }
+            })
+            .collect())
     }
 
     async fn analyze_and_optimize(&self, collection_id: &str) -> anyhow::Result<()> {

--- a/src/index/axis/mod.rs
+++ b/src/index/axis/mod.rs
@@ -84,6 +84,7 @@ pub mod filterable_metadata;
 
 // Storage↔index decoupling contract (DIP/ISP): boundary impl of the
 // `proximadb-index-traits` role traits for `AxisManager`.
+pub mod compaction_update;
 pub mod contract;
 
 // Shared utilities and types

--- a/src/storage/multimodel/stores/vector_store.rs
+++ b/src/storage/multimodel/stores/vector_store.rs
@@ -12,9 +12,9 @@
 use std::sync::Arc;
 
 use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
-use crate::index::axis::AxisManager;
 use crate::storage::cache::orchestrator::CrossCacheOrchestrator;
 use crate::storage::traits::UnifiedStorageFormat;
+use proximadb_index_traits::IndexEngine;
 // Re-export foundation quantization types
 pub use proximadb_quantization_types::{QuantizationLevel, QuantizationType};
 
@@ -128,8 +128,8 @@ pub struct VectorStore {
     dimension_threshold: usize,
     /// Shared quantization engine
     quantizer: Option<Arc<UnifiedQuantizationEngine>>,
-    /// Index manager for HNSW/IVF indexes
-    index_manager: Option<Arc<AxisManager>>,
+    /// Index manager for HNSW/IVF indexes (the AXIS index-engine port).
+    index_manager: Option<Arc<dyn IndexEngine>>,
     /// Cache orchestrator
     cache_orchestrator: Option<Arc<CrossCacheOrchestrator>>,
     /// Configuration
@@ -177,7 +177,7 @@ impl VectorStore {
     }
 
     /// Set the index manager
-    pub fn with_index_manager(mut self, manager: Arc<AxisManager>) -> Self {
+    pub fn with_index_manager(mut self, manager: Arc<dyn IndexEngine>) -> Self {
         self.index_manager = Some(manager);
         self
     }
@@ -231,11 +231,6 @@ impl VectorStore {
     /// Get the quantizer
     pub fn quantizer(&self) -> Option<&Arc<UnifiedQuantizationEngine>> {
         self.quantizer.as_ref()
-    }
-
-    /// Get the index manager
-    pub fn index_manager(&self) -> Option<&Arc<AxisManager>> {
-        self.index_manager.as_ref()
     }
 
     /// Get the cache orchestrator

--- a/src/storage/persistence/write_ahead_log/compaction_axis_integration.rs
+++ b/src/storage/persistence/write_ahead_log/compaction_axis_integration.rs
@@ -7,37 +7,42 @@
 
 //! AXIS Index Integration for Compaction Process
 //!
-//! This module handles index updates during compaction operations,
-//! ensuring that AXIS indexes remain consistent with the compacted data.
+//! Thin storage-side façade over the `IndexMaintenance` port: storage announces
+//! post-compaction changes and reads index stats; the index side (AXIS) owns the
+//! reader mechanics. The former in-storage reader manipulation (remove/add/rebuild
+//! on live `Arc<dyn AxisVectorIndex>` handles) moved to
+//! `crate::index::axis::compaction_update` as part of the storage→index
+//! dependency inversion — storage now depends only on the foundation port + DTO.
+
+use std::sync::Arc;
 
 use anyhow::Result;
-use std::collections::HashSet;
-use std::sync::Arc;
-use tracing::{debug, info, warn};
 
-use crate::index::axis::{AxisManager, AxisVectorIndex};
-use crate::storage::traits::CompactionResult;
+use proximadb_index_traits::{IndexMaintenance, IndexReaderSnapshot};
+use proximadb_index_types::IndexAlgorithm;
 use proximadb_records::ProximaRecord;
 
-/// AXIS index updater for compaction operations
+use crate::storage::traits::CompactionResult;
+
+/// AXIS index updater for compaction operations.
 #[derive(Clone)]
 pub struct CompactionAxisUpdater {
-    /// AXIS manager for index operations
-    axis_manager: Option<Arc<AxisManager>>,
+    /// Index-maintenance port; the concrete AXIS impl is injected by the
+    /// composition root. `None` disables index updates (no index configured).
+    axis_manager: Option<Arc<dyn IndexMaintenance>>,
 }
 
 impl CompactionAxisUpdater {
-    /// Create a new AXIS updater for compaction
-    pub fn new(axis_manager: Option<Arc<AxisManager>>) -> Self {
+    /// Create a new AXIS updater for compaction.
+    pub fn new(axis_manager: Option<Arc<dyn IndexMaintenance>>) -> Self {
         Self { axis_manager }
     }
 
-    /// Update AXIS indexes after compaction
+    /// Update AXIS indexes after compaction.
     ///
-    /// This method handles:
-    /// 1. Removing deleted vectors from indexes
-    /// 2. Re-indexing merged/updated vectors
-    /// 3. Rebuilding static indexes (like Annoy) if needed
+    /// Delegates the reconciliation (deletions, merged re-indexing, static-index
+    /// rebuilds) to the index side via the port; the live index readers never
+    /// cross into storage.
     pub async fn update_indexes_after_compaction(
         &self,
         collection_id: &str,
@@ -45,269 +50,60 @@ impl CompactionAxisUpdater {
         deleted_vector_ids: &[String],
         merged_vectors: &[ProximaRecord],
     ) -> Result<()> {
-        let axis = match &self.axis_manager {
-            Some(manager) => manager,
+        match &self.axis_manager {
+            Some(axis) => {
+                axis.update_indexes_after_compaction(
+                    collection_id,
+                    deleted_vector_ids,
+                    merged_vectors,
+                )
+                .await
+            }
             None => {
-                debug!("No AXIS manager configured, skipping index updates");
-                return Ok(());
-            }
-        };
-
-        info!(
-            "🔄 AXIS Compaction: Updating indexes for collection {} after compaction_info",
-            collection_id
-        );
-
-        // Get all indexes for the collection
-        let indexes = axis.get_collection_indexes(collection_id).await?;
-        if indexes.is_empty() {
-            debug!(
-                "No indexes found for collection {}, skipping",
-                collection_id
-            );
-            return Ok(());
-        }
-
-        info!(
-            "🔄 AXIS Compaction: Found {} indexes to update for collection {}",
-            indexes.len(),
-            collection_id
-        );
-
-        // Process deletions first
-        if !deleted_vector_ids.is_empty() {
-            self.remove_deleted_vectors_from_indexes(&indexes, deleted_vector_ids, collection_id)
-                .await?;
-        }
-
-        // Process merged/updated vectors
-        if !merged_vectors.is_empty() {
-            self.update_merged_vectors_in_indexes(&indexes, merged_vectors, collection_id)
-                .await?;
-        }
-
-        // Handle static indexes that need rebuilding
-        self.rebuild_static_indexes_if_needed(axis, collection_id, &indexes)
-            .await?;
-
-        info!(
-            "✅ AXIS Compaction: Successfully updated {} indexes for collection {}",
-            indexes.len(),
-            collection_id
-        );
-
-        Ok(())
-    }
-
-    /// Remove deleted vectors from all indexes
-    async fn remove_deleted_vectors_from_indexes(
-        &self,
-        indexes: &[(String, Arc<dyn AxisVectorIndex>)],
-        deleted_vector_ids: &[String],
-        collection_id: &str,
-    ) -> Result<()> {
-        info!(
-            "🗑️ AXIS Compaction: Removing {} deleted vectors from indexes for {}",
-            deleted_vector_ids.len(),
-            collection_id
-        );
-
-        let _deleted_set: HashSet<&str> = deleted_vector_ids.iter().map(|s| s.as_str()).collect();
-        let mut removal_errors = Vec::new();
-
-        for (index_name, index) in indexes {
-            debug!(
-                "Removing deleted vectors from index {} for collection {}",
-                index_name, collection_id
-            );
-
-            for vector_id in deleted_vector_ids {
-                match index.remove(vector_id).await {
-                    Ok(_) => {
-                        debug!("Removed vector {} from index {}", vector_id, index_name);
-                    }
-                    Err(e) => {
-                        // Some indexes (like Annoy) don't support removal
-                        if e.to_string().contains("does not support removal") {
-                            debug!(
-                                "Index {} is static and doesn't support removal, will need rebuild",
-                                index_name
-                            );
-                            break; // No point trying more removals on this index
-                        } else {
-                            warn!(
-                                "Failed to remove vector {} from index {}: {}",
-                                vector_id, index_name, e
-                            );
-                            removal_errors.push((vector_id.clone(), index_name.clone(), e));
-                        }
-                    }
-                }
+                tracing::debug!("No AXIS manager configured, skipping index updates");
+                Ok(())
             }
         }
-
-        // Log removal statistics
-        if !removal_errors.is_empty() {
-            warn!(
-                "⚠️ AXIS Compaction: {} removal errors occurred during compaction_info",
-                removal_errors.len()
-            );
-        }
-
-        Ok(())
     }
 
-    /// Update merged vectors in all indexes
-    async fn update_merged_vectors_in_indexes(
-        &self,
-        indexes: &[(String, Arc<dyn AxisVectorIndex>)],
-        merged_vectors: &[ProximaRecord],
-        collection_id: &str,
-    ) -> Result<()> {
-        info!(
-            "🔄 AXIS Compaction: Updating {} merged vectors in indexes for {}",
-            merged_vectors.len(),
-            collection_id
-        );
-
-        let mut update_errors = Vec::new();
-
-        for (index_name, index) in indexes {
-            debug!(
-                "Updating merged vectors in index {} for collection {}",
-                index_name, collection_id
-            );
-
-            for vector in merged_vectors {
-                let vector_id = &vector.oid;
-                let Some(embedding) = vector.embeddings.first() else {
-                    debug!(
-                        "Skipping merged record {} with no embedding for index {}",
-                        vector_id, index_name
-                    );
-                    continue;
-                };
-
-                // Remove old version first (if it exists)
-                let _ = index.remove(vector_id).await; // Ignore errors as it might not exist
-
-                // Add updated version
-                match index
-                    .add(vector_id.clone(), embedding.values.to_fp32_owned())
-                    .await
-                {
-                    Ok(_) => {
-                        debug!("Updated vector {} in index {}", vector_id, index_name);
-                    }
-                    Err(e) => {
-                        // Some indexes (like Annoy) don't support dynamic updates
-                        if e.to_string().contains("cannot be modified") {
-                            debug!(
-                                "Index {} is static and doesn't support updates, will need rebuild",
-                                index_name
-                            );
-                            break; // No point trying more updates on this index
-                        } else {
-                            warn!(
-                                "Failed to update vector {} in index {}: {}",
-                                vector_id, index_name, e
-                            );
-                            update_errors.push((vector_id.clone(), index_name.clone(), e));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Log update statistics
-        if !update_errors.is_empty() {
-            warn!(
-                "⚠️ AXIS Compaction: {} update errors occurred during compaction_info",
-                update_errors.len()
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Rebuild static indexes that don't support dynamic updates
-    async fn rebuild_static_indexes_if_needed(
-        &self,
-        axis: &AxisManager,
-        collection_id: &str,
-        indexes: &[(String, Arc<dyn AxisVectorIndex>)],
-    ) -> Result<()> {
-        for (index_name, index) in indexes {
-            // Check if this is a static index (like Annoy)
-            let algorithm = index.algorithm();
-            if matches!(
-                algorithm,
-                proximadb_index_types::IndexAlgorithm::Annoy { .. }
-            ) {
-                info!(
-                    "🔨 AXIS Compaction: Rebuilding static index {} for collection {}",
-                    index_name, collection_id
-                );
-
-                // Trigger a full rebuild through AXIS manager
-                match axis.rebuild_index(collection_id, index_name).await {
-                    Ok(_) => {
-                        info!(
-                            "✅ Successfully rebuilt static index {} for collection {}",
-                            index_name, collection_id
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            "❌ Failed to rebuild static index {} for collection {}: {}",
-                            index_name, collection_id, e
-                        );
-                        // Continue with other indexes even if one fails
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Get compaction statistics for AXIS indexes
+    /// Get compaction statistics for AXIS indexes.
     pub async fn get_compaction_stats(&self, collection_id: &str) -> Result<CompactionIndexStats> {
-        let axis = match &self.axis_manager {
-            Some(manager) => manager,
-            None => {
-                return Ok(CompactionIndexStats::default());
-            }
+        let Some(axis) = &self.axis_manager else {
+            return Ok(CompactionIndexStats::default());
         };
-
-        let indexes = axis.get_collection_indexes(collection_id).await?;
-
-        let mut stats = CompactionIndexStats {
-            total_indexes: indexes.len(),
-            ..Default::default()
-        };
-
-        for (_name, index) in indexes {
-            let index_stats = index.stats();
-            stats.total_vectors_indexed += index_stats.vector_count;
-            stats.total_memory_usage_bytes += index_stats.memory_usage_bytes;
-
-            // Count index types
-            match index.algorithm() {
-                proximadb_index_types::IndexAlgorithm::HNSW { .. } => stats.dynamic_indexes += 1,
-                proximadb_index_types::IndexAlgorithm::IVF { .. } => stats.dynamic_indexes += 1,
-                proximadb_index_types::IndexAlgorithm::LSH { .. } => stats.dynamic_indexes += 1,
-                proximadb_index_types::IndexAlgorithm::Annoy { .. } => stats.static_indexes += 1,
-                _ => {}
-            }
-        }
-
-        Ok(stats)
+        let snapshots = axis.collection_index_stats(collection_id).await?;
+        Ok(aggregate_index_stats(&snapshots))
     }
 }
 
-/// Statistics for AXIS indexes during compaction
-#[derive(Debug, Default)]
+/// Aggregate per-index snapshots into compaction stats.
+///
+/// Pure (no I/O), so it is unit-testable in isolation: classifies HNSW/IVF/LSH as
+/// dynamic and Annoy as static, summing vector counts and memory across indexes.
+pub(crate) fn aggregate_index_stats(snapshots: &[IndexReaderSnapshot]) -> CompactionIndexStats {
+    let mut stats = CompactionIndexStats {
+        total_indexes: snapshots.len(),
+        ..Default::default()
+    };
+
+    for snap in snapshots {
+        stats.total_vectors_indexed += snap.vector_count;
+        stats.total_memory_usage_bytes += snap.memory_usage_bytes;
+
+        match &snap.algorithm {
+            IndexAlgorithm::HNSW { .. }
+            | IndexAlgorithm::IVF { .. }
+            | IndexAlgorithm::LSH { .. } => stats.dynamic_indexes += 1,
+            IndexAlgorithm::Annoy { .. } => stats.static_indexes += 1,
+            _ => {}
+        }
+    }
+
+    stats
+}
+
+/// Statistics for AXIS indexes during compaction.
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct CompactionIndexStats {
     pub total_indexes: usize,
     pub dynamic_indexes: usize,
@@ -316,7 +112,6 @@ pub struct CompactionIndexStats {
     pub total_memory_usage_bytes: usize,
 }
 
-// Test module moved to separate file for better organization
 #[cfg(test)]
 #[path = "compaction_axis_integration_tests.rs"]
 mod tests;

--- a/src/storage/persistence/write_ahead_log/compaction_axis_integration_tests.rs
+++ b/src/storage/persistence/write_ahead_log/compaction_axis_integration_tests.rs
@@ -13,7 +13,90 @@ mod tests {
 
     use crate::storage::traits::CompactionResult;
     use chrono::Utc;
+    use proximadb_index_traits::IndexReaderSnapshot;
+    use proximadb_index_types::IndexAlgorithm;
     use std::collections::HashMap;
+
+    fn hnsw() -> IndexAlgorithm {
+        IndexAlgorithm::HNSW {
+            m: 16,
+            ef_construction: 200,
+            ef_search: 50,
+            max_elements: 1000,
+        }
+    }
+
+    fn ivf() -> IndexAlgorithm {
+        IndexAlgorithm::IVF {
+            nlist: 100,
+            nprobe: 8,
+            quantizer: None,
+        }
+    }
+
+    fn annoy() -> IndexAlgorithm {
+        IndexAlgorithm::Annoy {
+            n_trees: 10,
+            search_k: -1,
+            max_leaf_size: 64,
+        }
+    }
+
+    fn snap(name: &str, vc: usize, mem: usize, algorithm: IndexAlgorithm) -> IndexReaderSnapshot {
+        IndexReaderSnapshot {
+            name: name.to_string(),
+            vector_count: vc,
+            memory_usage_bytes: mem,
+            algorithm,
+        }
+    }
+
+    #[test]
+    fn aggregate_empty_is_default() {
+        assert_eq!(aggregate_index_stats(&[]), CompactionIndexStats::default());
+    }
+
+    #[test]
+    fn aggregate_single_hnsw_counts_as_dynamic() {
+        let stats = aggregate_index_stats(&[snap("primary", 10, 100, hnsw())]);
+        assert_eq!(
+            stats,
+            CompactionIndexStats {
+                total_indexes: 1,
+                dynamic_indexes: 1,
+                static_indexes: 0,
+                total_vectors_indexed: 10,
+                total_memory_usage_bytes: 100,
+            }
+        );
+    }
+
+    #[test]
+    fn aggregate_single_annoy_counts_as_static() {
+        let stats = aggregate_index_stats(&[snap("ann", 5, 50, annoy())]);
+        assert_eq!(stats.total_indexes, 1);
+        assert_eq!(stats.dynamic_indexes, 0);
+        assert_eq!(stats.static_indexes, 1);
+    }
+
+    #[test]
+    fn aggregate_mixed_classifies_and_sums() {
+        let stats = aggregate_index_stats(&[
+            snap("a", 10, 100, hnsw()),
+            snap("b", 20, 200, ivf()),
+            snap("c", 7, 70, annoy()),
+        ]);
+        assert_eq!(
+            stats,
+            CompactionIndexStats {
+                total_indexes: 3,
+                dynamic_indexes: 2, // HNSW + IVF
+                static_indexes: 1,  // Annoy
+                total_vectors_indexed: 37,
+                total_memory_usage_bytes: 370,
+            }
+        );
+    }
 
     // Note: These tests focus on the CompactionAxisUpdater behavior without a real AxisManager.
     // Testing with a real AxisManager would require a more complex setup and is covered

--- a/src/storage/persistence/write_ahead_log/compaction_coordinator.rs
+++ b/src/storage/persistence/write_ahead_log/compaction_coordinator.rs
@@ -21,9 +21,9 @@ use tracing::{debug, info, warn};
 
 // Temporarily disabled due to arrow-arith compilation conflicts - DEFERRED: Re-enable when resolved
 // use crate::storage::engines::viper::ViperEngine;
-use crate::index::axis::AxisManager;
 use crate::storage::engines::sst::SstEngine;
 use crate::storage::traits::FlushResult;
+use proximadb_index_traits::IndexMaintenance;
 
 use super::compaction_axis_integration::CompactionAxisUpdater;
 
@@ -210,7 +210,7 @@ impl CompactionCoordinator {
         viper_engine: Arc<crate::storage::engines::viper::engine::ViperEngine>,
         sst_engine: Arc<SstEngine>,
         config: Option<WalCompactionConfig>,
-        axis_manager: Option<Arc<AxisManager>>,
+        axis_manager: Option<Arc<dyn IndexMaintenance>>,
     ) -> Self {
         let config_ref = config.as_ref();
 

--- a/src/storage/persistence/write_ahead_log/flush_coordinator.rs
+++ b/src/storage/persistence/write_ahead_log/flush_coordinator.rs
@@ -79,8 +79,6 @@ pub struct WALFlushCoordinator {
     next_flush_id: Arc<tokio::sync::Mutex<u64>>,
     /// Storage engine registry for polymorphic flush delegation
     storage_engines: Arc<RwLock<HashMap<String, Arc<dyn UnifiedStorageFormat>>>>,
-    /// AXIS manager for IndexConfig-based indexing after flush
-    axis_manager: Option<Arc<crate::index::axis::management::manager::AxisManager>>,
     /// Optimized flush coordinator for high-performance flushing
     optimized_coordinator: Option<Arc<OptimizedFlushCoordinator>>,
     /// Collection service for fetching metadata
@@ -103,7 +101,6 @@ impl WALFlushCoordinator {
             flush_states: Arc::new(RwLock::new(HashMap::new())),
             next_flush_id: Arc::new(tokio::sync::Mutex::new(1)),
             storage_engines: Arc::new(RwLock::new(HashMap::new())),
-            axis_manager: None,
             optimized_coordinator: None,
             collection_service: None,
             metrics_updater: None,
@@ -191,15 +188,6 @@ impl WALFlushCoordinator {
             "🚀 FlushCoordinator: Optimized flush enabled with batch_size={}, workers={}",
             batch_size, worker_count
         );
-    }
-
-    /// Set the AXIS manager for IndexConfig-based indexing
-    pub fn set_axis_manager(
-        &mut self,
-        axis_manager: Arc<crate::index::axis::management::manager::AxisManager>,
-    ) {
-        self.axis_manager = Some(axis_manager);
-        info!("🔗 FlushCoordinator: AXIS manager registered for IndexConfig-based indexing");
     }
 
     /// Initialize flush state for a collection


### PR DESCRIPTION
## What

Completes the storage→index dependency inversion (`IndexPort`): removes the concrete `crate::index::axis::AxisManager` from storage's compaction, flush, and vector-store paths. Storage now depends only on the foundation `proximadb-index-traits` port + DTO; the live `Arc<dyn AxisVectorIndex>` reader handles never cross into `src/storage`.

## Why

Slice D's last storage→up coupling. The index inversion was already ~95% done (the `proximadb-index-traits` role traits + slim DTOs exist; all 6 engines hold `Arc<dyn IndexEngine>`); this narrows the remaining 4 files. Unblocks the engine-crate extractions (Slices E/F) on the read/maintenance surface.

## Design — intent-level inversion (DIP, first-principles)

Scoping found compaction doesn't just *read* index stats — `update_indexes_after_compaction` uses the live readers to **mutate** indexes (remove/add/rebuild). A stats-only DTO can't back that, and the prior authors deliberately avoided putting `Arc<dyn AxisVectorIndex>` in the foundation trait. So the boundary is the **intent**, not the mechanism: storage announces *what changed*; AXIS owns *how* it reconciles its own readers.

- **`proximadb-index-traits`**: `IndexReaderSnapshot` DTO (slim, foundation-only — `name`/`vector_count`/`memory_usage_bytes`/`algorithm`) + two `IndexMaintenance` methods: `update_indexes_after_compaction(collection_id, deleted, merged)` and `collection_index_stats(...) -> Vec<IndexReaderSnapshot>`. Adds the `proximadb-index-types` dep (foundation→foundation) for `IndexAlgorithm`.
- **`src/index/axis/compaction_update.rs`** (new): the ~150 lines of remove/add/rebuild reconciliation moved **verbatim** from the in-storage `CompactionAxisUpdater` into `AxisManager` — readers stay in AXIS.
- **`contract.rs`**: adapter delegates both port methods to `AxisManager`, projecting concrete readers → snapshots at the boundary (anti-corruption).
- **`compaction_axis_integration.rs`**: thin port façade; stats via a pure, **TDD'd** `aggregate_index_stats` fn (SOLID — pure logic split from I/O).
- **`compaction_coordinator.rs`** / **`vector_store.rs`** / **`flush_coordinator.rs`**: narrowed to `dyn IndexMaintenance`/`dyn IndexEngine`; removed a dead getter and a dead write-only field+setter.

## TDD

4 new table tests for `aggregate_index_stats` (empty → default; single HNSW → dynamic+sums; single Annoy → static; mixed HNSW+IVF+Annoy → dynamic=2/static=1 + summed totals); existing `new(None)` compaction tests still green. **13/13** pass.

## Verification

- `cargo check -p proximadb --tests` ✅ · `cargo clippy -p proximadb --lib --bins -- -D warnings` ✅
- `cargo check -p proximadb-server -p proximadb-bench -p proximadb-migrate` ✅
- `cargo clippy -p proximadb-index-traits --all-targets -- -D warnings` ✅ · nextest 13/13 ✅
- `scripts/check-layering.sh` → No boundary findings ✅ · capability validator ✅
- **Edge ratchet:** `Arc<AxisManager>` under `src/storage` is now only `engine.rs:29` (construction — deferred to the composition-root PR2) + one test.

## Follow-ups (separate PRs)
- **PR2:** move `AxisManager::new` out of `engine.rs:137` to the composition root + add the D5 storage-up-edge ratchet → zero.
- Repo-wide `clippy::approx_constant` (≈π) sweep + dead-code cleanup (pre-existing, unrelated).