### PR TITLE
docs(phase-f): PAX default-on arming runbook

### DIFF
--- a/docs/_internal/status/PHASE_F_ARMING_RUNBOOK_2026_07_02.adoc
+++ b/docs/_internal/status/PHASE_F_ARMING_RUNBOOK_2026_07_02.adoc
@@ -1,0 +1,121 @@
+= PAX Default-On (Phase F) Arming Runbook
+
+== Overview
+
+This runbook guides the operational arming of PAX RaBitQ→SQ8 quantization as the
+default segment format for new collections. All code is merged to `develop`; this
+is a per-deployment env flip, not a code change.
+
+== Prerequisites (all met)
+
+* **WS8 recall gate:** recall@10 = **0.9920** @ SIFT1M (1M vectors, provided GT,
+  128-d Euclidean) — well above the 0.90 floor. Measured locally 2026-07-01.
+* **Cascade search perf:** ~330ms/query @ N=100k (competitive with brute-force
+  ~190ms) after the rotation-matrix cache (#608) + contiguous flattening (#613).
+* **Flush perf:** ~80s for 1M vectors (compute-bound; acceptable for the rollout
+  scale).
+* **Metric consistency:** 2 production drift bugs fixed (#607); `Cosine ≠ Euclidean`
+  end-to-end test (#611) proves the metric threads correctly.
+* **Escape hatches:** global kill-switch + per-collection opt-out + configurable f32
+  tier.
+
+== How to arm
+
+Set ONE environment variable on the target deployment:
+
+[source,bash]
+----
+export PROXIMADB_PAX_DEFAULT_ON=1
+----
+
+This makes PAX (RaBitQ hot + SQ8 rerank) the **default segment format** for every
+newly flushed collection. Existing `.sst` / `.arrow` segments continue to read
+back unchanged (mixed-format-safe). AXIS in-memory indexes are unaffected (they
+index the vectors, not the segment format).
+
+=== Recommended arming sequence
+
+1. **qa/staging:** Set `PROXIMADB_PAX_DEFAULT_ON=1` on the qa deployment. Run
+   production-like workloads. Verify recall + latency.
+2. **Canary production:** Arm on one production pod (or one collection via the
+   `pax_vector_format:on` tag — no global flip). Monitor.
+3. **Full production:** Set `PROXIMADB_PAX_DEFAULT_ON=1` globally.
+
+== Escape hatches (rollback)
+
+=== Global kill-switch (immediate)
+[source,bash]
+----
+export PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE=1
+----
+Forces **legacy `.sst`** for ALL collections — every flush writes ProximaBlocks
+again. New `.pax` segments already on disk still read back (mixed-format-safe).
+The system returns to pre-PAX behavior immediately.
+
+=== Per-collection opt-out (granular)
+Tag the collection:
+[source,json]
+----
+{"tags": ["pax_vector_format:off"]}
+----
+That collection writes legacy `.sst` regardless of the global default. Use this
+for collections that can't tolerate quantization or need exact-vector return
+without the f32 tier.
+
+=== Exact-vector fidelity (opt-in f32 tier)
+For collections that need exact `include_vectors` returns alongside PAX:
+[source,json]
+----
+{"tags": ["pax_f32_tier:on"]}
+----
+Writes a co-located raw-f32 column (lazy-read — only decoded for `include_vectors`
+or exact final rerank). Storage cost: +260 bytes/vector.
+
+== What changes when armed
+
+* **New flushes** write `.pax` segments (RaBitQ hot codes + SQ8 rerank column).
+  ~260 bytes/vector on disk (vs ~512 bytes raw f32 — ~2× compression; the RaBitQ
+  hot column alone is ~30× compressed).
+* **Cold queries** (AXIS not yet built) route through the RaBitQ→SQ8 cascade
+  (stage-1 binary rank → stage-2 SQ8 rerank → top-k). The cascade serves Euclidean
+  + Cosine; DotProduct falls back to the generic scan.
+* **Warm queries** (AXIS built) are unaffected — AXIS serves from its in-memory
+  HNSW/IVF index. PAX only affects the cold path + the on-disk format.
+* **Compaction** preserves the PAX format (re-encodes as `.pax` with RaBitQ).
+
+== What does NOT change
+
+* Existing `.sst` / `.arrow` segments — read back unchanged (mixed-format-safe).
+* AXIS index build — uses the collection's metric (independent of segment format).
+* REST / gRPC / pgwire API — no protocol change.
+* Collection create / search / insert — transparent (the format is internal).
+
+== Key env vars reference
+
+[cols="1,1,3", options="header"]
+|===
+| Env var | Default | Effect
+
+| `PROXIMADB_PAX_DEFAULT_ON` | OFF (0) | **The Phase F arm.** Makes PAX the default segment format for all new flushes.
+| `PROXIMADB_PAX_VECTOR_SEGMENTS` | OFF | Explicit opt-in (pre-Phase-F mechanism; `PROXIMADB_PAX_DEFAULT_ON=1` supersedes).
+| `PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE` | unset | **Kill-switch.** Forces legacy `.sst` for ALL collections.
+| `PROXIMADB_PAX_VECTOR_QUANT` | rabitq | Quantization strategy (`rabitq` / `sq8` / `auto`).
+| `PROXIMADB_PAX_F32_TIER` | OFF | Global f32-tier opt-in (per-collection: `pax_f32_tier:on` tag).
+| `PROXIMADB_PAX_RABITQ_POOL_MULT` | 100 | Stage-1 candidate pool multiplier (pool = max(k × mult, min)).
+| `PROXIMADB_PAX_RABITQ_POOL_MIN` | 1000 | Stage-1 pool minimum.
+|===
+
+== Measured performance (local, indicative)
+
+[cols="1,1,1", options="header"]
+|===
+| Metric | Value | Notes
+
+| Recall@10 @ 1M | 0.9920 | SIFT1M, provided GT, 50 queries
+| Recall@10 @ 100k | 0.9905 | brute-force GT, 200 queries
+| Search latency @ 100k | ~340ms/query | rotation-cached + flattened
+| Flush throughput | ~6 MB/s (1M / ~80s) | compute-bound (RaBitQ encode)
+| PAX segment size | 260 B/vector | RaBitQ + SQ8 + overhead
+|===
+
+*Indicative local baseline, NOT an SLA.*


### PR DESCRIPTION
Operational runbook for arming PAX default-on (Phase F): how to arm, escape hatches (kill-switch + opt-out + f32 tier), what changes, what doesn't, env var reference, measured perf (recall 0.9920, search ~340ms/q, flush ~80s/1M, 260 B/vec). For the release.