### PR TITLE
feat(fusion): wire DocumentExpander into shared FusionService (TD-138)

### DIFF
--- a/clients/go/proximadb/internal/genrest/genrest.gen.go
+++ b/clients/go/proximadb/internal/genrest/genrest.gen.go
@@ -445,8 +445,15 @@ type FusionHit struct {
 // FusionSearchRequest defines model for FusionSearchRequest.
 type FusionSearchRequest struct {
 	// ConsensusBeta Consensus boost added to any `oid` present in ≥2 sources.
-	ConsensusBeta *float32  `json:"consensus_beta"`
-	EdgeTypes     *[]string `json:"edge_types,omitempty"`
+	ConsensusBeta *float32 `json:"consensus_beta"`
+
+	// DocumentCollection Collection whose document index to BM25-search. Defaults to `vector_collection` (documents
+	// co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+	DocumentCollection *string `json:"document_collection"`
+
+	// DocumentWeight Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.
+	DocumentWeight *float32  `json:"document_weight"`
+	EdgeTypes      *[]string `json:"edge_types,omitempty"`
 
 	// Grain Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`.
 	Grain       *string  `json:"grain"`
@@ -467,8 +474,13 @@ type FusionSearchRequest struct {
 	QueryVector []float32 `json:"query_vector"`
 
 	// Rrf Use the rank-based RRF fallback instead of PIT-calibrated linear.
-	Rrf         *bool `json:"rrf,omitempty"`
-	TotalBudget *int  `json:"total_budget"`
+	Rrf *bool `json:"rrf,omitempty"`
+
+	// TextQuery Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the
+	// collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+	// (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
+	TextQuery   *string `json:"text_query"`
+	TotalBudget *int    `json:"total_budget"`
 
 	// VectorCollection Vector collection to seed from (its records co-indexed with this graph by `oid`).
 	VectorCollection string   `json:"vector_collection"`

--- a/clients/nodejs-embedded/src/generated/schema.ts
+++ b/clients/nodejs-embedded/src/generated/schema.ts
@@ -1187,6 +1187,16 @@ export interface components {
              * @description Consensus boost added to any `oid` present in ≥2 sources.
              */
             consensus_beta?: number | null;
+            /**
+             * @description Collection whose document index to BM25-search. Defaults to `vector_collection` (documents
+             *     co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+             */
+            document_collection?: string | null;
+            /**
+             * Format: float
+             * @description Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.
+             */
+            document_weight?: number | null;
             edge_types?: string[];
             /** @description Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`. */
             grain?: string | null;
@@ -1210,6 +1220,12 @@ export interface components {
             query_vector: number[];
             /** @description Use the rank-based RRF fallback instead of PIT-calibrated linear. */
             rrf?: boolean;
+            /**
+             * @description Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the
+             *     collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+             *     (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
+             */
+            text_query?: string | null;
             total_budget?: number | null;
             /** @description Vector collection to seed from (its records co-indexed with this graph by `oid`). */
             vector_collection: string;

--- a/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_search_request.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/models/fusion_search_request.py
@@ -21,6 +21,11 @@ class FusionSearchRequest:
         query_vector (list[float]): Query embedding for the ANN seed.
         vector_collection (str): Vector collection to seed from (its records co-indexed with this graph by `oid`).
         consensus_beta (Union[None, Unset, float]): Consensus boost added to any `oid` present in ≥2 sources.
+        document_collection (Union[None, Unset, str]): Collection whose document index to BM25-search. Defaults to
+            `vector_collection` (documents
+            co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+        document_weight (Union[None, Unset, float]): Document modality weight (mirrors `vector_weight` /
+            `graph_weight`). Defaults to 1.0.
         edge_types (Union[Unset, list[str]]):
         grain (Union[None, Unset, str]): Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`.
         graph_weight (Union[None, Unset, float]):
@@ -31,6 +36,10 @@ class FusionSearchRequest:
             (weight fraction) and budget each.
             When absent, fusion is unbounded.
         rrf (Union[Unset, bool]): Use the rank-based RRF fallback instead of PIT-calibrated linear.
+        text_query (Union[None, Unset, str]): Optional BM25/full-text query (TD-138). When present (and non-empty),
+            fusion also searches the
+            collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+            (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
         total_budget (Union[None, Unset, int]):
         vector_weight (Union[None, Unset, float]):
     """
@@ -38,6 +47,8 @@ class FusionSearchRequest:
     query_vector: list[float]
     vector_collection: str
     consensus_beta: Union[None, Unset, float] = UNSET
+    document_collection: Union[None, Unset, str] = UNSET
+    document_weight: Union[None, Unset, float] = UNSET
     edge_types: Union[Unset, list[str]] = UNSET
     grain: Union[None, Unset, str] = UNSET
     graph_weight: Union[None, Unset, float] = UNSET
@@ -46,6 +57,7 @@ class FusionSearchRequest:
     max_seeds: Union[Unset, int] = UNSET
     min_weight_fraction: Union[None, Unset, float] = UNSET
     rrf: Union[Unset, bool] = UNSET
+    text_query: Union[None, Unset, str] = UNSET
     total_budget: Union[None, Unset, int] = UNSET
     vector_weight: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -60,6 +72,18 @@ class FusionSearchRequest:
             consensus_beta = UNSET
         else:
             consensus_beta = self.consensus_beta
+
+        document_collection: Union[None, Unset, str]
+        if isinstance(self.document_collection, Unset):
+            document_collection = UNSET
+        else:
+            document_collection = self.document_collection
+
+        document_weight: Union[None, Unset, float]
+        if isinstance(self.document_weight, Unset):
+            document_weight = UNSET
+        else:
+            document_weight = self.document_weight
 
         edge_types: Union[Unset, list[str]] = UNSET
         if not isinstance(self.edge_types, Unset):
@@ -91,6 +115,12 @@ class FusionSearchRequest:
 
         rrf = self.rrf
 
+        text_query: Union[None, Unset, str]
+        if isinstance(self.text_query, Unset):
+            text_query = UNSET
+        else:
+            text_query = self.text_query
+
         total_budget: Union[None, Unset, int]
         if isinstance(self.total_budget, Unset):
             total_budget = UNSET
@@ -113,6 +143,10 @@ class FusionSearchRequest:
         )
         if consensus_beta is not UNSET:
             field_dict["consensus_beta"] = consensus_beta
+        if document_collection is not UNSET:
+            field_dict["document_collection"] = document_collection
+        if document_weight is not UNSET:
+            field_dict["document_weight"] = document_weight
         if edge_types is not UNSET:
             field_dict["edge_types"] = edge_types
         if grain is not UNSET:
@@ -129,6 +163,8 @@ class FusionSearchRequest:
             field_dict["min_weight_fraction"] = min_weight_fraction
         if rrf is not UNSET:
             field_dict["rrf"] = rrf
+        if text_query is not UNSET:
+            field_dict["text_query"] = text_query
         if total_budget is not UNSET:
             field_dict["total_budget"] = total_budget
         if vector_weight is not UNSET:
@@ -151,6 +187,26 @@ class FusionSearchRequest:
             return cast(Union[None, Unset, float], data)
 
         consensus_beta = _parse_consensus_beta(d.pop("consensus_beta", UNSET))
+
+        def _parse_document_collection(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        document_collection = _parse_document_collection(
+            d.pop("document_collection", UNSET)
+        )
+
+        def _parse_document_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        document_weight = _parse_document_weight(d.pop("document_weight", UNSET))
 
         edge_types = cast(list[str], d.pop("edge_types", UNSET))
 
@@ -191,6 +247,15 @@ class FusionSearchRequest:
 
         rrf = d.pop("rrf", UNSET)
 
+        def _parse_text_query(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        text_query = _parse_text_query(d.pop("text_query", UNSET))
+
         def _parse_total_budget(data: object) -> Union[None, Unset, int]:
             if data is None:
                 return data
@@ -213,6 +278,8 @@ class FusionSearchRequest:
             query_vector=query_vector,
             vector_collection=vector_collection,
             consensus_beta=consensus_beta,
+            document_collection=document_collection,
+            document_weight=document_weight,
             edge_types=edge_types,
             grain=grain,
             graph_weight=graph_weight,
@@ -221,6 +288,7 @@ class FusionSearchRequest:
             max_seeds=max_seeds,
             min_weight_fraction=min_weight_fraction,
             rrf=rrf,
+            text_query=text_query,
             total_budget=total_budget,
             vector_weight=vector_weight,
         )

--- a/clients/rust/src/genrest.rs
+++ b/clients/rust/src/genrest.rs
@@ -2490,6 +2490,21 @@ pub mod types {
     ///      ],
     ///      "format": "float"
     ///    },
+    ///    "document_collection": {
+    ///      "description": "Collection whose document index to BM25-search. Defaults to `vector_collection` (documents\nco-indexed with the vectors share the record `oid`, so they merge by `oid`).",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
+    ///    "document_weight": {
+    ///      "description": "Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.",
+    ///      "type": [
+    ///        "number",
+    ///        "null"
+    ///      ],
+    ///      "format": "float"
+    ///    },
     ///    "edge_types": {
     ///      "type": "array",
     ///      "items": {
@@ -2545,6 +2560,13 @@ pub mod types {
     ///      "description": "Use the rank-based RRF fallback instead of PIT-calibrated linear.",
     ///      "type": "boolean"
     ///    },
+    ///    "text_query": {
+    ///      "description": "Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the\ncollection's document index and merges BM25 hits into the result by shared `oid` — tri-modal\n(vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).",
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
+    ///    },
     ///    "total_budget": {
     ///      "type": [
     ///        "integer",
@@ -2572,6 +2594,13 @@ pub mod types {
         ///Consensus boost added to any `oid` present in ≥2 sources.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub consensus_beta: ::std::option::Option<f32>,
+        /// Collection whose document index to BM25-search. Defaults to `vector_collection` (documents
+        /// co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub document_collection: ::std::option::Option<::std::string::String>,
+        ///Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub document_weight: ::std::option::Option<f32>,
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub edge_types: ::std::vec::Vec<::std::string::String>,
         ///Graph contribution grain: `"nodes"` (default), `"edges"`, or `"both"`.
@@ -2596,6 +2625,11 @@ pub mod types {
         ///Use the rank-based RRF fallback instead of PIT-calibrated linear.
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub rrf: ::std::option::Option<bool>,
+        /// Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the
+        /// collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+        /// (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub text_query: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub total_budget: ::std::option::Option<u64>,
         ///Vector collection to seed from (its records co-indexed with this graph by `oid`).
@@ -8763,6 +8797,12 @@ pub mod types {
         pub struct FusionSearchRequest {
             consensus_beta:
                 ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
+            document_collection: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+            document_weight:
+                ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
             edge_types: ::std::result::Result<
                 ::std::vec::Vec<::std::string::String>,
                 ::std::string::String,
@@ -8779,6 +8819,10 @@ pub mod types {
                 ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
             query_vector: ::std::result::Result<::std::vec::Vec<f32>, ::std::string::String>,
             rrf: ::std::result::Result<::std::option::Option<bool>, ::std::string::String>,
+            text_query: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
             total_budget: ::std::result::Result<::std::option::Option<u64>, ::std::string::String>,
             vector_collection: ::std::result::Result<::std::string::String, ::std::string::String>,
             vector_weight: ::std::result::Result<::std::option::Option<f32>, ::std::string::String>,
@@ -8787,6 +8831,8 @@ pub mod types {
             fn default() -> Self {
                 Self {
                     consensus_beta: Ok(Default::default()),
+                    document_collection: Ok(Default::default()),
+                    document_weight: Ok(Default::default()),
                     edge_types: Ok(Default::default()),
                     grain: Ok(Default::default()),
                     graph_weight: Ok(Default::default()),
@@ -8796,6 +8842,7 @@ pub mod types {
                     min_weight_fraction: Ok(Default::default()),
                     query_vector: Err("no value supplied for query_vector".to_string()),
                     rrf: Ok(Default::default()),
+                    text_query: Ok(Default::default()),
                     total_budget: Ok(Default::default()),
                     vector_collection: Err("no value supplied for vector_collection".to_string()),
                     vector_weight: Ok(Default::default()),
@@ -8810,6 +8857,26 @@ pub mod types {
             {
                 self.consensus_beta = value.try_into().map_err(|e| {
                     format!("error converting supplied value for consensus_beta: {e}")
+                });
+                self
+            }
+            pub fn document_collection<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.document_collection = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for document_collection: {e}")
+                });
+                self
+            }
+            pub fn document_weight<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<f32>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.document_weight = value.try_into().map_err(|e| {
+                    format!("error converting supplied value for document_weight: {e}")
                 });
                 self
             }
@@ -8903,6 +8970,16 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for rrf: {e}"));
                 self
             }
+            pub fn text_query<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.text_query = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for text_query: {e}"));
+                self
+            }
             pub fn total_budget<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<::std::option::Option<u64>>,
@@ -8941,6 +9018,8 @@ pub mod types {
             ) -> ::std::result::Result<Self, super::error::ConversionError> {
                 Ok(Self {
                     consensus_beta: value.consensus_beta?,
+                    document_collection: value.document_collection?,
+                    document_weight: value.document_weight?,
                     edge_types: value.edge_types?,
                     grain: value.grain?,
                     graph_weight: value.graph_weight?,
@@ -8950,6 +9029,7 @@ pub mod types {
                     min_weight_fraction: value.min_weight_fraction?,
                     query_vector: value.query_vector?,
                     rrf: value.rrf?,
+                    text_query: value.text_query?,
                     total_budget: value.total_budget?,
                     vector_collection: value.vector_collection?,
                     vector_weight: value.vector_weight?,
@@ -8960,6 +9040,8 @@ pub mod types {
             fn from(value: super::FusionSearchRequest) -> Self {
                 Self {
                     consensus_beta: Ok(value.consensus_beta),
+                    document_collection: Ok(value.document_collection),
+                    document_weight: Ok(value.document_weight),
                     edge_types: Ok(value.edge_types),
                     grain: Ok(value.grain),
                     graph_weight: Ok(value.graph_weight),
@@ -8969,6 +9051,7 @@ pub mod types {
                     min_weight_fraction: Ok(value.min_weight_fraction),
                     query_vector: Ok(value.query_vector),
                     rrf: Ok(value.rrf),
+                    text_query: Ok(value.text_query),
                     total_budget: Ok(value.total_budget),
                     vector_collection: Ok(value.vector_collection),
                     vector_weight: Ok(value.vector_weight),

--- a/docs/openapi/proximadb-openapi.yaml
+++ b/docs/openapi/proximadb-openapi.yaml
@@ -729,6 +729,19 @@ components:
           type:
           - number
           - 'null'
+        document_collection:
+          description: |-
+            Collection whose document index to BM25-search. Defaults to `vector_collection` (documents
+            co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+          type:
+          - string
+          - 'null'
+        document_weight:
+          description: Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.
+          format: float
+          type:
+          - number
+          - 'null'
         edge_types:
           items:
             type: string
@@ -772,6 +785,14 @@ components:
         rrf:
           description: Use the rank-based RRF fallback instead of PIT-calibrated linear.
           type: boolean
+        text_query:
+          description: |-
+            Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the
+            collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+            (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
+          type:
+          - string
+          - 'null'
         total_budget:
           minimum: 0
           type:

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -3707,6 +3707,10 @@ impl EmbeddedProximaDB {
             let service = FusionService::new(
                 self.shared_services.vector_operations_service.clone(),
                 self.shared_services.graph_service.clone(),
+                // TD-138: share the live full-text index map so the document modality is powered
+                // when a caller supplies a document spec (the params below pass `document: None`
+                // for now; the shared map is wired so a future embedded text_query works directly).
+                self.shared_services.fulltext_indexes.clone(),
             );
             let params = GraphFusionParams {
                 route_policy: None,
@@ -3733,6 +3737,9 @@ impl EmbeddedProximaDB {
                     FusionPolicy::default()
                 },
                 oid_key: FusionOidKey::Canonical,
+                // TD-138 document modality is REST-only for now; embedded passes `None`
+                // (vector+graph only). The service above still shares the live index map.
+                document: None,
             };
             service.graph_fusion_search(params).await.map_err(
                 |e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -68,7 +68,11 @@ impl ProximaEntityServiceImpl {
         Self {
             graph_service: graph.clone(),
             vector_service: vector.clone(),
-            fusion_service: Arc::new(FusionService::new(vector, graph)),
+            fusion_service: Arc::new(FusionService::new(
+                vector,
+                graph,
+                crate::network::hybrid_search::HybridFullTextIndexMap::default(),
+            )),
             document_service: document,
         }
     }
@@ -504,6 +508,8 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 principal,
                 policy: FusionPolicy::default(),
                 oid_key: FusionOidKey::EntityNode,
+                // TD-138 document modality is REST-only for now; gRPC entity fusion is deferred.
+                document: None,
             };
 
             let (items, _stats) = self

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -45,7 +45,11 @@ impl ProximaFusionServiceImpl {
         graph: Arc<crate::graph::GraphOperationsService>,
     ) -> Self {
         Self {
-            fusion: Arc::new(FusionService::new(vector, graph)),
+            fusion: Arc::new(FusionService::new(
+                vector,
+                graph,
+                crate::network::hybrid_search::HybridFullTextIndexMap::default(),
+            )),
         }
     }
 
@@ -130,6 +134,9 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
             principal,
             policy,
             oid_key: FusionOidKey::Canonical,
+            // TD-138 document modality is REST-only for now; gRPC document fusion is deferred
+            // (TD-143). `None` ⇒ vector+graph only (no behavior change).
+            document: None,
         };
 
         let (items, stats) = self

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -206,12 +206,18 @@ impl AppState {
         let record_ops = request_handlers.record_ops();
         let observability_service = request_handlers.observability_service.clone();
         let event_log = request_handlers.event_log.clone();
-        // Cross-modal fusion port — built once at boot from the vector + graph
-        // services (search-surface contract: one retrieval engine, shared port).
+        // Cross-modal fusion port — built once at boot from the vector + graph services and the
+        // shared full-text index map (search-surface contract: one retrieval engine, shared port).
+        // The empty default map here powers the document expander fail-closed; production replaces
+        // it via `with_fulltext_indexes`, which rebuilds this service with the LIVE index map so the
+        // document modality (TD-138) is powered for REST fusion.
+        let fulltext_indexes: FullTextIndexMap =
+            std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
         let fusion_service =
             std::sync::Arc::new(crate::services::fusion_service::FusionService::new(
                 vector_operations_service.clone(),
                 graph_operations_service.clone(),
+                fulltext_indexes.clone(),
             ));
         // TD-104 2(b): default `api_handlers` to the root handler cast to its
         // `ApiHandlersPort` impl. Production overrides via `with_api_handlers`
@@ -234,9 +240,7 @@ impl AppState {
             security_coordinator,
             data_dir,
             query_adapter,
-            fulltext_indexes: Some(Arc::new(std::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            ))),
+            fulltext_indexes: Some(fulltext_indexes),
             catalog_manager: Arc::new(crate::catalog::CatalogManager::new()),
             // Default: standalone pin registry. Production wires
             // SharedServices.pin_registry via `with_pin_registry` so
@@ -324,6 +328,16 @@ impl AppState {
     /// same in-process map — an indexed document is searchable on
     /// both protocols.
     pub fn with_fulltext_indexes(mut self, indexes: FullTextIndexMap) -> Self {
+        // Rebuild the shared fusion service so its DocumentExpander (TD-138) shares this live
+        // index map. This builder runs during boot, before any request is served, so the rebuild
+        // is safe; the fusion service remains a single boot-constructed instance from the
+        // request-serving perspective. (The map type is structurally `HybridFullTextIndexMap`.)
+        self.fusion_service =
+            std::sync::Arc::new(crate::services::fusion_service::FusionService::new(
+                self.vector_operations_service.clone(),
+                self.graph_operations_service.clone(),
+                indexes.clone(),
+            ));
         self.fulltext_indexes = Some(indexes);
         self
     }

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -18,7 +18,9 @@ use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::openapi::ErrorResponse;
 use crate::network::rest::v1::handlers::AppState;
 use crate::security::rbac_service::UnifiedUserContext;
-use crate::services::fusion_service::{FusionOidKey, GraphFusionParams, GraphGrain};
+use crate::services::fusion_service::{
+    DocumentFusionSpec, FusionOidKey, GraphFusionParams, GraphGrain,
+};
 
 fn default_limit() -> usize {
     10
@@ -59,6 +61,15 @@ pub struct FusionSearchRequest {
     /// When absent, fusion is unbounded.
     pub min_weight_fraction: Option<f32>,
     pub total_budget: Option<usize>,
+    /// Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also searches the
+    /// collection's document index and merges BM25 hits into the result by shared `oid` — tri-modal
+    /// (vector + graph + document) fusion. Absent ⇒ vector+graph only (unchanged).
+    pub text_query: Option<String>,
+    /// Collection whose document index to BM25-search. Defaults to `vector_collection` (documents
+    /// co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+    pub document_collection: Option<String>,
+    /// Document modality weight (mirrors `vector_weight` / `graph_weight`). Defaults to 1.0.
+    pub document_weight: Option<f32>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -184,6 +195,18 @@ pub async fn fusion_search_v2(
         },
         policy,
         oid_key: FusionOidKey::Canonical,
+        // TD-138 document modality: enable iff a non-empty `text_query` was supplied. Built from the
+        // request fields; the shared service's DocumentExpander runs the BM25 search.
+        document: request
+            .text_query
+            .as_ref()
+            .filter(|t| !t.trim().is_empty())
+            .map(|t| DocumentFusionSpec {
+                text_query: t.clone(),
+                collection: request.document_collection.clone(),
+                weight: request.document_weight.unwrap_or(1.0),
+                k: None,
+            }),
     };
 
     let (items, stats) = service

--- a/src/services/entity_orchestrator.rs
+++ b/src/services/entity_orchestrator.rs
@@ -346,6 +346,8 @@ impl EntityOrchestrator {
                 principal: None,
                 policy: FusionPolicy::default(),
                 oid_key: FusionOidKey::EntityNode,
+                // TD-138 document modality is REST-only for now; orchestrator passes `None`.
+                document: None,
             };
             let (items, _stats) = self
                 .fusion

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -353,6 +353,25 @@ pub enum GraphGrain {
     Both,
 }
 
+/// Optional document-modality contribution to a fusion query (TD-138). When present, the shared
+/// [`FusionService`] runs BM25/full-text search over the collection's in-memory index (via
+/// [`DocumentExpander`]) and emits an `oid`-keyed [`SourceId::Document`] source that merges with the
+/// vector + graph sources by shared `oid`. Absent ⇒ no document contribution (the default, preserving
+/// plain vector+graph fusion). The expander fails closed on a missing/poisoned index, so fusion
+/// proceeds on the other modalities rather than erroring (D5/D6).
+#[derive(Debug, Clone)]
+pub struct DocumentFusionSpec {
+    /// The BM25/full-text query. Its presence is what enables the document source.
+    pub text_query: String,
+    /// Collection whose full-text index to search. `None` ⇒ the vector collection (documents
+    /// co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+    pub collection: Option<String>,
+    /// Document modality weight (mirrors `vector_weight` / `graph_weight`).
+    pub weight: f32,
+    /// Top-k documents to take from the index. `None` ⇒ reuse the query `limit`.
+    pub k: Option<usize>,
+}
+
 /// Parameters for one graph-modality fusion query.
 #[derive(Debug, Clone)]
 pub struct GraphFusionParams {
@@ -384,17 +403,35 @@ pub struct GraphFusionParams {
     /// [`FusionOidKey::EntityNode`] so its auxiliary vector oids and canonical graph oids
     /// co-rank under the entity `node_id`.
     pub oid_key: FusionOidKey,
+    /// Optional document-modality contribution (TD-138). `None` ⇒ vector+graph only (the default).
+    pub document: Option<DocumentFusionSpec>,
 }
 
 /// Orchestrates the graph instance of the fusion seam over the live vector + graph engines.
 pub struct FusionService {
     vector: Arc<VectorOperationsService>,
     graph: Arc<GraphOperationsService>,
+    /// Document modality expander (TD-138). Holds the shared full-text index map; fail-closed when
+    /// the map is empty (surfaces that don't wire live documents pass `HybridFullTextIndexMap::default()`).
+    document: DocumentExpander,
 }
 
 impl FusionService {
-    pub fn new(vector: Arc<VectorOperationsService>, graph: Arc<GraphOperationsService>) -> Self {
-        Self { vector, graph }
+    /// Construct the shared fusion service. `fulltext_indexes` powers the optional document modality
+    /// (via [`DocumentExpander`]); an empty map ([`HybridFullTextIndexMap::default`]) leaves the
+    /// document expander fail-closed so fusion is vector+graph only — used by surfaces (gRPC/embedded)
+    /// that don't wire live documents yet. Constructed ONCE at boot and shared via `Arc`, per the
+    /// search-surface contract (never per-handler).
+    pub fn new(
+        vector: Arc<VectorOperationsService>,
+        graph: Arc<GraphOperationsService>,
+        fulltext_indexes: HybridFullTextIndexMap,
+    ) -> Self {
+        Self {
+            vector,
+            graph,
+            document: DocumentExpander::new(fulltext_indexes),
+        }
     }
 
     /// Vector-seed → graph-expand → fuse-by-`oid`. Tenant isolation is structural (the collection and
@@ -543,6 +580,27 @@ impl FusionService {
                 traversal_edges_to_source(&params.graph_id, &edges, params.graph_weight),
                 params.oid_key,
             ));
+        }
+
+        // 3b. Optional document modality (TD-138): BM25 over the collection's full-text index → an
+        //     `oid`-keyed [`SourceId::Document`] source that merges with vector + graph by shared `oid`.
+        //     Pushed BEFORE cost routing so TD-141 budgets it like any other source, and key-normalized
+        //     so it lands in the same fusion-key space as the vector + graph sources. Fail-closed on a
+        //     missing/poisoned index (empty source → no contribution, no error).
+        if let Some(spec) = params.document.as_ref()
+            && !spec.text_query.is_empty()
+        {
+            let collection = spec
+                .collection
+                .as_deref()
+                .unwrap_or(&params.vector_collection);
+            let doc_source = self.document.expand(
+                collection,
+                &spec.text_query,
+                spec.k.unwrap_or(params.limit),
+                spec.weight,
+            );
+            sources.push(normalize_source_keys(doc_source, params.oid_key));
         }
 
         // 3c. Optional cost routing (TD-141): budget each modality by weight and drop negligible ones.
@@ -794,6 +852,28 @@ mod tests {
             .find(|i| i.oid == oid)
             .expect("shared oid fused");
         assert_eq!(fused.source_count, 2, "vector + document merge by oid");
+    }
+
+    /// TD-138 end-state: a vector hit, a graph-expanded node, and a BM25 document hit that are the
+    /// SAME entity (same canonical `oid`) fuse into one item with `source_count == 3` — all three
+    /// modalities converge onto the seam by shared `oid`, calibrated by the Fuser.
+    #[test]
+    fn vector_graph_document_sources_tri_modal_fuse_by_shared_oid() {
+        let oid = "graph/g1/node/n1";
+        let vector = vector_hits_to_source(&[hit(oid, 0.9)], 1.0);
+        let graph = traversal_nodes_to_source("g1", &[node("n1")], 1.0);
+        let document = bm25_hits_to_source(&[doc_hit(oid, 3.2)], 1.0);
+        let (items, stats) =
+            Fuser::new(FusionPolicy::default()).fuse(vec![vector, graph, document], 10);
+        assert_eq!(stats.sources_fused, 3);
+        let fused = items
+            .iter()
+            .find(|i| i.oid == oid)
+            .expect("shared oid fused across all three modalities");
+        assert_eq!(
+            fused.source_count, 3,
+            "vector + graph + document merge by oid"
+        );
     }
 
     fn edge(id: &str) -> Edge {


### PR DESCRIPTION
## What

Adds the **document modality** to v2 cross-modal fusion — live **vector + graph + document** fusion through the **shared** `FusionService`. This is the unique unlanded half of #257 (the document-modality commit there was dropped for using per-handler `FusionService::new`; the cost-routing half already landed via #469).

## Why this approach

`DocumentExpander` already existed on develop (PR #237) but was never wired into the shared service — commit `198f45b95` flagged it as a TD-138 follow-on ("bootstrap plumbing"). The fusion core is modality-agnostic (`SourceId::Document` + the `Fuser` fuse any `oid`-keyed source). So the work is plumbing, not new fusion logic — and it must honor the search-surface contract: **one retrieval engine, shared at boot, no per-handler construction**.

## Change

- **`FusionService`** (`src/services/fusion_service.rs`) gains a `DocumentExpander` field (holds the shared `HybridFullTextIndexMap`). `graph_fusion_search` pushes an `oid`-keyed `SourceId::Document` source **before** TD-141 cost routing, so the router budgets it automatically and the `Fuser` merges it by shared `oid`.
- **`GraphFusionParams.document: Option<DocumentFusionSpec>`** — one optional field gates the document contribution; `None` ⇒ vector+graph only (existing behavior unchanged). Added `document: None` to the 4 non-REST callers (gRPC fusion, gRPC entity, embedded, entity orchestrator).
- **Boot wiring** (`src/network/rest/v1/handlers.rs`): `AppState::new` builds the service with a shared empty map (fail-closed); `with_fulltext_indexes` (the production hook) **rebuilds** the fusion service with the live map, so REST document fusion is powered. gRPC/embedded stay fail-closed this PR (deferred).
- **REST v2** (`src/network/rest/v2/graphs.rs`): `FusionSearchRequest` gains optional `text_query` / `document_collection` / `document_weight` (additive, backward-compatible); the handler builds the `DocumentFusionSpec` (thin facade — no fusion logic in the handler).
- **Regen** the OpenAPI spec (+21 lines, only the 3 new fields) + all 4 SDKs (Go / Rust / Python / TypeScript).

## Safety
Mixed-read-safe / additive: every new field is optional, so existing vector+graph fusion is byte-identical when `text_query` is absent. The document expander fails closed on a missing/poisoned index (empty source → no contribution, no error).

## Verification
- `cargo clippy --lib --bins -- -D warnings` ✓ · `cargo fmt --check` ✓ · panic-policy no-regression (+0) ✓ · `proximadb-server` builds ✓
- 382 tests pass, incl. new **tri-modality** test `vector_graph_document_sources_tri_modal_fuse_by_shared_oid` (vector+graph+document on one `oid` ⇒ `source_count == 3`) and all existing `DocumentExpander`/fusion tests.
- OpenAPI drift gate + all 4 `<lang>-sdk-codegen-drift` gates green (regenerated).

## Deferred
- gRPC v2 + embedded document fusion (pass the live map + a proto/embedded `text_query`) — follow-up.
- Retiring the legacy 12-strategy `HybridFusionEngine` onto the seam (the original TD-138 headline) — separate, larger.
- Per-record RBAC on document hits (tenant isolation is already structural via the collection-scoped index).

Closes the document-modality gap from #257.