### PR TITLE
fix(runtime): 8MB tokio worker stack — fixes TPC-H Q2 stack overflow

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -88,6 +88,10 @@ jobs:
             --test td112_postflush_recall_e2e --test raptor_recall_test \
             --test helix_cold_search_recall_test --no-run
       - name: Run TPC-H over pgwire
+        env:
+          # 8MB worker stack: correlated subqueries (Q2/Q20-Q22) produce
+          # deep-but-finite async call chains that overflow the default ~2MB.
+          RUST_MIN_STACK: "8388608"
         run: cargo test --test tpch_pgwire_e2e -- --nocapture
       - name: Run TPC-DS over pgwire
         run: cargo test --test tpcds_pgwire_e2e -- --nocapture

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -837,9 +837,13 @@ impl EmbeddedProximaDB {
             );
         }
 
-        // Create tokio runtime for async operations
+        // Create tokio runtime for async operations.
+        // 8MB worker stack: correlated subqueries (TPC-H Q2/Q20-Q22) produce
+        // deep-but-finite async call chains through join/predicate evaluation
+        // that overflow the default ~2MB stack. 8MB passes all 22 TPC-H queries.
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(num_cpus::get().min(4))
+            .thread_stack_size(8 * 1024 * 1024)
             .enable_all()
             .build()?;
 


### PR DESCRIPTION
## What

Fixes the TPC-H Q2 stack overflow that blocks the develop→qa promotion (#560): the default ~2MB tokio worker stack overflows during Q2's correlated scalar subquery execution.

## Root cause (confirmed by local reproduction)

The default ~2MB tokio worker thread stack is insufficient for Q2's deep-but-finite async call chain. Q2's correlated subquery (`ps_supplycost = (SELECT min(ps_supplycost) ... WHERE p_partkey = ps_partkey ...)`) is decorrelated to a LEFT JOIN + per-row predicate evaluation through a 5-table join. The async execution stack exceeds 2MB but is **finite** (not infinite recursion).

**Proof**: all 22 TPC-H queries pass with 8MB stack (locally verified, including Q2, Q20 with nested subqueries, Q21 with EXISTS/NOT EXISTS, Q22 with correlated subquery). The TPC-H tracing (added in #564) confirmed Q2 is the first query to overflow.

## Fix

- **`src/embedded/mod.rs`**: `.thread_stack_size(8 * 1024 * 1024)` on the tokio runtime builder — production server worker threads get 8MB (4 workers × 8MB = 32MB stack overhead — negligible vs the data-plane memory budget).
- **`.github/workflows/qa-gate.yml`**: `RUST_MIN_STACK: "8388608"` on the TPC-H test step — the `#[tokio::test]` runtime respects this env var for worker thread stack size.

## Defense-in-depth (follow-up, not in this PR)

A `DepthGuard` (recursion circuit breaker — returns a graceful `QueryError::ExpressionDepthExceeded` instead of SIGABRT) is tracked as a separate item. The 8MB stack bump is the pragmatic cloud-native fix for now (bounded per-worker stack, configurable, reasonable for a database server).

## Verification

```bash
# Locally (in the worktree, cached binary):
RUST_MIN_STACK=8388608 cargo test --test tpch_pgwire_e2e -- --nocapture
# Result: 22/22 passed (ratchet 22) ✅
```

Unblocks #560 (develop→qa promotion → release).