### PR TITLE
fix(dml): TD-110 S1 intra-pod op-lock for ON DELETE critical sections (+ worktree WIP mandate)

### DIFF
--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -94,6 +94,21 @@ new feat/x  ──▶  edit · commit · push · open PR  ──▶  PR merges  
 3. Commit only files you created/changed (the worktree makes this natural; if
    ever in a shared tree, fall back to `git commit -o <file>`).
 4. Clean up (`rm`) once your PR merges.
+5. **Commit WIP to your branch early and often — never carry valuable
+   uncommitted work in a worktree.** A worktree is disposable: `clean`,
+   `rm --force`, a concurrent session, or a merge/cleanup pass can remove or
+   reset it at any time, and **uncommitted edits are lost with the directory**.
+   Committed work survives in the branch ref (recoverable even if the worktree
+   is deleted). Commit each coherent increment (it's fine to amend/rebase
+   later); treat "still in the editor, not yet committed" as fragile.
+6. **Re-verify state before resuming or acting.** After any gap — and before
+   any destructive or push step — confirm the worktree still exists
+   (`scripts/worktree.sh list`) and the branch hasn't advanced under you
+   (`git log --oneline -3`; unexpected commits you didn't author mean a
+   concurrent session is on the same task — stop and reconcile, don't blindly
+   re-edit on top). A worktree whose directory vanishes mid-session is the
+   signal that another session merged/cleaned the branch; your uncommitted WIP
+   is gone — recover from your last commit, not from memory of the edits.
 
 ## Runtime isolation (beyond git)
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -112,7 +112,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use tokio::sync::RwLock;
+use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
 use tracing::info;
 
 pub use self::partition_pruning::{
@@ -125,6 +126,92 @@ pub use proximadb_catalog::*;
 // (which is also pulled in via `pub use proximadb_catalog::*`).
 pub use self::traits::{Catalog, CatalogHealth};
 
+/// TD-110 S1: per-table, non-reentrant, in-process DML operation lock registry.
+///
+/// The durable DML lock (`crate::cluster::partition_lease::DmlLockService`)
+/// serializes DML *across pods* but is deliberately re-entrant within a pod: a
+/// pod re-acquiring its own table lease *renews* it, and the in-memory check
+/// skips same-pod/same-scope as compatible. Embedded and single-pod deployments
+/// therefore need a separate, *non-reentrant* in-process lock to serialize
+/// concurrent connections that touch the same table during a referential-action
+/// critical section (ON DELETE CASCADE/RESTRICT child scan → child mutation →
+/// parent tombstone). Without it, a child row inserted by connection B while
+/// connection A's parent DELETE is mid-flight can be orphaned (B's row survives
+/// referencing a now-deleted parent).
+///
+/// Each `(namespace, table)` key maps to a binary semaphore (1 permit);
+/// `acquire_owned` yields an owned permit held across the critical section and
+/// released on drop. Multi-table critical sections (a cascading DELETE) acquire
+/// the whole set in a deterministic `(namespace, name)` order to avoid
+/// self-deadlock — single-table acquirers (INSERT/UPDATE) cannot form a cycle
+/// with a sorted multi-table acquirer.
+#[derive(Default)]
+pub struct TableOpLockRegistry {
+    locks: Mutex<HashMap<TableIdentifier, Arc<Semaphore>>>,
+}
+
+impl TableOpLockRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Resolve (lazily creating) the binary semaphore for a table.
+    fn semaphore_for(&self, table_id: &TableIdentifier) -> Arc<Semaphore> {
+        // Sync lock held only for the map get/insert — never across an await.
+        let mut locks = self.locks.lock();
+        locks
+            .entry(table_id.clone())
+            .or_insert_with(|| Arc::new(Semaphore::new(1)))
+            .clone()
+    }
+
+    /// Acquire the (non-reentrant) operation lock for one table, blocking until
+    /// free. The returned permit is released on drop.
+    pub async fn acquire(&self, table_id: &TableIdentifier) -> Result<OwnedSemaphorePermit> {
+        self.semaphore_for(table_id)
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "operation lock for table '{}/{}' was closed unexpectedly",
+                    table_id.namespace.join("."),
+                    table_id.name
+                )
+            })
+    }
+
+    /// Acquire operation locks for a set of tables in deterministic `(namespace,
+    /// name)` order (de-duplicated), blocking until all are held. The returned
+    /// permits are released on drop, so bind them to a guard that outlives the
+    /// critical section.
+    pub async fn acquire_sorted(
+        &self,
+        mut tables: Vec<TableIdentifier>,
+    ) -> Result<Vec<OwnedSemaphorePermit>> {
+        tables.sort_by(|a, b| {
+            a.namespace
+                .cmp(&b.namespace)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        tables.dedup();
+        let mut permits = Vec::with_capacity(tables.len());
+        for table_id in &tables {
+            permits.push(self.acquire(table_id).await?);
+        }
+        Ok(permits)
+    }
+}
+
+impl std::fmt::Debug for TableOpLockRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableOpLockRegistry")
+            .finish_non_exhaustive()
+    }
+}
+
 /// Catalog manager - manages multiple catalog instances
 pub struct CatalogManager {
     /// Registered catalogs by name
@@ -133,6 +220,10 @@ pub struct CatalogManager {
     default_catalog: RwLock<Option<String>>,
     /// Catalog cache for metadata
     cache: Arc<CatalogCache>,
+    /// TD-110 S1: per-table, non-reentrant in-process DML operation locks used
+    /// to serialize referential-action critical sections within a single pod.
+    /// See [`TableOpLockRegistry`].
+    op_locks: TableOpLockRegistry,
 }
 
 impl CatalogManager {
@@ -142,6 +233,7 @@ impl CatalogManager {
             catalogs: RwLock::new(HashMap::new()),
             default_catalog: RwLock::new(None),
             cache: Arc::new(CatalogCache::new(10000, 300)), // 10K entries, 5min TTL
+            op_locks: TableOpLockRegistry::new(),
         }
     }
 
@@ -151,7 +243,17 @@ impl CatalogManager {
             catalogs: RwLock::new(HashMap::new()),
             default_catalog: RwLock::new(None),
             cache: Arc::new(CatalogCache::new(max_entries, ttl_seconds)),
+            op_locks: TableOpLockRegistry::new(),
         }
+    }
+
+    /// TD-110 S1: per-table, non-reentrant in-process DML operation locks.
+    /// Hosted on `CatalogManager` because it is the single object shared across
+    /// all per-connection `DmlService` instances (pgwire builds a fresh
+    /// `DmlService` per connection), so a registry here is the one place
+    /// concurrent connections actually contend.
+    pub fn op_locks(&self) -> &TableOpLockRegistry {
+        &self.op_locks
     }
 
     /// Register a pre-created catalog

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -2762,6 +2762,11 @@ impl DmlService {
         let dml_lock_guard = self
             .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
             .await?;
+        // TD-110 S1: non-reentrant in-process operation lock for this table,
+        // held for the whole INSERT. Pairs with the same lock a cascading
+        // parent DELETE takes on its child set, so a child INSERT concurrent
+        // with a parent DELETE serializes (blocks) rather than orphaning.
+        let _op_lock = self.catalog_manager.op_locks().acquire(&table_id).await?;
         let (write_intent, write_lane_decision) = Self::route_row_dml_write_intent(
             &table_schema,
             WriteOperationKind::Insert,
@@ -2944,6 +2949,8 @@ impl DmlService {
         let dml_lock_guard = self
             .acquire_table_dml_lock(&table_id, tenant_context, LockIntent::Write)
             .await?;
+        // TD-110 S1: non-reentrant in-process operation lock (see execute_insert).
+        let _op_lock = self.catalog_manager.op_locks().acquire(&table_id).await?;
         let ids_to_update = if let Some(ref wc) = where_clause {
             self.resolve_matching_ids(&table_schema, &table_id.name, wc, tenant_context)
                 .await?
@@ -3106,6 +3113,39 @@ impl DmlService {
         if ids_to_delete.is_empty() {
             return Ok(DmlResult::success(0, "No rows matched WHERE clause"));
         }
+
+        // TD-110 S1: lock the transitive child set for the FULL critical section
+        // (cascade scan → child mutations → parent tombstone) so a concurrent
+        // writer cannot slip a child row in mid-flight and orphan it. Two layers:
+        //   • in-process op-locks (`TableOpLockRegistry`, non-reentrant, blocking):
+        //     serialize concurrent CONNECTIONS on a single (embedded) pod. The
+        //     durable DML lock below is pod-level + re-entrant, so without this an
+        //     intra-pod child INSERT during the parent DELETE could orphan.
+        //   • durable DML write locks (cross-pod, non-blocking): serialize the same
+        //     section across pods; a conflict surfaces as a typed `DmlLockConflict`
+        //     (pgwire 55P03 / gRPC ABORTED) for client retry.
+        // Acquired in deterministic (namespace, name) order (op-locks block, so the
+        // global order avoids self-deadlock). Guards are bound to the end of this
+        // function — released only after the parent tombstone is written.
+        let child_closure = self
+            .discover_cascade_child_set(&catalog, &table_id, &table_schema, tenant_context)
+            .await?;
+        let mut op_lock_tables: Vec<TableIdentifier> = child_closure
+            .iter()
+            .map(|(namespace, name)| TableIdentifier {
+                namespace: namespace.clone(),
+                name: name.clone(),
+            })
+            .collect();
+        op_lock_tables.push(table_id.clone()); // parent is in the critical section too
+        let _cascade_op_locks = self
+            .catalog_manager
+            .op_locks()
+            .acquire_sorted(op_lock_tables)
+            .await?;
+        let _cascade_child_dml_locks = self
+            .acquire_cascade_child_dml_locks(&child_closure, tenant_context)
+            .await?;
 
         // TD-110: apply ON DELETE referential actions (RESTRICT/CASCADE/SET NULL)
         // BEFORE removing the parent rows — RESTRICT may abort the DELETE, and
@@ -4004,8 +4044,13 @@ impl DmlService {
             return Ok(()); // No PK → nothing can reference these rows.
         };
 
-        // Reject a cyclic CASCADE chain up front, before any lock or mutation,
-        // so the error leaves nothing partially deleted.
+        // Reject a cyclic CASCADE chain up front, before any mutation, so the
+        // error leaves nothing partially deleted. The transitive write locks
+        // (in-process op-locks + durable DML locks) for the child set are
+        // acquired by the caller, `execute_delete`, and held across this cascade
+        // AND the subsequent parent-tombstone write — closing the cross-table
+        // TOCTOU for the full critical section (cross-pod via the durable locks,
+        // intra-pod via the non-reentrant op-locks).
         self.assert_no_cascade_cycle(
             parent_catalog,
             parent_table_id,
@@ -4014,22 +4059,39 @@ impl DmlService {
         )
         .await?;
 
-        // Discover the transitive child set (any FK action — RESTRICT scans and
-        // SET-NULL updates also need the lock) and acquire write locks in a
-        // deterministic order before any mutation.
-        let child_set = self
-            .discover_cascade_child_set(
-                parent_catalog,
-                parent_table_id,
-                parent_schema,
-                tenant_context,
-            )
-            .await?;
-        let mut sorted_children: Vec<(Vec<String>, String)> = child_set.into_iter().collect();
-        sorted_children.sort();
-        let mut child_guards: Vec<DmlLockGuard> = Vec::with_capacity(sorted_children.len());
-        for (namespace, name) in &sorted_children {
-            let lock_target = crate::catalog::TableIdentifier {
+        self.enforce_delete_referential_actions_inner(
+            parent_catalog,
+            parent_table_id,
+            parent_schema,
+            deleted_keys,
+            tenant_context,
+            std::collections::HashSet::new(),
+            0,
+        )
+        .await
+    }
+
+    /// TD-110 S1: acquire the cross-pod DML write locks for the transitive child
+    /// set (a `BTreeSet`, so already in deterministic `(namespace, name)` order)
+    /// to close the cross-table TOCTOU across pods. Non-blocking: a conflict
+    /// surfaces as a typed `ProximaDBError::DmlLockConflict` (pgwire 55P03 / gRPC
+    /// ABORTED) for client retry, and already-acquired guards are released first
+    /// so no lock is leaked. Returns an empty vec when no DML lock service is
+    /// configured (embedded/test paths — intra-pod serialization is then provided
+    /// by the in-process op-locks).
+    async fn acquire_cascade_child_dml_locks(
+        &self,
+        child_set: &std::collections::BTreeSet<(Vec<String>, String)>,
+        tenant_context: Option<&TenantContext>,
+    ) -> Result<Vec<DmlLockGuard>> {
+        if self.dml_lock_service.is_none() || child_set.is_empty() {
+            return Ok(Vec::new());
+        }
+        // BTreeSet iterates in sorted (namespace, name) order — acquire in that
+        // order so concurrent DELETEs over overlapping child sets can't deadlock.
+        let mut guards: Vec<DmlLockGuard> = Vec::with_capacity(child_set.len());
+        for (namespace, name) in child_set {
+            let lock_target = TableIdentifier {
                 namespace: namespace.clone(),
                 name: name.clone(),
             };
@@ -4037,36 +4099,17 @@ impl DmlService {
                 .acquire_table_dml_lock(&lock_target, tenant_context, LockIntent::Write)
                 .await
             {
-                Ok(Some(guard)) => child_guards.push(guard),
+                Ok(Some(guard)) => guards.push(guard),
                 Ok(None) => {} // No lock service configured → locking is a no-op.
                 Err(e) => {
-                    // Release whatever we acquired before propagating the
-                    // conflict so we never leak held child locks.
-                    for guard in child_guards {
+                    for guard in guards {
                         guard.release().await;
                     }
                     return Err(e);
                 }
             }
         }
-
-        let outcome = self
-            .enforce_delete_referential_actions_inner(
-                parent_catalog,
-                parent_table_id,
-                parent_schema,
-                deleted_keys,
-                tenant_context,
-                std::collections::HashSet::new(),
-                0,
-            )
-            .await;
-
-        // Always release the child locks, whether the cascade succeeded or not.
-        for guard in child_guards {
-            guard.release().await;
-        }
-        outcome
+        Ok(guards)
     }
 
     /// TD-110: the same-namespace/tenant child tables whose single-column FK

--- a/tests/pgwire_fk_referential_actions_e2e.rs
+++ b/tests/pgwire_fk_referential_actions_e2e.rs
@@ -554,15 +554,82 @@ async fn pgwire_cascade_recurses_and_rejects_cycles_depth_and_concurrency() {
         );
     }
 
-    // NOTE: a child-INSERT-vs-parent-DELETE(RESTRICT) no-orphan concurrency
-    // test is intentionally omitted from this single-server harness. The DML
-    // lock is per-pod and re-entrant within a pod
-    // (`lease.holder_pod != self.self_pod_id`, `src/cluster/partition_lease.rs`),
-    // so it serializes CROSS-POD cluster access only — not the intra-pod async
-    // race a single embedded server exhibits. The transitive write-lock
-    // acquisition added in `enforce_delete_referential_actions` closes that
-    // cross-pod TOCTOU and gives a deterministic lock order (avoids cross-pod
-    // deadlock); an intra-pod no-orphan guarantee needs a separate local
-    // per-table mutex and is out of S1 scope. The recursion / cycle / depth
-    // semantics above are the S1 correctness core.
+    // ── Section 4: concurrency — a child INSERT racing a parent DELETE
+    //    (RESTRICT) can never orphan. The DELETE holds the non-reentrant
+    //    in-process op-lock on the transitive child set for its whole critical
+    //    section (cascade scan → parent tombstone), so the INSERT serializes
+    //    behind it. The durable DML lock alone is pod-level + re-entrant and
+    //    would NOT serialize two connections on this single embedded server;
+    //    the op-lock (`TableOpLockRegistry`, shared via the CatalogManager) is
+    //    what closes the intra-pod cross-table TOCTOU. ──
+    {
+        // A second connection gives true intra-pod concurrency (a single
+        // tokio_postgres client serializes its own statements).
+        let (client_b, connection_b) =
+            tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+                .await
+                .expect("connect client_b");
+        tokio::spawn(async move {
+            if let Err(e) = connection_b.await {
+                eprintln!("pgwire connection_b error: {e}");
+            }
+        });
+
+        const ITERS: usize = 8;
+        for i in 0..ITERS {
+            let parent = format!("cc_par_{suffix}_{i}");
+            let child = format!("cc_chl_{suffix}_{i}");
+            client
+                .simple_query(&format!(
+                    "CREATE TABLE {parent} (id VARCHAR PRIMARY KEY, name VARCHAR)"
+                ))
+                .await
+                .expect("CREATE concurrency parent");
+            client
+                .simple_query(&format!(
+                    "CREATE TABLE {child} (id VARCHAR PRIMARY KEY, pid VARCHAR, \
+                     FOREIGN KEY (pid) REFERENCES {parent}(id))"
+                ))
+                .await
+                .expect("CREATE concurrency child");
+            client
+                .simple_query(&format!(
+                    "INSERT INTO {parent} (id, name) VALUES ('p1', 'root')"
+                ))
+                .await
+                .expect("INSERT concurrency parent");
+            sleep(Duration::from_millis(150)).await; // let p1 become visible
+
+            // Race: A deletes the referenced parent; B inserts a child row
+            // referencing it. Either may win — A wins ⇒ parent deleted, B's
+            // INSERT then fails the FK check; B wins ⇒ child committed, A's
+            // DELETE is RESTRICT-blocked — but the result can never be an orphan
+            // (a child row whose parent was deleted underneath it). Both calls
+            // tolerate an error; the invariant is asserted below.
+            let del_sql = format!("DELETE FROM {parent} WHERE id = 'p1'");
+            let ins_sql = format!("INSERT INTO {child} (id, pid) VALUES ('c1', 'p1')");
+            let a = client.simple_query(&del_sql);
+            let b = client_b.simple_query(&ins_sql);
+            let _ = tokio::join!(a, b);
+
+            let parent_rows = client
+                .simple_query(&format!("SELECT id FROM {parent}"))
+                .await
+                .expect("SELECT concurrency parent");
+            let parent_has_p1 = col_set(&parent_rows, "id").contains("p1");
+            let child_rows = client
+                .simple_query(&format!("SELECT id FROM {child}"))
+                .await
+                .expect("SELECT concurrency child");
+            let child_has_c1 = col_set(&child_rows, "id").contains("c1");
+
+            // No orphan: if the child row committed, its parent must survive.
+            assert!(
+                !child_has_c1 || parent_has_p1,
+                "orphaned child: {child}.c1 references {parent}.p1 which was deleted \
+                 (iteration {i}); the cascade op-lock must serialize the INSERT behind \
+                 the DELETE"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #530 (TD-110 S1 core). **HOLD for human merge.**

## Problem

#530 shipped recursive ON DELETE CASCADE + cycle/depth guards + **cross-pod** transitive DML locking. But the durable DML lock is **pod-level and re-entrant** — a pod re-acquiring its own table lease *renews* it (`partition_lease.rs`), and the in-memory check skips same-pod/same-scope as compatible. So it serializes **cross-pod only**. On a single (embedded) pod two concurrent connections did not contend, leaving the RESTRICT/CASCADE cross-table TOCTOU open: a child `INSERT` during a parent `DELETE` could commit between the restrict-check/cascade-scan and the parent tombstone and **orphan**. #530 explicitly deferred the concurrency test, noting it needed "a separate local per-table mutex."

## Fix

- **`TableOpLockRegistry`** (`src/catalog/mod.rs`): a non-reentrant, in-process, per-table operation-lock registry of binary semaphores, hosted on the **shared `CatalogManager`** (the one object shared across all per-connection `DmlService` instances — pgwire builds a fresh `DmlService` per connection, so a registry there is the only place concurrent connections contend).
- **INSERT/UPDATE** acquire the target table's op-lock for the operation.
- **DELETE** acquires op-locks on the parent + transitive child set (`discover_cascade_child_set`) for the **full critical section** (cascade scan → child mutations → parent tombstone), in deterministic `(namespace, name)` order (single-table acquirers can't deadlock with a sorted multi-table acquirer).
- Refactored the cross-pod child DML lock acquisition **up from `enforce_delete_referential_actions` into `execute_delete`** (new `acquire_cascade_child_dml_locks` helper) so **both** lock layers span the parent-tombstone write — closing the residual window the in-enforce placement left. The cascade worker (`enforce_delete_referential_actions_inner`) and the cycle/depth guards are unchanged.

Net: cross-pod TOCTOU closed by the durable DML locks; **intra-pod** TOCTOU closed by the op-locks.

## Test

Section 4 of `pgwire_fk_referential_actions_e2e.rs`: a second `tokio_postgres` connection races a child `INSERT` against a parent `DELETE (RESTRICT)` over 8 iterations and asserts the **no-orphan** invariant. The pgwire path has no `dml_lock_service`, so this passing proves the op-lock alone serializes. (Note: the pgwire path uses `dml_lock_service = None`, so this is the op-lock under test, not the durable lock.)

## Also

`docs/10-quality/WORKSPACE_ISOLATION.md`: two new agent-mandate rules — (5) commit WIP to the branch early/often (uncommitted edits die with a removed worktree), (6) re-verify worktree/branch state before resuming. Born from losing uncommitted WIP when #530 merged on a branch mid-session and cleanup removed the worktree.

No `.unwrap`/`.expect`/`panic!` in the new paths. `cargo clippy --lib --bins -- -D warnings` + `cargo fmt --check` clean; e2e suite green (2/2).