### PR TITLE
chore(gitignore): ignore local /audit/ secret/tooling access logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -465,6 +465,9 @@ docs/archive/sessions/
 /test_exists_dir/
 /test_metadata/
 /test_metadata_atomic/
+
+# Local secret/tooling audit logs (never commit — may contain access events)
+/audit/
 /test_size
 /test_filter_debug.rs
 /nohup.out


### PR DESCRIPTION
Adds `/audit/` to `.gitignore`.

The local `audit/` directory captures secret/tooling access events (`audit_*.jsonl` with actor/provider/keyring fields). It must never be tracked or committed. This was surfaced while cleaning a contaminated working tree that had staged such a log.

Security: one-line ignore; no code change. No drift gates apply (.gitignore only).