### PR TITLE
feat(sdk): cut over to canonical symbol oid by default (ADR-044 P2)

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -111,7 +111,9 @@ code-chunking = [
 # Published on PyPI: `pip install 'proximadb[codegraph]'` (for local source work:
 # pip install -e ../../victor/victor-codegraph).
 codegraph = [
-    "victor-codegraph>=0.1.0",
+    # >=0.1.2 ships the line-independent canonical symbol oid (ADR-044) the SDK now
+    # keys code records on by default (see _code_oid.record_symbol_id).
+    "victor-codegraph>=0.1.2",
 ]
 
 langchain = [

--- a/clients/python/src/proximadb_sdk/_code_oid.py
+++ b/clients/python/src/proximadb_sdk/_code_oid.py
@@ -3,9 +3,12 @@
 A code symbol's record id is the **line-independent canonical oid** minted by
 victor-codegraph — derived from the same ``(repo, language, fully_qualified_name,
 signature)`` coordinates Victor's adapter and the AnvaiOps connector use, so the same
-symbol gets the same oid wherever it is indexed. Gated default-OFF
-(``VICTOR_CODEGRAPH_STABLE_OID``): off keeps the legacy line-coupled ``path:line:name``
-id, byte-identical.
+symbol gets the same oid wherever it is indexed.
+
+P2 cutover (2026-06-29): **default-ON**, matching Victor's adapter (gated behind its
+parity ratchet — no collisions / completeness / line-shift stability). Opt out per-process
+with ``VICTOR_CODEGRAPH_STABLE_OID=0`` to keep the legacy line-coupled ``path:line:name``
+id, byte-identical, during the mixed-read bake.
 
 Pure + dependency-light (only ``os`` + a lazy ``victor_codegraph`` import) so it is
 unit-testable without the SDK's gRPC client surface.
@@ -19,7 +22,10 @@ _STABLE_OID_ENV = "VICTOR_CODEGRAPH_STABLE_OID"
 
 
 def _stable_oid_enabled() -> bool:
-    return os.getenv(_STABLE_OID_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+    val = os.getenv(_STABLE_OID_ENV)
+    if val is None or val.strip() == "":
+        return True  # ADR-044 P2: canonical is the default (parity-ratchet-gated)
+    return val.strip().lower() in ("1", "true", "yes", "on")
 
 
 def record_symbol_id(metadata: dict, repo_graph_id: str) -> str:

--- a/clients/python/tests/test_sdk_stable_oid.py
+++ b/clients/python/tests/test_sdk_stable_oid.py
@@ -2,9 +2,10 @@
 line-independent canonical oid Victor's adapter mints — so a symbol gets the same
 oid wherever it is indexed (Victor / AnvaiOps / the SDK).
 
-Gated default-OFF (``VICTOR_CODEGRAPH_STABLE_OID``); off keeps the legacy line-coupled
-id, byte-identical. Guarded with ``importorskip`` so it runs only where the optional
-``victor-codegraph`` extra is installed.
+P2 cutover (2026-06-29): **default-ON** (gated behind victor-codegraph's parity ratchet),
+matching Victor's adapter. Explicit opt-out (``VICTOR_CODEGRAPH_STABLE_OID=0``) keeps the
+legacy line-coupled id, byte-identical. Guarded with ``importorskip`` so it runs only
+where the optional ``victor-codegraph`` extra is installed.
 """
 
 from __future__ import annotations
@@ -23,8 +24,18 @@ _LEGACY_META = {
 }
 
 
-def test_default_off_returns_legacy_id(monkeypatch):
+def test_default_on_returns_canonical_form(monkeypatch):
+    # P2 cutover: with the env unset, the canonical line-independent oid is the default.
     monkeypatch.delenv("VICTOR_CODEGRAPH_STABLE_OID", raising=False)
+    key = victor_codegraph.stable_symbol_oid(
+        "repo1", "python", "auth.py::login", "(user)"
+    )
+    assert record_symbol_id(_LEGACY_META, "repo1") == f"graph/repo1/node/{key}"
+
+
+def test_explicit_opt_out_returns_legacy_id(monkeypatch):
+    # Opt-out keeps existing collections byte-identical during the bake.
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "0")
     assert record_symbol_id(_LEGACY_META, "repo1") == "auth.py:1:login"
 
 


### PR DESCRIPTION
## What

P2 cutover of the ADR-044 stable symbol-oid contract on the **SDK** (third surface).
The SDK now keys code records on victor-codegraph's line-independent canonical symbol
oid **by default**, matching Victor's adapter (already default-ON, #305) and the
AnvaiOps connector — so the same symbol gets the same oid wherever it is indexed and a
line shift no longer churns the vector + graph node + row.

## Changes

- Pin `victor-codegraph>=0.1.2` (the release that ships `stable_symbol_oid`).
- `_code_oid._stable_oid_enabled()` → **default-ON** (mirrors the victor adapter; opt
  out per-process with `VICTOR_CODEGRAPH_STABLE_OID=0` to keep legacy byte-identical
  during the mixed-read bake).
- Tests assert default-ON, the opt-out, and **cross-surface equality** with the adapter
  oid (`graph/{repo}/node/{key}`).

Gated behind victor-codegraph's parity ratchet (no collisions / completeness /
line-shift stability / determinism). The `record_symbol_id` helper still falls back to
the legacy id on any failure or when the minter is absent — never raises.

Part of the coordinated consumer cutover (SDK + AnvaiOps) following ADR-044 #519/#526.