### PR TITLE
docs(adr): ADR-033 catalog-object surrogate identity — immutable u64 oid, name as mutable attribute

### DIFF
--- a/docs/12-design/CATALOG_OID_MIGRATION_2026_06_27.adoc
+++ b/docs/12-design/CATALOG_OID_MIGRATION_2026_06_27.adoc
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Catalog-Object OID Migration Plan (TD-174 — ADR-033 execution)
+:toc: left
+:toclevels: 3
+:icons: font
+:source-highlighter: rouge
+:last-updated: 2026-06-27
+
+Paired ADR: link:adr/ADR-033-catalog-object-surrogate-identity.adoc[ADR-033] (the decision). Tracker: TD-174.
+
+== Goal
+
+Give every catalog object (account / namespace / table-collection / column / index) an immutable, system-generated `u64` `object_oid` (ADR-033); make every internal reference **and the storage path** key off it; and demote the name to a mutable attribute — so **rename is an O(1) metadata update, never a data move**, and catalog joins/FKs/lookups are fixed-width integer ops. Phased, durable-safe, behind a compat shim — never big-bang.
+
+== Invariants (a test enforces each, at every phase that touches it)
+
+* **Rename** a table/namespace/account ⇒ `object_oid` unchanged, every reference still resolves, **no data moved** (assert the on-disk location is byte-identical before/after).
+* **OID uniqueness + never reused** ⇒ drop+create yields a *new* oid; the old oid stays dangling-detectable, never re-aliased.
+* **Reserved low range** (`0..RESERVED_MAX`) ⇒ system objects (`ns_default`, the system schema) have pinned, stable oids.
+* **Backfill is idempotent** (re-runnable; skips objects that already have an oid).
+* **No persisted-shape break** without a serde deserialize-compat shim + a legacy round-trip test (the ADR-024 steps 3/4 discipline).
+
+== Phases
+
+=== Phase 0 — OID substrate (additive; no behavior change)
+
+* **The sequence.** A durable monotonic `next_object_oid`, owned by the catalog authority (the DDL serialization point — so it is never a hot-path bottleneck). Persisted (catalog/WAL); high-water mark recovered on restart; never decremented; never reused. Reserve `0..RESERVED_MAX`; allocate fixed oids for system objects (`ns_default` → a pinned oid).
+* **The column.** Add `object_oid` as an additive, **indexed** `ProximaType::UInt64` attribute on catalog-object records (reuse ADR-024; `#[serde(default)]` so old rows load). `ProximaRecord.oid: String` storage handle is unchanged — logical identity (`u64`) ≠ physical record handle (String).
+* *Targets:* the catalog authority (sequence + allocation), the catalog object-record schema, the system-object bootstrap.
+
+=== Phase 1 — Backfill + dual resolution maps (read-compat)
+
+* Assign an oid to **every existing** catalog object. Build + persist the resolution maps: `name→oid` (per scope) and legacy `ns_<uuid>` / `id → oid`.
+* Reads resolve by EITHER the legacy id/name OR the oid; new writes assign + carry the oid.
+* Backfill is idempotent.
+* *Verify:* every catalogued object has a unique oid; all legacy lookups still resolve.
+
+=== Phase 2 — Internal references cut over to the oid
+
+* Every catalog→catalog reference becomes oid-keyed: `column.table_oid`, `table.namespace_oid`, `namespace.account_oid`, `index.table_oid`. The planner, FK resolution, and joins operate on the `u64`; the name is resolved to an oid **once, at parse**.
+* Legacy name/uuid references become *derived* (via the Phase-1 maps) — read-compat only.
+* *Verify:* a plan over a multi-level catalog resolves entirely on `u64` (no string compare on the hot path); the introspection surface (`xcatalog` / `information_schema`) still renders names.
+
+=== Phase 3 — Storage location keys off the oid (the load-bearing change)
+
+The current DrPath *computes* `data/{tenant_id}/{namespace_id}/{collection_id}/` from the (renameable) id, so name-in-path means rename risks O(data). ADR-033 D6 fixes this by making **location a stored property resolved by oid, not a string computed from the name**:
+
+* The catalog object row stores its **storage location**, keyed by `object_oid`. The path resolver looks it up by oid instead of recomputing from the name/uuid.
+* **Compat shim (recommended — no data move):** existing data **stays at its legacy path**; the catalog records that legacy location for the migrated object. New objects get oid-keyed paths `data/{tenant_id}/{namespace_oid}/{table_oid}/`. Either way the resolver goes oid → stored-location, so **rename never recomputes or moves the path.**
+* *(Optional, deferred)* a background re-lay to oid-uniform paths — **not** required for correctness; the indirection already decouples path from name.
+* *Verify (the headline test):* create table → rename → assert oid, all references, AND the on-disk location are unchanged; zero bytes moved.
+
+=== Phase 4 — Demote legacy string identity
+
+* The `name` becomes purely a mutable display/DDL-lookup attribute; `ns_<uuid>` becomes a legacy alias resolved via the map; new namespaces are oid-native.
+* Retire dual-write once all references are oid; keep the deserialize-compat shim for persisted legacy rows (ADR-024 discipline).
+
+== Dependencies & coordination
+
+* **ADR-033** (the decision); **ADR-024** (`ProximaType::UInt64`; logical/physical separation; the 2026-06-27 identity addendum that distinguishes the record oid from this catalog oid); **ADR-027** (DrPath / storage layout — Phase 3 modifies it); `CATALOG_OBJECT_MODEL_2026_06_21` (the model refined).
+* Coordinate Phase 3 with in-flight path/storage work (PAX substrate; TD-173 canonical `SegmentStatistics`) so the path indirection lands once.
+* **Ledger note:** the `TD-174` row is intentionally **not** filed in `docs/10-quality/TECHNICAL_DEBT.adoc` yet — `develop`'s ledger does not carry TD-167..173 (those ride the unmerged #412), so adding TD-174 now would gap/conflict the numbering. File the TD-174 row once #412 merges and 167..173 land.
+
+== Risk
+
+* **Phase 3 is the risk** (storage location). The stored-location indirection (no physical move) is the safe path; a physical re-lay is deferred/optional.
+* Backfill (Phase 1) must be atomic with the catalog authority + idempotent.
+* Persisted catalog rows: every shape change ships a serde compat shim + a legacy round-trip test (ADR-024 steps 3/4 pattern).

--- a/docs/12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc
+++ b/docs/12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc
@@ -52,3 +52,16 @@ Each step compiles and lands independently; persisted-shape changes (3, 4) ship 
 * Positive: one logical type and one schema struct; the bridge web collapses to a single Arrow/pgwire/proto mapping; new code stops minting parallel types; logical/physical separation makes the type model honest about quantization.
 * Negative / cost: a durable migration for persisted catalog schemas (mitigated by serde compat shims); a multi-step rollout that temporarily keeps deprecated aliases; coordination with in-flight catalog (TD-061/TD-110) and storage (F-series) work.
 * The Convergence Gate is satisfied: this ADR is the cited justification for the type/schema seam change; seam S8 in `CONVERGENCE_AUDIT_2026_05_30.adoc` tracks it to closure.
+
+== Addendum (2026-06-27): object identity is a separate concern from the logical type
+
+`ProximaType` is the type of a *value* in a column — including id columns. It does **not** prescribe the *identity scheme* of an object (who mints the id, its uniqueness scope, its mutability). That is a separate decision, and the two object classes deliberately use different schemes:
+
+[cols="1,2,2", options="header"]
+|===
+| Object class | Identity | Why different
+| **Data record** (a row in a user table) | `ProximaRecord.oid: String` — a user-provided natural key, or an engine-minted **ULID** (ADR-031 scope) | High write-rate, distributed ⇒ coordination-free; ULID is time-sortable + index-friendly
+| **Catalog object** (account / namespace / table / column / index — metadata) | an immutable **`u64` `object_oid`** from the central catalog sequence; the *name* is a mutable attribute (ADR-033) | Low-rate, centrally-serialized DDL ⇒ coordination is free; fixed-width `u64` is fast to join/FK/index and survives rename
+|===
+
+Both id *values* are themselves `ProximaType`s — `String`/`ULID` for the record oid, `UInt64` for the catalog `object_oid` — so the canonical type system carries them, and this ADR stays the authority for the *value type*. The *identity strategy* is owned by ADR-031 (records) and ADR-033 (catalog objects), not here. And `pgwire_oid()` (Decision §3) is a **third, unrelated** concept: the PostgreSQL *type* OID for wire compatibility — not an object identity at all. Keeping these three apart — value type vs object identity vs pgwire type-OID — is the point of this addendum.

--- a/docs/12-design/adr/ADR-033-catalog-object-surrogate-identity.adoc
+++ b/docs/12-design/adr/ADR-033-catalog-object-surrogate-identity.adoc
@@ -1,0 +1,100 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-033: Catalog-Object Surrogate Identity — immutable u64 oid; the name is a mutable attribute
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-27
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-024 (single canonical type — `ProximaType::UInt64` reuse + the logical/physical separation this applies; note its `pgwire_oid()` is the *type* OID, a different concept), `CATALOG_OBJECT_MODEL_2026_06_21.adoc` (the object model this refines — today's `{namespace_id, tenant_id, name, object_id}` string identity), ADR-027 (DrPath / storage layout, which currently embeds the id in the path), ADR-031/032 (agent-facing catalog co-design tenets)
+|Co-designed with|**AnvaiOps ADR-0021** — the consumer catalog reads these objects; stable u64 oids make its cross-references and references-by-id cheap and rename-proof
+|Supersedes|— (refines `CATALOG_OBJECT_MODEL`'s string identity; additive migration)
+|Tracked under|TD-174 (catalog surrogate-oid sequence + name→oid resolution + DrPath migration from name/uuid to oid)
+|===
+
+== Context
+
+First principle: **a catalog object's identity is the object, not its name.** A renamed table, column, namespace, or account is the *same* object — so the name must be a **mutable attribute**, and identity must be a **stable surrogate** that every reference (foreign keys, the storage path, the query planner) points at. If identity *is* the name (or anything mutable/physical), rename becomes an O(data) reference-and-path rewrite instead of an O(1) metadata update.
+
+Two things about the engine today (audited 2026-06-27):
+
+* **Identity is string-based.** `namespace_id = ns_<uuid>`; the identity tuple is `{namespace_id, tenant_id, name, object_id}` (`CATALOG_OBJECT_MODEL_2026_06_21.adoc` §:67/:95); lookups filter on `table_id.name` (`catalog_introspection.rs`). UUID-strings *survive rename* (they're stable) but are **slow and wide on the catalog's hottest path** — every query resolves table → namespace → tenant by comparing/joining ~40-char strings.
+* **The id is baked into the physical path.** `data/{tenant_id}/{namespace_id}/{collection_id}/` (ADR-027). If any segment is the renameable id, rename risks a **data move**.
+
+These are **user objects** (accounts, namespaces, tables/collections, columns, indexes) that, in the tenant *system schema*, are stored as records — so they need both a fast *logical* identity and a *record* representation.
+
+**Scope boundary.** This ADR is about **catalog objects (metadata)** only. The **data-record** oid (`ProximaRecord.oid: String`) is a *separate, settled* concern — high write-rate, distributed, coordination-free (String / ULID natural or surrogate keys). Catalog metadata is the opposite rate class — low-cardinality, low-rate, centrally serialized through the catalog authority — which is exactly why it can and should use a different identity strategy (below). Do not conflate the two.
+
+== Decision
+
+=== D1 — Catalog identity is an immutable, system-generated `u64` surrogate (`object_oid`); the name is a mutable attribute
+
+Every catalog object gets an immutable `object_oid: u64` at creation. The **name** is a mutable attribute, unique within its parent scope (a table name within its namespace, a namespace name within its tenant, …). **Rename = a single-row name update**; the oid — and every reference to it — never changes. (Postgres precedent: `pg_class.oid` is the identity; `relname` is the attribute.)
+
+=== D2 — Every internal reference uses the oid; name→oid resolution happens once, at the boundary
+
+All cross-references are the u64: `column.table_oid`, `table.namespace_oid`, `namespace.account_oid`, `index.table_oid`, **and the storage path** (D6). A name is resolved to an oid **once**, at DDL / query parse (a per-scope name→oid index); the **hot path** — joins, FK resolution, path building, planning — is pure fixed-width integer comparison, never a string compare. The string lookup is amortized to parse time, off the per-row path.
+
+=== D3 — `u64`, system-wide monotonic, from a central catalog sequence; never reused
+
+* **Width: `u64`, not `u32`.** Postgres's 32-bit OID has real wraparound/exhaustion pain at scale; a multi-tenant system (tenants × namespaces × tables × columns) wants the 64-bit headroom.
+* **Allocation: one durable monotonic sequence owned by the catalog authority** — the component that already *serializes* DDL — so the sequence is never a hot-path bottleneck (catalog writes are rare). Recover the high-water mark on restart.
+* **Never reused, even after drop** (Postgres-style): a stale reference is then detectably *dangling*, never silently aliased onto a different object that reused the number.
+* **Coordination is acceptable here** precisely because catalog DDL is low-rate and already serialized — unlike high-rate distributed *data* records, which stay coordination-free. Different rate class ⇒ different identity strategy (the scope boundary above).
+
+=== D4 — Reserve a low oid range for system/built-in objects
+
+Reserve `0 .. RESERVED_MAX` (e.g. < 1000) for system objects — the tenant system schema, the default namespace (`ns_default` → a fixed, well-known oid), built-in indexes/types — so their oids are stable and pinned, not minted by the user sequence. User objects start above the reserved range. (Postgres precedent: low OIDs are the pinned system catalogs.)
+
+=== D5 — Stored as an indexed `ProximaType::UInt64` column; logical identity ≠ physical handle
+
+Catalog objects are records in the tenant system schema. The `object_oid` is a typed, **indexed** `ProximaType::UInt64` column (reuse ADR-024 — additive, no new type), so storage-layer lookup-by-oid is a native integer index probe, not a string scan. `ProximaRecord.oid` (the String storage handle) is unchanged. The **logical** catalog identity (`u64`) and the **physical** record handle (String) are deliberately separate — the same logical/physical split ADR-024 mandates. Catalog-record→catalog-record references are the u64, never the String record handle.
+
+=== D6 — The DrPath keys off the surrogate oid, not the name (rename becomes metadata-only)
+
+The storage path becomes `data/{tenant_id}/{namespace_oid}/{table_oid}/…`:
+
+* `tenant_id` stays the **externally-assigned** tenant identifier (from the auth system — not a catalog surrogate);
+* `namespace_oid` / `table_oid` are the **u64 surrogates**.
+
+Because the path is keyed by oid, **rename never moves data** — the name lives only in the catalog row. This is the load-bearing change that makes rename O(1) instead of O(data). Migrating ADR-027's current name/uuid-in-path to oid-in-path is **TD-174** (the real work; sequenced, not big-bang — see Consequences).
+
+== Authority and route declaration
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| `authority_mode` | `authoritative` — the catalog authority owns the oid sequence + the object↔oid mapping. This is durable identity, not a projection.
+| `policy_boundary` | Per-tenant via `tenant_id` + RLS. Oids are system-wide unique (per-tenant oid spaces are a rejected/deferred alternative below).
+| `workload_profile` | `ddl_low_rate` — oid allocation rides the already-serialized DDL path; no hot-path contention.
+| `freshness_sla` | `read_your_writes` — a newly created object's oid is immediately resolvable.
+| `compute_route` | name→oid resolution at parse; u64 on every internal route (joins, FK, path, plan).
+| `policy/RLS` | tenant_id scoping; reserved low range for system objects (D4).
+|===
+
+== Consequences
+
+* **Rename is O(1).** Renaming a table/column/namespace/account is a single name-column update — no data move, no reference rewrite. The invariant that prompted this ADR holds by construction.
+* **Catalog joins / FK / path-building become fixed-width `u64` integer ops** — faster compares, denser indexes, and far less storage than UUID-strings, on the per-query hot path.
+* **One new durable piece:** the central monotonic oid sequence (standard; recovered on restart; never-reuse).
+* **Migration cost (TD-174):** existing `ns_<uuid>` / name-keyed objects get an oid assigned; build name→oid + legacy-uuid→oid maps; rewrite the DrPath to be oid-keyed (existing data paths migrated or aliased). Sequenced behind a compatibility shim, not big-bang.
+* **Minor info exposure:** a system-wide monotonic oid leaks coarse cross-tenant creation order (oid gaps). Accepted for the simplicity of oid-alone foreign keys; per-tenant oid spaces remove it at the cost of `(tenant_id, oid)` compound FKs (deferred — see below).
+
+== Rejected alternatives
+
+* **Name as identity.** Rename breaks every reference and the path — the current pain. Rejected.
+* **UUID-string surrogate (today's `ns_<uuid>`).** Survives rename but is slow and wide on the catalog hot path (string compare/join, ~40 bytes per reference) — the regression this ADR fixes. Rejected for catalog; migrate off it.
+* **`u32` OID (Postgres).** Wraparound / exhaustion at multi-tenant scale. Rejected — `u64`.
+* **Random (coordination-free) `u64`.** Buys coordination-freedom the catalog doesn't need (DDL is low-rate, already serialized) and loses monotonic ordering (recent-object clustering, creation-order range scans), plus a small collision risk. Rejected for catalog in favor of monotonic-from-sequence.
+* **ULID for catalog objects.** 16 bytes (2× `u64`), time-sortable + coordination-free — the *right* choice for high-rate distributed **data records**, but for low-rate centrally-managed **catalog metadata** `u64` is half the width and a faster compare, and coordination is free. Rejected for catalog (it is the *data-record* choice — keep the two concerns separate per the scope boundary).
+* **Per-tenant oid space.** Stronger isolation (no cross-tenant ordering leak), but every foreign key becomes `(tenant_id, oid)`. Deferred — system-wide `u64` + a `tenant_id` RLS column is simpler; revisit only if strict isolation requires it.
+
+== References
+
+* ADR-024 (single canonical type — `ProximaType::UInt64` reuse; logical/physical separation; `pgwire_oid()` is the *type* OID, distinct from this *object* oid)
+* `CATALOG_OBJECT_MODEL_2026_06_21.adoc` (the object model refined — string identity → u64 surrogate; the `{namespace_id, tenant_id, name, object_id}` tuple)
+* ADR-027 (DrPath / storage layout — the path currently embeds the id; D6 migrates it to oid-keyed)
+* AnvaiOps ADR-0021 (the consumer catalog — cheap, stable, rename-proof cross-references)
+* TD-174 (catalog surrogate-oid sequence + name→oid resolution + DrPath migration)
+* PostgreSQL catalog OID precedent — `pg_class.oid` / `pg_namespace.oid`: a numeric surrogate is the identity, the name is a mutable attribute, references survive rename.

--- a/docs/12-design/adr/ADR-033-catalog-object-surrogate-identity.adoc
+++ b/docs/12-design/adr/ADR-033-catalog-object-surrogate-identity.adoc
@@ -11,6 +11,7 @@
 |Co-designed with|**AnvaiOps ADR-0021** — the consumer catalog reads these objects; stable u64 oids make its cross-references and references-by-id cheap and rename-proof
 |Supersedes|— (refines `CATALOG_OBJECT_MODEL`'s string identity; additive migration)
 |Tracked under|TD-174 (catalog surrogate-oid sequence + name→oid resolution + DrPath migration from name/uuid to oid)
+|Paired plan|link:../CATALOG_OID_MIGRATION_2026_06_27.adoc[CATALOG_OID_MIGRATION_2026_06_27] — the phased TD-174 execution plan (Phases 0–4 + per-phase invariants)
 |===
 
 == Context


### PR DESCRIPTION
## Summary

Records **ADR-033**: catalog-object identity (accounts, namespaces, tables/collections, columns, indexes) is an **immutable, system-generated `u64` `object_oid`**, with the **name as a mutable attribute**. Refines `CATALOG_OBJECT_MODEL_2026_06_21` (today's `{namespace_id=ns_<uuid>, tenant_id, name, object_id}` string identity).

## Why

A catalog object's identity is the *object*, not its *name* — a renamed table/namespace/account is the same object.

- **Rename survival**: every internal reference + the DrPath key off the oid, so rename is an O(1) metadata update — never a data move or reference rewrite (today's name/uuid-in-path makes rename risk O(data)).
- **Performance**: fixed-width `u64` lookup/join/FK beats the current ~40-char UUID-string on the catalog's hottest path (table → namespace → tenant resolution on every query) — faster compare, denser index, less storage.

## Decisions (D1–D6)

- **D1/D2** — immutable `u64` surrogate; name is a mutable attribute; all references use the oid; name→oid resolved once at parse.
- **D3** — `u64` (not `u32` — Postgres OID wraparound at multi-tenant scale); system-wide monotonic from the central catalog sequence (coordination is free at DDL rates); never reused (dangling-detectable).
- **D4** — reserved low oid range for system objects (`ns_default` → fixed oid).
- **D5** — stored as an indexed `ProximaType::UInt64` column (reuse ADR-024, additive; logical identity ≠ physical record handle).
- **D6** — DrPath keys off the oid (`data/{tenant_id}/{namespace_oid}/{table_oid}/`) → rename never moves data.

## Scope

Catalog objects (metadata) only. The data-record oid (`ProximaRecord.oid: String` / ULID) is a separate, settled concern (high-rate, distributed, coordination-free) — deliberately not conflated.

## Status

**Proposed** — decision only. Implementation (oid sequence + name→oid resolution + the DrPath migration behind a compat shim) is **TD-174**, sequenced (not big-bang). Reuses `ProximaType::UInt64` (ADR-024). Rejected alternatives (name-as-identity, UUID-string, `u32`, random u64, ULID-for-catalog, per-tenant oid space) are documented in the ADR.

Refs: ADR-024, ADR-027 (DrPath), `CATALOG_OBJECT_MODEL_2026_06_21`, AnvaiOps ADR-0021; TD-174.
