### PR TITLE
fix(flush): reap AxisManager collection_vectors after flush (TD-FLUSH-1)

### DIFF
--- a/docs/10-quality/td/TD-FLUSH-1-memtable-not-reaped-after-flush.adoc
+++ b/docs/10-quality/td/TD-FLUSH-1-memtable-not-reaped-after-flush.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open**
+| Status | **Partial** — Phase 1 (AXIS `collection_vectors` reap) resolved; Phase 2 (block-cache invalidation) deferred.
 | Severity | Critical — unbounded memory growth → OOM for large/long-running workloads; also masks the warm-path I/O measurement (warm GETs = 0 because the unreaped memtable serves everything).
 | Component | Flush path — `src/storage/flush_materializer.rs`; AXIS `collection_vectors` — `src/index/axis/management/`
 | Tracked-by | link:../../12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc[Storage-Format Decision Framework] (PR #553)
@@ -61,3 +61,39 @@ measurable via `CountingFileSystem`).
 - **Unblocks**: TD-IOTRACE-1 (warm-path GET measurement meaningful only after the memtable is reaped).
 - Related: TD-163 (PR #393, `free_wal=true` for the server flush) — the server path already sets
   `free_wal=true`; the embedded path does too, but the `collection_vectors` reap is missing in both.
+
+== Resolution (Phase 1 — AXIS `collection_vectors` reap)
+
+Phase 1 shipped. After a successful storage flush, the AxisManager's in-memory
+`collection_vectors` projection for the flushed collection is now reaped, mirroring
+the WAL-batch reap that already ran.
+
+*Added:* `AxisManager::clear_collection_vectors(collection_id)` — acquires the
+`collection_vectors` write lock, `.remove()`s the collection's entire in-memory
+`ProximaRecord` map (and drops its `global_id_index` entries, defense-in-depth). This
+is the in-memory projection only — it does NOT drop the persistent HNSW/IVF/metadata
+indexes (built from the flushed vectors, must stay servable). Use `drop_collection`
+for full teardown.
+
+*Wired into the shared flush core:* `materialize_collection` gained an
+`axis_index_manager: Option<&AxisManager>` parameter; both callers (server
+`StorageEngine::flush_memtable_to_storage` + embedded `EmbeddedProximaDB::flush`)
+thread their `Arc<AxisManager>` through. The reap runs after the WAL cleanup, keyed by
+the canonical collection UUID (`plan.canonical_id`) — the same key
+`handle_flushed_vectors` uses to populate the projection at flush time, so the reap
+removes exactly what was inserted. Failure to reap is logged and non-fatal (the
+durable segment is the source of truth post-flush).
+
+*Tests:* 3 focused unit tests in
+`src/index/axis/management/manager.rs::clear_collection_vectors_tests` — the core
+regression (projection emptied after flush; sibling collection untouched),
+idempotency on an unknown collection, and repopulation-after-reap (the projection is
+a cache, not the durable store, so a fresh post-flush insert must land back in it).
+
+== Phase 2 (deferred) — block-cache invalidation
+
+The 1 GiB block cache (DashMap/moka) still retains entries for the flushed
+collection. These are read-side caches over durable SST segments, so they are
+correctness-neutral (a stale cache entry points at the same durable bytes), but they
+hold memory that could be reclaimed. Deferred to a follow-up TD: the block cache has
+no per-collection eviction API today, so adding one is its own scoped change.

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -2347,12 +2347,17 @@ impl EmbeddedProximaDB {
                     // free_wal=true preserves embedded's existing behavior (delete the
                     // WAL after flush — no 2× overhead). Its cold-read recall gap is the
                     // same dependent TD as the server's.
+                    let axis_manager = self
+                        .shared_services
+                        .vector_operations_service
+                        .axis_index_manager();
                     match crate::storage::flush_materializer::materialize_collection(
                         &write_buffer,
                         &plan,
                         None,
                         Some(fallback_engine),
                         true,
+                        Some(&axis_manager),
                     )
                     .await
                     {

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -2830,6 +2830,45 @@ impl AxisManager {
         Ok(())
     }
 
+    /// Clear the in-memory `collection_vectors` projection for a collection after a
+    /// successful storage flush (TD-FLUSH-1).
+    ///
+    /// Inserted vectors are kept in two in-memory places until they are flushed: the
+    /// WAL/memtable batches (reaped by `write_buffer.clear_flushed`) and this
+    /// `collection_vectors` map (the AxisManager's `ProximaRecord` projection used to
+    /// serve warm reads + hydrate cold indexes). Before this method, only the WAL was
+    /// reaped on flush — every inserted vector stayed resident in `collection_vectors`
+    /// forever, so large workloads OOM'd and warm GETs served from the stale in-memory
+    /// copy instead of exercising the materialized segment (masking cold-read bugs).
+    ///
+    /// This is the in-memory projection only — it does NOT drop the persistent indexes
+    /// (HNSW/IVF/metadata), which were built from the flushed vectors and must remain
+    /// servable. Use [`drop_collection`] for full teardown. The durable record now lives
+    /// in the materialized storage segment that the flush just wrote.
+    pub async fn clear_collection_vectors(&self, collection_id: &str) -> Result<()> {
+        let removed_count = {
+            let mut collection_vectors = self.collection_vectors.write().await;
+            collection_vectors
+                .remove(collection_id)
+                .map(|vectors| vectors.len())
+                .unwrap_or(0)
+        };
+
+        // Defense-in-depth: drop the collection's entries from the global ID index
+        // (currently a placeholder, but the call mirrors `drop_collection` so the
+        // behavior stays correct the moment it is implemented).
+        self.global_id_index
+            .remove_collection(collection_id)
+            .await?;
+
+        tracing::info!(
+            "🧹 AXIS: Cleared {} in-memory collection_vectors for collection '{}' after flush",
+            removed_count,
+            collection_id
+        );
+        Ok(())
+    }
+
     /// Get collection statistics
     pub async fn get_collection_stats(&self, collection_id: &str) -> Result<IndexCollectionStats> {
         let search_strategy = self.get_collection_strategy(collection_id).await?;
@@ -6546,5 +6585,136 @@ mod hot_swap_ef_tests {
 
         let outcome = manager.apply_hnsw_ef_hot_swap("c1", 400).await.unwrap();
         assert!(matches!(outcome, HotSwapOutcome::NotApplicable { .. }));
+    }
+}
+
+#[cfg(test)]
+mod clear_collection_vectors_tests {
+    //! Tests for `AxisManager::clear_collection_vectors` — the in-memory reaping
+    //! step that must run after a successful storage flush (TD-FLUSH-1). Before the
+    //! fix, `db.flush()` cleared the WAL memtable batches but left the AxisManager's
+    //! `collection_vectors` projection fully resident → OOM for large workloads and
+    //! warm GETs serving from the unreaped copy (cold-read bugs masked).
+    use super::*;
+    use chrono::Utc;
+    use proximadb_records::{EmbeddingCell, LabelSet, ProximaRecord, ProximaTree};
+
+    async fn make_manager() -> AxisManager {
+        AxisManager::new(AxisConfig::default())
+            .await
+            .expect("AxisManager::new")
+    }
+
+    fn make_record(oid: &str) -> ProximaRecord {
+        let now_ns = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        ProximaRecord {
+            oid: oid.to_string(),
+            local_id: None,
+            tid: None,
+            variation_id: None,
+            record_version: 1,
+            spec_version: 1,
+            tenant_id: String::new(),
+            permitted_principals: Vec::new(),
+            rls_policy_id: None,
+            created_at_ns: now_ns,
+            updated_at_ns: now_ns,
+            valid_from_ns: None,
+            valid_to_ns: None,
+            origin: None,
+            actor: None,
+            method: None,
+            memory_type: None,
+            props: ProximaTree::new(),
+            refs: Vec::new(),
+            edge: None,
+            embeddings: vec![EmbeddingCell {
+                model_id: "default".to_string(),
+                modality: "dense_vector".to_string(),
+                values: proximadb_records::EmbeddingValues::Fp32(vec![1.0, 2.0, 3.0]),
+                dim: 3,
+                ..Default::default()
+            }],
+            sequence: None,
+            labels: LabelSet::new(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn clear_collection_vectors_empties_the_in_memory_projection() {
+        // The core TD-FLUSH-1 regression: after flush, the in-memory projection must
+        // be gone. Before the fix this map was never cleared → unbounded memory +
+        // warm reads served from the stale copy.
+        let manager = make_manager().await;
+
+        // Insert two records into collection "c1" + one into "c2".
+        manager
+            .insert_record("c1", &make_record("v1"))
+            .await
+            .unwrap();
+        manager
+            .insert_record("c1", &make_record("v2"))
+            .await
+            .unwrap();
+        manager
+            .insert_record("c2", &make_record("v3"))
+            .await
+            .unwrap();
+
+        assert_eq!(manager.registered_vector_count("c1").await, 2);
+        assert_eq!(manager.registered_vector_count("c2").await, 1);
+
+        // Simulate the flush callback reaping c1's in-memory projection.
+        manager.clear_collection_vectors("c1").await.unwrap();
+
+        assert_eq!(
+            manager.registered_vector_count("c1").await,
+            0,
+            "c1's collection_vectors must be reaped after flush"
+        );
+        // c2 is untouched (clear is per-collection, not global).
+        assert_eq!(
+            manager.registered_vector_count("c2").await,
+            1,
+            "clear_collection_vectors must not touch other collections"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_collection_vectors_is_idempotent_on_unknown_collection() {
+        // Flush iterates collections-with-unflushed-data; a collection that had no
+        // WAL batches (or was already reaped) must not error when cleared again.
+        let manager = make_manager().await;
+        // No inserts — collection "ghost" has never been seen.
+        manager.clear_collection_vectors("ghost").await.unwrap();
+        assert_eq!(manager.registered_vector_count("ghost").await, 0);
+    }
+
+    #[tokio::test]
+    async fn clear_collection_vectors_allows_repopulation_after_flush() {
+        // After a flush reaps the projection, subsequent inserts (a new write batch
+        // landed between flush and reap, or a fresh post-flush insert) must repopulate
+        // the map cleanly — the projection is a cache, not the durable store.
+        let manager = make_manager().await;
+        manager
+            .insert_record("c1", &make_record("v1"))
+            .await
+            .unwrap();
+        assert_eq!(manager.registered_vector_count("c1").await, 1);
+
+        manager.clear_collection_vectors("c1").await.unwrap();
+        assert_eq!(manager.registered_vector_count("c1").await, 0);
+
+        // A fresh insert after the reap must land back in the projection.
+        manager
+            .insert_record("c1", &make_record("v2"))
+            .await
+            .unwrap();
+        assert_eq!(
+            manager.registered_vector_count("c1").await,
+            1,
+            "post-flush insert must repopulate the projection"
+        );
     }
 }

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -355,6 +355,7 @@ impl StorageEngine {
                 self.storage_write_fence.as_ref(),
                 None,
                 true,
+                Some(&self.axis_index_manager),
             )
             .await
             {

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
+use crate::index::AxisManager;
 use crate::proto::proximadb_v1::{
     Collection, CollectionConfig, StorageAssignment, StorageEngine as ProtoStorageEngine,
 };
@@ -78,12 +79,22 @@ pub struct CollectionFlushOutcome {
 /// `false` keeps the WAL so recovery replays it into the FP32 memtable (exact recall
 /// that bypasses the cold SST path) — the escape hatch if a cold-read regression
 /// ever resurfaces. No caller uses `false` today.
+///
+/// `axis_index_manager` is the AxisManager whose in-memory `collection_vectors`
+/// projection must be reaped after the segment is durable (TD-FLUSH-1). Inserted
+/// vectors live in two places pre-flush — the WAL batches AND this projection — and
+/// before TD-FLUSH-1 only the WAL was cleared, so the projection grew unbounded
+/// (OOM) and warm GETs served from the stale copy (masked cold-read bugs). Pass
+/// `None` only when no AxisManager owns this collection (recovery / tests); the
+/// projection is then left as-is (caller's responsibility). Failure to reap is
+/// logged and non-fatal — the durable segment is the source of truth post-flush.
 pub async fn materialize_collection(
     write_buffer: &Arc<WALBehaviorWrapper>,
     plan: &CollectionFlushPlan,
     fence: Option<&Arc<dyn StorageWriteFence>>,
     fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
     free_wal: bool,
+    axis_index_manager: Option<&AxisManager>,
 ) -> Result<Option<CollectionFlushOutcome>> {
     // A6 storage-write fence — reject a displaced pod before touching storage.
     if write_fencing_enabled() {
@@ -221,6 +232,23 @@ pub async fn materialize_collection(
         tracing::debug!(
             "flush: kept WAL for '{}' (free_wal=false) — recovery replays it for exact recall",
             plan.wal_key
+        );
+    }
+
+    // TD-FLUSH-1: reap the AxisManager's in-memory `collection_vectors` projection
+    // for this collection now that the durable segment is written. The WAL cleanup
+    // above only clears the memtable batches — inserted vectors ALSO live in the
+    // AxisManager projection (used for warm reads + cold-index hydration), and
+    // leaving it resident caused unbounded memory growth (OOM) and masked cold-read
+    // bugs (warm GETs served from the stale copy). Non-fatal: the segment is the
+    // source of truth post-flush, so a reap failure is logged, not fatal.
+    if let Some(axis) = axis_index_manager
+        && let Err(e) = axis.clear_collection_vectors(&plan.canonical_id).await
+    {
+        tracing::warn!(
+            "flush: failed to clear in-memory collection_vectors for '{}': {}",
+            plan.canonical_id,
+            e
         );
     }
 


### PR DESCRIPTION
## Problem

After `db.flush()` (with `free_wal=true`), the WAL memtable batches were cleared but the AxisManager's `collection_vectors` projection — a separate in-memory `ProximaRecord` map used for warm reads + cold-index hydration — was **never reaped**. Every inserted vector stayed resident forever:

- **OOM risk**: the in-memory store grows unbounded — every insert accumulates and flush doesn't clear it. Large/long-running workloads exhaust memory.
- **Warm GETs = 0**: the unreaped in-memory copy serves every warm query → SST files are never read → the warm-path I/O is unmeasurable and cold-read regressions are masked.

This was filed as **TD-FLUSH-1** by the storage-format decision framework (PR #553).

## Fix (Phase 1 — AXIS `collection_vectors` reap)

- **`AxisManager::clear_collection_vectors(collection_id)`** — acquires the `collection_vectors` write lock and `.remove()`s the collection's entire in-memory `ProximaRecord` map (plus `global_id_index` entries, defense-in-depth). In-memory projection only; does **not** drop the persistent HNSW/IVF/metadata indexes (built from the flushed vectors, must stay servable). Use `drop_collection` for full teardown.
- **Wired into the shared flush core**: `materialize_collection` gained an `axis_index_manager: Option<&AxisManager>` parameter; both callers (server `StorageEngine::flush_memtable_to_storage` + embedded `EmbeddedProximaDB::flush`) thread their `Arc<AxisManager>` through. The reap runs after the WAL cleanup, keyed by the canonical collection UUID (`plan.canonical_id`) — the same key `handle_flushed_vectors` uses to populate the projection at flush time, so the reap removes exactly what was inserted. Non-fatal on failure (the durable segment is the source of truth post-flush).
- **Tests**: 3 focused unit tests in `clear_collection_vectors_tests` — the core regression (projection emptied after flush; sibling collection untouched), idempotency on an unknown collection, and repopulation-after-reap (the projection is a cache, not the durable store).

## Phase 2 (deferred) — block-cache invalidation

The 1 GiB block cache still retains entries for the flushed collection. These are read-side caches over durable SST segments, so they are correctness-neutral (a stale entry points at the same durable bytes), but they hold reclaimable memory. Deferred: the block cache has no per-collection eviction API today, so adding one is its own scoped change.

## Verification

- `cargo clippy --lib --bins -- -D warnings` — green
- `cargo fmt --check` — green
- `cargo test --lib -- 'axis::' 'flush' 'memtable' 'drop_collection'` — 476 passed, 0 failed (4 pre-existing ignored)
- `cargo test --lib -- 'embedded::'` — 111 passed, 0 failed
- `cargo test --lib clear_collection_vectors` — 3 passed
- No `.unwrap()/.expect()/panic!()` in prod diff; no AI-agent attribution

## TD

TD-FLUSH-1 → **Partial** (Phase 1 resolved; Phase 2 block-cache deferred).