### PR TITLE
docs(sdk): victor-codegraph is on PyPI — drop stale editable-install note

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -107,9 +107,9 @@ code-chunking = [
 
 # Shared code->CPG chunker (TD-CG2 / ADR-029). When installed, the deprecated
 # in-SDK `chunking_strategies/code.py` delegates to `victor_codegraph` so the
-# tree-sitter symbol+relation chunker lives in ONE place (Victor owns it). Until
-# `victor-codegraph` is published to PyPI, install it editable for now:
-#   pip install -e ../../victor/victor-codegraph && pip install 'proximadb[codegraph]'
+# tree-sitter symbol+relation chunker lives in ONE place (Victor owns it).
+# Published on PyPI: `pip install 'proximadb[codegraph]'` (for local source work:
+# pip install -e ../../victor/victor-codegraph).
 codegraph = [
     "victor-codegraph>=0.1.0",
 ]


### PR DESCRIPTION
The SDK `[codegraph]` extra already pins `victor-codegraph>=0.1.0`. Now that the package is published on PyPI, the pin resolves the wheel automatically — no code/pin change was needed (the floor was pre-set in anticipation). This drops the now-stale "install editable until published" instruction in `clients/python/pyproject.toml`, keeping the editable hint only for local source work.

Docs-only; no behavior change. The soft-import delegation + legacy fallback in `chunking_strategies/code.py` are unchanged (the `[codegraph]` extra is optional).