### PR TITLE
feat(observability): surface object-store GET count on KRU metering event (TD-IOTRACE-2)

### DIFF
--- a/src/observability/metering_event.rs
+++ b/src/observability/metering_event.rs
@@ -27,6 +27,7 @@
 //     "actual_scan_gb": <f64>,   "estimated_scan_gb": <f64>,
 //     "gls_score":    <f64>,     "failure_class": "<...>",
 //     "tier":         "free|community|business|enterprise"
+//     "object_store_gets": <int>,  "object_store_bytes_read": <int>
 //   }
 //
 // Only fields whose underlying value is `Some` are emitted (matching the
@@ -36,6 +37,7 @@
 
 use serde_json::{Map, Value, json};
 
+use crate::observability::io_trace::IoTraceSnapshot;
 use crate::observability::search_plan_trace::SearchPlanTrace;
 
 /// One metering event ready to POST to the operator-configured
@@ -75,6 +77,14 @@ pub struct MeteringInputs<'a> {
     /// ISO-8601 timestamp (UTC). The caller supplies this — the builder
     /// doesn't import a clock so the unit tests stay deterministic.
     pub occurred_at: String,
+    /// Per-query object-store I/O trace snapshot (co-design KOU dimension —
+    /// the dominant cloud cost term). When `Some`, its `get_ops` and
+    /// `bytes_read` are surfaced on the KRU event as `object_store_gets`
+    /// and `object_store_bytes_read` so the per-tenant metering collection
+    /// carries the measured GET-request count alongside the scanned-byte
+    /// quantity. `None` (the default for older call sites) omits both
+    /// fields, preserving the event's pre-existing shape.
+    pub io_trace: Option<&'a IoTraceSnapshot>,
 }
 
 /// Build the KRU billing event from a populated trace.
@@ -118,6 +128,17 @@ pub fn build_kru(inputs: &MeteringInputs<'_>) -> MeteringEvent {
     metadata.insert("cache_hits".into(), json!(stats.cache_hits));
     metadata.insert("cache_misses".into(), json!(stats.cache_misses));
     metadata.insert("latency_ms".into(), json!(trace.latency_ms));
+    // KOU dimension (co-design §2.1): object-store GET count + bytes read,
+    // sourced from the per-query io-trace snapshot. The GET-request count is
+    // the dominant cloud cost term (per-request fee × N round-trips), so it
+    // is surfaced on the per-tenant metering event for chargeback — alongside
+    // the scanned-byte quantity above, not instead of it. Only emitted when
+    // the snapshot was passed in; older call sites that leave `io_trace`
+    // `None` keep the pre-existing event shape.
+    if let Some(snap) = inputs.io_trace {
+        metadata.insert("object_store_gets".into(), json!(snap.get_ops));
+        metadata.insert("object_store_bytes_read".into(), json!(snap.bytes_read));
+    }
     // Trace-spine block (LLD §10).
     metadata.insert("block_fill_pct".into(), json!(stats.block_fill_pct));
     metadata.insert("tunneled_nodes".into(), json!(stats.tunneled_nodes));
@@ -273,6 +294,7 @@ mod tests {
             corpus_gb: 1.0,
             total_vectors: 1_000_000,
             occurred_at: "2026-05-21T15:00:00Z".into(),
+            io_trace: None,
         }
     }
 
@@ -319,6 +341,39 @@ mod tests {
         // Default (free same-AZ) path → 0.0, still present for a stable shape.
         let ev0 = build_kru(&inputs(&trace_template()));
         assert_eq!(ev0.metadata["actual_egress_gb"], 0.0);
+    }
+
+    #[test]
+    fn io_trace_get_ops_surface_on_the_metering_event() {
+        // TD-IOTRACE-2 / KOU dimension (co-design §2.1): the per-query
+        // object-store GET count is the dominant cloud cost term. When the
+        // caller passes an IoTraceSnapshot with non-zero get_ops, the KRU
+        // event must surface object_store_gets + object_store_bytes_read so
+        // the per-tenant metering collection carries the measured GET count.
+        use crate::observability::io_trace::IoTraceSnapshot;
+        let t = trace_template();
+        let snap = IoTraceSnapshot {
+            get_ops: 42,
+            bytes_read: 8_388_608, // 8 MiB
+            range_gets: 4,
+            ..Default::default()
+        };
+        let mut i = inputs(&t);
+        i.io_trace = Some(&snap);
+        let ev = build_kru(&i);
+        assert_eq!(ev.metadata["object_store_gets"], 42);
+        assert_eq!(ev.metadata["object_store_bytes_read"], 8_388_608);
+    }
+
+    #[test]
+    fn io_trace_fields_omitted_when_snapshot_is_none() {
+        // Older call sites that don't pass a snapshot keep the pre-existing
+        // event shape — the KOU fields are absent, not zero, so a downstream
+        // consumer distinguishing "unset" from "measured zero" can do so.
+        let t = trace_template();
+        let ev = build_kru(&inputs(&t)); // io_trace: None
+        assert!(ev.metadata.get("object_store_gets").is_none());
+        assert!(ev.metadata.get("object_store_bytes_read").is_none());
     }
 
     #[test]

--- a/src/observability/trace_batcher.rs
+++ b/src/observability/trace_batcher.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::observability::io_trace::IoTraceSnapshot;
 use crate::observability::metering_event::{MeteringInputs, build_kru};
 use crate::observability::search_plan_trace::SearchPlanTrace;
 use crate::observability::trace_digest::{DigestInputs, digest_hex};
@@ -71,6 +72,11 @@ pub struct TraceBatchInput<'a> {
     pub occurred_at_iso: String,
     /// Bucket for the idempotency-key timestamp. Defaults to 1s.
     pub idempotency_bucket: Duration,
+    /// Per-query object-store I/O trace snapshot (KOU dimension). Threaded
+    /// through to `build_kru` so the metering event can surface
+    /// `object_store_gets` / `object_store_bytes_read`. `None` keeps the
+    /// pre-existing metering shape (older call sites).
+    pub io_trace: Option<&'a IoTraceSnapshot>,
 }
 
 /// Build a batch from a slice of inputs. Returns an empty batch when
@@ -97,6 +103,7 @@ pub fn build_batch(inputs: &[TraceBatchInput<'_>]) -> TraceBatch {
             corpus_gb: input.corpus_gb,
             total_vectors: input.total_vectors,
             occurred_at: input.occurred_at_iso.clone(),
+            io_trace: input.io_trace,
         });
 
         let idempotency_key = digest_hex(&DigestInputs {
@@ -161,6 +168,7 @@ pub fn homogeneous_inputs<'a>(
             occurred_at_ms,
             occurred_at_iso: occurred_at_iso.to_string(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         })
         .collect()
 }
@@ -211,6 +219,7 @@ mod tests {
             occurred_at_ms: 1_700_000_000_000,
             occurred_at_iso: "2026-05-21T00:00:00Z".into(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         }
     }
 

--- a/tests/trace_pipeline_integration_test.rs
+++ b/tests/trace_pipeline_integration_test.rs
@@ -109,6 +109,7 @@ fn full_pipeline_composes_for_a_single_trace() {
         corpus_gb: 1.0,
         total_vectors: 1_000_000,
         occurred_at: "2026-05-22T00:00:00Z".into(),
+        io_trace: None,
     });
     assert_eq!(metering.event_type, "kru");
     assert_eq!(metering.tenant_id, "tenant-a");
@@ -145,6 +146,7 @@ fn full_pipeline_composes_for_a_single_trace() {
         occurred_at_ms: 1_700_000_000_000,
         occurred_at_iso: "2026-05-22T00:00:00Z".into(),
         idempotency_bucket: Duration::from_secs(1),
+        io_trace: None,
     };
     let batch = build_batch(&[batch_input]);
     assert_eq!(batch.count, 1);
@@ -207,6 +209,7 @@ fn batch_of_identical_shapes_collapses_fingerprint_but_keeps_idempotency_distinc
             occurred_at_ms: 1_700_000_000_000,
             occurred_at_iso: "2026-05-22T00:00:00Z".into(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         },
         TraceBatchInput {
             trace: &t2,
@@ -216,6 +219,7 @@ fn batch_of_identical_shapes_collapses_fingerprint_but_keeps_idempotency_distinc
             occurred_at_ms: 1_700_000_000_000,
             occurred_at_iso: "2026-05-22T00:00:00Z".into(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         },
     ];
 
@@ -285,6 +289,7 @@ fn cross_tenant_traces_share_fingerprint_but_have_distinct_idempotency_keys() {
             occurred_at_ms: 1_700_000_000_000,
             occurred_at_iso: "2026-05-22T00:00:00Z".into(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         },
         TraceBatchInput {
             trace: &t_b,
@@ -294,6 +299,7 @@ fn cross_tenant_traces_share_fingerprint_but_have_distinct_idempotency_keys() {
             occurred_at_ms: 1_700_000_000_000,
             occurred_at_iso: "2026-05-22T00:00:00Z".into(),
             idempotency_bucket: Duration::from_secs(1),
+            io_trace: None,
         },
     ];
     let batch = build_batch(&inputs);
@@ -360,6 +366,7 @@ fn non_default_plan_choice_propagates_through_the_pipeline() {
         corpus_gb: 0.01,
         total_vectors: 1_000,
         occurred_at: "2026-05-22T00:00:00Z".into(),
+        io_trace: None,
     });
     assert_eq!(
         metering.metadata["index_route"],


### PR DESCRIPTION
## Summary

Extends per-tenant metering to carry the co-design **KOU dimension** (object-store GET count + bytes read) on the KRU billing event. The per-query object-store GET-request count is the dominant cloud cost term (per-request fee x N round-trips); surfacing it on the KRU event lets the per-tenant metering collection chargeback against the same measured quantity the route cost model sees.

Closes TD-IOTRACE-2.

## Changes

- **`MeteringInputs`** gains `io_trace: Option<&IoTraceSnapshot>` (additive, defaults `None`; older call sites keep working).
- **`build_kru`** emits `object_store_gets` + `object_store_bytes_read` on the KRU event when the snapshot is `Some`. The fields are **absent (not zero)** when `None`, so downstream can distinguish "unset" from "measured zero".
- **`TraceBatchInput`** threads the same field through to `build_kru` so the batcher path can carry it.
- **2 TDD tests** in `metering_event`:
  - `io_trace_get_ops_surface_on_the_metering_event` — non-zero `get_ops` surfaces both fields.
  - `io_trace_fields_omitted_when_snapshot_is_none` — `None` omits them.

## Design notes

- **Additive plumbing via `Option<&IoTraceSnapshot>`** — the field defaults to `None`, so the 7 existing call sites (`trace_batcher` + `trace_pipeline_integration_test`) keep working unchanged in behavior by passing `None`.
- **Always-emit-when-present** (matches the precedent of `actual_egress_gb` / Dimension 2 KEU): emitted unconditionally when the snapshot is passed, for a stable event shape.
- **No new billing authority** — surfaces measured quantities only; per-tenant counters stay the source of truth (ADR-027/ADR-030 non-entanglement). The snapshot is already captured per-query via the `io_trace::instrument` task-local; this PR opens the seam for the metering builder to read it.

## Verification

- `cargo build --lib --bins` — green
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --lib metering_event` — 16/16 pass (incl. 2 new)
- `cargo test --test trace_pipeline_integration_test` — 5/5 pass
- Panic-policy lint: 36 (under 65 threshold); change adds **zero** `.unwrap/.expect/panic!` in prod code
- No AI-agent attribution (guard passes)