### PR TITLE
test(conformance): convert document suite to accuracy ratchet (ADR-040 Phase 1)

### DIFF
--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-183: Document JSON-path projection/filter returns 0 rows (7 of 11 queries)
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open (uncovered by ADR-040 Phase 1 accuracy conversion)
+| Severity | High — silent wrong answers (empty / divergent results), not errors
+| Component | Document modality — JSON-path SELECT-projection evaluation
+| Tracked-by | link:../../12-design/adr/ADR-040-conformance-accuracy-ratchet.adoc[ADR-040] (TD-182 umbrella)
+| Fix-in | PR2 of the ADR-040 document rollout
+|===
+
+toc::[]
+
+== Symptom
+
+The accuracy conversion of the document conformance suite
+(`tests/document_json_pgwire_e2e.rs`) exposed that **every** JSON-path extraction used
+in a SELECT projection or WHERE filter returns **0 rows on both the native and
+DataFusion engines**, while executing without error — exactly the class of silent
+wrong answer the old execution-only ratchet could not see. 7 of the 11 queries are
+affected:
+
+[cols="1,4,1", options="header"]
+|===
+| Id | Query (abbrev.) | Context
+| d04 | `doc->>'title'` | projection
+| d05 | `doc->'price'` | projection
+| d06 | `(doc->>'price')::int > 8` | filter
+| d07 | `doc->>'title' = 'alpha'` | filter
+| d08 | `doc->'author'->>'name'` | nested projection
+| d10 | `json_extract_path_text(doc, 'title')` | projection
+| d11 | `(doc->>'in_stock')::boolean` | filter
+|===
+
+Accurate today: **d01/d02/d03** (no JSON path) and **d09** (`GROUP BY
+doc->'author'->>'country' → CA=2, US=1`).
+
+== Why it matters / root-cause signal
+
+The identical extraction `doc->'author'->>'country'` is **correct** in d09's
+*aggregation*, so the JSON extraction UDFs in `src/datafusion/udf.rs` themselves work.
+The defect is in the non-aggregated path — JSON-path queries route to a path that
+yields an empty relation (candidate: the `JSON_EXTRACT*` → document-store routing in
+`src/query/multimodel_router.rs:182` returns no rows when the data lives in the
+relational/materialized store). One row per input should be emitted with the
+extracted (or NULL) value. Separately, the native engine errors on d09
+(`rebind_columns: column country not in narrowed schema`) — a native planner gap; the
+harness treats a native error as single-engine and anchors d09 on DataFusion.
+
+== Scope
+
+* Document modality JSON-path projection + filter routing/evaluation. No
+  storage-format change; read-path/query-planner defect.
+* Anchored + differential coverage for all 7 queries already exists (this TD's
+  guards in the accuracy harness) and will verify the fix.
+
+== Resolution plan (PR2)
+
+. Diagnose from the harness's per-engine report which engine drops rows and the exact
+  code site (projection lowering vs. UDF invocation vs. cast handling).
+. Fix the SELECT-projection JSON-path evaluation (and the d06 scalar-cast divergence)
+  so a projected JSON path yields one row per input row with the extracted value.
+. In `tests/document_json_pgwire_e2e.rs`: remove the fixed ids from `KNOWN_BAD_TD183`
+  and raise `DOC_ACCURACY_RATCHET` toward the full suite size (11). The existing
+  known-bad guards fail the moment the queries become correct, forcing this step.

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -1,10 +1,26 @@
-//! Document (SQL/JSON) over pgwire — conformance harness (first cut).
+//! Document (SQL/JSON) over pgwire — ACCURACY conformance harness (ADR-040).
 //!
 //! Documents are modeled as a relational table with a JSON column, queried over
 //! the PostgreSQL wire protocol — the open, standard way to store + query
 //! semi-structured documents in a SQL database. Same model as the TPC-H/TPC-DS
 //! harnesses: CREATE → INSERT → MATERIALIZE → query one by one, routed by
-//! ProximaDB. Each query that executes cleanly counts toward `DOC_RATCHET`.
+//! ProximaDB.
+//!
+//! Per ADR-040 (TD-182), a query counts toward the ratchet only when it is
+//! verified CORRECT, not merely that it executes without error:
+//!   * **Anchored** — the materialized (DataFusion) result must equal a
+//!     hand-computed expected answer derived from the deterministic seed.
+//!   * **Differential** — when BOTH the native (pre-MATERIALIZE) and DataFusion
+//!     (post-MATERIALIZE) engines return rows, they must agree after
+//!     canonicalization; disagreement means at least one engine is wrong and the
+//!     query does not count.
+//!
+//! The conversion exposed that **7 of 11** queries are wrong today: every
+//! `->` / `->>` / `json_extract_path_text` extraction used in a SELECT projection
+//! or WHERE filter returns 0 rows on both engines (only the aggregation path, d09,
+//! works). These are held KNOWN-BAD under TD-183 — asserted to still be wrong so
+//! PR2's fix trips the guards and forces the ratchet bump — and excluded from
+//! `DOC_ACCURACY_RATCHET`. Accurate today: d01, d02, d03, d09.
 //!
 //!   RUST_LOG=proximadb=debug cargo test --test document_json_pgwire_e2e -- --nocapture
 
@@ -16,8 +32,12 @@ use proximadb::database::ProximaDB;
 use tempfile::TempDir;
 use tokio::time::sleep;
 
-/// Document/JSON queries expected to execute cleanly over pgwire (the ratchet).
-const DOC_RATCHET: usize = 11;
+/// Queries that must be verified CORRECT (anchored + differential) to count.
+/// Only 4 of 11 are accurate today — d01/d02/d03 (no JSON path) and d09 (JSON
+/// extraction via the aggregation path). The other 7 are JSON-path projections/
+/// filters that return 0 rows, held known-bad under TD-183 until PR2's fix; the
+/// ratchet rises as they are repaired.
+const DOC_ACCURACY_RATCHET: usize = 4;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -136,8 +156,105 @@ fn doc_queries() -> Vec<(&'static str, String)> {
     ]
 }
 
+/// JSON-path bugs (TD-183): EVERY query that uses a `->` / `->>` /
+/// `json_extract_path_text` extraction in a SELECT projection or WHERE filter
+/// returns **0 rows on both engines** today (only the aggregation path, d09,
+/// handles JSON extraction). The accuracy conversion exposed that this is a whole
+/// class, not three queries. They are asserted to STAY wrong so PR2's fix trips
+/// the guard and forces the ratchet to rise. Excluded from `DOC_ACCURACY_RATCHET`.
+const KNOWN_BAD_TD183: &[&str] = &[
+    "d04_arrow_text",         // doc->>'title'                  projection
+    "d05_arrow_json",         // doc->'price'                   projection
+    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter
+    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter
+    "d08_nested_path",        // doc->'author'->>'name'         projection
+    "d10_json_extract_fn",    // json_extract_path_text(doc,..)  projection
+    "d11_bool_field",         // (doc->>'in_stock')::boolean    filter
+];
+
+/// One result row as text cells (pgwire `simple_query` form); SQL NULL → "NULL".
+type Rows = Vec<Vec<String>>;
+
+/// Run a query, returning ordered text rows or the server error string.
+async fn collect(client: &tokio_postgres::Client, sql: &str) -> Result<Rows, String> {
+    match client.simple_query(sql).await {
+        Ok(msgs) => Ok(msgs
+            .into_iter()
+            .filter_map(|m| match m {
+                tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                    (0..r.len())
+                        .map(|i| {
+                            r.get(i)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| "NULL".into())
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect()),
+        Err(e) => Err(explain_err(&e)),
+    }
+}
+
+/// Normalize a cell: JSON values are reparsed + reserialized (default serde_json
+/// sorts object keys) so whitespace / key-order differences across engines do not
+/// matter; non-JSON text (e.g. `alpha`, `product`) passes through unchanged.
+fn norm_cell(s: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(s)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| s.to_string())
+}
+
+/// Canonicalize a result for set-comparison: normalize every cell, then sort rows
+/// (order-independent; all anchored queries also carry ORDER BY, so this only
+/// guards against cross-engine ordering quirks).
+fn canon(rows: &Rows) -> Rows {
+    let mut out: Rows = rows
+        .iter()
+        .map(|row| row.iter().map(|c| norm_cell(c)).collect())
+        .collect();
+    out.sort();
+    out
+}
+
+/// Hand-computed CORRECT answer for each query id, derived from the seed `DATA`
+/// (docs 1/2/3 = Ann-CA / Bob-US / Ann-CA). Used to anchor good queries and to
+/// detect when a TD-183 known-bad query becomes correct.
+fn expected(id: &str) -> Rows {
+    let j1 = r#"{"title":"alpha","price":10,"in_stock":true,"tags":["x","y"],"author":{"name":"Ann","country":"CA"}}"#;
+    let j2 = r#"{"title":"beta","price":25,"in_stock":false,"tags":["y","z"],"author":{"name":"Bob","country":"US"}}"#;
+    let j3 = r#"{"title":"gamma","price":5,"in_stock":true,"tags":["x"],"author":{"name":"Ann","country":"CA"}}"#;
+    let r = |cols: &[&str]| cols.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    match id {
+        "d01_select_all" => vec![
+            r(&["1", "product", j1]),
+            r(&["2", "product", j2]),
+            r(&["3", "article", j3]),
+        ],
+        "d02_filter_col" => vec![r(&["1", j1]), r(&["2", j2])],
+        "d03_count_by_kind" => vec![r(&["article", "1"]), r(&["product", "2"])],
+        "d04_arrow_text" => vec![r(&["1", "alpha"]), r(&["2", "beta"]), r(&["3", "gamma"])],
+        "d05_arrow_json" => vec![r(&["1", "10"]), r(&["2", "25"]), r(&["3", "5"])],
+        "d06_filter_json_scalar" => vec![r(&["1"]), r(&["2"])],
+        "d07_filter_json_text" => vec![r(&["1"])],
+        "d08_nested_path" => vec![r(&["1", "Ann"]), r(&["2", "Bob"]), r(&["3", "Ann"])],
+        "d09_group_by_json" => vec![r(&["CA", "2"]), r(&["US", "1"])],
+        "d10_json_extract_fn" => vec![r(&["1", "alpha"]), r(&["2", "beta"]), r(&["3", "gamma"])],
+        "d11_bool_field" => vec![r(&["1"]), r(&["3"])],
+        other => panic!("no expected answer registered for {other}"),
+    }
+}
+
+fn fmt(res: &Result<Rows, String>) -> String {
+    match res {
+        Ok(rows) => format!("{} rows {:?}", rows.len(), rows),
+        Err(e) => format!("ERR {e}"),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn document_json_pgwire_conformance() {
+async fn document_json_pgwire_accuracy() {
     let server = PgServer::start().await.expect("server start");
     let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
         .await
@@ -165,6 +282,15 @@ async fn document_json_pgwire_conformance() {
     }
     eprintln!("✓ data: {} documents loaded", DATA.len());
 
+    let queries = doc_queries();
+
+    // Phase 1 — NATIVE engine (pre-MATERIALIZE).
+    let mut native: Vec<(&str, Result<Rows, String>)> = Vec::new();
+    for (id, sql) in &queries {
+        native.push((*id, collect(&client, sql).await));
+    }
+
+    // MATERIALIZE flips the table parquet-backed → DataFusion route.
     let mut materialized = 0;
     for (name, _) in SCHEMA {
         match client
@@ -177,75 +303,96 @@ async fn document_json_pgwire_conformance() {
     }
     eprintln!("✓ materialize: {materialized}/{} tables", SCHEMA.len());
 
-    let queries = doc_queries();
-    let mut passed = Vec::new();
-    let mut failed = Vec::new();
+    // Phase 2 — DataFusion engine (post-MATERIALIZE).
+    let mut df: Vec<(&str, Result<Rows, String>)> = Vec::new();
     for (id, sql) in &queries {
-        match client.simple_query(sql).await {
-            Ok(_) => {
-                eprintln!("  ✓ {id}");
-                passed.push(*id);
+        df.push((*id, collect(&client, sql).await));
+    }
+
+    // Classify each query: anchored (DataFusion == expected) AND differential
+    // (native == DataFusion when both returned rows).
+    let mut accurate: Vec<&str> = Vec::new();
+    let mut violations: Vec<String> = Vec::new();
+    eprintln!("\n=== Document accuracy (native | DataFusion vs expected) ===");
+    for ((id, nat), (_, dfr)) in native.iter().zip(df.iter()) {
+        let exp = canon(&expected(id));
+        let df_ok = matches!(dfr, Ok(rows) if canon(rows) == exp);
+        // Differential holds when native errors (single-engine) or matches DF.
+        let diff_ok = match (nat, dfr) {
+            (Ok(n), Ok(d)) => canon(n) == canon(d),
+            (Err(_), _) => true,
+            (_, Err(_)) => false,
+        };
+        let known_bad = KNOWN_BAD_TD183.contains(id);
+        let is_accurate = df_ok && diff_ok;
+
+        let tag = if known_bad {
+            if is_accurate {
+                "TD183-FIXED?"
+            } else {
+                "td183-known"
             }
-            Err(e) => {
-                eprintln!("  ✗ {id}: {}", explain_err(&e));
-                failed.push((*id, explain_err(&e)));
+        } else if is_accurate {
+            "OK"
+        } else {
+            "MISMATCH"
+        };
+        eprintln!(
+            "  [{tag:>12}] {id}\n      native: {}\n      datafu: {}",
+            fmt(nat),
+            fmt(dfr)
+        );
+
+        if known_bad {
+            // The guard: a known-bad query must STAY wrong. When PR2 fixes the
+            // projection path it becomes accurate → this fires → flip it to a
+            // normal anchored query and raise DOC_ACCURACY_RATCHET.
+            if is_accurate {
+                violations.push(format!(
+                    "{id}: TD-183 known-bad query now passes — remove it from \
+                     KNOWN_BAD_TD183 and raise DOC_ACCURACY_RATCHET"
+                ));
             }
+            continue;
+        }
+        if is_accurate {
+            accurate.push(id);
+        } else {
+            violations.push(format!(
+                "{id}: not accurate (anchored={df_ok}, differential={diff_ok})\n      \
+                 native:   {}\n      datafu:   {}\n      expected: {:?}",
+                fmt(nat),
+                fmt(dfr),
+                exp
+            ));
         }
     }
 
     eprintln!(
-        "\n=== Document JSON pgwire conformance: {}/{} passed (ratchet {}) ===",
-        passed.len(),
+        "\n=== accurate: {}/{} (ratchet {}; {} known-bad under TD-183) ===",
+        accurate.len(),
         queries.len(),
-        DOC_RATCHET
+        DOC_ACCURACY_RATCHET,
+        KNOWN_BAD_TD183.len()
     );
-    if !failed.is_empty() {
-        eprintln!("failing:");
-        for (id, err) in &failed {
-            eprintln!("  {id}: {err}");
+    eprintln!("  accurate: {accurate:?}");
+    if !violations.is_empty() {
+        eprintln!("violations:");
+        for v in &violations {
+            eprintln!("  ✗ {v}");
         }
     }
 
     assert!(
-        passed.len() >= DOC_RATCHET,
-        "Document JSON conformance regressed: {} passed < ratchet {}",
-        passed.len(),
-        DOC_RATCHET
+        violations.is_empty(),
+        "Document accuracy violations ({}):\n{}",
+        violations.len(),
+        violations.join("\n")
     );
-
-    // Value-correctness: GROUP BY a nested JSON field. The seeded authors are
-    // Ann/CA, Bob/US, Ann/CA → grouping by author.country yields CA=2, US=1.
-    // Proves JSON extraction + aggregation compute correct values on the OLAP
-    // route, not merely that the SQL runs.
-    let rows: Vec<_> = client
-        .simple_query(
-            "select doc->'author'->>'country' as country, count(*) as n from docs \
-             group by doc->'author'->>'country' order by country",
-        )
-        .await
-        .expect("group-by-json re-run")
-        .into_iter()
-        .filter_map(|m| match m {
-            tokio_postgres::SimpleQueryMessage::Row(r) => Some(r),
-            _ => None,
-        })
-        .collect();
-    let got: Vec<(String, String)> = rows
-        .iter()
-        .map(|r| {
-            (
-                r.get(0).unwrap_or("").to_string(),
-                r.get(1).unwrap_or("").to_string(),
-            )
-        })
-        .collect();
-    assert_eq!(
-        got,
-        vec![
-            ("CA".to_string(), "2".to_string()),
-            ("US".to_string(), "1".to_string())
-        ],
-        "GROUP BY nested JSON field should yield CA=2, US=1"
+    assert!(
+        accurate.len() >= DOC_ACCURACY_RATCHET,
+        "Document accuracy regressed: {} accurate < ratchet {}",
+        accurate.len(),
+        DOC_ACCURACY_RATCHET
     );
-    eprintln!("✓ value-correctness: GROUP BY author.country = CA:2, US:1");
 }


### PR DESCRIPTION
## What

First rollout of **ADR-040** (conformance ratchets must verify *accuracy*, not just clean execution). Converts the document suite (`tests/document_json_pgwire_e2e.rs`) from execution-counting to a **dual-engine accuracy harness**.

Each query now runs on **both** engines — native (pre-MATERIALIZE) and DataFusion (post-MATERIALIZE) — and must satisfy:
- **Anchored**: the materialized result equals a hand-computed expected answer derived from the deterministic seed.
- **Differential**: when both engines return rows, they agree after canonicalization (JSON cells are reparsed so key-order/whitespace differences don't matter; native errors → single-engine, anchored on DataFusion).

The ratchet moves from `passed.len() >= 11` (executed) to `accurate.len() >= 4` (executed **and** verified correct).

## What it exposed

The old execution-only ratchet was passing **64% wrong answers**. The accuracy conversion shows **7 of 11** queries are wrong today — the entire **JSON-path-in-projection-or-filter** class returns **0 rows on both engines**:

| Accurate (4) | Known-bad — 0 rows (7, TD-183) |
|---|---|
| d01 select doc, d02 filter col, d03 count-by-kind, d09 GROUP BY json | d04 `->>`, d05 `->`, d06 `(->> )::int`, d07 `->>=`, d08 nested `->`/`->>`, d10 `json_extract_path_text`, d11 `(->> )::bool` |

Only the **aggregation** path (d09) handles JSON extraction; plain projections/filters drop every row. Filed as **TD-183**.

## Why harness-first (PR1 of 2)

Per ADR-040's sanctioned rollout ("the count may drop until bugs are fixed"). The 7 known-bad queries are held under explicit guards that **assert they are still wrong** — so **PR2** (the fix to the JSON-path projection/filter path) will trip these guards and *force* the ratchet to climb back toward 11. No silent regression possible in either direction.

## Verify

`cargo test --test document_json_pgwire_e2e -- --nocapture` → `test result: ok` (4 accurate ≥ ratchet 4; 7 TD-183 guards hold). fmt + clippy clean; `scripts/check_td_adr_unique.py` → 0 errors (TD-183 unique).

## Follow-up (PR2)

Fix the JSON-path projection/filter evaluation (candidate: `JSON_EXTRACT*` document-store routing in `src/query/multimodel_router.rs` returning empty when data is in the relational/materialized store), remove fixed ids from `KNOWN_BAD_TD183`, raise the ratchet. Also tracked: native `rebind_columns` planner error on d09.