### PR TITLE
feat(fusion): document modality over gRPC + embedded (TD-138 surface close)

### DIFF
--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -7008,6 +7008,18 @@ pub struct FusionSearchRequest {
     /// Graph contribution grain (default NODES).
     #[prost(enumeration = "FusionGrain", tag = "12")]
     pub grain: i32,
+    /// Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also
+    /// searches the collection's document index and merges BM25 hits by shared `oid` —
+    /// tri-modal (vector + graph + document) fusion. Absent => vector+graph only.
+    #[prost(string, optional, tag = "13")]
+    pub text_query: ::core::option::Option<::prost::alloc::string::String>,
+    /// Collection whose document index to BM25-search (default = `vector_collection`;
+    /// documents co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+    #[prost(string, optional, tag = "14")]
+    pub document_collection: ::core::option::Option<::prost::alloc::string::String>,
+    /// Document modality weight (mirrors `vector_weight` / `graph_weight`; default 1.0).
+    #[prost(float, optional, tag = "15")]
+    pub document_weight: ::core::option::Option<f32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FusionHit {

--- a/proto/proximadb/v2/fusion.proto
+++ b/proto/proximadb/v2/fusion.proto
@@ -50,6 +50,15 @@ message FusionSearchRequest {
   optional float consensus_beta = 11;
   // Graph contribution grain (default NODES).
   FusionGrain grain = 12;
+  // Optional BM25/full-text query (TD-138). When present (and non-empty), fusion also
+  // searches the collection's document index and merges BM25 hits by shared `oid` —
+  // tri-modal (vector + graph + document) fusion. Absent => vector+graph only.
+  optional string text_query = 13;
+  // Collection whose document index to BM25-search (default = `vector_collection`;
+  // documents co-indexed with the vectors share the record `oid`, so they merge by `oid`).
+  optional string document_collection = 14;
+  // Document modality weight (mirrors `vector_weight` / `graph_weight`; default 1.0).
+  optional float document_weight = 15;
 }
 
 message FusionHit {

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -3691,6 +3691,9 @@ impl EmbeddedProximaDB {
         graph_weight: f32,
         rrf: bool,
         grain: &str,
+        text_query: Option<String>,
+        document_collection: Option<String>,
+        document_weight: Option<f32>,
     ) -> Result<
         (
             Vec<crate::core::search::cross_modal_fusion::FusedItem>,
@@ -3701,7 +3704,7 @@ impl EmbeddedProximaDB {
         self.runtime.block_on(async {
             use crate::core::search::cross_modal_fusion::FusionPolicy;
             use crate::services::fusion_service::{
-                FusionOidKey, FusionService, GraphFusionParams, GraphGrain,
+                DocumentFusionSpec, FusionOidKey, FusionService, GraphFusionParams, GraphGrain,
             };
 
             let service = FusionService::new(
@@ -3737,9 +3740,18 @@ impl EmbeddedProximaDB {
                     FusionPolicy::default()
                 },
                 oid_key: FusionOidKey::Canonical,
-                // TD-138 document modality is REST-only for now; embedded passes `None`
-                // (vector+graph only). The service above still shares the live index map.
-                document: None,
+                // TD-138 document modality (embedded parity with REST #508): enable iff a
+                // non-empty `text_query` was supplied. The service above shares the live
+                // full-text index map, so the DocumentExpander runs the BM25 search.
+                document: text_query
+                    .as_ref()
+                    .filter(|t| !t.trim().is_empty())
+                    .map(|t| DocumentFusionSpec {
+                        text_query: t.clone(),
+                        collection: document_collection.clone(),
+                        weight: document_weight.unwrap_or(1.0),
+                        k: None,
+                    }),
             };
             service.graph_fusion_search(params).await.map_err(
                 |e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/src/embedded/python.rs
+++ b/src/embedded/python.rs
@@ -2889,7 +2889,7 @@ impl PyProximaDB {
     /// core as the REST endpoint in-process, so embedded results match the server path by
     /// construction (the embedded-parity guarantee). Returns `{results: [{oid, score,
     /// source_count}], stats: {...}}`.
-    #[pyo3(signature = (graph_id, vector_collection, query_vector, max_depth=1, edge_types=None, max_seeds=5, limit=10, vector_weight=1.0, graph_weight=1.0, rrf=false, grain="nodes"))]
+    #[pyo3(signature = (graph_id, vector_collection, query_vector, max_depth=1, edge_types=None, max_seeds=5, limit=10, vector_weight=1.0, graph_weight=1.0, rrf=false, grain="nodes", text_query=None, document_collection=None, document_weight=None))]
     fn fusion_search(
         &self,
         py: Python<'_>,
@@ -2904,6 +2904,9 @@ impl PyProximaDB {
         graph_weight: f32,
         rrf: bool,
         grain: &str,
+        text_query: Option<String>,
+        document_collection: Option<String>,
+        document_weight: Option<f32>,
     ) -> PyResult<Py<PyAny>> {
         let (items, stats) = self
             .db()?
@@ -2919,6 +2922,9 @@ impl PyProximaDB {
                 graph_weight,
                 rrf,
                 grain,
+                text_query,
+                document_collection,
+                document_weight,
             )
             .map_err(|e| PyRuntimeError::new_err(format!("Failed fusion search: {}", e)))?;
 

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -24,7 +24,9 @@ use crate::proto::proximadb_v2 as pv2;
 use crate::proto::proximadb_v2::proxima_fusion_service_server::{
     ProximaFusionService, ProximaFusionServiceServer,
 };
-use crate::services::fusion_service::{FusionOidKey, FusionService, GraphFusionParams, GraphGrain};
+use crate::services::fusion_service::{
+    DocumentFusionSpec, FusionOidKey, FusionService, GraphFusionParams, GraphGrain,
+};
 
 /// Defaults shared with the REST handler (`src/network/rest/v2/graphs.rs`).
 const DEFAULT_LIMIT: usize = 10;
@@ -37,19 +39,17 @@ pub struct ProximaFusionServiceImpl {
 }
 
 impl ProximaFusionServiceImpl {
-    /// Build from the concrete vector + graph backing services. The `FusionService`
-    /// port is constructed once here (from the vector + graph services) and shared
-    /// across requests — never per-RPC.
+    /// Build from the concrete vector + graph backing services plus the shared
+    /// full-text index map (TD-138: powers the document modality). The
+    /// `FusionService` port is constructed once here and shared across requests —
+    /// never per-RPC.
     pub fn new(
         vector: Arc<crate::services::VectorOperationsService>,
         graph: Arc<crate::graph::GraphOperationsService>,
+        fulltext_indexes: crate::network::hybrid_search::HybridFullTextIndexMap,
     ) -> Self {
         Self {
-            fusion: Arc::new(FusionService::new(
-                vector,
-                graph,
-                crate::network::hybrid_search::HybridFullTextIndexMap::default(),
-            )),
+            fusion: Arc::new(FusionService::new(vector, graph, fulltext_indexes)),
         }
     }
 
@@ -134,9 +134,19 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
             principal,
             policy,
             oid_key: FusionOidKey::Canonical,
-            // TD-138 document modality is REST-only for now; gRPC document fusion is deferred
-            // (TD-143). `None` ⇒ vector+graph only (no behavior change).
-            document: None,
+            // TD-138 document modality (gRPC parity with REST #508): enable iff a non-empty
+            // `text_query` was supplied. The shared service's DocumentExpander runs the BM25
+            // search; absent/empty ⇒ vector+graph only (unchanged).
+            document: req
+                .text_query
+                .as_ref()
+                .filter(|t| !t.trim().is_empty())
+                .map(|t| DocumentFusionSpec {
+                    text_query: t.clone(),
+                    collection: req.document_collection.clone(),
+                    weight: req.document_weight.unwrap_or(1.0),
+                    k: None,
+                }),
         };
 
         let (items, stats) = self

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -204,6 +204,9 @@ impl MultiServer {
         crate::network::grpc::v2::ProximaFusionServiceImpl::new(
             services.vector_operations_service.clone(),
             services.request_handlers.graph_operations_service.clone(),
+            // TD-138: share the live full-text index map so the document modality is
+            // powered over gRPC (parity with REST #508).
+            services.fulltext_indexes.clone(),
         )
         .into_server()
     }

--- a/tests/embedded_code_graph_parity_e2e.rs
+++ b/tests/embedded_code_graph_parity_e2e.rs
@@ -129,6 +129,9 @@ fn embedded_fusion_search_seeds_and_expands() {
             1.0,   // graph_weight
             false, // calibrated (not rrf)
             "nodes",
+            None, // text_query — no document modality (vector+graph only)
+            None, // document_collection
+            None, // document_weight
         )
         .expect("embedded fusion_search");
 
@@ -142,6 +145,72 @@ fn embedded_fusion_search_seeds_and_expands() {
         oids.contains(&canonical_oid(graph_id, "parse"))
             && oids.contains(&canonical_oid(graph_id, "io")),
         "1-hop expand reaches parse + io: {oids:?}"
+    );
+}
+
+/// TD-138 document modality over embedded fusion (parity with REST #508): supplying a
+/// `text_query` makes the document source contribute. A document-ONLY oid (not in the vector or
+/// graph) surfacing in the results proves the document modality is live end-to-end; a document
+/// co-indexed with the top vector seed merges by shared `oid` (`source_count >= 2`).
+#[test]
+fn embedded_fusion_search_document_modality_contributes() {
+    use proximadb::storage::engines::core::formats::columnar::fulltext_index::{
+        FullTextIndex, TokenizerConfig,
+    };
+    let graph_id = "codegraph_fusion_doc";
+    let db = build_db(graph_id);
+
+    // Populate the co-indexed collection's full-text index with two documents whose doc_ids are
+    // oids: (a) `main`'s canonical oid (co-indexed → merges with the vector seed), and (b) a
+    // document-ONLY oid vector+graph alone could never surface.
+    let main_oid = canonical_oid(graph_id, "main");
+    let doc_solo = "doc_solo".to_string();
+    let mut index = FullTextIndex::new(TokenizerConfig::for_keyword_search());
+    index
+        .add_document(main_oid.as_str(), "machine learning model")
+        .expect("add main doc");
+    index
+        .add_document(doc_solo.as_str(), "machine learning algorithm")
+        .expect("add solo doc");
+    db.shared_services()
+        .fulltext_indexes
+        .write()
+        .expect("fulltext lock")
+        .insert(VEC_COLLECTION.to_string(), index);
+
+    let (items, _stats) = db
+        .fusion_search(
+            graph_id,
+            VEC_COLLECTION,
+            vec![1.0, 0.0, 0.0, 0.0], // == main's embedding → top vector seed
+            1,
+            vec!["CALLS".to_string()],
+            1,
+            10,
+            1.0,
+            1.0,
+            false,
+            "nodes",
+            Some("machine learning".to_string()), // text_query → document modality ON
+            None,
+            None,
+        )
+        .expect("embedded fusion_search with document modality");
+
+    let oids: HashSet<String> = items.iter().map(|i| i.oid.clone()).collect();
+    // The document-ONLY oid proves the document source contributed.
+    assert!(
+        oids.contains(&doc_solo),
+        "document-only oid must surface when text_query is set: {oids:?}"
+    );
+    // The co-indexed document merged with the vector seed by shared oid (source_count >= 2).
+    let main = items
+        .iter()
+        .find(|i| i.oid == main_oid)
+        .expect("main oid fused");
+    assert!(
+        main.source_count >= 2,
+        "vector + document merge on the shared oid: {main:?}"
     );
 }
 


### PR DESCRIPTION
## What

Closes the **deferred half of #508**: the document modality now ships on **every** transport, not just REST. The seam is now the complete hybrid (**vector + graph + document**) surface on REST, gRPC, and embedded — the prerequisite for retiring the legacy 12-strategy `HybridFusionEngine` (TD-138).

#508 wired `DocumentExpander` into the shared `FusionService` over REST only; gRPC + embedded were left fail-closed (empty index map, `document: None`). This PR is pure plumbing — surface the fields on gRPC + embedded and wire the live index map into the gRPC service.

## Change

- **Proto** (`proto/proximadb/v2/fusion.proto`): add `optional` `text_query` (13), `document_collection` (14), `document_weight` (15) to `FusionSearchRequest`. Regenerate the prost stub (`crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs`, +12 — only the 3 fields). No Python stub regen (the proto-drift gate flags new services/RPCs, not new fields on an existing message).
- **gRPC** (`src/network/grpc/v2/fusion_service.rs`, `src/network/multi_server.rs`): `ProximaFusionServiceImpl::new` takes the shared `HybridFullTextIndexMap`; `canonical_fusion_grpc_service` passes `services.fulltext_indexes` (was fail-closed empty); the `FusionSearch` RPC maps the request fields → `DocumentFusionSpec` (same guard as REST: non-empty `text_query`).
- **Embedded** (`src/embedded/mod.rs`, `src/embedded/python.rs`): `fusion_search` gains `text_query`/`document_collection`/`document_weight` params threaded through the PyO3 wrapper (defaults `None`). The service already shares the live index map (from #508), so documents contribute once a `text_query` is supplied.
- **Test** (`tests/embedded_code_graph_parity_e2e.rs`): `embedded_fusion_search_document_modality_contributes` — populates the collection's full-text index, calls `fusion_search(text_query=…)`, asserts a document-only `oid` surfaces (vector+graph alone can't produce it) and a co-indexed doc merges with the vector seed by shared `oid` (`source_count ≥ 2`).

## Safety
Backward-compatible: every new field is `optional` (proto3 presence-tracked); absent ⇒ vector+graph only (unchanged). No REST / OpenAPI / SDK change (the REST surface already had this in #508). Entity fusion stays vector+graph (documents don't apply).

## Verification
- 17 seam `fusion_service` tests (incl. tri-modality) + 4 embedded tests (incl. the new document-fusion test) — all pass.
- `proto-compat` clean (stub regenerated, +12 only the 3 fields); `cargo clippy --lib --bins -- -D warnings`; `cargo fmt --check`; panic-policy +0 (no regression); `proximadb-server` builds.

## Out of scope (still deferred)
- Per-record RBAC on document hits (within-tenant refinement; tenant isolation is already structural via the collection-scoped index).
- Retiring the v1 `/api/v1/hybrid/search` legacy 12-strategy engine onto the seam — the TD-138 close-out this parity work unblocks.