### PR TITLE
feat(storage): engine read-path typed consistency (ADR-031 Phase 4d)

### DIFF
--- a/benches/archived_duplicates/bench_05_storage_lifecycle.rs
+++ b/benches/archived_duplicates/bench_05_storage_lifecycle.rs
@@ -327,6 +327,7 @@ fn bench_engine_flush_with_compression(c: &mut Criterion) {
                                 engine_config: HashMap::new(),
                                 base_location: format!("/tmp/proximadb_bench/{}", engine_name),
                                 assigned_at: 0,
+                ..Default::default()
                             }),
                         };
 

--- a/benches/bench_09_columnar_viper.rs
+++ b/benches/bench_09_columnar_viper.rs
@@ -178,6 +178,7 @@ fn bench_viper_flush(c: &mut Criterion) {
                                 engine_config: HashMap::new(),
                                 base_location: "/tmp/proximadb-bench/viper".to_string(),
                                 assigned_at: 0,
+                                ..Default::default()
                             }),
                         };
 

--- a/benches/engine_performance_reporter.rs
+++ b/benches/engine_performance_reporter.rs
@@ -163,6 +163,7 @@ async fn benchmark_engine_configuration(
             engine: engine_enum,
             engine_config: Default::default(),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
         ..Default::default()
     };

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs
@@ -6366,6 +6366,15 @@ pub struct StorageAssignment {
     pub base_location: ::prost::alloc::string::String,
     #[prost(int64, tag = "6")]
     pub assigned_at: i64,
+    /// ADR-031 Phase 4d: typed collection identity triple, set at create when
+    /// PROXIMADB_TYPED_PATHS=1 so catalog-free engines can resolve the typed
+    /// account-rooted read path. All three are Some or all three are None.
+    #[prost(uint32, optional, tag = "7")]
+    pub typed_account_id: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "8")]
+    pub typed_namespace_id: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "9")]
+    pub typed_collection_id: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GetCollectionRequest {

--- a/proto/proximadb/v1/collection_types.proto
+++ b/proto/proximadb/v1/collection_types.proto
@@ -250,6 +250,13 @@ message StorageAssignment {
   // Additional fields for compatibility
   string base_location = 5;
   int64 assigned_at = 6;
+  // ADR-031 Phase 4d: the typed collection identity triple, set at create when
+  // PROXIMADB_TYPED_PATHS=1 so catalog-free engines can resolve the typed
+  // account-rooted read path. All three are Some or all three are None.
+  // uint32 in proto (no uint16); namespace_id is a u16 in Rust.
+  optional uint32 typed_account_id = 7;
+  optional uint32 typed_namespace_id = 8;
+  optional uint32 typed_collection_id = 9;
 }
 
 message GetCollectionRequest {

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1063,6 +1063,21 @@ impl CollectionService {
             None => base_location.clone(),
         };
 
+        // ADR-031 Phase 4d: when a typed identity was minted (env ON + account
+        // known), carry the triple on the proto `StorageAssignment` so the
+        // catalog-free engines can resolve the account-rooted read path
+        // (`accounts/{acct}/{ns}/{coll}/…`) at read time — they have no catalog
+        // access and can't mint it themselves. All three are Some together, or
+        // all None (env OFF / no account → legacy byte-identical path).
+        let (typed_account_id, typed_namespace_id, typed_collection_id) = match typed_identity {
+            Some(id) => (
+                Some(id.account_id),
+                Some(id.namespace_id as u32),
+                Some(id.collection_id),
+            ),
+            None => (None, None, None),
+        };
+
         // Create proto collection with stats and storage assignment
         let proto_collection = Collection {
             id: uuid.clone(),
@@ -1081,6 +1096,9 @@ impl CollectionService {
                 engine_config: std::collections::HashMap::new(),
                 base_location: tenant_base_location.clone(), // Tenant-prefixed path
                 assigned_at: chrono::Utc::now().timestamp_micros(),
+                typed_account_id,
+                typed_namespace_id,
+                typed_collection_id,
             }),
         };
 

--- a/src/storage/background_flush_context.rs
+++ b/src/storage/background_flush_context.rs
@@ -200,6 +200,7 @@ impl BackgroundFlushContext {
             engine_config: std::collections::HashMap::new(),
             base_location: self.base_location.clone(),
             assigned_at: chrono::Utc::now().timestamp_millis(),
+            ..Default::default()
         };
 
         let config = CollectionConfig {

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -1232,6 +1232,7 @@ impl NovaEngine {
                 engine: crate::proto::proximadb_v1::StorageEngine::Nova as i32,
                 engine_config: Default::default(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -1446,6 +1447,7 @@ impl UnifiedStorageFormat for NovaEngine {
                 engine_config: std::collections::HashMap::new(),
                 base_location: base_path.to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         });
 

--- a/src/storage/engines/nova/operations/search.rs
+++ b/src/storage/engines/nova/operations/search.rs
@@ -134,10 +134,16 @@ impl NovaSearchOperations {
             .ok_or_else(|| anyhow::anyhow!("No storage path in context"))?;
         let collection_id = &ctx.collection.id;
 
-        // Use standard collection data path (same as other engines)
-        let data_path = proximadb_storage_common::storage_path::StoragePath::collection_data_path(
+        // ADR-031 Phase 4d: use the typed data path when the collection carries
+        // a typed identity (env ON at create); else legacy (mixed-read-safe).
+        let typed_identity =
+            crate::storage::trait_components::path_resolver::typed_identity_from_storage_assignment(
+                ctx.collection.storage_assignment.as_ref(),
+            );
+        let data_path = crate::storage::trait_components::path_resolver::collection_data_path_typed(
             base_location,
             collection_id,
+            typed_identity,
         );
 
         debug!(

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -2331,6 +2331,7 @@ impl UnifiedStorageFormat for RaptorEngine {
                 engine_config: std::collections::HashMap::new(),
                 base_location: base_path.to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         });
 

--- a/src/storage/engines/sst/tests/sst_compactor_tests.rs
+++ b/src/storage/engines/sst/tests/sst_compactor_tests.rs
@@ -164,6 +164,7 @@ mod tests {
             storage_assignment: Some(crate::proto::proximadb_v1::StorageAssignment {
                 base_location: format!("file://{}", base_path),
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -1091,6 +1092,7 @@ mod tests {
             storage_assignment: Some(crate::proto::proximadb_v1::StorageAssignment {
                 base_location: format!("file://{}", base_path.to_str().unwrap()),
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -107,6 +107,7 @@ impl UnifiedStorageFormat for SstEngine {
                 engine_config: std::collections::HashMap::new(),
                 base_location: base_path.to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         });
 

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -1556,6 +1556,7 @@ impl ViperEngine {
                 engine: crate::proto::proximadb_v1::StorageEngine::Viper as i32,
                 engine_config: Default::default(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -2074,6 +2075,7 @@ impl UnifiedStorageFormat for ViperEngine {
                 engine_config: std::collections::HashMap::new(),
                 base_location: base_path.to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         });
 
@@ -3307,6 +3309,7 @@ mod minimal_compaction_tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: base_path.to_string(),
                 assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
             }),
         });
 

--- a/src/storage/engines/viper/tests/compaction_tests.rs
+++ b/src/storage/engines/viper/tests/compaction_tests.rs
@@ -104,6 +104,7 @@ fn create_test_collection(
             engine_config: HashMap::new(),
             base_location: base_path.to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
     }
 }
@@ -1602,6 +1603,7 @@ async fn test_compaction_with_metadata_filtering() {
             engine: crate::proto::proximadb_v1::StorageEngine::Viper as i32,
             engine_config: Default::default(),
             assigned_at: 0,
+            ..Default::default()
         });
         Arc::new(col)
     };

--- a/src/storage/engines/viper/tests/debug_compaction_test.rs
+++ b/src/storage/engines/viper/tests/debug_compaction_test.rs
@@ -142,6 +142,7 @@ fn create_test_collection(
             engine_config: std::collections::HashMap::new(),
             base_location: format!("file://{}", base_path),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
     }
 }

--- a/src/storage/engines/viper/tests/engine_tests.rs
+++ b/src/storage/engines/viper/tests/engine_tests.rs
@@ -147,6 +147,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: format!("file://{}", base_path),
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
         }
     }
@@ -252,6 +253,7 @@ mod tests {
                 engine: crate::proto::proximadb_v1::StorageEngine::Viper as i32,
                 engine_config: Default::default(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         });

--- a/src/storage/metadata/single_index.rs
+++ b/src/storage/metadata/single_index.rs
@@ -500,6 +500,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: format!("{}", temp_dir.path().display()),
                 assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
             }),
         }
     }

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -762,6 +762,7 @@ impl RecoveryManager {
                 engine_config: std::collections::HashMap::new(),
                 base_location: storage_url.to_string(),
                 assigned_at: chrono::Utc::now().timestamp_millis(),
+                ..Default::default()
             }),
             ..Default::default()
         })

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -529,6 +529,45 @@ pub fn typed_paths_enabled() -> bool {
     })
 }
 
+/// ADR-031 Phase 4d: recover a [`CollectionIdentity`] from a proto
+/// [`StorageAssignment`](crate::proto::proximadb_v1::StorageAssignment)'s typed
+/// triple, for the **catalog-free engine read paths**.
+///
+/// Engines resolve data/wal/index paths deep in the search/flush stack with no
+/// catalog/schema access — the typed identity cannot be re-minted at read time,
+/// so it is carried on the proto collection (set at create by the manager when
+/// `PROXIMADB_TYPED_PATHS=1`) and reconstituted here. All three fields are `Some`
+/// together (the manager sets them atomically) or all `None` (env OFF / legacy
+/// collection created before 4d) → `None` → the typed path helpers fall back to
+/// the byte-identical legacy path (mixed-read-safe per-collection).
+///
+/// `namespace_id` is a `u16` in the typed identity but stored as `uint32` in
+/// proto (proto has no `uint16`); it is narrowed here. Values > `u16::MAX` are
+/// impossible by construction (the catalog mints `NamespaceId = u16`), so the
+/// narrowing is infallible in practice — `None` is returned defensively if a
+/// future caller somehow stored an out-of-range value.
+pub fn typed_identity_from_storage_assignment(
+    storage_assignment: Option<&crate::proto::proximadb_v1::StorageAssignment>,
+) -> Option<CollectionIdentity> {
+    let sa = storage_assignment?;
+    let account_id = sa.typed_account_id?;
+    let namespace_id = sa.typed_namespace_id?;
+    let collection_id = sa.typed_collection_id?;
+    // Proto has no uint16; narrow back to the typed NamespaceId (u16).
+    let namespace_id = if namespace_id <= u32::from(u16::MAX) {
+        namespace_id as u16
+    } else {
+        // Defensive: out-of-range means the triple wasn't minted by the catalog
+        // — treat as legacy rather than truncate silently.
+        return None;
+    };
+    Some(CollectionIdentity {
+        account_id,
+        namespace_id,
+        collection_id,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // ADR-031 Phase 4c: typed collection DATA subpaths.
 // ---------------------------------------------------------------------------

--- a/src/storage/traits/query.rs
+++ b/src/storage/traits/query.rs
@@ -6,6 +6,9 @@
 use crate::core::search::BlockPruneMode;
 use crate::proto::proximadb_v1::Collection;
 use crate::security::rbac_service::{TenantContext, UnifiedUserContext};
+use crate::storage::trait_components::path_resolver::{
+    collection_data_path_typed, typed_identity_from_storage_assignment,
+};
 pub use proximadb_quantization_types::QuantizationType;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -506,13 +509,14 @@ impl StorageQueryContext {
             .map(|sa| sa.base_location.as_str())
     }
 
-    /// Get collection-specific storage path.
+    /// Get collection-specific storage path (ADR-031 Phase 4d: typed when the
+    /// collection carries a typed identity triple on its storage_assignment;
+    /// legacy `{base}/{coll_id}/data` otherwise — mixed-read-safe).
     pub fn collection_storage_path(&self) -> Option<String> {
         self.storage_url().map(|base| {
-            proximadb_storage_common::storage_path::StoragePath::collection_data_path(
-                base,
-                self.collection_id(),
-            )
+            let identity =
+                typed_identity_from_storage_assignment(self.collection.storage_assignment.as_ref());
+            collection_data_path_typed(base, self.collection_id(), identity)
         })
     }
 }

--- a/tests/common/collection_builder.rs
+++ b/tests/common/collection_builder.rs
@@ -204,6 +204,7 @@ impl TestCollectionBuilder {
                 engine_config: HashMap::new(),
                 base_location: temp_dir.path().to_str().unwrap().to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         };
 
@@ -262,6 +263,7 @@ impl TestCollectionBuilder {
                 engine_config: HashMap::new(),
                 base_location: path.to_str().unwrap().to_string(),
                 assigned_at: 0,
+                ..Default::default()
             }),
         }
     }

--- a/tests/common/integration_test_helpers.rs
+++ b/tests/common/integration_test_helpers.rs
@@ -233,6 +233,7 @@ impl UnifiedTestEnvironment {
                 // so engines can append collection_id to get /tmp/proximadb_unified_tests/<collection_id>/data/
                 base_location: self.persistent_base.to_str().unwrap().to_string(),
                 assigned_at: chrono::Utc::now().timestamp_millis(),
+                ..Default::default()
             }),
         }
     }
@@ -581,6 +582,7 @@ impl UnifiedTestEnvironment {
                 engine_config: std::collections::HashMap::new(),
                 base_location: _base_location,
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
         }
     }
@@ -1042,6 +1044,7 @@ pub fn create_test_collection_with_storage(name: &str, base_location: String) ->
             engine_config: std::collections::HashMap::new(),
             base_location: base_location.clone(),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+            ..Default::default()
         }),
     }
 }
@@ -1138,6 +1141,7 @@ pub async fn flush_sst_with_block_stats(
             engine_config: std::collections::HashMap::new(),
             base_location: environment.persistent_base.to_str().unwrap().to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
         config: Some(CollectionConfig {
             name: "test_collection".to_string(),

--- a/tests/dual_mode_integration_test.rs
+++ b/tests/dual_mode_integration_test.rs
@@ -127,6 +127,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: sst_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -186,6 +187,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: viper_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -244,6 +246,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: sst_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -264,6 +267,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: viper_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -339,6 +343,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: sst_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -431,6 +436,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: sst_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -451,6 +457,7 @@ mod tests {
                 engine_config: std::collections::HashMap::new(),
                 base_location: viper_path.clone(),
                 assigned_at: 0,
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/tests/integration/comprehensive_filter_test.rs
+++ b/tests/integration/comprehensive_filter_test.rs
@@ -179,6 +179,7 @@ async fn search_with_filter(
             engine: proximadb::proto::proximadb_v1::StorageEngine::Viper as i32,
             engine_config: Default::default(),
             assigned_at: 0,
+            ..Default::default()
         }),
         ..Default::default()
     });
@@ -288,6 +289,7 @@ async fn setup_test_collection(
             engine_config: HashMap::new(),
             base_location: format!("file://{}", base_path),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
         ..Default::default()
     };

--- a/tests/integration/optimization_e2e_test.rs
+++ b/tests/integration/optimization_e2e_test.rs
@@ -248,6 +248,7 @@ async fn test_optimization_end_to_end() -> anyhow::Result<()> {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+            ..Default::default()
         }),
     };
 
@@ -393,6 +394,7 @@ async fn test_optimization_end_to_end() -> anyhow::Result<()> {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+            ..Default::default()
         }),
     });
 
@@ -510,6 +512,7 @@ async fn test_optimization_end_to_end() -> anyhow::Result<()> {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+            ..Default::default()
         }),
     });
 

--- a/tests/integration/sst_collection_test_fixed.rs
+++ b/tests/integration/sst_collection_test_fixed.rs
@@ -185,6 +185,7 @@ async fn test_sst_collection_with_proper_routing() -> anyhow::Result<()> {
             // base_location should point to the parent directory where collection directories are
             base_location: format!("{}", env.persistent_base.display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+            ..Default::default()
         }),
     });
 

--- a/tests/integration/storage/metadata_backend_test.rs
+++ b/tests/integration/storage/metadata_backend_test.rs
@@ -205,6 +205,7 @@ async fn test_collection_service_dependency_injection() {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
         }),
     };
 
@@ -330,6 +331,7 @@ async fn test_metadata_backend_persistence() {
                     engine_config: std::collections::HashMap::new(),
                     base_location: format!("{}", temp_dir.path().display()),
                     assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
                 }),
             };
 
@@ -469,6 +471,7 @@ async fn test_metadata_backend_deletion() {
                 engine_config: std::collections::HashMap::new(),
                 base_location: format!("{}", temp_dir.path().display()),
                 assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
             }),
         };
 
@@ -592,6 +595,7 @@ async fn test_concurrent_metadata_operations() {
                     engine_config: std::collections::HashMap::new(),
                     base_location: temp_dir_path,
                     assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
                 }),
             };
 
@@ -696,6 +700,7 @@ async fn test_metadata_backend_updates() {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
         }),
     };
 
@@ -916,6 +921,7 @@ async fn test_metadata_backend_trait_implementation() {
             engine_config: std::collections::HashMap::new(),
             base_location: format!("{}", temp_dir.path().display()),
             assigned_at: chrono::Utc::now().timestamp_micros(),
+                ..Default::default()
         }),
     };
 

--- a/tests/integration/viper_compression_integration_test.rs
+++ b/tests/integration/viper_compression_integration_test.rs
@@ -286,6 +286,7 @@ async fn test_viper_engine_flush_creates_compressed_parquet_files() -> anyhow::R
             engine_config: std::collections::HashMap::new(),
             base_location: temp_dir.path().to_str().unwrap().to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
     };
 
@@ -405,6 +406,7 @@ async fn test_viper_search_compressed_data() -> anyhow::Result<()> {
             engine_config: std::collections::HashMap::new(),
             base_location: temp_dir.path().to_str().unwrap().to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+            ..Default::default()
         }),
     };
 
@@ -795,6 +797,7 @@ async fn test_compressions_comparison() -> anyhow::Result<()> {
                 engine_config: std::collections::HashMap::new(),
                 base_location: temp_dir.path().to_str().unwrap().to_string(),
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
         };
 
@@ -934,6 +937,7 @@ async fn test_compression_vs_disabled() -> anyhow::Result<()> {
                 engine_config: std::collections::HashMap::new(),
                 base_location: temp_dir.path().to_str().unwrap().to_string(),
                 assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
             }),
         };
 

--- a/tests/quantization/storage_engine_pq_tests.rs
+++ b/tests/quantization/storage_engine_pq_tests.rs
@@ -72,6 +72,7 @@ fn create_collection_with_engine_and_quantization(
             engine_config: HashMap::new(),
             base_location: "/tmp/proximadb_test".to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
         }),
         ..Default::default()
     }

--- a/tests/quantization/storage_vs_stateless_quantization_tests.rs
+++ b/tests/quantization/storage_vs_stateless_quantization_tests.rs
@@ -77,6 +77,7 @@ fn create_collection_with_quantization(
             engine_config: HashMap::new(),
             base_location: "/tmp/proximadb_test".to_string(),
             assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
         }),
         ..Default::default()
     }
@@ -293,6 +294,7 @@ mod optimized_quantization_tests {
                     engine_config: HashMap::new(),
                     base_location: "/tmp/proximadb_test".to_string(),
                     assigned_at: chrono::Utc::now().timestamp(),
+                ..Default::default()
                 }),
                 ..Default::default()
             };


### PR DESCRIPTION
Makes engine READS resolve the typed data path, so reads match where 4c creates data when `PROXIMADB_TYPED_PATHS=1`. Default-OFF = byte-identical legacy (mixed-read-safe).

## What
- **Proto**: `typed_account_id`/`typed_namespace_id`/`typed_collection_id` on `StorageAssignment` (optional uint32, no new RPC).
- **Manager**: stores the triple at create (from the already-computed `typed_identity`).
- **Read-path chokepoint**: `StorageQueryContext::collection_storage_path()` now uses `collection_data_path_typed(base, coll_id, typed_identity_from_storage_assignment(sa))` — covers SST + VIPER (they funnel through it).
- **NOVA** search read path: wired to `collection_data_path_typed` directly.
- **8 StorageAssignment literals** (engine registration/recovery/flush) fixed with `..Default::default()`.

## Known limitation
HELIX `vector_by_id` takes only `(collection_id, base_path)` — no identity access. Threading the identity there is a signature change (deferred). HELIX collections with env ON would have vector-by-id reads at legacy path — not a regression (env is default OFF).

## Verified
clippy `--lib -D warnings` clean (root + catalog); tenant-path / deterministic-contract / boundary guards clean.
