### PR TITLE
docs(status): TD/ADR convention developer broadcast

### DIFF
--- a/docs/_internal/status/TD_ADR_CONVENTION_BROADCAST_2026_06_27.adoc
+++ b/docs/_internal/status/TD_ADR_CONVENTION_BROADCAST_2026_06_27.adoc
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= 📢 Developer Broadcast — New canonical convention for filing TDs & ADRs (2026-06-27)
+:toc: macro
+:icons: font
+
+A linkable, team-facing announcement of the TD/ADR collision fix shipped in PR #441.
+The **canonical rules** live in link:../../12-design/HOW_TO_FILE_TD_AND_ADR.adoc[HOW_TO_FILE_TD_AND_ADR];
+this doc is the one-time "update your machine" notice.
+
+toc::[]
+
+== Why
+TD and ADR numbers kept colliding between concurrent agent sessions — ADR-031/032/033 and
+TD-167/168/169 were each double-assigned in a single week. Sequential numbering has no atomic
+allocator and **nothing in CI enforced uniqueness**. Two failure modes: textual conflicts on the
+single ~2000-line `TECHNICAL_DEBT.adoc` (5/14 open PRs touch it; churned 45× in 6 days), and silent
+number collisions caught only at merge.
+
+== Update your machine
+. Pull develop once #441 lands: `git fetch origin && git checkout develop && git pull`, then rebase
+  active branches (`git rebase origin/develop`).
+. Read the canonical convention — now the single source of truth:
+  `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`.
+. **No rule-file edits needed.** `CLAUDE.md` / `GEMINI.md` / `AGENTS.md` now only *point* to that doc
+  (they don't carry the rules), so your local agent files inherit it via git — nothing to
+  hand-maintain per machine.
+
+== The rules (effective immediately)
+* **One file per entry.** New ADRs → `docs/12-design/adr/ADR-<NNN>-<slug>.adoc` (already the norm).
+  **New TDs → `docs/10-quality/td/TD-<id>-<slug>.adoc`** (new directory; stop appending to the big
+  `TECHNICAL_DEBT.adoc` table).
+* **Declare the id in the title heading** (`= TD-167: …` / `= ADR-037: …`) — the guard reads it from
+  there, not the filename.
+* **Prefer a topic-scoped id** for any multi-step effort: `TD-<TOPIC>-N` (e.g. `TD-CAT-3`,
+  `TD-SC-2`). One initiative owns its prefix → collision-free across sessions. Reserve global
+  `TD-NNN` / `ADR-NNN` for standalone one-offs.
+* **Claim the next free global number by scanning the directory**, and **never reuse a number
+  already on `develop`** — rebase first (mandated ≤48h), then check.
+* **The guard is the backstop, not a lock:** `python3 scripts/check_td_adr_unique.py` (run before
+  pushing; exit 0 = unique). CI's *Docs Validation* job runs it on every PR; a rebased PR whose
+  number collides with freshly-merged develop now fails *before* merge instead of clobbering
+  silently.
+
+== Action items for in-flight branches
+* **PR #436** — has a second `ADR-033` (develop already owns `ADR-033-primary-storage-format-strategy`).
+  On its next rebase the guard fails; **renumber to the next free ADR** and update the README index.
+  (This is the guard doing its job.)
+* **Any branch that adds an ADR/TD off an older base:** rebase onto develop and re-check the number
+  is still free before pushing.
+
+== What was NOT changed
+The ~100 existing TDs stay in `TECHNICAL_DEBT.adoc` (referenced ~900× across code — not migrated).
+The guard treats those rows as declarations, so a new per-file TD cannot reuse a legacy id.
+Migrating the legacy table is a separate, batched, post-merge effort.


### PR DESCRIPTION
Team-facing, linkable announcement of the TD/ADR collision fix that landed in #441 (guard + per-file convention now live on develop). Doc-only; canonical rules live in `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`, this is the one-time 'update your machine' notice in `docs/_internal/status/`. Follow-up to #441 (which auto-merged before this could be folded in).