### PR TITLE
docs(adr): Lakebase/LTAP storage study — ADR-045/046 + TD-LTAP-1..4

### DIFF
--- a/docs/10-quality/td/TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc
+++ b/docs/10-quality/td/TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc
@@ -1,0 +1,53 @@
+= TD-LTAP-1: Implement the PAX durable-core / serving-metadata split (ADR-045)
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open
+| Severity | Medium-High — blocks cheap Iceberg export (LTAP single-copy) and forces full vector re-read on cold-start (TD-165 tax)
+| Component | `crates/storage/proximadb-block-format` (`header.rs`, `stripe.rs`, `writer.rs`, `reader.rs`, `rowgroup.rs`) + the PAX segment format
+| Tracked-by | link:../../12-design/adr/ADR-045-pax-durable-core-vs-serving-metadata.adoc[ADR-045]
+| Relates to | link:../../12-design/adr/ADR-010-pax-block-format.adoc[ADR-010] (refines Layer-2), link:../../12-design/adr/ADR-025-deletion-vectors-cold-path.adoc[ADR-025] (DV = Layer B), TD-165 (cold-start tax)
+| Pillar | PERF, COST, REL
+|===
+
+toc::[]
+
+== Symptom
+
+The PAX block treats durable-truth and rebuildable serving-metadata as one opaque Layer-2 unit
+(ADR-010 "Stacked Durability Alignment"). This (a) blocks shipping the durable bytes 1:1 as an
+Iceberg data file (the LTAP single-copy open-format story) and (b) forces a full re-read of vector
+stripe data to regenerate pruning/visibility metadata on cold-start.
+
+== Root cause
+
+No format-level distinction between *what is the durable open-format copy* (columnar stripes +
+WAL-derived MVCC columns) and *what is a regenerable serving cache* (row-directory, `ColumnMeta`
+stats/bloom, header zone summaries, deletion vector).
+
+== Fix approach
+
+Stratify the segment per ADR-045:
+
+* **Layer A — durable open core:** stripes (incl. co-located RaBitQ/SQ8 rerank) + MVCC columns.
+  Immutable; ships 1:1 to Iceberg.
+* **Layer B — rebuildable serving metadata:** `RowDirectory`, `ColumnMeta`, bloom, `BlockFooter`,
+  `SegmentIndex`, zone summaries, `PDV1` deletion vector. Regenerable from (Layer A + WAL).
+
+New segment magic/version (mixed-read-safe). On cold-start, regenerate Layer B from Layer A + WAL
+*without* re-reading vector data. **Co-location is inviolable:** filter + vector stripes stay
+together in Layer A (the cascade must keep working with no extra GET).
+
+== Dependencies
+
+ADR-045 acceptance. **Dual-write + SIFT1M recall ratchet before flip** (the standing format-flip
+rule — recall must not regress).
+
+== Verification
+
+* Recall ratchet (SIFT1M): split preserves ANN recall (co-location intact).
+* Cold-start bench: Layer-B regeneration time vs status-quo full re-read (target: regenerate
+  without vector re-read).

--- a/docs/10-quality/td/TD-LTAP-2-lsn-merge-read.adoc
+++ b/docs/10-quality/td/TD-LTAP-2-lsn-merge-read.adoc
@@ -1,0 +1,50 @@
+= TD-LTAP-2: Implement the LSN-coherent single-copy analytics read (ADR-046)
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open
+| Severity | Medium — analytics today is a separate engine copy, not a single-copy fresh read; Lakebase LTAP headline is unbuilt
+| Component | analytics read path (Parquet/VIPER arm + WAL-tail replay); generalization of `search_unflushed_vectors()` (`src/storage/persistence/write_ahead_log/mod.rs:2396`)
+| Tracked-by | link:../../12-design/adr/ADR-046-lsn-coherent-merge-read.adoc[ADR-046]
+| Relates to | link:../../12-design/adr/ADR-020-canonical-wal-authority.adoc[ADR-020] (delta source), link:../../12-design/adr/ADR-033-primary-storage-format-strategy.adoc[ADR-033] (materialized arm), link:../../12-design/adr/ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (engine isolation), link:TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc[TD-LTAP-1]
+| Pillar | PERF, REL
+|===
+
+toc::[]
+
+== Symptom
+
+No cross-format, LSN-merged analytics read. Analytics runs against a separate engine/format copy;
+there is no "read the materialized Parquet arm as-of LSN and merge the WAL-tail delta" path that
+gives a consistent, fully-fresh analytical read from a single governed copy with zero tx impact.
+
+== Root cause
+
+The pieces exist in isolation (ADR-020 WAL authority, ADR-033 Parquet arm, MVCC visibility, the
+vector-path `search_unflushed` memtable+engine merge) but were never composed into an
+**LSN-coherent merge read for analytics**.
+
+== Fix approach
+
+Per ADR-046:
+
+1. Analytical query obtains current WAL LSN (cheap lookup) — the read timestamp.
+2. Read materialized majority from the Parquet/VIPER arm as-of the last materialized snapshot ≤ LSN.
+3. Replay WAL-tail records with LSN ∈ (materialized, query-LSN], applying MVCC visibility.
+
+Small-table skip: tiny collections serve straight from memtable / row-directory (no Parquet
+materialization — bookkeeping > savings).
+
+== Dependencies
+
+ADR-046. A defined materialization cadence (config). Benefits from TD-LTAP-1's clean durable core
+(a stable Parquet arm), but can land first over the existing VIPER arm.
+
+== Verification
+
+* **Correctness ratchet:** analytics read at LSN ≡ tx read at LSN (differential), across LSNs
+  straddling materialization boundaries.
+* Freshness bench: analytical-query freshness vs materialization cadence.

--- a/docs/10-quality/td/TD-LTAP-3-quorum-wal-latency-only-wontdo.adoc
+++ b/docs/10-quality/td/TD-LTAP-3-quorum-wal-latency-only-wontdo.adoc
@@ -1,0 +1,61 @@
+= TD-LTAP-3: Quorum-replicated WAL (SafeKeeper-style) — Won't Do (latency-only)
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Won't Do (documented; revisit only if the workload changes)
+| Severity | Low — informational; closes a question, not a defect
+| Component | WAL durability — `src/storage/persistence/write_ahead_log/` + `FilesystemFactory` cloud backends
+| Tracked-by | link:../../12-design/adr/ADR-020-canonical-wal-authority.adoc[ADR-020]
+| Relates to | link:TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc[TD-LTAP-1], link:TD-LTAP-2-lsn-merge-read.adoc[TD-LTAP-2]
+| Pillar | REL, COST
+|===
+
+toc::[]
+
+== The question
+
+Does ProximaDB need a Lakebase/Neon-style **SafeKeeper** — a Paxos quorum of local-disk nodes
+replicating the WAL — for durable commits and stateless compute? (Initially raised as a candidate
+architecture move.)
+
+== Why Won't Do
+
+Verified in code AND by deep-research (`wf_93aa09c8-12b`, 24/25 claims): ProximaDB's
+object-store-backed WAL already gives stateless compute + durability + non-lossy restart — **the
+same properties Lakebase's SafeKeeper provides, without a separate quorum service to operate.**
+
+*Code proof:* the WAL writes through `FilesystemFactory` → `object_store`
+(`src/storage/persistence/filesystem/aws_s3.rs:179` — `store.put(...).await` blocks until S3/GCS/Azure
+acknowledges before the commit ack returns; `sync_file` is a no-op for cloud because the PUT was
+already durable; restart replays via `RecoveryMode::ViaMemtable`). Pods are stateless; restart is
+non-lossy.
+
+*Research proof:* a SafeKeeper quorum buys **only per-tx commit latency** (quorum-local-SSD fsync ≈
+single-digit ms vs object-store PUT ≈ tens-to-hundreds of ms) — NOT durability. Object storage IS
+the durable, already-replicated substrate (S3 Standard = 11 nines). For ProximaDB's **batch-ingestion**
+profile, per-batch PUT amortization makes the latency argument largely moot. Milvus, Pinecone, and
+Cloudflare Vectorize all use WAL + object storage, not quorum-consensus WAL.
+
+== Open caveat (a deferred question, NOT work)
+
+**Multi-AZ durability.** A SafeKeeper quorum gives multi-AZ durability *at commit*; S3 Standard is
+11-nines (multi-AZ); S3 Express One Zone is single-AZ. If ProximaDB ever needs multi-AZ-at-commit or
+sub-ms per-tx commits, the options are: cross-region S3 replication of the WAL, a lightweight quorum
+on the object-store seam, or accept single-AZ + async cross-region. This is tracked as an open
+question, not as work to do now.
+
+== Resolution
+
+Won't Do (documented with reasoning). Revisit only if the workload shifts to high-frequency per-tx
+OLTP or multi-AZ-at-commit becomes a hard product requirement.
+
+== References
+
+* https://neon.com/docs/introduction/architecture-overview[Neon architecture — object storage off the commit path]
+* https://github.com/neondatabase/neon/blob/main/docs/safekeeper-protocol.md[Neon SafeKeeper protocol — FlushLSN on local disk]
+* https://homepages.cwi.nl/~boncz/lsde/papers/aurora.pdf[Aurora — 4-of-6 local-SSD quorum (the quorum alternative)]
+* https://arxiv.org/html/2603.02108v1[Milliscale — object-store commit latency is NOT automatically competitive for per-tx]
+* https://jack-vanlightly.com/blog/2024/6/10/a-cost-analysis-of-replication-vs-s3-express-one-zone-in-transactional-data-systems[Replication vs S3 Express One Zone — cost analysis]

--- a/docs/10-quality/td/TD-LTAP-4-instant-branching-pitr.adoc
+++ b/docs/10-quality/td/TD-LTAP-4-instant-branching-pitr.adoc
@@ -1,0 +1,56 @@
+= TD-LTAP-4: Productize instant branching / cloning / PITR as metadata ops
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open (lower priority — product gap, not a defect)
+| Severity | Medium — Neon/Lakebase's flagship feature ("branch a large DB in seconds") is unbuilt
+| Component | catalog versioning, Iceberg snapshot refs, partition lease
+| Tracked-by | — (this TD is the tracker)
+| Relates to | link:../../12-design/adr/ADR-031-stable-object-id-physical-key.adoc[ADR-031] (stable ids), link:../../12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc[ADR-032] (object-store catalog), link:TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc[TD-LTAP-1] (immutable durable core)
+| Pillar | OE, COST
+|===
+
+toc::[]
+
+== Symptom
+
+No "branch this collection in seconds" surface. Neon/Lakebase's killer feature — instant
+branching/cloning/PITR as a **metadata operation** over versioned object storage — is unbuilt in
+ProximaDB.
+
+== Why it is cheap for ProximaDB
+
+The substrate already exists: object-store-backed WAL (ADR-020) + immutable durable-core segments
+(TD-LTAP-1/ADR-045) + Iceberg snapshot refs. Verified by research:
+
+* **Delta Lake shallow clones** copy only table metadata (the transaction log), not the underlying
+  Parquet data — "fast and computationally cheap."
+* **Iceberg branching/time-travel** = named references to immutable snapshots → zero-data-copy
+  isolated views.
+
+So branching/cloning is a catalog pointer-swap over the durable core's immutable snapshots, not a
+data copy.
+
+== Fix approach
+
+Expose branch / clone / PITR as **catalog-level metadata ops** over the durable core's immutable
+snapshot lineage (Iceberg refs) + a WAL range for PITR to an arbitrary LSN. Scope per-collection on
+the stable `object_id` (ADR-031).
+
+== Dependencies
+
+TD-LTAP-1 durable core (immutable segments) helps; ADR-032 object-store catalog for the pointer
+surface. Can prototype over existing Iceberg snapshots + partition leases.
+
+== Verification
+
+* Branch a large collection in seconds, fully isolated, zero data copy.
+* PITR to an arbitrary LSN returns the correct visible state (≡ tx read at that LSN).
+
+== References
+
+* https://delta.io/blog/delta-lake-clone/[Delta Lake clones — metadata-only]
+* https://lakefs.io/blog/shallow-copy-data/[Shallow copy — metadata-only branching]

--- a/docs/12-design/adr/ADR-010-pax-block-format.adoc
+++ b/docs/12-design/adr/ADR-010-pax-block-format.adoc
@@ -296,3 +296,18 @@ contract and Iceberg type coercion impact.
 |`crates/storage/proximadb-block-format/src/writer.rs`|PaxBlockWriter, BlockFooter (32B), flush() with crc32 checksum
 |`crates/storage/proximadb-block-format/src/reader.rs`|PaxBlockReader, block-level pruning, stripe decode helpers
 |===
+
+== Reconciliation & amendments (2026-06-30)
+
+* **Stratified Layer 2 (ADR-045).** The "Stacked Durability Alignment" Layer-2 unit is refined by
+  link:ADR-045-pax-durable-core-vs-serving-metadata.adoc[ADR-045] into a **durable open core**
+  (Layer 2a: stripes + MVCC columns; ships 1:1 to Iceberg) and a **rebuildable serving-metadata
+  layer** (Layer 2b: `RowDirectory`, `ColumnMeta` stats/bloom, header zone summaries, `BlockFooter`/
+  `SegmentIndex`, `PDV1` deletion vector). The "Iceberg / Arrow Flight Integration" mapping becomes
+  precise: the *core* is the Iceberg data-file content; serving metadata is not published and is
+  regenerable from (core + WAL) on cold-start. Tracked:
+  link:../../10-quality/td/TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc[TD-LTAP-1].
+* **PAX co-location is load-bearing (research).** VLDB'01 (Ailamaki/DeWitt/Hill/Skounakis) confirms
+  PAX co-locates filter + vector attributes in one page with no storage penalty and no I/O beyond the
+  page — validating that the ANN cascade (filter → RaBitQ → SQ8 rerank) must keep filter + vector
+  stripes together in the durable core. Source: https://www.vldb.org/conf/2001/P169.pdf.

--- a/docs/12-design/adr/ADR-020-canonical-wal-authority.adoc
+++ b/docs/12-design/adr/ADR-020-canonical-wal-authority.adoc
@@ -125,6 +125,35 @@ Wait for each TD to land before formalizing the contract. Rejected because the f
 * `Cargo.toml` `[features]` block — `canonical-document-store` default-enable (T2.2)
 * Future engine / projection / adapter ADRs — boundary contract section above
 
+== Reconciliation (2026-06-30 — where the WAL physically lives)
+
+A prior external comparison (Lakebase/LTAP; deep-research workflow `wf_93aa09c8-12b`) initially
+mistook the canonical WAL for local-disk-only. It is not. In cloud deployments the canonical WAL
+writes through `FilesystemFactory` → `object_store`
+(`src/storage/persistence/filesystem/aws_s3.rs:179` — `store.put(...).await` blocks until the object
+store acknowledges before the commit ack returns; `sync_file` is a no-op for cloud backends because
+the PUT is already durable). On restart the pod replays the WAL into the memtable
+(`RecoveryMode::ViaMemtable`).
+
+Consequences for this ADR's authority model:
+
+* Pods are **stateless** and restart is **non-lossy** — the same properties Lakebase/Neon's
+  SafeKeeper provides, achieved via object-storage durability (S3 Standard = 11 nines) **without a
+  separate quorum service**. This ADR's "performance buffer... must be flushed-through before commit
+  acknowledgement" still holds: the object-store PUT *is* that flush.
+* A SafeKeeper-style quorum WAL is **not needed for durability** — it would buy only per-tx commit
+  latency (quorum-local-SSD fsync ≈ single-digit ms vs object-store PUT ≈ tens-to-hundreds of ms),
+  which is moot for ProximaDB's batch-ingestion profile. Recorded as
+  link:../../10-quality/td/TD-LTAP-3-quorum-wal-latency-only-wontdo.adoc[TD-LTAP-3] (Won't Do).
+  Open caveat: multi-AZ durability *at commit* would require cross-region S3 replication or a
+  lightweight quorum on the object-store seam — tracked as an open question there, not work now.
+
+Sources: https://neon.com/docs/introduction/architecture-overview[Neon architecture — object
+storage deliberately off the commit path],
+https://github.com/neondatabase/neon/blob/main/docs/safekeeper-protocol.md[Neon SafeKeeper protocol],
+https://arxiv.org/html/2603.02108v1[Milliscale — object-store commit latency is not automatically
+competitive for per-tx].
+
 == References
 
 * `docs/12-design/RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc` — parent stacked-durability mandate

--- a/docs/12-design/adr/ADR-045-pax-durable-core-vs-serving-metadata.adoc
+++ b/docs/12-design/adr/ADR-045-pax-durable-core-vs-serving-metadata.adoc
@@ -1,0 +1,124 @@
+= ADR-045: PAX Durable-Open Core vs Rebuildable Serving Metadata
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-30
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-010 (refines its Layer-2 + Iceberg-integration sections), ADR-020 (WAL authority), ADR-025 (deletion vectors), ADR-027 (PAX single internal format), ADR-033 (dual-path), ADR-034 (read-path GET depth)
+|Supersedes|—
+|Tracked under|link:../../10-quality/td/TD-LTAP-1-pax-durable-core-serving-metadata-split.adoc[TD-LTAP-1]
+|Research|deep-research workflow `wf_93aa09c8-12b` (2026-06-30; 23 sources, 24/25 claims adversarially verified)
+|===
+
+== Context
+
+ADR-010 already establishes the PAX block as a Layer-2 *rebuildable projection* and notes that
+"each PAX block maps to one Iceberg manifest data-file descriptor." It treats the block as **one
+unit**. The Lakebase/LTAP research surfaced a sharper stratification that this ADR makes explicit:
+separate, *within the segment*, the bytes that are the **durable open-format truth** from the bytes
+that are a **regenerable serving cache**. This is the ProximaDB-native form of Lakebase's
+"separate durability from visibility" — except ProximaDB needs **no transcode seam**, because the
+PAX block already co-locates the row-directory and the column-stripes in one block.
+
+Three adversarially-verified findings drive the decision:
+
+1. **Aurora — "the log is the database; pages are a cache of log applications."** Only redo-log
+   records cross the network; page/segment materialization is rebuildable, decoupled from durable
+   truth. Foreground write path is just (receive into queue; persist + ack); all else backgrounded.
+   (Aurora SIGMOD'17 — 3-0 verified.)
+2. **PAX is a page-internal layout, "orthogonal to other storage decisions... incurs no storage
+   penalty,"** and the storage manager "can decide to use PAX or not when storing a relation, based
+   solely on the number of attributes." The PAX segment is therefore an independently-shippable,
+   regeneratable unit per collection. (Ailamaki/DeWitt/Hill/Skounakis, VLDB'01 — 3-0 verified.)
+3. **Iceberg requires only three filesystem operations — in-place write, seekable reads, deletes —**
+   "compatible with object stores, like S3... Once written, data and metadata files are immutable
+   until they are deleted." The durable core can therefore BE an Iceberg data file. (Iceberg spec —
+   3-0 verified. Note: commit via catalog pointer-swap, *not* rename — rename-commit is unsafe on S3.)
+
+== Decision
+
+Stratify the PAX segment into two layers with different durability/rebuild contracts.
+
+**Layer A — durable open core** (the source of truth; ships 1:1 to Iceberg):
+
+* The columnar stripes — including the vector embedding stripes **and** the co-located RaBitQ/SQ8
+  rerank columns (the ANN cascade).
+* The WAL-derived MVCC columns (`valid_from_ns`, `valid_to_ns`, tombstone flags) — these carry
+  version/visibility semantics.
+* This layer IS the Iceberg data-file content. It is immutable once written.
+
+**Layer B — rebuildable serving metadata** (the "cache"; regenerable from core + WAL, NOT part of
+the open format):
+
+* `RowDirectory` — the point-read accelerator (binary search by `row_id_hash`).
+* `ColumnMeta` stats (`min_val`/`max_val`, `distinct_hint`/HLL, `null_count`) + bloom filters.
+* `BlockHeader` zone summaries (`min/max_timestamp_ns`, `tenant_id_hash`, collection/schema hashes).
+* `BlockFooter` + `SegmentIndex`.
+* Deletion vector (`PDV1`) per ADR-025.
+
+Contracts:
+
+* **Layer B is derivable from (Layer A + WAL replay).** On cold-start, Layer B can be regenerated
+  *without* re-reading all vector stripe data — directly attacking the TD-165 cold-start tax
+  (measured: SST lazy 24 ms / 7 KB vs eager 133–271 ms / ~915–953 MiB).
+* **Layer A ships to Iceberg as the open-format copy; Layer B stays internal.** This realizes the
+  LTAP "one governed copy in open format" using ProximaDB's existing dual-path (ADR-033), without
+  Lakebase's row-cache/columnar-lake transcode seam.
+* **Co-location is inviolable.** Because PAX co-locates filter columns + vector data in one segment
+  (VLDB'01), an ANN cascade (filter → RaBitQ → SQ8 rerank) satisfies a query with no extra GET
+  beyond the segment. The split MUST keep filter + vector stripes together in Layer A. (This is the
+  load-bearing lesson from the PAX-cascade wiring work: discovery excluding `.pax` meant the cascade
+  never ran.)
+
+== What this changes vs ADR-010
+
+* ADR-010 "each PAX block maps to one Iceberg data-file descriptor" → now precise: the **core**
+  (stripes + MVCC) IS the descriptor's content; the serving metadata is not published.
+* ADR-010 "Stacked Durability Alignment" Layer 2 → stratified into **Layer 2a** (durable open core)
+  and **Layer 2b** (rebuildable serving metadata). ADR-020's WAL-as-authority model is unaffected.
+
+== Alternatives considered
+
+=== Option: keep PAX as one opaque Layer-2 unit (status quo, ADR-010) — REJECTED
+
+Conflates durable-truth with rebuildable cache; blocks cheap Iceberg export; forces a full vector
+re-read on cold-start.
+
+=== Option: Lakebase-style split (separate row-page cache + separate columnar lake files + heap-address pointers) — REJECTED
+
+ProximaDB needs no transcode seam — PAX already co-locates row-directory + stripes. A separate
+columnar lake would break filter+vector co-location and force extra GETs in the ANN cascade.
+
+== Consequences
+
+=== Positive
+
+* Single governed open-format copy (Layer A → Iceberg) → enables LTAP single-copy analytics (pairs
+  with ADR-046).
+* Fast cold-start (regenerate Layer B from Layer A + WAL without re-reading vector data).
+* "Serving layer is a cache" elegance — Layer B droppable under memory pressure and rebuildable.
+
+=== Negative / Trade-offs
+
+* Layer B regeneration cost must be bounded (add a rebuild-RTO line, à la ADR-010's `RebuildRtoSpec`).
+* Format-level decision → mixed-read-safe migration (new segment magic/version) required.
+
+== Verification
+
+* **Recall ratchet (SIFT1M):** the split must not regress ANN recall (co-location preserved) —
+  dual-write old + new, ratchet-verify, then flip. This is the standing format-flip rule.
+* **Cold-start bench:** Layer-B regeneration time vs status-quo full re-read (target: regenerate
+  without vector re-read).
+
+== References
+
+* Deep-research report `wf_93aa09c8-12b` (2026-06-30): Aurora SIGMOD'17 (log-is-database);
+  Ailamaki/DeWitt VLDB'01 PAX (page-internal orthogonality, no storage penalty); Iceberg spec
+  (3 FS ops, immutable files, object-store compatible).
+
+* Sources:
+  ** https://homepages.cwi.nl/~boncz/lsde/papers/aurora.pdf[Aurora SIGMOD'17]
+  ** https://www.vldb.org/conf/2001/P169.pdf[Weaving Relations for Cache Performance — PAX, VLDB'01]
+  ** https://iceberg.apache.org/spec/[Apache Iceberg specification]
+  ** https://www.databricks.com/blog/lakebase-ltap-rethinking-database-storage[Lakebase/LTAP blog]

--- a/docs/12-design/adr/ADR-046-lsn-coherent-merge-read.adoc
+++ b/docs/12-design/adr/ADR-046-lsn-coherent-merge-read.adoc
@@ -1,0 +1,107 @@
+= ADR-046: LSN-Coherent Single-Copy Analytics Read (LTAP without CDC)
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-06-30
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-020 (WAL authority), ADR-033 (dual-path), ADR-039 (OLAP engine boundary), ADR-045 (durable core), ADR-010 (ANN freshness gap), ADR-035 (catalog cache)
+|Supersedes|—
+|Tracked under|link:../../10-quality/td/TD-LTAP-2-lsn-merge-read.adoc[TD-LTAP-2]
+|Research|deep-research workflow `wf_93aa09c8-12b` (2026-06-30)
+|===
+
+== Context
+
+Lakebase LTAP's headline: transactions and analytics on **one copy**, real-time, no CDC. Its
+mechanism is an analytical query that asks Postgres for the current LSN, reads the materialized
+majority from object storage, then merges the recent un-materialized WAL-tail delta. The
+reconstruction primitive is verified directly: the Neon PageServer "reconstructs [a page] by
+finding the most recent materialized image of that page and replaying any WAL deltas on top"
+(Lakebase blog; Jack Vanlightly ASDS Ch.3 — 3-0 verified).
+
+**Crucially, the research found Lakebase's *shipping* analytics freshness (CDF) is actually CDC,
+not single-copy:** "wal2delta tails the WAL and flushes captured changes into Delta tables every
+~15 seconds" — a second, periodically-synced copy. A true single-copy LSN-merge read is therefore
+*genuinely better* than Lakebase's current analytics freshness.
+
+ProximaDB already has every piece:
+
+* ADR-020: WAL is the single durable authority (the delta source).
+* ADR-033: the Parquet/VIPER arm = the materialized lake copy.
+* MVCC `valid_from_ns`/`valid_to_ns` = the visibility merge logic.
+* `search_unflushed_vectors()` already merges memtable (unflushed) + engine (flushed) on the
+  *vector* read path.
+
+What is missing is an explicit **cross-format, LSN-coherent merge read for analytics** —
+Parquet-arm-as-of-LSN + WAL-tail-since-LSN. Hudi Merge-on-Read independently corroborates the
+shape: "immutable columnar base files are the source of truth; updates/deletes recorded in a
+separate append-only delta, merged only at read time."
+
+== Decision
+
+Implement an LSN-coherent merge read over the dual-path (ADR-033):
+
+1. An analytical query obtains the current WAL LSN (cheap metadata lookup) — the read timestamp.
+2. Read the materialized majority directly from the Parquet/VIPER arm in object storage (the
+   durable open core per ADR-045), as-of the last materialized snapshot ≤ LSN.
+3. Merge the un-materialized delta: replay WAL-tail records with LSN ∈ (materialized, query-LSN],
+   applying MVCC visibility, on top of the materialized base.
+
+Result: a consistent, fully-up-to-date analytical read as-of LSN, from a **single governed copy**,
+with zero transactional-workload impact (the tx path serves no analytical traffic beyond the LSN
+lookup). This is the ProximaDB-native LTAP — it unifies at the *storage* layer (one WAL authority
++ one durable core) while keeping specialized compute (ADR-039 OLAP engine boundary) — matching
+Lakebase's meta-principle **without** their second CDC copy.
+
+Contracts:
+
+* **LSN-coherent:** materialized base + WAL-tail replay = exactly the state a tx read at the same
+  LSN would see (modulo declared projection lag, à la ADR-010's ANN Freshness Gap).
+* **Small-table skip:** tiny collections serve straight from memtable / Layer-B row-directory; no
+  Parquet materialization (bookkeeping > savings — the Lakebase tactic).
+* **Zero tx impact:** analytics never contends with tx compute (separate engine, ADR-039).
+
+== Alternatives considered
+
+=== Option: CDC / "mirroring" / "zero-ETL" (Lakebase CDF — a second periodically-synced copy) — REJECTED
+
+Two copies → governance drift, replication lag, the exact problem LTAP exists to avoid.
+
+=== Option: single-engine HTAP — REJECTED
+
+Verified (Lakebase blog): incomplete feature set, no ecosystem, no performance isolation. ProximaDB
+keeps the best engine for each job and unifies at storage.
+
+== Consequences
+
+=== Positive
+
+* Single-copy real-time analytics; no ETL pipeline to build/monitor/unbreak; views never drift.
+* Reuses ADR-020 WAL authority + ADR-033 dual-path + ADR-039 engine boundary — additive, no new
+  durable truth.
+
+=== Negative / Trade-offs
+
+* WAL-tail replay cost on every fresh analytical read (bounded by materialization cadence;
+  amortized by columnar compression — Lakebase cites ~10×).
+* Needs a defined materialization cadence + an LSN-merge correctness ratchet.
+
+== Verification
+
+* **Correctness ratchet:** analytics read at LSN ≡ tx read at LSN (differential), across a range of
+  LSNs straddling materialization boundaries.
+* **Freshness bench:** analytical-query freshness vs materialization cadence.
+
+== References
+
+* Deep-research report `wf_93aa09c8-12b` (2026-06-30): Neon PageServer find-last-image +
+  replay-WAL-delta (3-0); Hudi Merge-on-Read (immutable base + delta merged at read); Lakebase CDF
+  = CDC / second-copy (the contrast); Lakebase LTAP blog.
+
+* Sources:
+  ** https://www.databricks.com/blog/lakebase-ltap-rethinking-database-storage[Lakebase/LTAP blog]
+  ** https://jack-vanlightly.com/analyses/2023/11/15/neon-serverless-postgresql-asds-chapter-3[Neon ASDS Ch.3 — Jack Vanlightly]
+  ** https://neon.com/blog/get-page-at-lsn[Neon — get page at LSN]
+  ** https://hudi.apache.org/blog/2025/07/21/mor-comparison/[Hudi — Merge-on-Read deep dive]
+  ** https://medium.com/towards-data-engineering/lakebase-cdf-the-simplest-way-to-stream-postgres-changes-into-your-lakehouse-e2fa48e4dfd5[Lakebase CDF — the CDC contrast]

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -1,7 +1,7 @@
 = Architecture Decision Records
 :toc: left
 :icons: font
-:last-updated: 2026-06-29
+:last-updated: 2026-06-30
 
 [.lead]
 This directory contains Architecture Decision Records (ADRs) governing ProximaDB's implementation across all open issues (#25-#61). Each ADR defines canonical contracts, interfaces, and file plans that implementation must follow.
@@ -164,6 +164,16 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Stable, line-independent symbol object_id — the correlated-CPG join key
 | Proposed
 | Cross-product audit 2026-06-28: the symbol `oid` is minted **3 different ways** across proximaDB / victor-codegraph / anvaiops and all embed the line number in identity, so a line move churns a symbol's vector + node + row — breaking fuse-on-shared-oid and forcing full re-index. *Decision:* one canonical, **line-independent** symbol oid minted once in `victor-codegraph`'s adapter and consumed verbatim by the SDK, connector, and substrate; identity = structural coordinates (`repo‖language‖module_path‖FQN‖overload-discriminator`), with line/col and body-hash as metadata, not identity. Extends ADR-031's tenet (stable id, mutable coordinate is metadata) to the symbol layer ADR-031 explicitly excluded. Mixed-read-safe, default-OFF. Tracked: TD-CG
+
+| link:ADR-045-pax-durable-core-vs-serving-metadata.adoc[ADR-045]
+| PAX Durable-Open Core vs Rebuildable Serving Metadata
+| Proposed
+| Stratify the PAX segment into a **durable open core** (stripes + MVCC; ships 1:1 to Iceberg) vs a **rebuildable serving-metadata layer** (row-dir, ColumnMeta, bloom, deletion vector, zone summaries). The ProximaDB-native form of Lakebase's "separate durability from visibility" — needs no transcode seam because PAX already co-locates row-directory + stripes; co-location of filter+vector stripes is inviolable (the ANN cascade must keep working with no extra GET). Enables LTAP single-copy export + fast cold-start (regenerate serving metadata without re-reading vectors). Grounded in Aurora "log is the database" (SIGMOD'17), PAX page-internal orthogonality (VLDB'01), Iceberg 3-FS-op immutable files. Refines ADR-010 Layer-2. Tracked: TD-LTAP-1
+
+| link:ADR-046-lsn-coherent-merge-read.adoc[ADR-046]
+| LSN-Coherent Single-Copy Analytics Read (LTAP without CDC)
+| Proposed
+| Analytical read obtains the WAL LSN, reads the materialized Parquet/VIPER arm as-of-LSN, then merges the un-materialized WAL-tail delta (MVCC-visible) — a consistent fresh read from ONE governed copy with zero tx impact. The ProximaDB-native LTAP: unify at the storage layer (one WAL authority + one durable core) with specialized compute (ADR-039). Research found Lakebase's *shipping* analytics freshness (CDF) is actually CDC (a second ~15s-synced copy), so a true single-copy LSN-merge is genuinely better. Reuses ADR-020/033/039 + the existing `search_unflushed` merge. Small-table skip. Tracked: TD-LTAP-2
 |===
 
 NOTE: ADR-010 through ADR-013 exist in this directory but are not yet


### PR DESCRIPTION
Deep-research-backed capture (workflow `wf_93aa09c8-12b`; 23 sources, 24/25 claims adversarially verified) of the Databricks Lakebase/Neon vs ProximaDB PAX+WAL comparison. **Docs only** — no code changes.

## New ADRs
- **ADR-045 — PAX durable-open core vs rebuildable serving metadata.** Stratify the segment into a durable open core (stripes + MVCC; ships 1:1 to Iceberg) vs a regenerable serving-metadata layer (row-dir / bloom / DV / zone-maps). Refines ADR-010 Layer-2. Grounded in Aurora "log is the database" (SIGMOD'17), PAX page-internal orthogonality (VLDB'01), Iceberg 3-FS-op immutable files. Filter+vector co-location is inviolable.
- **ADR-046 — LSN-coherent single-copy analytics read (LTAP without CDC).** Read LSN → materialized Parquet/VIPER arm as-of-LSN → merge WAL-tail delta (MVCC-visible). Research found Lakebase's *shipping* freshness (CDF) is actually CDC (a second ~15s copy), so a true single-copy merge is genuinely better.

## New TDs
- **TD-LTAP-1** — implement the (a) split; **TD-LTAP-2** — implement the (b) merge read.
- **TD-LTAP-3 — Won't Do:** SafeKeeper-style quorum WAL. Verified in code (`aws_s3.rs` `put().await` gates commit ack; `sync_file` no-op for cloud; `ViaMemtable` replay) that the object-store WAL is already stateless + non-lossy; a quorum buys only per-tx commit latency (moot for batch ingestion). Open caveat: multi-AZ-at-commit.
- **TD-LTAP-4** — productize instant branching/cloning/PITR as metadata ops (substrate already exists).

## Amendments (surgical)
ADR-010 (Layer-2 stratification + PAX co-location research), ADR-020 (records where the WAL physically lives — object-store-durable, **not** local-fsync; kills the "lossy" mis-derivation), README index (045/046).

## Verification
`check_td_adr_unique.py` → **0 errors**, 46 ADR files, 129 TD ids; ADR-045/046 correctly indexed.