### PR TITLE
feat(catalog): tenant-prefix collection namespaces + idempotent provisioning (TD-CAT-2b S3a + TD-SC-4 S4)

### DIFF
--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -115,6 +115,14 @@ pub struct CollectionService {
     /// `with_catalog_manager` (which builds the cache). `None` ⇒ hot → canonical.
     syscat_warm_dir: Option<std::path::PathBuf>,
 
+    /// TD-CAT-2b (S3a): whether collection catalog assets are stored under a
+    /// tenant-prefixed namespace (`[tenant, ...levels]`, the convention the
+    /// DDL/DML path already uses via `resolve_table_scoped`). Read once from
+    /// `PROXIMADB_CATALOG_TENANT_NAMESPACES` at construction (default-OFF);
+    /// interior mutability so tests toggle it deterministically without env
+    /// races. Off ⇒ today's bare-namespace behavior.
+    tenant_namespaces: std::sync::atomic::AtomicBool,
+
     // NEW: Multi-tenant integration
     /// Optional tenant manager for multi-tenant isolation
     tenant_manager: Option<Arc<crate::storage::tenant::TenantManager>>,
@@ -164,8 +172,9 @@ impl CollectionService {
             catalog_manager: None,
             syscat_cache: None,    // Built in `with_catalog_manager`.
             syscat_warm_dir: None, // Set via `with_syscat_warm_dir` / env.
-            tenant_manager: None,  // Will be set via with_tenant_manager()
-            rbac_enforcer: None,   // Will be set via with_rbac_enforcer()
+            tenant_namespaces: std::sync::atomic::AtomicBool::new(Self::tenant_namespaces_enabled()),
+            tenant_manager: None, // Will be set via with_tenant_manager()
+            rbac_enforcer: None,  // Will be set via with_rbac_enforcer()
             #[cfg(feature = "experimental-turboquant")]
             turboquant_registry: None, // Will be set via with_turboquant_registry()
         })
@@ -306,6 +315,51 @@ impl CollectionService {
     /// gates that share that one primitive.
     pub(crate) fn collection_tenant_id(collection: &Collection) -> Option<String> {
         proximadb_tenant::tenant_id_of(collection)
+    }
+
+    /// TD-CAT-2b (S3a): presence-based, default-OFF gate for storing collection
+    /// catalog assets under a tenant-prefixed namespace. Read once at
+    /// construction into [`tenant_namespaces`](Self::tenant_namespaces); call
+    /// sites consult [`tenant_namespaces_on`](Self::tenant_namespaces_on).
+    fn tenant_namespaces_enabled() -> bool {
+        std::env::var_os("PROXIMADB_CATALOG_TENANT_NAMESPACES").is_some()
+    }
+
+    /// Whether collection assets are written under a tenant-prefixed namespace.
+    fn tenant_namespaces_on(&self) -> bool {
+        self.tenant_namespaces
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Test-only deterministic toggle for the tenant-namespaces gate, avoiding
+    /// the process-global env races a parallel test suite would otherwise hit.
+    #[cfg(test)]
+    fn set_tenant_namespaces_for_test(&self, on: bool) {
+        self.tenant_namespaces
+            .store(on, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// TD-CAT-2b (S3a): tenant-scope a collection's catalog identifier by
+    /// prepending the tenant as namespace level 0 — the same convention the
+    /// DDL/DML path uses via `CatalogManager::resolve_table_scoped`. This keeps
+    /// two tenants' identically-named namespaces (`default`, …) structurally
+    /// distinct in the single multi-tenant catalog instead of colliding on the
+    /// bare `levels.join(".")` key. A no-op when the gate is off or the
+    /// collection is not tenant-scoped, so legacy bare assets are unchanged.
+    fn tenant_scoped_identifier(
+        enabled: bool,
+        tenant: Option<&str>,
+        identifier: crate::catalog::TableIdentifier,
+    ) -> crate::catalog::TableIdentifier {
+        match tenant {
+            Some(tenant) if enabled && !tenant.is_empty() => {
+                let mut namespace = Vec::with_capacity(identifier.namespace.len() + 1);
+                namespace.push(tenant.to_string());
+                namespace.extend(identifier.namespace.iter().cloned());
+                crate::catalog::TableIdentifier::new(namespace, identifier.name)
+            }
+            _ => identifier,
+        }
     }
 
     /// Default corpus-version bucket for writes without a threaded tenant context
@@ -1980,8 +2034,16 @@ impl CollectionService {
         };
 
         let catalog = catalog_manager.default_catalog().await?;
-        let identifier =
-            crate::storage::metadata::collection_mapping::collection_table_identifier(config);
+        // TD-CAT-2b (S3a): scope the asset under a tenant-prefixed namespace when
+        // the gate is on, so two tenants' identically-named namespaces don't
+        // collide on the bare key. Done once here, then every op below
+        // (namespace_exists / create / table_exists / get / drop / create_table)
+        // is consistently tenant-scoped.
+        let identifier = Self::tenant_scoped_identifier(
+            self.tenant_namespaces_on(),
+            Self::collection_tenant_id(collection).as_deref(),
+            crate::storage::metadata::collection_mapping::collection_table_identifier(config),
+        );
 
         if !catalog.namespace_exists(&identifier.namespace).await? {
             // TD-CAT-2a (audit gap G6): record the owning tenant on the persisted
@@ -2057,8 +2119,13 @@ impl CollectionService {
         };
 
         let catalog = catalog_manager.default_catalog().await?;
-        let identifier =
-            crate::storage::metadata::collection_mapping::collection_table_identifier(config);
+        // TD-CAT-2b (S3a): mirror the write-side scoping so a drop targets the
+        // same tenant-prefixed asset the upsert created.
+        let identifier = Self::tenant_scoped_identifier(
+            self.tenant_namespaces_on(),
+            Self::collection_tenant_id(collection).as_deref(),
+            crate::storage::metadata::collection_mapping::collection_table_identifier(config),
+        );
         if catalog.table_exists(&identifier).await? {
             let _ = catalog.drop_table(&identifier, false).await?;
         }
@@ -2771,6 +2838,107 @@ mod tests {
             ns.tenant_id.as_deref(),
             Some("acme"),
             "the freshly-created namespace must record the owning tenant (TD-CAT-2a)"
+        );
+
+        Ok(())
+    }
+
+    /// TD-CAT-2b (S3a): the pure scoping function prepends the tenant as
+    /// namespace level 0 only when enabled and a non-empty tenant is present.
+    #[test]
+    fn tenant_scoped_identifier_prepends_tenant_when_enabled() {
+        let base = TableIdentifier::new(vec!["default".to_string()], "t".to_string());
+
+        let scoped = CollectionService::tenant_scoped_identifier(true, Some("acme"), base.clone());
+        assert_eq!(
+            scoped.namespace,
+            vec!["acme".to_string(), "default".to_string()]
+        );
+        assert_eq!(scoped.name, "t");
+
+        // Off ⇒ unchanged; no tenant ⇒ unchanged; empty tenant ⇒ unchanged.
+        assert_eq!(
+            CollectionService::tenant_scoped_identifier(false, Some("acme"), base.clone())
+                .namespace,
+            vec!["default".to_string()]
+        );
+        assert_eq!(
+            CollectionService::tenant_scoped_identifier(true, None, base.clone()).namespace,
+            vec!["default".to_string()]
+        );
+        assert_eq!(
+            CollectionService::tenant_scoped_identifier(true, Some(""), base).namespace,
+            vec!["default".to_string()]
+        );
+    }
+
+    /// TD-CAT-2b (S3a): with the gate ON, two tenants creating an
+    /// identically-named namespace land under DISTINCT tenant-prefixed
+    /// namespaces — no collision on the bare key — each recording its own tenant.
+    #[tokio::test]
+    async fn tenant_namespaces_isolate_same_named_namespace() -> Result<()> {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("xcatalog")?;
+        let service = CollectionService::new(StorageConfig::default())
+            .await
+            .context("service")?
+            .with_catalog_manager(catalog_manager.clone());
+        service.set_tenant_namespaces_for_test(true);
+
+        // Two collections in the SAME bare namespace `shared`, different tenants
+        // (distinct collection names — the service dedupes by name; it's the
+        // shared NAMESPACE that must not collide across tenants).
+        for tenant in ["acme", "globex"] {
+            let config = CollectionConfig {
+                name: format!("shared.{tenant}_tbl"),
+                dimension: 8,
+                primary_index: Some("default".to_string()),
+                auto_index_selection: Some(false),
+                tags: vec![format!("tenant:{tenant}")],
+                ..Default::default()
+            };
+            assert!(
+                service
+                    .create_collection(&config)
+                    .await
+                    .with_context(|| format!("create for {tenant}"))?
+                    .success
+            );
+        }
+
+        let catalog = catalog_manager
+            .default_catalog()
+            .await
+            .context("default catalog")?;
+
+        // Each tenant has its OWN `shared` namespace, recording its own tenant.
+        for tenant in ["acme", "globex"] {
+            let ns = catalog
+                .get_namespace(&[tenant.to_string(), "shared".to_string()])
+                .await
+                .with_context(|| format!("get_namespace for {tenant}"))?;
+            assert_eq!(
+                ns.tenant_id.as_deref(),
+                Some(tenant),
+                "tenant-prefixed namespace records its owning tenant"
+            );
+        }
+
+        // The bare `shared` namespace was never created — no cross-tenant
+        // collision on the shared key.
+        assert!(
+            !catalog
+                .namespace_exists(&["shared".to_string()])
+                .await
+                .context("bare namespace_exists")?,
+            "no bare `shared` namespace ⇒ tenants did not collide on the shared key"
         );
 
         Ok(())

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -362,6 +362,21 @@ impl CollectionService {
         }
     }
 
+    /// TD-SC-4 (S4): provision a tenant's bare-minimum system-catalog skeleton at
+    /// signup (idempotent). A no-op unless tenant-prefixed namespaces are enabled
+    /// (a single-tenant deployment needs no per-tenant skeleton) and a catalog is
+    /// configured — so it's safe to call unconditionally from any onboarding
+    /// path. Delegates to the catalog-manager-only free function of the same name.
+    pub async fn provision_tenant_system_catalog(&self, tenant: &str) -> Result<()> {
+        if !self.tenant_namespaces_on() {
+            return Ok(());
+        }
+        let Some(catalog_manager) = &self.catalog_manager else {
+            return Ok(());
+        };
+        provision_tenant_system_catalog(catalog_manager, tenant).await
+    }
+
     /// Default corpus-version bucket for writes without a threaded tenant context
     /// (single-tenant / anonymous deployments). Reads of the same
     /// corpus-version-keyed caches use the same bucket, so invalidation stays
@@ -2258,6 +2273,36 @@ async fn read_collections_from_catalog(
     Ok(collections)
 }
 
+/// TD-SC-4 (S4): idempotently pre-create a tenant's bare-minimum system-catalog
+/// skeleton at signup — the tenant's system namespace (`[tenant, "default"]`,
+/// the same tenant-prefixed shape S3a stores collections under), recorded with
+/// its owning `tenant_id`. Pre-creating it means the first collection/list for a
+/// freshly-signed-up tenant doesn't hit a cold/missing namespace.
+///
+/// Idempotent: a re-signup (namespace already present) is a no-op, and a partial
+/// failure is safe to retry (the `namespace_exists` guard converges). Free
+/// function (catalog-manager-only) so it can be called from any onboarding path
+/// without holding the `CollectionService`. **No user tables are created.**
+async fn provision_tenant_system_catalog(
+    catalog_manager: &CatalogManager,
+    tenant: &str,
+) -> Result<()> {
+    if tenant.is_empty() {
+        return Ok(());
+    }
+    let catalog = catalog_manager.default_catalog().await?;
+    // Bare-minimum skeleton: the tenant's default namespace, tenant-prefixed to
+    // match where S3a stores this tenant's collections (no collision with other
+    // tenants' identically-named namespaces).
+    let namespace = vec![tenant.to_string(), "default".to_string()];
+    if !catalog.namespace_exists(&namespace).await? {
+        catalog
+            .create_namespace_for_tenant(&namespace, std::collections::HashMap::new(), Some(tenant))
+            .await?;
+    }
+    Ok(())
+}
+
 /// Hot-cache inner source: reads collection metadata straight from the catalog.
 /// Holds `Arc<CatalogManager>` (not the `CollectionService`), so the cache and the
 /// service do not form an `Arc` cycle.
@@ -2939,6 +2984,92 @@ mod tests {
                 .await
                 .context("bare namespace_exists")?,
             "no bare `shared` namespace ⇒ tenants did not collide on the shared key"
+        );
+
+        Ok(())
+    }
+
+    /// TD-SC-4 (S4): provisioning pre-creates the tenant's system namespace and
+    /// is idempotent — a second call is a no-op, and the namespace records its
+    /// owning tenant.
+    #[tokio::test]
+    async fn provision_tenant_system_catalog_is_idempotent() -> Result<()> {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("xcatalog")?;
+        let service = CollectionService::new(StorageConfig::default())
+            .await
+            .context("service")?
+            .with_catalog_manager(catalog_manager.clone());
+        service.set_tenant_namespaces_for_test(true);
+
+        // Provision twice — the second call must be a safe no-op.
+        service
+            .provision_tenant_system_catalog("acme")
+            .await
+            .context("provision 1")?;
+        service
+            .provision_tenant_system_catalog("acme")
+            .await
+            .context("provision 2 (idempotent)")?;
+
+        let catalog = catalog_manager
+            .default_catalog()
+            .await
+            .context("default catalog")?;
+        let ns = catalog
+            .get_namespace(&["acme".to_string(), "default".to_string()])
+            .await
+            .context("provisioned namespace present")?;
+        assert_eq!(
+            ns.tenant_id.as_deref(),
+            Some("acme"),
+            "provisioned system namespace records its owning tenant"
+        );
+
+        Ok(())
+    }
+
+    /// TD-SC-4 (S4): with tenant namespaces off (single-tenant deployments),
+    /// provisioning is a no-op — no per-tenant skeleton is created.
+    #[tokio::test]
+    async fn provision_tenant_system_catalog_noop_when_gate_off() -> Result<()> {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("xcatalog")?;
+        let service = CollectionService::new(StorageConfig::default())
+            .await
+            .context("service")?
+            .with_catalog_manager(catalog_manager.clone());
+        service.set_tenant_namespaces_for_test(false);
+
+        service
+            .provision_tenant_system_catalog("acme")
+            .await
+            .context("provision (gate off)")?;
+
+        let catalog = catalog_manager
+            .default_catalog()
+            .await
+            .context("default catalog")?;
+        assert!(
+            !catalog
+                .namespace_exists(&["acme".to_string(), "default".to_string()])
+                .await
+                .context("namespace_exists")?,
+            "gate off ⇒ provisioning creates nothing"
         );
 
         Ok(())


### PR DESCRIPTION
Two related tenant-isolation slices (squashed together):

## S3a — tenant-prefix collection namespaces (TD-CAT-2b)

Two tenants creating an identically-named namespace (e.g. `default`) via the **collections** path collided: the single multi-tenant catalog keyed the namespace store by the bare `levels.join(".")`, so the second tenant's record overwrote the first. The **DDL/DML path already avoids this** by prepending the tenant as namespace level 0 (`resolve_table_scoped`); only the collections path was inconsistent.

Behind the presence-based, default-OFF gate `PROXIMADB_CATALOG_TENANT_NAMESPACES` (read once into an `AtomicBool` for deterministic test toggling), `upsert`/`drop` of a collection catalog asset scope the identifier under `[tenant, ...levels]` via the pure `tenant_scoped_identifier`. Done once at the top so all ops are consistently scoped. **Read path unchanged** — `read_collections_from_catalog` already enumerates every namespace and matches by collection identity. No trait change, no backend churn.

## S4 — idempotent tenant provisioning (TD-SC-4)

`provision_tenant_system_catalog(tenant)` — the ADR-035 D3 signup entry point — idempotently pre-creates a tenant's bare-minimum system namespace (`[tenant, "default"]`) recorded with its `tenant_id`, so the first list/collection for a freshly signed-up tenant doesn't hit a cold namespace. No user tables. Idempotent (`namespace_exists` guard converges on retry) and gated (no-op unless tenant namespaces are on + a catalog is configured). Exposed as a free function + `CollectionService` method. Signup-wiring into the enterprise handler (which doesn't currently hold a catalog) is a noted follow-up.

## Tests
- `tenant_scoped_identifier_prepends_tenant_when_enabled`, `tenant_namespaces_isolate_same_named_namespace` (two tenants' `shared` namespace stay distinct, no bare collision), `provision_tenant_system_catalog_is_idempotent`, `provision_tenant_system_catalog_noop_when_gate_off`. Existing TD-CAT-2a test still green.

## Verification
`cargo test --lib services::collection::manager::tests::{tenant_,provision_}` ✅ · `cargo clippy --lib --bins -- -D warnings` ✅ · fmt clean.

Approach chosen with user: align collections to the existing DDL tenant-as-level convention (not a new tenant-keyed map across 8 backends). S3b reassessed away (its write-guard came from S2a's `_syscat` reserve; S3a already tenant-prefixes the legacy metadata path; `DrPathBuilder` lives in a crate `native.rs` can't depend on).