### PR TITLE
ci(accuracy): gate the orphaned pgwire value-accuracy e2e suite (TD-182 P0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       core_changes: ${{ steps.filter.outputs.core_changes }}
       gpu_paths: ${{ steps.filter.outputs.gpu_paths }}
       network_changes: ${{ steps.filter.outputs.network_changes }}
+      pgwire_accuracy_changes: ${{ steps.filter.outputs.pgwire_accuracy_changes }}
       # SDK change detection
       go_sdk: ${{ steps.filter.outputs.go_sdk }}
       nodejs_sdk: ${{ steps.filter.outputs.nodejs_sdk }}
@@ -199,6 +200,20 @@ jobs:
               - 'src/network/**'
               - 'src/api_handlers/**'
               - 'proto/**'
+            # Multi-modal pgwire value-accuracy e2e suite (TD-182 P0). The suite
+            # exercises the SQL/pgwire + relational + DML + cold-path-merge code,
+            # so re-run it when any of those change, when the suite files change,
+            # or when this workflow itself changes (so wiring edits self-verify).
+            pgwire_accuracy_changes:
+              - 'src/query/**'
+              - 'src/network/**'
+              - 'src/services/dml/**'
+              - 'src/core/**'
+              - 'tests/*pgwire*'
+              - 'tests/document_json*'
+              - 'tests/events_tsbs*'
+              - 'tests/sql_value_roundtrip.rs'
+              - '.github/workflows/ci.yml'
             # SDK filters
             go_sdk:
               - 'clients/go/**'
@@ -1266,6 +1281,46 @@ jobs:
             fi
           done
 
+  rust-integration-test-pgwire-accuracy:
+    name: Rust Integration Tests (pgwire accuracy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [changes]
+    if: |
+      !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
+      needs.changes.outputs.pgwire_accuracy_changes == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-nightly-dev"
+          shared-key: "build"
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      # TD-182 P0: the multi-modal pgwire VALUE-ACCURACY suite — these e2e tests
+      # assert exact result values (and the merged cold-path aggregates), not just
+      # clean execution, so they catch silent wrong-answer regressions the
+      # conformance ratchets miss. Run with --test-threads=1: they toggle the
+      # PROXIMADB_OLAP_DELTA_MERGE process env between awaited queries, so they
+      # must not run concurrently within one process.
+      - name: Run pgwire accuracy e2e
+        run: |
+          for test_name in \
+            pgwire_relational_engine_e2e \
+            pgwire_olap_delta_merge_e2e \
+            document_json_pgwire_e2e \
+            events_tsbs_pgwire_e2e \
+            pgwire_null_rendering_e2e \
+            pgwire_select_or_predicate_e2e \
+            sql_value_roundtrip; do
+            echo "Running $test_name..."
+            cargo test --test "$test_name" -- --test-threads=1
+          done
+
   rust-integration-test-graph:
     name: Rust Integration Tests (graph)
     runs-on: ubuntu-latest
@@ -1691,6 +1746,7 @@ jobs:
       - rust-test
       - rust-integration-test-storage
       - rust-integration-test-query
+      - rust-integration-test-pgwire-accuracy
       - rust-integration-test-graph
       - rust-integration-test-cluster
       - rust-coverage

--- a/tests/pgwire_olap_delta_merge_e2e.rs
+++ b/tests/pgwire_olap_delta_merge_e2e.rs
@@ -423,6 +423,10 @@ async fn olap_delta_merge_correct_aggregates_through_join() {
         let _ = conn.await;
     });
 
+    // Idempotent setup: the catalog can survive across local re-runs, so drop any
+    // leftovers first (matching the DROP-IF-EXISTS convention of the sibling tests).
+    client.simple_query("DROP TABLE IF EXISTS txn").await.ok();
+    client.simple_query("DROP TABLE IF EXISTS acct").await.ok();
     client
         .simple_query("CREATE TABLE acct (id INT PRIMARY KEY, region VARCHAR)")
         .await


### PR DESCRIPTION
## What (TD-182 P0)

The cross-modality accuracy audit (#482) found that **115 of 150 integration tests are orphaned** — no CI tier runs them, so the strong *value-accuracy* pgwire e2e suites gate nowhere. This adds a develop-tier **`rust-integration-test-pgwire-accuracy`** job that runs them with `--test-threads=1` and wires it into **CI Success**, so silent wrong-answer regressions actually block merges.

Suite gated (all assert exact values / merged aggregates, not just clean execution):
`pgwire_relational_engine_e2e`, `pgwire_olap_delta_merge_e2e`, `document_json_pgwire_e2e` (ADR-040 accuracy), `events_tsbs_pgwire_e2e`, `pgwire_null_rendering_e2e`, `pgwire_select_or_predicate_e2e`, `sql_value_roundtrip`.

## How

- New `pgwire_accuracy_changes` path filter triggers the job on SQL/pgwire/DML/core changes, on the suite files, **and on this workflow itself** — so the wiring self-verifies on this very PR.
- `--test-threads=1` because the suite toggles the `PROXIMADB_OLAP_DELTA_MERGE` process env between awaited queries (can't run concurrently in one process).
- Made `olap_delta_merge_correct_aggregates_through_join` idempotent (`DROP TABLE IF EXISTS acct/txn`) to match the sibling tests — the catalog can survive local re-runs, and gating surfaced this immediately (it passed clean-state but failed on re-run).

## Verification

All 7 suites green locally with `--test-threads=1`; the olap-merge suite verified **4/4 twice** (idempotency). This PR's CI run is itself the proof the job wiring works (the workflow change triggers the new job).

Part of the TD-182 program (P0 gate existing → P1 ADR-040 conversion → P2 fill gaps).