### PR TITLE
feat: env-gated typed object-store paths + durable account registry (ADR-031 Phase 4b)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4418,6 +4418,15 @@ pub trait Catalog: Send + Sync {
     ) -> anyhow::Result<Vec<CatalogNamespace>>;
     async fn namespace_exists(&self, namespace: &[String]) -> anyhow::Result<bool>;
     async fn get_namespace(&self, namespace: &[String]) -> anyhow::Result<CatalogNamespace>;
+    /// ADR-031 Phase 4b: resolve the numeric account u32 for an account string
+    /// (lookup in the durable account registry; mints+persists on first sight).
+    /// Returns `None` for an empty/absent account. The root path-resolver uses
+    /// this to compose a `CollectionIdentity` for the typed object-store path.
+    /// Default `None` — only the native catalog mints; federated/external
+    /// catalogs have no typed identity (legacy paths).
+    async fn account_id_u32(&self, _account: &str) -> anyhow::Result<Option<u32>> {
+        Ok(None)
+    }
     async fn update_namespace_properties(
         &self,
         namespace: &[String],

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -207,6 +207,15 @@ struct ObjectIndexEntry {
     name: String,
 }
 
+/// ADR-031 Phase 4b: durable account-string → u32 registry sidecar
+/// (`_syscat/account_registry.json`). Keeps the typed path's account segment
+/// stable across restarts.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct AccountRegistryFile {
+    #[serde(default)]
+    entries: Vec<(String, u32)>,
+}
+
 /// TD-181 P3 (S2a): marker recording that this catalog has begun writing
 /// object_id-keyed metadata under `_syscat/objects/{oid}.json`. Written once
 /// when the first oid-keyed object is persisted. A reader uses its presence to
@@ -253,7 +262,7 @@ impl NativeCatalog {
     /// registry-derived value, numeric in-memory). Returns `None` for an
     /// empty/absent account string (legacy/anonymous namespaces get no typed
     /// identity — mixed-read-safe).
-    fn account_u32(&self, account_str: &str) -> Option<u32> {
+    async fn account_u32(&self, account_str: &str) -> Option<u32> {
         if account_str.is_empty() {
             return None;
         }
@@ -264,6 +273,13 @@ impl NativeCatalog {
             .account_floor
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.account_registry.insert(account_str.to_string(), next);
+        // ADR-031 Phase 4b: persist the new account-string→u32 mapping so the
+        // typed object-store path is stable across restarts (best-effort,
+        // mirrors `object_name_index`). The lookup path above is read-only → no
+        // save; only the mint branch writes.
+        if let Err(e) = self.save_account_registry().await {
+            warn!("account-registry persist failed (continuing in-memory): {e}");
+        }
         Some(next)
     }
 
@@ -273,13 +289,13 @@ impl NativeCatalog {
     /// otherwise the schema keeps `None` for both (legacy path, mixed-read-safe).
     /// The namespace u16 is STABLE per namespace (every collection in the same
     /// `namespace_key` gets the same u16) via the transient `namespace_registry`.
-    fn mint_stable_identity(
+    async fn mint_stable_identity(
         &self,
         account_str: &str,
         namespace_key: &str,
         schema: &mut CatalogTableSchema,
     ) {
-        let Some(account) = self.account_u32(account_str) else {
+        let Some(account) = self.account_u32(account_str).await else {
             return; // no account → no typed identity (legacy)
         };
         let ns = schema.stable_namespace_id.unwrap_or_else(|| {
@@ -301,13 +317,13 @@ impl NativeCatalog {
     /// schema's persisted typed identity, so a restart never reuses them. The
     /// load-path inverse of `mint_stable_identity`. Re-derives the namespace u16
     /// into the transient `namespace_registry` so siblings share it.
-    fn recover_stable_identity(
+    async fn recover_stable_identity(
         &self,
         account_str: &str,
         namespace_key: &str,
         schema: &CatalogTableSchema,
     ) {
-        let Some(account) = self.account_u32(account_str) else {
+        let Some(account) = self.account_u32(account_str).await else {
             return;
         };
         if let Some(ns) = schema.stable_namespace_id {
@@ -387,6 +403,12 @@ impl NativeCatalog {
 
         // Load existing namespaces
         catalog.load_namespaces().await?;
+
+        // ADR-031 Phase 4b: load the durable account-string → u32 registry
+        // BEFORE any `load_table` (which recovers typed identities via
+        // `account_u32`), so a persisted account u32 is reused, not re-minted
+        // (a re-mint would drift the typed object-store path → data loss).
+        catalog.load_account_registry().await?;
 
         // TD-181 P1: load the durable table object_id index eagerly (rebuilding
         // it from the authoritative object files if it is absent — first boot
@@ -556,6 +578,48 @@ impl NativeCatalog {
             "Rebuilt durable object_id index from {} object file(s)",
             entries.len()
         );
+        Ok(())
+    }
+
+    // ── ADR-031 Phase 4b: durable account-string → u32 registry ──────────
+    // Mirrors `object_name_index` (`_syscat/index.json`): a sidecar JSON the
+    // catalog loads eagerly at startup + writes on every new account mint, so
+    // the typed object-store path segment for an account is stable across
+    // restarts (a drift would silently relocate every typed-path object).
+
+    fn account_registry_rel() -> String {
+        "_syscat/account_registry.json".to_string()
+    }
+
+    /// Persist the current account-string → u32 map (called on every mint).
+    async fn save_account_registry(&self) -> Result<()> {
+        let entries: Vec<(String, u32)> = self
+            .account_registry
+            .iter()
+            .map(|kv| (kv.key().clone(), *kv.value()))
+            .collect();
+        let data = serde_json::to_vec_pretty(&AccountRegistryFile { entries })?;
+        self.io_write(&Self::account_registry_rel(), &data).await
+    }
+
+    /// Load the durable account registry eagerly. MUST run before any
+    /// `load_table` (which recovers typed identities + calls `account_u32`),
+    /// so the persisted u32 for an account is reused, not re-minted. Absent on
+    /// first boot → no-op (mixed-read-safe).
+    async fn load_account_registry(&self) -> Result<()> {
+        let Some(data) = self.io_read_opt(&Self::account_registry_rel()).await? else {
+            return Ok(()); // first boot — nothing to load
+        };
+        let file: AccountRegistryFile = serde_json::from_slice(&data)?;
+        for (account, u) in &file.entries {
+            self.account_registry.insert(account.clone(), *u);
+        }
+        // Raise the floor above the max persisted u32 so the next mint is new.
+        if let Some(max) = file.entries.iter().map(|(_, u)| *u).max() {
+            self.account_floor
+                .fetch_max(max + 1, std::sync::atomic::Ordering::Relaxed);
+        }
+        debug!("Loaded {} account-registry entries", file.entries.len());
         Ok(())
     }
 
@@ -1015,7 +1079,8 @@ impl NativeCatalog {
             if let Some(ns) = self.namespaces.read().await.get(&ns_key)
                 && let Some(account) = ns.account_id.as_deref()
             {
-                self.recover_stable_identity(account, &ns_key, &meta.schema);
+                self.recover_stable_identity(account, &ns_key, &meta.schema)
+                    .await;
             }
         }
         if let Some(id) = meta.schema.object_id {
@@ -1286,6 +1351,12 @@ impl Catalog for NativeCatalog {
             .ok_or_else(|| anyhow!("Namespace '{}' not found", key))
     }
 
+    async fn account_id_u32(&self, account: &str) -> Result<Option<u32>> {
+        // Thin public wrapper over the private registry lookup-or-mint. The
+        // root path-resolver calls this to compose a `CollectionIdentity`.
+        Ok(self.account_u32(account).await)
+    }
+
     async fn update_namespace_properties(
         &self,
         namespace: &[String],
@@ -1355,7 +1426,8 @@ impl Catalog for NativeCatalog {
         // (mixed-read-safe — the typed path is opt-in, env-gated).
         let ns = self.get_namespace(&identifier.namespace).await?;
         if let Some(account) = ns.account_id.as_deref() {
-            self.mint_stable_identity(account, &identifier.namespace.join("."), &mut schema);
+            self.mint_stable_identity(account, &identifier.namespace.join("."), &mut schema)
+                .await;
         }
 
         // Check table doesn't exist
@@ -1888,19 +1960,19 @@ mod tests {
 
         // No account → legacy, no typed identity (mixed-read-safe).
         let mut legacy = CatalogTableSchema::new("legacy");
-        cat.mint_stable_identity("", "ns", &mut legacy);
+        cat.mint_stable_identity("", "ns", &mut legacy).await;
         assert!(legacy.stable_namespace_id.is_none());
         assert!(legacy.stable_collection_id.is_none());
 
         // Account present → per-scope compact ids minted.
         let mut a1 = CatalogTableSchema::new("a1");
-        cat.mint_stable_identity("acct", "ns1", &mut a1);
+        cat.mint_stable_identity("acct", "ns1", &mut a1).await;
         assert_eq!(a1.stable_namespace_id, Some(1), "first ns in acct = 1");
         assert_eq!(a1.stable_collection_id, Some(1), "first coll = 1");
 
         // Same namespace, new collection → SAME namespace id, NEXT collection id.
         let mut a2 = CatalogTableSchema::new("a2");
-        cat.mint_stable_identity("acct", "ns1", &mut a2);
+        cat.mint_stable_identity("acct", "ns1", &mut a2).await;
         assert_eq!(
             a2.stable_namespace_id,
             Some(1),
@@ -1910,7 +1982,7 @@ mod tests {
 
         // Different namespace → NEXT namespace id, collection restarts at 1.
         let mut b1 = CatalogTableSchema::new("b1");
-        cat.mint_stable_identity("acct", "ns2", &mut b1);
+        cat.mint_stable_identity("acct", "ns2", &mut b1).await;
         assert_eq!(b1.stable_namespace_id, Some(2), "new ns = 2");
         assert_eq!(
             b1.stable_collection_id,
@@ -1924,14 +1996,53 @@ mod tests {
         let (cat, _d) = catalog_in_tempdir().await;
         // Same account string → same account u32 (registry lookup-or-mint).
         let mut a = CatalogTableSchema::new("a");
-        cat.mint_stable_identity("acct", "ns", &mut a);
-        let acct_u32_a = cat.account_u32("acct").expect("account resolved");
+        cat.mint_stable_identity("acct", "ns", &mut a).await;
+        let acct_u32_a = cat.account_u32("acct").await.expect("account resolved");
         // A second call for the same account must NOT re-mint a different u32.
-        let acct_u32_b = cat.account_u32("acct").expect("account resolved");
+        let acct_u32_b = cat.account_u32("acct").await.expect("account resolved");
         assert_eq!(acct_u32_a, acct_u32_b, "account u32 stable within a run");
         // And namespace siblings share the namespace id (covered above) because
         // they share the account u32.
         assert_eq!(a.stable_namespace_id, Some(1));
+    }
+
+    #[tokio::test]
+    async fn account_registry_survives_restart() {
+        // ADR-031 Phase 4b: the account-string → u32 mapping MUST persist across
+        // restarts, else the typed object-store path drifts → silent data loss.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = || NativeCatalogConfig {
+            storage_url: format!("file://{}/cat", dir.path().display()),
+            metadata_format: "json".into(),
+            versioned: false,
+            max_versions: 100,
+        };
+        let cache = || Arc::new(crate::cache::CatalogCache::new(64, 60));
+
+        // First instance: mint account "acct" → u32 (persists the sidecar).
+        let cat1 = NativeCatalog::new("t".into(), cfg(), cache())
+            .await
+            .expect("construct cat1");
+        let first = cat1.account_u32("acct").await.expect("minted");
+        assert_eq!(first, 1, "first account mints u32 1");
+        drop(cat1);
+
+        // Second instance from the SAME dir: load_account_registry must reuse u32
+        // 1 (not re-mint 2) + raise the floor above it.
+        let cat2 = NativeCatalog::new("t".into(), cfg(), cache())
+            .await
+            .expect("construct cat2");
+        let second = cat2
+            .account_u32("acct")
+            .await
+            .expect("lookup after restart");
+        assert_eq!(
+            first, second,
+            "account u32 must be stable across restart (durable registry)"
+        );
+        // A genuinely new account mints above the recovered floor (2, not 1).
+        let new_acct = cat2.account_u32("other").await.expect("mint new");
+        assert_eq!(new_acct, 2, "new account mints above recovered floor");
     }
 
     // Note: These tests require a mock filesystem or temp directory

--- a/src/catalog/index_location_resolver.rs
+++ b/src/catalog/index_location_resolver.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::catalog::CatalogManager;
+use crate::core::stable_id::CollectionIdentity;
 use crate::index::IndexLocationResolver;
-use crate::storage::trait_components::path_resolver::ann_index_locations;
+use crate::storage::trait_components::path_resolver::{ann_index_locations, typed_paths_enabled};
 
 /// Resolves a collection's ANN index location from the catalog on demand — the
 /// control-layer implementation of AXIS's [`IndexLocationResolver`] read-port.
@@ -52,9 +53,33 @@ impl IndexLocationResolver for CatalogIndexLocationResolver {
             .ok()?;
         let namespace = catalog.get_namespace(&table_id.namespace).await.ok()?;
         let schema = catalog.get_table(&table_id).await.ok()?;
+        // ADR-031 Phase 4b: compose the typed identity when the env gate is ON
+        // and the schema + namespace carry the stable ids + account string.
+        // Legacy collections (missing any id) or env OFF → None → legacy path.
+        let typed_identity = if typed_paths_enabled() {
+            match (
+                namespace.account_id.as_deref(),
+                schema.stable_namespace_id,
+                schema.stable_collection_id,
+            ) {
+                (Some(acct), Some(ns), Some(coll)) => catalog
+                    .account_id_u32(acct)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|a| CollectionIdentity {
+                        account_id: a,
+                        namespace_id: ns,
+                        collection_id: coll,
+                    }),
+                _ => None,
+            }
+        } else {
+            None
+        };
         // A collection has at most one ANN projection in AXIS's per-collection
         // index model; take the first resolved location (or None to fall back).
-        ann_index_locations(&namespace, &schema, self.migrate)
+        ann_index_locations(&namespace, &schema, self.migrate, typed_identity)
             .into_iter()
             .next()
             .map(|(_collection, location)| location)

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -515,6 +515,19 @@ impl DrResolvedPath {
     }
 }
 
+/// ADR-031 Phase 4b: whether the typed object-store path
+/// (`accounts/{base62}/{base62}/{base62}/`, no tenant slot) is enabled. Read
+/// **once per process** (cached in a `OnceLock`, mirroring the `oid_paths`
+/// pattern) to avoid env races across the multi-threaded runtime. Default OFF
+/// → legacy string-resolved `data/…` / `accounts/{str}/…` paths (mixed-read-safe).
+pub fn typed_paths_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| match std::env::var("PROXIMADB_TYPED_PATHS") {
+        Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),
+        Err(_) => false,
+    })
+}
+
 /// Resolve the catalog-addressed index locations for a collection's vector-ANN
 /// projections — the pure core of the CATALOG_OBJECT_MODEL P1 boot adapter.
 ///
@@ -536,10 +549,19 @@ pub fn ann_index_locations(
     namespace: &CatalogNamespace,
     schema: &CatalogTableSchema,
     migrate_to_catalog_paths: bool,
+    typed_identity: Option<CollectionIdentity>,
 ) -> Vec<(String, String)> {
-    let resolved = match DrPathBuilder::build(namespace, &schema.name) {
-        Ok(resolved) => resolved,
-        Err(_) => return Vec::new(), // legacy / non-DR-addressable namespace → leave convention
+    // ADR-031 Phase 4b: when the caller resolved a typed identity (env ON +
+    // schema has stable ids + account u32 known), build the path from it — the
+    // zero-padded base62 `accounts/{a}/{ns}/{c}/` prefix with no tenant slot.
+    // Otherwise the legacy string-resolved path (byte-identical when env OFF).
+    let resolved = if let Some(identity) = typed_identity {
+        DrPathBuilder::build_from_identity(identity, namespace.storage_pool_class)
+    } else {
+        match DrPathBuilder::build(namespace, &schema.name) {
+            Ok(resolved) => resolved,
+            Err(_) => return Vec::new(), // legacy / non-DR-addressable namespace → leave convention
+        }
     };
     schema
         .projections
@@ -1294,10 +1316,10 @@ mod tests {
         ));
 
         // No explicit location + migrate off → register nothing (convention kept).
-        assert!(ann_index_locations(&ns, &schema, false).is_empty());
+        assert!(ann_index_locations(&ns, &schema, false, None).is_empty());
 
         // migrate on → DrPath default, ANN projection only.
-        let migrated = ann_index_locations(&ns, &schema, true);
+        let migrated = ann_index_locations(&ns, &schema, true, None);
         assert_eq!(
             migrated,
             vec![(
@@ -1315,13 +1337,63 @@ mod tests {
         )
         .with_location("s3://hot-tier/ann/");
         assert_eq!(
-            ann_index_locations(&ns, &schema, false),
+            ann_index_locations(&ns, &schema, false, None),
             vec![("col_orders".to_string(), "s3://hot-tier/ann/".to_string())]
         );
 
         // Non-DR-addressable namespace (legacy) → empty, leave the convention.
         let legacy = CatalogNamespace::new(vec!["legacy".into()]);
-        assert!(ann_index_locations(&legacy, &schema, true).is_empty());
+        assert!(ann_index_locations(&legacy, &schema, true, None).is_empty());
+    }
+
+    #[test]
+    fn ann_index_locations_uses_typed_identity_when_provided() {
+        // ADR-031 Phase 4b: a Some(identity) flips the index location to the
+        // typed account-rooted prefix (no tenant slot); None keeps the legacy
+        // string-resolved path. This is the dispatch the env gate controls.
+        use crate::core::stable_id::CollectionIdentity;
+        use proximadb_catalog::CatalogProjection;
+        let ns = dr_addressable_namespace();
+        let mut schema = CatalogTableSchema::new("col_orders");
+        schema.projections.push(CatalogProjection::rebuildable(
+            "vector_ann",
+            CatalogProjectionKind::VectorAnn,
+            "primary",
+        ));
+        let identity = CollectionIdentity {
+            account_id: 7,
+            namespace_id: 5,
+            collection_id: 9,
+        };
+        let typed = ann_index_locations(&ns, &schema, true, Some(identity));
+        assert_eq!(typed.len(), 1, "one ANN projection");
+        let (_coll, loc) = &typed[0];
+        assert!(
+            loc.starts_with("accounts/"),
+            "typed path is account-rooted: {loc}"
+        );
+        assert!(
+            loc.ends_with("/indexes/vector_ann/"),
+            "still under indexes/: {loc}"
+        );
+        assert!(
+            !loc.starts_with("data/"),
+            "typed path must not be the legacy flat render: {loc}"
+        );
+        // Root prefix is the fixed 27-char typed form: accounts/000007/005/000009/
+        let root = loc.strip_suffix("indexes/vector_ann/").unwrap();
+        assert_eq!(
+            root.len(),
+            27,
+            "typed root must be exactly 27 chars (zero-padded base62): {root}"
+        );
+        // None identity → legacy path (the data/ flat render), unaffected by 4b.
+        let legacy = ann_index_locations(&ns, &schema, true, None);
+        let (_, legacy_loc) = &legacy[0];
+        assert!(
+            legacy_loc.starts_with("data/") || legacy_loc.starts_with("accounts/acct"),
+            "None identity keeps the legacy string-resolved path: {legacy_loc}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacks on #559 + #566 (merged). The typed identity is minted + persisted (4a); this PR makes it **live** (env-gated) + **durable**.

## What
- **Durable account registry** — `_syscat/account_registry.json` sidecar (mirrors `object_name_index`). Saved on every account mint; loaded eagerly in the constructor AFTER `load_namespaces`, BEFORE `load_table` (load→recover→account_u32 needs it loaded first, else the first table load silently mints a wrong u32 → typed-path drift → data loss). `account_u32`/`mint_stable_identity`/`recover_stable_identity` → async.
- **`typed_paths_enabled()`** — `OnceLock`-cached read of `PROXIMADB_TYPED_PATHS` (default OFF; process-stable, no env races).
- **`Catalog::account_id_u32(account)`** trait method (default `None` → federated catalogs stay legacy); NativeCatalog impls it.
- **Compose `CollectionIdentity` at the resolve site** — when env ON + `account_id` + `stable_namespace_id` + `stable_collection_id` all present, `resolve_index_location` builds the identity and `ann_index_locations` routes through `DrPathBuilder::build_from_identity` (the typed `accounts/{base62}/{base62}/{base62}/` prefix, no tenant slot). Legacy collections / env OFF → today's string-resolved path (byte-identical).

## Scope boundary (deliberate)
Types only paths flowing through `DrPathBuilder` — **ANN index locations** today. Collection **DATA** paths (WAL/SST via `ConfigFallbackResolver`, the embedded/local single-tenant mode) stay legacy → **Phase 4c** (SaaS object-store data-root migration; higher-risk). `build_from_parts` / `build_tenant_system` sites lack the schema → stay legacy.

## Verified
353 catalog tests pass (incl. `account_registry_survives_restart`: mint → restart → same u32); typed-vs-legacy dispatch test green; `clippy --lib` clean (catalog + root); tenant-path / boundary / oss guards clean. No proto/OpenAPI change (trait method has a default impl; schema fields merged in 4a).
