### PR TITLE
feat(sdk): delegate ingest_documents to the generated openapi client (ADR-041 P2)

### DIFF
--- a/clients/python/src/proximadb_sdk/unified_client.py
+++ b/clients/python/src/proximadb_sdk/unified_client.py
@@ -17,6 +17,7 @@ import sys
 import time
 from typing import Any, Union
 
+import httpx
 import numpy as np
 
 from .adapters import BaseProtocolAdapter, create_adapter
@@ -24,7 +25,9 @@ from .auth import AuthConfig, AuthMethod, ProximaDBAuth
 from .config import ClientConfig, PortMode, Protocol, load_config
 from .exceptions import (
     CollectionNotFoundError,
+    NetworkError,
     ProximaDBError,
+    ServerError,
 )
 from .models import (
     BatchResult,
@@ -269,6 +272,9 @@ class ProximaDBClient:
         self._timeseries_repository = None
         self._closed = False
         self._prefer_local_fallback = False
+        # Generated openapi Client (ADR-041) backing ingest_documents; built
+        # lazily so a client that never ingests pays no import/construction cost.
+        self._generated_document_client = None
 
         # Setup operation routing if enabled
         if self.enable_operation_routing:
@@ -848,6 +854,38 @@ class ProximaDBClient:
         if self._rest_adapter is None:
             self._rest_adapter = self._create_adapter("rest")
         return self._rest_adapter
+
+    def _get_generated_document_client(self):
+        """Lazily build the shared *base* generated openapi ``Client`` (ADR-041).
+
+        This base client carries only ``base_url`` + auth headers; it is NEVER
+        used to issue a request directly, so its underlying httpx client is
+        never materialized. Per-call headers (``X-Tenant-ID`` / ``X-Ingest-Mode``
+        / ``X-Embed-Source``) are attached on each :meth:`ingest_documents` call
+        via ``Client.with_headers(...)`` — which returns a fresh ``evolve(...)``
+        client whose own httpx client is materialized, so per-call headers never
+        accumulate on this shared base. Returns ``None`` when no server URL is
+        configured; the caller (:meth:`ingest_documents`) decides whether to
+        fall back to the in-memory repository or raise.
+        """
+        if self._generated_document_client is None and self._url:
+            from ._generated.rest.client import Client as GeneratedClient
+
+            headers: dict[str, str] = {}
+            if self._auth is not None:
+                try:
+                    headers.update(self._auth.get_auth_headers())
+                except Exception as e:  # auth is best-effort on the ingest path
+                    logger.debug(
+                        "Could not attach auth headers to generated client: %s", e
+                    )
+            self._generated_document_client = GeneratedClient(
+                base_url=self._url,
+                headers=headers,
+                raise_on_unexpected_status=True,
+                follow_redirects=False,
+            )
+        return self._generated_document_client
 
     def _call_document_adapter(self, method_name: str, *args, **kwargs):
         candidates: list[BaseProtocolAdapter] = []
@@ -1858,6 +1896,162 @@ class ProximaDBClient:
             )
         )
         return {"success": True, "collection_id": collection_id}
+
+    def ingest_documents(
+        self,
+        collection_id: str,
+        records: list[dict[str, Any]],
+        *,
+        tenant_id: str | None = None,
+        ingest_mode: str | None = None,
+        embed_source: str = "native",
+        allow_local_fallback: bool = False,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Ingest documents for native server-side embedding (ADR-041).
+
+        Canonical document-ingest surface — delegates to the GENERATED openapi
+        op ``POST /api/v2/collections/{collection_id}/documents``
+        (``_generated/rest/api/documents/ingest_documents.py``), NOT the
+        hand-written ``adapters/rest_adapter.py`` path whose ``insert_document``
+        silently falls back to an in-memory repository on any error.
+
+        The server embeds each record's ``text`` natively (``X-Embed-Source:
+        native``, the default) when no per-record ``vector`` is supplied; pass a
+        ``vector`` to skip server embedding for that record.
+
+        Per-call headers ride the generated client via ``Client.with_headers``
+        (a fresh ``evolve`` client per call — no header accumulation across
+        calls).
+
+        Args:
+            collection_id: Target collection id.
+            records: Each is a ``dict`` with at least ``id`` and (for native
+                embedding) ``text``; optionally ``metadata`` (``dict``) and
+                ``vector`` (``list[float]``). An ``IngestDocument`` is passed
+                through unchanged.
+            tenant_id: Optional tenant scope -> ``X-Tenant-ID``.
+            ingest_mode: Optional billing/metering mode -> ``X-Ingest-Mode``.
+            embed_source: Embedding source -> ``X-Embed-Source`` (default
+                ``"native"``). Pass ``""`` or ``None`` to omit the header.
+            allow_local_fallback: If ``True`` and no server URL is configured,
+                fall back to the in-memory ``DocumentRepository`` instead of
+                raising. Default ``False`` — a server-backed client must surface
+                failures, not swallow them into a local dict.
+
+        Returns:
+            The parsed ``IngestDocumentsResponse`` as a dict
+            (``{"mode", "records", ...}``); ``{"mode": "local", ...}`` on the
+            fallback path.
+
+        Raises:
+            ProximaDBError: No server configured and ``allow_local_fallback`` is
+                False, or a record is malformed.
+            NetworkError: Transport-level failure talking to the server.
+            ServerError: The server returned a documented error envelope
+                (HTTP 400/404) or an unexpected status.
+        """
+        from ._generated.rest.api.documents.ingest_documents import sync_detailed
+        from ._generated.rest.models.error_response import ErrorResponse
+        from ._generated.rest.models.ingest_document import IngestDocument
+        from ._generated.rest.models.ingest_document_metadata import (
+            IngestDocumentMetadata,
+        )
+        from ._generated.rest.models.ingest_documents_request import (
+            IngestDocumentsRequest,
+        )
+        from ._generated.rest.types import UNSET
+
+        # 1. Build the request body from ergonomic record dicts.
+        body_records: list[IngestDocument] = []
+        for rec in records:
+            if isinstance(rec, IngestDocument):
+                body_records.append(rec)
+                continue
+            if not isinstance(rec, dict):
+                raise ProximaDBError(
+                    "ingest_documents record must be a dict or IngestDocument, "
+                    f"got {type(rec).__name__}"
+                )
+            if "id" not in rec:
+                raise ProximaDBError("ingest_documents record missing 'id'")
+            metadata = rec.get("metadata")
+            body_records.append(
+                IngestDocument(
+                    id=str(rec["id"]),
+                    text=rec.get("text", UNSET),
+                    vector=rec.get("vector", UNSET),
+                    metadata=(
+                        IngestDocumentMetadata.from_dict(metadata)
+                        if metadata is not None
+                        else UNSET
+                    ),
+                )
+            )
+        request_body = IngestDocumentsRequest(records=body_records)
+
+        # 2. Resolve the generated client. No server -> caller-controlled fallback.
+        base_client = self._get_generated_document_client()
+        if base_client is None:
+            if not allow_local_fallback:
+                raise ProximaDBError(
+                    "ingest_documents requires a server URL (no PROXIMADB_URL "
+                    "configured). Set allow_local_fallback=True to store records "
+                    "in the in-memory repository."
+                )
+            repo = self._get_document_repository()
+            inserted = []
+            for rec in records:
+                doc = rec if isinstance(rec, dict) else rec.to_dict()
+                doc_id = rec.get("id") if isinstance(rec, dict) else rec.id
+                inserted.append(repo.insert(collection_id, doc, doc_id))
+            return {
+                "mode": "local",
+                "records": [
+                    {
+                        "id": getattr(d, "id", None),
+                        "version": getattr(d, "version", None),
+                    }
+                    for d in inserted
+                ],
+            }
+
+        # 3. Per-call headers on a fresh evolved client (no accumulation).
+        per_call_headers: dict[str, str] = {}
+        if embed_source:
+            per_call_headers["X-Embed-Source"] = embed_source
+        if tenant_id is not None:
+            per_call_headers["X-Tenant-ID"] = str(tenant_id)
+        if ingest_mode is not None:
+            per_call_headers["X-Ingest-Mode"] = str(ingest_mode)
+        client = base_client.with_headers(per_call_headers)
+
+        # 4. Call the generated op and map outcomes.
+        try:
+            response = sync_detailed(
+                collection_id=collection_id, client=client, body=request_body
+            )
+        except httpx.HTTPError as e:
+            raise NetworkError(
+                f"ingest_documents transport error: {e}", original_error=e
+            ) from e
+
+        parsed = response.parsed
+        if isinstance(parsed, ErrorResponse):
+            detail = getattr(getattr(parsed, "error", None), "message", None)
+            raise ServerError(
+                "ingest_documents rejected by server"
+                f"{f': {detail}' if detail else ''}",
+                status_code=response.status_code,
+            )
+        if parsed is None:
+            # raise_on_unexpected_status=True makes this unreachable in practice;
+            # guard anyway so a future regression can't silently return None.
+            raise ServerError(
+                "ingest_documents returned no body",
+                status_code=response.status_code,
+            )
+        return parsed.to_dict()
 
     def insert_document(
         self,

--- a/clients/python/tests/unit/test_unified_client_ingest_documents.py
+++ b/clients/python/tests/unit/test_unified_client_ingest_documents.py
@@ -1,0 +1,242 @@
+"""Offline unit tests for ``ProximaDBClient.ingest_documents`` (ADR-041, P2).
+
+The hand-written ``ingest_documents`` delegates to the GENERATED openapi op
+(``_generated/rest/api/documents/ingest_documents.py``) — NOT the broken
+``adapters/rest_adapter.py`` path whose ``insert_document`` silently falls back
+to an in-memory repository on any error. These tests patch the generated
+``sync_detailed`` so we assert request-shaping, per-call header passthrough,
+header non-accumulation, and outcome mapping — with no server on the wire.
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from proximadb_sdk._generated.rest.models.error_body import ErrorBody
+from proximadb_sdk._generated.rest.models.error_response import ErrorResponse
+from proximadb_sdk._generated.rest.models.ingest_documents_response import (
+    IngestDocumentsResponse,
+)
+from proximadb_sdk._generated.rest.models.ingested_record import IngestedRecord
+from proximadb_sdk._generated.rest.types import Response
+from proximadb_sdk.config import Protocol
+from proximadb_sdk.exceptions import NetworkError, ProximaDBError, ServerError
+from proximadb_sdk.unified_client import ProximaDBClient
+
+# The lazy `from ... import sync_detailed` inside ingest_documents re-reads this
+# attribute at call time, so patching the module attribute is what the method sees.
+INGEST_MOD = "proximadb_sdk._generated.rest.api.documents.ingest_documents"
+
+
+def make_client(url="http://testserver:5678"):
+    """A REST-mode client whose internals are inert MagicMocks (offline)."""
+    c = ProximaDBClient(url=url, protocol="rest")
+    c._adapter = MagicMock()
+    c._client = MagicMock()
+    c._active_protocol = Protocol.REST
+    return c
+
+
+def _ok_response():
+    parsed = IngestDocumentsResponse(
+        mode="native", records=[IngestedRecord(dim=4, id="r1")]
+    )
+    return Response(status_code=HTTPStatus.OK, content=b"{}", headers={}, parsed=parsed)
+
+
+def _err_response(message="bad dims", code=400):
+    err = ErrorResponse(
+        error=ErrorBody(code=code, message=message, type_="invalid_argument")
+    )
+    return Response(status_code=HTTPStatus(code), content=b"{}", headers={}, parsed=err)
+
+
+# ---------------------------------------------------------------------------
+# No server configured: raise vs. caller-opted local fallback
+# ---------------------------------------------------------------------------
+
+
+def test_no_server_without_fallback_raises():
+    c = make_client()
+    c._url = None
+    c._generated_document_client = None
+    with pytest.raises(ProximaDBError, match="server URL"):
+        c.ingest_documents("coll", [{"id": "r1", "text": "hi"}])
+
+
+def test_no_server_with_fallback_uses_local_repo():
+    c = make_client()
+    c._url = None
+    c._generated_document_client = None
+    repo = MagicMock()
+    repo.insert.return_value = MagicMock(id="r1", version=1)
+    c._get_document_repository = MagicMock(return_value=repo)
+
+    out = c.ingest_documents(
+        "coll", [{"id": "r1", "text": "hi"}], allow_local_fallback=True
+    )
+
+    assert out["mode"] == "local"
+    assert out["records"] == [{"id": "r1", "version": 1}]
+    repo.insert.assert_called_once_with("coll", {"id": "r1", "text": "hi"}, "r1")
+
+
+# ---------------------------------------------------------------------------
+# Per-call header passthrough + non-accumulation
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_headers_passed_via_with_headers(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    c.ingest_documents(
+        "coll",
+        [{"id": "r1", "text": "hi"}],
+        tenant_id="tenant-a",
+        ingest_mode="streaming",
+    )
+
+    client = mock_sync.call_args.kwargs["client"]
+    assert client._headers["X-Tenant-ID"] == "tenant-a"
+    assert client._headers["X-Ingest-Mode"] == "streaming"
+    assert client._headers["X-Embed-Source"] == "native"
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_per_call_headers_do_not_accumulate(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    base = c._get_generated_document_client()
+    assert base is not None
+    base_headers_before = dict(base._headers)
+
+    c.ingest_documents("coll", [{"id": "r1", "text": "a"}], tenant_id="t1")
+    c.ingest_documents("coll", [{"id": "r2", "text": "b"}], tenant_id="t2")
+
+    # Each evolved client carries only its own tenant header...
+    client1 = mock_sync.call_args_list[0].kwargs["client"]
+    client2 = mock_sync.call_args_list[1].kwargs["client"]
+    assert client1._headers["X-Tenant-ID"] == "t1"
+    assert client2._headers["X-Tenant-ID"] == "t2"
+    # ...and the shared base client is never mutated (with_headers uses evolve).
+    assert "X-Tenant-ID" not in base_headers_before
+    assert base._headers == base_headers_before
+    assert "X-Tenant-ID" not in base._headers
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_empty_embed_source_omits_header(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    c.ingest_documents("coll", [{"id": "r1", "text": "hi"}], embed_source="")
+
+    client = mock_sync.call_args.kwargs["client"]
+    assert "X-Embed-Source" not in client._headers
+
+
+# ---------------------------------------------------------------------------
+# Record dict -> IngestDocument conversion
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_record_dict_converted_to_request_body(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    c.ingest_documents(
+        "coll",
+        [{"id": "r1", "text": "hello", "metadata": {"k": "v"}, "vector": [0.1, 0.2]}],
+    )
+
+    body = mock_sync.call_args.kwargs["body"]
+    assert body.to_dict() == {
+        "records": [
+            {"id": "r1", "text": "hello", "metadata": {"k": "v"}, "vector": [0.1, 0.2]}
+        ]
+    }
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_record_without_text_or_metadata_is_omitted(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    c.ingest_documents("coll", [{"id": "r1", "vector": [0.1]}])
+
+    rec = mock_sync.call_args.kwargs["body"].to_dict()["records"][0]
+    assert rec == {"id": "r1", "vector": [0.1]}
+    assert "text" not in rec and "metadata" not in rec
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_ingestdocument_record_passed_through_unchanged(mock_sync):
+    from proximadb_sdk._generated.rest.models.ingest_document import IngestDocument
+
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+    doc = IngestDocument(id="r9", text="raw")
+
+    c.ingest_documents("coll", [doc])
+
+    body = mock_sync.call_args.kwargs["body"]
+    assert body.records[0] is doc
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_record_missing_id_raises():
+    c = make_client()
+    with pytest.raises(ProximaDBError, match="missing 'id'"):
+        c.ingest_documents("coll", [{"text": "hi"}])
+
+
+def test_non_dict_record_raises():
+    c = make_client()
+    with pytest.raises(ProximaDBError, match="dict or IngestDocument"):
+        c.ingest_documents("coll", [42])
+
+
+# ---------------------------------------------------------------------------
+# Outcome mapping
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_success_returns_parsed_dict(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _ok_response()
+
+    out = c.ingest_documents("coll", [{"id": "r1", "text": "hi"}])
+
+    assert out["mode"] == "native"
+    assert out["records"] == [{"dim": 4, "id": "r1"}]
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_error_response_mapped_to_server_error(mock_sync):
+    c = make_client()
+    mock_sync.return_value = _err_response(message="bad dims", code=400)
+
+    with pytest.raises(ServerError, match="bad dims") as exc:
+        c.ingest_documents("coll", [{"id": "r1", "text": "hi"}])
+
+    assert exc.value.status_code == 400
+
+
+@patch(f"{INGEST_MOD}.sync_detailed")
+def test_transport_error_mapped_to_network_error(mock_sync):
+    c = make_client()
+    mock_sync.side_effect = httpx.ConnectError("boom")
+
+    with pytest.raises(NetworkError, match="transport error"):
+        c.ingest_documents("coll", [{"id": "r1", "text": "hi"}])


### PR DESCRIPTION
## What

P2 of the spec-driven-primary initiative (ADR-041). Adds `ProximaDBClient.ingest_documents` on the unified Python client, routing through the **generated** openapi op (`_generated/.../documents/ingest_documents.py` → `POST /api/v2/collections/{collection_id}/documents`) instead of the hand-written `adapters/rest_adapter.py::insert_document`.

## Why

`rest_adapter.insert_document` reaches into `self._client._session` / `_timeout`, which don't exist on the generated `Client` → the access raises inside a bare `except` → swallowed → the call silently falls back to an in-memory `DocumentRepository`. That is one of the 5 root causes that blocked aligning the connector SDK to `ProximaDBClient`. P0+P1 (#462) made `ingestDocuments` the canonical Rust-generated surface across all 4 clients; P2 now makes the hand-written client actually use it.

## Design

- **Generated transport.** `ingest_documents` builds an `IngestDocumentsRequest(records=[IngestDocument(id, text, metadata, vector)])` and calls the generated `sync_detailed`.
- **Per-call headers, no accumulation.** A lazily-built shared *base* generated `Client` carries only `base_url` + auth headers and is never used to issue a request directly (its httpx client is never materialized). Each call derives a fresh client via `Client.with_headers({...})` (`evolve`, not mutation) for `X-Tenant-ID` / `X-Ingest-Mode` / `X-Embed-Source`, so headers never accumulate on the base across calls.
- **No silent fallback.** `allow_local_fallback=False` is the default: a server-backed client with no `PROXIMADB_URL` raises `ProximaDBError` rather than swallowing the failure into a local dict. Opt in explicitly with `allow_local_fallback=True` for embedded/local parity.
- **Outcome mapping.** `ErrorResponse` → `ServerError(status_code=…)`; transport error (`httpx.HTTPError`) → `NetworkError(original_error=…)`; success → parsed `IngestDocumentsResponse` dict (`{mode, records, …}`).

## Tests

New `tests/unit/test_unified_client_ingest_documents.py` (13 tests, all offline — `sync_detailed` patched): header passthrough, per-call header non-accumulation (base client never mutated), record-dict → `IngestDocument` conversion (incl. omission of absent `text`/`metadata`), `IngestDocument` pass-through, input validation, no-silent-fallback (raise vs. opt-in local), and outcome mapping (success / `ErrorResponse` → `ServerError` / transport → `NetworkError`).

No change to `_generated/` or the OpenAPI spec, so the codegen-drift gate is unaffected. Purely additive on `unified_client.py` (+195 lines); existing unified-client + document suites still green (348 passed).

## Follow-ups (out of scope here)

- **P3** — deprecate `insert_document` (point callers at `ingest_documents`).
- **P4** — align AnvaiOps `packages/connector-sdk/.../ingest.py` to this generated client.
- **P5** — remove the hand-rolled document path.

Refs ADR-041 (`docs/12-design/adr/ADR-041-spec-driven-primary-document-surface.adoc`).