### PR TITLE
feat(graph): wire ColdGraphSegmentStore behind a gate, fail-safe on the recovery backstop (#52 slice 2)

### DIFF
--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -125,6 +125,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// still servable. When unset, the engine's all-RAM path is used unchanged.
 const COLD_PAYLOADS_ENV: &str = "PROXIMADB_GRAPH_COLD_PAYLOADS";
 
+/// When the cold-payload tier is on (`COLD_PAYLOADS_ENV`), back it with the
+/// **segment** store (`ColdGraphSegmentStore`, batches records into shared object
+/// segments — far fewer PUTs) instead of the per-record `ColdGraphRecordStore`. The
+/// segment store BUFFERS in RAM, so it is only crash-safe with the recovery
+/// re-population backstop ([`crate::storage::persistence::write_ahead_log::wal_operations::canonical_recovery_repopulate_enabled`])
+/// and the checkpoint/shutdown flush hook; the wiring (`shared_services`) refuses to
+/// use it without that backstop. Default-OFF (#52).
+const SEGMENT_STORE_ENV: &str = "PROXIMADB_GRAPH_SEGMENT_STORE";
+
 /// Per-tenant byte budget for the cold graph-payload caches (TD-168). Coarse
 /// default; criticality-aware sizing is deferred to TD-171.
 const GRAPH_PAYLOAD_CACHE_BYTES: u64 = 128 * 1024 * 1024;
@@ -156,6 +165,14 @@ impl GraphPayloadCaches {
 /// the same switch (TD-168 Phase 1b).
 pub(crate) fn cold_payloads_enabled() -> bool {
     std::env::var(COLD_PAYLOADS_ENV)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// True when the cold-payload tier should use the batched segment store
+/// (`SEGMENT_STORE_ENV`) rather than the per-record store. See [`SEGMENT_STORE_ENV`].
+pub(crate) fn segment_store_enabled() -> bool {
+    std::env::var(SEGMENT_STORE_ENV)
         .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
         .unwrap_or(false)
 }
@@ -927,6 +944,12 @@ impl GraphOperationsService {
         let Some(engine) = self.graphs.get(graph_id).map(|e| e.value().clone()) else {
             return Ok(0);
         };
+        // PRECONDITION (#52 Phase 1): rebuilding the cold store from the engine assumes
+        // the engine is FULL-RESIDENT — `get_all_nodes`/`get_all_edges` must return the
+        // complete graph. This holds while ORION keeps all payload in RAM and snapshots
+        // it. True payload-offload cold-tiering (engine evicts payload to the cold store
+        // as the sole home) breaks this assumption: the cold store would then have to be
+        // a durable authority (flush + segment-tail index rebuild), not a projection.
         let nodes = engine.get_all_nodes()?;
         let edges = engine.get_all_edges()?;
         let mut records = Vec::with_capacity(nodes.len() + edges.len());

--- a/src/graph/service_edge_ops.rs
+++ b/src/graph/service_edge_ops.rs
@@ -1384,4 +1384,115 @@ mod tests {
             unsafe { std::env::remove_var("PROXIMADB_GRAPH_CANONICAL_REPLAY_SCOPE") };
         }
     }
+
+    /// #52 end-to-end: a graph backed by the BUFFERED `ColdGraphSegmentStore` that
+    /// crashes before the buffer flushes loses the cold copy — but recovery
+    /// re-population rebuilds it from the (full-resident) engine, and a flush makes it
+    /// durable again. This is the safety property that lets the segment store be wired.
+    #[tokio::test]
+    async fn segment_store_crash_without_flush_recovers_via_repopulate() {
+        use crate::graph::ColdGraphSegmentStore;
+        use proximadb_object_store::ProximaObjectStore;
+        use proximadb_storage_filesystem_types::ObjectAccessTier;
+
+        let backing = ProximaObjectStore::from_url("memory://").expect("mem store");
+        // High thresholds ⇒ writes stay buffered (the pre-flush crash window).
+        let cold = Arc::new(
+            ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool)
+                .with_flush_thresholds(u64::MAX, usize::MAX),
+        );
+        let graph_id = format!("seg_crash_recover_{}", std::process::id());
+        let graph_id = graph_id.as_str();
+        let service = GraphOperationsService::new().with_canonical_record_store(cold.clone());
+
+        service
+            .create_graph_collection(CreateGraphRequest {
+                graph_id: graph_id.to_string(),
+                name: None,
+                description: None,
+                schema: None,
+                storage_config: None,
+                engine_config: None,
+                access_control: None,
+            })
+            .await
+            .expect("create graph");
+        for node_id in ["n1", "n2", "n3"] {
+            service
+                .create_node(
+                    graph_id,
+                    Node {
+                        id: node_id.to_string(),
+                        labels: vec!["Person".to_string()],
+                        properties: HashMap::new(),
+                        embedding: None,
+                        created_at_ms: 1,
+                        updated_at_ms: 1,
+                    },
+                )
+                .await
+                .expect("create node");
+        }
+        service
+            .create_edge(
+                graph_id,
+                Edge {
+                    id: "e1".to_string(),
+                    from_node_id: "n1".to_string(),
+                    to_node_id: "n2".to_string(),
+                    edge_type: "KNOWS".to_string(),
+                    properties: HashMap::new(),
+                    weight: None,
+                    created_at_ms: 1,
+                    updated_at_ms: 1,
+                },
+            )
+            .await
+            .expect("create edge");
+
+        // CRASH: the buffer was never flushed. A fresh store over the same backing
+        // has an empty buffer and `load_index` finds nothing — the records are lost.
+        let crashed = ColdGraphSegmentStore::new(backing.clone(), ObjectAccessTier::Cool);
+        crashed.load_index().await.expect("load index");
+        assert!(
+            crashed
+                .get_record(&RecordKey::new(format!("graph/{graph_id}/node/n1")))
+                .await
+                .expect("get")
+                .is_none(),
+            "buffered records are lost on crash without flush"
+        );
+
+        // RECOVERY: re-drive the recovered engine state back into the cold store, then
+        // flush to make it durable (in production: `recover_graph` repopulates,
+        // `flush_wal` flushes).
+        let driven = service
+            .repopulate_canonical_store(graph_id)
+            .await
+            .expect("repopulate");
+        assert_eq!(driven, 4, "3 nodes + 1 edge re-driven");
+        cold.flush().await.expect("flush");
+
+        // A fresh reopen now finds every node + edge durably.
+        let recovered = ColdGraphSegmentStore::new(backing, ObjectAccessTier::Cool);
+        recovered.load_index().await.expect("load index");
+        for node_id in ["n1", "n2", "n3"] {
+            assert!(
+                recovered
+                    .get_record(&RecordKey::new(format!("graph/{graph_id}/node/{node_id}")))
+                    .await
+                    .expect("get")
+                    .is_some(),
+                "node {node_id} durable after recovery + flush"
+            );
+        }
+        assert!(
+            recovered
+                .get_record(&RecordKey::new(format!("graph/{graph_id}/edge/e1")))
+                .await
+                .expect("get")
+                .is_some(),
+            "edge durable after recovery + flush"
+        );
+    }
 }

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1502,21 +1502,68 @@ impl SharedServices {
         // Default-OFF: with the gate unset nothing is constructed, the canonical
         // record store stays None, and the all-RAM path is unchanged.
         if crate::graph::service::cold_payloads_enabled() {
-            match crate::graph::ColdGraphRecordStore::from_storage_root(
-                &graph_storage_url,
-                proximadb_storage_filesystem_types::ObjectAccessTier::Cool,
-            ) {
-                Ok(cold_store) => {
-                    graph_service_inst =
-                        graph_service_inst.with_canonical_record_store(Arc::new(cold_store));
-                    info!(
-                        "✅ SharedServices: graph cold-payload tier ON — canonical node/edge payloads → Cool object storage ({graph_storage_url})"
-                    );
+            let tier = proximadb_storage_filesystem_types::ObjectAccessTier::Cool;
+            // #52: optionally back the cold tier with the BATCHED segment store
+            // (`ColdGraphSegmentStore`) instead of the per-record store — far fewer
+            // object PUTs. It BUFFERS in RAM, so it is crash-safe only with the
+            // recovery re-population backstop (PR #520, gated separately and
+            // default-OFF) plus the checkpoint/shutdown flush hook. If that backstop
+            // is OFF we REFUSE to wire it and fall back to the durable-on-write
+            // `ColdGraphRecordStore` — fail-safe, never an unprotected buffered store.
+            //
+            // Phase-1 precondition: recovery re-population rebuilds the cold store via
+            // `engine.get_all_nodes()/get_all_edges()`, valid only while the ORION
+            // engine is FULL-RESIDENT and snapshots full payloads. True payload-offload
+            // cold-tiering (engine evicts payload) is a later phase that needs the
+            // segment store to be a durable authority (segment-tail index rebuild), not
+            // a projection.
+            let mut use_segment_store = crate::graph::service::segment_store_enabled();
+            if use_segment_store
+                && !crate::storage::persistence::write_ahead_log::wal_operations::canonical_recovery_repopulate_enabled()
+            {
+                warn!(
+                    "SharedServices: PROXIMADB_GRAPH_SEGMENT_STORE is set but PROXIMADB_GRAPH_CANONICAL_RECOVERY is OFF — the buffered segment store has no crash-recovery backstop; refusing to wire it and falling back to the durable-on-write ColdGraphRecordStore. Set PROXIMADB_GRAPH_CANONICAL_RECOVERY=1 to enable the segment store."
+                );
+                use_segment_store = false;
+            }
+
+            if use_segment_store {
+                match crate::graph::ColdGraphSegmentStore::from_storage_root(
+                    &graph_storage_url,
+                    tier,
+                )
+                .await
+                {
+                    Ok(seg_store) => {
+                        graph_service_inst =
+                            graph_service_inst.with_canonical_record_store(Arc::new(seg_store));
+                        info!(
+                            "✅ SharedServices: graph cold-payload tier ON (SEGMENT store) — canonical node/edge payloads batched → Cool object storage ({graph_storage_url}); crash-recovery backstop enabled"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "SharedServices: segment store requested (PROXIMADB_GRAPH_SEGMENT_STORE) but init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
+                        );
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        "SharedServices: graph cold-payload tier requested (PROXIMADB_GRAPH_COLD_PAYLOADS) but cold store init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
-                    );
+            } else {
+                match crate::graph::ColdGraphRecordStore::from_storage_root(
+                    &graph_storage_url,
+                    tier,
+                ) {
+                    Ok(cold_store) => {
+                        graph_service_inst =
+                            graph_service_inst.with_canonical_record_store(Arc::new(cold_store));
+                        info!(
+                            "✅ SharedServices: graph cold-payload tier ON — canonical node/edge payloads → Cool object storage ({graph_storage_url})"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "SharedServices: graph cold-payload tier requested (PROXIMADB_GRAPH_COLD_PAYLOADS) but cold store init failed for `{graph_storage_url}`: {e}; falling back to the all-RAM path"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What

Wire the batched `ColdGraphSegmentStore` into production behind a gate. **Slice 2 — closes the wiring half of #52.** Stacked on #537 (slice 1: the flush hook).

When the cold-payload tier is on (`PROXIMADB_GRAPH_COLD_PAYLOADS`), an additional gate `PROXIMADB_GRAPH_SEGMENT_STORE` (default-OFF) backs it with the **segment** store (records batched into shared object segments — far fewer PUTs) instead of the per-record `ColdGraphRecordStore`.

## Fail-safe coupling

The segment store buffers in RAM, so it is crash-safe only with the recovery re-population backstop (PR #520) + the checkpoint/shutdown flush hook (#537). The two gates are independent, so the wiring is **fail-safe**: if `PROXIMADB_GRAPH_SEGMENT_STORE` is set but `PROXIMADB_GRAPH_CANONICAL_RECOVERY` is OFF, it **refuses** to wire the buffered store and falls back to the durable-on-write `ColdGraphRecordStore` with a clear warning — never an unprotected buffered store.

## Changes

- `segment_store_enabled()` + `SEGMENT_STORE_ENV` in `graph::service` (mirrors `cold_payloads_enabled`).
- `shared_services` constructs `ColdGraphSegmentStore::from_storage_root(..).await` when the gate is on AND the backstop is on; else the existing `ColdGraphRecordStore` path (unchanged).
- **Phase-1 precondition** documented on `repopulate_canonical_store` + at the wiring site: re-population rebuilds the cold store via `engine.get_all_nodes/get_all_edges`, valid only while the ORION engine is **full-resident**. Payload-offload cold-tiering is a later phase that needs the segment store to be a durable authority (segment-tail index rebuild), not a projection.

## Test

`segment_store_crash_without_flush_recovers_via_repopulate`: a graph backed by a buffered segment store crashes pre-flush (records lost from the cold store), then recovery re-population + flush rebuilds them durably. All 11 cold-segment + recovery tests green; CI-exact clippy clean.

## Closes #52

With #537 (flush hook) + this, the buffered segment store is crash-safe (flush at checkpoint/shutdown) and recovery-backstopped, wired fail-safe behind a default-OFF gate.