### PR TITLE
docs(olap): re-home native-OLAP mandate into seeds + preserve 8-engine study

### DIFF
--- a/docs/12-design/NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc
+++ b/docs/12-design/NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc
@@ -1,0 +1,669 @@
+= ProximaDB Native OLAP Engine — Comparative Study And Future-Shape Blueprint
+:toc:
+:toclevels: 3
+:sectnums:
+
+Status: Active design blueprint (research-grounded) +
+Date: 2026-06-22 +
+Scope: the future shape of ProximaDB's *native, Rust, object-store-first, multimodal OLAP
+execution engine*, derived from a source-level study of eight open-source MPP / data-engineering
+engines, positioned against the existing **Volcano OLTP** path (PostgreSQL-wire, strong-freshness)
+and the **DataFusion** interim OLAP seam.
+
+[IMPORTANT]
+====
+**Convergence, not competition.** This document extends — it does not replace — the existing
+architecture spine:
+
+* link:DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc[DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04]
+  — the strategic pivot to object-store-first, Rust-native MPP, Intelligent Multi-Engine Routing.
+* link:CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19]
+  — the five-dimension cost spine; every claim here ties to a *dominant cost term*.
+* link:COMPETITIVE_OLTP_OLAP_MPP_TRAJECTORY_2026_05_20.adoc[COMPETITIVE_OLTP_OLAP_MPP_TRAJECTORY_2026_05_20]
+  — the product-shape lessons from PostgreSQL/Vertica/Trino/Snowflake; this doc supplies the
+  *execution-shape* detail one layer down.
+* link:DATAFUSION_BALLISTA_DISTRIBUTED_EXECUTION_2026_06_05.adoc[DATAFUSION_BALLISTA_DISTRIBUTED_EXECUTION_2026_06_05]
+  — the read-route / split-plan / Ballista boundary; this doc supplies the *intra-node engine* and
+  the *object-store shuffle inversion* it leaves open.
+
+Engine selection (`ComputeScheduler::route_select`, `src/query/compute_scheduler.rs`),
+the `ComputeBackend` vocabulary (`src/query/table_write_plan.rs`), and the read-route contract
+(`src/query/read_route.rs`) are the seams this engine plugs into. Nothing here weakens the
+**shared logical plane / split physical plane** rule (§5.1 of the course correction).
+====
+
+== 1. Purpose And Thesis
+
+ProximaDB's relational wedge is *already live* — but on a **hand-rolled, pull-based Volcano
+push-executor over WAL + `RecordStorage`** (`src/network/postgres/relational_pipeline.rs`,
+`try_run_select`), with DataFusion wired only behind a feature gate for Parquet-backed tables.
+That Volcano engine is the right tool for **OLTP**: point lookups, high-concurrency single-row DML,
+and queries that demand immediate strong freshness against the live WAL/memtable. It is the
+*wrong* tool for **OLAP**: large scans, multi-table joins, wide aggregates, and window functions
+over cold object-store data.
+
+This document answers one question: **what should ProximaDB's native OLAP engine look like** —
+the engine that, over the next phases, becomes the analytical peer of Volcano, outcompetes
+Spark/Trino on efficiency per the course-correction mandate, and natively executes vector / graph /
+document operators in the *same* vectorized pipeline rather than in bolted-on silos.
+
+.The dual-engine thesis
+[cols="1,3,3",options="header"]
+|===
+| Axis | Volcano (OLTP — keep) | Native OLAP Engine (this doc — build)
+
+| Workload
+| Point/range lookups, single-row DML, strong-freshness reads
+| Large scans, joins, GROUP BY, window, set ops, ANN-at-scale, graph traversal
+
+| Freshness contract
+| Read-your-writes off live WAL/memtable
+| Snapshot-isolated reads off Parquet/Iceberg + PAX base (manifest-fenced)
+
+| Execution model
+| Pull-based iterator, row/small-batch
+| **Push-based, morsel-driven, vectorized columnar** (Arrow batches)
+
+| Parallelism
+| Per-statement, concurrency from many sessions
+| Intra-query: morsels × work-stealing pool; cross-node: object-store shuffle
+
+| Wire surface
+| pgwire (Postgres-native auth), gRPC relational reads/writes
+| Same pgwire/Flight surface; engine chosen by `ComputeScheduler` from measured trace
+
+| Dominant cost term
+| WAL fsync + memtable CPU
+| **Object-store I/O round-trips + egress bytes** (not CPU)
+|===
+
+The engine is **multimodal by construction**: ANN search, graph traversal, and document scans are
+*operators in the same DAG* as relational scan/join/aggregate, over the *same* Arrow chunk +
+selection-vector substrate. This is the structural payoff — one engine, one cost model, one
+isolation boundary, many modalities — rather than N parallel execution stacks.
+
+== 2. Where We Are Today (Grounded Reality, 2026-06-22)
+
+[source,mermaid]
+----
+flowchart TB
+  subgraph FE["Frontends"]
+    PG["pgwire SELECT/DML"]
+    GRPC["gRPC ExecuteQuery"]
+    FL["Arrow Flight bulk"]
+    REST["REST v2"]
+  end
+  PG & GRPC --> LOWER["Shared relational frontend\nlower_sql to LogicalNode"]
+  LOWER --> CS{"ComputeScheduler\nroute_select"}
+  CS -->|"OLTP / native / always today"| VOL["Native Volcano\npull-executor over WAL+RecordStorage"]
+  CS -.->|"OLAP / parquet_backed\nfeature-gated, not live"| DF["DataFusionLocal"]
+  CS -.->|"reserved"| DFD["DataFusionDistributed\nBallista — unwired"]
+  CS -.->|"reserved, benchmark-gated"| POL["PolarsLocal"]
+  VOL --> RS[("RecordStorage + WAL\nProximaRecord")]
+  DF -.-> OS[("Object store\nParquet/Iceberg")]
+  MM["Multimodel router"] --> VEC["SST/HELIX/NOVA\nANN scan to rerank"]
+  MM --> GR["GraphOperationsService"]
+  MM --> DOC["DocumentService"]
+  VEC --> OS
+  classDef live fill:#d6f5d6,stroke:#2a2;
+  classDef gated fill:#fff3cd,stroke:#cc0;
+  classDef silo fill:#f5d6d6,stroke:#a22;
+  class VOL,RS,PG,GRPC,FL,REST,LOWER,CS live;
+  class DF,DFD,POL,OS gated;
+  class VEC,GR,DOC,MM silo;
+----
+
+**Reality:** the relational engine is Volcano (pull); DataFusion OLAP is real code but unwired in
+the product path; distribution is a reserved enum arm; and the vector/graph/document modalities
+execute in *separate service stacks* (SST/HELIX/NOVA, `GraphOperationsService`, `DocumentService`)
+rather than as operators in a shared analytical plan. The native OLAP engine is the convergence of
+these: a push-based vectorized core that DataFusion seeds and eventually a native engine surpasses,
+into which the modal operators fold.
+
+== 3. Comparative Study — Eight Engines, Source-Level
+
+Studied in place (shallow clones under `../`): **DataFusion** + **Ballista** (Rust),
+**DuckDB** + **Velox** (C++ vectorized cores), **Trino** + **Spark** (JVM MPP),
+**ClickHouse** + **Polars** (columnar OLAP / Rust DataFrame). The full per-engine extractions live
+in the research appendix (§12); this section distils the cross-cutting design axes.
+
+=== 3.1 The Execution-Model Spectrum
+
+Every engine sits on a line from *pull/row* to *push/morsel-vectorized*. ProximaDB's Volcano is at
+the far-left (correct for OLTP); the native OLAP engine must land at the far-right.
+
+[source,mermaid]
+----
+flowchart LR
+  A["Pull / row-at-a-time\nclassic Volcano\n= ProximaDB OLTP today"] --> B["Vectorized-pull\nRecordBatch ~8192\nDataFusion"]
+  B --> C["Processor graph\nprepare/work/schedule\nClickHouse"]
+  C --> D["Push + morsel-driven\nSource/Operator/Sink\nDuckDB / Velox"]
+  D --> E["Morsel ComputeNode\nupdate_state fixpoint + spawn\nPolars-stream"]
+  style A fill:#f5d6d6
+  style D fill:#d6f5d6
+  style E fill:#d6e8ff
+----
+
+[cols="1,2,2,2",options="header"]
+|===
+| Engine | Unit moved | Parallelism mechanism | Key transferable idea
+
+| DataFusion
+| `RecordBatch` (~8192 rows)
+| Partition × Tokio task; `RepartitionExec` = exchange
+| One `ExecutionPlan` trait returning a per-partition `SendableRecordBatchStream`;
+  *requirement-driven* exchange insertion (`EnsureRequirements`)
+
+| DuckDB
+| Chunk (2048) / morsel (1 row group ≈ 122 880)
+| Atomic morsel hand-out over lock-free work-stealing queue; push Source→Operator→Sink
+| Morsel-driven parallelism; parallel `Sink` → serial `Finalize`; `BLOCKED`/`InterruptState` async
+
+| Velox
+| `RowVector` batch
+| `Driver` = 1 pipeline-thread; cooperative time-slice + `kYield`
+| Plan-consumer seam; `BlockingReason`+`ContinueFuture` *off-thread* park on I/O; `ScanSpec` adaptivity
+
+| ClickHouse
+| Chunk of `IColumn`s
+| Processor graph; `prepare()` cheap-serial routing, `work()` parallel-heavy, `schedule()` async-fd
+| Two-phase operator contract; async-fd I/O overlap; whole-column `filter(mask)` late materialization
+
+| Polars
+| `Morsel` (DataFrame chunk + `MorselSeq`)
+| Custom crossbeam work-stealing runtime; `ComputeNode` `update_state` fixpoint + `spawn`
+| **Rust** template: arena IR, memory-aware subgraph scheduling, linearizer for ordered parallel
+
+| Trino
+| `Page` of `Block`s
+| Coordinator/worker; streaming peer-to-peer exchange
+| Streaming exchange (no materialization); property-driven `AddExchanges`; dynamic filtering
+
+| Spark
+| `RDD[InternalRow]` / `ColumnarBatch`
+| Driver/executor; materialized shuffle = stage boundary = stats checkpoint
+| **AQE**: re-plan remaining query from *measured* shuffle stats (coalesce/skew/broadcast-flip)
+
+| Volcano (ProximaDB)
+| Row / small batch
+| Per-statement, pull iterator
+| (Keep for OLTP; do not extend to OLAP scans)
+|===
+
+**Verdict.** The native OLAP core is **DuckDB's push-based morsel engine wearing Velox's
+plan-consumer / async / encoding clothes**, implemented in the **Polars-stream `ComputeNode`
+idiom** (because it is the proven *Rust* shape), costed against measured object-store I/O. Rust +
+Arrow gives the cache-locality and monomorphization that Spark buys with Tungsten codegen and that
+Trino buys with bytecode-gen — **for free, and without the GC tax both pay**.
+
+=== 3.2 The Storage / Scan Spine — ClickHouse Is The Template
+
+For an object-store engine, the dominant cost is *bytes fetched × round-trips*, so the scan spine
+matters more than the operator algebra. ClickHouse is the gold standard; every lever below attacks
+Dimension 1 (object storage) of the co-design spine.
+
+[cols="1,3,2",options="header"]
+|===
+| Lever | What it does | ProximaDB mapping
+
+| **Sparse primary index + granules**
+| One PK entry per *granule* (8192 rows), index fully in RAM; predicate → a few `MarkRange`s →
+  read only those byte ranges
+| In-memory **mark index per PAX segment**; granule = unit of *both* skip-index *and* ranged S3
+  read. Turns "scan the object" into "fetch matching granule ranges"
+
+| **PREWHERE / late materialization**
+| Read the smallest-byte selective predicate columns first → build a filter mask → never fetch
+  wide columns for fully-filtered granules
+| **PREWHERE-on-quantized → rerank-on-f32**: prune on SQ8/RaBitQ + zone-map, materialize f32
+  embeddings only for survivors. The single biggest egress win
+
+| **Zone maps / skip indices**
+| Per-granule min/max + bloom + set summaries prune ranges before reading
+| PAX footer min/max + bloom; expressed as a *predicate rewrite* (Polars `skip_batches` style) over
+  PAX zone-maps + Iceberg manifest stats — reuse `PaxSegmentScanner` zone-maps as the stats frame
+
+| **`QueryConditionCache`** (learned skip)
+| Persists per-(part, condition-hash) matching-mark bitmaps from query history → repeat predicate
+  scans become near-zero-I/O
+| **Per-tenant, per-segment learned mark-skip cache** — cheap, tenant-natural, directly cuts
+  round-trips; folds into the footer/tenant cache (`proximadb-cache`)
+
+| **Type-aware chained codecs**
+| Per-column codec by data shape: Delta/DoubleDelta (timestamps), Gorilla (gauges), T64 (ints),
+  chained with ZSTD
+| Cold/warehouse-tier PAX columns; complements SQ8/RaBitQ *vector* quantization (codecs for
+  scalars, quantization for embeddings)
+
+| **Cache stack**
+| MarkCache (index hot) + UncompressedCache (decoded granules) + FS byte-range cache (S3 ranges on
+  local SSD)
+| Tenant-scoped mark + decompressed-block + byte-range caches; structurally Velox's
+  `AsyncDataCache`→`SsdCache` RAM→SSD tiering, co-budgeted with query memory
+|===
+
+DataFusion already ships the *philosophy* — a layered cheap-first pruning pipeline (file stats →
+row-group min/max → bloom → page index → row filter, `datafusion/datasource-parquet/src/opener`)
+with `EarlyStoppingStream` on LIMIT and a pluggable `ParquetFileReaderFactory` +
+`FileMetadataCache`. ProximaDB's job is to (a) make that factory **tenant-aware** (footer/metadata
+cache keyed by `TenantContext`, egress metered at the I/O boundary) and (b) push it past Parquet's
+granularity using ClickHouse's sparse-mark + PREWHERE machinery over PAX.
+
+=== 3.3 Distribution — Streaming vs Materialized, And The Object-Store Inversion
+
+[source,mermaid]
+----
+flowchart TB
+  subgraph T["Trino — streaming"]
+    T1["Stage"] -->|"in-memory Pages\npeer-to-peer, backpressure"| T2["Stage"]
+    T2 -.->|"any task fails ⇒ whole-query retry"| TX[("no checkpoint")]
+  end
+  subgraph S["Spark — materialized"]
+    S1["ShuffleMapStage"] -->|"write to disk\n+ MapOutputStatistics"| S2["ResultStage"]
+    S2 -.->|"partition-granular recompute\n+ AQE re-plan from stats"| SX[("disk = checkpoint")]
+  end
+  subgraph P["ProximaDB target — object-store shuffle"]
+    P1["Stage"] -->|"write partitions to\nobject store under DrPathBuilder"| OSS[("S3/GCS/Azure\ndata/tenant/ns/shuffle/...")]
+    OSS --> P2["Stage"]
+    P2 -.->|"stateless executors\nno recompute on loss"| PX[("durable, elastic")]
+  end
+----
+
+The decisive lessons:
+
+* **Trino** proves streaming exchange (lowest latency, but whole-query retry). **Spark** proves
+  materialized shuffle buys *two* things from one mechanism — partition-granular fault recovery
+  *and* the stats checkpoint that **AQE** re-plans from. The native engine should make that purchase
+  **selectively per-stage from the measured trace**, not as a global mode.
+* **Ballista** (the Rust precedent) cuts the DataFusion plan at pipeline-breakers
+  (`RepartitionExec(Hash)`/`Coalesce`/`SortPreservingMerge`,
+  `ballista/scheduler/src/planner.rs::plan_query_stages_internal`), runs a clean stage state machine
+  (`UnResolved→Resolved→Running→Successful/Failed`), and shuffles **local-disk Arrow-IPC + pull over
+  Arrow Flight**. Its two production gaps are exactly ProximaDB's structural advantages:
+  ** **Disk-local shuffle** ties data to one executor's lifetime → executor loss = stage recompute,
+     SPOF placement. **ProximaDB inverts this: write shuffle partitions to object storage under
+     `DrPathBuilder`** (`data/{tenant}/{ns}/shuffle/{job}/{stage}/{part}`) with `TenantContext` on
+     the boundary → stateless, elastic, no-recompute-on-loss executors (the Snowflake/Databricks
+     disaggregation calculus). Keep a local-disk fast path for same-node consumers ("object-store
+     unless local" — Ballista's split, inverted).
+  ** **In-memory-only scheduler state** = SPOF. ProximaDB already has an **object-store-CAS,
+     embedded-peer catalog** (`SystemCatalog`) — the right substrate for durable, multi-scheduler
+     job/stage state. Reuse it; do not reinvent etcd.
+* **Dynamic filtering** (Trino `DynamicFilterService`, Spark DPP, DuckDB `JOIN_FILTER_PUSHDOWN`,
+  Velox `addDynamicFilter`): the build side publishes its actual key set/range at runtime → pushed
+  into the probe-side scan → **prunes splits/files/granules before reading**. This is the
+  highest-ROI distributed pattern for an object-store engine and wires straight into ProximaDB's
+  zone-map + mark-index pruning.
+
+== 4. Design Principles Distilled
+
+.Adopt
+. **One operator trait, push-based, morsel-driven.** `ExecutionPlan`-style node returning a
+  per-partition stream (DataFusion's composability) but driven *push* with parallel `Sink` → serial
+  `Finalize` pipeline-breakers (DuckDB) over a work-stealing morsel pool (DuckDB/Polars). Vector,
+  graph, and relational operators are all impls of this one trait.
+. **Vectorized Arrow columnar end-to-end, with execution-time encodings.** Carry
+  dictionary/constant/sequence vectors and **SQ8/RaBitQ-quantized vectors *through* the pipeline**
+  the way DuckDB carries FSST — compute distances on compressed vectors, materialize f32 only at
+  rerank. Selection vectors, not compaction. This is the natural home for
+  `proximadb-quantization-kernel`.
+. **ClickHouse storage spine over PAX:** sparse mark index + granules, PREWHERE staged reads,
+  zone-map/bloom skip indices as predicate rewrites, learned `QueryConditionCache`, type-aware
+  chained codecs.
+. **Cooperative async park-on-I/O.** An S3 ranged read must *suspend the task*
+  (`BlockingReason`/`ContinueFuture` ≈ `BLOCKED`/`InterruptState`), not block a worker thread —
+  native Rust `async`. Overlap cold-S3 latency against CPU.
+. **Velox-grade expression engine in Rust:** encoding peeling (evaluate on distinct dictionary
+  values, re-wrap), CSE, constant folding, cross-batch memoization, flat-no-nulls SIMD fast path,
+  adaptive conjunct reordering by measured selectivity (DuckDB `adaptive_filter`).
+. **Requirement-driven exchange + Ballista-style stage cut**, made native (PAX/vector/graph nodes
+  first-class, no foreign serde codec gymnastics), shuffling **through object storage**.
+. **AQE-style adaptivity** from measured exchange stats: coalesce tiny partitions, flip
+  broadcast↔partitioned, split skew, dynamic-filter. Only possible *after* the exchange seam reports
+  stats — so it follows distribution, not precedes it.
+. **Structural per-tenant isolation + metering at every boundary** — `TaskContext` carries
+  `TenantContext`; object-store path prefix, metadata-cache key, memory pool, *and* scheduler
+  job/stage/slot accounting are all tenant-scoped, fail-closed. KSU/KRU/KIU/KEU emitted at the
+  I/O + shuffle boundary. (Neither Trino, Spark, nor Ballista has first-class tenancy — this is
+  ProximaDB's structural differentiator.)
+
+.Avoid / invert
+* **No whole-stage row codegen / UnsafeRow** (Spark) and **no JIT bytecode-gen** (Trino) — JVM
+  escape hatches Rust+Arrow doesn't need. Go vectorized columnar; monomorphized kernels.
+* **No single-file block manager / single-node assumptions** (DuckDB) — the "buffer manager"
+  becomes a tenant-scoped object cache (RAM→SSD tiering).
+* **No cheap-random-I/O assumption** (DuckDB/Velox) — hand out morsels at a granularity that
+  amortizes a round-trip; cost routes from *measured bytes/requests*, not row counts.
+* **No disk-local shuffle, no in-memory-only scheduler state, no bolt-distribution-onto-a-foreign-
+  planner** (Ballista's three production gaps).
+* **No MergeTree consistency model** (ClickHouse): reject weak txns / eventual consistency / merge
+  amplification / `FINAL`. Use manifest/Iceberg **snapshot isolation** and a deliberate join layer.
+* **No C++ memory-safety burden** (DuckDB/Velox `Vector`/`SelectionVector`/`BufferPtr` aliasing) —
+  `Arc<Buffer>` + index slices give safe no-copy semantics for free.
+
+== 5. The Future Shape — ProximaDB Native OLAP Engine
+
+=== 5.1 Layered Architecture
+
+[source,mermaid]
+----
+flowchart TB
+  subgraph FE["Surfaces — unchanged"]
+    PG["pgwire"] & GRPC["gRPC"] & FL["Arrow Flight"]
+  end
+  FE --> FR["Shared relational frontend\nlower_sql to LogicalNode"]
+  FR --> OPT["Logical + physical optimizer\narena IR · pushdown/CSE/slice · PREWHERE"]
+  OPT --> CS{"ComputeScheduler\ncost from MEASURED I/O trace"}
+  CS -->|"OLTP / strong freshness"| VOL["Volcano OLTP\npull over WAL+RecordStorage"]
+  CS -->|"OLAP now"| DF["DataFusionLocal\ninterim seam"]
+  CS -->|"OLAP target"| NE
+
+  subgraph NE["Native OLAP Engine"]
+    direction TB
+    PLAN["Physical plan = DAG of one Operator trait"]
+    PLAN --> SCHED["Morsel scheduler\nwork-stealing pool · cooperative async park-on-IO"]
+    SCHED --> OPS["Operators: Scan · Filter · Project · HashJoin · Agg · Sort · TopK\nVectorScan · GraphTraversal · Rerank · Fuse"]
+    OPS --> XCH["Exchange seam\nstreaming over Flight ⟷ materialized over object store"]
+    OPS --> MEM["Tenant-aware memory broker + spill\nto DrPathBuilder temp"]
+  end
+
+  NE --> SCAN["PAX scan spine\nsparse mark index · PREWHERE · zone-map · learned skip · codecs"]
+  DF --> SCAN
+  SCAN --> CACHE["Tenant cache stack\nmark · decoded-block · byte-range RAM→SSD"]
+  CACHE --> OS[("Object store S3/GCS/Azure\nDrPathBuilder · ranged reads · TenantContext")]
+  VOL --> WAL[("WAL + RecordStorage\nProximaRecord authority")]
+  WAL -.->|"background flush/compaction"| OS
+
+  CS -.->|"every operator emits per-query I/O trace"| TRACE[("I/O trace substrate\nbytes/requests/latency/cache-hit")]
+  TRACE -.->|"EWMA per shape-class × backend"| CS
+----
+
+=== 5.2 The Unifying Operator Trait
+
+The single seam that makes the engine multimodal. Sketch (illustrative, Rust):
+
+[source,rust]
+----
+/// One trait; relational, vector, and graph operators all implement it.
+/// Push-based: the source drives; pipeline-breakers are explicit Sinks.
+trait Operator: Send + Sync {
+    /// Optimizer's whole view of this node (DataFusion PlanProperties idea).
+    fn properties(&self) -> &PlanProperties;          // partitioning, ordering, boundedness
+    fn required_input_distribution(&self) -> Distribution;
+    fn required_input_ordering(&self) -> Option<LexOrdering>;
+
+    /// Execute one output partition as a push pipeline stage.
+    /// Returns morsels; BLOCKED parks the task on a future (object-store I/O).
+    fn execute(&self, partition: usize, ctx: Arc<TaskContext /* carries TenantContext */>)
+        -> Result<MorselStream>;
+}
+
+enum ExecState { HaveMore, NeedInput, Blocked(ContinueFuture), Finished }
+----
+
+* **Relational:** `ScanExec` (PAX/Parquet), `FilterExec`, `ProjectExec`, `HashJoinExec`
+  (parallel build `Sink` → serial probe), `AggregateExec` (two-phase + adaptive skip-partial),
+  `SortExec`, `TopKExec` (per-thread bounded heaps → `Combine`).
+* **Vector:** `VectorScanExec` (HNSW/IVF) is a **partitioned Source** — morsel = one IVF cell /
+  HNSW shard / PAX segment; emits `(rowid, distance)` chunks; `SearchEffort` (ef/nprobe) is a
+  per-source-state param; cold IVF cluster load from S3 ⇒ `Blocked`. `RerankExec` is a streaming
+  Operator that fetches f32 by rowid (**late materialization**) only for the K survivors.
+* **Graph:** `GraphTraversalExec` is a **recursive pipeline** — a BFS/k-hop frontier `RowVector` →
+  adjacency-lookup operator (`IndexLookupJoin` analog) → next frontier as a dictionary over edge
+  columns, reusing the *exact* pipeline-breaker + dependency machinery DuckDB uses for recursive
+  CTEs. Kept vectorized (whole frontier per batch).
+* **Fusion:** `FuseExec` (calibrated `Fuser`, RRF/hybrid) combines two Sources (ANN + BM25) by
+  merging selection vectors + score columns — the home for the cross-modal fusion seam.
+
+Because all are the same trait over the same chunk + selection-vector substrate, the
+`ComputeScheduler` mixes them in **one** push-based plan and costs routes from each operator's
+emitted I/O trace.
+
+=== 5.3 The PREWHERE / Late-Materialization Scan Pipeline (the egress win)
+
+[source,mermaid]
+----
+flowchart LR
+  Q["Predicate + projection + top_k"] --> ZM["Zone-map / sparse-mark prune\nskip granules out of bounds"]
+  ZM --> SK["Learned skip cache\nQueryConditionCache hit ⇒ near-zero IO"]
+  SK --> PW["PREWHERE: fetch smallest\nselective predicate columns"]
+  PW --> MASK["Build selection vector\noperate on SQ8/RaBitQ codes"]
+  MASK --> LM["Late-materialize: fetch wide /\nf32 embedding columns by rowid\nONLY for survivors"]
+  LM --> OUT["Morsels upward"]
+  style ZM fill:#d6e8ff
+  style PW fill:#d6f5d6
+  style LM fill:#d6f5d6
+----
+
+This is one pipeline for relational *and* vector: a metadata-filtered ANN query prunes on
+zone-maps + quantized codes and materializes f32 vectors only for the rerank survivors — the
+"prune on quantized, rerank on f32" pattern expressed as PREWHERE. It directly amortizes the
+dominant cost term (egress bytes + round-trips), and every stage emits its slice of the per-query
+I/O trace.
+
+=== 5.4 Cost-Based Routing From Measured Traces
+
+The `ComputeScheduler` evolves from Phase-1 policy heuristics (`partitions==1 && join_count==0 →
+local`) to a trace-driven cost model (`src/query/route_cost_model.rs`), then to AQE-style runtime
+re-planning:
+
+[source,mermaid]
+----
+flowchart TB
+  PLAN["Physical plan"] --> CLASS["Shape class\nolap/oltp · native/parquet · card · fanout"]
+  CLASS --> COST["Cost model\nEWMA per shape-class × backend\nweights in neutral I/O units"]
+  COST --> PICK["Pick backend\nVolcano / DataFusion / Native / Distributed"]
+  PICK --> EXEC["Execute"]
+  EXEC --> XSTATS["Exchange stats\nrows/bytes/skew per partition"]
+  XSTATS -->|"AQE: coalesce · skew-split · broadcast-flip · dynamic-filter"| PLAN
+  EXEC --> TR[("Per-query I/O trace\nbytes/requests/latency/cache-hit")]
+  TR -->|"update EWMA"| COST
+  TIER["Tenant tier multiplier"] --> COST
+----
+
+Cost weights are **neutral I/O units** (object-store GET dominates, per Dimension 1 — *not* CPU);
+the tier multiplier is the per-tenant entitlement DI seam (OSS mechanism, anvaiops policy). This
+closes the co-design C0→C4 loop: **measure, don't assert.**
+
+== 6. Relationship To Volcano (OLTP) And DataFusion (Interim OLAP)
+
+* **Volcano stays** the OLTP authority — point lookups, single-row DML, strong-freshness reads off
+  the live WAL/memtable. It is *not* extended to OLAP scans. HTAP queries that need both fresh delta
+  and cold base read **Volcano over the delta ⊎ native engine over the Parquet/PAX base**, unioned
+  under one snapshot (the tiered-HTAP model of `RELATIONAL_STORAGE_FORMAT_AND_INTEROPERABILITY`).
+* **DataFusion is the interim OLAP engine and the seed.** It is strategically non-negotiable as the
+  *only* destination with a distributed path today, and its `ExecutionPlan` trait + object-store
+  pruning pipeline is the design template. The native engine is built **behind the same
+  `ComputeBackend` seam**, mixed-read-safe and default-OFF, and earns traffic only where measured
+  traces show it beats DataFusion (cold-S3 latency variance, quantized-vector pipelines,
+  graph traversal) — never by flag-day.
+* **Polars stays an optimization, not a pillar** (per the course correction). Reuse its *leaf
+  crates* as clean boundaries if useful (`polars-arrow`/`polars-compute` kernels, `polars-io` cloud
+  budgeting, the standalone `polars-async` work-stealing executor), and its *patterns* (arena IR,
+  morsel `ComputeNode`, `skip_batches` predicate compilation) — but do **not** embed its
+  planner/engine (explicitly internal, would collide with DataFusion).
+
+== 7. Phased Roadmap (Aligns With Course-Correction P0–P7)
+
+[cols="1,3,2",options="header"]
+|===
+| Phase | Deliverable | Gate
+
+| **N0 — Engine seam (additive)**
+| Native engine behind `ComputeBackend::Native` OLAP arm as a *plan-consumer* of the shared
+  physical plan; one push-based `Operator` trait; runs single-partition scans only. No routing
+  change (scheduler still advisory). EXPLAIN shows the route.
+| Compile + EXPLAIN parity; zero behavior change
+
+| **N1 — Vectorized single-node core**
+| Morsel-driven work-stealing scheduler; cooperative async park-on-I/O; Arrow chunk +
+  selection-vector substrate; PAX scan spine (sparse mark index + zone-map prune); PREWHERE late
+  materialization; tenant-aware memory broker + spill to `DrPathBuilder` temp. Serves most OLAP.
+| Recall/quality within tolerance of f32 baseline; per-query I/O trace emitted; nextest-isolated
+
+| **N2 — Multimodal operators**
+| `VectorScanExec`/`TopKExec`/`RerankExec` (quantized-through-pipeline), `GraphTraversalExec`,
+  `FuseExec`; pushdown of metadata filters + `top_k` slice into the vector source as just-another
+  rule. ANN + BM25 hybrid through one plan.
+| ANN recall@k + hybrid ranking **eval suites** (rubric: output + trajectory) gate CI
+
+| **N3 — Encoding-aware expression engine + adaptivity**
+| Encoding peeling, CSE, memoization, flat-no-nulls SIMD; DuckDB-style adaptive conjunct reorder;
+  learned `QueryConditionCache` (per-tenant); type-aware chained codecs for cold tiers.
+| Measured trace shows reduced bytes/requests vs N1 on the same query set
+
+| **N4 — Exchange seam (streaming first)**
+| Native PlanFragmenter (cut at pipeline-breakers); **object-store shuffle under `DrPathBuilder`**;
+  streaming exchange over Arrow Flight (default); broadcast joins for small build sides; thin,
+  HA-able coordinator over the object-store-CAS catalog. Dynamic filtering build→probe.
+| Multi-node correctness; no-overlap split contract; tenant-scoped shuffle paths + KEU metering
+
+| **N5 — Materialized exchange + AQE**
+| Per-stage opt-in materialized (object-store-backed) exchange for long-tail batch stages →
+  partition-granular fault recovery; AQE re-plan from measured exchange stats (coalesce / skew-split
+  / broadcast-flip).
+| Fault-injection recovery tests; AQE adopts a rewrite only when the cost-evaluator agrees
+|===
+
+Every phase is **mixed-read-safe, default-OFF, gated on measured per-query I/O traces** (not kernel
+microbenchmarks), per the storage-migration and Measure-Don't-Assert mandates.
+
+== 8. Co-Design Accounting (Five Dimensions)
+
+[cols="1,2,3",options="header"]
+|===
+| Dimension | Dominant cost term moved | Engine lever in this blueprint
+
+| 1. Object storage
+| GET round-trips, bytes fetched
+| Sparse mark index + granule ranged reads; PREWHERE late materialization; zone-map/learned skip;
+  object-store shuffle; quantized-through-pipeline (materialize f32 only at rerank)
+
+| 2. Network / egress
+| Cross-AZ $ / result serialization
+| Streaming exchange over Arrow Flight (zero-copy, raw-IPC-block fast path); broadcast small sides;
+  KEU metered at the shuffle/Flight boundary; same-AZ placement
+
+| 3. Local disk / cache
+| Footer/mark/block cache hit-miss
+| Tenant-scoped RAM→SSD cache stack (mark + decoded-block + byte-range), co-budgeted with query
+  memory; spill to object store under pressure
+
+| 4. Compute per modality
+| CPU-ms per modality
+| One vectorized morsel core serving relational + vector + graph; encoding-aware expression eval;
+  compute on quantized codes; DedicatedExecutor split (heavy compute off the IO/gRPC runtime)
+
+| 5. Governance / security
+| Isolation + billing enforcement
+| `TenantContext` in `TaskContext`, object-store path prefix, metadata-cache key, memory pool, and
+  scheduler job/stage/slot accounting — all structural, fail-closed; per-tenant entitlement
+  multiplier in the cost model
+|===
+
+== 9. Risks And What NOT To Inherit
+
+* **C++ engines optimize for cheap local I/O.** Do not import DuckDB/Velox morsel granularity
+  blindly — size morsels to amortize an S3 round-trip; coalesce ranged reads.
+* **Distribution is where engines rot** (Ballista shuffle immaturity, Trino coordinator bottleneck,
+  Spark small-query overhead). Stage it *last*, streaming-first, object-store-backed, and only after
+  the single-node core + multimodal operators are proven.
+* **AQE depends on a stats checkpoint.** It is impossible before the exchange seam reports measured
+  partition stats — sequencing N5 after N4 is structural, not preference.
+* **Don't let adaptivity skip lowering** (Ballista's AQE-bypasses-broadcast bug): runtime re-plans
+  must go through the same physical-lowering path as the initial plan.
+* **Ranked/generated surfaces need evals, not just tests** (mandate 13): ANN recall@k, hybrid/RRF
+  ranking, and graph-RAG retrieval ship eval suites with rubrics covering output *and* trajectory,
+  versioned in the PR that changes behavior.
+
+== 10. Open Questions
+
+. **Morsel vs partition granularity under object-store latency variance** — does a work-stealing
+  morsel layer measurably beat DataFusion's static partition count for skewed cold/warm cell access?
+  Needs the C0 cold-S3 trace (currently a co-design gap) to answer empirically.
+. **Native engine vs DataFusion crossover** — at what shape-class does a native quantized-vector /
+  graph pipeline beat DataFusion+UDF? The cost model must *learn* this, not assert it.
+. **Object-store shuffle latency floor** — is streaming-over-Flight enough for interactive OLAP, or
+  is a same-AZ peer fast path mandatory below a latency threshold?
+. **Snapshot isolation across delta ⊎ base** — the exact manifest fence semantics for HTAP reads
+  that union live Volcano delta with the native-engine Parquet/PAX base.
+
+== 11. Decision Summary
+
+Build the native OLAP engine as **DuckDB's push-based morsel core in the Polars-stream Rust idiom,
+wearing Velox's plan-consumer + async-park clothes, over ClickHouse's sparse-index/PREWHERE storage
+spine, distributed by Ballista's stage-cut inverted onto object-store shuffle, adapted by Spark's
+AQE from measured stats, with structural per-tenant isolation none of them have.** It plugs into the
+existing `ComputeScheduler` / `ComputeBackend` / read-route seams, keeps Volcano as the OLTP
+authority and DataFusion as the interim OLAP seed, and folds vector / graph / document execution
+into one vectorized DAG costed against the measured object-store trace.
+
+== 12. Research Appendix — Prior-Art File References
+
+Studied at depth-1 under `../` (datafusion, datafusion-ballista, velox, duckdb, polars, trino,
+spark, ClickHouse). Load-bearing paths cited for future reference:
+
+.DataFusion (single-node engine template)
+* `datafusion/physical-plan/src/execution_plan.rs` — the `ExecutionPlan` trait, `execute(partition)`,
+  `PlanProperties`.
+* `datafusion/physical-plan/src/repartition/mod.rs` — exchange operator, bounded MPSC backpressure,
+  spill.
+* `datafusion/physical-optimizer/src/ensure_requirements/` — requirement-driven exchange insertion.
+* `datafusion/datasource-parquet/src/{opener,reader,metadata}.rs` — layered cheap-first pruning,
+  `ParquetFileReaderFactory`, `FileMetadataCache`.
+* `datafusion/physical-plan/src/aggregates/` (`skip_partial.rs`), `joins/`, `spill/`.
+
+.Ballista (distribution template + the inversion targets)
+* `ballista/scheduler/src/planner.rs` — `plan_query_stages_internal` stage cut; broadcast promotion.
+* `ballista/core/src/execution_plans/{shuffle_writer,shuffle_reader,unresolved_shuffle}.rs` —
+  disk-local shuffle (invert to object store).
+* `ballista/scheduler/src/state/{execution_stage,execution_graph,task_manager}.rs` — stage state
+  machine; `cluster/memory.rs` (the in-memory SPOF to replace with object-store-CAS).
+* `ballista/executor/src/{flight_service.rs,cpu_bound_executor.rs}` — Flight exchange + compute/IO
+  split.
+
+.DuckDB (push-based morsel core)
+* `src/include/duckdb/execution/physical_operator.hpp` — Source/Operator/Sink contract.
+* `src/parallel/{pipeline_executor,meta_pipeline,task_scheduler,event}.cpp` — push exec, morsel
+  hand-out, work-stealing queue, event DAG.
+* `src/include/duckdb/common/types/vector.hpp` — `VectorType` (FLAT/CONSTANT/DICTIONARY/SEQUENCE/FSST),
+  `UnifiedVectorFormat`.
+* `src/execution/{expression_executor,adaptive_filter}.cpp`; `src/optimizer/` + `join_order/`;
+  `src/storage/compression/`; `src/storage/{buffer_manager,temporary_memory_manager}.cpp`.
+
+.Velox (plan-consumer + async + encoding clothes)
+* `velox/exec/{Driver,Operator,Task,Exchange,Spiller,JoinBridge,IndexLookupJoin}.h`,
+  `velox/exec/BlockingReason.h` — cooperative async park-on-I/O.
+* `velox/vector/{BaseVector,DictionaryVector,DecodedVector,LazyVector,SelectivityVector}.h`;
+  `velox/expression/` — encoding peeling, CSE, memoization.
+* `velox/dwio/common/ScanSpec.h` — mutable adaptive scan spec; `velox/common/caching/{AsyncDataCache,
+  SsdCache}.h` — RAM→SSD tiering; `velox/common/memory/{MemoryPool,MemoryArbitrator}.h`.
+* design docs: `velox/docs/develop/{task,operators,vectors,expression-evaluation,spilling,memory,
+  connectors}.rst`.
+
+.ClickHouse (storage / scan spine)
+* `src/Processors/IProcessor.h` — `prepare/work/schedule` two-phase contract;
+  `src/QueryPipeline/`, `src/Processors/Executors/PipelineExecutor.cpp`.
+* `src/Storages/MergeTree/{MarkRange.h,KeyCondition.h,MergeTreeRangeReader.h}` — sparse index,
+  granules, PREWHERE late materialization, hyperrectangle pruning; `MergeTreeIndexMinMax`.
+* `src/Interpreters/Cache/QueryConditionCache.h` — learned mark-skip cache; `src/Compression/` —
+  Delta/DoubleDelta/Gorilla/T64 codecs; `src/Columns/IColumn.h` — whole-column `filter(mask)`,
+  `ColumnLowCardinality`, `ColumnQBit`/`ColumnSparse`.
+* `src/Disks/DiskObjectStorage/`; `src/Interpreters/Cache/` (MarkCache/UncompressedCache).
+
+.Polars (Rust execution + optimizer template)
+* `crates/polars-stream/src/nodes/mod.rs` — `ComputeNode` (`update_state` fixpoint + `spawn`);
+  `src/execute.rs` (memory-aware subgraph scheduling); `src/morsel.rs` (`MorselSeq`, backpressure).
+* `crates/polars-async/src/executor/mod.rs` — custom crossbeam work-stealing runtime.
+* `crates/polars-plan/src/plans/{ir/mod.rs,optimizer/}` — arena IR, per-rule-per-file optimizer;
+  `aexpr/predicates/skip_batches.rs` — statistics-as-predicate pruning.
+* `crates/polars-io/cloud/` — object_store wrapper, global store cache, concurrency-budgeted reads.
+
+.Trino + Spark (distribution patterns)
+* Trino: `core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java`,
+  `optimizations/AddExchanges.java`, `server/DynamicFilterService.java`,
+  `execution/scheduler/faulttolerant/`; `core/trino-spi/.../Page.java`.
+* Spark: `sql/core/.../execution/adaptive/AdaptiveSparkPlanExec.scala`,
+  `CoalesceShufflePartitions.scala`, `OptimizeSkewedJoin.scala`,
+  `exchange/ShuffleExchangeExec.scala`, `execution/datasources/FilePartition.scala`
+  (split bin-packing by byte budget + open cost).

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -171,6 +171,10 @@ Read these in order for future-shaping architecture work:
   duplicate-doc findings, and archive batch plan.
 * `DESIGN_PATTERNS.adoc` - general design patterns and implementation references.
 * `SUPPORTED_SURFACES.adoc` - supported API/projection status and retirement candidates.
+* `NATIVE_OLAP_ENGINE_BLUEPRINT_2026_06_22.adoc` - the native Rust columnar OLAP engine blueprint
+  (PAX-columnar scan spine; DataFusion is the interim OLAP executor). Companion:
+  `NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc` - the source-level 8-engine comparative
+  study (DataFusion/Ballista/DuckDB/Velox/Trino/Spark/ClickHouse/Polars) that distilled the blueprint.
 
 == ADRs
 

--- a/docs/agent-rules/AGENTS.md.seed
+++ b/docs/agent-rules/AGENTS.md.seed
@@ -14,7 +14,7 @@ Depending on your identity, read the corresponding mandate file first:
 ProximaDB is undergoing a massive architectural shift to support a robust SaaS MVP. All agents must align their problem-solving, code generation, and architectural suggestions with the following truths:
 
 1.  **Intelligent Multi-Engine Routing:** We do not have a single physical execution layer. We route queries based on workload profiles.
-    *   **DataFusion & Polars:** Used for analytical (OLAP) and standard relational workloads over decoupled Object Storage (Iceberg/Parquet).
+    *   **DataFusion & Polars:** Used for analytical (OLAP) and standard relational workloads over decoupled Object Storage (Iceberg/Parquet). DataFusion is the **interim** OLAP engine; a native, push-based, morsel-driven vectorized OLAP engine is the build target, landing behind the same `ComputeBackend` seam — never assume DataFusion is the terminal OLAP backend (see `docs/12-design/NATIVE_OLAP_ENGINE_BLUEPRINT_2026_06_22.adoc`; source study `NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc`).
     *   **Volcano & Specialized Engines (SST, HELIX, VIPER, SWIFT, NOVA, RAPTOR):** Used for low-latency point lookups (OLTP) and high-performance Vector/ANN searches over PAX block formats.
 2.  **SaaS Mandates:**
     *   **Isolation:** Multi-tenant path isolation via `DrPathBuilder` is mandatory. Do not write to root directories or raw schema locations.

--- a/docs/agent-rules/CLAUDE.md.seed
+++ b/docs/agent-rules/CLAUDE.md.seed
@@ -11,7 +11,7 @@ ProximaDB is a high-performance, cloud-native vector and graph database built in
 ProximaDB has shifted from a monolithic custom WAL/PAX architecture to an **Intelligent Multi-Engine Routing** system running over decoupled **Object Storage**.
 
 When modifying architecture or execution paths, you MUST adhere to the dual-path mandate:
-1. **Data Warehouse/Relational Workloads:** Driven by DataFusion/Polars executing over standard Parquet files managed by Iceberg manifests.
+1. **Data Warehouse/Relational Workloads:** Driven by DataFusion/Polars executing over standard Parquet files managed by Iceberg manifests. *(DataFusion is the **interim** OLAP engine; a native, push-based, morsel-driven vectorized OLAP engine is the build target, landing behind the same `ComputeBackend` seam — never assume DataFusion is the terminal OLAP backend. See `docs/12-design/NATIVE_OLAP_ENGINE_BLUEPRINT_2026_06_22.adoc`; source study `NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc`.)*
 2. **Vector Search/ANN Workloads:** Driven by specialized high-performance engines (SST, HELIX, NOVA) utilizing the custom PAX block format.
 
 You must also strictly enforce SaaS Operational constraints:

--- a/docs/agent-rules/GEMINI.md.seed
+++ b/docs/agent-rules/GEMINI.md.seed
@@ -11,7 +11,7 @@ ProximaDB is a high-performance, cloud-native vector and graph database built in
 ProximaDB has shifted from a monolithic custom WAL/PAX architecture to an **Intelligent Multi-Engine Routing** system running over decoupled **Object Storage**.
 
 When modifying architecture or execution paths, you MUST adhere to the dual-path mandate:
-1. **Data Warehouse/Relational Workloads:** Driven by DataFusion/Polars executing over standard Parquet files managed by Iceberg manifests.
+1. **Data Warehouse/Relational Workloads:** Driven by DataFusion/Polars executing over standard Parquet files managed by Iceberg manifests. *(DataFusion is the **interim** OLAP engine; a native, push-based, morsel-driven vectorized OLAP engine is the build target, landing behind the same `ComputeBackend` seam — never assume DataFusion is the terminal OLAP backend. See `docs/12-design/NATIVE_OLAP_ENGINE_BLUEPRINT_2026_06_22.adoc`; source study `NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc`.)*
 2. **Vector Search/ANN Workloads:** Driven by specialized high-performance engines (SST, HELIX, NOVA) utilizing the custom PAX block format.
 
 You must also strictly enforce SaaS Operational constraints:


### PR DESCRIPTION
Salvages the two unique pieces of the `docs/olap-engine-research` branch onto develop (that branch can then be retired).

**1. Mandate restoration (high value):** the "DataFusion is the **interim** OLAP engine; a native push-based morsel-driven vectorized engine is the build target behind the `ComputeBackend` seam" directive had been written only to root `CLAUDE/GEMINI/AGENTS.md` — which are now local-only/gitignored (#443). The mandate was therefore absent from tracked content. Restored into `docs/agent-rules/{CLAUDE,GEMINI,AGENTS}.md.seed` so it ships again.

**2. Study preservation:** the source-level 8-engine comparative study (DataFusion/Ballista/DuckDB/Velox/Trino/Spark/ClickHouse/Polars) added as `NATIVE_OLAP_8ENGINE_COMPARATIVE_STUDY_2026_06_22.adoc` — distinct from (complementary to) the existing 109-line PAX `NATIVE_OLAP_ENGINE_BLUEPRINT`. Both indexed in `docs/12-design/README.adoc`.

Docs-only. No drift gates apply.