### PR TITLE
feat(graph): re-populate the canonical store on recovery (TD-066 Part 2, ADR-020)

### DIFF
--- a/src/graph/engines/mod.rs
+++ b/src/graph/engines/mod.rs
@@ -333,6 +333,13 @@ pub trait GraphEngine: Send + Sync {
     /// Get all nodes
     fn get_all_nodes(&self) -> Result<Vec<Arc<Node>>>;
 
+    /// Get all edges. Default returns empty (mocks / engines that don't persist);
+    /// real engines override it. Used by canonical-store recovery re-population
+    /// (TD-066 Part 2) to re-drive every recovered edge into the canonical store.
+    fn get_all_edges(&self) -> Result<Vec<Arc<Edge>>> {
+        Ok(Vec::new())
+    }
+
     // ===== Performance & Benchmarking Methods =====
 
     /// Get engine performance statistics
@@ -651,6 +658,12 @@ impl GraphEngine for GraphEngineImpl {
     fn get_all_nodes(&self) -> Result<Vec<Arc<Node>>> {
         match self {
             GraphEngineImpl::Orion(engine) => engine.get_all_nodes(),
+        }
+    }
+
+    fn get_all_edges(&self) -> Result<Vec<Arc<Edge>>> {
+        match self {
+            GraphEngineImpl::Orion(engine) => engine.get_all_edges(),
         }
     }
 

--- a/src/graph/engines/orion/mod.rs
+++ b/src/graph/engines/orion/mod.rs
@@ -1329,6 +1329,14 @@ impl GraphEngine for OrionGraphEngine {
         }
         Ok(nodes)
     }
+
+    fn get_all_edges(&self) -> Result<Vec<Arc<Edge>>> {
+        let mut edges = Vec::new();
+        for entry in self.memory_pool.edges.iter() {
+            edges.push(Arc::clone(&*entry));
+        }
+        Ok(edges)
+    }
 }
 
 impl Default for OrionGraphEngine {

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -912,6 +912,46 @@ impl GraphOperationsService {
         Ok(())
     }
 
+    /// Re-drive every recovered node/edge through the canonical record store so a
+    /// buffered cold store (e.g. `ColdGraphSegmentStore`, whose unflushed buffer is
+    /// lost on crash) is rebuilt from the authoritative recovered engine state
+    /// (TD-066 Part 2, ADR-020). Upserts are idempotent, so this is a no-op of cost
+    /// for an already-durable store and the data-loss fix for a buffered one. No-op
+    /// when no canonical store is wired or the graph is not resident. Returns the
+    /// number of records re-driven.
+    pub(crate) async fn repopulate_canonical_store(&self, graph_id: &str) -> Result<usize> {
+        let Some(record_store) = &self.canonical_record_store else {
+            return Ok(0);
+        };
+        // Clone the Arc out of the map so no DashMap guard is held across the await.
+        let Some(engine) = self.graphs.get(graph_id).map(|e| e.value().clone()) else {
+            return Ok(0);
+        };
+        let nodes = engine.get_all_nodes()?;
+        let edges = engine.get_all_edges()?;
+        let mut records = Vec::with_capacity(nodes.len() + edges.len());
+        for node in &nodes {
+            records.push(node_to_canonical_record(graph_id, node.as_ref()));
+        }
+        for edge in &edges {
+            records.push(edge_to_canonical_record(graph_id, edge.as_ref()));
+        }
+        let count = records.len();
+        if !records.is_empty() {
+            record_store
+                .upsert_records(records)
+                .await
+                .map_err(|error| ProximaDBError::Internal(error.to_string()))?;
+        }
+        tracing::info!(
+            graph_id,
+            nodes = nodes.len(),
+            edges = edges.len(),
+            "TD-066 Part 2: re-populated canonical store from recovered graph state"
+        );
+        Ok(count)
+    }
+
     /// Recover all graphs from persistent storage
     ///
     /// This method should be called during server startup to restore all graph state
@@ -1008,6 +1048,21 @@ impl GraphOperationsService {
         // Store in graphs map
         self.graphs
             .insert(graph_id.to_string(), Arc::new(engine_impl));
+
+        // TD-066 Part 2 (gated, default-OFF): engine-WAL replay above rebuilt the
+        // in-memory engine, but the canonical/cold record store — a buffered store
+        // for `ColdGraphSegmentStore` — is not rebuilt by that replay. Re-drive the
+        // recovered nodes/edges through the canonical store so the cold tier is
+        // rebuilt from the authoritative recovered state (the data-loss path that
+        // blocks wiring `ColdGraphSegmentStore` to production, #52).
+        if crate::storage::persistence::write_ahead_log::wal_operations::canonical_recovery_repopulate_enabled() {
+            let records = self.repopulate_canonical_store(graph_id).await?;
+            tracing::info!(
+                graph_id,
+                records,
+                "canonical store re-populated from recovered graph state"
+            );
+        }
 
         Ok(())
     }

--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -856,6 +856,103 @@ mod tests {
         );
     }
 
+    /// TD-066 Part 2 / #52: graph recovery replays the engine WAL into the in-memory
+    /// engine only, leaving a *buffered* canonical/cold store empty after a crash.
+    /// `repopulate_canonical_store` re-drives the recovered nodes + edges through the
+    /// canonical store so the cold tier is rebuilt from the authoritative recovered
+    /// engine state — the data-loss fix that unblocks wiring `ColdGraphSegmentStore`.
+    #[tokio::test]
+    async fn recovery_repopulates_canonical_store_from_engine() {
+        let graph_id = format!("canonical_recovery_test_{}", std::process::id());
+        let graph_id = graph_id.as_str();
+        let record_store = Arc::new(MemoryRecordStore::default());
+        let service =
+            GraphOperationsService::new().with_canonical_record_store(record_store.clone());
+
+        service
+            .create_graph_collection(CreateGraphRequest {
+                graph_id: graph_id.to_string(),
+                name: None,
+                description: None,
+                schema: None,
+                storage_config: None,
+                engine_config: None,
+                access_control: None,
+            })
+            .await
+            .expect("create graph");
+
+        for node_id in ["n1", "n2", "n3"] {
+            service
+                .create_node(
+                    graph_id,
+                    Node {
+                        id: node_id.to_string(),
+                        labels: vec!["Person".to_string()],
+                        properties: HashMap::new(),
+                        embedding: None,
+                        created_at_ms: 1,
+                        updated_at_ms: 1,
+                    },
+                )
+                .await
+                .expect("create node");
+        }
+        service
+            .create_edge(
+                graph_id,
+                Edge {
+                    id: "e1".to_string(),
+                    from_node_id: "n1".to_string(),
+                    to_node_id: "n2".to_string(),
+                    edge_type: "KNOWS".to_string(),
+                    properties: HashMap::new(),
+                    weight: None,
+                    created_at_ms: 1,
+                    updated_at_ms: 1,
+                },
+            )
+            .await
+            .expect("create edge");
+
+        // Simulate a crash that lost the buffered cold store while the engine —
+        // rebuilt from its own WAL on restart — retains the authoritative state.
+        record_store.records.write().expect("clear store").clear();
+        assert!(
+            record_store.records.read().expect("read store").is_empty(),
+            "cold store emptied (buffer lost on crash)"
+        );
+
+        // Recovery re-population rebuilds the canonical store from the engine.
+        let driven = service
+            .repopulate_canonical_store(graph_id)
+            .await
+            .expect("repopulate canonical store");
+        assert_eq!(
+            driven, 4,
+            "3 nodes + 1 edge re-driven into the canonical store"
+        );
+
+        for node_id in ["n1", "n2", "n3"] {
+            assert!(
+                record_store
+                    .get_record(&RecordKey::new(format!("graph/{graph_id}/node/{node_id}")))
+                    .await
+                    .expect("get recovered node")
+                    .is_some(),
+                "node {node_id} re-populated after recovery"
+            );
+        }
+        assert!(
+            record_store
+                .get_record(&RecordKey::new(format!("graph/{graph_id}/edge/e1")))
+                .await
+                .expect("get recovered edge")
+                .is_some(),
+            "edge re-populated after recovery"
+        );
+    }
+
     /// TD-168 cold-payload tier: a node/edge whose payload is durable in the
     /// canonical record store but NOT resident in the engine is servable when the
     /// gate is ON, and yields `None` (today's behavior) when OFF. Process-isolated

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -102,6 +102,19 @@ pub fn canonical_replay_scope_enabled() -> bool {
     std::env::var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE").as_deref() == Ok("1")
 }
 
+/// TD-066 (c) Part 2 — canonical-store recovery re-population (default OFF).
+/// Graph recovery replays the engine WAL into the in-memory engine only; the
+/// canonical/cold record store (a write-time projection, and a *buffered* one for
+/// `ColdGraphSegmentStore`) is NOT rebuilt — an unflushed buffer is lost on crash.
+/// When enabled, recovery re-drives every recovered node/edge through the
+/// canonical store (idempotent upsert) so the cold store is rebuilt from the
+/// authoritative recovered state — closing the data-loss path that blocks wiring
+/// `ColdGraphSegmentStore` to production. Aligns graph durability to ADR-020
+/// (canonical store rebuildable from recovery). Flip fleet-wide after baking.
+pub fn canonical_recovery_repopulate_enabled() -> bool {
+    std::env::var("PROXIMADB_GRAPH_CANONICAL_RECOVERY").as_deref() == Ok("1")
+}
+
 /// Parse the segment index out of a `wal_{:08}.log` segment filename. Accepts
 /// either a bare filename or a full path (takes the last path component).
 /// Returns `None` for anything that isn't a WAL segment file.


### PR DESCRIPTION
## What

On graph recovery, re-drive every recovered node/edge through the canonical record store so a **buffered** cold store is rebuilt from the authoritative recovered engine state. Gated default-OFF behind `PROXIMADB_GRAPH_CANONICAL_RECOVERY`.

## Why

ADR-020 makes the canonical store the durability authority that recovery must rebuild — relational already replays the canonical WAL. **Graph** recovery, however, replays the *engine* WAL into the in-memory ORION engine **only**; the canonical/cold record store (a write-time projection) is never rebuilt. For a buffered `ColdGraphSegmentStore` whose unflushed buffer is lost on crash, that means **buffered records are gone after a restart** — the data-loss path that blocks wiring the segment store to production (#52), and a cross-modality durability divergence.

This is **Part 2 of TD-066** (Part 1 — the `CanonicalEmission` marker + LSN replay-scope infra — already landed and is gated by `PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE`).

## How

`recover_graph`, after `engine.recover()`, calls `repopulate_canonical_store(graph_id)` (gated): it enumerates the recovered nodes + edges, projects them via the existing `node_to_canonical_record` / `edge_to_canonical_record`, and **idempotently** `upsert_records` into the canonical store. Idempotent ⇒ a no-op of cost for an already-durable store, the data-loss fix for a buffered one. No-op when no canonical store is wired or the graph is not resident.

## Changes

- **engines**: `GraphEngine::get_all_edges` (default-empty for mocks; real overrides in ORION + `GraphEngineImpl`), mirroring `get_all_nodes`.
- **wal_operations**: `canonical_recovery_repopulate_enabled()` gate (default-OFF).
- **service**: `repopulate_canonical_store(graph_id)` + gated wiring in `recover_graph`.
- **test**: `recovery_repopulates_canonical_store_from_engine` — writes 3 nodes + 1 edge, **clears the store to simulate a lost cold buffer**, asserts re-population restores all 4 records.

## Safety

Gated default-OFF, mixed-read-safe — old fleets unaffected. Flip fleet-wide after baking, then the buffered `ColdGraphSegmentStore` becomes WAL-recoverable and #52 can be wired.

## Tests

Lib + test green; CI-exact clippy (`--lib --bins -D warnings`) clean.