### PR TITLE
deprecate(v1): mark the legacy hybrid-search surface deprecated (TD-138 phase 1)

### DIFF
--- a/crates/platform/proximadb-api/src/grpc/v1/hybrid.rs
+++ b/crates/platform/proximadb-api/src/grpc/v1/hybrid.rs
@@ -48,6 +48,7 @@ impl HybridSearchServiceImpl {
 
 #[tonic::async_trait]
 impl HybridSearchService for HybridSearchServiceImpl {
+    #[allow(deprecated)] // forwards to the deprecated v1 HybridPort::hybrid_search (TD-138 phase 1)
     async fn hybrid_search(
         &self,
         request: Request<HybridFusionSearchRequest>,

--- a/crates/platform/proximadb-api/src/rest/v1/hybrid.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/hybrid.rs
@@ -153,6 +153,7 @@ pub fn sql_value_to_json(v: &SqlValue) -> serde_json::Value {
 /// `POST /api/v2/hybrid/search` — BM25 + vector hybrid search.
 ///
 /// Delegates to `HybridPort::hybrid_search`.
+#[allow(deprecated)] // delegates to the deprecated v1 HybridPort::hybrid_search (TD-138 phase 1)
 pub async fn hybrid_search(
     State(state): State<HybridRestState>,
     Json(request): Json<HybridSearchRestRequest>,
@@ -167,6 +168,19 @@ pub async fn hybrid_search(
             "at least one of vector or text_query is required".to_string(),
         ));
     }
+
+    // TD-138 phase 1 (deprecate, keep live): surface every use loudly so operators
+    // migrate to the v2 fusion seam. The endpoint already replies with HTTP
+    // deprecation headers (`with_v1_compatibility_headers`); this is the per-request
+    // runtime signal (mirrors TD-143's gRPC v1 deprecation warn).
+    tracing::warn!(
+        target: "proximadb::deprecation",
+        collection = %request.collection,
+        "POST /api/v{{1,2}}/hybrid/search (legacy 12-strategy HybridFusionEngine) is DEPRECATED \
+         — doc_id-keyed vector+BM25, no graph modality. Use the v2 fusion seam: \
+         POST /api/v2/graphs/{{graph_id}}/fusion-search (GraphFusionParams) or gRPC \
+         ProximaFusionService.FusionSearch (vector+graph+document, oid-keyed, calibrated). See TD-138."
+    );
 
     let proto_request = build_hybrid_fusion_request(request)?;
 

--- a/crates/platform/proximadb-runtime/src/hybrid_port.rs
+++ b/crates/platform/proximadb-runtime/src/hybrid_port.rs
@@ -17,6 +17,15 @@ use proximadb_proto::v1::{
 /// gRPC adapter returns `UNIMPLEMENTED` for every RPC.
 #[async_trait]
 pub trait HybridPort: Send + Sync {
+    /// DEPRECATED (TD-138): the v1 hybrid query — the legacy 12-strategy
+    /// `HybridFusionEngine` (vector+BM25, `doc_id`-keyed, no graph). Use the v2
+    /// fusion seam (`FusionService`) instead: `POST /api/v2/graphs/{graph_id}/fusion-search`
+    /// or gRPC `ProximaFusionService.FusionSearch`. Removal + caller migration is
+    /// phased (TD-143 did this for the gRPC v1 surface). Note-only (no `since`):
+    /// clippy `deprecated_semver` denies a non-semver `since`.
+    #[deprecated(
+        note = "v1 hybrid_search (legacy 12-strategy HybridFusionEngine) is deprecated; use the v2 fusion seam (FusionService). See TD-138."
+    )]
     async fn hybrid_search(
         &self,
         request: HybridFusionSearchRequest,

--- a/src/network/hybrid_search.rs
+++ b/src/network/hybrid_search.rs
@@ -565,6 +565,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)] // exercises the deprecated v1 HybridPort::hybrid_search (TD-138 phase 1)
     async fn rest_hybrid_port_forwards_proto_filters_to_vector_search() {
         let vector_ops = Arc::new(CapturingVectorOpsPort::default());
         let port =


### PR DESCRIPTION
## What

**Phase 1 of retiring the legacy 12-strategy `HybridFusionEngine` onto the v2 fusion seam (TD-138).** Formally deprecates the v1 hybrid-search port + REST/gRPC surfaces, mirroring **TD-143**'s gRPC v1 deprecation (#345). The endpoint **stays live** — no behavior change, no flag-gating — so removal + caller migration is a separate, breaking phase-2 PR.

This is the literal next step toward the TD-138 close-out: the v2 seam is now at full parity (vector + graph + **document** fusion on REST #508, gRPC + embedded #536), so the legacy v1 hybrid (12-strategy, `doc_id`-keyed, no graph) is superseded.

## Change
- **`#[deprecated(note)]` on `HybridPort::hybrid_search`** (`crates/platform/proximadb-runtime/src/hybrid_port.rs`) — the legacy port contract; mirrors TD-143's `#[deprecated]` on `execute_hybrid_query`. Note-only (no `since` — clippy `deprecated_semver` denies a non-semver `since`).
- **Per-request `tracing::warn!`** in the REST `POST /api/v{1,2}/hybrid/search` handler (`crates/platform/proximadb-api/src/rest/v1/hybrid.rs`) — the operator signal (mirrors TD-143's request-handlers warn). The endpoint already replies with HTTP deprecation headers (`with_v1_compatibility_headers`) + a "deprecated compatibility" startup log; this adds the per-request runtime warn.
- **`#[allow(deprecated)]`** at the two forwarders that call the now-deprecated port: the REST handler + the gRPC v1 `HybridSearch` handler (`grpc/v1/hybrid.rs`, which already wraps responses with `deprecated_status`/`deprecated_response`).

## Safety
Backward-compatible — deprecation only (attribute + warn). No proto / OpenAPI / SDK change. The v2 fusion seam (`FusionService`, vector+graph+document, `oid`-keyed) is the replacement.

## Verification
`cargo clippy -p proximadb -p proximadb-api -p proximadb-runtime --lib --bins -- -D warnings` ✓ · `cargo fmt --check` ✓ · panic-policy +0 (no regression) ✓ · 18 lib + 2 integration hybrid tests pass (incl. the v1 route tests) ✓ · `proximadb-server` builds ✓.

## Out of scope (phase 2, separate breaking PR)
- Gating/removing the v1 endpoint (mirror `enable_grpc_v1_compat` OFF) — requires caller migration.
- Exotic-strategy policy (BordaCount/CombSum/Condorcet/DempsterShafer…) — port-behind-a-flag vs drop, coupled to removal.
- Per-record RBAC on document hits.