### PR TITLE
fix(release): use -p (package) instead of --bin for apps/ binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,14 +293,14 @@ jobs:
 
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }} $FEATURES_FLAG \
-              --bin proximadb-server \
-              --bin proximadb-bench \
-              --bin proximadb-migrate
+              -p proximadb-server \
+              -p proximadb-bench \
+              -p proximadb-migrate
           else
             cargo build --release --target ${{ matrix.target }} $FEATURES_FLAG \
-              --bin proximadb-server \
-              --bin proximadb-bench \
-              --bin proximadb-migrate
+              -p proximadb-server \
+              -p proximadb-bench \
+              -p proximadb-migrate
           fi
         shell: bash
 


### PR DESCRIPTION
Fixes the release pipeline: cargo build --bin proximadb-server fails because the bins are in apps/ (workspace members), not the root crate. Using -p (explicit package) fixes the bin search.