### PR TITLE
fix(test): bound known async-test hang via real wall-clock watchdog + route bypassing tests through it

### DIFF
--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -446,20 +446,25 @@ mod tests {
         assert_eq!(normalize_table_key("\"Mixed\""), "mixed");
     }
 
-    #[tokio::test]
-    async fn dispatcher_rejects_unimplemented_backend_with_typed_error() {
-        let err = execute_sql_with_backend(
-            ComputeBackend::DataFusionDistributed,
-            "SELECT 1",
-            QueryExecutionContext::default(),
-        )
-        .await
-        .expect_err("distributed execution is not implemented");
+    // Watchdog-wrapped (`run_sync`): a bare `#[tokio::test]` here has no 30s bound,
+    // so the multi-threaded-runtime hang (CLAUDE.md #11) rides to nextest's 120s
+    // slow-timeout. These Volcano tests are pure compute (no real `.await` I/O).
+    #[test]
+    fn dispatcher_rejects_unimplemented_backend_with_typed_error() {
+        crate::query::execution::test_runtime::run_sync(async {
+            let err = execute_sql_with_backend(
+                ComputeBackend::DataFusionDistributed,
+                "SELECT 1",
+                QueryExecutionContext::default(),
+            )
+            .await
+            .expect_err("distributed execution is not implemented");
 
-        assert!(matches!(
-            err,
-            ExecutionError::UnsupportedBackend(ComputeBackend::DataFusionDistributed)
-        ));
+            assert!(matches!(
+                err,
+                ExecutionError::UnsupportedBackend(ComputeBackend::DataFusionDistributed)
+            ));
+        });
     }
 
     #[test]
@@ -496,46 +501,50 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn native_volcano_adapter_executes_values_plan() {
-        let result = NativeVolcanoEngine::execute_physical(
-            values_plan(),
-            &EmptyReaderFactory,
-            ExecutionControls::default(),
-        )
-        .await
-        .expect("values plan should execute");
+    #[test]
+    fn native_volcano_adapter_executes_values_plan() {
+        crate::query::execution::test_runtime::run_sync(async {
+            let result = NativeVolcanoEngine::execute_physical(
+                values_plan(),
+                &EmptyReaderFactory,
+                ExecutionControls::default(),
+            )
+            .await
+            .expect("values plan should execute");
 
-        assert_eq!(result.schema.columns[0].name, "id");
-        assert_eq!(
-            result.rows,
-            vec![vec![ProximaValue::Int64(1)], vec![ProximaValue::Int64(2)]]
-        );
+            assert_eq!(result.schema.columns[0].name, "id");
+            assert_eq!(
+                result.rows,
+                vec![vec![ProximaValue::Int64(1)], vec![ProximaValue::Int64(2)]]
+            );
+        });
     }
 
-    #[tokio::test]
-    async fn native_volcano_metered_adapter_returns_rows_and_metrics() {
-        let plan = PhysicalPlan::Limit {
-            input: Box::new(values_plan()),
-            limit: Some(1),
-            offset: 0,
-        };
-        let (result, metrics) = NativeVolcanoEngine::execute_physical_metered(
-            plan,
-            &EmptyReaderFactory,
-            ExecutionControls::default(),
-        )
-        .await
-        .expect("metered values plan should execute");
+    #[test]
+    fn native_volcano_metered_adapter_returns_rows_and_metrics() {
+        crate::query::execution::test_runtime::run_sync(async {
+            let plan = PhysicalPlan::Limit {
+                input: Box::new(values_plan()),
+                limit: Some(1),
+                offset: 0,
+            };
+            let (result, metrics) = NativeVolcanoEngine::execute_physical_metered(
+                plan,
+                &EmptyReaderFactory,
+                ExecutionControls::default(),
+            )
+            .await
+            .expect("metered values plan should execute");
 
-        assert_eq!(result.rows, vec![vec![ProximaValue::Int64(1)]]);
-        let labels: Vec<&str> = metrics.iter().map(|m| m.label.as_str()).collect();
-        assert_eq!(labels, vec!["Limit", "Values"]);
-        assert_eq!(
-            metrics.iter().map(|m| m.arity).collect::<Vec<_>>(),
-            vec![1, 0]
-        );
-        assert_eq!(metrics[0].rows, 1);
+            assert_eq!(result.rows, vec![vec![ProximaValue::Int64(1)]]);
+            let labels: Vec<&str> = metrics.iter().map(|m| m.label.as_str()).collect();
+            assert_eq!(labels, vec!["Limit", "Values"]);
+            assert_eq!(
+                metrics.iter().map(|m| m.arity).collect::<Vec<_>>(),
+                vec![1, 0]
+            );
+            assert_eq!(metrics[0].rows, 1);
+        });
     }
 
     #[test]
@@ -674,39 +683,43 @@ mod tests {
         });
     }
 
-    #[tokio::test]
-    async fn native_volcano_materialized_truncates_without_error() {
-        let controls = ExecutionControls {
-            max_rows: Some(1),
-            row_limit_mode: RowLimitMode::Truncate,
-            ..Default::default()
-        };
-        let result =
-            NativeVolcanoEngine::execute_physical(values_plan(), &EmptyReaderFactory, controls)
-                .await
-                .expect("truncate mode returns the capped result, not an error");
+    #[test]
+    fn native_volcano_materialized_truncates_without_error() {
+        crate::query::execution::test_runtime::run_sync(async {
+            let controls = ExecutionControls {
+                max_rows: Some(1),
+                row_limit_mode: RowLimitMode::Truncate,
+                ..Default::default()
+            };
+            let result =
+                NativeVolcanoEngine::execute_physical(values_plan(), &EmptyReaderFactory, controls)
+                    .await
+                    .expect("truncate mode returns the capped result, not an error");
 
-        assert_eq!(result.rows, vec![vec![ProximaValue::Int64(1)]]);
+            assert_eq!(result.rows, vec![vec![ProximaValue::Int64(1)]]);
+        });
     }
 
-    #[tokio::test]
-    async fn native_volcano_materialized_errors_on_overflow() {
-        let controls = ExecutionControls {
-            max_rows: Some(1),
-            row_limit_mode: RowLimitMode::Error,
-            ..Default::default()
-        };
-        let err =
-            NativeVolcanoEngine::execute_physical(values_plan(), &EmptyReaderFactory, controls)
-                .await
-                .expect_err("error mode rejects an oversized result");
+    #[test]
+    fn native_volcano_materialized_errors_on_overflow() {
+        crate::query::execution::test_runtime::run_sync(async {
+            let controls = ExecutionControls {
+                max_rows: Some(1),
+                row_limit_mode: RowLimitMode::Error,
+                ..Default::default()
+            };
+            let err =
+                NativeVolcanoEngine::execute_physical(values_plan(), &EmptyReaderFactory, controls)
+                    .await
+                    .expect_err("error mode rejects an oversized result");
 
-        assert!(matches!(
-            err,
-            ExecutionError::RowLimitExceeded {
-                limit: 1,
-                actual: 2
-            }
-        ));
+            assert!(matches!(
+                err,
+                ExecutionError::RowLimitExceeded {
+                    limit: 1,
+                    actual: 2
+                }
+            ));
+        });
     }
 }

--- a/src/query/execution/test_runtime.rs
+++ b/src/query/execution/test_runtime.rs
@@ -25,7 +25,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Hard wall-clock cap for hang-prone async tests. Well above their real runtime
 /// (<1s) but far below nextest's 120s slow-timeout, so a genuine hang fails the
@@ -51,21 +51,28 @@ fn with_watchdog<T>(body: impl FnOnce() -> T) -> T {
     let watchdog = std::thread::Builder::new()
         .name("async-test-watchdog".to_string())
         .spawn(move || {
-            let deadline = TEST_WATCHDOG_TIMEOUT;
+            // Bound by REAL wall-clock via `Instant::elapsed`, never by accumulating
+            // nominal sleep durations. On the oversubscribed CI runner this watchdog
+            // exists to protect (nextest fans out test-threads = ncpu while the host is
+            // contended), `thread::sleep(50ms)` overshoots, so summing the *nominal*
+            // 50ms steps reaches the 30s deadline only after far more than 30s of real
+            // time — dilating the bound toward (and past) nextest's 120s slow-timeout,
+            // the very hang it is meant to cut short. `Instant` is immune to that.
             let step = Duration::from_millis(50);
-            let mut waited = Duration::ZERO;
-            while waited < deadline {
+            let start = Instant::now();
+            while start.elapsed() < TEST_WATCHDOG_TIMEOUT {
                 if watchdog_done.load(Ordering::Acquire) {
                     return;
                 }
                 std::thread::sleep(step);
-                waited += step;
             }
             if !watchdog_done.load(Ordering::Acquire) {
                 eprintln!(
-                    "FATAL: async test exceeded {TEST_WATCHDOG_TIMEOUT:?} — a streaming/runtime \
-                     deadlock (CLAUDE.md #11). Aborting to fail fast instead of hanging the unit \
-                     job (safe under nextest process-per-test isolation)."
+                    "FATAL: async test exceeded {TEST_WATCHDOG_TIMEOUT:?} (real elapsed \
+                     {:.1}s) — a streaming/runtime deadlock (CLAUDE.md #11). Aborting to \
+                     fail fast instead of hanging the unit job (safe under nextest \
+                     process-per-test isolation).",
+                    start.elapsed().as_secs_f64()
                 );
                 std::process::abort();
             }

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -8006,91 +8006,96 @@ mod tests {
     /// `location` is exactly what the router registers and queries. Feature-gated
     /// because the DataFusion reader lives behind `datafusion-integration`.
     #[cfg(feature = "datafusion-integration")]
-    #[tokio::test]
-    async fn materialized_table_is_readable_through_datafusion_reader() {
-        use crate::datafusion::create_session_context;
-        use crate::datafusion::engine_adapters::register_object_store_parquet_location;
-        use crate::services::record_store::DirectWalTableRecordStore;
-        use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
-        use proximadb_iceberg_engine::IcebergObjectStoreBridge;
+    // Watchdog-bounded `current_thread` runtime instead of `#[tokio::test]`'s
+    // multi-threaded runtime, which intermittently hangs late in the suite and —
+    // with no 30s bound — rides to nextest's 120s slow-timeout (CLAUDE.md #11).
+    #[test]
+    fn materialized_table_is_readable_through_datafusion_reader() {
+        crate::query::execution::test_runtime::run_with_timeout(30, async {
+            use crate::datafusion::create_session_context;
+            use crate::datafusion::engine_adapters::register_object_store_parquet_location;
+            use crate::services::record_store::DirectWalTableRecordStore;
+            use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+            use proximadb_iceberg_engine::IcebergObjectStoreBridge;
 
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let wal_path = temp_dir.path().join("dml-mat-e2e.wal");
-        let manager = Arc::new(CatalogManager::new());
-        manager
-            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            let temp_dir = tempfile::tempdir().expect("tempdir");
+            let wal_path = temp_dir.path().join("dml-mat-e2e.wal");
+            let manager = Arc::new(CatalogManager::new());
+            manager
+                .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+                .await
+                .expect("native catalog");
+            let ddl = DdlService::new(manager.clone());
+            ddl.execute(DdlStatement::CreateNamespace {
+                namespace: vec!["default".to_string()],
+                if_not_exists: true,
+                properties: HashMap::new(),
+            })
             .await
-            .expect("native catalog");
-        let ddl = DdlService::new(manager.clone());
-        ddl.execute(DdlStatement::CreateNamespace {
-            namespace: vec!["default".to_string()],
-            if_not_exists: true,
-            properties: HashMap::new(),
-        })
-        .await
-        .expect("create namespace");
-        let parser = crate::query::sql_frontend::SqlFrontendParser::new();
-        let ddl_stmt = parser
-            .parse_ddl(
-                "CREATE TABLE inv (id TEXT NOT NULL, status TEXT, qty INT, PRIMARY KEY (id));",
-            )
-            .expect("parse ddl")
-            .expect("ddl stmt");
-        ddl.execute(ddl_stmt).await.expect("create table");
-        let record_store = Arc::new(DirectWalTableRecordStore::new(
-            Arc::new(MemtableRecordStorage::new()),
-            Arc::new(
-                FramedTableWalAppender::open(&wal_path)
-                    .await
-                    .expect("open WAL"),
-            ),
-        ));
-        let dml = DmlService::with_record_store_and_table_write_executor(
-            manager.clone(),
-            record_store,
-            Arc::new(PlannedOnlyTableWriteExecutor::new()),
-        );
-        for (id, status, qty) in [
-            ("i1", "active", 5),
-            ("i2", "active", 15),
-            ("i3", "idle", 25),
-        ] {
-            let stmt = parser
-                .parse_dml(&format!(
-                    "INSERT INTO inv (id, status, qty) VALUES ('{id}', '{status}', {qty});"
-                ))
-                .expect("parse insert")
-                .expect("insert stmt");
-            dml.execute(stmt).await.expect("insert");
-        }
+            .expect("create namespace");
+            let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+            let ddl_stmt = parser
+                .parse_ddl(
+                    "CREATE TABLE inv (id TEXT NOT NULL, status TEXT, qty INT, PRIMARY KEY (id));",
+                )
+                .expect("parse ddl")
+                .expect("ddl stmt");
+            ddl.execute(ddl_stmt).await.expect("create table");
+            let record_store = Arc::new(DirectWalTableRecordStore::new(
+                Arc::new(MemtableRecordStorage::new()),
+                Arc::new(
+                    FramedTableWalAppender::open(&wal_path)
+                        .await
+                        .expect("open WAL"),
+                ),
+            ));
+            let dml = DmlService::with_record_store_and_table_write_executor(
+                manager.clone(),
+                record_store,
+                Arc::new(PlannedOnlyTableWriteExecutor::new()),
+            );
+            for (id, status, qty) in [
+                ("i1", "active", 5),
+                ("i2", "active", 15),
+                ("i3", "idle", 25),
+            ] {
+                let stmt = parser
+                    .parse_dml(&format!(
+                        "INSERT INTO inv (id, status, qty) VALUES ('{id}', '{status}', {qty});"
+                    ))
+                    .expect("parse insert")
+                    .expect("insert stmt");
+                dml.execute(stmt).await.expect("insert");
+            }
 
-        // A file:// store the OLAP reader can REOPEN from the published URL.
-        let store_dir = tempfile::tempdir().expect("store tempdir");
-        let root_url = format!("file://{}", store_dir.path().display());
-        let bridge = Arc::new(IcebergObjectStoreBridge::from_url(&root_url).expect("bridge"));
+            // A file:// store the OLAP reader can REOPEN from the published URL.
+            let store_dir = tempfile::tempdir().expect("store tempdir");
+            let root_url = format!("file://{}", store_dir.path().display());
+            let bridge = Arc::new(IcebergObjectStoreBridge::from_url(&root_url).expect("bridge"));
 
-        let location = dml
-            .materialize_table_to_parquet(&*bridge, &root_url, "inv", None)
-            .await
-            .expect("materialize");
+            let location = dml
+                .materialize_table_to_parquet(&*bridge, &root_url, "inv", None)
+                .await
+                .expect("materialize");
 
-        // Read the published location back through the DataFusion OLAP reader.
-        let ctx = create_session_context().expect("session ctx");
-        register_object_store_parquet_location(&ctx, "inv_parquet", &location)
-            .await
-            .expect("register parquet location");
-        let batches = ctx
-            .sql("SELECT * FROM inv_parquet")
-            .await
-            .expect("plan select")
-            .collect()
-            .await
-            .expect("collect");
-        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        assert_eq!(
-            total, 3,
-            "DataFusion reads all materialized rows from the published location"
-        );
+            // Read the published location back through the DataFusion OLAP reader.
+            let ctx = create_session_context().expect("session ctx");
+            register_object_store_parquet_location(&ctx, "inv_parquet", &location)
+                .await
+                .expect("register parquet location");
+            let batches = ctx
+                .sql("SELECT * FROM inv_parquet")
+                .await
+                .expect("plan select")
+                .collect()
+                .await
+                .expect("collect");
+            let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+            assert_eq!(
+                total, 3,
+                "DataFusion reads all materialized rows from the published location"
+            );
+        });
     }
 
     /// `point_lookup_relational` (PATH B PkLookup backend) returns the full row by


### PR DESCRIPTION
## Problem

The `Rust Tests (unit)` job intermittently rides to nextest's **120s slow-timeout** on a cluster of Volcano/DataFusion engine tests (CLAUDE.md #11), then is reported as `timed out` — the ~20-min CI tax behind the recurring "rerun the flake" loop. Repeated `gh run rerun --failed` never stuck because **half the cluster had no watchdog to begin with**.

## Root cause (two compounding defects, both verified locally)

**1. Watchdog bypass — the dominant cause.** Three of the tests CI flagged were plain `#[tokio::test]` on the multi-threaded runtime, with **no 30s bound at all**:
- `native_volcano_materialized_errors_on_overflow`
- `native_volcano_metered_adapter_returns_rows_and_metrics`
- `materialized_table_is_readable_through_datafusion_reader`

A hang in these runs to the full 120s slow-timeout (and reports as `timed out`, not the SIGABRT the watchdog would produce — which is how I confirmed the watchdog wasn't firing). Sibling streaming tests had already been migrated to `run_sync`/`run_with_timeout`; these were missed.

**2. Watchdog dilation.** `with_watchdog` accumulated **nominal** 50ms sleep steps (`waited += step`) instead of measuring real elapsed time. Under the CPU oversubscription it exists to protect against, `thread::sleep` overshoots, so the 30s deadline is reached only after far more real time — dilating the bound toward the 120s slow-timeout. (Measured 1.1× on a 14-core Mac with accurate sleep; worse on constrained CI runners.)

## Fix

- **Watchdog**: measure real wall-clock via `Instant::elapsed`; log actual elapsed on abort for CI forensics.
- **Bypassing tests**: route the 3 hangers — plus the rest of `engine.rs`'s Volcano cluster, for uniformity (5 total) — through the watchdog wrappers. Pure-compute Volcano tests use `run_sync`; the DataFusion-I/O reader test uses `run_with_timeout(30)` (current_thread runtime + watchdog).

## Verification

- All 10 affected tests pass locally (incl. the gated DataFusion reader test): `test result: ok. 10 passed`.
- `engine.rs`/`dml` diffs are **wrapper + reindentation only** — `git diff -w` is empty outside the wrappers; no logic changed.
- Reproduced the dilation in a standalone harness; confirmed the isolated tests do **not** hang even under 3× CPU oversubscription (20/20 in ~0.05s), consistent with the module's diagnosis that the hang is a full-suite runtime/global-state interaction.

This is the structural fix for the flake that #455 and #445 kept tripping over.