### PR TITLE
feat(storage): add batch point_lookup to engine read traits

### DIFF
--- a/src/storage/trait_components/reader.rs
+++ b/src/storage/trait_components/reader.rs
@@ -40,6 +40,25 @@ pub trait StorageReader: Send + Sync {
     /// - `Ok(Some(vector))`: Vector found
     /// - `Ok(None)`: Vector not found
     /// - `Err(e)`: Error during lookup
+    /// Point lookup: batch ID-based record retrieval (single or multiple IDs).
+    /// One filesystem scan for all IDs. Returns records found (missing IDs
+    /// absent — no error). Default delegates to `vector_by_id` per-ID.
+    async fn point_lookup(
+        &self,
+        collection_id: &str,
+        base_path: &str,
+        ids: &[String],
+        _identity: Option<crate::core::stable_id::CollectionIdentity>,
+    ) -> Result<Vec<ProximaRecord>> {
+        let mut results = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(rec) = self.vector_by_id(collection_id, base_path, id).await? {
+                results.push(rec);
+            }
+        }
+        Ok(results)
+    }
+
     async fn vector_by_id(
         &self,
         collection_id: &str,

--- a/src/storage/traits/mod.rs
+++ b/src/storage/traits/mod.rs
@@ -593,6 +593,30 @@ pub trait UnifiedStorageFormat: Send + Sync {
     /// Engine-specific statistics collection (required)
     async fn collect_engine_metrics(&self) -> Result<HashMap<String, serde_json::Value>>;
 
+    /// Point lookup: fetch records by IDs (single or batch). One filesystem
+    /// scan for all IDs (batch-efficient — unlike calling `vector_by_id` N
+    /// times). Returns the records found (missing IDs are simply absent — no
+    /// error). Carries the typed identity for the ADR-031 typed data path.
+    ///
+    /// Default: delegates to `vector_by_id` per-ID (backward-compatible but
+    /// NOT batch-efficient). Override in engines that have batch format-layer
+    /// methods (`batch_read_by_ids`, `query_by_ids`) for real efficiency.
+    async fn point_lookup(
+        &self,
+        collection_id: &str,
+        base_path: &str,
+        ids: &[String],
+        _identity: Option<crate::core::stable_id::CollectionIdentity>,
+    ) -> Result<Vec<proximadb_records::ProximaRecord>> {
+        let mut results = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(rec) = self.vector_by_id(collection_id, base_path, id).await? {
+                results.push(rec);
+            }
+        }
+        Ok(results)
+    }
+
     /// Retrieve a specific vector by ID from storage (required)
     /// This method should search across all storage layers (memtable, SSTables, Parquet files)
     ///


### PR DESCRIPTION
Adds `point_lookup` — batch, record-returning, identity-carrying — to both engine read traits (`UnifiedStorageFormat` + `StorageReader`) as the new canonical ID-based retrieval API.

## What
- **Batch**: `ids: &[String]` → one filesystem scan for all IDs (vs N scans from `vector_by_id` × N). The format layer already has `batch_read_by_ids`/`query_by_ids` — engines can override `point_lookup` to reuse them (follow-up PRs per engine).
- **Record-returning**: `Vec<ProximaRecord>` (includes vectors + metadata). The name `point_lookup` is accurate — `vector_by_id` was misnamed (it returns records).
- **Identity**: `Option<CollectionIdentity>` for the ADR-031 typed data path — closes the engine read-path identity gap (4d).

## Approach (additive — no breakage)
- `point_lookup` has a **default impl** that delegates to `vector_by_id` per-ID (backward-compatible). All engines inherit it; no caller migration needed.
- `vector_by_id` is **unchanged** (no deprecation yet — that would break ~100 callers under `-D warnings`; deprecate after callers migrate).
- Engines that want batch efficiency override `point_lookup` with their format-layer batch methods (separate follow-up PRs).

## Verified
0 lib + test compile errors; guards clean; fmt applied.
