### PR TITLE
fix(query): fail-loud pushed-down predicates — never silently drop on eval error (ADR-043 Inv 1, TD-186)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -751,42 +751,35 @@ impl RelationalReader for DmlTableReader {
         if let Some(pred) = &ctx.predicate {
             pred.type_check(&self.full_schema)
                 .map_err(ReaderError::PredicateEval)?;
-            // The pushed-down predicate is evaluated row-wise below through a boolean
-            // closure that has no error channel, so an eval failure would otherwise be
-            // silently coerced to `false` and drop every row. Pre-validate that each
-            // referenced function resolves in the executor registry and fail loudly
-            // here instead. (TD-183: native JSON filters — `json_extract*` — are not
-            // yet registered natively, so they surface as a clear error and the OLAP
-            // route serves them, rather than silently returning 0 rows.)
-            let mut func_names: Vec<&str> = Vec::new();
-            pred.collect_func_names(&mut func_names);
-            for name in func_names {
-                if builtins().lookup_scalar(name).is_none() {
-                    return Err(ReaderError::PredicateEval(ExprError::UnknownFunction {
-                        name: name.to_string(),
-                    }));
-                }
-            }
         }
         let predicate: Option<Expr> = ctx.predicate.clone();
-        let row_pred = move |full_row: &[ProximaValue]| -> bool {
+        // ADR-043 Invariant 1 — fail-loud predicate: evaluate against the real
+        // builtin registry and PROPAGATE any eval error (unknown function, cast,
+        // arithmetic, type) instead of coercing it to `false`. The empty registry
+        // (`NoFunctions`) and the error-swallowing `matches!(…, Ok(Boolean(true)))`
+        // here were a silent-data-loss seam: a pushed-down predicate the native
+        // engine could not evaluate dropped every row and presented as a clean empty
+        // result. `scan_table_relational` now surfaces the captured error; a query
+        // native cannot serve fails loudly and the OLAP route answers it (ADR-039).
+        let row_pred = move |full_row: &[ProximaValue]| -> Result<bool, ExprError> {
             match &predicate {
-                // Evaluate against the real builtin registry (not an empty one) so
-                // functions actually resolve in pushed-down native predicates;
-                // unresolvable functions were already rejected in `open` above.
-                Some(expr) => matches!(
-                    expr.eval(&full_row.to_vec(), builtins()),
-                    Ok(ProximaValue::Boolean(true))
-                ),
-                None => true,
+                Some(expr) => match expr.eval(&full_row.to_vec(), builtins())? {
+                    ProximaValue::Boolean(b) => Ok(b),
+                    // SQL three-valued logic: NULL (and any non-boolean predicate
+                    // result) is not TRUE, so the row is excluded — this is a
+                    // *value*, not an error, and is the correct filter semantics.
+                    _ => Ok(false),
+                },
+                None => Ok(true),
             }
         };
-        let row_pred_ref: Option<&(dyn Fn(&[ProximaValue]) -> bool + Send + Sync)> =
-            if ctx.predicate.is_some() {
-                Some(&row_pred)
-            } else {
-                None
-            };
+        let row_pred_ref: Option<
+            &(dyn Fn(&[ProximaValue]) -> Result<bool, ExprError> + Send + Sync),
+        > = if ctx.predicate.is_some() {
+            Some(&row_pred)
+        } else {
+            None
+        };
         let limit = ctx.limit.map(|l| l as usize);
         let (_schema, rows) = self
             .dml

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -47,6 +47,7 @@ use proximadb_catalog::{
 use proximadb_data_model::ProximaType;
 use proximadb_data_model::ProximaValue;
 use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTreeNode};
+use proximadb_relational_types::ExprError;
 use tracing::{debug, info, warn};
 
 use crate::catalog::CatalogManager;
@@ -1197,7 +1198,9 @@ impl DmlService {
         &self,
         table_name: &str,
         output_columns: Option<&[String]>,
-        full_row_predicate: Option<&(dyn Fn(&[ProximaValue]) -> bool + Send + Sync)>,
+        full_row_predicate: Option<
+            &(dyn Fn(&[ProximaValue]) -> Result<bool, ExprError> + Send + Sync),
+        >,
         limit: Option<usize>,
         tenant_context: Option<&TenantContext>,
     ) -> Result<(CatalogTableSchema, Vec<Vec<ProximaValue>>)> {
@@ -1218,11 +1221,28 @@ impl DmlService {
         };
 
         // Push the predicate INTO the store scan: project each record to a full
-        // row and apply the caller's full-row predicate. A projection error
-        // (should not happen for a valid record) excludes the row.
+        // row and apply the caller's full-row predicate. The scan-predicate API is
+        // `Fn(&ProximaRecord) -> bool` (no error channel), so a predicate eval error
+        // is captured here and surfaced after the scan as a hard error — NEVER
+        // coerced to `false` (which would silently drop rows). ADR-043 Invariant 1:
+        // a predicate the engine cannot evaluate fails loudly so the OLAP route can
+        // serve it, instead of returning a silently-wrong empty result.
+        let pred_err: std::sync::Mutex<Option<ExprError>> = std::sync::Mutex::new(None);
         let record_pred = |record: &ProximaRecord| -> bool {
             match Self::project_one_record(record, &table_schema, &full_selected) {
-                Ok(full_row) => full_row_predicate.is_none_or(|p| p(&full_row)),
+                Ok(full_row) => match full_row_predicate {
+                    Some(p) => match p(&full_row) {
+                        Ok(keep) => keep,
+                        Err(e) => {
+                            let mut slot = pred_err.lock().unwrap_or_else(|p| p.into_inner());
+                            if slot.is_none() {
+                                *slot = Some(e);
+                            }
+                            false
+                        }
+                    },
+                    None => true,
+                },
                 Err(_) => false,
             }
         };
@@ -1243,6 +1263,10 @@ impl DmlService {
                 tenant_context,
             )
             .await?;
+
+        if let Some(e) = pred_err.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            return Err(anyhow!("predicate evaluation failed: {e}"));
+        }
 
         let rows = Self::project_select_rows(&records, &table_schema, &output_selected)?;
         Ok((table_schema, rows))
@@ -7511,8 +7535,9 @@ mod tests {
         assert!(rows.iter().all(|r| r.len() == 3));
 
         // (b) Predicate over the FULL row: status (ordinal 1) == 'active' → i1,i2.
-        let pred =
-            |row: &[ProximaValue]| matches!(&row[1], ProximaValue::String(s) if s == "active");
+        let pred = |row: &[ProximaValue]| -> Result<bool, ExprError> {
+            Ok(matches!(&row[1], ProximaValue::String(s) if s == "active"))
+        };
         let (_s, rows) = dml
             .scan_table_relational("inv", None, Some(&pred), None, None)
             .await
@@ -7526,6 +7551,22 @@ mod tests {
             .collect();
         ids.sort();
         assert_eq!(ids, vec!["i1", "i2"], "predicate filters to active rows");
+
+        // (b2) ADR-043 Invariant 1: a predicate that errors is surfaced as a hard
+        // error, NEVER silently dropped to an empty result.
+        let failing_pred = |_row: &[ProximaValue]| -> Result<bool, ExprError> {
+            Err(ExprError::UnknownFunction {
+                name: "does_not_exist".to_string(),
+            })
+        };
+        let err = dml
+            .scan_table_relational("inv", None, Some(&failing_pred), None, None)
+            .await
+            .expect_err("a predicate eval error must surface, not silently drop rows");
+        assert!(
+            err.to_string().contains("predicate evaluation failed"),
+            "expected a loud predicate error, got: {err}"
+        );
 
         // (c) Output projection narrows + orders columns → just [status].
         let cols = vec!["status".to_string()];


### PR DESCRIPTION
## What

First concrete enforcement of **ADR-043** (TD-186 Invariant 1). Eliminates the silent-data-loss seam in pushed-down native predicate evaluation.

## Problem

The storage-scan row predicate was `Fn(&[ProximaValue]) -> bool` — **no error channel**. A pushed-down `WHERE` predicate that failed to evaluate (unknown function, cast, arithmetic, type error) was coerced to `false` via `matches!(expr.eval(...), Ok(Boolean(true)))` and **silently dropped every row** — a wrong answer that presents as a clean empty result. PR4 (#496) added a name-only pre-validation, but that only caught *unknown functions*; cast/arithmetic errors in a pushed-down predicate still vanished.

## Fix

Give the boundary an error channel (ADR-043 Invariant 1 — "never silently drop on eval error"):
- `DmlService::scan_table_relational`'s `full_row_predicate` becomes `Fn(&[ProximaValue]) -> Result<bool, ExprError>`. The deep record-scan API stays `-> bool`, so the eval error is captured during the scan and surfaced as a hard error afterward — never coerced to `false`.
- `DmlTableReader::open` evaluates against `builtins()` and propagates the eval `Result`, **dropping the name-only pre-validation it subsumes**.

A query the native engine can't evaluate now fails loudly → the OLAP route serves it (ADR-039), instead of returning a silently-wrong empty set.

## Verify

- New unit case in `scan_table_relational_pushes_projection_predicate_limit` asserts a failing predicate surfaces `"predicate evaluation failed"` rather than 0 rows.
- Document accuracy harness stays green at **ratchet 9** (d07 still errors loud, now via propagation). fmt + clippy clean.

## Scope

Correctness-hardening; **ratchet-neutral by design**. d06 (frontend `Cast` gap) and d11 (`::boolean` strip) are fixed by **Invariant 2** (frontend `Cast` arm + delete the translator strip list) — the next TD-186 PR.