### PR TITLE
fix(manifest): prune stale lease/catalog manifests — TD-MANIFEST-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7084,6 +7084,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bytes",
+ "chrono",
  "futures",
  "object_store",
  "parquet",
@@ -7095,6 +7096,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/storage/proximadb-iceberg-engine/Cargo.toml
+++ b/crates/storage/proximadb-iceberg-engine/Cargo.toml
@@ -34,6 +34,10 @@ apache-avro = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
+# `prune_retention` compares `ObjectMeta.last_modified` (a `DateTime<Utc>`) against a
+# retention age; `tracing` logs best-effort delete failures without aborting the pass.
+chrono.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }

--- a/crates/storage/proximadb-iceberg-engine/src/manifest.rs
+++ b/crates/storage/proximadb-iceberg-engine/src/manifest.rs
@@ -18,10 +18,17 @@
 //! counts / column stats). This crate owns the *atomicity*, not the manifest schema.
 
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use object_store::path::Path;
 use proximadb_kernel::error::StorageError;
 use proximadb_object_store::ProximaObjectStore;
 pub use proximadb_storage_common::object_store_bridge::CommitOutcome;
+
+/// Floor for [`ManifestCommitter::prune_retention`]'s `keep_k`. Below this the log
+/// would collapse to little more than the tip, eliminating the concurrency window in
+/// which a reader may still hold a just-read parent and leaving a single point of
+/// failure for the generation fence.
+const MIN_PRUNE_KEEP_K: usize = 2;
 
 /// Atomic, optimistic-concurrency manifest committer over a [`ProximaObjectStore`].
 ///
@@ -140,6 +147,102 @@ impl ManifestCommitter {
     pub async fn read_fenced(&self, version: u64) -> Result<(u64, Bytes), StorageError> {
         Ok(decode_fenced(&self.read_manifest(version).await?))
     }
+
+    /// Best-effort retention prune of superseded manifest objects.
+    ///
+    /// The manifest log is append-only — every commit creates a new `v{N}.manifest`
+    /// via a create-only put, and historically **nothing reclaimed the stale tail**.
+    /// A long-lived lease renewed every few seconds therefore grows without bound
+    /// (observed: ~48k objects per collection, ~562 MB), which made every
+    /// [`latest_version`](Self::latest_version) a full O(n) `list` that pinned a CPU
+    /// core; on a cloud store each such `list` is a paginated HTTP LIST that grows
+    /// slower and costlier as `n` grows. Pruning the tail caps `n` — which is *itself*
+    /// the read-path fix, so no mutable tip pointer is needed (a pointer would
+    /// reintroduce the lost-update/ABA hazard the create-only-put protocol avoids).
+    ///
+    /// # Safety
+    ///
+    /// Only the **tip** (the max version) is ever read — by
+    /// [`commit_fenced`](Self::commit_fenced), [`read_fenced`](Self::read_fenced) and
+    /// the version CAS — so it is **never deleted**. A version becomes eligible only
+    /// when it is **both**:
+    ///
+    /// - ranked `keep_k` or more behind the tip (rank is the position in the sorted
+    ///   version list, **not** `tip - v` arithmetic, so a log with gaps from a prior
+    ///   partial prune is still ranked correctly), **and**
+    /// - at least `min_age` old (a grace window that protects the recent burst and the
+    ///   tombstone a release publishes at `generation + 1`).
+    ///
+    /// `keep_k` is clamped to [`MIN_PRUNE_KEEP_K`]. A future-dated `last_modified`
+    /// (cloud clock skew) is treated as not-yet-of-age and never reaped early. Deletes
+    /// are best-effort: a transient error — including [`StorageError::NotFound`] for an
+    /// object a concurrent pass already removed — is logged and the pass continues. A
+    /// crash mid-pass leaves the log half-pruned; the next pass recomputes from a fresh
+    /// `list`. Returns the number of objects deleted.
+    pub async fn prune_retention(
+        &self,
+        keep_k: usize,
+        min_age: std::time::Duration,
+    ) -> Result<usize, StorageError> {
+        // Defense in depth — the call sites clamp too, but never let the log collapse
+        // past the tip-plus-predecessor concurrency window.
+        let keep_k = keep_k.max(MIN_PRUNE_KEEP_K);
+        let min_age = chrono::Duration::from_std(min_age).unwrap_or(chrono::Duration::zero());
+
+        let prefix = Path::from(self.prefix.as_str());
+        let mut entries: Vec<(u64, DateTime<Utc>)> = self
+            .store
+            .list(Some(&prefix))
+            .await?
+            .into_iter()
+            .filter_map(|m| {
+                let version = Self::parse_version(m.location.filename()?)?;
+                Some((version, m.last_modified))
+            })
+            .collect();
+        if entries.len() <= keep_k {
+            return Ok(0);
+        }
+
+        // Oldest first; the tip is the last element and is never eligible.
+        entries.sort_unstable_by_key(|(v, _)| *v);
+        let now = Utc::now();
+        let count = entries.len();
+
+        let mut deleted = 0usize;
+        for (idx, (version, last_modified)) in entries.iter().enumerate() {
+            // rank 0 == the tip; rank grows toward the head of the list. Newer entries
+            // have smaller rank, so once rank drops below `keep_k` everything that
+            // remains is within the keep window — stop early.
+            let rank_from_tip = count - 1 - idx;
+            if rank_from_tip < keep_k {
+                break;
+            }
+            // `age < min_age` also covers a future-dated mtime (negative age) from cloud
+            // clock skew — such an object is never reaped early.
+            let age = now.signed_duration_since(*last_modified);
+            if age < min_age {
+                continue;
+            }
+            // Delete via the canonical `manifest_path(version)` — the same form `get` /
+            // `put_if_absent` address. A list-returned `location` is not always
+            // delete-safe across backends (the local store returns a root-relative form
+            // that `delete` would double-prefix), but the constructed path round-trips.
+            match self.store.delete(&self.manifest_path(*version)).await {
+                Ok(()) => deleted += 1,
+                // A concurrent pass (or a cross-pod owner) already removed it.
+                Err(StorageError::NotFound(_)) => {}
+                Err(e) => tracing::warn!(
+                    target: "proximadb::manifest::prune",
+                    prefix = %self.prefix,
+                    version,
+                    error = %e,
+                    "best-effort manifest delete failed; continuing pass"
+                ),
+            }
+        }
+        Ok(deleted)
+    }
 }
 
 /// Prepend the 8-byte big-endian `generation` header to `payload`.
@@ -164,8 +267,10 @@ fn decode_fenced(bytes: &Bytes) -> (u64, Bytes) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use object_store::ObjectStoreExt;
     use object_store::memory::InMemory;
     use std::sync::Arc;
+    use std::time::Duration;
 
     fn committer() -> ManifestCommitter {
         ManifestCommitter::new(
@@ -322,5 +427,178 @@ mod tests {
         let c = committer();
         c.commit(None, Bytes::from_static(b"plain")).await.unwrap();
         assert_eq!(c.read_fenced(0).await.unwrap().0, 0);
+    }
+
+    // ---- prune_retention ----
+
+    fn committer_with_store() -> (ManifestCommitter, Arc<InMemory>) {
+        let backend = Arc::new(InMemory::new());
+        let c = ManifestCommitter::new(
+            ProximaObjectStore::new(backend.clone()),
+            "data/t/ns/_manifests",
+        );
+        (c, backend)
+    }
+
+    /// Seed `n` fenced commits at a fixed generation; returns the final version.
+    async fn seed_fenced(c: &ManifestCommitter, n: u64, generation: u64) -> u64 {
+        let mut parent: Option<u64> = None;
+        let mut last = 0;
+        for v in 0..n {
+            assert_eq!(
+                c.commit_fenced(parent, generation, Bytes::from_static(b"g"))
+                    .await
+                    .unwrap(),
+                CommitOutcome::Committed(v)
+            );
+            parent = Some(v);
+            last = v;
+        }
+        last
+    }
+
+    /// Pruning deletes only the stale tail; the tip is always retained and readable.
+    #[tokio::test]
+    async fn prune_never_deletes_tip() {
+        let (c, _backend) = committer_with_store();
+        let tip = seed_fenced(&c, 50, 5).await;
+        assert_eq!(tip, 49);
+
+        let deleted = c.prune_retention(10, Duration::ZERO).await.unwrap();
+        assert_eq!(deleted, 40, "keep newest 10 of 50");
+        assert_eq!(c.latest_version().await.unwrap(), Some(49));
+        let (tip_gen, _bytes) = c.read_fenced(49).await.unwrap();
+        assert_eq!(tip_gen, 5, "tip still decodes after prune");
+    }
+
+    /// After pruning, the owner can still commit a fenced successor — the tip's
+    /// generation header survives. This is the load-bearing fence test.
+    #[tokio::test]
+    async fn prune_preserves_fenced_commit_after_prune() {
+        let (c, _backend) = committer_with_store();
+        let tip = seed_fenced(&c, 50, 5).await;
+        assert_eq!(c.prune_retention(5, Duration::ZERO).await.unwrap(), 45);
+
+        let out = c
+            .commit_fenced(Some(tip), 5, Bytes::from_static(b"next"))
+            .await
+            .unwrap();
+        assert_eq!(out, CommitOutcome::Committed(50));
+    }
+
+    /// A stale writer (generation below the tip's) is still fenced after pruning.
+    #[tokio::test]
+    async fn prune_then_stale_writer_still_fenced() {
+        let (c, _backend) = committer_with_store();
+        let tip = seed_fenced(&c, 50, 5).await;
+        c.prune_retention(5, Duration::ZERO).await.unwrap();
+
+        let out = c
+            .commit_fenced(Some(tip), 4, Bytes::from_static(b"stale"))
+            .await
+            .unwrap();
+        // Fenced at the generation check *before* any slot is claimed — the tip (still
+        // 49 after pruning) is returned, and no v50 is created.
+        assert_eq!(out, CommitOutcome::Conflict { latest: Some(tip) });
+        assert_eq!(c.latest_version().await.unwrap(), Some(tip));
+    }
+
+    /// `min_age` grants recent history a grace window: a large `min_age` reaps nothing,
+    /// then dropping it to zero reaps the stale tail while the keep window stays intact.
+    #[tokio::test]
+    async fn prune_respects_min_age_grace_window() {
+        let (c, _backend) = committer_with_store();
+        seed_fenced(&c, 50, 5).await;
+
+        // Everything was written moments ago → all within the grace window.
+        assert_eq!(
+            c.prune_retention(2, Duration::from_secs(3600))
+                .await
+                .unwrap(),
+            0,
+            "min_age=1h keeps the recent burst"
+        );
+        // Drop the age gate; keep only the newest 2.
+        assert_eq!(
+            c.prune_retention(2, Duration::ZERO).await.unwrap(),
+            48,
+            "keep newest 2 of 50"
+        );
+        assert_eq!(c.latest_version().await.unwrap(), Some(49));
+        assert!(c.read_manifest(48).await.is_ok(), "predecessor retained");
+    }
+
+    /// Rank is the position in the sorted version list, so a log with gaps (from a
+    /// prior partial prune) is still ranked correctly — not by `tip - v` arithmetic.
+    #[tokio::test]
+    async fn prune_rank_robust_to_gaps() {
+        let (c, backend) = committer_with_store();
+        seed_fenced(&c, 50, 5).await;
+        // Simulate a prior partial prune that already removed v25.
+        let gap_path = c.manifest_path(25);
+        backend.delete(&gap_path).await.unwrap();
+        assert!(c.read_manifest(25).await.is_err());
+
+        // 49 remaining; keep newest 5 by rank (v45..v49) → delete 44.
+        let deleted = c.prune_retention(5, Duration::ZERO).await.unwrap();
+        assert_eq!(deleted, 44);
+        for v in 45..50u64 {
+            assert!(c.read_manifest(v).await.is_ok(), "v{v} retained");
+        }
+        assert_eq!(c.latest_version().await.unwrap(), Some(49));
+    }
+
+    /// Pruning concurrently with commits never breaks the fence: the commit outcome is
+    /// always well-formed and the tip stays readable.
+    #[tokio::test]
+    async fn prune_concurrent_with_commit_fenced_is_safe() {
+        let (c, _backend) = committer_with_store();
+        let mut tip = seed_fenced(&c, 40, 5).await;
+
+        for _ in 0..20 {
+            let (pruned, committed) = tokio::join!(
+                c.prune_retention(5, Duration::ZERO),
+                c.commit_fenced(Some(tip), 5, Bytes::from_static(b"r")),
+            );
+            let pruned = pruned.unwrap();
+            let committed = committed.unwrap();
+            assert!(
+                matches!(committed, CommitOutcome::Committed(_)),
+                "commit must not error under concurrent prune (got {committed:?}, pruned {pruned})"
+            );
+            if let CommitOutcome::Committed(v) = committed {
+                tip = v;
+            }
+        }
+        assert_eq!(c.latest_version().await.unwrap(), Some(tip));
+        let (tip_gen, _) = c.read_fenced(tip).await.unwrap();
+        assert_eq!(tip_gen, 5);
+    }
+
+    /// An empty log is a no-op (never errors, deletes nothing).
+    #[tokio::test]
+    async fn prune_empty_log_is_noop() {
+        let (c, _backend) = committer_with_store();
+        assert_eq!(
+            c.prune_retention(10, Duration::from_secs(60))
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(c.latest_version().await.unwrap(), None);
+    }
+
+    /// `keep_k` below the floor is clamped, not honored — the log never collapses past
+    /// the tip-plus-predecessor window.
+    #[tokio::test]
+    async fn prune_clamps_keep_k_below_minimum() {
+        let (c, _backend) = committer_with_store();
+        seed_fenced(&c, 10, 5).await;
+        // keep_k=0 → clamped to MIN_PRUNE_KEEP_K (2): delete 8, keep newest 2.
+        let deleted = c.prune_retention(0, Duration::ZERO).await.unwrap();
+        assert_eq!(deleted, 8);
+        assert_eq!(c.latest_version().await.unwrap(), Some(9));
+        assert!(c.read_manifest(8).await.is_ok(), "predecessor retained");
+        assert!(c.read_manifest(7).await.is_err(), "v7 reaped");
     }
 }

--- a/docs/10-quality/td/TD-MANIFEST-1-manifest-retention.adoc
+++ b/docs/10-quality/td/TD-MANIFEST-1-manifest-retention.adoc
@@ -1,0 +1,95 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-MANIFEST-1: Unbounded manifest-log growth + O(n) tip scan on every lease op
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Resolved** — generic `ManifestCommitter::prune_retention` + owner-only lease prune loop + catalog prune-on-write (this PR).
+| Severity | High — unbounded object-store growth (observed 562 MB / 144,546 files from one 3-day run) + O(n) per lease op → O(n²) over a pod's lifetime: a pinned CPU core locally, escalating LIST latency + cost on a cloud store.
+| Component | Iceberg manifest committer — `crates/storage/proximadb-iceberg-engine/src/manifest.rs`; lease driver — `src/cluster/partition_lease.rs`; wiring — `src/network/shared_services.rs`; catalog snapshots — `src/services/catalog_snapshot_store.rs`.
+| Tracked-by | — (standalone; surfaced via the orphaned TD-163 benchmark process).
+| Pillar | COST, PERF, REL
+|===
+
+toc::[]
+
+== Symptom
+
+An orphaned `proximadb-server` (worktree deleted, killed) ran ~3 days and accumulated
+**144,546 manifest files (562 MB)** under
+`_operator/leases/{tenant}/{collection}/_manifests/`, pinning one core at 99 %. Each
+manifest is `v{version:020}.manifest` (~251 B payload, a 4 KiB block): three benchmark
+collections × ~48,182 versions each. A stack sample showed the CPU burning in
+`object_store::local`'s `list` walking the 48k-entry directory and running
+`is_valid_file_path` on every entry.
+
+On a cloud store (ABFS/S3/GCS) the symptom differs — a pinned core becomes an
+ever-slower, ever-costlier paginated `LIST`: every lease op pays a full prefix scan,
+renewals eventually can't keep up with the TTL (fence churn), and a cold failover must
+`LIST` thousands of objects just to find the tip.
+
+== Root cause
+
+The shared `ManifestCommitter` is an append-only, optimistically-concurrent commit log
+(create-only `put_if_absent` per `v{N}`), and **nothing ever reclaimed the stale tail**:
+
+* `commit` / `commit_fenced` only *create* `v{N}.manifest`; lease release writes a
+  tombstone at `generation + 1` (by design, not a delete).
+* `latest_version()` finds the tip by `store.list(prefix)` (materializing **all**
+  `ObjectMeta`) then `.iter().max()` — O(n) — and it is called on every `read`,
+  `acquire`, `renew`, and inside `commit_fenced`.
+* The renew loop (`spawn_renew_loop`, 5 s tick) drives the cadence: ~1 manifest /
+  5.4 s / collection.
+
+The bug is shared: `ManifestCommitter` is also used by `catalog_snapshot_store.rs`
+(append-per-checkpoint, also never pruned) and (transitively) anywhere the fenced-commit
+primitive is reused.
+
+== Fix approach
+
+Cap the manifest count per log. Capping `n` is *itself* the read-path fix —
+`latest_version()` over a bounded set is cheap, so **no mutable tip pointer is needed**
+(a pointer would reintroduce the lost-update/ABA hazard the create-only-put protocol
+exists to avoid).
+
+A generic `prune_retention(keep_k, min_age)` on `ManifestCommitter`, driven by:
+
+. an owner-only **lease prune loop** (`spawn_prune_loop`, same ownership gate as
+  `renew_held`), default ON, knobs `PROXIMADB_LEASE_MANIFEST_*`;
+. **catalog prune-on-write** — after each published snapshot, default ON, knobs
+  `PROXIMADB_CATALOG_SNAPSHOT_*` (`keep_k=3`, snapshots are large full-catalog blobs).
+
+Safety invariants (the tip is the only object the generation fence reads):
+
+. **Never delete the tip** (max version).
+. Eligible = ranked `keep_k`+ behind the tip **AND** at least `min_age` old (rank, not
+  `tip - v` arithmetic, so a gapped log still ranks correctly; the age gate protects the
+  recent burst and release tombstones).
+. `keep_k` clamped to ≥ 2; a future-dated `last_modified` (clock skew) is never reaped
+  early; deletes are best-effort + idempotent.
+
+== Resolution
+
+*Added:* `ManifestCommitter::prune_retention` + `MIN_PRUNE_KEEP_K` (8 unit tests,
+incl. the load-bearing `prune_preserves_fenced_commit_after_prune` and
+`prune_then_stale_writer_still_fenced`).
+
+*Lease wiring:* `PartitionLeaseManager::prune_held` + `spawn_prune_loop` (detached,
+mirrors `spawn_renew_loop`; only logs this pod owns are pruned; the held set is re-read
+fresh each tick). Knobs parsed in `shared_services.rs` (`lease_manifest_*` helpers).
+
+*Catalog wiring:* `CatalogSnapshotStore::prune_retention` trait method (default no-op
+for the local store) + `ObjectStoreSnapshotStore` override; prune-on-write in
+`write_atomic`, best-effort (never fails the publish). Knobs in
+`catalog_snapshot_store.rs`.
+
+== Follow-ups (out of scope)
+
+* `_catalog/leases` manager (`shared_services.rs` ~line 2250, off-by-default, no renew
+  loop) accumulates negligibly today; wire `spawn_prune_loop` there if its renew loop is
+  ever enabled.
+* Tip-pointer / probe-upward discovery to avoid the one O(n) `list` on cold start — not
+  needed once `n` is bounded.
+* Coalesce renewals (skip a write when expiry barely advanced) to cut the write rate.

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -2507,6 +2507,102 @@ impl PartitionLeaseManager {
             }
         })
     }
+
+    /// Prune the stale tail of every lease manifest log this pod owns. Best-effort and
+    /// idempotent: a transient object-store error is logged and the pass continues, and
+    /// a log visited twice in one pass (a collection acquired via both the legacy and
+    /// `ResourceKey` APIs shares one manifest log) is a harmless no-op the second time.
+    /// See [`ManifestCommitter::prune_retention`] for the safety invariants.
+    pub async fn prune_held(&self, keep_k: usize, min_age: std::time::Duration) -> Result<usize> {
+        let mut total = 0usize;
+
+        // Legacy (tenant, collection) leases this pod owns.
+        for (tenant_id, collection_id, binding) in self.registry.list() {
+            if binding.pod != self.self_pod_id {
+                continue;
+            }
+            let committer = self.store.committer(&tenant_id, &collection_id);
+            match committer.prune_retention(keep_k, min_age).await {
+                Ok(n) => total += n,
+                Err(e) => tracing::warn!(
+                    tenant = %tenant_id,
+                    collection = %collection_id,
+                    error = %e,
+                    "partition-lease manifest prune failed; retrying next interval"
+                ),
+            }
+        }
+
+        // Full-key leases (tables / graphs / models / collection-via-ResourceKey) this
+        // pod owns. Collect first so no DashMap shard read-guard is held across an await.
+        let held: Vec<ResourceKey> = self
+            .held_resource_keys
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        for key in held {
+            let path = key.to_path();
+            let committer = match self.store.committer_for_key(&key) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        key = %path,
+                        error = %e,
+                        "prune: skipping unaddressable held key"
+                    );
+                    continue;
+                }
+            };
+            match committer.prune_retention(keep_k, min_age).await {
+                Ok(n) => total += n,
+                Err(e) => tracing::warn!(
+                    key = %path,
+                    error = %e,
+                    "partition-lease manifest prune failed; retrying next interval"
+                ),
+            }
+        }
+
+        Ok(total)
+    }
+
+    /// Spawn a low-priority background task that prunes the stale tail of each lease
+    /// manifest log this pod owns, every `interval`. Drop the returned [`JoinHandle`]
+    /// as a temporary so the task runs detached — matches [`spawn_renew_loop`].
+    ///
+    /// Capping the manifest count per log is *itself* the read-path fix: every
+    /// `latest_version()` (a full `list`) stays cheap once `n` is bounded, instead of
+    /// growing O(n) per lease op and O(n²) over a pod's lifetime (the observed failure
+    /// was ~48k manifests/collection pinning a CPU core). See
+    /// [`ManifestCommitter::prune_retention`] for the safety invariants.
+    ///
+    /// **Scope / safety.** Only logs for resources this pod owns are pruned
+    /// (`binding.pod == self_pod_id`, same gate as [`renew_held`]); the held set is
+    /// re-read fresh each tick, so a key lost between ticks is not pruned again.
+    /// `prune_retention` is fence-safe by construction (it never deletes the tip — the
+    /// only object the generation fence reads), so even a displaced owner that prunes
+    /// for one extra tick before the renew loop steps it down can only delete non-tip
+    /// history, never break the fence. Detached, like the renew loop: process exit
+    /// tears the runtime down and aborts the task; a graceful SIGTERM flush races only
+    /// idempotent manifest deletes.
+    pub fn spawn_prune_loop(
+        self: Arc<Self>,
+        interval: std::time::Duration,
+        keep_k: usize,
+        min_age: std::time::Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            ticker.tick().await; // consume the immediate first tick
+            loop {
+                ticker.tick().await;
+                if let Err(e) = self.prune_held(keep_k, min_age).await {
+                    tracing::warn!(error = %e, "partition-lease prune loop pass failed");
+                }
+            }
+        })
+    }
 }
 
 /// Lease-aware write gate: `consult_for_write` over a registry the

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -35,6 +35,45 @@ use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactor
 use proximadb_graph_query::service::{GraphExecutionService, GraphQueryService};
 use proximadb_kernel::uuid::Uuid;
 
+// ---- TD-MANIFEST-1: lease manifest retention knobs (parsed once per boot) ----
+// Manifests are append-only and were never pruned, so a long-lived lease grew ~48k
+// objects (562 MB) and made every `latest_version()` an O(n) full `list`. A
+// low-priority prune of the stale tail caps n — itself the read-path fix. Default ON
+// with conservative knobs; set PROXIMADB_LEASE_MANIFEST_RETENTION=0 to disable.
+
+/// Whether the lease manifest prune loop runs (default ON).
+fn lease_manifest_retention_enabled() -> bool {
+    std::env::var("PROXIMADB_LEASE_MANIFEST_RETENTION")
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(true)
+}
+
+/// Number of newest manifests to keep per lease log (the committer clamps this to ≥2).
+fn lease_manifest_keep_k() -> usize {
+    std::env::var("PROXIMADB_LEASE_MANIFEST_KEEP")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(32)
+}
+
+/// Minimum age (seconds) a superseded manifest must reach before it is eligible to
+/// prune — a grace window that protects the recent burst and release tombstones.
+fn lease_manifest_min_age_secs() -> u64 {
+    std::env::var("PROXIMADB_LEASE_MANIFEST_MIN_AGE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(900)
+}
+
+/// How often the prune loop sweeps each held lease log (seconds).
+fn lease_manifest_prune_interval_secs() -> u64 {
+    std::env::var("PROXIMADB_LEASE_MANIFEST_PRUNE_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(300)
+}
+
 /// Which consumer is constructing the shared service core.
 ///
 /// The core (catalog, collection, vector/doc/graph compute, storage/WAL,
@@ -1955,6 +1994,23 @@ impl SharedServices {
                     manager
                         .clone()
                         .spawn_renew_loop(std::time::Duration::from_millis(5_000));
+
+                    // TD-MANIFEST-1: cap the lease manifest log. Manifests are
+                    // append-only and were never pruned, so a long-lived lease grew
+                    // ~48k objects (562 MB) and made every `latest_version()` an O(n)
+                    // full `list` that pinned a CPU core (and on a cloud store is a
+                    // paginated LIST that gets slower/costlier as n grows). A
+                    // low-priority prune of the stale tail caps n — itself the
+                    // read-path fix, since the tip scan stays cheap once bounded.
+                    // Default ON with conservative knobs; set
+                    // PROXIMADB_LEASE_MANIFEST_RETENTION=0 to disable.
+                    if lease_manifest_retention_enabled() {
+                        manager.clone().spawn_prune_loop(
+                            std::time::Duration::from_secs(lease_manifest_prune_interval_secs()),
+                            lease_manifest_keep_k(),
+                            std::time::Duration::from_secs(lease_manifest_min_age_secs()),
+                        );
+                    }
                     let lock_service = Arc::new(DmlLockService::new(manager.clone(), pod_id));
                     let _ = lock_service.spawn_reconciliation_loop(5_000);
                     // Surface the manager so RecordOpsService can lease-on-write:

--- a/src/services/catalog_snapshot_store.rs
+++ b/src/services/catalog_snapshot_store.rs
@@ -86,6 +86,18 @@ pub trait CatalogSnapshotStore: Send + Sync {
         Ok(None)
     }
 
+    /// Best-effort retention prune of superseded snapshot manifests. Default no-op —
+    /// the local single-pod store keeps one rotating blob. The object-store
+    /// implementation caps the manifest log; see
+    /// [`ManifestCommitter::prune_retention`]. Returns the count pruned.
+    async fn prune_retention(
+        &self,
+        _keep_k: usize,
+        _min_age: std::time::Duration,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+
     /// Human-readable location, for logs and error context.
     fn describe(&self) -> String;
 }
@@ -246,7 +258,27 @@ impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
             .await
             .with_context(|| format!("committing catalog snapshot {}", self.label))?
         {
-            CommitOutcome::Committed(version) => Ok(SnapshotWrite::Published { version }),
+            CommitOutcome::Committed(version) => {
+                // TD-MANIFEST-1: catalog snapshots are large full-catalog blobs and
+                // were never pruned, so the manifest log grows one-per-checkpoint
+                // forever. Prune the stale tail opportunistically after each publish
+                // (checkpoints are infrequent, so this is cheap and avoids a separate
+                // background task). `keep_k` is small — followers tail the tip, never
+                // history. Best-effort: a prune failure must not fail the publish.
+                if catalog_snapshot_retention_enabled() {
+                    let min_age = std::time::Duration::from_secs(catalog_snapshot_min_age_secs());
+                    if let Err(e) = self
+                        .prune_retention(catalog_snapshot_keep_k(), min_age)
+                        .await
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            "catalog snapshot prune failed (best-effort); publish unaffected"
+                        );
+                    }
+                }
+                Ok(SnapshotWrite::Published { version })
+            }
             // Fenced (stale generation) or lost the version CAS race — either way
             // this writer did not publish; it must re-read and step down/retry.
             CommitOutcome::Conflict { .. } => Ok(SnapshotWrite::Fenced),
@@ -260,9 +292,45 @@ impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
             .with_context(|| format!("probing catalog snapshot version {}", self.label))
     }
 
+    async fn prune_retention(&self, keep_k: usize, min_age: std::time::Duration) -> Result<usize> {
+        self.committer
+            .prune_retention(keep_k, min_age)
+            .await
+            .with_context(|| format!("pruning catalog snapshot log {}", self.label))
+    }
+
     fn describe(&self) -> String {
         self.label.clone()
     }
+}
+
+// ---- TD-MANIFEST-1: catalog snapshot manifest retention knobs (parsed per write) ----
+// Catalog snapshots are large full-catalog blobs, so keep only a tiny history (the
+// tip + a couple of predecessors); followers tail the tip, never old snapshots.
+
+/// Whether catalog snapshot manifest pruning runs (default ON). Set
+/// `PROXIMADB_CATALOG_SNAPSHOT_RETENTION=0` to disable.
+fn catalog_snapshot_retention_enabled() -> bool {
+    std::env::var("PROXIMADB_CATALOG_SNAPSHOT_RETENTION")
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(true)
+}
+
+/// Number of newest catalog snapshots to keep (the committer clamps this to ≥2).
+fn catalog_snapshot_keep_k() -> usize {
+    std::env::var("PROXIMADB_CATALOG_SNAPSHOT_KEEP")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(3)
+}
+
+/// Minimum age (seconds) a superseded snapshot must reach before it is pruned.
+fn catalog_snapshot_min_age_secs() -> u64 {
+    std::env::var("PROXIMADB_CATALOG_SNAPSHOT_MIN_AGE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(900)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

`ManifestCommitter` is an append-only fenced-commit log and **nothing reclaimed the stale tail**. A long-lived lease (renewed every 5 s) grew **~48k manifests / 562 MB / 144,546 files**, and every `latest_version()` was an O(n) full `list` — a pinned CPU core locally (confirmed via stack sample: `object_store::local::list → is_valid_file_path`), and an escalating paginated-LIST latency + cost on a cloud store (O(n) per lease op → O(n²) over a pod's lifetime).

Surfaced by an orphaned `proximadb-server` (TD-163 worktree, killed). See **TD-MANIFEST-1**.

## Fix

A generic `ManifestCommitter::prune_retention(keep_k, min_age)`. A version is eligible only when **ranked `keep_k`+ behind the tip AND at least `min_age` old**. The **tip is never deleted** (it's the only object the generation fence reads), `keep_k` is clamped to ≥ 2, future-dated mtime (clock skew) is never reaped early, and deletes are best-effort + idempotent.

Capping `n` is *itself* the read-path fix — the tip scan stays cheap once bounded, so no mutable tip-pointer is needed (one would reintroduce the lost-update/ABA hazard the create-only-put protocol avoids).

Driven by:
- **owner-only lease prune loop** (`PartitionLeaseManager::spawn_prune_loop`, mirrors `spawn_renew_loop`; held set re-read fresh each tick) — default ON, knobs `PROXIMADB_LEASE_MANIFEST_*` (keep=32, min_age=15m, interval=5m).
- **catalog prune-on-write** after each published snapshot (`keep_k=3` — snapshots are large blobs, followers tail the tip) — default ON, knobs `PROXIMADB_CATALOG_SNAPSHOT_*`.

## Bug the unit tests missed

`delete` must use the canonical `manifest_path(version)`, not the list-returned `location` — the latter **double-prefixes on the local backend** (`/root/root/_operator/...`). The InMemory unit tests didn't catch it (their list returns clean relative paths); draining the real 144k-file corpus did.

## Validation

- Drained the live orphaned corpus: **48,255 → 32 manifests, tip (v48254) preserved, 48,223 deleted.**
- 8 new unit tests incl. the load-bearing fence-safety cases (`prune_preserves_fenced_commit_after_prune`, `prune_then_stale_writer_still_fenced`, rank-robust-to-gaps, min_age grace window, concurrent prune+commit).
- `cargo fmt` clean; `cargo clippy --lib --bins` 0 warnings; TD-uniqueness guard 0 errors.

## Scope / out of scope

- In scope: leases (`_operator/leases`, the proven accumulator) + catalog snapshots.
- Deferred (noted in TD-MANIFEST-1): the `_catalog/leases` manager (off-by-default, no renew loop — accumulates negligibly); tip-pointer / cold-start `list` optimization; renewal coalescing.