### PR TITLE
feat(pax): configurable exact-f32 tier (Phase D write side)

### DIFF
--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -1184,6 +1184,65 @@ mod tests {
         (corpus, writer.flush().unwrap())
     }
 
+    /// P3 Phase D f32 tier: with `with_f32_tier(true)` + RaBitQ, the block ALSO
+    /// carries an exact-f32 column at `F32_TIER_BASE` (read lazily). It
+    /// round-trips the EXACT original vectors (vs the SQ8 rerank column's
+    /// approximation), and the RaBitQ hot + SQ8 rerank columns are still present.
+    #[test]
+    fn pax_block_f32_tier_round_trips_exact_vectors() {
+        let corpus = [lcg_vec(1, 64), lcg_vec(2, 64), lcg_vec(3, 64)];
+
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::RaBitQ)
+            .with_f32_tier(true);
+        for (i, v) in corpus.iter().enumerate() {
+            writer
+                .add_record(&make_record_with_embedding(
+                    &format!("r{i}"),
+                    "t",
+                    1000 + i as i64,
+                    v.clone(),
+                ))
+                .unwrap();
+        }
+        let block = writer.flush().unwrap();
+        let reader = PaxBlockReader::open(&block).unwrap();
+
+        // The f32 tier column is present + RAW_F32.
+        let entry = reader
+            .vector_params()
+            .get(col_id::F32_TIER_BASE)
+            .expect("f32 tier column present");
+        assert_eq!(entry.quant_kind, crate::vparam::QUANT_RAW_F32);
+        // The RaBitQ hot + SQ8 rerank columns are still present.
+        assert_eq!(
+            reader
+                .vector_params()
+                .get(col_id::EMBED_BASE)
+                .unwrap()
+                .quant_kind,
+            crate::vparam::QUANT_RABITQ_RESERVED
+        );
+        assert_eq!(
+            reader
+                .vector_params()
+                .get(crate::col_id::RERANK_BASE)
+                .unwrap()
+                .quant_kind,
+            QUANT_SQ8
+        );
+
+        // The f32 tier decodes the EXACT original vectors (row-for-row).
+        let f32_vecs = reader
+            .decode_f32_vec_stripe(col_id::F32_TIER_BASE)
+            .expect("f32 tier decodes");
+        assert_eq!(f32_vecs.len(), corpus.len());
+        for (got, want) in f32_vecs.iter().zip(corpus.iter()) {
+            let got = got.as_ref().expect("non-null f32 row");
+            assert_eq!(got.as_slice(), want.as_slice(), "f32 tier must be exact");
+        }
+    }
+
     /// Run the RaBitQ→SQ8 cold-scan cascade over `q` deterministic near-neighbor
     /// queries against `corpus` (read back via `reader`), returning mean recall@k
     /// vs the exact-f32 top-k. `refine` is the stage-1 RaBitQ candidate pool size.

--- a/crates/storage/proximadb-block-format/src/record.rs
+++ b/crates/storage/proximadb-block-format/src/record.rs
@@ -49,6 +49,16 @@ pub mod col_id {
     /// f32 rerank is added only if the recall gate can't be met on SQ8. Chosen
     /// well above `USER_BASE` so it never collides with catalog-driven columns.
     pub const RERANK_BASE: i32 = 1000;
+    /// First column ID for the OPTIONAL exact-f32 tier (f32_tier_0, …).
+    ///
+    /// Opt-in only (`pax_f32_tier:on` tag / `PROXIMADB_PAX_F32_TIER` env, default
+    /// OFF): when enabled on a RaBitQ collection, the writer ALSO emits the raw
+    /// f32 embedding at `F32_TIER_BASE + i`. The column is read LAZILY — normal
+    /// id+score queries never touch it (zero scan/egress cost); it is decoded
+    /// only for an exact final rerank (→ recall ≈ 1.0) or `include_vectors`. This
+    /// is the storage/egress trade for exact-vector fidelity. Well above
+    /// `RERANK_BASE` so it never collides.
+    pub const F32_TIER_BASE: i32 = 2000;
 }
 
 /// Descriptor for a single column stripe in a PAX block.

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -143,6 +143,12 @@ pub struct PaxBlockWriter {
     /// retained. Default from `PROXIMADB_PAX_DROP_TENANT_COL` (off) so the write
     /// format only changes once readers that stamp tenant are deployed.
     drop_tenant_col: bool,
+    /// Opt-in exact-f32 tier (P3 Phase D): when true + RaBitQ quant, the writer
+    /// ALSO emits the raw f32 embedding at `col_id::F32_TIER_BASE + i` (one
+    /// stripe per embedding column). Read LAZILY — only an exact final rerank or
+    /// `include_vectors` decodes it; id+score queries never touch it (zero scan /
+    /// egress cost when unused). Default OFF (set via `with_f32_tier`).
+    include_f32_tier: bool,
 
     // Accumulated column data
     oids: Vec<String>,
@@ -184,6 +190,7 @@ impl PaxBlockWriter {
             embedding_count,
             quant: VectorQuant::Auto,
             drop_tenant_col: drop_tenant_col_enabled(),
+            include_f32_tier: false,
             oids: Vec::new(),
             tenant_ids: Vec::new(),
             created_at: Vec::new(),
@@ -217,6 +224,15 @@ impl PaxBlockWriter {
     /// comes from `PROXIMADB_PAX_DROP_TENANT_COL`.
     pub fn with_drop_tenant_col(mut self, enabled: bool) -> Self {
         self.drop_tenant_col = enabled;
+        self
+    }
+
+    /// Enable (or disable) the optional exact-f32 tier (P3 Phase D). When true,
+    /// each RaBitQ-coded embedding also gets a co-located raw-f32 stripe at
+    /// `col_id::F32_TIER_BASE + i` for an exact final rerank / `include_vectors`.
+    /// Default OFF; the flush path enables it from the `pax_f32_tier` tag / env.
+    pub fn with_f32_tier(mut self, enabled: bool) -> Self {
+        self.include_f32_tier = enabled;
         self
     }
 
@@ -446,6 +462,17 @@ impl PaxBlockWriter {
                         self.build_sq8_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?;
                     stripes.push(rerank_stripe);
                     vparam_entries.push(rerank_entry);
+                }
+                // P3 Phase D f32 tier (opt-in): an exact-f32 copy of the embedding
+                // at `F32_TIER_BASE + i`, for an exact final rerank (→ recall ≈ 1.0)
+                // and exact `include_vectors`. The stripe is read LAZILY — id+score
+                // queries never decode it — so the only always-paid cost is the
+                // storage bytes (the egress/scan cost is paid only when used).
+                if self.include_f32_tier && is_rabitq {
+                    let (f32_stripe, f32_entry) =
+                        self.build_raw_f32_vec_stripe(col_id::F32_TIER_BASE + i as i32, &refs)?;
+                    stripes.push(f32_stripe);
+                    vparam_entries.push(f32_entry);
                 }
             }
         }
@@ -773,6 +800,55 @@ impl PaxBlockWriter {
             column_id: id,
             dim,
             quant_kind: QUANT_SQ8,
+            params,
+        };
+        Ok((ColumnStripe::new(meta, data), entry))
+    }
+
+    /// Build a raw-f32 vector stripe unconditionally (the optional exact-f32
+    /// tier). Mirrors [`build_sq8_vec_stripe`] but emits `QUANT_RAW_F32` (no
+    /// quantization) so the cascade can do an exact final rerank or
+    /// `include_vectors` can return exact vectors. Emitted only when the writer's
+    /// `include_f32_tier` flag is set (one stripe per embedding column).
+    fn build_raw_f32_vec_stripe(
+        &self,
+        id: i32,
+        vals: &[Option<&[f32]>],
+    ) -> Result<(ColumnStripe, VectorParamEntry)> {
+        let dim = vector_column_dim(vals)?;
+        let flat: Vec<f32> = vals
+            .iter()
+            .flatten()
+            .flat_map(|s| s.iter().copied())
+            .collect();
+        let params = functions::sq8::fit_params(&flat);
+        let data = encode_f32_vec_raw_v2(vals, dim);
+        let null_count = vals.iter().filter(|v| v.is_none()).count() as u32;
+        let meta = ColumnMeta {
+            column_id: id,
+            role: ColumnRole::Vector,
+            data_type_id: 0x01, // F32
+            encoding_id: ProximaScheme::Raw.to_marker(),
+            nullable: true,
+            has_bloom: false,
+            is_sorted: false,
+            stripe_offset: 0,
+            stripe_len: data.len() as u32,
+            null_count,
+            distinct_hint: vals
+                .iter()
+                .filter(|value| value.is_some())
+                .count()
+                .min(u32::MAX as usize) as u32,
+            min_val: [0u8; 16],
+            max_val: [0u8; 16],
+            bloom_offset: 0,
+            bloom_len: 0,
+        };
+        let entry = VectorParamEntry {
+            column_id: id,
+            dim,
+            quant_kind: QUANT_RAW_F32,
             params,
         };
         Ok((ColumnStripe::new(meta, data), entry))

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -502,6 +502,9 @@ pub struct PaxSegmentWriter {
     block_size_threshold: usize,
     /// Vector quantization strategy for every block in this segment (P3 Phase D).
     quant: VectorQuant,
+    /// Opt-in exact-f32 tier (P3 Phase D) — re-applied to every block writer so
+    /// each block carries the f32 stripe when enabled.
+    f32_tier: bool,
 
     current_writer: PaxBlockWriter,
     index: SegmentIndex,
@@ -546,6 +549,7 @@ impl PaxSegmentWriter {
             embedding_count,
             block_size_threshold: threshold,
             quant: VectorQuant::Auto,
+            f32_tier: false,
             current_writer: writer,
             index: SegmentIndex { blocks: Vec::new() },
             block_stats: Vec::new(),
@@ -566,7 +570,26 @@ impl PaxSegmentWriter {
             self.schema_fingerprint,
             self.embedding_count,
         )
-        .with_quant(quant);
+        .with_quant(quant)
+        .with_f32_tier(self.f32_tier);
+        self
+    }
+
+    /// Enable (or disable) the optional exact-f32 tier (P3 Phase D) for every
+    /// block in this segment. Builder form mirroring [`with_quant`]; rebuilds the
+    /// (still-empty) current block writer so it applies from the first record.
+    /// Default OFF; the flush path enables it from the `pax_f32_tier` tag / env.
+    pub fn with_f32_tier(mut self, enabled: bool) -> Self {
+        self.f32_tier = enabled;
+        self.current_writer = PaxBlockWriter::new(
+            self.mode,
+            self.compression,
+            &self.collection_id,
+            self.schema_fingerprint,
+            self.embedding_count,
+        )
+        .with_quant(self.quant)
+        .with_f32_tier(enabled);
         self
     }
 
@@ -623,7 +646,7 @@ impl PaxSegmentWriter {
         self.file_buf.extend_from_slice(&block_bytes);
         self.block_stats.push(stats);
 
-        // Reset writer for the next block (preserving the segment's quant strategy).
+        // Reset writer for the next block (preserving the segment's quant + f32-tier strategy).
         self.current_writer = PaxBlockWriter::new(
             self.mode,
             self.compression,
@@ -631,7 +654,8 @@ impl PaxSegmentWriter {
             self.schema_fingerprint,
             self.embedding_count,
         )
-        .with_quant(self.quant);
+        .with_quant(self.quant)
+        .with_f32_tier(self.f32_tier);
         Ok(())
     }
 

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -433,7 +433,7 @@ impl SstEngine {
                 // object-store) URL. Reads are mixed-format-safe via
                 // `segment_format::read_segment_records` (magic-byte detection), so no
                 // manifest/reader change is required for this segment to be read back.
-                use crate::storage::engines::sst::segment_format::write_pax_segment;
+                use crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier;
                 let staging_path = staging_url.strip_prefix("file://").unwrap_or(&staging_url);
                 if let Some(parent) = std::path::Path::new(staging_path).parent() {
                     tokio::fs::create_dir_all(parent)
@@ -460,12 +460,17 @@ impl SstEngine {
                 let target_block = std::env::var("PROXIMADB_PAX_BLOCK_SIZE")
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok());
-                let meta = write_pax_segment(
+                // P3 Phase D f32 tier (opt-in): per-collection `pax_f32_tier` tag >
+                // env `PROXIMADB_PAX_F32_TIER` > default off. Emits an exact-f32
+                // stripe (read lazily) for an exact final rerank + include_vectors.
+                let f32_tier = resolve_pax_f32_tier(params.collection_config.as_ref());
+                let meta = write_pax_segment_with_f32_tier(
                     std::path::Path::new(staging_path),
                     &records,
                     collection_id,
                     embedding_count,
                     quant,
+                    f32_tier,
                     target_block,
                 )
                 .context("Failed to write PAX vector segment")?;
@@ -898,6 +903,40 @@ fn resolve_pax_vector_quant(
             _ => VectorQuant::RaBitQ,
         },
     }
+}
+
+/// Tag prefix encoding the per-collection f32-tier opt-in on
+/// `CollectionConfig.tags` — mirrors `pax_vector_format:`. `on`/`off`.
+const PAX_F32_TIER_TAG_PREFIX: &str = "pax_f32_tier:";
+
+/// Read the per-collection `pax_f32_tier:on|off` tag (last wins; an unrecognized
+/// value keeps the prior resolution). Mirrors `pax_vector_format_tag`.
+fn pax_f32_tier_tag(config: &crate::proto::proximadb_v1::CollectionConfig) -> Option<bool> {
+    let mut latest: Option<bool> = None;
+    for tag in &config.tags {
+        if let Some(rest) = tag.strip_prefix(PAX_F32_TIER_TAG_PREFIX) {
+            latest = match rest.trim().to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" | "yes" => Some(true),
+                "off" | "false" | "0" | "no" => Some(false),
+                _ => latest,
+            };
+        }
+    }
+    latest
+}
+
+/// Resolve whether a flush should ALSO emit the exact-f32 tier (P3 Phase D).
+/// Precedence: per-collection `pax_f32_tier` tag > env `PROXIMADB_PAX_F32_TIER` >
+/// default OFF. The tier is read lazily (exact final rerank / `include_vectors`),
+/// so the only always-paid cost is the storage bytes — not scan/egress.
+fn resolve_pax_f32_tier(
+    collection_config: Option<&crate::proto::proximadb_v1::Collection>,
+) -> bool {
+    let per_collection = collection_config
+        .as_ref()
+        .and_then(|c| c.config.as_ref())
+        .and_then(pax_f32_tier_tag);
+    per_collection.unwrap_or_else(|| env_truthy("PROXIMADB_PAX_F32_TIER"))
 }
 
 #[cfg(test)]

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -118,6 +118,31 @@ pub fn write_pax_segment(
     quant: VectorQuant,
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
+    write_pax_segment_with_f32_tier(
+        path,
+        records,
+        collection_id,
+        embedding_count,
+        quant,
+        false,
+        target_block,
+    )
+}
+
+/// Like [`write_pax_segment`] but optionally emits the exact-f32 tier (P3 Phase
+/// D). When `f32_tier` is true (and the quant is RaBitQ), each embedding also
+/// gets a co-located raw-f32 stripe at `col_id::F32_TIER_BASE + i` for an exact
+/// final rerank / `include_vectors`. The flush path calls this with the resolved
+/// `pax_f32_tier` opt-in; compaction/tests use [`write_pax_segment`] (no tier).
+pub fn write_pax_segment_with_f32_tier(
+    path: &Path,
+    records: &[ProximaRecord],
+    collection_id: &str,
+    embedding_count: usize,
+    quant: VectorQuant,
+    f32_tier: bool,
+    target_block: Option<usize>,
+) -> Result<SegmentMeta> {
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,
@@ -127,7 +152,8 @@ pub fn write_pax_segment(
         embedding_count.max(1),
         target_block,
     )
-    .with_quant(quant);
+    .with_quant(quant)
+    .with_f32_tier(f32_tier);
     for record in records {
         writer.add_record(record)?;
     }


### PR DESCRIPTION
## Summary

**Phase D (Option C) — write side:** an opt-in exact-f32 tier for PAX segments. A RaBitQ
collection can additionally carry the raw f32 vectors for an exact final rerank (→ recall ≈
1.0) and exact `include_vectors`, closing the fidelity gap that **RaBitQ `.pax` segments
store no f32** (only RaBitQ hot + SQ8 rerank). **Default OFF; opt-in per-collection.**

Per the discussion: the f32 tier is a **normal stacked columnar stripe**
(`col_id::F32_TIER_BASE + i`, `QUANT_RAW_F32`) — same structure as the RaBitQ/SQ8 columns —
read **lazily**. id+score queries never decode it (**zero scan/egress cost when unused**);
only an exact rerank or `include_vectors` touches it. The always-paid cost is the storage
bytes, not the read.

## Changes (6 files, 3 crates)

- **block-format** — `PaxBlockWriter::with_f32_tier(bool)`: when set + RaBitQ, emits an extra
  raw-f32 stripe per embedding (`build_raw_f32_vec_stripe`, reusing `encode_f32_vec_raw_v2`).
  New `col_id::F32_TIER_BASE = 2000`.
- **storage-common** — `PaxSegmentWriter::with_f32_tier` passthrough (re-applied per block;
  preserved across quant changes).
- **sst** — `write_pax_segment_with_f32_tier`; `write_pax_segment` delegates with `false` so
  the 8 existing callers (compaction/tests) are unchanged. Flush resolves `pax_f32_tier`
  (per-collection tag `pax_f32_tier:on|off` > env `PROXIMADB_PAX_F32_TIER` > default off) and
  writes the tier.
- **test** — round-trip: with the tier, `F32_TIER_BASE` is `QUANT_RAW_F32`, the RaBitQ + SQ8
  columns remain, and the tier decodes the **exact** original vectors.

## Why configurable / lazy
- It's a **fidelity vs storage** trade, not a performance one (the cascade is fast *because*
  it avoids f32). Opt-in lets each collection choose.
- Lazy stripe reads mean the f32 bytes cost nothing at query time unless exact fidelity is
  requested — so default-off-with-opt-in is cheap to hold and only pays (storage) when wanted.

## Verification (local)
- `cargo clippy` clean across block-format (lib + tests), storage-common, sst lib.
- Round-trip test **passes**: `pax_block_f32_tier_round_trips_exact_vectors`.

## Follow-ups (separate PRs)
1. **Cascade consumption** — exact f32 final rerank when the tier is present (self-contained
   in `rabitq_search_segment`; recall → ~1.0).
2. **`include_vectors` exact materialization** — needs the `include_vectors` intent threaded
   to the cascade (today it's not on `ctx`/`SearchParams`).
3. **Compaction preserves the f32 tier** — `write_pax_segment` currently drops it (compaction
   uses the no-tier delegate).

## Config
Per-collection: add a `pax_f32_tier:on` tag. Or deployment-wide:
`PROXIMADB_PAX_F32_TIER=1`. Default OFF.
