### PR TITLE
feat(fusion): TD-141 RoutePolicy cost routing in graph fusion (rescued from #257)

### DIFF
--- a/clients/go/proximadb/internal/genrest/genrest.gen.go
+++ b/clients/go/proximadb/internal/genrest/genrest.gen.go
@@ -459,11 +459,16 @@ type FusionSearchRequest struct {
 	// MaxSeeds How many of the top vector seeds to expand from (bounded expansion).
 	MaxSeeds *int `json:"max_seeds,omitempty"`
 
+	// MinWeightFraction Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.
+	// When absent, fusion is unbounded.
+	MinWeightFraction *float32 `json:"min_weight_fraction"`
+
 	// QueryVector Query embedding for the ANN seed.
 	QueryVector []float32 `json:"query_vector"`
 
 	// Rrf Use the rank-based RRF fallback instead of PIT-calibrated linear.
-	Rrf *bool `json:"rrf,omitempty"`
+	Rrf         *bool `json:"rrf,omitempty"`
+	TotalBudget *int  `json:"total_budget"`
 
 	// VectorCollection Vector collection to seed from (its records co-indexed with this graph by `oid`).
 	VectorCollection string   `json:"vector_collection"`

--- a/clients/nodejs-embedded/package-lock.json
+++ b/clients/nodejs-embedded/package-lock.json
@@ -112,7 +112,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -125,7 +124,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -557,7 +555,6 @@
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -568,7 +565,6 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -1458,7 +1454,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1677,7 +1672,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1706,7 +1700,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1785,7 +1778,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -1893,7 +1885,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/clients/nodejs-embedded/src/generated/schema.ts
+++ b/clients/nodejs-embedded/src/generated/schema.ts
@@ -1200,10 +1200,17 @@ export interface components {
             max_depth?: number;
             /** @description How many of the top vector seeds to expand from (bounded expansion). */
             max_seeds?: number;
+            /**
+             * Format: float
+             * @description Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.
+             *     When absent, fusion is unbounded.
+             */
+            min_weight_fraction?: number | null;
             /** @description Query embedding for the ANN seed. */
             query_vector: number[];
             /** @description Use the rank-based RRF fallback instead of PIT-calibrated linear. */
             rrf?: boolean;
+            total_budget?: number | null;
             /** @description Vector collection to seed from (its records co-indexed with this graph by `oid`). */
             vector_collection: string;
             /** Format: float */

--- a/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_search_request.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_search_request.py
@@ -27,7 +27,11 @@ class FusionSearchRequest:
         limit (Union[Unset, int]):
         max_depth (Union[Unset, int]): k-hop expansion depth (bounded; default 1 — the validated sweet spot).
         max_seeds (Union[Unset, int]): How many of the top vector seeds to expand from (bounded expansion).
+        min_weight_fraction (Union[None, Unset, float]): Cost-routing policy inputs (TD-141): drop negligible modalities
+            (weight fraction) and budget each.
+            When absent, fusion is unbounded.
         rrf (Union[Unset, bool]): Use the rank-based RRF fallback instead of PIT-calibrated linear.
+        total_budget (Union[None, Unset, int]):
         vector_weight (Union[None, Unset, float]):
     """
 
@@ -40,7 +44,9 @@ class FusionSearchRequest:
     limit: Union[Unset, int] = UNSET
     max_depth: Union[Unset, int] = UNSET
     max_seeds: Union[Unset, int] = UNSET
+    min_weight_fraction: Union[None, Unset, float] = UNSET
     rrf: Union[Unset, bool] = UNSET
+    total_budget: Union[None, Unset, int] = UNSET
     vector_weight: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -77,7 +83,19 @@ class FusionSearchRequest:
 
         max_seeds = self.max_seeds
 
+        min_weight_fraction: Union[None, Unset, float]
+        if isinstance(self.min_weight_fraction, Unset):
+            min_weight_fraction = UNSET
+        else:
+            min_weight_fraction = self.min_weight_fraction
+
         rrf = self.rrf
+
+        total_budget: Union[None, Unset, int]
+        if isinstance(self.total_budget, Unset):
+            total_budget = UNSET
+        else:
+            total_budget = self.total_budget
 
         vector_weight: Union[None, Unset, float]
         if isinstance(self.vector_weight, Unset):
@@ -107,8 +125,12 @@ class FusionSearchRequest:
             field_dict["max_depth"] = max_depth
         if max_seeds is not UNSET:
             field_dict["max_seeds"] = max_seeds
+        if min_weight_fraction is not UNSET:
+            field_dict["min_weight_fraction"] = min_weight_fraction
         if rrf is not UNSET:
             field_dict["rrf"] = rrf
+        if total_budget is not UNSET:
+            field_dict["total_budget"] = total_budget
         if vector_weight is not UNSET:
             field_dict["vector_weight"] = vector_weight
 
@@ -156,7 +178,27 @@ class FusionSearchRequest:
 
         max_seeds = d.pop("max_seeds", UNSET)
 
+        def _parse_min_weight_fraction(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        min_weight_fraction = _parse_min_weight_fraction(
+            d.pop("min_weight_fraction", UNSET)
+        )
+
         rrf = d.pop("rrf", UNSET)
+
+        def _parse_total_budget(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        total_budget = _parse_total_budget(d.pop("total_budget", UNSET))
 
         def _parse_vector_weight(data: object) -> Union[None, Unset, float]:
             if data is None:
@@ -177,7 +219,9 @@ class FusionSearchRequest:
             limit=limit,
             max_depth=max_depth,
             max_seeds=max_seeds,
+            min_weight_fraction=min_weight_fraction,
             rrf=rrf,
+            total_budget=total_budget,
             vector_weight=vector_weight,
         )
 

--- a/clients/rust/src/genrest.rs
+++ b/clients/rust/src/genrest.rs
@@ -2525,6 +2525,14 @@ pub mod types {
     ///      "type": "integer",
     ///      "minimum": 0.0
     ///    },
+    ///    "min_weight_fraction": {
+    ///      "description": "Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.\nWhen absent, fusion is unbounded.",
+    ///      "type": [
+    ///        "number",
+    ///        "null"
+    ///      ],
+    ///      "format": "float"
+    ///    },
     ///    "query_vector": {
     ///      "description": "Query embedding for the ANN seed.",
     ///      "type": "array",
@@ -2536,6 +2544,13 @@ pub mod types {
     ///    "rrf": {
     ///      "description": "Use the rank-based RRF fallback instead of PIT-calibrated linear.",
     ///      "type": "boolean"
+    ///    },
+    ///    "total_budget": {
+    ///      "type": [
+    ///        "integer",
+    ///        "null"
+    ///      ],
+    ///      "minimum": 0.0
     ///    },
     ///    "vector_collection": {
     ///      "description": "Vector collection to seed from (its records co-indexed with this graph by `oid`).",
@@ -2572,11 +2587,17 @@ pub mod types {
         ///How many of the top vector seeds to expand from (bounded expansion).
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub max_seeds: ::std::option::Option<u64>,
+        /// Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.
+        /// When absent, fusion is unbounded.
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub min_weight_fraction: ::std::option::Option<f32>,
         ///Query embedding for the ANN seed.
         pub query_vector: ::std::vec::Vec<f32>,
         ///Use the rank-based RRF fallback instead of PIT-calibrated linear.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub rrf: ::std::option::Option<bool>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub total_budget: ::std::option::Option<u64>,
         ///Vector collection to seed from (its records co-indexed with this graph by `oid`).
         pub vector_collection: ::std::string::String,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -8754,8 +8775,11 @@ pub mod types {
             limit: ::std::result::Result<::std::option::Option<u64>, ::std::string::String>,
             max_depth: ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
             max_seeds: ::std::result::Result<::std::option::Option<u64>, ::std::string::String>,
+            min_weight_fraction:
+                ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
             query_vector: ::std::result::Result<::std::vec::Vec<f32>, ::std::string::String>,
             rrf: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
+            total_budget: ::std::result::Result<::std::option::Option<u64>, ::std::string::String>,
             vector_collection: ::std::result::Result<::std::string::String, ::std::string::String>,
             vector_weight: ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
         }
@@ -8769,8 +8793,10 @@ pub mod types {
                     limit: Ok(Default::default()),
                     max_depth: Ok(Default::default()),
                     max_seeds: Ok(Default::default()),
+                    min_weight_fraction: Ok(Default::default()),
                     query_vector: Err("no value supplied for query_vector".to_string()),
                     rrf: Ok(Default::default()),
+                    total_budget: Ok(Default::default()),
                     vector_collection: Err("no value supplied for vector_collection".to_string()),
                     vector_weight: Ok(Default::default()),
                 }
@@ -8847,6 +8873,16 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for max_seeds: {e}"));
                 self
             }
+            pub fn min_weight_fraction<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<f32>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.min_weight_fraction = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for min_weight_fraction: {e}")
+                });
+                self
+            }
             pub fn query_vector<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::vec::Vec<f32>>,
@@ -8865,6 +8901,16 @@ pub mod types {
                 self.rrf = value
                     .try_into()
                     .map_err(|e| format!("error converting supplied value for rrf: {e}"));
+                self
+            }
+            pub fn total_budget<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<u64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.total_budget = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for total_budget: {e}"));
                 self
             }
             pub fn vector_collection<T>(mut self, value: T) -> Self
@@ -8901,8 +8947,10 @@ pub mod types {
                     limit: value.limit?,
                     max_depth: value.max_depth?,
                     max_seeds: value.max_seeds?,
+                    min_weight_fraction: value.min_weight_fraction?,
                     query_vector: value.query_vector?,
                     rrf: value.rrf?,
+                    total_budget: value.total_budget?,
                     vector_collection: value.vector_collection?,
                     vector_weight: value.vector_weight?,
                 })
@@ -8918,8 +8966,10 @@ pub mod types {
                     limit: Ok(value.limit),
                     max_depth: Ok(value.max_depth),
                     max_seeds: Ok(value.max_seeds),
+                    min_weight_fraction: Ok(value.min_weight_fraction),
                     query_vector: Ok(value.query_vector),
                     rrf: Ok(value.rrf),
+                    total_budget: Ok(value.total_budget),
                     vector_collection: Ok(value.vector_collection),
                     vector_weight: Ok(value.vector_weight),
                 }

--- a/docs/openapi/proximadb-openapi.yaml
+++ b/docs/openapi/proximadb-openapi.yaml
@@ -755,6 +755,14 @@ components:
           description: How many of the top vector seeds to expand from (bounded expansion).
           minimum: 0
           type: integer
+        min_weight_fraction:
+          description: |-
+            Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.
+            When absent, fusion is unbounded.
+          format: float
+          type:
+          - number
+          - 'null'
         query_vector:
           description: Query embedding for the ANN seed.
           items:
@@ -764,6 +772,11 @@ components:
         rrf:
           description: Use the rank-based RRF fallback instead of PIT-calibrated linear.
           type: boolean
+        total_budget:
+          minimum: 0
+          type:
+          - integer
+          - 'null'
         vector_collection:
           description: Vector collection to seed from (its records co-indexed with this graph by `oid`).
           type: string

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -3709,6 +3709,7 @@ impl EmbeddedProximaDB {
                 self.shared_services.graph_service.clone(),
             );
             let params = GraphFusionParams {
+                route_policy: None,
                 graph_id: graph_id.to_string(),
                 vector_collection: vector_collection.to_string(),
                 query_vector,

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -484,6 +484,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 req.top_k as usize
             };
             let params = GraphFusionParams {
+                route_policy: None,
                 graph_id: collection.clone(),
                 vector_collection: collection.clone(),
                 query_vector,

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -101,6 +101,7 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
         };
 
         let params = GraphFusionParams {
+            route_policy: None,
             graph_id: req.graph_id.clone(),
             vector_collection: req.vector_collection.clone(),
             query_vector: req.query_vector.clone(),

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::core::search::cross_modal_fusion::{FusionPolicy, FusionStats};
+use crate::core::search::fusion_route::RoutePolicy;
 use crate::errors::{ApiError, ApiResult};
 use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::openapi::ErrorResponse;
@@ -54,6 +55,10 @@ pub struct FusionSearchRequest {
     pub consensus_beta: Option<f32>,
     /// Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`.
     pub grain: Option<String>,
+    /// Cost-routing policy inputs (TD-141): drop negligible modalities (weight fraction) and budget each.
+    /// When absent, fusion is unbounded.
+    pub min_weight_fraction: Option<f32>,
+    pub total_budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -162,6 +167,21 @@ pub async fn fusion_search_v2(
             _ => GraphGrain::Nodes,
         },
         principal: user_context.as_ref().map(|ctx| ctx.user_id.clone()),
+        route_policy: match (request.min_weight_fraction, request.total_budget) {
+            (Some(frac), Some(budget)) => Some(RoutePolicy {
+                min_weight_fraction: frac,
+                total_budget: budget,
+            }),
+            (Some(frac), None) => Some(RoutePolicy {
+                min_weight_fraction: frac,
+                total_budget: usize::MAX,
+            }),
+            (None, Some(budget)) => Some(RoutePolicy {
+                min_weight_fraction: 0.0,
+                total_budget: budget,
+            }),
+            (None, None) => None,
+        },
         policy,
         oid_key: FusionOidKey::Canonical,
     };

--- a/src/services/entity_orchestrator.rs
+++ b/src/services/entity_orchestrator.rs
@@ -329,6 +329,7 @@ impl EntityOrchestrator {
             // Vector mode → fusion seam (one retrieval engine; no ranking here).
             let limit = if top_k == 0 { 10 } else { top_k };
             let params = GraphFusionParams {
+                route_policy: None,
                 graph_id: collection.to_string(),
                 vector_collection: collection.to_string(),
                 query_vector,

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -25,6 +25,7 @@ use proximadb_records::{ProximaRecord, RecordKey};
 use crate::core::search::cross_modal_fusion::{
     FusedItem, Fuser, FusionPolicy, FusionStats, SourceCandidates, SourceId,
 };
+use crate::core::search::fusion_route::{RoutePolicy, plan_route};
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::graph::GraphOperationsService;
 use crate::graph::model::{Edge, Node};
@@ -374,6 +375,9 @@ pub struct GraphFusionParams {
     /// canonical record store is unwired or a record cannot be resolved (within-tenant RBAC only bites
     /// on records carrying explicit `permitted_principals`); the tenant boundary stays structural.
     pub principal: Option<String>,
+    /// Optional cost-routing policy (TD-141): budget each modality by weight and drop negligible ones.
+    /// When absent, fusion is unbounded (each source keeps its full candidate pool).
+    pub route_policy: Option<RoutePolicy>,
     pub policy: FusionPolicy,
     /// How source oids map to the fusion key (TD-142 / TD-146 scope B). Defaults to
     /// [`FusionOidKey::Canonical`] (co-indexed graph fusion). Entity search uses
@@ -541,6 +545,18 @@ impl FusionService {
             ));
         }
 
+        // 3c. Optional cost routing (TD-141): budget each modality by weight and drop negligible ones.
+        //     When a route policy is present, truncate each source to its allocated budget (top-k by
+        //     score), pre-fusion, so the calibrated blend works on the routed pool.
+        if let Some(ref policy) = params.route_policy {
+            let route = plan_route(&sources, policy);
+            for (source_id, budget) in route.budgets {
+                if let Some(source) = sources.iter_mut().find(|s| s.source == source_id) {
+                    truncate_source_to_budget(source, budget);
+                }
+            }
+        }
+
         // 4. Calibrate + fuse-by-oid + rank, OR the raw-union kill-switch fallback (TD-131). The OID
         //    set is identical between the two when `limit ≥ candidate count` — calibration only re-ranks.
         let result = if fusion_calibration_disabled() {
@@ -581,6 +597,20 @@ impl FusionService {
                 true
             }
         }
+    }
+}
+
+/// Truncate a source's candidate pool to the top `budget` entries by score (D9 per-modality budget).
+/// Scores are kept as-is; the fuser's PIT calibration will normalize them. In-place.
+fn truncate_source_to_budget(source: &mut SourceCandidates, budget: usize) {
+    if source.scores.len() <= budget {
+        return; // already within budget
+    }
+    // Collect into (oid, score) pairs, sort by score descending, keep top budget, rebuild.
+    let mut pairs: Vec<(String, f32)> = source.scores.drain().collect();
+    pairs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    for (oid, score) in pairs.into_iter().take(budget) {
+        source.scores.insert(oid, score);
     }
 }
 
@@ -873,5 +903,46 @@ mod tests {
             1,
         );
         assert_eq!(truncated.len(), 1, "limit truncates the raw union");
+    }
+
+    /// Cost routing truncates each source to its allocated budget (top-k by score), preserving the
+    /// highest-scoring candidates.
+    #[test]
+    fn truncate_source_to_budget_keeps_top_k_by_score() {
+        use crate::core::search::cross_modal_fusion::SourceId;
+
+        let mut source = SourceCandidates::new(
+            SourceId::Vector,
+            1.0,
+            HashMap::from([
+                ("a".to_string(), 0.9),
+                ("b".to_string(), 0.5),
+                ("c".to_string(), 0.7),
+                ("d".to_string(), 0.3),
+            ]),
+        );
+        truncate_source_to_budget(&mut source, 2);
+        assert_eq!(source.scores.len(), 2);
+        assert!(source.scores.contains_key("a"));
+        assert!(source.scores.contains_key("c"));
+        assert!(!source.scores.contains_key("d"));
+    }
+
+    /// When budget >= source size, truncation is a no-op.
+    #[test]
+    fn truncate_source_within_budget_is_noop() {
+        use crate::core::search::cross_modal_fusion::SourceId;
+
+        let mut source = SourceCandidates::new(
+            SourceId::Vector,
+            1.0,
+            HashMap::from([("a".to_string(), 0.9), ("b".to_string(), 0.5)]),
+        );
+        let original = source.scores.clone();
+        truncate_source_to_budget(&mut source, 10);
+        assert_eq!(
+            source.scores, original,
+            "no change when budget exceeds size"
+        );
     }
 }


### PR DESCRIPTION
Rescues TD-141 cost routing from closed #257 (rebased clean). route_policy (min_weight_fraction + total_budget) on GraphFusionParams + pre-fuse plan_route/truncate_source_to_budget; REST handler wired, other 4 sites default None. Document-modality commit dropped (outdated per-handler; TD-138 residual). clippy --lib --bins green.