### PR TITLE
feat(catalog): mint + persist per-scope typed identity (ADR-031 Phase 4a) [DRAFT, stacked on #559]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6809,6 +6809,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-glue",
+ "dashmap",
  "parking_lot",
  "proximadb-compression-types",
  "proximadb-data-model",

--- a/crates/control/proximadb-catalog/Cargo.toml
+++ b/crates/control/proximadb-catalog/Cargo.toml
@@ -31,6 +31,7 @@ arrow-schema = { workspace = true, default-features = false }
 async-trait.workspace = true
 aws-config = { version = "1.0", optional = true }
 aws-sdk-glue = { version = "1.0", optional = true }
+dashmap.workspace = true
 parking_lot.workspace = true
 reqwest = { version = "0.12", optional = true, features = ["json"] }
 urlencoding = { version = "2", optional = true }

--- a/crates/control/proximadb-catalog/src/id_allocator.rs
+++ b/crates/control/proximadb-catalog/src/id_allocator.rs
@@ -13,7 +13,10 @@
 //! never hand out an id already on disk. `0` is reserved as "unset" (so
 //! `Option<u64>::None` / `0` both mean "no id yet"); the first real id is `1`.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicI32, AtomicU16, AtomicU32, AtomicU64, Ordering};
+
+const RELAXED: Ordering = Ordering::Relaxed;
 
 /// Lock-free monotonic allocator for one object-type's stable `u64` id space.
 #[derive(Debug)]
@@ -80,9 +83,133 @@ impl StableIdAllocator for IdAllocator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// CatalogIdService: per-scope typed-atomic ID allocation (ADR-031 Phase 4a).
+// ---------------------------------------------------------------------------
+
+/// Per-scope stable-ID allocation using **typed atomics** (no `u64` casts).
+///
+/// Each scoped type has a per-parent counter at the **exact atomic width** of
+/// the target type (`AtomicU16` for namespace, `AtomicU32` for
+/// collection/index/segment, `AtomicI32` for column). `fetch_add` returns the
+/// correct type directly.
+///
+/// **Global uniqueness** is via the composite `(account, namespace, collection)`.
+/// Bare IDs reuse across scopes (namespace 1 in account A ≠ namespace 1 in
+/// account B) — the composite resolves them. This is the minting source for the
+/// typed identity stored on `CatalogTableSchema` (`stable_account_id` /
+/// `stable_namespace_id` / `stable_collection_id`); the root crate composes those
+/// primitives into a `CollectionIdentity` at the path boundary.
+///
+/// Uses plain `u32`/`u16`/`i32` (the catalog crate cannot import the root's type
+/// aliases — layering); the values are identical to `AccountId`/`NamespaceId`/…
+/// defined in `src/core/stable_id.rs`.
+pub struct CatalogIdService {
+    /// Per-account namespace counters (AtomicU16 → namespace u16).
+    namespace_allocators: DashMap<u32, AtomicU16>,
+    /// Per-(account, namespace) collection counters (AtomicU32 → collection u32).
+    collection_allocators: DashMap<(u32, u16), AtomicU32>,
+    /// Per-collection column counters (AtomicI32 → column i32).
+    column_allocators: DashMap<u32, AtomicI32>,
+    /// Per-collection index counters (AtomicU32 → index u32).
+    index_allocators: DashMap<u32, AtomicU32>,
+    /// Per-collection SST segment counters (AtomicU32 → segment u32).
+    segment_allocators: DashMap<u32, AtomicU32>,
+}
+
+impl Default for CatalogIdService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CatalogIdService {
+    pub fn new() -> Self {
+        Self {
+            namespace_allocators: DashMap::new(),
+            collection_allocators: DashMap::new(),
+            column_allocators: DashMap::new(),
+            index_allocators: DashMap::new(),
+            segment_allocators: DashMap::new(),
+        }
+    }
+
+    // ── Mint (typed atomics — no casts) ──────────────────────────────────
+
+    /// Mint a namespace id (u16) scoped to `account_id` (1, 2, 3 within account).
+    pub fn mint_namespace_id(&self, account_id: u32) -> u16 {
+        self.namespace_allocators
+            .entry(account_id)
+            .or_insert(AtomicU16::new(1))
+            .fetch_add(1, RELAXED)
+    }
+
+    /// Mint a collection id (u32) scoped to `(account_id, namespace_id)`.
+    pub fn mint_collection_id(&self, account_id: u32, namespace_id: u16) -> u32 {
+        self.collection_allocators
+            .entry((account_id, namespace_id))
+            .or_insert(AtomicU32::new(1))
+            .fetch_add(1, RELAXED)
+    }
+
+    /// Mint a column id (i32) scoped to `collection_id`.
+    pub fn mint_column_id(&self, collection_id: u32) -> i32 {
+        self.column_allocators
+            .entry(collection_id)
+            .or_insert(AtomicI32::new(1))
+            .fetch_add(1, RELAXED)
+    }
+
+    /// Mint an index id (u32) scoped to `collection_id`.
+    pub fn mint_index_id(&self, collection_id: u32) -> u32 {
+        self.index_allocators
+            .entry(collection_id)
+            .or_insert(AtomicU32::new(1))
+            .fetch_add(1, RELAXED)
+    }
+
+    /// Mint an SST segment id (u32) scoped to `collection_id` (1, 2, 3 …).
+    pub fn mint_segment_id(&self, collection_id: u32) -> u32 {
+        self.segment_allocators
+            .entry(collection_id)
+            .or_insert(AtomicU32::new(1))
+            .fetch_add(1, RELAXED)
+    }
+
+    // ── Per-scope recovery (typed — no casts) ────────────────────────────
+
+    /// Recover the namespace allocator floor for `account_id`. Call at startup
+    /// with `max(existing namespace u16 in this account)` so a restart never
+    /// reuses a persisted id.
+    pub fn recover_namespace_floor(&self, account_id: u32, max_existing: u16) {
+        self.namespace_allocators
+            .entry(account_id)
+            .or_insert(AtomicU16::new(1))
+            .fetch_max(max_existing + 1, RELAXED);
+    }
+
+    /// Recover the collection allocator floor for `(account_id, namespace_id)`.
+    pub fn recover_collection_floor(&self, account_id: u32, namespace_id: u16, max_existing: u32) {
+        self.collection_allocators
+            .entry((account_id, namespace_id))
+            .or_insert(AtomicU32::new(1))
+            .fetch_max(max_existing + 1, RELAXED);
+    }
+
+    /// Recover the segment allocator floor for `collection_id`.
+    pub fn recover_segment_floor(&self, collection_id: u32, max_existing: u32) {
+        self.segment_allocators
+            .entry(collection_id)
+            .or_insert(AtomicU32::new(1))
+            .fetch_max(max_existing + 1, RELAXED);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── IdAllocator tests ───────────────────────────────────────────────
 
     #[test]
     fn allocates_monotonic_distinct_ids_from_one() {
@@ -127,5 +254,66 @@ mod tests {
         assert_eq!(tables.allocate(), 1);
         assert_eq!(tables.allocate(), 2);
         assert_eq!(namespaces.allocate(), 1, "independent type space");
+    }
+
+    // ── CatalogIdService per-scope tests ────────────────────────────────
+
+    #[test]
+    fn namespace_ids_are_compact_per_account() {
+        let svc = CatalogIdService::new();
+        assert_eq!(svc.mint_namespace_id(1), 1);
+        assert_eq!(svc.mint_namespace_id(1), 2);
+        assert_eq!(svc.mint_namespace_id(1), 3);
+    }
+
+    #[test]
+    fn different_accounts_restart_namespace_at_one() {
+        let svc = CatalogIdService::new();
+        assert_eq!(svc.mint_namespace_id(1), 1);
+        assert_eq!(svc.mint_namespace_id(2), 1, "account 2 restarts at 1");
+        assert_eq!(svc.mint_namespace_id(1), 2);
+        assert_eq!(svc.mint_namespace_id(2), 2);
+    }
+
+    #[test]
+    fn collection_ids_are_compact_per_namespace() {
+        let svc = CatalogIdService::new();
+        assert_eq!(svc.mint_collection_id(1, 1), 1);
+        assert_eq!(svc.mint_collection_id(1, 1), 2);
+        assert_eq!(
+            svc.mint_collection_id(1, 2),
+            1,
+            "different namespace restarts at 1"
+        );
+    }
+
+    #[test]
+    fn segment_ids_are_per_collection() {
+        let svc = CatalogIdService::new();
+        assert_eq!(svc.mint_segment_id(1), 1);
+        assert_eq!(svc.mint_segment_id(1), 2);
+        assert_eq!(
+            svc.mint_segment_id(2),
+            1,
+            "different collection restarts at 1"
+        );
+    }
+
+    #[test]
+    fn per_scope_recovery_prevents_reuse() {
+        let svc = CatalogIdService::new();
+        svc.mint_namespace_id(1);
+        svc.mint_namespace_id(1);
+        svc.recover_namespace_floor(1, 100);
+        let next = svc.mint_namespace_id(1);
+        assert!(next > 100, "after recovery, next must be >100, got {next}");
+    }
+
+    #[test]
+    fn column_ids_are_compact_per_table() {
+        let svc = CatalogIdService::new();
+        assert_eq!(svc.mint_column_id(1), 1);
+        assert_eq!(svc.mint_column_id(1), 2);
+        assert_eq!(svc.mint_column_id(2), 1, "different table restarts at 1");
     }
 }

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -591,6 +591,21 @@ pub struct CatalogTableSchema {
     /// cuts over (ADR-031 O2).
     #[serde(default)]
     pub object_id: Option<u64>,
+    /// ADR-031 Phase 4a per-scope compact numeric identity for the typed
+    /// object-store path. `stable_namespace_id` (u16, per-account) and
+    /// `stable_collection_id` (u32, per-namespace) are minted by the catalog's
+    /// `CatalogIdService` at create time and persisted here. The **account** u32
+    /// is NOT stored (it would duplicate `account_id`); it's derived from the
+    /// account string via a registry at path-build time. Legacy rows load as
+    /// `None` (mixed-read-safe — the typed path is opt-in, env-gated
+    /// `PROXIMADB_TYPED_PATHS`). The root crate composes these primitives into a
+    /// `CollectionIdentity` at the path boundary (layering: the catalog cannot
+    /// import that root type). All values are numeric in-memory; base62 is
+    /// applied only to path segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_namespace_id: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_collection_id: Option<u32>,
     /// Table columns
     pub columns: Vec<CatalogColumn>,
     /// Primary key columns (by name)
@@ -749,6 +764,8 @@ impl Default for CatalogTableSchema {
         Self {
             name: String::new(),
             object_id: None,
+            stable_namespace_id: None,
+            stable_collection_id: None,
             columns: Vec::new(),
             primary_key: Vec::new(),
             indexes: Vec::new(),

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -42,9 +42,11 @@
 //! let catalog = NativeCatalog::new("default", config, cache).await?;
 //! ```
 
+use dashmap::DashMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
@@ -134,6 +136,24 @@ pub struct NativeCatalog {
     /// process-stable deployment setting, not a per-write toggle); interior
     /// mutability so tests can force it deterministically without env races.
     oid_paths: std::sync::atomic::AtomicBool,
+    /// ADR-031 Phase 4a: per-scope typed-atomic allocator — mints
+    /// `stable_namespace_id` (u16, per-account) and `stable_collection_id`
+    /// (u32, per-namespace) persisted on schemas. Account-scoped via the
+    /// numeric `account_registry` below (numerics in-memory; no string keys).
+    stable_ids: crate::id_allocator::CatalogIdService,
+    /// ADR-031 Phase 4a: transient account-string → u32 registry. The account
+    /// u32 is NOT persisted on the namespace (it would duplicate `account_id`);
+    /// it's minted on first sight per run and used to scope `stable_ids`.
+    /// Phase 4b makes it durable (for path stability); in 4a it only keys
+    /// in-memory minting.
+    account_registry: DashMap<String, u32>,
+    account_floor: AtomicU32,
+    /// ADR-031 Phase 4a: transient namespace-key → u16 map, so every collection
+    /// in the same namespace gets the SAME `stable_namespace_id` (per-account,
+    /// compact). Keyed by the namespace levels joined (`a.b`). Rebuilt from
+    /// persisted schemas on load (the u16 lives denormalized on each schema).
+    namespace_registry: DashMap<String, u16>,
+    namespace_floor: AtomicU32,
 }
 
 /// Table metadata stored in storage
@@ -227,6 +247,82 @@ impl NativeCatalog {
         }
     }
 
+    /// ADR-031 Phase 4a: resolve the numeric account u32 for an account string.
+    /// Lookup-or-mint against the transient `account_registry` (the account u32
+    /// is NOT stored on the namespace — it would duplicate `account_id`; it's a
+    /// registry-derived value, numeric in-memory). Returns `None` for an
+    /// empty/absent account string (legacy/anonymous namespaces get no typed
+    /// identity — mixed-read-safe).
+    fn account_u32(&self, account_str: &str) -> Option<u32> {
+        if account_str.is_empty() {
+            return None;
+        }
+        if let Some(entry) = self.account_registry.get(account_str) {
+            return Some(*entry.value());
+        }
+        let next = self
+            .account_floor
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.account_registry.insert(account_str.to_string(), next);
+        Some(next)
+    }
+
+    /// ADR-031 Phase 4a: mint the per-scope typed identity (`stable_namespace_id`
+    /// u16, `stable_collection_id` u32) for a collection being created under
+    /// `account_str` in `namespace_key`. Minted only when an account is known;
+    /// otherwise the schema keeps `None` for both (legacy path, mixed-read-safe).
+    /// The namespace u16 is STABLE per namespace (every collection in the same
+    /// `namespace_key` gets the same u16) via the transient `namespace_registry`.
+    fn mint_stable_identity(
+        &self,
+        account_str: &str,
+        namespace_key: &str,
+        schema: &mut CatalogTableSchema,
+    ) {
+        let Some(account) = self.account_u32(account_str) else {
+            return; // no account → no typed identity (legacy)
+        };
+        let ns = schema.stable_namespace_id.unwrap_or_else(|| {
+            // First collection in this namespace (this run) → mint a per-account
+            // namespace u16 + remember it so siblings reuse it.
+            *self
+                .namespace_registry
+                .entry(namespace_key.to_string())
+                .or_insert_with(|| self.stable_ids.mint_namespace_id(account))
+        });
+        schema.stable_namespace_id = Some(ns);
+        let coll = schema
+            .stable_collection_id
+            .unwrap_or_else(|| self.stable_ids.mint_collection_id(account, ns));
+        schema.stable_collection_id = Some(coll);
+    }
+
+    /// ADR-031 Phase 4a: recover the per-scope allocator floors from a loaded
+    /// schema's persisted typed identity, so a restart never reuses them. The
+    /// load-path inverse of `mint_stable_identity`. Re-derives the namespace u16
+    /// into the transient `namespace_registry` so siblings share it.
+    fn recover_stable_identity(
+        &self,
+        account_str: &str,
+        namespace_key: &str,
+        schema: &CatalogTableSchema,
+    ) {
+        let Some(account) = self.account_u32(account_str) else {
+            return;
+        };
+        if let Some(ns) = schema.stable_namespace_id {
+            self.stable_ids.recover_namespace_floor(account, ns);
+            self.namespace_floor
+                .fetch_max(ns as u32 + 1, std::sync::atomic::Ordering::Relaxed);
+            self.namespace_registry
+                .entry(namespace_key.to_string())
+                .or_insert(ns);
+            if let Some(coll) = schema.stable_collection_id {
+                self.stable_ids.recover_collection_floor(account, ns, coll);
+            }
+        }
+    }
+
     /// Create a new native catalog backed by local `tokio::fs` (the default,
     /// back-compat path). Equivalent to `new_with_filesystem(.., None)`.
     pub async fn new(
@@ -279,6 +375,11 @@ impl NativeCatalog {
             namespace_object_id_index: RwLock::new(HashMap::new()),
             object_name_index: RwLock::new(HashMap::new()),
             oid_paths: std::sync::atomic::AtomicBool::new(Self::object_id_paths_enabled()),
+            stable_ids: crate::id_allocator::CatalogIdService::new(),
+            account_registry: DashMap::new(),
+            account_floor: AtomicU32::new(1),
+            namespace_registry: DashMap::new(),
+            namespace_floor: AtomicU32::new(1),
         };
 
         // Ensure the base location exists (local mkdir; object-store no-op).
@@ -905,6 +1006,18 @@ impl NativeCatalog {
         // from persisted ids so a restart never reuses an id and object_id → table
         // resolution survives (best-effort as tables load on demand).
         self.raise_object_id_floor(meta.schema.object_id);
+        // ADR-031 Phase 4a: recover the per-scope typed-identity floors so a
+        // restart never reuses a persisted `stable_namespace_id` /
+        // `stable_collection_id`. Account u32 is re-derived from the transient
+        // registry (durable in 4b).
+        {
+            let ns_key = identifier.namespace.join(".");
+            if let Some(ns) = self.namespaces.read().await.get(&ns_key)
+                && let Some(account) = ns.account_id.as_deref()
+            {
+                self.recover_stable_identity(account, &ns_key, &meta.schema);
+            }
+        }
         if let Some(id) = meta.schema.object_id {
             // TD-181 P1: opportunistically heal the durable index if this object
             // file isn't indexed yet (an orphan from a crash between object-write
@@ -1234,6 +1347,15 @@ impl Catalog for NativeCatalog {
                 "Namespace '{}' does not exist",
                 identifier.namespace.join(".")
             ));
+        }
+
+        // ADR-031 Phase 4a: mint the per-scope typed identity
+        // (`stable_namespace_id` u16, `stable_collection_id` u32) when the
+        // namespace carries an account. Legacy/anonymous namespaces keep `None`
+        // (mixed-read-safe — the typed path is opt-in, env-gated).
+        let ns = self.get_namespace(&identifier.namespace).await?;
+        if let Some(account) = ns.account_id.as_deref() {
+            self.mint_stable_identity(account, &identifier.namespace.join("."), &mut schema);
         }
 
         // Check table doesn't exist
@@ -1739,6 +1861,78 @@ impl Catalog for NativeCatalog {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── ADR-031 Phase 4a: typed-identity minting ────────────────────────
+
+    async fn catalog_in_tempdir() -> (NativeCatalog, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = NativeCatalogConfig {
+            storage_url: format!("file://{}", dir.path().join("cat").display()),
+            metadata_format: "json".into(),
+            versioned: false,
+            max_versions: 100,
+        };
+        let cat = NativeCatalog::new(
+            "t".into(),
+            cfg,
+            Arc::new(crate::cache::CatalogCache::new(64, 60)),
+        )
+        .await
+        .expect("construct catalog");
+        (cat, dir)
+    }
+
+    #[tokio::test]
+    async fn stable_identity_is_per_scope_and_legacy_safe() {
+        let (cat, _d) = catalog_in_tempdir().await;
+
+        // No account → legacy, no typed identity (mixed-read-safe).
+        let mut legacy = CatalogTableSchema::new("legacy");
+        cat.mint_stable_identity("", "ns", &mut legacy);
+        assert!(legacy.stable_namespace_id.is_none());
+        assert!(legacy.stable_collection_id.is_none());
+
+        // Account present → per-scope compact ids minted.
+        let mut a1 = CatalogTableSchema::new("a1");
+        cat.mint_stable_identity("acct", "ns1", &mut a1);
+        assert_eq!(a1.stable_namespace_id, Some(1), "first ns in acct = 1");
+        assert_eq!(a1.stable_collection_id, Some(1), "first coll = 1");
+
+        // Same namespace, new collection → SAME namespace id, NEXT collection id.
+        let mut a2 = CatalogTableSchema::new("a2");
+        cat.mint_stable_identity("acct", "ns1", &mut a2);
+        assert_eq!(
+            a2.stable_namespace_id,
+            Some(1),
+            "same namespace → same ns id"
+        );
+        assert_eq!(a2.stable_collection_id, Some(2), "second coll in ns1 = 2");
+
+        // Different namespace → NEXT namespace id, collection restarts at 1.
+        let mut b1 = CatalogTableSchema::new("b1");
+        cat.mint_stable_identity("acct", "ns2", &mut b1);
+        assert_eq!(b1.stable_namespace_id, Some(2), "new ns = 2");
+        assert_eq!(
+            b1.stable_collection_id,
+            Some(1),
+            "new ns → coll restarts at 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn account_registry_is_stable_within_run() {
+        let (cat, _d) = catalog_in_tempdir().await;
+        // Same account string → same account u32 (registry lookup-or-mint).
+        let mut a = CatalogTableSchema::new("a");
+        cat.mint_stable_identity("acct", "ns", &mut a);
+        let acct_u32_a = cat.account_u32("acct").expect("account resolved");
+        // A second call for the same account must NOT re-mint a different u32.
+        let acct_u32_b = cat.account_u32("acct").expect("account resolved");
+        assert_eq!(acct_u32_a, acct_u32_b, "account u32 stable within a run");
+        // And namespace siblings share the namespace id (covered above) because
+        // they share the account u32.
+        assert_eq!(a.stable_namespace_id, Some(1));
+    }
 
     // Note: These tests require a mock filesystem or temp directory
     // Full integration tests should be in the tests/ directory

--- a/src/core/stable_id.rs
+++ b/src/core/stable_id.rs
@@ -13,11 +13,11 @@
 //! - In-memory: native types (u32/u16/i32 — compact for HashMaps, 1-cycle integer hash).
 //! - Wire/proto/JSON: native types (all < 2^31, JSON-safe — no base62 string needed for API).
 //! - Object-store path: `base62(type)` **zero-padded** to fixed width for lexicographic sort.
-
-use dashmap::DashMap;
-use std::sync::atomic::{AtomicI32, AtomicU16, AtomicU32, Ordering};
-
-const RELAXED: Ordering = Ordering::Relaxed;
+//!
+//! **Minting** lives in the catalog crate (`CatalogIdService`,
+//! `crates/control/proximadb-catalog/src/id_allocator.rs`) — the catalog owns ID allocation
+//! alongside `object_id`. This module owns only the **identity types + path encoding** (the
+//! path/encoding concerns consumed by the root crate's `DrPathBuilder`).
 
 /// Global customer identity (billing/auth). Assigned by the control plane.
 pub type AccountId = u32;
@@ -117,128 +117,6 @@ impl CollectionIdentity {
     }
 }
 
-// ---------------------------------------------------------------------------
-// CatalogIdService: per-scope typed-atomic ID allocation (no casts).
-// ---------------------------------------------------------------------------
-
-/// Per-scope stable-ID allocation using **typed atomics** (no u64 → type casts).
-///
-/// Each scoped type has a per-parent counter at the **exact atomic width** of the
-/// target type (AtomicU16 for namespace, AtomicU32 for collection/index/segment,
-/// AtomicI32 for column). `fetch_add` returns the correct type directly.
-///
-/// Global uniqueness is via the **composite** `(account, namespace, collection)`.
-/// Unscoped IDs (segment) are per-collection (scoped to the collection whose SST
-/// files they identify).
-pub struct CatalogIdService {
-    /// Per-account namespace counters (AtomicU16 → NamespaceId).
-    namespace_allocators: DashMap<AccountId, AtomicU16>,
-    /// Per-namespace collection counters (AtomicU32 → CollectionId).
-    collection_allocators: DashMap<(AccountId, NamespaceId), AtomicU32>,
-    /// Per-table column counters (AtomicI32 → ColumnId).
-    column_allocators: DashMap<CollectionId, AtomicI32>,
-    /// Per-collection index counters (AtomicU32 → IndexId).
-    index_allocators: DashMap<CollectionId, AtomicU32>,
-    /// Per-collection SST segment counters (AtomicU32 → SegmentId).
-    segment_allocators: DashMap<CollectionId, AtomicU32>,
-}
-
-impl Default for CatalogIdService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CatalogIdService {
-    pub fn new() -> Self {
-        Self {
-            namespace_allocators: DashMap::new(),
-            collection_allocators: DashMap::new(),
-            column_allocators: DashMap::new(),
-            index_allocators: DashMap::new(),
-            segment_allocators: DashMap::new(),
-        }
-    }
-
-    // ── Mint (typed atomics — no casts) ──────────────────────────────────
-
-    /// Mint a namespace ID (u16) scoped to `account_id`.
-    pub fn mint_namespace_id(&self, account_id: AccountId) -> NamespaceId {
-        self.namespace_allocators
-            .entry(account_id)
-            .or_insert(AtomicU16::new(1))
-            .fetch_add(1, RELAXED)
-    }
-
-    /// Mint a collection/table ID (u32) scoped to `(account_id, namespace_id)`.
-    pub fn mint_collection_id(
-        &self,
-        account_id: AccountId,
-        namespace_id: NamespaceId,
-    ) -> CollectionId {
-        self.collection_allocators
-            .entry((account_id, namespace_id))
-            .or_insert(AtomicU32::new(1))
-            .fetch_add(1, RELAXED)
-    }
-
-    /// Mint a column/field ID (i32) scoped to `collection_id`.
-    pub fn mint_column_id(&self, collection_id: CollectionId) -> ColumnId {
-        self.column_allocators
-            .entry(collection_id)
-            .or_insert(AtomicI32::new(1))
-            .fetch_add(1, RELAXED)
-    }
-
-    /// Mint an index ID (u32) scoped to `collection_id`.
-    pub fn mint_index_id(&self, collection_id: CollectionId) -> IndexId {
-        self.index_allocators
-            .entry(collection_id)
-            .or_insert(AtomicU32::new(1))
-            .fetch_add(1, RELAXED)
-    }
-
-    /// Mint an SST segment ID (u32) scoped to `collection_id`.
-    /// Each collection has its own file counter (1, 2, 3...).
-    pub fn mint_segment_id(&self, collection_id: CollectionId) -> SegmentId {
-        self.segment_allocators
-            .entry(collection_id)
-            .or_insert(AtomicU32::new(1))
-            .fetch_add(1, RELAXED)
-    }
-
-    // ── Per-scope recovery (typed — no casts) ────────────────────────────
-
-    /// Recover the namespace allocator floor for `account_id`.
-    pub fn recover_namespace_floor(&self, account_id: AccountId, max_existing: u16) {
-        self.namespace_allocators
-            .entry(account_id)
-            .or_insert(AtomicU16::new(1))
-            .fetch_max(max_existing + 1, RELAXED);
-    }
-
-    /// Recover the collection allocator floor.
-    pub fn recover_collection_floor(
-        &self,
-        account_id: AccountId,
-        namespace_id: NamespaceId,
-        max_existing: u32,
-    ) {
-        self.collection_allocators
-            .entry((account_id, namespace_id))
-            .or_insert(AtomicU32::new(1))
-            .fetch_max(max_existing + 1, RELAXED);
-    }
-
-    /// Recover the segment allocator floor for a collection.
-    pub fn recover_segment_floor(&self, collection_id: CollectionId, max_existing: u32) {
-        self.segment_allocators
-            .entry(collection_id)
-            .or_insert(AtomicU32::new(1))
-            .fetch_max(max_existing + 1, RELAXED);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,6 +160,7 @@ mod tests {
     // ── CollectionIdentity segment-encoding tests ───────────────────────
     // (Full-path construction tests live in path_resolver.rs, where
     // DrResolvedPath::typed_root_prefix composes the canonical prefix.)
+    // (Per-scope minting tests live in the catalog crate's id_allocator.rs.)
 
     #[test]
     fn path_segments_are_fixed_width() {
@@ -310,70 +189,4 @@ mod tests {
         // Fixed-width → the 3 segments total exactly 15 chars always.
         assert_eq!(acct.len() + ns.len() + coll.len(), 15);
     }
-
-    // ── Per-scope typed-atomic CatalogIdService tests ────────────────────
-
-    #[test]
-    fn namespace_ids_are_compact_per_account() {
-        let svc = CatalogIdService::new();
-        assert_eq!(svc.mint_namespace_id(1), 1);
-        assert_eq!(svc.mint_namespace_id(1), 2);
-        assert_eq!(svc.mint_namespace_id(1), 3);
-    }
-
-    #[test]
-    fn different_accounts_restart_namespace_at_one() {
-        let svc = CatalogIdService::new();
-        assert_eq!(svc.mint_namespace_id(1), 1);
-        assert_eq!(svc.mint_namespace_id(2), 1, "account 2 restarts at 1");
-        assert_eq!(svc.mint_namespace_id(1), 2);
-        assert_eq!(svc.mint_namespace_id(2), 2);
-    }
-
-    #[test]
-    fn collection_ids_are_compact_per_namespace() {
-        let svc = CatalogIdService::new();
-        assert_eq!(svc.mint_collection_id(1, 1), 1);
-        assert_eq!(svc.mint_collection_id(1, 1), 2);
-        assert_eq!(
-            svc.mint_collection_id(1, 2),
-            1,
-            "different namespace restarts at 1"
-        );
-    }
-
-    #[test]
-    fn segment_ids_are_per_collection() {
-        let svc = CatalogIdService::new();
-        // Collection 1: segments 1, 2.
-        assert_eq!(svc.mint_segment_id(1), 1);
-        assert_eq!(svc.mint_segment_id(1), 2);
-        // Collection 2: restarts at 1.
-        assert_eq!(
-            svc.mint_segment_id(2),
-            1,
-            "different collection restarts at 1"
-        );
-    }
-
-    #[test]
-    fn per_scope_recovery_prevents_reuse() {
-        let svc = CatalogIdService::new();
-        svc.mint_namespace_id(1);
-        svc.mint_namespace_id(1);
-        svc.recover_namespace_floor(1, 100);
-        let next = svc.mint_namespace_id(1);
-        assert!(next > 100, "after recovery, next must be >100, got {next}");
-    }
-
-    #[test]
-    fn column_ids_are_compact_per_table() {
-        let svc = CatalogIdService::new();
-        assert_eq!(svc.mint_column_id(1), 1);
-        assert_eq!(svc.mint_column_id(1), 2);
-        assert_eq!(svc.mint_column_id(2), 1, "different table restarts at 1");
-    }
-
-    // The 27-char fixed-width full-path test (`typed_root_prefix_is_27_chars`)
-    // lives in path_resolver.rs — full path construction is DrResolvedPath's job.
 }


### PR DESCRIPTION
Stacked on #559 (`feat/adr031-collection-id-base62`) — the diff collapses to just the Phase 4a commit once #559 merges.

## What
The catalog now mints + persists the compact per-scope numeric identity the typed object-store path needs (account u32 / namespace u16 / collection u32). **No path change yet** — the env-gated production switch is Phase 4b.

- `CatalogIdService` moved `core/stable_id.rs` → catalog crate `id_allocator.rs` (catalog owns minting alongside `object_id`; plain numerics — layering: catalog cannot import root aliases). `core/stable_id.rs` keeps identity types + base62 path encoding only.
- `CatalogTableSchema`: `+ stable_namespace_id (u16) + stable_collection_id (u32)`, additive + `#[serde(default)]` (legacy rows → None).
- `NativeCatalog`: transient `account_registry` (string→u32) + `namespace_registry` (key→u16, siblings share it) + `CatalogIdService`. Mints at `create_table` when the namespace has an account (legacy/anonymous → None); `load_table` recovers floors lazily.

## Design (settled)
- Numerics in-memory; base62 **only** for path segments (`DrResolvedPath`).
- Per-scope compact (namespace u16/account, collection u32/namespace).
- **Account: no duplicate field** — registry-derived u32 (`account_id` string is the single identity).
- `collection.id` = decimal `object_id` (not UUID/base62) — that is the #559 fix this stacks on.

## Verified
352 catalog tests pass (incl. 2 new: per-scope minting + account-registry stability); `clippy --lib` clean; tenant-path guard clean.

## Deferred (Phase 4b)
Durable account registry (sidecar) for path stability across restarts; env-gate `PROXIMADB_TYPED_PATHS=1` into `resolve_base_location` to compose `CollectionIdentity` (default OFF — mixed-read-safe).