### PR TITLE
docs(internals): operator guide for the 3-tier system-catalog cache (ADR-035 D2)

### DIFF
--- a/docs/06-internals/SYSTEM_CATALOG_CACHE.adoc
+++ b/docs/06-internals/SYSTEM_CATALOG_CACHE.adoc
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Per-Tenant System Catalog Cache — operator & internals guide (ADR-035 D2)
+:toc: macro
+:icons: font
+
+The system catalog (collection/table metadata) is authoritative in object storage,
+but resolving a collection on a cold cache costs **`1 + N + M`** object-store
+round-trips (`list_namespaces` + per-namespace `list_tables` + per-table
+`get_table`). The **3-tier read cache** in front of `CollectionService::collection()`
+amortises that to **at most once** per collection, then serves from RAM or local
+disk. This guide is how it works and **how to turn it on**.
+
+toc::[]
+
+== The three tiers
+
+[source,text]
+----
+CollectionService::collection(name)
+  └─ HOT   in-memory, <=1 MB/tenant, 5-min TTL, corpus-version stamped   (src/catalog/syscat_cache.rs)
+       └─ WARM   local disk (OS page cache), version stamped, 5-min mtime backstop  (src/catalog/syscat_warm.rs)
+            └─ CANONICAL   object-store catalog (the sole authority)     (CatalogAssetSource -> CatalogManager)
+----
+
+Each tier is a `CatalogMetadataSource` decorator over the next (dependency
+inversion) — the hot cache's inner is the warm store, whose inner is the canonical
+reader. A miss at one tier reads through to the next; a fetched value is written
+back up. So:
+
+* a read served from **HOT** = 0 I/O;
+* a read served from **WARM** (hot evicted / 5-min TTL expired / cold process) = an
+  OS-page-cache file read, **0 object GETs**;
+* a **cold** read = the full `1 + N + M`, paid **once**, then cached in both tiers.
+
+== Coherence — no stale reads, no write-path coupling
+
+Every cached entry (hot and warm) is **stamped with the `CorpusVersionRegistry`
+version** of its `(tenant, collection)` at the moment it was loaded. A read
+recomputes the live version and serves the entry **only when the stamp matches**.
+
+Writes keep this coherent **without touching the cache**: every `CREATE` / `UPDATE`
+/ `DELETE` **bumps `corpus_version` unconditionally** (keyed by the effective
+tenant — `"default"` when none is threaded). After a write the stamp no longer
+matches, so the next read drops the stale entry and refetches. A **5-minute mtime
+backstop** on the warm tier bounds staleness even if a version signal is ever
+missed. The bump *is* the invalidation — there is no separate cache-invalidation
+plumbing to get wrong.
+
+**Where the cache is active (correct-or-bypass).** `collection()` serves through the
+cache only where invalidation is provably coherent: **single-tenant mode** and a
+**name key**. A **UUID** identifier (a different version space the name-keyed bump
+never touches) and **multi-tenant** reads **bypass** the cache and read through —
+i.e. today's exact behaviour. A bypass is never wrong; it just isn't accelerated.
+
+== Enabling it (operator knobs)
+
+Both tiers are **default-OFF / additive** — unset means today's behaviour
+(hot -> canonical, in-memory only).
+
+[cols="2,3,2", options="header"]
+|===
+| Env var | Effect | Default
+
+| `PROXIMADB_SYSCAT_WARM_DIR`
+| Local directory for the **warm tier**. Set it to a fast local path (e.g. an
+  instance SSD or `emptyDir`) and a hot miss is served from disk instead of object
+  storage. Files are `<dir>/<tenant>/<name>.bin` (`[u64 version][prost Collection]`).
+| unset = no warm tier (hot -> canonical)
+
+| `PROXIMADB_CORPUS_VERSION_PATH`
+| File path for the **durable corpus-version store** (`FileSystemCorpusVersionStore`).
+  Set it so version stamps **survive a process restart** — which makes the hot and
+  warm tiers coherent *across restarts and pods* (otherwise versions reset to `1` on
+  restart and the tiers refetch once, which is correct but loses the warm-on-restart
+  speedup). Wired at boot, hydrated before serving (`src/database.rs`).
+| unset = in-memory only (single-node simple story)
+|===
+
+NOTE: For the full restart / multi-pod warm benefit, set **both**: the warm dir
+persists the data, the version path persists the freshness stamps that make the
+persisted data trustworthy. The hot pool is a fixed 256 MB shared budget with a
+1 MB/tenant ceiling (~256 concurrently-active tenants).
+
+== Sizing & lifecycle
+
+* **Hot**: `TenantCache`, 256 MB pool, **1 MB hard ceiling per tenant** (a tenant
+  over budget is served but not cached — never an OOM), 5-min TTL.
+* **Warm**: bounded by the configured dir's disk; entries are rewritten on a
+  version change and dropped when the asset is deleted. No background GC yet — size
+  the volume for the working set (collection metadata is small).
+* **Path safety**: a `(tenant, name)` with a path separator / `..` / NUL **bypasses
+  the disk tier** (never escapes the configured root).
+
+== Status & roadmap (ADR-035)
+
+* **D2 (this) — DONE**: the 3-tier read path is wired end-to-end (hot #427/#463,
+  warm #466/#472, coherence #435, durable versions TD-SC-5).
+* **D1 — open**: object-store-durable, tenant-prefixed catalog metadata
+  (`_syscat/objects/<object_id>.json`); depends on TD-CAT-2 (tenant-prefixed paths)
+  + the ADR-031/TD-181 stable-`object_id` work.
+* **D3 — open**: signup provisioning (`provision_tenant_system_catalog`) + a
+  system-only write guard for `_syscat/*`.
+
+== Pointers
+
+* Hot tier: `src/catalog/syscat_cache.rs` · Warm tier: `src/catalog/syscat_warm.rs`
+* Read wiring: `CollectionService::{with_catalog_manager, with_syscat_warm_dir, collection}`
+  (`src/services/collection/manager.rs`)
+* Version invalidation: `crate::catalog::CorpusVersionRegistry`
+  (`crates/control/proximadb-catalog/src/corpus_version.rs`); durable store
+  `src/catalog/corpus_version_fs_store.rs`; boot wiring `src/database.rs`
+* Design: `docs/12-design/adr/ADR-035-per-tenant-system-catalog-cache.adoc`


### PR DESCRIPTION
Step 1 of the catalog-tenancy drive-through. Documents the now-shipped 3-tier system-catalog read cache (hot → warm → canonical) end-to-end: the tier layering, the **corpus-version coherence model** (a write bumps the version → cached stamps mismatch → refetch; zero write-path coupling), and — the gap this closes — the **two operator env knobs** that were undocumented:

- `PROXIMADB_SYSCAT_WARM_DIR` — enable the on-disk warm tier
- `PROXIMADB_CORPUS_VERSION_PATH` — durable version stamps (cross-restart / multi-pod coherence)

Without these documented, the shipped feature is effectively un-enablable without reading source. Also: sizing (256 MB pool / 1 MB-per-tenant ceiling), path-traversal safety, and the D1/D3 roadmap.

Doc-only; zero risk. Env-knob names verified against `manager.rs`/`database.rs`; `asciidoctor` renders clean.