### PR TITLE
feat(fusion): populate FusionHit.labels from reached graph nodes (#485)

### DIFF
--- a/clients/go/proximadb/internal/genrest/genrest.gen.go
+++ b/clients/go/proximadb/internal/genrest/genrest.gen.go
@@ -437,9 +437,14 @@ type ExplainQueryRequest struct {
 
 // FusionHit defines model for FusionHit.
 type FusionHit struct {
-	Oid         string  `json:"oid"`
-	Score       float32 `json:"score"`
-	SourceCount int     `json:"source_count"`
+	// Labels Graph node label(s) of the reached node. Exposed so cross-modal-joint
+	// consumers can correlate a fused hit by its graph label without a separate
+	// node lookup (#485). The expansion already reaches the node, so this is
+	// near-free to fill. Additive + back-compat (empty until populated).
+	Labels      *[]string `json:"labels,omitempty"`
+	Oid         string    `json:"oid"`
+	Score       float32   `json:"score"`
+	SourceCount int       `json:"source_count"`
 }
 
 // FusionSearchRequest defines model for FusionSearchRequest.

--- a/clients/nodejs-embedded/src/generated/schema.ts
+++ b/clients/nodejs-embedded/src/generated/schema.ts
@@ -1176,6 +1176,13 @@ export interface components {
             query: string;
         };
         FusionHit: {
+            /**
+             * @description Graph node label(s) of the reached node. Exposed so cross-modal-joint
+             *     consumers can correlate a fused hit by its graph label without a separate
+             *     node lookup (#485). The expansion already reaches the node, so this is
+             *     near-free to fill. Additive + back-compat (empty until populated).
+             */
+            labels?: string[];
             oid: string;
             /** Format: float */
             score: number;

--- a/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_hit.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_hit.py
@@ -4,7 +4,7 @@
 # docs/openapi/proximadb-openapi.yaml. The CI gate `python-sdk-codegen-drift`
 # fails if this directory drifts from a fresh regeneration.
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, BinaryIO, Optional, TextIO, TypeVar
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional, TextIO, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -21,11 +21,16 @@ class FusionHit:
         oid (str):
         score (float):
         source_count (int):
+        labels (Union[Unset, list[str]]): Graph node label(s) of the reached node. Exposed so cross-modal-joint
+            consumers can correlate a fused hit by its graph label without a separate
+            node lookup (#485). The expansion already reaches the node, so this is
+            near-free to fill. Additive + back-compat (empty until populated).
     """
 
     oid: str
     score: float
     source_count: int
+    labels: Union[Unset, list[str]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,6 +39,10 @@ class FusionHit:
         score = self.score
 
         source_count = self.source_count
+
+        labels: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.labels, Unset):
+            labels = self.labels
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -44,6 +53,8 @@ class FusionHit:
                 "source_count": source_count,
             }
         )
+        if labels is not UNSET:
+            field_dict["labels"] = labels
 
         return field_dict
 
@@ -56,10 +67,13 @@ class FusionHit:
 
         source_count = d.pop("source_count")
 
+        labels = cast(list[str], d.pop("labels", UNSET))
+
         fusion_hit = cls(
             oid=oid,
             score=score,
             source_count=source_count,
+            labels=labels,
         )
 
         fusion_hit.additional_properties = d

--- a/clients/rust/src/genrest.rs
+++ b/clients/rust/src/genrest.rs
@@ -2444,6 +2444,13 @@ pub mod types {
     ///    "source_count"
     ///  ],
     ///  "properties": {
+    ///    "labels": {
+    ///      "description": "Graph node label(s) of the reached node. Exposed so cross-modal-joint\nconsumers can correlate a fused hit by its graph label without a separate\nnode lookup (#485). The expansion already reaches the node, so this is\nnear-free to fill. Additive + back-compat (empty until populated).",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    },
     ///    "oid": {
     ///      "type": "string"
     ///    },
@@ -2461,6 +2468,12 @@ pub mod types {
     /// </details>
     #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
     pub struct FusionHit {
+        /// Graph node label(s) of the reached node. Exposed so cross-modal-joint
+        /// consumers can correlate a fused hit by its graph label without a separate
+        /// node lookup (#485). The expansion already reaches the node, so this is
+        /// near-free to fill. Additive + back-compat (empty until populated).
+        #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+        pub labels: ::std::vec::Vec<::std::string::String>,
         pub oid: ::std::string::String,
         pub score: f32,
         pub source_count: u64,
@@ -8693,6 +8706,10 @@ pub mod types {
         }
         #[derive(Clone, Debug)]
         pub struct FusionHit {
+            labels: ::std::result::Result<
+                ::std::vec::Vec<::std::string::String>,
+                ::std::string::String,
+            >,
             oid: ::std::result::Result<::std::string::String, ::std::string::String>,
             score: ::std::result::Result<f32, ::std::string::String>,
             source_count: ::std::result::Result<u64, ::std::string::String>,
@@ -8700,6 +8717,7 @@ pub mod types {
         impl ::std::default::Default for FusionHit {
             fn default() -> Self {
                 Self {
+                    labels: Ok(Default::default()),
                     oid: Err("no value supplied for oid".to_string()),
                     score: Err("no value supplied for score".to_string()),
                     source_count: Err("no value supplied for source_count".to_string()),
@@ -8707,6 +8725,16 @@ pub mod types {
             }
         }
         impl FusionHit {
+            pub fn labels<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.labels = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for labels: {e}"));
+                self
+            }
             pub fn oid<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::string::String>,
@@ -8744,6 +8772,7 @@ pub mod types {
                 value: FusionHit,
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
+                    labels: value.labels?,
                     oid: value.oid?,
                     score: value.score?,
                     source_count: value.source_count?,
@@ -8753,6 +8782,7 @@ pub mod types {
         impl ::std::convert::From<super::FusionHit> for FusionHit {
             fn from(value: super::FusionHit) -> Self {
                 Self {
+                    labels: Ok(value.labels),
                     oid: Ok(value.oid),
                     score: Ok(value.score),
                     source_count: Ok(value.source_count),

--- a/docs/openapi/proximadb-openapi.yaml
+++ b/docs/openapi/proximadb-openapi.yaml
@@ -708,6 +708,15 @@ components:
       type: object
     FusionHit:
       properties:
+        labels:
+          description: |-
+            Graph node label(s) of the reached node. Exposed so cross-modal-joint
+            consumers can correlate a fused hit by its graph label without a separate
+            node lookup (#485). The expansion already reaches the node, so this is
+            near-free to fill. Additive + back-compat (empty until populated).
+          items:
+            type: string
+          type: array
         oid:
           type: string
         score:

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -192,25 +192,25 @@ pub async fn fusion_search_v2(
         oid_key: FusionOidKey::Canonical,
     };
 
-    let (items, stats) = service
-        .graph_fusion_search(params)
+    let (items, stats, node_labels) = service
+        .graph_fusion_search_with_labels(params)
         .await
         .map_err(|error| ApiError::Internal(format!("fusion search failed: {error}")))?;
 
     Ok(Json(FusionSearchResponse {
         results: items
             .into_iter()
-            .map(|item| FusionHit {
-                oid: item.oid,
-                score: item.score,
-                source_count: item.source_count,
-                // SEAM (#485): the contract field is landed here. POPULATE from the
-                // reached node's labels during graph expansion — thread `labels` onto
-                // the internal fusion item (the `graph_fusion_search` result type) from
-                // `Node.labels` at the point the expansion visits each node, then map it
-                // here (`labels: item.labels`). Empty for now keeps it compiling +
-                // back-compat; the population is the remaining producer work.
-                labels: Vec::new(),
+            .map(|item| {
+                // #485: the reached node's graph label(s), joined post-fuse by the fusion service
+                // (FusedItem stays modality-pure), so cross-modal-joint consumers read the label
+                // per fused hit without a separate node lookup. Empty for vector-only/edge hits.
+                let labels = node_labels.get(&item.oid).cloned().unwrap_or_default();
+                FusionHit {
+                    oid: item.oid,
+                    score: item.score,
+                    source_count: item.source_count,
+                    labels,
+                }
             })
             .collect(),
         stats: stats.into(),

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -66,6 +66,12 @@ pub struct FusionHit {
     pub oid: String,
     pub score: f32,
     pub source_count: usize,
+    /// Graph node label(s) of the reached node. Exposed so cross-modal-joint
+    /// consumers can correlate a fused hit by its graph label without a separate
+    /// node lookup (#485). The expansion already reaches the node, so this is
+    /// near-free to fill. Additive + back-compat (empty until populated).
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -198,6 +204,13 @@ pub async fn fusion_search_v2(
                 oid: item.oid,
                 score: item.score,
                 source_count: item.source_count,
+                // SEAM (#485): the contract field is landed here. POPULATE from the
+                // reached node's labels during graph expansion — thread `labels` onto
+                // the internal fusion item (the `graph_fusion_search` result type) from
+                // `Node.labels` at the point the expansion visits each node, then map it
+                // here (`labels: item.labels`). Empty for now keeps it compiling +
+                // back-compat; the population is the remaining producer work.
+                labels: Vec::new(),
             })
             .collect(),
         stats: stats.into(),

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -180,6 +180,28 @@ pub(crate) fn traversal_nodes_to_source(
     SourceCandidates::new(SourceId::Graph, weight, scores)
 }
 
+/// Map each reached node's fused `oid` → its graph label(s) (#485). The graph expansion already
+/// visits every node (with `Node.labels` in hand), so this is near-free and lets the cross-modal
+/// fusion service attach the label to a fused hit *post-fuse* without a separate node lookup —
+/// keeping [`FusedItem`] modality-pure. Unlabeled nodes are skipped (no entry ⇒ empty labels);
+/// vector-only and edge-grain hits never appear here. Keyed by the same `fusion_key` the sources
+/// use, so it joins on the `FusedItem.oid` for both `Canonical` and `EntityNode` keying.
+pub(crate) fn node_labels_by_oid(
+    graph_id: &str,
+    nodes: &[Node],
+    oid_key: FusionOidKey,
+) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    for node in nodes {
+        if node.labels.is_empty() {
+            continue;
+        }
+        let oid = oid_key.fusion_key(&GraphNodeKey::new(graph_id, node.id.clone()).canonical_oid());
+        map.entry(oid).or_insert_with(|| node.labels.clone());
+    }
+    map
+}
+
 /// Graph traversal **edges** → an `oid`-keyed graph source at *edge grain* (the relationship is the
 /// fusion unit). `oid` is the canonical `graph/{graph_id}/edge/{edge_id}` — distinct from node `oid`s,
 /// so edges rank as their own items. Score = `1/(rank+1)` from traversal order; an edge seen more than
@@ -410,10 +432,10 @@ impl FusionService {
     /// T1.2: Implements graceful degradation — if graph traversal fails for a seed, the search
     /// continues with the remaining seeds and the vector source alone. Only total failure (vector
     /// search exhausts retries) returns an error.
-    pub async fn graph_fusion_search(
+    pub async fn graph_fusion_search_with_labels(
         &self,
         params: GraphFusionParams,
-    ) -> Result<(Vec<FusedItem>, FusionStats)> {
+    ) -> Result<(Vec<FusedItem>, FusionStats, HashMap<String, Vec<String>>)> {
         use std::time::Instant;
 
         let started = Instant::now();
@@ -557,6 +579,15 @@ impl FusionService {
             }
         }
 
+        // #485: capture the reached node labels (node-grain only) before fusing, keyed by the same
+        // fused oid, so we can attach the graph label to each hit post-fuse without re-touching the
+        // node store and without polluting the modality-pure FusedItem.
+        let node_labels = if matches!(params.grain, GraphGrain::Nodes | GraphGrain::Both) {
+            node_labels_by_oid(&params.graph_id, &nodes, params.oid_key)
+        } else {
+            HashMap::new()
+        };
+
         // 4. Calibrate + fuse-by-oid + rank, OR the raw-union kill-switch fallback (TD-131). The OID
         //    set is identical between the two when `limit ≥ candidate count` — calibration only re-ranks.
         let result = if fusion_calibration_disabled() {
@@ -579,7 +610,19 @@ impl FusionService {
             started.elapsed(),
         );
 
-        Ok(result)
+        Ok((result.0, result.1, node_labels))
+    }
+
+    /// Vector → graph expand → calibrated fuse-by-oid (the back-compat surface used by the
+    /// gRPC / embedded / entity-orchestrator callers that do not need per-hit graph labels).
+    /// Delegates to [`graph_fusion_search_with_labels`](Self::graph_fusion_search_with_labels)
+    /// and drops the `oid → labels` join.
+    pub async fn graph_fusion_search(
+        &self,
+        params: GraphFusionParams,
+    ) -> Result<(Vec<FusedItem>, FusionStats)> {
+        let (items, stats, _labels) = self.graph_fusion_search_with_labels(params).await?;
+        Ok((items, stats))
     }
 
     /// Resolve `oid` → backing `ProximaRecord` via the graph service's canonical store and apply the
@@ -687,6 +730,55 @@ mod tests {
         assert_eq!(
             fused.source_count, 2,
             "vector + graph hit on the same oid merge"
+        );
+    }
+
+    /// #485: the reached node's labels join onto the fused hit by `oid`, and a fused hit from a
+    /// labeled node carries them while unlabeled / vector-only hits carry none.
+    #[test]
+    fn fused_hit_carries_reached_node_labels() {
+        let labeled = Node {
+            id: "fn_login".to_string(),
+            labels: vec!["Function".to_string()],
+            ..Default::default()
+        };
+        let nodes = [labeled.clone(), node("fn_anon")]; // fn_anon has no labels
+
+        let labels_by_oid = node_labels_by_oid("g1", &nodes, FusionOidKey::Canonical);
+        assert_eq!(
+            labels_by_oid.get("graph/g1/node/fn_login"),
+            Some(&vec!["Function".to_string()]),
+            "labeled node's canonical oid carries its labels"
+        );
+        assert!(
+            !labels_by_oid.contains_key("graph/g1/node/fn_anon"),
+            "unlabeled node has no entry → empty labels downstream"
+        );
+
+        // Join onto a fused hit: the labeled node fuses with a vector hit on the shared oid; the
+        // post-fuse join surfaces the label, while a vector-only oid stays unlabeled.
+        let oid = "graph/g1/node/fn_login";
+        let vector = vector_hits_to_source(&[hit(oid, 0.9), hit("graph/g1/node/other", 0.5)], 1.0);
+        let graph = traversal_nodes_to_source("g1", &[labeled], 1.0);
+        let (items, _stats) = Fuser::new(FusionPolicy::default()).fuse(vec![vector, graph], 10);
+
+        let fused = items.iter().find(|i| i.oid == oid).expect("shared oid fused");
+        assert_eq!(
+            labels_by_oid.get(&fused.oid).cloned().unwrap_or_default(),
+            vec!["Function".to_string()],
+            "fused hit from the labeled node carries its label"
+        );
+        let other = items
+            .iter()
+            .find(|i| i.oid == "graph/g1/node/other")
+            .expect("vector-only oid present");
+        assert!(
+            labels_by_oid
+                .get(&other.oid)
+                .cloned()
+                .unwrap_or_default()
+                .is_empty(),
+            "vector-only hit carries no label"
         );
     }
 

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -762,7 +762,10 @@ mod tests {
         let graph = traversal_nodes_to_source("g1", &[labeled], 1.0);
         let (items, _stats) = Fuser::new(FusionPolicy::default()).fuse(vec![vector, graph], 10);
 
-        let fused = items.iter().find(|i| i.oid == oid).expect("shared oid fused");
+        let fused = items
+            .iter()
+            .find(|i| i.oid == oid)
+            .expect("shared oid fused");
         assert_eq!(
             labels_by_oid.get(&fused.oid).cloned().unwrap_or_default(),
             vec!["Function".to_string()],


### PR DESCRIPTION
Lands the **population** for the `FusionHit.labels` seam (issue #485; contract scaffolded in `9ada3538`). Cross-modal-joint consumers (AnvaiOps #256 consumer slice) can now read each fused hit's graph label without a separate node lookup.

### Design (per the #485 note: keep `FusedItem` pure)
The neutral fuse core stays modality-agnostic — `FusedItem` is **unchanged**. The `oid → labels` join lives at the **graph-fusion service layer, post-`fuse()`**:
- `fusion_service.rs`: `node_labels_by_oid(graph_id, nodes, oid_key)` maps each reached node's fused `oid` → its `Node.labels` (keyed by the same `fusion_key`, so it joins for both `Canonical` and `EntityNode`). `graph_fusion_search_with_labels` builds it from the reached nodes and returns it as a 3rd element.
- `graph_fusion_search` is now a thin back-compat wrapper that drops the labels, so the **5 existing callers** (3 gRPC + embedded + entity-orchestrator) are untouched.
- `graphs.rs`: the REST `fusion-search` handler joins `node_labels` by `oid` into `FusionHit.labels` (empty for vector-only / edge-grain hits).
- Regenerated `docs/openapi/proximadb-openapi.yaml` (additive `labels` array — `utoipa` `ToSchema`).

### Verify
- New test `fused_hit_carries_reached_node_labels` (labeled node carries labels; vector-only/unlabeled carry none). 190 fusion tests pass.
- `cargo build -p proximadb-server` (server binary, not just `--lib`), `cargo clippy`, and the `openapi_spec_gen` drift gate all green. OSS-boundary guard: 0 errors.

Additive + back-compat. gRPC parity deferred (consumer uses REST). Tracks AnvaiOps #256.