### PR TITLE
feat(catalog): persist object-store catalogs via injected FileSystem (TD-CAT-1b)

### DIFF
--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -188,12 +188,42 @@ impl CatalogManager {
             ..Default::default()
         };
 
-        let catalog = proximadb_catalog::native::NativeCatalog::new(
-            name.to_string(),
-            config,
-            self.cache.clone(),
-        )
-        .await?;
+        // TD-CAT-1b (S0): object-store catalog URLs (s3://, gs://, az://) persist
+        // durably by routing all catalog I/O through an injected `FileSystem`
+        // backend resolved from the configured backends. `file://` (and bare
+        // local paths) keep the local-`tokio::fs` path (`fs = None`) so the
+        // on-disk layout and existing tests are byte-identical — the object-store
+        // branch only *relaxes* `NativeCatalog::parse_storage_url`'s fail-closed
+        // bail, it does not change the local path. A cloud scheme whose backend
+        // feature isn't compiled in surfaces a clear `UnsupportedScheme` error
+        // (still strictly safer than silently caching the catalog under /tmp).
+        let is_object_store = storage_url.starts_with("s3://")
+            || storage_url.starts_with("gs://")
+            || storage_url.starts_with("az://");
+
+        let catalog = if is_object_store {
+            let factory =
+                crate::storage::persistence::filesystem::FilesystemFactory::create_default()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("filesystem factory init failed: {e}"))?;
+            let fs = factory.get_filesystem(storage_url).map_err(|e| {
+                anyhow::anyhow!("no filesystem backend for catalog url '{storage_url}': {e}")
+            })?;
+            proximadb_catalog::native::NativeCatalog::new_with_filesystem(
+                name.to_string(),
+                config,
+                self.cache.clone(),
+                Some(fs),
+            )
+            .await?
+        } else {
+            proximadb_catalog::native::NativeCatalog::new(
+                name.to_string(),
+                config,
+                self.cache.clone(),
+            )
+            .await?
+        };
 
         let catalog: Arc<dyn Catalog> = Arc::new(catalog);
         self.register(catalog.clone()).await?;
@@ -1042,6 +1072,65 @@ mod tests {
         assert_eq!(default.name(), "first");
 
         // Clean up
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+    }
+
+    /// TD-CAT-1b (S0): the injected-`FileSystem` seam persists catalog metadata
+    /// durably and reads it back across a fresh catalog instance. This is the
+    /// exact code path `create_native_catalog` now uses for object-store URLs,
+    /// proven here over a real `file://` backend (the local backend is always
+    /// registered; cloud backends are feature-gated and covered by emulator
+    /// tests). Before #415 + this slice, object-store catalog URLs fail-closed;
+    /// this asserts the routed-through-backend write+read round-trips.
+    #[tokio::test]
+    async fn native_catalog_injected_filesystem_round_trips() {
+        use crate::storage::persistence::filesystem::FilesystemFactory;
+        use proximadb_catalog::Catalog;
+        use proximadb_catalog::native::{NativeCatalog, NativeCatalogConfig};
+
+        let temp_dir = std::env::temp_dir().join("proximadb_s0_injected_fs");
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+        let url = format!("file://{}", temp_dir.display());
+
+        let factory = FilesystemFactory::create_default()
+            .await
+            .expect("filesystem factory");
+        let fs = factory.get_filesystem(&url).expect("file:// backend");
+        let cache = CatalogManager::new().cache();
+        let config = NativeCatalogConfig {
+            storage_url: url.clone(),
+            ..Default::default()
+        };
+
+        // Write a namespace THROUGH the injected backend (fs = Some).
+        let catalog = NativeCatalog::new_with_filesystem(
+            "injected".to_string(),
+            config.clone(),
+            cache.clone(),
+            Some(fs.clone()),
+        )
+        .await
+        .expect("construct catalog with injected fs");
+        catalog
+            .create_namespace(&["s0_ns".to_string()], std::collections::HashMap::new())
+            .await
+            .expect("create namespace via injected fs");
+
+        // A FRESH catalog over the same URL+backend must load it from disk —
+        // proving the metadata was persisted durably through the backend, not
+        // just held in memory.
+        let reopened =
+            NativeCatalog::new_with_filesystem("injected".to_string(), config, cache, Some(fs))
+                .await
+                .expect("reopen catalog with injected fs");
+        assert!(
+            reopened
+                .namespace_exists(&["s0_ns".to_string()])
+                .await
+                .expect("namespace_exists"),
+            "namespace written through the injected backend must survive a reopen (durable)"
+        );
+
         let _ = tokio::fs::remove_dir_all(&temp_dir).await;
     }
 


### PR DESCRIPTION
## What

`create_native_catalog` (src/catalog/mod.rs) constructed every catalog with `fs = None`, so `NativeCatalog::parse_storage_url` **fail-closed** on `s3://`/`gs://`/`az://` — cloud catalog URLs could not start. This routes object-store schemes through a `FilesystemFactory`-resolved backend via the existing #415 `new_with_filesystem` seam, so cloud catalogs persist durably.

## Why it's safe (additive, mixed-read)

- `file://` and bare local paths keep the local-`tokio::fs` path (`fs = None`) — **byte-identical** on-disk layout, no test churn.
- The object-store branch only **relaxes** the fail-closed bail. A cloud scheme whose backend feature isn't compiled in surfaces a clear `UnsupportedScheme` error (still safer than caching the control-plane catalog under `/tmp`).

## Test

`native_catalog_injected_filesystem_round_trips`: a namespace written through an injected backend survives a catalog **reopen** over the same URL (durable round-trip) — the exact path cloud catalogs now take, proven over a real `file://` backend (cloud backends are feature-gated, covered by the emulator suite #483).

## Verification
- `cargo test --lib catalog::tests::native_catalog_injected_filesystem_round_trips` ✅
- `cargo clippy --lib --bins -- -D warnings` ✅ · `cargo fmt` clean

**S0** of the ADR-031/TD-181 catalog object_id-cutover program (the independent, layout-neutral slice — no `native.rs` on-disk-layout change, so no collision with the OID-substrate session).