### PR TITLE
fix(qa-gate): RUST_MIN_STACK=8MB at job level (all test steps)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -66,6 +66,10 @@ jobs:
     name: Integration tests (TPC-H/DS pgwire + PAX recall)
     runs-on: ubuntu-latest
     timeout-minutes: 100
+    env:
+      # 8MB worker stack: correlated subqueries + recall ratchets produce
+      # deep-but-finite async call chains that overflow the default ~2MB.
+      RUST_MIN_STACK: "8388608"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0


### PR DESCRIPTION
The TPC-H step had RUST_MIN_STACK but TPC-DS/PAX/vector-ANN steps didn't → they overflow on the default ~2MB. TPC-H passed 22/22 with 8MB; the overflow was on the NEXT step (TPC-DS). Moving RUST_MIN_STACK to the job level so ALL integration-test steps inherit it. Unblocks #571 (develop→qa).