### PR TITLE
feat(pax): include_vectors materialization + compaction tier-preservation (Phase D completion)

### DIFF
--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -497,6 +497,53 @@ impl<'a> PaxBlockReader<'a> {
         Some(scored)
     }
 
+    /// Decode the exact-f32 tier vectors for a specific set of `rows` (the
+    /// cascade's top-k), reading ONLY those rows' bytes from the `F32_TIER_BASE`
+    /// stripe — not the whole column (keeps the cascade's read budget tight).
+    /// Returns `None` if no f32-tier column is present; per-row `None` for
+    /// null/out-of-range rows. This is the `include_vectors` materialization path.
+    pub fn decode_f32_tier_rows(
+        &self,
+        emb_idx: usize,
+        rows: &[usize],
+    ) -> Option<Vec<Option<Vec<f32>>>> {
+        let column_id = crate::col_id::F32_TIER_BASE + emb_idx as i32;
+        let entry = self.vparams.get(column_id)?;
+        if entry.quant_kind != QUANT_RAW_F32 {
+            return None;
+        }
+        let raw = self.read_stripe_raw(column_id)?;
+        let n = self.row_count() as usize;
+        let dim = entry.dim as usize;
+        let bm_len = n.div_ceil(8);
+        if raw.len() < bm_len {
+            return None;
+        }
+        let bitmap = &raw[..bm_len];
+        let payload = &raw[bm_len..];
+        let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
+        let stride = dim * 4; // one little-endian f32 per dimension
+        let mut out = Vec::with_capacity(rows.len());
+        for &row in rows {
+            if row >= n || !is_present(row) {
+                out.push(None);
+                continue;
+            }
+            let off = row * stride;
+            let end = off + stride;
+            if end > payload.len() {
+                out.push(None);
+                continue;
+            }
+            let v: Vec<f32> = payload[off..end]
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            out.push(Some(v));
+        }
+        Some(out)
+    }
+
     /// Decode opaque byte blobs from a raw length-prefixed binary stripe — the
     /// inverse of the writer's `build_bytes_stripe` (used for the msgpack `PROPS`
     /// and `LABELS` columns). Each value is a 4-byte little-endian length prefix

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1180,12 +1180,17 @@ impl Compaction {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
                     }
-                    crate::storage::engines::sst::segment_format::write_pax_segment(
+                    let f32_tier =
+                        crate::storage::engines::sst::segment_format::pax_inputs_have_f32_tier(
+                            &task.input_files,
+                        );
+                    crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier(
                         &staging_file_path,
                         &records,
                         &collection_id,
                         records.len(),
                         proximadb_block_format::VectorQuant::RaBitQ,
+                        f32_tier,
                         None,
                     )
                     .map_err(|e| {
@@ -1324,12 +1329,17 @@ impl Compaction {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
                     }
-                    crate::storage::engines::sst::segment_format::write_pax_segment(
+                    let f32_tier =
+                        crate::storage::engines::sst::segment_format::pax_inputs_have_f32_tier(
+                            &task.input_files,
+                        );
+                    crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier(
                         &task.output_file,
                         &records,
                         &collection_id,
                         records.len(),
                         proximadb_block_format::VectorQuant::RaBitQ,
+                        f32_tier,
                         None,
                     )
                     .map_err(|e| {

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -283,13 +283,19 @@ impl SstEngine {
         let records = hits
             .into_iter()
             .map(|h| {
-                OptimizedSearchRecord::new(
+                let mut r = OptimizedSearchRecord::new(
                     h.oid,
                     OptimizedSearchRecord::standardized_distance_to_similarity(
                         h.distance,
                         &distance_metric,
                     ),
-                )
+                );
+                // include_vectors: attach the exact f32 vector when the tier
+                // provided one (filter_search_results strips it if not requested).
+                if let Some(v) = h.vector {
+                    r = r.add_vector(v);
+                }
+                r
             })
             .collect();
         Ok(Some(records))

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -162,6 +162,31 @@ pub fn write_pax_segment_with_f32_tier(
     writer.finish()
 }
 
+/// True if any input `.pax` segment carries the opt-in exact-f32 tier
+/// (`F32_TIER_BASE`). Compaction calls this to PRESERVE the tier across
+/// re-encoding — otherwise [`write_pax_segment`] drops it. Reads each `.pax`
+/// input's block metadata only; the inputs are page-cached (just read into
+/// records), so this is cheap. Correct for both env- and tag-opt-in (the source
+/// segment reflects whatever the collection wrote).
+pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
+    use proximadb_block_format::{PaxBlockReader, col_id};
+    for f in input_files {
+        if f.extension().and_then(|e| e.to_str()) != Some("pax") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(f) else {
+            continue;
+        };
+        let Ok(reader) = PaxBlockReader::open(&bytes) else {
+            continue;
+        };
+        if reader.vector_params().get(col_id::F32_TIER_BASE).is_some() {
+            return true;
+        }
+    }
+    false
+}
+
 /// One scored hit from a RaBitQ cascade segment scan: the record's `oid` and its
 /// L2 distance to the query (smaller = nearer), reranked against the co-located
 /// SQ8 column.
@@ -169,6 +194,10 @@ pub fn write_pax_segment_with_f32_tier(
 pub struct CascadeHit {
     pub oid: String,
     pub distance: f32,
+    /// Exact f32 vector (from the opt-in f32 tier) for `include_vectors`
+    /// materialization. `None` when no f32 tier is present (the caller gets
+    /// id+score only, as before). Populated lazily for the top-k rows only.
+    pub vector: Option<Vec<f32>>,
 }
 
 /// A metadata pre-prune for the cascade scan: a [`FilterExpression`] plus the
@@ -294,14 +323,22 @@ pub fn rabitq_search_segment(
                     .collect()
             });
         let oids = block.decode_str_stripe(col_id::OID);
-        for (row, dist) in scored.into_iter().take(k) {
+        // include_vectors: when the f32 tier is present, decode the top-k exact
+        // vectors (top-k rows only — lazy, read-budget-tight) and attach them so
+        // the caller can materialize exact vectors without a second segment scan.
+        let topk: Vec<(usize, f32)> = scored.into_iter().take(k).collect();
+        let topk_rows: Vec<usize> = topk.iter().map(|(r, _)| *r).collect();
+        let f32_vecs = block.decode_f32_tier_rows(0, &topk_rows);
+        for (i, (row, dist)) in topk.into_iter().enumerate() {
             let oid = oids
                 .as_ref()
                 .and_then(|o| o.get(row).cloned().flatten())
                 .unwrap_or_default();
+            let vector = f32_vecs.as_ref().and_then(|v| v.get(i).cloned().flatten());
             hits.push(CascadeHit {
                 oid,
                 distance: dist,
+                vector,
             });
         }
     }
@@ -708,6 +745,82 @@ mod tests {
     /// skipped before the vector pass), and (2) stay SOUND — a vector in a surviving
     /// block is still returned. This is the cheap pre-vector filter that moves the
     /// dominant cost term (I/O round-trips), measured by the I/O trace, not asserted.
+    /// Phase D completion: when the opt-in f32 tier is present, the cascade
+    /// materializes the EXACT f32 vector for each top-k hit (`include_vectors`).
+    /// Without the tier, hits carry `vector = None` (id+score only).
+    #[test]
+    fn rabitq_search_segment_materializes_vectors_when_f32_tier_present() {
+        const DIM: usize = 64;
+        const N: usize = 256;
+        const K: usize = 10;
+        const POOL: usize = 100;
+
+        let gen_vec = |seed: u64| -> Vec<f32> {
+            let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+            (0..DIM)
+                .map(|_| {
+                    s ^= s >> 30;
+                    s = s.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    s ^= s >> 27;
+                    ((s >> 11) as f32 / (1u64 << 53) as f32) * 2.0 - 1.0
+                })
+                .collect()
+        };
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| gen_vec(i as u64)).collect();
+        let by_oid = |oid: &str| -> Vec<f32> {
+            let i = oid[1..].parse::<usize>().unwrap();
+            corpus[i].clone()
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                rec(
+                    &format!("v{i}"),
+                    1_700_000_000_000_000_000 + i as i64,
+                    v.clone(),
+                )
+            })
+            .collect();
+
+        // WITH the f32 tier → hits carry their exact f32 vector.
+        let path = dir.path().join("f32_tier.pax");
+        write_pax_segment_with_f32_tier(&path, &records, "col", 1, VectorQuant::RaBitQ, true, None)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let query = corpus[0].clone();
+        let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, None)
+            .unwrap()
+            .expect("PAX+RaBitQ+tier segment runs the cascade");
+        assert!(!hits.is_empty(), "cascade must return top-k");
+        for h in &hits {
+            let v = h
+                .vector
+                .as_ref()
+                .expect("hit carries exact f32 vector when the tier is present");
+            assert_eq!(
+                v,
+                &by_oid(&h.oid),
+                "materialized vector must be exact for {}",
+                h.oid
+            );
+        }
+
+        // WITHOUT the tier → hits carry no vector (id+score only).
+        let path2 = dir.path().join("no_tier.pax");
+        write_pax_segment(&path2, &records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
+        let bytes2 = std::fs::read(&path2).unwrap();
+        let hits2 = rabitq_search_segment(&bytes2, &query, K, POOL, RankMetric::L2, None)
+            .unwrap()
+            .expect("cascade runs");
+        assert!(
+            hits2.iter().all(|h| h.vector.is_none()),
+            "no f32 tier → hits must not carry vectors"
+        );
+    }
+
     #[test]
     fn rabitq_search_segment_metadata_pruning_skips_blocks() {
         use proximadb_filter_expression::ComparisonOperator;


### PR DESCRIPTION
## Summary

**Phase D completion — closes the f32-tier feature.** Two pieces: the cascade now
**materializes exact vectors for `include_vectors`**, and **compaction preserves the
tier** across re-encoding. Builds on #588 (E), #590 (f32-tier write), #602 (f32 rerank).

## A. `include_vectors` materialization (the tier's core product value)
- **`reader.rs`** — `decode_f32_tier_rows(emb_idx, rows)`: decode the exact f32 vectors
  for the **top-k rows only** (lazy; None if no f32-tier column).
- **`CascadeHit`** += `vector: Option<Vec<f32>>`; `rabitq_search_segment` populates it for
  the top-k when the tier is present.
- **`try_pax_cascade`** attaches the exact vector via `OptimizedSearchRecord::add_vector`.
  `filter_search_results` strips it if `include_vectors` wasn't requested — so this matches
  the engine's existing materialize-then-strip pattern, **no `include_vectors` threading
  needed** (the original blocker).

## B. Compaction tier-preservation (don't drop the tier on re-encode)
- **`segment_format.rs`** — `pax_inputs_have_f32_tier(input_files)`: detect if any input
  `.pax` carries `F32_TIER_BASE` (page-cached re-read; **correct for both env and tag
  opt-in**, since the source reflects whatever the collection wrote).
- The two unified-compaction write sites use `write_pax_segment_with_f32_tier` when inputs
  had the tier.
- **Remaining gap:** `compactor_impl.rs` (a secondary compaction path) lacks input-file
  access and still drops the tier — noted, narrow.

## Verification (local)
- `cargo check -p proximadb --tests` clean (the #588 lesson — confirmed only one
  `CascadeHit` construction site, updated).
- Isolated clippy clean (block-format tests + sst lib).
- `rabitq_search_segment_materializes_vectors_when_f32_tier_present` — with the tier, hits
  carry their **EXACT** vector (matches the inserted vector per oid); without, `vector=None`.

## Status
This closes the f32 tier: write (#590) → exact rerank (#602) → **include_vectors + compaction
preservation (this)**. The full PAX default-on roadmap (A–F) + the f32 tier is now implemented.
