### PR TITLE
feat(sst): PAX segment compaction (P3 Phase E) — unblock default-on

### DIFF
--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1165,11 +1165,38 @@ impl Compaction {
 
             match block_format {
                 BlockFormat::PaxBlock => {
-                    // PAX segment compaction lands in P3 Phase E (reads mixed formats,
-                    // rewrites to the configured format). Fail closed until then.
-                    return Err(crate::core::StorageError::SstEngine(
-                        "PAX segment compaction not yet supported (P3 Phase E)".into(),
-                    ));
+                    // P3 Phase E: compact to a `.pax` segment, re-encoding the merged
+                    // records with RaBitQ. Mixed-read-safe — source segments may be
+                    // legacy `.sst` or `.pax` (btree_records already merged them); the
+                    // rewrite emits the configured PAX format. The output filename is
+                    // format-aware (`.pax`) via `generate_output_file_path`, so
+                    // discovery + the cascade dispatch route it correctly.
+                    let collection_id = self
+                        .extract_collection_id_from_paths(&task.input_files)
+                        .unwrap_or_else(|_| "default".to_string());
+                    let records: Vec<ProximaRecord> =
+                        btree_records.values().map(ProximaRecord::from).collect();
+                    if let Some(parent) = staging_file_path.parent() {
+                        std::fs::create_dir_all(parent)
+                            .map_err(crate::core::StorageError::DiskIO)?;
+                    }
+                    crate::storage::engines::sst::segment_format::write_pax_segment(
+                        &staging_file_path,
+                        &records,
+                        &collection_id,
+                        records.len(),
+                        proximadb_block_format::VectorQuant::RaBitQ,
+                        None,
+                    )
+                    .map_err(|e| {
+                        crate::core::StorageError::SstEngine(format!(
+                            "PAX compaction write failed: {e}"
+                        ))
+                    })?;
+                    info!(
+                        "✅ COMPACTION: Wrote {} records to PAX segment",
+                        records.len()
+                    );
                 }
                 BlockFormat::ArrowBlock => {
                     // Use ArrowBlockWriter for Arrow IPC format
@@ -1286,10 +1313,34 @@ impl Compaction {
 
             match block_format {
                 BlockFormat::PaxBlock => {
-                    // PAX segment compaction lands in P3 Phase E. Fail closed until then.
-                    return Err(crate::core::StorageError::SstEngine(
-                        "PAX segment compaction not yet supported (P3 Phase E)".into(),
-                    ));
+                    // P3 Phase E: compact to a `.pax` segment (re-encode RaBitQ).
+                    // See the atomic arm above; this is the non-atomic direct-write path.
+                    let collection_id = self
+                        .extract_collection_id_from_paths(&task.input_files)
+                        .unwrap_or_else(|_| "default".to_string());
+                    let records: Vec<ProximaRecord> =
+                        btree_records.values().map(ProximaRecord::from).collect();
+                    if let Some(parent) = task.output_file.parent() {
+                        std::fs::create_dir_all(parent)
+                            .map_err(crate::core::StorageError::DiskIO)?;
+                    }
+                    crate::storage::engines::sst::segment_format::write_pax_segment(
+                        &task.output_file,
+                        &records,
+                        &collection_id,
+                        records.len(),
+                        proximadb_block_format::VectorQuant::RaBitQ,
+                        None,
+                    )
+                    .map_err(|e| {
+                        crate::core::StorageError::SstEngine(format!(
+                            "PAX compaction write failed: {e}"
+                        ))
+                    })?;
+                    info!(
+                        "✅ COMPACTION (non-atomic): Wrote {} records to PAX segment",
+                        records.len()
+                    );
                 }
                 BlockFormat::ArrowBlock => {
                     // Use ArrowBlockWriter for Arrow IPC format

--- a/src/storage/engines/sst/compactor_impl.rs
+++ b/src/storage/engines/sst/compactor_impl.rs
@@ -967,9 +967,32 @@ impl SstCompactor {
 
         match block_format {
             super::block_format::BlockFormat::PaxBlock => {
-                // PAX segment compaction lands in P3 Phase E. Fail closed until then.
-                // (Unreachable today: detect_format only yields Arrow/ProximaBlocks.)
-                anyhow::bail!("PAX segment compaction not yet supported (P3 Phase E)");
+                // P3 Phase E: compact to a `.pax` segment, re-encoding the merged
+                // records with RaBitQ. Reachable once PAX write-default is on (the
+                // output path's `.pax` extension makes `detect_format` return Pax).
+                let path = std::path::Path::new(output_path);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let collection_id = output_path
+                    .split('/')
+                    .nth(1)
+                    .unwrap_or("default")
+                    .to_string();
+                let records: Vec<ProximaRecord> = records.iter().map(ProximaRecord::from).collect();
+                crate::storage::engines::sst::segment_format::write_pax_segment(
+                    path,
+                    &records,
+                    &collection_id,
+                    records.len(),
+                    proximadb_block_format::VectorQuant::RaBitQ,
+                    None,
+                )?;
+                stats.records_written += records.len() as u64;
+                info!(
+                    "✅ SST_COMPACTOR: Wrote {} records to PAX segment",
+                    records.len()
+                );
             }
             super::block_format::BlockFormat::ArrowBlock => {
                 // Use ArrowBlockWriter for Arrow IPC format


### PR DESCRIPTION
## What

PAX **compaction** (P3 Phase E) — a hard prerequisite for PAX default-on. Compaction previously **failed closed** on `.pax` segments (`"PAX segment compaction not yet supported (P3 Phase E)"`) at three sites. With PAX write-default ON, compaction would trigger on `.pax` → error (or unbounded segment growth if disabled).

## Changes

Implement the `PaxBlock` compaction arms at all three fail-closed sites — re-encode the merged records via `write_pax_segment` (RaBitQ), mixed-read-safe (source segments may be `.sst` or `.pax`; the rewrite emits PAX):
- `src/storage/engines/sst/compaction.rs` — atomic + non-atomic `LevelBasedSstCompactor` arms.
- `src/storage/engines/sst/compactor_impl.rs` — `SstCompactor` arm (reachable once PAX is on, per its own comment).

The output filename is already format-aware (`generate_output_file_path` → `.pax` for PaxBlock), so discovery + the cascade dispatch route the compacted segment correctly — no scheduler change needed.

## Context / roadmap

Phase A of the PAX default-on roadmap (follow-ups to #579, which wired the cascade into prod search). Default-on (Phase F) is gated on this + the SIFT1M artifact (Phase B) + opt-out/kill-switch (Phase C).

## Testing

- `cargo check` + `fmt` + `clippy --lib` clean.
- The arms mirror the existing tested `ArrowBlock`/`ProximaBlocks` arms; `write_pax_segment` + `read_segment_records` round-trip is covered by `tests/pax_cascade_prod_search_test` (#579).
- A full compaction→search integration test lands **before the Phase F default-on flip** (compaction only runs on `.pax` once PAX is on, so there's a window). Noted as a Phase-F prerequisite.

## Follow-ups (tracked)
- Compaction→search integration test (Phase-F prereq).
- Phase B (SIFT harness), C (opt-out/kill), D (materialization), E (metric generalization), F (default-on flip).