### PR TITLE
chore(test): clear clippy::approx_constant lints in test fixtures

### DIFF
--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -3010,11 +3010,11 @@ mod tests {
     fn test_sql_value_to_json_number() {
         use crate::proto::proximadb_v1::sql_value::Value;
         let sql_value = crate::proto::proximadb_v1::SqlValue {
-            value: Some(Value::NumberValue(3.14)),
+            value: Some(Value::NumberValue(3.5)),
         };
 
         let json = UnifiedHandlers::sql_value_to_json(&sql_value);
-        assert_eq!(json, serde_json::json!(3.14));
+        assert_eq!(json, serde_json::json!(3.5));
     }
 
     #[test]

--- a/src/automl/tuning.rs
+++ b/src/automl/tuning.rs
@@ -1099,13 +1099,13 @@ mod tests {
     #[test]
     fn test_parameter_value_types() {
         let int_val = ParameterValue::Integer(42);
-        let float_val = ParameterValue::Float(3.14);
+        let float_val = ParameterValue::Float(3.5);
         let string_val = ParameterValue::String("hello".to_string());
         let bool_val = ParameterValue::Boolean(true);
 
         // Verify Debug formatting works for all variants
         assert!(format!("{:?}", int_val).contains("42"));
-        assert!(format!("{:?}", float_val).contains("3.14"));
+        assert!(format!("{:?}", float_val).contains("3.5"));
         assert!(format!("{:?}", string_val).contains("hello"));
         assert!(format!("{:?}", bool_val).contains("true"));
 
@@ -1113,7 +1113,7 @@ mod tests {
         let int_clone = int_val.clone();
         assert!(matches!(int_clone, ParameterValue::Integer(42)));
         let float_clone = float_val.clone();
-        assert!(matches!(float_clone, ParameterValue::Float(f) if (f - 3.14).abs() < f64::EPSILON));
+        assert!(matches!(float_clone, ParameterValue::Float(f) if (f - 3.5).abs() < f64::EPSILON));
         let string_clone = string_val.clone();
         assert!(matches!(string_clone, ParameterValue::String(s) if s == "hello"));
         let bool_clone = bool_val.clone();
@@ -1880,7 +1880,7 @@ mod tests {
     fn test_parameter_value_serde_roundtrip() {
         let values = vec![
             ParameterValue::Integer(42),
-            ParameterValue::Float(3.14),
+            ParameterValue::Float(3.5),
             ParameterValue::String("test".to_string()),
             ParameterValue::Boolean(false),
         ];

--- a/src/cdc/connectors/mysql/decoder.rs
+++ b/src/cdc/connectors/mysql/decoder.rs
@@ -901,7 +901,7 @@ mod tests {
             ColumnValue::Null,
             ColumnValue::Int(-42),
             ColumnValue::UInt(42),
-            ColumnValue::Float(3.14),
+            ColumnValue::Float(3.5),
             ColumnValue::String("hello".to_string()),
             ColumnValue::Bytes(vec![1, 2, 3]),
         ];

--- a/src/cdc/connectors/postgres/decoder.rs
+++ b/src/cdc/connectors/postgres/decoder.rs
@@ -655,8 +655,8 @@ mod tests {
         let int_value = ColumnValue::Text("42".to_string());
         assert_eq!(int_value.parse_i64(), Some(42));
 
-        let float_value = ColumnValue::Text("3.14".to_string());
-        assert!((float_value.parse_f64().unwrap() - 3.14).abs() < 0.001);
+        let float_value = ColumnValue::Text("3.5".to_string());
+        assert!((float_value.parse_f64().unwrap() - 3.5).abs() < 0.001);
 
         let json_value = ColumnValue::Text(r#"{"key": "value"}"#.to_string());
         let parsed = json_value.parse_json().unwrap();

--- a/src/compute/proximacodec/simd/simd.rs
+++ b/src/compute/proximacodec/simd/simd.rs
@@ -1866,7 +1866,7 @@ mod tests {
             // Sequential data
             vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
             // Random data
-            vec![3.14, 2.71, 1.41, 0.57, 9.81, 6.28, 8.85, 4.67],
+            vec![3.5, 2.5, 1.5, 0.57, 9.81, 6.5, 8.85, 4.67],
             // Normalized embeddings
             vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
             // Mixed positive/negative

--- a/src/core/search/filter_pushdown_engine.rs
+++ b/src/core/search/filter_pushdown_engine.rs
@@ -618,7 +618,7 @@ mod tests {
         let result = planner.convert_value(&int_value).unwrap();
         assert!(matches!(result, FilterValue::Integer(42)));
 
-        let float_value = json!(3.14);
+        let float_value = json!(3.5);
         let result = planner.convert_value(&float_value).unwrap();
         assert!(matches!(result, FilterValue::Float(_)));
     }

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -3130,7 +3130,7 @@ mod tests {
         assert!(matches!(int_val, Some(Value::IntValue(42))));
 
         // Float
-        let float_val = json_to_filter_clause_value(&serde_json::json!(3.14));
+        let float_val = json_to_filter_clause_value(&serde_json::json!(3.5));
         assert!(matches!(float_val, Some(Value::DoubleValue(_))));
 
         // Boolean
@@ -3184,9 +3184,9 @@ mod tests {
     #[test]
     fn test_json_to_sql_value_float() {
         use crate::proto::proximadb_v1::sql_value::Value;
-        let val = json_to_sql_value(&serde_json::json!(3.14));
+        let val = json_to_sql_value(&serde_json::json!(3.5));
         match val.value {
-            Some(Value::NumberValue(f)) => assert!((f - 3.14).abs() < f64::EPSILON),
+            Some(Value::NumberValue(f)) => assert!((f - 3.5).abs() < f64::EPSILON),
             other => panic!("Expected NumberValue, got {:?}", other),
         }
     }
@@ -3282,10 +3282,10 @@ mod tests {
     fn test_sql_value_to_json_number() {
         use crate::proto::proximadb_v1::{SqlValue, sql_value::Value};
         let sv = SqlValue {
-            value: Some(Value::NumberValue(2.718)),
+            value: Some(Value::NumberValue(2.5)),
         };
         let result = sql_value_to_json(&sv).expect("Should convert number");
-        assert!((result.as_f64().expect("Should be f64") - 2.718).abs() < 0.001);
+        assert!((result.as_f64().expect("Should be f64") - 2.5).abs() < 0.001);
     }
 
     #[test]
@@ -3494,9 +3494,9 @@ mod tests {
 
     #[test]
     fn test_json_to_sql_float() {
-        let sv = json_to_sql_value(&serde_json::json!(3.14));
+        let sv = json_to_sql_value(&serde_json::json!(3.5));
         if let Some(crate::proto::proximadb_v1::sql_value::Value::NumberValue(f)) = sv.value {
-            assert!((f - 3.14).abs() < 1e-10);
+            assert!((f - 3.5).abs() < 1e-10);
         } else {
             panic!("Expected NumberValue");
         }
@@ -3604,7 +3604,7 @@ mod tests {
 
     #[test]
     fn test_filter_clause_float() {
-        let val = json_to_filter_clause_value(&serde_json::json!(3.14));
+        let val = json_to_filter_clause_value(&serde_json::json!(3.5));
         assert!(val.is_some());
     }
 

--- a/src/observability/ingestion/adapters/otlp.rs
+++ b/src/observability/ingestion/adapters/otlp.rs
@@ -830,12 +830,12 @@ mod tests {
             string_value: None,
             bool_value: None,
             int_value: None,
-            double_value: Some(3.14),
+            double_value: Some(3.5),
             array_value: None,
             kvlist_value: None,
             bytes_value: None,
         };
-        assert_eq!(double_val.double_value, Some(3.14));
+        assert_eq!(double_val.double_value, Some(3.5));
     }
 
     #[tokio::test]

--- a/src/observability/ingestion/adapters/otlp_grpc.rs
+++ b/src/observability/ingestion/adapters/otlp_grpc.rs
@@ -898,7 +898,7 @@ mod tests {
             string_value: None,
             bool_value: None,
             int_value: None,
-            double_value: Some(3.14),
+            double_value: Some(3.5),
             array_value: None,
             kvlist_value: None,
             bytes_value: None,
@@ -908,7 +908,7 @@ mod tests {
         let sql_val = result.unwrap();
         assert!(matches!(
             sql_val.value,
-            Some(sql_value::Value::NumberValue(f)) if (f - 3.14).abs() < f64::EPSILON
+            Some(sql_value::Value::NumberValue(f)) if (f - 3.5).abs() < f64::EPSILON
         ));
     }
 

--- a/src/observability/query/promql.rs
+++ b/src/observability/query/promql.rs
@@ -1915,7 +1915,7 @@ mod tests {
         let samples = vec![MetricSample {
             name: "values".to_string(),
             timestamp_ns: 1000,
-            value: 3.5,
+            value: 3.4,
             labels: HashMap::new(),
         }];
 

--- a/src/observability/query/promql.rs
+++ b/src/observability/query/promql.rs
@@ -1915,7 +1915,7 @@ mod tests {
         let samples = vec![MetricSample {
             name: "values".to_string(),
             timestamp_ns: 1000,
-            value: 3.14159,
+            value: 3.5,
             labels: HashMap::new(),
         }];
 

--- a/src/query/facade/strategies/columnar.rs
+++ b/src/query/facade/strategies/columnar.rs
@@ -1551,13 +1551,13 @@ mod tests {
         );
 
         // Float values
-        let float_val = strategy.parse_sql_value("3.14");
+        let float_val = strategy.parse_sql_value("3.5");
         assert!(float_val.is_some());
         let f = float_val
             .expect("Float value should be present")
             .as_f64()
             .expect("Should be a float64");
-        assert!((f - 3.14).abs() < 0.001);
+        assert!((f - 3.5).abs() < 0.001);
     }
 
     #[test]

--- a/src/query/facade/strategies/vector.rs
+++ b/src/query/facade/strategies/vector.rs
@@ -294,12 +294,12 @@ mod tests {
     fn test_sql_value_to_json_float() {
         use crate::proto::proximadb_v1::{SqlValue, sql_value::Value};
         let value = SqlValue {
-            value: Some(Value::NumberValue(3.14)),
+            value: Some(Value::NumberValue(3.5)),
         };
         let json = sql_value_to_json(&value);
         if let serde_json::Value::Number(n) = json {
             let f = n.as_f64().unwrap();
-            assert!((f - 3.14).abs() < 0.001);
+            assert!((f - 3.5).abs() < 0.001);
         } else {
             panic!("Expected Number");
         }

--- a/src/query/federated/execution/source_executors.rs
+++ b/src/query/federated/execution/source_executors.rs
@@ -281,7 +281,7 @@ mod tests {
     fn test_federated_value_display() {
         assert_eq!(FederatedValue::String("hello".into()).to_string(), "hello");
         assert_eq!(FederatedValue::Integer(42).to_string(), "42");
-        assert_eq!(FederatedValue::Float(3.14).to_string(), "3.14");
+        assert_eq!(FederatedValue::Float(3.5).to_string(), "3.5");
         assert_eq!(FederatedValue::Boolean(true).to_string(), "true");
         assert_eq!(FederatedValue::Null.to_string(), "NULL");
     }

--- a/src/query/prepared/statement.rs
+++ b/src/query/prepared/statement.rs
@@ -721,7 +721,7 @@ mod tests {
             "'test'"
         );
         assert_eq!(ParameterValue::Int(42).to_sql_string(), "42");
-        assert_eq!(ParameterValue::Float(3.14).to_sql_string(), "3.14");
+        assert_eq!(ParameterValue::Float(3.5).to_sql_string(), "3.5");
         assert_eq!(ParameterValue::Bool(true).to_sql_string(), "true");
         assert_eq!(ParameterValue::Null.to_sql_string(), "NULL");
         assert_eq!(

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -5254,7 +5254,7 @@ mod tests {
         let null = SqlValueLiteral::Null;
         let bool_val = SqlValueLiteral::Boolean(true);
         let int_val = SqlValueLiteral::Integer(42);
-        let _float_val = SqlValueLiteral::Float(3.14);
+        let _float_val = SqlValueLiteral::Float(3.5);
         let _string_val = SqlValueLiteral::String("hello".to_string());
         let _array_val = SqlValueLiteral::Array(vec![
             SqlValueLiteral::Float(1.0),
@@ -9304,7 +9304,7 @@ mod tests {
                 ),
                 (
                     "score".to_string(),
-                    ProximaTreeNode::Value(ProximaValue::Float32(3.14)),
+                    ProximaTreeNode::Value(ProximaValue::Float32(3.5)),
                 ),
                 (
                     "label".to_string(),

--- a/src/storage/engines/raptor/tests.rs
+++ b/src/storage/engines/raptor/tests.rs
@@ -396,7 +396,7 @@ mod tests {
                     value: Some(SqlVal::NullValue(0)),
                 },
                 SqlValue {
-                    value: Some(SqlVal::NumberValue(3.14)),
+                    value: Some(SqlVal::NumberValue(3.5)),
                 },
             ],
         };

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -5666,7 +5666,7 @@ mod tests {
                     value: Some(SqlVal::NullValue(0)),
                 },
                 SqlValue {
-                    value: Some(SqlVal::NumberValue(3.14)),
+                    value: Some(SqlVal::NumberValue(3.5)),
                 },
             ],
         };

--- a/src/storage/engines/swift/hierarchical_blocks.rs
+++ b/src/storage/engines/swift/hierarchical_blocks.rs
@@ -836,8 +836,8 @@ mod tests {
     fn test_ordered_value_number_ordering() {
         assert!(OrderedValue::Number(OrderedFloat(1.0)) < OrderedValue::Number(OrderedFloat(2.0)));
         assert_eq!(
-            OrderedValue::Number(OrderedFloat(3.14)),
-            OrderedValue::Number(OrderedFloat(3.14))
+            OrderedValue::Number(OrderedFloat(3.5)),
+            OrderedValue::Number(OrderedFloat(3.5))
         );
     }
 

--- a/src/storage/engines/swift/progressive_search.rs
+++ b/src/storage/engines/swift/progressive_search.rs
@@ -1224,7 +1224,7 @@ mod tests {
 
         let compute = UnifiedDistanceCompute::new(DistanceMetric::Euclidean);
         let euclidean_result = compute.calculate_distance(&a, &b, &DistanceMetric::Euclidean);
-        assert!((euclidean_result.distance - 1.414).abs() < 0.01);
+        assert!((euclidean_result.distance - std::f32::consts::SQRT_2).abs() < 0.01);
 
         let cosine_result = compute.calculate_distance(&a, &b, &DistanceMetric::Cosine);
         assert!((cosine_result.distance - 1.0).abs() < 0.01); // Orthogonal vectors

--- a/src/storage/formats/arrow_conversion.rs
+++ b/src/storage/formats/arrow_conversion.rs
@@ -516,7 +516,7 @@ mod tests {
         fields.insert(
             "float".to_string(),
             SqlValue {
-                value: Some(ProtoSqlValueInner::NumberValue(3.14)),
+                value: Some(ProtoSqlValueInner::NumberValue(3.5)),
             },
         );
         fields.insert(

--- a/src/storage/schema/proxima_record_bridge.rs
+++ b/src/storage/schema/proxima_record_bridge.rs
@@ -1473,7 +1473,7 @@ mod tests {
         // Spread across the fp16 dynamic range to catch any silent
         // downconversion: large, fractional, negative, denormal-ish.
         let src_a = vec![1.0_f32, -2.5, 65504.0, 0.0001, 100.25, -0.5, 42.0, 7.125];
-        let src_b = vec![0.0_f32, 1.0, -1.0, 0.5, -0.25, 32.0, -16.5, 3.140625];
+        let src_b = vec![0.0_f32, 1.0, -1.0, 0.5, -0.25, 32.0, -16.5, 3.5];
         let recs = vec![fp16_record("a", &src_a), fp16_record("b", &src_b)];
 
         let batch = bridge.records_to_batch(&recs).expect("records_to_batch");

--- a/src/storage/tests/storage_engine_simple_tests.rs
+++ b/src/storage/tests/storage_engine_simple_tests.rs
@@ -74,7 +74,7 @@ async fn test_storage_engine_creation() {
 
     // Test euclidean distance calculation
     let result = distance_compute.calculate_distance(&vec1, &vec2, &DistanceMetric::Euclidean);
-    assert!((result.rank_value - 1.4142135).abs() < 0.0001); // sqrt(2)
+    assert!((result.rank_value - std::f32::consts::SQRT_2).abs() < 0.0001); // sqrt(2)
 }
 
 #[tokio::test]

--- a/tests/arrow_native_api_test.rs
+++ b/tests/arrow_native_api_test.rs
@@ -743,9 +743,9 @@ mod hadoop_tests {
         assert_eq!(long_w.to_json(), serde_json::json!(9999999999i64));
 
         // Float
-        let float_w = HadoopWritable::FloatWritable(3.14);
+        let float_w = HadoopWritable::FloatWritable(3.5);
         let json = float_w.to_json();
-        assert!((json.as_f64().unwrap() - 3.14).abs() < 0.001);
+        assert!((json.as_f64().unwrap() - 3.5).abs() < 0.001);
 
         // Text
         let text_w = HadoopWritable::Text("hello".to_string());

--- a/tests/cdc_e2e_test.rs
+++ b/tests/cdc_e2e_test.rs
@@ -313,10 +313,7 @@ fn test_column_value_as_string_all_variants() {
     assert!(ColumnValue::Null.as_string().is_none());
     assert_eq!(ColumnValue::Int(-42).as_string(), Some("-42".to_string()));
     assert_eq!(ColumnValue::UInt(42).as_string(), Some("42".to_string()));
-    assert_eq!(
-        ColumnValue::Float(3.14).as_string(),
-        Some("3.14".to_string())
-    );
+    assert_eq!(ColumnValue::Float(3.5).as_string(), Some("3.5".to_string()));
     assert_eq!(
         ColumnValue::String("hello".to_string()).as_string(),
         Some("hello".to_string())

--- a/tests/integration/query_facade/test_sql_through_facade.rs
+++ b/tests/integration/query_facade/test_sql_through_facade.rs
@@ -395,7 +395,7 @@ async fn test_sql_response_data_types() {
     let rows = vec![serde_json::json!({
         "string_col": "hello",
         "int_col": 42,
-        "float_col": 3.14,
+        "float_col": 3.5,
         "bool_col": true,
         "null_col": null,
         "array_col": [1, 2, 3],

--- a/tests/integration/storage_engine_adapters_test.rs
+++ b/tests/integration/storage_engine_adapters_test.rs
@@ -593,8 +593,8 @@ mod cross_engine_tests {
             Some(ScalarValue::Int64(42))
         );
         assert_eq!(
-            ScalarValue::from_json(&serde_json::json!(3.14)),
-            Some(ScalarValue::Float64(3.14))
+            ScalarValue::from_json(&serde_json::json!(3.5)),
+            Some(ScalarValue::Float64(3.5))
         );
         assert_eq!(
             ScalarValue::from_json(&serde_json::json!("hello")),

--- a/tests/prepared_statement_test.rs
+++ b/tests/prepared_statement_test.rs
@@ -874,8 +874,8 @@ fn test_parameter_value_from_conversions() {
     assert!(matches!(pv, ParameterValue::Int(42)));
 
     // From f64
-    let pv: ParameterValue = 3.14f64.into();
-    assert!(matches!(pv, ParameterValue::Float(f) if (f - 3.14).abs() < 0.001));
+    let pv: ParameterValue = 3.5f64.into();
+    assert!(matches!(pv, ParameterValue::Float(f) if (f - 3.5).abs() < 0.001));
 
     // From bool
     let pv: ParameterValue = true.into();

--- a/tests/quantization/pq_codebook_training_tests.rs
+++ b/tests/quantization/pq_codebook_training_tests.rs
@@ -28,7 +28,7 @@ fn generate_training_vectors(count: usize, dimensions: usize, pattern: &str) -> 
                     match pattern {
                         "uniform" => base % 1.0,
                         "gaussian" => {
-                            let x = base * 6.28; // 2π
+                            let x = base * std::f32::consts::TAU; // 2π
                             (x.sin() + x.cos()) * 0.5
                         },
                         "clustered" => {

--- a/tests/quantization/storage_engine_pq_tests.rs
+++ b/tests/quantization/storage_engine_pq_tests.rs
@@ -21,7 +21,7 @@ fn create_test_vectors(count: usize, dimension: usize, pattern: &str) -> Vec<Vec
                     let base = (i as f32 + j as f32) * 0.01;
                     match pattern {
                         "linear" => base,
-                        "sinusoidal" => (base * 6.28).sin(),
+                        "sinusoidal" => (base * std::f32::consts::TAU).sin(),
                         "clustered" => {
                             let cluster = i % 3;
                             base + cluster as f32 * 2.0

--- a/tests/sql_value_roundtrip.rs
+++ b/tests/sql_value_roundtrip.rs
@@ -14,7 +14,7 @@ fn grpc_roundtrip_sqlvalue_prost() {
             v1::SqlRowField {
                 key: "f64".into(),
                 value: Some(v1::SqlValue {
-                    value: Some(v1::sql_value::Value::NumberValue(3.14)),
+                    value: Some(v1::sql_value::Value::NumberValue(3.5)),
                 }),
             },
             v1::SqlRowField {


### PR DESCRIPTION
## What

Makes `cargo clippy --all-targets` clean of the deny-by-default `clippy::approx_constant` lint. All ~47 sites are in **test code** (test modules + `tests/`), which is why the repo's `clippy --lib --bins -D` gate never surfaced them. **No lint suppression added.**

## How (behaviour-neutral)

- **Arbitrary fixtures** that merely *looked* like π/e (`json!(3.14)`, `NumberValue(2.718)`, a random SIMD input vector, …) → non-constant values (`3.5`/`2.5`/`1.5`). Swapped **per-file** so paired input+assertion stay consistent — including string literals (`Text("3.14")` + `parse - 3.14` both move together).
- **Genuine constants** use the named `std::f32::consts`:
  - euclidean distance of orthogonal unit vectors `⟨1,0,0⟩`/`⟨0,1,0⟩` == **√2** → `SQRT_2` (`progressive_search`, `storage_engine_simple_tests`)
  - `base * 2π` sinusoidal codebook-training generators → `TAU` (`pq_codebook_training_tests`, `storage_engine_pq_tests`)

Zero production-path edits.

## Dead code — intentionally left

The `dead_code` warnings that `--all-targets` also surfaces are **all in `benches/`/`tests/`** and dominated by the **ANN recall-eval toolkit** (`benches/recall_utils.rs`: `compute_recall_at_k`/`ndcg`/`mrr`, `SearchQualityMetrics`). Left intact per the eval mandate + defensive-before-destructive — deleting eval metrics to satisfy a test-only warning is the wrong trade. The remainder are trivial test-local unused vars/fields, not worth the churn/feature-gate risk.

## Verification

- `cargo clippy -p proximadb --all-targets` → **0** `approx_constant` ✅
- affected tests **113/113** pass (incl. the √2 distance computations + records round-trip) ✅
- `cargo fmt --all` ✅