### PR TITLE
feat(sst): PAX per-collection opt-out tag + global kill-switch (Phase C)

### DIFF
--- a/proto/proximadb/v1/collection_types.proto
+++ b/proto/proximadb/v1/collection_types.proto
@@ -85,6 +85,13 @@ message CollectionConfig {
   // PAX quant without a global flip (ADR-026/027). Precedence at flush:
   // per-collection pax_vector_quant > env > default-off.
   optional string pax_vector_quant = 29;
+
+  // Phase C: per-collection PAX *format* on/off is encoded as a TAG on `tags`
+  // (convention `pax_vector_format:on|off`), not a typed field, to avoid manual
+  // proto regen (same reason `recall_target` is a tag). Read at SST flush via
+  // `pax_vector_format_tag`. Precedence: kill-switch
+  // `PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE` > this tag > global
+  // `PROXIMADB_PAX_VECTOR_SEGMENTS` default (flipped on in Phase F).
 }
 
 // Canonical scalar type for a collection's embedding column. Mirrors

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -150,17 +150,29 @@ impl SstEngine {
         // Generate SSTable filename with appropriate extension based on block format
         let codec = FilenameCodec::new();
         let mut block_format = BlockFormat::parse_block_format(&self.config().block_format);
-        // P3 Phase B: flag-gated PAX vector segments (default OFF). Reads stay
-        // mixed-format-safe — see
+        // P3 Phase B / Phase C: PAX vector segments. Reads stay mixed-format-
+        // safe — see
         // `segment_format::mixed_format_legacy_and_pax_segments_coexist_and_read_back`
-        // — so flipping this on only changes newly written segments; existing
+        // — so enabling PAX only changes newly written segments; existing
         // ProximaBlocks segments still read back. STAGED ROLLOUT: default OFF in
         // v0.2; the develop→qa recall ratchet (qa-gate `pax-recall-ratchet`,
         // recall@10 >= 0.90 at N=100k) gates the v0.3 flip to default ON.
-        if std::env::var("PROXIMADB_PAX_VECTOR_SEGMENTS")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
-            .unwrap_or(false)
-        {
+        //
+        // Resolution (Phase C escape hatches — see `resolve_pax_segments_enabled`):
+        //   1. Global kill-switch `PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE` forces
+        //      legacy `.sst` for EVERY collection (the default-on reversal valve).
+        //   2. Per-collection `pax_vector_format:on|off` tag on
+        //      `CollectionConfig.tags` — explicit opt-in / opt-out (staged
+        //      adoption; mirrors the `recall_target:` tag convention; stored as a
+        //      tag rather than a typed field because proto regen is manual — see
+        //      collection_types.proto).
+        //   3. Global default `PROXIMADB_PAX_VECTOR_SEGMENTS` (env today; Phase F
+        //      flips the absence case to enabled).
+        if resolve_pax_segments_enabled(
+            env_truthy(PAX_VECTOR_SEGMENTS_DISABLE_ENV),
+            collection_pax_format_tag(params.collection_config.as_ref()),
+            env_truthy(PAX_VECTOR_SEGMENTS_ENV),
+        ) {
             block_format = BlockFormat::PaxBlock;
         }
         let file_extension = match block_format {
@@ -795,6 +807,79 @@ fn tokenize_into(text: &str, out: &mut Vec<String>) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// PAX vector-segment resolution (Phase C escape hatches).
+// ---------------------------------------------------------------------------
+
+/// Global default-on env. Today opt-in (absent → off); Phase F flips the
+/// absence case to enabled.
+const PAX_VECTOR_SEGMENTS_ENV: &str = "PROXIMADB_PAX_VECTOR_SEGMENTS";
+
+/// Global kill-switch. Any truthy value forces legacy `.sst` for EVERY
+/// collection regardless of the per-collection tag or the default-on flip — the
+/// default-on reversal valve (Phase F safety). Follows the `PROXIMADB_DISABLE_*`
+/// convention (`PROXIMADB_DISABLE_SYSTEM_CATALOG`, `PROXIMADB_DISABLE_WAL`).
+const PAX_VECTOR_SEGMENTS_DISABLE_ENV: &str = "PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE";
+
+/// Tag key prefix encoding the per-collection PAX-format override on
+/// `CollectionConfig.tags` — mirrors the `recall_target:` convention
+/// (`services::collection::recall_target`). Stored as a tag rather than a typed
+/// field because the proto-regen pipeline is manual (collection_types.proto).
+const PAX_VECTOR_FORMAT_TAG_PREFIX: &str = "pax_vector_format:";
+
+/// True when `key` is set to a truthy value (`1`/`true`/`on`/`yes`,
+/// case-insensitive). Unset / any other value → false.
+fn env_truthy(key: &str) -> bool {
+    std::env::var(key)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
+        .unwrap_or(false)
+}
+
+/// Read the per-collection `pax_vector_format:on|off` tag from
+/// `CollectionConfig.tags`. `Some(true)` opts the collection INTO PAX even when
+/// the global default is off (staged adoption); `Some(false)` opts it OUT
+/// (legacy `.sst`) even when the global default flips on. Unrecognized values
+/// and absence → `None` (defer to the global default). The last matching tag
+/// wins, matching `parse_recall_target`'s last-wins semantics.
+fn pax_vector_format_tag(config: &crate::proto::proximadb_v1::CollectionConfig) -> Option<bool> {
+    let mut latest: Option<bool> = None;
+    for tag in &config.tags {
+        if let Some(rest) = tag.strip_prefix(PAX_VECTOR_FORMAT_TAG_PREFIX) {
+            latest = match rest.trim().to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" | "yes" => Some(true),
+                "off" | "false" | "0" | "no" => Some(false),
+                _ => latest, // unrecognized value: keep prior resolution
+            };
+        }
+    }
+    latest
+}
+
+/// Traverse `Collection.config` to read the per-collection PAX-format tag.
+fn collection_pax_format_tag(
+    collection: Option<&crate::proto::proximadb_v1::Collection>,
+) -> Option<bool> {
+    collection
+        .as_ref()
+        .and_then(|c| c.config.as_ref())
+        .and_then(pax_vector_format_tag)
+}
+
+/// Resolve whether a flush should emit a PAX vector segment. Pure over its
+/// inputs so the precedence table is unit-testable without touching the process
+/// env. Precedence: kill-switch > per-collection tag > global default.
+fn resolve_pax_segments_enabled(
+    kill_switch: bool,
+    per_collection: Option<bool>,
+    global_default: bool,
+) -> bool {
+    if kill_switch {
+        false
+    } else {
+        per_collection.unwrap_or(global_default)
+    }
+}
+
 #[cfg(test)]
 mod statistics_observe_tests {
     use super::{scalar_text, tokenize_into};
@@ -965,5 +1050,203 @@ mod tests {
             3,
             "the live flush path must index all flushed vectors into AXIS (TD-112)"
         );
+    }
+
+    // ---- Phase C: per-collection PAX opt-out tag + global kill-switch ----
+
+    #[test]
+    fn pax_vector_format_tag_parses_on_off_and_aliases() {
+        use crate::proto::proximadb_v1::CollectionConfig;
+        let cfg = |tags: &[&str]| CollectionConfig {
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        // canonical on/off
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:on"])),
+            Some(true)
+        );
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:off"])),
+            Some(false)
+        );
+        // accepted aliases (case-insensitive, whitespace-trimmed)
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format: TRUE"])),
+            Some(true)
+        );
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:0"])),
+            Some(false)
+        );
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:Yes"])),
+            Some(true)
+        );
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:no"])),
+            Some(false)
+        );
+        // unrecognized value / unrelated tag / absent → None (defer to global)
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:maybe"])),
+            None
+        );
+        assert_eq!(pax_vector_format_tag(&cfg(&["recall_target:0.95"])), None);
+        assert_eq!(pax_vector_format_tag(&cfg(&[])), None);
+        // last matching tag wins
+        assert_eq!(
+            pax_vector_format_tag(&cfg(&["pax_vector_format:on", "pax_vector_format:off"])),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn resolve_pax_segments_enabled_precedence() {
+        // kill-switch dominates everything (the default-on reversal valve).
+        assert!(!resolve_pax_segments_enabled(true, Some(true), true));
+        assert!(!resolve_pax_segments_enabled(true, Some(false), true));
+        assert!(!resolve_pax_segments_enabled(true, None, true));
+        // per-collection tag overrides global default both ways.
+        assert!(resolve_pax_segments_enabled(false, Some(true), false));
+        assert!(!resolve_pax_segments_enabled(false, Some(false), true));
+        // absent per-collection tag → global default.
+        assert!(resolve_pax_segments_enabled(false, None, true));
+        assert!(!resolve_pax_segments_enabled(false, None, false));
+    }
+
+    fn collect_exts(dir: &std::path::Path, out: &mut std::collections::HashSet<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_exts(&path, out);
+            } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                out.insert(ext.to_string());
+            }
+        }
+    }
+
+    /// Flush `records` for a collection carrying `tags` and return the set of
+    /// segment-file extensions written under `base_location`.
+    async fn flush_segment_exts(
+        engine: &SstEngine,
+        collection_id: &str,
+        base_location: &str,
+        tags: Vec<String>,
+        records: Vec<ProximaRecord>,
+    ) -> std::collections::HashSet<String> {
+        use crate::proto::proximadb_v1::{
+            Collection, CollectionConfig, StorageAssignment, StorageEngine,
+        };
+        use crate::storage::traits::UnifiedStorageFormat;
+        let collection = Collection {
+            id: collection_id.to_string(),
+            config: Some(CollectionConfig {
+                name: collection_id.to_string(),
+                dimension: 4,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                tags,
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: base_location.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let params = FlushParameters {
+            collection_id: Some(collection_id.to_string()),
+            vector_records: records,
+            force: true,
+            synchronous: true,
+            hints: std::collections::HashMap::new(),
+            timeout_ms: None,
+            trigger_compaction: false,
+            batch_ids: vec![],
+            collection_config: Some(collection),
+            estimated_size: 0,
+        };
+        let result = engine
+            .do_flush(&params)
+            .await
+            .expect("flush should succeed");
+        assert!(result.success, "flush should succeed");
+
+        let mut exts = std::collections::HashSet::new();
+        collect_exts(std::path::Path::new(base_location), &mut exts);
+        assert!(
+            !exts.is_empty(),
+            "expected at least one flushed segment under {base_location}"
+        );
+        exts
+    }
+
+    /// Staged adoption: with no PAX env set, a `pax_vector_format:on` tag opts
+    /// the collection INTO PAX — the flush emits a `.pax` segment.
+    #[tokio::test]
+    async fn pax_optin_tag_writes_pax_segment_without_env() {
+        // nextest isolates each test in its own process; `set_var`/`remove_var`
+        // are `unsafe` (edition 2024).
+        unsafe {
+            std::env::remove_var(PAX_VECTOR_SEGMENTS_ENV);
+            std::env::remove_var(PAX_VECTOR_SEGMENTS_DISABLE_ENV);
+        }
+        let engine = create_test_engine().await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let base = temp_dir.path().to_str().unwrap();
+        let records = vec![
+            create_test_vector("v0", vec![1.0, 0.0, 0.0, 0.0]),
+            create_test_vector("v1", vec![0.0, 1.0, 0.0, 0.0]),
+        ];
+        let exts = flush_segment_exts(
+            &engine,
+            "pax_optin_tag",
+            base,
+            vec!["pax_vector_format:on".to_string()],
+            records,
+        )
+        .await;
+        assert!(
+            exts.contains("pax"),
+            "opt-in tag should write a .pax segment (got {exts:?})"
+        );
+    }
+
+    /// Global kill-switch forces legacy `.sst` even when the collection opts in
+    /// via tag — the default-on reversal valve.
+    #[tokio::test]
+    async fn pax_kill_switch_forces_legacy_sst_even_with_optin_tag() {
+        unsafe {
+            std::env::set_var(PAX_VECTOR_SEGMENTS_DISABLE_ENV, "1");
+        }
+        let engine = create_test_engine().await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let base = temp_dir.path().to_str().unwrap();
+        let records = vec![
+            create_test_vector("v0", vec![1.0, 0.0, 0.0, 0.0]),
+            create_test_vector("v1", vec![0.0, 1.0, 0.0, 0.0]),
+        ];
+        let exts = flush_segment_exts(
+            &engine,
+            "pax_kill_switch",
+            base,
+            vec!["pax_vector_format:on".to_string()],
+            records,
+        )
+        .await;
+        assert!(
+            exts.contains("sst"),
+            "kill-switch should force a legacy .sst segment (got {exts:?})"
+        );
+        assert!(
+            !exts.contains("pax"),
+            "kill-switch must suppress .pax even with an opt-in tag (got {exts:?})"
+        );
+        unsafe {
+            std::env::remove_var(PAX_VECTOR_SEGMENTS_DISABLE_ENV);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase C of the PAX default-on roadmap (`~/.claude/plans/cosmic-launching-treehouse.md`):
adds the two escape hatches that make the eventual **default-on flip (Phase F)** reversible
and granular, **before** the flip lands.

> Default-on remains **OFF** here — this PR only adds the hatches. Critical path to
> default-on: **A (compaction, #580) + B (SIFT artifact) + this (C) + F (flip).**

### 1. Per-collection opt-out — `pax_vector_format` tag
A `pax_vector_format:on|off` tag on `CollectionConfig.tags`:
- `on` → opts a collection **INTO** PAX even when the global default is off (**staged adoption**).
- `off` → opts it **OUT** (legacy `.sst`) even after default-on flips.

Mirrors the existing `recall_target:` tag convention (`services::collection::recall_target`).
Stored as a tag rather than a typed field because the proto-regen pipeline is manual
(same reason `recall_target` is a tag — see `collection_types.proto`).

### 2. Global kill-switch — `PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE`
Any truthy value forces legacy `.sst` for **EVERY** collection regardless of per-collection
config or the default-on flip — the **default-on reversal valve** (Phase F safety). Follows
the established `PROXIMADB_DISABLE_*` convention (`PROXIMADB_DISABLE_SYSTEM_CATALOG`,
`PROXIMADB_DISABLE_WAL`).

## Precedence at flush

```
kill-switch (PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE)
  > per-collection pax_vector_format tag
  > global default (PROXIMADB_PAX_VECTOR_SEGMENTS today; Phase F flips absence → on)
```

The resolution lives in pure, env-free helpers (`pax_vector_format_tag`,
`resolve_pax_segments_enabled`) so the precedence table is unit-tested without touching the
process env. Flush site (`flush/mod.rs`) reads the envs at the boundary and delegates.

## Why tag-based (not a typed proto field)
A typed `optional bool pax_vector_format` would have meant manual proto regen + editing ~20
`CollectionConfig` construction sites + satisfying the proto-compat / OpenAPI / SDK drift
gates — heavy for an ops escape hatch. The codebase's *own* documented convention
(`collection_types.proto:74-79`) is to store such knobs as tags to avoid manual regen.
The tag is documented in the proto comment for discoverability.

## Blast radius
**No proto field added** → no Rust/Python/SDK stub regen, no OpenAPI change, no drift gates
touched. Only `flush/mod.rs` + a proto comment.

## Testing
Four tests in `flush::tests` (nextest, process-isolated for the env-touching ones):
- `pax_vector_format_tag_parses_on_off_and_aliases` — pure; on/off + aliases, case-insensitive,
  trim, last-wins, unrecognized→None.
- `resolve_pax_segments_enabled_precedence` — pure; full kill-switch > tag > default truth table.
- `pax_optin_tag_writes_pax_segment_without_env` — integration; `on` tag → `.pax` segment with no env.
- `pax_kill_switch_forces_legacy_sst_even_with_optin_tag` — integration; kill-switch overrides `on` tag → `.sst`.

Local: `cargo fmt`, `cargo clippy -p proximadb --lib --bins` (CI gate), and the four tests all green.

## Roadmap status
- ✅ A (PAX compaction) — #580
- ✅ **C (this PR)** — opt-out + kill-switch
- ⏳ B (SIFT recall artifact) — the remaining gating artifact
- ⏳ F (default-on flip) — after A + B(artifact) + C; mandates a one-release-window ship-OFF
