### PR TITLE
feat(sdk): deprecate insert_document in favor of ingest_documents (ADR-041 P3)

### DIFF
--- a/clients/python/SDK_DOCUMENTATION.adoc
+++ b/clients/python/SDK_DOCUMENTATION.adoc
@@ -44,7 +44,8 @@ print(results)
 [source,python]
 ----
 client.create_document_collection("events")
-client.insert_document("events", {"service": "api", "status": "warn"})
+# insert_document is deprecated (ADR-041); prefer ingest_documents
+client.ingest_documents("events", [{"id": "evt-1", "text": "service=api status=warn"}])
 ----
 
 == Graph Operations (Beta)

--- a/clients/python/docs/multi_model_guide.md
+++ b/clients/python/docs/multi_model_guide.md
@@ -59,10 +59,15 @@ document = {
     "tags": ["example", "tutorial"],
 }
 
-result = docs.insert_document(
+# ingest_documents is the canonical write surface (ADR-041);
+# ProximaDBDocument.insert_document is deprecated.
+result = client.ingest_documents(
     collection_id="code_files",
-    document=document,
-    id="doc:main.py"
+    records=[{
+        "id": "doc:main.py",
+        "text": document["content"],
+        "metadata": document,
+    }],
 )
 print(f"Document inserted: {result}")
 
@@ -76,12 +81,14 @@ for i in range(100):
         "lines_of_code": 10 + i,
     })
 
-# Batch insert
-for doc in documents:
-    docs.insert_document(
-        collection_id="code_files",
-        document=doc
-    )
+# Batch ingest in one call (not a loop) — ADR-041 canonical surface
+client.ingest_documents(
+    collection_id="code_files",
+    records=[
+        {"id": doc["file_path"], "text": doc["content"], "metadata": doc}
+        for doc in documents
+    ],
+)
 ```
 
 ### Querying Documents
@@ -188,11 +195,14 @@ client.create_document_collection(
     }
 )
 
-# Insert document
-client.insert_document(
-    collection_name="my_docs",
-    document={"category": "tech", "title": "ProximaDB Guide"},
-    id="doc1"
+# Insert document (ingest_documents is the canonical write surface, ADR-041)
+client.ingest_documents(
+    collection_id="my_docs",
+    records=[{
+        "id": "doc1",
+        "text": "ProximaDB Guide",
+        "metadata": {"category": "tech", "title": "ProximaDB Guide"},
+    }],
 )
 
 # Query documents

--- a/clients/python/src/proximadb_sdk/_deprecations.py
+++ b/clients/python/src/proximadb_sdk/_deprecations.py
@@ -1,0 +1,54 @@
+"""Centralized deprecation signals for the ``proximadb_sdk`` public API.
+
+One module = one source of truth for the deprecation message text and the
+``stacklevel`` reasoning, so every public facade that must steer callers off a
+legacy surface emits the identical, on-message warning (DRY). The matching
+in-repo convention is a per-module ``_warn_*_deprecated()`` helper
+(``chunking_strategies/code.py``, ``embedding_providers/__init__.py``); that
+style is lifted to a shared module here only because the *same* message is shared
+across three facades in three different modules (SRP: this module owns the
+warning; the facades own document writes).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+__all__ = ["warn_insert_document_deprecated"]
+
+
+def warn_insert_document_deprecated(
+    *, is_async: bool = False, stacklevel: int = 3
+) -> None:
+    """Emit the ADR-041 (P3) ``DeprecationWarning`` for ``insert_document``.
+
+    Behavior-preserving: this ONLY warns; the legacy method still runs exactly as
+    before. ``insert_document`` is removed in a future minor release (ADR-041 P5).
+
+    Args:
+        is_async: When ``True``, append a note that an async ``ingest_documents``
+            variant is planned. The async ``EmbeddedProximaDB.insert_document``
+            points at the sync surface for now.
+        stacklevel: Forwarded to :func:`warnings.warn`. Lands the reported
+            ``filename:lineno`` on the frame ``stacklevel - 1`` calls above the
+            ``warn()`` call, so the user sees THEIR call site, not SDK internals.
+            For the standard wiring (user -> deprecated public method -> this
+            helper -> ``warn``), ``3`` is correct: ``1`` = this helper,
+            ``2`` = the deprecated method body, ``3`` = the user's call.
+    """
+    async_note = (
+        " An async ingest_documents variant is planned; until then call the "
+        "sync ingest_documents, or run it in a worker thread."
+        if is_async
+        else ""
+    )
+    warnings.warn(
+        "insert_document() is deprecated (ADR-041 spec-driven-primary P3). Use "
+        "ingest_documents() for document writes; it targets the canonical "
+        "POST /api/v2/collections/{collection_id}/documents route and surfaces "
+        "server errors instead of silently falling back to an in-memory "
+        "repository. insert_document() will be removed in a future minor "
+        f"release.{async_note}",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )

--- a/clients/python/src/proximadb_sdk/document.py
+++ b/clients/python/src/proximadb_sdk/document.py
@@ -69,6 +69,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from ._deprecations import warn_insert_document_deprecated
 from .exceptions import ProximaDBError
 
 # =============================================================================
@@ -1546,6 +1547,22 @@ class ProximaDBDocument:
         document: dict[str, Any],
         id: str | None = None,
     ) -> dict[str, Any]:
+        """Insert a document into the in-memory repository.
+
+        .. deprecated:: ADR-041 (P3)
+            ``insert_document`` is deprecated and will be removed in a future
+            minor release. On a :class:`ProximaDBClient`, use
+            :meth:`~ProximaDBClient.ingest_documents`. Behavior is unchanged
+            in P3.
+
+        Note:
+            This facade delegates to ``DocumentRepository.insert``, which calls
+            the (also deprecated) ``ProximaDBClient.insert_document`` — so a call
+            here may emit two ``DeprecationWarning``\\s. Both are expected and
+            filtered by the SDK's default ``ignore::DeprecationWarning`` setting;
+            both disappear once P5 removes the legacy surface.
+        """
+        warn_insert_document_deprecated(stacklevel=3)
         created = self._repository.insert(collection_id, document, id)
         return {
             "id": created.id,

--- a/clients/python/src/proximadb_sdk/embedded.py
+++ b/clients/python/src/proximadb_sdk/embedded.py
@@ -72,6 +72,8 @@ from typing import (
     runtime_checkable,
 )
 
+from ._deprecations import warn_insert_document_deprecated
+
 # Socket file names MUST match the Rust constants in
 # crates/platform/proximadb-runtime/src/bootstrap_config.rs.
 UDS_REST_SOCKET_NAME = "rest.sock"
@@ -1459,7 +1461,14 @@ prefetch_budget = 4
 
         Returns:
             Insert result with document ID and version
+
+        .. deprecated:: ADR-041 (P3)
+            ``insert_document`` is deprecated and will be removed in a future
+            minor release. Use the (sync) :meth:`~ProximaDBClient.ingest_documents`
+            for document writes; an async ``ingest_documents`` variant is
+            planned. Behavior is unchanged in P3.
         """
+        warn_insert_document_deprecated(is_async=True, stacklevel=3)
         if not self._started:
             await self.start()
 

--- a/clients/python/src/proximadb_sdk/unified_client.py
+++ b/clients/python/src/proximadb_sdk/unified_client.py
@@ -20,6 +20,7 @@ from typing import Any, Union
 import httpx
 import numpy as np
 
+from ._deprecations import warn_insert_document_deprecated
 from .adapters import BaseProtocolAdapter, create_adapter
 from .auth import AuthConfig, AuthMethod, ProximaDBAuth
 from .config import ClientConfig, PortMode, Protocol, load_config
@@ -2060,7 +2061,16 @@ class ProximaDBClient:
         id: str | None = None,
         **kwargs,
     ) -> dict[str, Any]:
-        """Insert a document."""
+        """Insert a document.
+
+        .. deprecated:: ADR-041 (P3)
+            ``insert_document`` is deprecated and will be removed in a future
+            minor release. Use :meth:`ingest_documents` for document writes; it
+            targets the canonical ``POST /api/v2/collections/{id}/documents``
+            route and surfaces server errors instead of silently falling back to
+            an in-memory repository. Behavior is unchanged in P3.
+        """
+        warn_insert_document_deprecated(stacklevel=3)
         adapter_result = self._call_document_adapter(
             "insert_document", collection_name, document, id, **kwargs
         )

--- a/clients/python/tests/unit/test_insert_document_deprecation.py
+++ b/clients/python/tests/unit/test_insert_document_deprecation.py
@@ -1,0 +1,202 @@
+"""Deprecation contract tests for ``insert_document`` (ADR-041, P3).
+
+P3 deprecates the three public ``insert_document`` facades in favor of
+``ingest_documents``. These tests pin the deprecation CONTRACT — not legacy
+behavior — so a careless edit (wrong stacklevel, missing warning, changed
+message) fails loudly here:
+
+1. each public facade emits a ``DeprecationWarning`` citing ADR-041,
+2. the warning's reported ``filename`` is the CALLER's frame (stacklevel=3 guard),
+3. the return value is unchanged when the warning is suppressed (behavior-preserving),
+4. the shared helper's message names the replacement surface.
+
+All offline: the unified facade uses a ``MagicMock`` adapter (returns a dict, so
+no fallback path), the document facade runs the real ``DocumentRepository``
+against a mock client, and the async embedded facade runs against a patched
+``httpx.AsyncClient``.
+"""
+
+import asyncio
+import warnings
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from proximadb_sdk._deprecations import warn_insert_document_deprecated
+from proximadb_sdk.config import Protocol
+from proximadb_sdk.document import ProximaDBDocument
+from proximadb_sdk.embedded import EmbeddedProximaDB
+from proximadb_sdk.unified_client import ProximaDBClient
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_unified_client():
+    """REST-mode client whose adapter returns a dict (no fallback path)."""
+    c = ProximaDBClient(url="http://testserver:5678", protocol="rest")
+    adapter = MagicMock()
+    adapter.insert_document.return_value = {
+        "id": "d1",
+        "version": 3,
+        "document": {"a": 1},
+    }
+    c._adapter = adapter
+    c._client = MagicMock()
+    c._active_protocol = Protocol.REST
+    return c, adapter
+
+
+def make_document_facade():
+    """``ProximaDBDocument`` over a mock client (real DocumentRepository)."""
+    client = MagicMock()
+    client.insert_document.return_value = {}  # server echoes no id -> keep caller id
+    return ProximaDBDocument(client), client
+
+
+# --- minimal async fakes (self-contained; mirror test_embedded_cov.py) ---
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeResp:
+    def __init__(self, json_body):
+        self._json = json_body
+        self.status_code = 200
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeAsyncClient:
+    """Drop-in for ``httpx.AsyncClient`` (async context manager)."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, **kw):
+        return _FakeResp({"id": "doc1", "version": 1})
+
+
+@pytest.fixture
+def started_embedded(monkeypatch):
+    """An ``EmbeddedProximaDB`` flagged started, with httpx patched out."""
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    db = EmbeddedProximaDB(data_dir="/tmp/proximadb-test-deprecation")
+    db._started = True
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Facade 1: ProximaDBClient.insert_document
+# ---------------------------------------------------------------------------
+
+
+def test_unified_facade_warns_and_points_at_caller():
+    c, _ = make_unified_client()
+    with pytest.warns(DeprecationWarning, match="ADR-041") as record:
+        result = c.insert_document("coll", {"a": 1})
+    # stacklevel=3 guard: the warning is attributed to THIS test file, not SDK internals.
+    assert record[0].filename == __file__
+    assert "ingest_documents" in str(record[0].message)
+    assert result == {"id": "d1", "version": 3, "document": {"a": 1}}
+
+
+def test_unified_facade_behavior_unchanged_when_suppressed():
+    c, adapter = make_unified_client()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = c.insert_document("coll", {"a": 1}, id="x")
+    adapter.insert_document.assert_called_once()
+    assert result == adapter.insert_document.return_value
+
+
+# ---------------------------------------------------------------------------
+# Facade 2: ProximaDBDocument.insert_document
+# ---------------------------------------------------------------------------
+
+
+def test_document_facade_warns_and_points_at_caller():
+    docs, _ = make_document_facade()
+    with pytest.warns(DeprecationWarning, match="ADR-041") as record:
+        result = docs.insert_document("code_files", {"content": "hi"}, id="doc:main.py")
+    assert record[0].filename == __file__
+    assert "ingest_documents" in str(record[0].message)
+    # Behavior unchanged: the legacy {id, version, document} shape is preserved.
+    assert result["id"] == "doc:main.py"
+    assert result["document"] == {"content": "hi"}
+    assert "version" in result
+
+
+def test_document_facade_behavior_unchanged_when_suppressed():
+    docs, _ = make_document_facade()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = docs.insert_document("code_files", {"content": "hi"}, id="doc:main.py")
+    assert result["id"] == "doc:main.py"
+
+
+# ---------------------------------------------------------------------------
+# Facade 3: EmbeddedProximaDB.insert_document (async)
+# ---------------------------------------------------------------------------
+
+
+def test_embedded_facade_warns_with_async_note(started_embedded):
+    with pytest.warns(DeprecationWarning, match="ADR-041") as record:
+        result = _run(started_embedded.insert_document("coll", {"content": "hi"}))
+    # NOTE: we do NOT assert record[0].filename here. ``warnings.warn``'s
+    # stacklevel is unreliable across the coroutine/event-loop boundary (the
+    # reported frame lands in asyncio internals, not the caller) — a known
+    # Python limitation. The warning still fires with the canonical message;
+    # that message is what guides migration. The deterministic stacklevel guard
+    # lives in the two SYNC facade tests above.
+    msg = str(record[0].message)
+    assert "ingest_documents" in msg
+    # Async variant appends the future-work note.
+    assert "async ingest_documents variant is planned" in msg
+    assert result == {"id": "doc1", "version": 1}
+
+
+def test_embedded_facade_behavior_unchanged_when_suppressed(started_embedded):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = _run(started_embedded.insert_document("coll", {"content": "hi"}))
+    assert result == {"id": "doc1", "version": 1}
+
+
+# ---------------------------------------------------------------------------
+# Helper message contract
+# ---------------------------------------------------------------------------
+
+
+def test_helper_message_names_replacement_surface():
+    with pytest.warns(DeprecationWarning) as record:
+        warn_insert_document_deprecated()
+    assert len(record) == 1
+    msg = str(record[0].message)
+    for needle in (
+        "insert_document()",
+        "ingest_documents()",
+        "ADR-041",
+        "removed in a future minor",
+    ):
+        assert needle in msg, f"message missing {needle!r}: {msg!r}"


### PR DESCRIPTION
## What

P3 of the spec-driven-primary initiative (ADR-041): **deprecate** the three public `insert_document` facades in favor of the canonical `ingest_documents` surface (added P2, #532). This is the DEPRECATE step — behavior-preserving, no removal. P4 aligns the anvaiops connector-sdk; P5 removes the legacy surface.

## Why

`insert_document` is the legacy hand-written write path: the REST adapter variant is outright broken (`self._client._session`/`_timeout` don't exist → swallowed → silent in-memory fallback), and the whole adapter-based document layer is the surface ADR-041 is phasing out in favor of the generated client. P2 made `ingest_documents` the canonical write surface; P3 now officially steers callers off `insert_document` without breaking them.

## Design (first-principles / SOLID)

- **No shim.** The two surfaces aren't 1:1 substitutable (different routes `document-collections/{name}` vs `collections/{id}`, singular vs batch, `{id,version,document}` vs `{mode,records}`, silent-fallback vs raise). A delegating shim would silently change semantics — that's P5's job, done deliberately. P3 only *warns* (LSP: the deprecated method still honors its contract).
- **`ingest_documents` stays off the adapter contract.** It bypasses `BaseProtocolAdapter` by design (generated transport = new canonical; adapters = legacy). Adding it there would graft the new surface onto the soon-removed layer. P3 deprecates only the **public facades**; the adapter-contract methods are P5.
- **One shared helper** (`_deprecations.warn_insert_document_deprecated`) — SRP/DRY: three facades in three modules emit one identical message from one place (DIP: facades depend on the stable helper, not triplicated inline `warnings.warn`).
- **`stacklevel=3`** so the warning's reported `filename:lineno` is the caller's frame, not SDK internals. (Python's `warnings.warn` counts its own frame as 1; for user→facade→helper→warn that's 3.) Verified empirically + pinned by the new test for the two sync facades. The async facade can't be pinned across the event-loop boundary — documented.

## Changes

- **NEW** `src/proximadb_sdk/_deprecations.py` — shared deprecation helper (single message source).
- **3 public facades** get `warn_insert_document_deprecated(...)` as the first statement + a Sphinx `.. deprecated:: ADR-041 (P3)` docstring; bodies otherwise untouched:
  - `ProximaDBClient.insert_document` (`unified_client.py`)
  - `ProximaDBDocument.insert_document` (`document.py`)
  - `EmbeddedProximaDB.insert_document` — async (`embedded.py`)
- **Docs/examples** migrated to show `ingest_documents` as primary: `SDK_DOCUMENTATION.adoc`, `docs/multi_model_guide.md` (×3).
- **NEW** `tests/unit/test_insert_document_deprecation.py` — pins the contract: warning fires + cites ADR-041, caller-frame attribution (`record[0].filename == __file__`), behavior unchanged when suppressed, helper message names the replacement.

## Deliberately untouched (P5)

The adapter-contract `insert_document` methods (`base.py`, `rest_adapter.py`, `embedded_adapter.py`), the 6 SDK-internal callers, and the 20 existing test calls — they exercise the legacy path and stay until P5 removes the surface wholesale.

## Verification

- New deprecation contract test: **7 passed**.
- Behavior oracles unchanged: `test_document_cov` + `test_unified_client_cov` + `test_unified_client_ingest_documents` + `test_rest_adapter_cov` → **437 passed**.
- Full unit suite: **4488 passed**. The 2 failures + 2 errors (`test_chunking_code_cov`, `test_chunking_top_cov`, `test_emb_core_mixins_cov`) are **pre-existing on develop** — verified by reproducing them on a clean develop worktree (deprecated `victor-codegraph` code chunker + a missing fixture; unrelated to document writes).
- Lint: `ruff --select=E9,F63,F7`, `black --check`, `isort --check` clean on all touched files (the pre-existing full-config ruff findings in the large src files are not CI-gated and not touched here).
- DeprecationWarnings are `ignore`d by default in both pytest configs, so the 20 legacy callers stay silent.

Refs ADR-041 (`docs/12-design/adr/ADR-041-spec-driven-primary-document-surface.adoc`). Plan: `.claude/plans/quiet-foraging-waterfall.md`.