### PR TITLE
feat(bench): SIFT1M PAX recall ratchet (WS8) — real-dataset default-on gate

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -12,6 +12,14 @@ on:
   push:
     branches: [qa]
   workflow_dispatch:
+    inputs:
+      # WS8 SIFT1M PAX recall ratchet (see the `sift-pax-recall` job). 100000 =
+      # the fast CI floor; 1000000 = the full gating artifact for the default-on
+      # flip (Phase F).
+      sift_n:
+        description: "SIFT base-vector count (100000 floor | 1000000 full gate)"
+        required: false
+        default: "100000"
 
 concurrency:
   group: qa-gate-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -122,6 +130,59 @@ jobs:
         run: cargo test --test raptor_recall_test -- --nocapture
       - name: Run TD-112 post-flush recall ratchet (TD-182 P0b)
         run: cargo test --test td112_postflush_recall_e2e recall -- --nocapture
+
+  # WS8: real-dataset PAX RaBitQ→SQ8 recall artifact. MANUAL ONLY
+  # (workflow_dispatch) — it downloads the SIFT1M corpus (~160 MB) and runs a
+  # heavy recall bench, so it is deliberately NOT in the always-on
+  # `pgwire-recall-tests` job (avoids 160 MB-download flakiness on every qa PR).
+  # Produces the dated recall@10 ≥ 0.90 artifact that GATES the PAX default-on
+  # flip (Phase F): the existing `pax-recall-ratchet` is a synthetic DIM=64 CI
+  # floor only (representativeness caveat in BENCHMARK_EVIDENCE.toml WS8). The
+  # ratchet self-skips when the corpus is absent, so a non-manual trigger would
+  # just skip — the `if:` keeps it from scheduling at all.
+  sift-pax-recall:
+    name: SIFT1M PAX RaBitQ recall ratchet (WS8)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-qa-sift"
+      - name: Cache SIFT1M corpus (TEXMEX .fvecs — no native dep)
+        uses: actions/cache@v4
+        with:
+          path: ~/sift1m
+          key: sift1m-texmem-fvecs-v1
+      - name: Download SIFT1M corpus (HTTPS Hugging Face mirror)
+        run: |
+          mkdir -p "$HOME/sift1m"
+          cd "$HOME/sift1m"
+          base=https://huggingface.co/datasets/qbo-odp/sift1m/resolve/main
+          for f in sift_base.fvecs sift_query.fvecs sift_groundtruth.ivecs; do
+            if [ ! -s "$f" ]; then
+              echo "::group::download $f"
+              curl -L --fail --retry 3 -o "$f" "$base/$f"
+              echo "::endgroup::"
+            fi
+          done
+          ls -lh "$HOME/sift1m"
+      - name: Build ratchet binary
+        env:
+          CARGO_BUILD_JOBS: "4"
+        run: cargo test --test sift_pax_recall_ratchet_test --no-run
+      - name: Run SIFT PAX recall ratchet (N=${{ inputs.sift_n || '100000' }})
+        env:
+          PROXIMADB_SIFT_DATASET_DIR: /home/runner/sift1m
+          PROXIMADB_SIFT_N: ${{ inputs.sift_n || '100000' }}
+          PROXIMADB_SIFT_QUERIES: "1000"
+        run: cargo test --test sift_pax_recall_ratchet_test -- --nocapture
 
   # Validate the object-store access-tier cost lever (TD-168/TD-173) against REAL
   # cloud APIs via emulators — Azurite (Azure), MinIO (S3), fake-gcs (GCP) — the

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -146,6 +146,32 @@ version = "v0.2"
 notes = "qa-gate ratchet (develop→qa promotion). Deterministic seeded LCG corpus (DIM=64). N=1000 REFINE=100 mean recall@10 = 0.9340; N=100000 REFINE=1000 mean recall@10 = 0.9320. Both >= 0.90 ratchet (only goes up, #10). Proves the RaBitQ->SQ8 cascade (stage-1 binary rank -> stage-2 SQ8 rerank, no f32 GET) holds recall at this scale -- a prerequisite for flipping PAX quant default-on (rollout Phase 2). NOTE: REFINE=200 at N=100k gave 0.708; a 1000-wide stage-1 pool (1% of corpus) recovers to 0.932. REPRESENTATIVENESS CAVEAT (audit 2026-06-25, PAX_SUBSTRATE_DESIGN_PLAN_2026_06_25.adoc): this is a DIM=64 synthetic corpus, N<=100k, with a FIXED absolute REFINE=1000 (=1% only at 100k; <0.1% at 1M). It is a fast CI floor, NOT representative of production high-dim embeddings or N>=1M -- the default-on flip (TD-150) is GATED on an additional real-embedding (e.g. SIFT1M / 768-d) N>=1M recall artifact (WS8). Indicative local run, not an SLA."
 
 [[claims]]
+id = "pax_rabitq_sq8_sift1m_recall_at_10"
+claim = "PAX RaBitQ→SQ8 cascade recall@10 on real SIFT (128-d, Euclidean): N=100k indicative 0.9905; N=1M canonical pending qa-gate — WS8 default-on gate"
+metric = "recall_at_10"
+status = "measured"
+asserted_in = ["tests/sift_pax_recall_ratchet_test.rs", ".github/workflows/qa-gate.yml"]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
+bench_command = "PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=1000000 cargo test --test sift_pax_recall_ratchet_test -- --nocapture"
+artifact = "docs/_internal/status/SIFT1M_RECALL_RATCHET_2026_06_30.adoc"
+hardware = "local macOS arm64 (indicative; N=1M canonical = qa-gate `sift-pax-recall`, ubuntu-latest)"
+date = "2026-06-30"
+version = "v0.2"
+notes = """Real-dataset WS8 gate resolving the REPRESENTATIVENESS CAVEAT on the
+synthetic pax_rabitq_sq8_recall_at_10 entry above. RESULT (2026-06-30, indicative):
+on REAL SIFT descriptors the PAX RaBitQ->SQ8 cascade holds recall@10 = 0.9905 at
+N=100k (200 queries, brute-force-L2 GT over the subset) -- well above the 0.90
+floor and HIGHER than the synthetic 0.932, directly refuting the worry that real
+(mildly clustered) data degrades RaBitQ. The N=1M CANONICAL confirmation (SIFT's
+provided .ivecs ground truth) is the qa-gate `sift-pax-recall` job's output
+(workflow_dispatch, ubuntu-latest, 120 min; downloads the ~160 MB TEXMEX corpus).
+The default-on flip (Phase F) remains GATED on that N=1M run recording recall@10
+>= 0.90 here. Dataset format: plain-binary .fvecs/.ivecs (NO hdf5 native dep --
+the plan's mandated evaluation to avoid libhdf5 CI friction). Indicative local
+run, NOT an SLA; N=1M canonical pending qa-gate."""
+
+
+[[claims]]
 id = "pax_footer_cache_ranged_read_economics"
 claim = "PAX footer-cache + ranged-read cloud-economics vs whole-byte (local S3-proxy measurement)"
 metric = "object_store_read_economics"

--- a/docs/_internal/status/SIFT1M_RECALL_RATCHET_2026_06_30.adoc
+++ b/docs/_internal/status/SIFT1M_RECALL_RATCHET_2026_06_30.adoc
@@ -1,0 +1,50 @@
+= SIFT1M PAX RaBitQ→SQ8 Recall Ratchet — WS8 Real-Dataset Run 2026-06-30
+
+== Run provenance
+- **Date:** 2026-06-30
+- **Hardware:** local macOS arm64 (shared dev machine — indicative, *not* an SLA)
+- **Toolchain:** `rust-toolchain.toml` pinned 1.95.0
+- **Dataset:** TEXMEX SIFT1M (`sift_base.fvecs` 1 000 000 × 128, `sift_query.fvecs`,
+  `sift_groundtruth.ivecs`) — plain-binary `.fvecs`/`.ivecs`, no hdf5 native dep.
+  Downloaded from the Hugging Face mirror `qbo-odp/sift1m`.
+- **Command (indicative N=100k subset):**
+  `PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 \
+   PROXIMADB_SIFT_QUERIES=200 cargo test --test sift_pax_recall_ratchet_test \
+   sift_pax_cascade_recall_at_10_ratchet -- --nocapture`
+- **Canonical N=1M command (qa-gate `sift-pax-recall` job):**
+  `PROXIMADB_SIFT_N=1000000 cargo test --test sift_pax_recall_ratchet_test \
+   -- --nocapture` (uses SIFT's provided `.ivecs` ground truth).
+- **Source:** `tests/sift_pax_recall_ratchet_test.rs` — `sift_pax_cascade_recall_at_10_ratchet`.
+
+== Result (real SIFT descriptors, 128-d, Euclidean)
+[cols="1,1,1,1,1", options="header"]
+|===
+| N | Ground truth | Queries | mean recall@10 | ratchet
+
+| 100 000 | brute-force L2 over subset | 200 | 0.9905 | ≥ 0.90 — PASS
+| 1 000 000 | provided `sift_groundtruth.ivecs` | (qa-gate) | *pending qa-gate `sift-pax-recall`* | TBD
+|===
+
+== What this proves
+On **real** SIFT image descriptors (not synthetic LCG), the PAX RaBitQ→SQ8 cascade holds
+**recall@10 = 0.9905 at N=100k** — well above the 0.90 floor and *higher* than the
+synthetic-DIM=64 ratchet's 0.932. This directly refutes the representativeness caveat's
+specific worry that real (mildly clustered) data degrades RaBitQ recall: at N=100k it does
+not. The cascade is sound on real 128-d Euclidean data.
+
+[NOTE]
+====
+**WS8 gate status.** The synthetic `pax_rabitq_sq8_recall_at_10` ratchet's caveat required a
+**real-dataset N≥1M** artifact before the default-on flip (Phase F). This run provides the
+**real-dataset** half (N=100k indicative: 0.9905). The **N=1M canonical** confirmation is the
+qa-gate `sift-pax-recall` job's output (workflow_dispatch, ubuntu-latest, 120 min) — it runs
+the same ratchet at `PROXIMADB_SIFT_N=1000000` against SIFT's provided ground truth. The flip
+remains gated until that N=1M run records recall@10 ≥ 0.90 here.
+====
+
+NOTE: the indicative N=100k run wall-clock ≈ 353 s (load 52 MB + 5 PAX/RaBitQ flush batches
+of 20k + brute-force GT for 200 queries + 200 cascade searches). The N=1M run is ~10× the
+flush cost and is why it lives in a dedicated 120-min CI job rather than the always-on qa-gate
+floor (which would re-download 160 MB on every qa PR).
+
+*Indicative local baseline, NOT an SLA. N=1M canonical pending qa-gate `sift-pax-recall`.*

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -1,0 +1,411 @@
+//! WS8 — real-dataset PAX RaBitQ→SQ8 recall ratchet on SIFT1M.
+//!
+//! The existing PAX recall ratchet (`pax-recall-ratchet`, qa-gate) runs on a
+//! synthetic DIM=64 LCG corpus and explicitly flags itself as NOT representative
+//! of production (clustered / high-dim / N≥1M). The default-on flip (Phase F) is
+//! GATED on a real-dataset recall@10 ≥ 0.90 artifact — this test produces it.
+//!
+//! It mirrors `pax_cascade_prod_search_test` (Euclidean `SstEngine`, PAX env on,
+//! `search_vectors_unified` dispatch) but swaps:
+//!   - synthetic vectors → the real SIFT1M corpus (TEXMEX `.fvecs`, 128-d), and
+//!   - brute-force ground truth → SIFT's provided `.ivecs` neighbours (full 1M),
+//!     or a brute-force oracle over the inserted subset (N < 1M floor).
+//!
+//! Format choice: plain-binary `.fvecs`/`.ivecs` (no native dep), deliberately
+//! avoiding the `hdf5` crate's libhdf5 build friction across CI platforms (the
+//! plan's mandated evaluation). Parsed with std only (little-endian).
+//!
+//! Dataset (env `PROXIMADB_SIFT_DATASET_DIR`):
+//!   - `sift_base.fvecs`       (1 000 000 × 128)  — insert set
+//!   - `sift_query.fvecs`      (10 000 × 128)     — query set
+//!   - `sift_groundtruth.ivecs`(10 000 × 100)     — true neighbours (full 1M only)
+//! Download (qa-gate `sift-pax-recall` job or local):
+//! ```text
+//! curl -L -O https://huggingface.co/datasets/qbo-odp/sift1m/resolve/main/<file>
+//! ```
+//!
+//! Env knobs:
+//!   PROXIMADB_SIFT_DATASET_DIR   dir holding the three files (unset → SKIP)
+//!   PROXIMADB_SIFT_N             insert only the first N base vectors (subset /
+//!                                CI floor); unset → full 1M + provided GT
+//!   PROXIMADB_SIFT_QUERIES       cap the query count (default 1000)
+//!   PROXIMADB_SIFT_RECALL_FLOOR  ratchet threshold (default 0.90)
+//!
+//! nextest isolates each test in its own process, so the PAX env vars set here
+//! don't leak. `set_var` is `unsafe` (edition 2024).
+
+use proximadb::compute::distance_computation::DistanceMetric;
+use proximadb::core::search::{BlockPruneConfig, BlockPruneMode, SearchParams};
+use proximadb::proto::proximadb_v1::{
+    Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
+};
+use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::traits::{
+    FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
+};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const DIMENSION: usize = 128;
+const TOP_K: usize = 10;
+const BATCH_SIZE: usize = 20_000;
+const DEFAULT_QUERIES: usize = 1000;
+
+// ---------------------------------------------------------------------------
+// TEXMEX .fvecs / .ivecs loader (std-only, little-endian — no native dep).
+// ---------------------------------------------------------------------------
+
+/// Read up to `limit` records from an `.fvecs`/`.ivecs` file. Each record is
+/// `[count: i32 LE][count × T LE]` where T is f32 for fvecs. `None` = all.
+fn read_vec_records_f32(path: &Path, limit: Option<usize>) -> std::io::Result<Vec<Vec<f32>>> {
+    let bytes = std::fs::read(path)?;
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos + 4 <= bytes.len() {
+        let dim = i32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+        let need = dim.checked_mul(4).expect("fvecs dim overflow");
+        if pos + need > bytes.len() {
+            break;
+        }
+        let mut v = Vec::with_capacity(dim);
+        for j in 0..dim {
+            let off = pos + j * 4;
+            v.push(f32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()));
+        }
+        pos += need;
+        out.push(v);
+        if matches!(limit, Some(n) if out.len() >= n) {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Read an `.ivecs` file of integer records → `Vec<Vec<u32>>` (SIFT ground-truth
+/// neighbour indices are non-negative).
+fn read_vec_records_u32(path: &Path, limit: Option<usize>) -> std::io::Result<Vec<Vec<u32>>> {
+    let bytes = std::fs::read(path)?;
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos + 4 <= bytes.len() {
+        let dim = i32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+        let need = dim.checked_mul(4).expect("ivecs dim overflow");
+        if pos + need > bytes.len() {
+            break;
+        }
+        let mut v = Vec::with_capacity(dim);
+        for j in 0..dim {
+            let off = pos + j * 4;
+            v.push(i32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as u32);
+        }
+        pos += need;
+        out.push(v);
+        if matches!(limit, Some(n) if out.len() >= n) {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+fn dataset_path(filename: &str) -> Option<PathBuf> {
+    std::env::var("PROXIMADB_SIFT_DATASET_DIR").ok().map(|d| {
+        let mut p = PathBuf::from(d);
+        p.push(filename);
+        p
+    })
+}
+
+/// Squared L2 distance (order-preserving — fine for ranking).
+fn l2_sq(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+/// Brute-force exact top-`k` neighbour ids over `base` for `query` (subset GT).
+fn brute_force_topk(base: &[Vec<f32>], query: &[f32], k: usize) -> Vec<String> {
+    let mut sims: Vec<(usize, f32)> = base
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, l2_sq(query, v)))
+        .collect();
+    sims.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    sims.iter().take(k).map(|(i, _)| format!("v{i}")).collect()
+}
+
+fn vid(i: u32) -> String {
+    format!("v{i}")
+}
+
+fn collection(id: &str, temp_dir: &TempDir) -> Collection {
+    Collection {
+        id: id.to_string(),
+        config: Some(CollectionConfig {
+            name: id.to_string(),
+            dimension: DIMENSION as u32,
+            distance_metric: Some(DistanceMetric::Euclidean as i32),
+            storage_engine: Some(StorageEngine::Sst as i32),
+            ..Default::default()
+        }),
+        storage_assignment: Some(StorageAssignment {
+            base_location: temp_dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn vector_record(i: u32, v: Vec<f32>) -> VectorRecord {
+    VectorRecord {
+        id: vid(i),
+        vector: v,
+        metadata: HashMap::new(),
+        version: Some(1),
+        timestamp: Some(i as i64),
+        updated_at: None,
+        expires_at: None,
+        source: None,
+    }
+}
+
+async fn flush_batch(engine: &SstEngine, collection: &Collection, batch: Vec<VectorRecord>) {
+    let n = batch.len();
+    let params = FlushParameters {
+        collection_id: Some(collection.id.clone()),
+        vector_records: batch.into_iter().map(Into::into).collect(),
+        force: true,
+        synchronous: true,
+        hints: HashMap::new(),
+        timeout_ms: None,
+        trigger_compaction: false,
+        batch_ids: vec![],
+        collection_config: Some(collection.clone()),
+        estimated_size: 0,
+    };
+    let result = engine.do_flush(&params).await.expect("flush succeeds");
+    assert!(result.success, "flush should succeed");
+    assert!(
+        result.entries_flushed.unwrap_or(0) > 0,
+        "flush should write vectors (batch of {n})"
+    );
+}
+
+async fn search_topk(engine: &SstEngine, collection: &Collection, query: Vec<f32>) -> Vec<String> {
+    let ctx = StorageQueryContext {
+        search_params: Arc::new(SearchParams {
+            query_vectors: Some(vec![query]),
+            top_k: Some(TOP_K),
+            distance_metric: Some(DistanceMetric::Euclidean),
+            block_prune: BlockPruneConfig {
+                force_exact: false,
+                mode: BlockPruneMode::Ratio,
+                ratio: 1.0,
+                min_keep: 1,
+                max_keep: 0,
+                min_blocks_override: Some(0),
+            },
+            ..Default::default()
+        }),
+        collection: Arc::new(collection.clone()),
+        metadata: StorageQueryMetadata {
+            collection_id: collection.id.clone(),
+            ..Default::default()
+        },
+        user_context: None,
+        tenant_context: None,
+    };
+    engine
+        .search_vectors_unified(&ctx)
+        .await
+        .expect("search succeeds")
+        .into_iter()
+        .map(|r| r.id)
+        .collect()
+}
+
+/// WS8 real-dataset ratchet: PAX RaBitQ→SQ8 cascade recall@10 on SIFT1M.
+#[tokio::test]
+async fn sift_pax_cascade_recall_at_10_ratchet() {
+    // PAX write-default stays OFF in prod; opt this collection in via env so `.pax`
+    // segments flush + RaBitQ-code (the cascade is the only path that can rank
+    // them). nextest isolates each test in its own process.
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+    }
+
+    let base_path = match dataset_path("sift_base.fvecs") {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "skip: PROXIMADB_SIFT_DATASET_DIR unset — SIFT1M ratchet needs the TEXMEX corpus"
+            );
+            return;
+        }
+    };
+    if !base_path.exists() {
+        eprintln!("skip: {base_path:?} not found — download SIFT1M (.fvecs) to enable");
+        return;
+    }
+
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+    let subset_n: Option<usize> = std::env::var("PROXIMADB_SIFT_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0);
+    let max_queries: usize = std::env::var("PROXIMADB_SIFT_QUERIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_QUERIES);
+    let floor: f64 = std::env::var("PROXIMADB_SIFT_RECALL_FLOOR")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|f| (0.0..=1.0).contains(f))
+        .unwrap_or(0.90);
+
+    let temp_dir = TempDir::new().unwrap();
+    let collection = collection("sift_pax_ratchet", &temp_dir);
+    let engine = SstEngine::new().await.unwrap();
+
+    // --- Load base (subset or full) ---------------------------------------------------
+    eprintln!("loading base vectors ({})", {
+        subset_n
+            .map(|n| format!("subset N={n}"))
+            .unwrap_or_else(|| "full 1M".to_string())
+    });
+    let base = read_vec_records_f32(&base_path, subset_n).expect("read sift_base.fvecs");
+    let n = base.len();
+    assert!(n >= TOP_K, "need at least {TOP_K} base vectors, got {n}");
+
+    // --- Insert + flush in batches ----------------------------------------------------
+    let mut batch: Vec<VectorRecord> = Vec::with_capacity(BATCH_SIZE);
+    for (i, v) in base.iter().enumerate() {
+        batch.push(vector_record(i as u32, v.clone()));
+        if batch.len() == BATCH_SIZE {
+            let b = std::mem::take(&mut batch);
+            flush_batch(&engine, &collection, b).await;
+        }
+    }
+    if !batch.is_empty() {
+        flush_batch(&engine, &collection, batch).await;
+    }
+    eprintln!("flushed {n} base vectors");
+
+    // --- Load queries -----------------------------------------------------------------
+    let query_path = dataset_path("sift_query.fvecs");
+    let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
+        Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
+        None => {
+            // Fall back to the first base vectors as queries (degenerate but lets
+            // the ratchet run without the query file; recall is then self-match).
+            base.iter().take(max_queries.min(n)).cloned().collect()
+        }
+    };
+    let qcount = queries.len();
+
+    // --- Ground truth: provided (.ivecs) for full 1M, brute-force for subsets ---------
+    let gt_path = dataset_path("sift_groundtruth.ivecs");
+    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
+    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
+        eprintln!("using provided sift_groundtruth.ivecs (full 1M)");
+        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
+        gt.into_iter()
+            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
+            .collect()
+    } else {
+        eprintln!("computing brute-force L2 ground truth over the {n}-vector subset");
+        queries
+            .iter()
+            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
+            .collect()
+    };
+    // base no longer needed for GT in the provided-GT path; drop to free memory
+    // before the query loop on the 1M run.
+    drop(base);
+
+    // --- Search + recall --------------------------------------------------------------
+    let mut recall_sum = 0.0f64;
+    let mut measured = 0usize;
+    for (qi, query) in queries.iter().enumerate() {
+        let got = search_topk(&engine, &collection, query.clone()).await;
+        if got.is_empty() {
+            eprintln!("  warn: query {qi} returned no results");
+            continue;
+        }
+        let got_ids: std::collections::HashSet<String> = got.into_iter().take(TOP_K).collect();
+        let gt_ids = &ground_truth[qi];
+        let overlap = got_ids.intersection(gt_ids).count();
+        recall_sum += overlap as f64 / TOP_K as f64;
+        measured += 1;
+    }
+    assert!(measured > 0, "no queries succeeded — cannot report recall");
+    let recall = recall_sum / measured as f64;
+    eprintln!(
+        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, floor={floor}); {}",
+        if use_provided_gt {
+            "provided-GT"
+        } else {
+            "brute-force-GT"
+        }
+    );
+    assert!(
+        recall >= floor,
+        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} < {floor} floor (N={n}) — \
+         default-on flip (Phase F) is BLOCKED until the cascade is tuned (pool/REFINE via \
+         PROXIMADB_PAX_RABITQ_POOL_MULT / _MIN)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Loader unit tests — synthetic .fvecs/.ivecs round-trip (no dataset needed).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fvecs_round_trip_parses_dim_and_values() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("synth.fvecs");
+    // 3 vectors of dim 4, little-endian.
+    let mut bytes = Vec::<u8>::new();
+    for v in [
+        [1.0f32, 2.0, 3.0, 4.0],
+        [10.0, 20.0, 30.0, 40.0],
+        [-1.0, -2.0, -3.0, -4.0],
+    ] {
+        bytes.extend_from_slice(&4i32.to_le_bytes());
+        for x in v {
+            bytes.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    std::fs::write(&path, &bytes).unwrap();
+
+    let got = read_vec_records_f32(&path, None).unwrap();
+    assert_eq!(got.len(), 3);
+    assert_eq!(got[0], vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(got[1], vec![10.0, 20.0, 30.0, 40.0]);
+    assert_eq!(got[2], vec![-1.0, -2.0, -3.0, -4.0]);
+
+    // limit honored
+    let got2 = read_vec_records_f32(&path, Some(2)).unwrap();
+    assert_eq!(got2.len(), 2);
+}
+
+#[test]
+fn ivecs_round_trip_parses_neighbour_indices() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("synth.ivecs");
+    let mut bytes = Vec::<u8>::new();
+    // 2 rows of 3 indices each.
+    for row in [[7i32, 3, 99], [0, 1, 2]] {
+        bytes.extend_from_slice(&3i32.to_le_bytes());
+        for x in row {
+            bytes.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+    std::fs::write(&path, &bytes).unwrap();
+
+    let got = read_vec_records_u32(&path, None).unwrap();
+    assert_eq!(got, vec![vec![7, 3, 99], vec![0, 1, 2]]);
+}


### PR DESCRIPTION
## Summary

**Phase B of the PAX default-on roadmap** (`~/.claude/plans/cosmic-launching-treehouse.md`):
the real-dataset PAX RaBitQ→SQ8 recall ratchet on SIFT1M — the **WS8 artifact that gates
the default-on flip (Phase F)**. The existing `pax-recall-ratchet` runs on a synthetic
DIM=64 corpus and explicitly flags itself as not representative of production; WS8 requires
a real N≥1M measurement.

> Critical path → default-on: **A (compaction #580 ✅) + C (opt-out/kill #581 ✅) + this (B) + F (flip).**
> Builds on develop; rebased onto latest (#581/#582/#583/#585).

## What's here

- **`tests/sift_pax_recall_ratchet_test.rs`** — a std-only `.fvecs`/`.ivecs` loader
  (**no `hdf5` native dep** — the plan's mandated evaluation to avoid libhdf5 build friction
  across CI platforms) + a ratchet mirroring `pax_cascade_prod_search_test` (Euclidean
  `SstEngine`, PAX env on, `search_vectors_unified` dispatch).
  - **Subset (N<1M):** brute-force L2 ground truth over the inserted subset (fast CI floor).
  - **Full (N=1M):** SIFT's provided `.ivecs` ground truth (the canonical gate).
  - **Self-skips** when `PROXIMADB_SIFT_DATASET_DIR` is unset/missing → no-ops outside the
    qa-gate job. Knobs: `PROXIMADB_SIFT_N`, `PROXIMADB_SIFT_QUERIES`, `PROXIMADB_SIFT_RECALL_FLOOR`.
  - Loader unit tests (synthetic round-trip) run without the dataset.
- **`qa-gate.yml` → `sift-pax-recall` job** — `workflow_dispatch`-only (avoids a 160 MB
  download on every qa PR): `actions/cache` + HTTPS download of the TEXMEX corpus from the
  Hugging Face mirror, runs the ratchet at N=100k floor or N=1M canonical (workflow_dispatch
  `sift_n` input). 120-min timeout.
- **`BENCHMARK_EVIDENCE.toml`** — WS8 entry `pax_rabitq_sq8_sift1m_recall_at_10` (validator
  passes: 19 claims).
- **`SIFT1M_RECALL_RATCHET_2026_06_30.adoc`** — dated artifact.

## Measured result (indicative, local)

| N | Ground truth | Queries | recall@10 | ratchet |
|---|---|---|---|---|
| 100 000 | brute-force L2 over subset | 200 | **0.9905** | ≥ 0.90 — PASS |
| 1 000 000 | provided `.ivecs` | (qa-gate) | *pending qa-gate job* | TBD |

**recall@10 = 0.9905 at N=100k on real SIFT** — well above the 0.90 floor and *higher* than
the synthetic DIM=64 ratchet's 0.932. This directly refutes the representativeness caveat's
specific worry that real (mildly clustered) data degrades RaBitQ: at N=100k it does not.

The **N=1M canonical** confirmation (provided ground truth) is the qa-gate `sift-pax-recall`
job's output. The default-on flip (Phase F) remains gated on that N=1M run.

## Format decision (hdf5 vs .fbin/.fvecs)

Plain-binary TEXMEX `.fvecs`/`.ivecs` — **no native dep**. The `hdf5` crate binds to libhdf5
(a system build dependency with cross-platform CI friction); the plan explicitly directs
evaluating a plain-binary format first. Parsed with `std` only (little-endian). Download via
the Hugging Face `qbo-odp/sift1m` mirror (reliable HTTPS).

## Verification (local)
- `cargo fmt`; ledger validator passes (19 claims).
- `cargo clippy --test sift_pax_recall_ratchet_test` — clean.
- 3 tests pass via nextest (2 loader round-trips + ratchet skip-without-dataset).
- Real measurement: `PROXIMADB_SIFT_DATASET_DIR=/tmp/sift1m PROXIMADB_SIFT_N=100000
  PROXIMADB_SIFT_QUERIES=200 cargo test --test sift_pax_recall_ratchet_test -- --nocapture`
  → recall@10 = 0.9905 (353 s).

## Notes / follow-ups
- The ratchet asserts `recall@10 ≥ floor` (default 0.90); if a future real-data run regresses,
  it fails by design and the cascade is tuned via `PROXIMADB_PAX_RABITQ_POOL_MULT`/`_MIN`
  before the flip.
- N=1M local run skipped (≈40–60 min flush, indicative-only); the qa-gate job is the canonical
  measuring path (ubuntu, 120 min).
