### PR TITLE
feat(oltp): TD-127/128 — secondary-index + IN-list pushdown in the Volcano relational path

### DIFF
--- a/crates/query/proximadb-relational-engine/src/lib.rs
+++ b/crates/query/proximadb-relational-engine/src/lib.rs
@@ -766,6 +766,7 @@ mod tests {
         let planner = Planner::new(StaticCapabilities {
             caps: RC::full(),
             pk_columns: vec![0],
+            secondary_columns: Vec::new(),
         });
         let physical = planner.plan(logical).unwrap();
         let factory = EngineReaderFactory::new(engine.clone());
@@ -823,6 +824,7 @@ mod tests {
         let planner = Planner::new(StaticCapabilities {
             caps: RC::full(),
             pk_columns: vec![0],
+            secondary_columns: Vec::new(),
         });
         let physical = planner.plan(logical).unwrap();
         let factory = EngineReaderFactory::new(engine.clone());
@@ -863,6 +865,7 @@ mod tests {
         let planner = Planner::new(StaticCapabilities {
             caps: RC::full(),
             pk_columns: vec![0],
+            secondary_columns: Vec::new(),
         });
         let physical = planner.plan(logical).unwrap();
         let factory = EngineReaderFactory::new(engine.clone());

--- a/crates/query/proximadb-relational-executor/src/lib.rs
+++ b/crates/query/proximadb-relational-executor/src/lib.rs
@@ -472,6 +472,16 @@ pub struct ScanExec {
     pk_emitted: bool,
     /// PkLookup row, computed at `open`.
     pk_row: Option<RelationalRow>,
+    /// For PkLookupBatch / SecondaryLookup (candidate path): the FULL
+    /// rows resolved at `open`, streamed (with projection narrowing)
+    /// by `next_row`. (TD-127 / TD-128.)
+    buffered_rows: Vec<RelationalRow>,
+    buffer_cursor: usize,
+    /// For SecondaryLookup: the reader had no built index (`Ok(None)`)
+    /// so `open` fell back to a full scan; `next_row` streams the
+    /// reader directly (it applies projection internally) instead of
+    /// the buffer. (TD-127.)
+    secondary_fell_back: bool,
 }
 
 impl ScanExec {
@@ -494,7 +504,41 @@ impl ScanExec {
             snapshot,
             pk_emitted: false,
             pk_row: None,
+            buffered_rows: Vec::new(),
+            buffer_cursor: 0,
+            secondary_fell_back: false,
         }
+    }
+
+    /// Narrow a FULL (unprojected) row to the scan's projection,
+    /// resolving names against the reader's full schema (the reader
+    /// is not `open`ed on the lookup paths, so `schema()` is the full
+    /// table schema). Shared by the PkLookup / PkLookupBatch /
+    /// SecondaryLookup candidate paths.
+    fn project_full_row(&self, row: RelationalRow) -> Result<RelationalRow, ExecError> {
+        let Some(names) = &self.projection else {
+            return Ok(row);
+        };
+        let full = self.reader.schema();
+        let mut out = Vec::with_capacity(names.len());
+        for name in names {
+            let (idx, _) = full.column_by_name(name).ok_or_else(|| {
+                ExecError::Internal(format!("projection column `{}` not in reader schema", name))
+            })?;
+            out.push(row[idx].clone());
+        }
+        Ok(out)
+    }
+
+    /// Stream the next buffered (lookup-path) row, narrowing it to the
+    /// projection. `Ok(None)` at buffer EOF.
+    fn next_buffered_row(&mut self) -> Result<Option<RelationalRow>, ExecError> {
+        if self.buffer_cursor >= self.buffered_rows.len() {
+            return Ok(None);
+        }
+        let row = self.buffered_rows[self.buffer_cursor].clone();
+        self.buffer_cursor += 1;
+        Ok(Some(self.project_full_row(row)?))
     }
 }
 
@@ -520,6 +564,40 @@ impl ExecNode for ScanExec {
                 self.pk_row = self.reader.lookup_pk(&key_values).await?;
                 self.pk_emitted = false;
             }
+            ScanAccess::PkLookupBatch { keys } => {
+                // Evaluate each constant key tuple, then probe in one batch.
+                let mut key_values = Vec::with_capacity(keys.len());
+                for k in keys {
+                    key_values.push(evaluate_key(k)?);
+                }
+                self.buffered_rows = self.reader.lookup_pk_batch(&key_values).await?;
+                self.buffer_cursor = 0;
+            }
+            ScanAccess::SecondaryLookup { column, values } => {
+                let probe_values = evaluate_key(values)?;
+                match self.reader.lookup_secondary(column, &probe_values).await? {
+                    Some(rows) => {
+                        // Index answered — stream candidates (the residual
+                        // Filter the planner kept re-checks each).
+                        self.buffered_rows = rows;
+                        self.buffer_cursor = 0;
+                        self.secondary_fell_back = false;
+                    }
+                    None => {
+                        // No built index — fall back to a full scan. The
+                        // reader applies projection/predicate internally; the
+                        // residual Filter above still re-checks for correctness.
+                        let ctx = ScanContext {
+                            projection: self.projection.clone(),
+                            predicate: self.predicate.clone(),
+                            limit: self.limit,
+                            snapshot: self.snapshot,
+                        };
+                        self.reader.open(&ctx).await?;
+                        self.secondary_fell_back = true;
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -540,27 +618,20 @@ impl ExecNode for ScanExec {
                     None => return Ok(None),
                     Some(r) => r,
                 };
-                let projected = match &self.projection {
-                    None => row,
-                    Some(names) => {
-                        // Reader's schema() returns the full table
-                        // schema when not opened — exactly what we
-                        // need to resolve projection ordinals.
-                        let full = self.reader.schema();
-                        let mut out = Vec::with_capacity(names.len());
-                        for name in names {
-                            let (idx, _) = full.column_by_name(name).ok_or_else(|| {
-                                ExecError::Internal(format!(
-                                    "projection column `{}` not in reader schema",
-                                    name
-                                ))
-                            })?;
-                            out.push(row[idx].clone());
-                        }
-                        out
-                    }
-                };
-                Ok(Some(projected))
+                Ok(Some(self.project_full_row(row)?))
+            }
+            // TD-128: discrete batch — stream the buffered FULL rows,
+            // narrowing each to the projection.
+            ScanAccess::PkLookupBatch { .. } => self.next_buffered_row(),
+            // TD-127: secondary lookup — either the buffered candidate
+            // rows (narrowed) or, on the no-index fallback, the reader's
+            // own (already-projected) full-scan stream.
+            ScanAccess::SecondaryLookup { .. } => {
+                if self.secondary_fell_back {
+                    Ok(self.reader.next_row().await?)
+                } else {
+                    self.next_buffered_row()
+                }
             }
         }
     }
@@ -2427,12 +2498,15 @@ mod tests {
     /// table returns a clone of a stored `VecReader` source.
     struct VecReaderFactory {
         sources: Mutex<HashMap<String, (RelationalSchema, Vec<RelationalRow>, Vec<usize>)>>,
+        /// Optional non-PK secondary-index ordinals per table (TD-127).
+        secondary: Mutex<HashMap<String, Vec<usize>>>,
     }
 
     impl VecReaderFactory {
         fn new() -> Self {
             Self {
                 sources: Mutex::new(HashMap::new()),
+                secondary: Mutex::new(HashMap::new()),
             }
         }
         fn register(
@@ -2447,6 +2521,14 @@ mod tests {
                 .unwrap()
                 .insert(name.to_string(), (schema, rows, pk_columns));
         }
+        /// Register a non-PK secondary index on the given ordinals (TD-127),
+        /// so the table's reader answers `lookup_secondary` for them.
+        fn register_secondary(&self, name: &str, columns: Vec<usize>) {
+            self.secondary
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), columns);
+        }
     }
 
     impl ReaderFactory for VecReaderFactory {
@@ -2456,7 +2538,16 @@ mod tests {
                 .get(&table.name)
                 .ok_or_else(|| ExecError::Internal(format!("no table {}", table.name)))?
                 .clone();
-            Ok(Box::new(VecReader::new(schema, rows, pk)))
+            let secondary = self
+                .secondary
+                .lock()
+                .unwrap()
+                .get(&table.name)
+                .cloned()
+                .unwrap_or_default();
+            Ok(Box::new(
+                VecReader::new(schema, rows, pk).with_secondary_index(secondary),
+            ))
         }
     }
 
@@ -3360,6 +3451,114 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].len(), 1, "row should be narrowed to one column");
         assert_eq!(rows[0][0], ProximaValue::String("bob".into()));
+    }
+
+    // ----- PK batch lookup (TD-128) ------------------------------------
+
+    #[tokio::test]
+    async fn scan_pk_lookup_batch_returns_matching_rows() {
+        let plan = PhysicalPlan::Scan {
+            table: TableId::new("users"),
+            output_schema: users_schema(),
+            projection: None,
+            predicate: None,
+            limit: None,
+            access: ScanAccess::PkLookupBatch {
+                keys: vec![
+                    vec![Expr::literal(ProximaValue::Int64(1))],
+                    vec![Expr::literal(ProximaValue::Int64(3))],
+                    vec![Expr::literal(ProximaValue::Int64(999))], // miss
+                ],
+            },
+        };
+        let f = factory_with_users();
+        let mut exec = build_executor(plan, &f, &ExecutionContext::default()).unwrap();
+        exec.open().await.unwrap();
+        let rows = collect(&mut *exec).await.unwrap();
+        assert_eq!(rows.len(), 2, "two hits, miss omitted");
+        let names: Vec<&str> = rows
+            .iter()
+            .map(|r| match &r[1] {
+                ProximaValue::String(s) => s.as_str(),
+                _ => unreachable!(),
+            })
+            .collect();
+        assert!(names.contains(&"alice"));
+        assert!(names.contains(&"carol"));
+    }
+
+    #[tokio::test]
+    async fn scan_pk_lookup_batch_applies_projection() {
+        let narrowed =
+            RelationalSchema::new(vec![ColumnInfo::new("name", ProximaType::String, true)]);
+        let plan = PhysicalPlan::Scan {
+            table: TableId::new("users"),
+            output_schema: narrowed,
+            projection: Some(vec!["name".into()]),
+            predicate: None,
+            limit: None,
+            access: ScanAccess::PkLookupBatch {
+                keys: vec![
+                    vec![Expr::literal(ProximaValue::Int64(1))],
+                    vec![Expr::literal(ProximaValue::Int64(2))],
+                ],
+            },
+        };
+        let f = factory_with_users();
+        let mut exec = build_executor(plan, &f, &ExecutionContext::default()).unwrap();
+        exec.open().await.unwrap();
+        let rows = collect(&mut *exec).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.len() == 1), "narrowed to one column");
+    }
+
+    // ----- Secondary lookup (TD-127) -----------------------------------
+
+    #[tokio::test]
+    async fn scan_secondary_lookup_returns_candidates() {
+        // Secondary index on `name` (ordinal 1).
+        let plan = PhysicalPlan::Scan {
+            table: TableId::new("users"),
+            output_schema: users_schema(),
+            projection: None,
+            predicate: None,
+            limit: None,
+            access: ScanAccess::SecondaryLookup {
+                column: "name".into(),
+                values: vec![Expr::literal(ProximaValue::String("bob".into()))],
+            },
+        };
+        let f = factory_with_users();
+        f.register_secondary("users", vec![1]);
+        let mut exec = build_executor(plan, &f, &ExecutionContext::default()).unwrap();
+        exec.open().await.unwrap();
+        let rows = collect(&mut *exec).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], ProximaValue::Int64(2));
+    }
+
+    #[tokio::test]
+    async fn scan_secondary_lookup_falls_back_to_full_scan_without_index() {
+        // No secondary index registered → reader answers Ok(None) → the
+        // executor falls back to a full scan (all rows). The residual
+        // Filter the planner keeps would re-narrow in a full plan; here we
+        // assert the fallback streams every row rather than erroring.
+        let plan = PhysicalPlan::Scan {
+            table: TableId::new("users"),
+            output_schema: users_schema(),
+            projection: None,
+            predicate: None,
+            limit: None,
+            access: ScanAccess::SecondaryLookup {
+                column: "name".into(),
+                values: vec![Expr::literal(ProximaValue::String("bob".into()))],
+            },
+        };
+        let f = factory_with_users(); // NO register_secondary
+        let mut exec = build_executor(plan, &f, &ExecutionContext::default()).unwrap();
+        exec.open().await.unwrap();
+        let rows = collect(&mut *exec).await.unwrap();
+        assert_eq!(rows.len(), 3, "fallback full scan emits all rows");
     }
 
     // ----- Values ------------------------------------------------------

--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -84,6 +84,28 @@ pub enum ScanAccess {
         /// declared primary key.
         key: Vec<Expr>,
     },
+    /// Discrete multi-key point lookup (TD-128): `PK IN (...)` or a
+    /// pure `PK = a OR PK = b OR …` disjunction. Each inner `Vec`
+    /// is one full primary-key tuple (single-component in v1). The
+    /// predicate is fully captured by these keys, so the planner
+    /// DROPS it (like single-key `PkLookup`). Gated on
+    /// [`ReaderCapabilities::pk_lookup_batch`] + a declared PK.
+    PkLookupBatch {
+        keys: Vec<Vec<Expr>>,
+    },
+    /// OLTP secondary-index lookup (TD-127): an equality / `IN`-list
+    /// on a non-PK column that the table declares as a single-column
+    /// secondary index. `values` are the constant probe expressions
+    /// (one for `=`, many for `IN`). Unlike PK access this only
+    /// NARROWS, so the planner KEEPS the residual `Filter` above the
+    /// scan, and the executor falls back to a full scan when the
+    /// reader answers `Ok(None)` (index unbuilt / disabled). Gated
+    /// on [`ReaderCapabilities::secondary_lookup`] +
+    /// [`CapabilityResolver::secondary_index_columns`].
+    SecondaryLookup {
+        column: String,
+        values: Vec<Expr>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -295,6 +317,8 @@ fn render_explain_node(plan: &PhysicalPlan, depth: usize, lines: &mut Vec<String
             let access = match access {
                 ScanAccess::FullScan => "FullScan",
                 ScanAccess::PkLookup { .. } => "PkLookup",
+                ScanAccess::PkLookupBatch { .. } => "PkLookupBatch",
+                ScanAccess::SecondaryLookup { .. } => "SecondaryLookup",
             };
             let predicate = if predicate.is_some() { "yes" } else { "no" };
             let projection = match projection {
@@ -430,6 +454,16 @@ pub trait CapabilityResolver: Send + Sync {
         let _ = table;
         Vec::new()
     }
+
+    /// Names of `table`'s single-column non-PK secondary indexes
+    /// (TD-127). Used by the `SecondaryLookup` rewrite to gate which
+    /// columns an equality / `IN`-list may probe. Empty (the
+    /// default) means no secondary index is known, so the rewrite is
+    /// skipped and the predicate stays a scan + filter.
+    fn secondary_index_columns(&self, table: &TableId) -> Vec<String> {
+        let _ = table;
+        Vec::new()
+    }
 }
 
 /// Reference resolver that always returns the same capabilities
@@ -437,6 +471,9 @@ pub trait CapabilityResolver: Send + Sync {
 pub struct StaticCapabilities {
     pub caps: ReaderCapabilities,
     pub pk_columns: Vec<usize>,
+    /// Names of the table's non-PK secondary-indexed columns
+    /// (TD-127). Empty = none.
+    pub secondary_columns: Vec<String>,
 }
 
 impl CapabilityResolver for StaticCapabilities {
@@ -445,6 +482,9 @@ impl CapabilityResolver for StaticCapabilities {
     }
     fn primary_key(&self, _table: &TableId) -> Vec<usize> {
         self.pk_columns.clone()
+    }
+    fn secondary_index_columns(&self, _table: &TableId) -> Vec<String> {
+        self.secondary_columns.clone()
     }
 }
 
@@ -903,6 +943,62 @@ pub fn push_predicates<R: CapabilityResolver>(plan: PhysicalPlan, resolver: &R) 
                             access: ScanAccess::PkLookup { key },
                         };
                     }
+                    // TD-128: discrete multi-key batch — `PK IN (...)`
+                    // or a pure `PK = a OR PK = b …`. Fully captured by
+                    // the keys, so (like single-key PkLookup) DROP the
+                    // predicate.
+                    if caps.pk_lookup_batch
+                        && !pk_cols.is_empty()
+                        && matches!(access, ScanAccess::FullScan)
+                        && let Some(keys) = try_pk_lookup_batch(&combined, &pk_cols)
+                    {
+                        return PhysicalPlan::Scan {
+                            table,
+                            output_schema,
+                            projection,
+                            predicate: None,
+                            limit,
+                            access: ScanAccess::PkLookupBatch { keys },
+                        };
+                    }
+                    // TD-127: secondary-index lookup — an equality / IN
+                    // on a non-PK secondary-indexed column. The index
+                    // only NARROWS, so KEEP the predicate as a residual
+                    // Filter above the scan (the executor re-checks every
+                    // candidate, and falls back to a full scan when the
+                    // reader has no built index).
+                    let secondary_cols = resolver.secondary_index_columns(&table);
+                    if caps.secondary_lookup
+                        && !secondary_cols.is_empty()
+                        && matches!(access, ScanAccess::FullScan)
+                        && let Some((column, values)) =
+                            try_secondary_lookup(&combined, &secondary_cols, &output_schema)
+                    {
+                        // Push the combined predicate into the scan too
+                        // (used only on the full-scan fallback) when the
+                        // adapter pushes predicates; the residual Filter
+                        // is the row-exact authority on both paths.
+                        let scan_predicate = if caps.push_predicate {
+                            combined.clone()
+                        } else {
+                            None
+                        };
+                        let scan = PhysicalPlan::Scan {
+                            table,
+                            output_schema,
+                            projection,
+                            predicate: scan_predicate,
+                            limit,
+                            access: ScanAccess::SecondaryLookup { column, values },
+                        };
+                        return match combined {
+                            Some(p) => PhysicalPlan::Filter {
+                                input: Box::new(scan),
+                                predicate: p,
+                            },
+                            None => scan,
+                        };
+                    }
                     if caps.push_predicate {
                         PhysicalPlan::Scan {
                             table,
@@ -1199,6 +1295,151 @@ fn try_pk_lookup(
     }
     // All PK slots must be covered.
     key.into_iter().collect()
+}
+
+/// TD-128: extract a discrete multi-key batch from a predicate that is
+/// ENTIRELY a single-column `PK IN (v1, v2, …)` or a pure
+/// `PK = a OR PK = b OR …` disjunction. Returns one key tuple per
+/// value (single-component in v1). Returns `None` when the predicate
+/// has any other shape (an ANDed residual, a non-PK column, a
+/// column-referencing value, or `NOT IN`) so the caller leaves the
+/// predicate intact. Only fires for single-column PKs.
+fn try_pk_lookup_batch(predicate: &Option<Expr>, pk_cols: &[usize]) -> Option<Vec<Vec<Expr>>> {
+    // v1: single-column PK only.
+    let [pk] = pk_cols else {
+        return None;
+    };
+    let pk = *pk;
+    let p = predicate.as_ref()?;
+    match p {
+        // `PK IN (v1, v2, …)` (not negated).
+        Expr::In {
+            expr,
+            list,
+            not: false,
+        } => {
+            let Expr::Column(c) = expr.as_ref() else {
+                return None;
+            };
+            if c.ordinal != pk || list.is_empty() {
+                return None;
+            }
+            if list.iter().any(expression_references_columns) {
+                return None;
+            }
+            Some(list.iter().map(|v| vec![v.clone()]).collect())
+        }
+        // `PK = a OR PK = b OR …` — every disjunct must be a PK
+        // equality against a constant.
+        Expr::BinaryOp {
+            op: BinaryOp::Or, ..
+        } => {
+            let mut keys = Vec::new();
+            collect_pk_eq_disjuncts(p, pk, &mut keys)?;
+            if keys.is_empty() { None } else { Some(keys) }
+        }
+        _ => None,
+    }
+}
+
+/// Walk an OR-tree, collecting one `[value]` key per `PK = const`
+/// leaf. Returns `None` if any leaf is not a PK equality against a
+/// constant.
+fn collect_pk_eq_disjuncts(expr: &Expr, pk: usize, out: &mut Vec<Vec<Expr>>) -> Option<()> {
+    match expr {
+        Expr::BinaryOp {
+            op: BinaryOp::Or,
+            left,
+            right,
+        } => {
+            collect_pk_eq_disjuncts(left, pk, out)?;
+            collect_pk_eq_disjuncts(right, pk, out)?;
+            Some(())
+        }
+        Expr::BinaryOp {
+            op: BinaryOp::Eq,
+            left,
+            right,
+        } => {
+            let (col, value) = match (left.as_ref(), right.as_ref()) {
+                (Expr::Column(c), v) => (c, v),
+                (v, Expr::Column(c)) => (c, v),
+                _ => return None,
+            };
+            if col.ordinal != pk || expression_references_columns(value) {
+                return None;
+            }
+            out.push(vec![value.clone()]);
+            Some(())
+        }
+        _ => None,
+    }
+}
+
+/// TD-127: find one secondary-index probe in a predicate — an
+/// equality (`col = const`) or `IN`-list (`col IN (…)`, not negated)
+/// on a column the table declares as a single-column secondary index.
+/// Returns `(column_name, probe_values)` for the FIRST matching
+/// conjunct. The remaining conjuncts stay in the residual Filter (the
+/// index only narrows), so this scans the AND-conjuncts and does NOT
+/// require the whole predicate to be the probe.
+fn try_secondary_lookup(
+    predicate: &Option<Expr>,
+    secondary_cols: &[String],
+    output_schema: &RelationalSchema,
+) -> Option<(String, Vec<Expr>)> {
+    let p = predicate.as_ref()?;
+    // Resolve indexed column NAMES to ordinals in the (still full at
+    // this pass) scan schema, matching how PK lookup matches on ordinal.
+    let indexed: Vec<(usize, String)> = secondary_cols
+        .iter()
+        .filter_map(|name| {
+            output_schema
+                .column_by_name(name)
+                .map(|(idx, info)| (idx, info.name.clone()))
+        })
+        .collect();
+    if indexed.is_empty() {
+        return None;
+    }
+    for conj in flatten_and(p) {
+        match conj {
+            Expr::BinaryOp {
+                op: BinaryOp::Eq,
+                left,
+                right,
+            } => {
+                let (col, value) = match (left.as_ref(), right.as_ref()) {
+                    (Expr::Column(c), v) => (c, v),
+                    (v, Expr::Column(c)) => (c, v),
+                    _ => continue,
+                };
+                if expression_references_columns(value) {
+                    continue;
+                }
+                if let Some((_, name)) = indexed.iter().find(|(idx, _)| *idx == col.ordinal) {
+                    return Some((name.clone(), vec![value.clone()]));
+                }
+            }
+            Expr::In {
+                expr,
+                list,
+                not: false,
+            } => {
+                let Expr::Column(c) = expr.as_ref() else {
+                    continue;
+                };
+                if list.is_empty() || list.iter().any(expression_references_columns) {
+                    continue;
+                }
+                if let Some((_, name)) = indexed.iter().find(|(idx, _)| *idx == c.ordinal) {
+                    return Some((name.clone(), list.clone()));
+                }
+            }
+            _ => continue,
+        }
+    }
+    None
 }
 
 fn flatten_and(expr: &Expr) -> Vec<&Expr> {
@@ -2093,6 +2334,7 @@ mod tests {
         StaticCapabilities {
             caps: ReaderCapabilities::full(),
             pk_columns: pk,
+            secondary_columns: Vec::new(),
         }
     }
 
@@ -2100,6 +2342,16 @@ mod tests {
         StaticCapabilities {
             caps: ReaderCapabilities::none(),
             pk_columns: Vec::new(),
+            secondary_columns: Vec::new(),
+        }
+    }
+
+    /// `cap_full` plus a set of secondary-indexed column names (TD-127).
+    fn cap_full_with_secondary(pk: Vec<usize>, secondary: Vec<&str>) -> StaticCapabilities {
+        StaticCapabilities {
+            caps: ReaderCapabilities::full(),
+            pk_columns: pk,
+            secondary_columns: secondary.into_iter().map(String::from).collect(),
         }
     }
 
@@ -2399,6 +2651,242 @@ mod tests {
         }
     }
 
+    // --- TD-128: PK batch (IN-list / eq-OR) ---------------------------
+
+    #[test]
+    fn push_predicate_pk_in_list_becomes_pk_lookup_batch() {
+        let id = users_schema().resolve_column("id").unwrap();
+        let pred = Expr::In {
+            expr: Box::new(Expr::column(id)),
+            list: vec![
+                Expr::literal(ProximaValue::Int64(1)),
+                Expr::literal(ProximaValue::Int64(2)),
+                Expr::literal(ProximaValue::Int64(3)),
+            ],
+            not: false,
+        };
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        match push_predicates(physical, &cap_full(vec![0])) {
+            PhysicalPlan::Scan {
+                access: ScanAccess::PkLookupBatch { keys },
+                predicate,
+                ..
+            } => {
+                assert_eq!(keys.len(), 3, "one key per IN value");
+                assert!(keys.iter().all(|k| k.len() == 1), "single-column PK");
+                // Fully captured → predicate dropped.
+                assert_eq!(predicate, None);
+            }
+            other => panic!("expected PkLookupBatch scan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_pk_eq_or_becomes_pk_lookup_batch() {
+        // id = 1 OR id = 2
+        let id = users_schema().resolve_column("id").unwrap();
+        let pred = Expr::BinaryOp {
+            op: BinaryOp::Or,
+            left: Box::new(Expr::bin(
+                BinaryOp::Eq,
+                Expr::column(id.clone()),
+                Expr::literal(ProximaValue::Int64(1)),
+            )),
+            right: Box::new(Expr::bin(
+                BinaryOp::Eq,
+                Expr::column(id),
+                Expr::literal(ProximaValue::Int64(2)),
+            )),
+        };
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        match push_predicates(physical, &cap_full(vec![0])) {
+            PhysicalPlan::Scan {
+                access: ScanAccess::PkLookupBatch { keys },
+                predicate,
+                ..
+            } => {
+                assert_eq!(keys.len(), 2);
+                assert_eq!(predicate, None);
+            }
+            other => panic!("expected PkLookupBatch scan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_pk_in_list_skipped_without_capability() {
+        let id = users_schema().resolve_column("id").unwrap();
+        let pred = Expr::In {
+            expr: Box::new(Expr::column(id)),
+            list: vec![
+                Expr::literal(ProximaValue::Int64(1)),
+                Expr::literal(ProximaValue::Int64(2)),
+            ],
+            not: false,
+        };
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        // pk_lookup (single) on, but batch capability off → stays a scan+predicate.
+        let caps = StaticCapabilities {
+            caps: ReaderCapabilities::full().with_pk_lookup_batch(false),
+            pk_columns: vec![0],
+            secondary_columns: Vec::new(),
+        };
+        match push_predicates(physical, &caps) {
+            PhysicalPlan::Scan {
+                access: ScanAccess::FullScan,
+                predicate: Some(_),
+                ..
+            } => {}
+            other => panic!("expected FullScan with predicate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_not_in_list_not_batched() {
+        // `id NOT IN (...)` is not a discrete-key batch.
+        let id = users_schema().resolve_column("id").unwrap();
+        let pred = Expr::In {
+            expr: Box::new(Expr::column(id)),
+            list: vec![Expr::literal(ProximaValue::Int64(1))],
+            not: true,
+        };
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        match push_predicates(physical, &cap_full(vec![0])) {
+            PhysicalPlan::Scan {
+                access: ScanAccess::FullScan,
+                ..
+            } => {}
+            other => panic!("expected FullScan, got {other:?}"),
+        }
+    }
+
+    // --- TD-127: secondary-index lookup -------------------------------
+
+    #[test]
+    fn push_predicate_secondary_eq_becomes_secondary_lookup_keeps_filter() {
+        // WHERE name = 'bob' with a secondary index on `name`.
+        let name = users_schema().resolve_column("name").unwrap();
+        let pred = Expr::bin(
+            BinaryOp::Eq,
+            Expr::column(name),
+            Expr::literal(ProximaValue::String("bob".into())),
+        );
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        let result = push_predicates(physical, &cap_full_with_secondary(vec![0], vec!["name"]));
+        // The index only narrows → planner KEEPS the residual Filter above the scan.
+        match result {
+            PhysicalPlan::Filter { input, predicate } => {
+                assert!(
+                    matches!(predicate, Expr::BinaryOp { .. }),
+                    "residual filter kept"
+                );
+                match *input {
+                    PhysicalPlan::Scan {
+                        access: ScanAccess::SecondaryLookup { column, values },
+                        ..
+                    } => {
+                        assert_eq!(column, "name");
+                        assert_eq!(values.len(), 1);
+                    }
+                    other => panic!("expected SecondaryLookup scan, got {other:?}"),
+                }
+            }
+            other => panic!("expected Filter(SecondaryLookup), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_secondary_in_list_becomes_secondary_lookup() {
+        let name = users_schema().resolve_column("name").unwrap();
+        let pred = Expr::In {
+            expr: Box::new(Expr::column(name)),
+            list: vec![
+                Expr::literal(ProximaValue::String("alice".into())),
+                Expr::literal(ProximaValue::String("carol".into())),
+            ],
+            not: false,
+        };
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        let result = push_predicates(physical, &cap_full_with_secondary(vec![0], vec!["name"]));
+        match result {
+            PhysicalPlan::Filter { input, .. } => match *input {
+                PhysicalPlan::Scan {
+                    access: ScanAccess::SecondaryLookup { column, values },
+                    ..
+                } => {
+                    assert_eq!(column, "name");
+                    assert_eq!(values.len(), 2);
+                }
+                other => panic!("expected SecondaryLookup scan, got {other:?}"),
+            },
+            other => panic!("expected Filter(SecondaryLookup), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_secondary_skipped_when_column_unindexed() {
+        // `age` is not declared as a secondary index → normal scan+predicate.
+        let age = users_schema().resolve_column("age").unwrap();
+        let pred = Expr::bin(
+            BinaryOp::Eq,
+            Expr::column(age),
+            Expr::literal(ProximaValue::Int32(30)),
+        );
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        let result = push_predicates(physical, &cap_full_with_secondary(vec![0], vec!["name"]));
+        match result {
+            PhysicalPlan::Scan {
+                access: ScanAccess::FullScan,
+                predicate: Some(_),
+                ..
+            } => {}
+            other => panic!("expected FullScan with predicate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_predicate_secondary_skipped_without_declared_index() {
+        // Same predicate but NO secondary index declared → not a SecondaryLookup.
+        let name = users_schema().resolve_column("name").unwrap();
+        let pred = Expr::bin(
+            BinaryOp::Eq,
+            Expr::column(name),
+            Expr::literal(ProximaValue::String("bob".into())),
+        );
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(lower_to_physical(users_scan())),
+            predicate: pred,
+        };
+        match push_predicates(physical, &cap_full(vec![0])) {
+            PhysicalPlan::Scan {
+                access: ScanAccess::FullScan,
+                predicate: Some(_),
+                ..
+            } => {}
+            other => panic!("expected FullScan with predicate, got {other:?}"),
+        }
+    }
+
     // --- EXPLAIN rendering --------------------------------------------
 
     #[test]
@@ -2521,8 +3009,11 @@ mod tests {
         };
         // Caps: push_predicate but NOT pk_lookup.
         let caps = StaticCapabilities {
-            caps: ReaderCapabilities::full().with_pk_lookup(false),
+            caps: ReaderCapabilities::full()
+                .with_pk_lookup(false)
+                .with_pk_lookup_batch(false),
             pk_columns: vec![0],
+            secondary_columns: Vec::new(),
         };
         let result = push_predicates(physical, &caps);
         // Falls back to predicate pushdown (FullScan + predicate).

--- a/crates/query/proximadb-relational-reader/src/lib.rs
+++ b/crates/query/proximadb-relational-reader/src/lib.rs
@@ -164,6 +164,26 @@ pub struct ReaderCapabilities {
     /// Reader has zone maps (min/max per block) for range
     /// predicates.
     pub zone_map_skip: bool,
+
+    /// Reader supports a discrete multi-key point lookup via
+    /// [`RelationalReader::lookup_pk_batch`] (TD-128). Falsy =
+    /// the default loop-over-`lookup_pk` implementation is used,
+    /// so this is purely an efficiency signal (a real engine may
+    /// batch the probes); the planner only emits
+    /// `ScanAccess::PkLookupBatch` when this is true AND a PK is
+    /// declared.
+    pub pk_lookup_batch: bool,
+
+    /// Reader has an OLTP secondary (non-PK) hash index it can
+    /// probe via [`RelationalReader::lookup_secondary`] (TD-127).
+    /// Falsy = the default returns `Ok(None)` and the planner
+    /// never emits `ScanAccess::SecondaryLookup`. When true the
+    /// planner additionally consults
+    /// [`super::CapabilityResolver::secondary_index_columns`] to
+    /// gate which columns are eligible; the reader MAY still
+    /// answer `Ok(None)` at runtime (index not built / disabled),
+    /// in which case the executor falls back to a full scan.
+    pub secondary_lookup: bool,
 }
 
 impl ReaderCapabilities {
@@ -177,6 +197,8 @@ impl ReaderCapabilities {
             pk_lookup: false,
             bloom_probe: false,
             zone_map_skip: false,
+            pk_lookup_batch: false,
+            secondary_lookup: false,
         }
     }
 
@@ -189,6 +211,8 @@ impl ReaderCapabilities {
             pk_lookup: true,
             bloom_probe: true,
             zone_map_skip: true,
+            pk_lookup_batch: true,
+            secondary_lookup: true,
         }
     }
 
@@ -210,6 +234,14 @@ impl ReaderCapabilities {
     }
     pub const fn with_zone_map_skip(mut self, b: bool) -> Self {
         self.zone_map_skip = b;
+        self
+    }
+    pub const fn with_pk_lookup_batch(mut self, b: bool) -> Self {
+        self.pk_lookup_batch = b;
+        self
+    }
+    pub const fn with_secondary_lookup(mut self, b: bool) -> Self {
+        self.secondary_lookup = b;
         self
     }
 }
@@ -236,8 +268,13 @@ impl ReaderCapabilities {
 /// - Re-evaluating the predicate per row (the executor does that).
 /// - Enforcing the limit (the executor does that).
 /// - Handling NULL semantics (the executor does that).
+// `Send + Sync`: `Sync` is required by async_trait for the provided
+// (default) `&self` methods `lookup_pk_batch` / `lookup_secondary`
+// (TD-127/128) — the generated default future captures `&self`, which
+// is `Send` only when `Self: Sync`. Every implementor holds plain
+// data / `Arc`s and is already `Sync`.
 #[async_trait]
-pub trait RelationalReader: Send {
+pub trait RelationalReader: Send + Sync {
     /// Stable identifier for logs and metrics, e.g. `"sst"`,
     /// `"viper"`, `"nova"`, `"vec"` (test).
     fn name(&self) -> &'static str;
@@ -272,6 +309,54 @@ pub trait RelationalReader: Send {
     /// [`ReaderError::PkArityMismatch`] otherwise.
     async fn lookup_pk(&self, key: &[ProximaValue]) -> Result<Option<RelationalRow>, ReaderError>;
 
+    /// Discrete multi-key point lookup (TD-128): resolve each key
+    /// in `keys` and return the FULL row for every key that hits.
+    /// Each `key` is one primary-key tuple (single-component in
+    /// v1). Missing keys are simply absent from the result — the
+    /// returned vec is NOT positionally aligned with `keys`.
+    ///
+    /// The default implementation loops [`Self::lookup_pk`]; an
+    /// engine that declares
+    /// [`ReaderCapabilities::pk_lookup_batch`] MAY override this to
+    /// batch the probes. Rows are FULL (unprojected) — the executor
+    /// narrows them against the scan projection, exactly as on the
+    /// single-key `lookup_pk` path.
+    async fn lookup_pk_batch(
+        &self,
+        keys: &[Vec<ProximaValue>],
+    ) -> Result<Vec<RelationalRow>, ReaderError> {
+        let mut rows = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(row) = self.lookup_pk(key).await? {
+                rows.push(row);
+            }
+        }
+        Ok(rows)
+    }
+
+    /// OLTP secondary-index point lookup (TD-127): probe a
+    /// single-column non-PK hash index for the rows whose `column`
+    /// value equals any of `values` (an equality is a one-element
+    /// `values`; an `IN`-list is many). Returns:
+    ///
+    /// - `Ok(None)` when no index is available for `column` (the
+    ///   default, and at runtime when an engine's index is
+    ///   unbuilt / disabled) — the executor falls back to a full
+    ///   scan, re-applying the predicate the planner deliberately
+    ///   left in place.
+    /// - `Ok(Some(rows))` (possibly empty) when the index
+    ///   answered. The rows are CANDIDATES (FULL, unprojected): the
+    ///   hash index only NARROWS, so the residual `Filter` above the
+    ///   scan still re-checks every row.
+    async fn lookup_secondary(
+        &self,
+        column: &str,
+        values: &[ProximaValue],
+    ) -> Result<Option<Vec<RelationalRow>>, ReaderError> {
+        let _ = (column, values);
+        Ok(None)
+    }
+
     /// Release any resources. Idempotent; safe to call even if
     /// `open` was never called.
     async fn close(&mut self) -> Result<(), ReaderError>;
@@ -299,6 +384,11 @@ pub struct VecReader {
     full_schema: RelationalSchema,
     rows: Vec<RelationalRow>,
     pk_columns: Vec<usize>,
+    /// Ordinals (within `full_schema`) carrying a non-PK secondary
+    /// hash index (TD-127). Empty = no secondary index; then
+    /// `lookup_secondary` returns `Ok(None)` and the planner won't
+    /// pick `SecondaryLookup`.
+    secondary_columns: Vec<usize>,
     open_ctx: Option<OpenState>,
 }
 
@@ -323,8 +413,18 @@ impl VecReader {
             full_schema: schema,
             rows,
             pk_columns,
+            secondary_columns: Vec::new(),
             open_ctx: None,
         }
+    }
+
+    /// Register a non-PK secondary index on the given column
+    /// ordinals (TD-127). Chainable. Enables
+    /// [`ReaderCapabilities::secondary_lookup`] and makes
+    /// [`Self::lookup_secondary`] answer for those columns.
+    pub fn with_secondary_index(mut self, columns: Vec<usize>) -> Self {
+        self.secondary_columns = columns;
+        self
     }
 
     fn resolve_projection(
@@ -362,7 +462,11 @@ impl RelationalReader for VecReader {
     }
 
     fn capabilities(&self) -> ReaderCapabilities {
-        ReaderCapabilities::full().with_pk_lookup(!self.pk_columns.is_empty())
+        let has_pk = !self.pk_columns.is_empty();
+        ReaderCapabilities::full()
+            .with_pk_lookup(has_pk)
+            .with_pk_lookup_batch(has_pk)
+            .with_secondary_lookup(!self.secondary_columns.is_empty())
     }
 
     fn schema(&self) -> &RelationalSchema {
@@ -452,6 +556,61 @@ impl RelationalReader for VecReader {
         Ok(None)
     }
 
+    async fn lookup_pk_batch(
+        &self,
+        keys: &[Vec<ProximaValue>],
+    ) -> Result<Vec<RelationalRow>, ReaderError> {
+        if self.pk_columns.is_empty() {
+            return Err(ReaderError::PkLookupUnsupported);
+        }
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            if key.len() != self.pk_columns.len() {
+                return Err(ReaderError::PkArityMismatch {
+                    expected: self.pk_columns.len(),
+                    actual: key.len(),
+                });
+            }
+            for row in &self.rows {
+                let matches = self
+                    .pk_columns
+                    .iter()
+                    .zip(key.iter())
+                    .all(|(&idx, expected)| &row[idx] == expected);
+                if matches {
+                    out.push(row.clone());
+                    break;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn lookup_secondary(
+        &self,
+        column: &str,
+        values: &[ProximaValue],
+    ) -> Result<Option<Vec<RelationalRow>>, ReaderError> {
+        // Resolve the probed column to an ordinal; only answer when
+        // it carries a registered secondary index (else `Ok(None)`
+        // so the executor falls back to a scan).
+        let Some((ordinal, _)) = self.full_schema.column_by_name(column) else {
+            return Ok(None);
+        };
+        if !self.secondary_columns.contains(&ordinal) {
+            return Ok(None);
+        }
+        // Candidate rows: every row whose indexed value is in the
+        // probe set. FULL (unprojected); the executor narrows.
+        let candidates: Vec<RelationalRow> = self
+            .rows
+            .iter()
+            .filter(|row| values.iter().any(|v| &row[ordinal] == v))
+            .cloned()
+            .collect();
+        Ok(Some(candidates))
+    }
+
     async fn close(&mut self) -> Result<(), ReaderError> {
         self.open_ctx = None;
         Ok(())
@@ -526,6 +685,8 @@ mod tests {
         assert!(!c.pk_lookup);
         assert!(!c.bloom_probe);
         assert!(!c.zone_map_skip);
+        assert!(!c.pk_lookup_batch);
+        assert!(!c.secondary_lookup);
     }
 
     #[test]
@@ -536,6 +697,8 @@ mod tests {
         assert!(c.pk_lookup);
         assert!(c.bloom_probe);
         assert!(c.zone_map_skip);
+        assert!(c.pk_lookup_batch);
+        assert!(c.secondary_lookup);
     }
 
     #[test]
@@ -767,6 +930,115 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ReaderError::PkArityMismatch { .. }));
+    }
+
+    // --- PK batch lookup (TD-128) ---------------------------------
+
+    #[tokio::test]
+    async fn vec_reader_pk_lookup_batch_returns_matching_rows() {
+        let r = users_reader();
+        let keys = vec![
+            vec![ProximaValue::Int64(1)],
+            vec![ProximaValue::Int64(3)],
+            vec![ProximaValue::Int64(999)], // miss — simply absent
+        ];
+        let rows = r.lookup_pk_batch(&keys).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        let names: Vec<&str> = rows
+            .iter()
+            .map(|row| match &row[1] {
+                ProximaValue::String(s) => s.as_str(),
+                _ => unreachable!(),
+            })
+            .collect();
+        assert!(names.contains(&"alice"));
+        assert!(names.contains(&"carol"));
+    }
+
+    #[tokio::test]
+    async fn vec_reader_pk_lookup_batch_unsupported_when_no_pk() {
+        let r = VecReader::new(users_schema(), users_rows(), vec![]);
+        let err = r
+            .lookup_pk_batch(&[vec![ProximaValue::Int64(1)]])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ReaderError::PkLookupUnsupported));
+    }
+
+    #[test]
+    fn vec_reader_pk_lookup_batch_capability_tracks_pk() {
+        assert!(users_reader().capabilities().pk_lookup_batch);
+        let no_pk = VecReader::new(users_schema(), users_rows(), vec![]);
+        assert!(!no_pk.capabilities().pk_lookup_batch);
+    }
+
+    // --- Secondary lookup (TD-127) --------------------------------
+
+    fn users_reader_with_name_index() -> VecReader {
+        // PK on id (ordinal 0), secondary index on name (ordinal 1).
+        VecReader::new(users_schema(), users_rows(), vec![0]).with_secondary_index(vec![1])
+    }
+
+    #[test]
+    fn vec_reader_secondary_capability_tracks_index() {
+        assert!(
+            users_reader_with_name_index()
+                .capabilities()
+                .secondary_lookup
+        );
+        assert!(!users_reader().capabilities().secondary_lookup);
+    }
+
+    #[tokio::test]
+    async fn vec_reader_secondary_lookup_returns_candidates() {
+        let r = users_reader_with_name_index();
+        let rows = r
+            .lookup_secondary("name", &[ProximaValue::String("bob".into())])
+            .await
+            .unwrap()
+            .expect("indexed column answers Some");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], ProximaValue::Int64(2));
+        // Candidate rows are FULL (unprojected).
+        assert_eq!(rows[0].len(), 3);
+    }
+
+    #[tokio::test]
+    async fn vec_reader_secondary_lookup_in_list_unions() {
+        let r = users_reader_with_name_index();
+        let rows = r
+            .lookup_secondary(
+                "name",
+                &[
+                    ProximaValue::String("alice".into()),
+                    ProximaValue::String("carol".into()),
+                ],
+            )
+            .await
+            .unwrap()
+            .expect("indexed column answers Some");
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn vec_reader_secondary_lookup_none_when_unindexed() {
+        // `age` has no secondary index → Ok(None) (scan fallback).
+        let r = users_reader_with_name_index();
+        let out = r
+            .lookup_secondary("age", &[ProximaValue::Int32(30)])
+            .await
+            .unwrap();
+        assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn vec_reader_secondary_lookup_none_when_no_index_registered() {
+        let r = users_reader(); // no secondary index at all
+        let out = r
+            .lookup_secondary("name", &[ProximaValue::String("bob".into())])
+            .await
+            .unwrap();
+        assert!(out.is_none());
     }
 
     // --- Trait object dispatch -----------------------------------

--- a/docs/10-quality/TECHNICAL_DEBT.adoc
+++ b/docs/10-quality/TECHNICAL_DEBT.adoc
@@ -97,11 +97,11 @@ NOTE: `Pri` = product priority (CRIT/HIGH/MED/LOW). The status line in the `Note
 |===
 | ID | Area | Pri | Status | Dim | Pillar | Notes — problem → next action (key location; deps)
 
-| TD-127 | OLTP secondary indexes | HIGH | Open | D4 | PERF
-| Volcano point-lookup covers PK only (`ScanAccess::PkLookup`); code-graph lookups by name/file fall to full-scan+filter. → secondary-index access path + reader cap `secondary_lookup` in `proximadb-relational-planner` (`push_predicates`) + `record_store.rs`. See `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
+| TD-127 | OLTP secondary indexes | HIGH | Partial | D4 | PERF
+| *Volcano access path landed (this PR):* `ScanAccess::SecondaryLookup` + reader cap `secondary_lookup` in `proximadb-relational-planner` (`push_predicates`), wired to the existing `TableRecordStore::lookup_secondary` hash index (PR #215). Correct-but-dormant: `lookup_secondary` returns `None` → graceful FullScan fallback until a SQL `CREATE INDEX`→catalog `secondary_indexes` surface lands. *Residual:* `CREATE INDEX` DDL wiring (overlaps TD-061). See `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc`.
 
-| TD-128 | OLTP IN-list / range pushdown | HIGH | Open | D4 | PERF
-| `WHERE col IN (...)` / `BETWEEN` not pushed to a multi-key batch (full-scan+filter today). → planner predicate pushdown + `ScanAccess` multi-key batch; reader `pk_lookup_batch`. Companion to TD-127.
+| TD-128 | OLTP IN-list / range pushdown (discrete batches) | HIGH | Resolved | D4 | PERF
+| *Resolved (this PR):* `WHERE pk IN (...)` / eq-OR lowers to `ScanAccess::PkLookupBatch` (single-col PK) via `proximadb-relational-planner` `push_predicates` + reader `pk_lookup_batch`, in the Volcano path pgwire drives (EXPLAIN discloses `access=PkLookupBatch`). Pending archive move. *Deferred (new follow-on TD):* true range (`BETWEEN`→`RangeScan`) — no ordered/range index exists; ranges keep `zone_map_skip`.
 
 | TD-076 | pgwire SQL parity Phase 2/3 (ADR-018) | MED | Open | D4 | OE
 | Phase 1 (basic DML + vector-distance) wired. Phase 2 (`ORDER BY`/aggregates/joins/`pg_class`) + Phase 3 (PG parity) gap; live probe found crashes on aggregates/joins. v0.2 ships pgwire Beta @ Phase 1. See ADR-018.

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -166,6 +166,7 @@ pub async fn try_run_select(
         let resolver = StaticCapabilities {
             caps: ReaderCapabilities::full(),
             pk_columns: Vec::new(),
+            secondary_columns: Vec::new(),
         };
         return Some(run_plan(&factory, resolver, logical, controls).await);
     }
@@ -416,7 +417,17 @@ fn plan_over_snapshot(
         .iter()
         .map(|(key, prepared)| (key.clone(), prepared.pk_columns.clone()))
         .collect();
-    let resolver = SnapshotCapabilities { pk_by_table };
+    // TD-127: per-table secondary-indexed columns so the planner can rewrite a
+    // non-PK equality / IN-list to ScanAccess::SecondaryLookup.
+    let secondary_by_table: HashMap<String, Vec<String>> = snapshot
+        .tables
+        .iter()
+        .map(|(key, prepared)| (key.clone(), prepared.secondary_columns.clone()))
+        .collect();
+    let resolver = SnapshotCapabilities {
+        pk_by_table,
+        secondary_by_table,
+    };
     let planner = Planner::new(resolver);
     Some(planner.plan(logical).map_err(|e| format!("plan: {e}")))
 }
@@ -521,6 +532,11 @@ struct PreparedTable {
     table_name: String,
     schema: RelationalSchema,
     pk_columns: Vec<usize>,
+    /// TD-127: names of this table's single-column non-PK secondary indexes
+    /// (from `schema_secondary_index_columns`). Threaded into the planner's
+    /// `CapabilityResolver::secondary_index_columns` so an equality / IN on
+    /// one of these columns can rewrite to `ScanAccess::SecondaryLookup`.
+    secondary_columns: Vec<String>,
 }
 
 impl PreparedTable {
@@ -540,6 +556,9 @@ impl PreparedTable {
             table_name: name.to_string(),
             schema: RelationalSchema::new(cols),
             pk_columns: pk,
+            secondary_columns: crate::services::record_store::schema_secondary_index_columns(
+                schema,
+            ),
         }
     }
 }
@@ -588,17 +607,31 @@ impl ReaderFactory for SnapshotCatalog {
 /// route). ADR-018 Phase 2 (pgwire SQL parity); TD-076.
 struct SnapshotCapabilities {
     pk_by_table: HashMap<String, Vec<usize>>,
+    /// TD-127: per-table secondary-indexed column names. Empty / absent =
+    /// no secondary index → planner keeps a full scan + filter.
+    secondary_by_table: HashMap<String, Vec<String>>,
 }
 
 impl CapabilityResolver for SnapshotCapabilities {
     fn capabilities(&self, _table: &TableId) -> ReaderCapabilities {
-        // Unchanged pushdown behavior (projection/predicate); PK-lookup is gated
-        // per-table by `primary_key` below.
+        // Unchanged pushdown behavior (projection/predicate). PK-lookup,
+        // PK-batch (TD-128) and secondary-lookup (TD-127) are advertised here
+        // but gated per-table by `primary_key` / `secondary_index_columns`
+        // below, so a table without the relevant index keeps a full scan.
         ReaderCapabilities::full()
+            .with_pk_lookup_batch(true)
+            .with_secondary_lookup(true)
     }
 
     fn primary_key(&self, table: &TableId) -> Vec<usize> {
         self.pk_by_table
+            .get(&normalize_table_key(&table.name))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn secondary_index_columns(&self, table: &TableId) -> Vec<String> {
+        self.secondary_by_table
             .get(&normalize_table_key(&table.name))
             .cloned()
             .unwrap_or_default()
@@ -660,9 +693,14 @@ impl RelationalReader for DmlTableReader {
 
     fn capabilities(&self) -> ReaderCapabilities {
         // Honors projection + predicate + limit + single-column PK lookup
-        // (see `lookup_pk`). The planner gates PkLookup per-table via the
-        // resolver's `primary_key`, so this flag is informational here.
-        ReaderCapabilities::full().with_pk_lookup(true)
+        // (see `lookup_pk`), discrete PK batch (TD-128, `lookup_pk_batch`) and
+        // OLTP secondary lookup (TD-127, `lookup_secondary`). The planner gates
+        // each per-table via the resolver's `primary_key` /
+        // `secondary_index_columns`, so these flags are informational here.
+        ReaderCapabilities::full()
+            .with_pk_lookup(true)
+            .with_pk_lookup_batch(true)
+            .with_secondary_lookup(true)
     }
 
     fn schema(&self) -> &RelationalSchema {
@@ -751,6 +789,80 @@ impl RelationalReader for DmlTableReader {
         );
         self.dml
             .point_lookup_relational(&self.table_name, &key_str, self.tenant.as_ref())
+            .await
+            .map_err(|e| ReaderError::Storage(e.to_string()))
+    }
+
+    /// TD-128: discrete multi-key OLTP point-read (`PK IN (...)` / eq-OR).
+    /// Forwards to [`DmlService::point_lookup_batch_relational`], which reuses
+    /// the same `get_by_key` path (dead-record-filtered) as the single-key
+    /// fast-path. Single-column PK only; SQL NULL keys can't match a stored oid
+    /// and are skipped. Returns the FULL candidate rows (the executor narrows).
+    async fn lookup_pk_batch(
+        &self,
+        keys: &[Vec<ProximaValue>],
+    ) -> Result<Vec<RelationalRow>, ReaderError> {
+        let mut key_strs = Vec::with_capacity(keys.len());
+        for key in keys {
+            if key.len() != 1 {
+                return Err(ReaderError::PkArityMismatch {
+                    expected: 1,
+                    actual: key.len(),
+                });
+            }
+            if let Some(s) = text_encode(&key[0]) {
+                key_strs.push(s);
+            }
+        }
+        tracing::debug!(
+            target: "proximadb::pgwire::new_pipeline",
+            access_path = "PkLookupBatch",
+            table = %self.table_name,
+            keys = key_strs.len(),
+            "relational PK batch point lookup"
+        );
+        self.dml
+            .point_lookup_batch_relational(&self.table_name, &key_strs, self.tenant.as_ref())
+            .await
+            .map_err(|e| ReaderError::Storage(e.to_string()))
+    }
+
+    /// TD-127: OLTP secondary-index point-read. Forwards to
+    /// [`DmlService::secondary_lookup_relational`], which probes the store's
+    /// single-column hash index and re-materializes each live candidate via
+    /// `get_by_key` (dead-record-filtered). `Ok(None)` (no built index, or all
+    /// probe values NULL) → the executor falls back to a full scan + the
+    /// residual filter; `Ok(Some(rows))` → FULL candidate rows (the executor
+    /// narrows and the residual filter re-checks — the index only narrows).
+    async fn lookup_secondary(
+        &self,
+        column: &str,
+        values: &[ProximaValue],
+    ) -> Result<Option<Vec<RelationalRow>>, ReaderError> {
+        let mut value_strs = Vec::with_capacity(values.len());
+        for v in values {
+            if let Some(s) = text_encode(v) {
+                value_strs.push(s);
+            }
+        }
+        if value_strs.is_empty() {
+            // No probe-able (non-NULL) values — let the executor scan + filter.
+            return Ok(None);
+        }
+        tracing::debug!(
+            target: "proximadb::pgwire::new_pipeline",
+            access_path = "SecondaryLookup",
+            table = %self.table_name,
+            column = %column,
+            "relational secondary index point lookup"
+        );
+        self.dml
+            .secondary_lookup_relational(
+                &self.table_name,
+                column,
+                &value_strs,
+                self.tenant.as_ref(),
+            )
             .await
             .map_err(|e| ReaderError::Storage(e.to_string()))
     }
@@ -1575,7 +1687,12 @@ mod tests {
         let mut pk_by_table = HashMap::new();
         pk_by_table.insert("users".to_string(), vec![0]); // single-col PK at ordinal 0
         pk_by_table.insert("edges".to_string(), Vec::new()); // composite/no-PK → none
-        let resolver = SnapshotCapabilities { pk_by_table };
+        let mut secondary_by_table = HashMap::new();
+        secondary_by_table.insert("users".to_string(), vec!["name".to_string()]);
+        let resolver = SnapshotCapabilities {
+            pk_by_table,
+            secondary_by_table,
+        };
 
         // Single-col PK table → planner can pick PkLookup (name normalized).
         assert_eq!(resolver.primary_key(&TableId::new("users")), vec![0]);
@@ -1585,6 +1702,28 @@ mod tests {
         assert!(resolver.primary_key(&TableId::new("unknown")).is_empty());
         // Pushdown capabilities unchanged (pk_lookup gated per-table by primary_key).
         assert!(resolver.capabilities(&TableId::new("users")).pk_lookup);
+        // TD-128/TD-127: batch + secondary advertised (gated per-table below).
+        assert!(
+            resolver
+                .capabilities(&TableId::new("users"))
+                .pk_lookup_batch
+        );
+        assert!(
+            resolver
+                .capabilities(&TableId::new("users"))
+                .secondary_lookup
+        );
+        // TD-127: secondary-indexed columns surfaced per-table (name-normalized);
+        // unknown tables → empty → planner keeps a full scan.
+        assert_eq!(
+            resolver.secondary_index_columns(&TableId::new("USERS")),
+            vec!["name".to_string()]
+        );
+        assert!(
+            resolver
+                .secondary_index_columns(&TableId::new("edges"))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1492,6 +1492,119 @@ impl DmlService {
         }
     }
 
+    /// TD-128: discrete multi-key OLTP point-read for the Volcano relational
+    /// pipeline. Resolves each PK in `keys` via [`TableRecordStore::get_by_key`]
+    /// (which applies the canonical dead-record filter — invariant #16), and
+    /// returns the FULL projected row for every key that hits a live record.
+    /// Missing / dead keys are simply absent — the result is NOT positionally
+    /// aligned with `keys`. Single-column PK only (mirrors
+    /// [`Self::point_lookup_relational`]); reuses the same `get_by_key` path the
+    /// legacy native DML PK fast-path uses.
+    pub async fn point_lookup_batch_relational(
+        &self,
+        table_name: &str,
+        keys: &[String],
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Vec<Vec<ProximaValue>>> {
+        let (table_schema, table_id_name) = self
+            .resolve_select_table(table_name, tenant_context.map(|t| t.tenant_id.as_str()))
+            .await?;
+        let all_columns: Vec<String> = table_schema
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .collect();
+        let full_selected = Self::resolve_select_projection(&table_schema, &all_columns)?;
+        let mut rows = Vec::with_capacity(keys.len());
+        for key in keys {
+            let record = self
+                .record_store
+                .get_by_key(
+                    &table_schema,
+                    TableRecordGetRequest {
+                        table_id: table_id_name.clone(),
+                        key: key.clone(),
+                        include_vector: true,
+                        include_props: true,
+                    },
+                    tenant_context,
+                )
+                .await?;
+            if let Some(rich) = record {
+                let record = Self::rich_result_to_record(rich);
+                rows.push(Self::project_one_record(
+                    &record,
+                    &table_schema,
+                    &full_selected,
+                )?);
+            }
+        }
+        Ok(rows)
+    }
+
+    /// TD-127: secondary-index point-read for the Volcano relational pipeline.
+    /// Probes the store's single-column non-PK hash index for the rows whose
+    /// `column` value (canonical text) is in `values`, then returns the FULL
+    /// projected row for each live candidate. Reuses the exact
+    /// [`TableRecordStore::lookup_secondary`] + [`TableRecordStore::get_by_key`]
+    /// path the legacy native DML secondary fast-path uses (so both agree on
+    /// which columns are indexed and on dead-record filtering — invariant #16).
+    ///
+    /// Returns `Ok(None)` when the store has no built index for `column` (the
+    /// caller falls back to a full scan); `Ok(Some(rows))` (possibly empty) when
+    /// the index answered. The index only NARROWS — the caller's residual filter
+    /// re-checks every candidate.
+    pub async fn secondary_lookup_relational(
+        &self,
+        table_name: &str,
+        column: &str,
+        values: &[String],
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Option<Vec<Vec<ProximaValue>>>> {
+        let (table_schema, table_id_name) = self
+            .resolve_select_table(table_name, tenant_context.map(|t| t.tenant_id.as_str()))
+            .await?;
+        let value_set: std::collections::HashSet<String> = values.iter().cloned().collect();
+        let Some(candidate_oids) = self
+            .record_store
+            .lookup_secondary(&table_schema, column, &value_set, tenant_context)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let all_columns: Vec<String> = table_schema
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .collect();
+        let full_selected = Self::resolve_select_projection(&table_schema, &all_columns)?;
+        let mut rows = Vec::with_capacity(candidate_oids.len());
+        for oid in candidate_oids {
+            let record = self
+                .record_store
+                .get_by_key(
+                    &table_schema,
+                    TableRecordGetRequest {
+                        table_id: table_id_name.clone(),
+                        key: oid,
+                        include_vector: true,
+                        include_props: true,
+                    },
+                    tenant_context,
+                )
+                .await?;
+            if let Some(rich) = record {
+                let record = Self::rich_result_to_record(rich);
+                rows.push(Self::project_one_record(
+                    &record,
+                    &table_schema,
+                    &full_selected,
+                )?);
+            }
+        }
+        Ok(Some(rows))
+    }
+
     /// Records-returning, limit-honoring twin of [`Self::resolve_matching_ids`] for
     /// the SELECT path: PK fast-path (OR-safe via [`Self::extract_pk_candidate_ids`],
     /// re-checked against the full tree) else a predicate scan with the limit pushed in.
@@ -7089,8 +7202,13 @@ mod tests {
     /// not a full `TableScan`, and returns exactly the rows the scan would — while
     /// the kill-switch falls back to a scan with identical rows. The schema is
     /// registered programmatically because no DDL surface declares secondary
-    /// indexes yet (a noted follow-on); the cataloged `secondary_indexes` survive
-    /// the `ObjectSchema` round-trip, so the read path sees them.
+    /// indexes yet (a noted follow-on — until a `CREATE INDEX` DDL lands, the
+    /// Volcano relational stack's `SecondaryLookup` path is correct-but-dormant);
+    /// the cataloged `secondary_indexes` survive the `ObjectSchema` round-trip, so
+    /// the read path sees them. This test also covers the Volcano-pipeline
+    /// forwarders `secondary_lookup_relational` (TD-127) and
+    /// `point_lookup_batch_relational` (TD-128), which reuse this same index +
+    /// `get_by_key` path.
     #[tokio::test]
     async fn select_where_uses_secondary_index_for_nonpk_name_and_file() {
         use crate::services::record_store::DirectWalTableRecordStore;
@@ -7253,6 +7371,59 @@ mod tests {
         unsafe { std::env::remove_var("PROXIMADB_SECONDARY_INDEX_DISABLE") };
         assert_eq!(path, RelationalSelectAccessPath::TableScan);
         assert_eq!(ids, vec!["s1", "s2"], "scan fallback returns the same rows");
+
+        // TD-127: the Volcano-pipeline forwarder `secondary_lookup_relational`
+        // reuses the same index + `get_by_key` path and returns FULL projected
+        // rows for each live candidate. `name='emit'` → s3,s4.
+        let mut got: Vec<String> = dml
+            .secondary_lookup_relational("code_symbol", "name", &["emit".to_string()], None)
+            .await
+            .expect("secondary lookup")
+            .expect("name is indexed → Some(rows)")
+            .into_iter()
+            .map(|row| match &row[0] {
+                ProximaValue::String(s) => s.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["s3", "s4"],
+            "secondary_lookup_relational candidates"
+        );
+
+        // A non-indexed column → Ok(None) (the Volcano executor falls back to a
+        // full scan + residual filter).
+        let none = dml
+            .secondary_lookup_relational("code_symbol", "oid", &["s1".to_string()], None)
+            .await
+            .expect("secondary lookup on non-indexed column");
+        assert!(none.is_none(), "non-indexed column → None (scan fallback)");
+
+        // TD-128: the discrete-batch forwarder `point_lookup_batch_relational`
+        // reuses `get_by_key` per key and returns FULL rows for the hits only
+        // (the missing key is absent).
+        let mut batch: Vec<String> = dml
+            .point_lookup_batch_relational(
+                "code_symbol",
+                &["s1".to_string(), "s3".to_string(), "missing".to_string()],
+                None,
+            )
+            .await
+            .expect("point batch lookup")
+            .into_iter()
+            .map(|row| match &row[0] {
+                ProximaValue::String(s) => s.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        batch.sort();
+        assert_eq!(
+            batch,
+            vec!["s1", "s3"],
+            "batch lookup returns hits, omits miss"
+        );
     }
 
     /// `scan_table_relational` (PATH B reader backend) pushes the output

--- a/tests/pgwire_relational_engine_e2e.rs
+++ b/tests/pgwire_relational_engine_e2e.rs
@@ -288,6 +288,24 @@ async fn pgwire_relational_engine_serves_joins_and_aggregates_over_real_data() {
         "PK point lookup feeds the aggregate with the correct single row"
     );
 
+    // (2c-batch) TD-128: discrete multi-key `PK IN (...)` under an aggregate →
+    // the planner rewrites the IN-list into ScanAccess::PkLookupBatch (one probe
+    // per key, predicate dropped) over real data, exercising the relational
+    // reader's lookup_pk_batch. i1+i2 are both active → {(active, 2)}.
+    let rows = client
+        .simple_query(&format!(
+            "SELECT status, COUNT(*) AS n FROM {inv} WHERE id IN ('i1', 'i2') GROUP BY status"
+        ))
+        .await
+        .expect("SELECT PK-IN-list aggregate");
+    assert_eq!(
+        pair_set(&rows, "status", "n"),
+        [("active".to_string(), "2".to_string())]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        "PK IN-list batch lookup feeds the aggregate with both matched rows"
+    );
+
     // (2d) Stage 2 — uncorrelated scalar subquery in a WHERE comparison. The
     // subquery `(SELECT avg(qty) FROM inv)` over [5,15,25,35] = 20 is hoisted to
     // a LEFT JOIN ON TRUE (AssertMaxOneRow-guarded) and the predicate becomes
@@ -555,6 +573,50 @@ async fn pgwire_relational_engine_serves_joins_and_aggregates_over_real_data() {
             && !plan.contains("actual rows=")
             && !plan.contains("self="),
         "plain EXPLAIN omits ANALYZE execution metrics: {plan}"
+    );
+
+    // (3h-batch) TD-128: EXPLAIN discloses a `PK IN (...)` rewrite as a
+    // PkLookupBatch scan access path (the EXPLAIN-access-path evidence, not a
+    // microbenchmark). Under an aggregate so the query engages PATH B.
+    let rows = client
+        .simple_query(&format!(
+            "EXPLAIN SELECT status, COUNT(*) FROM {inv} WHERE id IN ('i1', 'i2') GROUP BY status"
+        ))
+        .await
+        .expect("EXPLAIN PK IN-list aggregate");
+    let plan = query_plan_cell(&rows);
+    assert!(
+        plan.contains("access=PkLookupBatch"),
+        "PK IN-list disclosed as a PkLookupBatch scan: {plan}"
+    );
+
+    // (3h-secondary-fallback) TD-127: an equality on a NON-indexed, non-PK column
+    // must NOT rewrite to SecondaryLookup (no secondary index is declared via DDL
+    // yet — that path stays dormant). It stays a FullScan with the predicate
+    // pushed, and still returns correct rows. (active = i1,i2 → count 2.)
+    let rows = client
+        .simple_query(&format!(
+            "EXPLAIN SELECT status, COUNT(*) FROM {inv} WHERE status = 'active' GROUP BY status"
+        ))
+        .await
+        .expect("EXPLAIN non-indexed equality aggregate");
+    let plan = query_plan_cell(&rows);
+    assert!(
+        plan.contains("access=FullScan") && !plan.contains("access=SecondaryLookup"),
+        "non-indexed equality stays a FullScan (secondary path dormant): {plan}"
+    );
+    let rows = client
+        .simple_query(&format!(
+            "SELECT status, COUNT(*) AS n FROM {inv} WHERE status = 'active' GROUP BY status"
+        ))
+        .await
+        .expect("SELECT non-indexed equality aggregate");
+    assert_eq!(
+        pair_set(&rows, "status", "n"),
+        [("active".to_string(), "2".to_string())]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        "non-indexed equality returns correct rows on the scan+filter path"
     );
 
     // (3h-analyze) EXPLAIN ANALYZE additionally EXECUTES the (read-only) plan and


### PR DESCRIPTION
## Summary
Brings the **Volcano relational stack** (which pgwire drives via `ComputeScheduler::route_select`) to parity with the native DML path (PR #215): non-PK secondary-indexed equality/`IN` and discrete PK `IN`-list batches now lower to dedicated access paths instead of full-scan+filter — **reusing** the existing `TableRecordStore::lookup_secondary` hash index (not rebuilt).

## What landed
- `ScanAccess::PkLookupBatch{keys}` (TD-128, single-col PK `IN`/eq-OR) and `ScanAccess::SecondaryLookup{column,values}` (TD-127).
- `ReaderCapabilities {secondary_lookup, pk_lookup_batch}` + `RelationalReader::{lookup_pk_batch, lookup_secondary}` (default impls → all readers compile; `VecReader` overrides for tests).
- `push_predicates` rewrite ladder: PK eq → PK batch → secondary (keeps residual Filter — index only *narrows*) → push/restore. `CapabilityResolver::secondary_index_columns` from the catalog.
- `ScanExec` arms for both; `SecondaryLookup` **falls back to FullScan** when `lookup_secondary` returns `None` (correct-but-dormant until a `CREATE INDEX` DDL surface lands). Dead-record filter preserved (#16) — candidates flow through `DmlService`/`get_by_key`.
- Production wiring in `relational_pipeline.rs` (`SnapshotCapabilities`, `DmlTableReader`) + thin `DmlService` methods.

## Scope
- **TD-128 = discrete `IN`/eq-OR batches only.** True range (`BETWEEN`→`RangeScan`) is **deferred to a follow-on TD** — no ordered/range index exists, so it'd be a no-op; ranges keep `zone_map_skip`. → TD-128 **Resolved**.
- **TD-127 access path landed but graceful-dormant** (no SQL `CREATE INDEX`→catalog yet; tests register indexes programmatically). → TD-127 **Partial**, residual = `CREATE INDEX` DDL (overlaps TD-061).

## Verification (offline, 1.95.0)
- ✅ **107 relational unit tests** (planner 38 / reader 39 / executor 30) — incl. PkLookupBatch, SecondaryLookup, capability-gating, and the **None→FullScan fallback**.
- ✅ **pgwire e2e** (`tests/pgwire_relational_engine_e2e.rs`): EXPLAIN discloses `access=PkLookupBatch` for `WHERE id IN (...)`; non-indexed equality stays `access=FullScan` (secondary dormant). EXPLAIN-access-path evidence per mandate #6/#10 (not a microbenchmark).
- ✅ root-crate build + clippy on the relational crates clean.

> **CI note:** the final post-rebase full root-crate build + server-binary was run locally up to a transient **disk-full** on the shared dev box (many concurrent worktrees), so I'm relying on CI for that last build leg. Pre-rebase the full build+e2e passed and the rebase onto develop was conflict-free.

Held for review — not merging.