### PR TITLE
fix(axis): use collection.id (UUID) for AXIS HMGI routing — fixes TD-AXIS-1

### DIFF
--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -3283,7 +3283,14 @@ impl VectorOperationsService {
             collection_id
         );
         let axis_optimized_results = match build_axis_hybrid_query_with_policy(
-            collection_id,
+            // TD-AXIS-1: use the collection's canonical id (UUID) — NOT the
+            // caller's collection_id (which may be the human-readable NAME).
+            // enable_hmgi registered the UUID in hmgi_enabled_collections;
+            // passing the name caused is_hmgi_enabled to return false → HMGI
+            // skipped → IVF fallback → 0 results (ANN index not serving).
+            // ADR-031 follow-up: migrate hmgi_enabled_collections to the stable
+            // object_id (base62) and use that here instead of the UUID.
+            &collection.id,
             &axis_search_params,
             ann_filtering_mode,
             ann_filtering_selectivity.map(|_| proximadb_catalog::AnnFilteringPolicy::default()),


### PR DESCRIPTION
## Summary
Fixes TD-AXIS-1: the production Approximate search path was getting **zero ANN benefit** — AXIS returned 0 for every query because of a collection_id mismatch.

## Root cause (confirmed by diagnostic)
`execute_two_stage_search_with_mode` passed the collection **NAME** (e.g. `"recall_sst"`) to the AXIS query builder, but `hmgi_enabled_collections` was populated with the collection **UUID** during insert. `is_hmgi_enabled(name)` → false → HMGI skipped → IVF fallback → 0 results.

## Fix (one line)
```diff
- build_axis_hybrid_query_with_policy(collection_id, ...)   // name
+ build_axis_hybrid_query_with_policy(&collection.id, ...)  // UUID
```

## Verification
- Diagnostic: `hmgi_enabled=true` for ALL queries (was false for name-based).
- `bench_24` recall@{1,10,100} = **100.00%** (unchanged — correct results).
- fmt + clippy `--lib --bins` clean.

## ADR-031 follow-up
The collection `id` is currently a UUID string. ADR-031 O3 (#525) migrated the memtable + WAL to the stable `object_id` (u64/base62). The AXIS HMGI enabled_collections should follow (migrate from UUID to object_id). This PR uses the UUID as a short-term unblock; the ADR-031 migration for AXIS is a separate TD.

## Note on testing
The AXIS-returns-0 bug is **masked** by the WAL memtable fallback (Stage 1 returns all vectors → recall is 100% even with AXIS broken). A direct AXIS-served test is deferred until TD-FLUSH-1 (memtable reaped after flush) — then AXIS must serve and the test becomes meaningful.

Holding for human merge.