### PR TITLE
refactor: unify collection.id ↔ schema.object_id (ADR-031)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4427,6 +4427,15 @@ pub trait Catalog: Send + Sync {
     async fn account_id_u32(&self, _account: &str) -> anyhow::Result<Option<u32>> {
         Ok(None)
     }
+    /// ADR-031 allocator unification: the highest persisted `object_id` across
+    /// all tables (from the durable `object_name_index`). The root startup path
+    /// uses this to raise the collection-id allocator floor above every existing
+    /// object_id, so a freshly minted collection id can never collide with a
+    /// legacy (pre-unification) `schema.object_id` → no oid-index corruption.
+    /// Default `None` (federated catalogs have no native object_ids).
+    async fn max_object_id(&self) -> anyhow::Result<Option<u64>> {
+        Ok(None)
+    }
     async fn update_namespace_properties(
         &self,
         namespace: &[String],

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -1357,6 +1357,13 @@ impl Catalog for NativeCatalog {
         Ok(self.account_u32(account).await)
     }
 
+    async fn max_object_id(&self) -> Result<Option<u64>> {
+        // Max persisted object_id from the durable forward index (name→oid),
+        // loaded eagerly at startup. Used by the root to raise the collection-id
+        // allocator floor above every existing object_id (collision safety).
+        Ok(self.object_name_index.read().await.values().copied().max())
+    }
+
     async fn update_namespace_properties(
         &self,
         namespace: &[String],

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -700,6 +700,33 @@ impl SharedServices {
         // Collection service will be injected into StorageEngine by ProximaDB::new
         info!("✅ SharedServices: Collection service created for injection into StorageEngine");
 
+        // ADR-031 allocator unification: raise the collection-id allocator floor
+        // above every existing object_id — both `collection.id` (numeric) AND
+        // `schema.object_id` — so a freshly minted collection id can never
+        // collide with a legacy (pre-unification) schema.object_id (which would
+        // corrupt the oid→name index). Best-effort: a failure logs + continues
+        // (startup must not block on this).
+        {
+            let max_coll_id = collection_service
+                .list_collections()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|c| c.id.parse::<u64>().ok())
+                .max();
+            let max_schema_oid = match catalog_manager.default_catalog().await {
+                Ok(cat) => cat.max_object_id().await.unwrap_or(None),
+                Err(e) => {
+                    warn!("collection-id floor recovery: default catalog unavailable: {e}");
+                    None
+                }
+            };
+            if let Some(floor) = max_coll_id.max(max_schema_oid) {
+                crate::services::collection::manager::recover_collection_id_floor(floor);
+                debug!("collection-id allocator floor raised to {floor} (max existing object_id)");
+            }
+        }
+
         // Phase P Site 2 — boot-time hydration of the TurboQuant store
         // registry. After a restart, every existing collection whose
         // proto QuantizationConfig set `enable_turboquant=true` needs

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2080,9 +2080,22 @@ impl CollectionService {
                 .await?;
         }
 
-        let schema = crate::storage::metadata::collection_mapping::catalog_schema_from_collection(
-            collection,
-        )?;
+        let mut schema =
+            crate::storage::metadata::collection_mapping::catalog_schema_from_collection(
+                collection,
+            )?;
+        // ADR-031 allocator unification: pre-set `schema.object_id` from the
+        // collection's numeric id so `create_table` ADOPTS it
+        // (`mint_object_id(Some)` raises the floor + returns the id) instead of
+        // minting a separate one. Result: `schema.object_id == collection.id`'s
+        // oid — one identity per collection, not two divergent ones.
+        // Only the fresh-create path (`create_table(schema)` below) is affected;
+        // the existing-table path preserves its already-minted object_id. Legacy
+        // UUID collection.ids don't parse → leave None (create_table mints fresh,
+        // un-unified — mixed-read-safe).
+        if let Ok(oid) = collection.id.parse::<u64>() {
+            schema.object_id = Some(oid);
+        }
         if catalog.table_exists(&identifier).await? {
             let mut existing = catalog.get_table(&identifier).await?;
             if existing
@@ -3399,6 +3412,13 @@ mod tests {
         );
         let schema = catalog.get_table(&table_id).await?;
         assert_eq!(schema.properties.get("collection.id"), Some(&collection.id));
+        // ADR-031 allocator unification: schema.object_id must equal collection.id's
+        // oid (create_table adopted it) — one identity, not two divergent ones.
+        assert_eq!(
+            schema.object_id,
+            collection.id.parse::<u64>().ok(),
+            "schema.object_id must equal collection.id's oid (unified identity)"
+        );
         assert_eq!(
             schema.properties.get("asset.capability.vector"),
             Some(&"true".to_string())


### PR DESCRIPTION
Each collection had **two numeric identities from separate allocators that diverged**: `collection.id` (root `COLLECTION_ID_ALLOCATOR`, decimal) and `schema.object_id` (`NativeCatalog.object_id_allocator`, catalog). This unifies them: `schema.object_id == collection.id`'s oid — one identity per collection.

## Approach (no create-flow reorder; catalog *adopts* the root-minted oid)
- `upsert_collection_catalog_asset`: pre-set `schema.object_id = Some(oid)` (decoded from the numeric `collection.id`) before `create_table`. `create_table`'s existing `mint_object_id(Some)` adoption path raises the floor + returns the id → `schema.object_id == oid`. Legacy UUID ids don't parse → left None (mixed-read-safe, forward-only).
- **Startup floor recovery** (was test-only) wired at `SharedServices` boot: raise `COLLECTION_ID_ALLOCATOR` above `max(collection.id, schema.object_id)` via a new `Catalog::max_object_id()` (NativeCatalog impls from the durable `object_name_index`). Guarantees a fresh collection id can't collide with a legacy pre-unification `schema.object_id` (oid-index corruption prevention).

## Scope note
The global `COLLECTION_ID_ALLOCATOR` stays as the collection-id source (catalog adopts). Fully moving minting into the catalog would require reordering `create_collection` (catalog-create before storage-dir create → orphan-on-failure risk) — deferred; this achieves the identity unification safely.

## Verified
Collection lifecycle test now asserts `schema.object_id == collection.id`'s oid; `clippy --lib` clean (catalog + root); tenant-path / deterministic-contract / boundary guards clean. No proto/OpenAPI change (Catalog trait method has a default impl).
