### PR TITLE
feat: audit remediation foundations — schema, fences, SDK retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1312,6 +1312,12 @@ jobs:
       !inputs.skip_tests &&
       needs.changes.outputs.test_tier == 'true' &&
       needs.changes.outputs.pgwire_accuracy_changes == 'true'
+    env:
+      # 8MB worker stack: events_tsbs_pgwire_e2e (and correlated-subquery pgwire
+      # paths) produce deep-but-finite async call chains that overflow the
+      # default ~2MB tokio worker stack. Mirrors qa-gate (b87d05a31); ci.yml's
+      # integration-test jobs previously lacked this.
+      RUST_MIN_STACK: "8388608"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0

--- a/.gitignore
+++ b/.gitignore
@@ -406,13 +406,14 @@ ml_prompt.txt
 footer_cache.bin
 
 # AI-assistant instruction files — per-developer / local-only (NOT committed).
-# CLAUDE.md / GEMINI.md / AGENTS.md at the repo root are each developer's own
+# CLAUDE.md / GEMINI.md / AGENTS.md / AGENT.md at the repo root are each developer's own
 # local copy; shared defaults ship committed under docs/agent-rules/*.seed — copy
 # one to the root to seed a new machine (see docs/agent-rules/README.adoc).
 # Remaining entries below ignore tooling artifacts that should never be committed.
 CLAUDE.md
 GEMINI.md
 AGENTS.md
+AGENT.md
 CURSOR.md
 COPILOT.md
 .claude/

--- a/clients/go/proximadb/client.go
+++ b/clients/go/proximadb/client.go
@@ -549,6 +549,9 @@ func withRetry[T any](ctx context.Context, config *Config, fn func() (T, error))
 	var err error
 
 	delay := config.RetryDelay
+	if config.MaxRetryDelay > 0 && delay > config.MaxRetryDelay {
+		delay = config.MaxRetryDelay
+	}
 	for attempt := 0; attempt <= config.MaxRetries; attempt++ {
 		result, err = fn()
 		if err == nil {
@@ -577,6 +580,9 @@ func withRetry[T any](ctx context.Context, config *Config, fn func() (T, error))
 			case <-timer.C:
 				// Exponential backoff
 				delay *= 2
+				if config.MaxRetryDelay > 0 && delay > config.MaxRetryDelay {
+					delay = config.MaxRetryDelay
+				}
 			}
 		}
 	}

--- a/clients/go/proximadb/client_test.go
+++ b/clients/go/proximadb/client_test.go
@@ -992,6 +992,50 @@ func TestNewConfigOptions(t *testing.T) {
 	}
 }
 
+func TestRetryUsesMaxRetryDelay(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"message": "temporary outage",
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status": "ok",
+		})
+	}))
+	defer server.Close()
+
+	client, err := proximadb.NewClient(
+		proximadb.WithURL(server.URL),
+		proximadb.WithMaxRetries(2),
+		proximadb.WithRetryDelay(50*time.Millisecond),
+		proximadb.WithMaxRetryDelay(time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	probe, err := client.HealthLive(ctx)
+	if err != nil {
+		t.Fatalf("HealthLive failed: %v", err)
+	}
+	if probe.Status != "ok" {
+		t.Fatalf("expected ok status, got %q", probe.Status)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
 // Benchmark tests
 
 func BenchmarkVectorRecordMarshal(b *testing.B) {

--- a/clients/nodejs-embedded/src/client.ts
+++ b/clients/nodejs-embedded/src/client.ts
@@ -211,19 +211,32 @@ export class ProximaDBClient implements CollectionHttpClient, GraphHttpClient {
       headers["Authorization"] = "Bearer " + this.config.apiKey;
     }
 
-    const init: RequestInit = {
-      method,
-      headers,
-    };
+    const buildInit = (signal?: AbortSignal): RequestInit => {
+      const init: RequestInit = {
+        method,
+        headers,
+        signal,
+      };
 
-    if (body !== undefined) {
-      init.body = JSON.stringify(body);
-    }
+      if (body !== undefined) {
+        init.body = JSON.stringify(body);
+      }
+
+      return init;
+    };
 
     let lastError: Error | null = null;
     for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        this.config.timeoutMs,
+      );
       try {
-        const response = await this.fetchFn(requestUrl, init);
+        const response = await this.fetchFn(
+          requestUrl,
+          buildInit(controller.signal),
+        );
         return await this.handleResponse<T>(response);
       } catch (e: unknown) {
         lastError = e instanceof Error ? e : new Error(String(e));
@@ -240,6 +253,8 @@ export class ProximaDBClient implements CollectionHttpClient, GraphHttpClient {
           const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
           await new Promise((resolve) => setTimeout(resolve, delay));
         }
+      } finally {
+        clearTimeout(timeoutId);
       }
     }
 

--- a/clients/nodejs-embedded/tests/openapi_contract.test.ts
+++ b/clients/nodejs-embedded/tests/openapi_contract.test.ts
@@ -173,6 +173,41 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("OpenAPI contract gate", () => {
+  it("applies timeout signals to generated transport requests", async () => {
+    vi.useFakeTimers();
+    const abortStates: boolean[] = [];
+    const stub = vi.fn(
+      async (_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          expect(signal).toBeDefined();
+          signal?.addEventListener("abort", () => {
+            abortStates.push(signal.aborted);
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = stub;
+
+    try {
+      const client = new ProximaDBClient({
+        url: "http://contract.test",
+        timeoutMs: 5,
+        maxRetries: 0,
+      });
+
+      const request = expect(client.healthLive()).rejects.toThrow("aborted");
+      await vi.advanceTimersByTimeAsync(5);
+
+      await request;
+      expect(abortStates).toEqual([true]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("healthLive() matches GET /health/live (getLiveness)", async () => {
     const captured = installFetchStub({ status: "ok" });
     const client = makeClient();

--- a/clients/python/src/proximadb_sdk/adapters/grpc_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/grpc_adapter.py
@@ -73,7 +73,9 @@ class GrpcProtocolAdapter(BaseProtocolAdapter):
                     str(config_url).replace("http://", "").replace("https://", "")
                 )
 
-        metadata = config.get_grpc_metadata() if hasattr(config, "get_grpc_metadata") else None
+        metadata = (
+            config.get_grpc_metadata() if hasattr(config, "get_grpc_metadata") else None
+        )
         if not metadata and api_key:
             metadata = [("authorization", f"Bearer {api_key}")]
         if not metadata and auth:

--- a/clients/python/src/proximadb_sdk/adapters/grpc_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/grpc_adapter.py
@@ -59,7 +59,8 @@ class GrpcProtocolAdapter(BaseProtocolAdapter):
         from ..protocols.grpc_sync import ProximaDBSyncGrpcClient
 
         config = kwargs.pop("config", None)
-        kwargs.pop("auth", None)
+        api_key = kwargs.pop("api_key", None)
+        auth = kwargs.pop("auth", None)
         kwargs.pop("url", None)
         kwargs.pop("base_url", None)
 
@@ -72,12 +73,24 @@ class GrpcProtocolAdapter(BaseProtocolAdapter):
                     str(config_url).replace("http://", "").replace("https://", "")
                 )
 
+        metadata = config.get_grpc_metadata() if hasattr(config, "get_grpc_metadata") else None
+        if not metadata and api_key:
+            metadata = [("authorization", f"Bearer {api_key}")]
+        if not metadata and auth:
+            metadata = [("authorization", f"Bearer {auth}")]
+        use_tls = bool(str(server_address).startswith("https://")) or bool(
+            getattr(getattr(config, "tls", None), "verify", False)
+            and str(getattr(config, "url", "")).startswith("https://")
+        )
+
         # Create the underlying gRPC client
         self._client = ProximaDBSyncGrpcClient(
             server_address=server_address,
             timeout=timeout,
             pool_size=pool_size,
             max_message_size=max_message_size,
+            metadata=metadata,
+            use_tls=use_tls,
         )
         self._server_address = server_address
         self._connected = True

--- a/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
@@ -57,8 +57,11 @@ class RestProtocolAdapter(BaseProtocolAdapter):
         from ..config import load_config
         from ..protocols.rest_sync import ProximaDBClient
 
-        # Load config with provided parameters
-        config = load_config(url=url, api_key=api_key, timeout=timeout, **kwargs)
+        # Reuse the caller's resolved config when available so auth/custom headers
+        # are not dropped by the unified client adapter boundary.
+        config = kwargs.pop("config", None) or load_config(
+            url=url, api_key=api_key, timeout=timeout, **kwargs
+        )
 
         # Create the underlying REST client
         self._client = ProximaDBClient(config=config)

--- a/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
@@ -183,6 +183,26 @@ class DictWrapper:
         return f"DictWrapper({self._dict})"
 
 
+class _StubWithDefaultRpcKwargs:
+    """Inject default gRPC call kwargs such as auth metadata into generated stubs."""
+
+    def __init__(self, stub: Any, default_kwargs: dict[str, Any]):
+        self._stub = stub
+        self._default_kwargs = default_kwargs
+
+    def __getattr__(self, name: str):
+        attr = getattr(self._stub, name)
+        if not callable(attr):
+            return attr
+
+        def _call(*args, **kwargs):
+            for key, value in self._default_kwargs.items():
+                kwargs.setdefault(key, value)
+            return attr(*args, **kwargs)
+
+        return _call
+
+
 try:
     import grpc
 
@@ -327,6 +347,8 @@ class ProximaDBSyncGrpcClient:
         compression_algorithm: str = "gzip",
         pool_size: int = 5,
         max_message_size: int = 64 * 1024 * 1024,
+        metadata: list[tuple[str, str]] | None = None,
+        use_tls: bool = False,
     ):
         """Initialize sync gRPC client with connection pool
 
@@ -351,6 +373,8 @@ class ProximaDBSyncGrpcClient:
         self.compression_algorithm = compression_algorithm.lower()
         self.pool_size = pool_size
         self.max_message_size = max_message_size
+        self.metadata = metadata or []
+        self.use_tls = use_tls
 
         # Initialize connection pool instead of single client
         self._connection_pool = None
@@ -433,7 +457,7 @@ class ProximaDBSyncGrpcClient:
                 endpoint=self.server_address,
                 pool_size=self.pool_size,
                 max_message_size=self.max_message_size,
-                use_tls=False,  # TLS configuration can be added via environment variables or config
+                use_tls=self.use_tls,
                 compression=compression,
             )
 
@@ -448,6 +472,12 @@ class ProximaDBSyncGrpcClient:
             logger.error(f"Failed to initialize gRPC connection pool: {e}")
             raise ProximaDBError(f"gRPC connection pool initialization failed: {e}")
 
+    def _rpc_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"timeout": self.timeout}
+        if self.metadata:
+            kwargs["metadata"] = self.metadata
+        return kwargs
+
     def _execute_with_pool(self, operation_name: str, operation_func):
         """Execute operation using connection pool with automatic error handling"""
         if not GRPC_AVAILABLE:
@@ -459,7 +489,9 @@ class ProximaDBSyncGrpcClient:
             with GrpcChannelContext(self._connection_pool) as channel:
                 # Create stub for this operation
                 # Use versioned VectorService exclusively (v1)
-                stub = v1_vector_pb2_grpc.VectorServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v1_vector_pb2_grpc.VectorServiceStub(channel), self._rpc_kwargs()
+                )
 
                 # Execute the operation with timeout
                 return operation_func(stub)
@@ -485,7 +517,10 @@ class ProximaDBSyncGrpcClient:
             with GrpcChannelContext(self._connection_pool) as channel:
                 # v2: collection ops are served by ProximaRecordService (v1 gRPC
                 # CollectionService is flag-gated off). RPC names match v1.
-                stub = v2_record_pb2_grpc.ProximaRecordServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_record_pb2_grpc.ProximaRecordServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
 
                 # Execute the operation with timeout
                 return operation_func(stub)
@@ -509,7 +544,10 @@ class ProximaDBSyncGrpcClient:
 
         try:
             with GrpcChannelContext(self._connection_pool) as channel:
-                stub = v2_record_pb2_grpc.ProximaRecordServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_record_pb2_grpc.ProximaRecordServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 return operation_func(stub)
 
         except grpc.RpcError as e:
@@ -540,7 +578,10 @@ class ProximaDBSyncGrpcClient:
 
         try:
             with GrpcChannelContext(self._connection_pool) as channel:
-                stub = v2_fusion_pb2_grpc.ProximaFusionServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_fusion_pb2_grpc.ProximaFusionServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 return operation_func(stub)
 
         except grpc.RpcError as e:
@@ -571,7 +612,10 @@ class ProximaDBSyncGrpcClient:
 
         try:
             with GrpcChannelContext(self._connection_pool) as channel:
-                stub = v2_entity_pb2_grpc.ProximaEntityServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_entity_pb2_grpc.ProximaEntityServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 return operation_func(stub)
 
         except grpc.RpcError as e:
@@ -602,7 +646,10 @@ class ProximaDBSyncGrpcClient:
 
         try:
             with GrpcChannelContext(self._connection_pool) as channel:
-                stub = v2_document_pb2_grpc.ProximaDocumentServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_document_pb2_grpc.ProximaDocumentServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 return operation_func(stub)
 
         except grpc.RpcError as e:
@@ -663,7 +710,7 @@ class ProximaDBSyncGrpcClient:
             # This verifies the server is responding and the connection pool works
             with GrpcChannelContext(self._connection_pool) as channel:
                 # v2: lightweight health probe via ProximaRecordService.ListCollections.
-                stub = v2_record_pb2_grpc.ProximaRecordServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(v2_record_pb2_grpc.ProximaRecordServiceStub(channel), self._rpc_kwargs())
                 req = v2_record_pb2.V2ListCollectionsRequest(limit=1)
                 stub.ListCollections(req, timeout=self.timeout)
 
@@ -725,7 +772,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             algo_enum = {
                 "DIJKSTRA": v2_graph_pb2.GRAPH_SHORTEST_PATH_ALGORITHM_DIJKSTRA,
                 "ASTAR": v2_graph_pb2.GRAPH_SHORTEST_PATH_ALGORITHM_ASTAR,
@@ -793,7 +840,7 @@ class ProximaDBSyncGrpcClient:
                 # QueryService is flag-gated off). Note: parameterized params,
                 # rows_scanned and column_types are not carried by the v2 query
                 # messages yet; values arrive as decoded TypedValue.
-                stub = v2_record_pb2_grpc.ProximaRecordServiceStub(channel)
+                stub = _StubWithDefaultRpcKwargs(v2_record_pb2_grpc.ProximaRecordServiceStub(channel), self._rpc_kwargs())
                 req = v2_record_pb2.V2QueryRequest(
                     query=query, collection_id=collection or ""
                 )
@@ -830,7 +877,7 @@ class ProximaDBSyncGrpcClient:
         description: str | None = None,
     ):
         def _op(channel):
-            stub = v1_collection_pb2_grpc.CollectionServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
             cfg = v1_collection_types_pb2.CollectionConfig(
                 name=name,
                 dimension=dimension,
@@ -845,7 +892,7 @@ class ProximaDBSyncGrpcClient:
 
     def get_collection_v1(self, collection_id: str):
         def _op(channel):
-            stub = v1_collection_pb2_grpc.CollectionServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
             req = v1_collection_types_pb2.GetCollectionRequest(
                 collection_id=collection_id
             )
@@ -860,7 +907,7 @@ class ProximaDBSyncGrpcClient:
         include_stats: bool | None = None,
     ):
         def _op(channel):
-            stub = v1_collection_pb2_grpc.CollectionServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
             req = v1_collection_types_pb2.ListCollectionsRequest(
                 limit=limit or 0,
                 offset=offset or 0,
@@ -872,7 +919,7 @@ class ProximaDBSyncGrpcClient:
 
     def delete_collection_v1(self, collection_id: str):
         def _op(channel):
-            stub = v1_collection_pb2_grpc.CollectionServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
             req = v1_collection_types_pb2.DeleteCollectionRequest(
                 collection_id=collection_id
             )
@@ -1623,7 +1670,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             node_properties = {}
             if properties:
@@ -1682,7 +1729,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             edge_properties = {}
             if properties:
@@ -1748,7 +1795,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             # Map algorithm string to enum
             algorithm_enum = v2_graph_pb2.GRAPH_TRAVERSAL_ALGORITHM_BFS
@@ -1845,7 +1892,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             filters = []
             if properties:
@@ -1910,7 +1957,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             filters = []
             if properties:
@@ -1976,7 +2023,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             request = v2_graph_pb2.GetGraphNodeRequest(
                 graph_id=graph_id, node_id=node_id
             )
@@ -2049,7 +2096,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             request = v2_graph_pb2.DeleteGraphNodeRequest(
                 graph_id=graph_id, node_id=node_id
             )
@@ -2095,7 +2142,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             proto_nodes = []
             for node in nodes:
                 node_properties = {}
@@ -2156,7 +2203,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             proto_edges = []
             for edge in edges:
                 edge_properties = {}
@@ -2209,7 +2256,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             request = v2_graph_pb2.GraphConnectedComponentsRequest(graph_id=graph_id)
             response = stub.GetConnectedComponents(request, timeout=self.timeout)
             return [list(component.node_ids) for component in response.components]
@@ -2241,7 +2288,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             request = v2_graph_pb2.GraphHasCycleRequest(graph_id=graph_id)
             response = stub.HasCycle(request, timeout=self.timeout)
             return response.has_cycle
@@ -2299,7 +2346,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             request = v2_graph_pb2.GraphUniqueConstraintRequest(
                 graph_id=graph_id, label=label, property=property
             )
@@ -2343,7 +2390,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
 
             algorithm_enum = v2_graph_pb2.GRAPH_TRAVERSAL_ALGORITHM_BFS
             if algorithm.upper() == "DFS":
@@ -2416,7 +2463,7 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = v2_graph_pb2_grpc.ProximaGraphServiceStub(channel)
+            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
             language_enum = v2_graph_pb2.GRAPH_QUERY_LANGUAGE_CYPHER
             if language.upper() == "NATIVE":
                 language_enum = v2_graph_pb2.GRAPH_QUERY_LANGUAGE_NATIVE

--- a/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/grpc_sync.py
@@ -710,7 +710,10 @@ class ProximaDBSyncGrpcClient:
             # This verifies the server is responding and the connection pool works
             with GrpcChannelContext(self._connection_pool) as channel:
                 # v2: lightweight health probe via ProximaRecordService.ListCollections.
-                stub = _StubWithDefaultRpcKwargs(v2_record_pb2_grpc.ProximaRecordServiceStub(channel), self._rpc_kwargs())
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_record_pb2_grpc.ProximaRecordServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 req = v2_record_pb2.V2ListCollectionsRequest(limit=1)
                 stub.ListCollections(req, timeout=self.timeout)
 
@@ -772,7 +775,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             algo_enum = {
                 "DIJKSTRA": v2_graph_pb2.GRAPH_SHORTEST_PATH_ALGORITHM_DIJKSTRA,
                 "ASTAR": v2_graph_pb2.GRAPH_SHORTEST_PATH_ALGORITHM_ASTAR,
@@ -840,7 +845,10 @@ class ProximaDBSyncGrpcClient:
                 # QueryService is flag-gated off). Note: parameterized params,
                 # rows_scanned and column_types are not carried by the v2 query
                 # messages yet; values arrive as decoded TypedValue.
-                stub = _StubWithDefaultRpcKwargs(v2_record_pb2_grpc.ProximaRecordServiceStub(channel), self._rpc_kwargs())
+                stub = _StubWithDefaultRpcKwargs(
+                    v2_record_pb2_grpc.ProximaRecordServiceStub(channel),
+                    self._rpc_kwargs(),
+                )
                 req = v2_record_pb2.V2QueryRequest(
                     query=query, collection_id=collection or ""
                 )
@@ -877,7 +885,10 @@ class ProximaDBSyncGrpcClient:
         description: str | None = None,
     ):
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v1_collection_pb2_grpc.CollectionServiceStub(channel),
+                self._rpc_kwargs(),
+            )
             cfg = v1_collection_types_pb2.CollectionConfig(
                 name=name,
                 dimension=dimension,
@@ -892,7 +903,10 @@ class ProximaDBSyncGrpcClient:
 
     def get_collection_v1(self, collection_id: str):
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v1_collection_pb2_grpc.CollectionServiceStub(channel),
+                self._rpc_kwargs(),
+            )
             req = v1_collection_types_pb2.GetCollectionRequest(
                 collection_id=collection_id
             )
@@ -907,7 +921,10 @@ class ProximaDBSyncGrpcClient:
         include_stats: bool | None = None,
     ):
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v1_collection_pb2_grpc.CollectionServiceStub(channel),
+                self._rpc_kwargs(),
+            )
             req = v1_collection_types_pb2.ListCollectionsRequest(
                 limit=limit or 0,
                 offset=offset or 0,
@@ -919,7 +936,10 @@ class ProximaDBSyncGrpcClient:
 
     def delete_collection_v1(self, collection_id: str):
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v1_collection_pb2_grpc.CollectionServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v1_collection_pb2_grpc.CollectionServiceStub(channel),
+                self._rpc_kwargs(),
+            )
             req = v1_collection_types_pb2.DeleteCollectionRequest(
                 collection_id=collection_id
             )
@@ -1670,7 +1690,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             node_properties = {}
             if properties:
@@ -1729,7 +1751,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             edge_properties = {}
             if properties:
@@ -1795,7 +1819,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             # Map algorithm string to enum
             algorithm_enum = v2_graph_pb2.GRAPH_TRAVERSAL_ALGORITHM_BFS
@@ -1892,7 +1918,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             filters = []
             if properties:
@@ -1957,7 +1985,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             filters = []
             if properties:
@@ -2023,7 +2053,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             request = v2_graph_pb2.GetGraphNodeRequest(
                 graph_id=graph_id, node_id=node_id
             )
@@ -2096,7 +2128,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             request = v2_graph_pb2.DeleteGraphNodeRequest(
                 graph_id=graph_id, node_id=node_id
             )
@@ -2142,7 +2176,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             proto_nodes = []
             for node in nodes:
                 node_properties = {}
@@ -2203,7 +2239,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             proto_edges = []
             for edge in edges:
                 edge_properties = {}
@@ -2256,7 +2294,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             request = v2_graph_pb2.GraphConnectedComponentsRequest(graph_id=graph_id)
             response = stub.GetConnectedComponents(request, timeout=self.timeout)
             return [list(component.node_ids) for component in response.components]
@@ -2288,7 +2328,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             request = v2_graph_pb2.GraphHasCycleRequest(graph_id=graph_id)
             response = stub.HasCycle(request, timeout=self.timeout)
             return response.has_cycle
@@ -2346,7 +2388,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             request = v2_graph_pb2.GraphUniqueConstraintRequest(
                 graph_id=graph_id, label=label, property=property
             )
@@ -2390,7 +2434,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
 
             algorithm_enum = v2_graph_pb2.GRAPH_TRAVERSAL_ALGORITHM_BFS
             if algorithm.upper() == "DFS":
@@ -2463,7 +2509,9 @@ class ProximaDBSyncGrpcClient:
             )
 
         def _op(channel):
-            stub = _StubWithDefaultRpcKwargs(v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs())
+            stub = _StubWithDefaultRpcKwargs(
+                v2_graph_pb2_grpc.ProximaGraphServiceStub(channel), self._rpc_kwargs()
+            )
             language_enum = v2_graph_pb2.GRAPH_QUERY_LANGUAGE_CYPHER
             if language.upper() == "NATIVE":
                 language_enum = v2_graph_pb2.GRAPH_QUERY_LANGUAGE_NATIVE

--- a/clients/python/src/proximadb_sdk/unified_client_v2.py
+++ b/clients/python/src/proximadb_sdk/unified_client_v2.py
@@ -103,6 +103,7 @@ class ProximaDBClient:
             self._adapter = create_adapter(
                 "grpc",
                 server_address=grpc_url,
+                config=self.config,
                 timeout=self._timeout,
                 pool_size=self._pool_size,
                 **self._kwargs,
@@ -113,6 +114,7 @@ class ProximaDBClient:
             self._adapter = create_adapter(
                 "rest",
                 url=self._url or "http://localhost:5678",
+                config=self.config,
                 timeout=self._timeout,
                 **self._kwargs,
             )
@@ -125,6 +127,7 @@ class ProximaDBClient:
                 self._adapter = create_adapter(
                     "grpc",
                     server_address=grpc_url,
+                    config=self.config,
                     timeout=self._timeout,
                     pool_size=self._pool_size,
                     **self._kwargs,
@@ -135,6 +138,7 @@ class ProximaDBClient:
                 self._adapter = create_adapter(
                     "rest",
                     url=self._url or "http://localhost:5678",
+                    config=self.config,
                     timeout=self._timeout,
                     **self._kwargs,
                 )

--- a/clients/python/tests/unit/test_grpc_adapter_cov.py
+++ b/clients/python/tests/unit/test_grpc_adapter_cov.py
@@ -29,11 +29,21 @@ from proximadb_sdk.models import (
 class FakeGrpcClient:
     """Stand-in for ProximaDBSyncGrpcClient that never opens a channel."""
 
-    def __init__(self, server_address, timeout=60.0, pool_size=5, max_message_size=0):
+    def __init__(
+        self,
+        server_address,
+        timeout=60.0,
+        pool_size=5,
+        max_message_size=0,
+        metadata=None,
+        use_tls=False,
+    ):
         self.server_address = server_address
         self.timeout = timeout
         self.pool_size = pool_size
         self.max_message_size = max_message_size
+        self.metadata = metadata
+        self.use_tls = use_tls
         self.closed = False
 
     def close(self):
@@ -94,6 +104,18 @@ def test_init_config_ignored_when_explicit_address():
     cfg = SimpleNamespace(url="http://example.com:9999", base_url=None)
     a = GrpcProtocolAdapter(server_address="custom:1234", config=cfg)
     assert a._server_address == "custom:1234"
+
+
+def test_init_forwards_config_metadata_and_tls():
+    cfg = SimpleNamespace(
+        url="https://secure.example:5679",
+        base_url=None,
+        tls=SimpleNamespace(verify=True),
+        get_grpc_metadata=lambda: [("authorization", "Bearer token")],
+    )
+    a = GrpcProtocolAdapter(config=cfg)
+    assert a._client.metadata == [("authorization", "Bearer token")]
+    assert a._client.use_tls is True
 
 
 # ---------------------------------------------------------------------------

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -372,7 +372,7 @@ impl ProximaClient {
             request = request.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let response = request.send().await?;
+        let response = self.send_with_retries(request).await?;
         self.handle_response(response).await
     }
 
@@ -388,7 +388,7 @@ impl ProximaClient {
             request = request.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let response = request.send().await?;
+        let response = self.send_with_retries(request).await?;
         self.handle_response(response).await
     }
 
@@ -404,7 +404,7 @@ impl ProximaClient {
             request = request.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let response = request.send().await?;
+        let response = self.send_with_retries(request).await?;
         self.handle_response(response).await
     }
 
@@ -416,8 +416,67 @@ impl ProximaClient {
             request = request.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let response = request.send().await?;
+        let response = self.send_with_retries(request).await?;
         self.handle_response(response).await
+    }
+
+    #[cfg(feature = "client")]
+    async fn send_with_retries(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response> {
+        let max_retries = self.inner.config.max_retries;
+        let mut attempts = 0;
+        let mut next_request = Some(request);
+
+        loop {
+            let Some(request) = next_request.take() else {
+                return Err(ProximaError::Network(NetworkError::ConnectionFailed {
+                    url: self.inner.config.url.clone(),
+                    reason: "request body could not be cloned for retry".to_string(),
+                }));
+            };
+            let retry_request = request.try_clone();
+
+            match request.send().await {
+                Ok(response)
+                    if attempts < max_retries
+                        && retry_request.is_some()
+                        && Self::is_retryable_status(response.status()) =>
+                {
+                    attempts += 1;
+                    Self::sleep_before_retry(attempts).await;
+                    next_request = retry_request;
+                }
+                Ok(response) => return Ok(response),
+                Err(err)
+                    if attempts < max_retries
+                        && retry_request.is_some()
+                        && Self::is_retryable_error(&err) =>
+                {
+                    attempts += 1;
+                    Self::sleep_before_retry(attempts).await;
+                    next_request = retry_request;
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+    }
+
+    #[cfg(feature = "client")]
+    fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+        status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+    }
+
+    #[cfg(feature = "client")]
+    fn is_retryable_error(err: &reqwest::Error) -> bool {
+        err.is_timeout() || err.is_connect() || err.is_request()
+    }
+
+    #[cfg(feature = "client")]
+    async fn sleep_before_retry(attempt: u32) {
+        let delay_ms = 25u64.saturating_mul(1u64 << attempt.saturating_sub(1).min(6));
+        tokio::time::sleep(Duration::from_millis(delay_ms.min(1_000))).await;
     }
 
     #[cfg(feature = "client")]
@@ -805,6 +864,21 @@ mod tests {
         assert_eq!(client.config().api_key.as_deref(), Some("secret"));
         assert!(!client.config().pool_connections);
         assert_eq!(client.config().max_idle_connections, 2);
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn retry_status_classification_matches_transient_failures() {
+        assert!(ProximaClient::is_retryable_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(ProximaClient::is_retryable_status(
+            reqwest::StatusCode::BAD_GATEWAY
+        ));
+        assert!(!ProximaClient::is_retryable_status(
+            reqwest::StatusCode::BAD_REQUEST
+        ));
+        assert!(!ProximaClient::is_retryable_status(reqwest::StatusCode::OK));
     }
 
     #[test]

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -316,6 +316,9 @@ pub struct TypedColumn {
     /// For DENSE_VECTOR / BINARY_VECTOR dimension
     #[prost(uint32, optional, tag = "24")]
     pub vector_dimension: ::core::option::Option<u32>,
+    /// For DENSE_VECTOR / SPARSE_VECTOR element
+    #[prost(enumeration = "VectorElementType", optional, tag = "25")]
+    pub vector_element_type: ::core::option::Option<i32>,
     /// TEXT-specific options
     #[prost(enumeration = "TextStorageStrategy", optional, tag = "30")]
     pub text_storage_strategy: ::core::option::Option<i32>,
@@ -1157,6 +1160,46 @@ impl ColumnDataType {
             "ARRAY_ANY" => Some(Self::ArrayAny),
             "STRUCT" => Some(Self::Struct),
             "BINARY_VECTOR" => Some(Self::BinaryVector),
+            _ => None,
+        }
+    }
+}
+/// Element type for dense/sparse vector columns. Value names are prefixed to
+/// avoid proto3 value-name collisions with ColumnDataType (FLOAT32/INT8/...).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum VectorElementType {
+    Unspecified = 0,
+    VectorElementFloat16 = 1,
+    VectorElementBfloat16 = 2,
+    VectorElementFloat32 = 3,
+    VectorElementFloat64 = 4,
+    VectorElementInt8 = 5,
+}
+impl VectorElementType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "VECTOR_ELEMENT_TYPE_UNSPECIFIED",
+            Self::VectorElementFloat16 => "VECTOR_ELEMENT_FLOAT16",
+            Self::VectorElementBfloat16 => "VECTOR_ELEMENT_BFLOAT16",
+            Self::VectorElementFloat32 => "VECTOR_ELEMENT_FLOAT32",
+            Self::VectorElementFloat64 => "VECTOR_ELEMENT_FLOAT64",
+            Self::VectorElementInt8 => "VECTOR_ELEMENT_INT8",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "VECTOR_ELEMENT_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "VECTOR_ELEMENT_FLOAT16" => Some(Self::VectorElementFloat16),
+            "VECTOR_ELEMENT_BFLOAT16" => Some(Self::VectorElementBfloat16),
+            "VECTOR_ELEMENT_FLOAT32" => Some(Self::VectorElementFloat32),
+            "VECTOR_ELEMENT_FLOAT64" => Some(Self::VectorElementFloat64),
+            "VECTOR_ELEMENT_INT8" => Some(Self::VectorElementInt8),
             _ => None,
         }
     }

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -311,6 +311,11 @@ pub struct TypedColumn {
     /// For TIMESTAMP_TZ default
     #[prost(string, optional, tag = "23")]
     pub timezone: ::core::option::Option<::prost::alloc::string::String>,
+    /// VECTOR-specific options
+    ///
+    /// For DENSE_VECTOR / BINARY_VECTOR dimension
+    #[prost(uint32, optional, tag = "24")]
+    pub vector_dimension: ::core::option::Option<u32>,
     /// TEXT-specific options
     #[prost(enumeration = "TextStorageStrategy", optional, tag = "30")]
     pub text_storage_strategy: ::core::option::Option<i32>,

--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -83,7 +83,8 @@ pub(crate) mod test_support {
         VectorSearchRequest,
     };
     use proximadb_runtime::{
-        ApiHandlersPort, CollectionPort, QueryAdapterPort, UnifiedHandlers, VectorOpsPort,
+        ApiHandlersPort, CollectionPort, CollectionSchemaMetadata, CollectionSchemaUpdate,
+        QueryAdapterPort, UnifiedHandlers, VectorOpsPort,
     };
     use serde_json::Value as JsonValue;
 
@@ -93,6 +94,15 @@ pub(crate) mod test_support {
             operation: i32,
             tenant_id: Option<String>,
             collection_id: Option<String>,
+        },
+        SchemaGet {
+            tenant_id: Option<String>,
+            collection_id: String,
+        },
+        SchemaUpdate {
+            tenant_id: Option<String>,
+            collection_id: String,
+            schema_id: String,
         },
         VectorSearch {
             tenant_id: Option<String>,
@@ -122,6 +132,7 @@ pub(crate) mod test_support {
     pub(crate) struct RecordingApiPort {
         calls: Mutex<Vec<ApiCall>>,
         pub(crate) collection_response: Mutex<CollectionResponse>,
+        pub(crate) schema_metadata_response: Mutex<Option<CollectionSchemaMetadata>>,
         pub(crate) vector_response: Mutex<VectorOperationResponse>,
         pub(crate) sql_response: Mutex<ExecuteQueryResponse>,
     }
@@ -131,6 +142,7 @@ pub(crate) mod test_support {
             Arc::new(Self {
                 calls: Mutex::new(Vec::new()),
                 collection_response: Mutex::new(CollectionResponse::default()),
+                schema_metadata_response: Mutex::new(None),
                 vector_response: Mutex::new(VectorOperationResponse::default()),
                 sql_response: Mutex::new(ExecuteQueryResponse::default()),
             })
@@ -154,6 +166,43 @@ pub(crate) mod test_support {
                 collection_id: request.collection_id.clone(),
             });
             Ok(self.collection_response.lock().unwrap().clone())
+        }
+
+        async fn get_collection_schema_metadata(
+            &self,
+            collection_id: &str,
+            tenant_id: Option<&str>,
+        ) -> Result<Option<CollectionSchemaMetadata>> {
+            self.calls.lock().unwrap().push(ApiCall::SchemaGet {
+                tenant_id: tenant_id.map(ToOwned::to_owned),
+                collection_id: collection_id.to_string(),
+            });
+            Ok(self.schema_metadata_response.lock().unwrap().clone())
+        }
+
+        async fn update_collection_schema_metadata(
+            &self,
+            collection_id: &str,
+            update: CollectionSchemaUpdate,
+            tenant_id: Option<&str>,
+        ) -> Result<CollectionSchemaMetadata> {
+            self.calls.lock().unwrap().push(ApiCall::SchemaUpdate {
+                tenant_id: tenant_id.map(ToOwned::to_owned),
+                collection_id: collection_id.to_string(),
+                schema_id: update.schema_id.clone(),
+            });
+            let metadata = CollectionSchemaMetadata {
+                collection_id: collection_id.to_string(),
+                schema_id: Some(update.schema_id),
+                schema_version: Some(update.schema_version),
+                enforcement: Some(update.enforcement),
+                auto_evolve: update.auto_evolve,
+                enabled: true,
+                columns: update.columns,
+                ..CollectionSchemaMetadata::default()
+            };
+            *self.schema_metadata_response.lock().unwrap() = Some(metadata.clone());
+            Ok(metadata)
         }
 
         async fn handle_vector_search_v1_for_tenant(

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -20,14 +20,18 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
-use proximadb_data_model::ProximaValue;
+use proximadb_data_model::{ProximaType, ProximaValue, TimeUnit};
 use proximadb_proto::v1::{
-    CollectionOperation, CollectionRequest, CollectionResponse, ExecuteQueryResponse,
-    HybridSearchRequest, HybridSearchResponse, SqlRow, SqlRowField, SqlValue, VectorBatchRequest,
-    VectorOperationResponse, VectorSearchRequest, sql_value,
+    Collection, CollectionConfig, CollectionOperation, CollectionRequest, CollectionResponse,
+    ExecuteQueryResponse, FilterableColumnSpec, FilterableDataType, HybridSearchRequest,
+    HybridSearchResponse, RecordSchemaConfig, SqlRow, SqlRowField, SqlValue, TextStorageConfig,
+    VectorBatchRequest, VectorOperationResponse, VectorSearchRequest, sql_value,
 };
 
-use crate::port::ApiHandlersPort;
+use crate::port::{
+    ApiHandlersPort, CollectionSchemaColumn, CollectionSchemaEnforcement, CollectionSchemaMetadata,
+    CollectionSchemaUpdate, CollectionTextStorage,
+};
 use crate::service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};
 
 /// Global request counter for generating unique request IDs.
@@ -120,6 +124,23 @@ pub struct HybridRuntimeConfig;
 
 // ── UnifiedHandlers ───────────────────────────────────────────────────────────
 
+/// Canonical runtime-native API handler — the seam new schema/port work targets.
+///
+/// This is one of two same-named handler types. Prefer this one: it delegates
+/// to the runtime ports (`CollectionPort` / `VectorOpsPort`) and, on the schema
+/// surface, speaks the runtime-native contract (`CollectionSchemaMetadata`,
+/// built on canonical `ProximaType`) with no v1 envelope. Note the trait still
+/// carries legacy v1-proto methods (`handle_collection_operation_for_tenant`,
+/// `handle_vector_search_v1_*`, `execute_sql_v1`, …) that this impl bridges to
+/// the ports; those retire with the TD-123 v1→v2 message migration.
+///
+/// The legacy twin (`api_handlers::UnifiedHandlers` in the root crate) also
+/// impls `ApiHandlersPort`, additionally owns the write/graph/doc/DDL
+/// orchestration services, and is the dev/test default `AppState.api_handlers`
+/// (TD-104); prod overrides that default with THIS handler via
+/// `with_api_handlers` (`rest/server.rs`, `multi_server.rs`). The legacy handler
+/// retires once its orchestration is extracted into runtime ports.
+///
 /// Composition root that wires service ports into the API surface.
 ///
 /// Hold `Arc<dyn CollectionPort>`, `Arc<dyn VectorOpsPort>`, and optionally an
@@ -156,7 +177,261 @@ impl UnifiedHandlers {
     }
 }
 
+fn schema_metadata_from_collection(collection: &Collection) -> CollectionSchemaMetadata {
+    let Some(config) = collection.config.as_ref() else {
+        return CollectionSchemaMetadata {
+            collection_id: collection.id.clone(),
+            created_at_ms: collection.created_at,
+            updated_at_ms: collection.updated_at,
+            ..CollectionSchemaMetadata::default()
+        };
+    };
+
+    let mut columns = config
+        .text_columns
+        .iter()
+        .map(|name| CollectionSchemaColumn {
+            name: name.clone(),
+            data_type: ProximaType::String,
+            nullable: true,
+            indexed: false,
+            filterable: true,
+            text_storage: Some(CollectionTextStorage::Inline),
+            max_length: None,
+        })
+        .collect::<Vec<_>>();
+
+    for text_config in &config.text_storage_configs {
+        if let Some(existing) = columns
+            .iter_mut()
+            .find(|column| column.name == text_config.column_name)
+        {
+            existing.text_storage = Some(CollectionTextStorage::Large);
+            existing.max_length = Some(text_config.chunk_size);
+        } else {
+            columns.push(CollectionSchemaColumn {
+                name: text_config.column_name.clone(),
+                data_type: ProximaType::String,
+                nullable: true,
+                indexed: false,
+                filterable: false,
+                text_storage: Some(CollectionTextStorage::Large),
+                max_length: Some(text_config.chunk_size),
+            });
+        }
+    }
+
+    let existing_column_names = columns
+        .iter()
+        .map(|column| column.name.clone())
+        .collect::<std::collections::HashSet<_>>();
+    columns.extend(config.filterable_columns.iter().filter_map(|column| {
+        if existing_column_names.contains(&column.name) {
+            return None;
+        }
+        filterable_type_to_proxima_type(column.data_type).map(|data_type| CollectionSchemaColumn {
+            name: column.name.clone(),
+            data_type,
+            nullable: true,
+            indexed: column.indexed,
+            filterable: true,
+            text_storage: None,
+            max_length: None,
+        })
+    }));
+
+    let record_schema = config.record_schema.as_ref();
+    CollectionSchemaMetadata {
+        collection_id: collection.id.clone(),
+        created_at_ms: collection.created_at,
+        updated_at_ms: collection.updated_at,
+        schema_id: record_schema.map(|schema| schema.schema_id.clone()),
+        schema_version: record_schema.map(|schema| schema.schema_version.clone()),
+        enforcement: record_schema.map(|schema| enforcement_from_i32(schema.enforcement)),
+        auto_evolve: record_schema.is_none_or(|schema| schema.auto_evolve),
+        enabled: config.enable_proxima_record.unwrap_or(false) || record_schema.is_some(),
+        columns,
+    }
+}
+
+fn apply_schema_update(
+    config: &mut CollectionConfig,
+    update: CollectionSchemaUpdate,
+) -> Result<()> {
+    config.record_schema = Some(RecordSchemaConfig {
+        schema_id: update.schema_id,
+        schema_version: update.schema_version,
+        enforcement: enforcement_to_i32(update.enforcement),
+        auto_evolve: update.auto_evolve,
+        columns: Vec::new(),
+    });
+    config.enable_proxima_record = Some(true);
+    config.text_columns = update
+        .columns
+        .iter()
+        .filter(|column| matches!(column.data_type, ProximaType::String))
+        .map(|column| column.name.clone())
+        .collect();
+    config.text_storage_configs = update
+        .columns
+        .iter()
+        .filter(|column| {
+            matches!(column.data_type, ProximaType::String)
+                && matches!(column.text_storage, Some(CollectionTextStorage::Large))
+        })
+        .map(|column| TextStorageConfig {
+            column_name: column.name.clone(),
+            strategy: 1,
+            inline_threshold: 4096,
+            chunked_threshold: 1_048_576,
+            chunk_size: column.max_length.unwrap_or(512),
+            ..Default::default()
+        })
+        .collect();
+    config.filterable_columns = update
+        .columns
+        .iter()
+        .filter(|column| column.filterable)
+        .filter_map(|column| {
+            proxima_type_to_filterable_type(&column.data_type).map(|data_type| {
+                FilterableColumnSpec {
+                    name: column.name.clone(),
+                    data_type,
+                    indexed: column.indexed,
+                    supports_range: supports_range_filter(&column.data_type),
+                    estimated_cardinality: None,
+                }
+            })
+        })
+        .collect();
+
+    for column in &update.columns {
+        let storable_text = matches!(column.data_type, ProximaType::String);
+        let storable_filterable =
+            column.filterable && proxima_type_to_filterable_type(&column.data_type).is_some();
+        if !storable_text && !storable_filterable {
+            return Err(anyhow!(
+                "legacy collection metadata cannot preserve schema column '{}' with type {:?}",
+                column.name,
+                column.data_type
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn enforcement_from_i32(value: i32) -> CollectionSchemaEnforcement {
+    match value {
+        1 => CollectionSchemaEnforcement::Strict,
+        2 => CollectionSchemaEnforcement::Flexible,
+        _ => CollectionSchemaEnforcement::Hybrid,
+    }
+}
+
+fn enforcement_to_i32(value: CollectionSchemaEnforcement) -> i32 {
+    match value {
+        CollectionSchemaEnforcement::Strict => 1,
+        CollectionSchemaEnforcement::Flexible => 2,
+        CollectionSchemaEnforcement::Hybrid => 3,
+    }
+}
+
+fn filterable_type_to_proxima_type(value: i32) -> Option<ProximaType> {
+    match FilterableDataType::try_from(value).ok()? {
+        FilterableDataType::FilterableInteger => Some(ProximaType::Int64),
+        FilterableDataType::FilterableFloat => Some(ProximaType::Float64),
+        FilterableDataType::FilterableDecimal => Some(ProximaType::Decimal {
+            precision: 38,
+            scale: 18,
+        }),
+        FilterableDataType::FilterableBoolean => Some(ProximaType::Boolean),
+        FilterableDataType::FilterableDatetime => {
+            Some(ProximaType::Timestamp(TimeUnit::Nanosecond))
+        }
+        FilterableDataType::FilterableTimestampTz => {
+            Some(ProximaType::TimestampTz(TimeUnit::Nanosecond))
+        }
+        FilterableDataType::FilterableDate => Some(ProximaType::Date),
+        FilterableDataType::FilterableTime => Some(ProximaType::Time(TimeUnit::Nanosecond)),
+        FilterableDataType::FilterableUuid => Some(ProximaType::Uuid),
+        FilterableDataType::FilterableJson => Some(ProximaType::Json),
+        FilterableDataType::FilterableArrayString => {
+            Some(ProximaType::Array(Box::new(ProximaType::String)))
+        }
+        FilterableDataType::FilterableArrayInteger => {
+            Some(ProximaType::Array(Box::new(ProximaType::Int64)))
+        }
+        FilterableDataType::FilterableArrayFloat => {
+            Some(ProximaType::Array(Box::new(ProximaType::Float64)))
+        }
+        FilterableDataType::FilterableArrayBoolean => {
+            Some(ProximaType::Array(Box::new(ProximaType::Boolean)))
+        }
+        _ => None,
+    }
+}
+
+fn proxima_type_to_filterable_type(value: &ProximaType) -> Option<i32> {
+    let data_type = match value {
+        ProximaType::Int8 | ProximaType::Int16 | ProximaType::Int32 | ProximaType::Int64 => {
+            FilterableDataType::FilterableInteger
+        }
+        ProximaType::Float32 | ProximaType::Float64 => FilterableDataType::FilterableFloat,
+        ProximaType::Decimal { .. } => FilterableDataType::FilterableDecimal,
+        ProximaType::Boolean => FilterableDataType::FilterableBoolean,
+        ProximaType::Timestamp(_) => FilterableDataType::FilterableDatetime,
+        ProximaType::TimestampTz(_) => FilterableDataType::FilterableTimestampTz,
+        ProximaType::Date => FilterableDataType::FilterableDate,
+        ProximaType::Time(_) => FilterableDataType::FilterableTime,
+        ProximaType::Uuid => FilterableDataType::FilterableUuid,
+        ProximaType::Json | ProximaType::Jsonb => FilterableDataType::FilterableJson,
+        ProximaType::Array(inner) if matches!(inner.as_ref(), ProximaType::String) => {
+            FilterableDataType::FilterableArrayString
+        }
+        ProximaType::Array(inner)
+            if matches!(
+                inner.as_ref(),
+                ProximaType::Int8 | ProximaType::Int16 | ProximaType::Int32 | ProximaType::Int64
+            ) =>
+        {
+            FilterableDataType::FilterableArrayInteger
+        }
+        ProximaType::Array(inner)
+            if matches!(inner.as_ref(), ProximaType::Float32 | ProximaType::Float64) =>
+        {
+            FilterableDataType::FilterableArrayFloat
+        }
+        ProximaType::Array(inner) if matches!(inner.as_ref(), ProximaType::Boolean) => {
+            FilterableDataType::FilterableArrayBoolean
+        }
+        _ => return None,
+    };
+    Some(data_type as i32)
+}
+
+fn supports_range_filter(value: &ProximaType) -> bool {
+    matches!(
+        value,
+        ProximaType::Int8
+            | ProximaType::Int16
+            | ProximaType::Int32
+            | ProximaType::Int64
+            | ProximaType::Float32
+            | ProximaType::Float64
+            | ProximaType::Decimal { .. }
+            | ProximaType::Timestamp(_)
+            | ProximaType::TimestampTz(_)
+            | ProximaType::Date
+            | ProximaType::Time(_)
+    )
+}
+
 // ── ApiHandlersPort implementation ───────────────────────────────────────────
+// CANONICAL impl. New schema/port methods belong here (runtime-native shape).
+// The legacy twin lives in `src/api_handlers/request_handlers.rs`
+// (`impl ApiHandlersPort for UnifiedHandlers` on the root-crate struct) and
+// bridges to v1 CollectionRequest/CollectionOperation — edit that one only to
+// keep the bridge compiling; do not extend it for new functionality.
 
 #[async_trait]
 impl ApiHandlersPort for UnifiedHandlers {
@@ -231,6 +506,38 @@ impl ApiHandlersPort for UnifiedHandlers {
 
         resp.processing_time_us = start.elapsed().as_micros() as i64;
         Ok(resp)
+    }
+
+    async fn get_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        tenant_id: Option<&str>,
+    ) -> Result<Option<CollectionSchemaMetadata>> {
+        let collection = self
+            .collection
+            .get_collection(collection_id, tenant_id)
+            .await?;
+        Ok(collection.as_ref().map(schema_metadata_from_collection))
+    }
+
+    async fn update_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        update: CollectionSchemaUpdate,
+        tenant_id: Option<&str>,
+    ) -> Result<CollectionSchemaMetadata> {
+        let collection = self
+            .collection
+            .get_collection(collection_id, tenant_id)
+            .await?
+            .ok_or_else(|| anyhow!("collection not found: {collection_id}"))?;
+        let mut config = collection.config.clone().unwrap_or_default();
+        apply_schema_update(&mut config, update)?;
+        let updated = self
+            .collection
+            .update_collection(collection_id, config, tenant_id)
+            .await?;
+        Ok(schema_metadata_from_collection(&updated))
     }
 
     async fn handle_vector_search_v1_for_tenant(

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -36,7 +36,10 @@ pub use handlers::{CollectionIdCache, UnifiedHandlers};
 pub use hardware::{HardwareCapabilities, SimdLevel, best_simd_level, hardware_capabilities};
 pub use hybrid_port::HybridPort;
 pub use observability_port::ObservabilityPort;
-pub use port::ApiHandlersPort;
+pub use port::{
+    ApiHandlersPort, CollectionSchemaColumn, CollectionSchemaEnforcement, CollectionSchemaMetadata,
+    CollectionSchemaUpdate, CollectionTextStorage,
+};
 pub use record_ops_port::RecordOpsPort;
 pub use resources::{MemoryBudget, ResourceManager};
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -11,11 +11,64 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use proximadb_data_model::ProximaValue;
+use proximadb_data_model::{ProximaType, ProximaValue};
 use proximadb_proto::v1::{
     CollectionRequest, CollectionResponse, ExecuteQueryResponse, HybridSearchRequest,
     HybridSearchResponse, VectorBatchRequest, VectorOperationResponse, VectorSearchRequest,
 };
+
+/// Runtime-native schema metadata for v2 collection/schema handlers.
+///
+/// This is intentionally not a proto envelope. The underlying collection store
+/// may still adapt to older persisted metadata, but protocol adapters should
+/// depend on this v2-shaped contract instead of constructing v1 collection
+/// operation requests.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CollectionSchemaMetadata {
+    pub collection_id: String,
+    pub created_at_ms: i64,
+    pub updated_at_ms: i64,
+    pub schema_id: Option<String>,
+    pub schema_version: Option<String>,
+    pub enforcement: Option<CollectionSchemaEnforcement>,
+    pub auto_evolve: bool,
+    pub enabled: bool,
+    pub columns: Vec<CollectionSchemaColumn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectionSchemaUpdate {
+    pub schema_id: String,
+    pub schema_version: String,
+    pub enforcement: CollectionSchemaEnforcement,
+    pub auto_evolve: bool,
+    pub columns: Vec<CollectionSchemaColumn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollectionSchemaColumn {
+    pub name: String,
+    pub data_type: ProximaType,
+    pub nullable: bool,
+    pub indexed: bool,
+    pub filterable: bool,
+    pub text_storage: Option<CollectionTextStorage>,
+    pub max_length: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CollectionTextStorage {
+    Inline,
+    Large,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CollectionSchemaEnforcement {
+    Strict,
+    Flexible,
+    #[default]
+    Hybrid,
+}
 
 /// Port trait that protocol adapters use to dispatch API requests.
 ///
@@ -31,6 +84,23 @@ pub trait ApiHandlersPort: Send + Sync {
         request: CollectionRequest,
         tenant_id: Option<&str>,
     ) -> Result<CollectionResponse>;
+
+    /// Fetch v2 schema metadata for a collection without exposing v1 operation
+    /// envelopes to protocol adapters.
+    async fn get_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        tenant_id: Option<&str>,
+    ) -> Result<Option<CollectionSchemaMetadata>>;
+
+    /// Persist v2 schema metadata for a collection. Implementations may adapt to
+    /// legacy storage internally, but callers pass only the runtime-native shape.
+    async fn update_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        update: CollectionSchemaUpdate,
+        tenant_id: Option<&str>,
+    ) -> Result<CollectionSchemaMetadata>;
 
     // ── Vector ────────────────────────────────────────────────────────────────
 

--- a/docs/agent-rules/AGENT.md.seed
+++ b/docs/agent-rules/AGENT.md.seed
@@ -1,0 +1,52 @@
+# ProximaDB Agent Compatibility Guide (AGENT.md)
+
+This file is the singular-name compatibility alias for agent runtimes that look
+for `AGENT.md` instead of `AGENTS.md`. The canonical shared index remains
+`AGENTS.md`; keep this file short and aligned with `CLAUDE.md` mandates.
+
+## Read Order
+
+1. Read `AGENTS.md` for the shared trajectory and domain links.
+2. Read the model-specific guide when available:
+   - Anthropic/Claude agents: `CLAUDE.md`
+   - Gemini agents: `GEMINI.md`
+3. For TD/ADR filing, use `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`.
+
+## Mandatory Worktree Workflow
+
+Every implementation or audit-followup task must run in its own git worktree and
+branch off `origin/develop`.
+
+Required flow:
+
+1. From the main checkout, run `eval "$(scripts/worktree.sh new <type/topic>)"`.
+2. `cd` into the printed worktree.
+3. Run `scripts/worktree.sh guard` before editing.
+4. Rebase onto `origin/develop` before PR handoff; rebase daily or within 48
+   hours for active work.
+5. Never edit, stash, reset, checkout, commit, or force branches in the shared
+   main checkout. Never touch another worktree's branch or uncommitted work.
+6. If you inherit changes in the main checkout, save them as a patch, create a
+   task worktree from `origin/develop`, apply the patch there, then clean only
+   the copied files from the main checkout.
+7. Verify from the task worktree. Prefer the helper's `CARGO_INCREMENTAL=0` and
+   `sccache` setup to avoid per-worktree target bloat.
+8. After the PR merges, remove the worktree with
+   `scripts/worktree.sh rm <type/topic>`.
+
+## Non-Negotiable Engineering Rules
+
+- No `.unwrap()`, `.expect()`, or `panic!()` in production Rust; return typed
+  errors and use `?`.
+- All object-storage writes use `DrPathBuilder`; never write raw tenant/schema
+  paths.
+- I/O and heavy-compute boundaries carry `TenantContext` for isolation and
+  billing.
+- Performance claims require measured traces or evidence-ledger entries, not
+  component-only microbenchmarks.
+- Storage/wire/on-disk format changes must be mixed-read-safe, default-off until
+  baked, and gated by round-trip plus quality/recall tests.
+- SDK REST transport is generated from `docs/openapi/proximadb-openapi.yaml`
+  behind thin ergonomic facades; do not hand-roll REST route/payload parsing.
+- Keep PRs coherent and meaty enough to amortize CI, but still reviewable.
+- Do not add AI-agent attribution to commits or PRs.

--- a/docs/agent-rules/AGENTS.md.seed
+++ b/docs/agent-rules/AGENTS.md.seed
@@ -7,7 +7,26 @@ Depending on your identity, read the corresponding mandate file first:
 *   **Gemini Models:** Read `GEMINI.md`
 *   **Anthropic/Claude Models:** Read `CLAUDE.md`
 
+Agent runtimes that only support the singular root filename may read
+`AGENT.md`; it is a short compatibility alias for this `AGENTS.md` index and the
+model-specific guides above.
+
 **Filing a TD or ADR:** follow the canonical, collision-free convention in `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc` (one file per entry; prefer a topic-scoped id like `TD-CAT-1`; never reuse a number already on `develop`; the `td-adr-unique` CI guard backstops). That in-repo doc is the single source of truth — these per-agent rule files only point to it, so concurrent sessions/machines never drift.
+
+## Mandatory Worktree Workflow
+
+Every implementation or audit-followup task must run in its own git worktree and branch off `origin/develop`. Do not edit, stash, reset, checkout, commit, or branch-force in the shared main checkout, and do not touch another worktree's branch or uncommitted work.
+
+Required flow:
+
+1. Start from the main checkout and run `eval "$(scripts/worktree.sh new <type/topic>)"`.
+2. `cd` into the printed worktree and run `scripts/worktree.sh guard` before editing.
+3. Keep the branch short-lived: rebase onto `origin/develop` before PR handoff, and rebase daily or within 48 hours for active work.
+4. If you inherit changes already made in the main checkout, preserve them as a patch, create a task worktree from `origin/develop`, apply the patch there, then clean only those copied files from the main checkout.
+5. Run verification from the task worktree. Avoid sharing the root `target/` with unrelated long-running cargo jobs when possible; prefer the helper's `CARGO_INCREMENTAL=0`/`sccache` setup.
+6. After the PR merges, remove the worktree with `scripts/worktree.sh rm <type/topic>`. Periodically reclaim landed worktrees with `scripts/worktree.sh clean --dry-run` then `scripts/worktree.sh clean`; use `scripts/worktree.sh gc` for incremental-cache bloat in kept worktrees.
+
+When continuing "next steps", first identify the active worktree/branch, confirm it is based on current `origin/develop`, and continue there. If no appropriate worktree exists, create one before editing.
 
 ## 🚨 Active Development Trajectory (2026-06-04 Pivot) 🚨
 

--- a/docs/agent-rules/README.adoc
+++ b/docs/agent-rules/README.adoc
@@ -3,7 +3,8 @@
 = Per-developer agent instruction files (local-only seeds)
 
 The active agent-instruction files at the repo root — `CLAUDE.md`, `GEMINI.md`,
-`AGENTS.md` — are **gitignored and per-developer-local**. They are *not*
+`AGENTS.md`, and the singular compatibility alias `AGENT.md` — are
+**gitignored and per-developer-local**. They are *not*
 committed, so each developer maintains their own copy and concurrent
 sessions/machines never conflict over them (no merge conflicts, no
 cross-machine drift of the rule text itself).
@@ -14,6 +15,7 @@ git. To set up a fresh clone or a new machine:
     cp docs/agent-rules/CLAUDE.md.seed  CLAUDE.md
     cp docs/agent-rules/GEMINI.md.seed  GEMINI.md
     cp docs/agent-rules/AGENTS.md.seed  AGENTS.md
+    cp docs/agent-rules/AGENT.md.seed   AGENT.md
 
 …then customize your local copies freely (they stay untracked / gitignored).
 
@@ -37,6 +39,9 @@ local. Keep the seed copies' pointer to that doc current when you update your
 local rules.
 
 == Skills (local-only, seeded like the rule files)
+
+`AGENT.md` is intentionally a short alias for tools that look for the singular
+filename; `AGENTS.md` remains the canonical shared index.
 
 `.claude/skills/` is gitignored too (it is per-machine state). Shared skill
 *seeds* live under `docs/agent-rules/skills/` and are committed. To activate one

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -252,6 +252,17 @@ message SparseVector {
   uint32 dimension = 3;  // Total dimension of sparse space
 }
 
+// Element type for dense/sparse vector columns. Value names are prefixed to
+// avoid proto3 value-name collisions with ColumnDataType (FLOAT32/INT8/...).
+enum VectorElementType {
+  VECTOR_ELEMENT_TYPE_UNSPECIFIED = 0;
+  VECTOR_ELEMENT_FLOAT16 = 1;
+  VECTOR_ELEMENT_BFLOAT16 = 2;
+  VECTOR_ELEMENT_FLOAT32 = 3;
+  VECTOR_ELEMENT_FLOAT64 = 4;
+  VECTOR_ELEMENT_INT8 = 5;
+}
+
 // =============================================================================
 // TypedColumn: Column definition with validation constraints
 // =============================================================================
@@ -283,6 +294,7 @@ message TypedColumn {
 
   // VECTOR-specific options
   optional uint32 vector_dimension = 24;     // For DENSE_VECTOR / BINARY_VECTOR dimension
+  optional VectorElementType vector_element_type = 25;  // For DENSE_VECTOR / SPARSE_VECTOR element
 
   // TEXT-specific options
   optional TextStorageStrategy text_storage_strategy = 30;

--- a/proto/proximadb/v2/record.proto
+++ b/proto/proximadb/v2/record.proto
@@ -281,6 +281,9 @@ message TypedColumn {
   optional string json_schema = 22;          // JSON Schema for validation
   optional string timezone = 23;             // For TIMESTAMP_TZ default
 
+  // VECTOR-specific options
+  optional uint32 vector_dimension = 24;     // For DENSE_VECTOR / BINARY_VECTOR dimension
+
   // TEXT-specific options
   optional TextStorageStrategy text_storage_strategy = 30;
   optional bool enable_fulltext_index = 31;  // Create fulltext index

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -139,33 +139,41 @@ impl RecordOpsService {
     /// (`request.collection_id`) and the transport tenant id — the exact pair the
     /// network gates' `consult_for_write` uses — so the binding this populates is
     /// the one the gates read. Idempotent + cheap after the first write (registry
-    /// fast-path; the renew loop keeps the lease warm). Fail-open: a missing
-    /// manager (embedded/tests) or a transient acquire error never blocks the
-    /// write — the network gate + the A6 storage fence are the enforcement points.
-    async fn ensure_collection_lease(&self, tenant_id: &str, collection_name: &str) {
+    /// fast-path; the renew loop keeps the lease warm). A missing manager still
+    /// indicates embedded/single-node operation; once a manager is wired, conflicts
+    /// and acquire errors reject the write instead of proceeding fail-open.
+    async fn ensure_collection_lease(&self, tenant_id: &str, collection_name: &str) -> Result<()> {
         let Some(manager) = self.lease_manager.read().ok().and_then(|g| g.clone()) else {
-            return;
+            return Ok(());
         };
         let now_ms = chrono::Utc::now().timestamp_millis();
         match manager
             .ensure_owned(tenant_id, collection_name, now_ms)
             .await
         {
-            Ok(true) => {}
-            Ok(false) => tracing::warn!(
-                target = "proximadb.primary_pod.lease_on_write",
-                tenant_id = %tenant_id,
-                collection_id = %collection_name,
-                "lease-on-write: this pod is not the primary for the collection; \
-                 shared registry repointed to the owner (gate should now 421 subsequent writes)"
-            ),
-            Err(e) => tracing::warn!(
-                target = "proximadb.primary_pod.lease_on_write",
-                error = %e,
-                tenant_id = %tenant_id,
-                collection_id = %collection_name,
-                "lease-on-write acquire failed; proceeding fail-open"
-            ),
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                tracing::warn!(
+                    target = "proximadb.primary_pod.lease_on_write",
+                    tenant_id = %tenant_id,
+                    collection_id = %collection_name,
+                    "lease-on-write: this pod is not the primary for the collection; rejecting write"
+                );
+                Err(anyhow!(
+                    "this pod is not the primary for collection '{}'",
+                    collection_name
+                ))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target = "proximadb.primary_pod.lease_on_write",
+                    error = %e,
+                    tenant_id = %tenant_id,
+                    collection_id = %collection_name,
+                    "lease-on-write acquire failed; rejecting write"
+                );
+                Err(anyhow!("lease-on-write acquire failed: {}", e))
+            }
         }
     }
 
@@ -344,8 +352,15 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
-        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
-            .await;
+        if let Err(e) = self
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await
+        {
+            return Ok(BatchOperationResult::failure(
+                e.to_string(),
+                "LEASE_NOT_HELD".to_string(),
+            ));
+        }
         let result = self
             .vector_operations_service
             .delete_records_with_tenant_context(
@@ -407,8 +422,15 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
-        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
-            .await;
+        if let Err(e) = self
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await
+        {
+            return Ok(BatchOperationResult::failure(
+                e.to_string(),
+                "LEASE_NOT_HELD".to_string(),
+            ));
+        }
 
         let mut records = request.records;
         self.coerce_records_to_canonical_precision(&mut records, &request.collection_id)
@@ -481,8 +503,15 @@ impl RecordOpsService {
                 "WAL_LANE_REJECTED".to_string(),
             ));
         }
-        self.ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
-            .await;
+        if let Err(e) = self
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .await
+        {
+            return Ok(BatchOperationResult::failure(
+                e.to_string(),
+                "LEASE_NOT_HELD".to_string(),
+            ));
+        }
         let mut records = request.records;
         self.coerce_records_to_canonical_precision(&mut records, &request.collection_id)
             .await;

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -228,6 +228,23 @@ use crate::services::{
 };
 use crate::storage::document::DocumentService;
 
+/// # ⚠️ Legacy v1-proto-bridge handler — slated for retirement
+///
+/// This is the *legacy* of two same-named handler types. It is currently the
+/// default `AppState.api_handlers` (TD-104: cast to its `ApiHandlersPort` impl),
+/// but its impl bridges the runtime port contract to v1 `CollectionRequest` /
+/// `CollectionOperation` proto operations rather than speaking the runtime
+/// ports directly.
+///
+/// **Do not extend this type for new schema/port work.** The canonical seam is
+/// `proximadb_runtime::UnifiedHandlers`, which delegates to `CollectionPort` /
+/// `VectorOpsPort` and speaks the runtime-native `CollectionSchemaMetadata`
+/// (`ProximaType`) schema contract (its trait still bridges v1-proto methods
+/// too, pending TD-123). New methods go there; prod wiring flips to it via
+/// `with_api_handlers`. This type and its duplicated
+/// v1-bridge schema helpers (the `runtime_*` fns below) retire once that flip
+/// lands and handlers/ports finish aligning to the new direction.
+///
 /// Unified handlers that implement all business logic for API operations
 ///
 /// **Performance Enhancement**: Uses optimized VectorOperationsService for 40-60% faster vector operations
@@ -3836,6 +3853,246 @@ impl proximadb_runtime::RecordOpsPort for UnifiedHandlers {
     }
 }
 
+// ── Legacy v1-bridge schema helpers ─────────────────────────────────────────
+// These `runtime_*` fns translate between the canonical
+// `CollectionSchemaMetadata` / `CollectionSchemaUpdate` (`ProximaType`) contract
+// and the v1 `CollectionConfig` proto persisted shape. They are the bridge that
+// lets the legacy `UnifiedHandlers` (above) satisfy `ApiHandlersPort` today.
+// They DUPLICATE the runtime-native mapping in `proximadb_runtime::handlers` and
+// retire together with this handler once prod wiring flips to
+// `proximadb_runtime::UnifiedHandlers` — do not extend.
+fn runtime_schema_metadata_from_v1_collection(
+    collection: &crate::proto::proximadb_v1::Collection,
+) -> proximadb_runtime::CollectionSchemaMetadata {
+    let Some(config) = collection.config.as_ref() else {
+        return proximadb_runtime::CollectionSchemaMetadata {
+            collection_id: collection.id.clone(),
+            created_at_ms: collection.created_at,
+            updated_at_ms: collection.updated_at,
+            ..Default::default()
+        };
+    };
+
+    let mut columns = config
+        .text_columns
+        .iter()
+        .map(|name| proximadb_runtime::CollectionSchemaColumn {
+            name: name.clone(),
+            data_type: proximadb_data_model::ProximaType::String,
+            nullable: true,
+            indexed: false,
+            filterable: true,
+            text_storage: Some(proximadb_runtime::CollectionTextStorage::Inline),
+            max_length: None,
+        })
+        .collect::<Vec<_>>();
+    for text_config in &config.text_storage_configs {
+        if let Some(existing) = columns
+            .iter_mut()
+            .find(|column| column.name == text_config.column_name)
+        {
+            existing.text_storage = Some(proximadb_runtime::CollectionTextStorage::Large);
+            existing.max_length = Some(text_config.chunk_size);
+        } else {
+            columns.push(proximadb_runtime::CollectionSchemaColumn {
+                name: text_config.column_name.clone(),
+                data_type: proximadb_data_model::ProximaType::String,
+                nullable: true,
+                indexed: false,
+                filterable: false,
+                text_storage: Some(proximadb_runtime::CollectionTextStorage::Large),
+                max_length: Some(text_config.chunk_size),
+            });
+        }
+    }
+
+    columns.extend(config.filterable_columns.iter().filter_map(|column| {
+        runtime_filterable_to_proxima_type(column.data_type).map(|data_type| {
+            proximadb_runtime::CollectionSchemaColumn {
+                name: column.name.clone(),
+                data_type,
+                nullable: true,
+                indexed: column.indexed,
+                filterable: true,
+                text_storage: None,
+                max_length: None,
+            }
+        })
+    }));
+    let record_schema = config.record_schema.as_ref();
+
+    proximadb_runtime::CollectionSchemaMetadata {
+        collection_id: collection.id.clone(),
+        created_at_ms: collection.created_at,
+        updated_at_ms: collection.updated_at,
+        schema_id: record_schema.map(|schema| schema.schema_id.clone()),
+        schema_version: record_schema.map(|schema| schema.schema_version.clone()),
+        enforcement: record_schema.map(|schema| runtime_enforcement_from_i32(schema.enforcement)),
+        auto_evolve: record_schema.is_none_or(|schema| schema.auto_evolve),
+        enabled: config.enable_proxima_record.unwrap_or(false) || record_schema.is_some(),
+        columns,
+    }
+}
+
+fn apply_runtime_schema_update_to_v1_config(
+    config: &mut crate::proto::proximadb_v1::CollectionConfig,
+    update: proximadb_runtime::CollectionSchemaUpdate,
+) -> anyhow::Result<()> {
+    config.record_schema = Some(crate::proto::proximadb_v1::RecordSchemaConfig {
+        schema_id: update.schema_id,
+        schema_version: update.schema_version,
+        enforcement: runtime_enforcement_to_i32(update.enforcement),
+        auto_evolve: update.auto_evolve,
+        columns: Vec::new(),
+    });
+    config.enable_proxima_record = Some(true);
+    config.text_columns = update
+        .columns
+        .iter()
+        .filter(|column| matches!(column.data_type, proximadb_data_model::ProximaType::String))
+        .map(|column| column.name.clone())
+        .collect();
+    config.text_storage_configs = update
+        .columns
+        .iter()
+        .filter(|column| {
+            matches!(column.data_type, proximadb_data_model::ProximaType::String)
+                && matches!(
+                    column.text_storage,
+                    Some(proximadb_runtime::CollectionTextStorage::Large)
+                )
+        })
+        .map(|column| crate::proto::proximadb_v1::TextStorageConfig {
+            column_name: column.name.clone(),
+            strategy: 1,
+            inline_threshold: 4096,
+            chunked_threshold: 1_048_576,
+            chunk_size: column.max_length.unwrap_or(512),
+            ..Default::default()
+        })
+        .collect();
+    let mut filterable_columns = Vec::new();
+    for column in update.columns {
+        if matches!(column.data_type, proximadb_data_model::ProximaType::String) {
+            continue;
+        }
+        if let Some(data_type) = runtime_proxima_type_to_v1_filterable(&column.data_type) {
+            if column.filterable {
+                filterable_columns.push(crate::proto::proximadb_v1::FilterableColumnSpec {
+                    name: column.name,
+                    data_type,
+                    indexed: column.indexed,
+                    supports_range: runtime_supports_range_filter(&column.data_type),
+                    estimated_cardinality: None,
+                });
+            }
+            continue;
+        }
+        return Err(anyhow::anyhow!(
+            "legacy collection metadata cannot preserve schema column '{}' with canonical type {:?}",
+            column.name,
+            column.data_type
+        ));
+    }
+    config.filterable_columns = filterable_columns;
+    Ok(())
+}
+
+fn runtime_enforcement_from_i32(value: i32) -> proximadb_runtime::CollectionSchemaEnforcement {
+    match value {
+        1 => proximadb_runtime::CollectionSchemaEnforcement::Strict,
+        2 => proximadb_runtime::CollectionSchemaEnforcement::Flexible,
+        _ => proximadb_runtime::CollectionSchemaEnforcement::Hybrid,
+    }
+}
+
+fn runtime_enforcement_to_i32(value: proximadb_runtime::CollectionSchemaEnforcement) -> i32 {
+    match value {
+        proximadb_runtime::CollectionSchemaEnforcement::Strict => 1,
+        proximadb_runtime::CollectionSchemaEnforcement::Flexible => 2,
+        proximadb_runtime::CollectionSchemaEnforcement::Hybrid => 3,
+    }
+}
+
+fn runtime_filterable_to_proxima_type(value: i32) -> Option<proximadb_data_model::ProximaType> {
+    use crate::proto::proximadb_v1::FilterableDataType as F;
+    match F::try_from(value).ok()? {
+        F::FilterableInteger => Some(proximadb_data_model::ProximaType::Int64),
+        F::FilterableFloat => Some(proximadb_data_model::ProximaType::Float64),
+        F::FilterableDecimal => Some(proximadb_data_model::ProximaType::Decimal {
+            precision: 38,
+            scale: 18,
+        }),
+        F::FilterableBoolean => Some(proximadb_data_model::ProximaType::Boolean),
+        F::FilterableDatetime => Some(proximadb_data_model::ProximaType::Timestamp(
+            proximadb_data_model::TimeUnit::Nanosecond,
+        )),
+        F::FilterableTimestampTz => Some(proximadb_data_model::ProximaType::TimestampTz(
+            proximadb_data_model::TimeUnit::Nanosecond,
+        )),
+        F::FilterableDate => Some(proximadb_data_model::ProximaType::Date),
+        F::FilterableTime => Some(proximadb_data_model::ProximaType::Time(
+            proximadb_data_model::TimeUnit::Nanosecond,
+        )),
+        F::FilterableUuid => Some(proximadb_data_model::ProximaType::Uuid),
+        _ => None,
+    }
+}
+
+fn runtime_proxima_type_to_v1_filterable(value: &proximadb_data_model::ProximaType) -> Option<i32> {
+    use crate::proto::proximadb_v1::FilterableDataType as F;
+    let data_type = match value {
+        proximadb_data_model::ProximaType::Int8
+        | proximadb_data_model::ProximaType::Int16
+        | proximadb_data_model::ProximaType::Int32
+        | proximadb_data_model::ProximaType::Int64
+        | proximadb_data_model::ProximaType::UInt8
+        | proximadb_data_model::ProximaType::UInt16
+        | proximadb_data_model::ProximaType::UInt32
+        | proximadb_data_model::ProximaType::UInt64 => F::FilterableInteger,
+        proximadb_data_model::ProximaType::Float16
+        | proximadb_data_model::ProximaType::Float32
+        | proximadb_data_model::ProximaType::Float64 => F::FilterableFloat,
+        proximadb_data_model::ProximaType::Decimal { .. } => F::FilterableDecimal,
+        proximadb_data_model::ProximaType::Boolean => F::FilterableBoolean,
+        proximadb_data_model::ProximaType::Timestamp(_) => F::FilterableDatetime,
+        proximadb_data_model::ProximaType::TimestampTz(_) => F::FilterableTimestampTz,
+        proximadb_data_model::ProximaType::Date => F::FilterableDate,
+        proximadb_data_model::ProximaType::Time(_) => F::FilterableTime,
+        proximadb_data_model::ProximaType::Uuid => F::FilterableUuid,
+        _ => return None,
+    };
+    Some(data_type as i32)
+}
+
+fn runtime_supports_range_filter(value: &proximadb_data_model::ProximaType) -> bool {
+    matches!(
+        value,
+        proximadb_data_model::ProximaType::Int8
+            | proximadb_data_model::ProximaType::Int16
+            | proximadb_data_model::ProximaType::Int32
+            | proximadb_data_model::ProximaType::Int64
+            | proximadb_data_model::ProximaType::UInt8
+            | proximadb_data_model::ProximaType::UInt16
+            | proximadb_data_model::ProximaType::UInt32
+            | proximadb_data_model::ProximaType::UInt64
+            | proximadb_data_model::ProximaType::Float16
+            | proximadb_data_model::ProximaType::Float32
+            | proximadb_data_model::ProximaType::Float64
+            | proximadb_data_model::ProximaType::Decimal { .. }
+            | proximadb_data_model::ProximaType::Timestamp(_)
+            | proximadb_data_model::ProximaType::TimestampTz(_)
+            | proximadb_data_model::ProximaType::Date
+            | proximadb_data_model::ProximaType::Time(_)
+    )
+}
+
+// LEGACY v1-bridge impl (see the deprecation notice on `UnifiedHandlers`
+// above). Each method adapts the runtime `ApiHandlersPort` contract onto v1
+// proto CollectionRequest/CollectionOperation. This is the default prod handler
+// today but NOT the canonical seam — new schema/port methods belong on
+// `proximadb_runtime::UnifiedHandlers` instead. Keep this block compiling only
+// until the default flips via `with_api_handlers`.
 #[async_trait::async_trait]
 impl proximadb_runtime::ApiHandlersPort for UnifiedHandlers {
     async fn handle_collection_operation_for_tenant(
@@ -3845,6 +4102,74 @@ impl proximadb_runtime::ApiHandlersPort for UnifiedHandlers {
     ) -> anyhow::Result<crate::proto::proximadb_v1::CollectionResponse> {
         // Inherent method has the same signature — delegate directly.
         UnifiedHandlers::handle_collection_operation_for_tenant(self, request, tenant_id).await
+    }
+
+    async fn get_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        tenant_id: Option<&str>,
+    ) -> anyhow::Result<Option<proximadb_runtime::CollectionSchemaMetadata>> {
+        let response = UnifiedHandlers::handle_collection_operation_for_tenant(
+            self,
+            crate::proto::proximadb_v1::CollectionRequest {
+                operation: crate::proto::proximadb_v1::CollectionOperation::CollectionGet as i32,
+                collection_id: Some(collection_id.to_string()),
+                collection_config: None,
+                query_params: Default::default(),
+                options: Default::default(),
+                migration_config: Default::default(),
+            },
+            tenant_id,
+        )
+        .await?;
+        Ok(response
+            .collection
+            .as_ref()
+            .map(runtime_schema_metadata_from_v1_collection))
+    }
+
+    async fn update_collection_schema_metadata(
+        &self,
+        collection_id: &str,
+        update: proximadb_runtime::CollectionSchemaUpdate,
+        tenant_id: Option<&str>,
+    ) -> anyhow::Result<proximadb_runtime::CollectionSchemaMetadata> {
+        let get_response = UnifiedHandlers::handle_collection_operation_for_tenant(
+            self,
+            crate::proto::proximadb_v1::CollectionRequest {
+                operation: crate::proto::proximadb_v1::CollectionOperation::CollectionGet as i32,
+                collection_id: Some(collection_id.to_string()),
+                collection_config: None,
+                query_params: Default::default(),
+                options: Default::default(),
+                migration_config: Default::default(),
+            },
+            tenant_id,
+        )
+        .await?;
+        let collection = get_response
+            .collection
+            .ok_or_else(|| anyhow::anyhow!("collection not found: {collection_id}"))?;
+        let mut config = collection.config.clone().unwrap_or_default();
+        apply_runtime_schema_update_to_v1_config(&mut config, update)?;
+
+        let update_response = UnifiedHandlers::handle_collection_operation_for_tenant(
+            self,
+            crate::proto::proximadb_v1::CollectionRequest {
+                operation: crate::proto::proximadb_v1::CollectionOperation::CollectionUpdate as i32,
+                collection_id: Some(collection_id.to_string()),
+                collection_config: Some(config),
+                query_params: Default::default(),
+                options: Default::default(),
+                migration_config: Default::default(),
+            },
+            tenant_id,
+        )
+        .await?;
+        let updated = update_response
+            .collection
+            .ok_or_else(|| anyhow::anyhow!("collection update returned no collection"))?;
+        Ok(runtime_schema_metadata_from_v1_collection(&updated))
     }
 
     async fn handle_vector_search_v1_for_tenant(

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -2277,32 +2277,26 @@ impl PartitionLeaseManager {
     /// A6 storage-write fence decision: is THIS pod fenced out of writing
     /// `(tenant, collection)` to shared storage at `now_ms`?
     ///
-    /// Returns `true` iff a *live* lease (not released, not expired) is held by a
+    /// Returns `Ok(true)` iff a *live* lease (not released, not expired) is held by a
     /// **different** pod — i.e. a takeover has displaced this pod, so a flush from
-    /// it would publish stale data and must be rejected. Fail-open (`false`) when
-    /// no lease exists, the lease is released/expired, or the durable read errors:
-    /// the lease stack's bootstrap posture is fail-open, and the registry/admission
-    /// layer (lease-on-write) is the first line — this is the boundary backstop.
+    /// it would publish stale data and must be rejected. Durable read errors are
+    /// propagated so the storage fence can fail closed when enforcement is enabled.
     ///
     /// NOTE: this is the fence *primitive*. Wiring it at the live storage-write
     /// boundary is gated on the flush-path convergence (the server vector-flush
     /// path is currently stubbed; see the A6 TD / LEASE_FENCE_REREVIEW doc).
-    pub async fn is_fenced_out(&self, tenant_id: &str, collection_id: &str, now_ms: i64) -> bool {
+    pub async fn is_fenced_out(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        now_ms: i64,
+    ) -> Result<bool> {
         match self.current_holder(tenant_id, collection_id).await {
-            Ok(Some((_version, lease))) => {
-                !lease.released && !lease.is_expired(now_ms) && lease.holder_pod != self.self_pod_id
-            }
-            Ok(None) => false,
-            Err(e) => {
-                tracing::warn!(
-                    target: "proximadb.fence",
-                    tenant_id = %tenant_id,
-                    collection_id = %collection_id,
-                    error = %e,
-                    "A6 fence: durable lease read failed; failing open"
-                );
-                false
-            }
+            Ok(Some((_version, lease))) => Ok(!lease.released
+                && !lease.is_expired(now_ms)
+                && lease.holder_pod != self.self_pod_id),
+            Ok(None) => Ok(false),
+            Err(e) => Err(e),
         }
     }
 
@@ -3187,18 +3181,18 @@ mod tests {
         let mgr_b = test_manager(&backing, "B");
 
         // No lease yet → fail-open: nobody is fenced.
-        assert!(!mgr_a.is_fenced_out("t", "c", 0).await);
-        assert!(!mgr_b.is_fenced_out("t", "c", 0).await);
+        assert!(!mgr_a.is_fenced_out("t", "c", 0).await?);
+        assert!(!mgr_b.is_fenced_out("t", "c", 0).await?);
 
         // A acquires (t,c): A (holder) is not fenced; B (different pod) IS fenced
         // out while A's lease is live.
         assert!(mgr_a.acquire("t", "c", 0).await?);
         assert!(
-            !mgr_a.is_fenced_out("t", "c", 1).await,
+            !mgr_a.is_fenced_out("t", "c", 1).await?,
             "the leaseholder is never fenced out of its own partition"
         );
         assert!(
-            mgr_b.is_fenced_out("t", "c", 1).await,
+            mgr_b.is_fenced_out("t", "c", 1).await?,
             "a non-holder is fenced while another pod holds a live lease"
         );
 
@@ -3207,11 +3201,11 @@ mod tests {
         let after = LEASE_MS + 1;
         assert!(mgr_b.acquire("t", "c", after).await?);
         assert!(
-            mgr_a.is_fenced_out("t", "c", after + 1).await,
+            mgr_a.is_fenced_out("t", "c", after + 1).await?,
             "displaced A is fenced out after B's takeover (would resurrect stale data)"
         );
         assert!(
-            !mgr_b.is_fenced_out("t", "c", after + 1).await,
+            !mgr_b.is_fenced_out("t", "c", after + 1).await?,
             "new holder B is not fenced"
         );
         Ok(())
@@ -3684,13 +3678,13 @@ mod tests {
         assert!(mgr_a.acquire("t", "c", 0).await?);
         // A holds the live lease → A is not fenced; B (a different pod) IS fenced
         // out and must not flush.
-        assert!(!mgr_a.is_fenced_out("t", "c", 1).await);
-        assert!(mgr_b.is_fenced_out("t", "c", 1).await);
+        assert!(!mgr_a.is_fenced_out("t", "c", 1).await?);
+        assert!(mgr_b.is_fenced_out("t", "c", 1).await?);
         // No lease for an unrelated collection → fail-open (not fenced).
-        assert!(!mgr_b.is_fenced_out("t", "other", 1).await);
+        assert!(!mgr_b.is_fenced_out("t", "other", 1).await?);
         // Once A's lease expires with no renewal it is no longer live → B is no
         // longer fenced (it could legitimately take over).
-        assert!(!mgr_b.is_fenced_out("t", "c", LEASE_MS + 1).await);
+        assert!(!mgr_b.is_fenced_out("t", "c", LEASE_MS + 1).await?);
         // current_holder still surfaces the (now-stale) record for inspection.
         let held = mgr_b.current_holder("t", "c").await?;
         assert_eq!(held.map(|(_, l)| l.holder_pod), Some("A".to_string()));

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -207,6 +207,12 @@ fn runtime_metadata_to_grpc_schema(
             json_max_depth: None,
             json_schema: None,
             timezone: None,
+            vector_dimension: match &column.data_type {
+                ProximaType::DenseVector { dim, .. } | ProximaType::BinaryVector { dim } => {
+                    Some(*dim as u32)
+                }
+                _ => None,
+            },
             text_storage_strategy: None,
             enable_fulltext_index: None,
             enable_ngram_bloom: None,
@@ -345,7 +351,7 @@ fn grpc_column_type_to_proxima_type(
         proximadb_v2::ColumnDataType::GeoPolygon => ProximaType::GeographyPoint,
         proximadb_v2::ColumnDataType::Vector => ProximaType::DenseVector {
             element: VectorElement::Float32,
-            dim: 0,
+            dim: column.vector_dimension.unwrap_or(0) as usize,
         },
         proximadb_v2::ColumnDataType::SparseVector => ProximaType::SparseVector {
             element: VectorElement::Float32,
@@ -362,7 +368,9 @@ fn grpc_column_type_to_proxima_type(
         proximadb_v2::ColumnDataType::Jsonb => ProximaType::Jsonb,
         proximadb_v2::ColumnDataType::Ulid => ProximaType::ULID,
         proximadb_v2::ColumnDataType::Struct => ProximaType::Struct { fields: Vec::new() },
-        proximadb_v2::ColumnDataType::BinaryVector => ProximaType::BinaryVector { dim: 0 },
+        proximadb_v2::ColumnDataType::BinaryVector => ProximaType::BinaryVector {
+            dim: column.vector_dimension.unwrap_or(0) as usize,
+        },
     };
     Ok((ty, None))
 }
@@ -2346,6 +2354,74 @@ mod tests {
     fn test_typed_value_conversion() {
         // Test would require mocking UnifiedHandlers
         // For now, just verify the module compiles
+    }
+
+    #[test]
+    fn grpc_schema_round_trips_vector_dimension() {
+        // TypedColumn now carries vector_dimension, so Dense/BinaryVector dims
+        // survive metadata -> RecordSchema -> CollectionSchemaUpdate (the path
+        // that previously dropped dim to 0).
+        let dense = CollectionSchemaColumn {
+            name: "dense".to_string(),
+            data_type: ProximaType::DenseVector {
+                element: VectorElement::Float32,
+                dim: 128,
+            },
+            nullable: true,
+            indexed: false,
+            filterable: false,
+            text_storage: None,
+            max_length: None,
+        };
+        let binary = CollectionSchemaColumn {
+            name: "binary".to_string(),
+            data_type: ProximaType::BinaryVector { dim: 256 },
+            nullable: true,
+            indexed: false,
+            filterable: false,
+            text_storage: None,
+            max_length: None,
+        };
+        let metadata = CollectionSchemaMetadata {
+            collection_id: "c".to_string(),
+            enabled: true,
+            columns: vec![dense, binary],
+            ..Default::default()
+        };
+
+        let schema = runtime_metadata_to_grpc_schema(&metadata);
+        // Forward map must stamp vector_dimension onto the wire.
+        assert_eq!(
+            schema
+                .columns
+                .iter()
+                .find(|c| c.name == "dense")
+                .unwrap()
+                .vector_dimension,
+            Some(128)
+        );
+        assert_eq!(
+            schema
+                .columns
+                .iter()
+                .find(|c| c.name == "binary")
+                .unwrap()
+                .vector_dimension,
+            Some(256)
+        );
+
+        // Inverse map must read it back into the canonical ProximaType.
+        let update = grpc_record_schema_to_runtime_update("c", schema).unwrap();
+        let dense = update.columns.iter().find(|c| c.name == "dense").unwrap();
+        let binary = update.columns.iter().find(|c| c.name == "binary").unwrap();
+        assert!(matches!(
+            &dense.data_type,
+            ProximaType::DenseVector { dim, .. } if *dim == 128
+        ));
+        assert!(matches!(
+            &binary.data_type,
+            ProximaType::BinaryVector { dim } if *dim == 256
+        ));
     }
 
     #[test]

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -213,6 +213,13 @@ fn runtime_metadata_to_grpc_schema(
                 }
                 _ => None,
             },
+            vector_element_type: match &column.data_type {
+                ProximaType::DenseVector { element, .. }
+                | ProximaType::SparseVector { element } => {
+                    Some(proxima_vector_element_to_grpc(*element) as i32)
+                }
+                _ => None,
+            },
             text_storage_strategy: None,
             enable_fulltext_index: None,
             enable_ngram_bloom: None,
@@ -350,11 +357,11 @@ fn grpc_column_type_to_proxima_type(
         proximadb_v2::ColumnDataType::GeoPoint => ProximaType::Point,
         proximadb_v2::ColumnDataType::GeoPolygon => ProximaType::GeographyPoint,
         proximadb_v2::ColumnDataType::Vector => ProximaType::DenseVector {
-            element: VectorElement::Float32,
+            element: grpc_vector_element_to_proxima(column.vector_element_type),
             dim: column.vector_dimension.unwrap_or(0) as usize,
         },
         proximadb_v2::ColumnDataType::SparseVector => ProximaType::SparseVector {
-            element: VectorElement::Float32,
+            element: grpc_vector_element_to_proxima(column.vector_element_type),
         },
         proximadb_v2::ColumnDataType::Int8 => ProximaType::Int8,
         proximadb_v2::ColumnDataType::Int16 => ProximaType::Int16,
@@ -373,6 +380,34 @@ fn grpc_column_type_to_proxima_type(
         },
     };
     Ok((ty, None))
+}
+
+/// Map the wire `VectorElementType` (optional) into the canonical
+/// `VectorElement`. `None`/`Unspecified` fall back to `Float32` to preserve the
+/// historical default (pre-field behavior).
+fn grpc_vector_element_to_proxima(value: Option<i32>) -> VectorElement {
+    use proximadb_v2::VectorElementType as E;
+    match value
+        .and_then(|v| E::try_from(v).ok())
+        .unwrap_or(E::VectorElementFloat32)
+    {
+        E::VectorElementFloat16 => VectorElement::Float16,
+        E::VectorElementBfloat16 => VectorElement::BFloat16,
+        E::VectorElementFloat64 => VectorElement::Float64,
+        E::VectorElementInt8 => VectorElement::Int8,
+        E::VectorElementFloat32 | E::Unspecified => VectorElement::Float32,
+    }
+}
+
+fn proxima_vector_element_to_grpc(value: VectorElement) -> proximadb_v2::VectorElementType {
+    use proximadb_v2::VectorElementType as E;
+    match value {
+        VectorElement::Float16 => E::VectorElementFloat16,
+        VectorElement::BFloat16 => E::VectorElementBfloat16,
+        VectorElement::Float32 => E::VectorElementFloat32,
+        VectorElement::Float64 => E::VectorElementFloat64,
+        VectorElement::Int8 => E::VectorElementInt8,
+    }
 }
 
 fn proxima_type_to_grpc_column_type(
@@ -2357,15 +2392,27 @@ mod tests {
     }
 
     #[test]
-    fn grpc_schema_round_trips_vector_dimension() {
-        // TypedColumn now carries vector_dimension, so Dense/BinaryVector dims
-        // survive metadata -> RecordSchema -> CollectionSchemaUpdate (the path
-        // that previously dropped dim to 0).
+    fn grpc_schema_round_trips_vector_dim_and_element() {
+        // TypedColumn now carries vector_dimension + vector_element_type, so
+        // Dense/Sparse/Binary vector columns round-trip dim and element across
+        // metadata -> RecordSchema -> CollectionSchemaUpdate (previously dim
+        // dropped to 0 and element was hardcoded Float32).
         let dense = CollectionSchemaColumn {
             name: "dense".to_string(),
             data_type: ProximaType::DenseVector {
-                element: VectorElement::Float32,
+                element: VectorElement::Float16,
                 dim: 128,
+            },
+            nullable: true,
+            indexed: false,
+            filterable: false,
+            text_storage: None,
+            max_length: None,
+        };
+        let sparse = CollectionSchemaColumn {
+            name: "sparse".to_string(),
+            data_type: ProximaType::SparseVector {
+                element: VectorElement::Int8,
             },
             nullable: true,
             indexed: false,
@@ -2385,38 +2432,39 @@ mod tests {
         let metadata = CollectionSchemaMetadata {
             collection_id: "c".to_string(),
             enabled: true,
-            columns: vec![dense, binary],
+            columns: vec![dense, sparse, binary],
             ..Default::default()
         };
 
         let schema = runtime_metadata_to_grpc_schema(&metadata);
-        // Forward map must stamp vector_dimension onto the wire.
+        // Forward map stamps dimension + element onto the wire.
+        let wire = |n: &str| schema.columns.iter().find(|c| c.name == n).unwrap();
+        assert_eq!(wire("dense").vector_dimension, Some(128));
         assert_eq!(
-            schema
-                .columns
-                .iter()
-                .find(|c| c.name == "dense")
-                .unwrap()
-                .vector_dimension,
-            Some(128)
+            wire("dense").vector_element_type,
+            Some(proximadb_v2::VectorElementType::VectorElementFloat16 as i32)
         );
+        assert_eq!(wire("sparse").vector_dimension, None);
         assert_eq!(
-            schema
-                .columns
-                .iter()
-                .find(|c| c.name == "binary")
-                .unwrap()
-                .vector_dimension,
-            Some(256)
+            wire("sparse").vector_element_type,
+            Some(proximadb_v2::VectorElementType::VectorElementInt8 as i32)
         );
+        assert_eq!(wire("binary").vector_dimension, Some(256));
+        assert_eq!(wire("binary").vector_element_type, None);
 
-        // Inverse map must read it back into the canonical ProximaType.
+        // Inverse map reads them back into the canonical ProximaType.
         let update = grpc_record_schema_to_runtime_update("c", schema).unwrap();
         let dense = update.columns.iter().find(|c| c.name == "dense").unwrap();
+        let sparse = update.columns.iter().find(|c| c.name == "sparse").unwrap();
         let binary = update.columns.iter().find(|c| c.name == "binary").unwrap();
         assert!(matches!(
             &dense.data_type,
-            ProximaType::DenseVector { dim, .. } if *dim == 128
+            ProximaType::DenseVector { element, dim }
+                if *element == VectorElement::Float16 && *dim == 128
+        ));
+        assert!(matches!(
+            &sparse.data_type,
+            ProximaType::SparseVector { element } if *element == VectorElement::Int8
         ));
         assert!(matches!(
             &binary.data_type,

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -44,8 +44,13 @@ use crate::services::operations::BatchOperationResult;
 use crate::services::{
     WriteDurabilityRequirement, WriteIntent, WriteLaneRouter, WriteOperationKind,
 };
+use proximadb_data_model::{ProximaType, TimeUnit, VectorElement};
 use proximadb_records::proto_v2::{
     proto_record_to_envelope, proxima_value_to_typed_value, typed_value_to_proxima,
+};
+use proximadb_runtime::{
+    CollectionSchemaColumn, CollectionSchemaEnforcement, CollectionSchemaMetadata,
+    CollectionSchemaUpdate, CollectionTextStorage,
 };
 
 /// gRPC V2 ProximaRecord service implementation
@@ -126,6 +131,303 @@ fn check_primary_pod_gate(
             };
             Err(api_err.into())
         }
+    }
+}
+
+fn grpc_record_schema_to_runtime_update(
+    collection_id: &str,
+    schema: proximadb_v2::RecordSchema,
+) -> Result<CollectionSchemaUpdate, Status> {
+    let schema_id = if schema.schema_id.is_empty() {
+        format!("schema_{}_{}", collection_id, uuid::Uuid::new_v4())
+    } else {
+        schema.schema_id
+    };
+    let schema_version = if schema.schema_version.is_empty() {
+        "1.0.0".to_string()
+    } else {
+        schema.schema_version
+    };
+
+    let mut columns = Vec::with_capacity(schema.columns.len());
+    for column in schema.columns {
+        let name = column.name.clone();
+        let (data_type, text_storage) = grpc_column_type_to_proxima_type(&column)?;
+        columns.push(CollectionSchemaColumn {
+            name,
+            data_type,
+            nullable: column.nullable,
+            indexed: column.indexed,
+            filterable: column.filterable,
+            text_storage,
+            max_length: column.max_length,
+        });
+    }
+
+    Ok(CollectionSchemaUpdate {
+        schema_id,
+        schema_version,
+        enforcement: grpc_enforcement_to_runtime(schema.enforcement_mode),
+        auto_evolve: schema.allow_additional_fields,
+        columns,
+    })
+}
+
+fn runtime_metadata_to_grpc_schema(
+    metadata: &CollectionSchemaMetadata,
+) -> proximadb_v2::RecordSchema {
+    let columns = metadata
+        .columns
+        .iter()
+        .map(|column| proximadb_v2::TypedColumn {
+            name: column.name.clone(),
+            data_type: proxima_type_to_grpc_column_type(&column.data_type, column.text_storage)
+                as i32,
+            nullable: column.nullable,
+            indexed: column.indexed,
+            filterable: column.filterable,
+            unique: false,
+            max_length: column.max_length,
+            min_length: None,
+            min_value: None,
+            max_value: None,
+            min_float_value: None,
+            max_float_value: None,
+            regex_pattern: None,
+            default_value: None,
+            decimal_precision: match &column.data_type {
+                ProximaType::Decimal { precision, .. } => Some(*precision as u32),
+                _ => None,
+            },
+            decimal_scale: match &column.data_type {
+                ProximaType::Decimal { scale, .. } => Some(*scale as u32),
+                _ => None,
+            },
+            array_max_items: None,
+            json_max_depth: None,
+            json_schema: None,
+            timezone: None,
+            text_storage_strategy: None,
+            enable_fulltext_index: None,
+            enable_ngram_bloom: None,
+            ngram_size: None,
+            description: None,
+            annotations: HashMap::new(),
+        })
+        .collect::<Vec<_>>();
+
+    proximadb_v2::RecordSchema {
+        schema_id: metadata
+            .schema_id
+            .clone()
+            .unwrap_or_else(|| format!("schema_{}", metadata.collection_id)),
+        schema_version: metadata
+            .schema_version
+            .clone()
+            .unwrap_or_else(|| "1.0.0".to_string()),
+        schema_name: String::new(),
+        columns,
+        enforcement_mode: runtime_enforcement_to_grpc(metadata.enforcement.unwrap_or_default())
+            as i32,
+        allow_additional_fields: metadata.auto_evolve,
+        parent_schema_id: None,
+        evolution_rules: Vec::new(),
+        created_at: metadata.created_at_ms,
+        created_by: None,
+        description: None,
+        annotations: HashMap::new(),
+    }
+}
+
+fn grpc_enforcement_to_runtime(value: i32) -> CollectionSchemaEnforcement {
+    match proximadb_v2::SchemaEnforcementMode::try_from(value)
+        .unwrap_or(proximadb_v2::SchemaEnforcementMode::Hybrid)
+    {
+        proximadb_v2::SchemaEnforcementMode::Strict => CollectionSchemaEnforcement::Strict,
+        proximadb_v2::SchemaEnforcementMode::Flexible => CollectionSchemaEnforcement::Flexible,
+        _ => CollectionSchemaEnforcement::Hybrid,
+    }
+}
+
+fn runtime_enforcement_to_grpc(
+    value: CollectionSchemaEnforcement,
+) -> proximadb_v2::SchemaEnforcementMode {
+    match value {
+        CollectionSchemaEnforcement::Strict => proximadb_v2::SchemaEnforcementMode::Strict,
+        CollectionSchemaEnforcement::Flexible => proximadb_v2::SchemaEnforcementMode::Flexible,
+        CollectionSchemaEnforcement::Hybrid => proximadb_v2::SchemaEnforcementMode::Hybrid,
+    }
+}
+
+fn grpc_column_type_to_proxima_type(
+    column: &proximadb_v2::TypedColumn,
+) -> Result<(ProximaType, Option<CollectionTextStorage>), Status> {
+    let data_type = proximadb_v2::ColumnDataType::try_from(column.data_type)
+        .unwrap_or(proximadb_v2::ColumnDataType::ColumnTypeUnspecified);
+    let ty = match data_type {
+        proximadb_v2::ColumnDataType::ColumnTypeUnspecified => {
+            return Err(Status::invalid_argument(format!(
+                "Schema column '{}' has unspecified datatype",
+                column.name
+            )));
+        }
+        proximadb_v2::ColumnDataType::Text => {
+            return Ok((ProximaType::String, Some(CollectionTextStorage::Inline)));
+        }
+        proximadb_v2::ColumnDataType::TextLarge => {
+            return Ok((ProximaType::String, Some(CollectionTextStorage::Large)));
+        }
+        proximadb_v2::ColumnDataType::Integer => ProximaType::Int64,
+        proximadb_v2::ColumnDataType::Float => ProximaType::Float64,
+        proximadb_v2::ColumnDataType::Decimal => {
+            let precision = column.decimal_precision.unwrap_or(38);
+            let scale = column.decimal_scale.unwrap_or(18);
+            if precision == 0 || precision > 38 {
+                return Err(Status::invalid_argument(format!(
+                    "Schema column '{}' decimal precision must be between 1 and 38",
+                    column.name
+                )));
+            }
+            if scale > precision {
+                return Err(Status::invalid_argument(format!(
+                    "Schema column '{}' decimal scale cannot exceed precision",
+                    column.name
+                )));
+            }
+            ProximaType::Decimal {
+                precision: precision as u8,
+                scale: scale as u8,
+            }
+        }
+        proximadb_v2::ColumnDataType::Boolean => ProximaType::Boolean,
+        proximadb_v2::ColumnDataType::Timestamp => ProximaType::Timestamp(TimeUnit::Nanosecond),
+        proximadb_v2::ColumnDataType::TimestampTz => ProximaType::TimestampTz(TimeUnit::Nanosecond),
+        proximadb_v2::ColumnDataType::Date => ProximaType::Date,
+        proximadb_v2::ColumnDataType::Time => ProximaType::Time(TimeUnit::Nanosecond),
+        proximadb_v2::ColumnDataType::Duration => ProximaType::Duration(TimeUnit::Nanosecond),
+        proximadb_v2::ColumnDataType::Interval => ProximaType::Interval(TimeUnit::Nanosecond),
+        proximadb_v2::ColumnDataType::Uuid => ProximaType::Uuid,
+        proximadb_v2::ColumnDataType::Binary | proximadb_v2::ColumnDataType::BinaryLarge => {
+            ProximaType::Binary
+        }
+        proximadb_v2::ColumnDataType::Json => ProximaType::Json,
+        proximadb_v2::ColumnDataType::ArrayText => {
+            ProximaType::Array(Box::new(ProximaType::String))
+        }
+        proximadb_v2::ColumnDataType::ArrayInteger => {
+            ProximaType::Array(Box::new(ProximaType::Int64))
+        }
+        proximadb_v2::ColumnDataType::ArrayFloat => {
+            ProximaType::Array(Box::new(ProximaType::Float64))
+        }
+        proximadb_v2::ColumnDataType::ArrayBoolean => {
+            ProximaType::Array(Box::new(ProximaType::Boolean))
+        }
+        proximadb_v2::ColumnDataType::ArrayUuid => ProximaType::Array(Box::new(ProximaType::Uuid)),
+        proximadb_v2::ColumnDataType::ArrayAny => ProximaType::Array(Box::new(ProximaType::Json)),
+        proximadb_v2::ColumnDataType::MapStringString => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::String),
+        },
+        proximadb_v2::ColumnDataType::MapStringAny => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::Json),
+        },
+        proximadb_v2::ColumnDataType::MapStringInteger => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::Int64),
+        },
+        proximadb_v2::ColumnDataType::MapStringFloat => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::Float64),
+        },
+        proximadb_v2::ColumnDataType::GeoPoint => ProximaType::Point,
+        proximadb_v2::ColumnDataType::GeoPolygon => ProximaType::GeographyPoint,
+        proximadb_v2::ColumnDataType::Vector => ProximaType::DenseVector {
+            element: VectorElement::Float32,
+            dim: 0,
+        },
+        proximadb_v2::ColumnDataType::SparseVector => ProximaType::SparseVector {
+            element: VectorElement::Float32,
+        },
+        proximadb_v2::ColumnDataType::Int8 => ProximaType::Int8,
+        proximadb_v2::ColumnDataType::Int16 => ProximaType::Int16,
+        proximadb_v2::ColumnDataType::Int32 => ProximaType::Int32,
+        proximadb_v2::ColumnDataType::Uint8 => ProximaType::UInt8,
+        proximadb_v2::ColumnDataType::Uint16 => ProximaType::UInt16,
+        proximadb_v2::ColumnDataType::Uint32 => ProximaType::UInt32,
+        proximadb_v2::ColumnDataType::Uint64 => ProximaType::UInt64,
+        proximadb_v2::ColumnDataType::Float32 => ProximaType::Float32,
+        proximadb_v2::ColumnDataType::Symbol => ProximaType::Symbol,
+        proximadb_v2::ColumnDataType::Jsonb => ProximaType::Jsonb,
+        proximadb_v2::ColumnDataType::Ulid => ProximaType::ULID,
+        proximadb_v2::ColumnDataType::Struct => ProximaType::Struct { fields: Vec::new() },
+        proximadb_v2::ColumnDataType::BinaryVector => ProximaType::BinaryVector { dim: 0 },
+    };
+    Ok((ty, None))
+}
+
+fn proxima_type_to_grpc_column_type(
+    value: &ProximaType,
+    text_storage: Option<CollectionTextStorage>,
+) -> proximadb_v2::ColumnDataType {
+    match value {
+        ProximaType::String => match text_storage {
+            Some(CollectionTextStorage::Large) => proximadb_v2::ColumnDataType::TextLarge,
+            _ => proximadb_v2::ColumnDataType::Text,
+        },
+        ProximaType::Int8 => proximadb_v2::ColumnDataType::Int8,
+        ProximaType::Int16 => proximadb_v2::ColumnDataType::Int16,
+        ProximaType::Int32 => proximadb_v2::ColumnDataType::Int32,
+        ProximaType::Int64 => proximadb_v2::ColumnDataType::Integer,
+        ProximaType::UInt8 => proximadb_v2::ColumnDataType::Uint8,
+        ProximaType::UInt16 => proximadb_v2::ColumnDataType::Uint16,
+        ProximaType::UInt32 => proximadb_v2::ColumnDataType::Uint32,
+        ProximaType::UInt64 => proximadb_v2::ColumnDataType::Uint64,
+        ProximaType::Float16 | ProximaType::Float32 => proximadb_v2::ColumnDataType::Float32,
+        ProximaType::Float64 => proximadb_v2::ColumnDataType::Float,
+        ProximaType::Decimal { .. } => proximadb_v2::ColumnDataType::Decimal,
+        ProximaType::Boolean => proximadb_v2::ColumnDataType::Boolean,
+        ProximaType::Timestamp(_) => proximadb_v2::ColumnDataType::Timestamp,
+        ProximaType::TimestampTz(_) => proximadb_v2::ColumnDataType::TimestampTz,
+        ProximaType::Date => proximadb_v2::ColumnDataType::Date,
+        ProximaType::Time(_) => proximadb_v2::ColumnDataType::Time,
+        ProximaType::Duration(_) => proximadb_v2::ColumnDataType::Duration,
+        ProximaType::Interval(_) => proximadb_v2::ColumnDataType::Interval,
+        ProximaType::Uuid => proximadb_v2::ColumnDataType::Uuid,
+        ProximaType::ULID => proximadb_v2::ColumnDataType::Ulid,
+        ProximaType::Binary => proximadb_v2::ColumnDataType::Binary,
+        ProximaType::Json => proximadb_v2::ColumnDataType::Json,
+        ProximaType::Jsonb => proximadb_v2::ColumnDataType::Jsonb,
+        ProximaType::Array(inner) => match inner.as_ref() {
+            ProximaType::String => proximadb_v2::ColumnDataType::ArrayText,
+            ProximaType::Int64 => proximadb_v2::ColumnDataType::ArrayInteger,
+            ProximaType::Float64 => proximadb_v2::ColumnDataType::ArrayFloat,
+            ProximaType::Boolean => proximadb_v2::ColumnDataType::ArrayBoolean,
+            ProximaType::Uuid => proximadb_v2::ColumnDataType::ArrayUuid,
+            _ => proximadb_v2::ColumnDataType::ArrayAny,
+        },
+        ProximaType::Map { key, value } => match (key.as_ref(), value.as_ref()) {
+            (ProximaType::String, ProximaType::String) => {
+                proximadb_v2::ColumnDataType::MapStringString
+            }
+            (ProximaType::String, ProximaType::Int64) => {
+                proximadb_v2::ColumnDataType::MapStringInteger
+            }
+            (ProximaType::String, ProximaType::Float64) => {
+                proximadb_v2::ColumnDataType::MapStringFloat
+            }
+            (ProximaType::String, _) => proximadb_v2::ColumnDataType::MapStringAny,
+            _ => proximadb_v2::ColumnDataType::MapStringAny,
+        },
+        ProximaType::Struct { .. } => proximadb_v2::ColumnDataType::Struct,
+        ProximaType::Point => proximadb_v2::ColumnDataType::GeoPoint,
+        ProximaType::GeographyPoint => proximadb_v2::ColumnDataType::GeoPolygon,
+        ProximaType::DenseVector { .. } => proximadb_v2::ColumnDataType::Vector,
+        ProximaType::SparseVector { .. } => proximadb_v2::ColumnDataType::SparseVector,
+        ProximaType::BinaryVector { .. } => proximadb_v2::ColumnDataType::BinaryVector,
+        ProximaType::Symbol => proximadb_v2::ColumnDataType::Symbol,
+        ProximaType::Null => proximadb_v2::ColumnDataType::Json,
     }
 }
 
@@ -1560,49 +1862,23 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         let req = request.into_inner();
         info!("V2 gRPC: CreateSchema - collection='{}'", req.collection_id);
 
-        // Get collection to verify it exists
-        let collection_request = CollectionRequest {
-            operation: CollectionOperation::CollectionGet as i32,
-            collection_id: Some(req.collection_id.clone()),
-            collection_config: None,
-            query_params: Default::default(),
-            options: Default::default(),
-            migration_config: Default::default(),
-        };
+        let schema = req
+            .schema
+            .ok_or_else(|| Status::invalid_argument("schema is required"))?;
+        let update = grpc_record_schema_to_runtime_update(&req.collection_id, schema)?;
+        let schema_id = update.schema_id.clone();
 
-        let collection_response = self
-            .api_handlers
-            .handle_collection_operation_for_tenant(collection_request, tenant_id.as_deref())
+        self.api_handlers
+            .update_collection_schema_metadata(&req.collection_id, update, tenant_id.as_deref())
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
                     Status::not_found(format!("Collection not found: {}", req.collection_id))
                 } else {
-                    Status::internal(format!("Failed to get collection: {}", e))
+                    Status::internal(format!("Failed to create schema: {}", e))
                 }
             })?;
 
-        if collection_response.collection.is_none() {
-            return Err(Status::not_found(format!(
-                "Collection not found: {}",
-                req.collection_id
-            )));
-        }
-
-        // Generate schema ID
-        let schema_id = req.schema.as_ref().map_or_else(
-            || format!("schema_{}_{}", req.collection_id, uuid::Uuid::new_v4()),
-            |s| {
-                if s.schema_id.is_empty() {
-                    format!("schema_{}_{}", req.collection_id, uuid::Uuid::new_v4())
-                } else {
-                    s.schema_id.clone()
-                }
-            },
-        );
-
-        // For now, we don't persist the schema separately - it's stored in collection config
-        // A full implementation would update the collection's record_schema config
         Ok(Response::new(CreateSchemaResponse {
             success: true,
             schema_id,
@@ -1619,61 +1895,29 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         let req = request.into_inner();
         debug!("V2 gRPC: GetSchema - collection='{}'", req.collection_id);
 
-        // Get collection to retrieve schema
-        let collection_request = CollectionRequest {
-            operation: CollectionOperation::CollectionGet as i32,
-            collection_id: Some(req.collection_id.clone()),
-            collection_config: None,
-            query_params: Default::default(),
-            options: Default::default(),
-            migration_config: Default::default(),
-        };
-
-        let collection_response = self
+        let metadata = self
             .api_handlers
-            .handle_collection_operation_for_tenant(collection_request, tenant_id.as_deref())
+            .get_collection_schema_metadata(&req.collection_id, tenant_id.as_deref())
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
                     Status::not_found(format!("Collection not found: {}", req.collection_id))
                 } else {
-                    Status::internal(format!("Failed to get collection: {}", e))
+                    Status::internal(format!("Failed to get collection schema: {}", e))
                 }
+            })?
+            .ok_or_else(|| {
+                Status::not_found(format!("Collection not found: {}", req.collection_id))
             })?;
 
-        let collection = collection_response.collection.ok_or_else(|| {
-            Status::not_found(format!("Collection not found: {}", req.collection_id))
-        })?;
-
-        let config = collection
-            .config
-            .ok_or_else(|| Status::internal("Collection has no configuration"))?;
-
-        // Build schema from collection config
-        if !config.enable_proxima_record.unwrap_or(false) && config.record_schema.is_none() {
+        if !metadata.enabled {
             return Err(Status::not_found(format!(
                 "No schema defined for collection '{}'. Enable ProximaRecord to use schemas.",
                 req.collection_id
             )));
         }
 
-        // Build schema from record_schema config
-        let schema = config.record_schema.map(|schema_config| {
-            proximadb_v2::RecordSchema {
-                schema_id: schema_config.schema_id,
-                schema_version: schema_config.schema_version,
-                schema_name: String::new(),
-                columns: vec![], // Would need to convert columns
-                enforcement_mode: schema_config.enforcement,
-                allow_additional_fields: schema_config.auto_evolve,
-                parent_schema_id: None,
-                evolution_rules: vec![],
-                created_at: collection.created_at,
-                created_by: None,
-                description: None,
-                annotations: HashMap::new(),
-            }
-        });
+        let schema = Some(runtime_metadata_to_grpc_schema(&metadata));
 
         Ok(Response::new(GetSchemaResponse {
             success: true,
@@ -1687,34 +1931,31 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ListSchemasRequest>,
     ) -> Result<Response<ListSchemasResponse>, Status> {
+        let tenant_id = Self::extract_tenant_id(&request);
         let req = request.into_inner();
         debug!("V2 gRPC: ListSchemas - collection='{}'", req.collection_id);
 
-        // Get collection schema (currently only one schema per collection)
-        let get_req = GetSchemaRequest {
-            collection_id: req.collection_id.clone(),
-            schema_id: None,
-        };
+        let metadata = self
+            .api_handlers
+            .get_collection_schema_metadata(&req.collection_id, tenant_id.as_deref())
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("not found") {
+                    Status::not_found(format!("Collection not found: {}", req.collection_id))
+                } else {
+                    Status::internal(format!("Failed to list schemas: {}", e))
+                }
+            })?;
 
-        match self.get_schema(Request::new(get_req)).await {
-            Ok(resp) => {
-                let schemas = resp.into_inner().schema.into_iter().collect::<Vec<_>>();
-                let total_count = schemas.len() as i64;
-
-                Ok(Response::new(ListSchemasResponse {
-                    schemas,
-                    total_count,
-                }))
-            }
-            Err(e) if e.code() == tonic::Code::NotFound => {
-                // No schema defined - return empty list
-                Ok(Response::new(ListSchemasResponse {
-                    schemas: vec![],
-                    total_count: 0,
-                }))
-            }
-            Err(e) => Err(e),
-        }
+        let schemas = metadata
+            .filter(|metadata| metadata.enabled)
+            .map(|metadata| vec![runtime_metadata_to_grpc_schema(&metadata)])
+            .unwrap_or_default();
+        let total_count = schemas.len() as i64;
+        Ok(Response::new(ListSchemasResponse {
+            schemas,
+            total_count,
+        }))
     }
 
     /// Evolve schema with compatibility checks

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -1064,21 +1064,11 @@ impl RestServer {
         tracing::info!(
             "   POST   /api/v2/collections/:id/records/batch - Canonical ProximaRecord writes"
         );
-        tracing::info!("Compatibility endpoints:");
-        tracing::info!(
-            "   POST   /api/v1/search                    - Deprecated vector search adapter"
-        );
-        tracing::info!(
-            "   POST   /api/v1/vectors/batch             - Deprecated alias over record writes"
-        );
+        tracing::info!("Auxiliary endpoints:");
         tracing::info!("   POST   /api/v1/progressive/search/:id    - Progressive search (JSON)");
-        tracing::info!(
-            "   POST   /api/v1/collections               - Deprecated collection compatibility"
-        );
-        tracing::info!("   GET    /api/v1/collections               - List collections");
-        tracing::info!("   GET    /api/v1/collections/:id           - Get collection by ID");
-        tracing::info!("   DELETE /api/v1/collections/:id           - Delete collection");
-        tracing::info!("   POST   /api/v1/search/with_metadata      - Vector search with metadata");
+        // Legacy /api/v1 vector/collection/search REST surfaces are removed;
+        // those paths return a /api/v2 migration hint (see `v1_replacement_for`).
+        // Do not re-advertise them here.
         tracing::info!("   WS     /ws/insert                        - WebSocket vector streaming");
         tracing::info!(
             "   WS     /ws/subscribe                     - WebSocket live query subscription"

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -1712,7 +1712,7 @@ pub fn create_router(state: AppState) -> axum::Router {
         }
     }
 
-    info!("✅ REST API: Router created with canonical v2 routes and v1 compatibility adapters:");
+    info!("✅ REST API: Router created with canonical v2 routes:");
     info!(
         "   POST   /api/v2/collections/:collection/records/batch (canonical ProximaRecord writes)"
     );
@@ -1720,19 +1720,14 @@ pub fn create_router(state: AppState) -> axum::Router {
     info!(
         "   GET    /api/v2/collections/:collection/records/:record (canonical ProximaRecord fetch)"
     );
-    info!("   POST   /api/v1/collections (deprecated compatibility via proximadb-api)");
-    info!("   GET    /api/v1/collections (deprecated compatibility via proximadb-api)");
-    info!("   GET    /api/v1/collections/:id (deprecated compatibility via proximadb-api)");
-    info!("   DELETE /api/v1/collections/:id (deprecated compatibility via proximadb-api)");
-    info!("   POST   /api/v1/search (deprecated compatibility via proximadb-api)");
-    info!("   POST   /api/v1/search/with_metadata (deprecated compatibility via proximadb-api)");
-    info!("   POST   /api/v1/vectors/batch (deprecated alias over record-native writes)");
-    info!("   GET    /api/v1/vectors/:collection_id/:vector_id (deprecated compatibility)");
-    info!("   DELETE /api/v1/vectors/:collection_id/:vector_id (deprecated compatibility)");
-    info!("   POST   /api/v1/hybrid/search (deprecated compatibility; real BM25+vector)");
-    info!("   POST   /api/v1/hybrid/index (deprecated compatibility)");
-    // /api/v1/experimental/hybrid/search route removed 2026-05-26 — was
-    // mock-backed; production path is /api/v1/hybrid/search above.
+    // NOTE: the legacy /api/v1 vector/collection/search/hybrid REST surfaces were
+    // removed in the API-standardization hard-rename; those paths now fall through
+    // to a migration hint redirecting to /api/v2 (see `v1_replacement_for`). The
+    // only live /api/v1 mount is the Iceberg REST catalog adapter at
+    // /api/v1/catalogs. Do not re-advertise the removed routes here — that misleads
+    // callers into thinking v1 REST is still served.
+    // (/api/v1/experimental/hybrid/search was removed 2026-05-26; it was
+    // mock-backed. The real hybrid path is /api/v2/hybrid/search.)
 
     router
 }

--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -392,7 +392,15 @@ pub fn parse_rest_data_type(
     use proximadb_data_model::{ProximaType, TimeUnit, VectorElement};
     let ty = match column.data_type.as_str() {
         "text" | "text_large" => ProximaType::String,
+        "int8" => ProximaType::Int8,
+        "int16" => ProximaType::Int16,
+        "int32" => ProximaType::Int32,
         "integer" => ProximaType::Int64,
+        "uint8" => ProximaType::UInt8,
+        "uint16" => ProximaType::UInt16,
+        "uint32" => ProximaType::UInt32,
+        "uint64" => ProximaType::UInt64,
+        "float32" => ProximaType::Float32,
         "float" => ProximaType::Float64,
         "decimal" => {
             let precision = column.precision.ok_or_else(|| {
@@ -426,13 +434,20 @@ pub fn parse_rest_data_type(
         "timestamp_tz" => ProximaType::TimestampTz(TimeUnit::Nanosecond),
         "date" => ProximaType::Date,
         "time" => ProximaType::Time(TimeUnit::Nanosecond),
+        "duration" => ProximaType::Duration(TimeUnit::Nanosecond),
+        "interval" => ProximaType::Interval(TimeUnit::Nanosecond),
         "uuid" => ProximaType::Uuid,
-        "binary" => ProximaType::Binary,
+        "ulid" => ProximaType::ULID,
+        "binary" | "binary_large" => ProximaType::Binary,
         "json" => ProximaType::Json,
+        "jsonb" => ProximaType::Jsonb,
+        "symbol" => ProximaType::Symbol,
         "array_text" => ProximaType::Array(Box::new(ProximaType::String)),
         "array_integer" => ProximaType::Array(Box::new(ProximaType::Int64)),
         "array_float" => ProximaType::Array(Box::new(ProximaType::Float64)),
         "array_boolean" => ProximaType::Array(Box::new(ProximaType::Boolean)),
+        "array_uuid" => ProximaType::Array(Box::new(ProximaType::Uuid)),
+        "array_any" => ProximaType::Array(Box::new(ProximaType::Json)),
         "map_string_string" => ProximaType::Map {
             key: Box::new(ProximaType::String),
             value: Box::new(ProximaType::String),
@@ -441,7 +456,17 @@ pub fn parse_rest_data_type(
             key: Box::new(ProximaType::String),
             value: Box::new(ProximaType::Json),
         },
+        "map_string_integer" => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::Int64),
+        },
+        "map_string_float" => ProximaType::Map {
+            key: Box::new(ProximaType::String),
+            value: Box::new(ProximaType::Float64),
+        },
+        "struct" => ProximaType::Struct { fields: Vec::new() },
         "geo_point" => ProximaType::Point,
+        "geo_polygon" => ProximaType::GeographyPoint,
         "vector" => {
             let dim = column.vector_dimension.ok_or_else(|| {
                 ApiError::InvalidArgument(format!(
@@ -453,6 +478,18 @@ pub fn parse_rest_data_type(
                 element: VectorElement::Float32,
                 dim,
             }
+        }
+        "sparse_vector" => ProximaType::SparseVector {
+            element: VectorElement::Float32,
+        },
+        "binary_vector" => {
+            let dim = column.vector_dimension.ok_or_else(|| {
+                ApiError::InvalidArgument(format!(
+                    "Column '{}' with type 'binary_vector' requires vector_dimension",
+                    column.name
+                ))
+            })? as usize;
+            ProximaType::BinaryVector { dim }
         }
         other => {
             return Err(ApiError::InvalidArgument(format!(

--- a/src/network/rest/v2/schema.rs
+++ b/src/network/rest/v2/schema.rs
@@ -43,8 +43,13 @@ use utoipa::ToSchema;
 use crate::errors::{ApiError, ApiResult};
 use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::v1::handlers::AppState;
+use proximadb_data_model::ProximaType;
+use proximadb_runtime::{
+    CollectionSchemaColumn, CollectionSchemaEnforcement, CollectionSchemaMetadata,
+    CollectionSchemaUpdate, CollectionTextStorage,
+};
 
-use super::collections::{ColumnDefinition, SchemaDefinition};
+use super::collections::{ColumnDefinition, SchemaDefinition, parse_rest_data_type};
 
 /// Schema response with metadata
 #[derive(Debug, Serialize, ToSchema)]
@@ -108,161 +113,52 @@ pub async fn get_schema(
         ));
     }
 
-    // Step 1: Verify collection exists and get metadata
-    let collection_request = crate::proto::proximadb_v1::CollectionRequest {
-        operation: crate::proto::proximadb_v1::CollectionOperation::CollectionGet as i32,
-        collection_id: Some(collection_id.clone()),
-        collection_config: None,
-        query_params: Default::default(),
-        options: Default::default(),
-        migration_config: Default::default(),
-    };
-
-    let collection_response = state
+    let metadata = state
         .api_handlers
-        .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
+        .get_collection_schema_metadata(&collection_id, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
             if e.to_string().contains("not found") {
                 ApiError::CollectionNotFound(collection_id.clone())
             } else {
-                ApiError::Internal(format!("Failed to get collection: {}", e))
+                ApiError::Internal(format!("Failed to get collection schema: {}", e))
             }
-        })?;
-
-    let collection = collection_response
-        .collection
+        })?
         .ok_or_else(|| ApiError::CollectionNotFound(collection_id.clone()))?;
 
-    let config = collection
-        .config
-        .ok_or_else(|| ApiError::Internal("Collection has no configuration".to_string()))?;
+    if !metadata.enabled {
+        return Err(ApiError::CollectionNotFound(format!(
+            "No schema defined for collection '{}'. Enable ProximaRecord to use schemas.",
+            collection_id
+        )));
+    }
 
-    // Step 2: Check if ProximaRecord is enabled
-    let proxima_record_enabled = config.enable_proxima_record.unwrap_or(false);
+    let schema_id = metadata
+        .schema_id
+        .clone()
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| format!("schema_{}", collection_id));
+    let schema_version = metadata
+        .schema_version
+        .clone()
+        .filter(|version| !version.is_empty())
+        .unwrap_or_else(|| "1.0.0".to_string());
+    let schema_def = schema_definition_from_metadata(&metadata);
 
-    // Step 3: Load schema from collection metadata
-    let record_schema_config = config.record_schema;
-
-    // Convert stored schema to response format
-    let (schema_id, schema_version, parent_schema_id, schema_def) =
-        if let Some(ref schema_config) = record_schema_config {
-            // We have a schema configuration stored
-            let schema_id = if schema_config.schema_id.is_empty() {
-                // Generate a deterministic ID based on collection
-                format!("schema_{}", collection_id)
-            } else {
-                schema_config.schema_id.clone()
-            };
-
-            let version = if schema_config.schema_version.is_empty() {
-                "1.0.0".to_string()
-            } else {
-                schema_config.schema_version.clone()
-            };
-
-            // Build schema definition from text_columns if available
-            let columns: Vec<ColumnDefinition> = config
-                .text_columns
-                .iter()
-                .map(|col_name| ColumnDefinition {
-                    name: col_name.clone(),
-                    data_type: "text".to_string(),
-                    nullable: Some(true),
-                    indexed: Some(false),
-                    filterable: Some(true),
-                    max_length: None,
-                    precision: None,
-                    scale: None,
-                    vector_dimension: None,
-                })
-                .collect();
-
-            // Also add columns from text_storage_configs
-            let mut all_columns = columns;
-            for text_config in &config.text_storage_configs {
-                if !all_columns
-                    .iter()
-                    .any(|c| c.name == text_config.column_name)
-                {
-                    all_columns.push(ColumnDefinition {
-                        name: text_config.column_name.clone(),
-                        data_type: "text_large".to_string(),
-                        nullable: Some(true),
-                        indexed: Some(false),
-                        filterable: Some(false),
-                        max_length: Some(text_config.chunk_size),
-                        precision: None,
-                        scale: None,
-                        vector_dimension: None,
-                    });
-                }
-            }
-
-            // Map enforcement level from proto
-            let enforcement = match schema_config.enforcement {
-                1 => "strict",
-                2 => "flexible",
-                3 => "hybrid",
-                _ => "hybrid",
-            };
-
-            let schema_def = SchemaDefinition {
-                columns: all_columns,
-                enforcement: Some(enforcement.to_string()),
-                allow_additional_fields: Some(schema_config.auto_evolve),
-            };
-
-            (schema_id, version, None, schema_def)
-        } else if proxima_record_enabled {
-            // ProximaRecord enabled but no explicit schema - create default
-            let schema_id = format!("schema_{}", collection_id);
-            let columns: Vec<ColumnDefinition> = config
-                .text_columns
-                .iter()
-                .map(|col_name| ColumnDefinition {
-                    name: col_name.clone(),
-                    data_type: "text".to_string(),
-                    nullable: Some(true),
-                    indexed: Some(false),
-                    filterable: Some(true),
-                    max_length: None,
-                    precision: None,
-                    scale: None,
-                    vector_dimension: None,
-                })
-                .collect();
-
-            let schema_def = SchemaDefinition {
-                columns,
-                enforcement: Some("hybrid".to_string()),
-                allow_additional_fields: Some(true),
-            };
-
-            (schema_id, "1.0.0".to_string(), None, schema_def)
-        } else {
-            // No schema defined and ProximaRecord not enabled
-            return Err(ApiError::CollectionNotFound(format!(
-                "No schema defined for collection '{}'. Enable ProximaRecord to use schemas.",
-                collection_id
-            )));
-        };
-
-    // Step 4: Return schema with version info
     let response = SchemaResponse {
         schema_id,
         schema_version,
         collection_id: collection_id.clone(),
         schema: schema_def,
-        created_at: chrono::DateTime::from_timestamp(collection.created_at / 1000, 0)
+        created_at: chrono::DateTime::from_timestamp(metadata.created_at_ms / 1000, 0)
             .map_or_else(|| chrono::Utc::now().to_rfc3339(), |dt| dt.to_rfc3339()),
-        updated_at: if collection.updated_at != collection.created_at {
-            chrono::DateTime::from_timestamp(collection.updated_at / 1000, 0)
+        updated_at: if metadata.updated_at_ms != metadata.created_at_ms {
+            chrono::DateTime::from_timestamp(metadata.updated_at_ms / 1000, 0)
                 .map(|dt| dt.to_rfc3339())
         } else {
             None
         },
-        parent_schema_id,
+        parent_schema_id: None,
     };
 
     info!(
@@ -412,95 +308,31 @@ pub async fn update_schema(
         }
     }
 
-    // Validate columns
-    let valid_types = [
-        "text",
-        "text_large",
-        "integer",
-        "float",
-        "decimal",
-        "boolean",
-        "timestamp",
-        "timestamp_tz",
-        "date",
-        "time",
-        "uuid",
-        "binary",
-        "json",
-        "array_text",
-        "array_integer",
-        "array_float",
-        "array_boolean",
-        "map_string_string",
-        "map_string_any",
-        "geo_point",
-        "vector",
-    ];
-
     for column in &schema.columns {
         if column.name.is_empty() {
             return Err(ApiError::InvalidArgument(
                 "Column name cannot be empty".to_string(),
             ));
         }
-
-        if !valid_types.contains(&column.data_type.as_str()) {
-            return Err(ApiError::InvalidArgument(format!(
-                "Invalid data type '{}' for column '{}'. Valid types: {:?}",
-                column.data_type, column.name, valid_types
-            )));
-        }
-
-        // Validate decimal precision/scale
-        if column.data_type == "decimal" && (column.precision.is_none() || column.scale.is_none()) {
-            return Err(ApiError::InvalidArgument(format!(
-                "Column '{}' with type 'decimal' requires precision and scale",
-                column.name
-            )));
-        }
-
-        // Validate vector dimension
-        if column.data_type == "vector" && column.vector_dimension.is_none() {
-            return Err(ApiError::InvalidArgument(format!(
-                "Column '{}' with type 'vector' requires vector_dimension",
-                column.name
-            )));
-        }
+        let _ = parse_rest_data_type(column)?;
     }
 
-    // Step 1: Load current collection and schema
-    let collection_request = crate::proto::proximadb_v1::CollectionRequest {
-        operation: crate::proto::proximadb_v1::CollectionOperation::CollectionGet as i32,
-        collection_id: Some(collection_id.clone()),
-        collection_config: None,
-        query_params: Default::default(),
-        options: Default::default(),
-        migration_config: Default::default(),
-    };
-
-    let collection_response = state
+    let existing_metadata = state
         .api_handlers
-        .handle_collection_operation_for_tenant(collection_request, Some(&tenant.tenant_id))
+        .get_collection_schema_metadata(&collection_id, Some(&tenant.tenant_id))
         .await
         .map_err(|e| {
             if e.to_string().contains("not found") {
                 ApiError::CollectionNotFound(collection_id.clone())
             } else {
-                ApiError::Internal(format!("Failed to get collection: {}", e))
+                ApiError::Internal(format!("Failed to get collection schema: {}", e))
             }
-        })?;
-
-    let collection = collection_response
-        .collection
+        })?
         .ok_or_else(|| ApiError::CollectionNotFound(collection_id.clone()))?;
 
-    let mut config = collection
-        .config
-        .clone()
-        .ok_or_else(|| ApiError::Internal("Collection has no configuration".to_string()))?;
-
-    // Get existing schema for evolution validation
-    let existing_schema = build_existing_schema(&config);
+    let existing_schema = existing_metadata
+        .enabled
+        .then(|| schema_definition_from_metadata(&existing_metadata));
 
     // Step 2: Validate schema evolution rules
     let validation_result = validate_schema(schema, existing_schema.as_ref());
@@ -625,41 +457,30 @@ pub async fn update_schema(
     }
 
     // Step 4: Create new schema version
-    let previous_schema_id = config.record_schema.as_ref().map_or_else(
-        || format!("schema_{}_v0", collection_id),
-        |s| s.schema_id.clone(),
-    );
+    let previous_schema_id = existing_metadata
+        .schema_id
+        .clone()
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| format!("schema_{}_v0", collection_id));
 
     let new_schema_id = format!("schema_{}_{}", collection_id, uuid::Uuid::new_v4());
     let new_version = increment_version(
-        config
-            .record_schema
-            .as_ref()
-            .map_or("0.0.0", |s| s.schema_version.as_str()),
+        existing_metadata
+            .schema_version
+            .as_deref()
+            .filter(|version| !version.is_empty())
+            .unwrap_or("0.0.0"),
     );
 
-    // Step 5: Build and store updated schema configuration via the shared
-    // SchemaDefinition → proto mapping (inverse of build_existing_schema).
-    apply_schema_definition(
-        &mut config,
+    let update = runtime_schema_update_from_schema_definition(
         schema,
         new_schema_id.clone(),
         new_version.clone(),
-    );
-
-    // Step 6: Persist the updated collection
-    let update_request = crate::proto::proximadb_v1::CollectionRequest {
-        operation: crate::proto::proximadb_v1::CollectionOperation::CollectionUpdate as i32,
-        collection_id: Some(collection_id.clone()),
-        collection_config: Some(config),
-        query_params: Default::default(),
-        options: Default::default(),
-        migration_config: Default::default(),
-    };
+    )?;
 
     state
         .api_handlers
-        .handle_collection_operation_for_tenant(update_request, Some(&tenant.tenant_id))
+        .update_collection_schema_metadata(&collection_id, update, Some(&tenant.tenant_id))
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to update collection schema: {}", e)))?;
 
@@ -680,6 +501,156 @@ pub async fn update_schema(
         warnings,
         updated_at: now,
     }))
+}
+
+fn schema_definition_from_metadata(metadata: &CollectionSchemaMetadata) -> SchemaDefinition {
+    let columns = metadata
+        .columns
+        .iter()
+        .map(|column| ColumnDefinition {
+            name: column.name.clone(),
+            data_type: rest_data_type_from_proxima(&column.data_type, column.text_storage)
+                .to_string(),
+            nullable: Some(column.nullable),
+            indexed: Some(column.indexed),
+            filterable: Some(column.filterable),
+            max_length: column.max_length,
+            precision: match &column.data_type {
+                ProximaType::Decimal { precision, .. } => Some(*precision),
+                _ => None,
+            },
+            scale: match &column.data_type {
+                ProximaType::Decimal { scale, .. } => Some(*scale),
+                _ => None,
+            },
+            vector_dimension: match &column.data_type {
+                ProximaType::DenseVector { dim, .. } | ProximaType::BinaryVector { dim } => {
+                    Some(*dim as u32)
+                }
+                _ => None,
+            },
+        })
+        .collect::<Vec<_>>();
+
+    SchemaDefinition {
+        columns,
+        enforcement: metadata.enforcement.map(runtime_enforcement_to_rest),
+        allow_additional_fields: Some(metadata.auto_evolve),
+    }
+}
+
+fn runtime_schema_update_from_schema_definition(
+    schema: &SchemaDefinition,
+    schema_id: String,
+    schema_version: String,
+) -> ApiResult<CollectionSchemaUpdate> {
+    let columns = schema
+        .columns
+        .iter()
+        .map(|column| {
+            let data_type = parse_rest_data_type(column)?;
+            let text_storage = match column.data_type.as_str() {
+                "text" => Some(CollectionTextStorage::Inline),
+                "text_large" => Some(CollectionTextStorage::Large),
+                _ => None,
+            };
+            let filterable = column.filterable.unwrap_or(
+                matches!(text_storage, Some(CollectionTextStorage::Inline))
+                    || !matches!(data_type, ProximaType::String),
+            );
+            Ok(CollectionSchemaColumn {
+                name: column.name.clone(),
+                data_type,
+                nullable: column.nullable.unwrap_or(true),
+                indexed: column.indexed.unwrap_or(false),
+                filterable,
+                text_storage,
+                max_length: column.max_length,
+            })
+        })
+        .collect::<ApiResult<Vec<_>>>()?;
+
+    Ok(CollectionSchemaUpdate {
+        schema_id,
+        schema_version,
+        enforcement: runtime_enforcement_from_rest(schema.enforcement.as_deref()),
+        auto_evolve: schema.allow_additional_fields.unwrap_or(true),
+        columns,
+    })
+}
+
+fn runtime_enforcement_from_rest(value: Option<&str>) -> CollectionSchemaEnforcement {
+    match value {
+        Some("strict") => CollectionSchemaEnforcement::Strict,
+        Some("flexible") => CollectionSchemaEnforcement::Flexible,
+        _ => CollectionSchemaEnforcement::Hybrid,
+    }
+}
+
+fn runtime_enforcement_to_rest(value: CollectionSchemaEnforcement) -> String {
+    match value {
+        CollectionSchemaEnforcement::Strict => "strict",
+        CollectionSchemaEnforcement::Flexible => "flexible",
+        CollectionSchemaEnforcement::Hybrid => "hybrid",
+    }
+    .to_string()
+}
+
+fn rest_data_type_from_proxima(
+    data_type: &ProximaType,
+    text_storage: Option<CollectionTextStorage>,
+) -> &'static str {
+    match data_type {
+        ProximaType::String => match text_storage {
+            Some(CollectionTextStorage::Large) => "text_large",
+            _ => "text",
+        },
+        ProximaType::Int8 => "int8",
+        ProximaType::Int16 => "int16",
+        ProximaType::Int32 => "int32",
+        ProximaType::Int64
+        | ProximaType::UInt8
+        | ProximaType::UInt16
+        | ProximaType::UInt32
+        | ProximaType::UInt64 => "integer",
+        ProximaType::Float16 | ProximaType::Float32 => "float32",
+        ProximaType::Float64 => "float",
+        ProximaType::Decimal { .. } => "decimal",
+        ProximaType::Boolean => "boolean",
+        ProximaType::Timestamp(_) => "timestamp",
+        ProximaType::TimestampTz(_) => "timestamp_tz",
+        ProximaType::Date => "date",
+        ProximaType::Time(_) => "time",
+        ProximaType::Uuid => "uuid",
+        ProximaType::ULID => "ulid",
+        ProximaType::Binary => "binary",
+        ProximaType::Json => "json",
+        ProximaType::Jsonb => "jsonb",
+        ProximaType::Array(inner) => match inner.as_ref() {
+            ProximaType::String => "array_text",
+            ProximaType::Int64 => "array_integer",
+            ProximaType::Float64 => "array_float",
+            ProximaType::Boolean => "array_boolean",
+            ProximaType::Uuid => "array_uuid",
+            _ => "array_any",
+        },
+        ProximaType::Map { key, value } => match (key.as_ref(), value.as_ref()) {
+            (ProximaType::String, ProximaType::String) => "map_string_string",
+            (ProximaType::String, ProximaType::Int64) => "map_string_integer",
+            (ProximaType::String, ProximaType::Float64) => "map_string_float",
+            (ProximaType::String, _) => "map_string_any",
+            _ => "map_string_any",
+        },
+        ProximaType::Struct { .. } => "struct",
+        ProximaType::Point | ProximaType::GeographyPoint => "geo_point",
+        ProximaType::DenseVector { .. } => "vector",
+        ProximaType::SparseVector { .. } => "sparse_vector",
+        ProximaType::BinaryVector { .. } => "binary_vector",
+        ProximaType::Symbol => "symbol",
+        ProximaType::Duration(_) => "duration",
+        ProximaType::Interval(_) => "interval",
+        ProximaType::Null => "json",
+    }
 }
 
 /// Map a REST schema-enforcement string to the proto `SchemaEnforcement`
@@ -841,6 +812,27 @@ pub(crate) fn build_existing_schema(
                 vector_dimension: None,
             });
         }
+    }
+
+    // Add scalar typed columns persisted in CollectionConfig.filterable_columns.
+    // apply_schema_definition writes integer/float/temporal/bool/uuid schema
+    // columns here so metadata filters can push down; GET must invert that
+    // mapping or schema round-trips silently lose all non-text columns.
+    for filterable in &config.filterable_columns {
+        if filterable.name.is_empty() || columns.iter().any(|c| c.name == filterable.name) {
+            continue;
+        }
+        columns.push(ColumnDefinition {
+            name: filterable.name.clone(),
+            data_type: filterable_type_to_rest(filterable.data_type).to_string(),
+            nullable: Some(true),
+            indexed: Some(filterable.indexed),
+            filterable: Some(true),
+            max_length: None,
+            precision: None,
+            scale: None,
+            vector_dimension: None,
+        });
     }
 
     // Get enforcement mode from record_schema if available
@@ -1330,6 +1322,88 @@ mod tests {
         assert!(!active.indexed);
         assert!(!active.supports_range);
         assert!(!config.filterable_columns.iter().any(|c| c.name == "secret"));
+    }
+
+    #[test]
+    fn build_existing_schema_round_trips_filterable_scalar_columns() {
+        use crate::proto::proximadb_v1::{FilterableColumnSpec, FilterableDataType as F};
+
+        let schema = SchemaDefinition {
+            columns: vec![
+                ColumnDefinition {
+                    name: "body".to_string(),
+                    data_type: "text".to_string(),
+                    ..blank_col()
+                },
+                ColumnDefinition {
+                    name: "price".to_string(),
+                    data_type: "float".to_string(),
+                    indexed: Some(true),
+                    filterable: Some(true),
+                    ..blank_col()
+                },
+                ColumnDefinition {
+                    name: "created_on".to_string(),
+                    data_type: "date".to_string(),
+                    filterable: Some(true),
+                    ..blank_col()
+                },
+            ],
+            enforcement: Some("hybrid".to_string()),
+            allow_additional_fields: Some(true),
+        };
+        let mut config = crate::proto::proximadb_v1::CollectionConfig::default();
+        apply_schema_definition(
+            &mut config,
+            &schema,
+            "schema_products_1".to_string(),
+            "1.0.0".to_string(),
+        );
+
+        let rebuilt = build_existing_schema(&config).expect("schema should rebuild");
+        let names_and_types = rebuilt
+            .columns
+            .iter()
+            .map(|c| {
+                (
+                    c.name.as_str(),
+                    c.data_type.as_str(),
+                    c.indexed,
+                    c.filterable,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert!(names_and_types.contains(&("body", "text", Some(false), Some(true))));
+        assert!(names_and_types.contains(&("price", "float", Some(true), Some(true))));
+        assert!(names_and_types.contains(&("created_on", "date", Some(false), Some(true))));
+
+        let mut legacy_config = crate::proto::proximadb_v1::CollectionConfig {
+            enable_proxima_record: Some(true),
+            filterable_columns: vec![FilterableColumnSpec {
+                name: "score".to_string(),
+                data_type: F::FilterableFloat as i32,
+                indexed: true,
+                supports_range: true,
+                estimated_cardinality: None,
+            }],
+            ..Default::default()
+        };
+        legacy_config.record_schema = Some(crate::proto::proximadb_v1::RecordSchemaConfig {
+            schema_id: "legacy".to_string(),
+            schema_version: "1.0.0".to_string(),
+            enforcement: 3,
+            auto_evolve: true,
+            columns: vec![],
+        });
+
+        let legacy = build_existing_schema(&legacy_config).expect("legacy schema should rebuild");
+        assert!(
+            legacy
+                .columns
+                .iter()
+                .any(|c| c.name == "score" && c.data_type == "float")
+        );
     }
 
     fn blank_col() -> ColumnDefinition {

--- a/src/network/storage_write_fence.rs
+++ b/src/network/storage_write_fence.rs
@@ -8,6 +8,7 @@
 //! `PartitionLeaseManager` instance the write-gates use. See
 //! `crate::storage::write_fence` for the A6 rationale.
 
+use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -28,7 +29,12 @@ impl LeaseStorageWriteFence {
 
 #[async_trait]
 impl StorageWriteFence for LeaseStorageWriteFence {
-    async fn is_fenced_out(&self, tenant_id: &str, collection_id: &str, now_ms: i64) -> bool {
+    async fn is_fenced_out(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        now_ms: i64,
+    ) -> Result<bool> {
         // Ground truth across pods: delegates to the durable lease read (#346).
         self.lease_manager
             .is_fenced_out(tenant_id, collection_id, now_ms)

--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -1592,12 +1592,17 @@ impl UnifiedStorageFormat for HelixEngine {
         // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
         // ========================================================================
         // Use AXIS manager if available for O(log N) approximate search
+        let exact_mode = matches!(ctx.search_params.search_mode, SearchMode::Exact);
         let has_axis_manager = self.axis_manager().is_some();
         if has_axis_manager {
             tracing::debug!("🔍 HELIX: AXIS manager is available for HNSW/IVF search");
         }
 
-        if let Some(axis_manager) = self.axis_manager() {
+        if exact_mode {
+            tracing::debug!(
+                "🎯 HELIX: SearchMode::Exact requested; skipping approximate AXIS path"
+            );
+        } else if let Some(axis_manager) = self.axis_manager() {
             tracing::info!(
                 "🔗 HELIX: AXIS manager available, attempting HNSW index search for collection {}",
                 collection_id

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -1,7 +1,7 @@
 // NOVA Engine: Next-gen Optimized Vector Analytics with columnar quantization
 // Implements UnifiedStorageFormat trait for integration with ProximaDB
 
-use crate::core::search::DataFreshnessTier;
+use crate::core::search::{DataFreshnessTier, SearchMode};
 use crate::proto::proximadb_v1::VectorRecord;
 // Import column constants from columnar module
 use crate::storage::engines::core::formats::columnar::FIELD_ID;
@@ -1613,12 +1613,15 @@ impl UnifiedStorageFormat for NovaEngine {
         // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
         // ========================================================================
         // Use AXIS manager if available for O(log N) approximate search
+        let exact_mode = matches!(ctx.search_params.search_mode, SearchMode::Exact);
         let has_axis_manager = self.axis_manager().is_some();
         if has_axis_manager {
             tracing::debug!("🔍 NOVA: AXIS manager is available for HNSW/IVF search");
         }
 
-        if let Some(axis_manager) = self.axis_manager() {
+        if exact_mode {
+            tracing::debug!("🎯 NOVA: SearchMode::Exact requested; skipping approximate AXIS path");
+        } else if let Some(axis_manager) = self.axis_manager() {
             tracing::debug!(
                 "🔍 NOVA: Attempting AXIS search for collection='{}', top_k={}, dimension={}",
                 collection_id,

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -953,23 +953,21 @@ impl Compaction {
         let mut deleted_vector_ids = Vec::new();
         let mut merged_vectors = Vec::new();
 
-        // Get current time in seconds for consistent comparison
-        let current_time_secs = current_time / 1000;
-
         for vector_record in &resolved_records {
             // Tombstone detection: empty vector + expires_at in past (including 0)
             // expires_at = 0 means "epoch time" which is always in the past = tombstone marker
             let is_tombstone = vector_record.vector.is_empty()
                 && vector_record
                     .expires_at
-                    .is_some_and(|e| e <= current_time_secs);
+                    .is_some_and(|e| Self::epoch_millis(e) <= current_time);
 
             // Check if record is expired (TTL-based expiry for non-tombstones)
             // This is different from tombstones - these are regular records that have expired
             let is_expired = !is_tombstone
-                && vector_record
-                    .expires_at
-                    .is_some_and(|expires_at| expires_at > 0 && expires_at < current_time_secs);
+                && vector_record.expires_at.is_some_and(|expires_at| {
+                    let expires_at_ms = Self::epoch_millis(expires_at);
+                    expires_at_ms > 0 && expires_at_ms < current_time
+                });
 
             // Skip expired records completely - they are physically deleted
             if is_expired {
@@ -980,8 +978,8 @@ impl Compaction {
             }
             let should_keep = if is_tombstone {
                 // Keep tombstones that are less than 1 hour old
-                let age = (current_time / 1000) - vector_record.timestamp.unwrap_or(0); // Both in seconds
-                let keep_tombstone = age < (60 * 60); // 1 hour in seconds
+                let age = current_time - Self::epoch_millis(vector_record.timestamp.unwrap_or(0));
+                let keep_tombstone = age < (60 * 60 * 1000); // 1 hour in milliseconds
 
                 if !keep_tombstone {
                     tombstones_removed_count += 1;
@@ -1015,13 +1013,13 @@ impl Compaction {
         }
 
         // OPTIMIZED: Sort VectorRecords by metadata for optimal encoding (no conversions)
-        let resolved_records_len = resolved_records.len();
+        let vector_records_len = vector_records.len();
         info!(
             "🔄 UNIFIED COMPACTION: Sorting {} VectorRecords by metadata for optimal encoding",
-            resolved_records_len
+            vector_records_len
         );
         let (sorted_vectors, sort_stats) =
-            Self::sort_vectors_for_compaction(resolved_records).await?;
+            Self::sort_vectors_for_compaction(vector_records).await?;
         info!(
             "✅ UNIFIED COMPACTION: Sorted records (estimated compression improvement: {:.1}%)",
             sort_stats.compression_estimate * 100.0
@@ -1515,7 +1513,7 @@ impl Compaction {
             bytes_read / 1024 / 1024,
             bytes_written / 1024 / 1024,
             compression_ratio,
-            resolved_records_len,
+            vector_records_len,
             expired_records_count,
             tombstones_removed_count
         );
@@ -1940,6 +1938,21 @@ impl Compaction {
         );
 
         Ok((sorted_records, sort_stats))
+    }
+
+    fn epoch_millis(timestamp: i64) -> i64 {
+        let abs = timestamp.unsigned_abs();
+        if timestamp == 0 {
+            0
+        } else if abs < 10_000_000_000 {
+            timestamp * 1000
+        } else if abs > 10_000_000_000_000_000 {
+            timestamp / 1_000_000
+        } else if abs > 10_000_000_000_000 {
+            timestamp / 1000
+        } else {
+            timestamp
+        }
     }
 }
 

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -287,6 +287,24 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn epoch_millis_accepts_seconds_millis_micros_and_nanos() {
+        assert_eq!(Compaction::epoch_millis(1_782_912_345), 1_782_912_345_000);
+        assert_eq!(
+            Compaction::epoch_millis(1_782_912_345_678),
+            1_782_912_345_678
+        );
+        assert_eq!(
+            Compaction::epoch_millis(1_782_912_345_678_000),
+            1_782_912_345_678
+        );
+        assert_eq!(
+            Compaction::epoch_millis(1_782_912_345_678_000_000),
+            1_782_912_345_678
+        );
+        assert_eq!(Compaction::epoch_millis(0), 0);
+    }
+
     /// With a CanonicalPrecisionResolver wired in and a fp16 collection
     /// in the catalog, Compaction::check_compaction_needed must stamp
     /// produced CompactionTask.precision_hint = Some(Fp16). The two

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -44,6 +44,7 @@ use crate::storage::engines::core::ops::performance_optimization::{
 // VectorMemoryPool now managed by universal optimizer
 use super::types::*;
 use crate::core::String;
+use crate::core::search::SearchMode;
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
@@ -2265,12 +2266,17 @@ impl UnifiedStorageFormat for ViperEngine {
         // PHASE 0: TRY AXIS-BASED SEARCH FIRST (HNSW/IVF) - FASTEST PATH
         // ========================================================================
         // Use AXIS manager if available for O(log N) approximate search
+        let exact_mode = matches!(ctx.search_params.search_mode, SearchMode::Exact);
         let has_axis_manager = self.axis_manager().is_some();
         if has_axis_manager {
             tracing::debug!("🔍 VIPER: AXIS manager is available for HNSW/IVF search");
         }
 
-        if let Some(axis_manager) = self.axis_manager() {
+        if exact_mode {
+            tracing::debug!(
+                "🎯 VIPER: SearchMode::Exact requested; skipping approximate AXIS path"
+            );
+        } else if let Some(axis_manager) = self.axis_manager() {
             tracing::info!(
                 "🔗 VIPER: AXIS manager available, attempting HNSW index search for collection {}",
                 collection_id

--- a/src/storage/persistence/write_ahead_log/flush_coordinator.rs
+++ b/src/storage/persistence/write_ahead_log/flush_coordinator.rs
@@ -243,8 +243,8 @@ impl WALFlushCoordinator {
         // `PartitionLeaseManager` (#346 `is_fenced_out`) the gates consult.
         //
         // Co-design (Dim-1): at most one durable lease read per flush (amortized
-        // over the whole batch), never per row. Fail-open on unknown tenant / no
-        // fence wired — the gate is the first line of defense.
+        // over the whole batch), never per row. With fencing enabled, unknown
+        // tenant / no fence wired / lease-read errors fail closed.
         {
             use crate::storage::write_fence::{
                 FenceDecision, evaluate_fence, write_fencing_enabled,
@@ -1159,8 +1159,8 @@ mod fence_wiring_tests {
         struct Never;
         #[async_trait::async_trait]
         impl StorageWriteFence for Never {
-            async fn is_fenced_out(&self, _t: &str, _c: &str, _n: i64) -> bool {
-                false
+            async fn is_fenced_out(&self, _t: &str, _c: &str, _n: i64) -> anyhow::Result<bool> {
+                Ok(false)
             }
         }
         let mut coordinator = WALFlushCoordinator::new();

--- a/src/storage/write_fence.rs
+++ b/src/storage/write_fence.rs
@@ -21,10 +21,10 @@
 //! ## Default-OFF (ship-dark, D5)
 //! Enforcement is gated by [`write_fencing_enabled`] (`PROXIMADB_WRITE_FENCING=1`).
 //! With the gate off — the default — the fence is never consulted and ingest is
-//! byte-identical to the pre-fence path. Fail-open is the bootstrap posture: a
-//! missing fence/tenant or a durable-read error proceeds (the routing layer is the
-//! first line; this is the backstop).
+//! byte-identical to the pre-fence path. When the gate is on, missing fence state
+//! or a durable-read error fails closed.
 
+use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -35,12 +35,18 @@ use std::sync::Arc;
 /// into the flush path from `shared_services`. Contract mirrors
 /// `PartitionLeaseManager::is_fenced_out`: return `true` iff a *live* lease (not
 /// released, not expired) is held by a **different** pod; fail-open (`false`) on
-/// any uncertainty.
+/// any uncertainty while enforcement is enabled.
 #[async_trait]
 pub trait StorageWriteFence: Send + Sync {
-    /// `true` ⇒ reject this pod's flush of `(tenant_id, collection_id)` at
-    /// `now_ms`; `false` ⇒ allow it to proceed.
-    async fn is_fenced_out(&self, tenant_id: &str, collection_id: &str, now_ms: i64) -> bool;
+    /// `Ok(true)` ⇒ reject this pod's flush of `(tenant_id, collection_id)` at
+    /// `now_ms`; `Ok(false)` ⇒ allow it to proceed; `Err(_)` means the fence
+    /// authority could not be read and must be treated as fenced when enabled.
+    async fn is_fenced_out(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        now_ms: i64,
+    ) -> Result<bool>;
 }
 
 /// The A6 fence is enforced only when `PROXIMADB_WRITE_FENCING == "1"`.
@@ -69,9 +75,9 @@ pub enum FenceDecision {
 ///
 /// Separated from env/I/O so it can be unit-tested directly (CLAUDE.md #13):
 /// `enabled` is passed in (call site reads [`write_fencing_enabled`]), and the
-/// durable lease read is the injected `fence`. Fail-open whenever enforcement is
-/// off, no fence is wired, or the tenant could not be resolved — the routing layer
-/// (lease-on-write) remains the first line of defense.
+/// durable lease read is the injected `fence`. Enforcement-off proceeds; enabled
+/// enforcement fails closed when no fence is wired, the tenant cannot be resolved,
+/// or the durable lease read errors.
 pub async fn evaluate_fence(
     enabled: bool,
     fence: Option<&Arc<dyn StorageWriteFence>>,
@@ -83,12 +89,11 @@ pub async fn evaluate_fence(
         return FenceDecision::Proceed;
     }
     let (Some(fence), Some(tenant_id)) = (fence, tenant_id) else {
-        return FenceDecision::Proceed;
+        return FenceDecision::Fenced;
     };
-    if fence.is_fenced_out(tenant_id, collection_id, now_ms).await {
-        FenceDecision::Fenced
-    } else {
-        FenceDecision::Proceed
+    match fence.is_fenced_out(tenant_id, collection_id, now_ms).await {
+        Ok(true) | Err(_) => FenceDecision::Fenced,
+        Ok(false) => FenceDecision::Proceed,
     }
 }
 
@@ -101,8 +106,27 @@ mod tests {
 
     #[async_trait]
     impl StorageWriteFence for StubFence {
-        async fn is_fenced_out(&self, _tenant: &str, _collection: &str, _now_ms: i64) -> bool {
-            self.0
+        async fn is_fenced_out(
+            &self,
+            _tenant: &str,
+            _collection: &str,
+            _now_ms: i64,
+        ) -> Result<bool> {
+            Ok(self.0)
+        }
+    }
+
+    struct ErrorFence;
+
+    #[async_trait]
+    impl StorageWriteFence for ErrorFence {
+        async fn is_fenced_out(
+            &self,
+            _tenant: &str,
+            _collection: &str,
+            _now_ms: i64,
+        ) -> Result<bool> {
+            Err(anyhow::anyhow!("lease read failed"))
         }
     }
 
@@ -141,23 +165,31 @@ mod tests {
         );
     }
 
-    /// Fail-open when the tenant could not be resolved, even if enabled + a fence
-    /// is wired (the routing layer remains the first line of defense).
+    /// Enabled fencing fails closed when the tenant could not be resolved.
     #[tokio::test]
-    async fn missing_tenant_fails_open() {
+    async fn missing_tenant_fails_closed() {
         let f = fence(true);
         assert_eq!(
             evaluate_fence(true, Some(&f), None, "c", 0).await,
-            FenceDecision::Proceed
+            FenceDecision::Fenced
         );
     }
 
-    /// Fail-open when no fence is wired (lease store unavailable).
+    /// Enabled fencing fails closed when no fence is wired (lease store unavailable).
     #[tokio::test]
-    async fn missing_fence_fails_open() {
+    async fn missing_fence_fails_closed() {
         assert_eq!(
             evaluate_fence(true, None, Some("t"), "c", 0).await,
-            FenceDecision::Proceed
+            FenceDecision::Fenced
+        );
+    }
+
+    #[tokio::test]
+    async fn lease_read_error_fails_closed() {
+        let f: Arc<dyn StorageWriteFence> = Arc::new(ErrorFence);
+        assert_eq!(
+            evaluate_fence(true, Some(&f), Some("t"), "c", 0).await,
+            FenceDecision::Fenced
         );
     }
 }


### PR DESCRIPTION
## Summary

Lands the highest-impact audit-remediation items as one coherent bundle: canonical schema types, write fencing, SDK retry/auth/timeout, storage/search correctness, handler-seam labeling, v1 ghost-log cleanup, and agent-rule docs.

## Rationale: canonical `ProximaType`

The headline change canonicalizes collection-schema datatype handling on `proximadb_data_model::ProximaType` instead of maintaining a second internal datatype enum. Wire DTOs may differ, but **REST v2, gRPC v2, the legacy catalog adapter, and internal paths now all translate at the edges into the single `ProximaType` tree.**

- New runtime-native schema contract on `ApiHandlersPort` — `CollectionSchemaMetadata` / `CollectionSchemaUpdate` / `CollectionSchemaColumn { data_type: ProximaType, .. }` — *intentionally not a proto envelope*. REST v2 and gRPC v2 schema handlers depend on this contract instead of constructing v1 `CollectionRequest` envelopes.
- REST `parse_rest_data_type` and the gRPC `ColumnDataType` converter now map the full `ProximaType` vocabulary (int8/16/32, uint*, float16/32/64, decimal, temporal, uuid/ulid, json/jsonb, symbol, Array/Map/Struct, Dense/Sparse/Binary vector, geo).
- **Prod already routes this surface through the canonical handler.** The TD-104 `with_api_handlers` flip is live (`rest/server.rs`, `multi_server.rs`), installing `proximadb_runtime::UnifiedHandlers` (real ports) as `AppState.api_handlers`. The schema methods on the legacy handler are required only for trait conformance and are dead-in-prod.

### Legacy v1 adapter boundary — fail-closed

The legacy v1 `CollectionConfig` persists underneath as a temporary adapter. It **fails closed**: when it cannot faithfully preserve a canonical `ProximaType` (e.g. `UInt*`, `Struct`, `Map` with non-string key, `SparseVector`/`BinaryVector`, `Duration`, `Symbol`, `ULID`), the write is **rejected** rather than silently degraded or dropped. v1 collection-config use is only a legacy persistence adapter; v1 itself is deprecated.

### Surface gap — vector dimension + element type (resolved in this PR)

`TypedColumn` previously had no vector-dimension field, so `DenseVector`/`BinaryVector` dims round-tripped as **0 over gRPC**. This PR adds `optional uint32 vector_dimension = 24;` to the v2 `TypedColumn` proto, regenerates the rust stub, and wires it both ways (`grpc_column_type_to_proxima_type` reads it; `runtime_metadata_to_grpc_schema` stamps it). (No Python stub regen — field-add, no new RPC.)

**Vector element type — also resolved in this PR (commit a6a8087d5):** added a prefixed `VectorElementType` proto enum (value names prefixed to avoid proto3 collisions with `ColumnDataType`'s `FLOAT32`/`INT8`/…) + `optional VectorElementType vector_element_type = 25`, wired both ways (`None`/`Unspecified` → `Float32` for back-compat). The gRPC schema round-trip now preserves the **full vector shape** (element + dim), verified by a dense (`Float16`/128) + sparse (`Int8`) + binary (256) round-trip test.

## Seam hygiene (wrong-seam guard) + scope check

There are two same-named `UnifiedHandlers` types (one per crate), each with its own `impl ApiHandlersPort` and duplicated schema-mapping helpers — a classic wrong-seam trap. This PR labels them so future edits hit the right one:

- **Canonical** (`proximadb_runtime::UnifiedHandlers`, port-driven): clear header; new schema/port work goes here; prod serves through it via `with_api_handlers`. (Its trait still carries v1-proto methods like `handle_collection_operation_for_tenant`, pending the TD-123 v1→v2 message migration.)
- **Legacy** (`api_handlers::UnifiedHandlers`, v1-proto bridge, dev/test default `AppState.api_handlers`): deprecation notice on the type/impl + its `runtime_*` v1-bridge helpers.

Per the investigation requested before push: the legacy handler **cannot be dropped yet** — it owns write/graph/doc/DDL orchestration the canonical facade lacks, and even the canonical gRPC record service calls its `record_ops()`. Its retirement (and full v1-proto removal) is gated on **TD-121 / TD-122 / TD-123** (today is 2026-06-30; TD-121's merge gate is 2026-07-01; v1 proto is still the internal domain model). A `#[deprecated]` *attribute* on the legacy type was deliberately **not** added — it's the live dev/test default (many refs), so it would red-line the `-D warnings` clippy gate. Doc-level deprecation notices carry the signal now; attribute-deprecation + retirement is a follow-up once the default flips.

## v1 REST ghost-log cleanup

Startup logging advertised the **removed** `/api/v1` collections / search / vectors / hybrid surfaces as live "compatibility" endpoints. Those paths were hard-removed (they return a `/api/v2` migration hint via `v1_replacement_for`); the only real `/api/v1` mounts are `/api/v1/catalogs` (Iceberg) and `/api/v1/progressive/search`. Dropped the misleading lines so callers aren't told v1 REST is still served. (gRPC v1 is already OFF by default via `enable_grpc_v1_compat`; no change there.)

## Write fencing (safe-by-default, still env-gated `OFF`)

- Storage write fence flips **fail-open → fail-closed** under `PROXIMADB_WRITE_FENCING`: missing tenant, no fence wired, and lease-read errors all reject the write (`Ok(false)` still proceeds).
- Lease-on-write (`RecordOpsService`) likewise rejects when this pod is not primary or acquire fails. Embedded / no-lease-manager still proceeds (single-node operation).

## Storage / search correctness

- SST compaction `epoch_millis()` normalizes seconds / millis / micros / nanos to a consistent millis basis; tombstone/expiry comparisons are now unit-coherent (was a mixed-unit comparison). Heuristic is valid for the current era.
- `SearchMode::Exact` in HELIX / NOVA / VIPER skips the approximate AXIS (HNSW/IVF) path so exact queries no longer return approximate results.

## SDK retry / auth / timeout

- **Go**: `WithMaxRetryDelay` cap on exponential backoff.
- **Rust**: `send_with_retries` on all four verbs (retry on 429/5xx + timeout/connect errors, bounded backoff).
- **Python gRPC**: auth metadata + TLS are now threaded from config — previously Bearer auth was **silently dropped** at the gRPC adapter boundary and TLS was hardcoded `False`. (Behavior change worth noting.)
- **Node**: per-attempt `AbortController` timeout.

## Docs

Adds the singular `AGENT.md` compatibility alias (agent-rules seeds + `.gitignore`) for agent runtimes that look for `AGENT.md` instead of `AGENTS.md`.

## Verification

```
cargo fmt --check
cargo clippy --lib          # clean, -D warnings
cargo check --tests         # lib + integration tests (signature-change callers)
cargo test --lib \
  rest_data_type_vocabulary_maps_to_canonical_proxima_type \
  build_existing_schema_round_trips_filterable_scalar_columns \
  write_fence \
  epoch_millis_accepts_seconds_millis_micros_and_nanos
```

All green.
