### PR TITLE
fix(query): route JSON-path projections/filters to the relational engine (TD-183)

### DIFF
--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -59,12 +59,40 @@ harness treats a native error as single-engine and anchors d09 on DataFusion.
 * Anchored + differential coverage for all 7 queries already exists (this TD's
   guards in the accuracy harness) and will verify the fix.
 
-== Resolution plan (PR2)
+== Root cause (diagnosed)
 
-. Diagnose from the harness's per-engine report which engine drops rows and the exact
-  code site (projection lowering vs. UDF invocation vs. cast handling).
-. Fix the SELECT-projection JSON-path evaluation (and the d06 scalar-cast divergence)
-  so a projected JSON path yields one row per input row with the extracted value.
-. In `tests/document_json_pgwire_e2e.rs`: remove the fixed ids from `KNOWN_BAD_TD183`
-  and raise `DOC_ACCURACY_RATCHET` toward the full suite size (11). The existing
-  known-bad guards fail the moment the queries become correct, forcing this step.
+A plain projection/filter SELECT does not *engage* the relational pipeline (no
+join/GROUP BY/aggregate), so `try_run_relational_select_pipeline` returns `None`
+and BOTH engines are bypassed (`relational_pipeline.rs` `set_expr_engages`;
+`protocol.rs:1497` `require_engagement`). The query then falls to store-type
+dispatch (`protocol.rs:1175`) where, because the translated SQL contains
+`JSON_EXTRACT`, `detect_store_type_from_query` (`multimodel_router.rs:182`)
+misclassifies it as `DataModel::Document`. `execute_document_query`
+(`protocol.rs:2680`) ignores the projection and reads an empty document collection
+→ 0 rows. d09 escapes only because GROUP BY makes it engage the pipeline first.
+
+== Resolution
+
+**PR2 — routing fix (done):** `set_expr_engages` now also engages when a projection
+or WHERE contains a `JSON_EXTRACT[_TEXT]` / `json_extract_path_text` call, so these
+queries reach the relational/OLAP route. This resolves the three SELECT projections
+**d04/d05/d08** (DataFusion answers them; native errors on the missing kernel and is
+anchored single-engine). Ratchet raised 4 → 7.
+
+**PR3 — remaining four (open):**
+
+* **d06, d07** — native filter evaluation silently returns 0 rows for JSON
+  functions. Register `json_extract` / `json_extract_text` native scalar kernels in
+  `crates/foundation/proximadb-functions/src/lib.rs` (`register_builtin_scalars`),
+  reusing the `extract_one` logic from `src/datafusion/udf.rs`.
+* **d10** — DataFusion has no `json_extract_path_text` (only `json_extract_text`);
+  register an alias UDF in `src/datafusion/udf.rs` (and the native kernel).
+* **d11** — DataFusion cannot coerce `Utf8 = Boolean` for `(doc->>'in_stock')::boolean
+  = true`; needs cast/coercion handling on the OLAP route.
+
+Each fix removes its ids from `KNOWN_BAD_TD183` and raises `DOC_ACCURACY_RATCHET`
+toward 11; the known-bad guards fail the moment a query becomes correct, forcing the
+bump.
+
+The secondary native d09 `rebind_columns` planner error
+(`proximadb-relational-planner/src/lib.rs:1735`) is independent and out of scope.

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -1646,6 +1646,15 @@ fn set_expr_engages(body: &SetExpr) -> bool {
             // the legacy single-table path can serve — engage the relational/OLAP
             // route so it reaches DataFusion.
             let has_derived = select.from.iter().any(table_with_joins_has_derived);
+            // TD-183: a JSON-path extraction (`->`/`->>`/`json_extract_path_text`,
+            // lowered to `JSON_EXTRACT[_TEXT]` calls by the translator) in a plain
+            // projection or WHERE must engage the relational/OLAP route. Otherwise the
+            // non-engaging SELECT falls through to store-type dispatch, is misread as a
+            // *document* query because the SQL text contains `JSON_EXTRACT`, and is
+            // served by the document handler against an empty collection → 0 rows.
+            // Aggregated forms (e.g. d09 GROUP BY) already engage via `has_group_by`.
+            let has_json_extract = select.projection.iter().any(select_item_has_json_extract)
+                || select.selection.as_ref().is_some_and(expr_has_json_extract);
             has_join
                 || has_group_by
                 || select.having.is_some()
@@ -1653,7 +1662,43 @@ fn set_expr_engages(body: &SetExpr) -> bool {
                 || has_where_subquery
                 || has_projection_subquery
                 || has_derived
+                || has_json_extract
         }
+        _ => false,
+    }
+}
+
+/// True if a projected item applies a JSON-path extraction function. Mirrors
+/// [`select_item_has_aggregate`]; used by the engagement gate (TD-183).
+fn select_item_has_json_extract(item: &SelectItem) -> bool {
+    match item {
+        SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+            expr_has_json_extract(expr)
+        }
+        _ => false,
+    }
+}
+
+/// True if `expr` contains a `JSON_EXTRACT` / `JSON_EXTRACT_TEXT` /
+/// `json_extract_path_text` call anywhere in its tree. The extraction is always the
+/// outermost function or is wrapped in Cast/Nested/Unary/Binary (e.g.
+/// `(JSON_EXTRACT_TEXT(doc,'price'))::int > 8`), so walking those node kinds — the
+/// same set [`expr_has_aggregate`] walks — is sufficient.
+fn expr_has_json_extract(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Function(f) => {
+            let name = f.name.to_string().to_ascii_lowercase();
+            matches!(
+                name.rsplit('.').next().unwrap_or(&name),
+                "json_extract" | "json_extract_text" | "json_extract_path_text"
+            )
+        }
+        SqlExpr::Nested(inner) => expr_has_json_extract(inner),
+        SqlExpr::UnaryOp { expr, .. } => expr_has_json_extract(expr),
+        SqlExpr::BinaryOp { left, right, .. } => {
+            expr_has_json_extract(left) || expr_has_json_extract(right)
+        }
+        SqlExpr::Cast { expr, .. } => expr_has_json_extract(expr),
         _ => false,
     }
 }

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -15,12 +15,14 @@
 //!     canonicalization; disagreement means at least one engine is wrong and the
 //!     query does not count.
 //!
-//! The conversion exposed that **7 of 11** queries are wrong today: every
-//! `->` / `->>` / `json_extract_path_text` extraction used in a SELECT projection
-//! or WHERE filter returns 0 rows on both engines (only the aggregation path, d09,
-//! works). These are held KNOWN-BAD under TD-183 — asserted to still be wrong so
-//! PR2's fix trips the guards and forces the ratchet bump — and excluded from
-//! `DOC_ACCURACY_RATCHET`. Accurate today: d01, d02, d03, d09.
+//! The accuracy conversion exposed that JSON-path extraction in a SELECT
+//! projection or WHERE filter returned 0 rows (the queries were misrouted to the
+//! document store). The routing fix (engagement-gate change in
+//! `relational_pipeline.rs`) resolved the three projections d04/d05/d08, so 7 of
+//! 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
+//! (projections). The remaining four (d06/d07/d10/d11) stay KNOWN-BAD under TD-183
+//! — asserted to still be wrong so the next fix trips the guards and forces the
+//! ratchet up — and excluded from `DOC_ACCURACY_RATCHET`.
 //!
 //!   RUST_LOG=proximadb=debug cargo test --test document_json_pgwire_e2e -- --nocapture
 
@@ -33,11 +35,12 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 /// Queries that must be verified CORRECT (anchored + differential) to count.
-/// Only 4 of 11 are accurate today — d01/d02/d03 (no JSON path) and d09 (JSON
-/// extraction via the aggregation path). The other 7 are JSON-path projections/
-/// filters that return 0 rows, held known-bad under TD-183 until PR2's fix; the
-/// ratchet rises as they are repaired.
-const DOC_ACCURACY_RATCHET: usize = 4;
+/// 7 of 11 are accurate after the JSON-path routing fix: d01/d02/d03 (no JSON
+/// path), d09 (aggregation path), and d04/d05/d08 (JSON-path projections now
+/// routed to the relational/OLAP engine). The remaining 4 (d06/d07/d10/d11) stay
+/// known-bad under TD-183 pending native JSON kernels + DataFusion fixes; the
+/// ratchet rises further as they land.
+const DOC_ACCURACY_RATCHET: usize = 7;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -156,20 +159,24 @@ fn doc_queries() -> Vec<(&'static str, String)> {
     ]
 }
 
-/// JSON-path bugs (TD-183): EVERY query that uses a `->` / `->>` /
-/// `json_extract_path_text` extraction in a SELECT projection or WHERE filter
-/// returns **0 rows on both engines** today (only the aggregation path, d09,
-/// handles JSON extraction). The accuracy conversion exposed that this is a whole
-/// class, not three queries. They are asserted to STAY wrong so PR2's fix trips
-/// the guard and forces the ratchet to rise. Excluded from `DOC_ACCURACY_RATCHET`.
+/// JSON-path bugs still open under TD-183, asserted to STAY wrong so the next
+/// fix trips the guard and forces the ratchet up. Excluded from the ratchet.
+///
+/// The routing fix (this PR — engagement-gate change in `relational_pipeline.rs`)
+/// resolved the three SELECT *projections* (d04/d05/d08): they now reach the
+/// relational/OLAP route and DataFusion answers them correctly. The remaining four
+/// need follow-up work that is a different concern (function registration / type
+/// coercion), tracked under TD-183 for PR3:
+///   * d06/d07 — native filter eval silently returns 0 rows for JSON functions
+///     (native scalar kernels not registered in `proximadb-functions`).
+///   * d10     — DataFusion has no `json_extract_path_text` (only `json_extract_text`);
+///     needs an alias UDF.
+///   * d11     — DataFusion cannot coerce `Utf8 = Boolean` for `(… )::boolean`.
 const KNOWN_BAD_TD183: &[&str] = &[
-    "d04_arrow_text",         // doc->>'title'                  projection
-    "d05_arrow_json",         // doc->'price'                   projection
-    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter
-    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter
-    "d08_nested_path",        // doc->'author'->>'name'         projection
-    "d10_json_extract_fn",    // json_extract_path_text(doc,..)  projection
-    "d11_bool_field",         // (doc->>'in_stock')::boolean    filter
+    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — native eval
+    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter — native eval
+    "d10_json_extract_fn",    // json_extract_path_text(doc,..)  proj  — DF missing fn
+    "d11_bool_field",         // (doc->>'in_stock')::boolean    filter — DF cast coercion
 ];
 
 /// One result row as text cells (pgwire `simple_query` form); SQL NULL → "NULL".


### PR DESCRIPTION
## What

Fixes the routing half of **TD-183** (uncovered by the ADR-040 document accuracy harness, #476). Three SELECT projections that the accuracy ratchet held known-bad — `d04` (`doc->>'title'`), `d05` (`doc->'price'`), `d08` (`doc->'author'->>'name'`) — now return correct results.

## Root cause

A plain projection/filter SELECT doesn't *engage* the relational pipeline (no join/GROUP BY/aggregate), so `try_run_relational_select_pipeline` returns `None` and **both** engines are bypassed. The query then falls to store-type dispatch (`protocol.rs:1175`) where, because the translated SQL contains `JSON_EXTRACT`, it's misclassified as a **document** query (`multimodel_router.rs:182`) and served by `execute_document_query` against an empty document collection → **0 rows**. `d09` escaped only because GROUP BY made it engage the pipeline first.

## Fix

Extend the engagement gate (`relational_pipeline.rs` `set_expr_engages`) to also engage when a projection or WHERE contains a `JSON_EXTRACT` / `JSON_EXTRACT_TEXT` / `json_extract_path_text` call, so these queries reach the relational/OLAP route (DataFusion for materialized tables). Adds a small recursive detector mirroring the existing `expr_has_aggregate`.

## Result (accuracy harness)

`d04/d05/d08` now pass (DataFusion answers correctly; native errors on the unregistered kernel → anchored single-engine). Removed from `KNOWN_BAD_TD183`; **ratchet 4 → 7**. The harness's known-bad guards confirmed the fix by firing the moment the queries became correct.

## Remaining under TD-183 → PR3 (distinct concern: function registration / coercion)

- **d06/d07** — native filter eval silently returns 0 rows for JSON functions → register `json_extract`/`json_extract_text` native scalar kernels in `proximadb-functions`.
- **d10** — DataFusion has no `json_extract_path_text` (only `json_extract_text`) → alias UDF.
- **d11** — DataFusion can't coerce `Utf8 = Boolean` for `(… )::boolean`.

## Verify

`cargo test --test document_json_pgwire_e2e -- --nocapture` → `test result: ok` (7 accurate ≥ ratchet 7; 4 TD-183 guards hold). fmt + clippy clean.