### PR TITLE
feat(query): cast unification — frontend owns casts, identity-folded (ADR-043 Inv 2, closes TD-183, doc ratchet 9->11)

### DIFF
--- a/crates/foundation/proximadb-relational-types/src/lib.rs
+++ b/crates/foundation/proximadb-relational-types/src/lib.rs
@@ -1297,6 +1297,26 @@ pub fn cast_value(v: &ProximaValue, target: &ProximaType) -> Result<ProximaValue
                 to: PT::Int64,
             })?)
         }
+        // `::int`/`::smallint`/`::tinyint` (now reaching here, no longer string-stripped):
+        // parse to the narrower width. Postgres `int4`→Int32 is the common d06 path.
+        (PV::String(s), PT::Int32) => {
+            PV::Int32(s.parse::<i32>().map_err(|_| ExprError::UnsupportedCast {
+                from: PT::String,
+                to: PT::Int32,
+            })?)
+        }
+        (PV::String(s), PT::Int16) => {
+            PV::Int16(s.parse::<i16>().map_err(|_| ExprError::UnsupportedCast {
+                from: PT::String,
+                to: PT::Int16,
+            })?)
+        }
+        (PV::String(s), PT::Float32) => {
+            PV::Float32(s.parse::<f32>().map_err(|_| ExprError::UnsupportedCast {
+                from: PT::String,
+                to: PT::Float32,
+            })?)
+        }
         (PV::String(s), PT::Float64) => {
             PV::Float64(s.parse::<f64>().map_err(|_| ExprError::UnsupportedCast {
                 from: PT::String,

--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -27,7 +27,7 @@
 //! Schema resolution: callers provide a [`CatalogLookup`] so we
 //! don't depend on the runtime catalog crate from here.
 
-use proximadb_data_model::{ProximaType, ProximaValue};
+use proximadb_data_model::{ProximaType, ProximaValue, TimeUnit};
 use proximadb_relational_algebra::{
     AggregateExpr, JoinKind, JoinStrategy, LogicalNode, NamedAggregate, NamedExpr, SetOpKind,
     SortKey, TableId,
@@ -36,10 +36,11 @@ use proximadb_relational_types::{
     BinaryOp, ColumnInfo, ColumnRef, Expr, RelationalSchema, UnaryOp,
 };
 use sqlparser::ast::{
-    BinaryOperator, Distinct, Expr as SqlExpr, FunctionArg, FunctionArgExpr, FunctionArguments,
-    GroupByExpr, JoinConstraint, JoinOperator, LimitClause, ObjectName, OrderByKind,
-    Query as SqlQuery, Select as SqlSelect, SelectItem, SetExpr, SetOperator, SetQuantifier,
-    Statement, TableFactor, UnaryOperator, Value as SqlValue, ValueWithSpan,
+    BinaryOperator, DataType as SqlDataType, Distinct, Expr as SqlExpr, FunctionArg,
+    FunctionArgExpr, FunctionArguments, GroupByExpr, JoinConstraint, JoinOperator, LimitClause,
+    ObjectName, OrderByKind, Query as SqlQuery, Select as SqlSelect, SelectItem, SetExpr,
+    SetOperator, SetQuantifier, Statement, TableFactor, UnaryOperator, Value as SqlValue,
+    ValueWithSpan,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
@@ -1334,11 +1335,56 @@ fn lower_expr(expr: &SqlExpr, scope: &Scope, ctx: &mut LoweringCtx) -> Result<Ex
         SqlExpr::Exists { .. } | SqlExpr::InSubquery { .. } => Err(FrontendError::Unsupported(
             "EXISTS / IN subquery in expression position".into(),
         )),
+        // CAST — the single, typed home for casts (ADR-043 Inv 2). The pgwire translator
+        // no longer string-strips cast suffixes, so an explicit `x::T` reaches here. Lower
+        // to one typed `Expr::Cast`, IDENTITY-FOLDED to zero-copy when the inner expression
+        // already has the target type (the redundant casts the old strip list silently
+        // dropped) — using the pure `Expr::result_type()` inference.
+        SqlExpr::Cast {
+            expr, data_type, ..
+        } => {
+            let inner = lower_expr(expr, scope, ctx)?;
+            let target = sql_type_to_proxima(data_type)?;
+            if inner.result_type() == target {
+                Ok(inner)
+            } else {
+                Ok(Expr::Cast {
+                    expr: Box::new(inner),
+                    ty: target,
+                })
+            }
+        }
         other => Err(FrontendError::Unsupported(format!(
             "expression {:?}",
             std::mem::discriminant(other)
         ))),
     }
+}
+
+/// Map a SQL `CAST` target type to the canonical [`ProximaType`]. Covers the standard
+/// scalar types (including every suffix the old translator strip list handled, so deleting
+/// it does not regress those casts). Postgres byte-width convention: `int4`/`int` →
+/// `Int32`, `int8`/`bigint` → `Int64`. Unknown targets are `Unsupported` so the query
+/// declines to the existing fallback rather than guessing.
+fn sql_type_to_proxima(dt: &SqlDataType) -> Result<ProximaType, FrontendError> {
+    use SqlDataType as D;
+    Ok(match dt {
+        D::Char(_) | D::Varchar(_) | D::Text => ProximaType::String,
+        D::TinyInt(_) => ProximaType::Int8,
+        D::SmallInt(_) => ProximaType::Int16,
+        D::Int(_) | D::Int4(_) | D::Integer(_) => ProximaType::Int32,
+        D::Int8(_) | D::BigInt(_) => ProximaType::Int64,
+        D::Float(_) | D::Float4 | D::Real => ProximaType::Float32,
+        D::Float8 | D::Double(_) => ProximaType::Float64,
+        D::Bool | D::Boolean => ProximaType::Boolean,
+        D::Date => ProximaType::Date,
+        D::Timestamp(_, _) => ProximaType::Timestamp(TimeUnit::Microsecond),
+        D::JSON => ProximaType::Json,
+        D::JSONB => ProximaType::Jsonb,
+        other => {
+            return Err(FrontendError::Unsupported(format!("CAST to {other}")));
+        }
+    })
 }
 
 fn lower_binary_op(op: &BinaryOperator) -> Result<BinaryOp, FrontendError> {
@@ -2967,6 +3013,31 @@ mod tests {
         // A bare aggregate name in scalar (non-GROUP-BY) position is still a misuse.
         let err = lower_sql("SELECT sum(age) + 1 FROM users", &catalog()).unwrap_err();
         assert!(matches!(err, FrontendError::Unsupported(_)));
+    }
+
+    #[test]
+    fn cast_lowers_typed_and_identity_folds() {
+        // ADR-043 Inv 2: a real conversion lowers to a typed `Expr::Cast`.
+        // age (Int32) AS bigint → Cast { ty: Int64 }.
+        let plan = lower("SELECT CAST(age AS bigint) FROM users");
+        let LogicalNode::Project { outputs, .. } = plan else {
+            panic!("expected Project");
+        };
+        match &outputs[0].expr {
+            Expr::Cast { ty, .. } => assert_eq!(*ty, ProximaType::Int64),
+            other => panic!("expected Cast to Int64, got {other:?}"),
+        }
+        // Identity-fold (zero-copy): name (String) AS varchar already has the target type,
+        // so it folds to the bare column — no `Cast` node emitted.
+        let plan = lower("SELECT CAST(name AS varchar) FROM users");
+        let LogicalNode::Project { outputs, .. } = plan else {
+            panic!("expected Project");
+        };
+        assert!(
+            matches!(&outputs[0].expr, Expr::Column(_)),
+            "identity cast should fold to the column (zero-copy), got {:?}",
+            outputs[0].expr
+        );
     }
 
     #[test]

--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -7,11 +7,11 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open (uncovered by ADR-040 Phase 1 accuracy conversion)
+| Status | **Resolved** — all 11 document queries accurate (ratchet 11); root-caused into ADR-043 and fixed by its invariants
 | Severity | High — silent wrong answers (empty / divergent results), not errors
 | Component | Document modality — JSON-path SELECT-projection evaluation
-| Tracked-by | link:../../12-design/adr/ADR-040-conformance-accuracy-ratchet.adoc[ADR-040] (TD-182 umbrella)
-| Fix-in | PR2 of the ADR-040 document rollout
+| Tracked-by | link:../../12-design/adr/ADR-040-conformance-accuracy-ratchet.adoc[ADR-040] (TD-182 umbrella); link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (root-cause unification, TD-186)
+| Resolution | routing (#480) → DataFusion alias (#486) → fail-loud predicates (Inv 1, #502) → typed JSON functions + Json coercion (Inv 3, #507) → cast unification (Inv 2). `DOC_ACCURACY_RATCHET = 11`, `KNOWN_BAD_TD183` empty.
 |===
 
 toc::[]

--- a/src/network/postgres/translator.rs
+++ b/src/network/postgres/translator.rs
@@ -114,8 +114,11 @@ impl QueryTranslator {
         // Translate PostgreSQL-specific functions
         translated = self.translate_functions(&translated);
 
-        // Translate data types
-        translated = self.translate_types(&translated);
+        // NOTE: casts are NO LONGER string-stripped here (ADR-043 Inv 2). Cast semantics
+        // belong to the typed relational frontend (`lower_expr`'s `SqlExpr::Cast` arm),
+        // which lowers `x::T` to a typed `Expr::Cast` (identity-folded to zero-copy when
+        // redundant). The old strip list silently dropped type information — it forgot
+        // `::int` and over-stripped `::boolean` (TD-183 d06/d11).
 
         Ok(translated)
     }
@@ -220,26 +223,6 @@ impl QueryTranslator {
 
         // array_agg -> not supported, return empty
         // string_agg -> not supported, return empty
-
-        result
-    }
-
-    /// Translate PostgreSQL data types
-    fn translate_types(&self, query: &str) -> String {
-        let mut result = query.to_string();
-
-        // Type casts
-        result = result.replace("::text", "");
-        result = result.replace("::varchar", "");
-        result = result.replace("::integer", "");
-        result = result.replace("::bigint", "");
-        result = result.replace("::float", "");
-        result = result.replace("::double precision", "");
-        result = result.replace("::boolean", "");
-        result = result.replace("::timestamp", "");
-        result = result.replace("::date", "");
-        result = result.replace("::jsonb", "");
-        result = result.replace("::json", "");
 
         result
     }

--- a/src/network/postgres/translator.rs
+++ b/src/network/postgres/translator.rs
@@ -175,8 +175,10 @@ impl QueryTranslator {
             }
         }
 
+        // `::jsonb` is outside the capture group so $2 is the bare string literal —
+        // the cast is consumed and dropped here (the @> rewrite owns the semantics).
         let re_contains =
-            regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_\.]*)\s*@>\s*('[^']+'(?:::jsonb)?)"#)?;
+            regex::Regex::new(r#"([A-Za-z_][A-Za-z0-9_\.]*)\s*@>\s*('[^']+')(?:::jsonb)?"#)?;
         result = re_contains
             .replace_all(&result, "JSON_CONTAINS($1, $2)")
             .to_string();

--- a/tests/document_json_pgwire_e2e.rs
+++ b/tests/document_json_pgwire_e2e.rs
@@ -37,13 +37,12 @@ use proximadb::database::ProximaDB;
 use tempfile::TempDir;
 use tokio::time::sleep;
 
-/// Queries that must be verified CORRECT (anchored + differential) to count.
-/// 9 of 11 are accurate: d01/d02/d03 (no JSON path), d09 (aggregation), d04/d05/d08
-/// (projections, routing fix #480), d10 (DataFusion `json_extract_path_text` alias
-/// #486), and d07 (native predicate fix, this PR). d06 (cast-path bypass) and d11
-/// (DataFusion `Utf8 = Boolean` coercion) remain known-bad under TD-183; the ratchet
-/// rises as those land.
-const DOC_ACCURACY_RATCHET: usize = 9;
+/// All 11 document queries are verified CORRECT (anchored + differential cross-engine).
+/// The TD-183 saga is closed across ADR-043: routing (#480), DataFusion alias (#486),
+/// fail-loud predicates (Inv 1, #502), typed JSON functions + Json coercion (Inv 3), and
+/// cast unification — the frontend Cast arm + deleting the translator strip (Inv 2, this
+/// PR). Native and DataFusion now agree on every query.
+const DOC_ACCURACY_RATCHET: usize = 11;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -178,10 +177,12 @@ fn doc_queries() -> Vec<(&'static str, String)> {
 ///     through the same validate/evaluate fix.
 ///   * d11 — DataFusion cannot coerce `Utf8 = Boolean` for `(doc->>'in_stock')::boolean
 ///     = true`; the `::boolean` cast is dropped in lowering.
-const KNOWN_BAD_TD183: &[&str] = &[
-    "d06_filter_json_scalar", // (doc->>'price')::int > 8       filter — cast-path bypass
-    "d11_bool_field",         // (doc->>'in_stock')::boolean    filter — DF cast coercion
-];
+// All 11 document queries are now accurate. d06/d11 were fixed by ADR-043 Invariant 2
+// (the frontend Cast arm + deleting the translator strip list): `::int` now lowers and
+// native `cast_value` String→Int32 computes it; `::boolean` is preserved as a real cast
+// instead of being string-stripped, so the comparison is `cast(... AS Boolean) = true`
+// (no `Utf8 = Boolean` clash).
+const KNOWN_BAD_TD183: &[&str] = &[];
 
 /// One result row as text cells (pgwire `simple_query` form); SQL NULL → "NULL".
 type Rows = Vec<Vec<String>>;


### PR DESCRIPTION
## What

**ADR-043 Invariant 2** — the last piece, which **closes TD-183** (document accuracy **9 → 11**, all 11 queries verified cross-engine).

Casts were handled by four disagreeing mechanisms; the worst was the pgwire translator **string-stripping** a hard-coded list of cast suffixes before parsing — it forgot `::int` (so it survived into a frontend that couldn't lower it → d06 declined to the legacy document path → 0 rows) and over-stripped `::boolean` (destroying the type DataFusion needed → d11 `Utf8 = Boolean` coercion failure).

## Changes

- **Frontend owns casts** — `lower_expr` gains a typed `SqlExpr::Cast` arm (one `sql_type → ProximaType` map covering every previously-stripped type), **identity-folded to zero-copy** when the inner expression already has the target type (via the pure `Expr::result_type`) — the redundant casts the old strip silently dropped now emit **no `Cast` node at all**.
- **Delete the translator strip** (`translate_types`). Unsupported cast targets **decline to the existing `ctx.sql` fallback** exactly as before (the frontend had no Cast arm previously), so the deletion is additive.
- **`cast_value`** gains `(String, Int32/Int16/Float32)` so `::int` etc. compute on the native engine (`Int64`/`Float64`/`Boolean` already existed).

With #507's native `json_extract_text`, d06 (`(doc->>'price')::int > 8`) now computes natively (json text → cast Int32 → compare) and d11 (`(doc->>'in_stock')::boolean = true`) compares `cast(... AS Boolean) = true` on both engines.

## Result

`KNOWN_BAD_TD183` is now **empty**, `DOC_ACCURACY_RATCHET` **9 → 11**. **TD-183 marked Resolved.** Unit test covers a typed cast and the identity-fold (zero-copy) path.

## Risk / verification

The strip deletion is broad-impact (casts appear in TPC-H/TPC-DS) — **watch the full CI suite**, not just unit. A cast target the `sql_type_to_proxima` map doesn't cover declines to `ctx.sql` (not an error). `cargo test --test document_json_pgwire_e2e` → `ok` (11 accurate); frontend cast tests + `relational-types` cast/coercion tests pass; fmt + clippy clean.