### PR TITLE
feat(statistics): expose per-cluster cluster_centroids in VectorStatistics (TD-175, #494)

### DIFF
--- a/src/core/statistics/mod.rs
+++ b/src/core/statistics/mod.rs
@@ -156,6 +156,16 @@ pub struct VectorStatistics {
     pub centroid: Vec<f64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cluster_occupancy: Vec<u64>,
+    /// Per-cluster centroid vectors, aligned **by index** with `cluster_occupancy`
+    /// (TD-175, #494). Lets a consumer seed `fusion-search` once per cluster to build
+    /// vector-cluster × graph-label co-statistics (the cluster partition the overall
+    /// `centroid` cannot provide). Populated by the same clustering pass that fills
+    /// `cluster_occupancy`. NOTE: `cluster_occupancy` is not yet fed from a clustering
+    /// pass (the AXIS k-means in `src/index/axis/clustering.rs` is decoupled from this
+    /// summary), so both stay empty until that wiring lands — this is the additive,
+    /// back-compat contract slot.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cluster_centroids: Vec<Vec<f64>>,
     #[serde(default)]
     pub approximate: bool,
 }
@@ -258,6 +268,45 @@ mod tests {
                 .iter()
                 .any(|m| matches!(m, ModalityStatistics::Graph(_))),
             "graph modality block must deserialize via the `kind` discriminator"
+        );
+    }
+
+    #[test]
+    fn vector_cluster_centroids_is_additive_and_back_compat() {
+        // #494 / TD-175: per-cluster centroids are an additive, back-compat slot —
+        // aligned by index with cluster_occupancy, omitted when empty, defaulted when
+        // absent from older payloads (same gating as cluster_occupancy).
+        let mut vs = VectorStatistics {
+            dimension: 2,
+            distance_metric: "cosine".into(),
+            spread: None,
+            centroid: vec![0.5, 0.5],
+            cluster_occupancy: vec![3, 1],
+            cluster_centroids: vec![vec![1.0, 0.0], vec![0.0, 1.0]],
+            approximate: true,
+        };
+
+        // Round-trips, aligned by index with occupancy.
+        let json = serde_json::to_string(&vs).expect("serialize");
+        let back: VectorStatistics = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.cluster_centroids, vs.cluster_centroids);
+        assert_eq!(back.cluster_centroids.len(), back.cluster_occupancy.len());
+
+        // Empty ⇒ omitted from the wire (skip_serializing_if), like cluster_occupancy.
+        vs.cluster_centroids = Vec::new();
+        let json_empty = serde_json::to_string(&vs).expect("serialize");
+        assert!(
+            !json_empty.contains("cluster_centroids"),
+            "empty cluster_centroids must be omitted"
+        );
+
+        // Absent from an older payload ⇒ defaults to empty (back-compat).
+        let older = r#"{"dimension":2,"distance_metric":"cosine","approximate":false}"#;
+        let parsed: VectorStatistics =
+            serde_json::from_str(older).expect("older payload without the field must parse");
+        assert!(
+            parsed.cluster_centroids.is_empty(),
+            "absent cluster_centroids defaults to empty"
         );
     }
 

--- a/src/core/statistics/summary.rs
+++ b/src/core/statistics/summary.rs
@@ -195,6 +195,10 @@ struct VectorAccumulator {
     /// Sum of L2 distance to the *running* centroid — an online spread proxy.
     spread_sum: f64,
     cluster_occupancy: Vec<u64>,
+    /// Per-cluster centroid vectors, aligned by index with `cluster_occupancy`
+    /// (#494). Filled by the same (future) clustering pass that fills occupancy —
+    /// empty today (the AXIS k-means is not yet wired into this accumulator).
+    cluster_centroids: Vec<Vec<f64>>,
 }
 
 /// Resident per-collection statistics. Mergeable across segments at compaction.
@@ -469,6 +473,7 @@ impl StatisticsSummary {
             spread,
             centroid,
             cluster_occupancy: v.cluster_occupancy.clone(),
+            cluster_centroids: v.cluster_centroids.clone(),
             // Centroid/spread are running estimates over a sample → approximate.
             approximate: v.count > 0,
         }


### PR DESCRIPTION
Closes the producer side of #494. Adds the per-cluster **`cluster_centroids: Vec<Vec<f64>>`** slot to `VectorStatistics`, aligned **by index** with `cluster_occupancy`, so a consumer can seed `fusion-search` once per cluster to build vector-cluster × graph-label co-statistics (the cluster partition the overall `centroid` can't provide). Same shape as #485 — expose an aligned attribute, keep the engine joint-free.

### ⚠️ Contract slot — population is a follow-up (important)
The issue's premise that "the clustering already produces `cluster_occupancy`, so centroids are in hand" **does not hold today**: `observe_vector` never writes `cluster_occupancy`, and the real k-means (`src/index/axis/clustering.rs`) is **decoupled** from `StatisticsSummary`. So **both `cluster_occupancy` and `cluster_centroids` are empty contract slots** right now (serde `skip_serializing_if = "Vec::is_empty"`).

This PR lands the **schema** so AnvaiOps #256 can pin it now. The **data** needs a separate follow-up that wires the AXIS cluster reps into the vector accumulator — at which point *both* fill together, aligned. Flagging so the consumer doesn't seed on empty centroids and look mysteriously broken.

### Change
- `VectorStatistics.cluster_centroids` (mod.rs) + `VectorAccumulator.cluster_centroids` (summary.rs) + clone in `vector_block`. Additive, back-compat, gated identically to `cluster_occupancy`.
- No OpenAPI/proto surface (internal struct, serde-only); the frozen **v1 golden contract** still round-trips green.

### Verify
`vector_cluster_centroids_is_additive_and_back_compat` (round-trip + omit-when-empty + default-when-absent); `golden_example_matches_frozen_v1_contract` green; `cargo build -p proximadb-server` + clippy green.

Tracks AnvaiOps #256.