### PR TITLE
feat(collection): persist canonical ProximaType schema columns (TD-TBL-1, Phase 1)

### DIFF
--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -256,11 +256,11 @@ fn schema_metadata_from_collection(collection: &Collection) -> CollectionSchemaM
 
 fn apply_schema_update(
     config: &mut CollectionConfig,
-    update: CollectionSchemaUpdate,
+    update: &CollectionSchemaUpdate,
 ) -> Result<()> {
     config.record_schema = Some(RecordSchemaConfig {
-        schema_id: update.schema_id,
-        schema_version: update.schema_version,
+        schema_id: update.schema_id.clone(),
+        schema_version: update.schema_version.clone(),
         enforcement: enforcement_to_i32(update.enforcement),
         auto_evolve: update.auto_evolve,
         columns: Vec::new(),
@@ -305,16 +305,22 @@ fn apply_schema_update(
         })
         .collect();
 
+    // ADR-047 / TD-TBL-1: the narrow v1 projection above is best-effort — it can
+    // only carry text + the `FilterableDataType` vocabulary. Columns it cannot
+    // represent (UInt/Struct/Map/Sparse/BinaryVector …) are preserved verbatim
+    // in the canonical sidecar written by `set_collection_schema_columns`; they
+    // are no longer rejected, so the canonical authority is never lossy.
     for column in &update.columns {
         let storable_text = matches!(column.data_type, ProximaType::String);
         let storable_filterable =
             column.filterable && proxima_type_to_filterable_type(&column.data_type).is_some();
         if !storable_text && !storable_filterable {
-            return Err(anyhow!(
-                "legacy collection metadata cannot preserve schema column '{}' with type {:?}",
+            tracing::debug!(
+                "schema column '{}' (type {:?}) preserved only in canonical sidecar \
+                 (not representable in the narrow v1 collection config)",
                 column.name,
                 column.data_type
-            ));
+            );
         }
     }
     Ok(())
@@ -517,7 +523,20 @@ impl ApiHandlersPort for UnifiedHandlers {
             .collection
             .get_collection(collection_id, tenant_id)
             .await?;
-        Ok(collection.as_ref().map(schema_metadata_from_collection))
+        let Some(collection) = collection else {
+            return Ok(None);
+        };
+        let mut metadata = schema_metadata_from_collection(&collection);
+        // ADR-047 / TD-TBL-1: the canonical sidecar (if present) is authoritative;
+        // otherwise keep the narrow-derived view (legacy collection fallback).
+        if let Some(canonical) = self
+            .collection
+            .get_collection_schema_columns(collection_id, tenant_id)
+            .await?
+        {
+            metadata.columns = canonical;
+        }
+        Ok(Some(metadata))
     }
 
     async fn update_collection_schema_metadata(
@@ -532,12 +551,21 @@ impl ApiHandlersPort for UnifiedHandlers {
             .await?
             .ok_or_else(|| anyhow!("collection not found: {collection_id}"))?;
         let mut config = collection.config.clone().unwrap_or_default();
-        apply_schema_update(&mut config, update)?;
+        // Narrow projection (best-effort); the canonical columns are persisted
+        // verbatim via the sidecar below so rich ProximaType variants survive.
+        apply_schema_update(&mut config, &update)?;
         let updated = self
             .collection
             .update_collection(collection_id, config, tenant_id)
             .await?;
-        Ok(schema_metadata_from_collection(&updated))
+        self.collection
+            .set_collection_schema_columns(collection_id, &update.columns, tenant_id)
+            .await?;
+        // Return the canonical columns as the authoritative view (the narrow
+        // config above cannot represent them, so re-deriving would lose them).
+        let mut metadata = schema_metadata_from_collection(&updated);
+        metadata.columns = update.columns;
+        Ok(metadata)
     }
 
     async fn handle_vector_search_v1_for_tenant(

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -16,6 +16,7 @@ use proximadb_proto::v1::{
     CollectionRequest, CollectionResponse, ExecuteQueryResponse, HybridSearchRequest,
     HybridSearchResponse, VectorBatchRequest, VectorOperationResponse, VectorSearchRequest,
 };
+use serde::{Deserialize, Serialize};
 
 /// Runtime-native schema metadata for v2 collection/schema handlers.
 ///
@@ -23,7 +24,7 @@ use proximadb_proto::v1::{
 /// may still adapt to older persisted metadata, but protocol adapters should
 /// depend on this v2-shaped contract instead of constructing v1 collection
 /// operation requests.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionSchemaMetadata {
     pub collection_id: String,
     pub created_at_ms: i64,
@@ -36,7 +37,7 @@ pub struct CollectionSchemaMetadata {
     pub columns: Vec<CollectionSchemaColumn>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionSchemaUpdate {
     pub schema_id: String,
     pub schema_version: String,
@@ -45,7 +46,7 @@ pub struct CollectionSchemaUpdate {
     pub columns: Vec<CollectionSchemaColumn>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionSchemaColumn {
     pub name: String,
     pub data_type: ProximaType,
@@ -56,13 +57,13 @@ pub struct CollectionSchemaColumn {
     pub max_length: Option<u32>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CollectionTextStorage {
     Inline,
     Large,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CollectionSchemaEnforcement {
     Strict,
     Flexible,

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -11,6 +11,7 @@
 //! service is responsible for resolving that string to its internal `TenantContext` and
 //! enforcing access control.  No tenant context type leaks through the port boundary.
 
+use crate::port::CollectionSchemaColumn;
 use anyhow::Result;
 use async_trait::async_trait;
 use proximadb_proto::v1::{
@@ -59,6 +60,32 @@ pub trait CollectionPort: Send + Sync {
 
     /// Resolve a collection name or UUID to its canonical internal ID.
     async fn resolve_collection_id(&self, identifier: &str) -> Result<Option<String>>;
+
+    /// Persist the canonical ProximaType columns for a collection (ADR-047 /
+    /// TD-TBL-1 authority). The narrow v1 `CollectionConfig` cannot represent
+    /// the full `ProximaType` vocabulary, so these are stored as a catalog-asset
+    /// sidecar. An empty slice clears them. The default no-op keeps ports without
+    /// a catalog (mocks, `NoopCollectionPort`) compiling; `CollectionService`
+    /// overrides to actually persist.
+    async fn set_collection_schema_columns(
+        &self,
+        _id: &str,
+        _columns: &[CollectionSchemaColumn],
+        _tenant_id: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Read back the canonical ProximaType columns, or `None` when the collection
+    /// has none (legacy collection → caller falls back to the narrow-derived view).
+    /// Default no-op returns `None`.
+    async fn get_collection_schema_columns(
+        &self,
+        _id: &str,
+        _tenant_id: Option<&str>,
+    ) -> Result<Option<Vec<CollectionSchemaColumn>>> {
+        Ok(None)
+    }
 }
 
 // ── Vector operations ─────────────────────────────────────────────────────────

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -3988,11 +3988,19 @@ fn apply_runtime_schema_update_to_v1_config(
             }
             continue;
         }
-        return Err(anyhow::anyhow!(
-            "legacy collection metadata cannot preserve schema column '{}' with canonical type {:?}",
+        // ADR-047 / TD-TBL-1 (legacy twin): this v1-bridge path is the dormant
+        // fallback (used only when no runtime port is wired, `ports: None`). It
+        // has no `CollectionPort` and so cannot persist the canonical sidecar;
+        // columns the narrow v1 config cannot represent are dropped here rather
+        // than rejected — best-effort, matching the canonical path's no-longer-
+        // fail-closed stance. The active runtime path persists them via the
+        // canonical sidecar (`set_collection_schema_columns`).
+        tracing::debug!(
+            "legacy v1 config cannot preserve schema column '{}' (canonical type {:?}); \
+             dropped from the narrow projection on this dormant fallback path",
             column.name,
             column.data_type
-        ));
+        );
     }
     config.filterable_columns = filterable_columns;
     Ok(())

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2244,8 +2244,18 @@ impl CollectionService {
             schema.stable_namespace_id = Some(id.namespace_id);
             schema.stable_collection_id = Some(id.collection_id);
         }
+        // ADR-047 / TD-TBL-1: the fresh `schema` above is rebuilt from the narrow
+        // `Collection` config, which cannot carry the canonical ProximaType
+        // columns. Capture any existing canonical-schema sidecar here so it can
+        // be re-attached below — otherwise an unrelated `update_collection`
+        // (e.g. an index-param tweak) would silently drop the canonical schema.
+        let mut preserved_canonical_schema: Option<String> = None;
         if catalog.table_exists(&identifier).await? {
             let mut existing = catalog.get_table(&identifier).await?;
+            preserved_canonical_schema = existing
+                .properties
+                .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)
+                .cloned();
             if existing
                 .properties
                 .get("asset.kind")
@@ -2280,6 +2290,12 @@ impl CollectionService {
             }
 
             let _ = catalog.drop_table(&identifier, false).await?;
+        }
+        if let Some(canonical) = preserved_canonical_schema {
+            schema.properties.insert(
+                crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY.to_string(),
+                canonical,
+            );
         }
         catalog.create_table(&identifier, schema).await?;
         Ok(())
@@ -3713,6 +3729,215 @@ mod tests {
         assert_eq!(quant.enabled, Some(true));
         assert_eq!(quant.strategy, Some(Strategy::Aggressive as i32));
     }
+
+    /// Build a canonical schema column (non-filterable, non-indexed) for the
+    /// round-trip tests. Fully-qualified types so it needs no test-fn imports.
+    fn canonical_col(
+        name: &str,
+        data_type: proximadb_data_model::ProximaType,
+    ) -> proximadb_runtime::CollectionSchemaColumn {
+        proximadb_runtime::CollectionSchemaColumn {
+            name: name.to_string(),
+            data_type,
+            nullable: true,
+            indexed: false,
+            filterable: false,
+            text_storage: None,
+            max_length: None,
+        }
+    }
+
+    /// ADR-047 / TD-TBL-1: canonical ProximaType columns (incl. UInt/Struct/Map/
+    /// Sparse/BinaryVector — none representable in the narrow v1 config) must
+    /// survive create → set → catalog restart → read-back.
+    #[tokio::test]
+    async fn canonical_schema_columns_survive_catalog_restart() -> Result<()> {
+        use proximadb_data_model::{ProximaType, TimeUnit, VectorElement};
+        use proximadb_runtime::CollectionPort;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+
+        let columns = vec![
+            canonical_col("u", ProximaType::UInt64),
+            canonical_col(
+                "st",
+                ProximaType::Struct {
+                    fields: vec![("a".to_string(), ProximaType::Int64)],
+                },
+            ),
+            canonical_col(
+                "m",
+                ProximaType::Map {
+                    key: Box::new(ProximaType::String),
+                    value: Box::new(ProximaType::Int64),
+                },
+            ),
+            canonical_col(
+                "sv",
+                ProximaType::SparseVector {
+                    element: VectorElement::Float32,
+                },
+            ),
+            canonical_col("bv", ProximaType::BinaryVector { dim: 256 }),
+            canonical_col(
+                "dv",
+                ProximaType::DenseVector {
+                    element: VectorElement::Float32,
+                    dim: 128,
+                },
+            ),
+            canonical_col("ts", ProximaType::Timestamp(TimeUnit::Nanosecond)),
+        ];
+
+        let name = "canon_rt";
+        // Instance A: create the collection, then persist the canonical sidecar.
+        let mgr_a = Arc::new(CatalogManager::new());
+        mgr_a
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("create test catalog A")?;
+        let svc_a = CollectionService::new(StorageConfig::default())
+            .await
+            .context("collection service A")?
+            .with_catalog_manager(mgr_a);
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension: 8,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            ..Default::default()
+        };
+        assert!(
+            svc_a
+                .create_collection(&config)
+                .await
+                .context("create collection A")?
+                .success
+        );
+        svc_a
+            .set_collection_schema_columns(name, &columns, None)
+            .await
+            .context("set canonical columns")?;
+        drop(svc_a);
+
+        // Instance B: a fresh service + catalog manager on the SAME on-disk dir
+        // simulates a restart (the canonical sidecar must be read from disk).
+        let mgr_b = Arc::new(CatalogManager::new());
+        mgr_b
+            .create_native_catalog("default", &temp_path)
+            .await
+            .context("create test catalog B")?;
+        let svc_b = CollectionService::new(StorageConfig::default())
+            .await
+            .context("collection service B")?
+            .with_catalog_manager(mgr_b);
+
+        let restored = svc_b
+            .get_collection_schema_columns(name, None)
+            .await
+            .context("read canonical columns after restart")?
+            .expect("canonical columns persisted across catalog restart");
+        assert_eq!(restored.len(), columns.len());
+        assert_eq!(
+            restored, columns,
+            "every canonical ProximaType variant round-trips through the catalog"
+        );
+
+        // Legacy collection (no canonical sidecar) → None (mixed-read-safe).
+        let legacy = CollectionConfig {
+            name: "canon_legacy".to_string(),
+            dimension: 4,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            ..Default::default()
+        };
+        assert!(
+            svc_b
+                .create_collection(&legacy)
+                .await
+                .context("create legacy collection")?
+                .success
+        );
+        assert_eq!(
+            svc_b
+                .get_collection_schema_columns("canon_legacy", None)
+                .await?,
+            None,
+            "collection without a canonical sidecar returns None"
+        );
+
+        Ok(())
+    }
+
+    /// ADR-047 / TD-TBL-1: an unrelated `update_collection` (e.g. a description
+    /// tweak) must NOT drop the canonical sidecar — the sticky-preserve in
+    /// `upsert_collection_catalog_asset` carries it across the narrow rebuild.
+    #[tokio::test]
+    async fn canonical_schema_columns_survive_unrelated_update_collection() -> Result<()> {
+        use proximadb_data_model::ProximaType;
+        use proximadb_runtime::CollectionPort;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let mgr = Arc::new(CatalogManager::new());
+        mgr.create_native_catalog("default", &temp_path)
+            .await
+            .context("create test catalog")?;
+        let svc = CollectionService::new(StorageConfig::default())
+            .await
+            .context("collection service")?
+            .with_catalog_manager(mgr);
+
+        let name = "canon_sticky";
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension: 8,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            ..Default::default()
+        };
+        assert!(
+            svc.create_collection(&config)
+                .await
+                .context("create collection")?
+                .success
+        );
+
+        let columns = vec![canonical_col(
+            "s",
+            ProximaType::Struct {
+                fields: vec![("a".to_string(), ProximaType::Int64)],
+            },
+        )];
+        svc.set_collection_schema_columns(name, &columns, None)
+            .await
+            .context("set canonical columns")?;
+
+        // Unrelated config change — rebuilds the catalog asset from the narrow
+        // config, which must re-attach the preserved canonical sidecar.
+        let update = CollectionConfig {
+            description: Some("tweaked".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            svc.update_collection(name, Some(update))
+                .await
+                .context("unrelated update_collection")?
+                .success
+        );
+
+        let restored = svc
+            .get_collection_schema_columns(name, None)
+            .await
+            .context("read canonical after update")?
+            .expect("canonical sidecar survived unrelated update_collection");
+        assert_eq!(restored, columns);
+
+        Ok(())
+    }
 }
 
 // ── CollectionPort impl ───────────────────────────────────────────────────────
@@ -3780,5 +4005,84 @@ impl proximadb_runtime::CollectionPort for CollectionService {
 
     async fn resolve_collection_id(&self, identifier: &str) -> anyhow::Result<Option<String>> {
         CollectionService::resolve_collection_id(self, identifier).await
+    }
+
+    async fn set_collection_schema_columns(
+        &self,
+        id: &str,
+        columns: &[proximadb_runtime::CollectionSchemaColumn],
+        tenant_id: Option<&str>,
+    ) -> anyhow::Result<()> {
+        // ADR-047 / TD-TBL-1: persist the canonical ProximaType columns as a
+        // catalog-asset sidecar. Resolve the SAME asset `upsert_collection_catalog_asset`
+        // writes (config → table identifier → tenant-scoped) so the sidecar lands
+        // on the exact table the narrow config lives on. Best-effort no-op when
+        // there is no catalog or no such collection (preserves the trait default).
+        let Some(catalog_manager) = &self.catalog_manager else {
+            return Ok(());
+        };
+        let Some(collection) = self.get_collection(id, tenant_id).await? else {
+            return Ok(());
+        };
+        let Some(config) = collection.config.as_ref() else {
+            return Ok(());
+        };
+        let catalog = catalog_manager.default_catalog().await?;
+        let identifier = Self::tenant_scoped_identifier(
+            self.tenant_namespaces_on(),
+            Self::collection_tenant_id(&collection).as_deref(),
+            crate::storage::metadata::collection_mapping::collection_table_identifier(config),
+        );
+        if !catalog.table_exists(&identifier).await.unwrap_or(false) {
+            return Ok(());
+        }
+        let mut schema = catalog.get_table(&identifier).await?;
+        if columns.is_empty() {
+            schema
+                .properties
+                .remove(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY);
+        } else {
+            schema.properties.insert(
+                crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY.to_string(),
+                crate::storage::metadata::catalog_config::canonical_schema_columns_to_json(
+                    columns,
+                )?,
+            );
+        }
+        let _ = catalog.drop_table(&identifier, false).await?;
+        catalog.create_table(&identifier, schema).await?;
+        Ok(())
+    }
+
+    async fn get_collection_schema_columns(
+        &self,
+        id: &str,
+        tenant_id: Option<&str>,
+    ) -> anyhow::Result<Option<Vec<proximadb_runtime::CollectionSchemaColumn>>> {
+        let Some(catalog_manager) = &self.catalog_manager else {
+            return Ok(None);
+        };
+        let Some(collection) = self.get_collection(id, tenant_id).await? else {
+            return Ok(None);
+        };
+        let Some(config) = collection.config.as_ref() else {
+            return Ok(None);
+        };
+        let catalog = catalog_manager.default_catalog().await?;
+        let identifier = Self::tenant_scoped_identifier(
+            self.tenant_namespaces_on(),
+            Self::collection_tenant_id(&collection).as_deref(),
+            crate::storage::metadata::collection_mapping::collection_table_identifier(config),
+        );
+        if !catalog.table_exists(&identifier).await.unwrap_or(false) {
+            return Ok(None);
+        }
+        let schema = catalog.get_table(&identifier).await?;
+        Ok(schema
+            .properties
+            .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)
+            .and_then(|json| {
+                crate::storage::metadata::catalog_config::canonical_schema_columns_from_json(json)
+            }))
     }
 }

--- a/src/storage/metadata/catalog_config.rs
+++ b/src/storage/metadata/catalog_config.rs
@@ -26,6 +26,7 @@ use crate::proto::proximadb_v1::{
     CollectionConfig, HnswConfig, IndexConfig, IndexPolicy, IvfConfig, QuantizationConfig,
     RecordSchemaConfig, TextStorageConfig,
 };
+use proximadb_runtime::CollectionSchemaColumn;
 
 /// Catalog-bag key holding the neutral per-index config array.
 pub const INDEX_CONFIGS_KEY: &str = "index_configs";
@@ -403,6 +404,39 @@ pub(crate) fn apply_record_schema_from_json(config: &mut CollectionConfig, json:
         .collect();
 }
 
+// --- Canonical ProximaType schema columns (ADR-047 authority) -----------------
+//
+// ADR-047 / TD-TBL-1: the narrow v1 `CollectionConfig` cannot represent the full
+// `ProximaType` vocabulary (UInt/Struct/Map/Sparse/BinaryVector …), so the
+// canonical `Vec<CollectionSchemaColumn>` is persisted verbatim as a neutral JSON
+// sidecar on the catalog asset (`collection.canonical_schema`), mirroring the
+// `collection.config_json` / `collection.record_schema` idiom. The narrow config
+// stays the legacy read view; this sidecar is the authority for rich types.
+
+/// Serialize the canonical ProximaType columns to a neutral JSON string for the
+/// catalog asset property bag.
+pub(crate) fn canonical_schema_columns_to_json(
+    columns: &[CollectionSchemaColumn],
+) -> Result<String> {
+    serde_json::to_string(columns)
+        .map_err(|e| anyhow::anyhow!("serialize canonical_schema columns for catalog asset: {e}"))
+}
+
+/// Reconstruct the canonical ProximaType columns from a neutral JSON string, or
+/// `None` on a decode error (legacy/corrupt asset) so the caller keeps its
+/// narrow-derived default (mixed-read-safe).
+pub(crate) fn canonical_schema_columns_from_json(
+    json: &str,
+) -> Option<Vec<CollectionSchemaColumn>> {
+    match serde_json::from_str(json) {
+        Ok(columns) => Some(columns),
+        Err(e) => {
+            tracing::warn!("⚠️ catalog-asset canonical_schema decode failed, ignoring: {e}");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -520,5 +554,77 @@ mod tests {
         assert_eq!(restored.text_storage_configs.len(), 1);
         assert_eq!(restored.text_storage_configs[0].column_name, "body");
         assert_eq!(restored.text_storage_configs[0].chunk_size, 512);
+    }
+
+    #[test]
+    fn canonical_schema_columns_round_trip_across_proxima_type_variants() {
+        use proximadb_data_model::{ProximaType, TimeUnit, VectorElement};
+
+        let col = |name: &str, data_type: ProximaType| CollectionSchemaColumn {
+            name: name.to_string(),
+            data_type,
+            nullable: true,
+            indexed: false,
+            filterable: true,
+            text_storage: None,
+            max_length: None,
+        };
+
+        let columns = vec![
+            col("s", ProximaType::String),
+            col("u", ProximaType::UInt64),
+            col(
+                "d",
+                ProximaType::Decimal {
+                    precision: 38,
+                    scale: 18,
+                },
+            ),
+            col(
+                "st",
+                ProximaType::Struct {
+                    fields: vec![("a".to_string(), ProximaType::Int64)],
+                },
+            ),
+            col(
+                "m",
+                ProximaType::Map {
+                    key: Box::new(ProximaType::String),
+                    value: Box::new(ProximaType::Int64),
+                },
+            ),
+            col(
+                "sv",
+                ProximaType::SparseVector {
+                    element: VectorElement::Float32,
+                },
+            ),
+            col("bv", ProximaType::BinaryVector { dim: 1024 }),
+            col(
+                "dv",
+                ProximaType::DenseVector {
+                    element: VectorElement::Float32,
+                    dim: 128,
+                },
+            ),
+            col("arr", ProximaType::Array(Box::new(ProximaType::String))),
+            col("ts", ProximaType::Timestamp(TimeUnit::Nanosecond)),
+        ];
+
+        let json = canonical_schema_columns_to_json(&columns).expect("serialize");
+        let restored = canonical_schema_columns_from_json(&json).expect("deserialize");
+        assert_eq!(restored.len(), columns.len());
+        assert_eq!(
+            restored, columns,
+            "every ProximaType variant must round-trip losslessly through the catalog sidecar"
+        );
+
+        // Decode-failure safety → None (mixed-read-safe for legacy/corrupt assets).
+        assert!(canonical_schema_columns_from_json("{not valid json").is_none());
+        assert_eq!(
+            canonical_schema_columns_from_json("[]"),
+            Some(Vec::new()),
+            "an empty sidecar deserializes to an empty column set"
+        );
     }
 }

--- a/src/storage/metadata/collection_mapping.rs
+++ b/src/storage/metadata/collection_mapping.rs
@@ -22,6 +22,15 @@ use crate::proto::proximadb_v1::{
     IndexConfig, IndexingAlgorithm, StorageAssignment, StorageEngine,
 };
 
+/// Catalog-asset property key holding the canonical ProximaType columns
+/// (ADR-047 / TD-TBL-1). The narrow v1 `CollectionConfig` cannot represent the
+/// full `ProximaType` vocabulary (UInt/Struct/Map/Sparse/BinaryVector …), so the
+/// canonical `Vec<CollectionSchemaColumn>` is persisted as a neutral JSON sidecar
+/// here — the authority for rich types, with the narrow config remaining the
+/// legacy read view. Written by `CollectionService::set_collection_schema_columns`,
+/// preserved across unrelated `upsert_collection_catalog_asset` rebuilds.
+pub(crate) const CANONICAL_SCHEMA_PROPERTY: &str = "collection.canonical_schema";
+
 pub(crate) fn collection_from_catalog_schema(
     table_id: &TableIdentifier,
     schema: &CatalogTableSchema,


### PR DESCRIPTION
## Summary

Phase 1 (TD-TBL-1) of the collection-as-table initiative (ADR-047, #605). Persists canonical `ProximaType` collection columns the narrow v1 `CollectionConfig` cannot represent (UInt/Struct/Map/Sparse/BinaryVector…), so a collection's schema survives create → persist → read-back — including restart.

#595 added the runtime-native canonical schema types + the v2 schema handlers, but they were in-memory only: `apply_schema_update` downconverted canonical columns into the narrow config and **failed closed** on any type the narrow `FilterableDataType` enum can't hold. This stops failing closed and persists the canonical columns verbatim.

## Approach

Canonical `Vec<CollectionSchemaColumn>` is persisted as serde-JSON under a new `collection.canonical_schema` catalog-asset sidecar (mirroring the existing `collection.config_json` / `collection.record_schema` property idiom). The narrow config stays the legacy read view; the sidecar is authoritative for rich types.

- `port.rs` — `Serialize, Deserialize` on the runtime schema types.
- `service_ports.rs` — `CollectionPort::set/get_collection_schema_columns` with default no-op bodies (3 impls exist, incl. `NoopCollectionPort` in `proximadb-api`).
- `catalog_config.rs` — `canonical_schema_columns_to_json/_from_json` helpers.
- `collection_mapping.rs` — `CANONICAL_SCHEMA_PROPERTY` const.
- `manager.rs` — `CollectionService` writes/reads the sidecar (catalog get_table→drop+create, same tenant-scoped asset as `upsert`); **sticky-preserve** in `upsert_collection_catalog_asset` so an unrelated config tweak never silently drops canonical.
- `handlers.rs` — `apply_schema_update` stops failing closed (best-effort narrow projection); write persists canonical after narrow; read overrides narrow-derived with canonical when present.
- `request_handlers.rs` — legacy twin stops failing closed (stays narrow-only — dormant `ports:None` fallback).

## Scope / risk

No proto/SDK/storage-format change. Additive metadata only — no env gate (opt-in via the v2 schema endpoint; default behavior unchanged for collections without canonical). Mixed-read-safe: legacy collections lack the sidecar → fall back to narrow-derived.

## Verification

- `cargo fmt --all --check`, `cargo clippy --lib -p proximadb-runtime -p proximadb -- -D warnings`, `cargo check --tests` — all green.
- New tests: serde round-trip across ProximaType variants; e2e persistence across catalog restart (instance A → disk → fresh instance B); sticky-preserve across an unrelated `update_collection`.
- No regressions in the affected suites (manager / catalog_config / runtime handlers).

Refs: ADR-047, TD-TBL-1 (#605). Builds on #595.