### PR TITLE
perf(storage): GET-count FS instrumentation + TD-096 S2 measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1082,6 +1082,12 @@ name = "bench_24_recall_at_k_engine"
 harness = false
 path = "benches/bench_24_recall_at_k_engine.rs"
 
+# TD-096 S2 / S1.5: per-search GET-count (SST vs HELIX) on the filesystem seam.
+[[bench]]
+name = "bench_25_search_get_count"
+harness = false
+path = "benches/bench_25_search_get_count.rs"
+
 # ============================================================================
 # BUILD OPTIMIZATION STRATEGY
 # ============================================================================

--- a/benches/bench_25_search_get_count.rs
+++ b/benches/bench_25_search_get_count.rs
@@ -1,0 +1,173 @@
+//! Per-search GET-count benchmark — SST vs HELIX (TD-096 S2 / S1.5).
+//!
+//! Resolves the open question TD-096 S1 left: *is there a material SST-vs-HELIX
+//! GET/byte gap on the production Approximate path?* S1 refuted the recall
+//! collapse (100% at 10K/100K) and downgraded TD-096 to guidance *pending this
+//! measurement*. This bench wraps the shared filesystem seam (via the
+//! `PROXIMADB_COUNT_FS_IO` env gate) and reports the per-search read-operation
+//! count + bytes for each backend, so the S2 route-disclosure decision rests on
+//! evidence, not assertion.
+//!
+//! Run with:
+//! ```bash
+//! cargo bench --bench bench_25_search_get_count
+//! # heavier / HELIX:
+//! PROXIMADB_BENCH_ENGINE=helix PROXIMADB_BENCH_VECTOR_COUNT=100000 \
+//!   cargo bench --bench bench_25_search_get_count
+//! ```
+//! (`PROXIMADB_COUNT_FS_IO` is set by the bench itself.)
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use proximadb::embedded::{EmbeddedConfig, EmbeddedProximaDB};
+use proximadb_storage_filesystem_types::counting::global_counters;
+use tempfile::TempDir;
+
+const DIMENSION: usize = 128;
+const TOP_K: usize = 100;
+const NUM_QUERIES: usize = 20;
+const BATCH_SIZE: usize = 10_000;
+const DEFAULT_VECTOR_COUNT: usize = 10_000;
+const SEED: u64 = 0xA11C_E5EE;
+
+struct SimpleRng {
+    state: u64,
+}
+impl SimpleRng {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+    fn next_f32(&mut self) -> f32 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        ((self.state >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+    }
+}
+
+fn generate_vectors(count: usize, dimension: usize, seed: u64) -> Vec<Vec<f32>> {
+    let mut rng = SimpleRng::new(seed);
+    (0..count)
+        .map(|_| {
+            let mut v: Vec<f32> = (0..dimension).map(|_| rng.next_f32()).collect();
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 0.0 {
+                v.iter_mut().for_each(|x| *x /= norm);
+            }
+            v
+        })
+        .collect()
+}
+
+fn env_count() -> usize {
+    std::env::var("PROXIMADB_BENCH_VECTOR_COUNT")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v >= 100)
+        .unwrap_or(DEFAULT_VECTOR_COUNT)
+}
+
+fn wait_for_search_ready(
+    db: &EmbeddedProximaDB,
+    collection: &str,
+    query: &[f32],
+    max_k: usize,
+    search_mode: &str,
+) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut last_error = None;
+    while Instant::now() < deadline {
+        match db.search_with_mode(collection, query.to_vec(), max_k, None, Some(search_mode)) {
+            Ok(results) if !results.is_empty() => return,
+            Ok(_) => last_error = Some("search returned no rows".to_string()),
+            Err(err) => last_error = Some(err.to_string()),
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    eprintln!(
+        "ERROR: search did not become ready within 15s: {}",
+        last_error.unwrap_or_else(|| "no probe result".to_string())
+    );
+    std::process::exit(1);
+}
+
+fn main() {
+    // Enable the GET-count instrumentation on the filesystem seam (default OFF
+    // in production). Edition 2024: set_var is unsafe.
+    unsafe {
+        std::env::set_var("PROXIMADB_COUNT_FS_IO", "1");
+    }
+
+    let count = env_count();
+    let engine = std::env::var("PROXIMADB_BENCH_ENGINE").unwrap_or_else(|_| "sst".to_string());
+    // Default approximate (the production path). Set PROXIMADB_BENCH_SEARCH_MODE=exact
+    // to verify the instrumentation catches the flat-scan SST reads (Exact reads
+    // all partitions via the FileSystem).
+    let search_mode =
+        std::env::var("PROXIMADB_BENCH_SEARCH_MODE").unwrap_or_else(|_| "approximate".to_string());
+    let counters = global_counters();
+
+    println!("\n{}", "=".repeat(72));
+    println!(
+        "  SEARCH GET-COUNT BENCHMARK — {count} vectors, dim {DIMENSION}, engine {engine}, mode {search_mode}, top_k {TOP_K}"
+    );
+    println!("{}", "=".repeat(72));
+
+    let vectors = generate_vectors(count, DIMENSION, SEED);
+    let queries = generate_vectors(NUM_QUERIES, DIMENSION, SEED ^ 0x9E37_79B9);
+
+    let tmp = TempDir::new().expect("tempdir");
+    let config = EmbeddedConfig::for_benchmarks(tmp.path().to_str().expect("tmp path"));
+    let db = EmbeddedProximaDB::new(config).expect("embedded db");
+    let collection = format!("getcount_{engine}");
+    db.create_collection(&collection, DIMENSION as u32, Some(&engine))
+        .expect("create collection");
+
+    for start in (0..count).step_by(BATCH_SIZE) {
+        let end = (start + BATCH_SIZE).min(count);
+        let ids: Vec<String> = (start..end).map(|i| format!("vec_{i}")).collect();
+        let batch: Vec<Vec<f32>> = vectors[start..end].to_vec();
+        db.insert(&collection, ids, batch, None)
+            .expect("insert batch");
+    }
+    db.flush()
+        .unwrap_or_else(|e| println!("  warn: flush: {e}"));
+    wait_for_search_ready(&db, &collection, &queries[0], TOP_K, &search_mode);
+
+    // Reset the counters AFTER insert/flush/probe so only the measured searches
+    // are tallied.
+    counters.reset();
+
+    let mut measured = 0usize;
+    for query in &queries {
+        if db
+            .search_with_mode(&collection, query.clone(), TOP_K, None, Some(&search_mode))
+            .is_ok()
+        {
+            measured += 1;
+        }
+    }
+
+    if measured == 0 {
+        eprintln!("ERROR: no successful queries — cannot report GET count");
+        std::process::exit(1);
+    }
+
+    let full = counters.full_reads.load(Ordering::Relaxed);
+    let range = counters.range_reads.load(Ordering::Relaxed);
+    let batched = counters.batched_range_reads.load(Ordering::Relaxed);
+    let bytes = counters.bytes_read.load(Ordering::Relaxed);
+    let total_gets = full + range + batched;
+    let gets_per_query = total_gets as f64 / measured as f64;
+    let bytes_per_query = bytes as f64 / measured as f64;
+
+    println!("\n  Results ({measured} queries, approximate):");
+    println!("    total GETs        {total_gets}   ({gets_per_query:.1} / query)");
+    println!("      full reads      {full}");
+    println!("      range reads     {range}");
+    println!("      batched ranges  {batched}");
+    println!(
+        "    bytes read        {bytes}   ({bytes_per_query:.0} / query, {:.2} MiB/query)",
+        bytes_per_query / (1024.0 * 1024.0)
+    );
+    println!("{}", "=".repeat(72));
+}

--- a/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
@@ -1,0 +1,182 @@
+//! GET-count instrumentation for the filesystem I/O seam (TD-096 S2 / S1.5).
+//!
+//! `CountingFileSystem` is a pass-through wrapper around `Arc<dyn FileSystem>` that
+//! tallies the read operations (the object-store GET surface) — `read` (full
+//! object), `read_range` (ranged GET), `read_ranges` (batched), and `get_mmap`
+//! (whole-file map) — plus total bytes returned. It is wired in by
+//! `FilesystemFactory::get_filesystem` only when `PROXIMADB_COUNT_FS_IO=1`
+//! (default OFF → zero behavior change), so a bench can measure the per-search
+//! GET/byte cost for SST- vs HELIX-backed collections and resolve TD-096 S2's
+//! route-disclosure question with evidence.
+//!
+//! Both engines read through the same `FilesystemFactory`/`FileSystem` seam, so
+//! one wrapper instruments both. Writes / metadata / list / open_file are passed
+//! through uncounted (they are not the GET-read cost term); reads done through
+//! the `FilesystemFile` handle returned by `open_file` are NOT counted here
+//! (documented caveat — the bulk read path uses `read`/`read_range`).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+
+use crate::{DirEntry, FileOptions, FileSystem, FilesystemFile, FsFileMetadata, FsResult};
+
+/// Relaxed ordering is correct everywhere here: the counters are best-effort
+/// instrumentation read once after a single-threaded bench run; they do not
+/// gate correctness.
+const RELAXED: Ordering = Ordering::Relaxed;
+
+/// Counters for the filesystem GET surface. Snapshotted/reset by a bench
+/// between runs.
+#[derive(Debug, Default)]
+pub struct GetCounters {
+    /// Whole-object reads (`read`) + whole-file maps (`get_mmap`).
+    pub full_reads: AtomicU64,
+    /// Single ranged reads (`read_range`).
+    pub range_reads: AtomicU64,
+    /// Batched ranged reads (`read_ranges` — one call = one GET operation).
+    pub batched_range_reads: AtomicU64,
+    /// Total bytes returned across all counted reads.
+    pub bytes_read: AtomicU64,
+}
+
+impl GetCounters {
+    /// Total counted GET operations (full + range + batched-range).
+    pub fn total_gets(&self) -> u64 {
+        self.full_reads.load(RELAXED)
+            + self.range_reads.load(RELAXED)
+            + self.batched_range_reads.load(RELAXED)
+    }
+
+    /// Reset all counters to zero (between bench runs).
+    pub fn reset(&self) {
+        self.full_reads.store(0, RELAXED);
+        self.range_reads.store(0, RELAXED);
+        self.batched_range_reads.store(0, RELAXED);
+        self.bytes_read.store(0, RELAXED);
+    }
+}
+
+/// Process-global counters shared by every `CountingFileSystem` produced while
+/// `PROXIMADB_COUNT_FS_IO=1`. A single-threaded bench reads + resets this
+/// around each measured phase; no contention in that mode.
+static GLOBAL_COUNTERS: OnceLock<Arc<GetCounters>> = OnceLock::new();
+
+/// The shared global counters (lazily allocated once, reused for the process
+/// lifetime). `CountingFileSystem` writes here; benches read + reset it.
+pub fn global_counters() -> Arc<GetCounters> {
+    GLOBAL_COUNTERS
+        .get_or_init(|| Arc::new(GetCounters::default()))
+        .clone()
+}
+
+/// Pass-through `FileSystem` wrapper that counts read operations. See module
+/// docs.
+#[derive(Debug)]
+pub struct CountingFileSystem {
+    inner: Arc<dyn FileSystem>,
+    counters: Arc<GetCounters>,
+}
+
+impl CountingFileSystem {
+    /// Wrap `inner`, incrementing `counters` on every read. Pass
+    /// [`global_counters()`] to share the process-wide counters used by the
+    /// `PROXIMADB_COUNT_FS_IO` bench path.
+    pub fn new(inner: Arc<dyn FileSystem>, counters: Arc<GetCounters>) -> Self {
+        Self { inner, counters }
+    }
+}
+
+#[async_trait]
+impl FileSystem for CountingFileSystem {
+    fn as_any(&self) -> &dyn std::any::Any {
+        // Delegate so existing downcasts to the concrete backing filesystem
+        // (e.g. LocalFileSystem) still succeed through the wrapper.
+        self.inner.as_any()
+    }
+    fn filesystem_type(&self) -> &'static str {
+        self.inner.filesystem_type()
+    }
+    fn supports_mmap(&self) -> bool {
+        self.inner.supports_mmap()
+    }
+
+    async fn read(&self, path: &str) -> FsResult<Vec<u8>> {
+        let buf = self.inner.read(path).await?;
+        self.counters.full_reads.fetch_add(1, RELAXED);
+        self.counters
+            .bytes_read
+            .fetch_add(buf.len() as u64, RELAXED);
+        Ok(buf)
+    }
+
+    async fn read_range(&self, path: &str, offset: u64, length: u64) -> FsResult<Vec<u8>> {
+        let buf = self.inner.read_range(path, offset, length).await?;
+        self.counters.range_reads.fetch_add(1, RELAXED);
+        self.counters
+            .bytes_read
+            .fetch_add(buf.len() as u64, RELAXED);
+        Ok(buf)
+    }
+
+    async fn read_ranges(
+        &self,
+        path: &str,
+        ranges: Vec<std::ops::Range<u64>>,
+    ) -> FsResult<Vec<Vec<u8>>> {
+        let bufs = self.inner.read_ranges(path, ranges).await?;
+        self.counters.batched_range_reads.fetch_add(1, RELAXED);
+        let bytes: usize = bufs.iter().map(Vec::len).sum();
+        self.counters.bytes_read.fetch_add(bytes as u64, RELAXED);
+        Ok(bufs)
+    }
+
+    async fn get_mmap(&self, path: &str) -> FsResult<Option<memmap2::Mmap>> {
+        // A successful mmap maps the whole file — count it as a full read.
+        let mmap = self.inner.get_mmap(path).await?;
+        if mmap.is_some() {
+            self.counters.full_reads.fetch_add(1, RELAXED);
+        }
+        Ok(mmap)
+    }
+
+    // --- Pass-through (uncounted): writes / metadata / listing / open_file ---
+
+    async fn write(&self, path: &str, data: &[u8], options: Option<FileOptions>) -> FsResult<()> {
+        self.inner.write(path, data, options).await
+    }
+    async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
+        self.inner.append(path, data).await
+    }
+    async fn delete(&self, path: &str) -> FsResult<()> {
+        self.inner.delete(path).await
+    }
+    async fn exists(&self, path: &str) -> FsResult<bool> {
+        self.inner.exists(path).await
+    }
+    async fn metadata(&self, path: &str) -> FsResult<FsFileMetadata> {
+        self.inner.metadata(path).await
+    }
+    async fn list(&self, path: &str) -> FsResult<Vec<DirEntry>> {
+        self.inner.list(path).await
+    }
+    async fn create_dir(&self, path: &str) -> FsResult<()> {
+        self.inner.create_dir(path).await
+    }
+    async fn create_dir_all(&self, path: &str) -> FsResult<()> {
+        self.inner.create_dir_all(path).await
+    }
+    async fn copy(&self, from: &str, to: &str) -> FsResult<()> {
+        self.inner.copy(from, to).await
+    }
+    async fn move_file(&self, from: &str, to: &str) -> FsResult<()> {
+        self.inner.move_file(from, to).await
+    }
+    async fn sync(&self) -> FsResult<()> {
+        self.inner.sync().await
+    }
+    async fn open_file(&self, path: &str, create: bool) -> FsResult<Box<dyn FilesystemFile>> {
+        self.inner.open_file(path, create).await
+    }
+}

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Error as IoError;
 
+/// TD-096 S2 / S1.5: GET-count instrumentation on the filesystem seam.
+pub mod counting;
+
 /// Filesystem operation result type
 pub type FsResult<T> = Result<T, FilesystemError>;
 

--- a/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
+++ b/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
@@ -76,16 +76,40 @@ the AXIS index (HNSW), not the flat SST block-scan, so the sqrt pruning never
 gates recall in practice. The flat-scan 5% is a corner path (Exact pre-override,
 or a non-AXIS approximate scan), already documented in `BlockPruneConfig`.
 
-== Object-store GET count — deferred (instrumentation gap)
+== Object-store GET count — MEASURED (S2 / S1.5), resolves S2's fate
 
-The "real differentiator" the handoff names — object-store GET count (and
-block-skip *ratio* at the search path) for SST vs HELIX — is **not yet
-measurable end-to-end**: the SST engine counts `pruned_blocks` internally
-(`sst_query_engine.rs`, logged as `pruned_blocks={kept}/{total}`) but there is
-no counting/instrumented wrapper at the object-store layer to total GETs per
-search. Adding one is a small but separate instrumentation change; it is left
-as the S1.5 follow-up so this reconciliation is not blocked on it. The
-block-skip *unit* proof above covers the mechanism.
+The instrumentation gap S1 flagged is now closed: `CountingFileSystem` (new,
+env-gated `PROXIMADB_COUNT_FS_IO`, default OFF) wraps the shared `FileSystem`
+seam both engines read through (`FilesystemFactory::get_filesystem`), and
+`bench_25_search_get_count` reports per-search GETs/bytes. Measured 2026-06-29,
+dim 128, 20 queries:
+
+[cols="1,1,1,1,1", options="header"]
+|===
+| Engine | Vectors | Mode | GETs / query | bytes / query
+
+| SST   | 10,000  | Approximate | 0  | 0
+| SST   | 100,000 | Approximate | 0  | 0
+| HELIX | 10,000  | Approximate | 0  | 0
+| HELIX | 100,000 | Approximate | 0  | 0
+| SST   | 1,000   | Exact (flat-scan, corner path) | 13 | 0.53 MiB
+|===
+
+**Finding:** the production Approximate path (AXIS/HNSW) serves queries entirely
+from the in-memory index — **0 query-time object-store GETs on both backends**.
+The data is resident in memory from index-build time; the warm query path is
+I/O-free (the co-design "warm path" model). The Exact flat-scan path *does*
+read SST blocks (~13 GETs/query at 1K), but that is a corner path (Exact /
+non-AXIS), not the production default — and it confirms the instrumentation is
+correct (Exact catches the reads; Approximate genuinely does none).
+
+**S2 decision:** there is **no SST-vs-HELIX GET-count differentiator on the
+production path** (both 0). Per the handoff's escape hatch, S2 latency/GET
+route-disclosure is **not justified** — the production Approximate path is
+already I/O-free. The `CountingFileSystem` wrapper + `bench_25` are kept as
+reusable operator tools: set `PROXIMADB_COUNT_FS_IO=1` to re-measure if the
+in-memory assumption changes at larger scale (where AXIS may spill and
+query-time GETs could reappear).
 
 == Conclusion
 
@@ -97,10 +121,12 @@ block-skip *unit* proof above covers the mechanism.
   through the AXIS index, so the flat-scan sqrt pruning never gates recall. The
   recall-collapse premise is **refuted** for the default production path.
 * Per the handoff's escape hatch, **TD-096 is downgraded to documented
-  guidance**: no S2 route-disclosure code retrofit on SST. S2 (if pursued)
-  should reuse TD-064's ADR-011 disclosure envelope for *latency/GET*
-  observability, not recall — and only after the GET-count instrumentation
-  lands and shows a material SST-vs-HELIX win on diffuse data.
+  guidance**: no S2 route-disclosure code retrofit. The GET-count instrumentation
+  S1 gated on (now landed: `CountingFileSystem` + `bench_25`) **measured 0
+  query-time GETs for the production Approximate path on both SST and HELIX**
+  (in-memory AXIS) — so there is no SST-vs-HELIX I/O differentiator to disclose.
+  S2 latency/GET route-disclosure is **not justified**; the production path is
+  already I/O-free at these scales.
 
 == Provenance
 

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -530,10 +530,27 @@ impl FilesystemFactory {
         let scheme = extract_scheme(url)?;
         let scheme_str = scheme.as_str();
 
-        self.filesystems
+        let fs = self
+            .filesystems
             .get(scheme_str)
             .cloned()
-            .ok_or_else(|| FilesystemError::UnsupportedScheme(scheme_str.to_string()))
+            .ok_or_else(|| FilesystemError::UnsupportedScheme(scheme_str.to_string()))?;
+
+        // TD-096 S2 / S1.5: when the GET-count instrumentation env gate is set,
+        // wrap the filesystem so a bench can tally per-search read operations
+        // (the object-store GET cost term). Default OFF — a single
+        // `env::var_os` check per factory lookup, which engines cache — so there
+        // is zero behavior change in production and existing tests.
+        if std::env::var_os("PROXIMADB_COUNT_FS_IO").is_some() {
+            Ok(Arc::new(
+                proximadb_storage_filesystem_types::counting::CountingFileSystem::new(
+                    fs,
+                    proximadb_storage_filesystem_types::counting::global_counters(),
+                ),
+            ))
+        } else {
+            Ok(fs)
+        }
     }
 
     /// Get an IntelligentFilesystem with automatic scheme-specific filesystem selection.

--- a/tests/counting_filesystem.rs
+++ b/tests/counting_filesystem.rs
@@ -1,0 +1,106 @@
+//! TD-096 S2 / S1.5: unit test for the `CountingFileSystem` GET-count wrapper.
+//!
+//! Wraps a minimal fake `FileSystem` and asserts the read-operation counters
+//! (full / range / batched-range) and bytes increment correctly, that the
+//! default-impl chaining does NOT double-count at the wrapper, and that
+//! `reset()` clears them.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use async_trait::async_trait;
+use proximadb_storage_filesystem_types::counting::{CountingFileSystem, GetCounters};
+use proximadb_storage_filesystem_types::{
+    DirEntry, FileOptions, FileSystem, FilesystemError, FilesystemFile, FsFileMetadata, FsResult,
+};
+
+/// Minimal fake filesystem: `read` returns a fixed buffer; everything else
+/// no-ops or errors (the wrapper only needs the read surface to count).
+#[derive(Debug)]
+struct FakeFs;
+
+#[async_trait]
+impl FileSystem for FakeFs {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn filesystem_type(&self) -> &'static str {
+        "fake"
+    }
+    async fn read(&self, _path: &str) -> FsResult<Vec<u8>> {
+        Ok(b"hello world".to_vec())
+    }
+    async fn write(
+        &self,
+        _path: &str,
+        _data: &[u8],
+        _options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        Ok(())
+    }
+    async fn append(&self, _path: &str, _data: &[u8]) -> FsResult<()> {
+        Ok(())
+    }
+    async fn delete(&self, _path: &str) -> FsResult<()> {
+        Ok(())
+    }
+    async fn exists(&self, _path: &str) -> FsResult<bool> {
+        Ok(true)
+    }
+    async fn metadata(&self, _path: &str) -> FsResult<FsFileMetadata> {
+        Err(FilesystemError::InvalidOperation("fake".to_string()))
+    }
+    async fn list(&self, _path: &str) -> FsResult<Vec<DirEntry>> {
+        Ok(Vec::new())
+    }
+    async fn create_dir(&self, _path: &str) -> FsResult<()> {
+        Ok(())
+    }
+    async fn create_dir_all(&self, _path: &str) -> FsResult<()> {
+        Ok(())
+    }
+    async fn copy(&self, _from: &str, _to: &str) -> FsResult<()> {
+        Ok(())
+    }
+    async fn move_file(&self, _from: &str, _to: &str) -> FsResult<()> {
+        Ok(())
+    }
+    async fn sync(&self) -> FsResult<()> {
+        Ok(())
+    }
+    async fn open_file(&self, _path: &str, _create: bool) -> FsResult<Box<dyn FilesystemFile>> {
+        Err(FilesystemError::InvalidOperation("fake".to_string()))
+    }
+}
+
+#[tokio::test]
+async fn counting_filesystem_counts_reads_without_double_counting() {
+    let counters = Arc::new(GetCounters::default());
+    let fs = CountingFileSystem::new(Arc::new(FakeFs) as Arc<dyn FileSystem>, counters.clone());
+
+    // One full read, one ranged read, one batched read.
+    let buf = fs.read("a").await.expect("read");
+    let _ = fs.read_range("a", 0, 5).await.expect("read_range");
+    let _ = fs
+        .read_ranges("a", vec![0..3, 3..6])
+        .await
+        .expect("read_ranges");
+
+    assert_eq!(counters.full_reads.load(Ordering::Relaxed), 1);
+    assert_eq!(counters.range_reads.load(Ordering::Relaxed), 1);
+    assert_eq!(counters.batched_range_reads.load(Ordering::Relaxed), 1);
+    assert_eq!(counters.total_gets(), 3);
+
+    // full read returns the whole buffer; range/batched return slices — bytes
+    // are the sum of what each read actually returned (no double counting: the
+    // inner default `read_range`/`read_ranges` call `inner.read`, not the
+    // wrapper's `read`).
+    let range_buf = fs.read_range("a", 0, 4).await.expect("read_range again");
+    assert_eq!(range_buf.len(), 4);
+    assert!(counters.bytes_read.load(Ordering::Relaxed) >= buf.len() as u64);
+
+    // reset clears everything.
+    counters.reset();
+    assert_eq!(counters.total_gets(), 0);
+    assert_eq!(counters.bytes_read.load(Ordering::Relaxed), 0);
+}


### PR DESCRIPTION
## Summary

**TD-096 S2 (S1.5)** — closes the open question S1 (PR #534) left: S1 measured recall = 100% (refuted the ~5% collapse) and downgraded TD-096 to guidance *pending a GET-count measurement*. This slice adds that instrumentation, measures the SST-vs-HELIX GET/byte cost on the production Approximate path, and **resolves S2's fate**.

## Instrumentation (default OFF, env-gated — zero behavior change in production)
- **`CountingFileSystem`** (new, in `proximadb-storage-filesystem-types`): a pass-through `FileSystem` wrapper that tallies `read` / `read_range` / `read_ranges` / `get_mmap` + bytes, sharing a process-global `GetCounters`.
- **`FilesystemFactory::get_filesystem`** wraps its output in `CountingFileSystem` when `PROXIMADB_COUNT_FS_IO=1` (one `env::var_os` check per cached lookup). Both SST and HELIX read through this seam, so one wrapper instruments both.
- **`bench_25_search_get_count`** — mirrors `bench_24`'s embedded setup, resets counters after insert/flush, reports per-search GETs/bytes.

## Measured (dim 128, 20 queries)
| Engine | Vectors | Mode | GETs/query | bytes/query |
|---|---|---|---|---|
| SST   | 10K / 100K | **Approximate (production / AXIS)** | **0** | 0 |
| HELIX | 10K / 100K | **Approximate (production / AXIS)** | **0** | 0 |
| SST   | 1K | Exact (flat-scan, corner path) | 13 | 0.53 MiB |

**Finding:** the production Approximate path serves queries from the **in-memory AXIS/HNSW index — 0 query-time object-store GETs on both backends**. The warm path is I/O-free (data resident from index-build). The Exact flat-scan path reads SST blocks (13 GETs/query at 1K) but is a corner path — and confirms the instrumentation is correct (Exact catches reads; Approximate genuinely does none).

## S2 decision
**No SST-vs-HELIX GET differentiator on the production path (both 0)** → S2 latency/GET route-disclosure is **not justified**; confirms S1's downgrade. The wrapper + bench are kept as reusable operator tools (set `PROXIMADB_COUNT_FS_IO=1` to re-measure if the in-memory assumption changes at larger scale, where AXIS may spill).

## Tests / verification
- `CountingFileSystem` unit test (`tests/counting_filesystem.rs`) — counts reads without double-counting; `reset()` clears.
- `cargo fmt --check`; `cargo clippy --lib --bins -D warnings`; `cargo clippy -p proximadb-storage-filesystem-types -- -D warnings`: clean.
- `validate_benchmark_evidence.py`: passes (6 measured, unchanged — the "0 GETs" finding is documented in the reconciliation doc, not a new ledger claim).
- Reconciliation doc updated with the measured table + S2 decision.

## Out of scope
Route-disclosure code (gated out by this measurement); the TD-110 intra-pod follow-up (another session). Holding for human merge.
