### PR TITLE
feat(catalog+dml): cross-namespace FK child discovery (TD-110 S3)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4420,6 +4420,41 @@ pub trait Catalog: Send + Sync {
     async fn table_exists(&self, identifier: &TableIdentifier) -> anyhow::Result<bool>;
     async fn get_table(&self, identifier: &TableIdentifier) -> anyhow::Result<CatalogTableSchema>;
 
+    /// TD-110 S3: enumerate every table in a namespace subtree (the `scope`),
+    /// for cross-namespace FOREIGN KEY child discovery on ON DELETE.
+    /// `scope = None` → all top-level namespaces; `scope = Some([tenant])` → the
+    /// tenant's subtree (keeps FK child discovery intra-tenant — cross-tenant
+    /// children are never enumerated). Default impl BFS-walks `list_namespaces`
+    /// + `list_tables`; correct for every backend (a backend-specific global
+    /// index override is possible but would miss legacy name-keyed tables, so
+    /// the recursive default is the complete path).
+    async fn list_all_tables_in_scope(
+        &self,
+        scope: Option<&[String]>,
+    ) -> anyhow::Result<Vec<TableIdentifier>> {
+        let mut tables = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        let mut frontier: Vec<Vec<String>> = match scope {
+            Some(ns) => vec![ns.to_vec()],
+            None => self
+                .list_namespaces(None)
+                .await?
+                .into_iter()
+                .map(|ns| ns.levels)
+                .collect(),
+        };
+        while let Some(ns) = frontier.pop() {
+            if !visited.insert(ns.clone()) {
+                continue;
+            }
+            tables.extend(self.list_tables(&ns).await?);
+            for child in self.list_namespaces(Some(&ns)).await? {
+                frontier.push(child.levels);
+            }
+        }
+        Ok(tables)
+    }
+
     /// ADR-031 O1 (dual-read): resolve a table by its stable `object_id` — the
     /// inverse of `get_table(...).object_id`. Returns `None` when no table carries
     /// that id, or when the backend does not allocate object_ids (external

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -4179,12 +4179,13 @@ impl DmlService {
         Ok(guards)
     }
 
-    /// TD-110: the same-namespace/tenant child tables whose (single- or
-    /// multi-column) FK references `parent_id`'s full primary key, with the FK
-    /// columns and action. Factored out so both the discovery pass and the
-    /// recursive worker share one copy of the FK-matching logic. Self-references
-    /// are excluded; only FKs that reference the parent's FULL PK (in order) are
-    /// returned — partial / non-PK references remain unsupported (S2 scope).
+    /// TD-110: the child tables (anywhere in the tenant's namespace subtree —
+    /// cross-namespace within the tenant, S3) whose (single- or multi-column) FK
+    /// references `parent_id`'s full primary key, with the FK columns and action.
+    /// Factored out so both the discovery pass and the recursive worker share one
+    /// copy of the FK-matching logic. Self-references are excluded; only FKs that
+    /// reference the parent's FULL PK (in order) are returned — partial / non-PK
+    /// references remain unsupported (S2 scope).
     async fn child_tables_referencing(
         &self,
         catalog: &Arc<dyn crate::catalog::Catalog>,
@@ -4203,7 +4204,17 @@ impl DmlService {
         if parent_pk_cols.is_empty() {
             return Ok(Vec::new());
         }
-        let sibling_ids = catalog.list_tables(&parent_id.namespace).await?;
+        // TD-110 S3: enumerate candidate children across the tenant's WHOLE
+        // namespace subtree (not just the parent's namespace), so a child living
+        // in another namespace whose FK references this parent is found. Scoped
+        // to the tenant (`Some([tenant])`) to keep child discovery intra-tenant;
+        // cross-tenant children are never enumerated. The per-child reference
+        // match below still requires the FK to resolve to THIS parent (name AND
+        // namespace), so a same-named table in another namespace never matches.
+        let tenant_scope = tenant_context.map(|t| vec![t.tenant_id.clone()]);
+        let sibling_ids = catalog
+            .list_all_tables_in_scope(tenant_scope.as_deref())
+            .await?;
         let mut out = Vec::new();
         for child_id in sibling_ids {
             if child_id.name == parent_id.name && child_id.namespace == parent_id.namespace {

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -10010,6 +10010,127 @@ mod tests {
         );
     }
 
+    /// TD-110 S3: cross-namespace FOREIGN KEY — a child in namespace B whose FK
+    /// references a parent in namespace A is found by ON DELETE child discovery
+    /// (a RESTRICT child blocks the parent delete; a CASCADE child is removed).
+    #[tokio::test]
+    async fn delete_enforces_cross_namespace_fk() {
+        use crate::query::table_write_executor::PlannedOnlyTableWriteExecutor;
+        use crate::services::record_store::{DirectWalTableRecordStore, TableRecordGetRequest};
+        use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let manager = Arc::new(CatalogManager::new());
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+        let ddl = DdlService::new(manager.clone());
+        for ns in ["xns_a", "xns_b"] {
+            ddl.execute(DdlStatement::CreateNamespace {
+                namespace: vec![ns.to_string()],
+                if_not_exists: true,
+                properties: HashMap::new(),
+            })
+            .await
+            .expect("create namespace");
+        }
+        let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+        for create in [
+            "CREATE TABLE xns_a.xpar (id TEXT NOT NULL, name TEXT, PRIMARY KEY (id));",
+            "CREATE TABLE xns_b.xchl_casc (id TEXT NOT NULL, pid TEXT, PRIMARY KEY (id), FOREIGN KEY (pid) REFERENCES xns_a.xpar (id) ON DELETE CASCADE);",
+            "CREATE TABLE xns_b.xchl_restr (id TEXT NOT NULL, pid TEXT, PRIMARY KEY (id), FOREIGN KEY (pid) REFERENCES xns_a.xpar (id));",
+        ] {
+            let stmt = parser
+                .parse_ddl(create)
+                .expect("parse create")
+                .expect("ddl");
+            ddl.execute(stmt).await.expect("create table");
+        }
+
+        let wal_appender = Arc::new(
+            FramedTableWalAppender::open(temp_dir.path().join("xns_fk.wal"))
+                .await
+                .expect("open WAL"),
+        );
+        let record_store = Arc::new(DirectWalTableRecordStore::new(
+            Arc::new(MemtableRecordStorage::new()),
+            wal_appender,
+        ));
+        let dml = DmlService::with_record_store_and_table_write_executor(
+            manager.clone(),
+            record_store.clone(),
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        );
+        let run = |sql: &'static str| parser.parse_dml(sql).expect("parse dml").expect("dml");
+
+        dml.execute(run(
+            "INSERT INTO xns_a.xpar (id, name) VALUES ('p1', 'Al');",
+        ))
+        .await
+        .expect("seed cross-ns parent");
+        dml.execute(run(
+            "INSERT INTO xns_b.xchl_restr (id, pid) VALUES ('r1', 'p1');",
+        ))
+        .await
+        .expect("seed restrict child");
+
+        // RESTRICT: deleting the parent is rejected — a child in ANOTHER
+        // namespace still references it (cross-namespace child discovery).
+        let err = dml
+            .execute(run("DELETE FROM xns_a.xpar WHERE id = 'p1';"))
+            .await
+            .expect_err("cross-ns RESTRICT must reject the parent delete");
+        assert!(
+            err.to_string().contains("ON DELETE NO ACTION"),
+            "unexpected error: {err}"
+        );
+
+        // Drop the RESTRICT child, add a CASCADE child, then the parent delete
+        // cascades across namespaces.
+        dml.execute(run("DELETE FROM xns_b.xchl_restr WHERE id = 'r1';"))
+            .await
+            .expect("remove restrict child");
+        dml.execute(run(
+            "INSERT INTO xns_b.xchl_casc (id, pid) VALUES ('c1', 'p1');",
+        ))
+        .await
+        .expect("seed cascade child");
+
+        let get_casc = |key: &'static str| {
+            let store = record_store.clone();
+            let manager = manager.clone();
+            async move {
+                let (catalog, id) = manager
+                    .resolve_table("xns_b.xchl_casc")
+                    .await
+                    .expect("resolve");
+                let schema = catalog.get_table(&id).await.expect("schema");
+                store
+                    .get_by_key(
+                        &schema,
+                        TableRecordGetRequest {
+                            table_id: id.name.clone(),
+                            key: key.to_string(),
+                            include_vector: false,
+                            include_props: true,
+                        },
+                        None,
+                    )
+                    .await
+                    .expect("get_by_key")
+            }
+        };
+        assert!(get_casc("c1").await.is_some());
+        dml.execute(run("DELETE FROM xns_a.xpar WHERE id = 'p1';"))
+            .await
+            .expect("cross-ns CASCADE delete must succeed");
+        assert!(
+            get_casc("c1").await.is_none(),
+            "cross-ns CASCADE must remove the child in the other namespace"
+        );
+    }
+
     /// TD-110 S1: N-level CASCADE recursion, cyclic-FK rejection (no partial
     /// deletion), and the bounded-depth guard.
     #[tokio::test]

--- a/tests/pgwire_fk_referential_actions_e2e.rs
+++ b/tests/pgwire_fk_referential_actions_e2e.rs
@@ -832,3 +832,168 @@ async fn pgwire_enforces_composite_fk_referential_actions() {
             .expect_err("a dangling composite FK tuple must be rejected");
     }
 }
+
+/// TD-110 S3: cross-namespace FOREIGN KEY over pgwire — a child in namespace B
+/// whose FK references a parent in namespace A (`REFERENCES a.parent`) is found
+/// by ON DELETE child discovery: CASCADE removes it, RESTRICT rejects the parent
+/// delete, SET NULL nulls the FK.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pgwire_enforces_cross_namespace_fk_referential_actions() {
+    let server = PgwireTestServer::start().await.expect("server start");
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+            .await
+            .expect("connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let ns_a = format!("xnsa_{suffix}");
+    let ns_b = format!("xnsb_{suffix}");
+    let parent = format!("{ns_a}.parent");
+    client
+        .simple_query(&format!("CREATE NAMESPACE {ns_a}"))
+        .await
+        .expect("CREATE NAMESPACE a");
+    client
+        .simple_query(&format!("CREATE NAMESPACE {ns_b}"))
+        .await
+        .expect("CREATE NAMESPACE b");
+    client
+        .simple_query(&format!(
+            "CREATE TABLE {parent} (id VARCHAR PRIMARY KEY, name VARCHAR)"
+        ))
+        .await
+        .expect("CREATE cross-ns parent");
+
+    // ---- CASCADE: child in ns_b references the parent in ns_a. ----
+    {
+        let child = format!("{ns_b}.chl_casc");
+        client
+            .simple_query(&format!(
+                "CREATE TABLE {child} (id VARCHAR PRIMARY KEY, pid VARCHAR, \
+                 FOREIGN KEY (pid) REFERENCES {parent}(id) ON DELETE CASCADE)"
+            ))
+            .await
+            .expect("CREATE cross-ns cascade child");
+        client
+            .simple_query(&format!(
+                "INSERT INTO {parent} (id, name) VALUES ('p1', 'Al')"
+            ))
+            .await
+            .expect("INSERT cross-ns parent");
+        client
+            .simple_query(&format!(
+                "INSERT INTO {child} (id, pid) VALUES ('c1', 'p1')"
+            ))
+            .await
+            .expect("INSERT cross-ns cascade child");
+        sleep(Duration::from_millis(300)).await;
+
+        client
+            .simple_query(&format!("DELETE FROM {parent} WHERE id = 'p1'"))
+            .await
+            .expect("cross-ns CASCADE delete must succeed");
+
+        let rows = client
+            .simple_query(&format!("SELECT COUNT(*) AS n FROM {child}"))
+            .await
+            .expect("COUNT cross-ns cascade child");
+        assert_eq!(
+            count_star(&rows),
+            0,
+            "cross-ns CASCADE must remove the child in the other namespace"
+        );
+    }
+
+    // ---- RESTRICT: a child in ns_b blocks deleting the parent in ns_a. ----
+    {
+        client
+            .simple_query(&format!(
+                "INSERT INTO {parent} (id, name) VALUES ('p2', 'Bo')"
+            ))
+            .await
+            .expect("INSERT parent p2");
+        let child = format!("{ns_b}.chl_restr");
+        client
+            .simple_query(&format!(
+                "CREATE TABLE {child} (id VARCHAR PRIMARY KEY, pid VARCHAR, \
+                 FOREIGN KEY (pid) REFERENCES {parent}(id))"
+            ))
+            .await
+            .expect("CREATE cross-ns restrict child");
+        client
+            .simple_query(&format!(
+                "INSERT INTO {child} (id, pid) VALUES ('r2', 'p2')"
+            ))
+            .await
+            .expect("INSERT cross-ns restrict child");
+        sleep(Duration::from_millis(300)).await;
+
+        let _ = client
+            .simple_query(&format!("DELETE FROM {parent} WHERE id = 'p2'"))
+            .await
+            .expect_err("cross-ns RESTRICT must reject the parent delete");
+
+        let parent_rows = client
+            .simple_query(&format!("SELECT COUNT(*) AS n FROM {parent}"))
+            .await
+            .expect("COUNT parent (restrict)");
+        assert_eq!(
+            count_star(&parent_rows),
+            1,
+            "parent must survive a cross-ns RESTRICT-rejected delete"
+        );
+    }
+
+    // ---- SET NULL: deleting the parent nulls the FK on the ns_b child. ----
+    {
+        client
+            .simple_query(&format!(
+                "INSERT INTO {parent} (id, name) VALUES ('p3', 'Cy')"
+            ))
+            .await
+            .expect("INSERT parent p3");
+        let child = format!("{ns_b}.chl_null");
+        client
+            .simple_query(&format!(
+                "CREATE TABLE {child} (id VARCHAR PRIMARY KEY, pid VARCHAR, \
+                 FOREIGN KEY (pid) REFERENCES {parent}(id) ON DELETE SET NULL)"
+            ))
+            .await
+            .expect("CREATE cross-ns set-null child");
+        client
+            .simple_query(&format!(
+                "INSERT INTO {child} (id, pid) VALUES ('s3', 'p3')"
+            ))
+            .await
+            .expect("INSERT cross-ns set-null child");
+        sleep(Duration::from_millis(300)).await;
+
+        client
+            .simple_query(&format!("DELETE FROM {parent} WHERE id = 'p3'"))
+            .await
+            .expect("cross-ns SET NULL delete must succeed");
+
+        let rows = client
+            .simple_query(&format!("SELECT id, pid FROM {child}"))
+            .await
+            .expect("SELECT cross-ns set-null child");
+        assert_eq!(
+            col_set(&rows, "id"),
+            ["s3".to_string()].into_iter().collect::<BTreeSet<_>>(),
+            "cross-ns SET NULL must keep the child row"
+        );
+        assert_eq!(
+            scalar(&rows, "pid"),
+            None,
+            "cross-ns SET NULL must clear the child FK"
+        );
+    }
+}


### PR DESCRIPTION
TD-110 Slice 3: cross-namespace FOREIGN KEY ON DELETE child discovery.

Continues TD-110 (S1 recursive ON DELETE + intra-pod op-lock #530/#541; S2 composite-FK + composite-PK DELETE #550).

## Problem
ON DELETE child discovery was scoped to the parent's **own namespace** (`list_tables(&parent.namespace)`), so a child living in another namespace whose FK references the parent was never found — a cross-namespace `REFERENCES ns.parent` CASCADE/RESTRICT silently missed it (orphan / no protection). Parent resolution (`resolve_table_scoped`) already handled dotted cross-namespace names; only child discovery was namespace-bound.

## Fix
- **Catalog trait** (`crates/control/proximadb-catalog/src/lib.rs`): add `list_all_tables_in_scope(scope)` with a recursive default impl (BFS over `list_namespaces` + `list_tables`). `scope = Some([tenant])` → the tenant's subtree (intra-tenant); `None` → all top-level namespaces. Correct for every backend (a global-index override would miss legacy name-keyed tables).
- **`child_tables_referencing`** (`src/services/dml/mod.rs`): enumerate via `list_all_tables_in_scope(tenant_scope)` instead of `list_tables(&parent.namespace)`. The per-child reference match is **unchanged** — the FK must still resolve to THIS parent (name AND namespace), so a same-named table in another namespace never false-matches; only the enumeration scope broadens (cross-namespace within the tenant).

`enforce_foreign_keys` (INSERT/UPDATE FK existence) already resolves the parent cross-namespace — no change. S1 op-lock + S2 composite-FK apply to cross-namespace children unchanged.

## Tests
- Unit `delete_enforces_cross_namespace_fk`: child in ns B references parent in ns A — RESTRICT rejects, CASCADE removes the cross-ns child.
- e2e `pgwire_enforces_cross_namespace_fk_referential_actions`: the same over pgwire with qualified `ns.table` names (CASCADE/RESTRICT/SET NULL). All 4 e2e + 3 unit FK tests green.

## Scope / risks
- **Perf**: child discovery is now O(tables in the tenant subtree) per DELETE (was O(one namespace)); acceptable for correctness-first S3. A reverse-FK-index would make it O(children) — deferred follow-up.
- **Tenant safety**: enumeration is scoped to the tenant subtree; cross-tenant FK stays blocked (intra-tenant contract preserved).
- Out of scope: ON UPDATE (S4, needs TD-181), cross-tenant FK, DDL-time FK-target validation.

`cargo clippy --lib --bins -- -D warnings` + `cargo fmt --check` clean. No `.unwrap`/`.expect`/`panic!` in new paths.