### PR TITLE
fix(ci): resolve ci.yml conflict markers leaked from qa merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,11 +308,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Lint customer-facing docs vs the support contract
         run: python3 scripts/check_doc_authority.py
-<<<<<<< HEAD
       - name: Cross-check perf claims vs BENCHMARK_EVIDENCE.toml
         run: python3 scripts/check_perf_claims.py
-=======
->>>>>>> origin/qa
 
   risk-coverage:
     name: Risk-Coverage Contract


### PR DESCRIPTION
URGENT: the develop→qa merge (567b07349) committed ci.yml with unresolved conflict markers (31 markers). This breaks ALL CI on develop. This PR restores develop's clean ci.yml (pre-merge version).