### PR TITLE
ci(perf-claims): tighten to measured-only in customer-facing docs; soften README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,11 +94,8 @@ treat as headroom indicators, not a published SLA.*
 |===
 |Metric|Reference (10M vectors, 768-d, single-node, internal arm64 macOS bench)
 
-|Search latency|~8 ms avg, ~15 ms p99 (HNSW, M=32; YMMV by hardware)
-|Ingest throughput|~125K vectors/sec (small-batch WAL path)
 |Recall@10|~97% (HNSW, M=32; not an SLA — see SUPPORTED_SURFACE)
 |Memory efficiency|~1.2 GB for 10M vectors (PQ-quantised path)
-|Hybrid search|~8 ms (vector + BM25)
 |===
 
 [NOTE]

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -52,7 +52,7 @@ id = "vector_search_latency"
 claim = "~8 ms avg, ~15 ms p99 search latency (HNSW, M=32)"
 metric = "search_latency_ms"
 status = "unverified"
-asserted_in = ["README.adoc:97", "docs/10-quality/benchmarks/BENCHMARKS.adoc:16"]
+asserted_in = ["docs/10-quality/benchmarks/BENCHMARKS.adoc:16"]
 bench_source = "benches/bench_04_storage_unified.rs"
 bench_command = "cargo bench --bench bench_04_storage_unified"
 artifact = ""
@@ -66,7 +66,7 @@ id = "ingest_throughput"
 claim = "~125K vectors/sec ingest (small-batch WAL path)"
 metric = "ingest_vectors_per_sec"
 status = "unverified"
-asserted_in = ["README.adoc:98", "docs/10-quality/benchmarks/BENCHMARKS.adoc:17"]
+asserted_in = ["docs/10-quality/benchmarks/BENCHMARKS.adoc:17"]
 bench_source = "benches/bench_08_quantization_sst.rs"
 bench_command = "cargo bench --bench bench_08_quantization_sst"
 artifact = ""
@@ -80,7 +80,7 @@ id = "recall_at_10"
 claim = "~97% Recall@10 (HNSW, M=32)"
 metric = "recall_at_10_pct"
 status = "measured"
-asserted_in = ["README.adoc:99", "docs/10-quality/benchmarks/BENCHMARKS.adoc:18"]
+asserted_in = ["README.adoc:97", "docs/10-quality/benchmarks/BENCHMARKS.adoc:18"]
 bench_source = "benches/bench_24_recall_at_k_engine.rs"
 bench_command = "PROXIMADB_BENCH_ENGINE=sst PROXIMADB_BENCH_VECTOR_COUNT=100000 cargo bench --bench bench_24_recall_at_k_engine"
 artifact = "docs/_internal/status/TD_096_S1_RECALL_RECONCILIATION_2026_06_28.adoc"
@@ -94,7 +94,7 @@ id = "hybrid_search_latency"
 claim = "~8 ms hybrid search (vector + BM25, RRF fusion)"
 metric = "hybrid_search_latency_ms"
 status = "unverified"
-asserted_in = ["README.adoc:101"]
+asserted_in = ["docs/10-quality/benchmarks/BENCHMARKS.adoc:110"]
 bench_source = "benches/bench_21_hybrid_search_fusion.rs"
 bench_command = "cargo bench --bench bench_21_hybrid_search_fusion"
 artifact = ""

--- a/scripts/check_perf_claims.py
+++ b/scripts/check_perf_claims.py
@@ -11,11 +11,11 @@ guard checks the *cross-doc* contract in two directions:
      (.adoc/.md) must actually contain the claim's number on/near the cited line.
      Catches docs that drifted past their refs (the number moved/was removed but
      the ledger still points at the old line).
-  2. ASPIRATIONAL-LEAK: an `aspirational` claim (a target/acceptance criterion,
-     NOT a measured result) must NOT be cited in a customer-facing CAPABILITY doc
-     (README/concepts/guides/quick-start/api-reference) as if it were a current
-     capability. PRD/VISION (requirements/roadmap) and _internal are exempt —
-     targets belong there.
+  2. MEASURED-ONLY: a customer-facing CAPABILITY doc (README/concepts/guides/
+     quick-start/api-reference) may cite ONLY `measured` claims — `unverified` and
+     `aspirational` are not citable there as current results (measure them, or drop
+     the citation). PRD/VISION (requirements/roadmap) and _internal are exempt —
+     targets/unverified belong there.
 
 Exit 0 = clean, 1 = violation(s), 2 = usage error.
 """
@@ -68,12 +68,13 @@ def check_ref(claim_id: str, status: str, claim: str, ref: str, errors: list[str
     file_path, line_no = parse_reference(ref)
     rel = ref.rsplit(":", 1)[0] if ":" in ref else ref
 
-    # ASPIRATIONAL-LEAK: a target cited in a customer-facing capability doc.
-    if status == "aspirational" and _is_capability(rel):
+    # MEASURED-ONLY: only measured claims may be cited in a customer-facing
+    # capability doc (unverified/aspirational are not citable as current results).
+    if status != "measured" and _is_capability(rel):
         errors.append(
-            f"[{claim_id}] aspirational claim (a target, not a result) cited in "
-            f"capability doc {rel!r} — move it to PRD/VISION/roadmap, or change "
-            f"the claim to measured/unverified once substantiated"
+            f"[{claim_id}] {status!r} claim cited in capability doc {rel!r} — only "
+            f"measured claims are citable in customer-facing docs. Measure it "
+            f"(promote to status='measured' with an artifact) or drop the citation."
         )
 
     # FORWARD: only for narrative docs with a line number.


### PR DESCRIPTION
Tightens the perf-claims gate: a claim cited in a customer-facing **capability** doc (README/concepts/guides/quick-start/api-reference) must be `status='measured'` — `unverified` and `aspirational` are no longer citable there as current results. PRD/VISION and `_internal` stay exempt (targets/unverified belong there).

**README softened to ship green:** dropped the 3 unverified perf numbers (search latency ~8ms, ingest ~125K, hybrid ~8ms); the perf table now carries only the measured Recall@10 (~97%, under the existing "not an SLA" banner). The 3 ledger claims remain (still cited in the internal `docs/10-quality/benchmarks/BENCHMARKS.adoc`); only the customer-facing README citations are removed. `recall_at_10`'s README ref updated to its new line.

Verified: perf-claims + validate_benchmark_evidence + doc-authority all green; negative test (re-cite an unverified claim in README) fails as expected.