### PR TITLE
fix(query): evaluate pushed-down native predicates against builtins + fail loud (TD-183, doc ratchet 8→9)

### DIFF
--- a/crates/foundation/proximadb-relational-types/src/lib.rs
+++ b/crates/foundation/proximadb-relational-types/src/lib.rs
@@ -604,6 +604,63 @@ impl Expr {
             }
         }
     }
+
+    /// Recursively collect every function-call name referenced in this expression
+    /// (in evaluation order). Used to pre-validate that a predicate's functions
+    /// resolve against the executor's registry before scanning, so a scan that
+    /// cannot evaluate a function fails loudly instead of silently dropping rows.
+    pub fn collect_func_names<'a>(&'a self, out: &mut Vec<&'a str>) {
+        match self {
+            Expr::Column(_) | Expr::Literal { .. } => {}
+            Expr::Cast { expr, .. } | Expr::UnaryOp { expr, .. } | Expr::IsNull { expr, .. } => {
+                expr.collect_func_names(out)
+            }
+            Expr::BinaryOp { left, right, .. } | Expr::NullIf { left, right } => {
+                left.collect_func_names(out);
+                right.collect_func_names(out);
+            }
+            Expr::Between {
+                expr, low, high, ..
+            } => {
+                expr.collect_func_names(out);
+                low.collect_func_names(out);
+                high.collect_func_names(out);
+            }
+            Expr::In { expr, list, .. } => {
+                expr.collect_func_names(out);
+                for e in list {
+                    e.collect_func_names(out);
+                }
+            }
+            Expr::Like { expr, pattern, .. } => {
+                expr.collect_func_names(out);
+                pattern.collect_func_names(out);
+            }
+            Expr::Case {
+                branches,
+                otherwise,
+            } => {
+                for (cond, then) in branches {
+                    cond.collect_func_names(out);
+                    then.collect_func_names(out);
+                }
+                if let Some(default) = otherwise {
+                    default.collect_func_names(out);
+                }
+            }
+            Expr::Coalesce(args) => {
+                for a in args {
+                    a.collect_func_names(out);
+                }
+            }
+            Expr::FuncCall { name, args, .. } => {
+                out.push(name.as_str());
+                for a in args {
+                    a.collect_func_names(out);
+                }
+            }
+        }
+    }
 }
 
 /// Best-effort inference of a `ProximaValue`'s `ProximaType`.

--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -92,15 +92,30 @@ regresses DataFusion coercion in comparison contexts (observed on d07). They als
 NOT fix d06/d07 — the native *filter* path returns 0 rows without ever invoking the
 kernel, so that is a separate native-filter-evaluation defect, not a missing kernel.
 
-**PR4 — remaining three (open):**
+**PR4 — native predicate fix (done):**
 
-* **d06, d07** — the native (pre-MATERIALIZE) filter path returns 0 rows for a JSON
-  function in WHERE; the scan does not evaluate the json-extract scalar. Fix the
-  native filter/scan path to evaluate JSON-extract predicates (and add native kernels
-  *without* the registry-shadow regression — e.g. skip F2 binding for them robustly).
-* **d07, d11** — DataFusion coercion: `json_extract_text(Utf8,Utf8)` in a bare `=`
-  comparison, and `Utf8 = Boolean` for `(doc->>'in_stock')::boolean = true`, both fail
-  type coercion on the OLAP route.
+Root cause of the native filter 0-rows: `DmlTableReader::open`'s pushed-down predicate
+closure (`relational_pipeline.rs`) evaluated against an EMPTY registry (`&NoFunctions`)
+and coerced any eval `Err` to `false` via `matches!(…, Ok(Boolean(true)))` — so *any*
+function in a pushed-down WHERE (even `upper`) silently dropped every row. Fix: evaluate
+against `proximadb_functions::builtins()`, and pre-validate in `open` that every
+predicate function resolves (new `Expr::collect_func_names`), returning a loud
+`UnknownFunction` error instead of silently dropping rows.
+
+* **d07** (`doc->>'title' = 'alpha'`) — now native errors loud on the unregistered
+  `json_extract_text` → anchored single-engine (DataFusion correct). Accurate. Ratchet
+  8 → 9. Also fixes the latent "no function works in a pushed-down native WHERE" bug.
+
+**PR5 — remaining two (open):**
+
+* **d06** (`(doc->>'price')::int > 8`) — the cast-wrapped predicate takes a path that
+  bypasses `DmlTableReader::open`'s pre-validation, so it still silently returns 0 rows
+  on native (DataFusion correct). Route that path through the same validate/evaluate
+  fix (or evaluate it through `builtins()` so the cast-of-json predicate errors loud).
+* **d11** (`(doc->>'in_stock')::boolean = true`) — DataFusion drops the `::boolean`
+  cast in frontend lowering, so the analyzer sees `Utf8 = Boolean` and fails coercion
+  (`src/datafusion/logical_lowering.rs:429` is correct; the gap is upstream in
+  `proximadb-relational-frontend` not emitting the `Expr::Cast { ty: Boolean }`).
 
 Each fix removes its ids from `KNOWN_BAD_TD183` and raises `DOC_ACCURACY_RATCHET`
 toward 11; the known-bad guards fail the moment a query becomes correct, forcing the

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -31,6 +31,7 @@ use crate::query::execution::{
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use proximadb_data_model::{ProximaType, ProximaValue};
+use proximadb_functions::builtins;
 use proximadb_relational_algebra::TableId;
 use proximadb_relational_engine::{
     EngineReaderFactory, InMemoryRelationalEngine, RelationalWriter,
@@ -41,7 +42,7 @@ use proximadb_relational_planner::{
     CapabilityResolver, PhysicalPlan, Planner, StaticCapabilities, explain_physical,
 };
 use proximadb_relational_reader::{ReaderCapabilities, ReaderError, RelationalReader, ScanContext};
-use proximadb_relational_types::{ColumnInfo, Expr, NoFunctions, RelationalRow, RelationalSchema};
+use proximadb_relational_types::{ColumnInfo, Expr, ExprError, RelationalRow, RelationalSchema};
 use sqlparser::ast::{
     BinaryOperator, Expr as SqlExpr, GroupByExpr, Query as SqlQuery, SelectItem, SetExpr,
     Statement, TableFactor, TableWithJoins,
@@ -750,12 +751,31 @@ impl RelationalReader for DmlTableReader {
         if let Some(pred) = &ctx.predicate {
             pred.type_check(&self.full_schema)
                 .map_err(ReaderError::PredicateEval)?;
+            // The pushed-down predicate is evaluated row-wise below through a boolean
+            // closure that has no error channel, so an eval failure would otherwise be
+            // silently coerced to `false` and drop every row. Pre-validate that each
+            // referenced function resolves in the executor registry and fail loudly
+            // here instead. (TD-183: native JSON filters — `json_extract*` — are not
+            // yet registered natively, so they surface as a clear error and the OLAP
+            // route serves them, rather than silently returning 0 rows.)
+            let mut func_names: Vec<&str> = Vec::new();
+            pred.collect_func_names(&mut func_names);
+            for name in func_names {
+                if builtins().lookup_scalar(name).is_none() {
+                    return Err(ReaderError::PredicateEval(ExprError::UnknownFunction {
+                        name: name.to_string(),
+                    }));
+                }
+            }
         }
         let predicate: Option<Expr> = ctx.predicate.clone();
         let row_pred = move |full_row: &[ProximaValue]| -> bool {
             match &predicate {
+                // Evaluate against the real builtin registry (not an empty one) so
+                // functions actually resolve in pushed-down native predicates;
+                // unresolvable functions were already rejected in `open` above.
                 Some(expr) => matches!(
-                    expr.eval(&full_row.to_vec(), &NoFunctions),
+                    expr.eval(&full_row.to_vec(), builtins()),
                     Ok(ProximaValue::Boolean(true))
                 ),
                 None => true,

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -18,11 +18,14 @@
 //! The accuracy conversion exposed that JSON-path extraction in a SELECT
 //! projection or WHERE filter returned 0 rows (the queries were misrouted to the
 //! document store). Fixed incrementally: the routing fix (#480) repaired the
-//! projections d04/d05/d08; the DataFusion `json_extract_path_text` alias UDF (this
-//! PR) repaired the function-form projection d10. 8 of 11 are now accurate. The
-//! filters d06/d07 (native filter path returns 0 rows for a JSON function) and d11
-//! (DataFusion `Utf8 = Boolean` coercion) stay KNOWN-BAD under TD-183 — asserted to
-//! still be wrong so the next fix trips the guard — and excluded from the ratchet.
+//! projections d04/d05/d08; the DataFusion `json_extract_path_text` alias UDF (#486)
+//! repaired the function-form projection d10; the native predicate fix (this PR)
+//! repaired d07 (pushed-down WHERE predicates now evaluate against the real builtin
+//! registry and reject unresolvable functions loudly instead of silently dropping
+//! rows). 9 of 11 are now accurate. d06 (a cast-wrapped predicate that bypasses the
+//! new pre-validation) and d11 (DataFusion `Utf8 = Boolean` coercion) stay KNOWN-BAD
+//! under TD-183 — asserted to still be wrong so the next fix trips the guard —
+//! excluded from the ratchet.
 //!
 //!   RUST_LOG=proximadb=debug cargo test --test document_json_pgwire_e2e -- --nocapture
 
@@ -35,11 +38,12 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 /// Queries that must be verified CORRECT (anchored + differential) to count.
-/// 8 of 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
-/// (projections, routing fix #480), and d10 (DataFusion `json_extract_path_text`
-/// alias UDF, this PR). d06/d07/d11 remain known-bad under TD-183 (native filter
-/// eval + DataFusion coercion); the ratchet rises as those land.
-const DOC_ACCURACY_RATCHET: usize = 8;
+/// 9 of 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
+/// (projections, routing fix #480), d10 (DataFusion `json_extract_path_text` alias
+/// #486), and d07 (native predicate fix, this PR). d06 (cast-path bypass) and d11
+/// (DataFusion `Utf8 = Boolean` coercion) remain known-bad under TD-183; the ratchet
+/// rises as those land.
+const DOC_ACCURACY_RATCHET: usize = 9;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -162,16 +166,20 @@ fn doc_queries() -> Vec<(&'static str, String)> {
 /// fix trips the guard and forces the ratchet up. Excluded from the ratchet.
 ///
 /// Resolved so far: the routing fix (#480) fixed the projections d04/d05/d08; the
-/// DataFusion `json_extract_path_text` alias UDF (this PR) fixed the function-form
-/// projection d10. Remaining, all needing deeper work (separate follow-up):
-///   * d06/d07 — the native (pre-MATERIALIZE) filter path returns 0 rows for a JSON
-///     function in WHERE (it is not evaluated through the scalar kernel); registering
-///     the native kernel does not help and regresses DataFusion via registry binding.
-///   * d07/d11 — DataFusion coercion: `json_extract_text(Utf8,Utf8)` in a bare `=`
-///     comparison and `Utf8 = Boolean` for `(… )::boolean` both fail type coercion.
+/// DataFusion `json_extract_path_text` alias UDF (#486) fixed the function-form
+/// projection d10; the native predicate fix (this PR — pushed-down WHERE predicates
+/// now evaluate against the real builtin registry and reject unresolvable functions
+/// loudly instead of silently dropping rows) made d07 accurate (native errors on the
+/// unregistered JSON function → anchored single-engine; DataFusion is correct).
+/// Remaining:
+///   * d06 — `(doc->>'price')::int > 8`: the cast-wrapped predicate takes a path that
+///     bypasses the new `DmlTableReader::open` pre-validation, so it still silently
+///     returns 0 rows on native (DataFusion is correct). Needs that path to route
+///     through the same validate/evaluate fix.
+///   * d11 — DataFusion cannot coerce `Utf8 = Boolean` for `(doc->>'in_stock')::boolean
+///     = true`; the `::boolean` cast is dropped in lowering.
 const KNOWN_BAD_TD183: &[&str] = &[
-    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — native 0-rows
-    "d07_filter_json_text",   // doc->>'title' = 'alpha'        filter — native 0-rows + DF coercion
+    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — cast-path bypass
     "d11_bool_field",         // (doc->>'in_stock')::boolean    filter — DF cast coercion
 ];
 


### PR DESCRIPTION
## What
Fourth increment on **TD-183**. Fixes a **latent silent-data-loss bug** and makes the document accuracy suite's `d07` pass.

## Root cause
`DmlTableReader::open`'s pushed-down predicate closure (`relational_pipeline.rs`) evaluated rows against an **empty** function registry (`&NoFunctions`) and coerced any eval error to `false` via `matches!(expr.eval(...), Ok(Boolean(true)))`. So a pushed-down WHERE predicate calling **any** function — even `upper` — silently dropped every row. For JSON filters (`json_extract_text`, not registered natively), this is why d06/d07 returned **0 rows on native** while DataFusion answered correctly.

## Fix
- Evaluate the predicate against `proximadb_functions::builtins()` instead of an empty registry.
- Pre-validate in `open()` that every function the predicate references resolves in `builtins()` (new `Expr::collect_func_names` walker over all `Expr` variants) → loud `UnknownFunction` error instead of silently dropping rows.

No DataFusion / registry-binding changes (avoids the F2-shadow minefield from the reverted native-kernel attempt).

## Result
`d07` is now accurate (native errors loud → anchored single-engine; DataFusion correct). Removed from `KNOWN_BAD_TD183`; **ratchet 8 → 9**.

## Remaining under TD-183 → PR5
- **d06** (`(doc->>'price')::int > 8`) — the cast-wrapped predicate takes a path that **bypasses** this pre-validation and still returns 0 rows. (This is the seam a holistic unification of pushed-down predicate evaluation should close.)
- **d11** (`(doc->>'in_stock')::boolean = true`) — DataFusion drops the `::boolean` cast in lowering → `Utf8 = Boolean` coercion failure.

## Verify
`cargo test --test document_json_pgwire_e2e -- --nocapture` → `ok` (9 accurate ≥ ratchet 9; d06/d11 guards hold). fmt + clippy clean.