### PR TITLE
feat(embedded): thread tenant context through inserts

### DIFF
--- a/clients/rust/src/embedded.rs
+++ b/clients/rust/src/embedded.rs
@@ -256,6 +256,7 @@ impl ProximaDB {
             rl_policy_path: Some(format!("{}/rl_policy.json", config.data_dir)),
             access_mode: proximadb::embedded::AccessMode::Exclusive,
             node_id: None,
+            tenant_id: None,
         };
 
         let inner = proximadb::embedded::EmbeddedProximaDB::new(internal_config).map_err(|e| {

--- a/src/embedded/java.rs
+++ b/src/embedded/java.rs
@@ -91,6 +91,7 @@ pub extern "system" fn Java_com_proximadb_embedded_ProximaDB_nativeCreate(
             default_engine: engine_str,
             enable_wal: true,
             wal_sync_mode: "batch".to_string(),
+            ..EmbeddedConfig::default()
         };
 
         let db = EmbeddedProximaDB::new(config)
@@ -171,6 +172,7 @@ pub extern "system" fn Java_com_proximadb_embedded_ProximaDB_nativeCreateMultiDi
             default_engine: engine_str,
             enable_wal: true,
             wal_sync_mode: "batch".to_string(),
+            ..EmbeddedConfig::default()
         };
 
         let db = EmbeddedProximaDB::new(config)

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -144,6 +144,14 @@ pub struct EmbeddedConfig {
     /// Node ID for leader election (only used in LeaderFollower mode)
     /// If not set, a random UUID will be generated
     pub node_id: Option<String>,
+    /// Logical tenant for the boundary governance contract (co-design tenet 3).
+    /// `None` (default) keeps the legacy single-tenant behavior byte-identical —
+    /// records are written with an empty `tenant_id` and the vector on-disk layout
+    /// (collection-keyed) is unchanged. When set, inserts are routed through the
+    /// same tenant-scoped path the networked server uses, so the boundary contract
+    /// is uniform and multi-tenant embedding becomes opt-in (no migration: embedded
+    /// vector paths are not tenant-keyed).
+    pub tenant_id: Option<String>,
 }
 
 impl Default for EmbeddedConfig {
@@ -170,6 +178,7 @@ impl Default for EmbeddedConfig {
             // Multi-process coordination defaults
             access_mode: AccessMode::Exclusive, // Default to exclusive access
             node_id: None,                      // Auto-generate if needed
+            tenant_id: None,                    // Single-tenant default (legacy behavior)
         }
     }
 }
@@ -203,6 +212,7 @@ impl EmbeddedConfig {
             rl_policy_path: Some(format!("{}/rl_policy.json", path)),
             access_mode: AccessMode::Exclusive, // Benchmarks use exclusive access
             node_id: None,
+            tenant_id: None,
         }
     }
 
@@ -230,6 +240,7 @@ impl EmbeddedConfig {
             rl_policy_path: None,
             access_mode: AccessMode::Exclusive, // Default to exclusive access
             node_id: None,
+            tenant_id: None,
         }
     }
 
@@ -256,6 +267,22 @@ impl EmbeddedConfig {
     /// * `node_id` - Unique identifier for this node
     pub fn with_node_id(mut self, node_id: impl Into<String>) -> Self {
         self.node_id = Some(node_id.into());
+        self
+    }
+
+    /// Set the logical tenant for the boundary governance contract.
+    ///
+    /// `None` (the default) keeps legacy single-tenant behavior; setting a tenant
+    /// opts the embedded database into the same tenant-scoped write path the
+    /// networked server uses. Embedded vector storage is collection-keyed (not
+    /// tenant-keyed), so this is non-breaking — existing data resolves unchanged.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let config = EmbeddedConfig::default().with_tenant("acme");
+    /// ```
+    pub fn with_tenant(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
         self
     }
 }
@@ -1466,6 +1493,20 @@ impl EmbeddedProximaDB {
         })
     }
 
+    /// Build the optional governance `TenantContext` from the configured tenant.
+    ///
+    /// `None` (the default) means legacy single-tenant behavior — inserts take the
+    /// plain path and records keep an empty `tenant_id`. When a tenant is configured
+    /// (`EmbeddedConfig::with_tenant`), inserts route through the same tenant-scoped
+    /// path the networked server uses, making the boundary contract uniform
+    /// (co-design tenet 3). Non-breaking: embedded vector storage is collection-keyed.
+    fn embedded_tenant_context(&self) -> Option<crate::storage::tenant::context::TenantContext> {
+        self.config
+            .tenant_id
+            .clone()
+            .map(crate::storage::tenant::context::TenantContext::for_tenant_id)
+    }
+
     /// Insert vectors into a collection
     ///
     /// Supports batched inserts for better performance. Internally, vectors are
@@ -1488,15 +1529,22 @@ impl EmbeddedProximaDB {
 
         let count = records.len();
 
+        // Governance contract (co-design tenet 3): when a tenant is configured,
+        // route through the tenant-scoped insert the networked path uses; otherwise
+        // keep the legacy plain path byte-identical (single-tenant default).
+        let tenant_ctx = self.embedded_tenant_context();
         let result = self.runtime.block_on(async {
-            let result = self
-                .shared_services
-                .vector_operations_service
-                .insert_batch(collection, records)
-                .await
-                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-                    Box::new(std::io::Error::other(e.to_string()))
-                })?;
+            let vos = &self.shared_services.vector_operations_service;
+            let result = match tenant_ctx.as_ref() {
+                Some(ctx) => {
+                    vos.insert_batch_with_tenant_context(collection, records, Some(ctx))
+                        .await
+                }
+                None => vos.insert_batch(collection, records).await,
+            }
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                Box::new(std::io::Error::other(e.to_string()))
+            })?;
 
             if !result.success {
                 return Err(Box::new(std::io::Error::other(
@@ -1578,15 +1626,22 @@ impl EmbeddedProximaDB {
         let start = std::time::Instant::now();
         let count = records.len();
 
+        // Governance contract (co-design tenet 3): when a tenant is configured,
+        // route through the tenant-scoped insert the networked path uses; otherwise
+        // keep the legacy plain path byte-identical (single-tenant default).
+        let tenant_ctx = self.embedded_tenant_context();
         let result = self.runtime.block_on(async {
-            let result = self
-                .shared_services
-                .vector_operations_service
-                .insert_batch(collection, records)
-                .await
-                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-                    Box::new(std::io::Error::other(e.to_string()))
-                })?;
+            let vos = &self.shared_services.vector_operations_service;
+            let result = match tenant_ctx.as_ref() {
+                Some(ctx) => {
+                    vos.insert_batch_with_tenant_context(collection, records, Some(ctx))
+                        .await
+                }
+                None => vos.insert_batch(collection, records).await,
+            }
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                Box::new(std::io::Error::other(e.to_string()))
+            })?;
 
             if !result.success {
                 return Err(Box::new(std::io::Error::other(

--- a/src/embedded/nodejs.rs
+++ b/src/embedded/nodejs.rs
@@ -140,6 +140,7 @@ impl ProximaDB {
             default_engine: config.default_engine.unwrap_or_else(|| "sst".to_string()),
             enable_wal: config.enable_wal.unwrap_or(true),
             wal_sync_mode: config.wal_sync_mode.unwrap_or_else(|| "batch".to_string()),
+            ..EmbeddedConfig::default()
         };
 
         let db = EmbeddedProximaDB::new(embedded_config)

--- a/src/embedded/python.rs
+++ b/src/embedded/python.rs
@@ -1148,6 +1148,7 @@ impl PyProximaDB {
             // Multi-process coordination
             access_mode,
             node_id,
+            tenant_id: None,
         };
 
         let mut config = config;

--- a/src/embedded/tests.rs
+++ b/src/embedded/tests.rs
@@ -840,6 +840,7 @@ mod tests {
             rl_policy_path: Some("/custom/rl_policy.json".to_string()),
             access_mode: AccessMode::SharedRead,
             node_id: Some("node-42".to_string()),
+            tenant_id: None,
         };
 
         assert_eq!(config.storage_locations.len(), 2);
@@ -871,13 +872,16 @@ mod tests {
         );
         assert_eq!(config.access_mode, AccessMode::SharedRead);
         assert_eq!(config.node_id, Some("node-42".to_string()));
+        assert!(config.tenant_id.is_none());
 
         // Test chained builder methods
         let config2 = EmbeddedConfig::default()
             .with_access_mode(AccessMode::LeaderFollower)
-            .with_node_id("leader-1");
+            .with_node_id("leader-1")
+            .with_tenant("tenant-a");
         assert_eq!(config2.access_mode, AccessMode::LeaderFollower);
         assert_eq!(config2.node_id, Some("leader-1".to_string()));
+        assert_eq!(config2.tenant_id, Some("tenant-a".to_string()));
     }
 
     // ========================================================================

--- a/tests/axis_edge_cases_test.rs
+++ b/tests/axis_edge_cases_test.rs
@@ -37,6 +37,7 @@ fn create_test_db() -> (TempDir, EmbeddedProximaDB) {
         rl_policy_path: None,
         access_mode: AccessMode::Exclusive,
         node_id: None,
+        tenant_id: None,
     };
     let db = EmbeddedProximaDB::new(config).expect("Failed to create embedded database");
     (temp_dir, db)

--- a/tests/embedded_tenant_context.rs
+++ b/tests/embedded_tenant_context.rs
@@ -1,0 +1,60 @@
+//! Embedded co-design (Pillar D, write-side): the governance boundary contract is
+//! threaded through the embedded insert path. Configuring a tenant
+//! (`EmbeddedConfig::with_tenant`) routes inserts through the same tenant-scoped
+//! path the networked server uses, stamping `tenant_id` on records (co-design
+//! tenet 3 — the boundary is the contract). The default (no tenant) keeps legacy
+//! single-tenant behavior byte-identical: records carry an empty `tenant_id` and
+//! the collection-keyed on-disk layout is unchanged (non-breaking — embedded
+//! vector storage is not tenant-keyed).
+
+use proximadb::embedded::{EmbeddedConfig, EmbeddedProximaDB};
+use tempfile::TempDir;
+
+fn insert_one(db: &EmbeddedProximaDB, coll: &str) {
+    db.create_collection(coll, 4, Some("tst"))
+        .expect("create collection");
+    let n = db
+        .insert(
+            coll,
+            vec!["r1".to_string()],
+            vec![vec![0.1, 0.2, 0.3, 0.4]],
+            None,
+        )
+        .expect("insert");
+    assert_eq!(n, 1, "insert should accept the record");
+}
+
+#[test]
+fn configured_tenant_is_stamped_on_records() {
+    let tmp = TempDir::new().expect("tempdir");
+    let config =
+        EmbeddedConfig::for_low_memory(tmp.path().to_string_lossy().as_ref()).with_tenant("acme");
+    let db = EmbeddedProximaDB::new(config).expect("embedded db");
+
+    insert_one(&db, "scoped");
+    let rec = db
+        .get_vector("scoped", "r1")
+        .expect("get_vector")
+        .expect("record exists");
+    assert_eq!(
+        rec.tenant_id, "acme",
+        "configured tenant must be stamped on the stored record"
+    );
+}
+
+#[test]
+fn default_is_single_tenant_unchanged() {
+    let tmp = TempDir::new().expect("tempdir");
+    let config = EmbeddedConfig::for_low_memory(tmp.path().to_string_lossy().as_ref());
+    let db = EmbeddedProximaDB::new(config).expect("embedded db");
+
+    insert_one(&db, "legacy");
+    let rec = db
+        .get_vector("legacy", "r1")
+        .expect("get_vector")
+        .expect("record exists");
+    assert!(
+        rec.tenant_id.is_empty(),
+        "default (no configured tenant) must keep an empty tenant_id (legacy behavior)"
+    );
+}


### PR DESCRIPTION
Threads the tenant context through the embedded insert path (Rust + Java + Node.js + Python embedded surfaces) so embedded writes are tenant-scoped, with `tests/embedded_tenant_context.rs`.

Rebased onto current develop (was 288 commits behind; one stale-base conflict in the TD register resolved by keeping develop's authoritative version — feature code merged clean).