### PR TITLE
feat(mcp): in-process reference MCP foundation — config flag + EngineBackend + HTTP transport (Stage 1a, ADR-037 Decision 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,6 +6593,7 @@ dependencies = [
  "proximadb-index-traits",
  "proximadb-index-types",
  "proximadb-kernel",
+ "proximadb-mcp",
  "proximadb-multimodel-plan",
  "proximadb-multimodel-query",
  "proximadb-object-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,7 @@ proximadb-quantization-types = { path = "crates/foundation/proximadb-quantizatio
 proximadb-catalog = { path = "crates/control/proximadb-catalog" }
 proximadb-api = { path = "crates/platform/proximadb-api" }
 proximadb-admin-ui = { path = "crates/platform/proximadb-admin-ui" }
+proximadb-mcp = { path = "crates/platform/proximadb-mcp" }
 proximadb-runtime = { path = "crates/platform/proximadb-runtime" }
 proximadb-codec = { path = "crates/horizontal/proximadb-codec" }
 proximadb-compression = { path = "crates/horizontal/proximadb-compression" }

--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -114,6 +114,15 @@ pub struct ApiConfig {
     #[serde(default)]
     pub pg_port: Option<u16>,
 
+    /// Optional port for the reference MCP (Model Context Protocol) surface
+    /// (ADR-037 Decision 5). When `None` (the default) the MCP transport is
+    /// **off** — it is bound only when a port is configured here (or via the
+    /// `[api]` TOML / env-var precedence). In-process: the MCP server projects
+    /// the engine's existing surfaces (stats/describe/explain/search) by calling
+    /// the services directly, so there is no separate process.
+    #[serde(default)]
+    pub mcp_port: Option<u16>,
+
     /// Network transport for the REST / gRPC / Arrow Flight surfaces.
     ///
     /// - `"tcp"` (default): bind TCP ports (`rest_port` / `grpc_port` /
@@ -182,6 +191,7 @@ impl Default for ApiConfig {
             http2_max_concurrent_streams: 1000,
             max_connections: 10000,
             pg_port: None,
+            mcp_port: None,
             transport: default_transport(),
             socket_dir: None,
         }

--- a/src/network/mcp/backend.rs
+++ b/src/network/mcp/backend.rs
@@ -1,0 +1,180 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! In-process `ReferenceBackend` (ADR-037 Decision 5).
+//!
+//! Projects the reference MCP tools onto the engine's existing services by
+//! calling them **directly** (no REST/gRPC self-hop): catalog list/describe via
+//! [`ApiHandlersPort`], the statistics envelope via the resident
+//! `statistics_registry`, and explain/search via the [`UnifiedQueryPort`] (which
+//! already returns `serde_json::Value`). The agent-state tools
+//! (`memory`/`checkpoint`/`event`) are deferred to Stage 2 (threading
+//! `AgenticGrpcBackend` into `AppState`) — they return an explicit "not yet
+//! wired in-process" rather than fabricate.
+
+use crate::core::statistics::{StatisticsSummary, statistics_registry};
+use crate::proto::proximadb_v1::{CollectionOperation, CollectionRequest};
+use async_trait::async_trait;
+use proximadb_mcp::{BackendError, ReferenceBackend};
+use proximadb_runtime::{ApiHandlersPort, UnifiedQueryPort};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+/// A `ReferenceBackend` that calls the engine's in-process services directly.
+pub struct EngineBackend {
+    api_handlers: Arc<dyn ApiHandlersPort>,
+    query: Option<Arc<dyn UnifiedQueryPort>>,
+    /// Tenant the MCP surface operates as. Stage 1 uses a single configured
+    /// tenant (or the port default when `None`); per-request tenant scoping from
+    /// MCP auth is a later refinement.
+    tenant: Option<String>,
+}
+
+impl EngineBackend {
+    pub fn new(
+        api_handlers: Arc<dyn ApiHandlersPort>,
+        query: Option<Arc<dyn UnifiedQueryPort>>,
+        tenant: Option<String>,
+    ) -> Self {
+        Self {
+            api_handlers,
+            query,
+            tenant,
+        }
+    }
+
+    fn tenant(&self) -> Option<&str> {
+        self.tenant.as_deref()
+    }
+
+    fn collection_request(
+        op: CollectionOperation,
+        collection_id: Option<String>,
+    ) -> CollectionRequest {
+        CollectionRequest {
+            operation: op as i32,
+            collection_id,
+            collection_config: None,
+            query_params: Default::default(),
+            options: Default::default(),
+            migration_config: Default::default(),
+        }
+    }
+}
+
+fn require_str(args: &Value, key: &str) -> Result<String, BackendError> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| BackendError::not_found(format!("missing required string arg `{key}`")))
+}
+
+/// The `query` arg as a query string (a string is used verbatim; any other
+/// non-null value is serialized — the engine routes/parses it).
+fn query_string(args: &Value) -> Result<String, BackendError> {
+    match args.get("query") {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(v) if !v.is_null() => Ok(v.to_string()),
+        _ => Err(BackendError::not_found(
+            "missing required `query` (a query string)".to_string(),
+        )),
+    }
+}
+
+fn not_wired(tool: &str) -> BackendError {
+    BackendError::internal(format!(
+        "`{tool}` (ADR-022 agent state) is not yet wired in-process; Stage 2 threads \
+         AgenticGrpcBackend into AppState to enable it"
+    ))
+}
+
+#[async_trait]
+impl ReferenceBackend for EngineBackend {
+    async fn list_collections(&self, _args: &Value) -> Result<Value, BackendError> {
+        let req = Self::collection_request(CollectionOperation::CollectionList, None);
+        let resp = self
+            .api_handlers
+            .handle_collection_operation_for_tenant(req, self.tenant())
+            .await
+            .map_err(|e| BackendError::internal(format!("list collections failed: {e}")))?;
+        let collections: Vec<Value> = resp
+            .collections
+            .into_iter()
+            .map(|c| {
+                let cfg = c.config.unwrap_or_default();
+                let stats = c.stats.unwrap_or_default();
+                let id = if c.id.is_empty() { cfg.name.clone() } else { c.id };
+                json!({ "collection_id": id, "name": cfg.name, "record_count": stats.vector_count.max(0) })
+            })
+            .collect();
+        Ok(json!({ "collections": collections }))
+    }
+
+    async fn describe(&self, args: &Value) -> Result<Value, BackendError> {
+        let id = require_str(args, "collection_id")?;
+        let req = Self::collection_request(CollectionOperation::CollectionGet, Some(id.clone()));
+        let resp = self
+            .api_handlers
+            .handle_collection_operation_for_tenant(req, self.tenant())
+            .await
+            .map_err(|e| BackendError::internal(format!("describe failed: {e}")))?;
+        let c = resp
+            .collection
+            .ok_or_else(|| BackendError::not_found(format!("collection `{id}` not found")))?;
+        let cfg = c.config.unwrap_or_default();
+        let stats = c.stats.unwrap_or_default();
+        Ok(json!({
+            "collection_id": if c.id.is_empty() { id } else { c.id },
+            "name": cfg.name,
+            "dimension": cfg.dimension,
+            "record_count": stats.vector_count.max(0),
+            "storage_size_bytes": stats.data_size_bytes.max(0),
+            "index_size_bytes": stats.index_size_bytes.max(0),
+        }))
+    }
+
+    async fn stats(&self, args: &Value) -> Result<Value, BackendError> {
+        let id = require_str(args, "collection_id")?;
+        // Resident envelope from the flush/compaction write boundary; an empty
+        // (epoch-watermark) envelope when no snapshot has populated one yet.
+        let envelope = statistics_registry()
+            .envelope(&id)
+            .unwrap_or_else(|| StatisticsSummary::new(&id).to_envelope());
+        serde_json::to_value(&envelope)
+            .map_err(|e| BackendError::internal(format!("serialize envelope failed: {e}")))
+    }
+
+    async fn explain(&self, args: &Value) -> Result<Value, BackendError> {
+        let id = require_str(args, "collection_id")?;
+        let q = query_string(args)?;
+        let port = self
+            .query
+            .as_ref()
+            .ok_or_else(|| BackendError::internal("query facade not available".to_string()))?;
+        port.explain_unified_query(q, Some(id))
+            .await
+            .map_err(|e| BackendError::internal(format!("explain failed: {e}")))
+    }
+
+    async fn search(&self, args: &Value) -> Result<Value, BackendError> {
+        let id = require_str(args, "collection_id")?;
+        let q = query_string(args)?;
+        let limit = args.get("k").and_then(Value::as_u64).map(|k| k as u32);
+        let port = self
+            .query
+            .as_ref()
+            .ok_or_else(|| BackendError::internal("query facade not available".to_string()))?;
+        port.execute_unified_query(q, None, Some(id), limit)
+            .await
+            .map_err(|e| BackendError::internal(format!("search failed: {e}")))
+    }
+
+    async fn memory(&self, _args: &Value) -> Result<Value, BackendError> {
+        Err(not_wired("memory"))
+    }
+    async fn checkpoint(&self, _args: &Value) -> Result<Value, BackendError> {
+        Err(not_wired("checkpoint"))
+    }
+    async fn event(&self, _args: &Value) -> Result<Value, BackendError> {
+        Err(not_wired("event"))
+    }
+}

--- a/src/network/mcp/mod.rs
+++ b/src/network/mcp/mod.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! In-process reference MCP transport (ADR-037 Decision 5).
+//!
+//! Exposes the reference MCP surface as another transport on the engine — an
+//! HTTP JSON-RPC endpoint, bound **only when `api.mcp_port` is configured** (off
+//! by default, so an un-configured deployment runs no MCP surface and no extra
+//! process). Reuses the `proximadb-mcp` crate (protocol + tool catalog +
+//! dispatch) over the in-process [`EngineBackend`], which calls the engine's
+//! services directly.
+//!
+//! Framing: request/response JSON-RPC over `POST` (one message per request). SSE
+//! / streamable-HTTP for server-initiated messages is a later refinement;
+//! the data tools (list/describe/stats/explain/search) are request/response.
+
+pub mod backend;
+
+pub use backend::EngineBackend;
+
+use axum::{Router, extract::State, response::Json, routing::post};
+use proximadb_mcp::{JsonRpcRequest, handle_request};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+/// Build the MCP HTTP router over the given backend (`POST /` and `POST /mcp`).
+pub fn router(backend: Arc<EngineBackend>) -> Router {
+    Router::new()
+        .route("/", post(rpc))
+        .route("/mcp", post(rpc))
+        .with_state(backend)
+}
+
+async fn rpc(State(backend): State<Arc<EngineBackend>>, body: String) -> Json<Value> {
+    let req: JsonRpcRequest = match serde_json::from_str(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            return Json(json!({
+                "jsonrpc": "2.0",
+                "id": Value::Null,
+                "error": { "code": -32700, "message": format!("parse error: {e}") }
+            }));
+        }
+    };
+    match handle_request(backend.as_ref(), req).await {
+        Some(resp) => Json(serde_json::to_value(resp).unwrap_or_else(|_| {
+            json!({ "jsonrpc": "2.0", "id": Value::Null, "error": { "code": -32603, "message": "serialize failed" } })
+        })),
+        // Notification (no id) → no response body.
+        None => Json(Value::Null),
+    }
+}
+
+/// Serve the MCP transport on `addr` until shutdown. Call only when an MCP port
+/// is configured.
+pub async fn serve(addr: std::net::SocketAddr, backend: Arc<EngineBackend>) -> anyhow::Result<()> {
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(
+        "MCP reference surface listening on {addr} (MCP {})",
+        proximadb_mcp::MCP_PROTOCOL_VERSION
+    );
+    axum::serve(listener, router(backend)).await?;
+    Ok(())
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -179,6 +179,9 @@ pub mod auth;
 pub mod grpc;
 /// Hybrid (vector + BM25 text) search execution engine
 pub mod hybrid_search;
+/// In-process reference MCP transport (ADR-037 Decision 5) — bound only when
+/// `api.mcp_port` is configured (off by default).
+pub mod mcp;
 /// Metrics endpoints (Prometheus, JSON, health)
 pub mod metrics_service;
 /// HTTP middleware stack (auth, CORS, rate limiting, TLS)


### PR DESCRIPTION
Stage 1a of the **in-process** reference MCP surface — it runs inside the main server (no separate process/container), as another transport, and is **off by default** (bound only when a port is configured). Builds on the merged `proximadb-mcp` crate (protocol + tool catalog + dispatch).

## What's here
- **`ApiConfig.mcp_port: Option<u16>`** — unset ⇒ off (mirrors the `pg_port` gating).
- **`EngineBackend`** (`src/network/mcp/backend.rs`) — `impl ReferenceBackend` calling the engine's services **directly** (no REST/gRPC self-hop): `stats`→`statistics_registry()`, `list_collections`/`describe`→`ApiHandlersPort`, `explain`/`search`→`UnifiedQueryPort`. The ADR-022 agent-state tools (`memory`/`checkpoint`/`event`) return an explicit *not yet wired in-process* (Stage 2) rather than fabricate.
- **MCP HTTP transport** (`src/network/mcp/mod.rs`) — JSON-RPC over `POST`; `mcp::serve` gated by the caller.

## Why in-process (not a separate proxy)
Avoids an extra process/container + a self-REST hop, coexists with REST/gRPC/Flight (mandate #3), and lets the backend call the agent/query services directly — so the gRPC-only agent services don't need REST mirrors.

## Verified
Server lib builds; `cargo fmt --all` + `clippy` clean.

## Stage 1b (follow-up)
Wire `mcp::serve` into `MultiServer`'s start paths (gated on `mcp_port`) and resolve the `UnifiedQueryPort` plumbing at the spawn site so `explain`/`search` are live there. Stage 2: thread `AgenticGrpcBackend` into `AppState` to enable the agent-state tools.