### PR TITLE
chore: add storage up-edge ratchet

### DIFF
--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -83,6 +83,7 @@ jobs:
         echo "## Layering Violations Detected" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Run \`python3 scripts/check_workspace_boundaries.py --strict\` locally and review the workspace refactor plan plus ADR-001." >> $GITHUB_STEP_SUMMARY
+        echo "For storage decomposition regressions, run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290\` and lower the max when your branch removes edges." >> $GITHUB_STEP_SUMMARY
 
     - name: Post results to PR (on failure)
       if: failure() && github.event_name == 'pull_request'
@@ -100,6 +101,7 @@ jobs:
             **What to check:**
             - Run \`./scripts/check-layering.sh\` locally
             - Run \`python3 scripts/check_workspace_boundaries.py --strict\` directly for the canonical checker
+            - Run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290\` for the Slice-D storage decomposition ratchet
             - Review [Workspace Refactor Plan](https://github.com/${context.repo.owner}/${context.repo.name}/blob/main/roadmap/techdebt/WORKSPACE_REFACTOR_PLAN_2026_05_07.adoc)
             **Golden Rule:** Lower layers must not depend on higher layers.
 

--- a/docs/10-quality/QUERY_ACCURACY_AUDIT_2026_06_28.adoc
+++ b/docs/10-quality/QUERY_ACCURACY_AUDIT_2026_06_28.adoc
@@ -18,6 +18,16 @@ test actually *gate* in CI.
 
 == Two structural findings
 
+[NOTE]
+====
+2026-07-02 refresh: this audit remains the historical baseline for TD-182, but
+part of Finding 2 has been corrected. CI now includes an explicit pgwire accuracy
+job in the success set, and the QA gate runs vector recall ratchets. The remaining
+gap is no longer "all strong tests run nowhere"; it is "some modality value
+assertions are gated, while graph/document/time-series depth and additional
+coverage shards still need to be made cheap and mandatory."
+====
+
 === Finding 1 — most "ratchets" count execution, not correctness
 
 The TPC-H, TPC-DS, graph-LDBC, document, and events ratchets gate on "the query
@@ -30,9 +40,9 @@ ran without error", not "the query returned the right answer". `ADR-040` (accept
 *Vector is the exception*: it is genuinely accuracy-based (recall@k vs an f32
 brute-force baseline) across many engines and quantizers.
 
-=== Finding 2 — the accuracy tests that exist mostly do not gate in CI
+=== Finding 2 — the accuracy tests that exist were under-gated in CI
 
-115 of 150 integration tests are *orphaned* (no CI tier runs them). An integration
+Original 2026-06-28 finding: 115 of 150 integration tests were *orphaned* (no CI tier runs them). An integration
 test gates only if its filename matches an integration-job glob (`+*graph*+`,
 `+*query*+`, `+*cache*+`, `+*storage*+`, `+*sst*+`, `+*wal*+`, `+*cluster*+`,
 `+*distributed*+`) or is explicitly named in the qa-gate. The strong
@@ -41,6 +51,9 @@ value-correctness / recall suites that already exist run *nowhere* in CI:
 `pgwire_olap_delta_merge_e2e` (incl. the JOIN value-accuracy test added in the
 ADR-025 PR3 flip), `vector_ann_recall_e2e` / `raptor` / `helix` / `nova` /
 `td112_postflush` recall, `document_json_pgwire_e2e`, `events_tsbs_pgwire_e2e`.
+Current checkout status: the pgwire accuracy suite and QA vector recall ratchets
+are now wired. Keep this finding open only for the remaining orphaned/deep
+accuracy surfaces and for coverage-shard cost control.
 
 == CI tiers
 
@@ -66,28 +79,25 @@ ADR-025 PR3 flip), `vector_ann_recall_e2e` / `raptor` / `helix` / `nova` /
 |===
 | Modality | Accuracy test? | Gates in CI? | Where / note
 
-| Vector ANN / recall | yes (strong) | partial | block-format + sst-prune gate; ANN/RAPTOR/HELIX/NOVA/TD-112 recall *orphaned*
+| Vector ANN / recall | yes (strong) | partial | QA gate runs ANN/RAPTOR/HELIX/NOVA/TD-112 recall; SIFT1M and broader stress recall remain manual/heavy
 | Vector quantization | yes (sq8 0.90 / rabitq 0.80 / fp16 0.99) | likely (crate `--lib`) | sign-magnitude + turboquant have *no* recall test
-| Relational (dedicated) | yes (strong value) | *no — orphaned* | `pgwire_relational_engine_e2e`, olap-merge, null/OR/roundtrip
+| Relational (dedicated) | yes (strong value) | yes | pgwire accuracy job covers relational engine, OLAP delta merge, null/OR/roundtrip, and FP16/Mem0 pgwire e2e
 | Relational TPC-H/DS | execution-only (+ Q1, INTERSECT spot) | yes | qa-tier
 | Graph (impact/fusion/paths) | yes (value) | yes | develop-tier (`+*graph*+`)
 | Graph LDBC pgwire | execution-only (recursive CTE unasserted) | yes (execution only) | develop-tier
-| Document JSON | converting (ADR-040 PR#476; TD-183) | *no — orphaned* | 4 accurate / 7 known-bad
-| Time-series TSBS | execution-only (+ 1 spot) | *no — orphaned* | windows/buckets unverified
+| Document JSON | converting (ADR-040 PR#476; TD-183) | partial | `document_json_pgwire_e2e` gates in pgwire accuracy; TD-183 keeps full JSON projection/filter accuracy open
+| Time-series TSBS | execution-only (+ 1 spot) | partial | `events_tsbs_pgwire_e2e` gates in pgwire accuracy; windows/buckets still need stronger value checks
 |===
 
 == Prioritized program (TD-182)
 
-=== P0 — gate the accuracy tests that already exist
+=== P0 — keep newly wired accuracy gates mandatory and finish the remaining cheap gaps
 
-Wire the orphaned accuracy/recall e2e suite into CI with `--test-threads=1` (they
-toggle process env) and a Linux-sized run. Split by cost: a fast develop-tier
-pgwire-accuracy job (`pgwire_relational_engine_e2e`, `pgwire_olap_delta_merge_e2e`,
-`document_json_pgwire_e2e`, `events_tsbs_pgwire_e2e`) and the heavier vector recall
-ratchets (`vector_ann_recall_e2e`, `raptor`, `helix`, `nova`, `td112_postflush`)
-in the qa-tier alongside the existing recall ratchets. Verify each passes in CI
-before declaring done. Cheapest high-value win — these tests are written and green
-locally; they just run nowhere.
+Keep the pgwire accuracy job in the CI success set and the heavier vector recall
+ratchets in the QA gate. Do not collapse them back into the monolithic root crate
+coverage job. The next cheapest high-value work is to move remaining value
+assertions into similarly narrow package/test shards so `cargo llvm-cov` and
+Tarpaulin do not need to compile the whole root crate for every modality.
 
 === P1 — finish the ADR-040 execution→accuracy conversion
 

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
@@ -155,11 +155,15 @@ boundaries are ports. E/F are large and must be coordinated.
 
 == Multi-session coordination protocol (mandatory)
 
-This repo is worked by many concurrent sessions; at time of writing ~7 worktrees are active
-and several edit `src/storage`. Large file-moves conflict violently with in-flight work, so:
+This repo is worked by many concurrent sessions; at the 2026-07-02 refresh more than 30
+worktrees were active, with several storage/vector/recall branches in flight. Large file-moves
+conflict violently with in-flight work, so:
 
 * *Pick cold subtrees.* Before moving a subtree, check open PRs and active worktrees touching
   it; defer if hot.
+* *Use one worktree per decomposition slice.* Keep docs, ratchets, port definitions, and hot
+  storage wiring in separate branches unless they must land atomically. This lets CI compile and
+  coverage-shard behavior be evaluated independently.
 * *Mechanical-only PRs.* A decomposition slice is `git mv` + re-export + `Cargo.toml` member
   add — nothing else. Easy to review, easy to rebase.
 * *Land within the day.* Don't let an extraction branch sit; divergence cost is the dominant
@@ -168,6 +172,13 @@ and several edit `src/storage`. Large file-moves conflict violently with in-flig
   coordination window, not an opportunistic PR.
 * The `layering-check` workflow + `scripts/affected_crates.py` already enforce/observe the
   boundaries; keep them green at every slice.
+* Measure the source-level Slice-D seam before and after every storage PR:
+  `python3 scripts/check_workspace_boundaries.py --storage-up-edges`. When a branch removes
+  edges, set `--max-storage-up-edges` to the new lower count in its validation notes so the next
+  branch has a ratchet target.
+* The current ceiling is wired into `scripts/check-layering.sh`, which CI runs via
+  `.github/workflows/layering-check.yml`. A branch that intentionally removes storage up-edges
+  should lower that ceiling in the same PR.
 
 == Non-goals / explicitly deferred
 
@@ -184,7 +195,7 @@ and several edit `src/storage`. Large file-moves conflict violently with in-flig
 * coverage producible without exclusions (eventually yes),
 * CI compile wall-clock for the root crate (down).
 
-== Status & next action (2026-06-25)
+== Status & next action (refreshed 2026-07-02)
 
 Four clean storage leaves have landed as pure `git mv` + re-export extractions, all
 layering-green with no call-site churn: `proximadb-storage-kv`, `-transaction` (#329),
@@ -199,3 +210,16 @@ upward edges into root subsystems (`compute`, `persistence`, `engines`, `core`, 
 `storage::traits`) and are not clean leaves. The leaf inventory is effectively exhausted, so
 *D* (the trait/index/compute port-inversion enabler) is the next linchpin — it unblocks both
 cache and the large engine slices.
+
+Current measured Slice-D baseline from
+`python3 scripts/check_workspace_boundaries.py --storage-up-edges`: 290 remaining storage
+up-edges (`compute` 239, `index` 31, `query` 10, `services` 10). This is now the enforced
+non-regression ceiling in `scripts/check-layering.sh`. That is the parallelization ground truth:
+do not move an engine crate while these edges still point at root modules; first split independent
+worktrees by edge class:
+
+* `query` edges: extract/filter DTOs or redirect to query-contract crates; low coordination cost.
+* `services` edges: finish metadata/collection ports and injection; moderate cost.
+* `index` edges: design `IndexPort` facade or pre-extract leaked AXIS types; high review cost.
+* `compute` edges: separate pure kernel redirects from quantization/runtime policy ports; highest
+  compile-payoff because it dominates the remaining count.

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
@@ -142,6 +142,13 @@ then depends *down* on the trait crate, never *up* on the implementor.
 
 == D2 detailed spec — the measured port surface (2026-06-26)
 
+2026-07-02 measurement update: the source-level ratchet now lives in
+`scripts/check_workspace_boundaries.py --storage-up-edges`. Current checkout count is 290
+remaining `src/storage` up-edges (`compute` 239, `index` 31, `query` 10, `services` 10), and
+`scripts/check-layering.sh` enforces `--max-storage-up-edges 290` in CI. Use this count as the
+worktree baseline for Slice D. Each decomposition branch should reduce one edge class and lower the
+checked ceiling before handing off to the next branch.
+
 The mechanical phase (D0/D1) is **complete** (PRs #370, #377, #379, #386). The remaining
 D0 tail items are **not** clean Mechanism-A redirects and fold into Mechanism B:
 
@@ -225,7 +232,7 @@ first so the hot edits are mechanical.
 | D2 | **Define `proximadb-storage-ports`** — the `IndexPort` + `CollectionMetadataPort` traits. **DONE (CollectionMetadataPort):** crate created (`crates/storage/proximadb-storage-ports`, storage tier — same-tier deps allowed) with `async fn collection(&str) -> Result<Option<Collection>>` (the *measured* surface is one method; `get_collection_stats` turned out to be on `AxisManager`, not the service); `impl CollectionMetadataPort for CollectionService`. **Remaining:** `IndexPort` (leaks `AxisHybridQuery`/`AxisManagerQueryResult`/`AxisConfig`/`AxisVectorIndex` — per-type facade-vs-pre-extract decision; re-exporting root types into the port crate is a *cycle*, impossible). | Low–Med
 | D3 | **Refactor storage to consume injected ports.** `engine.rs`/compaction stop constructing `AxisManager` / calling `CollectionService` directly; take `Arc<dyn IndexPort>` / `Arc<dyn CollectionMetadataPort>` via constructor injection. Same concrete behavior, now behind the trait. **This is the hot, coordination-window phase.** **DONE (metadata side):** storage fields/params/setters in viper engine+flush, flush-coordinator, and background-flush-context retyped from `Arc<CollectionService>` to `Arc<dyn CollectionMetadataPort>` (these injection setters currently have no callers — latent infra — so this is a pure structural edge removal). **DONE (tenant resolver):** `collection_tenant_id` relocated *down* to a new foundation crate **`proximadb-tenant`** (`tenant_id_of(&Collection)`) — not "down to catalog" as first sketched, because tenant resolution is a *cross-cutting economics/isolation primitive* (storage, embedded, services, and the network gates all share it; coupling it to any one tier is wrong). Foundation tier = every layer depends *down* on the single fail-closed attribution seam, and resolution is a pure function of collection metadata so any node in an autoscaled fleet attributes identically without coordination (elasticity) and per-tenant meters reconcile (economics). `CollectionService::collection_tenant_id` is now a thin alias; storage/embedded call `proximadb_tenant::tenant_id_of` directly. **DONE (catalog↔Collection mapping):** the `collection_from_catalog_schema`/`catalog_schema_from_collection` pair + 6 private helpers (8 fns, ~546 LOC) moved verbatim out of `CollectionService` into a new storage module `crate::storage::metadata::collection_mapping` — *not* down to `proximadb-catalog` as first sketched, because the mapping reaches *up* into storage's own `catalog_config` json round-trip (control-tier can't depend on storage → cycle). Storage is its natural home (WAL-recovery driven, round-trips through storage-owned config); services now calls *down* into it. **This clears the last storage→`crate::services::collection` reference** (`generate_unique_collection_id`, an interleaved `&self` async method, correctly stayed behind). **Remaining:** the whole `IndexPort` wiring (the larger port). | Med-High
 | D4 | **Implement ports + wire injection.** `impl IndexPort for AxisManager`, `impl CollectionMetadataPort for CollectionService`; the composition root injects them. | Med
-| D5 | **Gate to zero.** `scripts/check_workspace_boundaries.py` + a storage-up-edge ratchet asserting `crate::{index,compute,services,query}` references under `src/storage` == 0 (core type refs already redirected in D0/D1). Engines (Slice E) now unblocked. | Low
+| D5 | **Gate to zero.** `scripts/check_workspace_boundaries.py --storage-up-edges` reports the ratchet; `scripts/check-layering.sh` now enforces the current ceiling (`--max-storage-up-edges 290`) and should be lowered whenever a branch removes edges. Terminal target remains `crate::{index,compute,services,query}` references under `src/storage` == 0 (core type refs already redirected in D0/D1). Engines (Slice E) are unblocked only after the terminal gate, not merely after the report exists. | Low
 |===
 
 D0 and D1 are opportunistic (mechanical, independent, no coordination needed) and should be
@@ -238,7 +245,7 @@ orchestrator, and the composition root, so they need the **announced coordinatio
 * **Behavior-neutral:** D0–D2 are path/trait plumbing; D3/D4 are DIP wrapping around the
   *same* concrete impls (`AxisManager`, `CollectionService`) — no algorithm changes. Gate on
   the existing storage unit/integration suites + ANN recall ratchet (unchanged numbers).
-* **Layering:** every phase keeps `scripts/check-layering.sh` green; D5 adds the
+* **Layering:** every phase keeps `scripts/check-layering.sh` green; D5 uses the
   storage-up-edge ratchet (count only goes down, terminal 0).
 * **No new upward edges:** the port crate sits below both storage and the implementors; the
   layering validator already forbids storage→{modality,query,platform,app} — extend it to

--- a/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
+++ b/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
@@ -4,10 +4,10 @@
 :icons: font
 :source-highlighter: rouge
 :sectnums:
-:last-updated: 2026-06-24
+:last-updated: 2026-07-02
 
 Status: Apex reference index (active baseline) +
-Date: 2026-06-24 (filename `SYSTEM_MAP_2026_05_30` is the original; content tracks current HEAD) +
+Date: 2026-07-02 (filename `SYSTEM_MAP_2026_05_30` is the original; content tracks current HEAD) +
 Cost spine: the multi-engine routing + cache policy shown here is co-optimized against the *measured
 per-query I/O trace* across the five physical dimensions — see
 `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (the unified cost objective the `ComputeScheduler`
@@ -22,8 +22,8 @@ feeders (see <<feeders>>).
 
 [.lead]
 This is the **single pane of glass** for ProximaDB. It exists to answer one question fast — "where does
-a thing live, and what does it converge on?" Current manifest reality: 79 workspace members
-under `crates/` + `apps/`, and ~52 real top-level `src/` module directories. It is navigation-first: it does not
+a thing live, and what does it converge on?" Current checkout reality: 91 workspace members
+under `crates/` + `apps/`, and 42 real top-level `src/` module directories. It is navigation-first: it does not
 duplicate the per-module detail in the feeder docs, it indexes and ties them together so they stop
 diverging.
 
@@ -35,6 +35,13 @@ Each is correct but none is canonical, so they drift. This doc is declared the a
 subordinate feeders. New whole-system diagrams belong here or in a feeder linked from here — **not in a
 fourth competing map**. That rule is itself a convergence gate (see
 link:CONVERGENCE_AUDIT_2026_05_30.adoc[CONVERGENCE_AUDIT_2026_05_30]).
+
+Production composition is still mostly rooted in the legacy crate (`src/database.rs`,
+`src/network/shared_services.rs`, `src/network/multi_server.rs`). `proximadb-runtime` is the target
+composition boundary and partial shell, not yet the sole owner. Workspace decomposition therefore
+remains a first-principles build-scaling requirement: split ownership only where it reduces compile
+fan-out, enables independent worktrees, and lets CI coverage shards (`cargo llvm-cov`, Tarpaulin, and
+focused `cargo test -p ...`) compile smaller units without timeout or OOM pressure.
 ====
 
 == How to use this map
@@ -73,7 +80,7 @@ flowchart TB
   subgraph EDGE[Protocol Facades]
     NET["network/<br/>REST v1/v2/v3, gRPC, pgwire, Arrow IPC/Flight"]:::edge
     API["api_handlers/ + proximadb-api<br/>request lowering, tenant extraction, response shaping"]:::edge
-    RT["proximadb-runtime<br/>ports and composition boundary"]:::edge
+    RT["root server wiring + target proximadb-runtime<br/>ports and composition boundary"]:::edge
   end
 
   subgraph PLANE[Logical Plane]
@@ -130,7 +137,9 @@ flowchart TB
 Load-bearing invariants:
 
 * Protocols and modalities are facades. Durable truth converges on `ProximaRecord`, xCatalog,
-canonical WAL/log/manifest state, and tenant-isolated paths.
+canonical WAL/log/manifest state, and tenant-isolated paths. ADR-048 makes the catalog direction
+explicit: typed `CatalogTableSchema`/`CatalogColumn` metadata becomes the native authority, while
+v1 `Collection`/`CollectionConfig` are compatibility read views rather than a second truth.
 * Routing happens in the logical plane. Native Volcano, DataFusionLocal, specialized vector engines,
 and modality runtimes are physical execution choices behind one contract. Standard and metered native
 physical plans execute through the query-layer `NativeVolcanoEngine` adapter; pgwire owns wire

--- a/docs/12-design/UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc
+++ b/docs/12-design/UNIFIED_RESOURCE_LEASE_LOCKING_REVIEW_2026_06_24.adoc
@@ -16,12 +16,24 @@ intentionally correction-first: the unified `ResourceKey` direction is retained,
 but the lock semantics and object-store path contracts must be tightened before
 the feature is exposed through `DmlService` or protocol handlers.
 
+2026-07-02 refresh: DML lock wiring and the A6 storage-write fence seam have
+partially landed in the current checkout. `DmlService` can carry an optional
+`DmlLockService`; `SharedServices` can build the lease manager, reconciliation
+loops, and a `StorageWriteFence` adapter when the metadata lease store opens; and
+flush/materialization paths consult the fence before publishing storage writes
+when `PROXIMADB_WRITE_FENCING=1`. This does **not** graduate the feature to
+supported distributed/serverless locking. The remaining correctness gate is to
+make the policy support-grade: prove the full DML→lease→flush fence path
+end-to-end, decide when the fence becomes default-on/mandatory, and remove
+fail-open deployment semantics for configurations that claim distributed write
+safety.
+
 [IMPORTANT]
 ====
-Do not wire DML locks into REST, gRPC, pgwire, or Arrow Flight until the
-foundation gates in <<approved-foundation-gates>> are complete. A protocol-level
-lock that is not tenant-correct, path-compatible, hierarchically enforced, and
-fenced at the storage writer is only advisory and can create split-brain writes.
+DML locks may be wired only as an internal guarded path until the foundation
+gates in <<approved-foundation-gates>> are complete. A protocol-level lock that
+is not tenant-correct, path-compatible, hierarchically enforced, and fenced at the
+storage writer is only advisory and can create split-brain writes.
 ====
 
 == First-principles position
@@ -198,19 +210,23 @@ true multi-reader durable state is implemented.
 | A6
 | P0
 | DML lock acquisition returns a guard that owns renewal/release and carries the
-fencing generation to the writer.
-| Protocol exposure.
+fencing generation to the writer; the storage boundary rejects displaced pods
+before publishing shared-storage writes. Current code has the default-off
+`StorageWriteFence` backstop (`PROXIMADB_WRITE_FENCING=1`); support requires
+end-to-end evidence and strict fail-closed deployment semantics.
+| Supported protocol exposure and multi-pod correctness claims.
 
 | A7
 | P1
 | `DmlService::execute_scoped` acquires locks after catalog resolution, using
 real tenant/schema/table identity.
-| REST/gRPC/pgwire/Flight wiring.
+| Partially landed. Still blocks support claims until A6 storage enforcement and
+strict non-fail-open configuration are complete.
 
 | A8
 | P1
 | Protocol handlers map lock outcomes consistently.
-| User-visible protocol behavior.
+| User-visible protocol behavior and retry/backoff policy.
 
 | A9
 | P1

--- a/docs/_internal/status/MVP_RELEASE_READINESS_RECONCILIATION_2026_05_28.adoc
+++ b/docs/_internal/status/MVP_RELEASE_READINESS_RECONCILIATION_2026_05_28.adoc
@@ -2,7 +2,7 @@
 :toc: left
 :toclevels: 3
 :icons: font
-:last-updated: 2026-05-28
+:last-updated: 2026-07-02
 
 [.lead]
 Current-state reconciliation of the release-facing design docs against the codebase. This is a
@@ -22,6 +22,26 @@ MVP is shippable only as a **narrow single-node release**:
 
 Do not cut the release with docs or dashboards claiming broader production readiness than
 `docs/SUPPORTED_SURFACE.adoc`.
+
+== Status Refresh -- 2026-07-02
+
+Several release-gate gaps identified in the original audit have moved from
+"missing structure" to "must run and verify on the candidate":
+
+* `make release-check` now exists and composes the release smoke path, proto
+  check, and server build. Treat it as the candidate release gate rather than a
+  future TODO.
+* The release smoke path now includes a non-ignored v2 smoke plus route health,
+  query optimizer, object-economy directory, graph branch merge, and gRPC hybrid
+  checks.
+* CI now has an explicit pgwire accuracy job in the success set, and the QA gate
+  runs vector recall ratchets. This closes part of the "tests exist but do not
+  gate" problem, while deeper document/time-series/graph value assertions remain
+  post-MVP hardening work.
+* MVP scope remains intentionally narrow: single-node canonical CRUD/search can
+  be considered for support; distributed execution, serverless elasticity,
+  cluster-wide locking, broad SQL parity, and multimodal production claims remain
+  Beta or Experimental unless `SUPPORTED_SURFACE` says otherwise.
 
 == Architecture Grounding
 
@@ -111,6 +131,14 @@ Release rule:
   planner paths still return explicit unsupported/not-yet-wired errors.
 | Keep pgwire Beta. Do not make SQL parity a release blocker unless release scope says SQL MVP.
 
+| `docs/12-design/adr/ADR-048-unified-system-catalog-native-authority.adoc`
+| Catalog-native typed schema authority.
+| Newly proposed direction: `CatalogTableSchema`/typed columns should become the source of truth and
+  v1 collection configs should become compatibility read views. Current code still has transitional
+  collection-mapping and properties-bag paths.
+| Correct architectural direction, not an MVP expansion. Keep schema/catalog-native claims Beta until
+  ADR-048 P1/P2 phases land and mixed-read-safe tests cover the transition.
+
 | `docs/12-design/SUPPORTED_SURFACES.adoc`
 | Technical API/projection matrix.
 | More optimistic than some live code; useful for architecture direction, not a customer support
@@ -165,9 +193,11 @@ Release rule:
 | Beta only. MVP release notes must name supported SQL subset.
 
 | Test gaps
-| Live-server parity and several benchmark/recall tests are ignored/manual; v2 insert/search index
-  E2E still has an ignored pre-existing gap.
-| Need a release smoke suite that runs without a pre-existing server plus one manual/live suite.
+| `make release-check` and pgwire/vector accuracy gates now cover part of the original gap. Some
+  live-server parity, benchmark, and deeper modality value-accuracy checks remain outside the MVP
+  hard gate.
+| Run `make release-check` on the release candidate and keep unfrozen/broad modalities Beta or
+  Experimental.
 |===
 
 == MVP Blockers
@@ -183,13 +213,13 @@ Release rule:
 
 | P0
 | Release gate is not explicit.
-| Add a single `make release-check` or documented command list covering `cargo fmt`, focused unit
-  suites, proto compatibility, REST/gRPC v2 record smoke, route-health smoke, and packaging build.
+| **Structurally closed.** Run `make release-check` for the release candidate and treat any failure
+  as a release blocker.
 
 | P0
 | v2 record insert/search contract has an ignored E2E noting insert does not feed v2 search index.
-| Either unignore/fix the E2E or document the exact path that is supported for insert-then-search.
-  This is a customer-facing vector MVP risk.
+| Release smoke now covers the v2 path, but the release owner must verify insert-then-search on the
+  candidate and document the exact supported freshness/indexing semantics.
 
 | P1
 | Route-health exposes unsupported write modes but APIs/protos contain optimistic version fields.
@@ -224,6 +254,7 @@ Release rule:
 1. Freeze product scope to `docs/SUPPORTED_SURFACE.adoc`.
 2. Fix or quarantine stale docs listed above.
 3. Run:
+   * `make release-check`
    * `cargo fmt`
    * `cargo test --lib route_health`
    * `cargo test --lib query_optimizer`
@@ -237,4 +268,3 @@ Release rule:
 4. Add one non-ignored REST/gRPC v2 record smoke that creates a collection, inserts records, searches,
    reads route-health, and deletes/tombstones a record.
 5. Publish release notes with the supported/beta/experimental split and known limitations.
-

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -10,3 +10,4 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 python3 scripts/check_workspace_boundaries.py --strict
+python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290

--- a/scripts/check_workspace_boundaries.py
+++ b/scripts/check_workspace_boundaries.py
@@ -8,6 +8,7 @@ run before or during expensive Rust builds without taking a cargo build lock.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import sys
 import tomllib
 from dataclasses import dataclass
@@ -116,6 +117,17 @@ class SourceModuleTarget:
     layer: str
     target: str
     rationale: str
+
+
+@dataclass(frozen=True)
+class StorageUpEdge:
+    path: Path
+    line: int
+    target: str
+    text: str
+
+
+STORAGE_UP_EDGE_TARGETS = ("compute", "index", "query", "services")
 
 
 LAYER_RULES = (
@@ -746,6 +758,77 @@ def print_source_module_map() -> int:
     return 0
 
 
+def storage_up_edges() -> list[StorageUpEdge]:
+    storage_dir = ROOT / "src" / "storage"
+    findings: list[StorageUpEdge] = []
+
+    if not storage_dir.exists():
+        return findings
+
+    for path in sorted(storage_dir.rglob("*.rs")):
+        relative_path = path.relative_to(ROOT)
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("//"):
+                    continue
+                for target in STORAGE_UP_EDGE_TARGETS:
+                    if f"crate::{target}" in line:
+                        findings.append(
+                            StorageUpEdge(
+                                path=relative_path,
+                                line=line_number,
+                                target=target,
+                                text=stripped,
+                            )
+                        )
+    return findings
+
+
+def print_storage_up_edge_report(
+    max_allowed: int | None,
+    include_details: bool,
+) -> int:
+    findings = storage_up_edges()
+    by_target = Counter(finding.target for finding in findings)
+    by_file = Counter(finding.path for finding in findings)
+
+    print("Storage up-edge ratchet")
+    print(f"targets: {', '.join(f'crate::{target}' for target in STORAGE_UP_EDGE_TARGETS)}")
+    print(f"total edges: {len(findings)}")
+
+    if by_target:
+        print()
+        print("By target:")
+        for target, count in sorted(by_target.items()):
+            print(f"crate::{target}: {count}")
+
+    if by_file:
+        print()
+        print("Top files:")
+        for path, count in by_file.most_common(20):
+            print(f"{path.as_posix()}: {count}")
+
+    if include_details and findings:
+        print()
+        print("Details:")
+        for finding in findings:
+            print(
+                f"{finding.path.as_posix()}:{finding.line}: "
+                f"crate::{finding.target}: {finding.text}"
+            )
+
+    if max_allowed is not None and len(findings) > max_allowed:
+        print()
+        print(
+            f"FAIL: storage up-edge count {len(findings)} exceeds "
+            f"--max-storage-up-edges={max_allowed}"
+        )
+        return 1
+
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -768,6 +851,21 @@ def main() -> int:
         action="store_true",
         help="print the root src module migration map and exit",
     )
+    parser.add_argument(
+        "--storage-up-edges",
+        action="store_true",
+        help="print storage-to-root up-edge counts and exit",
+    )
+    parser.add_argument(
+        "--storage-up-edge-details",
+        action="store_true",
+        help="include line-level storage up-edge details",
+    )
+    parser.add_argument(
+        "--max-storage-up-edges",
+        type=int,
+        help="fail if storage up-edge count exceeds this value",
+    )
     args = parser.parse_args()
 
     if args.rules:
@@ -776,6 +874,12 @@ def main() -> int:
 
     if args.src_map:
         return print_source_module_map()
+
+    if args.storage_up_edges:
+        return print_storage_up_edge_report(
+            args.max_storage_up_edges,
+            args.storage_up_edge_details,
+        )
 
     crates = workspace_crates()
     if args.deps:

--- a/src/storage/engines/factory.rs
+++ b/src/storage/engines/factory.rs
@@ -108,8 +108,8 @@ use tracing::{info, warn};
 
 use crate::metrics::collectors::EngineMetricsCollector;
 use crate::proto::proximadb_v1::StorageEngine as ProtoStorageEngine;
-use crate::query::capability::CapabilityRegistry;
 use crate::storage::traits::{StorageEngineStrategy, UnifiedStorageFormat};
+use proximadb_query_capability::CapabilityRegistry;
 
 use super::{nova::NovaEngine, sst::SstEngine, viper::ViperEngine};
 #[cfg(feature = "experimental-engines")]

--- a/src/storage/traits/mod.rs
+++ b/src/storage/traits/mod.rs
@@ -863,9 +863,9 @@ pub trait UnifiedStorageFormat: Send + Sync {
     ///
     /// Default implementation provides capability sets based on engine strategy.
     /// Engines can override this method to customize their declared capabilities.
-    fn capabilities(&self) -> crate::query::capability::CapabilitySet {
-        use crate::query::capability::{Capability, CapabilitySet};
+    fn capabilities(&self) -> proximadb_query_capability::CapabilitySet {
         use crate::storage::traits::StorageEngineStrategy;
+        use proximadb_query_capability::{Capability, CapabilitySet};
 
         match self.strategy() {
             StorageEngineStrategy::Sst => CapabilitySet::from_capabilities(&[


### PR DESCRIPTION
## Summary
- refresh system map, MVP readiness, query accuracy, and lease-locking docs against current code
- add a storage up-edge ratchet to `check_workspace_boundaries.py`
- wire the ratchet into `scripts/check-layering.sh` and CI failure guidance
- redirect storage capability references to `proximadb-query-capability`
- lower storage up-edge ceiling from 293 to 290

## Validation
- `rustup run 1.95.0 cargo fmt --all`
- `scripts/check-layering.sh`
- `git diff --check HEAD`
- `cargo check --lib`

## Notes
Remaining storage up-edges after this slice: compute 239, index 31, query 10, services 10.