### PR TITLE
refactor(query): lock-free route consult/learn split + decision observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6490,6 +6490,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "apache-avro",
+ "arc-swap",
  "arrow",
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ proximadb-relational-executor = { path = "crates/query/proximadb-relational-exec
 proximadb-relational-frontend = { path = "crates/query/proximadb-relational-frontend" }
 proximadb-relational-engine = { path = "crates/query/proximadb-relational-engine" }
 proximadb-catalog = { path = "crates/control/proximadb-catalog" }
+arc-swap = "1.7"
 dashmap = "6.1.0"
 moka = { version = "0.12", features = ["future"] }
 parking_lot = "0.12"
@@ -527,6 +528,7 @@ ring = "0.17"  # Cryptographic operations for field-level encryption
 crossbeam = "0.8"  # Lock-free ring buffers for observability ingestion
 
 parking_lot = "0.12"
+arc-swap = { workspace = true }
 async-trait = "0.1"
 futures = "0.3"
 regex = "1.10"

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -212,6 +212,8 @@ pub mod query_service;
 /// gauge + observation / hot-swap counters for /route-health +
 /// /recall-tune.
 pub mod recall_drift_metrics;
+/// Read-route decision observability (co-design C4 operator surface).
+pub mod route_metrics;
 pub mod schema;
 pub mod store;
 /// TD-064 predicate-aware vector search shortfall counters.

--- a/src/metrics/route_metrics.rs
+++ b/src/metrics/route_metrics.rs
@@ -1,0 +1,159 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+// dedicated metric-registration module: static registration is infallible / fail-fast at startup;
+// lazy_static can't carry per-site allows.
+// Copyright 2026 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! Read-route decision observability (co-design C4 operator surface).
+//!
+//! The `ComputeScheduler` route decision was previously observable only via a
+//! `tracing::debug!` line — invisible in production dashboards. These counters
+//! and the consult-latency histogram make the route distribution, the
+//! static/override/explore split, and the cost of the (now lock-free) consult
+//! itself operationally visible. Labels are deliberately low-cardinality:
+//! `backend` is the canonical engine label, `shape_class` the coarse cost-model
+//! class key, and `source` one of `static` / `override_exploit` / `override_explore`.
+//!
+//! `ROUTE_OLAP_ON_NATIVE_TOTAL` is an operator nudge: an analytic (`olap/*`)
+//! query served by the Native/Volcano row engine is paying N row-gets instead of
+//! a columnar scan — the table is a materialization candidate.
+
+use std::time::Duration;
+
+use lazy_static::lazy_static;
+use prometheus::{
+    CounterVec, HistogramOpts, HistogramVec, Opts, register_counter_vec, register_histogram_vec,
+};
+use tracing::error;
+
+fn register_counter_vec_safe(name: &str, help: &str, labels: &[&str]) -> CounterVec {
+    match register_counter_vec!(name, help, labels) {
+        Ok(metric) => metric,
+        Err(reg_err) => {
+            error!("Failed to register {}: {}", name, reg_err);
+            CounterVec::new(Opts::new(name, help), labels).unwrap_or_else(|_| {
+                CounterVec::new(Opts::new(format!("{}_fallback", name), help), labels)
+                    .unwrap_or_else(|_| unreachable!("valid counter metric descriptor"))
+            })
+        }
+    }
+}
+
+fn register_histogram_vec_safe(
+    name: &str,
+    help: &str,
+    labels: &[&str],
+    buckets: Vec<f64>,
+) -> HistogramVec {
+    match register_histogram_vec!(name, help, labels, buckets.clone()) {
+        Ok(metric) => metric,
+        Err(reg_err) => {
+            error!("Failed to register {}: {}", name, reg_err);
+            HistogramVec::new(
+                HistogramOpts::new(name, help).buckets(buckets.clone()),
+                labels,
+            )
+            .unwrap_or_else(|_| {
+                HistogramVec::new(
+                    HistogramOpts::new(format!("{}_fallback", name), help).buckets(buckets),
+                    labels,
+                )
+                .unwrap_or_else(|_| unreachable!("valid histogram metric descriptor"))
+            })
+        }
+    }
+}
+
+lazy_static! {
+    /// Route decisions by backend, shape-class, and decision source.
+    pub static ref ROUTE_DECISIONS_TOTAL: CounterVec = register_counter_vec_safe(
+        "proximadb_route_decisions_total",
+        "Read-route decisions by backend, shape-class, and source (static | override_exploit | override_explore)",
+        &["backend", "shape_class", "source"],
+    );
+
+    /// Consult (route-decision) latency. Proves the consult stays sub-microsecond
+    /// now that it is a lock-free `ArcSwap` load + `HashMap` get.
+    pub static ref ROUTE_CONSULT_DURATION_SECONDS: HistogramVec = register_histogram_vec_safe(
+        "proximadb_route_consult_duration_seconds",
+        "Read-route decision latency, by whether a cost model was consulted",
+        &["had_model"],
+        // Sub-microsecond to ~1ms — the consult is a hot-path, lock-free read.
+        vec![1e-7, 5e-7, 1e-6, 2e-6, 5e-6, 1e-5, 5e-5, 1e-4, 1e-3],
+    );
+
+    /// Analytic (`olap/*`) queries served by the Native/Volcano row engine — a
+    /// materialization nudge (the query would be cheaper over a Parquet base).
+    pub static ref ROUTE_OLAP_ON_NATIVE_TOTAL: CounterVec = register_counter_vec_safe(
+        "proximadb_route_olap_on_native_total",
+        "Analytic queries routed to the Native row engine (unmaterialized) — consider ALTER TABLE MATERIALIZE",
+        &["shape_class"],
+    );
+}
+
+/// Record one route-decision outcome. `source` is the [`crate::query::compute_scheduler::RouteSource`]
+/// label string (`static` / `override_exploit` / `override_explore`).
+pub fn record_decision(backend_label: &str, shape_class: &str, source: &str) {
+    ROUTE_DECISIONS_TOTAL
+        .with_label_values(&[backend_label, shape_class, source])
+        .inc();
+}
+
+/// Record an analytic query served by the Native row engine (operator nudge).
+pub fn record_olap_on_native(shape_class: &str) {
+    ROUTE_OLAP_ON_NATIVE_TOTAL
+        .with_label_values(&[shape_class])
+        .inc();
+}
+
+/// Observe one consult's wall-clock duration. `had_model` distinguishes the
+/// pure-static path (no consult) from the advised path.
+pub fn observe_consult_duration(had_model: bool, duration: Duration) {
+    ROUTE_CONSULT_DURATION_SECONDS
+        .with_label_values(&[if had_model { "true" } else { "false" }])
+        .observe(duration.as_secs_f64());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_decision_increments_the_right_label_set() {
+        // nextest process-isolation: this process's registry starts empty, so an
+        // absolute count is meaningful here.
+        let before = ROUTE_DECISIONS_TOTAL
+            .with_label_values(&["DataFusionLocal", "olap/parquet", "static"])
+            .get();
+        record_decision("DataFusionLocal", "olap/parquet", "static");
+        let after = ROUTE_DECISIONS_TOTAL
+            .with_label_values(&["DataFusionLocal", "olap/parquet", "static"])
+            .get();
+        assert_eq!(after - before, 1.0);
+    }
+
+    #[test]
+    fn record_olap_on_native_increments() {
+        let before = ROUTE_OLAP_ON_NATIVE_TOTAL
+            .with_label_values(&["olap/native"])
+            .get();
+        record_olap_on_native("olap/native");
+        record_olap_on_native("olap/native");
+        let after = ROUTE_OLAP_ON_NATIVE_TOTAL
+            .with_label_values(&["olap/native"])
+            .get();
+        assert_eq!(after - before, 2.0);
+    }
+
+    #[test]
+    fn observe_consult_duration_lands_a_sample() {
+        // A fresh histogram with one observed sample has count 1.
+        let hist = ROUTE_CONSULT_DURATION_SECONDS.with_label_values(&["true"]);
+        let before = hist.get_sample_count();
+        observe_consult_duration(true, Duration::from_nanos(500));
+        let after = hist.get_sample_count();
+        assert_eq!(after - before, 1u64);
+    }
+}

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -259,6 +259,17 @@ pub async fn try_run_select(
     #[cfg(not(feature = "datafusion-integration"))]
     let (partition_fanout, cardinality) = (Default::default(), Default::default());
 
+    // AST cardinality fallback: when the footer-warmed stat is `Unknown` (native
+    // storage, or a cold Parquet table never yet scanned), derive a cheap
+    // syntax-only hint (LIMIT / scalar aggregate) so the cost-model shape-class
+    // still discriminates instead of collapsing to the coarse class. Pure AST
+    // walk — zero route-time I/O (co-design P5).
+    let cardinality = if cardinality == crate::query::compute_scheduler::CardinalityClass::Unknown {
+        query_cardinality_hint(query)
+    } else {
+        cardinality
+    };
+
     let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
@@ -274,6 +285,7 @@ pub async fn try_run_select(
         target: "proximadb::compute_route",
         backend = ?decision.backend,
         workload = ?decision.workload_profile,
+        source = decision.source.as_str(),
         reason = %decision.reason,
         "{}",
         decision.explain_line()
@@ -1000,6 +1012,7 @@ pub fn classify_select_route(
             crate::query::compute_scheduler::QueryShape {
                 engages_relational: engages,
                 parquet_backed: false,
+                cardinality: query_cardinality_hint(query),
                 ..Default::default()
             },
             Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
@@ -1295,6 +1308,7 @@ async fn route_and_plan_select(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: engages,
             parquet_backed,
+            cardinality: query_cardinality_hint(query),
             ..Default::default()
         },
         Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
@@ -1510,6 +1524,9 @@ mod route_explain_tests {
         for _ in 0..3 {
             GLOBAL_ROUTE_COST_MODEL.observe_by_label("olap/native", "Native(Volcano)", &snap);
         }
+        // Publish the frozen consult table so the advisory is visible this query
+        // (production recomputes debounced every N observations; tests force it).
+        GLOBAL_ROUTE_COST_MODEL.recompute();
         let expl = explain_select_route("SELECT service, count(*) FROM events GROUP BY service")
             .expect("routable");
         // Observe-mode: the chosen engine is unchanged ...
@@ -1533,6 +1550,73 @@ mod route_explain_tests {
 /// return false and stay on the legacy path.
 fn query_engages_relational_engine(query: &SqlQuery) -> bool {
     set_expr_engages(&query.body)
+}
+
+/// A cheap, syntax-only cardinality hint from the parsed AST — the fallback
+/// when the footer-warmed [`crate::query::route_cost_model::classify_table_shapes`]
+/// stat is `Unknown` (native storage, or a cold Parquet table never yet scanned),
+/// so the cost-model shape-class still discriminates instead of collapsing to
+/// the coarse class. Returns [`CardinalityClass::Small`] only when the query
+/// shape GUARANTEES a tiny result, else `Unknown` (never over-claims). Pure AST
+/// walk — zero route-time I/O (co-design P5: I/O round-trips, not CPU, dominate;
+/// the route path must not probe storage).
+fn query_cardinality_hint(query: &SqlQuery) -> crate::query::compute_scheduler::CardinalityClass {
+    use crate::query::compute_scheduler::CardinalityClass;
+    // sqlparser 0.59 carries LIMIT on the Query as a `LimitClause` enum (standard
+    // `LIMIT N [OFFSET]` vs MySQL `LIMIT offset, N`). A literal renders to a bare
+    // number string; a placeholder / expression doesn't parse → stay Unknown
+    // (never over-claim). Version-agnostic (no `Value::Number` probe).
+    if let Some(rows) = query
+        .limit_clause
+        .as_ref()
+        .and_then(limit_expr)
+        .and_then(|e| e.to_string().parse::<u64>().ok())
+    {
+        return CardinalityClass::from_estimate(Some(rows));
+    }
+    cardinality_hint_body(&query.body)
+}
+
+/// The limit `Expr` from either `LimitClause` variant (`None` for `LIMIT ALL`).
+fn limit_expr(clause: &sqlparser::ast::LimitClause) -> Option<&SqlExpr> {
+    use sqlparser::ast::LimitClause;
+    match clause {
+        LimitClause::LimitOffset { limit, .. } => limit.as_ref(),
+        LimitClause::OffsetCommaLimit { limit, .. } => Some(limit),
+    }
+}
+
+fn cardinality_hint_body(body: &SetExpr) -> crate::query::compute_scheduler::CardinalityClass {
+    use crate::query::compute_scheduler::CardinalityClass;
+    match body {
+        SetExpr::Select(select) => {
+            // A scalar aggregate (aggregate projection, no GROUP BY / HAVING)
+            // yields exactly one row.
+            let has_agg = select.projection.iter().any(select_item_has_aggregate);
+            let has_group_by = match &select.group_by {
+                GroupByExpr::All(_) => true,
+                GroupByExpr::Expressions(exprs, _) => !exprs.is_empty(),
+            };
+            if has_agg && !has_group_by && select.having.is_none() {
+                return CardinalityClass::Small;
+            }
+            CardinalityClass::Unknown
+        }
+        // A parenthesized subquery may carry its own LIMIT; a set-op branch's
+        // LIMIT does not bound the whole result, so be conservative elsewhere.
+        SetExpr::Query(q) => {
+            if let Some(rows) = q
+                .limit_clause
+                .as_ref()
+                .and_then(limit_expr)
+                .and_then(|e| e.to_string().parse::<u64>().ok())
+            {
+                return CardinalityClass::from_estimate(Some(rows));
+            }
+            cardinality_hint_body(&q.body)
+        }
+        _ => CardinalityClass::Unknown,
+    }
 }
 
 fn set_expr_engages(body: &SetExpr) -> bool {
@@ -1763,6 +1847,50 @@ mod tests {
         ));
         assert!(!gate("SELECT id FROM inv ORDER BY qty LIMIT 5"));
         assert!(!gate("SELECT id, status FROM inv WHERE id = 'i1'"));
+    }
+
+    fn card_hint(sql: &str) -> crate::query::compute_scheduler::CardinalityClass {
+        let statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse");
+        match statements.as_slice() {
+            [Statement::Query(query)] => query_cardinality_hint(query),
+            _ => panic!("expected a single SELECT statement"),
+        }
+    }
+
+    #[test]
+    fn cardinality_hint_small_for_limit_and_scalar_aggregate() {
+        use crate::query::compute_scheduler::CardinalityClass;
+        // LIMIT n bounds the result (a literal renders to a bare number string).
+        assert_eq!(
+            card_hint("SELECT * FROM inv LIMIT 10"),
+            CardinalityClass::Small
+        );
+        // A large LIMIT still buckets via from_estimate (≤1M → Medium).
+        assert_eq!(
+            card_hint("SELECT * FROM inv LIMIT 100000"),
+            CardinalityClass::Medium
+        );
+        // A scalar aggregate (no GROUP BY / HAVING) → exactly one row → Small.
+        assert_eq!(
+            card_hint("SELECT COUNT(*) FROM inv"),
+            CardinalityClass::Small
+        );
+        assert_eq!(
+            card_hint("SELECT SUM(qty), AVG(qty) FROM inv"),
+            CardinalityClass::Small
+        );
+        // GROUP BY defeats the scalar-aggregate signal (could be many groups).
+        assert_eq!(
+            card_hint("SELECT status, COUNT(*) FROM inv GROUP BY status"),
+            CardinalityClass::Unknown
+        );
+        // A plain unbounded scan → Unknown (never over-claim).
+        assert_eq!(card_hint("SELECT * FROM inv"), CardinalityClass::Unknown);
+        // A non-literal LIMIT expression doesn't parse to a count → Unknown.
+        assert_eq!(
+            card_hint("SELECT * FROM inv LIMIT 1 + 1"),
+            CardinalityClass::Unknown
+        );
     }
 
     #[test]

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -143,6 +143,31 @@ pub struct QueryShape {
     pub partition_fanout: PartitionFanout,
 }
 
+/// What produced a [`SelectRouteDecision`] — a `route_decisions_total` metric
+/// label (co-design C4 operator surface). `Static` is the policy rule; the two
+/// override variants only occur when `PROXIMADB_ROUTE_COST_OVERRIDE` is enabled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RouteSource {
+    /// The static shape-rule decision (no cost-model override fired).
+    #[default]
+    Static,
+    /// Live cost-model override to a confidently-cheaper freshness-safe backend.
+    OverrideExploit,
+    /// Rate-limited exploration flip to a cold freshness-safe backend (warm-up).
+    OverrideExplore,
+}
+
+impl RouteSource {
+    /// Stable metric-label form for `route_decisions_total{source}`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RouteSource::Static => "static",
+            RouteSource::OverrideExploit => "override_exploit",
+            RouteSource::OverrideExplore => "override_explore",
+        }
+    }
+}
+
 /// A materialized read-route decision: the engine, the workload it was
 /// classified as, and a human-readable reason. Emitted to telemetry and, once a
 /// SELECT `EXPLAIN` surface exists, surfaced there via [`Self::explain_line`].
@@ -154,6 +179,8 @@ pub struct SelectRouteDecision {
     pub workload_profile: CatalogWorkloadProfile,
     /// Human-readable reason for the choice.
     pub reason: String,
+    /// What produced this decision (static rule vs cost-model override/explore).
+    pub source: RouteSource,
 }
 
 impl SelectRouteDecision {
@@ -283,17 +310,25 @@ impl ComputeScheduler {
 
     /// Route a relational `SELECT` plan to a physical engine.
     ///
-    /// P0 invariant: the backend is ALWAYS `Native`. Only the workload
-    /// classification and reason vary, so the contract is locked before any
-    /// second physical executor exists.
+    /// Public entry: applies the static shape rule, then records the decision
+    /// metric and stamps the route onto the io_trace scope via [`finalize_route`].
     pub fn route_select(&self, shape: QueryShape) -> SelectRouteDecision {
-        let decision = match (shape.engages_relational, shape.parquet_backed) {
+        finalize_route(self.route_select_inner(shape), shape)
+    }
+
+    /// The static shape rule ONLY — no metric, no io_trace stamp. The pure
+    /// policy core; [`Self::route_select`] and [`Self::route_select_advised`]
+    /// wrap it (the latter may override the backend before stamping, so the
+    /// stamp reflects the FINAL engine — see [`finalize_route`]).
+    fn route_select_inner(&self, shape: QueryShape) -> SelectRouteDecision {
+        match (shape.engages_relational, shape.parquet_backed) {
             // P1: OLAP shape over Parquet-backed (object-store) table(s) → DataFusion.
             (true, true) => SelectRouteDecision {
                 backend: ComputeBackend::DataFusionLocal,
                 workload_profile: CatalogWorkloadProfile::Olap,
                 reason: "OLAP shape over Parquet-backed table(s) — DataFusion over object storage"
                     .to_string(),
+                source: RouteSource::Static,
             },
             // OLAP shape on native storage — Volcano serves it from WAL+RecordStorage
             // until the relational base tier is Parquet/Iceberg (course-correction §6 P3).
@@ -302,22 +337,15 @@ impl ComputeScheduler {
                 workload_profile: CatalogWorkloadProfile::Olap,
                 reason: "OLAP shape (join/group-by/aggregate/set-op) on native storage — Volcano"
                     .to_string(),
+                source: RouteSource::Static,
             },
             (false, _) => SelectRouteDecision {
                 backend: ComputeBackend::Native,
                 workload_profile: CatalogWorkloadProfile::Oltp,
                 reason: "OLTP shape (point/simple select) — Volcano".to_string(),
+                source: RouteSource::Static,
             },
-        };
-        // C4 ingestion: stamp the chosen route onto the active io_trace scope (a
-        // no-op when unscoped, e.g. unit tests / EXPLAIN-only). The completed
-        // query's measured snapshot then feeds the trace-driven cost model at
-        // flush; empty traces are skipped, so EXPLAIN-only calls cost nothing.
-        crate::observability::io_trace::record_route(
-            &crate::query::route_cost_model::shape_class(&shape),
-            &backend_label(&decision.backend),
-        );
-        decision
+        }
     }
 
     /// Route a relational `SELECT` and materialize the typed read-route plan.
@@ -326,96 +354,161 @@ impl ComputeScheduler {
     }
 
     /// Route a `SELECT`, then — if a trace-driven cost model is supplied —
-    /// **observe-mode** advise: consult the measured per-(shape-class, backend)
-    /// cost (co-design C4) and fold its recommendation into the decision's
-    /// `reason` for EXPLAIN/telemetry, *without changing the backend*.
+    /// consult its frozen recommendation table (a lock-free `ArcSwap` load +
+    /// `HashMap` get, never the learn-path mutex) and either disclose an advisory
+    /// (observe-mode) or flip to a freshness-safe challenger (live override,
+    /// flag-gated via `PROXIMADB_ROUTE_COST_OVERRIDE`). With override OFF (the
+    /// default) or no warmed history, the static decision is returned unchanged.
     ///
-    /// This closes the co-design loop (C0 trace → cost model → router). By
-    /// default it is **observe-mode**: the scheduler discloses what the trace
-    /// *would* recommend and whether it diverges from the static rule, without
-    /// changing the backend. When the model's live override is enabled (slice 4,
-    /// flag-gated via `PROXIMADB_ROUTE_COST_OVERRIDE`) and a freshness-safe
-    /// challenger is confidently cheaper, the route is *flipped* to it. With no
-    /// warmed history the static decision is returned unchanged.
+    /// This closes the co-design loop (C0 trace → cost model → router) while
+    /// keeping the decision lock-free and O(1): freshness-safety is baked into
+    /// the frozen table (only `olap/parquet` offers two safe engines), so the
+    /// consult can never flip a query onto an engine that would serve it
+    /// incorrectly (e.g. a point/OLTP query onto a stale base snapshot).
     pub fn route_select_advised(
         &self,
         shape: QueryShape,
         model: Option<&crate::query::route_cost_model::RouteCostModel>,
     ) -> SelectRouteDecision {
-        let mut decision = self.route_select(shape);
+        use crate::query::route_cost_model::RouteConsult;
+
+        let mut decision = self.route_select_inner(shape);
         let Some(model) = model else {
-            return decision;
+            return finalize_route(decision, shape);
         };
         let class = crate::query::route_cost_model::shape_class(&shape);
 
-        // Live override (flag-gated, confidence-gated). Only consider backends
-        // that are freshness-SAFE for this shape (see `override_candidates`), so
-        // the cost model can never flip a query onto an engine that would serve
-        // it incorrectly (e.g. a point/OLTP query onto a stale base snapshot).
-        if model.override_active() {
-            let safe = override_candidates(shape, &decision.backend);
-            // Exploration (Phase 2) first: warm an under-explored freshness-safe
-            // candidate so it accrues history the override can later act on.
-            // Bounded + rate-limited + freshness-safe (see `exploration_choice`).
-            if let Some(explore) = model.exploration_choice(&class, &safe)
-                && backend_label(&explore) != backend_label(&decision.backend)
+        // Lock-free consult: a single ArcSwap load + HashMap get. `None` on a
+        // cold table (no baked entry) → keep the static route unchanged.
+        let consult = model.consult(&class);
+
+        if model.override_active()
+            && let Some(consult) = consult.as_ref()
+        {
+            // Exploration (warm-up) first: rate-limited flip to the baked
+            // least-sampled freshness-safe candidate so it accrues history the
+            // exploit override can later act on. Bounded + freshness-safe.
+            if let Some(target) = consult
+                .explore_target()
+                // Staleness guard: the frozen target may have warmed since the
+                // last recompute; re-check against the frozen ranked samples (a
+                // target absent from `ranked` was never observed → still cold).
+                .filter(|t| {
+                    backend_label(t) != backend_label(&decision.backend)
+                        && consult
+                            .find(t)
+                            .is_none_or(|c| c.samples < model.min_samples())
+                })
+                && model
+                    .next_exploration_tick()
+                    .is_multiple_of(model.exploration_interval())
             {
                 let prev = backend_label(&decision.backend);
                 decision.reason = format!(
                     "{} | cost-model EXPLORE {prev}→{} (gathering cost history)",
                     decision.reason,
-                    backend_label(&explore)
+                    backend_label(target)
                 );
-                decision.backend = explore;
-                return decision;
+                decision.backend = target.clone();
+                decision.source = RouteSource::OverrideExplore;
+                return finalize_route(decision, shape);
             }
-            // Exploitation: override to the confidently-cheaper backend.
-            if let Some(rec) = model.recommend_override(&class, &decision.backend, &safe) {
-                let prev = backend_label(&decision.backend);
-                decision.reason = format!(
-                    "{} | cost-model OVERRIDE {prev}→{} ({})",
-                    decision.reason,
-                    backend_label(&rec.backend),
-                    rec.reason()
-                );
-                decision.backend = rec.backend;
-                return decision;
+
+            // Exploit override — TD-170 hard round-trip gate, then the soft
+            // min_advantage byte-cost gate — both resolved from frozen data.
+            if let Some(static_choice) = consult.find(&decision.backend)
+                && static_choice.samples >= model.min_samples()
+            {
+                // Hard gate: a backend over the round-trip budget loses even
+                // when it moves fewer bytes (latency = depth × RTT). Flip to the
+                // cheapest freshness-safe candidate WITHIN the budget.
+                if let Some(budget) = model.rtt_budget()
+                    && static_choice.range_gets > budget
+                    && let Some(within) = consult
+                        .ranked()
+                        .iter()
+                        .filter(|c| c.range_gets <= budget)
+                        .min_by(|a, b| {
+                            a.score
+                                .partial_cmp(&b.score)
+                                .unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                        .filter(|c| backend_label(&c.backend) != backend_label(&decision.backend))
+                {
+                    let prev = backend_label(&decision.backend);
+                    decision.reason = format!(
+                        "{} | cost-model OVERRIDE {prev}→{} (RTT budget {budget:.0} exceeded)",
+                        decision.reason,
+                        backend_label(&within.backend)
+                    );
+                    decision.backend = within.backend.clone();
+                    decision.source = RouteSource::OverrideExploit;
+                    return finalize_route(decision, shape);
+                }
+
+                // Soft gate: flip to the cheapest warmed candidate if it beats
+                // the static route by at least `min_advantage`.
+                if let Some(challenger) = consult
+                    .ranked()
+                    .iter()
+                    .filter(|c| c.samples >= model.min_samples())
+                    .find(|c| backend_label(&c.backend) != backend_label(&decision.backend))
+                    .filter(|c| c.score < static_choice.score * (1.0 - model.min_advantage()))
+                {
+                    let prev = backend_label(&decision.backend);
+                    decision.reason = format!(
+                        "{} | cost-model OVERRIDE {prev}→{} (score {:.1} vs {:.1})",
+                        decision.reason,
+                        backend_label(&challenger.backend),
+                        challenger.score,
+                        static_choice.score
+                    );
+                    decision.backend = challenger.backend.clone();
+                    decision.source = RouteSource::OverrideExploit;
+                    return finalize_route(decision, shape);
+                }
             }
         }
 
-        // Observe-mode advisory (no behavior change): disclose the recommendation.
-        let candidates = [ComputeBackend::Native, ComputeBackend::DataFusionLocal];
-        if let Some(rec) = model.recommend(&class, &candidates) {
-            let advisory = if rec.backend == decision.backend {
-                format!("cost-model concurs ({})", rec.reason())
+        // Observe-mode advisory (no behavior change): disclose the cheapest
+        // warmed freshness-safe candidate from the frozen table.
+        if let Some(consult) = consult.as_ref()
+            && let Some(rec) = consult
+                .ranked()
+                .iter()
+                .find(|c| c.samples >= model.min_samples())
+        {
+            let advisory = if backend_label(&rec.backend) == backend_label(&decision.backend) {
+                format!("cost-model concurs (score {:.1})", rec.score)
             } else {
                 format!(
-                    "cost-model would prefer {} ({}) — observe-mode, route unchanged",
+                    "cost-model would prefer {} (score {:.1}) — observe-mode, route unchanged",
                     backend_label(&rec.backend),
-                    rec.reason()
+                    rec.score
                 )
             };
             decision.reason = format!("{} | {advisory}", decision.reason);
         }
-        decision
+
+        finalize_route(decision, shape)
     }
 }
 
-/// The freshness-SAFE backend set a live override may choose among for `shape`.
-///
-/// Only OLAP-over-Parquet has more than one freshness-compatible engine: both
-/// Native's strong-freshness scan (WAL+RecordStorage) and DataFusion's
-/// base-snapshot scan correctly answer an analytic query, and both are already
-/// used by the static rule for this shape — so flipping between them is safe.
-/// OLTP (point/simple) is freshness-critical → never override off Native; OLAP
-/// on native storage has no Parquet base → DataFusion cannot serve it. Those
-/// keep only the static backend, so `recommend_override` can never flip them.
-fn override_candidates(shape: QueryShape, static_backend: &ComputeBackend) -> Vec<ComputeBackend> {
-    if shape.engages_relational && shape.parquet_backed {
-        vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal]
-    } else {
-        vec![static_backend.clone()]
+/// Record the decision metric (and the OLAP-on-Native nudge), then stamp the
+/// FINAL route onto the active io_trace scope. Called once per route decision,
+/// AFTER any override has settled the backend — so the learn loop attributes a
+/// query's measured cost to the engine that actually served it (fixing the prior
+/// bug where the static backend was stamped before an override could flip it).
+/// Stamping is a no-op when no io_trace scope is active (unit tests / EXPLAIN).
+fn finalize_route(decision: SelectRouteDecision, shape: QueryShape) -> SelectRouteDecision {
+    let class = crate::query::route_cost_model::shape_class(&shape);
+    let backend = backend_label(&decision.backend);
+    crate::metrics::route_metrics::record_decision(&backend, &class, decision.source.as_str());
+    if decision.backend == ComputeBackend::Native && class.starts_with("olap/") {
+        crate::metrics::route_metrics::record_olap_on_native(&class);
     }
+    crate::observability::io_trace::record_route(&class, &backend);
+    decision
 }
 
 #[cfg(test)]
@@ -532,32 +625,35 @@ mod tests {
     #[test]
     fn advised_is_observe_mode_never_overrides_backend() {
         use crate::query::route_cost_model::RouteCostModel;
-        // OLAP-on-native shape: static rule => Native(Volcano).
+        // OLAP-over-Parquet: static rule => DataFusionLocal. Warm Native as far
+        // cheaper (few coalesced GETs vs DataFusion's many) so observe-mode
+        // DISCLOSES the preference without flipping the backend. (The only class
+        // with two freshness-safe engines — the only one an advisory can prefer.)
         let shape = QueryShape {
             engages_relational: true,
-            parquet_backed: false,
+            parquet_backed: true,
             ..Default::default()
         };
-        let model = RouteCostModel::new().with_min_samples(1);
-        // Teach the model that DataFusion is far cheaper for this shape-class
-        // (few coalesced GETs vs Native's many small GETs).
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1);
         for _ in 0..4 {
             model.observe(
-                "olap/native",
-                &ComputeBackend::DataFusionLocal,
+                "olap/parquet",
+                &ComputeBackend::Native,
                 &io_snap(3, 16 << 20),
             );
             model.observe(
-                "olap/native",
-                &ComputeBackend::Native,
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
                 &io_snap(300, 16 << 20),
             );
         }
         let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
         // Backend is UNCHANGED (observe-mode) ...
-        assert_eq!(advised.backend, ComputeBackend::Native);
+        assert_eq!(advised.backend, ComputeBackend::DataFusionLocal);
         // ... but the divergence is disclosed for EXPLAIN/validation.
-        assert!(advised.reason.contains("would prefer DataFusionLocal"));
+        assert!(advised.reason.contains("would prefer Native"));
         assert!(advised.reason.contains("observe-mode"));
     }
 
@@ -569,7 +665,9 @@ mod tests {
             parquet_backed: false,
             ..Default::default()
         };
-        let model = RouteCostModel::new().with_min_samples(1);
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1);
         // Only Native has history for this shape-class → it is the min, concurring
         // with the static OLTP→Native rule.
         for _ in 0..3 {
@@ -588,7 +686,9 @@ mod tests {
             parquet_backed: true,
             ..Default::default()
         }; // static => DataFusionLocal
-        let model = RouteCostModel::new().with_min_samples(1); // override OFF (default)
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1); // override OFF (default)
         for _ in 0..5 {
             model.observe(
                 "olap/parquet",
@@ -615,7 +715,9 @@ mod tests {
             parquet_backed: true,
             ..Default::default()
         }; // static => DataFusionLocal
-        let model = RouteCostModel::new().with_min_samples(1);
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1);
         model.set_override_enabled(true);
         for _ in 0..5 {
             model.observe(
@@ -645,7 +747,8 @@ mod tests {
         }; // static => DataFusionLocal
         let model = RouteCostModel::new()
             .with_min_samples(1)
-            .with_exploration_interval(1);
+            .with_exploration_interval(1)
+            .with_recompute_every(1);
         model.set_override_enabled(true);
         // DataFusion (the static route) is warm; Native is unexplored → explore it.
         for _ in 0..5 {
@@ -674,7 +777,8 @@ mod tests {
         }; // static => Native (OLTP)
         let model = RouteCostModel::new()
             .with_min_samples(1)
-            .with_exploration_interval(1);
+            .with_exploration_interval(1)
+            .with_recompute_every(1);
         model.set_override_enabled(true);
         // Even with DataFusion history for this class, OLTP's freshness-safe set
         // is just [Native], so exploration has nothing to probe.
@@ -700,7 +804,9 @@ mod tests {
             parquet_backed: true,
             ..Default::default()
         };
-        let model = RouteCostModel::new().with_min_samples(1);
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1);
         model.set_override_enabled(true);
         // Even if DataFusion looks absurdly cheap for this class, it is not a
         // freshness-safe candidate for OLTP, so it can never be chosen.
@@ -740,5 +846,66 @@ mod tests {
             plan.route_explanation().policy_boundary,
             "connector-enforced"
         );
+    }
+
+    #[test]
+    fn cold_model_consult_returns_static_decision() {
+        use crate::query::route_cost_model::RouteCostModel;
+        // Empty model (no observations) → frozen table empty → consult None →
+        // static decision unchanged, no advisory appended.
+        let model = RouteCostModel::new();
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            ..Default::default()
+        };
+        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(advised.backend, ComputeBackend::DataFusionLocal);
+        assert_eq!(advised.source, RouteSource::Static);
+        assert!(!advised.reason.contains("cost-model"));
+    }
+
+    #[test]
+    fn override_sets_decision_source_label() {
+        use crate::query::route_cost_model::RouteCostModel;
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            ..Default::default()
+        };
+        let model = RouteCostModel::new()
+            .with_min_samples(1)
+            .with_recompute_every(1);
+        model.set_override_enabled(true);
+        for _ in 0..5 {
+            model.observe(
+                "olap/parquet",
+                &ComputeBackend::Native,
+                &io_snap(3, 16 << 20),
+            );
+            model.observe(
+                "olap/parquet",
+                &ComputeBackend::DataFusionLocal,
+                &io_snap(300, 16 << 20),
+            );
+        }
+        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        assert_eq!(d.backend, ComputeBackend::Native);
+        assert_eq!(d.source, RouteSource::OverrideExploit);
+    }
+
+    #[test]
+    fn olap_on_native_is_static_with_volcano_backend() {
+        // An olap/native route stays on Volcano (single freshness-safe candidate)
+        // with a Static source; the ROUTE_OLAP_ON_NATIVE_TOTAL nudge is the
+        // operator signal (asserted in route_metrics tests), recorded in finalize_route.
+        let shape = QueryShape {
+            engages_relational: true,
+            parquet_backed: false,
+            ..Default::default()
+        };
+        let d = ComputeScheduler::new().route_select(shape);
+        assert_eq!(d.backend, ComputeBackend::Native);
+        assert_eq!(d.source, RouteSource::Static);
     }
 }

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -38,7 +38,9 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use arc_swap::ArcSwap;
 
 use crate::observability::io_trace::IoTraceSnapshot;
 use crate::query::compute_scheduler::{QueryShape, backend_label};
@@ -391,6 +393,124 @@ impl RouteRecommendation {
     }
 }
 
+// ── Frozen recommendation table: the lock-free consult path (co-design C4) ──
+//
+// The consult half of the cost model. `RouteCostModel::consult` does a single
+// `ArcSwap::load` + `HashMap` get — never the learn-path `cells` mutex — so the
+// route decision stays O(1) and lock-free even when live override is enabled.
+// The EWMA learner is the SOLE writer, recomputing this table debounced on the
+// observe path; readers always see a consistent immutable snapshot.
+
+/// One freshness-safe candidate's baked cost summary in the frozen table.
+#[derive(Debug, Clone)]
+pub struct BackendChoice {
+    /// The candidate engine.
+    pub backend: ComputeBackend,
+    /// Weighted neutral score (lower = cheaper) — the soft byte-cost term.
+    pub score: f64,
+    /// EWMA sample count at bake time.
+    pub samples: u64,
+    /// Predicted ranged-GET count — the TD-170 hard round-trip-budget term.
+    pub range_gets: f64,
+}
+
+/// Per-shape-class pre-baked recommendation: everything the lock-free consult
+/// needs to reproduce the explore / override / advisory decision without a
+/// lock. Immutable once published via [`ArcSwap`].
+#[derive(Debug, Clone)]
+pub struct ClassRecommendation {
+    /// Every freshness-safe candidate with ANY history, cheapest-first. Carries
+    /// score/samples/range_gets so the consult can apply BOTH the soft
+    /// `min_advantage` gate and the hard `rtt_budget` gate from frozen data.
+    ranked: Vec<BackendChoice>,
+    /// The least-sampled freshness-safe candidate still under `min_samples` (the
+    /// exploration warm-up target), or `None` once all are warm. May target a
+    /// never-observed safe candidate (0 samples). Resolved against the live
+    /// `explore_tick` at consult time.
+    explore_target: Option<ComputeBackend>,
+}
+
+impl ClassRecommendation {
+    /// Ranked freshness-safe candidates with history, cheapest-first.
+    pub fn ranked(&self) -> &[BackendChoice] {
+        &self.ranked
+    }
+    /// The baked exploration warm-up target, if any candidate is still cold.
+    pub fn explore_target(&self) -> Option<&ComputeBackend> {
+        self.explore_target.as_ref()
+    }
+    /// Find the candidate matching `backend` (by canonical label). Used to
+    /// resolve the static route's baked cost at consult time.
+    pub fn find(&self, backend: &ComputeBackend) -> Option<&BackendChoice> {
+        let want = backend_label(backend);
+        self.ranked
+            .iter()
+            .find(|c| backend_label(&c.backend) == want)
+    }
+}
+
+/// Immutable snapshot of all per-class recommendations, held in an [`ArcSwap`]
+/// inside [`RouteCostModel`]. The consult path loads it once and does a
+/// `HashMap` get — fully lock-free.
+#[derive(Debug, Clone, Default)]
+struct RouteRecommendationTable {
+    by_class: HashMap<String, ClassRecommendation>,
+}
+
+/// Lock-free consult over the frozen recommendation table (DIP seam). The
+/// scheduler depends on this abstraction, not the concrete [`RouteCostModel`];
+/// the concrete model implements it backed by its [`ArcSwap`] table, and a test
+/// double can satisfy it with canned data. Production consult stays
+/// monomorphized over the concrete model (no `&dyn` on the hot path) — the
+/// trait exists for testability and a future persisted/remote cost model.
+pub trait RouteConsult {
+    /// Lock-free consult for one shape-class. `None` when the class has no baked
+    /// entry (cold start — the caller keeps the static route).
+    fn consult(&self, shape_class: &str) -> Option<ClassRecommendation>;
+    /// Whether live override is currently enabled (reads the live `AtomicBool`).
+    fn override_active(&self) -> bool;
+    /// Advance and return the exploration rate-limit tick (pre-increment value).
+    fn next_exploration_tick(&self) -> u64;
+    /// Config surfaced for the consult's gate logic.
+    fn min_samples(&self) -> u64;
+    fn min_advantage(&self) -> f64;
+    fn exploration_interval(&self) -> u64;
+    /// TD-170 hard round-trip budget (`None` = disabled).
+    fn rtt_budget(&self) -> Option<f64>;
+}
+
+/// Inverse of [`backend_label`] — recover a [`ComputeBackend`] from its frozen
+/// label. Returns `None` for an unrecognized label so the recomputer skips it
+/// instead of panicking (a stale/mistyped label never corrupts the frozen table).
+fn parse_backend_label(label: &str) -> Option<ComputeBackend> {
+    match label {
+        "Native(Volcano)" => Some(ComputeBackend::Native),
+        "DataFusionLocal" => Some(ComputeBackend::DataFusionLocal),
+        "DataFusionDistributed" => Some(ComputeBackend::DataFusionDistributed),
+        "PolarsLocal" => Some(ComputeBackend::PolarsLocal),
+        "DuckDbCompat" => Some(ComputeBackend::DuckDbCompat),
+        _ => label
+            .strip_prefix("ExternalDelegated(")
+            .and_then(|s| s.strip_suffix(')'))
+            .map(|s| ComputeBackend::ExternalDelegated(s.to_string())),
+    }
+}
+
+/// The freshness-safe backend SET for a shape-class, derived from its prefix —
+/// reproduces `compute_scheduler::override_candidates` without a [`QueryShape`].
+/// Only `olap/parquet` has two freshness-compatible engines (Native's
+/// strong-freshness scan and DataFusion's base-snapshot scan both correctly
+/// answer an analytic query); every other class keeps its single static
+/// backend, so a baked override can never flip a query onto an engine that
+/// would serve it incorrectly.
+fn freshness_safe_backends_from_class(shape_class: &str) -> Vec<ComputeBackend> {
+    if shape_class.starts_with("olap/parquet") {
+        vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal]
+    } else {
+        vec![ComputeBackend::Native]
+    }
+}
+
 /// Trace-driven, thread-safe route cost model. One instance is consulted at the
 /// route decision and fed by completed-query traces.
 #[derive(Debug)]
@@ -418,6 +538,16 @@ pub struct RouteCostModel {
     /// latency = depth × RTT, so a backend over the round-trip budget loses even
     /// when it moves fewer bytes.
     rtt_budget: Option<f64>,
+    /// Frozen recommendation table — the LOCK-FREE consult surface. Read via
+    /// [`ArcSwap`] (`load` + `HashMap` get) on the route hot path; written only
+    /// by [`Self::recompute_locked`] (debounced on the observe path). Empty at
+    /// construction → consult returns `None` → callers keep the static route.
+    table: ArcSwap<RouteRecommendationTable>,
+    /// Observation counter driving the debounced frozen-table recompute.
+    observation_count: AtomicU64,
+    /// Recompute the frozen table every Nth observation (debounce). Lower warms
+    /// the consult view faster at more recompute cost; min 1 (recompute always).
+    recompute_every: u64,
 }
 
 /// Parse `PROXIMADB_ROUTE_RTT_BUDGET` (a positive round-trip count) — the
@@ -449,6 +579,9 @@ impl RouteCostModel {
             explore_tick: AtomicU64::new(0),
             exploration_interval: 16,
             rtt_budget: rtt_budget_from_env(),
+            table: ArcSwap::from_pointee(RouteRecommendationTable::default()),
+            observation_count: AtomicU64::new(0),
+            recompute_every: 64,
         }
     }
 
@@ -479,9 +612,22 @@ impl RouteCostModel {
         self
     }
 
-    /// Enable/disable live route override (flag-gated; default OFF).
+    /// Tune how often the frozen consult table is recomputed (every Nth
+    /// observation). `1` rebuilds on every observe (deterministic for tests);
+    /// production defaults to `64`. Min 1.
+    pub fn with_recompute_every(mut self, n: u64) -> Self {
+        self.recompute_every = n.max(1);
+        self
+    }
+
+    /// Enable/disable live route override (flag-gated; default OFF). Enabling
+    /// forces a frozen-table recompute so the very first override consult reads
+    /// current history, not a possibly-stale debounced snapshot.
     pub fn set_override_enabled(&self, on: bool) {
         self.override_enabled.store(on, Ordering::Relaxed);
+        if on {
+            self.recompute_locked();
+        }
     }
 
     /// Whether live override is currently enabled.
@@ -517,11 +663,21 @@ impl RouteCostModel {
     /// neutral label, not a `ComputeBackend` (no layer-up dependency).
     pub fn observe_by_label(&self, shape_class: &str, backend_label: &str, snap: &IoTraceSnapshot) {
         let key = (shape_class.to_string(), backend_label.to_string());
-        let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
-        cells
-            .entry(key)
-            .or_default()
-            .fold(self.alpha, CostQuantities::from_snapshot(snap));
+        {
+            let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+            cells
+                .entry(key)
+                .or_default()
+                .fold(self.alpha, CostQuantities::from_snapshot(snap));
+        }
+        // Debounced recompute of the frozen consult table. Every Nth observation
+        // rebuilds it (O(cells), tiny); the consult path stays lock-free between
+        // recomputes. Runs inline on the (less latency-sensitive) query-completion
+        // path — no background thread, no shutdown wiring.
+        let n = self.observation_count.fetch_add(1, Ordering::Relaxed);
+        if (n + 1).is_multiple_of(self.recompute_every) {
+            self.recompute_locked();
+        }
     }
 
     /// Current learned estimate for one (shape-class, backend), if any history.
@@ -682,6 +838,112 @@ impl RouteCostModel {
         } else {
             None
         }
+    }
+}
+
+impl RouteConsult for RouteCostModel {
+    fn consult(&self, shape_class: &str) -> Option<ClassRecommendation> {
+        // Single ArcSwap load + HashMap get — the only consult-path cost. The
+        // returned ClassRecommendation is cloned out (cheap: a small Vec) so the
+        // Guard is released immediately; the learn-path mutex is never touched.
+        self.table.load().by_class.get(shape_class).cloned()
+    }
+    fn override_active(&self) -> bool {
+        self.override_enabled.load(Ordering::Relaxed)
+    }
+    fn next_exploration_tick(&self) -> u64 {
+        self.explore_tick.fetch_add(1, Ordering::Relaxed)
+    }
+    fn min_samples(&self) -> u64 {
+        self.min_samples
+    }
+    fn min_advantage(&self) -> f64 {
+        self.min_advantage
+    }
+    fn exploration_interval(&self) -> u64 {
+        self.exploration_interval
+    }
+    fn rtt_budget(&self) -> Option<f64> {
+        self.rtt_budget
+    }
+}
+
+impl RouteCostModel {
+    /// Force a frozen-table recompute now (tests / a future EXPLAIN nudge).
+    /// Production relies on the debounced recompute inside [`Self::observe_by_label`].
+    pub fn recompute(&self) {
+        self.recompute_locked();
+    }
+
+    /// Rebuild the frozen [`RouteRecommendationTable`] from the current `cells`
+    /// and publish it via [`ArcSwap::store`]. The SOLE writer of the frozen
+    /// table — the consult path only reads it. O(cells) (tiny: ≤ ~16 classes ×
+    /// 2 backends). Locks `cells` once for the read.
+    fn recompute_locked(&self) {
+        let cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+        // Group observed cells by shape-class (the first tuple element).
+        let mut by_class: HashMap<String, Vec<(String, Cell)>> = HashMap::new();
+        for ((class, label), cell) in cells.iter() {
+            by_class
+                .entry(class.clone())
+                .or_default()
+                .push((label.clone(), *cell));
+        }
+        let mut table = RouteRecommendationTable {
+            by_class: HashMap::new(),
+        };
+        for (class, entries) in by_class {
+            let safe = freshness_safe_backends_from_class(&class);
+            // ranked: freshness-safe candidates with ANY history, cheapest-first.
+            let mut ranked: Vec<BackendChoice> = entries
+                .iter()
+                .filter_map(|(label, cell)| {
+                    let backend = parse_backend_label(label)?;
+                    let is_safe = safe.iter().any(|s| backend_label(s) == *label);
+                    if !is_safe || cell.samples == 0 {
+                        return None;
+                    }
+                    Some(BackendChoice {
+                        backend,
+                        score: self.score(cell.quantities()),
+                        samples: cell.samples,
+                        range_gets: cell.range_gets,
+                    })
+                })
+                .collect();
+            ranked.sort_by(|a, b| {
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            // explore_target: least-sampled freshness-safe candidate still under
+            // min_samples. Only meaningful when ≥2 safe candidates exist; a
+            // never-observed safe candidate (0 samples) is a valid target.
+            let explore_target = if safe.len() < 2 {
+                None
+            } else {
+                safe.iter()
+                    .map(|b| {
+                        let s = entries
+                            .iter()
+                            .find(|(l, _)| backend_label(b) == *l)
+                            .map(|(_, c)| c.samples)
+                            .unwrap_or(0);
+                        (b.clone(), s)
+                    })
+                    .filter(|(_, s)| *s < self.min_samples)
+                    .min_by_key(|(_, s)| *s)
+                    .map(|(b, _)| b)
+            };
+            table.by_class.insert(
+                class,
+                ClassRecommendation {
+                    ranked,
+                    explore_target,
+                },
+            );
+        }
+        self.table.store(Arc::new(table));
     }
 }
 
@@ -1157,6 +1419,116 @@ mod tests {
     }
 
     #[test]
+    fn recompute_bakes_ranked_cheapest_first() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        // Native cheap (3 GETs), DataFusion dear (300 GETs) for olap/parquet.
+        for _ in 0..3 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(3, 1 << 20, 1));
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(300, 1 << 20, 1));
+        }
+        m.recompute();
+        let consult = m.consult("olap/parquet").expect("baked");
+        let ranked = consult.ranked();
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(
+            backend_label(&ranked[0].backend),
+            "Native(Volcano)",
+            "cheapest first"
+        );
+        assert!(ranked[0].score < ranked[1].score);
+    }
+
+    #[test]
+    fn recompute_explore_target_is_least_sampled_cold_candidate() {
+        let m = RouteCostModel::new().with_min_samples(3);
+        // DataFusion warm; Native never observed (0 samples) → explore Native.
+        for _ in 0..5 {
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 1 << 20, 1));
+        }
+        m.recompute();
+        let consult = m.consult("olap/parquet").expect("baked");
+        assert_eq!(
+            consult.explore_target().map(backend_label).as_deref(),
+            Some("Native(Volcano)")
+        );
+    }
+
+    #[test]
+    fn recompute_explore_target_none_once_all_safe_candidates_warm() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        for _ in 0..3 {
+            m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 1 << 20, 1));
+            m.observe_by_label("olap/parquet", "DataFusionLocal", &snap(4, 1 << 20, 1));
+        }
+        m.recompute();
+        let consult = m.consult("olap/parquet").expect("baked");
+        assert_eq!(
+            consult.explore_target(),
+            None,
+            "both warm → nothing to explore"
+        );
+    }
+
+    #[test]
+    fn recompute_only_olap_parquet_exposes_two_safe_candidates() {
+        // The freshness-safety gate from the class prefix: only olap/parquet
+        // exposes both engines; every other class keeps a single static backend.
+        let m = RouteCostModel::new().with_min_samples(1);
+        for (class, label) in [
+            ("olap/parquet", "Native(Volcano)"),
+            ("olap/parquet", "DataFusionLocal"),
+            ("olap/native", "Native(Volcano)"),
+            ("olap/native", "DataFusionLocal"), // NOT freshness-safe here
+            ("oltp/parquet", "DataFusionLocal"), // NOT freshness-safe here
+            ("oltp/native", "Native(Volcano)"),
+        ] {
+            m.observe_by_label(class, label, &snap(2, 1 << 20, 1));
+        }
+        m.recompute();
+        let olap_parquet = m.consult("olap/parquet").expect("baked");
+        assert_eq!(
+            olap_parquet.ranked().len(),
+            2,
+            "olap/parquet has two safe engines"
+        );
+        let olap_native = m.consult("olap/native").expect("baked");
+        assert_eq!(
+            olap_native.ranked().len(),
+            1,
+            "olap/native drops non-safe DataFusion"
+        );
+        assert_eq!(
+            backend_label(&olap_native.ranked()[0].backend),
+            "Native(Volcano)"
+        );
+        let oltp_parquet = m.consult("oltp/parquet").expect("baked");
+        assert!(
+            oltp_parquet.ranked().is_empty(),
+            "oltp/parquet keeps only Native (unobserved) — DF is not freshness-safe"
+        );
+        assert_eq!(
+            oltp_parquet.explore_target(),
+            None,
+            "single safe candidate → no explore"
+        );
+    }
+
+    #[test]
+    fn recompute_skips_unknown_backend_labels() {
+        let m = RouteCostModel::new().with_min_samples(1);
+        // A synthetic/unknown label must be dropped, never panic.
+        m.observe_by_label("olap/parquet", "SomeUnknownEngine", &snap(2, 1 << 20, 1));
+        m.observe_by_label("olap/parquet", "Native(Volcano)", &snap(2, 1 << 20, 1));
+        m.recompute();
+        let consult = m.consult("olap/parquet").expect("baked");
+        assert_eq!(consult.ranked().len(), 1);
+        assert_eq!(
+            backend_label(&consult.ranked()[0].backend),
+            "Native(Volcano)"
+        );
+    }
+
+    #[test]
     fn exploration_never_fires_with_a_single_candidate() {
         // OLTP gets a single freshness-safe candidate → nothing to explore.
         let m = RouteCostModel::new().with_exploration_interval(1);
@@ -1265,7 +1637,8 @@ mod tests {
         };
         let m = RouteCostModel::new()
             .with_min_samples(1)
-            .with_min_advantage(0.1);
+            .with_min_advantage(0.1)
+            .with_recompute_every(1);
         m.set_override_enabled(true);
         let big = QueryShape {
             engages_relational: true,


### PR DESCRIPTION
## Problem

The route-decision consult path took `RouteCostModel`'s `cells` Mutex on **every** SELECT (and again at query completion), so enabling the cost-driven override (`PROXIMADB_ROUTE_COST_OVERRIDE`) would serialize every advised query on a global lock — exactly the bottleneck the architecture must avoid. The decision itself was also observable only via a `tracing::debug!` line (no Prometheus metric).

## Change

**1. Lock-free consult/learn split (`route_cost_model.rs`)** — the headline.
- Consult is now a single `ArcSwap` load + `HashMap` get over a frozen `RouteRecommendationTable` (lock-free, O(1)); the EWMA learner is the **sole** writer, recomputing debounced on the observe path (every N observations, no background thread).
- `RouteConsult` trait (DIP/ISP); prod stays monomorphized over the concrete model (no `&dyn` on the hot path), but the seam exists for tests + a future persisted cost model.
- `ClassRecommendation` bakes `ranked` candidates (score/samples/range_gets) + `explore_target` — enough to reproduce **both** the soft `min_advantage` and hard TD-170 `rtt_budget` gates + exploration from frozen data. Freshness-safety is derived from the shape-class prefix (only `olap/parquet` offers two safe engines), replacing the now-removed `override_candidates`.

**2. Bugfix: `record_route` attribution (`compute_scheduler.rs`).** It stamped the *static* backend *before* an override could flip it, so the learn loop mis-attributed overridden queries' cost. `route_select_advised` now stamps the **final** engine via a shared `finalize_route`.

**3. Decision observability (new `src/metrics/route_metrics.rs`):** `route_decisions_total{backend,shape_class,source}`, `route_consult_duration_seconds`, `route_olap_on_native_total` (operator nudge to materialize). Plus `RouteSource{Static,OverrideExploit,OverrideExplore}` on the decision + in the structured log.

**4. AST cardinality hints (`relational_pipeline.rs`):** LIMIT / scalar-aggregate → `Small`, as a **fallback** when the footer-warmed `classify_table_shapes` stat is `Unknown` (native storage / cold parquet). Complements the existing parquet-backed mechanism; pure AST walk, zero route-time I/O.

## SOLID
SRP (scheduler=policy, model=learning, table=snapshot) · OCP (frozen table is the extension point) · LSP/ISP (`RouteConsult`) · DIP (scheduler depends on the trait).

## Safety / scope
- Override stays **default-OFF** (co-design mandate #8). This PR makes it *safe to enable* at any QPS; flipping it on is a separate soak-gated change.
- Empty frozen table at cold start ⇒ consult returns `None` ⇒ static decision unchanged (no behavior regression).
- `arc-swap` was already a workspace dep (rank-profile); added to root `[workspace.dependencies]` + root `[dependencies]`.

## Verification
`cargo clippy --lib --bins -- -D warnings` ✓ · `cargo fmt --check` ✓ · 130 lib tests ✓ (incl. new recomputer / freshness-safety / source-tracking / cardinality-hint tests, and the TD-170 hard-gate test) · `proximadb-server` binary builds ✓ · panic-policy = 36 (baseline, no regression).

## Deferred (follow-up TDs)
1. Flip override default ON (separate soak gate).
2. Unify vector/multimodel routing under this cost lens.
3. Flip `&dyn RouteConsult` onto the prod hot path once a 2nd real impl exists.