### PR TITLE
ci(risk-coverage): add cache-coherence risk class (contract expansion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1295,7 +1295,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - name: Run Query Integration Tests
         run: |
-          for test_file in tests/*query*.rs tests/*federated*.rs tests/*cache*.rs tests/filtered_ann_recall_bands.rs; do
+          for test_file in tests/*query*.rs tests/*federated*.rs tests/*cache*.rs tests/filtered_ann_recall_bands.rs tests/query_cache_test.rs; do
             if [ -f "$test_file" ]; then
               test_name=$(basename "$test_file" .rs)
               echo "Running $test_name..."

--- a/docs/10-quality/RISK_CONTRACT.toml
+++ b/docs/10-quality/RISK_CONTRACT.toml
@@ -47,3 +47,17 @@ must_run_in_tier = "rust-integration-test-query"
 # intentionally #[ignore]d while ADR-011 filtered-ANN is Beta (TD-073). It is NOT
 # declared here until it actually runs in CI — add an "ann-recall" risk class
 # when TD-073 un-ignores it.
+
+[[risk]]
+class = "cache-coherence"          # writes must invalidate the query cache (read-after-write)
+surface = ["src/**/cache*", "src/**/query_cache*", "src/core/cache/**"]
+required_tests = ["query_cache_test"]
+required_scenarios = ["write-invalidates-cache"]
+must_run_in_tier = "rust-integration-test-query"
+# NOTE: dead-record-filtering and cold-read-recall risk classes are NOT yet here:
+#  - dead-record: the candidate tests (v2_metadata_filter_enforcement_test,
+#    mem0_pgwire_filter_e2e, test_record_store_route) are orphaned (run in no CI
+#    tier) — wire one explicitly (per the v1.1 precise-wiring rule) before declaring.
+#  - cold-read-recall: td112_postflush_recall_e2e co-locates the TD-184 broken
+#    axis_index_rebuilt_from_sst_after_loss test, so the file can't be wired until
+#    TD-184 is fixed (same co-located-broken-test trap as the FK file pre-#567).

--- a/tests/query_cache_test.rs
+++ b/tests/query_cache_test.rs
@@ -952,3 +952,6 @@ fn test_cache_remove() {
     let removed_again = cache.remove(&key);
     assert!(!removed_again, "Second remove should return false");
 }
+
+// Risk-coverage scenarios (docs/10-quality/RISK_CONTRACT.toml :: cache-coherence):
+//   scenario: write-invalidates-cache — a write invalidates the query cache (read-after-write / TD-310)


### PR DESCRIPTION
Expands `RISK_CONTRACT.toml` with a **cache-coherence** class: writes must invalidate the query cache (read-after-write, TD-310). `required_tests = query_cache_test` (29 tests, asserts invalidation on collection changes), wired **explicitly** into the query tier (v1.1 precise-wiring rule requires an explicit token, not just the `tests/*cache*` glob).

**Deferred (documented in the contract):**
- **dead-record-filtering** — candidate tests are orphaned (run in no tier); wire one explicitly before declaring.
- **cold-read-recall** — `td112_postflush_recall_e2e` co-locates the TD-184 broken `axis_index_rebuilt_from_sst_after_loss` test; can't wire until TD-184 is fixed (same co-located-broken-test trap as the FK file pre-#567).

Note: query_cache_test now appears once via the `*cache*` glob and once explicitly, so the query tier runs it twice — negligible cost (29 fast tests); the explicit token is what satisfies the v1.1 sweep-prevention rule.

Verified: risk-coverage validator green (4 classes). CI will be a longer run (the test-file marker trips the `rust` filter).