### PR TITLE
fix(rest): correct stale v1-hybrid docs + add native embedding dev→qa gate

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,5 +59,14 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'test(/_e2e$/) | test(/_integration_test$/) | binary(integration)'
 test-group = 'serial-network'
 
+[[profile.default.overrides]]
+filter = 'test(/datafusion/) | test(/native_volcano/)'
+test-group = 'datafusion-heavy'
+
+[[profile.unit.overrides]]
+filter = 'test(/datafusion/) | test(/native_volcano/)'
+test-group = 'datafusion-heavy'
+
 [test-groups]
 serial-network = { max-threads = 1 }
+datafusion-heavy = { max-threads = 1 }

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -186,3 +186,40 @@ jobs:
             /tmp/llvm-cov.json
             rust-coverage-seed.json
           if-no-files-found: ignore
+
+  embedding-smoke:
+    name: Native embedding smoke (runtime-full / onnx)
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    # FIRST CUT — the dev->qa gate for native embedding. `onnx` is a non-default
+    # cargo feature and the default `:latest` image is the no-onnx `runtime`
+    # target, so nothing else in CI exercises the BGE/onnx path. This builds the
+    # `runtime-full` image (onnx + baked BGE model) and runs
+    # scripts/embedding_smoke.sh against it, failing if native ingest returns
+    # model_unavailable. Non-blocking until proven green on qa; flip to required
+    # (remove continue-on-error) once stable — same rollout pattern as
+    # rust-coverage-ratchet above.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build runtime-full (onnx) image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          target: runtime-full
+          tags: proximadb:runtime-full-smoke
+          load: true
+          cache-from: type=gha,scope=runtime-full
+          cache-to: type=gha,scope=runtime-full,mode=max
+      - name: Run engine + embedding smoke
+        run: |
+          set -euo pipefail
+          docker run -d --name px -p 5678:5678 proximadb:runtime-full-smoke
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:5678/health >/dev/null 2>&1; then break; fi
+            sleep 2
+          done
+          curl -fsS http://localhost:5678/health >/dev/null || { echo '::error:: engine did not become healthy'; docker logs px; exit 1; }
+          bash scripts/embedding_smoke.sh http://localhost:5678

--- a/scripts/embedding_smoke.sh
+++ b/scripts/embedding_smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Embedding dev->qa gate smoke.
+#
+# Ingests one document with server-side (native) embedding and asserts the
+# engine actually embeds it — failing LOUD if the build lacks the `onnx`
+# feature (model_unavailable). That failure is the gate's whole point: `onnx`
+# is a non-default cargo feature and the default `:latest` image is the no-onnx
+# `runtime` target, so without this check nothing in CI catches "embedding
+# broken" or "the `-full` (onnx) image fails to embed".
+#
+# Usage:  scripts/embedding_smoke.sh [ENGINE_URL]    (default http://localhost:5678)
+# Exit:   0 = native embedding works; 1 = engine can't embed (model_unavailable / non-2xx).
+set -euo pipefail
+
+URL="${1:-http://localhost:5678}"
+URL="${URL%/}"
+COLL="embedding_smoke_$$"
+
+echo "→ creating collection $COLL (dim 384 = BGE-small)"
+curl -fsS -X POST "$URL/api/v2/collections" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$COLL\",\"dimension\":384}" >/dev/null
+
+echo "→ ingesting a doc with X-Embed-Source: native (server-side embed)"
+CODE=$(curl -s -o /tmp/embedding_smoke_resp.json -w "%{http_code}" -X POST \
+  "$URL/api/v2/collections/$COLL/documents" \
+  -H 'Content-Type: application/json' -H 'X-Embed-Source: native' \
+  -d '{"records":[{"id":"s1","text":"spark executor out of memory after autoscaling","metadata":{"tenant_id":"smoke","source":"probe"}}]}')
+
+fail() {
+  echo "::error:: $1"
+  echo "--- response (HTTP $CODE) ---"
+  cat /tmp/embedding_smoke_resp.json 2>/dev/null || true
+  echo
+  exit 1
+}
+
+case "$CODE" in
+  200|201|202) ;;
+  *) fail "native ingest returned HTTP $CODE (expected 2xx)" ;;
+esac
+
+if grep -q "model_unavailable" /tmp/embedding_smoke_resp.json 2>/dev/null; then
+  fail "engine returned model_unavailable — the 'onnx' feature is disabled in this build. Rebuild with --features onnx (the runtime-full image), or use a non-BGE route."
+fi
+
+echo "✓ native embedding works (HTTP $CODE) — onnx/BGE path is live in this image."

--- a/src/network/hybrid_search.rs
+++ b/src/network/hybrid_search.rs
@@ -78,7 +78,7 @@ use proximadb_runtime::HybridPort;
 /// `VectorOpsPort` trait object for vector similarity search.
 ///
 /// This replaces the mock `HybridSearchServiceImpl` for the REST hybrid search
-/// route (`POST /api/v1/hybrid/search`).
+/// route (`POST /api/v2/hybrid/search`).
 pub struct RestHybridPortImpl {
     vector_ops: Arc<dyn proximadb_runtime::VectorOpsPort>,
     indexes: HybridFullTextIndexMap,

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -320,7 +320,7 @@ impl AppState {
 
     /// Inject the shared full-text index map (T3.2 Slice 1b).
     /// Production wires this from `SharedServices.fulltext_indexes` so
-    /// REST `/api/v1/hybrid/search` and gRPC `hybrid_search` share the
+    /// REST `/api/v2/hybrid/search` and gRPC `hybrid_search` share the
     /// same in-process map — an indexed document is searchable on
     /// both protocols.
     pub fn with_fulltext_indexes(mut self, indexes: FullTextIndexMap) -> Self {
@@ -1534,7 +1534,7 @@ pub fn create_router(state: AppState) -> axum::Router {
 
     // Experimental hybrid API removed 2026-05-26: it returned mock-backed
     // results that misled customers into thinking the endpoint computed real
-    // BM25+vector fusion. The production hybrid endpoint at `/api/v1/hybrid/search`
+    // BM25+vector fusion. The production hybrid endpoint at `/api/v2/hybrid/search`
     // (port-backed via `RestHybridPortImpl`) is the supported path; gRPC parity
     // landed in commit 6a73ead7f. The module at `src/network/rest/v1/hybrid.rs`
     // remains in-tree for reference but is no longer mounted.
@@ -1581,7 +1581,7 @@ pub fn create_router(state: AppState) -> axum::Router {
         // Agent-memory read surface (TD-100, ADR-022): scoped + fused + audited.
         // Converges on the existing scoped vector search + BM25 + RRF fusion —
         // no new storage path. The lexical leg reuses the same in-process
-        // HybridFullTextIndexMap as /api/v1/hybrid.
+        // HybridFullTextIndexMap as /api/v2/hybrid.
         {
             let mem_indexes = state.fulltext_indexes.clone().unwrap_or_else(|| {
                 Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()))
@@ -1733,10 +1733,10 @@ pub fn create_router(state: AppState) -> axum::Router {
     info!("   POST   /api/v1/vectors/batch (deprecated alias over record-native writes)");
     info!("   GET    /api/v1/vectors/:collection_id/:vector_id (deprecated compatibility)");
     info!("   DELETE /api/v1/vectors/:collection_id/:vector_id (deprecated compatibility)");
-    info!("   POST   /api/v1/hybrid/search (deprecated compatibility; real BM25+vector)");
-    info!("   POST   /api/v1/hybrid/index (deprecated compatibility)");
+    info!("   POST   /api/v2/hybrid/search (canonical BM25+vector; v1 hybrid removed 2026-06-06)");
+    info!("   POST   /api/v2/hybrid/index (canonical; v1 removed 2026-06-06)");
     // /api/v1/experimental/hybrid/search route removed 2026-05-26 — was
-    // mock-backed; production path is /api/v1/hybrid/search above.
+    // mock-backed; production path is /api/v2/hybrid/search above.
 
     router
 }

--- a/src/network/rest/v1/hybrid.rs
+++ b/src/network/rest/v1/hybrid.rs
@@ -3,7 +3,8 @@
 //! Experimental REST API for hybrid search combining BM25 full-text search with vector similarity.
 //!
 //! This module is mock-backed and intended for fusion strategy experimentation.
-//! Production hybrid search lives in `handlers.rs` at `/api/v1/hybrid/search`.
+//! Production hybrid search lives in `handlers.rs` at `/api/v2/hybrid/search`
+//! (relocated from /api/v1 on 2026-06-06; v1 hybrid was removed).
 //!
 //! ## Available Endpoints
 //!

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -155,7 +155,7 @@ pub struct SharedServices {
     pub graph_port: Arc<dyn proximadb_runtime::GraphPort>,
 
     /// Shared in-process full-text index map for hybrid retrieval
-    /// (BM25 side of `/api/v1/hybrid/search`). REST and gRPC entry
+    /// (BM25 side of `/api/v2/hybrid/search`). REST and gRPC entry
     /// points read from this single map so an indexed document is
     /// immediately searchable on both protocols.
     ///


### PR DESCRIPTION
## Summary
Cleanup of stale v1-hybrid references (v1 hybrid was **removed** 2026-06-06 in `7adff1000`) + a new dev→qa gate for native embedding (onnx), which was previously ungated.

## Changes
- **Stale v1-hybrid docs/logs** (`fix(rest,sdk)` commit): the startup log lines advertised the removed `/api/v1/hybrid/*` routes as "deprecated compatibility" — corrected to `/api/v2`. 5 more stale v1-hybrid doc references cleaned (`hybrid.rs`, `hybrid_search.rs`, `shared_services.rs`, `handlers.rs`).
  > Note: this commit's subject also says "rename dist to proximadb", but that rename was **already on `develop`** — so the actual diff in this commit is the doc/log cleanup only.
- **Embedding dev→qa gate** (`ci(qa)` commit): new `qa-gate.yml` `embedding-smoke` job builds the `runtime-full` (onnx + baked BGE) image and runs `scripts/embedding_smoke.sh` (ingest with `X-Embed-Source: native`; fail loud on `model_unavailable`). Non-blocking (`continue-on-error`) first cut — same rollout as `rust-coverage-ratchet`; flip to required once green.

## Why the gate
`onnx` is a non-default cargo feature, the default `:latest` image is the no-onnx `runtime` target, and embedding tests skip by default — so nothing in CI exercised the BGE/onnx path. A regression there would ship undetected.

## Verification
`embedding_smoke.sh` validated against a no-onnx engine (correctly fails `model_unavailable`); pre-push hook passed `worktree + fmt`.