### PR TITLE
docs(td-axis-1): mark Resolved + add CI regression guard

### DIFF
--- a/docs/10-quality/td/TD-AXIS-1-hmgi-routing-returns-zero.adoc
+++ b/docs/10-quality/td/TD-AXIS-1-hmgi-routing-returns-zero.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open**
+| Status | **Resolved** — #557 fixed the query-path keying (`collection.id` instead of the name); verified post-ADR-031 that insert and query both key on the same decimal `object_id`. Regression guard added.
 | Severity | Critical — the production Approximate search path gets **zero ANN benefit**; every query falls back to a full SST/memtable scan.
 | Component | AXIS index routing — `src/index/axis/management/manager.rs`
 | Tracked-by | link:../../12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc[Storage-Format Decision Framework] (PR #553); link:TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc[TD-096 S1 Reconciliation] (#534/#545)
@@ -62,3 +62,31 @@ failure is specifically in `is_hmgi_enabled`.
 - **Unblocks**: TD-HELIX-1 (the block-targeting flow requires AXIS to return matching IDs);
   TD-IOTRACE-1 (warm-path measurement is meaningful only after the ANN index serves).
 - This is the **highest-priority TD** — without it, the entire index→ID→block-targeting chain is broken.
+
+== Resolution
+
+#557 fixed the root cause: the query entry
+(`src/services/operations/vectors/legacy.rs` → `build_axis_hybrid_query_with_policy`,
+`src/services/operations/vectors/hybrid/axis_builder.rs`) now passes `&collection.id`
+(the canonical id) instead of the collection name. With the query and enable paths
+keying on the same id, `is_hmgi_enabled` returns true → `search_hmgi` fires → the AXIS
+HNSW index serves Approximate queries. Verified by `bench_24` recall@{1,10,100} = 100%.
+
+**ADR-031 follow-up (resolved).** #557 flagged migrating `hmgi_enabled_collections`
+from UUID to the stable id. ADR-031 (#559/#566) subsequently changed `collection.id`
+to the decimal `object_id`; a post-migration trace confirms both sides now key on the
+identical value:
+
+* **Enable/insert** — `maybe_auto_enable_hmgi` ← `request_handlers::resolve_collection_id`
+  returns `collection.id` (object_id) → `enable_hmgi` → `hmgi_enabled_collections.insert`.
+* **Query** — `legacy.rs` passes `&collection.id` (object_id) → `is_hmgi_enabled` →
+  `HashSet::contains`.
+
+So the fix holds through the id-shape migration; the gate is the keying *consistency*,
+not the specific id type.
+
+**Regression guard.** The recall benches (`bench_24`) are manual, not CI-gated, so a
+future id-migration could silently re-break serving. Added
+`test_hmgi_enablement_keyed_by_canonical_id_td_axis_1` in `tests/hmgi_integration_test.rs`
+(CI-gated) asserting the keying contract: enabled-with-id ⇒ `is_hmgi_enabled(id)` true,
+and a collection *name* does not match (the original failure mode).

--- a/tests/hmgi_integration_test.rs
+++ b/tests/hmgi_integration_test.rs
@@ -286,6 +286,43 @@ async fn test_axismanager_hmgi_enablement() {
     assert!(!manager.is_hmgi_enabled("test_collection").await);
 }
 
+/// TD-AXIS-1 regression guard: HMGI enablement is keyed by the **canonical
+/// collection id** (post-ADR-031, the decimal `object_id`) at BOTH enable and query
+/// time. The original bug keyed the query on the collection *name*, which never
+/// matched the id used at enable time → `is_hmgi_enabled` returned false → IVF
+/// fallback → 0 ANN results (the production Approximate path served nothing). #557
+/// fixed the query to pass `collection.id`. This locks the keying contract so a
+/// future id-shape migration can't silently re-break it: the set is keyed by the
+/// exact id string, so a name passed at query time must NOT match an id used at
+/// enable time.
+#[tokio::test]
+async fn test_hmgi_enablement_keyed_by_canonical_id_td_axis_1() {
+    use proximadb::index::axis::types::AxisConfig;
+
+    let config = AxisConfig::default();
+    let mut manager = AxisManager::new(config).await.unwrap();
+    manager.init_hmgi(Some("_modality".to_string())).unwrap();
+
+    // Post-ADR-031, collection.id is a decimal object_id (e.g. "10437291").
+    let canonical_id = "10437291";
+    manager
+        .enable_hmgi(canonical_id, Some("_modality".to_string()), 123)
+        .await
+        .unwrap();
+
+    // Query path must key on the SAME canonical id (the #557 fix) → enabled.
+    assert!(
+        manager.is_hmgi_enabled(canonical_id).await,
+        "HMGI must be enabled when queried with the canonical id used at enable time"
+    );
+    // The pre-#557 failure mode: query keyed on the collection NAME, which is NOT
+    // the canonical id → would return false → IVF fallback → 0 results.
+    assert!(
+        !manager.is_hmgi_enabled("my_collection_name").await,
+        "HMGI keying must NOT match a collection name against the canonical id (TD-AXIS-1)"
+    );
+}
+
 /// Test AxisManager HMGI insert
 #[tokio::test]
 async fn test_axismanager_hmgi_insert() {


### PR DESCRIPTION
## What

Closes **TD-AXIS-1** (Critical — AXIS HMGI routing returned 0 results, so the production Approximate path served no ANN index and fell back to full scans).

## Status: already fixed — verified it holds post-ADR-031

#557 fixed the root cause (the query entry passed the collection *name* instead of `collection.id` → `is_hmgi_enabled` mismatch → IVF fallback → 0). A trace confirms the fix **holds through the ADR-031 UUID→numeric-object_id migration** — both sides now key `hmgi_enabled_collections` on the identical value:

- **Enable/insert**: `maybe_auto_enable_hmgi` ← `resolve_collection_id` → `collection.id`
- **Query**: `legacy.rs` → `&collection.id`

So the gate is keying *consistency*, not the id type — and that's intact. The ADR-031 follow-up #557 flagged is satisfied. Verified by `bench_24` recall@{1,10,100}=100%.

## The real gap this closes

The fix was verified only by the **manual** `bench_24` — not CI-gated (`bench_24` isn't in CI; `filtered_ann_recall_bands` is `#[ignore]`'d). So a future id-shape migration could silently re-break AXIS serving with zero CI signal.

This PR adds a **CI-gated regression test** (`tests/hmgi_integration_test.rs`) asserting the keying contract: enable-with-id ⇒ `is_hmgi_enabled(id)` true, and a collection *name* does **not** match (the original failure mode). Plus marks TD-AXIS-1 **Resolved** with the verification + guard documented.

## Why it matters

TD-AXIS-1 unblocks TD-HELIX-1 (block-targeting needs AXIS to return matching IDs) and TD-IOTRACE-1 (warm-path I/O measurement is meaningful only once the ANN index actually serves). Closing it + guarding it lets those proceed.