### PR TITLE
docs(adr): ADR-047 collection-as-table — canonical schema, multi-vector, per-column quant (Phase 0)

### DIFF
--- a/docs/10-quality/td/TD-TBL-1-canonical-schema-authority.adoc
+++ b/docs/10-quality/td/TD-TBL-1-canonical-schema-authority.adoc
@@ -1,0 +1,47 @@
+= TD-TBL-1: Persist canonical ProximaType schema as the collection/table authority
+:status: Open
+:dim: D4
+:pillar: OE
+:adr: ADR-047
+:phase: 1
+
+== Problem
+
+The persisted collection schema is the narrow v1 `CollectionConfig` proto (single `dimension`/
+`distance_metric`/`pax_vector_quant`; `FilterableDataType` enum with no Map/Array/Struct/UInt),
+and the catalog round-trip `StoredSchema` (`src/storage/metadata/catalog_config.rs:333-404`)
+**drops every non-text typed column** on read-back (`record_schema.columns: Vec::new()` at
+`:391`). The runtime-native `CollectionSchemaMetadata` (PR #595) is arbitrary `ProximaType` but
+**in-memory only**; its legacy adapter *downconverts* `ProximaType → FilterableDataType` and *fails
+closed* on types it cannot represent (UInt/Struct/non-string-Map/Sparse/BinaryVector). So a
+collection cannot durably hold rich-typed or multi-vector columns. A canonical ProximaType-native
+schema (`CatalogTableSchema`/`CatalogColumn`, `crates/control/proximadb-catalog/src/lib.rs:314,582`)
+already exists but is not the persisted authority for the collection create path.
+
+== Next action (Phase 1)
+
+Make `CatalogTableSchema` the single persisted authority:
+
+. Extend `StoredSchema` (`catalog_config.rs:333-404`) to carry the full
+  `Vec<CollectionSchemaColumn>` (name, `ProximaType`, nullable, indexed, filterable, text_storage)
+  as neutral JSON — additive `#[serde(default)]`, so old catalogs load unchanged (mixed-read-safe).
+. **Fix the column-drop** (`:391`): reconstruct the full column list on read.
+. Change the runtime adapter (`crates/platform/proximadb-runtime/src/handlers.rs:257-410`) and its
+  mirror (`src/api_handlers/request_handlers.rs:3937`) to **write canonical, read-project-to-legacy**
+  — the narrow `filterable_columns`/`text_columns` become a *derived, lossy read view* (logged, not
+  errored). **Stop failing closed**: persist UInt/Struct/Map/Sparse/BinaryVector.
+. Create path (`src/services/collection/manager.rs:580`) writes the canonical schema.
+
+No proto regen, no SDK change, no storage-format change — catalog/serde only.
+
+== Key files
+
+`src/storage/metadata/catalog_config.rs`; `crates/platform/proximadb-runtime/src/handlers.rs`;
+`src/api_handlers/request_handlers.rs`; `crates/control/proximadb-catalog/src/lib.rs`;
+`src/services/collection/manager.rs`.
+
+== Dependencies / verification
+
+Extends PR #595. Supersedes the collection-schema residual of TD-061 and closes the schema holdout
+of TD-106/TD-111. Verify: extend #595's round-trip tests to assert UInt/Struct/Map/Sparse/BinaryVector
+survive create → persist → restart read-back; `cargo test --lib`; `cargo check --tests`; clippy `--lib`.

--- a/docs/10-quality/td/TD-TBL-2-multi-vector-columns.adoc
+++ b/docs/10-quality/td/TD-TBL-2-multi-vector-columns.adoc
@@ -1,0 +1,39 @@
+= TD-TBL-2: Multi-vector columns with per-column metric/element
+:status: Open
+:dim: D4
+:pillar: OE
+:adr: ADR-047
+:phase: 2
+
+== Problem
+
+A collection is limited to a single vector (one `dimension`, one collection-global
+`distance_metric`, one `canonical_embedding_precision`). `ProximaRecord` is already multi-vector
+(`Vec<EmbeddingCell>` with per-cell model_id/modality/dim/precision/element,
+`crates/foundation/proximadb-records/src/lib.rs:384`), and the PAX writer already holds a `Vec` of
+embedding positions (`crates/storage/proximadb-block-format/src/writer.rs:163`), but the collection
+schema and the flush path assume one vector. Cannot model multi-modal (text+image) or multi-model
+embeddings in one collection.
+
+== Next action (Phase 2)
+
+. Allow `N > 1` vector columns in the canonical schema, each a named `CatalogColumn` of
+  `DenseVector`/`SparseVector`/`BinaryVector` with per-column `element`/`dim`/`metric` in
+  `proxima.vector.*` properties (ADR-047 §Decision 3).
+. Generalize flush (`src/storage/engines/sst/flush/mod.rs:337`, currently reads single
+  `cfg.dimension`) to per-column dim; the PAX writer is already position-indexed.
+. **AXIS (hard part):** the index trait is single-vector
+  (`src/index/axis/index_factory.rs:48 add(id, Vec<f32>)`, `:209 create_index(..., dimension)`).
+  Use **one `AxisIndex` per vector column**, registered as separate projections. May warrant a
+  sub-ADR.
+
+== Key files
+
+`crates/control/proximadb-catalog/src/lib.rs`; `crates/storage/proximadb-block-format/src/writer.rs`;
+`src/storage/engines/sst/flush/mod.rs`; `src/index/axis/index_factory.rs`.
+
+== Dependencies / verification
+
+Depends on TD-TBL-1. Default-off `PROXIMADB_MULTI_VECTOR`, per-collection opt-in first. Verify:
+mixed-read (single-vector blocks still read); multi-vector insert+search round-trip; one-index-per-column
+build/maintenance cost assessed. Cross-vector hybrid search semantics defined.

--- a/docs/10-quality/td/TD-TBL-3-per-column-quantization.adoc
+++ b/docs/10-quality/td/TD-TBL-3-per-column-quantization.adoc
@@ -1,0 +1,38 @@
+= TD-TBL-3: Per-column quantization in PAX (writer); named vector columns
+:status: Open
+:dim: D4
+:pillar: PERF
+:adr: ADR-047
+:phase: 3
+
+== Problem
+
+Quantization is a single per-collection choice (`CollectionConfig.pax_vector_quant` tag 29, or
+`PROXIMADB_PAX_VECTOR_QUANT` env; resolved in `src/storage/engines/sst/flush/mod.rs:870`). All
+vectors in a collection share one `VectorQuant` (`{Auto, RawF32, Sq8, RaBitQ}`,
+`crates/storage/proximadb-block-format/src/writer.rs:119`). Cannot apply different precision to
+different vector columns (e.g. high-precision query vector + aggressively-quantized cache vector).
+
+== Next action (Phase 3)
+
+. The PAX **reader is already per-column-quant-capable** (`reader.rs:41
+  PerVectorColumnQuantParams`, `:647 match entry.quant_kind`) — old blocks decode via the block's
+  own `quant_kind`, so this is mixed-read-safe by construction.
+. Generalize the **writer** (`writer.rs:139,652-674` — currently applies one `self.quant` to all
+  columns) to resolve a per-column `VectorQuant` from the canonical schema's `proxima.vector.quant`
+  property. Precedence: per-column > `pax_vector_quant` tag 29 > env > default-off (mirrors
+  `resolve_pax_vector_quant` at `flush/mod.rs:875`).
+. Name vector columns on disk (today they are positional).
+
+== Key files
+
+`crates/storage/proximadb-block-format/src/writer.rs`; `src/storage/engines/sst/flush/mod.rs`;
+`crates/control/proximadb-catalog/src/lib.rs` (vector-column `proxima.vector.quant` property).
+
+== Dependencies / verification
+
+Depends on TD-TBL-1 (and benefits from TD-TBL-2 for multi-column). **Highest-risk phase** — needs a
+cross-quant-in-one-block accuracy/rerank test (extend the qa-gate conformance ratchet, ADR-040):
+verify rerank correctness when columns in the same block use different quant (RaBitQ on col A, SQ8
+on col B). Default-off `PROXIMADB_PER_COLUMN_QUANT` + global kill-switch
+`PROXIMADB_PER_COLUMN_QUANT_DISABLE`.

--- a/docs/10-quality/td/TD-TBL-4-complex-type-columns.adoc
+++ b/docs/10-quality/td/TD-TBL-4-complex-type-columns.adoc
@@ -1,0 +1,36 @@
+= TD-TBL-4: Complex-type columns (Map/Array/Struct) — PAX storage + nested predicate pushdown
+:status: Open
+:dim: D4
+:pillar: OE
+:adr: ADR-047
+:phase: 4
+
+== Problem
+
+`ProximaType` already carries `Map{k,v}`, `Array<t>`, `Struct{fields}` and the v2 REST/gRPC schema
+converters (PR #595) accept them, but they cannot be **stored or filtered** — the narrow persisted
+schema (`FilterableDataType`) has no complex types, and PAX scalar stripes have no encoders for
+nested types. So complex columns are accepted at the edge and then fail-closed on persist (TD-TBL-1
+fixes the persist; this TD makes them queryable).
+
+== Next action (Phase 4)
+
+. **Storage:** extend PAX scalar stripe builders/decoders
+  (`crates/storage/proximadb-block-format/src/{writer,reader}.rs`) to encode Map/Array/Struct.
+  Arrow nested types are already derivable via `ProximaType::to_arrow_type` (ADR-024) — reuse
+  Parquet/Arrow nested-column encoding.
+. **Filterability (the novel part):** extend the L5 storage adapter (ADR-019) and NOVA zone-map /
+  bloom pushdown to reach into struct fields and map keys (e.g. `map['key'] > 5`,
+  `struct.field IS NULL`). Generalizes TD-127 (OLTP secondary indexes) to sub-field projections.
+
+== Key files
+
+`crates/storage/proximadb-block-format/src/{writer,reader}.rs`; `src/query/...` (L5 pushdown,
+ADR-019); `src/index/axis/filterable_metadata.rs`.
+
+== Dependencies / verification
+
+Depends on TD-TBL-1 (canonical schema persists complex types). Default-off per new column type;
+gated behind schema-enforcement mode. Verify: complex-type column round-trips (store + read);
+nested predicate pushdown correctness; pgwire DDL round-trip for rich types (also unblocks TD-076
+rich-type pgwire parity).

--- a/docs/10-quality/td/TD-TBL-5-retire-backing-collection-shim.adoc
+++ b/docs/10-quality/td/TD-TBL-5-retire-backing-collection-shim.adoc
@@ -1,0 +1,39 @@
+= TD-TBL-5: Retire backing-collection shim + drop narrow CollectionConfig (ADR-019 closure)
+:status: Open
+:dim: D4
+:pillar: OE
+:adr: ADR-047
+:phase: 5
+
+== Problem
+
+ADR-019 calls the "backing-collection shim" a design smell: every `CREATE TABLE` auto-creates a
+dimension=1 vector collection and threads relational data through the vector pipeline. With
+TD-TBL-1..4 done, a table is just a `CatalogTableSchema` with zero-or-more vector columns and
+arbitrary typed columns — the shim and the narrow `CollectionConfig` schema fields become dead
+weight and a second (lossy) schema authority.
+
+== Next action (Phase 5)
+
+. Execute ADR-019 S5: drop the dimension=1 backing-collection shim — relational tables are a
+  first-class engine path with no vector-side detour.
+. Remove `CollectionConfig`'s schema-bearing fields (`dimension`, `distance_metric`,
+  `filterable_columns`, `text_columns`, `record_schema`, `canonical_embedding_precision`,
+  `pax_vector_quant`), keeping only transport/ops fields (`storage_engine`, `index_policy`,
+  `permitted_principals`, …).
+. Delete the fail-closed legacy adapter (`crates/platform/proximadb-runtime/src/handlers.rs:257-410`
+  + `src/api_handlers/request_handlers.rs:3937`) once no consumer reads the narrow fields as truth.
+
+== Key files
+
+`proto/proximadb/v1/collection_types.proto`; `src/network/rest/v2/collections.rs`;
+`src/services/collection/manager.rs`; `src/storage/engines/sst/flush/mod.rs`; all 4 SDKs;
+`crates/platform/proximadb-runtime/src/handlers.rs`.
+
+== Dependencies / verification
+
+Depends on TD-TBL-1..4. **Breaking proto/SDK change** — stage it: deprecate fields first (TD-TBL-1
+already stops *writing* them as authority), then remove after a release cycle. Coordinate with
+ADR-031 (object_id stability — renames must not break the physical key). Verify: no remaining reader
+of the removed fields; full v2 surface still creates/queries collections; pgwire `CREATE TABLE` no
+longer mints a vector collection.

--- a/docs/12-design/adr/ADR-009-schema-modes-and-proximarecord-surfaces.adoc
+++ b/docs/12-design/adr/ADR-009-schema-modes-and-proximarecord-surfaces.adoc
@@ -8,6 +8,13 @@
 
 Accepted
 
+*Forward link (2026-07-01):* ADR-047 operationalizes this ADR's "xCatalog is the schema
+authority" / "table-collection interchangeable" stance: it makes the canonical `ProximaType`-native
+`CatalogTableSchema` the single persisted schema authority for collections *and* tables, retires the
+narrow `CollectionConfig` schema fields to a legacy read-adapter, and fixes the `StoredSchema`
+non-text-column drop on round-trip. The `collection ≡ table` equivalence is formalized there (no
+rename). See ADR-047 Phases 1 and 5.
+
 == Context
 
 ProximaDB is moving from a vector-first database into a stacked storage platform where the primary

--- a/docs/12-design/adr/ADR-019-relational-query-architecture.adoc
+++ b/docs/12-design/adr/ADR-019-relational-query-architecture.adoc
@@ -8,6 +8,13 @@
 
 Accepted
 
+*Forward link (2026-07-01):* the "drop the relational backing-collection shim" decision (S5, §Decision
+and §Implications) is scoped and sequenced by ADR-047. ADR-047 first makes the canonical
+`ProximaType`-native `CatalogTableSchema` the persisted schema authority (so a table can have
+zero-or-more vector columns and arbitrary typed columns) and *then* — Phase 5 / `TD-TBL-5` — removes
+the dimension=1 backing-collection shim entirely. The shim cannot be dropped before ADR-047 Phases 1-4
+land.
+
 == Context
 
 ADR-018 captures the multi-phase pgwire/SQL parity roadmap. Phase 1

--- a/docs/12-design/adr/ADR-047-collection-as-table-canonical-schema-multivector.adoc
+++ b/docs/12-design/adr/ADR-047-collection-as-table-canonical-schema-multivector.adoc
@@ -1,0 +1,173 @@
+= ADR-047: Collection-as-Table — Canonical ProximaType Schema Authority, Multi-Vector, Per-Column Quantization
+:toc: left
+:toclevels: 3
+:icons: font
+:source-highlighter: rouge
+:status: Proposed
+:date: 2026-07-01
+:deciders: ProximaDB Architecture
+:supersedes: none
+:relates: ADR-009 (ProximaRecord-centric surfaces), ADR-019 (relational query architecture), ADR-024 (canonical ProximaType), ADR-031 (stable object id), ADR-010 (PAX block format)
+
+== Status
+
+Proposed. Tracker TDs: `TD-TBL-1..5` (see _Phased rollout_).
+
+== Context
+
+`CollectionService` "registers a table," but the persisted collection schema is the v1
+`CollectionConfig` proto — and it is *severely narrow*:
+
+* *Single vector only:* one `dimension` (`proto/proximadb/v1/collection_types.proto`,
+  rust `crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs:~6096`), one
+  collection-global `distance_metric`, one collection-global `canonical_embedding_precision`,
+  one collection-global `pax_vector_quant` (tag 29). No representation for >1 vector column,
+  per-column metric/element, or per-column quantization.
+* *No complex types:* `filterable_columns[]` use the fixed `FilterableDataType` enum, which
+  has no `Map`/`Array`/`Struct`/`UInt*`. `RecordSchemaConfig`/`TypedColumnConfig` use the same
+  enum.
+* *Lossy persistence:* the catalog round-trip `StoredSchema`
+  (`src/storage/metadata/catalog_config.rs:333-404`) carries only `text_columns`/`text_storage`
+  and rebuilds `record_schema.columns: Vec::new()` on read-back (`:391`) — **every non-text
+  typed column is dropped** across a restart.
+
+The crucial finding is that **the canonical target already exists and is not used as the
+authority.** In parallel to the narrow `CollectionConfig`, the codebase carries a
+ProximaType-native schema that is already rich enough:
+
+* `CatalogTableSchema` / `CatalogColumn { data_type: ProximaType, ... }`
+  (`crates/control/proximadb-catalog/src/lib.rs:314,582`) — dimensionless vectors, full
+  `ProximaType`, serde-stable, the xCatalog row ADR-009 names as schema authority. Used by the
+  SQL/relational path only.
+* `ProximaRecord` (`crates/foundation/proximadb-records/src/lib.rs:384`) — already multi-vector
+  (`embeddings: Vec<EmbeddingCell>` with per-cell `model_id`/`modality`/`dim`/`precision`/`element`).
+* The PAX **reader** is already per-column-quant-capable
+  (`crates/storage/proximadb-block-format/src/reader.rs:41,647`).
+* The runtime-native `CollectionSchemaMetadata`/`CollectionSchemaColumn { data_type: ProximaType }`
+  (`crates/platform/proximadb-runtime/src/port.rs:27`, landed in PR #595) — arbitrary
+  `ProximaType`, but **in-memory only**; its legacy adapter *downconverts* `ProximaType →
+  FilterableDataType` and *fails closed* on types it cannot represent (`UInt*`, `Struct`,
+  non-string `Map`, `Sparse/BinaryVector`).
+
+ADR-009 already makes `ProximaRecord`/`ProximaType` canonical and xCatalog the schema authority;
+ADR-024 already collapses the parallel type enums onto `ProximaType`; ADR-019 explicitly calls the
+current "backing-collection shim" (`CREATE TABLE` auto-creates a dimension=1 vector collection)
+a *design smell to be dropped*. The narrow `CollectionConfig` is the last holdout that prevents a
+collection from behaving like a relational table with arbitrary typed columns, multiple vector
+schemas, and per-column quantization.
+
+This is therefore **convergence, not invention**: make the canonical `ProximaType` schema the
+single persisted authority, demote the narrow `CollectionConfig` fields to a legacy read-adapter,
+then add multi-vector and per-column quantization on top.
+
+== Decision
+
+. **Naming — `collection` ≡ `table`, no rename.** `collection` is the REST/gRPC/SDK noun and
+  `table` is the SQL/catalog/internal noun; both denote one `CatalogTableSchema` row. Relational
+  behavior comes from the schema model (arbitrary typed columns, multi-vector, constraints), not
+  from the noun, and "collection" is embedded across all SDKs, the proto, `/api/v2/collections`,
+  and deployed users. A rename is rejected as all-cost-no-benefit (see _Alternatives_). The SQL
+  surface stays strictly "table" (pgwire requires it); no `CREATE COLLECTION` sugar.
+
+. **`CatalogTableSchema` (ProximaType-native) is the single persisted schema authority** for both
+  REST collections and SQL tables (reinforces ADR-009). The narrow `CollectionConfig` schema
+  fields (`dimension`, `distance_metric`, `filterable_columns`, `text_columns`, `record_schema`,
+  `canonical_embedding_precision`, `pax_vector_quant`) become a *legacy read-adapter* (a derived,
+  lossy view for old consumers), then are removed (Phase 5).
+
+. **Column taxonomy.** Every column in the canonical `CatalogTableSchema.columns` is a
+  `CatalogColumn { data_type: ProximaType }` in exactly one role. Roles are encoded in the column
+  `properties` map (already `HashMap<String,String>`, `lib.rs:347`) plus a role tag — **not** in
+  parallel vectors:
+  ** *Vector column* — `DenseVector{element,dim}`, `SparseVector{element,dim}`, `BinaryVector{dim}`;
+  **multiple, named**; per-column `element`/`dim`/`metric`/`quantization` carried in reserved
+  `proxima.vector.*` properties (`proxima.vector.metric`, `proxima.vector.quant`,
+  `proxima.vector.element`). The `ProximaType` enum itself stays stable (ADR-024).
+  ** *Defined scalar/complex column* — full `ProximaType` incl. `Map`/`Array`/`Struct`/`UInt*`;
+  typed at create; filterable + indexable; survives round-trip; constraint-checkable.
+  ** *Free-form tag* — untyped, **non-filterable**, collection-level property bag (today's
+  `tags[]` semantics lifted to a catalog property bag). Tags are ergonomic only.
+
+. **Storage-format changes are default-off + mixed-read-safe** per repo norms (kill-switch >
+  per-collection config > default-off; pattern at `src/storage/engines/sst/flush/mod.rs:793-808`).
+  Every on-disk change must read old blocks/catalogs unchanged.
+
+. **Phased rollout** (each independently shippable; see _Phased rollout_): P1 persisted canonical
+  schema (retire narrow authority, fix the column-drop), P2 multi-vector + per-column
+  metric/element (one `AxisIndex` per vector column), P3 per-column quantization (PAX writer
+  generalizes; reader is already per-column), P4 complex-type storage + nested predicate
+  pushdown, P5 retire the backing-collection shim + drop narrow `CollectionConfig` (ADR-019
+  closure).
+
+== Considered alternatives
+
+* **(a) Extend the `FilterableDataType` enum** with `Map`/`Array`/`Struct`/`UInt*`.*Rejected.* It
+  deepens the wrong schema — ADR-024 already collapsed the parallel enums onto `ProximaType`, and
+  the canonical ProximaType-native `CatalogTableSchema` already exists. Extending the legacy enum
+  would be re-creating the duplicate-abstraction ADR-024 spent a convergence cycle killing.
+
+* **(b) Keep `CollectionConfig` as authority and add parallel multi-vector fields.** *Rejected.* It
+  entrenches the dual-schema (narrow proto vs. canonical catalog) and the lossy `StoredSchema`
+  round-trip; the work would have to be done twice. The canonical schema is already the right
+  authority — converge on it.
+
+* **(c) Full rename `collection` → `table`.** *Rejected.* Breaks every SDK, the proto,
+  `/api/v2/collections`, and deployed users for zero semantic gain; the noun carries no relational
+  constraint (Decision 1). SQL already says "table"; the REST noun can stay "collection."
+
+* **(d) Introduce "table" as a *distinct* new object alongside "collection."** *Rejected.* Recreates
+  the dual-authority ambiguity ADR-009 collapsed; two nouns would imply two storage paths.
+
+== Consequences
+
+*Positive:* relational parity (arbitrary typed columns, constraints); true multi-vector
+collections (multi-modal embeddings in one table); per-column quantization (right-precision per
+column); pgwire `CREATE TABLE` correctness without the dimension=1 shim; complex-type filtering.
+
+*Negative:* a long P1→P5 deprecation window with two schema representations coexisting; one
+breaking proto/SDK change at P5 (field removal); P2 (AXIS multi-index) and P3 (cross-quant
+rerank) carry real correctness risk and may each warrant a sub-ADR.
+
+*Invariant during P1→P5:* the canonical schema is authoritative; the narrow `CollectionConfig`
+fields are a **derived read view only**. Any code that reads a narrow field as the source of truth
+is a latent bug (candidate for a lint/clippy guard).
+
+== Phased rollout
+
+* **Phase 0 — this ADR + TDs** (`TD-TBL-1..5`). Docs only. Decision gate.
+* **Phase 1 (`TD-TBL-1`) — persisted canonical schema.** Make `CatalogTableSchema` the persisted
+  authority; extend `StoredSchema` to carry the full `Vec<CollectionSchemaColumn>` (ProximaType);
+  fix the column-drop (`catalog_config.rs:391`); the runtime adapter
+  (`crates/platform/proximadb-runtime/src/handlers.rs:257-410`) and its mirror
+  (`src/api_handlers/request_handlers.rs:3937`) **write canonical, read-project-to-legacy**
+  (lossy projection logged, not errored; **stop failing closed**). *No storage-format change →
+  mixed-read-safe; additive `#[serde(default)]`.* Risk: MEDIUM.
+* **Phase 2 (`TD-TBL-2`) — multi-vector + per-column metric/element.** Repeated vector columns;
+  generalize flush (`src/storage/engines/sst/flush/mod.rs:337`) and PAX writer (already a `Vec` of
+  positions, `writer.rs:163`). **AXIS is the hard part** — the index trait is single-vector
+  (`src/index/axis/index_factory.rs:48,209`); use **one `AxisIndex` per vector column**. Default-off
+  `PROXIMADB_MULTI_VECTOR`. Risk: MEDIUM-HIGH.
+* **Phase 3 (`TD-TBL-3`) — per-column quantization + named PAX vector columns.** Reader is already
+  per-column (`reader.rs:647`); generalize the **writer** (`writer.rs:139,652-674`) to per-column
+  `VectorQuant` resolved from `proxima.vector.quant` (precedence: per-column > `pax_vector_quant`
+  tag 29 > env > off). **Highest risk** — mixed-read-safe (old blocks decode via the block's
+  `quant_kind`); needs a cross-quant-in-one-block accuracy test (qa-gate ratchet). Default-off +
+  kill-switch. Risk: HIGH.
+* **Phase 4 (`TD-TBL-4`) — complex types (Map/Array/Struct) PAX storage + nested predicate
+  pushdown.** Additive stripe encoders (Arrow nested via `ProximaType::to_arrow_type`); novel part
+  is making complex types **filterable** (sub-field zone-maps/blooms; generalizes TD-127).
+  Default-off per new type. Risk: MEDIUM-HIGH.
+* **Phase 5 (`TD-TBL-5`) — retire backing-collection shim + drop narrow `CollectionConfig`**
+  (ADR-019 closure). Remove the dimension=1 shim; remove `CollectionConfig` schema fields, keeping
+  transport/ops fields only; delete the fail-closed adapter. **Breaking proto/SDK change** — staged
+  deprecation first; coordinate with ADR-031 (object_id stability). Risk: HIGH.
+
+== References
+
+* ADR-009 (ProximaRecord/ProximaType canonical; xCatalog schema authority) — tightened by this
+  ADR's Decision 2.
+* ADR-019 (relational query architecture) — its "drop the backing-collection shim" is scoped here
+  to Phase 5.
+* ADR-024 (single canonical `ProximaType`) — Decision 3 reuses it unchanged.
+* PR #595 — landed the runtime-native `CollectionSchemaMetadata` and the (now-to-be-retired)
+  fail-closed legacy adapter that Phase 1 evolves.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -175,6 +175,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Proposed
 | Analytical read obtains the WAL LSN, reads the materialized Parquet/VIPER arm as-of-LSN, then merges the un-materialized WAL-tail delta (MVCC-visible) — a consistent fresh read from ONE governed copy with zero tx impact. The ProximaDB-native LTAP: unify at the storage layer (one WAL authority + one durable core) with specialized compute (ADR-039). Research found Lakebase's *shipping* analytics freshness (CDF) is actually CDC (a second ~15s-synced copy), so a true single-copy LSN-merge is genuinely better. Reuses ADR-020/033/039 + the existing `search_unflushed` merge. Small-table skip. Tracked: TD-LTAP-2
 
+| link:ADR-047-collection-as-table-canonical-schema-multivector.adoc[ADR-047]
+| Collection-as-Table — Canonical ProximaType Schema Authority, Multi-Vector, Per-Column Quantization
+| Proposed
+| Make the canonical `ProximaType`-native `CatalogTableSchema` the single persisted schema authority for collections and tables (reinforces ADR-009); demote the narrow `CollectionConfig` schema fields to a legacy read-adapter and fix the `StoredSchema` non-text-column drop; add multi-vector columns (one `AxisIndex` per column), per-column quantization, and complex-type (Map/Array/Struct) columns. `collection ≡ table` (no rename). Phased TD-TBL-1..5; retires the ADR-019 backing-collection shim in Phase 5.
+
 | link:ADR-050-statistics-fed-datafusion-route-selection.adoc[ADR-050]
 | Statistics-fed cost-based routing into the DataFusion OLAP arm
 | Proposed


### PR DESCRIPTION
## Summary

Phase 0 (docs) of the **collection-as-table** initiative: a new ADR + TDs that formalize making a ProximaDB collection behave like relational TABLE creation — arbitrary typed columns (incl. Map/Array/Struct), multiple vector columns, and per-column quantization. **Docs only; no code in this PR.**

## Why

`CollectionService` "registers a table" but the persisted schema is the narrow v1 `CollectionConfig` (single `dimension`/`distance_metric`/`pax_vector_quant`; `FilterableDataType` enum with no Map/Array/Struct/UInt), and the catalog round-trip **drops every non-text typed column** on restart (`StoredSchema` → `columns: Vec::new()`, `catalog_config.rs:391`). The canonical target **already exists and is unused as authority**: `CatalogTableSchema`/`CatalogColumn { data_type: ProximaType }` is ProximaType-native and dimensionless; `ProximaRecord` is already multi-vector; the PAX **reader** is already per-column-quant-capable; the runtime-native `CollectionSchemaMetadata` (#595) is arbitrary ProximaType but in-memory only and fails-closed on rich types. ADR-009/024 already name ProximaType/ProximaRecord canonical; ADR-019 already calls the backing-collection shim a "design smell."

So this is **convergence, not invention.**

## Decisions (ADR-047)

1. **Naming — keep `collection` ≡ `table`** (no rename). Relational behavior comes from the schema model, not the noun; "collection" is embedded across all SDKs/proto/`/api/v2/collections`. SQL surface stays "table."
2. **`CatalogTableSchema` (ProximaType-native) is the single persisted schema authority** for collections and tables; narrow `CollectionConfig` fields become a legacy read-adapter, then are removed.
3. **Column taxonomy:** vector columns (multiple, named, per-column element/dim/metric/quantization via `proxima.vector.*` properties), defined scalar/complex columns (full ProximaType, filterable+indexable), free-form tags (untyped, non-filterable).
4. Storage-format changes are default-off + mixed-read-safe.

## Phased rollout (TD-TBL-1..5)

- **P1** persisted canonical schema (retire narrow authority; fix column-drop; stop #595's fail-closed downconvert). *No storage-format change.* → next PR
- **P2** multi-vector columns + one `AxisIndex` per vector column (AXIS trait is single-vector — the hard part).
- **P3** per-column quantization (PAX writer generalizes; reader already per-column — mixed-read-safe). Highest risk; needs cross-quant-in-one-block accuracy test.
- **P4** complex-type (Map/Array/Struct) PAX storage + nested predicate pushdown.
- **P5** retire the backing-collection shim + drop narrow `CollectionConfig` (ADR-019 closure; breaking proto/SDK change, staged).

## In this PR

- **New ADR-047** (`docs/12-design/adr/ADR-047-…`) — full context/decision/alternatives/phased rollout.
- **Refine ADR-009** and **ADR-019** — forward-links to ADR-047.
- **ADR-047 indexed** in `adr/README.adoc`.
- **TD-TBL-1..5** (`docs/10-quality/td/`) — one per phase, topic-scoped (collision-free). Cross-refs to TD-061/106/111/076 live inside the new TD files (the legacy `TECHNICAL_DEBT.adoc` is deliberately not edited — it conflicts with nearly every open PR; batched migration is a separate effort per the td-adr convention).

## Verification

`python3 scripts/check_td_adr_unique.py` → `checked 47 ADR files, 134 TD ids — 0 error(s)` (the 13 unindexed-ADR warnings are pre-existing, not ADR-047, which is indexed).

## Next

Phase 1 code PR (extends #595): persist the canonical `CollectionSchemaColumn` list in `StoredSchema`, fix the column-drop, write-canonical/read-project-to-legacy, stop failing closed. No proto/SDK/storage-format change.
