### PR TITLE
feat(olap): flip ADR-025 OLAP read-merge to default-ON + kill-switch (PR3)

### DIFF
--- a/docs/12-design/adr/ADR-025-deletion-vectors-cold-path.adoc
+++ b/docs/12-design/adr/ADR-025-deletion-vectors-cold-path.adoc
@@ -133,6 +133,30 @@ legacy when the marker is absent. Template: `RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2
 
 Each phase gated by round-trip + recall/quality tests vs the f32 baseline.
 
+[NOTE]
+====
+**Relational cold path — shipped (WAL-first realization).** The relational
+OLTP+OLAP cold path realizes ADR-025 _WAL-first_: rather than a persistent
+on-disk DV, an OLAP `SELECT` over a materialized Parquet base is reconciled at
+read time against the canonical-WAL change-feed, keyed by record `oid`. The
+in-memory suppress-set this computes **is** the deletion vector — a rebuildable
+projection of the WAL by construction (ADR-020, never a parallel authority), and
+re-`MATERIALIZE` plays the role of N3 compaction (atomic dead-filtered rewrite).
+
+Phases shipped: read-merge core + pgwire wiring (PR1); the `DeletionVector` N0
+primitive + tenant-scoped feed + empty-delta fast path (PR2); and the
+**default-ON** flip (PR3) once the TPC-H(22)/TPC-DS(16) pgwire ratchets held.
+Kill-switch: `PROXIMADB_OLAP_DELTA_MERGE=0` (any falsy token) forces the legacy
+bare-Parquet read engine-wide; per-table opt-in via the `olap_delta_merge`
+storage-layout property survives the kill-switch. Read-mostly tables (no
+post-snapshot change) take the empty-delta fast path — a bare Parquet read — so
+default-ON is correctness- and cost-neutral for them.
+
+The persistent on-disk DV (N0–N4 above — Puffin / inline PAX, ANN-segment DV)
+remains the deferred follow-up, where the vector/graph modalities plug in (you
+cannot cheaply merge a WAL delta into HNSW traversal).
+====
+
 == Open Decisions (resolve before N0)
 
 1. **DV storage location** — Puffin sidecar (Iceberg-standard, interop) vs

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -476,14 +476,35 @@ fn catalog_table_is_parquet_backed(
     })
 }
 
-/// Global master switch for the ADR-025 OLAP read-merge (default-OFF). A table is
-/// merged only when this is on OR the table carries an `olap_delta_merge` opt-in
-/// property — honoring the staged, per-collection-opt-in rollout mandate.
+/// Master switch for the ADR-025 OLAP read-merge. **Default-ON** (ADR-025 PR3):
+/// once a table is materialized, OLAP `SELECT`s reconcile its cold Parquet base
+/// with the authoritative post-snapshot WAL delta so `DELETE`/`UPDATE`/`INSERT`
+/// written after `MATERIALIZE` are reflected. Read-mostly tables (nothing changed
+/// since the snapshot) take the empty-delta fast path — a bare Parquet read — so
+/// default-ON is correctness- and cost-neutral for them.
+///
+/// Kill-switch: set `PROXIMADB_OLAP_DELTA_MERGE` to a falsy token
+/// (`0`/`false`/`off`/`no`, case-insensitive) to force the legacy bare-Parquet
+/// read engine-wide; individual tables can still opt back in via the
+/// `olap_delta_merge` storage-layout property. Any other value — or leaving it
+/// unset — keeps the merge on.
 #[cfg(feature = "datafusion-integration")]
 fn olap_delta_merge_enabled() -> bool {
-    std::env::var("PROXIMADB_OLAP_DELTA_MERGE")
-        .ok()
-        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+    olap_delta_merge_on(std::env::var("PROXIMADB_OLAP_DELTA_MERGE").ok().as_deref())
+}
+
+/// Pure kill-switch policy for [`olap_delta_merge_enabled`], split out so it is
+/// unit-testable without mutating the process environment: `None` (unset) or any
+/// non-falsy value ⇒ merge ON; only an explicit falsy token turns it OFF.
+#[cfg(feature = "datafusion-integration")]
+fn olap_delta_merge_on(var: Option<&str>) -> bool {
+    match var {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => true,
+    }
 }
 
 /// Resolve the ADR-025 read-merge parameters for a parquet-backed table, or `None`
@@ -1847,6 +1868,26 @@ mod tests {
         ));
         assert!(!gate("SELECT id FROM inv ORDER BY qty LIMIT 5"));
         assert!(!gate("SELECT id, status FROM inv WHERE id = 'i1'"));
+    }
+
+    /// ADR-025 PR3: the OLAP read-merge is default-ON, with an explicit falsy
+    /// `PROXIMADB_OLAP_DELTA_MERGE` token as the engine-wide kill-switch. Tests the
+    /// pure policy directly so it never has to mutate the process environment.
+    #[cfg(feature = "datafusion-integration")]
+    #[test]
+    fn olap_delta_merge_default_on_with_explicit_killswitch() {
+        // Default-ON: unset and any non-falsy value enable the merge.
+        assert!(olap_delta_merge_on(None));
+        for on in ["1", "true", "on", "yes", "anything", ""] {
+            assert!(olap_delta_merge_on(Some(on)), "`{on}` must keep merge ON");
+        }
+        // Kill-switch: explicit falsy tokens (case-insensitive, trimmed) disable it.
+        for off in ["0", "false", "off", "no", "OFF", " False ", "No"] {
+            assert!(
+                !olap_delta_merge_on(Some(off)),
+                "`{off}` must disable merge"
+            );
+        }
     }
 
     fn card_hint(sql: &str) -> crate::query::compute_scheduler::CardinalityClass {

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -87,12 +87,14 @@ impl DataFusionLocalEngine {
         .map_err(|e| ExecutionError::Context(format!("session: {e}")))?;
 
         for (name, location) in &context.parquet_tables {
-            // ADR-025 (relational cold path): an opt-in table reads its cold
+            // ADR-025 (relational cold path): a materialized table reads its cold
             // Parquet base reconciled with the authoritative post-snapshot WAL
             // delta (deletes/updates/inserts after the `MATERIALIZE` snapshot),
-            // keyed by canonical oid. Non-opt-in tables fall through to the bare
-            // Parquet read below (default-OFF), so the OLAP ratchet tables are
-            // untouched.
+            // keyed by canonical oid. The merge is default-ON; a table with
+            // nothing changed since its snapshot takes the empty-delta fast path
+            // inside `register_merged_olap_table` (a bare Parquet read), so
+            // read-mostly OLAP ratchet tables are untouched. Kill-switched or
+            // ineligible tables fall through to the bare Parquet read below.
             if let Some(cfg) = &context.olap_delta
                 && let Some(tbl) = cfg.tables.get(&normalize_table_key(name))
             {

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -167,7 +167,8 @@ pub struct QueryExecutionContext {
     /// tables listed here are reconciled at scan time against the authoritative
     /// post-snapshot WAL delta (deletes/updates/inserts that landed after the
     /// `MATERIALIZE` snapshot), keyed by canonical `oid`. `None` ⇒ legacy bare
-    /// Parquet reads (default-OFF). See [`super::olap_delta_merge`].
+    /// Parquet reads (the merge is default-ON; the kill-switch
+    /// `PROXIMADB_OLAP_DELTA_MERGE=0` forces this). See [`super::olap_delta_merge`].
     pub olap_delta: Option<super::olap_delta_merge::OlapDeltaConfig>,
     /// Escape hatch for SQL dialect gaps while the shared relational lowering
     /// catches up. Keep false for production routes that require one logical

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -385,3 +385,104 @@ async fn olap_delta_merge_reconciles_mixed_name_and_object_id_keyed_wal() {
     unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
     unsafe { std::env::remove_var("PROXIMADB_WAL_OBJECT_ID_KEY") };
 }
+
+/// Run a (text, i64) 2-column query into `(String, i64)` pairs — for a grouped
+/// aggregate keyed by a string dimension.
+async fn text_i64_pairs(client: &tokio_postgres::Client, sql: &str) -> Vec<(String, i64)> {
+    client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)))
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some((
+                r.get(0).unwrap_or_default().to_string(),
+                r.get(1).unwrap_or_default().parse().unwrap_or(i64::MIN),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// VALUE-ACCURACY on the analytical path: a multi-table JOIN + GROUP BY + SUM over
+/// a fact table carrying a NON-EMPTY post-snapshot delta must return the *merged*
+/// aggregate values — not the stale base, and without double-counting the appended
+/// rows. The TPC-H/TPC-DS ratchets never mutate after MATERIALIZE, so they only
+/// ever exercise the empty-delta fast path; this is the case they do not cover.
+/// The merge reconciles rows into the scanned table BEFORE planning, so a correct
+/// SUM here proves merged rows flow correctly through JOIN + aggregation (the
+/// dimension `acct` is also materialized but unmutated → empty-delta fast path,
+/// while `txn` is merged — exercising both registration paths in one query).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn olap_delta_merge_correct_aggregates_through_join() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    client
+        .simple_query("CREATE TABLE acct (id INT PRIMARY KEY, region VARCHAR)")
+        .await
+        .unwrap_or_else(|e| panic!("create acct: {}", explain_err(&e)));
+    client
+        .simple_query("CREATE TABLE txn (id INT PRIMARY KEY, acct_id INT, amount INT)")
+        .await
+        .unwrap_or_else(|e| panic!("create txn: {}", explain_err(&e)));
+    for sql in [
+        "INSERT INTO acct (id, region) VALUES (1, 'US')",
+        "INSERT INTO acct (id, region) VALUES (2, 'EU')",
+        "INSERT INTO txn (id, acct_id, amount) VALUES (1, 1, 10)",
+        "INSERT INTO txn (id, acct_id, amount) VALUES (2, 1, 20)",
+        "INSERT INTO txn (id, acct_id, amount) VALUES (3, 2, 30)",
+    ] {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("seed `{sql}`: {}", explain_err(&e)));
+    }
+    for t in ["acct", "txn"] {
+        client
+            .simple_query(&format!("ALTER TABLE {t} MATERIALIZE"))
+            .await
+            .unwrap_or_else(|e| panic!("materialize {t}: {}", explain_err(&e)));
+    }
+
+    // Post-snapshot mutations on the FACT only: delete(2) drops 20 from US,
+    // update(3→99) lifts EU from 30 to 99, insert(4=40) adds 40 to US.
+    client
+        .simple_query("DELETE FROM txn WHERE id = 2")
+        .await
+        .unwrap_or_else(|e| panic!("delete: {}", explain_err(&e)));
+    client
+        .simple_query("UPDATE txn SET amount = 99 WHERE id = 3")
+        .await
+        .unwrap_or_else(|e| panic!("update: {}", explain_err(&e)));
+    client
+        .simple_query("INSERT INTO txn (id, acct_id, amount) VALUES (4, 1, 40)")
+        .await
+        .unwrap_or_else(|e| panic!("insert: {}", explain_err(&e)));
+
+    let q = "SELECT a.region, SUM(t.amount) AS s FROM txn t \
+             JOIN acct a ON t.acct_id = a.id GROUP BY a.region ORDER BY a.region";
+
+    // Kill-switch OFF → stale base: US = 10 + 20 = 30, EU = 30.
+    // SAFETY: env toggled only between awaited queries — no in-flight request;
+    // nextest / `--test-threads=1` process/thread isolation (CLAUDE.md §11).
+    unsafe { std::env::set_var("PROXIMADB_OLAP_DELTA_MERGE", "0") };
+    assert_eq!(
+        text_i64_pairs(&client, q).await,
+        vec![("EU".to_string(), 30), ("US".to_string(), 30)],
+        "kill-switch must serve stale aggregates through the join (US=30, EU=30)"
+    );
+
+    // Default-ON (env unset) → merged: US = 10 + 40 = 50 (id2 deleted), EU = 99.
+    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+    assert_eq!(
+        text_i64_pairs(&client, q).await,
+        vec![("EU".to_string(), 99), ("US".to_string(), 50)],
+        "merge must reflect delete/update/insert in JOIN+GROUP BY+SUM (US=50, EU=99)"
+    );
+}

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -5,8 +5,9 @@
 //! Proves the central correctness property: after `ALTER TABLE … MATERIALIZE`
 //! freezes a cold Parquet snapshot, subsequent `DELETE` / `UPDATE` / `INSERT`
 //! over pgwire are reflected in OLAP `SELECT`s that route to the DataFusion
-//! engine — and that the behavior is genuinely gated (default-OFF serves the
-//! stale snapshot; opt-in reconciles it).
+//! engine — and that the behavior is genuinely gated (the
+//! `PROXIMADB_OLAP_DELTA_MERGE=0` kill-switch serves the stale snapshot; the
+//! default-ON merge reconciles it).
 //!
 //! Gated on `datafusion-integration`: the read-merge lives on the DataFusion
 //! OLAP route, and the gate-OFF assertion (stale snapshot) is only meaningful
@@ -210,17 +211,18 @@ async fn olap_delta_merge_gate_off_stale_then_on_corrects() {
     let q_rows = "SELECT id, v FROM dvm GROUP BY id, v ORDER BY id";
     let q_count = "SELECT COUNT(*) AS c FROM dvm";
 
-    // Gate OFF (default): the DataFusion route serves the STALE snapshot — this
-    // proves the merge is genuinely gated and the legacy behavior is preserved.
+    // Gate OFF (kill-switch): the merge is default-ON, so an explicit falsy value
+    // forces the legacy bare-Parquet read and the DataFusion route serves the
+    // STALE snapshot — proving the kill-switch preserves legacy behavior.
     // SAFETY: toggled only between awaited queries — no request is in flight, so
     // no server thread reads this env var concurrently (Rust 2024 marks env
     // mutation unsafe for the general concurrent case). Tests run under nextest
     // process isolation (CLAUDE.md §11).
-    unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+    unsafe { std::env::set_var("PROXIMADB_OLAP_DELTA_MERGE", "0") };
     assert_eq!(
         pairs(&client, q_rows).await,
         vec![(1, 10), (2, 20), (3, 30)],
-        "gate-off must serve the stale materialized snapshot"
+        "kill-switch (=0) must serve the stale materialized snapshot"
     );
 
     // Gate ON: the read-merge reconciles delete(2) / update(3→99) / insert(4).
@@ -237,11 +239,19 @@ async fn olap_delta_merge_gate_off_stale_then_on_corrects() {
         "COUNT(*) must be the merged cardinality, not the Parquet footer count"
     );
 
+    // Default-ON (ADR-025 PR3, the headline of this flip): with the env var UNSET
+    // the merge is on by default — removing it must STILL reconcile the snapshot,
+    // not revert to the stale base. This also leaves the var cleared for cleanup.
     // SAFETY: toggled only between awaited queries — no request is in flight, so
     // no server thread reads this env var concurrently (Rust 2024 marks env
     // mutation unsafe for the general concurrent case). Tests run under nextest
     // process isolation (CLAUDE.md §11).
     unsafe { std::env::remove_var("PROXIMADB_OLAP_DELTA_MERGE") };
+    assert_eq!(
+        pairs(&client, q_rows).await,
+        vec![(1, 10), (3, 99), (4, 40)],
+        "default-ON (env unset) must reconcile post-snapshot delete/update/insert"
+    );
 }
 
 /// Tenant isolation of the read-merge (and the empty-delta fast path). Two


### PR DESCRIPTION
## What

Flip the **ADR-025 OLAP read-merge** (relational cold path, WAL-first) from default-OFF to **default-ON**, with an explicit engine-wide **kill-switch**. This is **PR3** of the ADR-025 relational sequence — PR1 (read-merge core + pgwire wiring) and PR2 (the `DeletionVector` N0 primitive + tenant-scoped feed + empty-delta fast path) shipped default-OFF in #405.

After `ALTER TABLE … MATERIALIZE` freezes a cold Parquet snapshot, a subsequent `DELETE` / `UPDATE` / `INSERT` lives only in the authoritative store (memtable + canonical WAL + PAX). With the merge on, an OLAP `SELECT` routed to DataFusion reconciles the Parquet base against the post-snapshot WAL change-feed, keyed by canonical `oid`. This flip makes that the default so OLAP reads are correct out of the box — no per-table opt-in required.

## How

- **`olap_delta_merge_enabled()`** is now default-ON, implemented over a pure, unit-testable policy `olap_delta_merge_on(Option<&str>)`: `None` (unset) or any non-falsy value ⇒ ON; only a falsy token (`0`/`false`/`off`/`no`, case-insensitive, trimmed) is the **kill-switch**. The per-table `olap_delta_merge` storage-layout opt-in still works under the kill-switch.
- **Cost/correctness-neutral for read-mostly tables**: a table with nothing changed since its snapshot takes the **empty-delta fast path** inside `register_merged_olap_table` — a bare Parquet read, identical to the legacy path.
- **Acceptance e2e** (`pgwire_olap_delta_merge_e2e`): the gate-off assertion now uses the explicit `=0` kill-switch (unset no longer means OFF), and a new **default-ON (env-unset)** assertion proves the flip's headline.
- New pure parse-semantics unit test (no process-env mutation).
- Docs: refreshed `engine.rs` / `datafusion_engine.rs` comments; added an ADR-025 "Relational cold path — shipped (WAL-first)" note recording PR1/PR2/PR3 + the kill-switch.

## Validation (local)

Ratchets pass **identically at OFF and ON**, proving behavioral neutrality:

| Suite  | env=0 (OFF) | env=1 (ON) |
|--------|-------------|------------|
| TPC-H  | 22/22       | 22/22      |
| TPC-DS | 16/16       | 16/16      |

- `pgwire_olap_delta_merge_e2e`: **4/4** (kill-switch stale → ON corrects → default-ON corrects; tenant isolation; mixed name/object_id-keyed WAL dual-read; **+ new JOIN value-accuracy test**).
- `cargo test --lib olap_delta_merge`: 7/7 — the 6 merge-core unit tests + the new kill-switch policy test.

### Query value-accuracy (not just conformance)

The TPC-H/TPC-DS ratchets are mostly *execution conformance* and never mutate after `MATERIALIZE`, so they only ever hit the empty-delta fast path. To prove the merge returns **correct values** under an analytical query with a *non-empty* delta, this PR adds `olap_delta_merge_correct_aggregates_through_join`: a multi-table **JOIN + GROUP BY + SUM** over a fact table that has a post-snapshot `DELETE`/`UPDATE`/`INSERT`. It asserts the merged aggregates (`US=50, EU=99`) against the stale base (`US=30, EU=30`) — catching both suppression bugs (wrong group sum) and double-append bugs (inflated sum). The dimension table in the same query is materialized-but-unmutated, so one query exercises *both* the merged-MemTable and empty-delta-fast-path registration routes.

> Note: the TPC-H/TPC-DS suites require a Linux-sized thread stack; on macOS run with `RUST_MIN_STACK=67108864` (CI's ubuntu runner already has an 8 MB default). This is a debug-build/macOS artifact, unrelated to the flip — the crash point is identical with the merge on or off.

### Why default-ON cannot regress accuracy

The flip is **monotonic** — it can only improve correctness or leave it unchanged, never regress:

- **Single-column-PK materialized tables** — eligible for the merge. With a non-empty delta they now return *correct* (merged) results instead of the stale base; with an empty delta they take the fast path (bare Parquet, identical to before). Strict improvement or no-op.
- **Composite-PK / keyless tables** — `olap_delta_table_params` returns `None`, so they fall through to the bare Parquet read **exactly as under default-OFF**. Their (documented, pre-existing) staleness-if-mutated is unchanged by this flip — not a new regression.
- **Vector / recall** — the gate lives on the relational DataFusion route only; vector ANN search never consults it, so recall@k ratchets are untouched by construction.

## Rollout / reversibility

Default-ON, instantly reversible engine-wide via `PROXIMADB_OLAP_DELTA_MERGE=0`. The persistent on-disk DV (ADR-025 N0–N4: Puffin / inline PAX, ANN-segment DV) remains the deferred follow-up where the vector/graph modalities plug in.
