### PR TITLE
feat(catalog): ADR-031/TD-181 P0 — stable object_id for indexes (Phase 0 tail)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -1387,6 +1387,13 @@ fn measured_ratio(raw_bytes: u64, encoded_bytes: u64) -> f64 {
 /// Index definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CatalogIndex {
+    /// ADR-031 / TD-181 P0: stable, immutable `u64` catalog object identity,
+    /// minted from the single system-wide catalog sequence (globally unique,
+    /// never reused) — the same sequence that mints table and namespace oids.
+    /// Additive + `#[serde(default)]`, so legacy persisted indexes load as
+    /// `None` (mixed-read-safe; backfilled on first allocation pass).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_id: Option<u64>,
     /// Index name
     pub name: String,
     /// Indexed columns
@@ -1407,6 +1414,7 @@ impl CatalogIndex {
         index_type: CatalogIndexType,
     ) -> Self {
         Self {
+            object_id: None,
             name: name.into(),
             columns,
             index_type,
@@ -1418,6 +1426,12 @@ impl CatalogIndex {
     /// Set unique
     pub fn unique(mut self) -> Self {
         self.is_unique = true;
+        self
+    }
+
+    /// Set the stable `u64` catalog object identity (ADR-031 / TD-181 P0).
+    pub fn with_object_id(mut self, object_id: u64) -> Self {
+        self.object_id = Some(object_id);
         self
     }
 }

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -525,6 +525,13 @@ impl NativeCatalog {
                 .await
                 .insert(id, identifier.clone());
         }
+        // ADR-031 / TD-181 P0: recover the floor from persisted index object_ids
+        // too (indexes ride in the table's schema), so a restart never reuses one.
+        for index in &meta.schema.indexes {
+            if let Some(id) = index.object_id {
+                self.object_id_allocator.raise_floor(id + 1);
+            }
+        }
 
         // Cache in memory
         self.tables.write().await.insert(key, meta.clone());
@@ -768,6 +775,16 @@ impl Catalog for NativeCatalog {
         match schema.object_id {
             None => schema.object_id = Some(self.object_id_allocator.allocate()),
             Some(id) => self.object_id_allocator.raise_floor(id + 1),
+        }
+
+        // ADR-031 / TD-181 P0: mint object_ids for any indexes carried in the
+        // schema (CTAS / import) from the same single sequence; a caller-supplied
+        // id raises the floor instead of being reused.
+        for index in &mut schema.indexes {
+            match index.object_id {
+                None => index.object_id = Some(self.object_id_allocator.allocate()),
+                Some(id) => self.object_id_allocator.raise_floor(id + 1),
+            }
         }
 
         // Check namespace exists
@@ -1036,6 +1053,15 @@ impl Catalog for NativeCatalog {
                     identifier
                 ));
             }
+        }
+
+        // ADR-031 / TD-181 P0: mint the index object_id from the shared sequence
+        // (a caller-supplied id raises the floor; never reused). Allocated after
+        // the dup/column validation so a rejected create doesn't burn an id.
+        let mut index = index;
+        match index.object_id {
+            None => index.object_id = Some(self.object_id_allocator.allocate()),
+            Some(id) => self.object_id_allocator.raise_floor(id + 1),
         }
 
         meta.schema.indexes.push(index.clone());
@@ -1661,6 +1687,90 @@ mod tests {
             .unwrap()
             .object_id
             .expect("namespace object_id");
+        assert!(
+            next > existing,
+            "reload recovered the floor: {next} > {existing}"
+        );
+    }
+
+    // ── ADR-031 / TD-181 P0 tail: index object_id ────────────────────
+
+    #[tokio::test]
+    async fn create_index_assigns_object_id_from_shared_sequence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let id = TableIdentifier::new(ns.clone(), "tbl");
+        let tbl_oid = cat
+            .create_table(&id, schema_with_id_col("tbl"))
+            .await
+            .unwrap()
+            .object_id
+            .expect("table object_id");
+
+        let created = cat
+            .create_index(
+                &id,
+                crate::CatalogIndex::new(
+                    "idx_id",
+                    vec!["id".to_string()],
+                    crate::CatalogIndexType::BTree,
+                ),
+            )
+            .await
+            .unwrap();
+        let idx_oid = created.object_id.expect("index got an object_id");
+
+        assert!(idx_oid >= 1, "ids start at 1, got {idx_oid}");
+        assert_ne!(
+            idx_oid, tbl_oid,
+            "one shared sequence: index and table oids never collide"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_object_id_recovered_on_reload_prevents_reuse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = vec!["t".to_string()];
+        let id = TableIdentifier::new(ns.clone(), "tbl");
+        let existing = {
+            let cat = fresh_catalog(&tmp).await;
+            cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+            cat.create_table(&id, schema_with_id_col("tbl"))
+                .await
+                .unwrap();
+            cat.create_index(
+                &id,
+                crate::CatalogIndex::new(
+                    "idx_a",
+                    vec!["id".to_string()],
+                    crate::CatalogIndexType::BTree,
+                ),
+            )
+            .await
+            .unwrap()
+            .object_id
+            .expect("index object_id")
+        };
+
+        // Cold restart: create_index loads the table first (load_table), which
+        // recovers the allocator floor from the persisted index object_id so the
+        // next index never reuses it.
+        let cat2 = fresh_catalog(&tmp).await;
+        let next = cat2
+            .create_index(
+                &id,
+                crate::CatalogIndex::new(
+                    "idx_b",
+                    vec!["id".to_string()],
+                    crate::CatalogIndexType::BTree,
+                ),
+            )
+            .await
+            .unwrap()
+            .object_id
+            .expect("index object_id");
         assert!(
             next > existing,
             "reload recovered the floor: {next} > {existing}"


### PR DESCRIPTION
## What

Continues the **TD-181 catalog-OID migration** (plan: `CATALOG_OID_MIGRATION_2026_06_27.adoc`; decision: ADR-031). Adds the stable `u64` catalog `object_id` to **indexes**, rounding out Phase 0 for the addressable catalog object types — **table** and **namespace** already landed (#454).

**Column `object_id` is deliberately deferred to P2.** That's where `column.table_oid` references actually consume column identity; meanwhile a column's physical identity is already its `i32` Iceberg field-id (ADR-031 reconciliation amendment 4 — both coexist by role), and adding the catalog oid now would be 21 struct-literal sites across 9 files (incl. the main crate) with **no current consumer**. Index, by contrast, has zero literal sites (all `CatalogIndex::new()`), so it's a clean low-churn increment.

## How

- **`CatalogIndex.object_id: Option<u64>`** — additive, `#[serde(default)]`, `skip_serializing_if = None` (legacy persisted indexes load as `None`; mixed-read-safe). No construction churn: all 20 sites go through `CatalogIndex::new()` (updated to `None`); `with_object_id()` builder added.
- **`create_index`** mints the oid from the **same** `object_id_allocator` as table/namespace — one system-wide sequence (amendment 1) — *after* the dup/column validation so a rejected create doesn't burn an id.
- **`create_table`** mints oids for any indexes carried in the schema (CTAS/import).
- **`load_table`** recovers the allocator floor from persisted index oids so a restart never reuses one.

## Tests / verification

- New: `create_index_assigns_object_id_from_shared_sequence` (index oid distinct + never collides with the table oid — one shared sequence), `index_object_id_recovered_on_reload_prevents_reuse`. All 10 `object_id` tests pass.
- `cargo clippy --lib --bins -- -D warnings` clean (server builds).

Additive substrate (nothing physical keys on `index.object_id` yet). Phase 0 of CATALOG_OID_MIGRATION_2026_06_27. Refs ADR-031, TD-181.