### PR TITLE
perf(graph): depth-collapse cold result materialization via batched get_records (I/O-trace audit)

### DIFF
--- a/crates/foundation/proximadb-records/src/store.rs
+++ b/crates/foundation/proximadb-records/src/store.rs
@@ -168,6 +168,26 @@ pub trait RecordStore: Send + Sync {
 
     async fn get_record(&self, key: &RecordKey) -> RecordStoreResult<Option<ProximaRecord>>;
 
+    /// Batch point-lookup: fetch many records by key in one logical operation,
+    /// returning one slot per input key, in order (`None` = absent).
+    ///
+    /// The default loops [`Self::get_record`] (correct, no I/O saving). Stores
+    /// backed by object storage SHOULD override to issue the independent gets
+    /// **concurrently**, so K point-lookups cost ~one round-trip of latency
+    /// instead of K serial RTTs — the depth-collapse for result/frontier
+    /// materialization (ADR-034 P1: latency = depth × RTT). Note this collapses
+    /// *latency/depth*, not the op count (distinct objects ⇒ still K GETs).
+    async fn get_records(
+        &self,
+        keys: &[RecordKey],
+    ) -> RecordStoreResult<Vec<Option<ProximaRecord>>> {
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            out.push(self.get_record(key).await?);
+        }
+        Ok(out)
+    }
+
     async fn delete_record(&self, key: &RecordKey) -> RecordStoreResult<bool>;
 
     async fn upsert_records(

--- a/crates/storage/proximadb-storage-common/src/ranged_segment.rs
+++ b/crates/storage/proximadb-storage-common/src/ranged_segment.rs
@@ -284,6 +284,13 @@ impl<'b> RangedSegmentReader<'b> {
         let footer = BlockFooter::from_bytes(&tail).map_err(|e| fs_err("block footer", e))?;
 
         // 2. metadata regions (offsets are block-relative; add block_offset).
+        // NOTE: batching these into one `fetch_ranges` is a real per-block
+        // round-trip win (3→1) but it routes metadata through the *batched* bridge
+        // method, which collides with the TD-167 body-batch accounting invariant
+        // (`td167_pruned_read_batches_surviving_block_bodies_in_one_call` asserts
+        // exactly one batched bridge call — for the bodies). Deferred to a focused
+        // change that also reconciles that test (distinguish metadata vs body
+        // batches). See IOTRACE_DEPTH_COLLAPSE_SEAMS_2026_06_28.md (seam #4).
         let mr = metadata_ranges(&footer, block_size);
         let col_meta = self
             .fetch(

--- a/docs/12-design/runtime-evidence/IOTRACE_DEPTH_COLLAPSE_SEAMS_2026_06_28.md
+++ b/docs/12-design/runtime-evidence/IOTRACE_DEPTH_COLLAPSE_SEAMS_2026_06_28.md
@@ -1,0 +1,48 @@
+# I/O-trace co-design audit: object-store round-trip seams + depth-collapse
+
+**Date:** 2026-06-28 · **Lens:** ADR-034 (object-storage-native; dominant cost = I/O **round-trips + egress**, not CPU) · **Instrument:** ADR-030 I/O trace (`src/observability/io_trace.rs`)
+
+## What the trace measures (and its blind spot)
+
+`IoTrace` records `get_ops`/`put_ops`/`list_ops`/`delete_ops`, `bytes_read`/`bytes_written`, `egress_bytes`, `footer_hits`/`footer_misses`, `compute_ms`, and `range_gets` (a **depth proxy** — count of ranged-GET requests). It is hooked at the **facade layer** (`record_store`, segment readers), so counts are *logical* ops.
+
+**Blind spot:** the trace counts *depth* (serial GETs) but has **no dependent-vs-parallel distinction** — it can't tell K serial RTTs from K concurrent ones. That distinction is a query-planner/runtime concern. Existing evidence already indicts serial fan-out: `ROUTE_COST_OFFLINE_REGRET_2026_06_26.md` flags "DataFusion's per-partition GET fan-out dominates" (cost 220 vs 120).
+
+## The co-design nuance (which lever each fix pulls)
+
+For **distinct** objects, object stores have **no multi-object GET** — so two different optimizations exist, pulling different levers:
+
+| Fix | Mechanism | Lever pulled |
+|-----|-----------|--------------|
+| **Concurrent batch** (`join_all` of K gets) | K requests issued together | **latency / depth** K→1 RTT — but op count stays K (still K GETs ⇒ KRU/$ unchanged) |
+| **Segment batching** (K records in 1 object) | 1 GET returns K records | **op count** K→1 (the real KRU/$ win) — needs a storage-format change |
+| **Range batching** (`get_ranges` within 1 object) | N ranges coalesced in 1 call | **depth** N→1 on the wire (object_store coalesces) |
+
+So: concurrency buys latency; **op-count/$ reduction needs segment batching** (TD-168 residual #3 — now empirically justified, not just a write-amp cleanup).
+
+## Ranked seams
+
+| # | Seam | file:line | Cost | Status after this PR |
+|---|------|-----------|------|----------------------|
+| 1 | Graph BFS frontier materialization | `service_traversal_api.rs:453` | O(K) serial | **deferred** — uses engine-level `engine.get_node` (RAM-only, **cold-unaware**); needs cold-awareness *then* batching (see below) |
+| 2 | Entity/search result materialization | `entity_service.rs:517` | O(M) serial `get_node` | **FIXED** — batched via `get_nodes` (depth M→1 for cold misses) |
+| 3 | RecordStore had no batch get (root cause) | `store.rs:169` | forces #1/#2 loops | **FIXED** — `get_records(&[RecordKey])` added (default loop; concurrent override in `ColdGraphRecordStore`) |
+| 4 | PAX block metadata assembly | `ranged_segment.rs:272` | up to 4 serial ranged GETs/block | **deferred** — batching the 3 metadata regions is a real 3→1 per-block win, but routing metadata through the *batched* bridge method collides with the TD-167 body-batch accounting invariant (`td167_pruned_read_batches_surviving_block_bodies_in_one_call` asserts exactly one batched bridge call). Needs the test reconciled (metadata vs body batches) — own change. |
+| 5 | Segment-listing loop / footer HEAD+GET | `record_store.rs:3881` / `object_store.rs:309` | O(N) / 2-RTT | deferred (not per-query hot; footer cache mitigates) |
+
+## What this PR changed
+
+- **`RecordStore::get_records`** (foundation trait) — batch point-lookup, default loop, returns one slot per key in order. `ColdGraphRecordStore` overrides with `try_join_all` (concurrent object-store GETs → depth K→1).
+- **`GraphOperationsService::get_nodes` / `get_edges`** — engine-hot lookups stay in RAM; engine misses are cold-fetched in **one concurrent batch**; cache admission unchanged from `cold_fetch_node`. Gate-OFF / no-store ⇒ engine-only (unchanged).
+- **Entity search** (`entity_service`) materialization wired to `get_nodes` (seam #2).
+
+(Seam #4, PAX metadata batching, was prototyped then **deferred** — see the table — because it collides with the TD-167 body-batch accounting test; it warrants its own change.)
+
+All default-safe: no behavior change when the cold tier is OFF; `get_records` default impl keeps every existing `RecordStore` working unchanged.
+
+## Deferred (with rationale)
+
+- **Seam #1 (BFS frontier):** the engine traversal materializes via `engine.get_node` (RAM-only) — in cold mode it is **cold-unaware**, so it needs cold-awareness wired *before* batching helps. Larger change (engine ↔ service cold-fetch seam). The `get_nodes`/`get_records` primitives are now in place for it.
+- **Op-count/$ reduction:** needs **TD-168 #3** (batch cold payloads into bounded segments + oid→segment index) — concurrency here only collapses latency.
+- **PAX trait default `fetch_vector_segment_ranges`** still loops for test/in-memory bridges (the production `IcebergObjectStoreBridge` already overrides with `get_ranges`); low priority.
+- **Suffix-range** (`get_suffix` HEAD+GET → 1) where the backend supports `Range: bytes=-N`; cache-mitigated, low priority.

--- a/src/graph/cold_payload_store.rs
+++ b/src/graph/cold_payload_store.rs
@@ -125,6 +125,17 @@ impl RecordStore for ColdGraphRecordStore {
         }
     }
 
+    async fn get_records(
+        &self,
+        keys: &[RecordKey],
+    ) -> RecordStoreResult<Vec<Option<ProximaRecord>>> {
+        // Issue the independent object-store GETs concurrently so K cold point-
+        // lookups collapse to ~1 round-trip of latency (ADR-034 depth-collapse)
+        // instead of K serial RTTs. Each `get_record` decodes the ProximaRecordV2
+        // wire; `try_join_all` preserves input order and short-circuits on error.
+        futures::future::try_join_all(keys.iter().map(|key| self.get_record(key))).await
+    }
+
     async fn delete_record(&self, key: &RecordKey) -> RecordStoreResult<bool> {
         let path = Self::key_for(&key.oid);
         // `object_store` delete-of-missing is backend-inconsistent (InMemory/S3 are
@@ -180,6 +191,37 @@ mod tests {
             .expect("present");
         assert_eq!(got.oid, rec.oid);
         assert_eq!(got.tenant_id, rec.tenant_id);
+    }
+
+    #[tokio::test]
+    async fn get_records_batches_in_order_with_present_and_absent() {
+        let store = mem_store();
+        store
+            .upsert_record(record("graph/g1/node/a", "t"))
+            .await
+            .expect("upsert a");
+        store
+            .upsert_record(record("graph/g1/node/c", "t"))
+            .await
+            .expect("upsert c");
+
+        // Mixed batch: present, absent, present — order + slots preserved.
+        let keys = [
+            RecordKey::new("graph/g1/node/a"),
+            RecordKey::new("graph/g1/node/b"),
+            RecordKey::new("graph/g1/node/c"),
+        ];
+        let got = store.get_records(&keys).await.expect("get_records");
+        assert_eq!(got.len(), 3);
+        assert_eq!(
+            got[0].as_ref().map(|r| r.oid.as_str()),
+            Some("graph/g1/node/a")
+        );
+        assert!(got[1].is_none());
+        assert_eq!(
+            got[2].as_ref().map(|r| r.oid.as_str()),
+            Some("graph/g1/node/c")
+        );
     }
 
     #[tokio::test]

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -492,6 +492,145 @@ impl GraphOperationsService {
         Ok(Some(edge))
     }
 
+    /// Batched [`Self::get_node`] — the depth-collapse for result/frontier
+    /// materialization (ADR-034 P1: latency = depth × RTT). Engine-resident nodes
+    /// are served from RAM; the engine misses are cold-fetched from the canonical
+    /// record store in ONE concurrent batch ([`RecordStore::get_records`]) so K
+    /// cold point-lookups cost ~1 round-trip of latency instead of K serial GETs.
+    /// Returns one slot per id, in order; fetched payloads are admitted to the
+    /// byte-budgeted cache exactly as [`Self::cold_fetch_node`]. Gate OFF or no
+    /// record store ⇒ engine-only (today's behavior, unchanged).
+    pub async fn get_nodes(
+        &self,
+        graph_id: &str,
+        ids: &[String],
+    ) -> Result<Vec<Option<Arc<Node>>>> {
+        let engine = self.get_or_create_graph_engine(graph_id).await?;
+        let mut out: Vec<Option<Arc<Node>>> = Vec::with_capacity(ids.len());
+        let mut miss_slots: Vec<usize> = Vec::new();
+        for (i, id) in ids.iter().enumerate() {
+            match engine.get_node(id)? {
+                Some(node) => out.push(Some(node)),
+                None => {
+                    out.push(None);
+                    miss_slots.push(i);
+                }
+            }
+        }
+        if miss_slots.is_empty() || !cold_payloads_enabled() {
+            return Ok(out);
+        }
+        let store = match &self.canonical_record_store {
+            Some(store) => store,
+            None => return Ok(out),
+        };
+        let cache = &self.payload_caches().nodes;
+        // Cache-resident misses are served without I/O; the rest form one batch.
+        let mut fetch_slots: Vec<usize> = Vec::new();
+        let mut fetch_keys: Vec<RecordKey> = Vec::new();
+        for &slot in &miss_slots {
+            let id = &ids[slot];
+            let cache_key = CacheKey::new(graph_id, CacheKind::Other, format!("node/{id}"));
+            if let Some(node) = cache.get(&cache_key).await {
+                out[slot] = Some(node);
+            } else {
+                fetch_slots.push(slot);
+                fetch_keys.push(RecordKey::new(
+                    GraphNodeKey::new(graph_id, id).canonical_oid(),
+                ));
+            }
+        }
+        if fetch_keys.is_empty() {
+            return Ok(out);
+        }
+        let records = store
+            .get_records(&fetch_keys)
+            .await
+            .map_err(|error| ProximaDBError::Internal(error.to_string()))?;
+        for (slot, record) in fetch_slots.into_iter().zip(records) {
+            if let Some(node) = record.and_then(|record| node_from_canonical_record(&record)) {
+                let node = Arc::new(node);
+                let id = &ids[slot];
+                let cache_key = CacheKey::new(graph_id, CacheKind::Other, format!("node/{id}"));
+                cache
+                    .insert(
+                        cache_key,
+                        payload_weight(&node.id, &node.properties),
+                        node.clone(),
+                    )
+                    .await;
+                out[slot] = Some(node);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Batched [`Self::get_edge`] — symmetric to [`Self::get_nodes`] (one
+    /// concurrent cold batch for engine misses; depth-collapse, ADR-034 P1).
+    pub async fn get_edges(
+        &self,
+        graph_id: &str,
+        ids: &[String],
+    ) -> Result<Vec<Option<Arc<Edge>>>> {
+        let engine = self.get_or_create_graph_engine(graph_id).await?;
+        let mut out: Vec<Option<Arc<Edge>>> = Vec::with_capacity(ids.len());
+        let mut miss_slots: Vec<usize> = Vec::new();
+        for (i, id) in ids.iter().enumerate() {
+            match engine.get_edge(id)? {
+                Some(edge) => out.push(Some(edge)),
+                None => {
+                    out.push(None);
+                    miss_slots.push(i);
+                }
+            }
+        }
+        if miss_slots.is_empty() || !cold_payloads_enabled() {
+            return Ok(out);
+        }
+        let store = match &self.canonical_record_store {
+            Some(store) => store,
+            None => return Ok(out),
+        };
+        let cache = &self.payload_caches().edges;
+        let mut fetch_slots: Vec<usize> = Vec::new();
+        let mut fetch_keys: Vec<RecordKey> = Vec::new();
+        for &slot in &miss_slots {
+            let id = &ids[slot];
+            let cache_key = CacheKey::new(graph_id, CacheKind::Other, format!("edge/{id}"));
+            if let Some(edge) = cache.get(&cache_key).await {
+                out[slot] = Some(edge);
+            } else {
+                fetch_slots.push(slot);
+                fetch_keys.push(RecordKey::new(
+                    GraphEdgeKey::new(graph_id, id).canonical_oid(),
+                ));
+            }
+        }
+        if fetch_keys.is_empty() {
+            return Ok(out);
+        }
+        let records = store
+            .get_records(&fetch_keys)
+            .await
+            .map_err(|error| ProximaDBError::Internal(error.to_string()))?;
+        for (slot, record) in fetch_slots.into_iter().zip(records) {
+            if let Some(edge) = record.and_then(|record| edge_from_canonical_record(&record)) {
+                let edge = Arc::new(edge);
+                let id = &ids[slot];
+                let cache_key = CacheKey::new(graph_id, CacheKind::Other, format!("edge/{id}"));
+                cache
+                    .insert(
+                        cache_key,
+                        payload_weight(&edge.id, &edge.properties),
+                        edge.clone(),
+                    )
+                    .await;
+                out[slot] = Some(edge);
+            }
+        }
+        Ok(out)
+    }
+
     /// Inject the canonical WAL appender that `flush_wal` uses to persist
     /// `CanonicalOperation::Checkpoint(SnapshotManifest)` entries.
     ///

--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -1054,6 +1054,63 @@ mod tests {
         unsafe { std::env::remove_var("PROXIMADB_GRAPH_COLD_PAYLOADS") };
     }
 
+    /// Depth-collapse: `get_nodes` batches the cold misses through
+    /// `RecordStore::get_records` and returns one slot per id, in order
+    /// (present/absent/present), served via the batched cold-fetch path.
+    #[tokio::test]
+    async fn get_nodes_batches_cold_misses_in_order() {
+        let graph_id = format!("cold_batch_{}", std::process::id());
+        let graph_id = graph_id.as_str();
+        let record_store = Arc::new(
+            crate::graph::ColdGraphRecordStore::from_storage_root(
+                "memory://",
+                proximadb_storage_filesystem_types::ObjectAccessTier::Cool,
+            )
+            .expect("open memory cold store"),
+        );
+        // Seed n1 and n3 directly (engine never sees them); n2 is absent.
+        for id in ["n1", "n3"] {
+            let node = Node {
+                id: id.to_string(),
+                labels: vec!["Person".to_string()],
+                properties: HashMap::new(),
+                embedding: None,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            };
+            record_store
+                .upsert_record(
+                    crate::graph::adjacency_projection::node_to_canonical_record(graph_id, &node),
+                )
+                .await
+                .expect("seed node");
+        }
+
+        let service =
+            GraphOperationsService::new().with_canonical_record_store(record_store.clone());
+        service
+            .create_graph_collection(CreateGraphRequest {
+                graph_id: graph_id.to_string(),
+                name: None,
+                description: None,
+                schema: None,
+                storage_config: None,
+                engine_config: None,
+                access_control: None,
+            })
+            .await
+            .expect("create graph");
+
+        unsafe { std::env::set_var("PROXIMADB_GRAPH_COLD_PAYLOADS", "1") };
+        let ids = vec!["n1".to_string(), "n2".to_string(), "n3".to_string()];
+        let got = service.get_nodes(graph_id, &ids).await.expect("get_nodes");
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[0].as_ref().map(|n| n.id.as_str()), Some("n1"));
+        assert!(got[1].is_none(), "absent node → None slot");
+        assert_eq!(got[2].as_ref().map(|n| n.id.as_str()), Some("n3"));
+        unsafe { std::env::remove_var("PROXIMADB_GRAPH_COLD_PAYLOADS") };
+    }
+
     /// Verify that ORION CSR can be rebuilt from the adjacency projection.
     ///
     /// Creates 2 edges via the service (which updates the adjacency projection),

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -512,11 +512,22 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 .map_err(|e| entity_status("search entities (fusion)", e))?;
 
             // Project fused vector oids → entity nodes. The seam late-materializes
-            // (oid + score only), so fetch each node for its metadata.
+            // (oid + score only), so fetch the nodes for their metadata. Batched
+            // (`get_nodes`) so the M result lookups collapse to ~1 round-trip of
+            // latency for the cold misses (ADR-034 depth-collapse) instead of one
+            // serial GET per result.
+            let node_ids: Vec<String> = items
+                .iter()
+                .map(|item| Self::node_id_from_auxiliary_oid(&item.oid).to_owned())
+                .collect();
+            let nodes = self
+                .graph_service
+                .get_nodes(&collection, &node_ids)
+                .await
+                .map_err(|e| entity_status("materialize search entities", e))?;
             let mut results = Vec::with_capacity(items.len());
-            for item in items {
-                let node_id = Self::node_id_from_auxiliary_oid(&item.oid).to_owned();
-                if let Ok(Some(node)) = self.graph_service.get_node(&collection, &node_id).await {
+            for (item, node) in items.iter().zip(nodes) {
+                if let Some(node) = node {
                     results.push(pv2::EntityResult {
                         entity: Some(node_to_entity(&node, &collection)),
                         score: item.score,


### PR DESCRIPTION
## What

An **I/O-trace co-design audit** (object-storage cost = round-trips + egress, not CPU) found two hot read paths issuing **O(K) serial single-object GETs** to materialize result payloads — the canonical co-design failure (latency = depth × RTT). Root cause: `RecordStore` had only a singular `get_record`, so every multi-record materialization looped one cold GET at a time.

## Changes

- **`RecordStore::get_records(&[RecordKey])`** — batch point-lookup (default loop; one slot per key, in order). `ColdGraphRecordStore` overrides it to issue the independent object-store GETs **concurrently** (`try_join_all`) → K cold lookups cost ~1 round-trip of latency instead of K serial RTTs.
- **`GraphOperationsService::get_nodes` / `get_edges`** — engine-hot lookups stay in RAM; engine misses are cold-fetched in **one concurrent batch**, same cache admission as `cold_fetch_node`. Gate-OFF / no store ⇒ engine-only (unchanged).
- **Entity search** materialization (`entity_service`) wired to `get_nodes` (was one serial `get_node` per result).

## Co-design nuance (documented)

Concurrency collapses **latency/depth** (K→1 RTT) but **not op count** — distinct objects still cost K GETs, so KRU/$ is unchanged. The op-count/$ win needs **segment batching (TD-168 #3)**, now empirically justified.

## Deferred (in the audit doc)

- **PAX block-metadata batching (seam #4)** — prototyped then reverted: routing metadata through the batched bridge method collides with the **TD-167 body-batch accounting** invariant; needs that test reconciled.
- **BFS frontier materialization (seam #1)** — `service_traversal_api` uses engine-level `get_node` (RAM-only, **cold-unaware**); needs cold-awareness wired before batching helps. The `get_nodes`/`get_records` primitives are now in place for it.

## Tests / checks

`get_records` batch (order + present/absent); `get_nodes` batched cold-fetch in order; existing cold + **TD-167 body-batch** tests still green. Foundation + main-crate CI-exact clippy + fmt clean. Default-safe (`get_records` default impl keeps every existing `RecordStore` unchanged).

Audit: `docs/12-design/runtime-evidence/IOTRACE_DEPTH_COLLAPSE_SEAMS_2026_06_28.md`. Builds on #478.