### PR TITLE
docs(adr): ADR-039 — OLAP engine boundary, DataFusion as a swappable physical backend

### DIFF
--- a/docs/12-design/adr/ADR-039-olap-engine-boundary-swappable-physical-backend.adoc
+++ b/docs/12-design/adr/ADR-039-olap-engine-boundary-swappable-physical-backend.adoc
@@ -1,0 +1,166 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-039: OLAP Engine Boundary — DataFusion is a swappable physical backend behind the shared `LogicalNode` seam
+
+[cols="1,3"]
+|===
+|Status|Accepted (ratifies + freezes the existing design; audited 2026-06-27)
+|Date|2026-06-27
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-018 (pgwire/SQL parity roadmap — the conformance driver), ADR-033 (own the vertical, keep the standard at the interop seam), ADR-024 (single canonical data type — `ProximaValue`), ADR-034 (route cost model / `ComputeScheduler`), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` ("vertical inside, standard outside")
+|Co-designed with|The "course-correction §5" guarantee — *shared logical plane, split physical plane* — which this ADR makes a frozen, ratcheted contract
+|Supersedes|—
+|Tracked under|TD-181 (no-DataFusion build CI guard + the leakage ratchet)
+|===
+
+== Context
+
+ProximaDB's OLAP/relational path uses Apache DataFusion as the engine for parquet-backed
+(MATERIALIZE'd / federated) tables, with a native **Volcano** engine for everything else
+(`ComputeScheduler::route_select` → `ComputeBackend`). DataFusion is a fast-moving 3rd-party
+crate with its own type system, release cadence, and design choices; we want the option to
+**swap it** (for Polars, DuckDB, a Velox-style vectorized engine, or our own) *without*
+rewriting the SQL frontend, planner, pgwire surface, storage, or result path — and **without
+the runtime bearing dispatch cost** or the team **re-analyzing the boundary** each time the
+question comes up.
+
+This ADR was written after a full read-only audit of the coupling (2026-06-27). The finding:
+**the boundary is already clean and swap-architected.** This ADR therefore *ratifies* that
+design, *names its invariants*, and *ratchets* them so the property cannot silently erode —
+turning an implicit good state into a frozen contract.
+
+== First principles (why this shape)
+
+* **Granularity beats dispatch-mechanism.** The engine seam is **per-query** (a whole logical
+  plan in, a result stream out), not per-row. At that granularity a `dyn`/enum virtual call is
+  nanoseconds against a query that scans millions of rows — so the runtime bears *no* load.
+  Reaching for compile-time generics *at the seam* would buy nothing and inflict a viral type
+  parameter + binary bloat; monomorphization belongs **inside** the engine's hot kernels, not
+  at the swap boundary.
+* **Decouple by IR direction, not by abstraction count.** "Swap not rewrite" holds iff the
+  frontend emits *our* engine-neutral IR and DataFusion is one *backend lowering* of it — never
+  the reverse (frontend emitting DataFusion's `LogicalPlan`). This is the same Dependency-
+  Inversion / port pattern as Slice D (storage↔index): the high-level policy owns the contract;
+  the 3rd-party engine implements it.
+* **Standard at the seam, vertical inside (ADR-033 / co-design).** The contract types are ours
+  (`LogicalNode`, `ProximaValue`, `RelationalRow`) and Arrow at the data plane; DataFusion's
+  types stay *inside* the adapter.
+
+== Current coupling — audit (2026-06-27, file:line evidence)
+
+`use datafusion::` appears in exactly **three** places; **zero** elsewhere:
+
+[cols="2,3,1",options="header"]
+|===
+| Layer | Where | Verdict
+| **DataFusion adapter** | `src/datafusion/**` (logical_lowering, table_provider, scan_executor, proxima_scan_exec, registry_udf, predicate_pushdown, schema_inference, engine_adapters/*, udf, mod) — 11 files | ✅ contained (by design)
+| **DataFusion engine impl** | `src/query/execution/datafusion_engine.rs`, `datafusion_bridge.rs` | ✅ contained
+| **Embedded Python DataFrame** | `src/embedded/python_dataframe.rs` | ⚠️ a *separate, deliberate* API surface (Python users opt into DF DataFrame semantics) — fenced, not part of the SQL seam
+| pgwire frontend (`src/network/postgres/**`), relational crates (`proximadb-relational-*`), storage, services, `compute_scheduler.rs`, `query/execution/engine.rs` | — | ✅ **zero** DataFusion types
+|===
+
+The four properties that make it swappable today:
+
+1. **Own engine-neutral IR.** `crates/query/proximadb-relational-algebra::LogicalNode`
+   (Scan/Filter/Project/Join/Aggregate/Sort/Limit/Union/SetOp/CTE/Distinct) has **zero**
+   DataFusion deps. SQL → `LogicalNode` in `proximadb-relational-frontend` (sqlparser, no DF).
+   Volcano executes `LogicalNode` directly; DataFusion lowers `LogicalNode → datafusion::LogicalPlan`
+   in `src/datafusion/logical_lowering.rs` ("shared logical plane, split physical plane").
+2. **Coarse trait seam, feature-gated.** `ExecutionEngine` trait (`src/query/execution/engine.rs`)
+   + `execute_sql_with_backend(backend, sql, ctx: QueryExecutionContext)`; the DataFusion arm is
+   behind `#[cfg(feature = "datafusion-integration")]` (`relational_pipeline.rs`). `QueryExecutionContext`
+   carries only engine-neutral table/tenant/control fields.
+3. **Engine-neutral output.** Arrow `RecordBatch` → `RelationalRow (Vec<ProximaValue>)` /
+   `RelationalSchema` via `record_batches_to_pipeline_result` (`datafusion_engine.rs`); the pgwire
+   encoder consumes `ExecutionPipelineResult` and **never** sees a DataFusion type.
+4. **One function definition, many bindings.** Scalar/UDFs are defined once as `ProximaValue`
+   kernels in `proximadb-functions::ProximaFunctionRegistry`; `src/datafusion/registry_udf.rs`
+   *wraps* them as `ScalarUDF` (Calcite/Velox "one definition, N physical bindings"). The native
+   path dispatches the same kernels. (This is also the answer to "where do SQL math constants /
+   scalar functions live": the registry — *not* a hand-rolled value map; niladic constants like
+   `pi()` fold to a literal.)
+
+**Build coupling:** `datafusion = { optional = true }`; feature `datafusion-integration` (currently
+in `default`); disabling it compiles a Volcano-only build (`engine.rs` returns
+`FeatureDisabled` on the DF arm). Relational crates carry **no** DF dependency.
+
+== Decision
+
+**DataFusion is a *physical backend* plugged in behind a frozen, engine-neutral query seam. The
+following are invariants, enforced by ratchets — not aspirations.**
+
+. **The seam is `LogicalNode` in, `ExecutionPipelineResult` out.** Every engine consumes the
+  shared `LogicalNode` IR and returns `RelationalSchema` + `Vec<RelationalRow>` (`ProximaValue`
+  cells), Arrow at the data plane. The frontend/planner emit `LogicalNode` and **never** a
+  3rd-party engine plan.
+. **DataFusion types are adapter-only.** `datafusion::`/`datafusion_common::` (`LogicalPlan`,
+  `Expr`, `ScalarValue`, `SessionContext`/`SessionState`, `DataFrame`, `TableProvider`,
+  `ExecutionPlan`, `PhysicalExpr`, `DFSchema`, `RuntimeEnv`) may appear **only** under
+  `src/datafusion/**`, `src/query/execution/datafusion_engine.rs`, `datafusion_bridge.rs`, and
+  the explicitly-fenced `src/embedded/python_dataframe.rs`. Anywhere else is a boundary breach.
+. **Relational crates stay DF-free.** `crates/**/proximadb-relational-*` and
+  `proximadb-relational-types`/`proximadb-functions` carry **no** `datafusion` Cargo dependency.
+. **Scalar functions: one definition.** New functions are added to `ProximaFunctionRegistry`;
+  engine adapters *bind*, never *redefine*. SQL math constants are registry functions
+  (`pi()`/`sqrt()`/`exp()`), constant-folded — not internal value dictionaries.
+. **DataFusion is a feature, the native path is the floor.** A `--no-default-features` (or
+  `datafusion-integration`-off) build must compile and pass the Volcano-only suite. The engine
+  is selected at runtime per query (`route_select`); dispatch is `dyn`/enum at the coarse seam.
+  **Do not** thread an engine generic `<E: ExecutionEngine>` through the pipeline.
+
+== How to swap (the canonical procedure — don't re-derive)
+
+To replace or add an engine `X` (Polars/DuckDB/external/our-own):
+
+. **Lower:** `src/x/logical_lowering.rs` — `fn lower_logical_node(&LogicalNode, ...) -> Result<XPlan>`,
+  same operator coverage as `src/datafusion/logical_lowering.rs`. Input `LogicalNode` is unchanged.
+. **Execute:** `impl ExecutionEngine for XEngine` in `src/query/execution/x_engine.rs` —
+  in: `QueryExecutionContext`; out: `ExecutionPipelineResult` (convert `X`'s batches → `RelationalRow`).
+. **Scan adapter:** map `LogicalNode` scan + pushed predicates/projection to `X`'s reader (reuse
+  the engine-neutral predicates; PAX zone-map pruning stays ours).
+. **Register:** add `ComputeBackend::X` arm in `execute_sql_with_backend`, behind
+  `#[cfg(feature = "x-integration")]`; Cargo `x-integration = ["dep:x", ...]`; point/extend
+  `route_select`.
+. **Reuse unchanged:** SQL frontend, `LogicalNode`, the function registry, the pgwire encoder,
+  storage, services, network. **Tests reuse the TPC-H/TPC-DS pgwire suites** (they exercise the
+  seam, not the engine).
+
+Estimated cost for a mature engine: lowering ~2–4 wk, `ExecutionEngine` impl ~1–2 wk, scan
+adapter ~1 wk, wiring ~1 d. **No frontend/planner/pgwire/storage refactor.**
+
+== Consequences
+
+* **Positive:** swap is additive (new backend crate + feature), not a rewrite; the dual-path
+  (DataFusion + Volcano) already proves the abstraction holds; one function registry keeps the
+  two engines semantically identical (no fork); the runtime pays one virtual call per query.
+* **Costs / watch-items:**
+  - The seam can **bit-rot** if the no-DataFusion build is never exercised → TD-181 adds a CI
+    Volcano-only build+test variant.
+  - The invariant can **erode** if someone imports a `datafusion::` type into the frontend/result
+    path → a grep ratchet (Verification) fails the build.
+  - `src/embedded/python_dataframe.rs` deliberately exposes DataFusion DataFrame semantics to
+    embedded Python; this is a *separate product surface*, documented as out-of-scope for the SQL
+    seam — a future native-backed embedded DataFrame would close even that.
+* **Non-goal:** this ADR does not pick a replacement engine or schedule a swap; it guarantees the
+  swap stays a *backend* exercise.
+
+== Verification (ratchets)
+
+. **Leakage ratchet (CI):** `datafusion::`/`datafusion_common::` imports appear only under the
+  allowed paths (invariant 2). A script greps `src/` and `crates/` and fails on any hit outside
+  the adapter allow-list (+ the fenced embedded file).
+. **Cargo ratchet:** `proximadb-relational-*` / `proximadb-relational-types` / `proximadb-functions`
+  have no `datafusion` dependency (grep their `Cargo.toml`).
+. **No-DataFusion build (TD-181):** a feature-matrix CI entry builds with `datafusion-integration`
+  off and runs the Volcano-only relational suite — proving the floor compiles and the seam is real.
+. **Conformance unchanged:** the TPC-H (22) / TPC-DS (16) pgwire ratchets pass identically with the
+  engine routed either way (they bind to the seam, not the engine).
+
+== Sources
+
+* Audit (file:line) of `use datafusion::` distribution, `proximadb-relational-algebra::LogicalNode`,
+  `src/datafusion/logical_lowering.rs`, `src/query/execution/{engine,datafusion_engine,datafusion_bridge}.rs`,
+  `src/network/postgres/relational_pipeline.rs`, `proximadb-functions` / `src/datafusion/registry_udf.rs`,
+  and the `datafusion-integration` Cargo feature — 2026-06-27.
+* ADR-033 (own the vertical, standard at the seam); ADR-018 (pgwire/SQL parity); ADR-024 (canonical
+  `ProximaValue`); ADR-034 (route cost model); `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -141,6 +141,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Statistics Envelope Freshness Coherence — per-source freshness, conservative floor (v1.1)
 | Proposed
 | v1.1 of the ADR-037 envelope: each modality/source block carries its **own** freshness watermark (it was produced at a different flush), and the envelope's top-level freshness is the **conservative floor** (oldest source) so a consumer never over-trusts a stale block. (Renumbered from ADR-032 — that number landed for the durable tenant-prefixed catalog.) Tracked: TD-174
+
+| link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039]
+| OLAP Engine Boundary — DataFusion is a swappable physical backend behind the shared `LogicalNode` seam
+| Accepted
+| Ratifies + freezes the (audited 2026-06-27) design that makes DataFusion swappable as a *backend*, not a rewrite: the SQL frontend emits ProximaDB's own engine-neutral `LogicalNode` IR (relational crates carry **zero** DataFusion deps); DataFusion lowers `LogicalNode → datafusion::LogicalPlan` inside `src/datafusion/**` only; results come back as Arrow → `RelationalRow`/`ProximaValue` (pgwire never sees a DataFusion type); scalar functions are defined **once** in `proximadb-functions` and merely *bound* per engine; DataFusion is an optional cargo feature with the native Volcano path as the floor. Invariants are **ratcheted** (a leakage grep + a no-DataFusion CI build) so the boundary can't erode, and the swap procedure is captured so it is never re-analyzed. Dispatch is `dyn`/enum at the **per-query** seam — coarse, so the runtime bears no per-row cost (no engine generics threaded through the pipeline). Tracked: TD-181
 |===
 
 NOTE: ADR-010 through ADR-013 exist in this directory but are not yet


### PR DESCRIPTION
## What

Adds **ADR-039**, which ratifies and freezes the architecture that makes DataFusion a **swappable physical backend** behind ProximaDB's engine-neutral query seam — and captures the swap procedure + invariants so the boundary is never re-analyzed or allowed to erode.

## Why

The question "can we swap out DataFusion later, with compile-time decoupling so the runtime bears no load, reusing rather than rebuilding?" keeps coming up. The answer turned out to be **yes — the design already does this (~80%)**, but it was implicit. This ADR makes it an explicit, ratcheted contract.

## Audit finding (2026-06-27, file:line evidence in the ADR)

`use datafusion::` is confined to **three** places — `src/datafusion/**` (11 adapter files), `src/query/execution/datafusion_{engine,bridge}.rs`, and the deliberately-fenced `src/embedded/python_dataframe.rs`. **Zero** in the pgwire frontend, the relational crates, storage, services, or `compute_scheduler.rs`. Concretely:

- **Own engine-neutral IR:** `proximadb-relational-algebra::LogicalNode` (no DF deps). SQL → `LogicalNode` → {Volcano executes directly | DataFusion lowers `LogicalNode → datafusion::LogicalPlan` in `src/datafusion/logical_lowering.rs`}.
- **Coarse trait seam:** `ExecutionEngine` + `execute_sql_with_backend(ctx: QueryExecutionContext)`, behind `#[cfg(feature = "datafusion-integration")]`.
- **Engine-neutral output:** Arrow `RecordBatch` → `RelationalRow`(`ProximaValue`)/`RelationalSchema`; pgwire never sees a DF type.
- **One function definition, many bindings:** `proximadb-functions::ProximaFunctionRegistry` defines kernels once; `registry_udf.rs` binds them as DF `ScalarUDF` (also the home for SQL math constants/functions — *not* a value dictionary).
- **Optional build:** `datafusion = { optional = true }`; native Volcano path is the floor.

## What the ADR freezes

- **Invariants** (DF types adapter-only; relational crates DF-free; `LogicalNode` in / `ExecutionPipelineResult` out; one function registry; feature-gated with Volcano floor; `dyn`/enum at the per-query seam — no engine generics threaded through).
- **Ratchets** (TD-181: a leakage grep + a no-DataFusion CI build so the seam can't bit-rot).
- **The canonical swap procedure** (LogicalNode→backend lowering + `ExecutionEngine` impl + scan adapter + feature-gated wiring) — so it's never re-derived.
- **First-principles rationale**: coarse per-query dispatch ⇒ no runtime per-row cost; own-IR direction ⇒ swap-not-rewrite; standard-at-the-seam / vertical-inside (ADR-033 / co-design).

## Scope

Docs-only: `ADR-039-*.adoc` + README index row. Validators pass (`validate_doc_structure.sh`, capability matrix); asciidoctor renders clean.