### PR TITLE
feat(mcp): reference MCP surface (OSS, unprivileged) — agent-facing catalog projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,6 +7131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proximadb-mcp"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "proximadb-memory-pool"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "crates/platform/proximadb-api",
     "crates/platform/proximadb-runtime",
     "crates/platform/proximadb-admin-ui",
+    "crates/platform/proximadb-mcp",
     "crates/modalities/proximadb-graph",
     "crates/modalities/proximadb-vector",
     "crates/modalities/proximadb-quantization-kernel",

--- a/crates/platform/proximadb-mcp/Cargo.toml
+++ b/crates/platform/proximadb-mcp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "proximadb-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "ProximaDB reference MCP surface (OSS, unprivileged) — projects existing engine affordances (the agent-facing catalog reference-MCP design)"
+
+[lib]
+name = "proximadb_mcp"
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/platform/proximadb-mcp/src/lib.rs
+++ b/crates/platform/proximadb-mcp/src/lib.rs
@@ -1,0 +1,238 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! # ProximaDB reference MCP surface (the agent-facing catalog reference-MCP design)
+//!
+//! A thin, OSS, **unprivileged** Model Context Protocol projection of surfaces the
+//! engine already exposes: catalog `list_collections`/`describe`, the statistics
+//! `stats` envelope, the ADR-004 `explain`, REST v2 `search`, and the ADR-022
+//! `memory`/`checkpoint`/`event` agent-state services. It is **adoption fuel and
+//! the conformance target** for the boundary object — deliberately stopping at the
+//! open-core line: no rate card, account entitlement, data redaction, or
+//! governance gating live here (those are AnvaiOps's governed gateway, ADR-0021,
+//! which *composes* this surface). The unprivileged invariant is enforced by the
+//! catalog guard test below.
+//!
+//! This crate is the **protocol + catalog + dispatch** layer over a
+//! [`ReferenceBackend`] trait; an adapter wires the trait to the engine's
+//! REST/gRPC surfaces (and an stdio loop drives [`handle_request`]). Keeping the
+//! engine out of this crate makes the surface independently testable.
+
+pub mod protocol;
+pub mod tools;
+
+pub use protocol::{JsonRpcRequest, JsonRpcResponse, Tool};
+pub use tools::{BackendError, ReferenceBackend, dispatch_tool, reference_tools, tool_name};
+
+use protocol::{ToolCallParams, error_code, tool_result_content};
+use serde_json::{Value, json};
+
+/// The MCP protocol version this reference surface implements.
+pub const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+fn server_info() -> Value {
+    json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": { "tools": {} },
+        "serverInfo": {
+            "name": "proximadb-reference-mcp",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
+/// Handle one JSON-RPC request against the backend. Returns `None` for
+/// notifications (requests without an `id`), which expect no response.
+pub async fn handle_request(
+    backend: &dyn ReferenceBackend,
+    req: JsonRpcRequest,
+) -> Option<JsonRpcResponse> {
+    let id = req.id.clone()?; // notification → no response
+
+    let response = match req.method.as_str() {
+        "initialize" => JsonRpcResponse::ok(id, server_info()),
+        "tools/list" => JsonRpcResponse::ok(id, json!({ "tools": reference_tools() })),
+        "tools/call" => match serde_json::from_value::<ToolCallParams>(req.params) {
+            Ok(params) => match dispatch_tool(backend, &params.name, &params.arguments).await {
+                Ok(payload) => JsonRpcResponse::ok(id, tool_result_content(&payload)),
+                Err(e) => JsonRpcResponse::err(id, e.code, e.message),
+            },
+            Err(e) => JsonRpcResponse::err(
+                id,
+                error_code::INVALID_PARAMS,
+                format!("invalid tools/call params: {e}"),
+            ),
+        },
+        other => JsonRpcResponse::err(
+            id,
+            error_code::METHOD_NOT_FOUND,
+            format!("unknown method: {other}"),
+        ),
+    };
+    Some(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    /// A canned backend that echoes which tool was called.
+    struct MockBackend;
+
+    #[async_trait]
+    impl ReferenceBackend for MockBackend {
+        async fn list_collections(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "collections": ["a", "b"] }))
+        }
+        async fn describe(&self, args: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "describe": args }))
+        }
+        async fn stats(&self, args: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "envelope_version": "1.0.0", "for": args }))
+        }
+        async fn explain(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "plan": "explain" }))
+        }
+        async fn search(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "hits": [] }))
+        }
+        async fn memory(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "memory": "ok" }))
+        }
+        async fn checkpoint(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "checkpoint": "ok" }))
+        }
+        async fn event(&self, _: &Value) -> Result<Value, BackendError> {
+            Ok(json!({ "event": "ok" }))
+        }
+    }
+
+    fn req(id: Value, method: &str, params: Value) -> JsonRpcRequest {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        }))
+        .expect("valid request")
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_server_info() {
+        let resp = handle_request(&MockBackend, req(json!(1), "initialize", json!({})))
+            .await
+            .expect("response");
+        let result = resp.result.expect("result");
+        assert_eq!(result["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["name"], "proximadb-reference-mcp");
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_the_eight_reference_tools() {
+        let resp = handle_request(&MockBackend, req(json!(2), "tools/list", json!({})))
+            .await
+            .expect("response");
+        let tools = resp.result.expect("result")["tools"].clone();
+        let names: Vec<String> = tools
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(names.len(), 8);
+        for expected in [
+            "list_collections",
+            "describe",
+            "stats",
+            "explain",
+            "search",
+            "memory",
+            "checkpoint",
+            "event",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "missing tool {expected}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_call_dispatches_and_wraps_content() {
+        let params = json!({ "name": "stats", "arguments": { "collection_id": "incidents" } });
+        let resp = handle_request(&MockBackend, req(json!(3), "tools/call", params))
+            .await
+            .expect("response");
+        let result = resp.result.expect("result");
+        // MCP content envelope with a text block carrying the JSON payload.
+        let text = result["content"][0]["text"].as_str().expect("text block");
+        assert!(text.contains("envelope_version"));
+        assert_eq!(result["isError"], false);
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_is_method_not_found() {
+        let params = json!({ "name": "delete_everything", "arguments": {} });
+        let resp = handle_request(&MockBackend, req(json!(4), "tools/call", params))
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.error.expect("error").code,
+            error_code::METHOD_NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_method_is_method_not_found() {
+        let resp = handle_request(&MockBackend, req(json!(5), "resources/list", json!({})))
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.error.expect("error").code,
+            error_code::METHOD_NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn notifications_get_no_response() {
+        // No `id` → notification → no response.
+        let notif = serde_json::from_value(json!({
+            "jsonrpc": "2.0", "method": "notifications/initialized", "params": {}
+        }))
+        .expect("valid notification");
+        assert!(handle_request(&MockBackend, notif).await.is_none());
+    }
+
+    /// the agent-facing catalog reference-MCP design / open-core guard: the reference surface stays
+    /// unprivileged — no pricing, governance, entitlement, redaction, or
+    /// per-account policy may leak into the tool catalog the server exposes. This
+    /// checks the runtime catalog (names + descriptions), the actual surface,
+    /// rather than explanatory source comments. (A complementary source-symbol CI
+    /// grep — mirroring the ADR-030 billing-never-gated guard — is the production
+    /// hook to add.)
+    #[test]
+    fn unprivileged_catalog_carries_no_pricing_or_governance() {
+        const FORBIDDEN: &[&str] = &[
+            "price",
+            "pricing",
+            "bill",
+            "invoice",
+            "rate card",
+            "rate_card",
+            "entitle",
+            "governance",
+            "redact",
+            "pii",
+            "per-account",
+            "per account",
+            "$",
+        ];
+        for tool in reference_tools() {
+            let haystack = format!("{} {}", tool.name, tool.description).to_lowercase();
+            for bad in FORBIDDEN {
+                assert!(
+                    !haystack.contains(bad),
+                    "reference tool '{}' leaks forbidden term '{bad}' (open-core boundary)",
+                    tool.name
+                );
+            }
+        }
+    }
+}

--- a/crates/platform/proximadb-mcp/src/protocol.rs
+++ b/crates/platform/proximadb-mcp/src/protocol.rs
@@ -1,0 +1,110 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! JSON-RPC 2.0 + minimal MCP wire types for the reference surface.
+//!
+//! Deliberately small and dependency-light (serde + serde_json only): MCP is one
+//! *projection* of the engine's affordances, not a new authority. If a different
+//! agent protocol displaces it, only this layer is re-skinned; the surfaces it
+//! projects (stats/describe/explain/search) do not move.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Standard JSON-RPC 2.0 error codes (plus MCP usage).
+pub mod error_code {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+}
+
+/// An incoming JSON-RPC 2.0 request (or notification when `id` is absent).
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(default)]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+impl JsonRpcRequest {
+    /// A request with no `id` is a notification — it expects no response.
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+/// A JSON-RPC 2.0 response (exactly one of `result`/`error` is set).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn ok(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn err(id: Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// An MCP tool descriptor (returned by `tools/list`).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    /// JSON Schema for the tool's arguments.
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+/// Parameters of a `tools/call` request.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolCallParams {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Value,
+}
+
+/// Wrap a tool's structured result as MCP tool-call content (a single text block
+/// carrying the JSON payload — the conformant, transport-stable shape).
+pub fn tool_result_content(payload: &Value) -> Value {
+    serde_json::json!({
+        "content": [
+            { "type": "text", "text": payload.to_string() }
+        ],
+        "isError": false
+    })
+}

--- a/crates/platform/proximadb-mcp/src/tools.rs
+++ b/crates/platform/proximadb-mcp/src/tools.rs
@@ -1,0 +1,183 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! The reference tool catalog + backend trait (the agent-facing catalog reference-MCP design).
+//!
+//! Each tool is a thin **projection of an existing engine surface** — catalog
+//! introspection, the statistics envelope, the unified EXPLAIN
+//! (ADR-004), REST v2 hybrid search, and the ADR-022 agent-state services. The
+//! surface is **generic and unprivileged**: no pricing, rate card, per-account
+//! entitlement, PII redaction, or governance policy — those belong to AnvaiOps's
+//! governed gateway (ADR-0021), which *composes* this reference surface. The
+//! unprivileged invariant is enforced by the `unprivileged_*` guard test.
+
+use crate::protocol::{Tool, error_code};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// An error from a backend projection, mapped to a JSON-RPC error.
+#[derive(Debug, Clone)]
+pub struct BackendError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl BackendError {
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: error_code::INVALID_PARAMS,
+            message: message.into(),
+        }
+    }
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: error_code::INTERNAL_ERROR,
+            message: message.into(),
+        }
+    }
+}
+
+/// The capabilities the reference MCP server projects. An adapter implements this
+/// over the engine's existing REST/gRPC surfaces; the protocol layer never
+/// touches the engine directly. All methods are tenant-scoped by the adapter
+/// (structural isolation), but carry **no** per-account entitlement (AnvaiOps).
+#[async_trait]
+pub trait ReferenceBackend: Send + Sync {
+    /// Catalog introspection: list collections (xcatalog / information_schema).
+    async fn list_collections(&self, args: &Value) -> Result<Value, BackendError>;
+    /// Catalog introspection: describe one collection's schema/indexes.
+    async fn describe(&self, args: &Value) -> Result<Value, BackendError>;
+    /// The statistics envelope (units only) for a collection.
+    async fn stats(&self, args: &Value) -> Result<Value, BackendError>;
+    /// The ADR-004 unified EXPLAIN for a query (selectivity/rows/cost).
+    async fn explain(&self, args: &Value) -> Result<Value, BackendError>;
+    /// REST v2 hybrid search.
+    async fn search(&self, args: &Value) -> Result<Value, BackendError>;
+    /// ADR-022 agent memory (store/get/list).
+    async fn memory(&self, args: &Value) -> Result<Value, BackendError>;
+    /// ADR-022 agent checkpoint (save/restore).
+    async fn checkpoint(&self, args: &Value) -> Result<Value, BackendError>;
+    /// ADR-022 agent event (append/list).
+    async fn event(&self, args: &Value) -> Result<Value, BackendError>;
+}
+
+/// Stable tool names (the conformance contract for the boundary object).
+pub mod tool_name {
+    pub const LIST_COLLECTIONS: &str = "list_collections";
+    pub const DESCRIBE: &str = "describe";
+    pub const STATS: &str = "stats";
+    pub const EXPLAIN: &str = "explain";
+    pub const SEARCH: &str = "search";
+    pub const MEMORY: &str = "memory";
+    pub const CHECKPOINT: &str = "checkpoint";
+    pub const EVENT: &str = "event";
+}
+
+fn collection_arg_schema(extra_desc: &str) -> Value {
+    json!({
+        "type": "object",
+        "required": ["collection_id"],
+        "properties": {
+            "collection_id": { "type": "string", "description": format!("Collection name or id.{extra_desc}") }
+        },
+        "additionalProperties": true
+    })
+}
+
+/// The reference tool catalog returned by `tools/list`.
+pub fn reference_tools() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: tool_name::LIST_COLLECTIONS.to_string(),
+            description: "List collections visible to the caller (catalog introspection)."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "limit": { "type": "integer", "minimum": 1 },
+                    "offset": { "type": "integer", "minimum": 0 }
+                },
+                "additionalProperties": true
+            }),
+        },
+        Tool {
+            name: tool_name::DESCRIBE.to_string(),
+            description: "Describe a collection's schema, indexes, and capabilities.".to_string(),
+            input_schema: collection_arg_schema(""),
+        },
+        Tool {
+            name: tool_name::STATS.to_string(),
+            description: "Return the statistics envelope (units and distributions only) for a \
+                          collection — record/field counts, cardinality, distributions, and \
+                          per-modality summaries. The engine attests a freshness fact (a \
+                          watermark)."
+                .to_string(),
+            input_schema: collection_arg_schema(""),
+        },
+        Tool {
+            name: tool_name::EXPLAIN.to_string(),
+            description: "Explain a query: the unified plan with estimated selectivity, rows, \
+                          and cost, plus stats freshness."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["collection_id", "query"],
+                "properties": {
+                    "collection_id": { "type": "string" },
+                    "query": { "type": "object", "description": "The query to explain." }
+                },
+                "additionalProperties": true
+            }),
+        },
+        Tool {
+            name: tool_name::SEARCH.to_string(),
+            description: "Hybrid search over a collection (vector + filter + text).".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["collection_id"],
+                "properties": {
+                    "collection_id": { "type": "string" },
+                    "query": { "type": "object" },
+                    "k": { "type": "integer", "minimum": 1 }
+                },
+                "additionalProperties": true
+            }),
+        },
+        Tool {
+            name: tool_name::MEMORY.to_string(),
+            description: "Agent memory: store, get, or list memory entries (ADR-022).".to_string(),
+            input_schema: json!({ "type": "object", "additionalProperties": true }),
+        },
+        Tool {
+            name: tool_name::CHECKPOINT.to_string(),
+            description: "Agent checkpoint: save or restore agent state (ADR-022).".to_string(),
+            input_schema: json!({ "type": "object", "additionalProperties": true }),
+        },
+        Tool {
+            name: tool_name::EVENT.to_string(),
+            description: "Agent event log: append or list events (ADR-022).".to_string(),
+            input_schema: json!({ "type": "object", "additionalProperties": true }),
+        },
+    ]
+}
+
+/// Route a `tools/call` to the backing projection. Unknown tool → method-not-found.
+pub async fn dispatch_tool(
+    backend: &dyn ReferenceBackend,
+    name: &str,
+    args: &Value,
+) -> Result<Value, BackendError> {
+    match name {
+        tool_name::LIST_COLLECTIONS => backend.list_collections(args).await,
+        tool_name::DESCRIBE => backend.describe(args).await,
+        tool_name::STATS => backend.stats(args).await,
+        tool_name::EXPLAIN => backend.explain(args).await,
+        tool_name::SEARCH => backend.search(args).await,
+        tool_name::MEMORY => backend.memory(args).await,
+        tool_name::CHECKPOINT => backend.checkpoint(args).await,
+        tool_name::EVENT => backend.event(args).await,
+        other => Err(BackendError {
+            code: error_code::METHOD_NOT_FOUND,
+            message: format!("unknown tool: {other}"),
+        }),
+    }
+}


### PR DESCRIPTION
## Summary

A thin, OSS, **unprivileged** reference **MCP** (Model Context Protocol) surface that projects engine affordances the database already exposes — so an agent (or any MCP client) can self-serve without bespoke gRPC/REST glue. This is the lower, open-core half of the agent surface; it deliberately stops at the open-core line.

This is a **follow-up** carved out of the agent-facing-catalog / statistics-substrate effort (its producer half is landing separately). The MCP crate is fully **standalone** — it has no dependency on the producer — so it lands cleanly on its own.

## What's here

- **New crate `proximadb-mcp`** (deps: serde / serde_json / async-trait):
  - `protocol` — JSON-RPC 2.0 + minimal MCP types (`Tool`, tool-call content envelope).
  - `tools` — the 8-tool reference catalog (`list_collections` / `describe` / `stats` / `explain` / `search` / `memory` / `checkpoint` / `event`), the async `ReferenceBackend` trait, and `dispatch_tool`.
  - `handle_request` — `initialize` / `tools/list` / `tools/call` / notifications.
- **Open-core guard** — the `unprivileged_catalog` test asserts the runtime tool catalog carries no pricing / governance / entitlement / redaction / per-account terms (those belong to AnvaiOps's governed gateway, which *composes* this surface).

## Verification
7 unit tests pass; `cargo clippy` + `cargo fmt --all` clean. The engine is kept out of the crate (backend trait) so the surface is independently testable.

## Remaining (separate follow-ups)
- A `ReferenceBackend` adapter wiring the trait to the engine's REST v2 / catalog / ADR-022 services.
- The stdio JSON-RPC loop binary.
- ADR/TD cross-references finalized once the statistics-substrate ADR lands.
