### PR TITLE
docs(agent-rules): td-adr-convention skill seed (operationalize #441-443 TD/ADR convention)

### DIFF
--- a/docs/agent-rules/README.adoc
+++ b/docs/agent-rules/README.adoc
@@ -35,3 +35,17 @@ on `develop`; the `td-adr-unique` CI guard backstops). That doc, the
 all ship via git and apply to everyone — only *these* per-agent rule files are
 local. Keep the seed copies' pointer to that doc current when you update your
 local rules.
+
+== Skills (local-only, seeded like the rule files)
+
+`.claude/skills/` is gitignored too (it is per-machine state). Shared skill
+*seeds* live under `docs/agent-rules/skills/` and are committed. To activate one
+on a fresh clone or new machine, copy the seed into the local skills tree:
+
+    mkdir -p .claude/skills/td-adr-convention
+    cp docs/agent-rules/skills/td-adr-convention/SKILL.md \
+       .claude/skills/td-adr-convention/SKILL.md
+
+The `td-adr-convention` skill operationalizes the TD/ADR filing rules above (it
+points at the same `HOW_TO_FILE_TD_AND_ADR` source of truth) so an agent can file
+or migrate TD/ADR entries collision-free without re-deriving the convention.

--- a/docs/agent-rules/skills/td-adr-convention/SKILL.md
+++ b/docs/agent-rules/skills/td-adr-convention/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: td-adr-convention
+description: File or migrate ProximaDB Technical Debt (TD) entries and Architecture Decision Records (ADRs) per the collision-free per-file convention (PRs #441–443). Use whenever filing a new TD/ADR, migrating a legacy TD to per-file, fixing a `td-adr-unique` guard failure, or choosing a TD/ADR id. Enforces topic-scoped ids, id-in-heading, and the uniqueness guard.
+---
+
+# File / migrate TD & ADR entries (collision-free per-file convention)
+
+**Source of truth:** `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`. This skill
+operationalizes it. Goal: concurrent sessions filing TDs/ADRs never textually
+conflict and never claim a duplicate id.
+
+## Layout
+- **ADRs:** `docs/12-design/adr/ADR-<NNN>-<slug>.adoc` (index it in `adr/README.adoc`)
+- **TDs (new):** `docs/10-quality/td/TD-<id>-<slug>.adoc`
+- **TDs (legacy ~100):** `docs/10-quality/TECHNICAL_DEBT.adoc` — **do NOT migrate ad hoc**
+
+## File a NEW TD
+1. `eval "$(scripts/worktree.sh new docs/td-<topic>)"` — branch off `origin/develop`.
+2. Pick the id:
+   - **Preferred — topic-scoped** `TD-<TOPIC>-N` (e.g. `TD-CAT-1`, `TD-SC-2`,
+     `TD-CG3`) for any multi-step effort. One initiative owns its prefix ⇒ parallel
+     sessions on different initiatives never collide.
+   - **Standalone one-off** → global `TD-NNN`: scan `docs/10-quality/td/` **and** the
+     legacy `TECHNICAL_DEBT.adoc` rows for the highest N, +1.
+3. Create `docs/10-quality/td/TD-<id>-<slug>.adoc`:
+   ```
+   = TD-<id>: <short title>
+   :status: Open | In Progress | Partial | Resolved | Won't Do
+   :dim: D1..D5
+   :pillar: OE | SEC | REL | PERF | COST | SUS
+
+   Problem → next action; key file location; deps.
+   ```
+   The id in the `= TD-<id>:` **title heading** is authoritative (the guard reads it
+   there, not the filename — the slug's hyphens make the filename ambiguous).
+4. Backstop: `python3 scripts/check_td_adr_unique.py` (and the `td-adr-unique` CI
+   job). Must pass — no duplicate id across the legacy table + per-file dir.
+5. Verify locally, commit, PR. If a rebase lands a colliding id, renumber yours
+   (never the merged one) and re-check within 48h (rebase mandate).
+
+## File a NEW ADR
+1. `docs/12-design/adr/ADR-<NNN>-<slug>.adoc` — scan `adr/` for the highest N, +1.
+2. First heading `= ADR-<NNN>: <title>`.
+3. **Index it** in `docs/12-design/adr/README.adoc` (the guard warns on unindexed ADRs).
+4. Run the guard; PR.
+
+## Migrate a LEGACY TD → per-file  (DELIBERATE, BATCHED, post-merge only)
+The legacy table is referenced **~900×** across code/docs and conflicts with every
+open PR touching `TECHNICAL_DEBT.adoc`. Do **not** migrate incidentally.
+
+When the TD-touching PR queue is clear, migrate as **one batched PR**:
+- For each legacy row: create `td/TD-<id>-<slug>.adoc` with the row's content, then
+  replace the row with a one-line pointer (e.g. `| TD-163 | → see td/TD-163-… |`).
+- **Keep the id identical** so the ~900 `TD-<id>` references across the codebase
+  still resolve.
+- The guard treats both the legacy row's `| TD-<id> |` and the per-file `= TD-<id>:` **as declarations**. During migration, leave exactly ONE declaration per id: the
+  per-file heading. Reduce the legacy row to a pointer that is NOT a `= TD-<id>:`
+  heading and does not re-declare the id, so the guard sees one.
+
+## Fix a `td-adr-unique` failure
+It fires on a duplicate ADR number or TD id (across legacy table + per-file dir).
+Renumber **your** new entry (never the already-merged one): pick the next-free id
+per the rules above, update filename + title heading, re-run the guard.
+
+## Why (don't subvert it)
+Sequential numbers in a shared space have no atomic allocator — `ADR-031/032/033`
+and `TD-167` were each claimed twice in one week, surfacing only at merge. One file
+per entry + topic-scoped ids + the guard removes both failure modes. If you're
+tempted to hand-edit the monolith or skip the guard, re-read
+`docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc` first.


### PR DESCRIPTION
## Summary

Adds a reusable **`td-adr-convention` skill** (seed) that operationalizes the TD/ADR per-file filing convention from #441–443, so an agent can file or migrate TD/ADR entries collision-free without re-deriving the rules each time.

## Why
The convention scaffolding (#441–443 — per-file `td/` dir, `HOW_TO_FILE_TD_AND_ADR`, the `td-adr-unique` guard, local-only rule seeds) is in place but lives across several docs. This skill bundles the actionable procedure (pick a topic-scoped id → one file per entry → declare id in the heading → run the guard → index ADRs) and the legacy-migration caveat (~100 legacy TDs referenced ~900× — migrate only as a deliberate batched, post-merge effort), pointing at `HOW_TO_FILE_TD_AND_ADR` as the single source of truth.

## What
- `docs/agent-rules/skills/td-adr-convention/SKILL.md` — the skill seed (committed, shareable).
- `docs/agent-rules/README.adoc` — documents the `cp` step to activate it locally (`.claude/skills/` is gitignored, same seed pattern as the per-agent rule files in #443).

To activate locally:
```
mkdir -p .claude/skills/td-adr-convention
cp docs/agent-rules/skills/td-adr-convention/SKILL.md .claude/skills/td-adr-convention/SKILL.md
```

Docs-only; no code/CI-behavior change.
