### PR TITLE
fix(prerelease-ci): use -p (package) instead of --bin for apps/ binaries

### DIFF
--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -229,14 +229,14 @@ jobs:
 
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }} $FEATURES_FLAG \
-              --bin proximadb-server \
-              --bin proximadb-bench \
-              --bin proximadb-migrate
+              -p proximadb-server \
+              -p proximadb-bench \
+              -p proximadb-migrate
           else
             cargo build --release --target ${{ matrix.target }} $FEATURES_FLAG \
-              --bin proximadb-server \
-              --bin proximadb-bench \
-              --bin proximadb-migrate
+              -p proximadb-server \
+              -p proximadb-bench \
+              -p proximadb-migrate
           fi
         shell: bash
 


### PR DESCRIPTION
Same bin-target fix as release.yml #594, applied to prerelease-ci.yml.