### PR TITLE
docs(internals): operator guide for the catalog object_id cutover + tenant isolation

### DIFF
--- a/docs/06-internals/CATALOG_OBJECT_ID_LAYOUT.adoc
+++ b/docs/06-internals/CATALOG_OBJECT_ID_LAYOUT.adoc
@@ -1,0 +1,136 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Catalog object_id layout & tenant isolation — operator & internals guide (ADR-031 / TD-181 / TD-CAT-2b)
+:toc: macro
+:icons: font
+
+The native catalog historically keyed table metadata **by name** on disk
+(`metadata/tables/{ns}/{name}.json`) and held all namespaces in one shared file.
+Because object **names are identical across tenants**, that is structurally unsafe
+for multi-tenant SaaS: two tenants' `default.users` collide by path, and the shared
+namespace map collapses them in RAM. The **object_id cutover** makes the stable
+global `u64 object_id` (ADR-031) the *physical* catalog key and tenant-prefixes the
+logical namespace, so identical names across tenants never collide. Every step is
+**default-OFF**, **mixed-read-safe**, and **rollback-safe** — unset means today's
+exact behaviour. This guide is how it works and **how to turn it on**.
+
+toc::[]
+
+== What changes (and what doesn't)
+
+[source,text]
+----
+LEGACY (default)                         OID-KEYED (gated on)
+metadata/tables/{ns}/{name}.json   --->  _syscat/objects/{object_id}.json   (authority)
+                                         metadata/object_index.json         (durable name<->oid index)
+                                         _syscat/_migration.json            (layout marker)
+metadata/namespaces.json (shared)  --->  namespace levels carry the tenant: [tenant, ...levels]
+----
+
+* **object_id is allocated already** (ADR-031 / TD-181 P0, on every
+  table/namespace/column/index) — the cutover makes it *load-bearing*, it does not
+  re-allocate anything.
+* The catalog **record** is re-keyed; **no data bytes move** — `data_location` is a
+  separate field the cutover never touches.
+* **Rename is safer** under oid-keying: the oid is stable, so the object file does
+  not move — an in-place overwrite + index upsert replaces the old non-atomic
+  write-new+delete-old.
+
+== Coherence — the index is a derived cache, the object files are authority
+
+Each `_syscat/objects/{oid}.json` is **self-describing** (it carries its own
+`(namespace, name)` + `object_id`), so `metadata/object_index.json` (the
+`name <-> object_id` map loaded eagerly at startup) is **always rebuildable** by
+scanning the object files. Writes are **authority-first**:
+
+* **create / rename** — write the object file, *then* upsert the index. A crash in
+  between leaves an orphan object that is re-indexed on the next load (never lost).
+* **drop** — delete the object file, *then* remove the index entry. A crash in
+  between leaves a dangling index entry that is pruned lazily on a NotFound read
+  (never resurrected).
+
+If the index is absent at boot (first upgrade) it is rebuilt **once** by scanning,
+then read as a single file thereafter — never an unconditional per-boot rescan.
+
+== Enabling it (operator knobs)
+
+All gates are **presence-based** (set to any value = on) and **default-OFF**.
+
+[cols="2,3,2", options="header"]
+|===
+| Env var | Effect | Default
+
+| `PROXIMADB_CATALOG_OBJECT_ID_PATHS`
+| **Object_id storage cutover.** On a create, **dual-writes** the metadata to the
+  oid-keyed authority path `_syscat/objects/{oid}.json` *and* the legacy name path
+  (the shadow), and writes the `_syscat/_migration.json` marker. Reads prefer the
+  oid file and **fall back to the legacy name path** on any miss; `list_tables`
+  unions both layouts (deduped); `drop` removes both copies.
+| unset = pure legacy name-keyed paths
+
+| `PROXIMADB_CATALOG_TENANT_NAMESPACES`
+| **Tenant isolation for collections.** Stores a collection's catalog asset under a
+  tenant-prefixed namespace `[tenant, ...levels]` (the same convention the DDL/DML
+  path already uses), so two tenants' identically-named namespaces stay structurally
+  distinct instead of colliding on the bare `levels.join(".")` key. The read path is
+  unchanged (collection lookup enumerates all namespaces and matches by identity).
+| unset = bare namespaces (single-tenant behaviour)
+
+| object-store catalog URL (no env)
+| `s3://` / `gs://` / `az://` catalog URLs now persist durably by routing catalog
+  I/O through an injected `FileSystem` backend (TD-CAT-1b). `file://` is unchanged.
+| `file://` = local `tokio::fs`
+|===
+
+NOTE: The two gates are independent and composable. Enabling **both** gives the full
+target: oid-keyed object files written under tenant-distinct namespaces, with the
+global object_id guaranteeing cross-tenant uniqueness even for identical names.
+
+== Mixed-read & rollback (CLAUDE.md #8)
+
+Because the object_id cutover **keeps writing the legacy name-path shadow** while the
+gate is on, the two layouts always coexist and agree (identical self-describing
+bytes). Consequences:
+
+* A catalog dir may hold legacy-only, oid-only, and dual-written tables at once —
+  all resolve (oid preferred, legacy fallback), and `list`/`exists`/`drop` see them
+  all.
+* Flipping the gate **off again is lossless** — the legacy shadow is still the
+  source the name-keyed path reads. There is no irreversible migration step.
+
+== Provisioning (signup lifecycle)
+
+`provision_tenant_system_catalog(tenant)` (ADR-035 D3) idempotently pre-creates a
+tenant's bare-minimum system namespace (`[tenant, "default"]`, recorded with its
+`tenant_id`) so the first list/collection for a freshly signed-up tenant does not hit
+a cold namespace. It is **idempotent** (a re-signup is a no-op; a partial failure is
+safe to retry) and a **no-op unless `PROXIMADB_CATALOG_TENANT_NAMESPACES` is on** and
+a catalog is configured. Exposed as a `CollectionService` method + a catalog-only
+free function; wiring it into a production signup endpoint is a follow-up (no such
+endpoint exists today).
+
+== Suggested rollout order
+
+. **Cloud durability first** (if applicable): point the catalog at an object-store
+  URL so metadata is durable/shared across pods.
+. **`PROXIMADB_CATALOG_OBJECT_ID_PATHS`**: turn on the storage cutover. Existing
+  catalogs rebuild the durable index once, then dual-write. Verify reads/lists, then
+  soak — rollback is free.
+. **`PROXIMADB_CATALOG_TENANT_NAMESPACES`**: turn on tenant isolation for new
+  collections. Call `provision_tenant_system_catalog` at tenant onboarding.
+
+== Status & pointers
+
+* Storage cutover (S1/S2a/S2b): `crates/control/proximadb-catalog/src/native.rs`
+  (`object_file_rel`, `read_table_bytes`, `load_object_index`, the `ObjectIndex` +
+  `MigrationMarker` types). PRs #490 (index), #497 (oid storage).
+* Object-store catalog (S0 / TD-CAT-1b): `src/catalog/mod.rs::create_native_catalog`.
+  PR #488.
+* Tenant namespaces + provisioning (S3a/S4): `src/services/collection/manager.rs`
+  (`tenant_scoped_identifier`, `provision_tenant_system_catalog`). PR #510.
+* `_syscat` reserved segment: `DrPathBuilder::RESERVED_SYSTEM_SEGMENTS`
+  (`src/storage/trait_components/path_resolver.rs`) — the data plane cannot address
+  `_syscat`, the structural half of the system-only write guard.
+* Design: `docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc`,
+  `docs/12-design/CATALOG_OID_MIGRATION_2026_06_27.adoc`,
+  `docs/12-design/adr/ADR-035-per-tenant-system-catalog-cache.adoc` (D1/D3).


### PR DESCRIPTION
## What

The object_id storage cutover (S0–S2b) and tenant-namespace isolation + provisioning (S3a/S4) ship behind **default-OFF env gates** that were undocumented — making the feature effectively un-enablable without reading source. This adds `docs/06-internals/CATALOG_OBJECT_ID_LAYOUT.adoc`, mirroring the D2 system-catalog-cache operator guide (#474):

- the legacy → oid-keyed layout (`_syscat/objects/{oid}.json` authority + durable `metadata/object_index.json` + `_syscat/_migration.json` marker; tenant-prefixed namespace levels)
- the **authority-first** coherence model (object files are authority; index is a rebuildable derived cache)
- **mixed-read & rollback** guarantees (legacy shadow kept ⇒ flipping the gate off is lossless)
- the two operator knobs (`PROXIMADB_CATALOG_OBJECT_ID_PATHS`, `PROXIMADB_CATALOG_TENANT_NAMESPACES`) + cloud catalog URLs
- the `provision_tenant_system_catalog` signup primitive
- a suggested rollout order

## Verification
`asciidoctor` renders clean. No code change.

Closes the documentation gap for the object_id cutover program (S0 #488, S1 #490, S2a/S2b #497, S3a/S4 #510).