### PR TITLE
docs(sst): TD-096 S1 recall reconciliation — refute the 5% collapse, promote recall_at_10 (measured)

### DIFF
--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -79,15 +79,15 @@ notes = "Ran 2026-06-16: bench_08 measures the quantization-speed kernel (dim 12
 id = "recall_at_10"
 claim = "~97% Recall@10 (HNSW, M=32)"
 metric = "recall_at_10_pct"
-status = "unverified"
+status = "measured"
 asserted_in = ["README.adoc:99", "docs/10-quality/benchmarks/BENCHMARKS.adoc:18"]
 bench_source = "benches/bench_24_recall_at_k_engine.rs"
-bench_command = "cargo bench --bench bench_24_recall_at_k_engine"
-artifact = ""
-hardware = ""
-date = ""
-version = ""
-notes = "Ran 2026-06-16: bench_23_recall_at_k is registered and runnable but only benchmarks the recall-COMPUTATION utility over synthetic vectors + SIMULATED approximate results. A real index-vs-ground-truth bench now exists at benches/bench_24_recall_at_k_engine.rs with deterministic vectors and bounded search-readiness probing, but this claim stays UNVERIFIED until that bench is run on recorded hardware and its output is archived. README states 'not an SLA'."
+bench_command = "PROXIMADB_BENCH_ENGINE=sst PROXIMADB_BENCH_VECTOR_COUNT=100000 cargo bench --bench bench_24_recall_at_k_engine"
+artifact = "docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), no other workload"
+date = "2026-06-28"
+version = "v0.2"
+notes = "TD-096 S1 (2026-06-28): ran bench_24_recall_at_k_engine in Approximate mode (dim 128, 20 queries, deterministic seeded LCG) at 10K and 100K vectors for BOTH sst and helix — Recall@{1,10,100} = 100.00% across the board, including the SST 100K case (>=100 blocks, the condition that historically tripped a ~5% collapse on the flat Exact block-scan path, now bypassed via force_exact). 100% >= the ~97% claim, so the claim is substantiated. DATA CAVEAT: this is random normalized dim-128 data (easy for HNSW — neighbors well-separated); the 97% figure in README is not an SLA and real high-dim embedding corpora may differ. See the reconciliation doc for the full table + the block-skip unit proof (block_pruning.rs::td096_block_skip_tests)."
 
 [[claims]]
 id = "hybrid_search_latency"

--- a/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
+++ b/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
@@ -1,0 +1,112 @@
+= TD-096 S1: Recall-Premise Reconciliation + Block-Skip Measurement
+:date: 2026-06-28
+:toc: left
+
+== Context
+
+TD-096 was opened against an in-code claim that SST block-pruning collapses
+recall to ~5%. The S1 slice (per
+`docs/_internal/status/TD_064_096_110_122_RECONCILE_AND_HANDOFFS_2026_06_28.adoc`)
+is to *measure* and *reconcile* that claim — "trace, don't assert" — and the
+output gates whether S2 (route-disclosure, reusing TD-064's ADR-011 types) is
+justified at all. If the recall premise does not hold, TD-096 is downgraded to
+documented guidance (no code).
+
+== What the ~5% actually was
+
+The number lives in `src/storage/engines/sst/search/mod.rs` (and is already
+contextualized in the `BlockPruneConfig` docs, `src/core/search/mod.rs:525`):
+
+* `select_blocks_by_centroid` (`src/storage/engines/sst/readers/block_pruning.rs`)
+  keeps only `sqrt(num_blocks)` blocks in `Sqrt` mode (the default), scoring
+  blocks by centroid distance.
+* At ≥`MIN_BLOCKS_FOR_PRUNING` (100) blocks — i.e. ~100K+ vectors — this is
+  aggressive: 100 blocks ⇒ 10 kept.
+* Before 2026-05-30, a `SearchMode::Exact` request did **not** bypass this, so
+  an Exact scan over a large SST silently returned ~5% recall vs brute force.
+  That is the historical collapse.
+
+== Current state — the collapse is already fixed for Exact
+
+Since 2026-05-30, `SearchMode::Exact` auto-sets `BlockPruneConfig.force_exact =
+true` (`sst/search/mod.rs`, the override block around `:786`), and
+`select_blocks_by_centroid` returns *all* blocks when `force_exact` is set. So
+Exact no longer collapses. The `BlockPruneConfig` docs now state plainly that
+flat approximate search on diffuse data has a recall floor of ~5–50% depending
+on layout, and recommends the AXIS (HNSW/IVF) path for high recall.
+
+== Block-skip mechanism — deterministic unit proof
+
+`src/storage/engines/sst/readers/block_pruning.rs::td096_block_skip_tests`
+pins the pruning behavior without a heavyweight recall bench:
+
+* `sqrt_pruning_keeps_approximately_sqrt_n_blocks` — 100 blocks ⇒ exactly 10
+  kept in `Sqrt` mode; the nearest block survives.
+* `force_exact_keeps_all_blocks` — `force_exact` keeps every block (the
+  override).
+* `below_threshold_no_pruning` — below `MIN_BLOCKS_FOR_PRUNING` (and no
+  override), all blocks are kept (small-collection path is always exact).
+
+== Recall evidence (Approximate, the production default)
+
+`benches/bench_24_recall_at_k_engine.rs` builds a real embedded index and
+computes Recall@{1,10,100} against a brute-force oracle. It runs in
+*Approximate* mode (the default; Exact is 100% by construction). Reproduce
+with `PROXIMADB_BENCH_ENGINE={sst,helix} PROXIMADB_BENCH_VECTOR_COUNT={10000,100000}
+cargo bench --bench bench_24_recall_at_k_engine`.
+
+// RECALL_TABLE: measured 2026-06-28 from /tmp/td096_recall_results.txt
+// (PROXIMADB_BENCH_ENGINE/BENCH_VECTOR_COUNT, Approximate mode, dim 128, 20 queries).
+
+[cols="1,1,1,1,1", options="header"]
+|===
+| Engine | Vectors | Recall@1 | Recall@10 | Recall@100
+
+| SST | 10,000 | 100.00% | 100.00% | 100.00%
+| SST | 100,000 | 100.00% | 100.00% | 100.00%
+| HELIX | 10,000 | 100.00% | 100.00% | 100.00%
+| HELIX | 100,000 | 100.00% | 100.00% | 100.00%
+|===
+
+Both engines hold 100% Recall@{1,10,100} even at 100K vectors — the SST 100K
+case is the one that would trip the historical collapse (≥100 blocks ⇒ the
+sqrt centroid pruning at the flat-scan path keeps only `sqrt(num_blocks)`
+blocks). The production Approximate path does not collapse: it routes through
+the AXIS index (HNSW), not the flat SST block-scan, so the sqrt pruning never
+gates recall in practice. The flat-scan 5% is a corner path (Exact pre-override,
+or a non-AXIS approximate scan), already documented in `BlockPruneConfig`.
+
+== Object-store GET count — deferred (instrumentation gap)
+
+The "real differentiator" the handoff names — object-store GET count (and
+block-skip *ratio* at the search path) for SST vs HELIX — is **not yet
+measurable end-to-end**: the SST engine counts `pruned_blocks` internally
+(`sst_query_engine.rs`, logged as `pruned_blocks={kept}/{total}`) but there is
+no counting/instrumented wrapper at the object-store layer to total GETs per
+search. Adding one is a small but separate instrumentation change; it is left
+as the S1.5 follow-up so this reconciliation is not blocked on it. The
+block-skip *unit* proof above covers the mechanism.
+
+== Conclusion
+
+* The ~5% recall collapse was an **Exact-mode, pre-2026-05-30** artifact on the
+  flat SST block-scan path, and is already fixed (`force_exact` override). It
+  does **not** reproduce on the current Exact path.
+* Approximate recall is **100.00% at Recall@{1,10,100} for both SST and HELIX
+  at 10K and 100K** (table above). The production Approximate path routes
+  through the AXIS index, so the flat-scan sqrt pruning never gates recall. The
+  recall-collapse premise is **refuted** for the default production path.
+* Per the handoff's escape hatch, **TD-096 is downgraded to documented
+  guidance**: no S2 route-disclosure code retrofit on SST. S2 (if pursued)
+  should reuse TD-064's ADR-011 disclosure envelope for *latency/GET*
+  observability, not recall — and only after the GET-count instrumentation
+  lands and shows a material SST-vs-HELIX win on diffuse data.
+
+== Provenance
+
+Measured 2026-06-28 on local macOS arm64 (Apple Silicon), offline build
+(`CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git`), develop `f1e6d88f8`. The recall
+numbers above are transcribed from the bench run
+(`PROXIMADB_BENCH_ENGINE/BENCH_VECTOR_COUNT` per the commands in the recall
+section); reproduce with the same env vars + `cargo bench --bench
+bench_24_recall_at_k_engine`.

--- a/src/storage/engines/sst/readers/block_pruning.rs
+++ b/src/storage/engines/sst/readers/block_pruning.rs
@@ -214,3 +214,90 @@ pub(crate) fn metric_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> f
     let distance_compute = UnifiedDistanceCompute::default();
     distance_compute.distance_with_metric(a, b, &metric)
 }
+
+#[cfg(test)]
+mod td096_block_skip_tests {
+    //! TD-096 S1: deterministic proof of the sqrt centroid-pruning block-skip
+    //! ratio — the mechanism behind the historical ~5% Exact-mode recall
+    //! collapse (now bypassed for `SearchMode::Exact` via `force_exact`; see
+    //! `src/storage/engines/sst/search/mod.rs` and the `BlockPruneConfig` docs).
+    //! These pin the pruning behavior so a regression that re-introduces the
+    //! collapse is caught without a heavyweight recall bench.
+    use super::*;
+    use crate::core::search::BlockPruneMode;
+
+    /// `n` orthogonal unit basis vectors in `dim` dimensions (e_0..e_{n-1}) —
+    /// distinct directions so Cosine ranking is unambiguous (e_i·e_j = δ_ij).
+    fn basis_centroids(n: usize, dim: usize) -> Vec<Vec<f32>> {
+        (0..n)
+            .map(|i| {
+                let mut v = vec![0.0f32; dim];
+                v[i] = 1.0;
+                v
+            })
+            .collect()
+    }
+
+    fn entries_with_centroids(centroids: &[Vec<f32>]) -> Vec<IndexEntry> {
+        centroids
+            .iter()
+            .map(|c| IndexEntry {
+                block_centroid: c.clone(),
+                block_centroid_fp16: None,
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    /// At N≥threshold blocks, Sqrt mode keeps only ~sqrt(N) — the aggressive
+    /// skip that, pre-`force_exact`, dropped Exact recall to ~5% at scale.
+    #[test]
+    fn sqrt_pruning_keeps_approximately_sqrt_n_blocks() {
+        // 100 orthogonal centroids (Cosine ranking is unambiguous: e_i·e_j=δ).
+        let entries = entries_with_centroids(&basis_centroids(100, 100));
+        let mut cfg = BlockPruneConfig::for_testing(); // bypass the 100-block threshold
+        cfg.mode = BlockPruneMode::Sqrt;
+        let mut query = vec![0.0f32; 100];
+        query[50] = 1.0; // == e_50, the nearest centroid by Cosine
+        let selected = select_blocks_by_centroid(&query, &entries, DistanceMetric::Cosine, &cfg);
+        assert_eq!(
+            selected.len(),
+            10,
+            "Sqrt mode must keep sqrt(100)=10 of 100 blocks"
+        );
+        // The nearest block (centroid e_50) must survive the prune.
+        assert!(selected.contains(&50));
+    }
+
+    /// `force_exact` bypasses pruning entirely — the override that eliminated
+    /// the 5% collapse for `SearchMode::Exact`.
+    #[test]
+    fn force_exact_keeps_all_blocks() {
+        let entries = entries_with_centroids(&basis_centroids(50, 50));
+        let mut cfg = BlockPruneConfig::for_testing();
+        cfg.force_exact = true;
+        // Direction is irrelevant under force_exact (no scoring).
+        let query = vec![1.0f32; 50];
+        let selected = select_blocks_by_centroid(&query, &entries, DistanceMetric::Cosine, &cfg);
+        assert_eq!(
+            selected.len(),
+            50,
+            "force_exact must keep every block (no pruning)"
+        );
+    }
+
+    /// Below the production MIN_BLOCKS_FOR_PRUNING threshold (and no override),
+    /// no pruning happens — the small-collection path is always exact.
+    #[test]
+    fn below_threshold_no_pruning() {
+        let entries = entries_with_centroids(&basis_centroids(10, 10));
+        let cfg = BlockPruneConfig::default(); // min_blocks_override=None → threshold=100
+        let query = vec![1.0f32; 10];
+        let selected = select_blocks_by_centroid(&query, &entries, DistanceMetric::Cosine, &cfg);
+        assert_eq!(
+            selected.len(),
+            10,
+            "below MIN_BLOCKS_FOR_PRUNING, all blocks are kept"
+        );
+    }
+}

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -777,6 +777,13 @@ impl SstEngine {
         // brute force on random data. Customers asking for `Exact` get
         // approximate results otherwise.
         //
+        // Reconciled + measured 2026-06-28 (TD-096 S1): the 5% was this
+        // Exact-pre-override path; with the override, Exact no longer
+        // collapses. Approximate recall at scale (sqrt pruning keeps
+        // sqrt(num_blocks) blocks — see the block-skip unit tests in
+        // block_pruning.rs) is measured in
+        // docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc.
+        //
         // For `SearchMode::Approximate` and `SearchMode::Adaptive` the
         // caller's `block_prune` config flows through unchanged.
         let prune_config_owned;


### PR DESCRIPTION
## Summary

**TD-096 S1** — measured the SST recall premise and reconciled the in-code ~5% recall claim. **Outcome: the recall-collapse premise is refuted for the production paths; TD-096 is downgraded to documented guidance (no S2 SST retrofit).** This is foundational-first ordering #4; independent of TD-064/110/122.

## What the ~5% was

The flat SST block-scan path's sqrt centroid pruning (`select_blocks_by_centroid` keeps only `sqrt(num_blocks)` blocks) under `SearchMode::Exact`, **pre-2026-05-30**. It is **already fixed**: `SearchMode::Exact` now auto-sets `BlockPruneConfig.force_exact`, so all blocks are scanned.

## Measured (refutes the collapse)

`benches/bench_24_recall_at_k_engine`, Approximate mode, dim 128, 20 queries, deterministic seeded LCG:

| Engine | Vectors | Recall@1 | Recall@10 | Recall@100 |
|---|---|---|---|---|
| SST  | 10,000  | 100.00% | 100.00% | 100.00% |
| SST  | 100,000 | 100.00% | 100.00% | 100.00% |
| HELIX| 10,000  | 100.00% | 100.00% | 100.00% |
| HELIX| 100,000 | 100.00% | 100.00% | 100.00% |

Including the **SST 100K** case (≥100 blocks — the condition that historically tripped the collapse). The production Approximate path routes through the **AXIS index (HNSW)**, so the flat-scan sqrt pruning never gates recall in practice.

## Changes

- **New reconciliation doc** `docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc` — the 5% explanation, measured table, block-skip unit proof, the GET-count instrumentation gap, and the downgrade conclusion.
- **`BENCHMARK_EVIDENCE.toml`** — promote `recall_at_10` `unverified → measured` (bench_24, 100% ≥ ~97% claim; random dim-128 data caveat noted). `validate_benchmark_evidence.py` passes (now 6 measured).
- **`block_pruning.rs`** — deterministic `td096_block_skip_tests`: sqrt(N) keep + `force_exact` bypass + below-threshold no-prune. Pins the mechanism behind the historical 5% without a heavyweight recall bench.
- **`sst/search/mod.rs`** — cross-reference the reconciliation from the ~5% comment (no number asserted in code; the doc carries the measurement).

## Out of scope / deferred

Object-store GET-count end-to-end measurement (needs a counting object-store wrapper — an instrumentation gap noted in the doc). **S2 route-disclosure, if pursued, should reuse TD-064's ADR-011 envelope for *latency/GET* observability, not recall**, and only after the GET-count instrumentation lands and shows a material SST-vs-HELIX win on diffuse data.

## Verification (local)

- `cargo fmt --check`; `cargo clippy --lib --bins -- -D warnings`: clean.
- `cargo test --lib td096_block_skip_tests`: 3 pass.
- `validate_benchmark_evidence.py`: passes (6 measured).
- Recall bench: 4 runs, all Recall@{1,10,100} = 100.00%.

Holding for human merge.
