### PR TITLE
docs(api): client surface map + spec-driven document-collections client

### DIFF
--- a/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
@@ -667,9 +667,9 @@ class RestProtocolAdapter(BaseProtocolAdapter):
     ) -> dict[str, Any]:
         """Ingest documents via the canonical generated client (ADR-041).
 
-        The legacy REST ``insert_document`` is intentionally absent here — it accessed
-        nonexistent ``self._client._session``/``_timeout`` and never worked. REST
-        document-collection writes fall through to the base ``NotImplementedError``.
+        Targets the **collections** vector-store document surface with server-side
+        embedding. For the separate JSON **document-collections** surface (no
+        embedding) see :meth:`insert_document`.
         """
         return self._client.ingest_documents(
             collection_id,
@@ -678,6 +678,34 @@ class RestProtocolAdapter(BaseProtocolAdapter):
             ingest_mode=ingest_mode,
             embed_source=embed_source,
             **kwargs,
+        )
+
+    def insert_document(
+        self,
+        collection_name: str,
+        document: dict[str, Any],
+        id: str | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Insert a JSON document into a document-collection (spec-driven, ADR-041).
+
+        Targets the **document-collections** surface
+        (`POST /api/v2/document-collections/{c}/documents`) via the GENERATED client
+        op — pure JSON storage, no server-side embedding. For semantic content with
+        embedding use :meth:`ingest_documents` (the collections vector store).
+        """
+        from .._generated.rest.api.documents.insert_document import sync_detailed
+        from .._generated.rest.client import Client as GeneratedClient
+        from .._generated.rest.models.insert_document_body import InsertDocumentBody
+
+        body = InsertDocumentBody.from_dict({"id": id, "document": document})
+        client = GeneratedClient(base_url=self._url, raise_on_unexpected_status=False)
+        response = sync_detailed(collection=collection_name, client=client, body=body)
+        if response.status_code in (200, 201, 202):
+            return response.parsed.to_dict() if response.parsed is not None else {}
+        raise RuntimeError(
+            f"insert_document (document-collections) failed {response.status_code}: "
+            f"{response.content!r}"
         )
 
     def get_document(

--- a/clients/python/tests/unit/test_rest_adapter_cov.py
+++ b/clients/python/tests/unit/test_rest_adapter_cov.py
@@ -708,6 +708,29 @@ def test_create_document_collection_error(adapter):
         adapter.create_document_collection("docs")
 
 
+def test_insert_document_delegates_to_generated_document_collections_op(adapter):
+    """insert_document targets the document-collections surface via the generated op (ADR-041)."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    op = "proximadb_sdk._generated.rest.api.documents.insert_document.sync_detailed"
+    with patch(op) as mock_op:
+        mock_op.return_value = SimpleNamespace(
+            status_code=200,
+            content=b"{}",
+            parsed=SimpleNamespace(to_dict=lambda: {"id": "d1"}),
+        )
+        out = adapter.insert_document("docs", {"title": "x"}, id="d1")
+
+    mock_op.assert_called_once()
+    kwargs = mock_op.call_args.kwargs
+    assert kwargs["collection"] == "docs"
+    # The generated InsertDocumentBody carries the {id, document} document-collections payload.
+    assert kwargs["body"].to_dict() == {"id": "d1", "document": {"title": "x"}}
+    assert "testserver" in str(kwargs["client"]._base_url)
+    assert out == {"id": "d1"}
+
+
 def test_get_document(adapter):
     adapter._client._session.program("get", FakeResp({"id": "d1", "title": "x"}))
     out = adapter.get_document("docs", "d1", projection=["title"])

--- a/docs/03-api-reference/client-surface-map.adoc
+++ b/docs/03-api-reference/client-surface-map.adoc
@@ -1,0 +1,244 @@
+= ProximaDB Client Surface Map
+:toc: left
+:toclevels: 3
+:icons: font
+:source-highlighter: rouge
+:sectnums:
+:last-updated: 2026-06-29
+
+*Audience: client-app developers.* This is the fast on-ramp — one map that ties
+together every external surface, its payload/response shape, and how the SDK and
+the PostgreSQL-wire protocol lower to the engine. It abstracts away internals;
+for the codebase/module-level view see
+link:../12-design/SYSTEM_MAP_2026_05_30.adoc[SYSTEM_MAP (internal)], which is the
+apex *internal* map (this doc is its *external* counterpart and does not compete
+with it).
+
+[NOTE]
+====
+**Two document surfaces — read this before choosing.** ProximaDB has *two*
+document-ish write paths and they are not interchangeable:
+
+* `/api/v2/collections/{id}/documents` (`ingestDocuments`) — the **vector store**
+  with **server-side embedding**. Send `{records:[{id,text,metadata}]}` +
+  `X-Embed-Source: native`; the server embeds `text`. This is the ADR-041
+  canonical surface for semantic content.
+* `/api/v2/document-collections/{c}/documents` — the **document store** (pure
+  JSON documents, no embedding). Use this for structured JSON / KV-style state
+  where you do *not* want server-side embedding.
+
+Both are live, advertised (`GET /api/v2/_meta/capabilities`), and spec'd — pick
+by whether you want embedding (collections) or raw JSON (document-collections).
+====
+
+== Surfaces at a glance
+
+Base URL: `http://<host>:5678/api/v2`. Canonical error envelope for all v2:
+`{error:{type, message, code, request_id?, details?}}` (snake_case `type`,
+HTTP `code`, optional correlation `request_id` echoed in the `X-Request-ID`
+header).
+
+[cols="3,4,3,2", options="header"]
+|====
+| Surface | Path(s) | Purpose | Status
+
+| Collections
+| `/collections`, `/collections/{id}`
+| Collection lifecycle (create/list/get/delete) with schema support
+| Supported
+
+| Records
+| `/collections/{id}/records`, `/records/batch`, `/records/{id}`
+| `ProximaRecord` CRUD + batch (vector + props). The dim-1 zero-vector record is the KV pattern.
+| Supported
+
+| Documents (embed)
+| `/collections/{id}/documents` (`ingestDocuments`)
+| **Vector store**, server-side embedding of `text`
+| Supported
+
+| Documents (JSON)
+| `/document-collections`, `/document-collections/{c}/documents`
+| **Document store**, pure JSON (no embedding)
+| Supported (Beta)
+
+| Search
+| `/collections/{id}/search`
+| Vector + typed-filter search
+| Supported
+
+| Query
+| `/query`, `/query/explain`
+| Shared SQL/UQL facade + plan explain
+| Supported
+
+| Graph
+| `/graphs`, `/graphs/{id}/{nodes,edges}[/batch]`, `/graphs/{id}/traverse`, `/graphs/{id}/fusion-search`, `/graphs/{id}/impact-analysis`
+| Graph topology CRUD, traversal, vector-seed→graph fusion, blast radius
+| Supported
+
+| Hybrid
+| `/hybrid/index`, `/hybrid/search`
+| Dense + BM25 fusion
+| Beta
+
+| Observability
+| `/observability/namespaces/{ns}/logs[/search]`
+| Log query/search
+| Beta
+
+| Entities
+| `/collections/{id}/entities`
+| Entity orchestration facade (upsert/search/get)
+| Beta
+
+| External
+| `/external-collections`
+| Lake/data-lake indexing
+| Experimental
+
+| Diagnostics
+| `/_diagnostics/collections/{id}/{route-health,statistics,recall-tune,recluster}`
+| Capability checks, stats, HNSW retune/recluster
+| Experimental
+
+| Meta
+| `/_meta/capabilities`
+| Feature negotiation (what this server advertises)
+| Supported
+|====
+
+*Status ladder (ADR-0014):* `planned` → `experimental` → `beta` → `supported`
+(+ AnvaiOps-side `private_preview`). AnvaiOps never claims a status above
+upstream ProximaDB.
+
+== Payload shapes (the ones you'll send most)
+
+*Create a collection:*
+[source,json]
+----
+{"name":"docs","dimension":768,"distance_metric":"cosine","storage_engine":"sst"}
+----
+
+*Records batch (vector + props):*
+[source,json]
+----
+{"records":[{"id":"v1","vector":[0.1,0.2,0.3],"props":{"category":"tech"}}],"upsert":true}
+----
+
+*Records KV (metadata-only, no embedding) — dim-1 zero vector:*
+[source,json]
+----
+{"records":[{"id":"acct_1","vector":[0.0],"props":{"cloud":"azure","tier":"pro"}}]}
+----
+
+*Ingest documents (vector store, server embeds `text`):*
+[source,json]
+----
+{"records":[{"id":"d1","text":"full document text","metadata":{"source":"web"}}]}
+----
+with header `X-Embed-Source: native` (omit `vector` to let the server embed).
+
+*Document store (pure JSON, no embedding):*
+[source,json]
+----
+{"id":"d1","document":{"title":"x","body":"raw json — the server stores, does not embed"}}
+----
+
+*Search:*
+[source,json]
+----
+{"vector":[0.1,0.2,0.3],"top_k":10,"filter":{"category":"tech"}}
+----
+
+== Headers
+
+[cols="2,4", options="header"]
+|====
+| Header | Meaning
+| `X-Request-ID` | Correlation id; echoed in `error.request_id` + response header
+| `X-Tenant-ID` | Multi-tenant scoping ( enforced server-side )
+| `X-Embed-Source` | `native` = server-side embedding (collections documents)
+| `X-Ingest-Mode` | Billing/metering mode
+| `Deprecation` / `X-ProximaDB-API-Status` | Set on deprecated v1 responses
+|====
+
+== SDK lowering (Python)
+
+Entry point: `from proximadb_sdk import ProximaDBClient` (the unified client,
+`clients/python/src/proximadb_sdk/unified_client.py`). Method groups on the
+client: collections, records/vectors, `ingest_documents`, search, graph, query.
+
+Lowering chain:
+
+....
+ProximaDBClient  ──(protocol adapter)──▶  BaseProtocolAdapter
+   │                                          ├── RestProtocolAdapter   ── HTTP/JSON ──▶ /api/v2/*
+   │                                          ├── GrpcProtocolAdapter    ── gRPC      ──▶ :5679
+   │                                          └── EmbeddedProtocolAdapter ── in-process (PyO3)
+   │
+   └──(canonical document write)──▶ ingest_documents() ──▶ generated Client
+                                                  └──▶ _generated/.../ingest_documents.sync_detailed
+                                                       ──▶ POST /api/v2/collections/{id}/documents
+....
+
+* The canonical surfaces (`ingest_documents`, and the records/collections ops)
+  route through the **generated** openapi-python-client package
+  (`proximadb_sdk._generated.rest.*`) — the spec is the single source of truth
+  (ADR-041).
+* The adapter layer abstracts protocol choice (REST default; gRPC opt-in;
+  embedded in-process).
+* **Three modes** via `PROXIMADB_MODE` / constructor: `server`
+  (`url=http://host:5678`), `sdk` / `embedded` (in-process, no server). See
+  link:../02-guides/sdk-python-guide.adoc[sdk-python-guide] for code.
+
+== pgwire lowering (PostgreSQL wire)
+
+Port `5433`. SQL in → engine out:
+
+....
+psql / pgvector client
+   └──▶ PostgresServer (src/network/postgres/)
+           └──▶ QueryTranslator  ──(pg SQL → ProximaDB SQL, pgvector ops <-> , <=>, <#>)──▶
+                   RelationalPipeline (opt-in PROXIMADB_NEW_RELATIONAL_PIPELINE=1)
+                      └──▶ logical plan ─▶ physical plan ─▶ ComputeScheduler
+                             ├── NativeVolcanoEngine  (OLTP/relational)
+                             └── DataFusionLocal      (OLAP/parquet; feature-gated)
+....
+
+* Accepts ANSI SQL (DataFusion planner) + pgvector distance operators +
+  `VECTOR_SEARCH()`. DDL/DML are tenant-scoped.
+* pgwire shares the query path with the REST `/query` surface (same planner →
+  same engines). See link:postgres.adoc[postgres] for wire details.
+
+== Ports + transport
+
+[cols="2,2,3,2", options="header"]
+|====
+| Port | Protocol | Used for | Status
+| 5678 | REST/HTTP | Canonical v2 surface, `ingestDocuments`, records, etc. | Supported
+| 5679 | gRPC | Internal/search; explicit opt-in for ingest | Supported (v2)
+| 5680 | Arrow Flight | Bulk columnar export | Beta
+| 5433 | PostgreSQL wire | SQL clients / pgvector | Supported
+|====
+
+Unified mode (default) serves all protocols on one port; multi-port mode is the
+legacy separate-port layout.
+
+== Deprecation map (what's going away)
+
+* **v1 (`/api/v1/*`)** — deprecated compatibility facades. Responses carry
+  `Deprecation: true` + `X-ProximaDB-API-Status: deprecated-compatibility`.
+  Sunset: 2026-06-30. Use v2.
+* **v3 (`/api/v3/*`)** — 308 permanent redirect → v2 (e.g.
+  `POST /api/v3/collections/{id}/documents` → v2). Clients must NOT rely on v3.
+* **gRPC v1** — off by default; opt-in via `enable_grpc_v1_compat`. Sunset
+  2026-06-30. Use gRPC v2.
+
+== Where to go next
+
+* REST detail: link:rest.adoc[REST API reference]
+* SQL/pgvector: link:postgres.adoc[PostgreSQL wire]
+* Python code: link:../02-guides/sdk-python-guide.adoc[Python SDK guide]
+* Graph: link:graph.adoc[Graph API]
+* Internals/modules: link:../12-design/SYSTEM_MAP_2026_05_30.adoc[SYSTEM_MAP (internal)]

--- a/docs/03-api-reference/index.md
+++ b/docs/03-api-reference/index.md
@@ -28,6 +28,10 @@ flowchart TB
   style SDK fill:#9b59b6,color:#fff
 ```
 
+> **New here?** Start with the **[Client Surface Map](./client-surface-map.adoc)** —
+> a one-page orientation to every surface, its payload/response shape, and how the
+> SDK + pgwire lower to the engine. Then dive into the per-surface reference below.
+
 ---
 
 ## REST API


### PR DESCRIPTION
## What

Two related spec-driven-clarity changes:

1. **Client Surface Map** (`docs/03-api-reference/client-surface-map.adoc`) — a one-page, client-app-facing orientation tying together every external surface, its payload/response shape, and how the Python SDK + the pgwire protocol lower to the engine. Linked from the section index as the "start here" entry. Complements (does not compete with) the internal `SYSTEM_MAP_2026_05_30.adoc` — this is the external/client counterpart.

2. **REST `insert_document` → generated document-collections op** — the right-shaped spec-driven cleanup for the document-collections surface (mirrors P2/#532's `ingest_documents` pattern).

## Why the map

Reduce cognitive load for client-app authors: one entry point that shows all the seams, payloads, the canonical error envelope, the SDK→adapter→generated-op→surface lowering, the pgwire→engine lowering, ports, and the v1/v3 deprecation story. The load-bearing callout is the **two document surfaces** distinction — `ingestDocuments` (`/collections/{id}/documents`, vector store + server-side embedding) vs `document-collections` (`/document-collections/{c}/documents`, pure JSON store).

## Why the code change

The precondition check for the (now-dropped) P5.2 confirmed `document-collections` is **live, advertised, and spec'd** — not deprecated. So the right cleanup is to make the SDK's client for it **spec-driven** (delegate to the generated op), not abandon the surface or migrate its consumer. `RestProtocolAdapter.insert_document` now builds an `InsertDocumentBody` + a generated `Client` + calls the generated `sync_detailed` — retiring the last hand-written document-write HTTP path. `agentic_store` keeps using it unchanged (it's a legitimate consumer of a supported surface).

## Verification

- New `insert_document` delegation test passes (asserts the generated op is called with the `{id, document}` document-collections payload + base URL); full `test_rest_adapter_cov` suite green (83 passed).
- ruff (`E9,F63,F7`) + black + isort clean on the touched Python files.

Refs ADR-041.