### PR TITLE
feat(wal): ADR-031 O2 — dual-write object_id as WAL collection_id + dual-read feed

### DIFF
--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -672,16 +672,36 @@ impl crate::query::execution::olap_delta_merge::OlapDeltaSource for DmlService {
         snapshot_lsn: u64,
         tenant: Option<&str>,
     ) -> anyhow::Result<Vec<String>> {
-        // Tenant-isolated canonical-WAL change-feed for this table after the
-        // snapshot LSN; the key is the canonical oid (= PK text). The feed is
-        // scoped by tenant_id because the WAL collection_id is the bare table name
-        // (not tenant-unique), so two tenants sharing a table name must not share
-        // the merge delta.
-        let changes = self
+        // Tenant-isolated canonical-WAL change-feed after the snapshot LSN; each
+        // ChangeRow.key is the canonical record oid (= PK text). The feed is scoped
+        // by tenant_id (the WAL collection_id is not tenant-unique under name-keying).
+        //
+        // ADR-031 O2 (mixed-read-safe dual-read): a table's WAL entries may be keyed
+        // by the bare name (legacy) OR the stable object_id (post-cutover), so we
+        // union both. With the object_id-first design this is the path that lets the
+        // tenant predicate drop out at O4 (object_id is globally unique).
+        let mut oids: std::collections::HashSet<String> = self
             .record_store
             .read_changes_since_scoped(table, tenant, snapshot_lsn)
-            .await?;
-        Ok(changes.into_iter().map(|c| c.key).collect())
+            .await?
+            .into_iter()
+            .map(|c| c.key)
+            .collect();
+        if let Ok((schema, _)) = self.resolve_select_table(table, tenant).await
+            && let Some(oid) = schema.object_id
+        {
+            let oid_key = oid.to_string();
+            if oid_key != table {
+                for c in self
+                    .record_store
+                    .read_changes_since_scoped(&oid_key, tenant, snapshot_lsn)
+                    .await?
+                {
+                    oids.insert(c.key);
+                }
+            }
+        }
+        Ok(oids.into_iter().collect())
     }
 
     async fn current_records(

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -678,6 +678,26 @@ pub struct UniqueConflict {
 /// tuple comparison and predicate evaluation. Shared by the record store and
 /// `DmlService` so the value seen at write time (index maintenance) matches the
 /// value seen at check time.
+///
+/// ADR-031 O2: master gate for keying the WAL `collection_id` by the stable
+/// `object_id` (default OFF). Mixed-read-safe — readers dual-read (name OR id), so
+/// this rolls out per-writer/per-deployment without a flag-day cutover.
+fn wal_object_id_keying_enabled() -> bool {
+    std::env::var("PROXIMADB_WAL_OBJECT_ID_KEY")
+        .ok()
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+}
+
+/// The WAL `collection_id` for a table: the stable `object_id` (decimal text) when
+/// `object_id_keying` is on and the table carries one, else the bare name (legacy).
+/// Pure (gate passed in) so it unit-tests without touching the process env.
+fn wal_collection_id(table_schema: &CatalogTableSchema, object_id_keying: bool) -> String {
+    if object_id_keying && let Some(oid) = table_schema.object_id {
+        return oid.to_string();
+    }
+    table_schema.name.clone()
+}
+
 pub(crate) fn proxima_value_to_unique_text(value: &proximadb_data_model::ProximaValue) -> String {
     use proximadb_data_model::ProximaValue;
     match value {
@@ -1714,6 +1734,11 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let tenant_scope = Self::tenant_key(tenant_context);
         let partition = self.partition(&tenant_scope, &table_schema.name);
         let index_key = (tenant_scope.clone(), table_schema.name.clone());
+        // ADR-031 O2: the WAL `collection_id` is the stable `object_id` (decimal)
+        // once the cutover gate is on and the table carries one; otherwise the bare
+        // name (legacy). Readers dual-read (name OR object_id), so this can roll out
+        // per-writer, mixed-read-safe.
+        let collection_id = wal_collection_id(table_schema, wal_object_id_keying_enabled());
 
         for mutation in mutations {
             let kind = mutation.kind;
@@ -1732,7 +1757,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
                         ));
                     }
                     operations.push(CanonicalOperation::RecordUpsert {
-                        collection_id: table_schema.name.clone(),
+                        collection_id: collection_id.clone(),
                         record: Box::new(record.clone()),
                         projections: projections.clone(),
                     });
@@ -1749,7 +1774,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
                         ));
                     }
                     operations.push(CanonicalOperation::RecordUpsert {
-                        collection_id: table_schema.name.clone(),
+                        collection_id: collection_id.clone(),
                         record: Box::new(record.clone()),
                         projections: projections.clone(),
                     });
@@ -1757,7 +1782,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
                 }
                 TableRecordMutationKind::Upsert => {
                     operations.push(CanonicalOperation::RecordUpsert {
-                        collection_id: table_schema.name.clone(),
+                        collection_id: collection_id.clone(),
                         record: Box::new(record.clone()),
                         projections: projections.clone(),
                     });
@@ -1765,7 +1790,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
                 }
                 TableRecordMutationKind::Delete => {
                     operations.push(CanonicalOperation::RecordDelete {
-                        collection_id: table_schema.name.clone(),
+                        collection_id: collection_id.clone(),
                         oid: record.oid.clone(),
                         projections: projections.clone(),
                     });
@@ -2095,6 +2120,33 @@ mod tests {
     use futures::stream::BoxStream;
     use proximadb_catalog::{CatalogColumn, CatalogStorageLayout};
     use proximadb_data_model::ProximaValue;
+
+    /// ADR-031 O2: the WAL `collection_id` is the stable `object_id` (decimal) when
+    /// keying is on AND the table carries one, else the bare name (legacy). This is
+    /// what makes the cutover mixed-read-safe + rename-safe.
+    #[test]
+    fn wal_collection_id_prefers_object_id_when_keying_on() {
+        let mut schema = CatalogTableSchema::new("orders");
+        // No object_id yet → always the name, regardless of the gate.
+        assert_eq!(wal_collection_id(&schema, false), "orders");
+        assert_eq!(
+            wal_collection_id(&schema, true),
+            "orders",
+            "no object_id → name even when keying is on"
+        );
+        // With an object_id: keying off → name; keying on → the decimal id.
+        schema.object_id = Some(42);
+        assert_eq!(
+            wal_collection_id(&schema, false),
+            "orders",
+            "keying off → name"
+        );
+        assert_eq!(
+            wal_collection_id(&schema, true),
+            "42",
+            "keying on + object_id → stable id, never the mutable name"
+        );
+    }
     use proximadb_data_model::{ProximaType, VectorElement};
     use proximadb_kernel::error::StorageError;
     use proximadb_records::{EmbeddingCell, EmbeddingValues, RecordScan, RecordStore};

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -302,3 +302,76 @@ async fn olap_delta_merge_is_tenant_isolated() {
 
     unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
 }
+
+/// ADR-031 O2 (end-to-end, mixed-read-safe): with the merge on, a delete written
+/// while WAL object_id-keying is OFF (name-keyed) plus an update + insert written
+/// while it is ON (object_id-keyed) must ALL be reconciled — the merge's dual-read
+/// unions name-keyed and object_id-keyed entries. pgwire CREATE goes through the
+/// native catalog, which allocates the table's object_id, so the update(3)/insert(4)
+/// are genuinely object_id-keyed; if dual-read were broken they'd be missed and this
+/// fails closed. SAFETY: env toggled only between awaited queries (nextest-isolated).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn olap_delta_merge_reconciles_mixed_name_and_object_id_keyed_wal() {
+    unsafe { std::env::set_var("PROXIMADB_OLAP_DELTA_MERGE", "1") };
+    unsafe { std::env::remove_var("PROXIMADB_WAL_OBJECT_ID_KEY") };
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    client
+        .simple_query("DROP TABLE IF EXISTS dvm_oid")
+        .await
+        .ok();
+    client
+        .simple_query("CREATE TABLE dvm_oid (id INT PRIMARY KEY, v INT)")
+        .await
+        .unwrap_or_else(|e| panic!("create: {}", explain_err(&e)));
+    for sql in [
+        "INSERT INTO dvm_oid (id, v) VALUES (1, 10)",
+        "INSERT INTO dvm_oid (id, v) VALUES (2, 20)",
+        "INSERT INTO dvm_oid (id, v) VALUES (3, 30)",
+    ] {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("insert `{sql}`: {}", explain_err(&e)));
+    }
+    client
+        .simple_query("ALTER TABLE dvm_oid MATERIALIZE")
+        .await
+        .unwrap_or_else(|e| panic!("materialize: {}", explain_err(&e)));
+
+    // Name-keyed delete (object_id WAL keying OFF).
+    client
+        .simple_query("DELETE FROM dvm_oid WHERE id = 2")
+        .await
+        .unwrap_or_else(|e| panic!("delete: {}", explain_err(&e)));
+
+    // Flip to object_id-keyed WAL for the subsequent writes.
+    unsafe { std::env::set_var("PROXIMADB_WAL_OBJECT_ID_KEY", "1") };
+    client
+        .simple_query("UPDATE dvm_oid SET v = 99 WHERE id = 3")
+        .await
+        .unwrap_or_else(|e| panic!("update: {}", explain_err(&e)));
+    client
+        .simple_query("INSERT INTO dvm_oid (id, v) VALUES (4, 40)")
+        .await
+        .unwrap_or_else(|e| panic!("insert4: {}", explain_err(&e)));
+
+    assert_eq!(
+        pairs(
+            &client,
+            "SELECT id, v FROM dvm_oid GROUP BY id, v ORDER BY id"
+        )
+        .await,
+        vec![(1, 10), (3, 99), (4, 40)],
+        "dual-read must union name-keyed delete(2) + object_id-keyed update(3)/insert(4)"
+    );
+
+    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+    unsafe { std::env::remove_var("PROXIMADB_WAL_OBJECT_ID_KEY") };
+}


### PR DESCRIPTION
## What

ADR-031 **O2**: begin keying the canonical WAL `collection_id` by the stable, globally-unique `object_id` instead of the mutable table name — the cutover that lets the per-query tenant predicate drop out at O4 (object_id is unique across tenants, so a tenant comparison is wasted CPU once keying is on).

Builds directly on the merged foundation: ADR-025 relational deletion-vector read-merge (#405) and ADR-031 O0+O1 — IdAllocator + reverse `object_id → table` resolver (#406).

## How (mixed-read-safe, default-OFF)

- **Dual-write** (`record_store::write_mutations`): `wal_collection_id(table_schema, gate)` stamps `collection_id = object_id` (decimal text) when the O2 gate is on **and** the table carries an `object_id`, else the bare name (legacy). Pure (gate passed in) so it unit-tests without touching process env.
- **Gate:** `PROXIMADB_WAL_OBJECT_ID_KEY` (**default OFF**) via `wal_object_id_keying_enabled()`. No flag-day — per-writer/per-deployment rollout.
- **Dual-read** (`DmlService::changed_oids_since`, the `OlapDeltaSource` feed): resolves the table's `object_id` and **unions** name-keyed (legacy) + object_id-keyed (post-cutover) change-feed entries, so the relational writer can migrate independently. A reader sees both regardless of which side wrote.

Because the gate defaults OFF and reads union both keyings, old and new WAL entries coexist and are reconciled — satisfying the §8 mixed-read-safe / no-flag-day mandate.

## Tests

- `wal_collection_id_prefers_object_id_when_keying_on` (unit, pure gate: name vs object_id).
- `olap_delta_merge_reconciles_mixed_name_and_object_id_keyed_wal` (pgwire e2e): a name-keyed `DELETE` (gate OFF) plus an object_id-keyed `UPDATE`+`INSERT` (gate ON) must **all** reconcile through the merge's dual-read — fails closed if dual-read breaks (pgwire `CREATE` allocates the table's object_id via the native catalog, so the update/insert are genuinely object_id-keyed).
- Existing `olap_delta_merge_gate_off_stale_then_on_corrects` + `olap_delta_merge_is_tenant_isolated` still green.

Local: clippy `--lib --bins -D warnings` clean; all 4 tests pass under the port-safe integration profile. TPC-H/TPC-DS unaffected (not merge-opted-in).

## Next (ADR-031)

O2 for graph/vector/doc writers (each safe via the same dual-read) → **O3** flips the gate default-ON after ratchets bake → **O4** drops the tenant predicate.

Refs ADR-031 (O2).