### PR TITLE
docs(design): handoff spec to unblock remaining catalog object_id / tenancy items

### DIFF
--- a/docs/12-design/CATALOG_OID_CUTOVER_HANDOFF_2026_06_28.adoc
+++ b/docs/12-design/CATALOG_OID_CUTOVER_HANDOFF_2026_06_28.adoc
@@ -1,0 +1,174 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Catalog object_id cutover — handoff spec for the remaining items (ADR-031 / TD-181 / ADR-035)
+:toc: macro
+:icons: font
+
+The object_id catalog cutover shipped end-to-end and is **live behind default-OFF
+gates** — the stable global `u64 object_id` is *available* as the physical catalog
+key but not yet *load-bearing*. This doc turns every deferred / blocked item into an
+actionable implementation spec so any contributor can pick one up without
+re-deriving the state. Each item lists **status · what's needed · files/reuse · risk
+· dependencies**. Everything stays **default-OFF + mixed-read-safe** (CLAUDE.md #8).
+
+toc::[]
+
+== What already shipped (do not redo)
+
+[cols="1,3,1", options="header"]
+|===
+| Slice | What | PR
+
+| S0 | object-store catalogs persist via injected `FileSystem` (s3/gs/az) | #488
+| S1 | durable `name↔object_id` index, eager load, rebuild-from-objects | #490
+| S2a/S2b | oid-keyed storage: dual-write `_syscat/objects/{oid}.json` + marker; oid-preferred read w/ legacy fallback; `list` union; `exists`/`drop` fixes | #497
+| S3a/S4 | tenant-prefixed collection namespaces; idempotent `provision_tenant_system_catalog` primitive | #510
+| docs | operator guide `CATALOG_OBJECT_ID_LAYOUT.adoc` | #516
+| polish | index → canonical `_syscat/index.json` + legacy-location migration | #518
+| hardening | pair-atomic index heal; rebuild scans the oid layout; dangling-entry prune-on-read | #522, #523
+|===
+
+Code lives in `crates/control/proximadb-catalog/src/native.rs` (storage cutover) and
+`src/services/collection/manager.rs` (tenant namespaces + provisioning).
+
+== Two corrections that prevent misdirected work
+
+. **Global `_syscat/objects/{oid}.json` is collision-correct.** Because `object_id`
+  is globally unique, two tenants' identically-named tables get *distinct* oids →
+  *distinct* files. The global layout already prevents cross-tenant collisions; a
+  per-tenant physical prefix (Item 4) is an **isolation/locality** choice, not a
+  correctness fix. S3a additionally isolates namespaces *logically* by prepending the
+  tenant as namespace level 0.
+. **`provision_tenant_system_catalog(tenant)` already exists** (free fn +
+  `CollectionService` method, idempotent, gated on
+  `PROXIMADB_CATALOG_TENANT_NAMESPACES`). The remaining gap is only an *explicit
+  caller* (Item 1) — S3a already creates a tenant's namespace lazily on first
+  collection.
+
+== Scoping: the cutover is native-catalog-only
+
+External backends — `hive`/`glue`/`iceberg`/`delta`/`unity`/`polaris`/`oltp`
+(`crates/control/proximadb-catalog/src/*.rs`) — are **pass-through**: they don't own
+the ProximaDB physical path, names are externally immutable, and
+`get_table_by_object_id` default-returns `None`. **Do not** add oid-keying to them.
+Only `native.rs` does the cutover.
+
+== Item 1 — Explicit tenant provisioning endpoint (unblocks the S4 "blocked" follow-up)
+
+* **Status:** primitive done; no production caller. Tenants are **ambient** today
+  (X-Tenant-ID header, `src/network/middleware/tenant.rs`); there is no tenant-create
+  RPC/endpoint, and the only `create_tenant` caller is the test-only enterprise
+  handler.
+* **What's needed:** a **system-admin-gated** provisioning surface (prefer an
+  explicit op — lazy-on-first-create is redundant with S3a):
+  ** REST first: `POST /api/v2/admin/tenants/{tenant_id}/provision` under
+     `src/network/rest/v2/` (mount in `v2/mod.rs`). Handler requires
+     `TenantContext.is_system_tenant`, then calls
+     `collection_service.provision_tenant_system_catalog(tenant_id)`. Expose
+     `collection_service` on the REST `AppState` (today only `request_handlers` is).
+  ** gRPC (follow-on): a `ProximaAdminService.ProvisionTenant` RPC
+     (`proto/proximadb/v2/admin.proto`), registered in the `multi_server.rs` gRPC
+     builder.
+* **Reuse:** `SharedServices` (`src/network/shared_services.rs`) already holds both
+  `catalog_manager` and `collection_service`. Response: `{created | already_exists}`
+  (idempotent).
+* **Risk:** low (additive, admin-gated). **Dependency:** none.
+
+== Item 2 — TD-181 P2: internal references keyed by object_id (largest)
+
+* **Status:** NOT STARTED. All catalog→catalog refs key by **name** today
+  (`TableIdentifier.to_fqn()` everywhere); the planner string-compares
+  `levels.join(".")`.
+* **What's needed:**
+  ** Add additive `#[serde(default)] Option<u64>` backrefs in
+     `crates/control/proximadb-catalog/src/lib.rs`: `CatalogTableSchema.namespace_oid`,
+     `CatalogIndex.table_oid`, `CatalogColumn.table_oid`. Populate on create via the
+     existing `mint_object_id` flow; backfill on load (mirror the `object_id`
+     backfill in `native.rs`).
+  ** Planner/resolver: resolve `name → oid` **once at parse** via
+     `object_name_index`, carry the oid through the plan, and replace name/FK string
+     compares with oid equality. Reuse `get_table_by_object_id` /
+     `get_namespace_by_object_id`.
+  ** Introspection (`information_schema`) keeps rendering **names** (dual-read) until
+     Item 3.
+* **Risk:** medium-high (planner blast radius) — slice it. **Dependency:** none;
+  **gates** Items 3 and 7.
+
+== Item 3 — TD-181 P4: retire the dual-write / pure-oid endgame
+
+* **Status:** NOT STARTED (gate stays ON until refs cut over).
+* **Preconditions:** Item 2 done **and** reads converged to oid-only (no name-path
+  fallback in steady state).
+* **What's needed:** stop writing the legacy `metadata/tables/{ns}/{name}.json`
+  shadow for *new* objects (keep read-only legacy fallback for data already on disk);
+  flip `PROXIMADB_CATALOG_OBJECT_ID_PATHS` to always-on, then remove it; an optional
+  background migration re-keys remaining legacy-only objects (the rebuild in
+  `scan_object_index_entries` already enumerates **both** layouts).
+* **Risk:** high (hard to reverse) — ship only after a qa soak with the gates on.
+  **Dependency:** Item 2.
+
+== Item 4 — Per-tenant `_syscat` physical layout (ADR-035 D1) — decision, then maybe a crate move
+
+* **Status:** global today; per-tenant is **optional** (see correction #1).
+* **Decision to record:** per-tenant `data/{tenant}/_syscat/...` buys physical
+  isolation + locality + per-tenant cache warming, **not** correctness. Only pursue
+  if physical isolation is a requirement.
+* **If pursued:** `native.rs` (crate `proximadb-catalog`) cannot reach `DrPathBuilder`
+  (in the main `proximadb` crate) — the reverse-dependency blocker that retired the
+  original "S3b". **Spec:** relocate `DrPathBuilder` (or extract a path-prefix port)
+  into a shared foundation crate (e.g. `proximadb-storage-filesystem-types`, or a new
+  `proximadb-paths`), then route the `_syscat`/index keys through it behind a
+  default-OFF gate with a legacy-flat fallback.
+* **Risk:** medium (crate move). **Dependency:** none.
+
+== Item 5 — Operational sink roots + provisioning skeleton (ADR-035 D3 tail)
+
+* **Status:** `_metering`/`_trace` roots already exist (ADR-027 + `DrPathBuilder`
+  subprefixes) — **reuse, don't rebuild**. Missing: `_billing` marker and the
+  per-tenant `_syscat` skeleton.
+* **What's needed:** extend `provision_tenant_system_catalog` to pre-create the
+  per-tenant skeleton (empty `index.json`, system-registry namespace, `_billing`
+  marker). The **system-only `_syscat/*` write guard** is largely already structural
+  (`DrPathBuilder::RESERVED_SYSTEM_SEGMENTS` + `validate_id` reject `_syscat` as a
+  user id).
+* **Risk:** low. **Dependency:** Item 1 (so something calls provisioning), optionally
+  Item 4.
+
+== Item 6 — P0 tail: reserved-oid range + durable high-water
+
+* **Status:** allocator recovers its floor by scan (`raise_object_id_floor`); no
+  reserved low range.
+* **What's needed:** pin a reserved range (`0..RESERVED_MAX`) for system oids, and
+  persist the allocator high-water in `IdAllocator`
+  (`crates/control/proximadb-catalog/src/id_allocator.rs`) instead of recover-by-scan.
+* **Risk:** low. **Dependency:** independent.
+
+== Item 7 — Storage-layer physical keying by object_id (deepest, own program)
+
+* **Status:** the WAL supports oid keying (`PROXIMADB_WAL_OBJECT_ID_KEY`,
+  `src/services/record_store.rs`); memtable/segment partitioning + path resolution
+  still key by **name**.
+* **What's needed:** thread the oid as the partition/path key through the storage
+  engine, default-OFF, mixed-read. This is the largest, highest-risk track — it makes
+  oid the *true* end-to-end physical key. Flag as its **own program**.
+* **Risk:** high. **Dependency:** Item 2/3 (catalog side) first.
+
+== Sequencing
+
+[source,text]
+----
+Item 1 (provisioning endpoint)  ── independent, smallest → do first
+Item 6 (P0 tail)                ── independent
+Item 5 (sink roots / skeleton)  ── after Item 1
+Item 2 (P2 internal oid refs)   ── independent of 1/5; gates 3 & 7
+Item 4 (per-tenant _syscat)     ── decision first; crate-move only if pursued
+Item 3 (P4 retire dual-write)   ── after Item 2 + read convergence
+Item 7 (storage oid keying)     ── after Item 2/3; own program
+----
+
+== References
+
+* Operator guide: `docs/06-internals/CATALOG_OBJECT_ID_LAYOUT.adoc`
+* Phase plan: `docs/12-design/CATALOG_OID_MIGRATION_2026_06_27.adoc`
+* `docs/12-design/adr/ADR-031-stable-object-id-physical-key.adoc`,
+  `docs/12-design/adr/ADR-035-per-tenant-system-catalog-cache.adoc` (D1/D3)


### PR DESCRIPTION
## What

The object_id catalog cutover shipped end-to-end (S0–S4 #488/#490/#497/#510 + operator guide #516 + index location #518 + hardening #522/#523), all gated default-OFF and mixed-read-safe. Several items were deliberately deferred or are blocked on infrastructure that doesn't exist yet.

This adds `docs/12-design/CATALOG_OID_CUTOVER_HANDOFF_2026_06_28.adoc` — a handoff spec turning every remaining item into an actionable implementation spec (**status · what's needed · files/reuse · risk · dependencies**), so any contributor can pick one up:

1. **Explicit tenant-provisioning endpoint** — the `provision_tenant_system_catalog` primitive exists; it needs an admin-gated REST/gRPC caller (no production tenant-signup path exists today; tenants are ambient via `X-Tenant-ID`).
2. **TD-181 P2** — internal references keyed by object_id (`namespace_oid`/`table_oid` backrefs + planner name→oid cutover).
3. **TD-181 P4** — retire the dual-write / pure-oid endgame.
4. **Per-tenant `_syscat` physical layout** — a decision (global is already collision-correct); needs `DrPathBuilder` relocated to a shared crate if pursued.
5. **Operational sink roots + provisioning skeleton** (ADR-035 D3 tail).
6. **P0 tail** — reserved-oid range + durable allocator high-water.
7. **Storage-layer physical keying by object_id** — its own program.

## Why it matters

It records two corrections that prevent misdirected future work — the global `_syscat/objects/{oid}.json` layout is **collision-correct** (global oid uniqueness), and `provision_tenant_system_catalog` **already exists** — and scopes the cutover to the **native catalog only** (external backends are pass-through), so nobody re-keys 8 backends or "fixes" a non-bug.

## Verification
`asciidoctor` renders clean · `check_td_adr_unique` 0 errors · no code change.