### PR TITLE
feat(sdk): doc-writers -> ingest_documents + remove broken REST insert_document (ADR-041 P5.1)

### DIFF
--- a/clients/python/src/proximadb_sdk/adapters/base.py
+++ b/clients/python/src/proximadb_sdk/adapters/base.py
@@ -208,9 +208,32 @@ class BaseProtocolAdapter(ABC):
         id: str | None = None,
         **kwargs,
     ) -> dict[str, Any]:
-        """Insert a document."""
+        """Insert a document into a document-collection (legacy document-collections surface).
+
+        Retained for document-collection CRUD consumers (e.g. the agentic store);
+        for new semantic-document writes prefer :meth:`ingest_documents` (ADR-041).
+        """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support document inserts"
+        )
+
+    def ingest_documents(
+        self,
+        collection_id: str,
+        records: list[dict[str, Any]],
+        *,
+        tenant_id: str | None = None,
+        ingest_mode: str | None = None,
+        embed_source: str = "native",
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Ingest documents for native server-side embedding (ADR-041 canonical surface).
+
+        Each record is a ``{id, text, metadata?, vector?}`` dict; the server embeds
+        ``text`` natively under ``embed_source="native"`` when no ``vector`` is given.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support document ingest"
         )
 
     def get_document(

--- a/clients/python/src/proximadb_sdk/adapters/embedded_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/embedded_adapter.py
@@ -1315,6 +1315,40 @@ class EmbeddedProtocolAdapter(BaseProtocolAdapter):
             },
         }
 
+    def ingest_documents(
+        self,
+        collection_id: str,
+        records: list[dict[str, Any]],
+        *,
+        tenant_id: str | None = None,
+        ingest_mode: str | None = None,
+        embed_source: str = "native",
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Ingest documents via the embedded API (native, else vector-fallback per record)."""
+        results: list[dict[str, Any]] = []
+        for rec in records:
+            rid = rec.get("id")
+            # Store the record's metadata AS the document — matches the legacy
+            # insert_document shape so document reads (get_document/query_documents)
+            # stay consistent. (embed_source/text aren't used on the embedded
+            # vector-fallback path.)
+            document = dict(rec.get("metadata") or {})
+            document.setdefault("id", rid)
+            try:
+                if hasattr(self._db, "insert_document"):
+                    doc_id, version = self._db.insert_document(
+                        collection_id, document, rid
+                    )
+                else:
+                    r = self._insert_document_as_vector(collection_id, document, rid)
+                    doc_id, version = r["id"], r.get("version", 1)
+                results.append({"id": doc_id, "version": version})
+            except Exception as e:
+                logger.error(f"Failed to ingest document {rid}: {e}")
+                raise
+        return {"mode": "embedded", "records": results}
+
     def insert_document(
         self,
         collection_name: str,

--- a/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
@@ -655,26 +655,30 @@ class RestProtocolAdapter(BaseProtocolAdapter):
             logger.error(f"Failed to create document collection: {e}")
             raise
 
-    def insert_document(
+    def ingest_documents(
         self,
-        collection_name: str,
-        document: dict[str, Any],
-        id: str | None = None,
+        collection_id: str,
+        records: list[dict[str, Any]],
+        *,
+        tenant_id: str | None = None,
+        ingest_mode: str | None = None,
+        embed_source: str = "native",
         **kwargs,
     ) -> dict[str, Any]:
-        """Insert a document via REST."""
-        try:
+        """Ingest documents via the canonical generated client (ADR-041).
 
-            response = self._client._session.post(
-                f"{self._url}/api/v2/document-collections/{collection_name}/documents",
-                json={"id": id, "document": document},
-                timeout=self._client._timeout,
-            )
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Failed to insert document: {e}")
-            raise
+        The legacy REST ``insert_document`` is intentionally absent here — it accessed
+        nonexistent ``self._client._session``/``_timeout`` and never worked. REST
+        document-collection writes fall through to the base ``NotImplementedError``.
+        """
+        return self._client.ingest_documents(
+            collection_id,
+            records,
+            tenant_id=tenant_id,
+            ingest_mode=ingest_mode,
+            embed_source=embed_source,
+            **kwargs,
+        )
 
     def get_document(
         self,

--- a/clients/python/src/proximadb_sdk/embedded_multi.py
+++ b/clients/python/src/proximadb_sdk/embedded_multi.py
@@ -259,10 +259,15 @@ class EmbeddedMultiModelProvider:
                 }
             )
 
-            self._adapter.insert_document(
-                collection_name=self._document_collection,
-                document=doc_meta,
-                id=f"doc:{file_hash}",
+            self._adapter.ingest_documents(
+                collection_id=self._document_collection,
+                records=[
+                    {
+                        "id": f"doc:{file_hash}",
+                        "text": content,
+                        "metadata": doc_meta,
+                    }
+                ],
             )
             results["document"] = True
         except Exception as e:

--- a/clients/python/src/proximadb_sdk/integrations/agentic_io.py
+++ b/clients/python/src/proximadb_sdk/integrations/agentic_io.py
@@ -112,10 +112,15 @@ class ProximaEventStore:
             global_position=global_position,
             created_at=time.time(),
         )
-        self.adapter.insert_document(
+        self.adapter.ingest_documents(
             self.collection,
-            _event_to_document(record),
-            id=_event_doc_id(stream_id, version, record.event_id),
+            records=[
+                {
+                    "id": _event_doc_id(stream_id, version, record.event_id),
+                    "text": str(record.data),
+                    "metadata": _event_to_document(record),
+                }
+            ],
         )
         return record
 
@@ -231,7 +236,10 @@ class ProximaMapperSession:
         existing = self.adapter.get_document(collection_name, doc_id)
         if existing:
             self.adapter.delete_document(collection_name, doc_id)
-        self.adapter.insert_document(collection_name, payload, id=doc_id)
+        self.adapter.ingest_documents(
+            collection_name,
+            records=[{"id": doc_id, "text": str(payload), "metadata": payload}],
+        )
 
         if vector is not None:
             from proximadb_sdk.integrations._records import (

--- a/clients/python/tests/integrations/test_agentic_io.py
+++ b/clients/python/tests/integrations/test_agentic_io.py
@@ -47,6 +47,24 @@ class FakeAdapter:
         self.documents.setdefault(collection_name, {})[doc_id] = dict(document)
         return {"success": True, "id": doc_id}
 
+    def ingest_documents(
+        self,
+        collection_id: str,
+        records: list[dict[str, Any]],
+        **_: Any,
+    ) -> dict[str, Any]:
+        # Store each record's metadata as the document so get_document/query_documents
+        # read-back stays consistent with the legacy insert_document shape.
+        bucket = self.documents.setdefault(collection_id, {})
+        for rec in records:
+            doc_id = rec["id"]
+            document = dict(rec.get("metadata") or {})
+            document["id"] = doc_id
+            if rec.get("text") is not None:
+                document["text"] = rec["text"]
+            bucket[doc_id] = document
+        return {"success": True, "records": [{"id": r["id"]} for r in records]}
+
     def get_document(self, collection_name: str, doc_id: str) -> dict[str, Any] | None:
         document = self.documents.get(collection_name, {}).get(doc_id)
         if document is None:

--- a/clients/python/tests/unit/test_embedded_multi_cov.py
+++ b/clients/python/tests/unit/test_embedded_multi_cov.py
@@ -68,6 +68,12 @@ class FakeAdapter:
     def insert_document(self, collection_name, document, id):
         self.inserted_documents.append((collection_name, document, id))
 
+    def ingest_documents(self, collection_id, records, **kwargs):
+        for rec in records:
+            self.inserted_documents.append(
+                (collection_id, rec.get("metadata") or rec, rec.get("id"))
+            )
+
     def create_node(self, graph, node_id, labels, properties):
         if self.raise_on_create_node:
             raise RuntimeError("node exists")
@@ -398,7 +404,7 @@ async def test_index_code_file_error_branches():
         def insert_records(self, *a, **k):
             raise RuntimeError("vec fail")
 
-        def insert_document(self, *a, **k):
+        def ingest_documents(self, *a, **k):
             raise RuntimeError("doc fail")
 
     adapter = BrokenAdapter()

--- a/clients/python/tests/unit/test_rest_adapter_cov.py
+++ b/clients/python/tests/unit/test_rest_adapter_cov.py
@@ -708,18 +708,6 @@ def test_create_document_collection_error(adapter):
         adapter.create_document_collection("docs")
 
 
-def test_insert_document(adapter):
-    adapter._client._session.program("post", FakeResp({"id": "d1"}))
-    out = adapter.insert_document("docs", {"title": "x"}, id="d1")
-    assert out == {"id": "d1"}
-
-
-def test_insert_document_error(adapter):
-    adapter._client._session.program("post", FakeResp(raise_exc=RuntimeError("x")))
-    with pytest.raises(RuntimeError):
-        adapter.insert_document("docs", {"title": "x"})
-
-
 def test_get_document(adapter):
     adapter._client._session.program("get", FakeResp({"id": "d1", "title": "x"}))
     out = adapter.get_document("docs", "d1", projection=["title"])

--- a/clients/python/tests/unit/test_victor_integrations_cov.py
+++ b/clients/python/tests/unit/test_victor_integrations_cov.py
@@ -1062,7 +1062,7 @@ def test_event_store_append_first():
     rec = store.append("s1", "created", {"x": 1}, expected_version=0)
     assert rec.version == 1
     assert rec.global_position == 1
-    adapter.insert_document.assert_called_once()
+    adapter.ingest_documents.assert_called_once()
 
 
 def test_event_store_append_version_conflict():
@@ -1177,7 +1177,7 @@ def test_session_upsert_dataclass():
     session, adapter = make_session()
     doc_id = session.upsert(_Sample(id="i1", name="x"))
     assert doc_id == "i1"
-    adapter.insert_document.assert_called_once()
+    adapter.ingest_documents.assert_called_once()
 
 
 def test_session_upsert_generates_id_and_deletes_existing():


### PR DESCRIPTION
## What

Scoped P5.1 follow-up to P5 (#546). The 3 semantic-document writers now use the canonical `ingest_documents` surface, and the **broken** `RestProtocolAdapter.insert_document` (ADR-041 root-cause bug #1 — accessed nonexistent `self._client._session`/`_timeout`) is removed.

## Why

P5 removed the 3 *public* `insert_document` facades. P5.1 cleans up the remaining internal callers + the broken REST impl. (Full removal was deferred — see scope note.)

## Changes

- **`adapters/base.py` + `embedded_adapter.py`**: add `ingest_documents` to the adapter contract (the doc-writers hold a *bare* adapter, so they need it on the contract). `insert_document` is **retained** — it's the sole write surface for the `document-collections` API consumed by the agentic store.
- **`adapters/rest_adapter.py`**: replace the broken `insert_document` with `ingest_documents` (delegates to `ProximaDBClient.ingest_documents`). REST document-collection writes now cleanly `NotImplementedError` (base default) instead of crashing on `_session`/`_timeout`.
- **`embedded_multi.py` + `integrations/agentic_io.py` (×2)**: migrate the 3 doc-writers from `self.adapter.insert_document(...)` → `self.adapter.ingest_documents(...)`.
- **Tests**: delete the 2 broken-REST `insert_document` tests; add `ingest_documents` to the test FakeAdapters/mocks; update assertions.

## Scope note (why not full removal)

`agentic_store` (ProximaBaseStore + CheckpointSaver) is a full **document-collection-CRUD** store — its writes use `insert_document` AND its reads use `get_document`/`query_documents` on the same `document-collections` surface. `insert_document` is its **only** write surface, and that surface is distinct from both `ingest_documents` (`collections`) and `records`. Migrating it off `document-collections` is a whole-store refactor (insert/get/query/delete) → deferred to **P5.2**. So `insert_document` stays on the contract as that surface's legitimate write method.

## Verification

- Unit suite: only pre-existing failures (victor-codegraph chunker, a missing fixture). **Zero new regressions.**
- Integration suite (`test_agentic_io`, `test_agentic_embedded`): only the 2 pre-existing failures (`mapper_session`, `unified_query` — both fail on clean develop). The 3 doc-writer regressions I introduced were fixed (embedded `ingest_documents` stores `metadata` as the document to match the legacy read-back shape).
- ruff (`E9,F63,F7`) + black + isort clean on all 9 touched files.

Refs ADR-041. Follows P0–P5 (#462, #532, #535, #546).