### PR TITLE
docs: realign customer-facing + concept docs to current reality

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,8 +70,8 @@ REST + gRPC + Arrow Flight]
   subgraph DataPlane[Data Plane]
     WAL[Unified WAL]
     MEM[Memtables]
-    ENG["Vector Engines<br/>(SST, HELIX, VIPER, SWIFT, NOVA, RAPTOR)"]
-    GRAPHENG["Graph Engines<br/>(ORION, PULSAR, QUASAR)"]
+    ENG["Vector Engines<br/>(SST, VIPER, HELIX, NOVA)"]
+    GRAPHENG["Graph Engine<br/>(ORION)"]
     OBSSTORE["Observability Storage<br/>(partitioned logs, time-series, traces)"]
   end
 
@@ -105,9 +105,11 @@ treat as headroom indicators, not a published SLA.*
 ====
 **v0.2 positioning**: this release is a narrow single-node cut. Hybrid retrieval,
 document/graph/observability, pgwire/federated SQL, object-economy and
-filtered-ANN routes are **Beta**. Distributed cluster execution, PULSAR/QUASAR,
-full SQL parity, external-table execution, and conditional/filter writes are
-**Experimental** and must not be inferred from the numbers above. See
+filtered-ANN routes are **Beta**. Distributed cluster execution, full SQL parity,
+external-table execution, Arrow Flight as a customer-facing transport, the
+SWIFT/RAPTOR storage engines, and conditional/filter writes are
+**Experimental** and must not be inferred from the numbers above. (The PULSAR and
+QUASAR graph engine names are *retired* — use ORION.) See
 link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`] for the support
 contract and
 link:docs/release-notes/v0.2.0.adoc[`docs/release-notes/v0.2.0.adoc`] for the
@@ -317,7 +319,7 @@ JOIN LATERAL GRAPH_QUERY('MATCH (s:Service {name: "' || l.service || '"})-[:DEPE
 |===
 | Capability | Status | Notes
 
-| Vector search + filters | Stable | 6 storage engines, AXIS indexes, metadata filters
+| Vector search + filters | Stable | 4 supported storage engines (SST/VIPER/HELIX/NOVA) + AXIS (HNSW/IVF) indexes, metadata filters
 | Document store | Stable | WAL‑backed, JSON path queries, full‑text search
 | Graph traversal | Stable | ORION (in‑memory CSR), WAL persistence, algorithms
 | Observability logs | Stable | WAL‑backed, partitioned storage, 6 SIEM adapters
@@ -328,6 +330,12 @@ JOIN LATERAL GRAPH_QUERY('MATCH (s:Service {name: "' || l.service || '"})-[:DEPE
 | Web UI dashboard | Stable | SQL editor, graph visualization, dark/light theme
 | Python SDK | Stable | Graph analytics, AutoML, observability, security
 |===
+
+NOTE: Tier detail lives in link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`]. A
+few capabilities in the tree are *not* in the supported surface above: the SWIFT and RAPTOR
+storage engines are **experimental** (off by default behind the `experimental-engines` cargo
+feature), Arrow Flight is an **experimental** customer-facing transport, and distributed
+cluster execution is **experimental**.
 
 ---
 
@@ -359,7 +367,7 @@ Features:
 * link:docs/04-operations/[Operations] - Deployment, monitoring, security
 * link:docs/06-internals/[Internals] - Contributing, testing, architecture decisions
 
-**v0.2.0 Release** (February 2026):
+**v0.2.0 Release** (June 2026):
 * Platform packages: link:docs/02-guides/platform-packages.md[RPM, DEB, MSI]
 * Unified port architecture (single port 5678)
 * Multi-model query engine with cross-model joins
@@ -367,8 +375,8 @@ Features:
 **Key Guides**:
 * link:docs/02-guides/vector-search.md[Vector Search] - Semantic search, filtering, hybrid search
 * link:docs/02-guides/multi-model-joins.md[Multi-Model Joins] - Cross-model SQL queries
-* link:docs/05-concepts/storage-engines.adoc[Storage Engines] - SST, HELIX, VIPER, SWIFT, NOVA, RAPTOR
-* link:docs/06-internals/GRAPH_ENGINES_GUIDE.adoc[Graph Engines Guide] - ORION (production), PULSAR (distributed), QUASAR (tiered)
+* link:docs/05-concepts/storage-engines.adoc[Storage Engines] - SST, VIPER, HELIX, NOVA (SWIFT/RAPTOR experimental)
+* link:docs/06-internals/GRAPH_ENGINES_GUIDE.adoc[Graph Engines Guide] - ORION
 
 ---
 

--- a/docs/00-product/PRD.adoc
+++ b/docs/00-product/PRD.adoc
@@ -4,7 +4,7 @@
 :icons: font
 :sectnums:
 :author: ProximaDB Team
-:revdate: March 2026
+:revdate: June 2026
 :revnumber: 0.2.0
 
 [IMPORTANT]
@@ -691,4 +691,4 @@ Theme: Production-ready with distributed consensus and security hardening.
 
 '''
 
-_Last Updated_: February 2026
+_Last Updated_: June 2026

--- a/docs/00-product/VISION.adoc
+++ b/docs/00-product/VISION.adoc
@@ -81,7 +81,7 @@ embedded deployment, or real-time event processing at the edge.
 ProximaDB takes a different path: _specialized engine per workload, unified under one query
 language and one data plane_.
 
-**Vector Engines** (6 engines, each optimized for a distinct access pattern):
+**Vector Engines** (4 supported engines, each optimized for a distinct access pattern):
 
 [cols="1,2,1"]
 |===
@@ -89,11 +89,13 @@ language and one data plane_.
 
 | SST | Write-optimized, real-time ingestion | ~5.32ms
 | HELIX | Locality-optimized, Hilbert curve ordering | ~13.2ms
-| RAPTOR | Adaptive row-group, dynamic workloads | ~9.36ms
 | VIPER | Columnar Parquet, analytics queries | ~89.5ms
-| SWIFT | Ultra-low latency, small collections (<5K) | ~95ms
 | NOVA | Progressive columnar, mixed read/write | ~101.6ms
 |===
+
+NOTE: The SWIFT and RAPTOR engines also exist but are *experimental* -- off by default behind
+the `experimental-engines` cargo feature and not part of the supported surface. They are
+excluded from the table above and the performance narrative.
 
 **Graph Engines** (native CSR format with Arc-based zero-copy memory):
 
@@ -513,6 +515,6 @@ organization-wide adoption.
 
 '''
 
-_Last Updated_: March 2026
+_Last Updated_: June 2026
 
 _Supersedes_: `docs/05-concepts/vision.adoc`

--- a/docs/02-guides/vector-search.md
+++ b/docs/02-guides/vector-search.md
@@ -341,10 +341,14 @@ for v, id in zip(vectors, ids):
 | Workload | Engine |
 |----------|--------|
 | Real-time ingest | SST |
-| Spatial queries | HELIX |
-| Analytics | VIPER |
-| Small dataset | SWIFT |
-| Unknown/RVarying | RAPTOR |
+| Spatial / locality queries | HELIX |
+| Columnar analytics | VIPER |
+| Mixed read/write | NOVA |
+
+> **SWIFT and RAPTOR are experimental** (off by default behind the `experimental-engines`
+> cargo feature) and are not v0.2-supported — don't target them for production. For small or
+> dynamic workloads use SST or NOVA. See
+> [Storage Engines](../05-concepts/storage-engines.adoc).
 
 ---
 

--- a/docs/05-concepts/architecture.adoc
+++ b/docs/05-concepts/architecture.adoc
@@ -107,16 +107,16 @@ sequenceDiagram
 
 == Target 8-Model Architecture
 
-ProximaDB's vision extends the current 4-model architecture (vector, graph, document, observability) to 8 models:
+ProximaDB's vision extends the current 4-model architecture (vector, graph, document, observability) to 8 models. Status reflects the v0.2 support tiers in link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] (Supported/Beta/Planned); the engines listed are the supported set (SWIFT/RAPTOR are experimental and omitted):
 
 [cols="1,2,2,1", options="header"]
 |===
 | Model | Engine | Use Case | Status
 
 | *Vector*
-| SST, HELIX, VIPER, SWIFT, NOVA, RAPTOR
+| SST, VIPER, HELIX, NOVA + AXIS (HNSW/IVF) indexes
 | Similarity search, embeddings, RAG
-| Production
+| Supported
 
 | *Graph*
 | ORION graph runtime over relational/storage substrate
@@ -126,27 +126,27 @@ ProximaDB's vision extends the current 4-model architecture (vector, graph, docu
 | *Document*
 | WAL-backed JSON store
 | Structured data, metadata, state management
-| Production
+| Beta
 
 | *Observability*
 | Partitioned logs, time-series metrics, trace spans
 | Monitoring, SIEM, audit
-| Production
+| Beta
 
 | *Time-Series*
 | TST (Time-Series Tree)
 | OHLC bars, IoT sensors, metrics, streaming data
-| Planned
+| Beta (engine complete; productization in progress)
 
 | *Event Sourcing*
 | Append-only WAL with indexed queries
 | Audit trails, compliance, CDC, order history
-| Planned
+| Beta (engine complete; productization in progress)
 
 | *Relational*
 | DataFusion-backed SQL tables
 | Structured queries, joins, aggregations
-| Foundation exists
+| Foundation exists (full RDBMS parity post-MVP, TD-110)
 
 | *Media*
 | Multi-modal embeddings (CLIP, ImageBind)
@@ -205,6 +205,16 @@ flowchart TB
   OBS --> ARROW
   ARROW --> Client
 ----
+
+[NOTE]
+====
+Regardless of entry point, ranking is owned by a *single shared `FusionService`*. Vector
+`/search`, hybrid dense+BM25 retrieval, and graph `fusion-search` all delegate to one fusion
+engine (calibrated candidate-set fusion over the `oid`-keyed seam). Per-surface fusion is an
+anti-pattern — each model service above is a *source of candidates*, not a ranker. See
+link:hybrid-fusion.adoc[Hybrid Fusion] and
+link:../12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc[Search Surface Contract].
+====
 
 === SQL Extensions
 
@@ -302,19 +312,23 @@ flowchart TB
 
 == Current Implementation Notes
 
-* **Phase 1 Complete**: All 6 storage engines, WAL, APIs, quantization, AXIS indexes.
+* **Phase 1 Complete**: 4 supported storage engines (SST/VIPER/HELIX/NOVA; SWIFT/RAPTOR are experimental), WAL, APIs, quantization, AXIS indexes.
 * **Phase 2 Complete**: Cross-model queries, graph database (ORION), document store, observability.
 * **Phase 3 In Progress**: External catalogs, streaming/CDC, distributed operations.
-* **Phase 4 Planned**: Time-series engine, event sourcing, hybrid search (BM25), framework integrations.
+* **Phase 4 Foundations Beta**: Time-series (TST) and event-sourcing engines are complete; hybrid search (BM25) is wired. Product packaging, API parity, and at-scale validation are in progress -- these are Beta surfaces in v0.2.
 * Document and observability services use WAL‑backed recovery.
 * Unified query execution supports VECTOR_SEARCH, GRAPH_QUERY, DOCUMENT_QUERY, LOGS, METRICS.
 
 == Stability Matrix
 
+*Status* below reflects implementation stability in the working tree; the customer-facing
+support tier (Supported/Beta/Experimental) is governed by
+link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] and wins for any product claim.
+
 |===
 | Area | Phase | Status | Notes
 
-| Vector engine + filters | P1 | ✅ Stable | 6 engines, AXIS indexes
+| Vector engine + filters | P1 | ✅ Stable | 4 supported engines (SST/VIPER/HELIX/NOVA), AXIS (HNSW/IVF) indexes
 | Document storage | P2 | ✅ Stable | WAL-backed, JSON path queries
 | Graph traversal | P2 | ✅ Stable | ORION, WAL persistence
 | Observability logs | P2 | ✅ Stable | WAL-backed, partitioned
@@ -322,9 +336,9 @@ flowchart TB
 | Unified query | P2 | ✅ Stable | Cross-model SQL
 | External catalogs | P3 | 🔄 In Progress | Iceberg, Delta Lake
 | Distributed ops | P3 | 🔄 In Progress | Raft, sharding
-| Hybrid search (BM25) | P4 | ✅ Stable | tantivy integration (Feb 2025)
-| Time-series engine | P4 | ✅ Stable | TST engine (Feb 2025)
-| Event sourcing | P4 | ✅ Stable | Append-only WAL (Feb 2025)
+| Hybrid search (BM25) | P4 | Beta | tantivy integration; Beta in v0.2
+| Time-series engine | P4 | Beta | TST engine complete; productization in progress
+| Event sourcing | P4 | Beta | Append-only WAL; productization in progress
 | Agentic Intelligence | P5 | 📅 Planned | Research frontier (arXiv:2604)
 |===
 

--- a/docs/05-concepts/hybrid-fusion.adoc
+++ b/docs/05-concepts/hybrid-fusion.adoc
@@ -81,48 +81,45 @@ Tunable parameters:
 | Selects between RRF and weighted-linear based on observed result overlap.
 |===
 
-== Selecting via REST Compatibility Facade
+== Selecting via REST (canonical fusion surfaces)
 
-The current REST hybrid route is a deprecated v1 compatibility facade and emits
-deprecation metadata. Prefer pgwire/SQL and record-native query routes as those
-surfaces are promoted.
+All cross-modal ranking in ProximaDB routes through one shared `FusionService`.
+The vector `/search` surface, the dense+BM25 hybrid, and the tri-modal
+`fusion-search` route are all instances of the same calibrated, `oid`-keyed
+fusion engine -- per-surface fusion is intentionally avoided (see
+link:../12-design/SEARCH_SURFACE_CONTRACT_2026_06_24.adoc[Search Surface Contract]).
 
-NOTE: The previously-documented `/api/v1/experimental/hybrid/search` route was
-mock-backed and removed 2026-05-26. Use the production endpoint
-`/api/v1/hybrid/search` below (real BM25 + vector fusion via
-`RestHybridPortImpl`). gRPC parity landed in commit `6a73ead7f` +
-`10a0ea1b2` — REST and gRPC share the same in-process index map.
+The canonical place to exercise the strategies above end-to-end is the v2 graph
+fusion-search route, which seeds from a vector ANN, expands over the graph, and
+-- when `text_query` is supplied -- merges a BM25 document leg by shared `oid`:
 
 [source,bash]
 ----
-# RRF (default)
-curl -X POST http://localhost:5678/api/v1/hybrid/search \
+# Tri-modal fusion (vector + graph + BM25), RRF fallback
+curl -X POST http://localhost:5678/api/v2/graphs/topology/fusion-search \
   -H "Content-Type: application/json" \
   -d '{
-    "collection": "products",
+    "vector_collection": "products",
+    "query_vector": [0.1, 0.2, 0.3],
     "text_query": "laptop",
-    "query_vector": [0.1, 0.2, ...],
-    "fusion_strategy": "rrf",
-    "top_k": 10
+    "limit": 10,
+    "max_depth": 1,
+    "rrf": true
   }'
 
-# Projection (speed/diversity tradeoff)
-curl -X POST http://localhost:5678/api/v1/hybrid/search \
-  -H "Content-Type: application/json" \
-  -d '{
-    "collection": "products",
-    "text_query": "laptop",
-    "query_vector": [0.1, 0.2, ...],
-    "fusion_strategy": "projection",
-    "top_k": 10
-  }'
-
-# NOTE: The `/strategies` listing endpoint that lived under the removed
-# experimental route has not been re-mounted on `/api/v1/hybrid`.
-# The supported strategy names are listed in the FusionStrategy enum at
-# `src/core/search/hybrid/strategies.rs` and reproduced below in
-# "Selecting via Python SDK".
+# Omit text_query for vector+graph-only fusion; tune vector_weight / graph_weight
+# / document_weight to bias a modality, or set rrf:false for PIT-calibrated linear.
 ----
+
+NOTE: The older `POST /api/v1/hybrid/search` route (dense+BM25 with an explicit
+`fusion_strategy` selector) is retained as a *deprecated compatibility alias*
+only -- new clients should target the v2 fusion surfaces above. The removed
+`/api/v1/experimental/hybrid/search` mock route (deleted 2026-05-26) is gone, and
+its `/strategies` listing was never re-mounted. The supported strategy names are
+the `FusionStrategy` enum at `src/core/search/hybrid/strategies.rs`, reproduced
+below in "Selecting via Python SDK". See
+link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE] for the current gRPC parity
+status of hybrid retrieval.
 
 == Selecting via Python SDK
 

--- a/docs/05-concepts/storage-engines.adoc
+++ b/docs/05-concepts/storage-engines.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 :icons: font
 :source-highlighter: rouge
-:last-updated: December 2025
+:last-updated: June 2026
 
 [.lead]
 Choose the vector storage engine that fits your workload. Engines are pluggable and optimized for different access patterns.
@@ -38,14 +38,6 @@ Choose the vector storage engine that fits your workload. Engines are pluggable 
 | High (batch)
 | 99%+
 
-| **SWIFT**
-| Small datasets (<10K), ultra-low latency
-| ~15ms
-| ~5ms
-| High
-| Low
-| 100%
-
 | **NOVA**
 | Mixed read/write workloads
 | ~30ms
@@ -53,14 +45,6 @@ Choose the vector storage engine that fits your workload. Engines are pluggable 
 | Medium
 | Medium
 | 97%+
-
-| **RAPTOR**
-| Evolving/dynamic workloads
-| ~10ms
-| ~10-15ms
-| Medium
-| High
-| 96%+
 |===
 
 [WARNING]
@@ -90,19 +74,13 @@ flowchart TD
     D -->|Analytics queries| VIPER
     D -->|Mixed queries| E{Dataset size?}
 
-    E -->|<10K vectors| SWIFT[SWIFT Engine]
-    E -->|10K-1M vectors| F{Workload stable?}
-    E -->|>1M vectors| SST
-
-    F -->|Yes| NOVA[NOVA Engine]
-    F -->|No, evolving| RAPTOR[RAPTOR Engine]
+    E -->|Small / medium| NOVA[NOVA Engine]
+    E -->|Large, >1M| SST[SST Engine]
 
     style SST fill:#4a90e2,color:#fff
     style HELIX fill:#2e5c8a,color:#fff
     style VIPER fill:#1a3a5c,color:#fff
-    style SWIFT fill:#6ba3d6,color:#fff
     style NOVA fill:#3d7ab8,color:#fff
-    style RAPTOR fill:#5090c8,color:#fff
 ----
 
 == Use Case Recommendations
@@ -187,52 +165,27 @@ client.create_collection(
 )
 ----
 
-=== Small Dataset, Maximum Speed
+=== Experimental Engines (SWIFT, RAPTOR)
 
-**Recommended: SWIFT Engine**
+[WARNING]
+====
+**SWIFT and RAPTOR are experimental and OFF by default.** They live behind the
+`experimental-engines` cargo feature; a stock build rejects them at the engine
+factory with "Use SST, VIPER, HELIX, or NOVA instead." They are *not* part of the
+v0.2 supported surface. Enable only with `cargo build --features experimental-engines`.
+====
 
-Best for:
+When enabled, they target two niches not covered by the supported engines:
 
-* Prototyping and development
-* Small reference datasets (<10K vectors)
-* Exact nearest neighbor (no approximation)
-* Multi-tenant with isolated small collections
+* **SWIFT** -- in-memory, exact nearest-neighbor for tiny collections (<10K vectors),
+  prototyping, and small isolated multi-tenant sets. Use **SST** or **NOVA** instead for
+  any supported workload.
+* **RAPTOR** -- adaptive row-group layout for evolving/unpredictable access patterns. Use
+  **NOVA** (mixed read/write) for supported mixed workloads.
 
-[source,python]
-----
-client.create_collection(
-    name="product_catalog",
-    dimension=384,
-    engine="swift",
-    engine_config={
-        "in_memory": True,
-        "exact_search": True
-    }
-)
-----
-
-=== Dynamic/Evolving Workloads
-
-**Recommended: RAPTOR Engine**
-
-Best for:
-
-* A/B testing with changing data patterns
-* Adaptive caching based on access patterns
-* Workloads with unpredictable query distribution
-
-[source,python]
-----
-client.create_collection(
-    name="adaptive_embeddings",
-    dimension=768,
-    engine="raptor",
-    engine_config={
-        "adaptive_pruning": True,
-        "cache_hot_blocks": True
-    }
-)
-----
+Config knobs and bench numbers for both appear in the SWIFT/RAPTOR subsections of the
+Engine Configuration Reference and Performance Benchmarks below (clearly marked experimental).
+Do not build production v0.2 collections on these engines.
 
 == Engine Configuration Reference
 
@@ -322,7 +275,9 @@ client.create_collection(
 | `2.0`
 |===
 
-=== SWIFT Engine Options
+=== SWIFT Engine Options (experimental — off by default)
+
+NOTE: SWIFT requires `--features experimental-engines` and is not a v0.2 supported engine.
 
 [cols="2,1,3,2", options="header"]
 |===
@@ -366,7 +321,9 @@ client.create_collection(
 | 128
 |===
 
-=== RAPTOR Engine Options
+=== RAPTOR Engine Options (experimental — off by default)
+
+NOTE: RAPTOR requires `--features experimental-engines` and is not a v0.2 supported engine.
 
 [cols="2,1,3,2", options="header"]
 |===
@@ -389,6 +346,10 @@ client.create_collection(
 |===
 
 == Performance Benchmarks
+
+NOTE: SWIFT and RAPTOR rows below are **experimental** (off by default) and are shown for
+reference only; they are not part of the v0.2 supported surface. Treat all figures as
+internal reference points, not a published SLA (see link:../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE]).
 
 === Latency Comparison (10K vectors, 128 dimensions)
 

--- a/docs/05-concepts/vision.adoc
+++ b/docs/05-concepts/vision.adoc
@@ -3,6 +3,16 @@
 :toclevels: 2
 :icons: font
 
+[IMPORTANT]
+====
+This concept-level vision is **superseded** by the canonical product vision at
+link:../00-product/VISION.adoc[`docs/00-product/VISION.adoc`] ("The Context Database"). This
+document is retained as historical context for the earlier "format-first multi-model platform"
+framing. For current vision, strategy, the 3-year horizon, and the near-term wedge, read the
+canonical VISION; for the supported/beta/experimental surface, read
+link:../SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`].
+====
+
 [.lead]
 ProximaDB aims to be a modular, multi-model database where storage formats and catalogs form the
 stable contract, and multiple compute engines can operate across vectors, graphs, documents,

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -1,7 +1,7 @@
 = Architecture Decision Records
 :toc: left
 :icons: font
-:last-updated: 2026-04-02
+:last-updated: 2026-06-29
 
 [.lead]
 This directory contains Architecture Decision Records (ADRs) governing ProximaDB's implementation across all open issues (#25-#61). Each ADR defines canonical contracts, interfaces, and file plans that implementation must follow.

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -37,7 +37,7 @@ ProximaDB development follows four phases:
 | **Phase 1** | Storage formats, catalog, core APIs | ✅ Core complete
 | **Phase 2** | Cross-model queries, graph, observability | ⚠ Core complete; modality projections Beta in v0.2 — see link:SUPPORTED_SURFACE.adoc[Supported Surface]
 | **Phase 3** | Ecosystem integration, streaming, SDKs | 🔄 In progress
-| **Phase 4** | Time-series, event sourcing, hybrid search, framework integrations | Planned post-v0.2
+| **Phase 4** | Time-series (TST), event sourcing, hybrid search | ⚠ Foundations Beta in v0.2 — engines complete; product packaging/at-scale validation in progress — see link:SUPPORTED_SURFACE.adoc[Supported Surface]
 |===
 
 For v0.2 release-cut scope and the canonical Supported / Beta / Experimental
@@ -142,7 +142,7 @@ link:_internal/roadmap/STRATEGIC_ROADMAP.adoc[Strategic Roadmap].
 
 * ProximaDB is evolving quickly; experimental features are documented in each API section.
 * Internal roadmap and archived docs live under `docs/_internal/` and are not part of the public API.
-* Phase 1 + Phase 2 complete; Phase 3 ecosystem features in progress; Phase 4 planned.
+* Phase 1 + Phase 2 complete; Phase 3 ecosystem features in progress; Phase 4 foundations are Beta (engines complete, productization in progress).
 * Anchoring artifacts: `docs/00-product/` (vision, PRD, competitive), `docs/11-usecases/` (use cases, dogfood), `docs/12-design/` (design patterns).
 
-_Version 0.2.0_ | _February 2026_
+_Version 0.2.0_ | _June 2026_

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ flowchart LR
   subgraph ProximaDB["ProximaDB"]
     API["Unified API<br/>REST + gRPC + SQL"]
     WAL["Unified WAL<br/>Single durability layer"]
-    ENGS["6 Storage Engines<br/>Tuned for workload"]
+    ENGS["4 Storage Engines + AXIS<br/>Tuned for workload"]
   end
 
   subgraph Output["Queries You Run"]
@@ -107,16 +107,18 @@ JOIN LATERAL DOCUMENT_QUERY('reviews', 'product_id = "' || v.product_id || '"') 
 
 ### Storage Engines
 
-6 specialized engines tuned for your workload:
+4 supported engines tuned for your workload (plus AXIS HNSW/IVF indexes):
 
 | Engine | Best For | Performance |
 |--------|----------|-------------|
 | **SST** | Real-time, write-heavy | ~5ms |
 | **HELIX** | Locality-optimized | ~13ms |
 | **VIPER** | Columnar analytics | ~89ms |
-| **SWIFT** | Ultra-low latency (<5K vectors) | ~95ms |
 | **NOVA** | Mixed workloads | ~101ms |
-| **RAPTOR** | Adaptive, dynamic workloads | ~9ms |
+
+> **Experimental (off by default):** the SWIFT and RAPTOR engines exist behind the
+> `experimental-engines` cargo feature and are disabled in stock builds. Do not target them
+> for v0.2. See [`05-concepts/storage-engines.adoc`](./05-concepts/storage-engines.adoc).
 
 ---
 
@@ -152,7 +154,7 @@ For future-shaping architecture work, start with `docs/12-design/README.adoc`.
 - Single-node scope for the v0.2 support contract
 
 ### Beta: Unified API
-- Single port (5678) for REST, gRPC, and Arrow Flight
+- Single port (5678) for REST, gRPC, and Arrow Flight (Arrow Flight as a customer transport is Experimental)
 - PostgreSQL wire protocol (5433) for SQL clients
 - Python SDK with async support
 
@@ -199,6 +201,7 @@ flowchart TB
     SST[SST Engine]
     HELIX[HELIX Engine]
     VIPER[VIPER Engine]
+    NOVA[NOVA Engine]
     ORION[ORION Graph Engine]
   end
 
@@ -207,6 +210,7 @@ flowchart TB
   WAL --> SST
   WAL --> HELIX
   WAL --> VIPER
+  WAL --> NOVA
   WAL --> ORION
 
   style UQ fill:#e74c3c,stroke:#c0392b,color:#fff
@@ -226,7 +230,7 @@ flowchart TB
 
 ## Version
 
-**Pre-release (in development)**: v0.2.0 — narrow single-node cut targeting May 2026. See
+**Pre-release (in development)**: v0.2.0 — a narrow single-node cut. See
 [`SUPPORTED_SURFACE.adoc`](./SUPPORTED_SURFACE.adoc) for the supported/beta/experimental split
 and [`release-notes/v0.2.0.adoc`](./release-notes/v0.2.0.adoc) for the release contract.
 
@@ -247,4 +251,4 @@ and [`release-notes/v0.2.0.adoc`](./release-notes/v0.2.0.adoc) for the release c
 
 ---
 
-*Last updated: 2026-02-22*
+*Last updated: 2026-06-29*


### PR DESCRIPTION
## Summary

Realigns the customer-facing + concept documentation to the actual product state. The TD register, ADRs, and roadmap were already reconciled (2026-06-24/28); the drift was concentrated in the reader-facing docs (README, docs landing, INDEX, PRD, VISION, `05-concepts` guides).

**Docs-only — no code / proto / OpenAPI / SDK changes.** None of the drift gates (proto / openapi / sdk-codegen / clippy) fire on this PR.

## What changed

**Engines** — lead with the 4 supported storage engines (SST, VIPER, HELIX, NOVA) + TST; demote **SWIFT / RAPTOR** to a clearly-marked *experimental, off-by-default* callout (they sit behind the `experimental-engines` cargo feature and bail on stock builds). **ORION** is the only graph engine; retired **PULSAR / QUASAR** removed from diagrams/prose (noted as retired). Names the **AXIS** (HNSW/IVF) ANN index layer.

**API surface** — REST `/api/v2` + gRPC `proximadb.v2.*` canonical; v1 deprecated-compat. **Arrow Flight** marked Experimental as a customer transport.

**Architecture / fusion** — documents the single shared **FusionService** seam (per-surface fusion is an anti-pattern); aligns the 8-model + stability-matrix status columns to `SUPPORTED_SURFACE.adoc` (Document/Observability/Time-Series/Event = Beta; Vector = Supported).

**hybrid-fusion.adoc** — switches the worked example from the deprecated `/api/v1/hybrid/search` alias to the canonical v2 fusion-search route.

**Date stamps** — refreshed stale stamps (Dec 2025 / Feb 2026 / Mar 2026, incl. the ADR index `2026-04-02`) to June 2026. The v0.2 framing and the 2026–2028 vision roadmap are left intact (reframing release dates is a product call).

## Verification

- `git diff --stat` → 11 files, `+144 / −144` (clean swaps).
- No `PULSAR`/`QUASAR`/`6 storage`/`6 engine` terms remain in scope except in correctly-marked retired context; `SWIFT`/`RAPTOR` appear only in labeled *experimental* callouts.
- No pre-June-2026 date stamps remain in the edited files.
- Mermaid `subgraph`/`end` blocks balanced; diagrams show the 4 live engines + ORION.
- `docs/12-design/adr/README.adoc` keeps develop's new ADR-044 index row and only updates the `:last-updated:` date.

## Authority

`docs/SUPPORTED_SURFACE.adoc` remains the authority for support tiers; narrative docs defer to it.
