### PR TITLE
feat(sst): wire PAX RaBitQ→SQ8 cascade into production search

### DIFF
--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -228,6 +228,80 @@ impl SstEngine {
         .await
     }
 
+    /// PAX RaBitQ→SQ8 cascade attempt for a `.pax` segment — the co-designed
+    /// approximate read path (P3 C.2: metadata pre-prune → RaBitQ candidate rank
+    /// → SQ8 rerank, full f32 never decoded). Returns `Ok(Some)` when the cascade
+    /// served, or `Ok(None)`/`Err` when it doesn't apply (segment isn't PAX, has no
+    /// RaBitQ-coded embedding, or a transient I/O error). The caller falls back to
+    /// the generic materialize-and-score scan in all of those cases, so this is
+    /// additive and mixed-read-safe.
+    ///
+    /// **Metric gate.** Serves only Euclidean collections — the cascade's rerank is
+    /// L2-validated (recall 0.932 @ N=100k). Other metrics stay on the generic scan
+    /// until the cascade is metric-generalized + re-validated (follow-up).
+    async fn try_pax_cascade(
+        &self,
+        sstable_path: &str,
+        query_vector: &[f32],
+        filter_expression: Option<&FilterExpression>,
+        k: usize,
+    ) -> anyhow::Result<Option<Vec<OptimizedSearchRecord>>> {
+        use crate::storage::engines::sst::segment_format::{
+            MetaPrune, pax_field_to_col, rabitq_search_segment,
+        };
+        // Read the segment bytes once; the generic-scan branch uses the sstable
+        // reader instead, so this read is exclusive to the cascade (no double-read).
+        let fs = self
+            .filesystem()
+            .get_filesystem(sstable_path)
+            .map_err(|e| anyhow::anyhow!("opening PAX segment {sstable_path}: {e}"))?;
+        let bytes = fs
+            .read(sstable_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("reading PAX segment {sstable_path}: {e}"))?;
+        let pool = Self::pax_rabitq_pool_for_top_k(k);
+        let prune = filter_expression.map(|filter| MetaPrune {
+            filter,
+            field_to_col: &pax_field_to_col,
+        });
+        let Some(hits) = rabitq_search_segment(&bytes, query_vector, k, pool, prune)? else {
+            return Ok(None); // not PAX / no RaBitQ → caller falls back
+        };
+        let metric = DistanceMetric::Euclidean;
+        let records = hits
+            .into_iter()
+            .map(|h| {
+                OptimizedSearchRecord::new(
+                    h.oid,
+                    OptimizedSearchRecord::standardized_distance_to_similarity(h.distance, &metric),
+                )
+            })
+            .collect();
+        Ok(Some(records))
+    }
+
+    /// Default RaBitQ candidate-pool size for top-`k` (recall: pool=200→0.708,
+    /// 1000→0.932 @ N=100k). `max(k * mult, min)`; the defaults (mult=100,
+    /// min=1000) reproduce the largest validated config (pool=1000 @ N=100k) at
+    /// k=10 and scale up for larger k, so recall holds across segment sizes until
+    /// the SIFT1M real-dataset validation lands. Env-overridable via
+    /// `PROXIMADB_PAX_RABITQ_POOL_MULT` / `_MIN`.
+    fn pax_rabitq_pool_for_top_k(k: usize) -> usize {
+        static C: std::sync::OnceLock<(usize, usize)> = std::sync::OnceLock::new();
+        let (mult, min) = C.get_or_init(|| {
+            let mult = std::env::var("PROXIMADB_PAX_RABITQ_POOL_MULT")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(100);
+            let min = std::env::var("PROXIMADB_PAX_RABITQ_POOL_MIN")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(1000);
+            (mult, min)
+        });
+        k.saturating_mul(*mult).max(*min)
+    }
+
     /// Main unified search implementation with orchestration
     ///
     /// This is the primary search entry point that implements intelligent
@@ -846,8 +920,37 @@ impl SstEngine {
                 block_prune.force_exact
             );
 
-            // Dispatch based on file format (Arrow vs ProximaBlocks)
-            let search_result = if sstable_path.ends_with(".arrow") {
+            // PAX RaBitQ→SQ8 cascade (PAX Phase 2 read-side wiring): try it first
+            // for `.pax` segments under the validated Euclidean metric. The generic
+            // dispatch below handles every other case — `.arrow`, legacy `.sst`, AND
+            // `.pax` under other metrics or any cascade miss (not-PAX / no RaBitQ /
+            // error) — so this is additive and mixed-read-safe.
+            let pax_cascade: Option<Vec<OptimizedSearchRecord>> =
+                if sstable_path.ends_with(".pax") && distance_metric == DistanceMetric::Euclidean {
+                    match self
+                        .try_pax_cascade(sstable_path, query_vector, filter_expression, k)
+                        .await
+                    {
+                        Ok(Some(records)) => Some(records),
+                        Ok(None) => None,
+                        Err(e) => {
+                            warn!(
+                                file = %sstable_path,
+                                error = %e,
+                                "PAX cascade unavailable; falling back to generic scan"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+            // Dispatch based on file format (Arrow vs ProximaBlocks); the PAX
+            // cascade short-circuits above when it applies.
+            let search_result = if let Some(records) = pax_cascade {
+                Ok(records)
+            } else if sstable_path.ends_with(".arrow") {
                 // Use ArrowBlockReader for Arrow format files
                 self.search_arrow_file(
                     sstable_path,
@@ -1260,7 +1363,9 @@ impl SstEngine {
                 entry.metadata.is_directory
             );
             if !entry.metadata.is_directory
-                && (entry.name.ends_with(".sst") || entry.name.ends_with(".arrow"))
+                && (entry.name.ends_with(".sst")
+                    || entry.name.ends_with(".arrow")
+                    || entry.name.ends_with(".pax"))
             {
                 files.push(entry.url);
                 tracing::debug!("[SST] Found data file: {}", entry.name);
@@ -1321,7 +1426,9 @@ impl SstEngine {
         if let Ok(mut entries) = tokio::fs::read_dir(data_dir).await {
             while let Some(entry) = entries.next_entry().await? {
                 if let Some(name) = entry.file_name().to_str()
-                    && (name.ends_with(".sst") || name.ends_with(".arrow"))
+                    && (name.ends_with(".sst")
+                        || name.ends_with(".arrow")
+                        || name.ends_with(".pax"))
                 {
                     sstable_files.push(format!("{}/{}", data_dir, name));
                 }

--- a/tests/pax_cascade_prod_search_test.rs
+++ b/tests/pax_cascade_prod_search_test.rs
@@ -1,0 +1,213 @@
+//! PAX Phase 2 (read-side wiring) — the production SST search dispatches a
+//! `.pax` segment to the RaBitQ→SQ8 cascade.
+//!
+//! Before this wiring, `rabitq_search_segment` had **zero non-test callers** — a
+//! PAX segment written with `PROXIMADB_PAX_VECTOR_SEGMENTS=1` was read in
+//! production only via the generic block scan (no RaBitQ acceleration), so the
+//! recall ratchet never reflected production behavior. This test exercises the
+//! wired dispatch end-to-end: flush a PAX+RaBitQ segment, search it through the
+//! production `search_vectors_unified` path under the Euclidean metric, and
+//! assert the cascade returns an accurate top-k. Recall@10 ≥ 0.90 vs the exact
+//! nearest neighbours proves the cascade served (the generic scan alone cannot
+//! rank a RaBitQ-coded segment without the cascade's rerank).
+//!
+//! Env-scoped (nextest runs each test in its own process, so the PAX env vars set
+//! here don't leak to other tests): `PROXIMADB_PAX_VECTOR_SEGMENTS=1` writes
+//! `.pax` segments on flush; `PROXIMADB_PAX_VECTOR_QUANT=rabitq` codes them with
+//! RaBitQ (no f32 tier) so the cascade is the only path that can rank them.
+
+use proximadb::compute::distance_computation::DistanceMetric;
+use proximadb::core::search::{BlockPruneConfig, BlockPruneMode, SearchParams};
+use proximadb::proto::proximadb_v1::{
+    Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
+};
+use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::traits::{
+    FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const DIMENSION: usize = 32;
+const N: usize = 512;
+const TOP_K: usize = 10;
+
+fn collection(id: &str, temp_dir: &TempDir) -> Collection {
+    Collection {
+        id: id.to_string(),
+        config: Some(CollectionConfig {
+            name: id.to_string(),
+            dimension: DIMENSION as u32,
+            distance_metric: Some(DistanceMetric::Euclidean as i32),
+            storage_engine: Some(StorageEngine::Sst as i32),
+            ..Default::default()
+        }),
+        storage_assignment: Some(StorageAssignment {
+            base_location: temp_dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Deterministic pseudo-random vectors (LCG) — the regime the RaBitQ cascade is
+/// validated on (recall 0.932 @ N=100k). Clustered data is a known hard case for
+/// quantization and is covered by the separate SIFT real-dataset validation gap,
+/// not this wiring test.
+fn vectors() -> Vec<VectorRecord> {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next_f32 = || {
+        // xorshift64 → f32 in [0, 1)
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        (state >> 11) as f32 / (1u64 << 53) as f32
+    };
+    (0..N)
+        .map(|i| VectorRecord {
+            id: format!("v{i:04}"),
+            vector: (0..DIMENSION).map(|_| next_f32()).collect(),
+            metadata: HashMap::new(),
+            version: Some(1),
+            timestamp: Some(i as i64),
+            updated_at: None,
+            expires_at: None,
+            source: None,
+        })
+        .collect()
+}
+
+fn l2(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+async fn search(
+    engine: &SstEngine,
+    collection: &Collection,
+    query: Vec<f32>,
+    force_exact: bool,
+) -> Vec<String> {
+    let ctx = StorageQueryContext {
+        search_params: Arc::new(SearchParams {
+            query_vectors: Some(vec![query]),
+            top_k: Some(TOP_K),
+            distance_metric: Some(DistanceMetric::Euclidean),
+            block_prune: BlockPruneConfig {
+                force_exact,
+                mode: BlockPruneMode::Ratio,
+                ratio: 1.0,
+                min_keep: 1,
+                max_keep: 0,
+                min_blocks_override: Some(0),
+            },
+            ..Default::default()
+        }),
+        collection: Arc::new(collection.clone()),
+        metadata: StorageQueryMetadata {
+            collection_id: collection.id.clone(),
+            ..Default::default()
+        },
+        user_context: None,
+        tenant_context: None,
+    };
+    engine
+        .search_vectors_unified(&ctx)
+        .await
+        .expect("search succeeds")
+        .into_iter()
+        .map(|r| r.id)
+        .collect()
+}
+
+async fn flush(engine: &SstEngine, collection: &Collection, vectors: Vec<VectorRecord>) {
+    let params = FlushParameters {
+        collection_id: Some(collection.id.clone()),
+        vector_records: vectors.into_iter().map(|v| v.into()).collect(),
+        force: true,
+        synchronous: true,
+        hints: HashMap::new(),
+        timeout_ms: None,
+        trigger_compaction: false,
+        batch_ids: vec![],
+        collection_config: Some(collection.clone()),
+        estimated_size: 0,
+    };
+    let result = engine.do_flush(&params).await.expect("flush succeeds");
+    assert!(result.success, "flush should succeed");
+    assert!(
+        result.entries_flushed.unwrap_or(0) > 0,
+        "flush should write vectors"
+    );
+}
+
+/// A PAX+RaBitQ segment searched through the production path returns an accurate
+/// top-k (recall@10 ≥ 0.90) — proving the RaBitQ→SQ8 cascade is wired into the
+/// dispatch (the only path that can rank a RaBitQ-coded segment).
+#[tokio::test]
+async fn pax_segment_cascade_serves_accurate_topk() {
+    // PAX write-default stays OFF in prod; opt this collection in via env so a
+    // `.pax` segment is flushed. nextest isolates each test in its own process.
+    // `set_var` is `unsafe` (edition 2024) — confined to this test process.
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+    }
+
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+    let temp_dir = TempDir::new().unwrap();
+    let collection = collection("pax_cascade_e2e", &temp_dir);
+
+    let engine = SstEngine::new().await.unwrap();
+    let vectors = vectors();
+    let query = vectors[0].vector.clone(); // a known vector; its true NN are well-defined
+    flush(&engine, &collection, vectors.clone()).await;
+
+    // A `.pax` segment was written (otherwise the cascade branch can't apply).
+    let mut all_files: Vec<String> = Vec::new();
+    fn walk(dir: &std::path::Path, out: &mut Vec<String>) {
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else {
+                out.push(p.to_string_lossy().to_string());
+            }
+        }
+    }
+    walk(temp_dir.path(), &mut all_files);
+    let wrote_pax = all_files.iter().any(|f| f.ends_with(".pax"));
+    assert!(
+        wrote_pax,
+        "flush should write a .pax segment under PAX_VECTOR_SEGMENTS=1 (wrote: {all_files:?})"
+    );
+
+    // True nearest neighbours by brute-force L2.
+    let mut exact: Vec<(String, f32)> = vectors
+        .iter()
+        .map(|v| (v.id.clone(), l2(&query, &v.vector)))
+        .collect();
+    exact.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let exact_ids: std::collections::HashSet<String> =
+        exact.iter().take(TOP_K).map(|(id, _)| id.clone()).collect();
+
+    // Production search over the PAX segment routes through the cascade (`.pax` +
+    // Euclidean) and returns a full top-k.
+    let got = search(&engine, &collection, query, false).await;
+    assert_eq!(
+        got.len(),
+        TOP_K,
+        "cascade should return a full top-k (got {})",
+        got.len()
+    );
+    let got_ids: std::collections::HashSet<String> = got.into_iter().collect();
+    let overlap = got_ids.intersection(&exact_ids).count();
+    let recall = overlap as f64 / TOP_K as f64;
+    assert!(
+        recall >= 0.90,
+        "PAX cascade recall@{TOP_K} = {recall:.2} (overlap {overlap}/{TOP_K}) < 0.90 ratchet"
+    );
+}


### PR DESCRIPTION
## What

Wires the PAX RaBitQ→SQ8 cascade into the **production** SST search path — the missing read-side prerequisite for PAX default-on (rollout Phase 2). Until now `rabitq_search_segment` had **zero non-test callers**: a `.pax` segment written under `PROXIMADB_PAX_VECTOR_SEGMENTS=1` was read in prod only via the generic block scan (no RaBitQ acceleration), so the recall ratchet never reflected production behavior.

## Changes

- **Discovery**: `discover_sstable_files` now includes `.pax` (was `.sst`/`.arrow` only). Without this, `.pax` segments were never searched at all — the cascade couldn't run.
- **Dispatch** (`search_vectors_unified` per-file loop): tries the cascade first for `.pax` + **Euclidean** (the validated metric); `CascadeHit`→`OptimizedSearchRecord` (oid→id, distance→similarity). Any miss (not-PAX / no RaBitQ / error) or a non-Euclidean metric falls through to the existing generic scan **unchanged** → mixed-read-safe, never drops results.
- **Pool**: `max(k·100, 1000)` reproduces the largest validated config (pool=1000→recall 0.932 @ N=100k); env-overridable `PROXIMADB_PAX_RABITQ_POOL_MULT`/`_MIN`.
- **Write-default stays OFF** — this PR is read-side wiring only. The default-on flip remains gated on the SIFT1M real-dataset artifact (`BENCHMARK_EVIDENCE.toml` WS8 caveat).

## Safety

1. Metric gate: cascade serves Euclidean only (L2-validated); cosine/dot → generic scan.
2. Mixed-read-safe: non-PAX segments unchanged; `SegmentFormat::detect` defaults to legacy.
3. `None`⇒fallback: any cascade miss transparently falls through to the existing scan.

## Validation

- New test `pax_cascade_prod_search_test`: flush a PAX+RaBitQ segment → search via the production path → **recall@10 ≥ 0.90** vs brute-force exact (the validated random-vector regime). Proves discovery + dispatch + mapping are correct end-to-end.
- Existing `.sst` search regression test (`sst_vector_bounds_prune_recall_test`) still green — the discovery change is additive.
- `cargo fmt` clean; `cargo clippy --lib --bins` 0 warnings.

## Debugging note (why this wasn't trivial)

Two hidden gaps surfaced only by running the test: (1) discovery excluded `.pax` (cascade never ran), and (2) the initial pool default (100) gave recall 0.60 — bumped to 1000 (the validated config). Both were invisible to the cascade's own unit tests (which call `rabitq_search_segment` directly, bypassing discovery + the prod pool).

## Follow-ups (out of scope)

- Default-on flip (gated on SIFT1M/768-d recall artifact).
- Metric generalization (cascade for cosine/dot).
- SIFT real-dataset harness via `src/bench/ann_benchmarks/adapter.rs`.