### PR TITLE
chore(proto): deprecate all 17 v1 services (M0-b, ADR-049)

### DIFF
--- a/proto/proximadb/v1/catalog.proto
+++ b/proto/proximadb/v1/catalog.proto
@@ -431,6 +431,8 @@ message FullTextConfig {
 // =============================================================================
 
 service CatalogService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Catalog management
   rpc CreateCatalog(CreateCatalogRequest) returns (CreateCatalogResponse);
   rpc GetCatalog(GetCatalogRequest) returns (GetCatalogResponse);

--- a/proto/proximadb/v1/cluster.proto
+++ b/proto/proximadb/v1/cluster.proto
@@ -26,6 +26,8 @@ import "proximadb/v1/vector_types.proto";
 // coordination. This handles leader election, log replication, and membership
 // changes for cluster metadata.
 service ConsensusService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // RequestVote is called by candidates to gather votes during leader election.
     // Implements Raft Section 5.2: Leader Election
     rpc RequestVote(RequestVoteRequest) returns (RequestVoteResponse);
@@ -198,6 +200,8 @@ message PreVoteResponse {
 // This is separate from Raft consensus and handles the actual vector data
 // replication with configurable consistency levels.
 service ReplicationService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // Replicate sends a single replication entry to a replica
     rpc Replicate(ReplicateRequest) returns (ReplicateResponse);
 
@@ -333,6 +337,8 @@ message AckReplicationResponse {
 // SearchFanoutService handles distributed search and write forwarding.
 // This implements the scatter-gather pattern for distributed queries.
 service SearchFanoutService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // ShardSearch executes a search on a specific shard
     rpc ShardSearch(ShardSearchRequest) returns (ShardSearchResponse);
 
@@ -509,6 +515,8 @@ message ForwardWriteBatchResponse {
 // HealthService provides health checking for inter-node communication.
 // This follows the gRPC Health Checking Protocol with extensions.
 service HealthService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // Check performs a health check (compatible with grpc.health.v1.Health)
     rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 

--- a/proto/proximadb/v1/document.proto
+++ b/proto/proximadb/v1/document.proto
@@ -373,6 +373,8 @@ message DeleteDocumentCollectionResponse {
 
 // Document gRPC service
 service DocumentService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Collection operations
   rpc CreateCollection(CreateDocumentCollectionRequest) returns (CreateDocumentCollectionResponse);
   rpc ListCollections(ListDocumentCollectionsRequest) returns (ListDocumentCollectionsResponse);

--- a/proto/proximadb/v1/entity.proto
+++ b/proto/proximadb/v1/entity.proto
@@ -92,6 +92,8 @@ message Relation {
 
 // Service definitions
 service EntityService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   rpc UpsertEntity(UpsertEntityRequest) returns (UpsertEntityResponse);
   rpc GetEntity(GetEntityRequest) returns (GetEntityResponse);
   rpc DeleteEntity(DeleteEntityRequest) returns (DeleteEntityResponse);

--- a/proto/proximadb/v1/graph.proto
+++ b/proto/proximadb/v1/graph.proto
@@ -392,6 +392,8 @@ message GetStatsRequest {
 
 // Service definition for graph operations
 service GraphService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // Node operations
     rpc CreateNode(CreateNodeRequest) returns (Node);
     rpc GetNode(GetNodeRequest) returns (Node);

--- a/proto/proximadb/v1/hybrid.proto
+++ b/proto/proximadb/v1/hybrid.proto
@@ -213,6 +213,8 @@ message ListFusionStrategiesResponse {
 // Provides gRPC endpoints for hybrid search combining BM25 full-text
 // search with vector similarity search using configurable fusion strategies.
 service HybridSearchService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Execute hybrid search combining BM25 and vector search
   //
   // Combines full-text BM25 search with vector similarity search using

--- a/proto/proximadb/v1/observability.proto
+++ b/proto/proximadb/v1/observability.proto
@@ -658,6 +658,8 @@ message QueryMetricsResponse {
 
 // Observability gRPC service
 service ObservabilityService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Namespace management
   rpc CreateNamespace(CreateObservabilityNamespaceRequest) returns (CreateObservabilityNamespaceResponse);
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);

--- a/proto/proximadb/v1/ranking.proto
+++ b/proto/proximadb/v1/ranking.proto
@@ -81,5 +81,7 @@ message RankSearchResponse {
 
 // gRPC service — handler wiring lands in R-7c.4a.1.
 service RankService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   rpc RankSearch(RankSearchRequest) returns (RankSearchResponse);
 }

--- a/proto/proximadb/v1/relations.proto
+++ b/proto/proximadb/v1/relations.proto
@@ -11,6 +11,8 @@ option go_package = "github.com/proximadb/proto/go/proximadb/v1";
 
 // Service for managing graph relationships between entities.
 service RelationsService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Creates a new relationship between two entities.
   rpc CreateRelation(CreateRelationRequest) returns (Relation);
 

--- a/proto/proximadb/v1/security.proto
+++ b/proto/proximadb/v1/security.proto
@@ -375,6 +375,8 @@ message DataEncryptionPolicy {
 
 // Security service for RBAC operations
 service SecurityService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   // Permission validation
   rpc ValidateAccess(ValidateAccessRequest) returns (ValidateAccessResponse);
   rpc BatchValidateAccess(BatchValidateAccessRequest) returns (BatchValidateAccessResponse);

--- a/proto/proximadb/v1/sql.proto
+++ b/proto/proximadb/v1/sql.proto
@@ -6,5 +6,7 @@ import "proximadb/v1/types.proto";
 
 // SQL execution service (v1, versioned namespace)
 service QueryService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
   rpc ExecuteQuery(ExecuteQueryRequest) returns (ExecuteQueryResponse);
 }

--- a/proto/proximadb/v1/streaming.proto
+++ b/proto/proximadb/v1/streaming.proto
@@ -21,6 +21,8 @@ import "proximadb/v1/types.proto";
 
 // StreamingService provides real-time vector streaming capabilities
 service StreamingService {
+  // Deprecated (ADR-049 / TD-121): v1 surface. Removed in M4; migrate to proximadb.v2.
+  option deprecated = true;
     // Bidirectional streaming for vector ingestion
     // Client sends vectors, server responds with acknowledgments and backpressure signals
     rpc StreamInsert(stream StreamInsertRequest) returns (stream StreamInsertResponse);


### PR DESCRIPTION
M0-b of the v1→v2 migration (ADR-049 #615). Adds `option deprecated = true` + ADR-049/TD-121 comment to the 15 v1 services lacking it (Collection/Vector already deprecated). Advisory only — v1 stays functional through M4. .proto-only (no v1.rs / service-set change → proto-check + python gRPC drift unaffected). The ratchet (#615) is the enforcement; this is the formal signal. Builds on #615 (M0-a ratchet + ADR-049).