### PR TITLE
ci: narrow query/storage tier test globs to explicit filenames (hotfix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1261,7 +1261,7 @@ jobs:
       - name: Run Storage Integration Tests
         run: |
           # Run only explicitly named storage test files (avoids compiling all tests)
-          for test_file in tests/*sst*.rs tests/*storage*.rs tests/*wal*.rs tests/*embedded*.rs; do
+          for test_file in tests/*sst*.rs tests/*storage*.rs tests/*wal*.rs tests/embedded_tenant_context.rs; do
             if [ -f "$test_file" ]; then
               test_name=$(basename "$test_file" .rs)
               echo "Running $test_name..."
@@ -1293,7 +1293,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - name: Run Query Integration Tests
         run: |
-          for test_file in tests/*query*.rs tests/*federated*.rs tests/*cache*.rs tests/*ann*.rs tests/*recall*.rs; do
+          for test_file in tests/*query*.rs tests/*federated*.rs tests/*cache*.rs tests/filtered_ann_recall_bands.rs; do
             if [ -f "$test_file" ]; then
               test_name=$(basename "$test_file" .rs)
               echo "Running $test_name..."


### PR DESCRIPTION
Hotfix for a regression introduced by #558.

#558 wired orphaned risk tests in via **broad globs** (`tests/*ann*.rs tests/*recall*.rs` for query; `tests/*embedded*.rs` for storage), which swept in several unverified files — most importantly `td112_postflush_recall_e2e.rs`, whose `axis_index_rebuilt_from_sst_after_loss` is a **known pre-existing failure** (TD-184: AXIS store not rebuilt from SST after loss, count 0 vs 144; deliberately left un-gated). The broad glob turned develop's query tier **red for every PR that triggers it** — caught blocking #559.

**Fix:** replace the broad globs with explicit filenames so only the intended risk tests run:
- query tier: `tests/filtered_ann_recall_bands.rs`
- storage tier: `tests/embedded_tenant_context.rs`

Zero sweep risk. The risk-coverage contract still validates (both remain selected by their declared tiers, verified locally). The other swept-in recall/embedded tests stay un-gated until each is verified passing and wired deliberately.

Lesson: wire orphaned tests with precise selectors, not broad globs. ci.yml-only change.