### PR TITLE
fix(distance): thread collection metric into rerank/centroid + align default to Cosine (P1+P2)

### DIFF
--- a/crates/foundation/proximadb-distance-kernel/src/engine.rs
+++ b/crates/foundation/proximadb-distance-kernel/src/engine.rs
@@ -629,7 +629,12 @@ impl std::fmt::Debug for UnifiedDistanceCompute {
 
 impl Default for UnifiedDistanceCompute {
     fn default() -> Self {
-        Self::new(DistanceMetric::Euclidean)
+        // P2: align the compute default with the product default (Cosine). Every
+        // other layer — collection create, proto Unspecified→Cosine,
+        // StorageQueryContext, the SIMD dispatcher — agrees on Cosine; this was
+        // the lone Euclidean outlier. Production code should still pass the
+        // collection metric explicitly per call (distance_with_metric).
+        Self::new(DistanceMetric::Cosine)
     }
 }
 
@@ -2304,15 +2309,19 @@ mod tests {
 
     #[test]
     fn test_default_unified_distance_compute() {
+        // P2: the default metric is now Cosine (the product default), aligning
+        // UnifiedDistanceCompute with the collection/proto + SIMD-dispatcher
+        // default. Production code should still pass the collection metric
+        // explicitly per call (distance_with_metric / calculate_distance).
         let compute = UnifiedDistanceCompute::default();
-        // Default is Euclidean
-        let a = vec![0.0, 0.0];
-        let b = vec![3.0, 4.0];
+        let a = vec![1.0, 0.0];
+        let b = vec![1.0, 1.0];
         let distance = compute.distance(&a, &b);
+        // cosine distance = 1 − (1·1 + 0·1) / (1 · √2) = 1 − 1/√2 ≈ 0.29289
+        let expected = 1.0 - 1.0 / 2.0_f32.sqrt();
         assert!(
-            (distance - 5.0).abs() < 1e-5,
-            "Default should be Euclidean, got {}",
-            distance
+            (distance - expected).abs() < 1e-5,
+            "default-Compute should use Cosine; got {distance}, expected {expected}"
         );
     }
 

--- a/src/storage/engines/core/search/search_common.rs
+++ b/src/storage/engines/core/search/search_common.rs
@@ -52,7 +52,7 @@ impl Default for UniversalSearchConfig {
             enable_reranking: true,
             max_parallel_files: 4,
             enable_progressive_search: true,
-            distance_metric: proximadb_distance_kernel::DistanceMetric::default(),
+            distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
         }
     }
 }
@@ -80,6 +80,12 @@ pub struct ProgressiveConfig {
 
     /// Final number of results
     pub final_top_k: usize,
+
+    /// Distance metric for the full-precision rerank stage. Defaults to Cosine
+    /// (the product default); callers with the collection's metric should set it
+    /// so the rerank matches the collection (P1.2 — was hard-coded Cosine via
+    /// `DistanceMetric::default()` = Unspecified).
+    pub distance_metric: proximadb_distance_kernel::DistanceMetric,
 }
 
 impl Default for ProgressiveConfig {
@@ -92,6 +98,7 @@ impl Default for ProgressiveConfig {
             enable_pq: true,
             pq_top_k: 50,
             final_top_k: 10,
+            distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
         }
     }
 }
@@ -349,8 +356,13 @@ impl UniversalSearchPipeline {
         }
 
         // Stage 4: Full precision ranking
-        self.full_precision_rank(candidates, query_vector, config.final_top_k)
-            .await
+        self.full_precision_rank(
+            candidates,
+            query_vector,
+            config.final_top_k,
+            &config.distance_metric,
+        )
+        .await
     }
 
     /// Binary filtering stage
@@ -421,6 +433,7 @@ impl UniversalSearchPipeline {
         records: Vec<VectorRecord>,
         query_vector: &[f32],
         top_k: usize,
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
     ) -> Result<Vec<OptimizedSearchRecord>> {
         let mut results = Vec::with_capacity(records.len());
 
@@ -428,7 +441,7 @@ impl UniversalSearchPipeline {
             let similarity_result = self.distance_compute.as_ref().calculate_distance(
                 query_vector,
                 &record.vector,
-                &proximadb_distance_kernel::DistanceMetric::default(),
+                distance_metric,
             );
 
             // Convert metadata from Vec<MetadataItem> to HashMap<String, Value>

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -906,7 +906,9 @@ impl RaptorEngine {
         );
 
         // Use clustering for efficient rowgroup pruning
-        let selected_rowgroups = self.select_rowgroups_by_clustering(query).await?;
+        let selected_rowgroups = self
+            .select_rowgroups_by_clustering(query, distance_metric)
+            .await?;
         debug!(
             "RAPTOR SEARCH_INTERNAL: Selected {} rowgroups",
             selected_rowgroups.len()
@@ -1207,7 +1209,11 @@ impl RaptorEngine {
             .await
     }
 
-    async fn select_rowgroups_by_clustering(&self, query: &[f32]) -> Result<Vec<u32>> {
+    async fn select_rowgroups_by_clustering(
+        &self,
+        query: &[f32],
+        distance_metric: &proximadb_distance_kernel::DistanceMetric,
+    ) -> Result<Vec<u32>> {
         debug!("SELECT_ROWGROUPS: Starting rowgroup selection");
         let cluster_manager = self.cluster_manager.read().await;
         let cluster_assignments = self.cluster_assignments.read().await;
@@ -1279,9 +1285,11 @@ impl RaptorEngine {
                 if let Some(rowgroup) = rowgroup_manager.row_group(&rg_id)
                     && let Some(centroid) = &rowgroup.centroid
                 {
-                    // Calculate distance using distance computation engine
-                    let compute = UnifiedDistanceCompute::default();
-                    let distance = compute.distance(query, centroid);
+                    // Use the query's metric (NOT the Euclidean default) to score
+                    // centroids. The 0.5 threshold is Cosine-calibrated (≈60°);
+                    // non-Cosine metrics may need separate tuning (TODO).
+                    let compute = UnifiedDistanceCompute::new(*distance_metric);
+                    let distance = compute.distance_with_metric(query, centroid, distance_metric);
                     if distance < 0.5 {
                         // Threshold for similarity
                         selected.push(rowgroup.id as u32);


### PR DESCRIPTION
## Summary

**Distance-metric consistency — Phase 1+2** of the approved plan: two production metric-drift bugs + the `Default`-metric footgun, found by a first-principles audit. P3 (deprecate the footgun API + promote the canonical resolver) + P4 (end-to-end consistency test) follow in separate PRs.

## P1.1 — Raptor centroid fallback (real bug)
`select_rowgroups_by_clustering` (`raptor/engine.rs`) built `UnifiedDistanceCompute::default()` (**Euclidean**) and called `.distance(query, centroid)` (no-metric → stored Euclidean), then applied a **0.5 Cosine-calibrated** threshold → wrong rowgroup selection for non-Cosine collections. The query's metric was in scope at the caller (`search_internal`) but never threaded in. **Fix:** thread `distance_metric` into the method + use `distance_with_metric`.

## P1.2 — Universal-search full-precision rerank (real bug)
`full_precision_rank` (`search_common.rs`) used `DistanceMetric::default()` (prost variant 0 = `Unspecified` → the SIMD dispatcher maps to Cosine), **forcing Cosine on the exact rerank for every collection** regardless of its real metric — silently wrong for Euclidean/Dot/Manhattan collections. **Fix:** thread the collection metric — new `ProgressiveConfig.distance_metric` field (Cosine default) → `full_precision_rank` param. Also fix `UniversalSearchConfig::default()` → Cosine (was `Unspecified`).

## P2 — Align `UnifiedDistanceCompute::default()` → Cosine
It was the **sole outlier**: every other layer (collection create, proto `Unspecified→Cosine`, `StorageQueryContext`, the SIMD dispatcher) agrees on Cosine; this returned Euclidean. Aligns the stored-default footgun with the product default. Production code still passes the metric per-call (`distance_with_metric`/`calculate_distance`); this fixes the stored-default path the `Option<DistanceMetric>`-taking methods (`distance`/`similarity`/etc.) fall back to. Updated the one assertion test (`test_default_unified_distance_compute`).

## Verification
- `cargo test -p proximadb-distance-kernel --lib`: **91 passed / 0 failed** (no flip-induced assertion failures).
- `cargo check -p proximadb --tests`: clean.

## Follow-ups (P3/P4, separate PRs)
- **P3**: `#[deprecated]` on the stored-default methods; promote `get_distance_metric_from_config` as the single resolver; migrate the ~13 hot-path ad-hoc `unwrap_or(Cosine)` sites.
- **P4**: end-to-end consistency test (Cosine/Euclidean/Dot collections → metric threads build→query→rerank, + negative assertion).
