### PR TITLE
feat(sst): exact PAX scan in search dispatch (ADR-049 M1-1 prerequisite)

### DIFF
--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -153,10 +153,14 @@ impl SstEngine {
         // P3 Phase B / Phase C: PAX vector segments. Reads stay mixed-format-
         // safe — see
         // `segment_format::mixed_format_legacy_and_pax_segments_coexist_and_read_back`
-        // — so enabling PAX only changes newly written segments; existing
-        // ProximaBlocks segments still read back. STAGED ROLLOUT: default OFF in
-        // v0.2; the develop→qa recall ratchet (qa-gate `pax-recall-ratchet`,
-        // recall@10 >= 0.90 at N=100k) gates the v0.3 flip to default ON.
+        // — and the search path's exact PAX scan (`search_pax_file_exact`) now
+        // makes a `.pax` file searchable under every metric/quant, so enabling PAX
+        // only changes newly written segments; existing ProximaBlocks segments
+        // still read back AND every new `.pax` segment is queryable. STAGED
+        // ROLLOUT: default OFF in v0.2; the develop→qa recall ratchet (qa-gate
+        // `pax-recall-ratchet`, recall@10 >= 0.90 at N=100k) gates the v0.3 flip
+        // to default ON. The exact PAX scan is the prerequisite that makes that
+        // flip safe — M1-1b flips the default once the integration tier is migrated.
         //
         // Resolution (Phase C escape hatches — see `resolve_pax_segments_enabled`):
         //   1. Global kill-switch `PROXIMADB_PAX_VECTOR_SEGMENTS_DISABLE` forces

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -993,6 +993,21 @@ impl SstEngine {
                     distance_metric,
                 )
                 .await
+            } else if sstable_path.ends_with(".pax") {
+                // A `.pax` segment the RaBitQ cascade did not cover (non-L2/Cosine
+                // metric, non-RaBitQ quant, or a cascade miss/error). Exact
+                // materialize-and-rank via the mixed-format reader so `.pax` is
+                // searchable under every metric/quant — this is what makes the PAX
+                // write-default flip safe (otherwise the ProximaBlocks-only
+                // `sstable_reader` below would fail to decode a `.pax` file).
+                self.search_pax_file_exact(
+                    sstable_path,
+                    query_vector,
+                    filter_expression.cloned(),
+                    k,
+                    distance_metric,
+                )
+                .await
             } else {
                 // Use SSTable reader for ProximaBlocks format
                 // Choose execution strategy based on flags (TD-041, TD-039, TD-031)
@@ -1554,6 +1569,98 @@ impl SstEngine {
         candidates.truncate(limit);
 
         debug!("🏹 Arrow search found {} candidates", candidates.len());
+        Ok(candidates)
+    }
+
+    /// Exact materialize-and-rank search over a `.pax` segment that the RaBitQ
+    /// cascade did not cover — a non-L2/Cosine metric (Dot / inner-product /
+    /// exotic), a non-RaBitQ quant (RawF32 / SQ8), or a cascade miss/error. The
+    /// segment is decoded back to `ProximaRecord`s via the mixed-format reader
+    /// (`segment_format::read_segment_records`, magic-detected) and ranked by
+    /// exact distance for the requested metric, so a `.pax` file is searchable
+    /// under EVERY metric and quant. This is the property that makes the PAX
+    /// write-default flip safe: the L2/Cosine fast path still takes the RaBitQ
+    /// cascade; everything else falls here instead of hitting the
+    /// ProximaBlocks-only `sstable_reader` (which cannot decode `.pax`). Recall
+    /// is exact for `RawF32` quant and dequantization-bound for `RaBitQ`/`SQ8`.
+    async fn search_pax_file_exact(
+        &self,
+        pax_path: &str,
+        query_vector: &[f32],
+        filter_expression: Option<FilterExpression>,
+        limit: usize,
+        distance_metric: DistanceMetric,
+    ) -> Result<Vec<OptimizedSearchRecord>> {
+        use proximadb_distance_kernel::engine::{SimilarityResult, UnifiedDistanceCompute};
+        use std::sync::Arc;
+
+        debug!("📦 Exact PAX scan: {}", pax_path);
+
+        let local_path = pax_path.strip_prefix("file://").unwrap_or(pax_path);
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("read pax segment {pax_path}: {e}"))?;
+        let records = crate::storage::engines::sst::segment_format::read_segment_records(
+            &bytes,
+            &[],
+            &[],
+            None,
+        )
+        .map_err(|e| anyhow::anyhow!("decode pax segment {pax_path}: {e}"))?;
+        trace!(
+            "📦 PAX segment {} decoded to {} records",
+            pax_path,
+            records.len()
+        );
+
+        let distance_computer = UnifiedDistanceCompute::new(distance_metric);
+        let mut candidates: Vec<OptimizedSearchRecord> =
+            Vec::with_capacity(records.len().min(limit));
+
+        for record in &records {
+            // Apply the metadata filter at record level (canonical props), mirroring
+            // the ProximaBlocks scan path — PAX is the default format, so filter
+            // support here is required, not optional (the Arrow path skips it).
+            if let Some(filter_expr) = &filter_expression
+                && !crate::core::search::sql_value_filter::evaluate_filter_proxima(
+                    filter_expr,
+                    &record.props,
+                )
+            {
+                continue;
+            }
+
+            let Some(embedding) = record.embeddings.first() else {
+                continue;
+            };
+            if embedding.values.is_empty() {
+                continue;
+            }
+
+            let raw_distance = distance_computer.distance(query_vector, &embedding.as_fp32_cow());
+            let similarity_result = SimilarityResult::new(raw_distance, distance_metric);
+            let metadata = proximadb_records::conversions::proxima_tree_to_value_map(&record.props);
+
+            candidates.push(OptimizedSearchRecord {
+                id: record.oid.clone(),
+                vector_id: Some(record.oid.clone()),
+                score: similarity_result.normalized_score,
+                similarity: Some(similarity_result.normalized_score),
+                vector: Some(Arc::new(embedding.values.to_fp32_owned())),
+                metadata,
+                ..Default::default()
+            });
+        }
+
+        // Sort by score descending (higher normalized_score = more similar = better).
+        candidates.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        candidates.truncate(limit);
+
+        debug!("📦 Exact PAX scan found {} candidates", candidates.len());
         Ok(candidates)
     }
 }

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -523,6 +523,65 @@ mod tests {
         assert_eq!(back.len(), records.len());
     }
 
+    /// M1 (ADR-049): a `VectorQuant::RawF32` PAX segment carries no RaBitQ codes,
+    /// so the RaBitQ cascade (`rabitq_search_segment`) returns `None` for it. The
+    /// search dispatch then takes the exact PAX scan (`search_pax_file_exact`),
+    /// which materialises records via `read_segment_records`. This proves the two
+    /// foundations of that path: a RawF32 PAX segment round-trips to EXACT f32
+    /// vectors (recall 1.0), and the cascade correctly reports it as a miss.
+    #[test]
+    fn rawf32_pax_segment_round_trips_exact_and_misses_rabitq_cascade() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rawf32.pax");
+        let records: Vec<ProximaRecord> = (0..8)
+            .map(|i| {
+                rec(
+                    &format!("v{i}"),
+                    1_700_000_000_000_000_000 + i,
+                    (0..16).map(|d| (i as f32 + d as f32) * 0.1).collect(),
+                )
+            })
+            .collect();
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RawF32, None).unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(SegmentFormat::detect(&bytes), SegmentFormat::Pax);
+
+        // Round-trip: RawF32 decodes to the EXACT input vectors (not an
+        // approximation, unlike RaBitQ/SQ8 reconstruction).
+        let back = read_segment_records(&bytes, &[], &[], None).unwrap();
+        assert_eq!(back.len(), records.len());
+        for (got, want) in back.iter().zip(records.iter()) {
+            assert_eq!(got.oid, want.oid, "oid must round-trip");
+            let got_vec = got
+                .embeddings
+                .first()
+                .expect("RawF32 segment must reconstruct its embedding");
+            let want_vec = want.embeddings.first().expect("input embedding");
+            assert_eq!(
+                got_vec.as_fp32_slice(),
+                want_vec.as_fp32_slice(),
+                "RawF32 PAX must reconstruct the exact vector for {}",
+                want.oid
+            );
+        }
+
+        // The RaBitQ cascade must report a miss (no RaBitQ codes) — the exact
+        // PAX scan in the search dispatch handles this segment instead.
+        let query = records[0]
+            .embeddings
+            .first()
+            .expect("query embedding")
+            .as_fp32_slice()
+            .to_vec();
+        assert!(
+            rabitq_search_segment(&bytes, &query, 4, 8, RankMetric::L2, None)
+                .unwrap()
+                .is_none(),
+            "RawF32 PAX has no RaBitQ codes → cascade must return None (exact scan handles it)"
+        );
+    }
+
     /// Mixed-read-safe coexistence (storage-format mandate #8). A store rolling
     /// PAX quantization on will have BOTH legacy `ProximaBlocks` segments (written
     /// before the flip) and new PAX segments side by side. The magic-byte router


### PR DESCRIPTION
## Context

ADR-049 M1 (the v1→v2 storage keystone) flips the SST write default from legacy v1 streaming (`.sst`) to native PAX (`.pax`). Investigation found a **prerequisite gap** that must close *before* that flip is safe:

The search dispatch only routes `.pax` through the RaBitQ cascade for **L2/Cosine**. For any other case — a Dot/exotic metric, a non-RaBitQ quant (RawF32/SQ8), or a cascade miss/error — the dispatch fell through to the ProximaBlocks `sstable_reader`, whose `ProximaDataBlock::deserialize` **cannot decode a `.pax` file**. The dispatch comment claimed the generic path handled `.pax`; it did not. So a default-PAX flip would silently break those collections.

## Change (purely additive — no behavior change)

Add `SstEngine::search_pax_file_exact`: a `.pax` segment that misses the cascade is materialized via the mixed-format reader (`segment_format::read_segment_records`, magic-detected) and ranked by exact distance for the requested metric — mirroring `search_arrow_file`, but **with metadata-filter support** (PAX becomes the default, so filtering here is required). Wired as a dedicated `.pax` branch in the per-file search dispatch (cascade → arrow → **pax** → sst).

Now `.pax` is searchable under **every** metric and quant: L2/Cosine keep the RaBitQ cascade fast path; everything else falls to the exact scan. Recall is exact for `RawF32` quant; dequantization-bound for `RaBitQ`/`SQ8`.

PAX remains **opt-in / default-OFF** — this PR only adds the read-side safety net. The default flip + integration-tier migration is **M1-1b** (deferred: `sst_vector_bounds_prune_recall_test`, `adaptive_pca_high_dim_test`, `clustering_pruning_integration_test` depend on ProximaBlocks-specific scan features that need migration first).

## Verification
- `cargo fmt --all --check` ✓
- `cargo clippy --lib --bins -- -D warnings` ✓ (CI gate)
- `cargo check --tests` ✓
- `make v1-proto-usage-no-regression` ✓ (delta +0 — no new v1 refs)
- `make workspace-boundaries-check` ✓ (no new storage up-edges)
- New unit test: a RawF32 PAX segment round-trips to **exact** f32 vectors, and the RaBitQ cascade correctly reports it as a miss (the case the exact scan now handles).