### PR TITLE
feat(catalog): ADR-048 unified system catalog — typed columns are the canonical schema (P1)

### DIFF
--- a/docs/12-design/adr/ADR-048-unified-system-catalog-native-authority.adoc
+++ b/docs/12-design/adr/ADR-048-unified-system-catalog-native-authority.adoc
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-048: Unified System Catalog as Native Authority
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-07-01
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-009 (schema modes), ADR-024 (single canonical `ProximaType`), ADR-028 (index policy), ADR-031 (stable object id), ADR-035 (per-tenant catalog cache), "ADR-047" (collection-as-table — in flight, see note)
+|Supersedes|—
+|===
+
+[NOTE]
+====
+**ADR-047 is referenced in code comments (`record_service.rs`, `collection_mapping.rs`, `manager.rs`, `catalog_config.rs`) but was never filed** — the latest filed ADR is 046. This ADR (048) should be filed concurrently with ADR-047, or those code references re-anchored to ADR-048. ADR-048 carries the *system-catalog-authority* decision that the collection-as-table work (PRs #606, #609) presupposes.
+====
+
+== Context
+
+ProximaDB maintains **two metadata authorities for one logical object** — a collection is described both by the typed catalog and by a stringly-typed properties bag, and the two can drift.
+
+1. **The typed catalog** (`CatalogTableSchema` / `CatalogColumn`, `crates/control/proximadb-catalog/src/lib.rs:582,314`) is already a rich, self-describing, `ProximaType`-native authority. It carries typed fields (`distance_metric`, `quantization`, `embedding_config`, `storage_config`), ADR-031 stable identities (`object_id`, `stable_namespace_id`, `stable_collection_id`), ADR-024 Step-4 storage-side evolution fields (`schema_id`, `version`, `parent_schema_id`, `fingerprint`, `is_deleted`, `original_id`), and the `Catalog` trait exposes typed mutation and introspection: `evolve_schema(CatalogSchemaEvolution)`, `get_schema_by_version`, `create_index` / `drop_index`, `get_statistics` / `update_statistics` (`CatalogTableStatistics`).
+
+2. **The collection-as-table shortcut** (`src/storage/metadata/collection_mapping.rs`) *bypasses* those primitives. `catalog_schema_from_collection` *derives* a thin typed column set (one hardcoded `"embedding"` `DenseVector` from `config.dimension` + `filterable_columns` at id `100+`) from a v1 `CollectionConfig`, then carries the real truth in a free-form `properties: HashMap<String,String>` bag: `collection.config_json` (authoritative on read), `collection.canonical_schema` (the Phase-1 rich-type sidecar, PR #606), `collection.quantization`, `collection.index_config`, `collection.index_policy`, `collection.record_schema`, `vector.*`, `stats.*`, `asset.*`. The reverse (`collection_from_catalog_schema`) rebuilds the v1 `Collection` by reading `config_json`, ignoring the typed fields.
+
+The catalog **already has** the typed primitives — the collection path simply doesn't use them. The result is the cohesion problem: every round-trip re-derives, every new capability adds another `collection.*` key, `pg_catalog` introspection reads strings instead of types, and the typed columns + the `canonical_schema` sidecar can silently drift. Operations metadata is likewise scattered: `SegmentRegistry` is in-memory, data manifests/snapshots/leases live in object storage (`ManifestCommitter`), and `CollectionStats` are approximate `stats.*` properties — none unified under the catalog.
+
+== Decision
+
+**Complete the wiring to the existing typed primitives and retire the properties-bag + v1-derivation shortcuts.** The unified system catalog becomes the single typed, self-describing authority for both object metadata (what exists) and operations metadata (how it runs). This is convergence, not invention — the typed model and trait surface already exist.
+
+**D1. Schema-as-authority, never derived from a wire type.** The catalog's typed `columns: Vec<CatalogColumn>` (ADR-024 `ProximaType`) *is* the canonical schema. `CollectionConfig` / `Collection` become *read views* projected from the catalog, not the source of truth. No path re-derives the schema from a v1 config when a typed catalog schema exists.
+
+**D2. Typed fields replace properties-bag keys.** Populate the existing typed fields instead of writing JSON sidecars: `quantization` ← `collection.quantization`; `distance_metric` ← `vector.distance_metric` / `config.distance_metric`; embedding-model identity ← `embedding_config`; storage layout knobs ← `storage_config`; `collection.canonical_schema` *becomes* the typed `columns` (no separate blob); `stats.*` ← `get_statistics` / `CatalogTableStatistics`.
+
+**D3. Mutation through the typed channel.** All schema change flows through `Catalog::evolve_schema(identifier, CatalogSchemaEvolution)` (`AddColumn` / `DropColumn` / `RenameColumn` / `ChangeType` / `PromotePropsKey` / `SetTableOption`), already implemented (`crates/control/proximadb-catalog/src/schema.rs::apply_evolution`). The Phase-1 `set_collection_schema_columns` (drop+create with a bag blob) is retired in favour of diff→`evolve_schema`.
+
+**D4. MVCC / versioned metadata as the persistence substrate.** `get_schema_by_version` declares the intent today but `NativeCatalog` serves only the current version (`native.rs:1763`). The catalog gains a persisted schema version chain (catalog WAL/snapshot) so historical retrieval, time-travel reads, and transactional DDL are real, not stubs.
+
+**D5. Tenant-by-construction.** `CatalogNamespace` already carries typed `tenant_id` / `account_id` / `namespace_id` / `object_id` (ADR-031). Collection-level tenancy (today tag-derived via `tenant_id_of`) is reconciled to the namespace's typed identity, and tenant-prefixed namespaces (`PROXIMADB_CATALOG_TENANT_NAMESPACES`, currently default-off) become the default as the typed path matures.
+
+**D6. Unified object + operations catalog.** Scattered operations metadata — in-memory `SegmentRegistry`, object-store manifests/snapshots/leases, `CorpusVersionRegistry` — converges under cataloged entries (segments/indexes/leases with staleness hints) surfaced through `get_statistics` and a segment catalog. Detailed modeling is deferred (P4); this ADR fixes the *direction*.
+
+**D7. Principled extension.** A new capability adds a typed field plus an `evolve_schema` change variant — never a new `properties` key. The properties bag is retained **only** for genuinely untyped/plugin metadata, never for first-class schema facts.
+
+== Roadmap (each phase activates existing primitives)
+
+[cols="1,3,1",width=100%]
+|===
+|Phase|Activates|Risk/Gate
+
+|P0|This ADR + filing/re-anchoring ADR-047.|docs-only
+
+|P1|Typed `CatalogTableSchema.columns` *becomes* the canonical schema; `catalog_schema_from_collection` builds columns from the canonical schema when present (v1-derivation as legacy fallback); `set/get_collection_schema_columns` operate on typed columns; the `collection.canonical_schema` bag key is retired (transitional read for mixed-read safety).|Low / mixed-read-safe
+
+|P2|Populate the typed `distance_metric` / `quantization` / `embedding_config` / `storage_config` fields; retire the corresponding `collection.*` / `vector.*` bag keys.|Medium (cross-cutting reads)
+
+|P3|All mutation via `evolve_schema`; retire `set_collection_schema_columns`; wire `get_schema_version` into catalog-cache invalidation (ADR-035).|Medium
+
+|P4|Cataloged operations metadata: persist segment/index/lease references; retire in-memory-only `SegmentRegistry`; `CorpusVersionRegistry` → catalog version bumps; rich per-column stats via `CatalogTableStatistics`.|High
+
+|P5|MVCC metadata: persist the schema version chain in `NativeCatalog` so `get_schema_by_version` returns real history; transactional DDL.|High
+|===
+
+== Considered alternatives
+
+* **Keep the sidecar overlay (status quo).** Rejected — the duality *is* the cohesion problem; every `ProximaType` variant or capability adds a bag key, and introspection reads strings not types. Defers the problem rather than solving it.
+* **Full rewrite of the collection path on a new catalog-native type.** Rejected — the typed primitives already exist; the leverage is in *wiring*, not *rebuilding*, and a rewrite would force a flag-day on the v1 `Collection` proto/SDK that the deprecation ratchet (#603) forbids.
+* **Promote everything to typed fields in one PR.** Rejected — not mixed-read-safe at every step. P1 is scoped to the highest-leverage, lowest-risk piece (the `canonical_schema` sidecar duality); P2–P3 follow.
+
+== Consequences
+
+* The catalog becomes the single source of truth; v1 `CollectionConfig` survives only as a legacy read-adapter (its removal is the ADR-019/#603 endgame).
+* Schema introspection (pgwire `pg_catalog`, REST/gRPC v2 `get_schema`) reads the typed model directly — richer, type-correct, drift-free.
+* The properties bag shrinks to a small, declared extension surface (plugin/opaque metadata), enforced by convention + future lint.
+* Per-phase, the work is mixed-read-safe (legacy catalogs deserialize and fall back) and default-off where it shifts behaviour, so no flag-day.

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2244,18 +2244,29 @@ impl CollectionService {
             schema.stable_namespace_id = Some(id.namespace_id);
             schema.stable_collection_id = Some(id.collection_id);
         }
-        // ADR-047 / TD-TBL-1: the fresh `schema` above is rebuilt from the narrow
-        // `Collection` config, which cannot carry the canonical ProximaType
-        // columns. Capture any existing canonical-schema sidecar here so it can
-        // be re-attached below — otherwise an unrelated `update_collection`
-        // (e.g. an index-param tweak) would silently drop the canonical schema.
+        // ADR-047 / TD-TBL-1 + ADR-048 P1: the fresh `schema` above is rebuilt
+        // from the narrow `Collection` config, which cannot carry the canonical
+        // ProximaType columns. Capture any existing canonical schema — both the
+        // legacy `collection.canonical_schema` property AND the typed 200+
+        // columns (ADR-048) — so they can be re-attached below; otherwise an
+        // unrelated `update_collection` (e.g. an index-param tweak) would
+        // silently drop the canonical schema.
         let mut preserved_canonical_schema: Option<String> = None;
+        let mut preserved_canonical_columns: Vec<_> = Vec::new();
         if catalog.table_exists(&identifier).await? {
             let mut existing = catalog.get_table(&identifier).await?;
             preserved_canonical_schema = existing
                 .properties
                 .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)
                 .cloned();
+            preserved_canonical_columns = existing
+                .columns
+                .iter()
+                .filter(|c| {
+                    c.id >= crate::storage::metadata::collection_mapping::CANONICAL_COLUMN_ID_BASE
+                })
+                .cloned()
+                .collect();
             if existing
                 .properties
                 .get("asset.kind")
@@ -2296,6 +2307,9 @@ impl CollectionService {
                 crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY.to_string(),
                 canonical,
             );
+        }
+        if !preserved_canonical_columns.is_empty() {
+            schema.columns.extend(preserved_canonical_columns);
         }
         catalog.create_table(&identifier, schema).await?;
         Ok(())
@@ -3871,6 +3885,152 @@ mod tests {
         Ok(())
     }
 
+    /// ADR-048 P1: canonical columns are stored as TYPED catalog columns (200+
+    /// band), not a `collection.canonical_schema` property — and the reserved v1
+    /// columns (oid/embedding) are preserved.
+    #[tokio::test]
+    async fn canonical_schema_columns_stored_as_typed_columns_not_sidecar() -> Result<()> {
+        use proximadb_data_model::ProximaType;
+        use proximadb_runtime::CollectionPort;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let mgr = Arc::new(CatalogManager::new());
+        mgr.create_native_catalog("default", &temp_path)
+            .await
+            .context("catalog")?;
+        let svc = CollectionService::new(StorageConfig::default())
+            .await
+            .context("service")?
+            .with_catalog_manager(mgr.clone());
+        let name = "canon_typed";
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension: 8,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            ..Default::default()
+        };
+        assert!(svc.create_collection(&config).await?.success);
+        let columns = vec![
+            canonical_col("u", ProximaType::UInt64),
+            canonical_col("s", ProximaType::String),
+        ];
+        svc.set_collection_schema_columns(name, &columns, None)
+            .await
+            .context("set canonical columns")?;
+
+        // Peek at the catalog table directly.
+        let catalog = mgr.default_catalog().await?;
+        let identifier =
+            crate::storage::metadata::collection_mapping::collection_table_identifier(&config);
+        let schema = catalog.get_table(&identifier).await?;
+
+        // Canonical columns are typed, in the 200+ band.
+        let typed: Vec<_> = schema.columns.iter().filter(|c| c.id >= 200).collect();
+        assert_eq!(typed.len(), 2, "two canonical columns in the 200+ band");
+        assert_eq!(typed[0].name, "u");
+        assert!(matches!(typed[0].data_type, ProximaType::UInt64));
+        assert_eq!(typed[1].name, "s");
+        // The legacy sidecar property is GONE (typed columns are the sole authority).
+        assert!(
+            schema
+                .properties
+                .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)
+                .is_none(),
+            "ADR-048 P1 retires the collection.canonical_schema sidecar property"
+        );
+        // Reserved v1 columns are preserved (oid + embedding).
+        assert!(
+            schema.columns.iter().any(|c| c.name == "oid"),
+            "reserved oid column preserved"
+        );
+        assert!(
+            schema.columns.iter().any(|c| c.name == "embedding"),
+            "reserved embedding column preserved"
+        );
+
+        // And the trait read returns them.
+        let restored = svc
+            .get_collection_schema_columns(name, None)
+            .await?
+            .expect("typed columns read back");
+        assert_eq!(restored, columns);
+        Ok(())
+    }
+
+    /// ADR-048 P1 mixed-read: a catalog written before P1 (canonical schema as a
+    /// `collection.canonical_schema` property, no typed 200+ columns) is still
+    /// readable via the transitional path, and a subsequent `set` migrates it to
+    /// typed columns (removing the property).
+    #[tokio::test]
+    async fn canonical_schema_transitional_read_of_legacy_sidecar() -> Result<()> {
+        use proximadb_data_model::ProximaType;
+        use proximadb_runtime::CollectionPort;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().context("temp dir")?;
+        let temp_path = format!("file://{}", temp_dir.path().display());
+        let mgr = Arc::new(CatalogManager::new());
+        mgr.create_native_catalog("default", &temp_path)
+            .await
+            .context("catalog")?;
+        let svc = CollectionService::new(StorageConfig::default())
+            .await
+            .context("service")?
+            .with_catalog_manager(mgr.clone());
+        let name = "canon_legacy_prop";
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension: 8,
+            primary_index: Some("default".to_string()),
+            auto_index_selection: Some(false),
+            ..Default::default()
+        };
+        assert!(svc.create_collection(&config).await?.success);
+
+        // Simulate a pre-P1 catalog: write the canonical schema as the legacy
+        // property directly (no typed 200+ columns).
+        let columns = vec![canonical_col("u", ProximaType::UInt64)];
+        let catalog = mgr.default_catalog().await?;
+        let identifier =
+            crate::storage::metadata::collection_mapping::collection_table_identifier(&config);
+        let mut schema = catalog.get_table(&identifier).await?;
+        schema.properties.insert(
+            crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY.to_string(),
+            serde_json::to_string(&columns).context("serialize legacy canonical sidecar")?,
+        );
+        let _ = catalog.drop_table(&identifier, false).await?;
+        catalog.create_table(&identifier, schema).await?;
+
+        // Transitional read returns the legacy sidecar.
+        let restored = svc
+            .get_collection_schema_columns(name, None)
+            .await?
+            .expect("transitional read of the legacy sidecar");
+        assert_eq!(restored, columns);
+
+        // A subsequent set migrates it to typed columns (property removed).
+        let columns2 = vec![canonical_col("n", ProximaType::Int64)];
+        svc.set_collection_schema_columns(name, &columns2, None)
+            .await?;
+        let restored2 = svc
+            .get_collection_schema_columns(name, None)
+            .await?
+            .expect("post-migration read");
+        assert_eq!(restored2, columns2);
+        let schema2 = catalog.get_table(&identifier).await?;
+        assert!(
+            schema2
+                .properties
+                .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)
+                .is_none(),
+            "set migrated the legacy sidecar to typed columns"
+        );
+        Ok(())
+    }
+
     /// ADR-047 / TD-TBL-1: an unrelated `update_collection` (e.g. a description
     /// tweak) must NOT drop the canonical sidecar — the sticky-preserve in
     /// `upsert_collection_catalog_asset` carries it across the narrow rebuild.
@@ -4037,16 +4197,23 @@ impl proximadb_runtime::CollectionPort for CollectionService {
             return Ok(());
         }
         let mut schema = catalog.get_table(&identifier).await?;
-        if columns.is_empty() {
-            schema
-                .properties
-                .remove(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY);
-        } else {
-            schema.properties.insert(
-                crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY.to_string(),
-                crate::storage::metadata::catalog_config::canonical_schema_columns_to_json(
+        // ADR-048 P1: the canonical schema IS the typed catalog columns (200+
+        // band), not a properties-bag sidecar. Preserve every reserved column
+        // (id < 200 — system/embedding/v1 filterable) and replace only the
+        // canonical band. Remove the legacy `collection.canonical_schema`
+        // property so the typed columns are the sole authority (mixed-read-safe:
+        // `get_collection_schema_columns` reads typed columns first, then the
+        // transitional property for catalogs not yet migrated).
+        let base = crate::storage::metadata::collection_mapping::CANONICAL_COLUMN_ID_BASE;
+        schema.columns.retain(|c| c.id < base);
+        schema
+            .properties
+            .remove(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY);
+        if !columns.is_empty() {
+            schema.columns.extend(
+                crate::storage::metadata::collection_mapping::collection_schema_columns_to_catalog_columns(
                     columns,
-                )?,
+                ),
             );
         }
         let _ = catalog.drop_table(&identifier, false).await?;
@@ -4078,6 +4245,15 @@ impl proximadb_runtime::CollectionPort for CollectionService {
             return Ok(None);
         }
         let schema = catalog.get_table(&identifier).await?;
+        // ADR-048 P1: read the canonical schema from the typed 200+ columns.
+        let typed = crate::storage::metadata::collection_mapping::catalog_columns_to_collection_schema_columns(&schema.columns);
+        if !typed.is_empty() {
+            return Ok(Some(typed));
+        }
+        // Transitional read (mixed-read-safe): a catalog written before ADR-048
+        // P1 carries the canonical schema as a `collection.canonical_schema`
+        // property. Serve it until the collection is next evolved (which writes
+        // typed columns), after which the property is gone.
         Ok(schema
             .properties
             .get(crate::storage::metadata::collection_mapping::CANONICAL_SCHEMA_PROPERTY)

--- a/src/storage/metadata/catalog_config.rs
+++ b/src/storage/metadata/catalog_config.rs
@@ -404,23 +404,14 @@ pub(crate) fn apply_record_schema_from_json(config: &mut CollectionConfig, json:
         .collect();
 }
 
-// --- Canonical ProximaType schema columns (ADR-047 authority) -----------------
+// --- Canonical ProximaType schema columns (ADR-047 / ADR-048) -----------------
 //
-// ADR-047 / TD-TBL-1: the narrow v1 `CollectionConfig` cannot represent the full
-// `ProximaType` vocabulary (UInt/Struct/Map/Sparse/BinaryVector …), so the
-// canonical `Vec<CollectionSchemaColumn>` is persisted verbatim as a neutral JSON
-// sidecar on the catalog asset (`collection.canonical_schema`), mirroring the
-// `collection.config_json` / `collection.record_schema` idiom. The narrow config
-// stays the legacy read view; this sidecar is the authority for rich types.
-
-/// Serialize the canonical ProximaType columns to a neutral JSON string for the
-/// catalog asset property bag.
-pub(crate) fn canonical_schema_columns_to_json(
-    columns: &[CollectionSchemaColumn],
-) -> Result<String> {
-    serde_json::to_string(columns)
-        .map_err(|e| anyhow::anyhow!("serialize canonical_schema columns for catalog asset: {e}"))
-}
+// ADR-048 P1: the canonical `Vec<CollectionSchemaColumn>` is now the TYPED
+// `CatalogTableSchema.columns` (200+ band) — the catalog's native authority (see
+// `collection_mapping::collection_schema_columns_to_catalog_columns`). The legacy
+// `collection.canonical_schema` JSON sidecar survives only as a transitional READ
+// fallback for catalogs written before P1 (mixed-read-safe); `_from_json` decodes
+// it. The write side was retired with P1 — new writes go to the typed columns.
 
 /// Reconstruct the canonical ProximaType columns from a neutral JSON string, or
 /// `None` on a decode error (legacy/corrupt asset) so the caller keeps its
@@ -611,7 +602,7 @@ mod tests {
             col("ts", ProximaType::Timestamp(TimeUnit::Nanosecond)),
         ];
 
-        let json = canonical_schema_columns_to_json(&columns).expect("serialize");
+        let json = serde_json::to_string(&columns).expect("serialize");
         let restored = canonical_schema_columns_from_json(&json).expect("deserialize");
         assert_eq!(restored.len(), columns.len());
         assert_eq!(

--- a/src/storage/metadata/collection_mapping.rs
+++ b/src/storage/metadata/collection_mapping.rs
@@ -31,6 +31,102 @@ use crate::proto::proximadb_v1::{
 /// preserved across unrelated `upsert_collection_catalog_asset` rebuilds.
 pub(crate) const CANONICAL_SCHEMA_PROPERTY: &str = "collection.canonical_schema";
 
+/// ADR-048: column-id base for canonical schema columns. The v1-derived
+/// `catalog_schema_from_collection` reserves ids 0–199 (system 0/1/2/3/8,
+/// embedding 20, v1 filterable 100+); canonical ProximaType columns live at
+/// 200+ so they never collide and stay invisible to the v1 read path (which
+/// reconstructs `filterable_columns` from `id >= 100`).
+pub(crate) const CANONICAL_COLUMN_ID_BASE: i32 = 200;
+
+/// ADR-048 P1: map canonical `CollectionSchemaColumn`s to typed `CatalogColumn`s
+/// in the 200+ band. `name`/`data_type`/`nullable` become the typed column; the
+/// per-column hints (indexed/filterable/text_storage/max_length) round-trip via
+/// the column's `properties` — the declared per-column extension surface (D7).
+pub(crate) fn collection_schema_columns_to_catalog_columns(
+    columns: &[proximadb_runtime::CollectionSchemaColumn],
+) -> Vec<CatalogColumn> {
+    columns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let mut col = CatalogColumn::new(
+                CANONICAL_COLUMN_ID_BASE + i as i32,
+                c.name.clone(),
+                c.data_type.clone(),
+            )
+            .nullable(c.nullable);
+            col.properties
+                .insert("proxima.indexed".to_string(), c.indexed.to_string());
+            col.properties
+                .insert("proxima.filterable".to_string(), c.filterable.to_string());
+            if let Some(ts) = c.text_storage {
+                col.properties.insert(
+                    "proxima.text_storage".to_string(),
+                    match ts {
+                        proximadb_runtime::CollectionTextStorage::Inline => "Inline",
+                        proximadb_runtime::CollectionTextStorage::Large => "Large",
+                    }
+                    .to_string(),
+                );
+            }
+            if let Some(ml) = c.max_length {
+                col.properties
+                    .insert("proxima.max_length".to_string(), ml.to_string());
+            }
+            // Catalog validation (schema.rs) requires vector columns to carry a
+            // "dimension" property. DenseVector/BinaryVector carry theirs;
+            // SparseVector has no fixed dim → 0 (unused on read-back, which reads
+            // the dim from the ProximaType itself).
+            match &c.data_type {
+                ProximaType::DenseVector { dim, .. } | ProximaType::BinaryVector { dim } => {
+                    col.properties
+                        .insert("dimension".to_string(), dim.to_string());
+                }
+                ProximaType::SparseVector { .. } => {
+                    col.properties
+                        .insert("dimension".to_string(), "0".to_string());
+                }
+                _ => {}
+            }
+            col
+        })
+        .collect()
+}
+
+/// ADR-048 P1: reverse — read the canonical schema from the typed 200+ columns
+/// (reserved v1 columns are excluded). Returns an empty vec when no canonical
+/// columns exist (legacy collection → caller falls back to the transitional
+/// sidecar read).
+pub(crate) fn catalog_columns_to_collection_schema_columns(
+    columns: &[CatalogColumn],
+) -> Vec<proximadb_runtime::CollectionSchemaColumn> {
+    columns
+        .iter()
+        .filter(|c| c.id >= CANONICAL_COLUMN_ID_BASE)
+        .map(|c| {
+            let bool_prop = |k: &str| c.properties.get(k).is_some_and(|v| v == "true");
+            proximadb_runtime::CollectionSchemaColumn {
+                name: c.name.clone(),
+                data_type: c.data_type.clone(),
+                nullable: c.nullable,
+                indexed: bool_prop("proxima.indexed"),
+                filterable: bool_prop("proxima.filterable"),
+                text_storage: c.properties.get("proxima.text_storage").and_then(|s| {
+                    match s.as_str() {
+                        "Inline" => Some(proximadb_runtime::CollectionTextStorage::Inline),
+                        "Large" => Some(proximadb_runtime::CollectionTextStorage::Large),
+                        _ => None,
+                    }
+                }),
+                max_length: c
+                    .properties
+                    .get("proxima.max_length")
+                    .and_then(|s| s.parse().ok()),
+            }
+        })
+        .collect()
+}
+
 pub(crate) fn collection_from_catalog_schema(
     table_id: &TableIdentifier,
     schema: &CatalogTableSchema,


### PR DESCRIPTION
## Summary

**ADR-048** establishes the catalog (`CatalogTableSchema`/`CatalogColumn`) as the single typed, self-describing authority for object + operations metadata. The catalog **already has** the typed primitives (`distance_metric`/`quantization`/`embedding_config`/`storage_config`, `evolve_schema`/`get_schema_by_version`, `CatalogTableStatistics`); the collection-as-table path **bypassed them** via a properties-bag sidecar + v1-derivation. ADR-048 = *complete the wiring + retire the shortcuts*, phased P1..P5. (ADR-047 is referenced in code but never filed — ADR-048 notes this.)

**P1 (this PR)** collapses the `collection.canonical_schema` sidecar duality (the cohesion concern): the typed `CatalogTableSchema.columns` (200+ band) **become** the canonical schema.

- `collection_mapping.rs`: `CollectionSchemaColumn`↔`CatalogColumn` helpers (id 200+, reserved 0–199 untouched; per-column hints round-trip via `CatalogColumn.properties`; vector columns carry the catalog-required `dimension`).
- `set_collection_schema_columns`: preserve reserved columns (id<200), replace the 200+ band, **remove the sidecar property** (typed columns are the sole authority). Uses the existing drop+create (no `evolve_schema` diff — that's P3).
- `get_collection_schema_columns`: read the typed 200+ columns; **transitional read** of the legacy sidecar for catalogs written before P1 (mixed-read-safe, lazy-migrates on next `set`).
- `upsert_collection_catalog_asset` sticky-preserve: also carry the 200+ typed columns across unrelated rebuilds (so `update_collection` can't drop the canonical schema).
- `catalog_config.rs`: retire `canonical_schema_columns_to_json` (dead after P1); keep `_from_json` for the transitional read.

## Scope / risk

No proto/SDK change. v1 path untouched (`enable_grpc_v1_compat` default-off). Mixed-read-safe at every step (200+ band invisible to v1's `id≥100` read filter). Files: ADR doc (new) + `collection_mapping.rs` + `catalog_config.rs` + `manager.rs`. Riskiest piece (reserved-column preservation) is mitigated by the 200+ band discipline.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --lib -p proximadb -p proximadb-catalog -- -D warnings` ✓
- `cargo check --tests` ✓
- `scripts/check_td_adr_unique.py` ✓ (ADR-048 collision-free; latest filed is 046)
- Tests: `canonical_schema_columns_stored_as_typed_columns_not_sidecar` (typed cols, no sidecar, reserved preserved); `canonical_schema_transitional_read_of_legacy_sidecar` (legacy read + set-migrates); existing restart/sticky/serde round-trip tests pass (5/5).

Refs: ADR-048 (this PR); builds on #606 (Phase 1) + #609 (v2 catalog-authoritative lifecycle). P2–P5 (typed config fields, evolve_schema-only mutation, cataloged ops metadata, MVCC version chain) are follow-ons.