### PR TITLE
feat(sdk): key code records on the canonical symbol oid — ADR-044 third surface

### DIFF
--- a/clients/python/src/proximadb_sdk/_code_oid.py
+++ b/clients/python/src/proximadb_sdk/_code_oid.py
@@ -1,0 +1,46 @@
+"""ADR-044: the SDK's code-record symbol oid.
+
+A code symbol's record id is the **line-independent canonical oid** minted by
+victor-codegraph — derived from the same ``(repo, language, fully_qualified_name,
+signature)`` coordinates Victor's adapter and the AnvaiOps connector use, so the same
+symbol gets the same oid wherever it is indexed. Gated default-OFF
+(``VICTOR_CODEGRAPH_STABLE_OID``): off keeps the legacy line-coupled ``path:line:name``
+id, byte-identical.
+
+Pure + dependency-light (only ``os`` + a lazy ``victor_codegraph`` import) so it is
+unit-testable without the SDK's gRPC client surface.
+"""
+
+from __future__ import annotations
+
+import os
+
+_STABLE_OID_ENV = "VICTOR_CODEGRAPH_STABLE_OID"
+
+
+def _stable_oid_enabled() -> bool:
+    return os.getenv(_STABLE_OID_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def record_symbol_id(metadata: dict, repo_graph_id: str) -> str:
+    """The record id for a code symbol (ADR-044).
+
+    Returns Victor's canonical adapter form ``graph/{repo}/node/{key}`` when the gate is
+    on and victor-codegraph supplies the derivation; otherwise the legacy ``symbol_id``
+    from ``metadata`` (and on any failure — never raises).
+    """
+    legacy = metadata.get("symbol_id") or ""
+    if not _stable_oid_enabled():
+        return legacy
+    try:
+        import victor_codegraph as _vcg
+
+        key = _vcg.stable_symbol_oid(
+            repo_graph_id,
+            metadata.get("language") or "",
+            metadata.get("fully_qualified_name") or "",
+            metadata.get("signature"),
+        )
+    except Exception:
+        return legacy
+    return f"graph/{repo_graph_id}/node/{key}"

--- a/clients/python/src/proximadb_sdk/code_knowledge.py
+++ b/clients/python/src/proximadb_sdk/code_knowledge.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from ._code_oid import record_symbol_id
 from .chunking_strategies.base import TextChunk
 from .chunking_strategies.code import (
     EXTENSION_TO_LANGUAGE,
@@ -519,7 +520,11 @@ class CodeKnowledgeBuilder:
 
             records.append(
                 {
-                    "id": metadata["symbol_id"],
+                    # ADR-044: line-independent canonical oid when gated (matches
+                    # Victor's adapter + the AnvaiOps connector for the same symbol);
+                    # legacy symbol_id otherwise. node_id below uses the same value so
+                    # the vector + graph projections correlate.
+                    "id": record_symbol_id(metadata, self.config.graph_name),
                     "vector": embedding,
                     "props": metadata,
                     "source": chunk.text,
@@ -551,7 +556,15 @@ class CodeKnowledgeBuilder:
 
             # Insert nodes for each symbol
             for chunk in chunks:
-                node_id = chunk.metadata.get("symbol_id", chunk.chunk_id)
+                # ADR-044: same id derivation as the vector record (above) so the
+                # graph node and the vector correlate on one oid.
+                node_id = record_symbol_id(
+                    {
+                        **chunk.metadata,
+                        "symbol_id": chunk.metadata.get("symbol_id", chunk.chunk_id),
+                    },
+                    self.config.graph_name,
+                )
 
                 node_properties = {
                     "symbol_type": chunk.metadata.get("symbol_type", "UNKNOWN"),

--- a/clients/python/tests/test_sdk_stable_oid.py
+++ b/clients/python/tests/test_sdk_stable_oid.py
@@ -1,0 +1,65 @@
+"""ADR-044 (SDK, third surface): the SDK keys code records on the same
+line-independent canonical oid Victor's adapter mints — so a symbol gets the same
+oid wherever it is indexed (Victor / AnvaiOps / the SDK).
+
+Gated default-OFF (``VICTOR_CODEGRAPH_STABLE_OID``); off keeps the legacy line-coupled
+id, byte-identical. Guarded with ``importorskip`` so it runs only where the optional
+``victor-codegraph`` extra is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+victor_codegraph = pytest.importorskip("victor_codegraph")
+
+from proximadb_sdk._code_oid import record_symbol_id  # noqa: E402
+
+_LEGACY_META = {
+    "symbol_id": "auth.py:1:login",
+    "language": "python",
+    "fully_qualified_name": "auth.py::login",
+    "signature": "(user)",
+}
+
+
+def test_default_off_returns_legacy_id(monkeypatch):
+    monkeypatch.delenv("VICTOR_CODEGRAPH_STABLE_OID", raising=False)
+    assert record_symbol_id(_LEGACY_META, "repo1") == "auth.py:1:login"
+
+
+def test_gated_on_returns_canonical_form(monkeypatch):
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "1")
+    key = victor_codegraph.stable_symbol_oid(
+        "repo1", "python", "auth.py::login", "(user)"
+    )
+    assert record_symbol_id(_LEGACY_META, "repo1") == f"graph/repo1/node/{key}"
+
+
+def test_cross_surface_matches_victor_adapter(monkeypatch):
+    # The SDK's record oid must equal Victor's adapter oid for the SAME symbol — derive
+    # the metadata from a real parse so the FQN/signature are the parser's own.
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "1")
+    src = "def login(user):\n    return check(user)\n"
+    parsed = victor_codegraph.parse(src, file_path="auth.py")
+    recs = victor_codegraph.to_proxima_records(
+        parsed, repo_graph_id="repo1", stable_oid=True
+    )
+    adapter = next(
+        r for r in recs if "graph_node" in r["labels"] and r["props"]["name"] == "login"
+    )
+    meta = {
+        "symbol_id": "legacy-placeholder",
+        "language": adapter["props"]["lang"],
+        "fully_qualified_name": adapter["props"]["fully_qualified_name"],
+        "signature": adapter["props"]["signature"],
+    }
+    assert record_symbol_id(meta, "repo1") == adapter["oid"]
+
+
+def test_falls_back_to_legacy_when_derivation_unavailable(monkeypatch):
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "1")
+    # Missing FQN/language → still returns a deterministic id (never raises).
+    assert record_symbol_id({"symbol_id": "x:1:y"}, "repo1").endswith(
+        "y"
+    ) or record_symbol_id({"symbol_id": "x:1:y"}, "repo1").startswith("graph/")


### PR DESCRIPTION
ADR-044 follow-up: the **third surface**. The SDK code-knowledge builder kept using victor-codegraph's **legacy** line-coupled symbol id as the record/graph-node id (the audit's gap). Behind the gate (`VICTOR_CODEGRAPH_STABLE_OID`, default OFF) it now mints the **same line-independent canonical oid** Victor's adapter and the AnvaiOps connector use — so a symbol gets the same oid wherever indexed.

## What
- **`_code_oid.record_symbol_id(metadata, repo)`** — pure, dependency-light (only `os` + a lazy `victor_codegraph` import) so it's unit-testable without the SDK's gRPC surface. Returns `graph/{repo}/node/{stable_symbol_oid(repo, lang, fqn, signature)}` when gated, else the legacy `symbol_id`; never raises.
- `code_knowledge.py`: the **vector record id** and the **graph node_id** both derive from it, so the two projections correlate on one oid (`graph_name` is the repo identifier).
- victor-codegraph `sizing` already carries `fqn`/`language`/`signature` in chunk metadata, so the key is well-formed for symbol chunks.

## TDD
`test_sdk_stable_oid`: off→legacy; on→canonical; **cross-surface == Victor's adapter oid** for the same parsed symbol; fallback never raises. Verified the helper locally via isolated load (the local SDK import is blocked by a pre-existing grpcio pin); the pytest suite runs in CI.

Mixed-read-safe, default OFF — byte-identical until the cutover. Completes the keystone across all three surfaces (victor #304, anvaiops #273, this).