### PR TITLE
test(qa-gate): fix recall_tune collection_id assertion + trace TPC-H pgwire per-query

### DIFF
--- a/tests/recall_tune_auth_e2e.rs
+++ b/tests/recall_tune_auth_e2e.rs
@@ -309,11 +309,22 @@ async fn unified_port_auth_converged_recall_tune_e2e() {
     );
     let create_json: serde_json::Value =
         serde_json::from_str(&body_text).expect("create json parse");
-    // v2 CreateCollectionV2Response echoes the collection_id on success.
+    // v2 CreateCollectionV2Response echoes the name + a canonical collection_id
+    // (UUID) on success (ADR-031 O3 / ADR-044 P2 — collection_id is the object
+    // UUID, not the name). Assert the echoed name + that a collection_id is present.
     assert_eq!(
-        create_json.get("collection_id").and_then(|v| v.as_str()),
+        create_json.get("name").and_then(|v| v.as_str()),
         Some("ivf_auth_e2e"),
-        "v2 create response must echo collection_id: {:?}",
+        "v2 create response must echo name: {:?}",
+        create_json
+    );
+    assert!(
+        create_json
+            .get("collection_id")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "v2 create response must include a collection_id (UUID): {:?}",
         create_json
     );
 

--- a/tests/tpch_pgwire_e2e.rs
+++ b/tests/tpch_pgwire_e2e.rs
@@ -242,6 +242,10 @@ async fn tpch_pgwire_conformance() {
     let mut passed = Vec::new();
     let mut failed = Vec::new();
     for (id, sql) in &queries {
+        // Trace BEFORE execution: a stack overflow / panic during simple_query
+        // aborts the process (the match below never runs), so the LAST line
+        // printed identifies the culprit query + its SQL. Run with --nocapture.
+        eprintln!("  ▶ {id}: {sql}");
         match client.simple_query(sql).await {
             Ok(_) => {
                 eprintln!("  ✓ {id}");


### PR DESCRIPTION
## What

Two qa-gate test fixes blocking the develop→qa promotion (#560):

1. **recall_tune_auth_e2e** — stale assertion: expected `collection_id == name`, but post-UUID-migration (ADR-031 O3 / ADR-044 P2) `collection_id` is the object UUID. Now asserts the echoed `name` + that a `collection_id` (UUID) is present.

2. **tpch_pgwire_e2e** — diagnostic tracing: `eprintln!("▶ {id}: {sql}")` before each `simple_query`. The qa-gate stack-overflow failure (Q1 passes, a later query overflows a tokio worker thread → abort, no backtrace) will now print each query's id + SQL *before* execution, so the **last printed line identifies the culprit query** on the next run.

## Why

The develop→qa promotion (#560) fails the qa-gate on:
- recall_tune (stale assertion — this fixes it).
- TPC-H stack overflow (real bug — the tracing pinpoints which query; the fix follows once identified).
- Coverage Ratchet + Cloud object-store (infra cancellations — re-run clears them).

## Verification
`cargo check --test recall_tune_auth_e2e` + `cargo check --test tpch_pgwire_e2e` both pass.