### PR TITLE
feat(relational): key the record memtable + indexes by object_id in lockstep with the WAL (ADR-031 O3)

### DIFF
--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -698,6 +698,50 @@ fn wal_collection_id(table_schema: &CatalogTableSchema, object_id_keying: bool) 
     table_schema.name.clone()
 }
 
+/// ADR-031 O3: the in-memory record partition / index key(s) for a table, kept in
+/// LOCKSTEP with the WAL `collection_id` (same gate) so recovery — which routes
+/// replayed entries by their stamped `collection_id` — lands records in the same
+/// partition the live path reads. Returns `(primary, legacy)`:
+/// - gate ON and the table carries an `object_id` ⇒ `primary` = the oid (decimal,
+///   == [`wal_collection_id`]), `legacy` = `Some(name)`. Records written before the
+///   flip live under the name key; the read path dual-reads and writes
+///   migrate-on-touch (memtable deletes don't tombstone, so a stale legacy copy
+///   would otherwise resurrect). Mixed-read-safe across the flip.
+/// - otherwise ⇒ `(name, None)` — today's behavior, byte-identical, zero overhead.
+///
+/// `primary` always equals `wal_collection_id(table_schema, gate)`, so the memtable,
+/// its indexes, and the WAL are keyed identically within a gate state.
+fn memtable_partition_keys(table_schema: &CatalogTableSchema) -> (String, Option<String>) {
+    let keying = wal_object_id_keying_enabled();
+    let primary = wal_collection_id(table_schema, keying);
+    let legacy = if keying && primary != table_schema.name {
+        Some(table_schema.name.clone())
+    } else {
+        None
+    };
+    (primary, legacy)
+}
+
+/// Merge a primary + legacy partition scan during an oid cutover: the primary
+/// (post-flip) partition wins on `oid` collisions, then the union is truncated to
+/// `limit`. With the gate off there is no legacy partition and this is never called.
+fn merge_scan_primary_wins(
+    mut primary: Vec<ProximaRecord>,
+    legacy: Vec<ProximaRecord>,
+    limit: Option<usize>,
+) -> Vec<ProximaRecord> {
+    let seen: std::collections::HashSet<String> = primary.iter().map(|r| r.oid.clone()).collect();
+    for record in legacy {
+        if !seen.contains(&record.oid) {
+            primary.push(record);
+        }
+    }
+    if let Some(limit) = limit {
+        primary.truncate(limit);
+    }
+    primary
+}
+
 pub(crate) fn proxima_value_to_unique_text(value: &proximadb_data_model::ProximaValue) -> String {
     use proximadb_data_model::ProximaValue;
     match value {
@@ -1549,6 +1593,26 @@ impl DirectWalTableRecordStore {
             .clone()
     }
 
+    /// ADR-031 O3: the primary record partition for a table, plus — during an oid
+    /// cutover with pre-flip data resident — the legacy name-keyed partition, so the
+    /// hot path is mixed-read-safe (dual-read + migrate-on-write). With the gate off,
+    /// `legacy` is `None` and this is exactly [`Self::partition`] by name.
+    fn partitions_for(
+        &self,
+        tenant_id: &str,
+        table_schema: &CatalogTableSchema,
+    ) -> (Arc<dyn RecordStorage>, Option<Arc<dyn RecordStorage>>) {
+        let (primary, legacy) = memtable_partition_keys(table_schema);
+        let primary_partition = self.partition(tenant_id, &primary);
+        let legacy_partition = legacy
+            .map(|key| self.partition(tenant_id, &key))
+            // A shared-storage store (`new`) routes every key to the same backing
+            // Arc; there is then no distinct legacy partition to dual-read/migrate
+            // (and migrate-on-write would otherwise delete what we just wrote).
+            .filter(|legacy| !Arc::ptr_eq(legacy, &primary_partition));
+        (primary_partition, legacy_partition)
+    }
+
     /// Replay canonical WAL entries into the correct `(tenant, table)` partitions
     /// on recovery, routing by the entry's `tenant_id` + the operation's
     /// `collection_id`. Reuses the per-store `RecordStore` point ops.
@@ -1599,7 +1663,8 @@ impl DirectWalTableRecordStore {
         table_schema: &CatalogTableSchema,
         tenant_id: &str,
     ) -> Result<()> {
-        let index_key = (tenant_id.to_string(), table_schema.name.clone());
+        let (collection_id, legacy_key) = memtable_partition_keys(table_schema);
+        let index_key = (tenant_id.to_string(), collection_id.clone());
         if self.unique_index.read().contains_key(&index_key) {
             return Ok(());
         }
@@ -1608,20 +1673,25 @@ impl DirectWalTableRecordStore {
             return Ok(());
         }
         let primary_key = schema_primary_key_column(table_schema);
-        let existing =
-            RecordStorageTableRecordStore::new(self.partition(tenant_id, &table_schema.name))
-                .scan_records(
-                    table_schema,
-                    TableRecordScanRequest {
-                        filter: None,
-                        table_id: table_schema.name.clone(),
-                        limit: None,
-                        include_vector: false,
-                        include_props: true,
-                    },
-                    None,
-                )
+        let scan_request = TableRecordScanRequest {
+            filter: None,
+            table_id: collection_id.clone(),
+            limit: None,
+            include_vector: false,
+            include_props: true,
+        };
+        let mut existing =
+            RecordStorageTableRecordStore::new(self.partition(tenant_id, &collection_id))
+                .scan_records(table_schema, scan_request.clone(), None)
                 .await?;
+        // O3: include any pre-flip records still in the legacy name-keyed partition
+        // so the index reflects current visible state across the cutover window.
+        if let Some(legacy) = &legacy_key {
+            let legacy_recs = RecordStorageTableRecordStore::new(self.partition(tenant_id, legacy))
+                .scan_records(table_schema, scan_request, None)
+                .await?;
+            existing = merge_scan_primary_wins(existing, legacy_recs, None);
+        }
         let mut index = TableUniqueIndex::with_sets(&set_columns);
         for record in &existing {
             index.upsert(record, primary_key.as_deref());
@@ -1643,7 +1713,8 @@ impl DirectWalTableRecordStore {
         if secondary_index_disabled() {
             return Ok(());
         }
-        let index_key = (tenant_id.to_string(), table_schema.name.clone());
+        let (collection_id, legacy_key) = memtable_partition_keys(table_schema);
+        let index_key = (tenant_id.to_string(), collection_id.clone());
         if self.secondary_index.read().contains_key(&index_key) {
             return Ok(());
         }
@@ -1651,20 +1722,24 @@ impl DirectWalTableRecordStore {
         if columns.is_empty() {
             return Ok(());
         }
-        let existing =
-            RecordStorageTableRecordStore::new(self.partition(tenant_id, &table_schema.name))
-                .scan_records(
-                    table_schema,
-                    TableRecordScanRequest {
-                        filter: None,
-                        table_id: table_schema.name.clone(),
-                        limit: None,
-                        include_vector: false,
-                        include_props: true,
-                    },
-                    None,
-                )
+        let scan_request = TableRecordScanRequest {
+            filter: None,
+            table_id: collection_id.clone(),
+            limit: None,
+            include_vector: false,
+            include_props: true,
+        };
+        let mut existing =
+            RecordStorageTableRecordStore::new(self.partition(tenant_id, &collection_id))
+                .scan_records(table_schema, scan_request.clone(), None)
                 .await?;
+        // O3: include any pre-flip records still in the legacy name-keyed partition.
+        if let Some(legacy) = &legacy_key {
+            let legacy_recs = RecordStorageTableRecordStore::new(self.partition(tenant_id, legacy))
+                .scan_records(table_schema, scan_request, None)
+                .await?;
+            existing = merge_scan_primary_wins(existing, legacy_recs, None);
+        }
         let mut index = TableSecondaryIndex::with_columns(&columns);
         for record in &existing {
             index.upsert(record);
@@ -1732,13 +1807,21 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let projections = projection_directives_for_schema(table_schema);
         // TD-064: structural per-(tenant, collection) partition selection.
         let tenant_scope = Self::tenant_key(tenant_context);
-        let partition = self.partition(&tenant_scope, &table_schema.name);
-        let index_key = (tenant_scope.clone(), table_schema.name.clone());
-        // ADR-031 O2: the WAL `collection_id` is the stable `object_id` (decimal)
+        // ADR-031 O2/O3: the WAL `collection_id` is the stable `object_id` (decimal)
         // once the cutover gate is on and the table carries one; otherwise the bare
-        // name (legacy). Readers dual-read (name OR object_id), so this can roll out
-        // per-writer, mixed-read-safe.
-        let collection_id = wal_collection_id(table_schema, wal_object_id_keying_enabled());
+        // name (legacy). The memtable partition + indexes key by the SAME id
+        // (lockstep), and during the mixed window writes also touch the legacy
+        // name-keyed partition (migrate-on-write) so a pre-flip copy can't resurrect
+        // (memtable deletes don't tombstone). Readers dual-read — mixed-read-safe.
+        let (collection_id, legacy_key) = memtable_partition_keys(table_schema);
+        let partition = self.partition(&tenant_scope, &collection_id);
+        let legacy_partition = legacy_key
+            .as_ref()
+            .map(|key| self.partition(&tenant_scope, key))
+            // Shared-storage stores route every key to one Arc — no distinct legacy
+            // partition, and migrate-on-write must NOT delete what we just wrote.
+            .filter(|legacy| !Arc::ptr_eq(legacy, &partition));
+        let index_key = (tenant_scope.clone(), collection_id.clone());
 
         for mutation in mutations {
             let kind = mutation.kind;
@@ -1747,7 +1830,12 @@ impl TableRecordStore for DirectWalTableRecordStore {
 
             match kind {
                 TableRecordMutationKind::Insert => {
-                    if partition.get_record(&key).await?.is_some() {
+                    let exists = partition.get_record(&key).await?.is_some()
+                        || match &legacy_partition {
+                            Some(legacy) => legacy.get_record(&key).await?.is_some(),
+                            None => false,
+                        };
+                    if exists {
                         return Ok(TableRecordWriteResult::failure(
                             format!(
                                 "Record '{}' already exists in table '{}'",
@@ -1764,7 +1852,12 @@ impl TableRecordStore for DirectWalTableRecordStore {
                     storage_actions.push((kind, record));
                 }
                 TableRecordMutationKind::Update => {
-                    if partition.get_record(&key).await?.is_none() {
+                    let exists = partition.get_record(&key).await?.is_some()
+                        || match &legacy_partition {
+                            Some(legacy) => legacy.get_record(&key).await?.is_some(),
+                            None => false,
+                        };
+                    if !exists {
                         return Ok(TableRecordWriteResult::failure(
                             format!(
                                 "Record '{}' does not exist in table '{}'",
@@ -1830,6 +1923,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
 
         let mut record_ids = Vec::with_capacity(storage_actions.len());
         for (kind, record) in storage_actions {
+            let key = RecordKey::from(&record);
             match kind {
                 TableRecordMutationKind::Insert
                 | TableRecordMutationKind::Upsert
@@ -1851,9 +1945,19 @@ impl TableRecordStore for DirectWalTableRecordStore {
                         let written = partition.upsert_record(record).await?;
                         record_ids.push(written.oid);
                     }
+                    // ADR-031 O3 migrate-on-write: drain any pre-flip copy from the
+                    // legacy name-keyed partition so it can't resurrect on a later
+                    // dual-read (memtable deletes don't tombstone). No-op when absent.
+                    if let Some(legacy) = &legacy_partition {
+                        legacy.delete_record(&key).await?;
+                    }
                 }
                 TableRecordMutationKind::Delete => {
-                    partition.delete_record(&RecordKey::from(&record)).await?;
+                    partition.delete_record(&key).await?;
+                    // Delete from BOTH partitions during the cutover window.
+                    if let Some(legacy) = &legacy_partition {
+                        legacy.delete_record(&key).await?;
+                    }
                     if maintain_index
                         && let Some(index) = self.unique_index.write().get_mut(&index_key)
                     {
@@ -1883,10 +1987,24 @@ impl TableRecordStore for DirectWalTableRecordStore {
         request: TableRecordGetRequest,
         tenant_context: Option<&TenantContext>,
     ) -> Result<TableRecordGetResponse> {
-        let partition = self.partition(&Self::tenant_key(tenant_context), &table_schema.name);
         // Pass `None`: the partition already scopes the tenant structurally, so
         // no per-record tenant filter is needed (TD-064).
-        RecordStorageTableRecordStore::new(partition)
+        let tenant = Self::tenant_key(tenant_context);
+        let (primary, legacy) = self.partitions_for(&tenant, table_schema);
+        let Some(legacy) = legacy else {
+            return RecordStorageTableRecordStore::new(primary)
+                .get_by_key(table_schema, request, None)
+                .await;
+        };
+        // O3 cutover window: the primary (post-flip) partition wins; fall back to
+        // the legacy name-keyed partition for records not yet migrated-on-write.
+        let primary_res = RecordStorageTableRecordStore::new(primary)
+            .get_by_key(table_schema, request.clone(), None)
+            .await?;
+        if primary_res.is_some() {
+            return Ok(primary_res);
+        }
+        RecordStorageTableRecordStore::new(legacy)
             .get_by_key(table_schema, request, None)
             .await
     }
@@ -1897,10 +2015,21 @@ impl TableRecordStore for DirectWalTableRecordStore {
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
     ) -> Result<TableRecordScanResponse> {
-        let partition = self.partition(&Self::tenant_key(tenant_context), &table_schema.name);
-        RecordStorageTableRecordStore::new(partition)
+        let tenant = Self::tenant_key(tenant_context);
+        let (primary, legacy) = self.partitions_for(&tenant, table_schema);
+        let Some(legacy) = legacy else {
+            return RecordStorageTableRecordStore::new(primary)
+                .scan_records(table_schema, request, None)
+                .await;
+        };
+        let limit = request.limit;
+        let primary_recs = RecordStorageTableRecordStore::new(primary)
+            .scan_records(table_schema, request.clone(), None)
+            .await?;
+        let legacy_recs = RecordStorageTableRecordStore::new(legacy)
             .scan_records(table_schema, request, None)
-            .await
+            .await?;
+        Ok(merge_scan_primary_wins(primary_recs, legacy_recs, limit))
     }
 
     async fn scan_records_filtered(
@@ -1910,10 +2039,21 @@ impl TableRecordStore for DirectWalTableRecordStore {
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
     ) -> Result<TableRecordScanResponse> {
-        let partition = self.partition(&Self::tenant_key(tenant_context), &table_schema.name);
-        RecordStorageTableRecordStore::new(partition)
+        let tenant = Self::tenant_key(tenant_context);
+        let (primary, legacy) = self.partitions_for(&tenant, table_schema);
+        let Some(legacy) = legacy else {
+            return RecordStorageTableRecordStore::new(primary)
+                .scan_records_filtered(table_schema, request, predicate, None)
+                .await;
+        };
+        let limit = request.limit;
+        let primary_recs = RecordStorageTableRecordStore::new(primary)
+            .scan_records_filtered(table_schema, request.clone(), predicate, None)
+            .await?;
+        let legacy_recs = RecordStorageTableRecordStore::new(legacy)
             .scan_records_filtered(table_schema, request, predicate, None)
-            .await
+            .await?;
+        Ok(merge_scan_primary_wins(primary_recs, legacy_recs, limit))
     }
 
     /// TD-110 Slice C: O(1) index-backed override of the default scan. Builds the
@@ -1931,7 +2071,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let tenant_scope = Self::tenant_key(tenant_context);
         self.ensure_unique_index_built(table_schema, &tenant_scope)
             .await?;
-        let index_key = (tenant_scope, table_schema.name.clone());
+        let index_key = (tenant_scope, memtable_partition_keys(table_schema).0);
         let index = self.unique_index.read();
         let Some(table_index) = index.get(&index_key) else {
             return Ok(None); // table has no UNIQUE/PK sets
@@ -1970,7 +2110,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let tenant_scope = Self::tenant_key(tenant_context);
         self.ensure_secondary_index_built(table_schema, &tenant_scope)
             .await?;
-        let index_key = (tenant_scope, table_schema.name.clone());
+        let index_key = (tenant_scope, memtable_partition_keys(table_schema).0);
         let index = self.secondary_index.read();
         let Some(table_index) = index.get(&index_key) else {
             return Ok(None);
@@ -2146,6 +2286,124 @@ mod tests {
             "42",
             "keying on + object_id → stable id, never the mutable name"
         );
+    }
+
+    /// ADR-031 O3: with the WAL/memtable oid gate ON, the in-memory partition is
+    /// keyed by the stable object_id, but a pre-flip record recovered into the
+    /// legacy name-keyed partition stays visible (dual-read), migrates to the oid
+    /// partition on write, and is deleted from BOTH partitions on delete (memtable
+    /// deletes don't tombstone, so a stale legacy copy must not resurrect).
+    /// Process-isolated under nextest, so the env gate does not leak across tests.
+    #[tokio::test]
+    async fn memtable_oid_cutover_dual_reads_and_migrates_legacy_partition() {
+        unsafe { std::env::set_var("PROXIMADB_WAL_OBJECT_ID_KEY", "1") };
+
+        let wal = Arc::new(RecordingWalAppender::default());
+        let store = DirectWalTableRecordStore::new_partitioned(wal);
+        let mut schema = CatalogTableSchema::new("orders");
+        schema.object_id = Some(123);
+
+        let get = |oid: &str| TableRecordGetRequest {
+            table_id: "orders".to_string(),
+            key: oid.to_string(),
+            include_vector: false,
+            include_props: true,
+        };
+        let scan = || TableRecordScanRequest {
+            filter: None,
+            table_id: "orders".to_string(),
+            limit: None,
+            include_vector: false,
+            include_props: true,
+        };
+
+        // Seed a PRE-FLIP record into the legacy name-keyed partition via WAL replay
+        // (a name-stamped entry written before the gate flip).
+        let legacy_rec = ProximaRecord {
+            oid: "r1".to_string(),
+            variation_id: Some("orders".to_string()),
+            ..Default::default()
+        };
+        store
+            .replay_wal_entries(vec![CanonicalWalEntry::new(
+                1,
+                CanonicalOperation::RecordUpsert {
+                    collection_id: "orders".to_string(),
+                    record: Box::new(legacy_rec),
+                    projections: vec![],
+                },
+                None,
+            )])
+            .await
+            .unwrap();
+
+        // Dual-read: under the oid gate, get + scan still see the legacy record.
+        assert!(
+            store
+                .get_by_key(&schema, get("r1"), None)
+                .await
+                .unwrap()
+                .is_some(),
+            "legacy-partition record visible via dual-read"
+        );
+        assert_eq!(
+            store
+                .scan_records(&schema, scan(), None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Migrate-on-write: an Update moves r1 into the oid partition and drains the
+        // legacy copy — exactly one visible record, the migrated (v2) version.
+        let updated = ProximaRecord {
+            oid: "r1".to_string(),
+            variation_id: Some("orders".to_string()),
+            record_version: 2,
+            ..Default::default()
+        };
+        store
+            .write_mutations(
+                &schema,
+                vec![TableRecordMutation::new(
+                    TableRecordMutationKind::Update,
+                    updated,
+                )],
+                None,
+            )
+            .await
+            .unwrap();
+        let after = store.scan_records(&schema, scan(), None).await.unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "no duplicate across legacy + oid partitions"
+        );
+        assert_eq!(after[0].record_version, 2, "migrated primary copy wins");
+
+        // Delete drains BOTH partitions — no legacy resurrection on the next read.
+        store
+            .write_mutations(
+                &schema,
+                vec![TableRecordMutation::new(
+                    TableRecordMutationKind::Delete,
+                    after[0].clone(),
+                )],
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            store
+                .get_by_key(&schema, get("r1"), None)
+                .await
+                .unwrap()
+                .is_none(),
+            "deleted from both partitions — legacy copy did not resurrect"
+        );
+
+        unsafe { std::env::remove_var("PROXIMADB_WAL_OBJECT_ID_KEY") };
     }
     use proximadb_data_model::{ProximaType, VectorElement};
     use proximadb_kernel::error::StorageError;


### PR DESCRIPTION
## What

Cut the relational **in-memory record partition + UNIQUE/PK + secondary indexes + scan path** over to the stable `object_id`, in **lockstep with the WAL** under the existing `PROXIMADB_WAL_OBJECT_ID_KEY` gate (default-OFF). Part of the ADR-031/ADR-035 physical-key cutover (O3).

## Why

The write path already stamps the canonical-WAL `collection_id` by `object_id` when the gate is on (O2: dual-write + dual-read). But the **memtable partition, its indexes, and the scan path still keyed by the mutable table name**. That desync is latent data loss: recovery routes replayed entries by their stamped `collection_id` (the oid, gate-on) into the oid partition, while live reads/writes used the **name** partition — recovered records would be invisible. It also kept the relational path rename-fragile and asymmetric vs graph/vector (which key by oid).

## How (mixed-read-safe, no new gate)

- `memtable_partition_keys(table_schema)` → `(primary, legacy)` with `primary == wal_collection_id(...)`. **Gate OFF (default) ⇒ `(name, None)` ⇒ byte-identical to today**; all new logic is behind `legacy.is_some()`.
- Across a flip with pre-existing data:
  - **dual-read** (oid partition wins, fall back to legacy-name partition) on `get_by_key` / `scan_records` / `scan_records_filtered`, the Insert/Update existence checks, and the index builds;
  - **migrate-on-write**: upsert/delete also drain the legacy partition (memtable deletes don't tombstone, so a stale legacy copy would otherwise resurrect on a later dual-read);
  - **`Arc::ptr_eq` guard** so the shared-storage `new` shape (single-store callers / tests) stays single-partition and migrate-on-write can't delete what it just wrote.
- Index keys (build + probe) follow the same primary id so enforcement aligns with the partition.
- `replay_wal_entries` unchanged — already routes by the stamped `collection_id`; the hot path dual-reads.

## Why one gate, not two

A separate memtable gate could desync from the WAL gate and split recovery. Reusing `PROXIMADB_WAL_OBJECT_ID_KEY` keeps WAL ↔ memtable ↔ indexes keyed identically within a gate state.

## Test

`memtable_oid_cutover_dual_reads_and_migrates_legacy_partition`: seeds a pre-flip record into the legacy partition via replay, asserts dual-read visibility, migrate-on-update (no duplicate, v2 wins), and delete-from-both (no resurrection). All 27 record_store + unique/secondary + DML tests green; CI-exact clippy (`--lib --bins -D warnings`) clean.

## Follow-ups

Storage/materialize path (`resolve_materialize_prefix` / `DrPathBuilder`) is the remaining name-keyed relational physical key — a separate slice.