### PR TITLE
test(timeseries): ADR-040 value-correctness for TSBS pgwire suite (TD-182 P1b)

### DIFF
--- a/tests/events_tsbs_pgwire_e2e.rs
+++ b/tests/events_tsbs_pgwire_e2e.rs
@@ -101,6 +101,39 @@ fn explain_err(e: &tokio_postgres::Error) -> String {
     }
 }
 
+/// Normalize a result cell for value comparison: numeric cells are reparsed to a
+/// canonical form (whole numbers without a decimal, fractions minimal) so engine
+/// rendering (`95` vs `95.0` vs `95.000`) doesn't matter; other text passes through.
+fn norm_cell(s: &str) -> String {
+    match s.parse::<f64>() {
+        Ok(f) if f.fract() == 0.0 => format!("{}", f as i64),
+        Ok(f) => format!("{f}"),
+        Err(_) => s.to_string(),
+    }
+}
+
+/// Run a query and return its rows as normalized text cells, **sorted** for
+/// order-independent set comparison (ADR-040 `canon()` style; row order across
+/// routes is a separate concern — see TD-185).
+async fn canon_rows(client: &tokio_postgres::Client, sql: &str) -> Vec<Vec<String>> {
+    let mut rows: Vec<Vec<String>> = client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)))
+        .into_iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                (0..r.len())
+                    .map(|i| norm_cell(r.get(i).unwrap_or("NULL")))
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
 const SCHEMA: &[(&str, &str)] = &[(
     "cpu",
     "CREATE TABLE cpu (ts TIMESTAMP, hostname VARCHAR, region VARCHAR, datacenter VARCHAR, usage_user DOUBLE PRECISION, usage_system DOUBLE PRECISION, usage_idle DOUBLE PRECISION)",
@@ -321,4 +354,81 @@ async fn events_tsbs_pgwire_conformance() {
         "second high-cpu host"
     );
     eprintln!("✓ value-correctness: high-cpu = host_0(95), host_1(92)");
+
+    // ADR-040 P1 (TD-182): VALUE-correctness for the time-series shapes the ratchet
+    // only EXECUTES. Expected values hand-derived from the 8-row seed (host_0/us-east
+    // usage_user 25,35,95,40; host_1/us-west 50,92,60,70 at 00:00/00:10/00:20/01:00).
+    // Order-independent (rows sorted, normalized) — see TD-185 for the materialized
+    // ORDER BY quirk.
+    let row = |cols: &[&str]| cols.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+    // max_all: per-host maximum of each metric.
+    assert_eq!(
+        canon_rows(
+            &client,
+            "select hostname, max(usage_user), max(usage_system), max(usage_idle) from cpu group by hostname order by hostname"
+        )
+        .await,
+        vec![
+            row(&["host_0", "95", "20", "65"]),
+            row(&["host_1", "92", "35", "20"]),
+        ],
+        "max_all: per-host metric maxima"
+    );
+
+    // high_cpu_by_region: count of usage_user > 90 per region (one each).
+    assert_eq!(
+        canon_rows(
+            &client,
+            "select region, count(*) as n from cpu where usage_user > 90.0 group by region order by region"
+        )
+        .await,
+        vec![row(&["us-east", "1"]), row(&["us-west", "1"])],
+        "high_cpu_by_region: one >90 reading per region"
+    );
+
+    // region_having: avg(usage_user) per region, HAVING avg > 40 (both qualify).
+    assert_eq!(
+        canon_rows(
+            &client,
+            "select region, avg(usage_user) as au from cpu group by region having avg(usage_user) > 40.0 order by region"
+        )
+        .await,
+        vec![
+            row(&["us-east", "48.75"]),
+            row(&["us-west", "68"]),
+        ],
+        "region_having: us-east avg 48.75, us-west avg 68"
+    );
+
+    // last_point: window row_number() — the latest reading per host.
+    assert_eq!(
+        canon_rows(
+            &client,
+            "select hostname, usage_user from (select hostname, ts, usage_user, row_number() over (partition by hostname order by ts desc) as rn from cpu) t where rn = 1 order by hostname"
+        )
+        .await,
+        vec![row(&["host_0", "40"]), row(&["host_1", "70"])],
+        "last_point: latest usage_user per host (window row_number)"
+    );
+
+    // windowed_avg: moving average over (1 preceding, current) per host by ts.
+    assert_eq!(
+        canon_rows(
+            &client,
+            "select hostname, avg(usage_user) over (partition by hostname order by ts rows between 1 preceding and current row) as moving_avg from cpu"
+        )
+        .await,
+        vec![
+            row(&["host_0", "25"]),
+            row(&["host_0", "30"]),
+            row(&["host_0", "65"]),
+            row(&["host_0", "67.5"]),
+            row(&["host_1", "50"]),
+            row(&["host_1", "65"]),
+            row(&["host_1", "71"]),
+            row(&["host_1", "76"]),
+        ],
+        "windowed_avg: per-host moving average (1 preceding + current)"
+    );
 }


### PR DESCRIPTION
## What (TD-182 P1b, time-series slice)

Continue the **ADR-040 execution→accuracy conversion** for the events/TSBS pgwire suite — turn *"the query ran"* into *"the answer is right."* Adds exact value-correctness asserts (order-independent, numeric-normalized) for:
- **max_all** — per-host metric maxima (host_0: 95/20/65, host_1: 92/35/20)
- **high_cpu_by_region** — count of usage_user>90 per region (1 each)
- **region_having** — `HAVING avg(usage_user)>40` (us-east 48.75, us-west 68)
- **last_point** — latest reading per host via `row_number()` window (host_0→40, host_1→70)
- **windowed_avg** — moving average over `(1 preceding, current)` window per host

## Result: clean — no new bugs

Unlike the graph slice (P1a, which surfaced TD-185), **TSBS exposed no wrong answers** — its window functions (`row_number`, moving `avg`) and time-bucketed aggregates all compute correctly. So this is a pure coverage upgrade, no known-bad pins needed.

## Verification

`cargo test --test events_tsbs_pgwire_e2e` → green (10/10 conformance + 1 existing high-cpu spot-check + 5 new value-checks). events_tsbs runs in the **develop-tier `rust-integration-test-pgwire-accuracy` job** (added in #484), so this PR's CI exercises it directly.

TD-182 progress: P0 done (#484/#489); P1a graph (#491); this is P1b; TPC-H/DS anchoring + P2 remain.