### PR TITLE
feat(pax): metric-generalized cascade — cosine support (Phase E)

### DIFF
--- a/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
@@ -255,6 +255,16 @@ impl RaBitQCode {
         let r = self.dist_to_centroid;
         r * r - 2.0 * r * self.estimate_unit_ip(q_rotated)
     }
+
+    /// Inner-product ranking score against a rotated query (lower = higher IP =
+    /// nearer) — the cosine / max-IP analog of [`l2_rank_score`]. Ranks by the
+    /// residual inner product `‖r‖·⟨r̂, q̃⟩`; the centroid·q term is dropped, as in
+    /// the L2 proxy (a ranking approximation validated empirically by the cosine
+    /// recall ratchet). Negated so the shared ascending "lower = nearer" order
+    /// selects max inner-product first.
+    pub fn ip_rank_score(&self, q_rotated: &[f32]) -> f32 {
+        -self.dist_to_centroid * self.estimate_unit_ip(q_rotated)
+    }
 }
 
 /// Stage-1 RaBitQ candidate ranking: score every present code with the binary L2
@@ -268,6 +278,25 @@ pub fn rank_candidates(q_rotated: &[f32], codes: &[Option<RaBitQCode>], pool: us
         .iter()
         .enumerate()
         .filter_map(|(i, c)| c.as_ref().map(|c| (i, c.l2_rank_score(q_rotated))))
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(pool);
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Stage-1 RaBitQ candidate ranking by **inner product** (cosine / max-IP):
+/// mirror of [`rank_candidates`] using [`RaBitQCode::ip_rank_score`] so the
+/// ascending "lower score = nearer" order surfaces the max-IP candidates first.
+/// Stage-2 rerank then computes the exact metric on the SQ8-decoded vectors.
+pub fn rank_candidates_ip(
+    q_rotated: &[f32],
+    codes: &[Option<RaBitQCode>],
+    pool: usize,
+) -> Vec<usize> {
+    let mut scored: Vec<(usize, f32)> = codes
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| c.as_ref().map(|c| (i, c.ip_rank_score(q_rotated))))
         .collect();
     scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(pool);

--- a/crates/storage/proximadb-block-format/src/lib.rs
+++ b/crates/storage/proximadb-block-format/src/lib.rs
@@ -89,7 +89,7 @@ pub use header::{
 };
 pub use prune::{BlockZoneSource, FieldToColumn, PruneResult, evaluate_block, evaluate_row_groups};
 pub use ranged::{BlockLayout, MetadataRanges, footer_tail_range, metadata_ranges};
-pub use reader::PaxBlockReader;
+pub use reader::{PaxBlockReader, RankMetric};
 pub use record::{
     ColumnDescriptor, FlatRow, canonical_columns, col_id, encode_f32_vec_col, encode_i64_col,
     encode_str_col, update_i64_bounds,

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -44,6 +44,20 @@ pub struct PaxBlockReader<'a> {
     rowgroups: RowGroupBlock,
 }
 
+/// Metric for the PAX cascade's ranking stages. Kept local to this crate to
+/// avoid pulling `DistanceMetric` (proximadb-distance-kernel) into the low-level
+/// block-format crate; the SST engine maps `DistanceMetric` → `RankMetric` at the
+/// dispatch seam. Both stage-1 (RaBitQ prefilter) and stage-2 (SQ8 rerank) key
+/// off this.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RankMetric {
+    /// Squared L2 distance (lower = nearer) — the validated default (recall 0.932).
+    L2,
+    /// Cosine: stage-1 ranks by inner product (`ip_rank_score`), stage-2 computes
+    /// the exact cosine distance `1 − cos_sim` on SQ8-decoded vectors.
+    Cosine,
+}
+
 impl<'a> PaxBlockReader<'a> {
     /// Parse the block header and footer from `data`.
     ///
@@ -326,11 +340,19 @@ impl<'a> PaxBlockReader<'a> {
     /// RaBitQ-quantized. The caller reranks the returned rows against the full-precision
     /// source (decoupled rerank) before taking the final top-k — this is the seam Phase C
     /// wires into the cold scan.
-    pub fn rabitq_rank(&self, query: &[f32], pool: usize) -> Option<Vec<usize>> {
+    pub fn rabitq_rank(
+        &self,
+        query: &[f32],
+        pool: usize,
+        metric: RankMetric,
+    ) -> Option<Vec<usize>> {
         let (params, codes) = self.decode_rabitq_codes(crate::col_id::EMBED_BASE)?;
         let rotation = rabitq::build_rotation(params.dim, params.seed);
         let q_rotated = rabitq::rotate_query(query, &params, &rotation);
-        Some(rabitq::rank_candidates(&q_rotated, &codes, pool))
+        Some(match metric {
+            RankMetric::L2 => rabitq::rank_candidates(&q_rotated, &codes, pool),
+            RankMetric::Cosine => rabitq::rank_candidates_ip(&q_rotated, &codes, pool),
+        })
     }
 
     /// Stage-2 of the cascade: rerank a RaBitQ candidate `rows` set for embedding
@@ -345,6 +367,7 @@ impl<'a> PaxBlockReader<'a> {
         emb_idx: usize,
         query: &[f32],
         rows: &[usize],
+        metric: RankMetric,
     ) -> Option<Vec<(usize, f32)>> {
         let column_id = crate::col_id::RERANK_BASE + emb_idx as i32;
         let entry = self.vparams.get(column_id)?;
@@ -376,11 +399,26 @@ impl<'a> PaxBlockReader<'a> {
             }
             decoded.clear();
             sq8::decode_into(&payload[off..end], &entry.params, &mut decoded);
-            let dist = decoded
-                .iter()
-                .zip(query)
-                .map(|(x, q)| (x - q) * (x - q))
-                .sum::<f32>();
+            let dist = match metric {
+                // Squared L2 (lower = nearer).
+                RankMetric::L2 => decoded
+                    .iter()
+                    .zip(query)
+                    .map(|(x, q)| (x - q) * (x - q))
+                    .sum::<f32>(),
+                // Cosine distance 1 − cos_sim (∈ [0, 2]; lower = nearer). Exact on
+                // the SQ8-decoded vector + query (handles non-normalized data).
+                RankMetric::Cosine => {
+                    let dot = decoded.iter().zip(query).map(|(x, q)| x * q).sum::<f32>();
+                    let norm_x = decoded.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    let norm_q = query.iter().map(|q| q * q).sum::<f32>().sqrt();
+                    if norm_x > 0.0 && norm_q > 0.0 {
+                        1.0 - (dot / (norm_x * norm_q))
+                    } else {
+                        1.0 // zero vector: maximally dissimilar
+                    }
+                }
+            };
             scored.push((row, dist));
         }
         scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -1219,11 +1257,102 @@ mod tests {
                 .collect();
 
             // Stage 1: RaBitQ candidate prefilter; Stage 2: SQ8 rerank over the pool.
-            let cand = reader.rabitq_rank(&query, refine).unwrap();
-            let reranked = reader.rerank_rows(0, &query, &cand).unwrap();
+            let cand = reader.rabitq_rank(&query, refine, RankMetric::L2).unwrap();
+            let reranked = reader
+                .rerank_rows(0, &query, &cand, RankMetric::L2)
+                .unwrap();
             let got: std::collections::HashSet<usize> =
                 reranked.into_iter().take(k).map(|(row, _)| row).collect();
 
+            let truth = exact_topk(&query);
+            let hits = truth.iter().filter(|i| got.contains(i)).count();
+            recalls.push(hits as f32 / k as f32);
+        }
+        recalls.iter().sum::<f32>() / recalls.len() as f32
+    }
+
+    /// Phase E — normalized-corpus variant of `build_cold_recall_corpus_and_block`:
+    /// L2-normalized DIM=64 vectors, the regime `RankMetric::Cosine` is validated on
+    /// (for unit vectors cosine similarity == inner product).
+    fn build_cold_recall_corpus_and_block_normalized(n: usize) -> (Vec<Vec<f32>>, Vec<u8>) {
+        const DIM: usize = 64;
+        let normalize = |v: Vec<f32>| -> Vec<f32> {
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 0.0 {
+                v.iter().map(|x| x / norm).collect()
+            } else {
+                v
+            }
+        };
+        let corpus: Vec<Vec<f32>> = (0..n).map(|i| normalize(lcg_vec(i as u64, DIM))).collect();
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::RaBitQ);
+        for (i, v) in corpus.iter().enumerate() {
+            writer
+                .add_record(&make_record_with_embedding(
+                    &format!("r{i}"),
+                    "t",
+                    1000 + i as i64,
+                    v.clone(),
+                ))
+                .unwrap();
+        }
+        (corpus, writer.flush().unwrap())
+    }
+
+    /// Phase E — cosine analog of `cold_cascade_recall_mean`: stage-1
+    /// `RankMetric::Cosine` (RaBitQ `ip_rank_score`) → stage-2 exact cosine rerank,
+    /// scored vs the exact-cosine top-k. Query is a perturbed, re-normalized corpus
+    /// vector so its true cosine-NN is well-defined.
+    fn cold_cascade_recall_mean_cosine(
+        reader: &PaxBlockReader,
+        corpus: &[Vec<f32>],
+        q: usize,
+        k: usize,
+        refine: usize,
+    ) -> f32 {
+        let n = corpus.len();
+        let dim = corpus[0].len();
+        let cos_dist = |a: &[f32], b: &[f32]| -> f32 {
+            let dot = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
+            let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if na > 0.0 && nb > 0.0 {
+                1.0 - dot / (na * nb)
+            } else {
+                1.0
+            }
+        };
+        let exact_topk = |qv: &[f32]| -> std::collections::HashSet<usize> {
+            let mut idx: Vec<usize> = (0..n).collect();
+            idx.sort_by(|&a, &b| {
+                cos_dist(&corpus[a], qv)
+                    .partial_cmp(&cos_dist(&corpus[b], qv))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            idx.into_iter().take(k).collect()
+        };
+        let mut recalls = Vec::with_capacity(q);
+        for qi in 0..q {
+            let base = (qi * (n / q)) % n;
+            let noise = lcg_vec((qi as u64).wrapping_add(7_000_000), dim);
+            let mut query: Vec<f32> = corpus[base]
+                .iter()
+                .zip(&noise)
+                .map(|(v, nn)| v + nn * 0.01)
+                .collect();
+            let qnorm: f32 = query.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if qnorm > 0.0 {
+                query = query.iter().map(|x| x / qnorm).collect();
+            }
+            let cand = reader
+                .rabitq_rank(&query, refine, RankMetric::Cosine)
+                .unwrap();
+            let reranked = reader
+                .rerank_rows(0, &query, &cand, RankMetric::Cosine)
+                .unwrap();
+            let got: std::collections::HashSet<usize> =
+                reranked.into_iter().take(k).map(|(row, _)| row).collect();
             let truth = exact_topk(&query);
             let hits = truth.iter().filter(|i| got.contains(i)).count();
             recalls.push(hits as f32 / k as f32);
@@ -1283,6 +1412,45 @@ mod tests {
             "P3 Phase G: RaBitQ→SQ8 cascade recall@{K} at N={N} = {mean:.3} < ratchet \
              {RATCHET}. Recall regressed — add an f32 rerank column rather than lowering \
              the ratchet."
+        );
+    }
+
+    /// Phase E — cosine cold-recall ratchet at N=1000. The RaBitQ→SQ8 cascade under
+    /// `RankMetric::Cosine` (stage-1 `ip_rank_score` → stage-2 exact cosine rerank)
+    /// must hold recall@10 vs the exact-cosine top-k on a normalized corpus. Gates
+    /// the cosine path opened in `try_pax_cascade`. On normalized data cosine ranking
+    /// coincides with L2 (‖a−b‖² = 2−2cos), so this lands near the L2 ratchet; the
+    /// ratchet starts at 0.90 and only goes up.
+    #[test]
+    fn rabitq_cold_recall_harness_cosine_n1000_recall_at_10() {
+        const N: usize = 1000;
+        const Q: usize = 50;
+        const K: usize = 10;
+        const REFINE: usize = 100;
+        const RATCHET: f32 = 0.90;
+
+        let (corpus, block) = build_cold_recall_corpus_and_block_normalized(N);
+        let reader = PaxBlockReader::open(&block).unwrap();
+
+        // The cosine path uses the same RaBitQ + SQ8 columns as L2.
+        let emb = reader.vector_params().get(col_id::EMBED_BASE).unwrap();
+        assert_eq!(emb.quant_kind, crate::vparam::QUANT_RABITQ_RESERVED);
+        assert_eq!(
+            reader
+                .vector_params()
+                .get(crate::col_id::RERANK_BASE)
+                .unwrap()
+                .quant_kind,
+            QUANT_SQ8
+        );
+
+        let mean = cold_cascade_recall_mean_cosine(&reader, &corpus, Q, K, REFINE);
+        eprintln!("[recall-ratchet/cosine] N={N} REFINE={REFINE} mean recall@{K} = {mean:.4}");
+        assert!(
+            mean >= RATCHET,
+            "Phase E: cosine RaBitQ→SQ8 cascade recall@{K} at N={N} = {mean:.3} < ratchet \
+             {RATCHET}. The cosine stage-1 proxy (ip_rank_score) needs tuning \
+             (pool/REFINE) or an f32 rerank column."
         );
     }
 

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -245,9 +245,21 @@ impl SstEngine {
         query_vector: &[f32],
         filter_expression: Option<&FilterExpression>,
         k: usize,
+        distance_metric: DistanceMetric,
     ) -> anyhow::Result<Option<Vec<OptimizedSearchRecord>>> {
         use crate::storage::engines::sst::segment_format::{
             MetaPrune, pax_field_to_col, rabitq_search_segment,
+        };
+        use proximadb_block_format::RankMetric;
+        // Map the query metric to a cascade rank metric. Dot/max-IP and exotic
+        // metrics stay on the generic scan (unvalidated recall / score polarity);
+        // the caller gate only routes Euclidean + Cosine here.
+        let Some(rank_metric) = (match distance_metric {
+            DistanceMetric::Euclidean => Some(RankMetric::L2),
+            DistanceMetric::Cosine => Some(RankMetric::Cosine),
+            _ => None,
+        }) else {
+            return Ok(None);
         };
         // Read the segment bytes once; the generic-scan branch uses the sstable
         // reader instead, so this read is exclusive to the cascade (no double-read).
@@ -264,16 +276,19 @@ impl SstEngine {
             filter,
             field_to_col: &pax_field_to_col,
         });
-        let Some(hits) = rabitq_search_segment(&bytes, query_vector, k, pool, prune)? else {
+        let Some(hits) = rabitq_search_segment(&bytes, query_vector, k, pool, rank_metric, prune)?
+        else {
             return Ok(None); // not PAX / no RaBitQ → caller falls back
         };
-        let metric = DistanceMetric::Euclidean;
         let records = hits
             .into_iter()
             .map(|h| {
                 OptimizedSearchRecord::new(
                     h.oid,
-                    OptimizedSearchRecord::standardized_distance_to_similarity(h.distance, &metric),
+                    OptimizedSearchRecord::standardized_distance_to_similarity(
+                        h.distance,
+                        &distance_metric,
+                    ),
                 )
             })
             .collect();
@@ -924,30 +939,39 @@ impl SstEngine {
             );
 
             // PAX RaBitQ→SQ8 cascade (PAX Phase 2 read-side wiring): try it first
-            // for `.pax` segments under the validated Euclidean metric. The generic
-            // dispatch below handles every other case — `.arrow`, legacy `.sst`, AND
-            // `.pax` under other metrics or any cascade miss (not-PAX / no RaBitQ /
-            // error) — so this is additive and mixed-read-safe.
-            let pax_cascade: Option<Vec<OptimizedSearchRecord>> =
-                if sstable_path.ends_with(".pax") && distance_metric == DistanceMetric::Euclidean {
-                    match self
-                        .try_pax_cascade(sstable_path, query_vector, filter_expression, k)
-                        .await
-                    {
-                        Ok(Some(records)) => Some(records),
-                        Ok(None) => None,
-                        Err(e) => {
-                            warn!(
-                                file = %sstable_path,
-                                error = %e,
-                                "PAX cascade unavailable; falling back to generic scan"
-                            );
-                            None
-                        }
+            // for `.pax` segments under a validated metric (Euclidean or Cosine).
+            // The generic dispatch below handles every other case — `.arrow`, legacy
+            // `.sst`, AND `.pax` under Dot/other metrics or any cascade miss
+            // (not-PAX / no RaBitQ / error) — so this is additive and mixed-read-safe.
+            let pax_cascade: Option<Vec<OptimizedSearchRecord>> = if sstable_path.ends_with(".pax")
+                && matches!(
+                    distance_metric,
+                    DistanceMetric::Euclidean | DistanceMetric::Cosine
+                ) {
+                match self
+                    .try_pax_cascade(
+                        sstable_path,
+                        query_vector,
+                        filter_expression,
+                        k,
+                        distance_metric,
+                    )
+                    .await
+                {
+                    Ok(Some(records)) => Some(records),
+                    Ok(None) => None,
+                    Err(e) => {
+                        warn!(
+                            file = %sstable_path,
+                            error = %e,
+                            "PAX cascade unavailable; falling back to generic scan"
+                        );
+                        None
                     }
-                } else {
-                    None
-                };
+                }
+            } else {
+                None
+            };
 
             // Dispatch based on file format (Arrow vs ProximaBlocks); the PAX
             // cascade short-circuits above when it applies.

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -22,7 +22,9 @@ use std::path::Path;
 
 use anyhow::Result;
 use proximadb_block_format::prune::{FieldToColumn, PruneResult, evaluate_block};
-use proximadb_block_format::{BLOCK_MAGIC, BlockCompression, BlockMode, VectorQuant, col_id};
+use proximadb_block_format::{
+    BLOCK_MAGIC, BlockCompression, BlockMode, RankMetric, VectorQuant, col_id,
+};
 use proximadb_filter_expression::FilterExpression;
 use proximadb_records::ProximaRecord;
 use proximadb_storage_common::pax_block::{
@@ -206,6 +208,7 @@ pub fn rabitq_search_segment(
     query: &[f32],
     k: usize,
     pool: usize,
+    metric: RankMetric,
     prune: Option<MetaPrune<'_>>,
 ) -> Result<Option<Vec<CascadeHit>>> {
     use crate::observability::io_trace;
@@ -231,7 +234,7 @@ pub fn rabitq_search_segment(
         // Stage 1: RaBitQ candidate prefilter on the hot codes column. A block
         // whose EMBED_BASE isn't RaBitQ-encoded yields `None` and is skipped
         // (mixed-quant segments stay safe).
-        let Some(cand) = block.rabitq_rank(query, pool) else {
+        let Some(cand) = block.rabitq_rank(query, pool, metric) else {
             continue;
         };
         any_rabitq = true;
@@ -254,12 +257,14 @@ pub fn rabitq_search_segment(
 
         // Stage 2: SQ8 cascade rerank over ONLY the candidate rows (no f32 GET).
         // Without a co-located SQ8 column, keep the RaBitQ-coarse order.
-        let scored = block.rerank_rows(0, query, &cand).unwrap_or_else(|| {
-            cand.iter()
-                .enumerate()
-                .map(|(rank, &row)| (row, rank as f32))
-                .collect()
-        });
+        let scored = block
+            .rerank_rows(0, query, &cand, metric)
+            .unwrap_or_else(|| {
+                cand.iter()
+                    .enumerate()
+                    .map(|(rank, &row)| (row, rank as f32))
+                    .collect()
+            });
         let oids = block.decode_str_stripe(col_id::OID);
         for (row, dist) in scored.into_iter().take(k) {
             let oid = oids
@@ -622,7 +627,7 @@ mod tests {
                     .map(|(v, n)| v + n * 0.01)
                     .collect();
 
-                let hits = rabitq_search_segment(&bytes, &query, K, POOL, None)
+                let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, None)
                     .unwrap()
                     .expect("PAX+RaBitQ segment must run the cascade");
                 let got: std::collections::HashSet<String> =
@@ -661,7 +666,7 @@ mod tests {
         .serialize()
         .unwrap();
         assert!(
-            rabitq_search_segment(&legacy, &vec![0.0; DIM], K, POOL, None)
+            rabitq_search_segment(&legacy, &vec![0.0; DIM], K, POOL, RankMetric::L2, None)
                 .unwrap()
                 .is_none(),
             "non-PAX input must return None (caller falls back)"
@@ -766,7 +771,7 @@ mod tests {
                 filter: &filter,
                 field_to_col: &f2c,
             };
-            let hits = rabitq_search_segment(&bytes, &query, K, POOL, Some(mp))
+            let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, Some(mp))
                 .unwrap()
                 .expect("PAX+RaBitQ segment");
             let snap = crate::observability::io_trace::snapshot().unwrap();

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -758,7 +758,7 @@ mod tests {
 
         // Baseline: no prune — scans every block.
         let baseline = rt.block_on(crate::observability::io_trace::scope(async {
-            let hits = rabitq_search_segment(&bytes, &query, K, POOL, None)
+            let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, None)
                 .unwrap()
                 .expect("PAX+RaBitQ segment");
             let snap = crate::observability::io_trace::snapshot().unwrap();


### PR DESCRIPTION
## Summary

**Phase E of the PAX default-on roadmap:** generalize the RaBitQ→SQ8 cascade from L2-only
to also support **cosine** (the dominant production metric). A `.pax` segment under Cosine
previously fell back to the generic scan; the cascade now serves it. **L2 is unchanged —
purely additive** (the L2 ratchets confirm no regression).

> Read-side only; no on-disk format change (RaBitQ codes already encode the inner-product
> signal via `estimate_unit_ip`). Builds on develop; rebases cleanly.

## Changes (5 files, 3 crates)

1. **`rabitq.rs` (proximadb-codec)** — add `ip_rank_score` = `-dist_to_centroid *
   estimate_unit_ip` (the cosine/max-IP ranking proxy; analog of `l2_rank_score`, which drops
   the centroid·q term) + `rank_candidates_ip`.
2. **`reader.rs` (proximadb-block-format)** — a local `RankMetric { L2, Cosine }` enum (kept
   local to avoid pulling `DistanceMetric` into the low-level crate). `rabitq_rank` and
   `rerank_rows` take `RankMetric`: L2 uses `l2_rank_score` + squared-L2 rerank; Cosine uses
   `ip_rank_score` (stage-1) + exact cosine distance (stage-2) on SQ8-decoded vectors.
3. **`segment_format.rs`** — `rabitq_search_segment` threads `RankMetric`.
4. **`search/mod.rs`** — `try_pax_cascade` takes `distance_metric`, maps Euclidean→L2 /
   Cosine→Cosine (Dot/other stay on the generic scan), opens the `.pax` gate to Euclidean +
   Cosine, and uses the real metric in `standardized_distance_to_similarity`.

## Why no write-side change
RaBitQ stores sign bits + `dist_to_centroid` + `inv_factor`; `estimate_unit_ip` already
estimates `⟨residual_unit, q̃⟩`. So ranking by inner product (cosine/max-IP) reuses the
existing codes — only the ranking + rerank math change.

## Validation (local)
- **New cosine recall ratchet** (`rabitq_cold_recall_harness_cosine_n1000_recall_at_10`):
  normalized corpus + exact-cosine ground truth → **recall@10 ≥ 0.90 @ N=1000** (cosine
  coincides with L2 on normalized data: ‖a−b‖² = 2−2cos).
- **L2 ratchets unchanged** (N=1k + N=100k) — **no regression** (the additive change leaves
  the L2 dispatch identical).
- `cargo clippy` clean across codec / block-format (lib + tests) / sst lib; `cargo fmt` clean.

## Scope
Cosine only. **DotProduct (max-IP)** has a score-polarity wrinkle
(`standardized_distance_to_similarity` expects distance ∈ [0,2]) and intentionally stays on
the generic scan — a focused follow-up. The Euclidean recall floor (real SIFT1M) is
unaffected; a real-dataset cosine ratchet is a follow-up once a cosine benchmark corpus is
chosen.
