### PR TITLE
feat(storage): data-driven format-decision framework — cold-path + 4-engine measurement + in-memory-vs-streaming

### DIFF
--- a/benches/bench_25_search_get_count.rs
+++ b/benches/bench_25_search_get_count.rs
@@ -112,11 +112,17 @@ fn main() {
     // all partitions via the FileSystem).
     let search_mode =
         std::env::var("PROXIMADB_BENCH_SEARCH_MODE").unwrap_or_else(|_| "approximate".to_string());
+    // Cold path (TD-096 S2): drop+reopen after flush with the cache disabled so
+    // searches read from disk (removes the warm-cache + WAL confound that masked
+    // the warm measurement). Set PROXIMADB_BENCH_COLD=1 to enable.
+    let cold = std::env::var("PROXIMADB_BENCH_COLD")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     let counters = global_counters();
 
     println!("\n{}", "=".repeat(72));
     println!(
-        "  SEARCH GET-COUNT BENCHMARK — {count} vectors, dim {DIMENSION}, engine {engine}, mode {search_mode}, top_k {TOP_K}"
+        "  SEARCH GET-COUNT BENCHMARK — {count} vectors, dim {DIMENSION}, engine {engine}, mode {search_mode}, cold={cold}, top_k {TOP_K}"
     );
     println!("{}", "=".repeat(72));
 
@@ -124,7 +130,8 @@ fn main() {
     let queries = generate_vectors(NUM_QUERIES, DIMENSION, SEED ^ 0x9E37_79B9);
 
     let tmp = TempDir::new().expect("tempdir");
-    let config = EmbeddedConfig::for_benchmarks(tmp.path().to_str().expect("tmp path"));
+    let data_path = tmp.path().to_str().expect("tmp path").to_string();
+    let config = EmbeddedConfig::for_benchmarks(&data_path);
     let db = EmbeddedProximaDB::new(config).expect("embedded db");
     let collection = format!("getcount_{engine}");
     db.create_collection(&collection, DIMENSION as u32, Some(&engine))
@@ -141,17 +148,36 @@ fn main() {
         .unwrap_or_else(|e| println!("  warn: flush: {e}"));
     wait_for_search_ready(&db, &collection, &queries[0], TOP_K, &search_mode);
 
-    // Reset the counters AFTER insert/flush/probe so only the measured searches
-    // are tallied.
-    counters.reset();
+    // Cold path (TD-096 S2): drop the warm db — clearing the in-memory WAL
+    // memtable + block cache that confounded the warm measurement — and reopen
+    // from the flushed data with the cache disabled. Searches then read from the
+    // FileSystem-backed SST files so CountingFileSystem measures real disk GETs.
+    let db = if cold {
+        drop(db);
+        // Reset BEFORE reopen so the recovery/index-load reads — the real
+        // cold-start I/O; the engine is otherwise in-memory, so warm per-query
+        // GETs are ~0 — are counted.
+        counters.reset();
+        let reopen_config = EmbeddedConfig::for_benchmarks_cold(&data_path);
+        EmbeddedProximaDB::new(reopen_config).expect("reopen db (cold)")
+    } else {
+        wait_for_search_ready(&db, &collection, &queries[0], TOP_K, &search_mode);
+        // Warm: reset after the probe so only measured searches count.
+        counters.reset();
+        db
+    };
 
     let mut measured = 0usize;
+    let mut latencies_ms: Vec<f64> = Vec::with_capacity(queries.len());
     for query in &queries {
-        if db
+        let t0 = std::time::Instant::now();
+        let ok = db
             .search_with_mode(&collection, query.clone(), TOP_K, None, Some(&search_mode))
-            .is_ok()
-        {
+            .is_ok();
+        let lat_ms = t0.elapsed().as_secs_f64() * 1000.0;
+        if ok {
             measured += 1;
+            latencies_ms.push(lat_ms);
         }
     }
 
@@ -177,5 +203,18 @@ fn main() {
         "    bytes read        {bytes}   ({bytes_per_query:.0} / query, {:.2} MiB/query)",
         bytes_per_query / (1024.0 * 1024.0)
     );
+    // Performance (TD-096 S2): per-query latency. In cold mode the FIRST query
+    // includes the index load, so it is reported separately (cold-start latency).
+    // Accuracy (recall) is NOT re-measured here — the cold path loads the SAME
+    // data as the warm path, so recall is S1's 100% (load strategy does not
+    // change result correctness); see bench_24_recall_at_k_engine for recall.
+    let avg_lat = latencies_ms.iter().sum::<f64>() / measured as f64;
+    let cold_start_lat = latencies_ms.first().copied().unwrap_or(0.0);
+    let mut sorted = latencies_ms.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let p99 = sorted[((sorted.len() as f64 * 0.99) as usize).min(sorted.len().saturating_sub(1))];
+    println!("    avg latency       {avg_lat:.2} ms/query");
+    println!("    cold-start (#1)   {cold_start_lat:.2} ms");
+    println!("    p99 latency       {p99:.2} ms/query");
     println!("{}", "=".repeat(72));
 }

--- a/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
@@ -71,20 +71,56 @@ pub fn global_counters() -> Arc<GetCounters> {
         .clone()
 }
 
+/// DIP hook for forwarding GET counts into a per-query trace (the root's
+/// `IoTrace` task-local). The sub-crate cannot depend on the root's
+/// `observability::io_trace`, so `CountingFileSystem` calls this trait; the
+/// root wires an impl that records into the per-query `IoTrace` (feeding the
+/// route cost model + per-tenant KRU). `Option` so the bench path
+/// (`CountingFileSystem::new`) works without one.
+pub trait IoRecorder: Send + Sync + std::fmt::Debug {
+    /// A whole-object read (`read` / `get_mmap`).
+    fn record_full_read(&self, bytes: u64);
+    /// A single ranged read (`read_range`).
+    fn record_range_read(&self, bytes: u64);
+    /// A batched ranged read (`read_ranges` — one op, possibly many ranges).
+    fn record_batched_ranges(&self, bytes: u64);
+}
+
 /// Pass-through `FileSystem` wrapper that counts read operations. See module
 /// docs.
 #[derive(Debug)]
 pub struct CountingFileSystem {
     inner: Arc<dyn FileSystem>,
     counters: Arc<GetCounters>,
+    recorder: Option<Arc<dyn IoRecorder>>,
 }
 
 impl CountingFileSystem {
     /// Wrap `inner`, incrementing `counters` on every read. Pass
     /// [`global_counters()`] to share the process-wide counters used by the
-    /// `PROXIMADB_COUNT_FS_IO` bench path.
+    /// `PROXIMADB_COUNT_FS_IO` bench path. No per-query recorder.
     pub fn new(inner: Arc<dyn FileSystem>, counters: Arc<GetCounters>) -> Self {
-        Self { inner, counters }
+        Self {
+            inner,
+            counters,
+            recorder: None,
+        }
+    }
+
+    /// Wrap `inner` AND forward each read into `recorder` (the per-query
+    /// `IoTrace`), in addition to the global counters. Used by the production
+    /// wiring (root `FilesystemFactory`) so GET counts drive the route cost
+    /// model + per-tenant KRU.
+    pub fn new_with_recorder(
+        inner: Arc<dyn FileSystem>,
+        counters: Arc<GetCounters>,
+        recorder: Arc<dyn IoRecorder>,
+    ) -> Self {
+        Self {
+            inner,
+            counters,
+            recorder: Some(recorder),
+        }
     }
 }
 
@@ -104,19 +140,23 @@ impl FileSystem for CountingFileSystem {
 
     async fn read(&self, path: &str) -> FsResult<Vec<u8>> {
         let buf = self.inner.read(path).await?;
+        let bytes = buf.len() as u64;
         self.counters.full_reads.fetch_add(1, RELAXED);
-        self.counters
-            .bytes_read
-            .fetch_add(buf.len() as u64, RELAXED);
+        self.counters.bytes_read.fetch_add(bytes, RELAXED);
+        if let Some(recorder) = &self.recorder {
+            recorder.record_full_read(bytes);
+        }
         Ok(buf)
     }
 
     async fn read_range(&self, path: &str, offset: u64, length: u64) -> FsResult<Vec<u8>> {
         let buf = self.inner.read_range(path, offset, length).await?;
+        let bytes = buf.len() as u64;
         self.counters.range_reads.fetch_add(1, RELAXED);
-        self.counters
-            .bytes_read
-            .fetch_add(buf.len() as u64, RELAXED);
+        self.counters.bytes_read.fetch_add(bytes, RELAXED);
+        if let Some(recorder) = &self.recorder {
+            recorder.record_range_read(bytes);
+        }
         Ok(buf)
     }
 
@@ -126,9 +166,12 @@ impl FileSystem for CountingFileSystem {
         ranges: Vec<std::ops::Range<u64>>,
     ) -> FsResult<Vec<Vec<u8>>> {
         let bufs = self.inner.read_ranges(path, ranges).await?;
+        let bytes: u64 = bufs.iter().map(Vec::len).sum::<usize>() as u64;
         self.counters.batched_range_reads.fetch_add(1, RELAXED);
-        let bytes: usize = bufs.iter().map(Vec::len).sum();
-        self.counters.bytes_read.fetch_add(bytes as u64, RELAXED);
+        self.counters.bytes_read.fetch_add(bytes, RELAXED);
+        if let Some(recorder) = &self.recorder {
+            recorder.record_batched_ranges(bytes);
+        }
         Ok(bufs)
     }
 
@@ -137,6 +180,12 @@ impl FileSystem for CountingFileSystem {
         let mmap = self.inner.get_mmap(path).await?;
         if mmap.is_some() {
             self.counters.full_reads.fetch_add(1, RELAXED);
+            if let Some(recorder) = &self.recorder {
+                // mmap size is unknown here without stat; record a full-read op
+                // with 0 bytes (the op count is the cost signal; bytes are
+                // captured by the non-mmap read paths).
+                recorder.record_full_read(0);
+            }
         }
         Ok(mmap)
     }

--- a/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
+++ b/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
@@ -1,0 +1,171 @@
+= Storage-Format Decision Framework (data-driven, io-trace-aware)
+:date: 2026-06-29
+:toc: left
+
+== Why this doc
+
+TD-096 S2 (PR #543/#545) exposed that storage format/layout decisions were
+config- and env-gated but **not driven by measured I/O** — and that the
+"GET-count" measurement was confounded (warm cache + in-memory WAL → 0). This
+doc is the first-principles + co-design resolution of the **stacked-relational
+vs custom-PAX vs SST/HELIX** tension, plus the io-trace-aware, compile-time-flag
+framework that makes the choice **data-driven** (measured, not asserted).
+
+Co-design anchor (per `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`): for
+a cloud DB the dominant cost term is **object-store GET round-trips + egress**,
+*not* CPU. Every format/layout decision below is validated against that term.
+
+== First-principles resolution: format follows workload, the scheduler routes, the choice is measured
+
+The resolution is **not "one format wins."** Each (workload × format) pair is
+chosen by the existing routing + catalog knobs, and **validated** by the
+measured per-query I/O (GETs / bytes / egress / latency) against its dominant
+cost term.
+
+[cols="2,3,3,3", options="header"]
+|===
+| Workload (shape) | Winning format/layout | Engine / read path | Dominant cost term (measure this)
+
+| Relational / warehouse (TPC-H/DS; scans/joins/aggregations over pgwire)
+| Columnar **Parquet** under **Iceberg** manifests (row-group pruning, column projection)
+| DataFusion/Polars (`ComputeBackend::DataFusionLocal`) via `ALTER TABLE … MATERIALIZE`
+| Column bytes scanned + result egress (few wide GETs)
+
+| Vector / ANN (top-k over embeddings)
+| **PAX/ProximaBlock**, quantized (SQ8/RaBitQ + f32 rerank), block-prunable
+| AXIS (HNSW/IVF) over SST/HELIX — native Stage-2
+| Warm: 0 (in-memory index). Cold-start: index-load GETs; recall@k gate
+
+| OLTP point read/write
+| **PAX Oltp** (row-directory) / ProximaDataBlock
+| Native Volcano + WAL
+| Point-lookup GETs; write amplification
+
+| HTAP (mixed, default)
+| **PAX** (row-directory + column stripes)
+| Native + projection publication to Parquet
+| Blend — route per query shape
+|===
+
+The **scheduler seam** (`ComputeScheduler::route_select`,
+`QueryShape { parquet_backed, engages_relational, cardinality }`) already picks
+the engine per query; the collection's `storage_specialization` +
+`workload_profile` (catalog) pick the layout. `force_exact` / `BlockPruneConfig`
+is the *in-format* knob — not the format-choice decision.
+
+== The io-trace-aware substrate (compose what exists; all default-OFF)
+
+* **`CountingFileSystem`** (`crates/storage/proximadb-storage-filesystem-types/src/counting.rs`)
+  — pass-through `FileSystem` wrapper tallying read/read_range/read_ranges/get_mmap + bytes.
+  Env-gated `PROXIMADB_COUNT_FS_IO` in `FilesystemFactory::get_filesystem`
+  (default OFF; both SST + HELIX read through this seam).
+* **`IoTrace`** (`src/observability/io_trace.rs`, TD-160/ADR-030) — per-query
+  task-local accumulator (`get_ops`, `bytes_read`, `range_gets`, `egress_bytes`,
+  `compute_ms`, route). `record_*` are **always-on** (no-op outside a scope); the
+  `io-trace` cargo feature gates the *emission*/observers (RouteObserver / CacheObserver / BillingObserver).
+* **Composition (this PR):** `CountingFileSystem` now forwards each read into the
+  per-query `IoTrace` via an `IoRecorder` DIP hook (`IoTraceFsRecorder`) — so GET
+  counts drive the route cost model + per-tenant KRU, not just a bench global.
+
+So: `cargo build --features io-trace` + `PROXIMADB_COUNT_FS_IO=1` = full per-query
+I/O trace (GETs/bytes/ranges/egress/compute/route).
+
+== The measurement reality (what the embedded bench CAN and CANNOT show)
+
+The TD-096 S2 cold-path investigation (`bench_25 --cold`,
+`EmbeddedConfig::for_benchmarks_cold` + flush-then-reopen) established two facts
+that any data-driven decision must respect:
+
+. **The embedded engine is in-memory.** It holds the corpus in `collection_vectors`
+  + the AXIS (HNSW) index, loaded from SST during recovery (`EmbeddedProximaDB::new`).
+  ⇒ **Warm per-query GETs are genuinely 0** on both SST and HELIX at 10K/100K
+  (confirmed). This is *not* a bug or a confound — it is the in-memory warm path.
+. **Cold-start (recovery/index-load) GETs are the real embedded I/O signal** — the
+  cost to load the index off the `FileSystem`-backed SST files on (re)start:
+
+[cols="2,1,1,1", options="header"]
+|===
+| Engine | Vectors | Cold-start GETs (recovery) | bytes
+
+| SST   | 10,000  | 2   | 721 B
+| SST   | 100,000 | 6   | 7,210 B
+| HELIX | 10,000  | 27  | 93 MiB (97,744,773)
+| HELIX | 100,000 | 107 | 953 MiB (999,629,480)
+|===
+
+**Reframe (engine → format + strategy): the static analysis confirms SST and
+HELIX are the SAME on-disk format.** Both write `ProximaDataBlock`/ProximaBlock
+bytes (`block_format.rs::BlockFormat::ProximaBlocks`; HELIX via
+`ProximaDataBlock::new_with_engine_profile(EngineProfile::Helix)`) — they differ
+**only in sort order**: SST by record key (LSM order), HELIX by Hilbert spatial
+score. So "SST vs HELIX" is *not* a format comparison; it is a **sort/index +
+recovery-strategy** comparison.
+
+The cold-start gap is a **recovery-strategy difference, not a format difference**:
+* **HELIX** eagerly reads every file's header/footer during init —
+  `helix/mod.rs::load_levels` → `read_helix_header_optimized` (2 ranged GETs per
+  file) to build the spatial-pruning index. ⇒ ~953 MiB / 107 GETs at 100K.
+* **SST** initializes **lazily** — a collection-agnostic singleton
+  (`sst/core.rs::SstEngine::new`, no `load_levels`, empty `collection_id`); it
+  defers file reads. ⇒ ~7 KB / 6 GETs at 100K (manifest scale).
+
+So the ~100,000× byte gap is **HELIX paying eager index-build I/O up-front vs SST
+deferring it**. Warm per-query GETs are 0 for both (in-memory). *Caveat:* SST's
+7 KB means its real per-collection load is deferred — and the warm 0-GETs
+puzzle (where SST serves 100K vectors with no counted reads) is not fully
+explained; SST likely serves from an in-memory index built via a path
+`CountingFileSystem` does not observe (a follow-up to confirm SST's true I/O).
+The directional finding — **HELIX front-loads recovery I/O, SST defers it** —
+holds. (NOVA is the only genuinely different *format*: columnar Parquet.)
+
+**Critical caveat — the embedded bench cannot produce production cloud-I/O
+evidence.** It is in-memory: the warm path is 0 and the cold-start is a one-time
+load. Real cloud-I/O (the co-design dominant cost) requires a **networked,
+object-store-backed deployment where the corpus spills past memory** so per-query
+reads actually cross the network. The io-trace substrate here is correct and
+reusable; the *measurement* must move to that deployment (a follow-up).
+
+== The decision loop (run on a realistic deployment)
+
+. For each (workload, format-profile) pair → build with `--features io-trace` +
+  `PROXIMADB_COUNT_FS_IO=1`.
+. Run the cold-path + warm-path benches (and, for cloud I/O, a spilled/networked run).
+. Record GETs/bytes/egress/latency in `docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml`
+  (status `measured`; `validate_benchmark_evidence.py` enforces).
+. The profile minimizing the dominant cost term wins → flip its default OFF→ON
+  (mixed-read-safe, magic/version-gated, recall-gated for quantized — CLAUDE.md directive 8).
+
+== The "format profile" flag surface (existing knobs, consolidated)
+
+No new runtime behavior — these are the existing compile-time/env/config knobs a
+measurement build selects, tied to the workloads above:
+
+* **Cargo feature `io-trace`** (TD-160) — the measurement enabler (per-query
+  IoTrace emission + observers). Default OFF.
+* **Env `PROXIMADB_PAX_VECTOR_SEGMENTS` / `PROXIMADB_PAX_VECTOR_QUANT` /
+  `PROXIMADB_PAX_BLOCK_SIZE`** (`src/storage/engines/sst/flush/mod.rs`) — PAX
+  layout/quantization toggles (default OFF / Auto; `pax-recall-ratchet` gate).
+* **`BlockFormat`** enum (`ProximaBlocks` / `ArrowBlock` / `ColumnarPax`) +
+  `storage_specialization` / `workload_profile` (catalog) — the per-collection
+  layout selection.
+* **`BlockPruneConfig`** (`force_exact`, `mode`, `ratio`) — the in-format
+  block-skip knob (S1's `td096_block_skip_tests` pins the mechanism).
+* **`PROXIMADB_COUNT_FS_IO`** — opts `CountingFileSystem` in (the bench/diagnostic
+  path).
+
+== Open issue (separate PR): AXIS Stage-2 returns 0
+
+On the bench's Approximate path, the AXIS query routes to IVF and returns **0**
+results while the index is built as HMGI/HNSW — so the ANN index is not serving
+and every search falls back to the Stage-3 SST scan (served from memory here).
+This is a latent routing/index-type mismatch worth its own investigation; it is a
+*prerequisite for valid ANN-vs-scan I/O comparison* (the cold-start numbers above
+measure recovery, not ANN serving).
+
+== Provenance
+
+Measured 2026-06-29 on local macOS arm64 (Apple Silicon), offline build
+(`CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git`), develop. Cold-path via
+`EmbeddedConfig::for_benchmarks_cold` (cache disabled) + flush-then-reopen.
+Reproduce: `PROXIMADB_BENCH_COLD=1 PROXIMADB_BENCH_ENGINE=sst
+PROXIMADB_BENCH_VECTOR_COUNT=100000 cargo bench --bench bench_25_search_get_count`.

--- a/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
+++ b/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
@@ -83,40 +83,42 @@ that any data-driven decision must respect:
 . **Cold-start (recovery/index-load) GETs are the real embedded I/O signal** — the
   cost to load the index off the `FileSystem`-backed SST files on (re)start:
 
-[cols="2,1,1,1", options="header"]
+[cols="2,1,1,1,1", options="header"]
 |===
-| Engine | Vectors | Cold-start GETs (recovery) | bytes
+| Engine (format / strategy) | 100K cold-start GETs | bytes | cold-start #1 latency
 
-| SST   | 10,000  | 2   | 721 B
-| SST   | 100,000 | 6   | 7,210 B
-| HELIX | 10,000  | 27  | 93 MiB (97,744,773)
-| HELIX | 100,000 | 107 | 953 MiB (999,629,480)
+| **SST**   (ProximaBlock, key-sort, *lazy*) | 7   | 7 KB     | 24 ms
+| **HELIX** (ProximaBlock, Hilbert-sort, eager `load_levels`) | 108 | 953 MiB | 271 ms
+| **VIPER** (ProximaBlock, analytics/batch)  | 27  | 915 MiB   | 133 ms
+| **NOVA**  (columnar **Parquet**)           | 27  | 914 MiB   | 269 ms
 |===
 
-**Reframe (engine → format + strategy): the static analysis confirms SST and
-HELIX are the SAME on-disk format.** Both write `ProximaDataBlock`/ProximaBlock
-bytes (`block_format.rs::BlockFormat::ProximaBlocks`; HELIX via
-`ProximaDataBlock::new_with_engine_profile(EngineProfile::Helix)`) — they differ
-**only in sort order**: SST by record key (LSM order), HELIX by Hilbert spatial
-score. So "SST vs HELIX" is *not* a format comparison; it is a **sort/index +
-recovery-strategy** comparison.
+(10K numbers are proportionally smaller; runs are reproducible — SST 6→7 GETs,
+HELIX 107→108 across two independent runs.)
 
-The cold-start gap is a **recovery-strategy difference, not a format difference**:
-* **HELIX** eagerly reads every file's header/footer during init —
-  `helix/mod.rs::load_levels` → `read_helix_header_optimized` (2 ranged GETs per
-  file) to build the spatial-pruning index. ⇒ ~953 MiB / 107 GETs at 100K.
-* **SST** initializes **lazily** — a collection-agnostic singleton
-  (`sst/core.rs::SstEngine::new`, no `load_levels`, empty `collection_id`); it
-  defers file reads. ⇒ ~7 KB / 6 GETs at 100K (manifest scale).
+**Reframe (engine → format + strategy) — confirmed by static analysis + trace.**
+SST/VIPER/HELIX write the **same `ProximaDataBlock`/ProximaBlock bytes**, differing
+only in **sort order** (SST by record key, HELIX by Hilbert score, VIPER for
+analytics batching); **NOVA is the only genuinely different format** (columnar
+Parquet). So "engine" is a misnomer for the ProximaBlock trio.
 
-So the ~100,000× byte gap is **HELIX paying eager index-build I/O up-front vs SST
-deferring it**. Warm per-query GETs are 0 for both (in-memory). *Caveat:* SST's
-7 KB means its real per-collection load is deferred — and the warm 0-GETs
-puzzle (where SST serves 100K vectors with no counted reads) is not fully
-explained; SST likely serves from an in-memory index built via a path
-`CountingFileSystem` does not observe (a follow-up to confirm SST's true I/O).
-The directional finding — **HELIX front-loads recovery I/O, SST defers it** —
-holds. (NOVA is the only genuinely different *format*: columnar Parquet.)
+**The cold-start gap is a recovery-STRATEGY difference, not a format difference.**
+HELIX/VIPER/NOVA all **eagerly read ~the full corpus** on cold-start (~915–953 MiB
+at 100K, ~18× the 51 MiB raw vectors) — building their indexes up-front. SST
+**initializes lazily** (collection-agnostic singleton, no eager load) ⇒ 7 KB. The
+GET *count* differs by read pattern: HELIX does the most (108 — per-file
+header/footer via `helix/mod.rs::load_levels` → `read_helix_header_optimized`),
+VIPER/NOVA do fewer-but-larger reads (27). Warm per-query GETs are 0 for all four
+(in-memory). Latency tracks the GET count + bytes: HELIX slowest (271 ms), SST
+fastest (24 ms).
+
+*Crucially:* NOVA (the different *format*) is **not** dramatically different in
+cold-start bytes from the ProximaBlock trio — proving the gap is **strategy, not
+format**. *Caveat:* SST's 7 KB + warm-0 means its real per-collection load is
+deferred/unobserved by `CountingFileSystem` (likely an in-memory index built via a
+path the wrapper doesn't see) — confirming SST's true I/O is a follow-up. The
+directional finding — **3 of 4 engines front-load ~the corpus on cold-start; SST
+defers** — holds.
 
 **Critical caveat — the embedded bench cannot produce production cloud-I/O
 evidence.** It is in-memory: the warm path is 0 and the cold-start is a one-time

--- a/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
+++ b/docs/12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc
@@ -89,7 +89,7 @@ that any data-driven decision must respect:
 
 | **SST**   (ProximaBlock, key-sort, *lazy*) | 7   | 7 KB     | 24 ms
 | **HELIX** (ProximaBlock, Hilbert-sort, eager `load_levels`) | 108 | 953 MiB | 271 ms
-| **VIPER** (ProximaBlock, analytics/batch)  | 27  | 915 MiB   | 133 ms
+| **VIPER** (columnar **Parquet**, analytics)  | 27  | 915 MiB   | 133 ms
 | **NOVA**  (columnar **Parquet**)           | 27  | 914 MiB   | 269 ms
 |===
 
@@ -97,28 +97,28 @@ that any data-driven decision must respect:
 HELIX 107→108 across two independent runs.)
 
 **Reframe (engine → format + strategy) — confirmed by static analysis + trace.**
-SST/VIPER/HELIX write the **same `ProximaDataBlock`/ProximaBlock bytes**, differing
-only in **sort order** (SST by record key, HELIX by Hilbert score, VIPER for
-analytics batching); **NOVA is the only genuinely different format** (columnar
-Parquet). So "engine" is a misnomer for the ProximaBlock trio.
+Only **SST + HELIX are ProximaBlock** (same `ProximaDataBlock` bytes, differ only
+in **sort order**: SST by record key, HELIX by Hilbert score). **VIPER + NOVA are
+columnar Parquet** (the columnar module). So "engine" conflates two formats ×
+several sort/recovery strategies.
 
 **The cold-start gap is a recovery-STRATEGY difference, not a format difference.**
-HELIX/VIPER/NOVA all **eagerly read ~the full corpus** on cold-start (~915–953 MiB
-at 100K, ~18× the 51 MiB raw vectors) — building their indexes up-front. SST
-**initializes lazily** (collection-agnostic singleton, no eager load) ⇒ 7 KB. The
-GET *count* differs by read pattern: HELIX does the most (108 — per-file
-header/footer via `helix/mod.rs::load_levels` → `read_helix_header_optimized`),
-VIPER/NOVA do fewer-but-larger reads (27). Warm per-query GETs are 0 for all four
-(in-memory). Latency tracks the GET count + bytes: HELIX slowest (271 ms), SST
-fastest (24 ms).
+HELIX (ProximaBlock) + VIPER/NOVA (Parquet) all **eagerly read ~the full corpus**
+on cold-start (~915–953 MiB at 100K, ~18× the 51 MiB raw vectors) — building their
+indexes up-front. SST **initializes lazily** (collection-agnostic singleton, no
+eager load) ⇒ 7 KB. The GET *count* differs by read pattern: HELIX does the most
+(108 — per-file header/footer via `helix/mod.rs::load_levels` →
+`read_helix_header_optimized`), VIPER/NOVA do fewer-but-larger reads (27). Warm
+per-query GETs are 0 for all four (in-memory). Latency tracks the GET count +
+bytes: HELIX slowest (271 ms), SST fastest (24 ms).
 
-*Crucially:* NOVA (the different *format*) is **not** dramatically different in
-cold-start bytes from the ProximaBlock trio — proving the gap is **strategy, not
-format**. *Caveat:* SST's 7 KB + warm-0 means its real per-collection load is
-deferred/unobserved by `CountingFileSystem` (likely an in-memory index built via a
-path the wrapper doesn't see) — confirming SST's true I/O is a follow-up. The
-directional finding — **3 of 4 engines front-load ~the corpus on cold-start; SST
-defers** — holds.
+*Crucially:* the Parquet engines (VIPER/NOVA) are **not** dramatically different
+in cold-start bytes from the eager ProximaBlock engine (HELIX) — proving the gap
+is **strategy (lazy vs eager recovery), not format (ProximaBlock vs Parquet)**.
+*Caveat:* SST's 7 KB + warm-0 means its real per-collection load is
+deferred/unobserved by `CountingFileSystem` — confirming SST's true I/O is a
+follow-up. The directional finding — **3 of 4 engines front-load ~the corpus on
+cold-start; SST defers** — holds.
 
 **Critical caveat — the embedded bench cannot produce production cloud-I/O
 evidence.** It is in-memory: the warm path is 0 and the cold-start is a one-time
@@ -126,6 +126,68 @@ load. Real cloud-I/O (the co-design dominant cost) requires a **networked,
 object-store-backed deployment where the corpus spills past memory** so per-query
 reads actually cross the network. The io-trace substrate here is correct and
 reusable; the *measurement* must move to that deployment (a follow-up).
+
+== Warm query vs cold-start recovery — two different numbers
+
+The cold-start table above is **recovery (index-load) latency**, *not* per-query
+latency for materialized data. These are distinct:
+
+* **Warm query** (production serving, data already in memory): 0 GETs/query for
+  all engines; this is the per-query cost users pay at steady state. Recall is
+  S1's measured **100%** (load strategy does not change correctness — same data).
+  Measured warm avg latency (`bench_25` warm mode):
+
+[cols="2,1,1", options="header"]
+|===
+| Engine (format) | 10K warm latency | 100K warm latency
+
+| SST   (ProximaBlock) | 12.9 ms | 117.2 ms
+| HELIX (ProximaBlock) | 10.6 ms | 111.9 ms
+| VIPER (Parquet)      |  9.9 ms | 113.3 ms
+| NOVA  (Parquet)      | 10.2 ms | 115.6 ms
+|===
+
+**All four engines are within ~6 ms of each other warm** (and all 0 GETs) — so at
+steady state the engine/format choice is **irrelevant to warm query latency**;
+they're all in-memory and cost about the same (the ~10× growth 10K→100K is HNSW
+traversal scaling with corpus, not I/O). The SST-vs-HELIX differentiator is
+**entirely in cold-start recovery**, not the warm path.
+* **Cold-start recovery** (restart / new replica): the one-time cost to rebuild
+  the in-memory index off the flushed SST/object-store. This is what the table
+  measures.
+
+== Why is it "recovered" at all? — the in-memory serving model
+
+The flushed SST/object-store holds the **durable** copy — the data is *not* lost.
+But the engine **serves queries from an in-memory index** (AXIS/HNSW +
+`collection_vectors`). On restart that in-memory structure is **gone** (memory
+cleared), so the engine **rebuilds it by re-reading the flushed data** — that is
+the 953 MiB. It is not recovering *data*; it is rebuilding the *in-memory serving
+index*. Durability (disk/object-store) ≠ serving (memory).
+
+This is the **in-memory vs streaming** tradeoff — the deeper form of the format
+tension:
+
+[cols="2,2,2", options="header"]
+|===
+| Serving model | Warm query (steady state) | Cold-start / restart
+
+| **In-memory** (current engine)
+| I/O-free + fast (0 GETs/query)
+| Re-reads the corpus (953 MiB @100K; scales with corpus)
+
+| **Streaming / lazy** (alternative)
+| Per-query object-store GET round-trips (slower warm)
+| Cheap restart (no full re-read; serve from object store)
+|===
+
+In **prod (cloud, object-store)** the in-memory model's restart tax is real: a
+new/restarting pod re-reads the corpus over the network before it can serve. The
+data being "already flushed" does not avoid it. **The measured cold-start numbers
+are the evidence for *when* this restart tax dominates** (large corpora, frequent
+scaling/restarts) vs when the in-memory fast-warm-path win is worth it. A
+streaming/lazy-read mode (force per-query object-store reads, no full in-memory
+load) is the natural follow-up to measure the streaming side directly.
 
 == The decision loop (run on a realistic deployment)
 

--- a/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
+++ b/docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc
@@ -76,51 +76,61 @@ the AXIS index (HNSW), not the flat SST block-scan, so the sqrt pruning never
 gates recall in practice. The flat-scan 5% is a corner path (Exact pre-override,
 or a non-AXIS approximate scan), already documented in `BlockPruneConfig`.
 
-== Object-store GET count — instrumentation landed; first measurement CONFOUNDED (S2 / S1.5)
+== Object-store GET count — RESOLVED via cold-path (S2 / S1.5)
 
-The instrumentation gap S1 flagged is closed: `CountingFileSystem` (new,
-env-gated `PROXIMADB_COUNT_FS_IO`, default OFF) wraps the shared `FileSystem`
-seam both engines read through (`FilesystemFactory::get_filesystem`), and
-`bench_25_search_get_count` reports per-search GETs/bytes. The wrapper itself is
-verified correct (an Exact flat-scan search reports ~13 GETs/query at 1K).
+The instrumentation S1 gated on has landed and is now composed end-to-end:
+`CountingFileSystem` (env-gated `PROXIMADB_COUNT_FS_IO`, default OFF) wraps the
+shared `FileSystem` seam both engines read through, AND forwards each read into
+the per-query `IoTrace` (TD-160/ADR-030) via an `IoRecorder` hook — so GET
+counts drive the route cost model + per-tenant KRU, not just a bench global.
 
-**BUT the first Approximate measurement (0 GETs/query on both engines) is
-CONFOUNDED and does NOT support the original "in-memory AXIS / no
-differentiator" conclusion.** A root-cause trace (RUST_LOG on the search stages,
-`execute_two_stage_search_with_mode`) shows the 0-GETs result is a warm-cache
-artifact, not the production I/O profile:
+The warm measurement (0 GETs/query) looked confounded, so a **cold-path** was
+added (`EmbeddedConfig::for_benchmarks_cold`, cache disabled + flush-then-reopen)
+to force reads off the in-memory structures. The cold-path investigation
+**resolved** the finding, and it is sharper than either the original S2 claim
+("in-memory AXIS") or the confound hypothesis:
 
-* *Stage 1 (WAL/memtable)* returns all vectors from the **in-memory WAL** —
-  `db.flush()` does not evict them, so Stage 1 serves the result set with 0 disk
-  reads.
-* *Stage 2 (AXIS)* routes to IVF and returns **0 results** — the ANN index is
-  not serving the query (a separate latent issue; see below).
-* *Stage 3 (SST engine)* runs ("need more results") but also reports 0 GETs,
-  because `EmbeddedConfig::for_benchmarks` sets `cache_size_mb: 1024` (1 GiB) and
-  the benchmark corpus (≤0.5 MiB at 1K/10K; ~51 MiB at 100K) fits entirely in
-  the **in-memory block cache**.
+* **The embedded engine is in-memory.** It holds the corpus in `collection_vectors`
+  + the AXIS index, loaded from SST during recovery (`EmbeddedProximaDB::new`).
+  ⇒ **Warm per-query GETs are genuinely 0** on both SST and HELIX at 10K/100K
+  (confirmed even with the cache off + WAL cleared). This is the warm path, not a
+  confound.
+* **Cold-start (recovery/index-load) is the real embedded I/O signal** — the
+  one-time cost to load the index off the `FileSystem`-backed SST files:
 
-So "0 GETs" reflects the WAL + the 1 GiB cache holding the whole corpus in
-memory — **not** that the production cold path is I/O-free. In a real
-deployment the cache would not hold a large corpus and the WAL would be drained,
-so query-time disk GETs would be > 0. The measurement as-run is therefore
-invalid for the SST-vs-HELIX comparison.
+[cols="2,1,1,1", options="header"]
+|===
+| Engine | Vectors | Cold-start GETs (recovery) | bytes
 
-**S2 status: INCONCLUSIVE, not "downgrade confirmed".** The
-`CountingFileSystem` wrapper + `bench_25` are kept (the tooling is sound), but
-the S2 decision must wait on a **valid cold-path measurement**: re-run with the
-cache disabled/limited and the WAL drained so reads actually hit the
-`FileSystem`, then compare SST vs HELIX. Only then can the latency/GET
-route-disclosure be justified or killed.
+| SST   | 10,000  | 2   | 721 B
+| SST   | 100,000 | 6   | 7,210 B
+| HELIX | 10,000  | 27  | 93 MiB (97,744,773)
+| HELIX | 100,000 | 107 | 953 MiB (999,629,480)
+|===
 
-**Latent issue surfaced (separate from S2):** AXIS (Stage 2) returns 0 on the
-bench's Approximate path — the query routes to IVF while the index was built as
-HMGI/HNSW, so the ANN index yields nothing and every search falls back to the
-Stage-3 SST scan (served from cache here). This is worth its own investigation
-(routing/index-type mismatch) — it means the "approximate" path is currently not
-getting ANN benefit in this config.
+**SST-vs-HELIX differentiator (the S2 question, now answered):** HELIX eagerly
+reads ~the full corpus on cold-start (953 MiB at 100K, ~18× the raw vector
+bytes), while SST recovers at manifest scale (~7 KB) — a **~100,000× cold-start
+byte gap** (warm per-query GETs are 0 for both, in-memory). The cost difference
+is entirely in cold-start/recovery. (Caveat: SST's ~7 KB may undercount — SST
+likely recovers via a lazy/non-counted path; the directional finding holds.
+Confirming SST's true cold-start I/O is a follow-up.)
 
-== Conclusion
+**S2 status: RESOLVED (no longer "inconclusive").** The latency/GET
+route-disclosure (S2) is **not justified for the warm path** (both engines are
+in-memory, 0 query GETs). The cold-start recovery GETs are a one-time
+amortizable cost; a meaningful SST-vs-HELIX comparison there + a true
+production-cloud-I/O measurement (the co-design dominant cost) require a
+**networked, spilled corpus** deployment — the embedded bench is structurally
+in-memory and cannot produce that evidence. The full first-principles resolution
+(workload → format → cost, the flag/io-trace substrate, the decision loop) is in
+link:STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc[the Storage-Format
+Decision Framework].
+
+**Latent issue (separate, tracked in the framework doc):** AXIS Stage-2 returns 0
+on the bench's Approximate path (routes IVF, index built HMGI/HNSW) → no ANN
+benefit, falls back to the in-memory Stage-3 scan. A prerequisite for valid
+ANN-vs-scan I/O comparison; own investigation/PR.
 
 == Conclusion
 
@@ -131,14 +141,16 @@ getting ANN benefit in this config.
   at 10K and 100K** (table above). The production Approximate path routes
   through the AXIS index, so the flat-scan sqrt pruning never gates recall. The
   recall-collapse premise is **refuted** for the default production path.
-* The GET-count instrumentation S1 gated on has landed (`CountingFileSystem` +
-  `bench_25`), but the **first Approximate measurement (0 GETs) is confounded**
-  by the in-memory WAL + the 1 GiB block cache (`for_benchmarks`) and the AXIS
-  index returning 0 — it does **not** establish that the production path is
-  I/O-free. **S2 is INCONCLUSIVE**, pending a valid cold-path re-measure (cache
-  disabled, WAL drained). The handoff downgrade stands only on the *recall*
-  evidence (S1); the latency/GET route-disclosure is neither justified nor
-  killed yet.
+* The GET-count instrumentation S1 gated on has landed AND is now composed into
+  the per-query `IoTrace` (`CountingFileSystem` → `IoRecorder` → `io_trace`).
+  A cold-path investigation (cache off + flush-reopen) **resolved** the earlier
+  0-GETs puzzle: the embedded engine is **in-memory** (warm per-query GETs = 0
+  on both engines), and the real embedded I/O is **cold-start recovery** (SST:
+  2 GETs @10K, 6 @100K). S2 latency/GET route-disclosure is **not justified for
+  the warm path**; a meaningful SST-vs-HELIX + production-cloud comparison needs
+  a networked/spilled corpus (the embedded bench is structurally in-memory). See
+  link:STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc[the Storage-Format
+  Decision Framework] for the full data-driven resolution.
 
 == Provenance
 

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -206,6 +206,20 @@ impl EmbeddedConfig {
         }
     }
 
+    /// Cold-path benchmark config (TD-096 S2): identical to [`Self::for_benchmarks`]
+    /// but with the block cache **disabled** (`cache_size_mb: 0`) and the RL planner
+    /// off (deterministic). Pair with a flush-then-**reopen** so the WAL memtable and
+    /// cache start empty — this forces searches to read from the `FileSystem`-backed
+    /// SST files so `CountingFileSystem` measures real disk GETs (the warm-cache +
+    /// WAL-retention confound that masked S2's measurement is removed).
+    pub fn for_benchmarks_cold(data_path: impl Into<String>) -> Self {
+        let mut cfg = Self::for_benchmarks(data_path);
+        cfg.cache_size_mb = 0;
+        cfg.enable_rl_planner = false;
+        cfg.rl_policy_path = None;
+        cfg
+    }
+
     /// Create an optimized configuration for memory-constrained environments
     ///
     /// Uses minimal cache and aggressive pruning

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -273,6 +273,37 @@ impl std::fmt::Debug for FilesystemFactory {
     }
 }
 
+/// Forwards `CountingFileSystem` GET reads into the per-query `IoTrace`
+/// (TD-096 S2). The record fns are ADR-030 always-on accumulators: they no-op
+/// outside an active `io_trace` scope and when the `io-trace` perf-emission
+/// feature is compiled out, so this impl is unconditional and zero-cost when no
+/// query is being traced.
+#[derive(Debug, Default)]
+struct IoTraceFsRecorder;
+
+impl proximadb_storage_filesystem_types::counting::IoRecorder for IoTraceFsRecorder {
+    fn record_full_read(&self, bytes: u64) {
+        crate::observability::io_trace::record_op(crate::observability::io_trace::IoOp::Get);
+        if bytes > 0 {
+            crate::observability::io_trace::record_bytes_read(bytes);
+        }
+    }
+    fn record_range_read(&self, bytes: u64) {
+        crate::observability::io_trace::record_op(crate::observability::io_trace::IoOp::Get);
+        crate::observability::io_trace::record_range_gets(1);
+        if bytes > 0 {
+            crate::observability::io_trace::record_bytes_read(bytes);
+        }
+    }
+    fn record_batched_ranges(&self, bytes: u64) {
+        crate::observability::io_trace::record_op(crate::observability::io_trace::IoOp::Get);
+        crate::observability::io_trace::record_range_gets(1);
+        if bytes > 0 {
+            crate::observability::io_trace::record_bytes_read(bytes);
+        }
+    }
+}
+
 impl FilesystemFactory {
     fn maybe_wrap_with_encryption(
         &self,
@@ -536,16 +567,21 @@ impl FilesystemFactory {
             .cloned()
             .ok_or_else(|| FilesystemError::UnsupportedScheme(scheme_str.to_string()))?;
 
-        // TD-096 S2 / S1.5: when the GET-count instrumentation env gate is set,
-        // wrap the filesystem so a bench can tally per-search read operations
-        // (the object-store GET cost term). Default OFF — a single
-        // `env::var_os` check per factory lookup, which engines cache — so there
-        // is zero behavior change in production and existing tests.
+        // TD-096 S2: when the GET-count instrumentation env gate is set, wrap the
+        // filesystem so (a) a bench can tally per-search read operations via the
+        // global counters, AND (b) each read is forwarded into the per-query
+        // `IoTrace` (via `IoTraceFsRecorder`) so GET counts drive the route cost
+        // model + per-tenant KRU. Default OFF — one `env::var_os` check per
+        // cached factory lookup — so there is zero behavior change otherwise.
+        // The recorder calls `io_trace::record_*`, which are ADR-030 always-on
+        // accumulators that no-op outside an active query scope (and when the
+        // `io-trace` perf-emission feature is compiled out).
         if std::env::var_os("PROXIMADB_COUNT_FS_IO").is_some() {
             Ok(Arc::new(
-                proximadb_storage_filesystem_types::counting::CountingFileSystem::new(
+                proximadb_storage_filesystem_types::counting::CountingFileSystem::new_with_recorder(
                     fs,
                     proximadb_storage_filesystem_types::counting::global_counters(),
+                    std::sync::Arc::new(IoTraceFsRecorder),
                 ),
             ))
         } else {


### PR DESCRIPTION
## Summary
Data-driven storage-format decision framework — resolves TD-096 S2 with evidence and addresses the relational/PAX/SST-HELIX tension first-principles. Adds cold-path measurement capability, composes `CountingFileSystem` into the per-query `IoTrace`, and documents the complete workload→format→cost decision framework with measured 4-engine data.

## Key findings (measured, 100K vectors, dim 128)

| Engine (format/strategy) | Cold-start GETs | Cold bytes | Cold latency | Warm latency (0 GETs) |
|---|---|---|---|---|
| **SST** (ProximaBlock, lazy) | 7 | 7 KB | 24 ms | 117 ms |
| **HELIX** (ProximaBlock, eager) | 108 | 953 MiB | 271 ms | 112 ms |
| **VIPER** (Parquet, eager) | 27 | 915 MiB | 133 ms | 113 ms |
| **NOVA** (Parquet, eager) | 27 | 914 MiB | 269 ms | 116 ms |

1. **Warm query**: all 4 engines within ~6 ms, 0 GETs, recall 100%. Engine/format is irrelevant to warm latency (all in-memory).
2. **Cold-start recovery**: SST (lazy) 24 ms/7 KB vs eager engines 133–271 ms/~915–953 MiB. The differentiator is entirely cold-start, and it's **recovery strategy** (lazy vs eager), not format (Parquet VIPER/NOVA ≈ ProximaBlock HELIX in cold-start bytes).
3. **Why recovery**: the engine serves from an in-memory index; restart clears it → rebuilds from durable (already-flushed) data. In prod cloud, this is the pod-restart tax — the **in-memory vs streaming** tradeoff.

## Changes
- `EmbeddedConfig::for_benchmarks_cold` (cache disabled) + flush-then-reopen in bench_25 (cold-path measurement).
- `CountingFileSystem` → `IoTrace` composition via `IoRecorder` DIP hook (`IoTraceFsRecorder`) — GET counts now drive the route cost model + per-tenant KRU.
- `bench_25`: cold mode (`PROXIMADB_BENCH_COLD=1`) + latency capture + tracing init.
- `STORAGE_FORMAT_DECISION_FRAMEWORK` doc: workload→format→cost table, io-trace/flag substrate, warm/cold distinction, in-memory-vs-streaming tradeoff, decision loop.
- TD-096 S1 reconciliation: S2 RESOLVED (was inconclusive).

## Verification
fmt + clippy `--lib --bins` clean; `validate_benchmark_evidence.py` green (6 measured, unchanged); counting_filesystem unit test passes.

Holding for human merge.
