### PR TITLE
feat(graph): wire ColdGraphSegmentStore crash-safely — flush hook + gated fail-safe wiring (closes #52)

### DIFF
--- a/crates/foundation/proximadb-records/src/store.rs
+++ b/crates/foundation/proximadb-records/src/store.rs
@@ -206,6 +206,16 @@ pub trait RecordStore: Send + Sync {
             record_oids,
         })
     }
+
+    /// Flush any in-memory write buffer to durable storage. The default is a no-op:
+    /// durable-on-write stores (one object PUT per record) have nothing to flush.
+    /// A **buffered** store (e.g. a segment store that batches records into one
+    /// object) MUST override this so callers can force its buffer durable at a
+    /// checkpoint / graceful-shutdown boundary — otherwise an unflushed buffer is
+    /// lost on crash. Called from the graph checkpoint/shutdown path (`flush_wal`).
+    async fn flush(&self) -> RecordStoreResult<()> {
+        Ok(())
+    }
 }
 
 /// Optional scan contract for stores that can expose canonical record ranges.

--- a/src/graph/cold_segment_store.rs
+++ b/src/graph/cold_segment_store.rs
@@ -149,20 +149,38 @@ impl ColdGraphSegmentStore {
             body.extend_from_slice(bytes);
             dir.push((oid.clone(), offset, bytes.len() as u64));
         }
-        let dir_bytes = bincode::serialize(&dir)
-            .map_err(|e| anyhow::anyhow!("cold segment store: encode directory failed: {e}"))?;
+        let dir_bytes = match bincode::serialize(&dir) {
+            Ok(dir_bytes) => dir_bytes,
+            Err(e) => {
+                self.requeue(pending)?;
+                return Err(anyhow::anyhow!(
+                    "cold segment store: encode directory failed: {e}"
+                ));
+            }
+        };
         body.extend_from_slice(&dir_bytes);
         body.extend_from_slice(&(dir_bytes.len() as u64).to_le_bytes());
         body.extend_from_slice(SEG_MAGIC);
 
-        self.store
+        // The records were `mem::take`-n out of the buffer by the caller BEFORE this
+        // PUT; if the PUT fails, re-queue them so a later flush retries rather than
+        // dropping them — a transient object-store error must not silently lose
+        // buffered writes (the engine is authoritative and recovery re-population is
+        // the backstop, but a blip shouldn't require a full recovery cycle).
+        if let Err(e) = self
+            .store
             .put_with_tier(
                 &ObjectPath::from(seg_path.clone()),
                 Bytes::from(body),
                 self.tier,
             )
             .await
-            .map_err(|e| anyhow::anyhow!("cold segment store: put `{seg_path}` failed: {e}"))?;
+        {
+            self.requeue(pending)?;
+            return Err(anyhow::anyhow!(
+                "cold segment store: put `{seg_path}` failed: {e}"
+            ));
+        }
 
         for (oid, offset, len) in dir {
             self.index.insert(
@@ -174,7 +192,25 @@ impl ColdGraphSegmentStore {
                 },
             );
         }
+        // The segment is now durable. An index-sidecar failure here leaves the
+        // records durable-but-unfindable until recovery re-population rewrites them
+        // (the segment-tail index rebuild that would heal this directly is a tracked
+        // follow-up). Do NOT re-queue — re-flushing would duplicate the durable
+        // segment.
         self.persist_index().await
+    }
+
+    /// Re-insert a failed flush batch at the FRONT of the buffer so a later flush
+    /// retries it. The records left the buffer (`mem::take`) before the segment PUT,
+    /// so on a transient PUT/encode failure this is what prevents silent data loss.
+    fn requeue(&self, mut pending: Vec<(String, Vec<u8>)>) -> RecordStoreResult<()> {
+        let restored: u64 = pending.iter().map(|(_, bytes)| bytes.len() as u64).sum();
+        let mut b = self.lock_buffer()?;
+        // Failed batch first, then any writes that landed since the take (FIFO-ish).
+        pending.append(&mut b.records);
+        b.records = pending;
+        b.bytes += restored;
+        Ok(())
     }
 
     /// Persist the oid→location index as a bincode sidecar (best-effort durable map
@@ -193,7 +229,11 @@ impl ColdGraphSegmentStore {
             .map_err(|e| anyhow::anyhow!("cold segment store: persist index failed: {e}"))
     }
 
-    async fn load_index(&self) -> RecordStoreResult<()> {
+    /// Load the persisted oid→location index sidecar over the current backing.
+    /// `pub(crate)` so a caller that constructs the store with [`Self::new`] over a
+    /// shared backing (e.g. crash-recovery tests / a reopen path) can rehydrate it,
+    /// mirroring what [`Self::from_storage_root`] does internally.
+    pub(crate) async fn load_index(&self) -> RecordStoreResult<()> {
         match self.store.get(&ObjectPath::from(INDEX_KEY)).await {
             Ok(bytes) => {
                 let snapshot: Vec<(String, RecordLoc)> = bincode::deserialize(&bytes)
@@ -274,6 +314,14 @@ impl RecordStore for ColdGraphSegmentStore {
         };
         self.write_segment(pending).await?;
         Ok(record)
+    }
+
+    /// Force the in-memory buffer durable (segment + index sidecar). Overrides the
+    /// `RecordStore` default no-op so the graph checkpoint / graceful-shutdown path
+    /// (`flush_wal`) can flush this buffered store. Delegates to the inherent
+    /// [`Self::flush`].
+    async fn flush(&self) -> RecordStoreResult<()> {
+        ColdGraphSegmentStore::flush(self).await
     }
 
     async fn get_record(&self, key: &RecordKey) -> RecordStoreResult<Option<ProximaRecord>> {
@@ -508,6 +556,61 @@ mod tests {
         assert_eq!(got.oid, "graph/g/node/a");
         // Sequence resumed past the loaded segment.
         assert_eq!(s2.seq.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn flush_via_record_store_trait_makes_buffer_durable_across_reopen() {
+        // The checkpoint/shutdown path flushes through the `RecordStore` trait
+        // object, so the trait override (not just the inherent method) must dispatch
+        // to the real flush. High thresholds keep writes buffered until we flush.
+        let backing = ProximaObjectStore::from_url("memory://").expect("mem");
+        let s1 = ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool)
+            .with_flush_thresholds(u64::MAX, usize::MAX);
+        for id in ["a", "b", "c"] {
+            s1.upsert_record(record(&format!("graph/g/node/{id}")))
+                .await
+                .expect("upsert");
+        }
+        assert!(s1.index.is_empty(), "buffered, nothing flushed yet");
+
+        // Flush THROUGH the trait object — proves `RecordStore::flush` dispatches.
+        let dyn_store: &dyn RecordStore = &s1;
+        dyn_store.flush().await.expect("trait flush");
+
+        // Reopen over the same backing: every record is durable + index-findable.
+        let s2 = ColdGraphSegmentStore::new(backing, ObjectAccessTier::Cool);
+        s2.load_index().await.expect("load index");
+        for id in ["a", "b", "c"] {
+            let oid = format!("graph/g/node/{id}");
+            assert!(
+                s2.get_record(&RecordKey::new(oid))
+                    .await
+                    .expect("get")
+                    .is_some(),
+                "record durable after trait flush + reopen"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn requeue_restores_failed_batch_to_buffer() {
+        // The buffer is `mem::take`-n before the segment PUT; `requeue` must put a
+        // failed batch back so a later flush retries instead of dropping it.
+        let store = mem_store().with_flush_thresholds(u64::MAX, usize::MAX);
+        store
+            .upsert_record(record("graph/g/node/a"))
+            .await
+            .expect("upsert");
+        let pending = {
+            let mut b = store.lock_buffer().expect("lock");
+            b.bytes = 0;
+            std::mem::take(&mut b.records)
+        };
+        assert_eq!(pending.len(), 1);
+        store.requeue(pending).expect("requeue");
+        // The record is back in the buffer and a real flush now persists it.
+        store.flush().await.expect("flush");
+        assert!(store.index.contains_key("graph/g/node/a"));
     }
 
     #[tokio::test]

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -1379,6 +1379,24 @@ impl GraphOperationsService {
                 }
             }
         }
+
+        // Flush the canonical/cold record store's write buffer to durable storage.
+        // This is an INDEPENDENT durability action — the cold store is a projection,
+        // not part of the engine-WAL snapshot/truncate ordering above — so it runs
+        // UNCONDITIONALLY (not gated on `scoped`): a buffered store (e.g.
+        // `ColdGraphSegmentStore`) must be flushed at every checkpoint AND graceful
+        // shutdown (`database.rs` calls `flush_wal` per graph on stop), in both the
+        // scoped and non-scoped configs, or its buffer is lost on crash/stop. A
+        // durable-on-write store overrides this to a no-op. NOTE: `canonical_record_store`
+        // is one store shared across graphs (oids embed `graph_id`), so this per-graph
+        // flush drains the global buffer — redundant across graphs but correct; if the
+        // store is ever made per-graph this flush becomes load-bearing.
+        if let Some(store) = &self.canonical_record_store {
+            store
+                .flush()
+                .await
+                .map_err(|e| ProximaDBError::Internal(format!("canonical store flush: {e}")))?;
+        }
         Ok(())
     }
 

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -125,6 +125,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// still servable. When unset, the engine's all-RAM path is used unchanged.
 const COLD_PAYLOADS_ENV: &str = "PROXIMADB_GRAPH_COLD_PAYLOADS";
 
+/// When the cold-payload tier is on (`COLD_PAYLOADS_ENV`), back it with the
+/// **segment** store (`ColdGraphSegmentStore`, batches records into shared object
+/// segments — far fewer PUTs) instead of the per-record `ColdGraphRecordStore`. The
+/// segment store BUFFERS in RAM, so it is only crash-safe with the recovery
+/// re-population backstop ([`crate::storage::persistence::write_ahead_log::wal_operations::canonical_recovery_repopulate_enabled`])
+/// and the checkpoint/shutdown flush hook; the wiring (`shared_services`) refuses to
+/// use it without that backstop. Default-OFF (#52).
+const SEGMENT_STORE_ENV: &str = "PROXIMADB_GRAPH_SEGMENT_STORE";
+
 /// Per-tenant byte budget for the cold graph-payload caches (TD-168). Coarse
 /// default; criticality-aware sizing is deferred to TD-171.
 const GRAPH_PAYLOAD_CACHE_BYTES: u64 = 128 * 1024 * 1024;
@@ -156,6 +165,14 @@ impl GraphPayloadCaches {
 /// the same switch (TD-168 Phase 1b).
 pub(crate) fn cold_payloads_enabled() -> bool {
     std::env::var(COLD_PAYLOADS_ENV)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// True when the cold-payload tier should use the batched segment store
+/// (`SEGMENT_STORE_ENV`) rather than the per-record store. See [`SEGMENT_STORE_ENV`].
+pub(crate) fn segment_store_enabled() -> bool {
+    std::env::var(SEGMENT_STORE_ENV)
         .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
         .unwrap_or(false)
 }
@@ -927,6 +944,12 @@ impl GraphOperationsService {
         let Some(engine) = self.graphs.get(graph_id).map(|e| e.value().clone()) else {
             return Ok(0);
         };
+        // PRECONDITION (#52 Phase 1): rebuilding the cold store from the engine assumes
+        // the engine is FULL-RESIDENT — `get_all_nodes`/`get_all_edges` must return the
+        // complete graph. This holds while ORION keeps all payload in RAM and snapshots
+        // it. True payload-offload cold-tiering (engine evicts payload to the cold store
+        // as the sole home) breaks this assumption: the cold store would then have to be
+        // a durable authority (flush + segment-tail index rebuild), not a projection.
         let nodes = engine.get_all_nodes()?;
         let edges = engine.get_all_edges()?;
         let mut records = Vec::with_capacity(nodes.len() + edges.len());

--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -1309,4 +1309,79 @@ mod tests {
             "CSR should have both outgoing neighbours for node a"
         );
     }
+
+    /// #52 / TD-066 Part 2: `flush_wal` (the checkpoint AND graceful-shutdown path)
+    /// must flush a BUFFERED canonical store unconditionally — in BOTH the scoped and
+    /// non-scoped engine-WAL configs. This is the regression guard for the flush
+    /// placement: if it were buried inside the `if scoped` block, the non-scoped run
+    /// would silently leave the buffer unflushed (lost on crash/stop). Verified by
+    /// reopening a fresh store over the same object backing and finding the record.
+    #[tokio::test]
+    async fn flush_wal_flushes_buffered_cold_store_in_both_gate_states() {
+        use crate::graph::ColdGraphSegmentStore;
+        use proximadb_object_store::ProximaObjectStore;
+        use proximadb_storage_filesystem_types::ObjectAccessTier;
+
+        for scoped in [None, Some("1")] {
+            match scoped {
+                Some(v) => unsafe {
+                    std::env::set_var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE", v)
+                },
+                None => unsafe { std::env::remove_var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE") },
+            }
+
+            let backing = ProximaObjectStore::from_url("memory://").expect("mem store");
+            // High thresholds ⇒ the write stays buffered until flush_wal flushes it.
+            let cold = ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool)
+                .with_flush_thresholds(u64::MAX, usize::MAX);
+            let graph_id = format!("flush_wal_cold_{}_{scoped:?}", std::process::id());
+            let graph_id = graph_id.as_str();
+            let service = GraphOperationsService::new().with_canonical_record_store(Arc::new(cold));
+
+            service
+                .create_graph_collection(CreateGraphRequest {
+                    graph_id: graph_id.to_string(),
+                    name: None,
+                    description: None,
+                    schema: None,
+                    storage_config: None,
+                    engine_config: None,
+                    access_control: None,
+                })
+                .await
+                .expect("create graph");
+            service
+                .create_node(
+                    graph_id,
+                    Node {
+                        id: "n1".to_string(),
+                        labels: vec!["Person".to_string()],
+                        properties: HashMap::new(),
+                        embedding: None,
+                        created_at_ms: 1,
+                        updated_at_ms: 1,
+                    },
+                )
+                .await
+                .expect("create node");
+
+            // The checkpoint/shutdown path must flush the cold buffer regardless of
+            // the scoped gate.
+            service.flush_wal(graph_id).await.expect("flush_wal");
+
+            // Reopen over the same backing: the buffered node is now durable.
+            let reopened = ColdGraphSegmentStore::new(backing, ObjectAccessTier::Cool);
+            reopened.load_index().await.expect("load index");
+            assert!(
+                reopened
+                    .get_record(&RecordKey::new(format!("graph/{graph_id}/node/n1")))
+                    .await
+                    .expect("get")
+                    .is_some(),
+                "flush_wal flushed the cold buffer (scoped={scoped:?})"
+            );
+
+            unsafe { std::env::remove_var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE") };
+        }
+    }
 }

--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -1384,4 +1384,115 @@ mod tests {
             unsafe { std::env::remove_var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE") };
         }
     }
+
+    /// #52 end-to-end: a graph backed by the BUFFERED `ColdGraphSegmentStore` that
+    /// crashes before the buffer flushes loses the cold copy — but recovery
+    /// re-population rebuilds it from the (full-resident) engine, and a flush makes it
+    /// durable again. This is the safety property that lets the segment store be wired.
+    #[tokio::test]
+    async fn segment_store_crash_without_flush_recovers_via_repopulate() {
+        use crate::graph::ColdGraphSegmentStore;
+        use proximadb_object_store::ProximaObjectStore;
+        use proximadb_storage_filesystem_types::ObjectAccessTier;
+
+        let backing = ProximaObjectStore::from_url("memory://").expect("mem store");
+        // High thresholds ⇒ writes stay buffered (the pre-flush crash window).
+        let cold = Arc::new(
+            ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool)
+                .with_flush_thresholds(u64::MAX, usize::MAX),
+        );
+        let graph_id = format!("seg_crash_recover_{}", std::process::id());
+        let graph_id = graph_id.as_str();
+        let service = GraphOperationsService::new().with_canonical_record_store(cold.clone());
+
+        service
+            .create_graph_collection(CreateGraphRequest {
+                graph_id: graph_id.to_string(),
+                name: None,
+                description: None,
+                schema: None,
+                storage_config: None,
+                engine_config: None,
+                access_control: None,
+            })
+            .await
+            .expect("create graph");
+        for node_id in ["n1", "n2", "n3"] {
+            service
+                .create_node(
+                    graph_id,
+                    Node {
+                        id: node_id.to_string(),
+                        labels: vec!["Person".to_string()],
+                        properties: HashMap::new(),
+                        embedding: None,
+                        created_at_ms: 1,
+                        updated_at_ms: 1,
+                    },
+                )
+                .await
+                .expect("create node");
+        }
+        service
+            .create_edge(
+                graph_id,
+                Edge {
+                    id: "e1".to_string(),
+                    from_node_id: "n1".to_string(),
+                    to_node_id: "n2".to_string(),
+                    edge_type: "KNOWS".to_string(),
+                    properties: HashMap::new(),
+                    weight: None,
+                    created_at_ms: 1,
+                    updated_at_ms: 1,
+                },
+            )
+            .await
+            .expect("create edge");
+
+        // CRASH: the buffer was never flushed. A fresh store over the same backing
+        // has an empty buffer and `load_index` finds nothing — the records are lost.
+        let crashed = ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool);
+        crashed.load_index().await.expect("load index");
+        assert!(
+            crashed
+                .get_record(&RecordKey::new(format!("graph/{graph_id}/node/n1")))
+                .await
+                .expect("get")
+                .is_none(),
+            "buffered records are lost on crash without flush"
+        );
+
+        // RECOVERY: re-drive the recovered engine state back into the cold store, then
+        // flush to make it durable (in production: `recover_graph` repopulates,
+        // `flush_wal` flushes).
+        let driven = service
+            .repopulate_canonical_store(graph_id)
+            .await
+            .expect("repopulate");
+        assert_eq!(driven, 4, "3 nodes + 1 edge re-driven");
+        cold.flush().await.expect("flush");
+
+        // A fresh reopen now finds every node + edge durably.
+        let recovered = ColdGraphSegmentStore::new(backing, ObjectAccessTier::Cool);
+        recovered.load_index().await.expect("load index");
+        for node_id in ["n1", "n2", "n3"] {
+            assert!(
+                recovered
+                    .get_record(&RecordKey::new(format!("graph/{graph_id}/node/{node_id}")))
+                    .await
+                    .expect("get")
+                    .is_some(),
+                "node {node_id} durable after recovery + flush"
+            );
+        }
+        assert!(
+            recovered
+                .get_record(&RecordKey::new(format!("graph/{graph_id}/edge/e1")))
+                .await
+                .expect("get")
+                .is_some(),
+            "edge durable after recovery + flush"
+        );
+    }
 }

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1502,21 +1502,68 @@ impl SharedServices {
         // Default-OFF: with the gate unset nothing is constructed, the canonical
         // record store stays None, and the all-RAM path is unchanged.
         if crate::graph::service::cold_payloads_enabled() {
-            match crate::graph::ColdGraphRecordStore::from_storage_root(
-                &graph_storage_url,
-                proximadb_storage_filesystem_types::ObjectAccessTier::Cool,
-            ) {
-                Ok(cold_store) => {
-                    graph_service_inst =
-                        graph_service_inst.with_canonical_record_store(Arc::new(cold_store));
-                    info!(
-                        "✅ SharedServices: graph cold-payload tier ON — canonical node/edge payloads → Cool object storage ({graph_storage_url})"
-                    );
+            let tier = proximadb_storage_filesystem_types::ObjectAccessTier::Cool;
+            // #52: optionally back the cold tier with the BATCHED segment store
+            // (`ColdGraphSegmentStore`) instead of the per-record store — far fewer
+            // object PUTs. It BUFFERS in RAM, so it is crash-safe only with the
+            // recovery re-population backstop (PR #520, gated separately and
+            // default-OFF) plus the checkpoint/shutdown flush hook. If that backstop
+            // is OFF we REFUSE to wire it and fall back to the durable-on-write
+            // `ColdGraphRecordStore` — fail-safe, never an unprotected buffered store.
+            //
+            // Phase-1 precondition: recovery re-population rebuilds the cold store via
+            // `engine.get_all_nodes()/get_all_edges()`, valid only while the ORION
+            // engine is FULL-RESIDENT and snapshots full payloads. True payload-offload
+            // cold-tiering (engine evicts payload) is a later phase that needs the
+            // segment store to be a durable authority (segment-tail index rebuild), not
+            // a projection.
+            let mut use_segment_store = crate::graph::service::segment_store_enabled();
+            if use_segment_store
+                && !crate::storage::persistence::write_ahead_log::wal_operations::canonical_recovery_repopulate_enabled()
+            {
+                warn!(
+                    "SharedServices: PROXIMADB_GRAPH_SEGMENT_STORE is set but PROXIMADB_GRAPH_CANONICAL_RECOVERY is OFF — the buffered segment store has no crash-recovery backstop; refusing to wire it and falling back to the durable-on-write ColdGraphRecordStore. Set PROXIMADB_GRAPH_CANONICAL_RECOVERY=1 to enable the segment store."
+                );
+                use_segment_store = false;
+            }
+
+            if use_segment_store {
+                match crate::graph::ColdGraphSegmentStore::from_storage_root(
+                    &graph_storage_url,
+                    tier,
+                )
+                .await
+                {
+                    Ok(seg_store) => {
+                        graph_service_inst =
+                            graph_service_inst.with_canonical_record_store(Arc::new(seg_store));
+                        info!(
+                            "✅ SharedServices: graph cold-payload tier ON (SEGMENT store) — canonical node/edge payloads batched → Cool object storage ({graph_storage_url}); crash-recovery backstop enabled"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "SharedServices: segment store requested (PROXIMADB_GRAPH_SEGMENT_STORE) but init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
+                        );
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        "SharedServices: graph cold-payload tier requested (PROXIMADB_GRAPH_COLD_PAYLOADS) but cold store init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
-                    );
+            } else {
+                match crate::graph::ColdGraphRecordStore::from_storage_root(
+                    &graph_storage_url,
+                    tier,
+                ) {
+                    Ok(cold_store) => {
+                        graph_service_inst =
+                            graph_service_inst.with_canonical_record_store(Arc::new(cold_store));
+                        info!(
+                            "✅ SharedServices: graph cold-payload tier ON — canonical node/edge payloads → Cool object storage ({graph_storage_url})"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "SharedServices: graph cold-payload tier requested (PROXIMADB_GRAPH_COLD_PAYLOADS) but cold store init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What

Wires the buffered `ColdGraphSegmentStore` into production **crash-safely**, closing #52. Two cohesive slices landed on this branch (slice 2 #539 stacked onto slice 1):

### Slice 1 — durability hook
- `RecordStore::flush` default-no-op (trait already uses default methods → zero churn for ~29 impls); `ColdGraphSegmentStore` overrides it.
- `flush_wal` flushes the canonical store **unconditionally at the end** (not inside `if scoped`) — covers checkpoint **and** graceful shutdown (`database.rs`), scoped and non-scoped. The cold store is an independent projection with no ordering dependency on the engine-WAL snapshot/truncate.
- Fix a pre-existing record-drop: `flush`/threshold path `mem::take` the buffer then `write_segment`; on a PUT/encode failure the batch was dropped — new `requeue` re-buffers it so a later flush retries.

### Slice 2 — gated, fail-safe wiring
- Gate `PROXIMADB_GRAPH_SEGMENT_STORE` (default-OFF) in `shared_services` swaps `ColdGraphRecordStore` → `ColdGraphSegmentStore` when the cold tier is on.
- **Fail-safe coupling**: if the segment-store gate is set but `PROXIMADB_GRAPH_CANONICAL_RECOVERY` (the crash-recovery backstop, PR #520) is OFF, it **refuses** to wire the buffered store and falls back to the durable-on-write `ColdGraphRecordStore` with a warning — never an unprotected buffered store.
- **Phase-1 precondition** documented: recovery re-population rebuilds the cold store from a **full-resident** engine; payload-offload cold-tiering is a later phase needing the segment store to be a durable authority (segment-tail index rebuild).

## Why

The segment store batches records into shared object segments (far fewer PUTs than per-record) but buffers in RAM. Without these changes an unflushed buffer is lost on crash/shutdown. Now: flush at checkpoint/shutdown + recovery re-population backstop + fail-safe gating.

## Tests (all green; CI-exact clippy clean)

- `flush_via_record_store_trait_makes_buffer_durable_across_reopen` (trait dispatch + durability)
- `flush_wal_flushes_buffered_cold_store_in_both_gate_states` (regression guard for the unconditional flush placement)
- `requeue_restores_failed_batch_to_buffer`
- `segment_store_crash_without_flush_recovers_via_repopulate` (end-to-end crash → recover)

## Out of scope (tracked follow-ups)

Segment-tail index rebuild in `load_index` (durable-but-unfindable window), incremental `persist_index` (write amplification), orphan-segment GC.

Closes #52.