### PR TITLE
chore: lower storage index edge ratchet

### DIFF
--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -83,7 +83,7 @@ jobs:
         echo "## Layering Violations Detected" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Run \`python3 scripts/check_workspace_boundaries.py --strict\` locally and review the workspace refactor plan plus ADR-001." >> $GITHUB_STEP_SUMMARY
-        echo "For storage decomposition regressions, run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290\` and lower the max when your branch removes edges." >> $GITHUB_STEP_SUMMARY
+        echo "For storage decomposition regressions, run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 275\` and lower the max when your branch removes edges." >> $GITHUB_STEP_SUMMARY
 
     - name: Post results to PR (on failure)
       if: failure() && github.event_name == 'pull_request'
@@ -101,7 +101,7 @@ jobs:
             **What to check:**
             - Run \`./scripts/check-layering.sh\` locally
             - Run \`python3 scripts/check_workspace_boundaries.py --strict\` directly for the canonical checker
-            - Run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290\` for the Slice-D storage decomposition ratchet
+            - Run \`python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 275\` for the Slice-D storage decomposition ratchet
             - Review [Workspace Refactor Plan](https://github.com/${context.repo.owner}/${context.repo.name}/blob/main/roadmap/techdebt/WORKSPACE_REFACTOR_PLAN_2026_05_07.adoc)
             **Golden Rule:** Lower layers must not depend on higher layers.
 

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc
@@ -212,8 +212,8 @@ upward edges into root subsystems (`compute`, `persistence`, `engines`, `core`, 
 cache and the large engine slices.
 
 Current measured Slice-D baseline from
-`python3 scripts/check_workspace_boundaries.py --storage-up-edges`: 290 remaining storage
-up-edges (`compute` 239, `index` 31, `query` 10, `services` 10). This is now the enforced
+`python3 scripts/check_workspace_boundaries.py --storage-up-edges`: 275 remaining storage
+up-edges (`compute` 239, `index` 16, `query` 10, `services` 10). This is now the enforced
 non-regression ceiling in `scripts/check-layering.sh`. That is the parallelization ground truth:
 do not move an engine crate while these edges still point at root modules; first split independent
 worktrees by edge class:

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc
@@ -143,11 +143,17 @@ then depends *down* on the trait crate, never *up* on the implementor.
 == D2 detailed spec — the measured port surface (2026-06-26)
 
 2026-07-02 measurement update: the source-level ratchet now lives in
-`scripts/check_workspace_boundaries.py --storage-up-edges`. Current checkout count is 290
-remaining `src/storage` up-edges (`compute` 239, `index` 31, `query` 10, `services` 10), and
-`scripts/check-layering.sh` enforces `--max-storage-up-edges 290` in CI. Use this count as the
+`scripts/check_workspace_boundaries.py --storage-up-edges`. Current checkout count is 275
+remaining `src/storage` up-edges (`compute` 239, `index` 16, `query` 10, `services` 10), and
+`scripts/check-layering.sh` enforces `--max-storage-up-edges 275` in CI. Use this count as the
 worktree baseline for Slice D. Each decomposition branch should reduce one edge class and lower the
 checked ceiling before handing off to the next branch.
+
+The 290 → 275 reduction was a pure re-export-path redirect: storage files that only needed
+`StorageEngineType` now import the canonical `crate::core::types::StorageEngineType` instead of
+walking through `crate::index::axis::eventlog::StorageEngineType`. This removes 15 index edges
+without touching the real event-log service or index-port surfaces, which remain separate D3/D4
+work.
 
 The mechanical phase (D0/D1) is **complete** (PRs #370, #377, #379, #386). The remaining
 D0 tail items are **not** clean Mechanism-A redirects and fold into Mechanism B:
@@ -232,7 +238,7 @@ first so the hot edits are mechanical.
 | D2 | **Define `proximadb-storage-ports`** — the `IndexPort` + `CollectionMetadataPort` traits. **DONE (CollectionMetadataPort):** crate created (`crates/storage/proximadb-storage-ports`, storage tier — same-tier deps allowed) with `async fn collection(&str) -> Result<Option<Collection>>` (the *measured* surface is one method; `get_collection_stats` turned out to be on `AxisManager`, not the service); `impl CollectionMetadataPort for CollectionService`. **Remaining:** `IndexPort` (leaks `AxisHybridQuery`/`AxisManagerQueryResult`/`AxisConfig`/`AxisVectorIndex` — per-type facade-vs-pre-extract decision; re-exporting root types into the port crate is a *cycle*, impossible). | Low–Med
 | D3 | **Refactor storage to consume injected ports.** `engine.rs`/compaction stop constructing `AxisManager` / calling `CollectionService` directly; take `Arc<dyn IndexPort>` / `Arc<dyn CollectionMetadataPort>` via constructor injection. Same concrete behavior, now behind the trait. **This is the hot, coordination-window phase.** **DONE (metadata side):** storage fields/params/setters in viper engine+flush, flush-coordinator, and background-flush-context retyped from `Arc<CollectionService>` to `Arc<dyn CollectionMetadataPort>` (these injection setters currently have no callers — latent infra — so this is a pure structural edge removal). **DONE (tenant resolver):** `collection_tenant_id` relocated *down* to a new foundation crate **`proximadb-tenant`** (`tenant_id_of(&Collection)`) — not "down to catalog" as first sketched, because tenant resolution is a *cross-cutting economics/isolation primitive* (storage, embedded, services, and the network gates all share it; coupling it to any one tier is wrong). Foundation tier = every layer depends *down* on the single fail-closed attribution seam, and resolution is a pure function of collection metadata so any node in an autoscaled fleet attributes identically without coordination (elasticity) and per-tenant meters reconcile (economics). `CollectionService::collection_tenant_id` is now a thin alias; storage/embedded call `proximadb_tenant::tenant_id_of` directly. **DONE (catalog↔Collection mapping):** the `collection_from_catalog_schema`/`catalog_schema_from_collection` pair + 6 private helpers (8 fns, ~546 LOC) moved verbatim out of `CollectionService` into a new storage module `crate::storage::metadata::collection_mapping` — *not* down to `proximadb-catalog` as first sketched, because the mapping reaches *up* into storage's own `catalog_config` json round-trip (control-tier can't depend on storage → cycle). Storage is its natural home (WAL-recovery driven, round-trips through storage-owned config); services now calls *down* into it. **This clears the last storage→`crate::services::collection` reference** (`generate_unique_collection_id`, an interleaved `&self` async method, correctly stayed behind). **Remaining:** the whole `IndexPort` wiring (the larger port). | Med-High
 | D4 | **Implement ports + wire injection.** `impl IndexPort for AxisManager`, `impl CollectionMetadataPort for CollectionService`; the composition root injects them. | Med
-| D5 | **Gate to zero.** `scripts/check_workspace_boundaries.py --storage-up-edges` reports the ratchet; `scripts/check-layering.sh` now enforces the current ceiling (`--max-storage-up-edges 290`) and should be lowered whenever a branch removes edges. Terminal target remains `crate::{index,compute,services,query}` references under `src/storage` == 0 (core type refs already redirected in D0/D1). Engines (Slice E) are unblocked only after the terminal gate, not merely after the report exists. | Low
+| D5 | **Gate to zero.** `scripts/check_workspace_boundaries.py --storage-up-edges` reports the ratchet; `scripts/check-layering.sh` now enforces the current ceiling (`--max-storage-up-edges 275`) and should be lowered whenever a branch removes edges. Terminal target remains `crate::{index,compute,services,query}` references under `src/storage` == 0 (core type refs already redirected in D0/D1). Engines (Slice E) are unblocked only after the terminal gate, not merely after the report exists. | Low
 |===
 
 D0 and D1 are opportunistic (mechanical, independent, no coordination needed) and should be

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -10,4 +10,4 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 python3 scripts/check_workspace_boundaries.py --strict
-python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 290
+python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 275

--- a/src/storage/engines/helix/eventlog_integration.rs
+++ b/src/storage/engines/helix/eventlog_integration.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::services::events::log::{
     EventLogService, event_log_service, register_collection_in_cache,

--- a/src/storage/engines/helix/extraction.rs
+++ b/src/storage/engines/helix/extraction.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 use crate::storage::persistence::filesystem::FileSystem;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;

--- a/src/storage/engines/nova/extraction.rs
+++ b/src/storage/engines/nova/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::engines::core::formats::columnar::columnar_query_engine::columnar_query_reader::UnifiedParquetReader;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;

--- a/src/storage/engines/raptor/extraction.rs
+++ b/src/storage/engines/raptor/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::cache::orchestrator::CrossCacheOrchestrator;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;

--- a/src/storage/engines/sst/extraction.rs
+++ b/src/storage/engines/sst/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::trait_components::extractor::{

--- a/src/storage/engines/sst/flush_eventlog_integration.rs
+++ b/src/storage/engines/sst/flush_eventlog_integration.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::services::events::log::{EventLogService, event_log_service};
 use crate::storage::engines::FlushParameters;

--- a/src/storage/engines/swift/engine.rs
+++ b/src/storage/engines/swift/engine.rs
@@ -1261,7 +1261,7 @@ impl UnifiedStorageFormat for SwiftEngine {
                     params.vector_records.len(),
                     has_quantized,
                     true, // SWIFT always stores FP32
-                    crate::index::axis::eventlog::StorageEngineType::SWIFT,
+                    crate::core::types::StorageEngineType::SWIFT,
                 )
                 .await
             {
@@ -1383,7 +1383,7 @@ impl UnifiedStorageFormat for SwiftEngine {
                 &collection_id,
                 vec![output_path],
                 merged_file.header.total_records as usize,
-                crate::index::axis::eventlog::StorageEngineType::SWIFT,
+                crate::core::types::StorageEngineType::SWIFT,
             );
         }
 

--- a/src/storage/engines/swift/extraction.rs
+++ b/src/storage/engines/swift/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::trait_components::extractor::{

--- a/src/storage/engines/tst/extraction.rs
+++ b/src/storage/engines/tst/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, warn};
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::trait_components::extractor::{
     ExtractedVector, ExtractionCapabilities, ExtractionCost, ExtractionError, ExtractionMode,

--- a/src/storage/engines/tst/mod.rs
+++ b/src/storage/engines/tst/mod.rs
@@ -117,7 +117,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::core::search::results::OptimizedSearchRecord;
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::proto::proximadb_v1::{Collection, VectorRecord};
 use crate::storage::StorageFormatStrategy;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};

--- a/src/storage/engines/viper/eventlog_flush.rs
+++ b/src/storage/engines/viper/eventlog_flush.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::services::events::log::{EventLogService, event_log_service};
 use crate::storage::engines::FlushParameters;

--- a/src/storage/engines/viper/extraction.rs
+++ b/src/storage/engines/viper/extraction.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::engines::core::formats::columnar::columnar_query_engine::columnar_query_reader::UnifiedParquetReader;
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;

--- a/src/storage/trait_components/extractor.rs
+++ b/src/storage/trait_components/extractor.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use thiserror::Error;
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 
 /// Unified interface for extracting vectors from storage files.

--- a/src/storage/trait_components/identity.rs
+++ b/src/storage/trait_components/identity.rs
@@ -4,7 +4,7 @@
 //! This trait satisfies the Single Responsibility Principle by focusing solely
 //! on engine identification and capability reporting.
 
-use crate::index::axis::eventlog::StorageEngineType;
+use crate::core::types::StorageEngineType;
 use crate::storage::traits::StorageFormatStrategy;
 
 /// Core identity trait for storage engines


### PR DESCRIPTION
## Summary
- redirect storage-only `StorageEngineType` references from the AXIS eventlog re-export to canonical `crate::core::types::StorageEngineType`
- lower the Slice-D storage up-edge ratchet from 290 to 275
- refresh decomposition docs and layering failure hints with the new baseline

## Measured impact
- total storage up-edges: 290 -> 275
- `crate::index` edges: 31 -> 16
- `crate::compute`: unchanged at 239
- `crate::query`: unchanged at 10
- `crate::services`: unchanged at 10

## Verification
- `cargo fmt --all`
- `git diff --check`
- `scripts/check-layering.sh`
- `cargo check --lib`
- exact-ceiling check: `--max-storage-up-edges 274` fails at 275, confirming the 275 ratchet is tight