### PR TITLE
feat(pax): configurable tier-2 rerank quant (SQ8/FP16/F32) — ADR-026 / TD-156 Phase 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,6 +6766,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "crc32fast",
+ "half",
  "proptest",
  "proximadb-codec",
  "proximadb-data-model",

--- a/crates/storage/proximadb-block-format/Cargo.toml
+++ b/crates/storage/proximadb-block-format/Cargo.toml
@@ -32,5 +32,8 @@ proximadb-records = { workspace = true }
 # Canonical filter tree for block-level predicate pruning (pushdown)
 proximadb-filter-expression = { workspace = true }
 
+# FP16 support for the configurable tier-2 rerank column
+half = "2.4"
+
 [dev-dependencies]
 proptest = "1"

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -23,7 +23,9 @@ use crate::{
     row_dir::{ROW_ENTRY_SIZE, RowDirectory},
     rowgroup::RowGroupBlock,
     stripe::{COLUMN_META_SIZE, ColumnMeta},
-    vparam::{QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock},
+    vparam::{
+        QUANT_FP16, QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
+    },
     writer::{BLOCK_FOOTER_SIZE, BlockFooter},
 };
 use proximadb_codec::functions::{rabitq, sq8};
@@ -371,7 +373,9 @@ impl<'a> PaxBlockReader<'a> {
     ) -> Option<Vec<(usize, f32)>> {
         let column_id = crate::col_id::RERANK_BASE + emb_idx as i32;
         let entry = self.vparams.get(column_id)?;
-        if entry.quant_kind != QUANT_SQ8 {
+        // Accept SQ8 (default tier-2) or FP16 (near-lossless tier-2). Other
+        // quant kinds → return None (caller falls back to RaBitQ-coarse order).
+        if entry.quant_kind != QUANT_SQ8 && entry.quant_kind != QUANT_FP16 {
             return None;
         }
         let raw = self.read_stripe_raw(column_id)?;
@@ -384,7 +388,12 @@ impl<'a> PaxBlockReader<'a> {
         let bitmap = &raw[..bm_len];
         let payload = &raw[bm_len..];
         let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
-        let stride = dim; // one u8 SQ8 code per dimension
+        // FP16: 2 bytes/value; SQ8: 1 byte/value.
+        let stride = if entry.quant_kind == QUANT_FP16 {
+            dim * 2
+        } else {
+            dim
+        };
 
         let mut scored: Vec<(usize, f32)> = Vec::with_capacity(rows.len());
         let mut decoded: Vec<f32> = Vec::with_capacity(dim);
@@ -398,7 +407,14 @@ impl<'a> PaxBlockReader<'a> {
                 continue;
             }
             decoded.clear();
-            sq8::decode_into(&payload[off..end], &entry.params, &mut decoded);
+            if entry.quant_kind == QUANT_FP16 {
+                use half::f16;
+                for chunk in payload[off..end].chunks_exact(2) {
+                    decoded.push(f16::from_le_bytes([chunk[0], chunk[1]]).to_f32());
+                }
+            } else {
+                sq8::decode_into(&payload[off..end], &entry.params, &mut decoded);
+            }
             let dist = match metric {
                 // Squared L2 (lower = nearer).
                 RankMetric::L2 => decoded
@@ -1397,6 +1413,86 @@ mod tests {
         for (got, want) in f32_vecs.iter().zip(corpus.iter()) {
             let got = got.as_ref().expect("non-null f32 row");
             assert_eq!(got.as_slice(), want.as_slice(), "f32 tier must be exact");
+        }
+    }
+
+    /// Tier-2 rerank quant = FP16 (configurable tier-2, ADR-026 / TD-156 Phase 1):
+    /// with `.with_rerank_quant(Fp16)` + RaBitQ, the co-located `RERANK_BASE`
+    /// column is FP16-encoded (2 bytes/value, near-lossless) instead of the
+    /// default SQ8. `rerank_rows` decodes it and scores candidates against a
+    /// query; the FP16 distances must match the exact-f32 ground truth within
+    /// FP16 tolerance, and the ranking order is preserved (FP16 is
+    /// near-lossless → ordering unchanged for well-separated vectors).
+    #[test]
+    fn pax_block_fp16_rerank_round_trips_near_exact() {
+        // Well-separated DIM=64 vectors so FP16 rounding can't reorder near-ties.
+        let corpus = [
+            lcg_vec(1, 64),
+            lcg_vec(2, 64),
+            lcg_vec(3, 64),
+            lcg_vec(4, 64),
+        ];
+
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::RaBitQ)
+            .with_rerank_quant(crate::writer::VectorQuant::Fp16);
+        for (i, v) in corpus.iter().enumerate() {
+            writer
+                .add_record(&make_record_with_embedding(
+                    &format!("r{i}"),
+                    "t",
+                    1000 + i as i64,
+                    v.clone(),
+                ))
+                .unwrap();
+        }
+        let block = writer.flush().unwrap();
+        let reader = PaxBlockReader::open(&block).unwrap();
+
+        // The rerank column is present + FP16 (not the default SQ8).
+        let entry = reader
+            .vector_params()
+            .get(crate::col_id::RERANK_BASE)
+            .expect("rerank column present");
+        assert_eq!(entry.quant_kind, QUANT_FP16);
+        // The RaBitQ hot column is still present.
+        assert_eq!(
+            reader
+                .vector_params()
+                .get(crate::col_id::EMBED_BASE)
+                .unwrap()
+                .quant_kind,
+            crate::vparam::QUANT_RABITQ_RESERVED
+        );
+
+        // Rerank the full candidate set against a query; FP16 distances must
+        // match the exact-f32 squared-L2 within tolerance and preserve order.
+        let rows: Vec<usize> = (0..corpus.len()).collect();
+        let scored = reader
+            .rerank_rows(0, &corpus[0], &rows, RankMetric::L2)
+            .expect("FP16 rerank returns Some");
+
+        // Ground-truth squared-L2 from the original f32 vectors.
+        let l2 =
+            |a: &[f32], b: &[f32]| -> f32 { a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum() };
+        let mut truth: Vec<(usize, f32)> = rows
+            .iter()
+            .map(|&r| (r, l2(&corpus[r], &corpus[0])))
+            .collect();
+        truth.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Same ranking (FP16 is near-lossless → order preserved).
+        let got_order: Vec<usize> = scored.iter().map(|(r, _)| *r).collect();
+        let want_order: Vec<usize> = truth.iter().map(|(r, _)| *r).collect();
+        assert_eq!(got_order, want_order, "FP16 rerank reorders candidates");
+
+        // Distances within FP16 tolerance (relative ~5e-4/value; loose bound).
+        for ((_, got), (_, want)) in scored.iter().zip(truth.iter()) {
+            let tol = (want.abs() * 1e-2).max(1e-2);
+            assert!(
+                (got - want).abs() <= tol,
+                "FP16 dist {got} vs exact {want} exceeds tolerance {tol}"
+            );
         }
     }
 

--- a/crates/storage/proximadb-block-format/src/vparam.rs
+++ b/crates/storage/proximadb-block-format/src/vparam.rs
@@ -35,6 +35,8 @@ pub const QUANT_RAW_F32: u8 = 0;
 pub const QUANT_SQ8: u8 = 1;
 /// Reserved for a future binary RaBitQ scheme (not yet implemented).
 pub const QUANT_RABITQ_RESERVED: u8 = 2;
+/// Vector stripe is stored as FP16 (2 bytes/value, near-lossless).
+pub const QUANT_FP16: u8 = 3;
 
 /// Bytes per [`VectorParamEntry`] on the wire.
 pub const ENTRY_SIZE: usize = 28;

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -35,8 +35,8 @@ use crate::{
     rowgroup::{RowGroupBlock, RowGroupEntry, f64_bounds, i64_bounds},
     stripe::{COLUMN_META_SIZE, ColumnMeta, ColumnRole, ColumnStripe},
     vparam::{
-        QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
-        VectorParamEntry,
+        QUANT_FP16, QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn,
+        VectorParamBlock, VectorParamEntry,
     },
 };
 
@@ -126,6 +126,9 @@ pub enum VectorQuant {
     Sq8,
     /// RaBitQ (~30×, lossy 1-bit) — requires a decoupled f32 rerank tier for recall.
     RaBitQ,
+    /// FP16 (2×, near-lossless). Suitable as a tier-2 rerank column when higher
+    /// fidelity than SQ8 is needed (recall ~0.999 vs ~0.98).
+    Fp16,
 }
 
 pub struct PaxBlockWriter {
@@ -149,6 +152,12 @@ pub struct PaxBlockWriter {
     /// `include_vectors` decodes it; id+score queries never touch it (zero scan /
     /// egress cost when unused). Default OFF (set via `with_f32_tier`).
     include_f32_tier: bool,
+    /// Quantization strategy for the co-located rerank column (RERANK_BASE).
+    /// Default `Sq8` (the validated tier-2); `Fp16` for near-lossless rerank;
+    /// `RawF32` for exact (equivalent to the f32 tier but at RERANK_BASE).
+    /// Only used when tier 1 is RaBitQ (the rerank column is emitted alongside
+    /// RaBitQ; non-RaBitQ tier 1 doesn't need a separate rerank column).
+    rerank_quant: VectorQuant,
 
     // Accumulated column data
     oids: Vec<String>,
@@ -191,6 +200,7 @@ impl PaxBlockWriter {
             quant: VectorQuant::Auto,
             drop_tenant_col: drop_tenant_col_enabled(),
             include_f32_tier: false,
+            rerank_quant: VectorQuant::Sq8,
             oids: Vec::new(),
             tenant_ids: Vec::new(),
             created_at: Vec::new(),
@@ -233,6 +243,14 @@ impl PaxBlockWriter {
     /// Default OFF; the flush path enables it from the `pax_f32_tier` tag / env.
     pub fn with_f32_tier(mut self, enabled: bool) -> Self {
         self.include_f32_tier = enabled;
+        self
+    }
+
+    /// Set the quantization strategy for the co-located rerank column
+    /// (RERANK_BASE). Default `Sq8`; `Fp16` for near-lossless; `RawF32` for
+    /// exact. Only used when tier 1 is RaBitQ.
+    pub fn with_rerank_quant(mut self, quant: VectorQuant) -> Self {
+        self.rerank_quant = quant;
         self
     }
 
@@ -452,14 +470,22 @@ impl PaxBlockWriter {
                 if let Some(rc) = rabitq_col {
                     vparam_rabitq.push(rc);
                 }
-                // P3 cascade: every RaBitQ-coded embedding gets a co-located SQ8
-                // rerank column at `RERANK_BASE + i`. RaBitQ codes drive the cheap
-                // candidate scan; the rerank pool is scored against this SQ8 copy
-                // (4× footprint, no GET to an external f32 tier) before the final
-                // top-k. f32 rerank is added only if the recall gate can't be met.
+                // P3 cascade: every RaBitQ-coded embedding gets a co-located rerank
+                // column at `RERANK_BASE + i`. The rerank quant strategy is
+                // configurable (default SQ8; Fp16 for near-lossless; RawF32 for
+                // exact). RaBitQ codes drive the cheap candidate scan; the rerank
+                // pool is scored against this co-located copy before the final top-k.
                 if is_rabitq {
-                    let (rerank_stripe, rerank_entry) =
-                        self.build_sq8_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?;
+                    let (rerank_stripe, rerank_entry) = match self.rerank_quant {
+                        VectorQuant::Fp16 => {
+                            self.build_fp16_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?
+                        }
+                        VectorQuant::RawF32 => {
+                            self.build_raw_f32_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?
+                        }
+                        // Default: SQ8 (the validated tier-2).
+                        _ => self.build_sq8_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?,
+                    };
                     stripes.push(rerank_stripe);
                     vparam_entries.push(rerank_entry);
                 }
@@ -695,7 +721,7 @@ impl PaxBlockWriter {
         let (use_rabitq, use_sq8) = match self.quant {
             VectorQuant::RaBitQ => (has_data, false),
             VectorQuant::Sq8 => (false, has_data),
-            VectorQuant::RawF32 => (false, false),
+            VectorQuant::RawF32 | VectorQuant::Fp16 => (false, false),
             VectorQuant::Auto => {
                 let r = has_data && rabitq_enabled();
                 (r, has_data && !r && !sq8_disabled())
@@ -849,6 +875,69 @@ impl PaxBlockWriter {
             column_id: id,
             dim,
             quant_kind: QUANT_RAW_F32,
+            params,
+        };
+        Ok((ColumnStripe::new(meta, data), entry))
+    }
+
+    /// Build an FP16-quantized vector stripe (2 bytes/value, near-lossless).
+    /// Used as a configurable tier-2 rerank column when higher fidelity than SQ8
+    /// is needed (recall ~0.999 vs ~0.98).
+    fn build_fp16_vec_stripe(
+        &self,
+        id: i32,
+        vals: &[Option<&[f32]>],
+    ) -> Result<(ColumnStripe, VectorParamEntry)> {
+        use half::f16;
+        let dim = vector_column_dim(vals)?;
+        let flat: Vec<f32> = vals
+            .iter()
+            .flatten()
+            .flat_map(|s| s.iter().copied())
+            .collect();
+        let params = functions::sq8::fit_params(&flat);
+        let mut data = vector_validity_bitmap(vals);
+        let stride = dim as usize * 2; // 2 bytes per f16 value
+        data.reserve(vals.len() * stride);
+        for v in vals {
+            match v {
+                Some(vec) => {
+                    for &x in vec.iter() {
+                        data.extend_from_slice(&f16::from_f32(x).to_le_bytes());
+                    }
+                }
+                None => {
+                    // Null: reserve stride bytes (will be skipped by the bitmap).
+                    data.extend(std::iter::repeat_n(0u8, stride));
+                }
+            }
+        }
+        let null_count = vals.iter().filter(|v| v.is_none()).count() as u32;
+        let meta = ColumnMeta {
+            column_id: id,
+            role: ColumnRole::Vector,
+            data_type_id: 0x01, // F32 (source type; encoding = FP16)
+            encoding_id: ProximaScheme::Raw.to_marker(),
+            nullable: true,
+            has_bloom: false,
+            is_sorted: false,
+            stripe_offset: 0,
+            stripe_len: data.len() as u32,
+            null_count,
+            distinct_hint: vals
+                .iter()
+                .filter(|value| value.is_some())
+                .count()
+                .min(u32::MAX as usize) as u32,
+            min_val: [0u8; 16],
+            max_val: [0u8; 16],
+            bloom_offset: 0,
+            bloom_len: 0,
+        };
+        let entry = VectorParamEntry {
+            column_id: id,
+            dim,
+            quant_kind: QUANT_FP16,
             params,
         };
         Ok((ColumnStripe::new(meta, data), entry))

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -505,6 +505,8 @@ pub struct PaxSegmentWriter {
     /// Opt-in exact-f32 tier (P3 Phase D) — re-applied to every block writer so
     /// each block carries the f32 stripe when enabled.
     f32_tier: bool,
+    /// Tier-2 rerank quant (default Sq8) — re-applied to every block writer.
+    rerank_quant: VectorQuant,
 
     current_writer: PaxBlockWriter,
     index: SegmentIndex,
@@ -550,6 +552,7 @@ impl PaxSegmentWriter {
             block_size_threshold: threshold,
             quant: VectorQuant::Auto,
             f32_tier: false,
+            rerank_quant: VectorQuant::Sq8,
             current_writer: writer,
             index: SegmentIndex { blocks: Vec::new() },
             block_stats: Vec::new(),
@@ -571,7 +574,8 @@ impl PaxSegmentWriter {
             self.embedding_count,
         )
         .with_quant(quant)
-        .with_f32_tier(self.f32_tier);
+        .with_f32_tier(self.f32_tier)
+        .with_rerank_quant(self.rerank_quant);
         self
     }
 
@@ -589,7 +593,26 @@ impl PaxSegmentWriter {
             self.embedding_count,
         )
         .with_quant(self.quant)
-        .with_f32_tier(enabled);
+        .with_f32_tier(enabled)
+        .with_rerank_quant(self.rerank_quant);
+        self
+    }
+
+    /// Set the tier-2 rerank quantization strategy for every block in this
+    /// segment. Default `Sq8` (the validated tier-2); `Fp16` for near-lossless;
+    /// `RawF32` for exact. Only used when tier 1 is RaBitQ.
+    pub fn with_rerank_quant(mut self, quant: VectorQuant) -> Self {
+        self.rerank_quant = quant;
+        self.current_writer = PaxBlockWriter::new(
+            self.mode,
+            self.compression,
+            &self.collection_id,
+            self.schema_fingerprint,
+            self.embedding_count,
+        )
+        .with_quant(self.quant)
+        .with_f32_tier(self.f32_tier)
+        .with_rerank_quant(quant);
         self
     }
 
@@ -646,7 +669,7 @@ impl PaxSegmentWriter {
         self.file_buf.extend_from_slice(&block_bytes);
         self.block_stats.push(stats);
 
-        // Reset writer for the next block (preserving the segment's quant + f32-tier strategy).
+        // Reset writer for the next block (preserving the segment's quant + f32-tier + rerank strategy).
         self.current_writer = PaxBlockWriter::new(
             self.mode,
             self.compression,
@@ -655,7 +678,8 @@ impl PaxSegmentWriter {
             self.embedding_count,
         )
         .with_quant(self.quant)
-        .with_f32_tier(self.f32_tier);
+        .with_f32_tier(self.f32_tier)
+        .with_rerank_quant(self.rerank_quant);
         Ok(())
     }
 

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1182,12 +1182,19 @@ impl Compaction {
                         crate::storage::engines::sst::segment_format::pax_inputs_have_f32_tier(
                             &task.input_files,
                         );
-                    crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier(
+                    // Preserve the source segments' tier-2 rerank quant (SQ8/FP16/f32)
+                    // through compaction — see `pax_inputs_rerank_quant`.
+                    let rerank_quant =
+                        crate::storage::engines::sst::segment_format::pax_inputs_rerank_quant(
+                            &task.input_files,
+                        );
+                    crate::storage::engines::sst::segment_format::write_pax_segment_full(
                         &staging_file_path,
                         &records,
                         &collection_id,
                         records.len(),
                         proximadb_block_format::VectorQuant::RaBitQ,
+                        rerank_quant,
                         f32_tier,
                         None,
                     )
@@ -1331,12 +1338,19 @@ impl Compaction {
                         crate::storage::engines::sst::segment_format::pax_inputs_have_f32_tier(
                             &task.input_files,
                         );
-                    crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier(
+                    // Preserve the source segments' tier-2 rerank quant (SQ8/FP16/f32)
+                    // through compaction — see `pax_inputs_rerank_quant`.
+                    let rerank_quant =
+                        crate::storage::engines::sst::segment_format::pax_inputs_rerank_quant(
+                            &task.input_files,
+                        );
+                    crate::storage::engines::sst::segment_format::write_pax_segment_full(
                         &task.output_file,
                         &records,
                         &collection_id,
                         records.len(),
                         proximadb_block_format::VectorQuant::RaBitQ,
+                        rerank_quant,
                         f32_tier,
                         None,
                     )

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -472,7 +472,16 @@ impl SstEngine {
                 // env `PROXIMADB_PAX_F32_TIER` > default off. Emits an exact-f32
                 // stripe (read lazily) for an exact final rerank + include_vectors.
                 let f32_tier = resolve_pax_f32_tier(params.collection_config.as_ref());
-                let rerank_quant = resolve_pax_rerank_quant(params.collection_config.as_ref());
+                // Extract the tag list here (flush config is the legacy v1 proto
+                // type, already referenced by the calls above) so resolve_pax_rerank_quant
+                // stays v1-free — TD-123: don't add new v1-proto references.
+                let rerank_tags: &[String] = params
+                    .collection_config
+                    .as_ref()
+                    .and_then(|c| c.config.as_ref())
+                    .map(|cfg| cfg.tags.as_slice())
+                    .unwrap_or(&[]);
+                let rerank_quant = resolve_pax_rerank_quant(rerank_tags);
                 let meta = write_pax_segment_full(
                     std::path::Path::new(staging_path),
                     &records,
@@ -953,11 +962,11 @@ fn resolve_pax_f32_tier(
 /// Mirrors the `pax_vector_quant:` convention. Values: `sq8`, `fp16`, `f32`.
 const PAX_RERANK_QUANT_TAG_PREFIX: &str = "pax_rerank_quant:";
 
-/// Read the per-collection `pax_rerank_quant:sq8|fp16|f32` tag.
-fn pax_rerank_quant_tag(
-    config: &crate::proto::proximadb_v1::CollectionConfig,
-) -> Option<proximadb_block_format::VectorQuant> {
-    for tag in &config.tags {
+/// Read the per-collection `pax_rerank_quant:sq8|fp16|f32` tag from a tag list.
+/// Takes `&[String]` (not the v1 config type) so this does not add a v1-proto
+/// reference (TD-123 ratchet) — tag extraction happens at the call site.
+fn pax_rerank_quant_tag(tags: &[String]) -> Option<proximadb_block_format::VectorQuant> {
+    for tag in tags {
         if let Some(rest) = tag.strip_prefix(PAX_RERANK_QUANT_TAG_PREFIX) {
             return match rest.trim().to_ascii_lowercase().as_str() {
                 "sq8" | "sq_8" => Some(proximadb_block_format::VectorQuant::Sq8),
@@ -972,15 +981,11 @@ fn pax_rerank_quant_tag(
 
 /// Resolve the tier-2 rerank quant strategy. Precedence: per-collection
 /// `pax_rerank_quant` tag > env `PROXIMADB_PAX_RERANK_QUANT` > default `Sq8`
-/// (the validated tier-2). Only used when tier 1 is RaBitQ.
-fn resolve_pax_rerank_quant(
-    collection_config: Option<&crate::proto::proximadb_v1::Collection>,
-) -> proximadb_block_format::VectorQuant {
+/// (the validated tier-2). Only used when tier 1 is RaBitQ. Takes the resolved
+/// tag slice (extracted by the caller) to avoid a v1-proto reference (TD-123).
+fn resolve_pax_rerank_quant(tags: &[String]) -> proximadb_block_format::VectorQuant {
     const ENV: &str = "PROXIMADB_PAX_RERANK_QUANT";
-    let per_collection = collection_config
-        .as_ref()
-        .and_then(|c| c.config.as_ref())
-        .and_then(pax_rerank_quant_tag);
+    let per_collection = pax_rerank_quant_tag(tags);
     per_collection.unwrap_or_else(|| {
         match std::env::var(ENV)
             .unwrap_or_default()
@@ -1508,66 +1513,34 @@ mod tests {
     /// anything else falls back to the default.
     #[test]
     fn resolve_pax_rerank_quant_default_and_precedence() {
-        use crate::proto::proximadb_v1::{Collection, CollectionConfig};
         use proximadb_block_format::VectorQuant;
         unsafe {
             std::env::remove_var("PROXIMADB_PAX_RERANK_QUANT");
         }
-        let none: Option<&Collection> = None;
-        // default → Sq8
-        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::Sq8);
+        // no tags → default Sq8
+        assert_eq!(resolve_pax_rerank_quant(&[]), VectorQuant::Sq8);
         // env overrides the default
         unsafe {
             std::env::set_var("PROXIMADB_PAX_RERANK_QUANT", "fp16");
         }
-        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::Fp16);
+        assert_eq!(resolve_pax_rerank_quant(&[]), VectorQuant::Fp16);
         unsafe {
             std::env::set_var("PROXIMADB_PAX_RERANK_QUANT", "f32");
         }
-        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::RawF32);
+        assert_eq!(resolve_pax_rerank_quant(&[]), VectorQuant::RawF32);
         unsafe {
             std::env::remove_var("PROXIMADB_PAX_RERANK_QUANT");
         }
         // per-collection tag overrides env + default
-        let coll_fp16 = Collection {
-            config: Some(CollectionConfig {
-                tags: vec!["pax_rerank_quant:fp16".into()],
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            resolve_pax_rerank_quant(Some(&coll_fp16)),
-            VectorQuant::Fp16
-        );
-        let coll_f32 = Collection {
-            config: Some(CollectionConfig {
-                tags: vec!["pax_rerank_quant:f32".into()],
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert_eq!(
-            resolve_pax_rerank_quant(Some(&coll_f32)),
-            VectorQuant::RawF32
-        );
-        let coll_sq8 = Collection {
-            config: Some(CollectionConfig {
-                tags: vec!["pax_rerank_quant:sq8".into()],
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert_eq!(resolve_pax_rerank_quant(Some(&coll_sq8)), VectorQuant::Sq8);
+        let tags_fp16 = ["pax_rerank_quant:fp16".to_string()];
+        assert_eq!(resolve_pax_rerank_quant(&tags_fp16), VectorQuant::Fp16);
+        let tags_f32 = ["pax_rerank_quant:f32".to_string()];
+        assert_eq!(resolve_pax_rerank_quant(&tags_f32), VectorQuant::RawF32);
+        let tags_sq8 = ["pax_rerank_quant:sq8".to_string()];
+        assert_eq!(resolve_pax_rerank_quant(&tags_sq8), VectorQuant::Sq8);
         // unrecognized tag value → None → default Sq8 (RaBitQ rerank is invalid
         // and rejected at the parser: the tag only accepts sq8/fp16/f32).
-        let coll_bad = Collection {
-            config: Some(CollectionConfig {
-                tags: vec!["pax_rerank_quant:rabitq".into()],
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert_eq!(resolve_pax_rerank_quant(Some(&coll_bad)), VectorQuant::Sq8);
+        let tags_bad = ["pax_rerank_quant:rabitq".to_string()];
+        assert_eq!(resolve_pax_rerank_quant(&tags_bad), VectorQuant::Sq8);
     }
 }

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -441,7 +441,7 @@ impl SstEngine {
                 // object-store) URL. Reads are mixed-format-safe via
                 // `segment_format::read_segment_records` (magic-byte detection), so no
                 // manifest/reader change is required for this segment to be read back.
-                use crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier;
+                use crate::storage::engines::sst::segment_format::write_pax_segment_full;
                 let staging_path = staging_url.strip_prefix("file://").unwrap_or(&staging_url);
                 if let Some(parent) = std::path::Path::new(staging_path).parent() {
                     tokio::fs::create_dir_all(parent)
@@ -472,12 +472,14 @@ impl SstEngine {
                 // env `PROXIMADB_PAX_F32_TIER` > default off. Emits an exact-f32
                 // stripe (read lazily) for an exact final rerank + include_vectors.
                 let f32_tier = resolve_pax_f32_tier(params.collection_config.as_ref());
-                let meta = write_pax_segment_with_f32_tier(
+                let rerank_quant = resolve_pax_rerank_quant(params.collection_config.as_ref());
+                let meta = write_pax_segment_full(
                     std::path::Path::new(staging_path),
                     &records,
                     collection_id,
                     embedding_count,
                     quant,
+                    rerank_quant,
                     f32_tier,
                     target_block,
                 )
@@ -945,6 +947,51 @@ fn resolve_pax_f32_tier(
         .and_then(|c| c.config.as_ref())
         .and_then(pax_f32_tier_tag);
     per_collection.unwrap_or_else(|| env_truthy("PROXIMADB_PAX_F32_TIER"))
+}
+
+/// Tag prefix encoding the per-collection tier-2 rerank quant strategy.
+/// Mirrors the `pax_vector_quant:` convention. Values: `sq8`, `fp16`, `f32`.
+const PAX_RERANK_QUANT_TAG_PREFIX: &str = "pax_rerank_quant:";
+
+/// Read the per-collection `pax_rerank_quant:sq8|fp16|f32` tag.
+fn pax_rerank_quant_tag(
+    config: &crate::proto::proximadb_v1::CollectionConfig,
+) -> Option<proximadb_block_format::VectorQuant> {
+    for tag in &config.tags {
+        if let Some(rest) = tag.strip_prefix(PAX_RERANK_QUANT_TAG_PREFIX) {
+            return match rest.trim().to_ascii_lowercase().as_str() {
+                "sq8" | "sq_8" => Some(proximadb_block_format::VectorQuant::Sq8),
+                "fp16" | "f16" => Some(proximadb_block_format::VectorQuant::Fp16),
+                "f32" | "raw" | "raw_f32" => Some(proximadb_block_format::VectorQuant::RawF32),
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
+/// Resolve the tier-2 rerank quant strategy. Precedence: per-collection
+/// `pax_rerank_quant` tag > env `PROXIMADB_PAX_RERANK_QUANT` > default `Sq8`
+/// (the validated tier-2). Only used when tier 1 is RaBitQ.
+fn resolve_pax_rerank_quant(
+    collection_config: Option<&crate::proto::proximadb_v1::Collection>,
+) -> proximadb_block_format::VectorQuant {
+    const ENV: &str = "PROXIMADB_PAX_RERANK_QUANT";
+    let per_collection = collection_config
+        .as_ref()
+        .and_then(|c| c.config.as_ref())
+        .and_then(pax_rerank_quant_tag);
+    per_collection.unwrap_or_else(|| {
+        match std::env::var(ENV)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "fp16" | "f16" => proximadb_block_format::VectorQuant::Fp16,
+            "f32" | "raw" | "raw_f32" => proximadb_block_format::VectorQuant::RawF32,
+            _ => proximadb_block_format::VectorQuant::Sq8,
+        }
+    })
 }
 
 #[cfg(test)]
@@ -1453,5 +1500,74 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(resolve_pax_vector_quant(Some(&coll_bad)), VectorQuant::Auto);
+    }
+
+    /// Tier-2 rerank quant default is SQ8 (the validated tier-2). Precedence:
+    /// per-collection `pax_rerank_quant` tag > env `PROXIMADB_PAX_RERANK_QUANT` >
+    /// default SQ8. Only the 3 valid values (sq8/fp16/f32) are accepted;
+    /// anything else falls back to the default.
+    #[test]
+    fn resolve_pax_rerank_quant_default_and_precedence() {
+        use crate::proto::proximadb_v1::{Collection, CollectionConfig};
+        use proximadb_block_format::VectorQuant;
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_RERANK_QUANT");
+        }
+        let none: Option<&Collection> = None;
+        // default → Sq8
+        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::Sq8);
+        // env overrides the default
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_RERANK_QUANT", "fp16");
+        }
+        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::Fp16);
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_RERANK_QUANT", "f32");
+        }
+        assert_eq!(resolve_pax_rerank_quant(none), VectorQuant::RawF32);
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_RERANK_QUANT");
+        }
+        // per-collection tag overrides env + default
+        let coll_fp16 = Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_rerank_quant:fp16".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_pax_rerank_quant(Some(&coll_fp16)),
+            VectorQuant::Fp16
+        );
+        let coll_f32 = Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_rerank_quant:f32".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_pax_rerank_quant(Some(&coll_f32)),
+            VectorQuant::RawF32
+        );
+        let coll_sq8 = Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_rerank_quant:sq8".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(resolve_pax_rerank_quant(Some(&coll_sq8)), VectorQuant::Sq8);
+        // unrecognized tag value → None → default Sq8 (RaBitQ rerank is invalid
+        // and rejected at the parser: the tag only accepts sq8/fp16/f32).
+        let coll_bad = Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_rerank_quant:rabitq".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(resolve_pax_rerank_quant(Some(&coll_bad)), VectorQuant::Sq8);
     }
 }

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -145,6 +145,32 @@ pub fn write_pax_segment_with_f32_tier(
     f32_tier: bool,
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
+    write_pax_segment_full(
+        path,
+        records,
+        collection_id,
+        embedding_count,
+        quant,
+        VectorQuant::Sq8,
+        f32_tier,
+        target_block,
+    )
+}
+
+/// Full PAX segment write with configurable tier-1 quant, tier-2 rerank quant,
+/// and optional f32 tier. This is the canonical write entry point; the legacy
+/// `write_pax_segment_with_f32_tier` delegates with `Sq8` rerank (the default).
+#[allow(clippy::too_many_arguments)]
+pub fn write_pax_segment_full(
+    path: &Path,
+    records: &[ProximaRecord],
+    collection_id: &str,
+    embedding_count: usize,
+    quant: VectorQuant,
+    rerank_quant: VectorQuant,
+    f32_tier: bool,
+    target_block: Option<usize>,
+) -> Result<SegmentMeta> {
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,
@@ -155,7 +181,8 @@ pub fn write_pax_segment_with_f32_tier(
         target_block,
     )
     .with_quant(quant)
-    .with_f32_tier(f32_tier);
+    .with_f32_tier(f32_tier)
+    .with_rerank_quant(rerank_quant);
     for record in records {
         writer.add_record(record)?;
     }
@@ -169,7 +196,7 @@ pub fn write_pax_segment_with_f32_tier(
 /// records), so this is cheap. Correct for both env- and tag-opt-in (the source
 /// segment reflects whatever the collection wrote).
 pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
-    use proximadb_block_format::{PaxBlockReader, col_id};
+    use proximadb_block_format::col_id;
     for f in input_files {
         if f.extension().and_then(|e| e.to_str()) != Some("pax") {
             continue;
@@ -177,7 +204,16 @@ pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
         let Ok(bytes) = std::fs::read(f) else {
             continue;
         };
-        let Ok(reader) = PaxBlockReader::open(&bytes) else {
+        // Read block 0's column metadata via the segment scanner. A `.pax`
+        // SEGMENT file is laid out `[block(s)][segment_index][SEGMENT_MAGIC]`;
+        // `PaxBlockReader::open` parses a SINGLE block and reads its footer from
+        // the trailing `BLOCK_FOOTER_SIZE` bytes, so opening the whole file
+        // misreads the segment index/magic as a block footer. The scanner parses
+        // the trailing index + magic and hands back block 0 correctly.
+        let Ok(mut scanner) = PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default()) else {
+            continue;
+        };
+        let Some(reader) = scanner.next_block() else {
             continue;
         };
         if reader.vector_params().get(col_id::F32_TIER_BASE).is_some() {
@@ -185,6 +221,48 @@ pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
         }
     }
     false
+}
+
+/// Detect the tier-2 rerank quant strategy of the source `.pax` segments, so
+/// compaction PRESERVES it when re-encoding (mirrors [`pax_inputs_have_f32_tier`]
+/// for the f32 tier). Returns the first detected strategy from the co-located
+/// `RERANK_BASE` column; defaults to [`VectorQuant::Sq8`] (the validated
+/// tier-2) when no `.pax` input carries a rerank column. Correct for both env-
+/// and tag-opt-in: the source segment reflects whatever the collection wrote,
+/// so preserving it keeps a configured FP16/f32 rerank from being silently
+/// downgraded to SQ8 on the first compaction.
+pub fn pax_inputs_rerank_quant(
+    input_files: &[std::path::PathBuf],
+) -> proximadb_block_format::VectorQuant {
+    use proximadb_block_format::vparam::{QUANT_FP16, QUANT_RAW_F32};
+    for f in input_files {
+        if f.extension().and_then(|e| e.to_str()) != Some("pax") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(f) else {
+            continue;
+        };
+        // Read block 0's column metadata via the segment scanner — a `.pax`
+        // SEGMENT file is `[block(s)][segment_index][SEGMENT_MAGIC]`, so opening
+        // the whole file as a single block misreads the footer (see
+        // [`pax_inputs_have_f32_tier`]). The rerank column is co-located in every
+        // block, so block 0 suffices to detect the segment's tier-2 strategy.
+        let Ok(mut scanner) = PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default()) else {
+            continue;
+        };
+        let Some(reader) = scanner.next_block() else {
+            continue;
+        };
+        if let Some(entry) = reader.vector_params().get(col_id::RERANK_BASE) {
+            return match entry.quant_kind {
+                QUANT_FP16 => VectorQuant::Fp16,
+                QUANT_RAW_F32 => VectorQuant::RawF32,
+                // SQ8 (the default) or any unknown/reserved kind → Sq8.
+                _ => VectorQuant::Sq8,
+            };
+        }
+    }
+    VectorQuant::Sq8
 }
 
 /// One scored hit from a RaBitQ cascade segment scan: the record's `oid` and its
@@ -878,6 +956,81 @@ mod tests {
             hits2.iter().all(|h| h.vector.is_none()),
             "no f32 tier → hits must not carry vectors"
         );
+    }
+
+    /// `pax_inputs_rerank_quant` detects the tier-2 rerank quant of a `.pax`
+    /// source segment so compaction PRESERVES it (an FP16/f32 rerank stays
+    /// FP16/f32; only a missing rerank column → default Sq8). Mirrors the
+    /// f32-tier detection contract — guards against compaction silently
+    /// downgrading a configured higher-fidelity rerank tier to SQ8.
+    #[test]
+    fn pax_inputs_rerank_quant_detects_source_tier() {
+        let dir = tempfile::tempdir().unwrap();
+        let records: Vec<ProximaRecord> = (0..8)
+            .map(|i| {
+                let vec: Vec<f32> = (0..32).map(|j| (i * 32 + j) as f32 * 0.01).collect();
+                rec(&format!("v{i}"), 1_700_000_000_000_000_000 + i as i64, vec)
+            })
+            .collect();
+
+        // FP16 rerank → detected as Fp16.
+        let fp16_path = dir.path().join("fp16.pax");
+        write_pax_segment_full(
+            &fp16_path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Fp16,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            pax_inputs_rerank_quant(&[fp16_path.clone()]),
+            VectorQuant::Fp16
+        );
+
+        // f32 rerank → detected as RawF32.
+        let f32_path = dir.path().join("f32.pax");
+        write_pax_segment_full(
+            &f32_path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::RawF32,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            pax_inputs_rerank_quant(&[f32_path.clone()]),
+            VectorQuant::RawF32
+        );
+
+        // Default (Sq8) rerank → detected as Sq8.
+        let sq8_path = dir.path().join("sq8.pax");
+        write_pax_segment_full(
+            &sq8_path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            pax_inputs_rerank_quant(&[sq8_path.clone()]),
+            VectorQuant::Sq8
+        );
+
+        // No `.pax` input (or none with a rerank column) → default Sq8.
+        let non_pax = dir.path().join("notpax.sst");
+        std::fs::write(&non_pax, b"junk").unwrap();
+        assert_eq!(pax_inputs_rerank_quant(&[non_pax]), VectorQuant::Sq8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The PAX cascade's tier-2 rerank column (`RERANK_BASE`) was hardcoded to **SQ8**. This makes it **definition-time configurable** so a collection can opt into a higher-fidelity rerank tier without changing the cascade's stage-1 RaBitQ scan.

| Tier | Column | Config | Default | This PR |
|---|---|---|---|---|
| 1 (hot scan) | `EMBED_BASE` | `pax_vector_quant` | `rabitq` | unchanged |
| **2 (rerank)** | `RERANK_BASE` | **`pax_rerank_quant`** *(new)* | `sq8` | **configurable** |
| 3 (exact) | `F32_TIER_BASE` | `pax_f32_tier` | off | unchanged |

- `pax_rerank_quant:sq8|fp16|f32` tag on `CollectionConfig.tags`, or env `PROXIMADB_PAX_RERANK_QUANT`. Default `sq8` = **unchanged behavior**.
- **FP16** (2 bytes/value): near-lossless rerank (recall ~0.999 vs ~0.98).
- **F32**: exact (equivalent to the f32 tier, but co-located at `RERANK_BASE`).

Backward-compatible: every existing collection writes exactly as before (the tag defaults to `sq8`). This is Phase 1 of the multi-tier quant plan (Phase 2 would wire in PQ4/PQ8 via the same seam).

## What changed

- **`writer.rs`** — `VectorQuant::Fp16` variant + `rerank_quant` field + `with_rerank_quant` builder + `build_fp16_vec_stripe` (2 bytes/value). The rerank column now dispatches on `rerank_quant` (SQ8 / FP16 / raw F32).
- **`reader.rs`** — `rerank_rows` accepts `QUANT_FP16` alongside `QUANT_SQ8` (stride `dim*2`, `f16::from_le_bytes` decode).
- **`vparam.rs`** — `QUANT_FP16 = 3` constant.
- **`segment_format.rs`** — new `write_pax_segment_full` (8-arg canonical entry; the legacy `write_pax_segment_with_f32_tier` delegates with `Sq8`). New `pax_inputs_rerank_quant` detects the source segments' rerank tier so compaction **preserves** it.
- **`flush/mod.rs`** — `resolve_pax_rerank_quant` (tag > env > `Sq8`); threaded into the flush write call.
- **`compaction.rs`** — both the atomic and non-atomic compaction arms now preserve the rerank tier (was hardcoded SQ8).
- **`pax_block.rs`** — `PaxSegmentWriter` threads `rerank_quant` across every block (carried on block reset, `with_quant`/`with_f32_tier` rebuilds, and `with_rerank_quant`).

## Bug fix included

`pax_inputs_have_f32_tier` (and the new `pax_inputs_rerank_quant`) opened the **whole segment file** as a single block via `PaxBlockReader::open`. But a `.pax` segment is laid out `[block(s)][segment_index][SEGMENT_MAGIC]`, so opening the whole file misread the trailing index/magic as a block footer and **always failed** — meaning compaction silently **dropped the f32 tier** on rewrite. Both helpers now open block 0 via `PaxSegmentScanner` (parses the trailing index + magic correctly).

## Tests

- `resolve_pax_rerank_quant_default_and_precedence` — tag > env > default `Sq8`; invalid values fall back to default.
- `pax_inputs_rerank_quant_detects_source_tier` — FP16/f32/SQ8 detection + default when no rerank column.
- `pax_block_fp16_rerank_round_trips_near_exact` — FP16 encode → decode → rerank matches exact-f32 ground truth within tolerance and preserves ranking order.

## Verification (local, pinned 1.95.0)

- `cargo check --workspace --tests` ✅
- `cargo clippy --workspace --lib --bins -- -D warnings` ✅ (the CI gate, `ci.yml:710`)
- All 3 new tests pass post-rebase onto `develop`.

## Out of scope / follow-ups

- **PQ4/PQ8 rerank** (Phase 2) — same seam; needs a codebook trailer in `VectorParamBlock`.
- The broader workspace `--all-targets` clippy debt (~10k findings, ~9.6k of which are normal `unwrap`/`expect` in test code, deliberately scoped out of CI via `--lib --bins`) is **not** addressed here — separate cleanup.