### PR TITLE
fix(datafusion): register json_extract_path_text UDF (TD-183, doc ratchet 7→8)

### DIFF
--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -73,22 +73,34 @@ misclassifies it as `DataModel::Document`. `execute_document_query`
 
 == Resolution
 
-**PR2 — routing fix (done):** `set_expr_engages` now also engages when a projection
-or WHERE contains a `JSON_EXTRACT[_TEXT]` / `json_extract_path_text` call, so these
-queries reach the relational/OLAP route. This resolves the three SELECT projections
-**d04/d05/d08** (DataFusion answers them; native errors on the missing kernel and is
-anchored single-engine). Ratchet raised 4 → 7.
+**PR2 — routing fix (done, #480):** `set_expr_engages` now also engages when a
+projection or WHERE contains a `JSON_EXTRACT[_TEXT]` / `json_extract_path_text` call,
+so these queries reach the relational/OLAP route. Resolved the three SELECT
+projections **d04/d05/d08**. Ratchet 4 → 7.
 
-**PR3 — remaining four (open):**
+**PR3 — DataFusion `json_extract_path_text` alias (done):**
 
-* **d06, d07** — native filter evaluation silently returns 0 rows for JSON
-  functions. Register `json_extract` / `json_extract_text` native scalar kernels in
-  `crates/foundation/proximadb-functions/src/lib.rs` (`register_builtin_scalars`),
-  reusing the `extract_one` logic from `src/datafusion/udf.rs`.
-* **d10** — DataFusion has no `json_extract_path_text` (only `json_extract_text`);
-  register an alias UDF in `src/datafusion/udf.rs` (and the native kernel).
-* **d11** — DataFusion cannot coerce `Utf8 = Boolean` for `(doc->>'in_stock')::boolean
-  = true`; needs cast/coercion handling on the OLAP route.
+* **d10** — added `json_extract_path_text_udf` in `src/datafusion/udf.rs` (registered
+  in `src/datafusion/mod.rs`), so the function-form `json_extract_path_text(doc,'k')`
+  resolves on the OLAP route (native errors on it → anchored single-engine). Ratchet
+  7 → 8.
+
+Native JSON scalar kernels were prototyped here but **reverted**: registering
+`json_extract`/`json_extract_text` in the engine-neutral registry causes the F2
+adapter to bind a registry UDF that shadows the typed `(Utf8,Utf8)` Arrow UDFs and
+regresses DataFusion coercion in comparison contexts (observed on d07). They also do
+NOT fix d06/d07 — the native *filter* path returns 0 rows without ever invoking the
+kernel, so that is a separate native-filter-evaluation defect, not a missing kernel.
+
+**PR4 — remaining three (open):**
+
+* **d06, d07** — the native (pre-MATERIALIZE) filter path returns 0 rows for a JSON
+  function in WHERE; the scan does not evaluate the json-extract scalar. Fix the
+  native filter/scan path to evaluate JSON-extract predicates (and add native kernels
+  *without* the registry-shadow regression — e.g. skip F2 binding for them robustly).
+* **d07, d11** — DataFusion coercion: `json_extract_text(Utf8,Utf8)` in a bare `=`
+  comparison, and `Utf8 = Boolean` for `(doc->>'in_stock')::boolean = true`, both fail
+  type coercion on the OLAP route.
 
 Each fix removes its ids from `KNOWN_BAD_TD183` and raises `DOC_ACCURACY_RATCHET`
 toward 11; the known-bad guards fail the moment a query becomes correct, forcing the

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -187,6 +187,7 @@ fn build_session_context(
     // columns (`doc->'a'->>'b'`) work on the OLAP route, not just the legacy path.
     ctx.register_udf(udf::json_extract_udf());
     ctx.register_udf(udf::json_extract_text_udf());
+    ctx.register_udf(udf::json_extract_path_text_udf());
 
     // F2: bind every NON-native registry scalar as a DataFusion ScalarUDF (the consolidated
     // engine-neutral functions defined once in proximadb-functions). DataFusion's own

--- a/src/datafusion/udf.rs
+++ b/src/datafusion/udf.rs
@@ -59,6 +59,20 @@ pub fn json_extract_text_udf() -> ScalarUDF {
     )
 }
 
+/// Postgres `json_extract_path_text(json_text, key)` — the text-extract form spelled
+/// as a function (the portable alternative to `->>`). Same kernel as
+/// `json_extract_text`; registered under its own name so the OLAP route resolves it
+/// (TD-183).
+pub fn json_extract_path_text_udf() -> ScalarUDF {
+    create_udf(
+        "json_extract_path_text",
+        vec![DataType::Utf8, DataType::Utf8],
+        DataType::Utf8,
+        Volatility::Immutable,
+        Arc::new(|args| json_extract_impl(args, true)),
+    )
+}
+
 fn json_extract_impl(args: &[ColumnarValue], as_text: bool) -> DFResult<ColumnarValue> {
     if args.len() != 2 {
         return Err(DataFusionError::Execution(format!(

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -17,12 +17,12 @@
 //!
 //! The accuracy conversion exposed that JSON-path extraction in a SELECT
 //! projection or WHERE filter returned 0 rows (the queries were misrouted to the
-//! document store). The routing fix (engagement-gate change in
-//! `relational_pipeline.rs`) resolved the three projections d04/d05/d08, so 7 of
-//! 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
-//! (projections). The remaining four (d06/d07/d10/d11) stay KNOWN-BAD under TD-183
-//! — asserted to still be wrong so the next fix trips the guards and forces the
-//! ratchet up — and excluded from `DOC_ACCURACY_RATCHET`.
+//! document store). Fixed incrementally: the routing fix (#480) repaired the
+//! projections d04/d05/d08; the DataFusion `json_extract_path_text` alias UDF (this
+//! PR) repaired the function-form projection d10. 8 of 11 are now accurate. The
+//! filters d06/d07 (native filter path returns 0 rows for a JSON function) and d11
+//! (DataFusion `Utf8 = Boolean` coercion) stay KNOWN-BAD under TD-183 — asserted to
+//! still be wrong so the next fix trips the guard — and excluded from the ratchet.
 //!
 //!   RUST_LOG=proximadb=debug cargo test --test document_json_pgwire_e2e -- --nocapture
 
@@ -35,12 +35,11 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 /// Queries that must be verified CORRECT (anchored + differential) to count.
-/// 7 of 11 are accurate after the JSON-path routing fix: d01/d02/d03 (no JSON
-/// path), d09 (aggregation path), and d04/d05/d08 (JSON-path projections now
-/// routed to the relational/OLAP engine). The remaining 4 (d06/d07/d10/d11) stay
-/// known-bad under TD-183 pending native JSON kernels + DataFusion fixes; the
-/// ratchet rises further as they land.
-const DOC_ACCURACY_RATCHET: usize = 7;
+/// 8 of 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
+/// (projections, routing fix #480), and d10 (DataFusion `json_extract_path_text`
+/// alias UDF, this PR). d06/d07/d11 remain known-bad under TD-183 (native filter
+/// eval + DataFusion coercion); the ratchet rises as those land.
+const DOC_ACCURACY_RATCHET: usize = 8;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -162,20 +161,17 @@ fn doc_queries() -> Vec<(&'static str, String)> {
 /// JSON-path bugs still open under TD-183, asserted to STAY wrong so the next
 /// fix trips the guard and forces the ratchet up. Excluded from the ratchet.
 ///
-/// The routing fix (this PR — engagement-gate change in `relational_pipeline.rs`)
-/// resolved the three SELECT *projections* (d04/d05/d08): they now reach the
-/// relational/OLAP route and DataFusion answers them correctly. The remaining four
-/// need follow-up work that is a different concern (function registration / type
-/// coercion), tracked under TD-183 for PR3:
-///   * d06/d07 — native filter eval silently returns 0 rows for JSON functions
-///     (native scalar kernels not registered in `proximadb-functions`).
-///   * d10     — DataFusion has no `json_extract_path_text` (only `json_extract_text`);
-///     needs an alias UDF.
-///   * d11     — DataFusion cannot coerce `Utf8 = Boolean` for `(… )::boolean`.
+/// Resolved so far: the routing fix (#480) fixed the projections d04/d05/d08; the
+/// DataFusion `json_extract_path_text` alias UDF (this PR) fixed the function-form
+/// projection d10. Remaining, all needing deeper work (separate follow-up):
+///   * d06/d07 — the native (pre-MATERIALIZE) filter path returns 0 rows for a JSON
+///     function in WHERE (it is not evaluated through the scalar kernel); registering
+///     the native kernel does not help and regresses DataFusion via registry binding.
+///   * d07/d11 — DataFusion coercion: `json_extract_text(Utf8,Utf8)` in a bare `=`
+///     comparison and `Utf8 = Boolean` for `(… )::boolean` both fail type coercion.
 const KNOWN_BAD_TD183: &[&str] = &[
-    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — native eval
-    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter — native eval
-    "d10_json_extract_fn",    // json_extract_path_text(doc,..)  proj  — DF missing fn
+    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — native 0-rows
+    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter — native 0-rows + DF coercion
     "d11_bool_field",         // (doc->>'in_stock')::boolean    filter — DF cast coercion
 ];
 


### PR DESCRIPTION
## What

Third increment on **TD-183** (after the routing fix #480). The document accuracy suite's `d10` uses the function spelling `json_extract_path_text(doc, 'title')` — the portable alternative to `->>` — but DataFusion only had `json_extract_text` registered, so the OLAP route failed with `Invalid function 'json_extract_path_text'`.

Add `json_extract_path_text_udf` (same kernel as `json_extract_text`) and register it in `create_session_context`.

## Result

`d10` is now accurate (DataFusion answers it correctly; native errors on the unregistered name → anchored single-engine). Removed from `KNOWN_BAD_TD183`; **ratchet 7 → 8**.

## Scope note — native kernels reverted

I prototyped native `json_extract`/`json_extract_text` scalar kernels to also fix the filter queries d06/d07, but **reverted** them — the harness caught two problems:
1. Registering them in the engine-neutral registry makes the F2 adapter bind an untyped UDF that **shadows** the typed `(Utf8,Utf8)` Arrow UDFs and regresses DataFusion coercion (broke d07's df path).
2. They don't fix d06/d07 anyway — the native *filter* path returns 0 rows **without invoking the kernel** (a separate native-scan defect).

So this PR is the clean, no-regression slice. d06/d07/d11 stay known-bad under TD-183 for **PR4** (native filter-eval + DataFusion coercion), with root causes now documented in the TD.

## Verify

`cargo test --test document_json_pgwire_e2e -- --nocapture` → `test result: ok` (8 accurate ≥ ratchet 8; d06/d07/d11 guards hold). fmt + clippy clean.