### PR TITLE
fix(functions): registry-init DashMap self-deadlock (intermittent streaming CI hang) + test watchdog

### DIFF
--- a/crates/foundation/proximadb-functions/src/lib.rs
+++ b/crates/foundation/proximadb-functions/src/lib.rs
@@ -187,9 +187,24 @@ impl ProximaFunctionRegistry {
     }
 
     /// Register the same scalar under an alias name (e.g. `ucase` → `upper`).
+    ///
+    /// The target lookup is cloned out and its `DashMap` read-guard dropped
+    /// *before* the alias insert. Holding the `get` `Ref` (a shard read-lock)
+    /// across `insert` (a shard write-lock) self-deadlocks the calling thread
+    /// whenever `alias` and `target` hash to the same shard — and DashMap's
+    /// hasher is random-seeded per process, so that collision (and the hang) was
+    /// intermittent (~1-2%/process). This was the root cause of the rare
+    /// `native_volcano_*` / SQL-function CI hang: the builtin-registry `LazyLock`
+    /// init wedged here (confirmed by stack sample), riding to nextest's 120s
+    /// slow-timeout. The registry init is on the server's first-SQL-function path
+    /// too, so this is a latent production hazard, not only a test flake.
     pub fn alias_scalar(&self, alias: &str, target: &str) {
-        if let Some(def) = self.scalars.get(&target.to_ascii_lowercase()) {
-            self.scalars.insert(alias.to_ascii_lowercase(), def.clone());
+        let target_def = self
+            .scalars
+            .get(&target.to_ascii_lowercase())
+            .map(|def| def.clone());
+        if let Some(def) = target_def {
+            self.scalars.insert(alias.to_ascii_lowercase(), def);
         }
     }
 
@@ -615,6 +630,35 @@ mod tests {
                 .unwrap(),
             ProximaValue::String("X".into())
         );
+    }
+
+    /// Regression: `alias_scalar` must not hold the target's `DashMap` read-guard
+    /// across the alias `insert` — that self-deadlocks when both keys hash to the
+    /// same shard (random per process, so it was a ~1-2% intermittent hang). Many
+    /// aliases over one target make a same-shard collision near-certain, so this
+    /// would wedge a thread WITHOUT the fix and completes instantly WITH it.
+    #[test]
+    fn alias_scalar_is_reentrancy_safe_under_shard_collisions() {
+        let r = ProximaFunctionRegistry::default();
+        r.register_scalar(ScalarFunctionDef {
+            signature: FunctionSignature {
+                name: "base".to_string(),
+                arg_types: vec![ProximaType::String],
+                variadic: false,
+                return_ty: ProximaType::String,
+                volatility: Volatility::Immutable,
+            },
+            kernel: Arc::new(|args: &[ProximaValue]| Ok(args[0].clone())),
+        });
+        // Enough aliases that two are overwhelmingly likely to share a shard.
+        for i in 0..256 {
+            r.alias_scalar(&format!("base_alias_{i}"), "base");
+        }
+        assert_eq!(r.scalar_count(), 257);
+        assert!(r.lookup_scalar("base_alias_200").is_some());
+        // Aliasing a missing target is a no-op (still no guard held across insert).
+        r.alias_scalar("orphan", "does_not_exist");
+        assert!(r.lookup_scalar("orphan").is_none());
     }
 
     #[test]

--- a/src/query/execution/test_runtime.rs
+++ b/src/query/execution/test_runtime.rs
@@ -23,7 +23,60 @@
 //!
 //! Tests use these via `#[test] fn` instead of `#[tokio::test] async fn`.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// Hard wall-clock cap for hang-prone async tests. Well above their real runtime
+/// (<1s) but far below nextest's 120s slow-timeout, so a genuine hang fails the
+/// test fast and clearly instead of stalling the whole unit job through nextest's
+/// slow-timeout + retry cycle (the measured ~20-min CI tax behind CLAUDE.md #11).
+const TEST_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Drive `body` (a closure that runs the test to completion on THIS thread) under
+/// an independent watchdog that bounds wall-clock time **even when the work blocks
+/// its thread** — a non-async deadlock (e.g. a re-entrant `std::sync::Mutex` in the
+/// Volcano executor) that an in-runtime `tokio::time::timeout` cannot interrupt,
+/// because the single runtime thread is the one that is wedged.
+///
+/// The work stays on the calling thread (so test futures need not be `Send`/
+/// `'static` — borrows are fine). A separate watchdog thread holds only an
+/// `Arc<AtomicBool>`; if `body` has not signalled completion within
+/// [`TEST_WATCHDOG_TIMEOUT`], the watchdog aborts the process. Under nextest's
+/// process-per-test isolation that fails ONLY this test (fast), instead of letting
+/// it hang to the 120s slow-timeout and be retried.
+fn with_watchdog<T>(body: impl FnOnce() -> T) -> T {
+    let done = Arc::new(AtomicBool::new(false));
+    let watchdog_done = done.clone();
+    let watchdog = std::thread::Builder::new()
+        .name("async-test-watchdog".to_string())
+        .spawn(move || {
+            let deadline = TEST_WATCHDOG_TIMEOUT;
+            let step = Duration::from_millis(50);
+            let mut waited = Duration::ZERO;
+            while waited < deadline {
+                if watchdog_done.load(Ordering::Acquire) {
+                    return;
+                }
+                std::thread::sleep(step);
+                waited += step;
+            }
+            if !watchdog_done.load(Ordering::Acquire) {
+                eprintln!(
+                    "FATAL: async test exceeded {TEST_WATCHDOG_TIMEOUT:?} — a streaming/runtime \
+                     deadlock (CLAUDE.md #11). Aborting to fail fast instead of hanging the unit \
+                     job (safe under nextest process-per-test isolation)."
+                );
+                std::process::abort();
+            }
+        })
+        .expect("spawn async-test watchdog thread");
+
+    let result = body();
+    done.store(true, Ordering::Release);
+    let _ = watchdog.join();
+    result
+}
 
 /// Run a synchronous-in-async test body without a tokio runtime.
 ///
@@ -36,7 +89,12 @@ pub fn run_sync<F, T>(f: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    futures::executor::block_on(f)
+    // The "no yield points → can't hang" assumption did NOT hold for the Volcano
+    // streaming path (`native_volcano_stream_*` intermittently hung past 120s in
+    // CI): `try_unfold` + the executor's `std::sync::Mutex` object pools can
+    // deadlock the single block_on thread. The watchdog bounds that to a fast,
+    // clear failure.
+    with_watchdog(|| futures::executor::block_on(f))
 }
 
 /// Run an async test body on a single-threaded tokio runtime with a bounded
@@ -61,13 +119,21 @@ pub fn run_with_timeout<F, T>(timeout_secs: u64, f: F) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("failed to build current_thread tokio runtime for test");
-    rt.block_on(async {
-        tokio::time::timeout(Duration::from_secs(timeout_secs), f)
-            .await
-            .expect("async test timed out — investigate for a genuine deadlock")
+    // The in-runtime `tokio::time::timeout` only fires for an *async* stall; if the
+    // future BLOCKS the current_thread runtime's only thread (a sync deadlock), the
+    // timer can never run and the 30s cap never triggers — which is exactly how the
+    // streaming/DataFusion tests rode to nextest's 120s slow-timeout. Keep the inner
+    // tokio timeout as the graceful path, and wrap the whole thing in the watchdog
+    // so a thread-blocking hang is still bounded (via abort) rather than indefinite.
+    with_watchdog(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build current_thread tokio runtime for test");
+        rt.block_on(async {
+            tokio::time::timeout(Duration::from_secs(timeout_secs), f)
+                .await
+                .expect("async test timed out — investigate for a genuine deadlock")
+        })
     })
 }


### PR DESCRIPTION
## Summary

Fixes the recurring intermittent CI hang in the unit-test job — `native_volcano_stream_*` and `datafusion_engine_streams_sql_over_parquet` going SLOW >120s, timing out, and being retried (the ~20-min tax + flaky failures behind CLAUDE.md #11). **It is a real deadlock, not just a test-timing issue, and it is reachable in production.**

## Root cause (stack-sampled)

A `sample` of a wedged process pinned the deadlock exactly:
```
ValuesExec::next_row
  -> LazyLock::force            (builtin ProximaFunctionRegistry init)
    -> alias_scalar
      -> DashMap::insert -> RawRwLock::lock_exclusive_slow   (parked forever)
```
`ProximaFunctionRegistry::alias_scalar` held the target's `get` `Ref` (a DashMap shard **read**-lock) across the alias `insert` (a shard **write**-lock):
```rust
if let Some(def) = self.scalars.get(&target) {   // read-guard held...
    self.scalars.insert(alias, def.clone());     // ...write-locks a shard -> self-deadlock
}
```
When `alias` and `target` hash to the **same shard** the write-lock blocks on the still-held read-lock on the **same thread**. DashMap's hasher is **random-seeded per process**, so the collision — and the hang — was intermittent (~1-2%/run). The builtin registry inits on the **server's first SQL-function call**, so this is a latent **production** deadlock, not only a test flake.

## Fix

1. **Root cause** (`proximadb-functions`): clone the target out and **drop the read-guard before inserting** (standard DashMap re-entrancy discipline). `alias_scalar` is the only such site (other `get` calls already `.map(clone)` and drop immediately).
2. **Regression test**: 256 aliases over one target make a same-shard collision near-certain — wedges WITHOUT the fix, instant WITH it.
3. **Defense-in-depth** (`test_runtime`): `run_sync`/`run_with_timeout` now bound any future hang with an **independent watchdog thread** that aborts at 30s. The in-runtime `tokio::time::timeout` could **not** catch this — the single runtime thread was the wedged one, so the timer never ran. Under nextest's process-per-test isolation, abort fails only this test, fast, instead of riding to the 120s slow-timeout + retries.

## Verification

- Stack-sampled the live deadlock (root cause is certain, not inferred).
- `proximadb-functions` regression test passes.
- **150× stress of the previously-flaky `native_volcano_stream_enforces_row_limit` -> 0 hangs** (reproduced at iters 1 and 12 BEFORE the fix).
- CI-exact `clippy -p proximadb-functions -p proximadb --lib --bins -- -D warnings` clean; fmt clean.

Once merged, the recurring unit-job flake is gone for **all** branches.
