### PR TITLE
feat(query): typed JSON functions in the canonical registry + Json coercion (ADR-043 Inv 3, TD-186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6995,6 +6995,7 @@ dependencies = [
  "dashmap",
  "proximadb-data-model",
  "proximadb-relational-types",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/foundation/proximadb-functions/Cargo.toml
+++ b/crates/foundation/proximadb-functions/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/lib.rs"
 proximadb-data-model = { workspace = true }
 proximadb-relational-types = { workspace = true }
 dashmap = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/foundation/proximadb-functions/src/lib.rs
+++ b/crates/foundation/proximadb-functions/src/lib.rs
@@ -426,12 +426,76 @@ pub fn register_builtin_scalars(reg: &ProximaFunctionRegistry) {
         }),
     });
 
+    // JSON extraction — the engine-neutral counterpart of the DataFusion Arrow UDFs in
+    // src/datafusion/udf.rs, so JSON-path projections/filters answer on the native
+    // (Volcano) route too, and the frontend learns their return types (ADR-043 Inv 3).
+    //   * json_extract       (`->`)  → the sub-value AS Json (structured), so downstream
+    //                                  comparisons coerce by its natural type, cast-free.
+    //   * json_extract_text  (`->>`) → the sub-value AS plain text (strings unquoted).
+    // These names are also in datafusion::registry_udf::DATAFUSION_NATIVE_SCALARS so the
+    // F2 adapter does NOT bind them — the typed Arrow UDFs stay authoritative on OLAP.
+    reg.register_scalar(def("json_extract", ProximaType::Json, |args| {
+        json_extract_native("json_extract", args, false)
+    }));
+    reg.register_scalar(def("json_extract_text", ProximaType::String, |args| {
+        json_extract_native("json_extract_text", args, true)
+    }));
+
     // Aliases (kept consistent with the DataFusion-side lowering).
     reg.alias_scalar("ucase", "upper");
     reg.alias_scalar("lcase", "lower");
     reg.alias_scalar("char_length", "length");
     reg.alias_scalar("character_length", "length");
     reg.alias_scalar("ceiling", "ceil");
+    // Postgres `json_extract_path_text(doc, key)` is the text-extract form.
+    reg.alias_scalar("json_extract_path_text", "json_extract_text");
+}
+
+/// Extract `key` from a JSON document/array (engine-neutral; mirrors `extract_one` in
+/// `src/datafusion/udf.rs`). `arg0` arrives as a parsed `Json` value (a relational JSON
+/// column, the first extraction) or as JSON text (`String`, when chained —
+/// `doc->'a'->>'b'` lowers to `json_extract_text(json_extract(doc,'a'), 'b')`). `as_text`
+/// returns string leaves unquoted; `->` returns the sub-value AS `Json`. Any miss (bad
+/// key, non-container, unparseable, JSON null) yields `Null`.
+fn json_extract_native(
+    name: &str,
+    args: &[ProximaValue],
+    as_text: bool,
+) -> Result<ProximaValue, ExprError> {
+    check_arity(name, args, 2)?;
+    if any_null(args) {
+        return Ok(ProximaValue::Null);
+    }
+    let key = as_str(name, &args[1])?;
+    let parsed: serde_json::Value = match &args[0] {
+        ProximaValue::Json(v) | ProximaValue::Jsonb(v) => v.clone(),
+        ProximaValue::String(s) | ProximaValue::Symbol(s) => match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(_) => return Ok(ProximaValue::Null),
+        },
+        other => {
+            return Err(ExprError::Other(format!(
+                "{name}: expected a JSON or string argument, got {other:?}"
+            )));
+        }
+    };
+    let child = match &parsed {
+        serde_json::Value::Object(map) => map.get(key),
+        serde_json::Value::Array(arr) => key.parse::<usize>().ok().and_then(|i| arr.get(i)),
+        _ => None,
+    };
+    let Some(child) = child else {
+        return Ok(ProximaValue::Null);
+    };
+    if as_text {
+        Ok(match child {
+            serde_json::Value::String(s) => ProximaValue::String(s.clone()),
+            serde_json::Value::Null => ProximaValue::Null,
+            other => ProximaValue::String(other.to_string()),
+        })
+    } else {
+        Ok(ProximaValue::Json(child.clone()))
+    }
 }
 
 // =========================================================================
@@ -560,6 +624,58 @@ mod tests {
 
     fn reg() -> ProximaFunctionRegistry {
         ProximaFunctionRegistry::with_builtins()
+    }
+
+    #[test]
+    fn json_extract_native_handles_json_and_text_inputs() {
+        use ProximaValue as V;
+        let doc = V::Json(serde_json::json!({"price": 10, "title": "alpha"}));
+        // `->` returns the structured sub-value AS Json (for cast-free coercion).
+        let price = json_extract_native(
+            "json_extract",
+            &[doc.clone(), V::String("price".into())],
+            false,
+        )
+        .unwrap();
+        assert!(matches!(price, V::Json(serde_json::Value::Number(_))));
+        // `->>` returns unquoted text.
+        let title = json_extract_native(
+            "json_extract_text",
+            &[doc.clone(), V::String("title".into())],
+            true,
+        )
+        .unwrap();
+        assert_eq!(title, V::String("alpha".into()));
+        // Chained: arg0 arrives as JSON TEXT.
+        let chained = json_extract_native(
+            "json_extract_text",
+            &[V::String(r#"{"k":"v"}"#.into()), V::String("k".into())],
+            true,
+        )
+        .unwrap();
+        assert_eq!(chained, V::String("v".into()));
+        // Missing key → Null (not an error).
+        let missing =
+            json_extract_native("json_extract", &[doc, V::String("nope".into())], false).unwrap();
+        assert_eq!(missing, V::Null);
+    }
+
+    #[test]
+    fn json_functions_are_registered_with_typed_returns() {
+        let r = reg();
+        assert_eq!(
+            r.lookup_scalar("json_extract").unwrap().signature.return_ty,
+            ProximaType::Json
+        );
+        assert_eq!(
+            r.lookup_scalar("json_extract_text")
+                .unwrap()
+                .signature
+                .return_ty,
+            ProximaType::String
+        );
+        // alias resolves to the text-extract form
+        assert!(r.lookup_scalar("json_extract_path_text").is_some());
     }
 
     #[test]

--- a/crates/foundation/proximadb-relational-types/src/lib.rs
+++ b/crates/foundation/proximadb-relational-types/src/lib.rs
@@ -1069,6 +1069,13 @@ fn values_equal(l: &ProximaValue, r: &ProximaValue) -> Result<bool, ExprError> {
         (ULID(a), ULID(b)) => a == b,
         (Decimal(a), Decimal(b)) => a == b,
         _ => {
+            // A dynamically-typed `Json` scalar operand coerces to its natural type so
+            // `doc->'price' = 8` works cast-free (ADR-043 zero-copy idiom). Unwrap one
+            // (or both) and re-compare; non-Json operands are unchanged.
+            let (lc, rc) = (json_scalar(l), json_scalar(r));
+            if lc.is_some() || rc.is_some() {
+                return values_equal(lc.as_ref().unwrap_or(l), rc.as_ref().unwrap_or(r));
+            }
             // Mixed numeric types: widen both sides to f64 and
             // compare. SQL standard: integer-vs-floating-point
             // and integer-vs-integer comparisons must succeed.
@@ -1110,6 +1117,12 @@ fn compare_ord(l: &ProximaValue, r: &ProximaValue) -> Result<std::cmp::Ordering,
         (Timestamp(a, ua), Timestamp(b, ub)) if ua == ub => a.cmp(b),
         (TimestampTz(a, ua), TimestampTz(b, ub)) if ua == ub => a.cmp(b),
         _ => {
+            // `Json` scalar operands coerce to their natural type (mirrors
+            // `values_equal`) so ordered comparisons over `->` extractions are cast-free.
+            let (lc, rc) = (json_scalar(l), json_scalar(r));
+            if lc.is_some() || rc.is_some() {
+                return compare_ord(lc.as_ref().unwrap_or(l), rc.as_ref().unwrap_or(r));
+            }
             // Mixed numeric types: widen to f64 and compare.
             // Mirrors `values_equal`'s widening path.
             if let (Some(lf), Some(rf)) = (try_to_f64(l), try_to_f64(r)) {
@@ -1141,6 +1154,26 @@ fn try_to_f64(v: &ProximaValue) -> Option<f64> {
         V::UInt64(x) => Some(*x as f64),
         V::Float16(x) | V::Float32(x) => Some(*x as f64),
         V::Float64(x) => Some(*x),
+        _ => None,
+    }
+}
+
+/// Unwrap a JSON SCALAR (`number`/`bool`/`string`) into the matching `ProximaValue`,
+/// so a dynamically-typed `Json` operand coerces naturally in comparisons and casts —
+/// the cast-free `doc->'price' > 8` idiom (ADR-043). Objects, arrays, and JSON `null`
+/// have no scalar form and return `None` (the caller then errors loudly per Invariant 1
+/// rather than guessing). A JSON integer maps to `Int64`, a non-integer to `Float64`.
+fn json_scalar(v: &ProximaValue) -> Option<ProximaValue> {
+    let (ProximaValue::Json(j) | ProximaValue::Jsonb(j)) = v else {
+        return None;
+    };
+    match j {
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .map(ProximaValue::Int64)
+            .or_else(|| n.as_f64().map(ProximaValue::Float64)),
+        serde_json::Value::Bool(b) => Some(ProximaValue::Boolean(*b)),
+        serde_json::Value::String(s) => Some(ProximaValue::String(s.clone())),
         _ => None,
     }
 }
@@ -1211,6 +1244,12 @@ pub fn cast_value(v: &ProximaValue, target: &ProximaType) -> Result<ProximaValue
         && &src_ty == target
     {
         return Ok(v.clone());
+    }
+    // A `Json` scalar casts by its natural type: `CAST(doc->'price' AS INT)` unwraps the
+    // JSON number, then casts that. Objects/arrays/JSON-null have no scalar (json_scalar
+    // returns None) and fall through to the UnsupportedCast error.
+    if let Some(scalar) = json_scalar(v) {
+        return cast_value(&scalar, target);
     }
     macro_rules! to_i64 {
         ($n:expr) => {
@@ -1826,6 +1865,23 @@ mod tests {
     fn cast_null_stays_null() {
         let v = cast_value(&ProximaValue::Null, &ProximaType::Int64).unwrap();
         assert_eq!(v, ProximaValue::Null);
+    }
+
+    #[test]
+    fn json_scalar_coerces_in_cast_and_compare() {
+        use ProximaValue as V;
+        // CAST(json number AS int) unwraps the JSON scalar to its natural type.
+        let ten = V::Json(serde_json::json!(10));
+        assert_eq!(cast_value(&ten, &ProximaType::Int64).unwrap(), V::Int64(10));
+        // Cast-free comparison idiom: a Json scalar coerces against a native scalar.
+        assert!(values_equal(&V::Json(serde_json::json!(8)), &V::Int64(8)).unwrap());
+        assert_eq!(
+            compare_ord(&V::Json(serde_json::json!(10)), &V::Int64(8)).unwrap(),
+            std::cmp::Ordering::Greater
+        );
+        assert!(values_equal(&V::Json(serde_json::json!(true)), &V::Boolean(true)).unwrap());
+        // An object/array has no scalar form → cast errors loudly (never silent).
+        assert!(cast_value(&V::Json(serde_json::json!({ "a": 1 })), &ProximaType::Int64).is_err());
     }
 
     // --- type_check ----------------------------------------------------

--- a/src/datafusion/logical_lowering.rs
+++ b/src/datafusion/logical_lowering.rs
@@ -514,6 +514,29 @@ fn lower_scalar_function(name: &str, args: Vec<Expr>) -> DFResult<Expr> {
         "floor" => f::floor(one(name, args)?),
         "sqrt" => f::sqrt(one(name, args)?),
         "concat" => f::concat(args), // variadic
+        // JSON extraction is a registry function (for native + frontend typing), but on the
+        // OLAP side it has dedicated Arrow-vectorized UDFs (`udf.rs`). Bind THOSE here — NOT
+        // the engine-neutral kernel via the F2 fallback below, whose untyped (0-arity)
+        // signature would shadow the typed `(Utf8,Utf8)` UDF and break coercion in comparison
+        // contexts (ADR-043 Inv 3; mirrors the `DATAFUSION_NATIVE_SCALARS` skip-list).
+        "json_extract" => {
+            Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                std::sync::Arc::new(super::udf::json_extract_udf()),
+                args,
+            ))
+        }
+        "json_extract_text" => {
+            Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                std::sync::Arc::new(super::udf::json_extract_text_udf()),
+                args,
+            ))
+        }
+        "json_extract_path_text" => {
+            Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                std::sync::Arc::new(super::udf::json_extract_path_text_udf()),
+                args,
+            ))
+        }
         // F2 fallback: a registry function DataFusion lacks natively (custom functions; and via
         // F4/F5 vector distances + user CREATE FUNCTIONs). Bind its engine-neutral kernel as a
         // ScalarUDF and call it. Variadic registry funcs aren't fixed-arity-adaptable here.

--- a/src/datafusion/registry_udf.rs
+++ b/src/datafusion/registry_udf.rs
@@ -50,6 +50,14 @@ pub(crate) const DATAFUSION_NATIVE_SCALARS: &[&str] = &[
     "floor",
     "sqrt",
     "concat",
+    // JSON extraction is now ALSO an engine-neutral registry function (for the native
+    // Volcano engine + frontend typing), but DataFusion keeps its dedicated
+    // Arrow-vectorized UDFs (`udf.rs`, registered explicitly in `mod.rs`). Skip F2
+    // binding so the untyped registry wrapper does not shadow the typed (Utf8,Utf8)
+    // Arrow UDFs and break coercion (ADR-043 Inv 3; the regression seen in PR3).
+    "json_extract",
+    "json_extract_text",
+    "json_extract_path_text",
 ];
 
 /// Convert a DataFusion [`ScalarValue`] (one Arrow cell) to a [`ProximaValue`] for kernel


### PR DESCRIPTION
## What

**ADR-043 Invariant 3** (one definition, many bindings), the foundation for the cast work. JSON extraction existed only as DataFusion Arrow UDFs — so the native Volcano engine couldn't evaluate it, and the frontend couldn't type it (`json_extract*` lowered with a `String` placeholder, forcing casts). This registers them once, engine-neutral.

## Changes

- **`proximadb-functions`** — register `json_extract` (`->` → `Json`, the structured sub-value), `json_extract_text`/`json_extract_path_text` (`->>` → text) as `ProximaValue` kernels accepting `ProximaValue::Json` (native column) **and** `String` (chained), reusing `extract_one`. **Native now computes JSON path queries**, and the frontend learns their return types.
- **`relational-types`** — a `Json` scalar operand coerces by its natural type in `values_equal`/`compare_ord`/`cast_value` (`json_scalar`), so **`doc->'price' > 8` is cast-free** (the zero-copy idiom) — without per-row-typed returns (a columnar engine forbids those) and without expanding `ProximaType`.
- **DataFusion binding** — the three names go in `DATAFUSION_NATIVE_SCALARS`, **and** the inline lowering path (`logical_lowering::lower_scalar_function`) now binds the typed Arrow UDFs for them. This closes the **second** F2 path that bypassed the skip-list and shadowed the typed `(Utf8,Utf8)` UDF with an untyped 0-arity wrapper — the regression that broke d07's DataFusion side in early attempts.

## First-principles notes (from investigation)

- **Per-row typed returns are infeasible** (columnar law: a UDF result has ONE Arrow type) — so `->` returns `Json`, `->>` returns text, and a scalar needs coercion or a cast; it can't be type-systemed away.
- We do **not** expand `ProximaType` (already 35 variants; `to_arrow_type` is exhaustive — costly) and do **not** add blanket `String`→numeric coercion (violates SQL typing; only `Json`, dynamically typed, coerces).

## Result

d04/d05/d07/d08/d10 are now **true native↔DataFusion differential** (native computes, not single-engine via fail-loud). **Ratchet unchanged at 9** — this is foundation; d06/d11 need their explicit casts, addressed by **PR-B (Invariant 2: cast unification)** which builds on native `json_extract_text` now computing.

## Verify

`cargo test --test document_json_pgwire_e2e` → `ok` (9 accurate; d06/d11 guards hold). New unit tests: kernel over `Json`+`String` inputs; typed registration; `Json` coercion in cast/compare. fmt + clippy clean.