### PR TITLE
feat(storage): typed collection DATA path (ADR-031 Phase 4c, create-side, default-OFF)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4436,6 +4436,20 @@ pub trait Catalog: Send + Sync {
     async fn max_object_id(&self) -> anyhow::Result<Option<u64>> {
         Ok(None)
     }
+    /// ADR-031 Phase 4c: pre-mint the typed identity triple
+    /// `(account_u32, namespace_u16, collection_u32)` for a collection being
+    /// created under `account`/`namespace_key`, BEFORE storage-dir creation.
+    /// The root composes a `CollectionIdentity` from it for the typed DATA path.
+    /// `None` when no account is known (legacy, mixed-safe). Idempotent with the
+    /// later `create_table`→`mint_stable_identity` (preserves pre-stamped values
+    /// via the shared `resolve_typed_triple`). Default `None`.
+    async fn mint_collection_typed_identity(
+        &self,
+        _account: &str,
+        _namespace_key: &str,
+    ) -> anyhow::Result<Option<(u32, u16, u32)>> {
+        Ok(None)
+    }
     async fn update_namespace_properties(
         &self,
         namespace: &[String],

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -289,16 +289,22 @@ impl NativeCatalog {
     /// otherwise the schema keeps `None` for both (legacy path, mixed-read-safe).
     /// The namespace u16 is STABLE per namespace (every collection in the same
     /// `namespace_key` gets the same u16) via the transient `namespace_registry`.
-    async fn mint_stable_identity(
+    /// ADR-031 Phase 4c: the single mint path for the typed identity triple
+    /// `(account_u32, namespace_u16, collection_u32)`. Shared by
+    /// [`mint_stable_identity`] (create_table) and the public
+    /// [`Catalog::mint_collection_typed_identity`] (pre-mint before storage-dir
+    /// creation) so both hit the SAME `stable_ids` allocators — pre-stamped
+    /// values are preserved (`existing_*` via `unwrap_or_else`), no double-mint.
+    /// Returns `None` when no account is known (legacy/anonymous → no typed path).
+    async fn resolve_typed_triple(
         &self,
         account_str: &str,
         namespace_key: &str,
-        schema: &mut CatalogTableSchema,
-    ) {
-        let Some(account) = self.account_u32(account_str).await else {
-            return; // no account → no typed identity (legacy)
-        };
-        let ns = schema.stable_namespace_id.unwrap_or_else(|| {
+        existing_ns: Option<u16>,
+        existing_coll: Option<u32>,
+    ) -> Option<(u32, u16, u32)> {
+        let account = self.account_u32(account_str).await?; // None → legacy
+        let ns = existing_ns.unwrap_or_else(|| {
             // First collection in this namespace (this run) → mint a per-account
             // namespace u16 + remember it so siblings reuse it.
             *self
@@ -306,11 +312,36 @@ impl NativeCatalog {
                 .entry(namespace_key.to_string())
                 .or_insert_with(|| self.stable_ids.mint_namespace_id(account))
         });
-        schema.stable_namespace_id = Some(ns);
-        let coll = schema
-            .stable_collection_id
-            .unwrap_or_else(|| self.stable_ids.mint_collection_id(account, ns));
-        schema.stable_collection_id = Some(coll);
+        let coll = existing_coll.unwrap_or_else(|| self.stable_ids.mint_collection_id(account, ns));
+        Some((account, ns, coll))
+    }
+
+    /// ADR-031 Phase 4a: mint the per-scope typed identity (`stable_namespace_id`
+    /// u16, `stable_collection_id` u32) for a collection being created under
+    /// `account_str` in `namespace_key`. Minted only when an account is known;
+    /// otherwise the schema keeps `None` for both (legacy path, mixed-read-safe).
+    /// The namespace u16 is STABLE per namespace (every collection in the same
+    /// `namespace_key` gets the same u16) via the transient `namespace_registry`.
+    /// Idempotent: pre-stamped `stable_*_id` (e.g. from a Phase 4c pre-mint) are
+    /// preserved — `resolve_typed_triple` short-circuits, no re-mint/drift.
+    async fn mint_stable_identity(
+        &self,
+        account_str: &str,
+        namespace_key: &str,
+        schema: &mut CatalogTableSchema,
+    ) {
+        if let Some((_acct, ns, coll)) = self
+            .resolve_typed_triple(
+                account_str,
+                namespace_key,
+                schema.stable_namespace_id,
+                schema.stable_collection_id,
+            )
+            .await
+        {
+            schema.stable_namespace_id = Some(ns);
+            schema.stable_collection_id = Some(coll);
+        }
     }
 
     /// ADR-031 Phase 4a: recover the per-scope allocator floors from a loaded
@@ -1364,6 +1395,20 @@ impl Catalog for NativeCatalog {
         Ok(self.object_name_index.read().await.values().copied().max())
     }
 
+    async fn mint_collection_typed_identity(
+        &self,
+        account: &str,
+        namespace_key: &str,
+    ) -> Result<Option<(u32, u16, u32)>> {
+        // Phase 4c pre-mint: a fresh typed triple (no existing values) via the
+        // shared `resolve_typed_triple`. The caller stamps it onto the schema
+        // before create_table, whose `mint_stable_identity` then preserves it
+        // (idempotent — no double-mint).
+        Ok(self
+            .resolve_typed_triple(account, namespace_key, None, None)
+            .await)
+    }
+
     async fn update_namespace_properties(
         &self,
         namespace: &[String],
@@ -2050,6 +2095,69 @@ mod tests {
         // A genuinely new account mints above the recovered floor (2, not 1).
         let new_acct = cat2.account_u32("other").await.expect("mint new");
         assert_eq!(new_acct, 2, "new account mints above recovered floor");
+    }
+
+    #[tokio::test]
+    async fn mint_collection_typed_identity_is_idempotent_with_mint_stable_identity() {
+        // ADR-031 Phase 4c: the pre-mint (`mint_collection_typed_identity`) and
+        // the create_table mint (`mint_stable_identity`) MUST agree — the
+        // pre-minted values are preserved (no double-mint / drift), because both
+        // hit the SAME `resolve_typed_triple` with `existing_*` short-circuits.
+        // This is the correctness invariant that lets the manager pre-mint for
+        // the typed DATA path before create_table stamps the schema.
+        use crate::Catalog; // trait method in scope
+        let (cat, _d) = catalog_in_tempdir().await;
+
+        // Phase 4c pre-mint: a fresh typed triple (no existing values).
+        let triple = cat
+            .mint_collection_typed_identity("acct", "ns1")
+            .await
+            .expect("mint ok")
+            .expect("Some triple");
+        let (acct, ns, coll) = triple;
+
+        // Stamp the pre-minted values onto a schema (as the manager does via
+        // `__typed_identity` → `schema.stable_*_id`).
+        let mut schema = CatalogTableSchema::new("col1");
+        schema.stable_namespace_id = Some(ns);
+        schema.stable_collection_id = Some(coll);
+
+        // create_table's mint path: `mint_stable_identity` MUST preserve the
+        // pre-stamped values (idempotent) — not re-mint new ones.
+        cat.mint_stable_identity("acct", "ns1", &mut schema).await;
+        assert_eq!(
+            schema.stable_namespace_id,
+            Some(ns),
+            "ns id preserved (no double-mint)"
+        );
+        assert_eq!(
+            schema.stable_collection_id,
+            Some(coll),
+            "coll id preserved (no double-mint)"
+        );
+
+        // And the account u32 matches what the pre-mint used.
+        assert_eq!(cat.account_u32("acct").await, Some(acct));
+
+        // A SECOND collection in the same namespace reuses the ns u16 but mints
+        // a new collection u32 (the pre-mint for col1 did NOT consume col2's id
+        // — `resolve_typed_triple` mints per-collection only when unset).
+        let triple2 = cat
+            .mint_collection_typed_identity("acct", "ns1")
+            .await
+            .expect("mint ok")
+            .expect("Some triple");
+        assert_eq!(triple2.1, ns, "same namespace → same ns u16");
+        assert_eq!(triple2.2, coll + 1, "next collection → coll u32 + 1");
+    }
+
+    #[tokio::test]
+    async fn mint_collection_typed_identity_returns_none_for_no_account() {
+        // Legacy/anonymous → None (no typed path; mixed-read-safe).
+        use crate::Catalog;
+        let (cat, _d) = catalog_in_tempdir().await;
+        let triple = cat.mint_collection_typed_identity("", "ns").await;
+        assert!(triple.unwrap().is_none(), "empty account → None");
     }
 
     // Note: These tests require a mock filesystem or temp directory

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -71,8 +71,13 @@ use tracing::{debug, error, info, warn};
 // Using String directly instead of String alias for proto-first architecture
 use crate::catalog::CatalogManager;
 use crate::core::config::StorageConfig;
+use crate::core::stable_id::CollectionIdentity;
 use crate::proto::proximadb_v1::{Collection, CollectionConfig, StorageEngine};
 use crate::storage::persistence::filesystem::FilesystemFactory;
+use crate::storage::trait_components::path_resolver::{
+    collection_data_path_typed, collection_index_path_typed, collection_wal_path_typed,
+    typed_paths_enabled,
+};
 use proximadb_storage_common::storage_path::StoragePath;
 
 // Proto-first architecture - use crate::proto::proximadb_v1::Collection directly
@@ -1019,10 +1024,36 @@ impl CollectionService {
                 .clone()
         };
 
+        // ADR-031 Phase 4c: pre-mint the typed collection identity
+        // `(account, namespace, collection)` BEFORE storage-dir creation, so the
+        // DATA/WAL/index dirs are created at the typed account-rooted path
+        // (`accounts/{base62}/…`) when `PROXIMADB_TYPED_PATHS=1` AND an account
+        // is known. The same triple is threaded to `upsert_collection_catalog_asset`
+        // so the persisted schema's `stable_namespace_id`/`stable_collection_id`
+        // match the path (create_table→`mint_stable_identity` then preserves them
+        // — idempotent, no double-mint). `None` when env OFF or no account → every
+        // path is byte-identical legacy (mixed-read-safe per-collection).
+        //
+        // The account string is derived from the tenant context inside
+        // `mint_typed_identity_for_collection` (Phase 4 collapses tenant into
+        // account; see the helper for the rationale + the Phase 5 forward-note).
+        let typed_identity = if typed_paths_enabled() {
+            self.mint_typed_identity_for_collection(tenant_context, &enriched_config.name, &uuid)
+                .await
+        } else {
+            None
+        };
+
         // Create storage directories (tenant-isolated if multi-tenant mode)
         let tenant_id = tenant_context.map(|ctx| ctx.tenant_id.as_str());
         let _storage_created = self
-            .create_storage_directories(&base_location, &enriched_config.name, &uuid, tenant_id)
+            .create_storage_directories(
+                &base_location,
+                &enriched_config.name,
+                &uuid,
+                tenant_id,
+                typed_identity,
+            )
             .await
             .context("Failed to create storage directories")?;
 
@@ -1054,7 +1085,7 @@ impl CollectionService {
         };
 
         if let Err(e) = self
-            .upsert_collection_catalog_asset(&proto_collection)
+            .upsert_collection_catalog_asset(&proto_collection, typed_identity)
             .await
         {
             return Ok(CollectionServiceResponse::error(
@@ -1546,7 +1577,7 @@ impl CollectionService {
             }
             record.updated_at = chrono::Utc::now().timestamp_millis();
 
-            self.upsert_collection_catalog_asset(&record).await?;
+            self.upsert_collection_catalog_asset(&record, None).await?;
         } else {
             warn!(
                 "⚠️ Attempted to update stats for non-existent collection: {}",
@@ -1692,7 +1723,7 @@ impl CollectionService {
                 .context("Failed to remove previous collection catalog asset")?;
         }
 
-        self.upsert_collection_catalog_asset(&record)
+        self.upsert_collection_catalog_asset(&record, None)
             .await
             .context("Failed to update collection catalog metadata")?;
 
@@ -1818,7 +1849,7 @@ impl CollectionService {
         }
 
         // Store the updated collection in the catalog (the sole authority).
-        self.upsert_collection_catalog_asset(&updated_collection)
+        self.upsert_collection_catalog_asset(&updated_collection, None)
             .await
             .context("Failed to update collection compression in catalog")?;
 
@@ -1872,15 +1903,80 @@ impl CollectionService {
         Ok(())
     }
 
+    /// ADR-031 Phase 4c: pre-mint the typed collection identity
+    /// `(account_u32, namespace_u16, collection_u32)` for a collection being
+    /// created, BEFORE storage-dir creation. The catalog mints the triple from
+    /// the SAME `stable_ids` allocators that `create_table`→`mint_stable_identity`
+    /// later hits, so the values are preserved (idempotent — no double-mint).
+    ///
+    /// Returns `None` when:
+    /// * no `catalog_manager` is configured (no catalog to mint against), or
+    /// * the tenant context carries no `account_id` (single-tenant / anonymous —
+    ///   the typed path is account-rooted, so no account ⇒ no typed path), or
+    /// * the catalog returns `None` (e.g. account registry lookup fails).
+    ///
+    /// `None` ⇒ the caller uses legacy byte-identical paths (mixed-read-safe).
+    async fn mint_typed_identity_for_collection(
+        &self,
+        tenant_context: Option<&crate::storage::tenant::TenantContext>,
+        collection_name: &str,
+        _collection_id: &str,
+    ) -> Option<CollectionIdentity> {
+        let catalog_manager = self.catalog_manager.as_ref()?;
+        // The account string is the SaaS billing/isolation tier — the top of the
+        // typed path (`accounts/{base62}/…`). ADR-031 Phase 4 collapses the
+        // tenant tier into the account, so the collection's owning TENANT (the
+        // `tenant_context.tenant_id`, mirroring `collection_tenant_id` /
+        // `tenant_id_of`) serves as the account string for typed-path minting.
+        // `None` when no tenant context ⇒ single-tenant/anonymous ⇒ no typed
+        // path (legacy, mixed-read-safe). NOTE: the network-layer
+        // `MiddlewareTenantContext.account_id` is a separate (Phase 5) field not
+        // threaded to the storage-layer `StorageTenantContext` yet; when it is,
+        // prefer it here. Until then the tenant IS the account (Phase 4 collapse).
+        let account = tenant_context.map(|ctx| ctx.tenant_id.as_str())?;
+        if account.is_empty() {
+            return None;
+        }
+        // Derive the namespace_key the SAME way `upsert_collection_catalog_asset`
+        // → `collection_table_identifier` scopes the asset: parse the qualified
+        // name, default the namespace to `["default"]` when bare (mirrors
+        // `collection_table_identifier`). Joined on '.' → the catalog namespace
+        // key, so the pre-minted namespace u16 matches the schema's landing ns.
+        let parsed = crate::catalog::TableIdentifier::parse(collection_name);
+        let namespace_key = if parsed.namespace.is_empty() {
+            "default".to_string()
+        } else {
+            parsed.namespace.join(".")
+        };
+
+        let catalog = catalog_manager.default_catalog().await.ok()?;
+        let triple = catalog
+            .mint_collection_typed_identity(account, &namespace_key)
+            .await
+            .ok()
+            .flatten()?;
+        Some(CollectionIdentity {
+            account_id: triple.0,
+            namespace_id: triple.1,
+            collection_id: triple.2,
+        })
+    }
+
     /// Create storage directories for a new collection
     ///
     /// For multi-tenant deployments, paths are isolated under `{base}/tenants/{tenant_id}/`.
+    /// ADR-031 Phase 4c: when `typed_identity` is `Some`, the data/wal/index
+    /// dirs are created at the typed account-rooted path
+    /// (`{base}/accounts/{base62}/…/{sub}`) instead of the tenant/legacy path.
+    /// `None` keeps the legacy `StoragePath::collection_*_path_with_tenant`
+    /// (byte-identical, mixed-read-safe).
     async fn create_storage_directories(
         &self,
         base_location: &str,
         collection_name: &str,
         collection_uuid: &str,
         tenant_id: Option<&str>,
+        typed_identity: Option<CollectionIdentity>,
     ) -> Result<Vec<StorageComponentType>> {
         let tenant_info = tenant_id.unwrap_or("(default)");
         info!(
@@ -1890,19 +1986,37 @@ impl CollectionService {
 
         let mut created_components = Vec::new();
 
-        // Build paths under base location using StoragePath utility (tenant-aware)
-        let write_buffer_dir =
-            StoragePath::collection_wal_path_with_tenant(base_location, tenant_id, collection_uuid);
-        let data_dir = StoragePath::collection_data_path_with_tenant(
-            base_location,
-            tenant_id,
-            collection_uuid,
-        );
-        let indexes_dir = StoragePath::collection_index_path_with_tenant(
-            base_location,
-            tenant_id,
-            collection_uuid,
-        );
+        // ADR-031 Phase 4c: typed path short-circuits the tenant/legacy layout.
+        // The typed helper's `None` branch is byte-identical to the legacy
+        // `StoragePath::collection_*_path` (non-tenant) — but the create path
+        // here historically used the `_with_tenant` variant. To preserve that
+        // exactly when no typed identity is set, fall through to the tenant-aware
+        // StoragePath calls below for `None`. For `Some`, use the typed helpers
+        // (the typed path has NO tenant slot — Phase 4 hierarchy collapse).
+        let (write_buffer_dir, data_dir, indexes_dir) = match typed_identity {
+            Some(id) => (
+                collection_wal_path_typed(base_location, collection_uuid, Some(id)),
+                collection_data_path_typed(base_location, collection_uuid, Some(id)),
+                collection_index_path_typed(base_location, collection_uuid, Some(id)),
+            ),
+            None => (
+                StoragePath::collection_wal_path_with_tenant(
+                    base_location,
+                    tenant_id,
+                    collection_uuid,
+                ),
+                StoragePath::collection_data_path_with_tenant(
+                    base_location,
+                    tenant_id,
+                    collection_uuid,
+                ),
+                StoragePath::collection_index_path_with_tenant(
+                    base_location,
+                    tenant_id,
+                    collection_uuid,
+                ),
+            ),
+        };
 
         // Create directories
         if let Ok(filesystem) = self.filesystem_factory.get_filesystem(base_location) {
@@ -2039,7 +2153,11 @@ impl CollectionService {
         Ok(cleaned_components)
     }
 
-    async fn upsert_collection_catalog_asset(&self, collection: &Collection) -> Result<()> {
+    async fn upsert_collection_catalog_asset(
+        &self,
+        collection: &Collection,
+        typed_identity: Option<CollectionIdentity>,
+    ) -> Result<()> {
         let Some(catalog_manager) = &self.catalog_manager else {
             return Ok(());
         };
@@ -2095,6 +2213,18 @@ impl CollectionService {
         // un-unified — mixed-read-safe).
         if let Ok(oid) = collection.id.parse::<u64>() {
             schema.object_id = Some(oid);
+        }
+        // ADR-031 Phase 4c: stamp the pre-minted typed identity onto the schema
+        // so the persisted `stable_namespace_id`/`stable_collection_id` match
+        // the typed DATA path that `create_storage_directories` just created.
+        // `create_table`→`mint_stable_identity` then preserves these (idempotent
+        // via `resolve_typed_triple`'s `existing_*` short-circuit — no double-mint).
+        // `None` (update/import paths, or env OFF) leaves them unset → legacy path
+        // (mixed-read-safe). This is the ONLY channel from the manager's pre-mint
+        // into the catalog schema (the proto `Collection` carries no properties map).
+        if let Some(id) = typed_identity {
+            schema.stable_namespace_id = Some(id.namespace_id);
+            schema.stable_collection_id = Some(id.collection_id);
         }
         if catalog.table_exists(&identifier).await? {
             let mut existing = catalog.get_table(&identifier).await?;

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -278,6 +278,12 @@ fn object_store_write_base_path(
     schema: &CatalogTableSchema,
     tenant_context: Option<&TenantContext>,
 ) -> String {
+    // TODO ADR-031 Phase 4d: thread the collection's pre-minted
+    // `CollectionIdentity` (from `schema.stable_namespace_id` /
+    // `stable_collection_id` + the account u32) into `DrPathBuilder::build_from_identity`
+    // when `typed_paths_enabled()`, so Parquet exports land at the typed
+    // account-rooted path (`accounts/{base62}/…/`). Today this builds the legacy
+    // string-resolved path (mixed-read-safe; env gate OFF).
     let tenant_id = tenant_context
         .map(|tc| tc.tenant_id.as_str())
         .unwrap_or("default_tenant");

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -6,7 +6,6 @@ use crate::storage::{
     persistence::disk_manager::DiskManager,
 };
 use proximadb_records::{EmbeddingCell, ProximaRecord};
-use proximadb_storage_common::storage_path::StoragePath;
 // Import ProximaBlockCollectionMetadata from the appropriate location
 use crate::storage::engines::core::formats::proximablocks::header_metadata::ProximaBlockCollectionMetadata;
 use dashmap::DashMap;
@@ -750,14 +749,41 @@ impl StorageEngine {
         collection_id: String,
         base_location: String,
     ) -> crate::storage::Result<()> {
+        // ADR-031 Phase 4c: this low-level entrypoint has no catalog/schema
+        // handle, so it cannot resolve a typed identity. Delegates to the
+        // typed-aware inner with `None` → byte-identical legacy paths. The
+        // authoritative create path (`CollectionService::create_storage_directories`)
+        // threads the pre-minted identity and creates the typed dirs; this path
+        // is a fallback that stays legacy (mixed-read-safe).
+        self.create_collection_with_storage_typed(collection_id, base_location, None)
+            .await
+    }
+
+    /// ADR-031 Phase 4c: typed-aware storage create. `Some(identity)` creates
+    /// the data/wal/index dirs at the account-rooted typed path
+    /// (`{base}/accounts/{base62}/…/{sub}`); `None` is byte-identical legacy.
+    /// Callers that hold a pre-minted [`CollectionIdentity`] (resolved from the
+    /// catalog's `stable_*_id` + account u32) pass it here so the engine writes
+    /// to the same typed path the catalog asset records.
+    pub async fn create_collection_with_storage_typed(
+        &self,
+        collection_id: String,
+        base_location: String,
+        typed_identity: Option<crate::core::stable_id::CollectionIdentity>,
+    ) -> crate::storage::Result<()> {
         // NOTE: Collection metadata should be managed by CollectionService
         // Storage layer should only handle storage concerns, not metadata
         tracing::debug!("💾 Creating storage for collection: {}", collection_id);
 
-        // Create directory paths based on base_location
-        let data_url = StoragePath::collection_data_path(&base_location, &collection_id);
-        let write_buffer_url = StoragePath::collection_wal_path(&base_location, &collection_id);
-        let index_url = StoragePath::collection_index_path(&base_location, &collection_id);
+        // Create directory paths based on base_location. The typed helper's
+        // `None` branch is byte-identical to the legacy `StoragePath::collection_*_path`.
+        use crate::storage::trait_components::path_resolver::{
+            collection_data_path_typed, collection_index_path_typed, collection_wal_path_typed,
+        };
+        let data_url = collection_data_path_typed(&base_location, &collection_id, typed_identity);
+        let write_buffer_url =
+            collection_wal_path_typed(&base_location, &collection_id, typed_identity);
+        let index_url = collection_index_path_typed(&base_location, &collection_id, typed_identity);
 
         // Create all required directories for the collection
         // This ensures directories exist before any writes occur

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -1110,7 +1110,13 @@ impl ViperEngine {
             "🔍 VIPER Engine: Looking up vector {} in collection {} at {}",
             vector_id, collection_id, base_path
         );
-        // Get all Parquet files from {base_path}/{collection_id}/data
+        // Get all Parquet files from {base_path}/{collection_id}/data.
+        // TODO ADR-031 Phase 4d: when `PROXIMADB_TYPED_PATHS=1`, this must resolve
+        // the typed account-rooted path (`accounts/{base62}/…/data`) via
+        // `collection_data_path_typed` using the collection's pre-minted
+        // `CollectionIdentity` (threaded from the catalog's `stable_*_id` +
+        // account u32). Until then the env gate stays OFF and this legacy path
+        // is byte-identical to the typed helper's `None` branch (mixed-read-safe).
         let data_dir = StoragePath::collection_data_path(base_path, collection_id);
         let parquet_files = self.list_parquet_files_in_dir(&data_dir).await?;
         if parquet_files.is_empty() {

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -47,6 +47,7 @@ use dashmap::DashMap;
 use proximadb_catalog::{
     CatalogNamespace, CatalogProjectionKind, CatalogTableSchema, StoragePoolClass,
 };
+use proximadb_storage_common::StoragePath;
 use std::sync::Arc;
 
 /// Storage location assignment for a collection
@@ -526,6 +527,82 @@ pub fn typed_paths_enabled() -> bool {
         Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),
         Err(_) => false,
     })
+}
+
+// ---------------------------------------------------------------------------
+// ADR-031 Phase 4c: typed collection DATA subpaths.
+// ---------------------------------------------------------------------------
+//
+// `CollectionIdentity` is a ROOT type (`crate::core::stable_id`); `StoragePath`
+// lives in `proximadb-storage-common`, which CANNOT import root types (workspace
+// boundary). So the typed variants live HERE — a root helper that wraps the
+// legacy `StoragePath` calls for the `None` (legacy) branch and composes the
+// account-rooted zero-padded base62 path for the `Some(identity)` branch.
+//
+// Both branches share the SAME trailing subpath suffix as the legacy
+// `StoragePath::collection_*_path` (`/data`, `/wal`, `/indexes` — NO trailing
+// slash), so the `None` branch is **byte-identical** to the pre-4c path and the
+// `Some` branch differs only in the prefix (mixed-read-safe per-collection).
+
+/// ADR-031 Phase 4c: typed collection **data** directory path.
+///
+/// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/data`
+///   (zero-padded base62, no tenant slot — Phase 4 hierarchy collapse).
+/// * `None`           → byte-identical legacy
+///   [`StoragePath::collection_data_path`] (`{base}/{collection_id}/data`).
+///
+/// The trailing suffix (`/data`, no slash) matches the legacy contract exactly
+/// so reads/writes against a legacy collection (`None`) resolve unchanged.
+pub fn collection_data_path_typed(
+    base: &str,
+    collection_id: &str,
+    identity: Option<CollectionIdentity>,
+) -> String {
+    match identity {
+        Some(id) => {
+            let (acct, ns, coll) = id.path_segments();
+            format!("{base}/accounts/{acct}/{ns}/{coll}/data")
+        }
+        None => StoragePath::collection_data_path(base, collection_id),
+    }
+}
+
+/// ADR-031 Phase 4c: typed collection **WAL** directory path.
+///
+/// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/wal`.
+/// * `None`           → byte-identical legacy
+///   [`StoragePath::collection_wal_path`] (`{base}/{collection_id}/wal`).
+pub fn collection_wal_path_typed(
+    base: &str,
+    collection_id: &str,
+    identity: Option<CollectionIdentity>,
+) -> String {
+    match identity {
+        Some(id) => {
+            let (acct, ns, coll) = id.path_segments();
+            format!("{base}/accounts/{acct}/{ns}/{coll}/wal")
+        }
+        None => StoragePath::collection_wal_path(base, collection_id),
+    }
+}
+
+/// ADR-031 Phase 4c: typed collection **indexes** directory path.
+///
+/// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/indexes`.
+/// * `None`           → byte-identical legacy
+///   [`StoragePath::collection_index_path`] (`{base}/{collection_id}/indexes`).
+pub fn collection_index_path_typed(
+    base: &str,
+    collection_id: &str,
+    identity: Option<CollectionIdentity>,
+) -> String {
+    match identity {
+        Some(id) => {
+            let (acct, ns, coll) = id.path_segments();
+            format!("{base}/accounts/{acct}/{ns}/{coll}/indexes")
+        }
+        None => StoragePath::collection_index_path(base, collection_id),
+    }
 }
 
 /// Resolve the catalog-addressed index locations for a collection's vector-ANN
@@ -1779,6 +1856,72 @@ mod tests {
         assert_eq!(
             prefixes, sorted,
             "typed collection prefixes must be pre-sorted lexicographically"
+        );
+    }
+
+    // ── ADR-031 Phase 4c: typed collection DATA subpath helpers ──────────
+
+    #[test]
+    fn typed_data_path_is_account_rooted_with_legacy_suffix() {
+        // Some(identity) → {base}/accounts/{acct}/{ns}/{coll}/data
+        // (zero-padded base62, no tenant slot). Trailing suffix `/data` (NO
+        // trailing slash) matches the legacy StoragePath contract.
+        let identity = CollectionIdentity {
+            account_id: 7,
+            namespace_id: 5,
+            collection_id: 9,
+        };
+        let p = collection_data_path_typed("/base", "coll_x", Some(identity));
+        assert_eq!(
+            p, "/base/accounts/000007/005/000009/data",
+            "typed data path"
+        );
+        assert!(
+            !p.ends_with('/'),
+            "no trailing slash (matches legacy /data suffix): {p}"
+        );
+    }
+
+    #[test]
+    fn typed_wal_and_index_paths_match_legacy_suffix_shape() {
+        let identity = CollectionIdentity {
+            account_id: 1,
+            namespace_id: 2,
+            collection_id: 3,
+        };
+        let wal = collection_wal_path_typed("/b", "c", Some(identity));
+        let idx = collection_index_path_typed("/b", "c", Some(identity));
+        assert_eq!(wal, "/b/accounts/000001/002/000003/wal");
+        assert_eq!(idx, "/b/accounts/000001/002/000003/indexes");
+    }
+
+    #[test]
+    fn typed_data_path_none_is_byte_identical_to_legacy_storage_path() {
+        // None → byte-identical legacy StoragePath::collection_data_path
+        // (the mixed-read-safety guarantee for legacy collections).
+        let base = "/data/store";
+        let cid = "my_collection";
+        let typed_none = collection_data_path_typed(base, cid, None);
+        let legacy = StoragePath::collection_data_path(base, cid);
+        assert_eq!(
+            typed_none, legacy,
+            "None branch must be byte-identical to legacy StoragePath"
+        );
+        // And it has the legacy shape {base}/{cid}/data (no trailing slash).
+        assert_eq!(typed_none, "/data/store/my_collection/data");
+    }
+
+    #[test]
+    fn typed_wal_and_index_paths_none_match_legacy() {
+        let base = "s3://bucket/path";
+        let cid = "col_1";
+        assert_eq!(
+            collection_wal_path_typed(base, cid, None),
+            StoragePath::collection_wal_path(base, cid)
+        );
+        assert_eq!(
+            collection_index_path_typed(base, cid, None),
+            StoragePath::collection_index_path(base, cid)
         );
     }
 }


### PR DESCRIPTION
Extends the typed account-rooted prefix from the ANN index location (4b) to the collection DATA path (WAL/SST/records), env-gated `PROXIMADB_TYPED_PATHS=1` (default OFF → byte-identical legacy). **Foundation/default-off** — see KNOWN LIMITATION; not safe to enable yet.

## What
- **Catalog**: factor `resolve_typed_triple` (shared mint path; idempotent — preserves pre-stamped `stable_*_id`, no double-mint) + new `Catalog::mint_collection_typed_identity` (pre-mint the triple before storage-dir creation).
- **Root helpers** `collection_{data,wal,index}_path_typed` (path_resolver.rs — NOT StoragePath; `CollectionIdentity` is root-only, layering): `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/{sub}`; `None` → byte-identical legacy `StoragePath`.
- **Manager**: pre-mint the typed identity (account from `tenant_context` — Phase-4 collapse interim) before `create_storage_directories`; thread it through dir-create + `upsert_collection_catalog_asset` (stamps `stable_*_id` before `create_table`, which preserves). Create dirs at the typed prefix when env ON + identity present.

## KNOWN LIMITATION (env stays default-OFF — do NOT enable yet)
1. **Engine read-path not wired**: engines take only `(collection_id, base_path)` — no identity/catalog — so READs still resolve legacy. env ON would create-at-typed/read-at-legacy → mismatch. Needs Phase 4d (engine read-path).
2. **account_id not threaded in prod**: `create_namespace_inner` hardcodes `account_id: None` → 4a's `mint_stable_identity` is dormant; this PR's tenant-as-account pre-mint is the interim until Phase 5 threads `MiddlewareTenantContext.account_id` → catalog.

Default-OFF = no behavior change. This lands the mechanism; activation needs 4d + Phase 5 + env flip.

## Verified
clippy `--lib -D warnings` clean (catalog + root); catalog 355 + path_resolver 37 tests pass; tenant-path / deterministic-contract / boundary guards clean.
