### PR TITLE
chore(clippy): apply mechanical --fix to proximadb test code

### DIFF
--- a/src/ai/nlp.rs
+++ b/src/ai/nlp.rs
@@ -739,7 +739,7 @@ mod tests {
             .unwrap();
 
         // Should recognize "risk" and "portfolio" entities
-        assert!(entities.len() >= 1);
+        assert!(!entities.is_empty());
         assert!(entities.iter().any(|e| e.entity_name == "risk"));
     }
 

--- a/src/api_handlers/enterprise.rs
+++ b/src/api_handlers/enterprise.rs
@@ -743,12 +743,10 @@ mod tests {
 
     #[test]
     fn test_multiple_compliance_frameworks() {
-        let frameworks = vec![
-            ComplianceFramework::SOC2,
+        let frameworks = [ComplianceFramework::SOC2,
             ComplianceFramework::SOX,
             ComplianceFramework::HIPAA,
-            ComplianceFramework::GDPR,
-        ];
+            ComplianceFramework::GDPR];
 
         assert_eq!(frameworks.len(), 4);
         assert!(frameworks.contains(&ComplianceFramework::GDPR));

--- a/src/api_handlers/enterprise.rs
+++ b/src/api_handlers/enterprise.rs
@@ -743,10 +743,12 @@ mod tests {
 
     #[test]
     fn test_multiple_compliance_frameworks() {
-        let frameworks = [ComplianceFramework::SOC2,
+        let frameworks = [
+            ComplianceFramework::SOC2,
             ComplianceFramework::SOX,
             ComplianceFramework::HIPAA,
-            ComplianceFramework::GDPR];
+            ComplianceFramework::GDPR,
+        ];
 
         assert_eq!(frameworks.len(), 4);
         assert!(frameworks.contains(&ComplianceFramework::GDPR));

--- a/src/api_handlers/request_handlers_tests.rs
+++ b/src/api_handlers/request_handlers_tests.rs
@@ -570,7 +570,7 @@ mod tests {
 
         let collection_id = "test_collection";
         let text_query = "machine learning algorithms";
-        let query_vector = vec![0.1, 0.2, 0.3, 0.4, 0.5];
+        let query_vector = [0.1, 0.2, 0.3, 0.4, 0.5];
         let top_k = 10;
         let _fusion_strategy = FusionStrategy::ReciprocalRank { k: 60 };
 

--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -1478,7 +1478,7 @@ mod tests {
         assert!(risk.is_some());
         // Risk should be between 0 and 1
         let risk_value = risk.unwrap();
-        assert!(risk_value >= 0.0 && risk_value <= 1.0);
+        assert!((0.0..=1.0).contains(&risk_value));
     }
 
     // ==================== Integration Tests ====================

--- a/src/auth/sso/types.rs
+++ b/src/auth/sso/types.rs
@@ -425,11 +425,13 @@ mod tests {
 
     #[test]
     fn test_security_clearance_all_levels() {
-        let levels = [SecurityClearance::Public,
+        let levels = [
+            SecurityClearance::Public,
             SecurityClearance::Internal,
             SecurityClearance::Confidential,
             SecurityClearance::Secret,
-            SecurityClearance::TopSecret];
+            SecurityClearance::TopSecret,
+        ];
 
         // Verify ordering
         for window in levels.windows(2) {

--- a/src/auth/sso/types.rs
+++ b/src/auth/sso/types.rs
@@ -425,13 +425,11 @@ mod tests {
 
     #[test]
     fn test_security_clearance_all_levels() {
-        let levels = vec![
-            SecurityClearance::Public,
+        let levels = [SecurityClearance::Public,
             SecurityClearance::Internal,
             SecurityClearance::Confidential,
             SecurityClearance::Secret,
-            SecurityClearance::TopSecret,
-        ];
+            SecurityClearance::TopSecret];
 
         // Verify ordering
         for window in levels.windows(2) {

--- a/src/automl/mod.rs
+++ b/src/automl/mod.rs
@@ -210,12 +210,14 @@ mod tests {
         }
 
         // Verify all OptimizationGoal variants
-        let goals = [OptimizationGoal::MinimizeLatency,
+        let goals = [
+            OptimizationGoal::MinimizeLatency,
             OptimizationGoal::MaximizeThroughput,
             OptimizationGoal::MinimizeMemory,
             OptimizationGoal::MaximizeAccuracy,
             OptimizationGoal::Balanced,
-            OptimizationGoal::Custom(optimization::ObjectiveWeights::default())];
+            OptimizationGoal::Custom(optimization::ObjectiveWeights::default()),
+        ];
         assert_eq!(goals.len(), 6, "Expected 6 optimization goal variants");
 
         // Verify default ObjectiveWeights
@@ -229,13 +231,15 @@ mod tests {
     #[test]
     fn test_workload_prediction_config() {
         // Verify WorkloadPattern variants
-        let patterns = [WorkloadPattern::ReadHeavy,
+        let patterns = [
+            WorkloadPattern::ReadHeavy,
             WorkloadPattern::WriteHeavy,
             WorkloadPattern::Balanced,
             WorkloadPattern::BatchProcessing,
             WorkloadPattern::Streaming,
             WorkloadPattern::Analytics,
-            WorkloadPattern::Mixed];
+            WorkloadPattern::Mixed,
+        ];
         assert_eq!(patterns.len(), 7, "Expected 7 workload pattern variants");
 
         // Verify PartialEq is implemented
@@ -244,10 +248,12 @@ mod tests {
 
         // Verify PredictionModel enum has the expected variant names (cannot construct
         // directly since model structs have private fields, so we verify via TargetMetric)
-        let target_variants = [prediction::TargetMetric::QueryLatency(10.0),
+        let target_variants = [
+            prediction::TargetMetric::QueryLatency(10.0),
             prediction::TargetMetric::Throughput(1000.0),
             prediction::TargetMetric::MemoryUsage(512.0),
-            prediction::TargetMetric::IndexBuildTime(30.0)];
+            prediction::TargetMetric::IndexBuildTime(30.0),
+        ];
         assert_eq!(
             target_variants.len(),
             4,

--- a/src/automl/mod.rs
+++ b/src/automl/mod.rs
@@ -210,14 +210,12 @@ mod tests {
         }
 
         // Verify all OptimizationGoal variants
-        let goals = vec![
-            OptimizationGoal::MinimizeLatency,
+        let goals = [OptimizationGoal::MinimizeLatency,
             OptimizationGoal::MaximizeThroughput,
             OptimizationGoal::MinimizeMemory,
             OptimizationGoal::MaximizeAccuracy,
             OptimizationGoal::Balanced,
-            OptimizationGoal::Custom(optimization::ObjectiveWeights::default()),
-        ];
+            OptimizationGoal::Custom(optimization::ObjectiveWeights::default())];
         assert_eq!(goals.len(), 6, "Expected 6 optimization goal variants");
 
         // Verify default ObjectiveWeights
@@ -231,15 +229,13 @@ mod tests {
     #[test]
     fn test_workload_prediction_config() {
         // Verify WorkloadPattern variants
-        let patterns = vec![
-            WorkloadPattern::ReadHeavy,
+        let patterns = [WorkloadPattern::ReadHeavy,
             WorkloadPattern::WriteHeavy,
             WorkloadPattern::Balanced,
             WorkloadPattern::BatchProcessing,
             WorkloadPattern::Streaming,
             WorkloadPattern::Analytics,
-            WorkloadPattern::Mixed,
-        ];
+            WorkloadPattern::Mixed];
         assert_eq!(patterns.len(), 7, "Expected 7 workload pattern variants");
 
         // Verify PartialEq is implemented
@@ -248,12 +244,10 @@ mod tests {
 
         // Verify PredictionModel enum has the expected variant names (cannot construct
         // directly since model structs have private fields, so we verify via TargetMetric)
-        let target_variants = vec![
-            prediction::TargetMetric::QueryLatency(10.0),
+        let target_variants = [prediction::TargetMetric::QueryLatency(10.0),
             prediction::TargetMetric::Throughput(1000.0),
             prediction::TargetMetric::MemoryUsage(512.0),
-            prediction::TargetMetric::IndexBuildTime(30.0),
-        ];
+            prediction::TargetMetric::IndexBuildTime(30.0)];
         assert_eq!(
             target_variants.len(),
             4,

--- a/src/cdc/connectors/mysql/decoder.rs
+++ b/src/cdc/connectors/mysql/decoder.rs
@@ -897,12 +897,14 @@ mod tests {
 
     #[test]
     fn test_column_value_variants() {
-        let values = [ColumnValue::Null,
+        let values = [
+            ColumnValue::Null,
             ColumnValue::Int(-42),
             ColumnValue::UInt(42),
             ColumnValue::Float(3.5),
             ColumnValue::String("hello".to_string()),
-            ColumnValue::Bytes(vec![1, 2, 3])];
+            ColumnValue::Bytes(vec![1, 2, 3]),
+        ];
 
         assert_eq!(values.len(), 6);
     }

--- a/src/cdc/connectors/mysql/decoder.rs
+++ b/src/cdc/connectors/mysql/decoder.rs
@@ -897,14 +897,12 @@ mod tests {
 
     #[test]
     fn test_column_value_variants() {
-        let values = vec![
-            ColumnValue::Null,
+        let values = [ColumnValue::Null,
             ColumnValue::Int(-42),
             ColumnValue::UInt(42),
             ColumnValue::Float(3.5),
             ColumnValue::String("hello".to_string()),
-            ColumnValue::Bytes(vec![1, 2, 3]),
-        ];
+            ColumnValue::Bytes(vec![1, 2, 3])];
 
         assert_eq!(values.len(), 6);
     }

--- a/src/cluster/consensus.rs
+++ b/src/cluster/consensus.rs
@@ -1887,7 +1887,7 @@ mod tests {
         for _ in 0..100 {
             let timeout = consensus.random_election_timeout();
             let ms = timeout.as_millis() as u64;
-            assert!(ms >= 100 && ms <= 200);
+            assert!((100..=200).contains(&ms));
         }
     }
 

--- a/src/cluster/distributed_ops.rs
+++ b/src/cluster/distributed_ops.rs
@@ -1469,7 +1469,7 @@ mod tests {
         assert_eq!(total_records, 2);
 
         // Check that records are enriched with tenant/domain metadata
-        for (_, shard_records) in &partitioned {
+        for shard_records in partitioned.values() {
             for record in shard_records {
                 assert_eq!(
                     record.metadata.get("tenant_id"),

--- a/src/cluster/routing.rs
+++ b/src/cluster/routing.rs
@@ -1686,21 +1686,21 @@ mod tests {
         let num1: u32 = shard1
             .id()
             .split('_')
-            .last()
+            .next_back()
             .expect("shard ID should have _ delimiter")
             .parse()
             .expect("shard number should be valid u32");
         let num2: u32 = shard2
             .id()
             .split('_')
-            .last()
+            .next_back()
             .expect("shard ID should have _ delimiter")
             .parse()
             .expect("shard number should be valid u32");
         let num3: u32 = shard3
             .id()
             .split('_')
-            .last()
+            .next_back()
             .expect("shard ID should have _ delimiter")
             .parse()
             .expect("shard number should be valid u32");

--- a/src/compute/proximacodec/simd/simd.rs
+++ b/src/compute/proximacodec/simd/simd.rs
@@ -1843,7 +1843,7 @@ mod tests {
             let packed = result
                 .unwrap_or_else(|e| panic!("Failed to encode bitpack for width {}: {}", bits, e));
             let expected_bits = values.len() * bits as usize;
-            let expected_bytes = (expected_bits + 7) / 8;
+            let expected_bytes = expected_bits.div_ceil(8);
 
             assert_eq!(
                 packed.len(),
@@ -1935,7 +1935,7 @@ mod tests {
                 .unwrap_or_else(|e| panic!("Failed to encode bitpack for width {}: {}", bits, e));
 
             // Verify output size
-            let expected_bytes = (values.len() * bits as usize + 7) / 8;
+            let expected_bytes = (values.len() * bits as usize).div_ceil(8);
             assert_eq!(
                 result.len(),
                 expected_bytes,
@@ -1995,11 +1995,9 @@ mod tests {
     #[test]
     fn test_round_trip_delta_vs_baseline() {
         // Test that SIMD Delta encoding matches baseline Delta encoding
-        let test_values = vec![
-            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        let test_values = [vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
             vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
-            vec![-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
-        ];
+            vec![-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0]];
 
         let codec = ProximaCodec::global();
 

--- a/src/compute/proximacodec/simd/simd.rs
+++ b/src/compute/proximacodec/simd/simd.rs
@@ -1995,9 +1995,11 @@ mod tests {
     #[test]
     fn test_round_trip_delta_vs_baseline() {
         // Test that SIMD Delta encoding matches baseline Delta encoding
-        let test_values = [vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        let test_values = [
+            vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
             vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
-            vec![-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0]];
+            vec![-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        ];
 
         let codec = ProximaCodec::global();
 

--- a/src/compute/proximacodec/wire_format.rs
+++ b/src/compute/proximacodec/wire_format.rs
@@ -303,7 +303,7 @@ mod tests {
 
             // Add dummy data
             let mut encoded = header_bytes.clone();
-            encoded.extend_from_slice(&vec![0u8; 100]);
+            encoded.extend_from_slice(&[0u8; 100]);
 
             let parsed = manager.read_header(&encoded).unwrap();
             assert_eq!(parsed.version, WIRE_FORMAT_VERSION);

--- a/src/core/flush_config_tests.rs
+++ b/src/core/flush_config_tests.rs
@@ -80,7 +80,7 @@ mod tests {
             8192 * 1024 * 1024
         );
         assert_eq!(toml_config.vector_count_threshold, 20000);
-        assert_eq!(toml_config.enable_wal, true);
+        assert!(toml_config.enable_wal);
         assert_eq!(
             toml_config.write_buffer_directory,
             "./test_data/write_buffer"

--- a/src/core/search/hybrid/fusion.rs
+++ b/src/core/search/hybrid/fusion.rs
@@ -1278,7 +1278,7 @@ mod tests {
 
         // All documents should have scores (3, 2, 1, 0)
         let scores: Vec<_> = fused.iter().map(|r| r.fused_score).collect();
-        assert!(scores.iter().all(|&s| s >= 0.0 && s <= 4.0));
+        assert!(scores.iter().all(|&s| (0.0..=4.0).contains(&s)));
     }
 
     #[test]

--- a/src/core/search/integrated_search_optimization.rs
+++ b/src/core/search/integrated_search_optimization.rs
@@ -1213,6 +1213,10 @@ impl Default for IntegratedOptimizationConfig {
     }
 }
 
+// Re-export types needed by other modules
+// Re-export from the smart_execution_strategy module
+pub use crate::core::search::smart_execution_strategy::ExecutionStrategy;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1251,7 +1255,3 @@ mod tests {
         }
     }
 }
-
-// Re-export types needed by other modules
-// Re-export from the smart_execution_strategy module
-pub use crate::core::search::smart_execution_strategy::ExecutionStrategy;

--- a/src/core/search/metadata_filter_pushdown.rs
+++ b/src/core/search/metadata_filter_pushdown.rs
@@ -861,7 +861,7 @@ mod tests {
         ]);
 
         let selectivity = pushdown.estimate_selectivity(&filter);
-        assert!(selectivity >= 0.0 && selectivity <= 1.0);
+        assert!((0.0..=1.0).contains(&selectivity));
     }
 
     #[test]

--- a/src/datafusion/engine_adapters/helix_adapter.rs
+++ b/src/datafusion/engine_adapters/helix_adapter.rs
@@ -670,7 +670,7 @@ mod tests {
     fn test_estimate_hilbert_range() {
         // Level 0: 10 files, each covers 1/10 of space
         let (min0, max0) = HelixTableProvider::estimate_hilbert_range(0, 0);
-        let (min1, max1) = HelixTableProvider::estimate_hilbert_range(0, 1);
+        let (min1, _max1) = HelixTableProvider::estimate_hilbert_range(0, 1);
 
         // Ranges should be non-overlapping
         assert!(max0 < min1);

--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -648,7 +648,7 @@ mod tests {
         let partitions = partition_splits(splits, 2);
         assert_eq!(partitions.len(), 2);
         // Greedy algorithm should balance approximately
-        assert!(partitions[0].len() >= 1 && partitions[1].len() >= 1);
+        assert!(!partitions[0].is_empty() && !partitions[1].is_empty());
     }
 
     #[test]

--- a/src/graph/service_algorithms.rs
+++ b/src/graph/service_algorithms.rs
@@ -516,7 +516,7 @@ mod tests {
 
         // Center node (n0) should have highest score in this star topology
         // because it has the most outgoing links
-        for (_node_id, score) in &scores {
+        for score in scores.values() {
             assert!(*score > 0.0, "All scores should be positive");
         }
     }

--- a/src/index/axis/flat_index_tests.rs
+++ b/src/index/axis/flat_index_tests.rs
@@ -256,11 +256,13 @@ mod tests {
         let dimension = 64;
 
         // Create vectors with metadata
-        let vectors_with_metadata = [("vec1", vec![1.0; dimension], "category_a"),
+        let vectors_with_metadata = [
+            ("vec1", vec![1.0; dimension], "category_a"),
             ("vec2", vec![0.8; dimension], "category_b"),
             ("vec3", vec![0.6; dimension], "category_a"),
             ("vec4", vec![0.4; dimension], "category_b"),
-            ("vec5", vec![0.2; dimension], "category_a")];
+            ("vec5", vec![0.2; dimension], "category_a"),
+        ];
 
         let query = vec![0.7; dimension];
         let filter_category = "category_a";

--- a/src/index/axis/flat_index_tests.rs
+++ b/src/index/axis/flat_index_tests.rs
@@ -256,13 +256,11 @@ mod tests {
         let dimension = 64;
 
         // Create vectors with metadata
-        let vectors_with_metadata = vec![
-            ("vec1", vec![1.0; dimension], "category_a"),
+        let vectors_with_metadata = [("vec1", vec![1.0; dimension], "category_a"),
             ("vec2", vec![0.8; dimension], "category_b"),
             ("vec3", vec![0.6; dimension], "category_a"),
             ("vec4", vec![0.4; dimension], "category_b"),
-            ("vec5", vec![0.2; dimension], "category_a"),
-        ];
+            ("vec5", vec![0.2; dimension], "category_a")];
 
         let query = vec![0.7; dimension];
         let filter_category = "category_a";
@@ -314,7 +312,7 @@ mod tests {
         debug!("Vectors within radius {}: {:?}", radius, within_range);
 
         // Should find vectors within the radius
-        assert!(within_range.len() > 0);
+        assert!(!within_range.is_empty());
         for (_, dist) in &within_range {
             assert!(*dist <= radius);
         }

--- a/src/index/axis/hybrid_index_tests.rs
+++ b/src/index/axis/hybrid_index_tests.rs
@@ -238,12 +238,11 @@ mod tests {
         if let IndexAlgorithm::IVF { quantizer, .. } = &ivf_pq_spec.algorithm {
             assert!(quantizer.is_some());
 
-            if let Some(q) = quantizer {
-                if let IndexAlgorithm::PQ { m, nbits, .. } = q.as_ref() {
+            if let Some(q) = quantizer
+                && let IndexAlgorithm::PQ { m, nbits, .. } = q.as_ref() {
                     assert_eq!(*m, 8);
                     assert_eq!(*nbits, 8);
                 }
-            }
         }
     }
 

--- a/src/index/axis/hybrid_index_tests.rs
+++ b/src/index/axis/hybrid_index_tests.rs
@@ -239,10 +239,11 @@ mod tests {
             assert!(quantizer.is_some());
 
             if let Some(q) = quantizer
-                && let IndexAlgorithm::PQ { m, nbits, .. } = q.as_ref() {
-                    assert_eq!(*m, 8);
-                    assert_eq!(*nbits, 8);
-                }
+                && let IndexAlgorithm::PQ { m, nbits, .. } = q.as_ref()
+            {
+                assert_eq!(*m, 8);
+                assert_eq!(*nbits, 8);
+            }
         }
     }
 

--- a/src/index/axis/indexes/dual_store_ivf.rs
+++ b/src/index/axis/indexes/dual_store_ivf.rs
@@ -2907,7 +2907,7 @@ mod tests {
         // Search
         let results = index.search(&[1.0, 0.0, 0.0, 0.0], 2, None).await.unwrap();
         assert!(
-            results.len() >= 1,
+            !results.is_empty(),
             "Should find at least 1 result, got {}",
             results.len()
         );

--- a/src/index/axis/indexes/hnsw_index.rs
+++ b/src/index/axis/indexes/hnsw_index.rs
@@ -1914,13 +1914,15 @@ mod tests {
         let index = AxisHnswIndex::new(config, 4).expect("Failed to create HNSW index");
 
         // Create a set of test vectors
-        let test_vectors = [("v1", vec![1.0, 0.0, 0.0, 0.0]),
+        let test_vectors = [
+            ("v1", vec![1.0, 0.0, 0.0, 0.0]),
             ("v2", vec![0.9, 0.1, 0.0, 0.0]),
             ("v3", vec![0.0, 1.0, 0.0, 0.0]),
             ("v4", vec![0.0, 0.0, 1.0, 0.0]),
             ("v5", vec![0.0, 0.0, 0.0, 1.0]),
             ("v6", vec![0.8, 0.2, 0.0, 0.0]),
-            ("v7", vec![0.7, 0.3, 0.0, 0.0])];
+            ("v7", vec![0.7, 0.3, 0.0, 0.0]),
+        ];
 
         for (id, vector) in test_vectors.iter() {
             index

--- a/src/index/axis/indexes/hnsw_index.rs
+++ b/src/index/axis/indexes/hnsw_index.rs
@@ -1914,15 +1914,13 @@ mod tests {
         let index = AxisHnswIndex::new(config, 4).expect("Failed to create HNSW index");
 
         // Create a set of test vectors
-        let test_vectors = vec![
-            ("v1", vec![1.0, 0.0, 0.0, 0.0]),
+        let test_vectors = [("v1", vec![1.0, 0.0, 0.0, 0.0]),
             ("v2", vec![0.9, 0.1, 0.0, 0.0]),
             ("v3", vec![0.0, 1.0, 0.0, 0.0]),
             ("v4", vec![0.0, 0.0, 1.0, 0.0]),
             ("v5", vec![0.0, 0.0, 0.0, 1.0]),
             ("v6", vec![0.8, 0.2, 0.0, 0.0]),
-            ("v7", vec![0.7, 0.3, 0.0, 0.0]),
-        ];
+            ("v7", vec![0.7, 0.3, 0.0, 0.0])];
 
         for (id, vector) in test_vectors.iter() {
             index
@@ -1941,7 +1939,7 @@ mod tests {
         // v1, v2, v6, v7 should be closest (all have high first component)
         // With default config, should find at least 1 result
         assert!(
-            results.len() >= 1,
+            !results.is_empty(),
             "Expected at least 1 result, got {}",
             results.len()
         );
@@ -1987,7 +1985,7 @@ mod tests {
             .search(&query, 10, None)
             .await
             .expect("Failed to search");
-        assert!(results.len() > 0);
+        assert!(!results.is_empty());
     }
 
     #[tokio::test]
@@ -2016,7 +2014,7 @@ mod tests {
         // Should find neighbors despite pruning
         // With small M=5, graph connectivity may be limited, so just check we get some results
         assert!(
-            results.len() >= 1,
+            !results.is_empty(),
             "Expected at least 1 result, got {}",
             results.len()
         );

--- a/src/index/axis/indexes/lsh_index.rs
+++ b/src/index/axis/indexes/lsh_index.rs
@@ -697,84 +697,6 @@ pub fn create_lsh_index_for_collection(
     )))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_lsh_basic_operations() {
-        let config = AxisLshConfig {
-            n_tables: 5,
-            n_hashes: 3,
-            hash_width: 2.0,
-            ..Default::default()
-        };
-
-        let index = AxisLshIndex::new(config, 4);
-
-        // Add vectors
-        let vectors = [
-            vec![1.0, 0.0, 0.0, 0.0],
-            vec![0.0, 1.0, 0.0, 0.0],
-            vec![0.0, 0.0, 1.0, 0.0],
-            vec![0.0, 0.0, 0.0, 1.0],
-            vec![0.9, 0.1, 0.0, 0.0], // Similar to first
-        ];
-
-        for (i, vector) in vectors.iter().enumerate() {
-            index
-                .add(format!("vec_{}", i), vector.clone())
-                .await
-                .unwrap();
-        }
-
-        // Search for similar to first vector
-        let query = vec![0.95, 0.05, 0.0, 0.0];
-        let results = index.search(&query, 3, None).await.unwrap();
-
-        assert!(!results.is_empty());
-        // Should find vec_0 and vec_4 as most similar
-        let result_ids: Vec<String> = results.iter().map(|(id, _)| id.clone()).collect();
-        assert!(
-            result_ids.contains(&"vec_0".to_string()) || result_ids.contains(&"vec_4".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_lsh_binary_mode() {
-        let config = AxisLshConfig {
-            n_tables: 3,
-            n_hashes: 8,
-            binary_mode: true,
-            distance_metric: DistanceMetric::Hamming,
-            ..Default::default()
-        };
-
-        let index = AxisLshIndex::new(config, 8);
-
-        // Add binary vectors (represented as 0.0 or 1.0)
-        let vectors = [
-            vec![1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
-            vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-            vec![1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
-        ];
-
-        for (i, vector) in vectors.iter().enumerate() {
-            index
-                .add(format!("binary_{}", i), vector.clone())
-                .await
-                .unwrap();
-        }
-
-        // Search
-        let query = vec![1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]; // Similar to first
-        let results = index.search(&query, 2, None).await.unwrap();
-
-        assert!(!results.is_empty());
-        assert_eq!(results[0].0, "binary_0"); // Should find the most similar
-    }
-}
-
 // Implement AxisVectorIndex trait for deep AXIS integration
 #[async_trait]
 impl AxisVectorIndex for AxisLshIndex {
@@ -856,5 +778,83 @@ impl AxisVectorIndex for AxisLshIndex {
             memory_usage_bytes: lsh_stats.memory_usage_bytes,
             index_type: "LSH".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_lsh_basic_operations() {
+        let config = AxisLshConfig {
+            n_tables: 5,
+            n_hashes: 3,
+            hash_width: 2.0,
+            ..Default::default()
+        };
+
+        let index = AxisLshIndex::new(config, 4);
+
+        // Add vectors
+        let vectors = [
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0, 0.0],
+            vec![0.0, 0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 0.0, 1.0],
+            vec![0.9, 0.1, 0.0, 0.0], // Similar to first
+        ];
+
+        for (i, vector) in vectors.iter().enumerate() {
+            index
+                .add(format!("vec_{}", i), vector.clone())
+                .await
+                .unwrap();
+        }
+
+        // Search for similar to first vector
+        let query = vec![0.95, 0.05, 0.0, 0.0];
+        let results = index.search(&query, 3, None).await.unwrap();
+
+        assert!(!results.is_empty());
+        // Should find vec_0 and vec_4 as most similar
+        let result_ids: Vec<String> = results.iter().map(|(id, _)| id.clone()).collect();
+        assert!(
+            result_ids.contains(&"vec_0".to_string()) || result_ids.contains(&"vec_4".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lsh_binary_mode() {
+        let config = AxisLshConfig {
+            n_tables: 3,
+            n_hashes: 8,
+            binary_mode: true,
+            distance_metric: DistanceMetric::Hamming,
+            ..Default::default()
+        };
+
+        let index = AxisLshIndex::new(config, 8);
+
+        // Add binary vectors (represented as 0.0 or 1.0)
+        let vectors = [
+            vec![1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+            vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            vec![1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+        ];
+
+        for (i, vector) in vectors.iter().enumerate() {
+            index
+                .add(format!("binary_{}", i), vector.clone())
+                .await
+                .unwrap();
+        }
+
+        // Search
+        let query = vec![1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]; // Similar to first
+        let results = index.search(&query, 2, None).await.unwrap();
+
+        assert!(!results.is_empty());
+        assert_eq!(results[0].0, "binary_0"); // Should find the most similar
     }
 }

--- a/src/index/axis/management/ivf_param_advisor.rs
+++ b/src/index/axis/management/ivf_param_advisor.rs
@@ -600,7 +600,7 @@ mod tests {
             IndexAlgorithm::IVF { nlist, nprobe, .. } => {
                 assert_eq!(nlist, 317); // sqrt(100K) ceiling
                 assert!(
-                    nprobe >= 10 && nprobe <= 50,
+                    (10..=50).contains(&nprobe),
                     "nprobe {} should land in [10, 50] for r=0.60",
                     nprobe
                 );

--- a/src/index/axis/pq_index_tests.rs
+++ b/src/index/axis/pq_index_tests.rs
@@ -85,9 +85,9 @@ mod tests {
             // Calculate theoretical compression ratio
             let original_size = 128 * 4; // 128 floats * 4 bytes
             let compressed_size = if nbits == 8 {
-                m * 1 // m bytes for 8-bit codes
+                m // m bytes for 8-bit codes
             } else {
-                (m * nbits as u32) / 8 // bits to bytes
+                (m * nbits) / 8 // bits to bytes
             };
             let ratio = original_size as f32 / compressed_size as f32;
 

--- a/src/metrics/collectors/tests/metrics_integration_test.rs
+++ b/src/metrics/collectors/tests/metrics_integration_test.rs
@@ -48,7 +48,7 @@ mod tests {
                 .contains_key("access_pattern.correlation_hit_rate")
         );
         let hit_rate = sample.values["access_pattern.correlation_hit_rate"];
-        assert!(hit_rate >= 0.0 && hit_rate <= 1.0);
+        assert!((0.0..=1.0).contains(&hit_rate));
     }
 
     #[tokio::test]

--- a/src/network/grpc/rank_service.rs
+++ b/src/network/grpc/rank_service.rs
@@ -487,7 +487,7 @@ mod tests {
             rank_profile: Some("ghost".into()),
             rank_overrides: None,
         });
-        let status = handler.rank_search(req).await.err().expect("must error");
+        let status = handler.rank_search(req).await.expect_err("must error");
         assert_eq!(status.code(), tonic::Code::NotFound);
         assert!(status.message().contains("ghost"));
     }

--- a/src/network/grpc/security_service.rs
+++ b/src/network/grpc/security_service.rs
@@ -686,7 +686,7 @@ mod tests {
 
         let response = result.unwrap().into_inner();
         // Default behavior: default_deny = false, so unassigned users are allowed
-        assert_eq!(response.allowed, true);
+        assert!(response.allowed);
     }
 
     /// ADR-016 / Task #69: lock in the lossy-projection semantics so

--- a/src/network/middleware/rate_limit.rs
+++ b/src/network/middleware/rate_limit.rs
@@ -642,13 +642,15 @@ enabled = false
 
         // Verify the structure can be parsed
         if let Some(network) = parsed.get("network")
-            && let Some(enabled) = network.get("enabled") {
-                assert_eq!(enabled.as_bool(), Some(false));
-            }
+            && let Some(enabled) = network.get("enabled")
+        {
+            assert_eq!(enabled.as_bool(), Some(false));
+        }
 
         if let Some(rate_limit) = parsed.get("rate_limit")
-            && let Some(enabled) = rate_limit.get("enabled") {
-                assert_eq!(enabled.as_bool(), Some(false));
-            }
+            && let Some(enabled) = rate_limit.get("enabled")
+        {
+            assert_eq!(enabled.as_bool(), Some(false));
+        }
     }
 }

--- a/src/network/middleware/rate_limit.rs
+++ b/src/network/middleware/rate_limit.rs
@@ -641,16 +641,14 @@ enabled = false
         let parsed: toml::Value = toml::from_str(toml_content).expect("Failed to parse TOML");
 
         // Verify the structure can be parsed
-        if let Some(network) = parsed.get("network") {
-            if let Some(enabled) = network.get("enabled") {
+        if let Some(network) = parsed.get("network")
+            && let Some(enabled) = network.get("enabled") {
                 assert_eq!(enabled.as_bool(), Some(false));
             }
-        }
 
-        if let Some(rate_limit) = parsed.get("rate_limit") {
-            if let Some(enabled) = rate_limit.get("enabled") {
+        if let Some(rate_limit) = parsed.get("rate_limit")
+            && let Some(enabled) = rate_limit.get("enabled") {
                 assert_eq!(enabled.as_bool(), Some(false));
             }
-        }
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -640,10 +640,10 @@ mod config_tests {
 
         let middleware_config = config.to_middleware_config();
 
-        assert_eq!(middleware_config.enabled, true);
+        assert!(middleware_config.enabled);
         assert_eq!(middleware_config.max_requests, 150); // Uses burst_size
         assert_eq!(middleware_config.window_duration.as_secs(), 60); // 1 minute
-        assert_eq!(middleware_config.limit_health_endpoints, true);
+        assert!(middleware_config.limit_health_endpoints);
         assert_eq!(middleware_config.global_max_requests, Some(5000));
     }
 }

--- a/src/network/rest/v1/multimodal_query.rs
+++ b/src/network/rest/v1/multimodal_query.rs
@@ -2151,7 +2151,7 @@ mod tests {
             json["records"][0].get("metadata").is_none()
                 || json["records"][0]["metadata"]
                     .as_object()
-                    .map_or(false, |m| m.is_empty()),
+                    .is_some_and(|m| m.is_empty()),
             "empty metadata should be skipped or empty"
         );
         assert!((json["metrics"]["total_time_ms"].as_f64().unwrap() - 12.5).abs() < f64::EPSILON);

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -3462,7 +3462,7 @@ mod tests {
 
         let result = convert_typed_filters_to_clauses(&filters);
         assert!(result.is_err());
-        let err_msg = format!("{:?}", result.err().expect("Should be error"));
+        let err_msg = format!("{:?}", result.expect_err("Should be error"));
         assert!(err_msg.contains("Unsupported"));
     }
 

--- a/src/observability/ingestion/adapters/cef_leef.rs
+++ b/src/observability/ingestion/adapters/cef_leef.rs
@@ -512,7 +512,7 @@ mod tests {
             entry
                 .source
                 .as_ref()
-                .map_or(false, |s| s.contains("Security"))
+                .is_some_and(|s| s.contains("Security"))
         );
     }
 
@@ -530,7 +530,7 @@ mod tests {
             entry
                 .source
                 .as_ref()
-                .map_or(false, |s| s.contains("Vendor"))
+                .is_some_and(|s| s.contains("Vendor"))
         );
     }
 

--- a/src/observability/ingestion/adapters/cef_leef.rs
+++ b/src/observability/ingestion/adapters/cef_leef.rs
@@ -526,12 +526,7 @@ mod tests {
         let entry = adapter.parse_leef(msg).unwrap();
 
         assert_eq!(entry.message, "EventID");
-        assert!(
-            entry
-                .source
-                .as_ref()
-                .is_some_and(|s| s.contains("Vendor"))
-        );
+        assert!(entry.source.as_ref().is_some_and(|s| s.contains("Vendor")));
     }
 
     #[test]

--- a/src/observability/ingestion/adapters/ocsf.rs
+++ b/src/observability/ingestion/adapters/ocsf.rs
@@ -378,7 +378,7 @@ mod tests {
             entry
                 .source
                 .as_ref()
-                .map_or(false, |s| s.contains("TestVendor"))
+                .is_some_and(|s| s.contains("TestVendor"))
         );
     }
 

--- a/src/observability/query/metrics.rs
+++ b/src/observability/query/metrics.rs
@@ -437,6 +437,6 @@ mod tests {
 
         let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
         let p50 = query.calculate_percentile(&values, 0.50);
-        assert!(p50 >= 5.0 && p50 <= 6.0);
+        assert!((5.0..=6.0).contains(&p50));
     }
 }

--- a/src/observability/query/mod.rs
+++ b/src/observability/query/mod.rs
@@ -1109,7 +1109,7 @@ mod tests {
             .unwrap();
 
         // Only log_1 has exact phrase "timeout error"
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
     }
 
     #[tokio::test]

--- a/src/observability/query/tantivy_log_index.rs
+++ b/src/observability/query/tantivy_log_index.rs
@@ -856,7 +856,7 @@ mod tests {
             .expect("Failed to search phrase");
 
         // Only log1 has exact phrase "connection timeout"
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
     }
 
     #[test]

--- a/src/query/cache/result_cache_gate.rs
+++ b/src/query/cache/result_cache_gate.rs
@@ -135,12 +135,12 @@ mod tests {
     }
 
     fn warm_learner_for_low_cost() -> MismatchCostLearner {
-        let learner = MismatchCostLearner::new(MismatchConfig {
+        
+        MismatchCostLearner::new(MismatchConfig {
             similarity_floor: 0.5,
             allowed_cost: 0.5,
             decay_seconds: 3600,
-        });
-        learner
+        })
     }
 
     #[tokio::test]

--- a/src/query/cache/result_cache_gate.rs
+++ b/src/query/cache/result_cache_gate.rs
@@ -135,7 +135,6 @@ mod tests {
     }
 
     fn warm_learner_for_low_cost() -> MismatchCostLearner {
-        
         MismatchCostLearner::new(MismatchConfig {
             similarity_floor: 0.5,
             allowed_cost: 0.5,

--- a/src/query/execution/executor.rs
+++ b/src/query/execution/executor.rs
@@ -747,14 +747,15 @@ impl MultiModalQueryExecutor {
         #[cfg(test)]
         if let Some(map) = TEST_SIMILAR_RESULTS.get()
             && let Ok(guard) = map.lock()
-                && let Some(rows) = guard.get(collection_id) {
-                    // Update performance metrics for test data
-                    metrics.vectors_scanned = rows.len();
-                    metrics.metadata_lookups += rows.len(); // Each result involves metadata access
+            && let Some(rows) = guard.get(collection_id)
+        {
+            // Update performance metrics for test data
+            metrics.vectors_scanned = rows.len();
+            metrics.metadata_lookups += rows.len(); // Each result involves metadata access
 
-                    // Avoid clone by using Arc for shared test data
-                    return Ok(rows.clone());
-                }
+            // Avoid clone by using Arc for shared test data
+            return Ok(rows.clone());
+        }
         // Convert FilterExpression to VOS-compatible format
         // The FilterExpression already represents HashMap.get() patterns from lowering
         let search_config = crate::services::operations::vectors::UnifiedSearchConfig {
@@ -1328,11 +1329,12 @@ impl MultiModalQueryExecutor {
         #[cfg(test)]
         if let Some(map) = TEST_GRAPH_RESULTS.get()
             && let Ok(guard) = map.lock()
-                && let Some(rows) = guard.get("test_graph") {
-                    // Update performance metrics for test data
-                    metrics.graph_nodes_visited = rows.len();
-                    return Ok(rows.clone());
-                }
+            && let Some(rows) = guard.get("test_graph")
+        {
+            // Update performance metrics for test data
+            metrics.graph_nodes_visited = rows.len();
+            return Ok(rows.clone());
+        }
 
         // Minimal traversal: depth-1 neighbors via the extracted traversal contract; track cache accesses
         let mut rows = Vec::new();
@@ -1454,10 +1456,11 @@ impl MultiModalQueryExecutor {
         {
             if let ExecutionOperation::VectorQuery { collection_id, .. } = operation
                 && let Some(map) = TEST_VECTOR_RESULTS.get()
-                    && let Ok(guard) = map.lock()
-                        && let Some(rows) = guard.get(collection_id) {
-                            return Ok(rows.clone());
-                        }
+                && let Ok(guard) = map.lock()
+                && let Some(rows) = guard.get(collection_id)
+            {
+                return Ok(rows.clone());
+            }
         }
         if let ExecutionOperation::VectorQuery {
             collection_id,
@@ -1470,9 +1473,10 @@ impl MultiModalQueryExecutor {
             #[cfg(test)]
             if let Some(map) = TEST_VECTOR_RESULTS.get()
                 && let Ok(guard) = map.lock()
-                    && let Some(rows) = guard.get(collection_id) {
-                        return Ok(rows.clone());
-                    }
+                && let Some(rows) = guard.get(collection_id)
+            {
+                return Ok(rows.clone());
+            }
             self.execute_vector_search_operation(
                 collection_id,
                 query_vector.as_ref(),

--- a/src/query/execution/executor.rs
+++ b/src/query/execution/executor.rs
@@ -745,9 +745,9 @@ impl MultiModalQueryExecutor {
         metrics: &mut QueryPerformanceMetrics,
     ) -> Result<Vec<QueryRow>> {
         #[cfg(test)]
-        if let Some(map) = TEST_SIMILAR_RESULTS.get() {
-            if let Ok(guard) = map.lock() {
-                if let Some(rows) = guard.get(collection_id) {
+        if let Some(map) = TEST_SIMILAR_RESULTS.get()
+            && let Ok(guard) = map.lock()
+                && let Some(rows) = guard.get(collection_id) {
                     // Update performance metrics for test data
                     metrics.vectors_scanned = rows.len();
                     metrics.metadata_lookups += rows.len(); // Each result involves metadata access
@@ -755,8 +755,6 @@ impl MultiModalQueryExecutor {
                     // Avoid clone by using Arc for shared test data
                     return Ok(rows.clone());
                 }
-            }
-        }
         // Convert FilterExpression to VOS-compatible format
         // The FilterExpression already represents HashMap.get() patterns from lowering
         let search_config = crate::services::operations::vectors::UnifiedSearchConfig {
@@ -1328,15 +1326,13 @@ impl MultiModalQueryExecutor {
     ) -> Result<Vec<QueryRow>> {
         // Check for test mock data first
         #[cfg(test)]
-        if let Some(map) = TEST_GRAPH_RESULTS.get() {
-            if let Ok(guard) = map.lock() {
-                if let Some(rows) = guard.get("test_graph") {
+        if let Some(map) = TEST_GRAPH_RESULTS.get()
+            && let Ok(guard) = map.lock()
+                && let Some(rows) = guard.get("test_graph") {
                     // Update performance metrics for test data
                     metrics.graph_nodes_visited = rows.len();
                     return Ok(rows.clone());
                 }
-            }
-        }
 
         // Minimal traversal: depth-1 neighbors via the extracted traversal contract; track cache accesses
         let mut rows = Vec::new();
@@ -1456,15 +1452,12 @@ impl MultiModalQueryExecutor {
     ) -> Result<Vec<QueryRow>> {
         #[cfg(test)]
         {
-            if let ExecutionOperation::VectorQuery { collection_id, .. } = operation {
-                if let Some(map) = TEST_VECTOR_RESULTS.get() {
-                    if let Some(guard) = map.lock().ok() {
-                        if let Some(rows) = guard.get(collection_id) {
+            if let ExecutionOperation::VectorQuery { collection_id, .. } = operation
+                && let Some(map) = TEST_VECTOR_RESULTS.get()
+                    && let Ok(guard) = map.lock()
+                        && let Some(rows) = guard.get(collection_id) {
                             return Ok(rows.clone());
                         }
-                    }
-                }
-            }
         }
         if let ExecutionOperation::VectorQuery {
             collection_id,
@@ -1475,13 +1468,11 @@ impl MultiModalQueryExecutor {
         } = operation
         {
             #[cfg(test)]
-            if let Some(map) = TEST_VECTOR_RESULTS.get() {
-                if let Ok(guard) = map.lock() {
-                    if let Some(rows) = guard.get(collection_id) {
+            if let Some(map) = TEST_VECTOR_RESULTS.get()
+                && let Ok(guard) = map.lock()
+                    && let Some(rows) = guard.get(collection_id) {
                         return Ok(rows.clone());
                     }
-                }
-            }
             self.execute_vector_search_operation(
                 collection_id,
                 query_vector.as_ref(),
@@ -2275,7 +2266,7 @@ mod executor_tests {
         );
         let wal_config = WALConfig::default();
         let strategy = WALBatchFactory::create_batch_serialization_strategy(
-            wal_config.strategy_type.clone(),
+            wal_config.strategy_type,
             &wal_config,
             filesystem,
         )
@@ -2358,7 +2349,7 @@ mod executor_tests {
         );
         let wal_config = WALConfig::default();
         let strategy = WALBatchFactory::create_batch_serialization_strategy(
-            wal_config.strategy_type.clone(),
+            wal_config.strategy_type,
             &wal_config,
             filesystem,
         )

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -325,7 +325,7 @@ mod execution_tests {
         );
         let wal_config = WALConfig::default();
         let strategy = WALBatchFactory::create_batch_serialization_strategy(
-            wal_config.strategy_type.clone(),
+            wal_config.strategy_type,
             &wal_config,
             filesystem,
         )

--- a/src/query/execution/planner.rs
+++ b/src/query/execution/planner.rs
@@ -325,16 +325,6 @@ impl ExecutionPlanner {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_hybrid_fusion_weights_follow_runtime_config() {
-        assert_eq!(default_hybrid_fusion_weights(), vec![0.6, 0.4]);
-    }
-}
-
 /// Simple cost model for execution planning
 struct CostModel;
 
@@ -354,5 +344,15 @@ impl CostModel {
             ExecutionOperation::Project { columns, .. } => columns.len() as f64 * 0.01,
             _ => 1.0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_hybrid_fusion_weights_follow_runtime_config() {
+        assert_eq!(default_hybrid_fusion_weights(), vec![0.6, 0.4]);
     }
 }

--- a/src/query/facade/strategies/observability.rs
+++ b/src/query/facade/strategies/observability.rs
@@ -1191,14 +1191,12 @@ mod tests {
                 if let Some(comma_pos) = rest.find(',') {
                     let after_comma = rest[comma_pos + 1..].trim();
                     // Extract quoted string
-                    if after_comma.starts_with('\'') {
-                        let rest = &after_comma[1..];
-                        if let Some(end) = rest.find('\'') {
+                    if let Some(rest) = after_comma.strip_prefix('\'')
+                        && let Some(end) = rest.find('\'') {
                             let expr = &rest[..end];
                             assert_eq!(expr, "rate(http_requests_total[5m])");
                             return;
                         }
-                    }
                 }
             }
             panic!("Failed to extract PromQL expression");
@@ -1277,14 +1275,12 @@ mod tests {
                     let after_metric = &rest[metric_pos..];
                     if let Some(eq_pos) = after_metric.find('=') {
                         let value_part = after_metric[eq_pos + 1..].trim();
-                        if value_part.starts_with('\'') {
-                            let rest = &value_part[1..];
-                            if let Some(end) = rest.find('\'') {
+                        if let Some(rest) = value_part.strip_prefix('\'')
+                            && let Some(end) = rest.find('\'') {
                                 let name = &rest[..end];
                                 assert_eq!(name, "cpu_usage");
                                 return;
                             }
-                        }
                     }
                 }
             }
@@ -1312,16 +1308,14 @@ mod tests {
 
             if let Some(interval_pos) = upper.find("INTERVAL") {
                 let rest = &content[interval_pos + 8..].trim();
-                if rest.starts_with('\'') {
-                    let inner = &rest[1..];
-                    if let Some(end) = inner.find('\'') {
+                if let Some(inner) = rest.strip_prefix('\'')
+                    && let Some(end) = inner.find('\'') {
                         let duration_str = &inner[..end];
                         let duration = PromQLParser::parse_duration(duration_str).unwrap();
                         // 1 hour = 3,600,000,000,000 nanoseconds
                         assert_eq!(duration.nanoseconds, 3_600_000_000_000);
                         return;
                     }
-                }
             }
             panic!("Failed to extract interval duration");
         }

--- a/src/query/facade/strategies/observability.rs
+++ b/src/query/facade/strategies/observability.rs
@@ -1192,11 +1192,12 @@ mod tests {
                     let after_comma = rest[comma_pos + 1..].trim();
                     // Extract quoted string
                     if let Some(rest) = after_comma.strip_prefix('\'')
-                        && let Some(end) = rest.find('\'') {
-                            let expr = &rest[..end];
-                            assert_eq!(expr, "rate(http_requests_total[5m])");
-                            return;
-                        }
+                        && let Some(end) = rest.find('\'')
+                    {
+                        let expr = &rest[..end];
+                        assert_eq!(expr, "rate(http_requests_total[5m])");
+                        return;
+                    }
                 }
             }
             panic!("Failed to extract PromQL expression");
@@ -1276,11 +1277,12 @@ mod tests {
                     if let Some(eq_pos) = after_metric.find('=') {
                         let value_part = after_metric[eq_pos + 1..].trim();
                         if let Some(rest) = value_part.strip_prefix('\'')
-                            && let Some(end) = rest.find('\'') {
-                                let name = &rest[..end];
-                                assert_eq!(name, "cpu_usage");
-                                return;
-                            }
+                            && let Some(end) = rest.find('\'')
+                        {
+                            let name = &rest[..end];
+                            assert_eq!(name, "cpu_usage");
+                            return;
+                        }
                     }
                 }
             }
@@ -1309,13 +1311,14 @@ mod tests {
             if let Some(interval_pos) = upper.find("INTERVAL") {
                 let rest = &content[interval_pos + 8..].trim();
                 if let Some(inner) = rest.strip_prefix('\'')
-                    && let Some(end) = inner.find('\'') {
-                        let duration_str = &inner[..end];
-                        let duration = PromQLParser::parse_duration(duration_str).unwrap();
-                        // 1 hour = 3,600,000,000,000 nanoseconds
-                        assert_eq!(duration.nanoseconds, 3_600_000_000_000);
-                        return;
-                    }
+                    && let Some(end) = inner.find('\'')
+                {
+                    let duration_str = &inner[..end];
+                    let duration = PromQLParser::parse_duration(duration_str).unwrap();
+                    // 1 hour = 3,600,000,000,000 nanoseconds
+                    assert_eq!(duration.nanoseconds, 3_600_000_000_000);
+                    return;
+                }
             }
             panic!("Failed to extract interval duration");
         }

--- a/src/query/federated/mod.rs
+++ b/src/query/federated/mod.rs
@@ -1007,7 +1007,7 @@ mod tests {
     fn test_federated_context_creation() {
         let storage = Arc::new(MultiModelStorageFacade::new());
         let ctx = FederatedQueryContext::new(storage);
-        assert!(ctx.parser.supported_extensions().len() > 0);
+        assert!(!ctx.parser.supported_extensions().is_empty());
     }
 
     #[test]

--- a/src/query/federated/optimizer/tests.rs
+++ b/src/query/federated/optimizer/tests.rs
@@ -481,7 +481,10 @@ mod tests {
 
         // Should identify that a and b can run in parallel
         // and that (a join b) and c can run in parallel
-        assert!(!stages.is_empty(), "Should find at least one parallel stage");
+        assert!(
+            !stages.is_empty(),
+            "Should find at least one parallel stage"
+        );
     }
 
     #[test]

--- a/src/query/federated/optimizer/tests.rs
+++ b/src/query/federated/optimizer/tests.rs
@@ -481,7 +481,7 @@ mod tests {
 
         // Should identify that a and b can run in parallel
         // and that (a join b) and c can run in parallel
-        assert!(stages.len() >= 1, "Should find at least one parallel stage");
+        assert!(!stages.is_empty(), "Should find at least one parallel stage");
     }
 
     #[test]

--- a/src/query/query_optimizer.rs
+++ b/src/query/query_optimizer.rs
@@ -3342,7 +3342,7 @@ mod tests {
         // With centroid routing: 1000 * (1 - 0.8) = 200 blocks
         let blocks = oe.expected_blocks_to_scan(true, false);
         assert!(
-            blocks >= 190 && blocks <= 210,
+            (190..=210).contains(&blocks),
             "Expected ~200 blocks, got {}",
             blocks
         );
@@ -3350,7 +3350,7 @@ mod tests {
         // With centroid + Z-order: 1000 * (1 - 0.8) * (1 - 0.5) = 100 blocks
         let blocks = oe.expected_blocks_to_scan(true, true);
         assert!(
-            blocks >= 90 && blocks <= 110,
+            (90..=110).contains(&blocks),
             "Expected ~100 blocks, got {}",
             blocks
         );
@@ -3369,7 +3369,7 @@ mod tests {
 
         // With centroid only: 1 - 0.9 = 0.1 (90% reduction)
         let mult = oe.io_cost_multiplier(true, false, false);
-        assert!(mult >= 0.09 && mult <= 0.11, "Expected ~0.1, got {}", mult);
+        assert!((0.09..=0.11).contains(&mult), "Expected ~0.1, got {}", mult);
 
         // With centroid + zone: raw multiplier is
         // (1 - 0.9) * (1 - 0.8) = 0.02, but the cost model applies a
@@ -3377,7 +3377,7 @@ mod tests {
         // stacked pruning signals.
         let mult = oe.io_cost_multiplier(true, false, true);
         assert!(
-            mult >= 0.09 && mult <= 0.11,
+            (0.09..=0.11).contains(&mult),
             "Expected conservative floor ~0.1, got {}",
             mult
         );

--- a/src/query/rl_planner/bandit.rs
+++ b/src/query/rl_planner/bandit.rs
@@ -570,7 +570,7 @@ mod tests {
         // Sample should be in [0, 1]
         for _ in 0..100 {
             let sample = beta.sample();
-            assert!(sample >= 0.0 && sample <= 1.0);
+            assert!((0.0..=1.0).contains(&sample));
         }
     }
 

--- a/src/query/rl_planner/mod.rs
+++ b/src/query/rl_planner/mod.rs
@@ -289,7 +289,7 @@ mod tests {
         let action = planner.select_action(&state).await;
 
         // Should return a valid action
-        assert!(!matches!(action.index_strategy, None));
+        assert!(action.index_strategy.is_some());
     }
 
     #[tokio::test]

--- a/src/query/rl_planner/state.rs
+++ b/src/query/rl_planner/state.rs
@@ -495,7 +495,12 @@ mod tests {
 
         // All features should be normalized roughly to [0, 1]
         for (i, &f) in features.iter().enumerate() {
-            assert!((0.0..=10.0).contains(&f), "Feature {} = {} out of range", i, f);
+            assert!(
+                (0.0..=10.0).contains(&f),
+                "Feature {} = {} out of range",
+                i,
+                f
+            );
         }
     }
 

--- a/src/query/rl_planner/state.rs
+++ b/src/query/rl_planner/state.rs
@@ -495,7 +495,7 @@ mod tests {
 
         // All features should be normalized roughly to [0, 1]
         for (i, &f) in features.iter().enumerate() {
-            assert!(f >= 0.0 && f <= 10.0, "Feature {} = {} out of range", i, f);
+            assert!((0.0..=10.0).contains(&f), "Feature {} = {} out of range", i, f);
         }
     }
 

--- a/src/query/sql_frontend/lowering.rs
+++ b/src/query/sql_frontend/lowering.rs
@@ -1080,10 +1080,10 @@ mod lowering_tests {
             Query::Select(select) => {
                 assert_eq!(select.projection.len(), 2);
                 assert_eq!(select.limit, Some(10));
-                assert!(select.from.len() > 0);
+                assert!(!select.from.is_empty());
 
                 // Verify projection contains expected fields
-                if let Some(item) = select.projection.get(0) {
+                if let Some(item) = select.projection.first() {
                     assert!(matches!(item.expr, Expr::Identifier(ref id) if id == "id"));
                 }
                 if let Some(item) = select.projection.get(1) {

--- a/src/query/table_write_executor.rs
+++ b/src/query/table_write_executor.rs
@@ -698,6 +698,185 @@ fn object_write_path(
     ))
 }
 
+/// Upper bound on optimistic-concurrency manifest-commit retries. A healthy
+/// system rebases past a handful of concurrent committers within a few attempts;
+/// hitting this ceiling means the conflict is persistent (a wedged committer or a
+/// `latest` that never lets this writer win the CAS), which we surface as an error
+/// rather than spinning forever.
+const MAX_MANIFEST_COMMIT_ATTEMPTS: usize = 32;
+
+/// DataFusion-based executor for OLAP/table-to-table write workloads.
+///
+/// This executor materializes query output into `ProximaRecord` batches and
+/// commits through `TableRecordStore`. It is not the direct authority for
+/// PostgreSQL-style OLTP writes; constraint-sensitive mutations must still pass
+/// through the native WAL/row-delta commit path selected by xCatalog routing.
+pub struct DataFusionTableWriteExecutor {
+    source_reader: Arc<dyn TableRecordSourceReader>,
+    record_store: Arc<dyn TableRecordStore>,
+    object_store_bridge: Option<Arc<dyn ObjectStoreBridge>>,
+}
+
+impl DataFusionTableWriteExecutor {
+    pub fn new(
+        source_reader: Arc<dyn TableRecordSourceReader>,
+        record_store: Arc<dyn TableRecordStore>,
+    ) -> Self {
+        Self {
+            source_reader,
+            record_store,
+            object_store_bridge: None,
+        }
+    }
+
+    pub fn with_object_store_bridge(mut self, bridge: Arc<dyn ObjectStoreBridge>) -> Self {
+        self.object_store_bridge = Some(bridge);
+        self
+    }
+}
+
+#[async_trait]
+impl TableWriteExecutor for DataFusionTableWriteExecutor {
+    async fn execute(
+        &self,
+        request: TableWriteExecutionRequest<'_>,
+    ) -> Result<TableWriteExecutionResult> {
+        use proximadb_storage_common::object_store_bridge::CommitOutcome;
+
+        validate_required_guards(request.target_schema, &request.routed_plan)?;
+        if !is_datafusion_backend(&request.routed_plan.backend) {
+            return Ok(TableWriteExecutionResult::planned(&request.routed_plan));
+        }
+        validate_datafusion_write_lane(request.target_schema, &request.routed_plan)?;
+
+        let mutation_kind = mutation_kind_for_write_mode(&request.routed_plan.plan.write_mode)?;
+        let mut rows_written = 0;
+        let mut cursor = TableRecordSourceCursor::default();
+        let is_bulk_append =
+            request.routed_plan.write_lane_decision.lane == WriteLane::BulkAppendCommit;
+        let mut batch_index = 0;
+        let mut wrote_any_parquet = false;
+
+        while let Some(batch) = self
+            .source_reader
+            .next_batch(
+                &request.routed_plan.plan.source,
+                request.source_schema,
+                request.target_schema,
+                request.tenant_context,
+                &mut cursor,
+            )
+            .await?
+        {
+            if batch.is_empty() {
+                continue;
+            }
+            if is_bulk_append {
+                let path = object_write_path(
+                    request.target_schema,
+                    &request.routed_plan,
+                    batch_index,
+                    request.tenant_context.map(|tc| tc.tenant_id.as_str()),
+                );
+                batch_index += 1;
+
+                let bridge = self.object_store_bridge.as_ref().ok_or_else(|| {
+                    anyhow!(
+                        "DataFusion bulk append for '{}' requires an ObjectStoreBridge",
+                        request.target_schema.name
+                    )
+                })?;
+                let tenant_id = request.tenant_context.map(|tc| tc.tenant_id.as_str());
+                bridge
+                    .write_records_to_parquet(&path, &batch, tenant_id)
+                    .await
+                    .map_err(|err| {
+                        anyhow!(
+                            "DataFusion Parquet write failed for '{}' at '{}': {err}",
+                            request.target_schema.name,
+                            path
+                        )
+                    })?;
+                rows_written += batch.len() as u64;
+                wrote_any_parquet = true;
+                continue;
+            }
+
+            let mutations = batch
+                .into_iter()
+                .map(|record| TableRecordMutation::new(mutation_kind, record))
+                .collect::<Vec<_>>();
+            // TD-113 family: thread the tenant so the non-bulk-append DataFusion
+            // route writes into the tenant's record partition (was `None`).
+            let result = self
+                .record_store
+                .write_mutations(request.target_schema, mutations, request.tenant_context)
+                .await?;
+            if !result.success {
+                return Err(anyhow!(
+                    "DataFusion table write failed for '{}': {:?}",
+                    request.target_schema.name,
+                    result.errors
+                ));
+            }
+            rows_written += result.record_ids.len() as u64;
+        }
+
+        if is_bulk_append && wrote_any_parquet {
+            let bridge = self.object_store_bridge.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "DataFusion bulk append for '{}' wrote Parquet without an ObjectStoreBridge",
+                    request.target_schema.name
+                )
+            })?;
+            let base = object_write_base_path(
+                request.target_schema,
+                request.tenant_context.map(|tc| tc.tenant_id.as_str()),
+            );
+            let data_prefix = format!("{base}/data");
+            let manifest_prefix = format!("{base}/_manifests");
+
+            // Optimistic-concurrency commit: rebase onto the latest snapshot and retry
+            // on conflict, bounded so a persistent conflict surfaces as an error instead
+            // of spinning forever.
+            let mut parent = bridge.latest_manifest_version(&manifest_prefix).await?;
+            let mut committed = false;
+            for _ in 0..MAX_MANIFEST_COMMIT_ATTEMPTS {
+                match bridge
+                    .publish_snapshot(&Path::from(data_prefix.as_str()), &manifest_prefix, parent)
+                    .await?
+                {
+                    CommitOutcome::Committed(_) => {
+                        committed = true;
+                        break;
+                    }
+                    CommitOutcome::Conflict { latest } => parent = latest,
+                }
+            }
+            if !committed {
+                return Err(anyhow!(
+                    "DataFusion manifest commit for '{}' failed after {} attempts due to \
+                     persistent snapshot conflict",
+                    request.target_schema.name,
+                    MAX_MANIFEST_COMMIT_ATTEMPTS
+                ));
+            }
+        }
+
+        Ok(TableWriteExecutionResult {
+            status: TableWriteExecutionStatus::Completed,
+            rows_written,
+            route_summary: format!(
+                "backend={:?}, access_method={:?}, batches={}",
+                request.routed_plan.backend,
+                request.routed_plan.selected_path.access_method,
+                batch_index
+            ),
+            guards: request.routed_plan.required_guards,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -971,7 +1150,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -999,7 +1178,7 @@ mod tests {
     async fn planned_executor_rejects_routes_missing_core_guards() {
         let schema = CatalogTableSchema::new("orders");
         let mut routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1097,7 +1276,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1243,7 +1422,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: schema,
                 target_stats: None,
                 source_schema: None,
@@ -1367,7 +1546,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("members"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1474,7 +1653,7 @@ mod tests {
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         plan.write_mode = WriteMode::Merge;
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1546,7 +1725,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1581,7 +1760,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1620,7 +1799,7 @@ mod tests {
             ..Default::default()
         };
         let mut routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1657,7 +1836,7 @@ mod tests {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("facts"), "SELECT * FROM staging");
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1710,7 +1889,7 @@ mod tests {
             ..Default::default()
         };
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1768,7 +1947,7 @@ mod tests {
             ..Default::default()
         };
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1814,7 +1993,7 @@ mod tests {
             ..Default::default()
         };
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1881,7 +2060,7 @@ mod tests {
             ..Default::default()
         };
         let routed =
-            TableWriteRouter::default().route(crate::query::table_write_plan::RoutingContext {
+            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
                 target_schema: &schema,
                 target_stats: None,
                 source_schema: None,
@@ -1917,184 +2096,5 @@ mod tests {
             bridge.commits.lock().unwrap().len(),
             MAX_MANIFEST_COMMIT_ATTEMPTS
         );
-    }
-}
-
-/// Upper bound on optimistic-concurrency manifest-commit retries. A healthy
-/// system rebases past a handful of concurrent committers within a few attempts;
-/// hitting this ceiling means the conflict is persistent (a wedged committer or a
-/// `latest` that never lets this writer win the CAS), which we surface as an error
-/// rather than spinning forever.
-const MAX_MANIFEST_COMMIT_ATTEMPTS: usize = 32;
-
-/// DataFusion-based executor for OLAP/table-to-table write workloads.
-///
-/// This executor materializes query output into `ProximaRecord` batches and
-/// commits through `TableRecordStore`. It is not the direct authority for
-/// PostgreSQL-style OLTP writes; constraint-sensitive mutations must still pass
-/// through the native WAL/row-delta commit path selected by xCatalog routing.
-pub struct DataFusionTableWriteExecutor {
-    source_reader: Arc<dyn TableRecordSourceReader>,
-    record_store: Arc<dyn TableRecordStore>,
-    object_store_bridge: Option<Arc<dyn ObjectStoreBridge>>,
-}
-
-impl DataFusionTableWriteExecutor {
-    pub fn new(
-        source_reader: Arc<dyn TableRecordSourceReader>,
-        record_store: Arc<dyn TableRecordStore>,
-    ) -> Self {
-        Self {
-            source_reader,
-            record_store,
-            object_store_bridge: None,
-        }
-    }
-
-    pub fn with_object_store_bridge(mut self, bridge: Arc<dyn ObjectStoreBridge>) -> Self {
-        self.object_store_bridge = Some(bridge);
-        self
-    }
-}
-
-#[async_trait]
-impl TableWriteExecutor for DataFusionTableWriteExecutor {
-    async fn execute(
-        &self,
-        request: TableWriteExecutionRequest<'_>,
-    ) -> Result<TableWriteExecutionResult> {
-        use proximadb_storage_common::object_store_bridge::CommitOutcome;
-
-        validate_required_guards(request.target_schema, &request.routed_plan)?;
-        if !is_datafusion_backend(&request.routed_plan.backend) {
-            return Ok(TableWriteExecutionResult::planned(&request.routed_plan));
-        }
-        validate_datafusion_write_lane(request.target_schema, &request.routed_plan)?;
-
-        let mutation_kind = mutation_kind_for_write_mode(&request.routed_plan.plan.write_mode)?;
-        let mut rows_written = 0;
-        let mut cursor = TableRecordSourceCursor::default();
-        let is_bulk_append =
-            request.routed_plan.write_lane_decision.lane == WriteLane::BulkAppendCommit;
-        let mut batch_index = 0;
-        let mut wrote_any_parquet = false;
-
-        while let Some(batch) = self
-            .source_reader
-            .next_batch(
-                &request.routed_plan.plan.source,
-                request.source_schema,
-                request.target_schema,
-                request.tenant_context,
-                &mut cursor,
-            )
-            .await?
-        {
-            if batch.is_empty() {
-                continue;
-            }
-            if is_bulk_append {
-                let path = object_write_path(
-                    request.target_schema,
-                    &request.routed_plan,
-                    batch_index,
-                    request.tenant_context.map(|tc| tc.tenant_id.as_str()),
-                );
-                batch_index += 1;
-
-                let bridge = self.object_store_bridge.as_ref().ok_or_else(|| {
-                    anyhow!(
-                        "DataFusion bulk append for '{}' requires an ObjectStoreBridge",
-                        request.target_schema.name
-                    )
-                })?;
-                let tenant_id = request.tenant_context.map(|tc| tc.tenant_id.as_str());
-                bridge
-                    .write_records_to_parquet(&path, &batch, tenant_id)
-                    .await
-                    .map_err(|err| {
-                        anyhow!(
-                            "DataFusion Parquet write failed for '{}' at '{}': {err}",
-                            request.target_schema.name,
-                            path
-                        )
-                    })?;
-                rows_written += batch.len() as u64;
-                wrote_any_parquet = true;
-                continue;
-            }
-
-            let mutations = batch
-                .into_iter()
-                .map(|record| TableRecordMutation::new(mutation_kind, record))
-                .collect::<Vec<_>>();
-            // TD-113 family: thread the tenant so the non-bulk-append DataFusion
-            // route writes into the tenant's record partition (was `None`).
-            let result = self
-                .record_store
-                .write_mutations(request.target_schema, mutations, request.tenant_context)
-                .await?;
-            if !result.success {
-                return Err(anyhow!(
-                    "DataFusion table write failed for '{}': {:?}",
-                    request.target_schema.name,
-                    result.errors
-                ));
-            }
-            rows_written += result.record_ids.len() as u64;
-        }
-
-        if is_bulk_append && wrote_any_parquet {
-            let bridge = self.object_store_bridge.as_ref().ok_or_else(|| {
-                anyhow!(
-                    "DataFusion bulk append for '{}' wrote Parquet without an ObjectStoreBridge",
-                    request.target_schema.name
-                )
-            })?;
-            let base = object_write_base_path(
-                request.target_schema,
-                request.tenant_context.map(|tc| tc.tenant_id.as_str()),
-            );
-            let data_prefix = format!("{base}/data");
-            let manifest_prefix = format!("{base}/_manifests");
-
-            // Optimistic-concurrency commit: rebase onto the latest snapshot and retry
-            // on conflict, bounded so a persistent conflict surfaces as an error instead
-            // of spinning forever.
-            let mut parent = bridge.latest_manifest_version(&manifest_prefix).await?;
-            let mut committed = false;
-            for _ in 0..MAX_MANIFEST_COMMIT_ATTEMPTS {
-                match bridge
-                    .publish_snapshot(&Path::from(data_prefix.as_str()), &manifest_prefix, parent)
-                    .await?
-                {
-                    CommitOutcome::Committed(_) => {
-                        committed = true;
-                        break;
-                    }
-                    CommitOutcome::Conflict { latest } => parent = latest,
-                }
-            }
-            if !committed {
-                return Err(anyhow!(
-                    "DataFusion manifest commit for '{}' failed after {} attempts due to \
-                     persistent snapshot conflict",
-                    request.target_schema.name,
-                    MAX_MANIFEST_COMMIT_ATTEMPTS
-                ));
-            }
-        }
-
-        Ok(TableWriteExecutionResult {
-            status: TableWriteExecutionStatus::Completed,
-            rows_written,
-            route_summary: format!(
-                "backend={:?}, access_method={:?}, batches={}",
-                request.routed_plan.backend,
-                request.routed_plan.selected_path.access_method,
-                batch_index
-            ),
-            guards: request.routed_plan.required_guards,
-        })
     }
 }

--- a/src/query/table_write_executor.rs
+++ b/src/query/table_write_executor.rs
@@ -1149,15 +1149,14 @@ mod tests {
             .with_storage_specialization(CatalogStorageSpecialization::PaxOltp);
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
 
         let result = PlannedOnlyTableWriteExecutor::new()
             .execute(TableWriteExecutionRequest {
@@ -1177,23 +1176,22 @@ mod tests {
     #[tokio::test]
     async fn planned_executor_rejects_routes_missing_core_guards() {
         let schema = CatalogTableSchema::new("orders");
-        let mut routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &CopyIntoPlan {
-                    source: crate::query::table_write_plan::ReadSource::QuerySql(
-                        "SELECT * FROM staging".to_string(),
-                    ),
-                    target: LogicalTableRef::new("orders"),
-                    write_mode: WriteMode::Append,
-                    conflict_policy: Default::default(),
-                    distribution: Default::default(),
-                },
-            });
+        let mut routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &CopyIntoPlan {
+                source: crate::query::table_write_plan::ReadSource::QuerySql(
+                    "SELECT * FROM staging".to_string(),
+                ),
+                target: LogicalTableRef::new("orders"),
+                write_mode: WriteMode::Append,
+                conflict_policy: Default::default(),
+                distribution: Default::default(),
+            },
+        });
         routed.required_guards.clear();
         routed.selected_path.guards.clear();
 
@@ -1275,15 +1273,14 @@ mod tests {
             .with_storage_specialization(CatalogStorageSpecialization::PaxOltp);
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
         assert_eq!(routed.backend, ComputeBackend::Native);
 
         let source = Arc::new(VecSourceReader::new(vec![
@@ -1421,15 +1418,14 @@ mod tests {
     fn fk_routed_plan(schema: &CatalogTableSchema) -> RoutedExecutionPlan {
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
         assert_eq!(routed.backend, ComputeBackend::Native);
         routed
     }
@@ -1545,15 +1541,14 @@ mod tests {
             });
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("members"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
         assert_eq!(routed.backend, ComputeBackend::Native);
 
         let with_email = |id: &str, email: &str| {
@@ -1652,15 +1647,14 @@ mod tests {
         let mut plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
         plan.write_mode = WriteMode::Merge;
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
 
         let err = NativeTableWriteExecutor::new(
             Arc::new(VecSourceReader::new(vec![vec![test_record("r1")]])),
@@ -1724,15 +1718,14 @@ mod tests {
             .with_storage_specialization(CatalogStorageSpecialization::PaxOltp);
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
 
         let result = NativeTableWriteExecutor::new(
             Arc::new(VecSourceReader::new(vec![])),
@@ -1759,15 +1752,14 @@ mod tests {
             .with_storage_specialization(CatalogStorageSpecialization::PaxOltp);
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("orders"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
 
         let err = NativeTableWriteExecutor::new(
             Arc::new(VecSourceReader::new(vec![vec![test_record("r1")]])),
@@ -1798,15 +1790,14 @@ mod tests {
             batch_local_constraints_sufficient: Some(true),
             ..Default::default()
         };
-        let mut routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: Some(&overrides),
-                plan: &plan,
-            });
+        let mut routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: Some(&overrides),
+            plan: &plan,
+        });
         assert_eq!(routed.write_lane_decision.lane, WriteLane::BulkAppendCommit);
         routed.backend = ComputeBackend::Native;
 
@@ -1835,15 +1826,14 @@ mod tests {
             .with_storage_specialization(CatalogStorageSpecialization::ColumnarAnalytics);
         let plan =
             CopyIntoPlan::insert_select(LogicalTableRef::new("facts"), "SELECT * FROM staging");
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: None,
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: None,
+            plan: &plan,
+        });
         assert_eq!(routed.backend, ComputeBackend::DataFusionLocal);
 
         let source = Arc::new(VecSourceReader::new(vec![
@@ -1888,15 +1878,14 @@ mod tests {
             batch_local_constraints_sufficient: Some(true),
             ..Default::default()
         };
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: Some(&overrides),
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: Some(&overrides),
+            plan: &plan,
+        });
         assert_eq!(routed.backend, ComputeBackend::DataFusionLocal);
         assert_eq!(routed.write_lane_decision.lane, WriteLane::BulkAppendCommit);
 
@@ -1946,15 +1935,14 @@ mod tests {
             batch_local_constraints_sufficient: Some(true),
             ..Default::default()
         };
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: Some(&overrides),
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: Some(&overrides),
+            plan: &plan,
+        });
         assert_eq!(routed.write_lane_decision.lane, WriteLane::BulkAppendCommit);
 
         let err = DataFusionTableWriteExecutor::new(
@@ -1992,15 +1980,14 @@ mod tests {
             batch_local_constraints_sufficient: Some(true),
             ..Default::default()
         };
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: Some(&overrides),
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: Some(&overrides),
+            plan: &plan,
+        });
 
         // Two source batches
         let source = Arc::new(VecSourceReader::new(vec![
@@ -2059,15 +2046,14 @@ mod tests {
             batch_local_constraints_sufficient: Some(true),
             ..Default::default()
         };
-        let routed =
-            TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
-                target_schema: &schema,
-                target_stats: None,
-                source_schema: None,
-                source_stats: None,
-                write_intent_overrides: Some(&overrides),
-                plan: &plan,
-            });
+        let routed = TableWriteRouter.route(crate::query::table_write_plan::RoutingContext {
+            target_schema: &schema,
+            target_stats: None,
+            source_schema: None,
+            source_stats: None,
+            write_intent_overrides: Some(&overrides),
+            plan: &plan,
+        });
 
         let source = Arc::new(VecSourceReader::new(vec![vec![test_record("r1")]]));
         // Bridge that never lets the writer win the CAS — the commit loop must give

--- a/src/query/unified/mod.rs
+++ b/src/query/unified/mod.rs
@@ -474,14 +474,14 @@ mod tests {
     #[tokio::test]
     async fn reorder_returns_none_without_optimizer() {
         let mut q = empty_query(vec![vector_component(), document_component()]);
-        let original_models: Vec<_> = q.components.iter().map(|c| c.model.clone()).collect();
+        let original_models: Vec<_> = q.components.iter().map(|c| c.model).collect();
 
         let none_opt: Option<&std::sync::Arc<dyn proximadb_query::QueryOptimizationService>> = None;
         let result = reorder_components_with_optimizer(none_opt, &mut q)
             .await
             .unwrap();
         assert!(result.is_none());
-        let after: Vec<_> = q.components.iter().map(|c| c.model.clone()).collect();
+        let after: Vec<_> = q.components.iter().map(|c| c.model).collect();
         assert_eq!(after, original_models, "no optimizer -> no reorder");
     }
 

--- a/src/search/optimization/batch_strategy.rs
+++ b/src/search/optimization/batch_strategy.rs
@@ -228,7 +228,7 @@ mod tests {
         let batch_size = selector.get_optimal_hardware_batch_size();
 
         // Should return reasonable batch size based on hardware
-        assert!(batch_size >= 16 && batch_size <= 128);
+        assert!((16..=128).contains(&batch_size));
     }
 
     #[test]

--- a/src/services/bulk_load.rs
+++ b/src/services/bulk_load.rs
@@ -374,7 +374,7 @@ mod tests {
     /// The contract for the LSM bypass requires sorted input.
     #[test]
     fn unsorted_records_get_sorted_by_oid() {
-        let mut records = vec![rec("zeta"), rec("alpha"), rec("mike")];
+        let mut records = [rec("zeta"), rec("alpha"), rec("mike")];
         records.sort_by(|a, b| a.oid.cmp(&b.oid));
         let oids: Vec<_> = records.iter().map(|r| r.oid.as_str()).collect();
         assert_eq!(oids, vec!["alpha", "mike", "zeta"]);

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -6773,7 +6773,7 @@ mod tests {
 
         let insert = |sql: &'static str| {
             let p = &parser;
-            
+
             p.parse_dml(sql).expect("parse dml").expect("dml")
         };
 

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -5824,7 +5824,7 @@ mod tests {
         schema
             .properties
             .insert("policy_boundary".to_string(), "engine-enforced".to_string());
-        let predicates = vec![RelationalSelectPredicate {
+        let predicates = [RelationalSelectPredicate {
             column: schema.columns[0].clone(),
             condition: RelationalSelectPredicateCondition::Comparison {
                 operator: RelationalSelectPredicateOperator::Equal,
@@ -6773,8 +6773,8 @@ mod tests {
 
         let insert = |sql: &'static str| {
             let p = &parser;
-            let stmt = p.parse_dml(sql).expect("parse dml").expect("dml");
-            stmt
+            
+            p.parse_dml(sql).expect("parse dml").expect("dml")
         };
 
         // First insert succeeds.

--- a/src/services/events/persistence.rs
+++ b/src/services/events/persistence.rs
@@ -495,7 +495,7 @@ mod tests {
 
         // Should have at least 1 WAL file (rotation creates a new current file)
         assert!(
-            wal_files.len() >= 1,
+            !wal_files.is_empty(),
             "Should have at least 1 WAL file after rotation, got {}",
             wal_files.len()
         );

--- a/src/services/operations/vectors/mod.rs
+++ b/src/services/operations/vectors/mod.rs
@@ -89,7 +89,7 @@ mod tests {
         // Verify module exports are accessible
         let _config = UnifiedSearchConfig::default();
         let _hints = SearchPlanHints::default();
-        let _generator = DefaultPseudoQueryGenerator::default();
+        let _generator = DefaultPseudoQueryGenerator;
         let _stages = default_progressive_stages();
     }
 }

--- a/src/services/operations/vectors/validation/metadata.rs
+++ b/src/services/operations/vectors/validation/metadata.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_default_pseudo_query_generator() {
-        let generator = DefaultPseudoQueryGenerator::default();
+        let generator = DefaultPseudoQueryGenerator;
         let mut metadata = HashMap::new();
         metadata.insert(
             "title".to_string(),

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -1364,7 +1364,7 @@ mod tests {
             // Drop half of them, checkpoint again.
             for round in 0..5 {
                 cat.drop_table(
-                    &TableIdentifier::new(nslevels(&["s"]), &format!("t_{round}_0")),
+                    &TableIdentifier::new(nslevels(&["s"]), format!("t_{round}_0")),
                     false,
                 )
                 .await?;

--- a/src/storage/cache/cache_coordinator.rs
+++ b/src/storage/cache/cache_coordinator.rs
@@ -533,7 +533,7 @@ mod tests {
             .unwrap();
 
         let graph = coordinator.dependency_graph.read().await;
-        assert!(graph.dependencies.len() > 0);
+        assert!(!graph.dependencies.is_empty());
     }
 
     #[tokio::test]

--- a/src/storage/document/aggregation.rs
+++ b/src/storage/document/aggregation.rs
@@ -872,11 +872,9 @@ mod tests {
     fn test_aggregation_count() {
         let executor = AggregationExecutor::new();
 
-        let docs = vec![
-            tree_doc(vec![("name", pv_str("Alice")), ("age", pv_int(30))]),
+        let docs = [tree_doc(vec![("name", pv_str("Alice")), ("age", pv_int(30))]),
             tree_doc(vec![("name", pv_str("Bob")), ("age", pv_int(25))]),
-            tree_doc(vec![("name", pv_str("Charlie")), ("age", pv_int(35))]),
-        ];
+            tree_doc(vec![("name", pv_str("Charlie")), ("age", pv_int(35))])];
 
         let agg = Aggregation {
             output_field: "count".to_string(),
@@ -900,11 +898,9 @@ mod tests {
     fn test_aggregation_sum() {
         let executor = AggregationExecutor::new();
 
-        let docs = vec![
-            tree_doc(vec![("amount", pv_int(100))]),
+        let docs = [tree_doc(vec![("amount", pv_int(100))]),
             tree_doc(vec![("amount", pv_int(200))]),
-            tree_doc(vec![("amount", pv_int(300))]),
-        ];
+            tree_doc(vec![("amount", pv_int(300))])];
 
         let agg = Aggregation {
             output_field: "total".to_string(),
@@ -928,11 +924,9 @@ mod tests {
     fn test_aggregation_avg() {
         let executor = AggregationExecutor::new();
 
-        let docs = vec![
-            tree_doc(vec![("score", pv_int(80))]),
+        let docs = [tree_doc(vec![("score", pv_int(80))]),
             tree_doc(vec![("score", pv_int(90))]),
-            tree_doc(vec![("score", pv_int(100))]),
-        ];
+            tree_doc(vec![("score", pv_int(100))])];
 
         let agg = Aggregation {
             output_field: "avg_score".to_string(),
@@ -956,11 +950,9 @@ mod tests {
     fn test_aggregation_min_max() {
         let executor = AggregationExecutor::new();
 
-        let docs = vec![
-            tree_doc(vec![("value", pv_int(5))]),
+        let docs = [tree_doc(vec![("value", pv_int(5))]),
             tree_doc(vec![("value", pv_int(3))]),
-            tree_doc(vec![("value", pv_int(8))]),
-        ];
+            tree_doc(vec![("value", pv_int(8))])];
 
         let doc_refs: Vec<&ProximaTree> = docs.iter().collect();
 

--- a/src/storage/document/aggregation.rs
+++ b/src/storage/document/aggregation.rs
@@ -872,9 +872,11 @@ mod tests {
     fn test_aggregation_count() {
         let executor = AggregationExecutor::new();
 
-        let docs = [tree_doc(vec![("name", pv_str("Alice")), ("age", pv_int(30))]),
+        let docs = [
+            tree_doc(vec![("name", pv_str("Alice")), ("age", pv_int(30))]),
             tree_doc(vec![("name", pv_str("Bob")), ("age", pv_int(25))]),
-            tree_doc(vec![("name", pv_str("Charlie")), ("age", pv_int(35))])];
+            tree_doc(vec![("name", pv_str("Charlie")), ("age", pv_int(35))]),
+        ];
 
         let agg = Aggregation {
             output_field: "count".to_string(),
@@ -898,9 +900,11 @@ mod tests {
     fn test_aggregation_sum() {
         let executor = AggregationExecutor::new();
 
-        let docs = [tree_doc(vec![("amount", pv_int(100))]),
+        let docs = [
+            tree_doc(vec![("amount", pv_int(100))]),
             tree_doc(vec![("amount", pv_int(200))]),
-            tree_doc(vec![("amount", pv_int(300))])];
+            tree_doc(vec![("amount", pv_int(300))]),
+        ];
 
         let agg = Aggregation {
             output_field: "total".to_string(),
@@ -924,9 +928,11 @@ mod tests {
     fn test_aggregation_avg() {
         let executor = AggregationExecutor::new();
 
-        let docs = [tree_doc(vec![("score", pv_int(80))]),
+        let docs = [
+            tree_doc(vec![("score", pv_int(80))]),
             tree_doc(vec![("score", pv_int(90))]),
-            tree_doc(vec![("score", pv_int(100))])];
+            tree_doc(vec![("score", pv_int(100))]),
+        ];
 
         let agg = Aggregation {
             output_field: "avg_score".to_string(),
@@ -950,9 +956,11 @@ mod tests {
     fn test_aggregation_min_max() {
         let executor = AggregationExecutor::new();
 
-        let docs = [tree_doc(vec![("value", pv_int(5))]),
+        let docs = [
+            tree_doc(vec![("value", pv_int(5))]),
             tree_doc(vec![("value", pv_int(3))]),
-            tree_doc(vec![("value", pv_int(8))])];
+            tree_doc(vec![("value", pv_int(8))]),
+        ];
 
         let doc_refs: Vec<&ProximaTree> = docs.iter().collect();
 

--- a/src/storage/engines/core/formats/codebook_integration_test.rs
+++ b/src/storage/engines/core/formats/codebook_integration_test.rs
@@ -71,8 +71,8 @@ mod tests {
         let deserialized_footer = serializer.deserialize_from_footer(&footer_bytes).unwrap();
 
         assert_eq!(deserialized_footer.collection_id, metadata.collection_id);
-        assert_eq!(deserialized_footer.binary_codebook.is_some(), true);
-        assert_eq!(deserialized_footer.int8_codebook.is_some(), true);
+        assert!(deserialized_footer.binary_codebook.is_some());
+        assert!(deserialized_footer.int8_codebook.is_some());
         assert_eq!(deserialized_footer.pq_codebooks.len(), 1);
 
         // Test sidecar serialization (for Parquet engines)

--- a/src/storage/engines/core/formats/columnar/common.rs
+++ b/src/storage/engines/core/formats/columnar/common.rs
@@ -1249,6 +1249,74 @@ impl Default for ResourceColumnarMonitoringConfig {
     }
 }
 
+/// Map core compression algorithm to Parquet compression
+/// This is shared by both NOVA and VIPER engines for consistent compression handling
+pub fn map_core_to_parquet_compression(
+    algorithm: CompressionAlgorithm,
+    level: Option<i32>,
+) -> Result<parquet::basic::Compression> {
+    use parquet::basic::Compression;
+
+    let compression = match algorithm {
+        CompressionAlgorithm::None => Compression::UNCOMPRESSED,
+        CompressionAlgorithm::Zstd => {
+            if let Some(lvl) = level {
+                Compression::ZSTD(parquet::basic::ZstdLevel::try_new(lvl)?)
+            } else {
+                Compression::ZSTD(parquet::basic::ZstdLevel::default())
+            }
+        }
+        CompressionAlgorithm::Lz4 => Compression::LZ4,
+        CompressionAlgorithm::Snappy => Compression::SNAPPY,
+        CompressionAlgorithm::Gzip => {
+            if let Some(lvl) = level {
+                Compression::GZIP(parquet::basic::GzipLevel::try_new(lvl as u32)?)
+            } else {
+                Compression::GZIP(parquet::basic::GzipLevel::default())
+            }
+        }
+        CompressionAlgorithm::Brotli => {
+            if let Some(lvl) = level {
+                Compression::BROTLI(parquet::basic::BrotliLevel::try_new(lvl as u32)?)
+            } else {
+                Compression::BROTLI(parquet::basic::BrotliLevel::default())
+            }
+        }
+        CompressionAlgorithm::Lzo => Compression::LZO,
+        // Map unsupported algorithms to fallbacks
+        CompressionAlgorithm::Deflate | CompressionAlgorithm::Zlib => {
+            // Deflate/Zlib are similar to GZIP
+            if let Some(lvl) = level {
+                Compression::GZIP(parquet::basic::GzipLevel::try_new(lvl as u32)?)
+            } else {
+                Compression::GZIP(parquet::basic::GzipLevel::default())
+            }
+        }
+        CompressionAlgorithm::Lz4hc => Compression::LZ4, // Use regular LZ4
+        CompressionAlgorithm::Xz | CompressionAlgorithm::Lzma => {
+            // XZ and LZMA provide high compression, map to ZSTD with high level
+            let high_level = level.unwrap_or(9).max(9);
+            Compression::ZSTD(parquet::basic::ZstdLevel::try_new(high_level)?)
+        }
+        CompressionAlgorithm::Bzip2 => {
+            // BZip2 provides good compression, map to Brotli
+            if let Some(lvl) = level {
+                Compression::BROTLI(parquet::basic::BrotliLevel::try_new(lvl as u32)?)
+            } else {
+                Compression::BROTLI(parquet::basic::BrotliLevel::default())
+            }
+        }
+        CompressionAlgorithm::Mixed => {
+            // Mixed compression - Use ZSTD level 3 as default for Parquet
+            // Per-column optimization will be handled at the writer level
+            info!("Using Mixed compression with ZSTD level 3 as base");
+            Compression::ZSTD(parquet::basic::ZstdLevel::try_new(3)?)
+        }
+    };
+
+    Ok(compression)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1318,72 +1386,4 @@ mod tests {
         assert_eq!(limits.pq_pool_max_vectors, 3000);
         assert_eq!(limits.max_vector_size_bytes, 64 * 1024);
     }
-}
-
-/// Map core compression algorithm to Parquet compression
-/// This is shared by both NOVA and VIPER engines for consistent compression handling
-pub fn map_core_to_parquet_compression(
-    algorithm: CompressionAlgorithm,
-    level: Option<i32>,
-) -> Result<parquet::basic::Compression> {
-    use parquet::basic::Compression;
-
-    let compression = match algorithm {
-        CompressionAlgorithm::None => Compression::UNCOMPRESSED,
-        CompressionAlgorithm::Zstd => {
-            if let Some(lvl) = level {
-                Compression::ZSTD(parquet::basic::ZstdLevel::try_new(lvl)?)
-            } else {
-                Compression::ZSTD(parquet::basic::ZstdLevel::default())
-            }
-        }
-        CompressionAlgorithm::Lz4 => Compression::LZ4,
-        CompressionAlgorithm::Snappy => Compression::SNAPPY,
-        CompressionAlgorithm::Gzip => {
-            if let Some(lvl) = level {
-                Compression::GZIP(parquet::basic::GzipLevel::try_new(lvl as u32)?)
-            } else {
-                Compression::GZIP(parquet::basic::GzipLevel::default())
-            }
-        }
-        CompressionAlgorithm::Brotli => {
-            if let Some(lvl) = level {
-                Compression::BROTLI(parquet::basic::BrotliLevel::try_new(lvl as u32)?)
-            } else {
-                Compression::BROTLI(parquet::basic::BrotliLevel::default())
-            }
-        }
-        CompressionAlgorithm::Lzo => Compression::LZO,
-        // Map unsupported algorithms to fallbacks
-        CompressionAlgorithm::Deflate | CompressionAlgorithm::Zlib => {
-            // Deflate/Zlib are similar to GZIP
-            if let Some(lvl) = level {
-                Compression::GZIP(parquet::basic::GzipLevel::try_new(lvl as u32)?)
-            } else {
-                Compression::GZIP(parquet::basic::GzipLevel::default())
-            }
-        }
-        CompressionAlgorithm::Lz4hc => Compression::LZ4, // Use regular LZ4
-        CompressionAlgorithm::Xz | CompressionAlgorithm::Lzma => {
-            // XZ and LZMA provide high compression, map to ZSTD with high level
-            let high_level = level.unwrap_or(9).max(9);
-            Compression::ZSTD(parquet::basic::ZstdLevel::try_new(high_level)?)
-        }
-        CompressionAlgorithm::Bzip2 => {
-            // BZip2 provides good compression, map to Brotli
-            if let Some(lvl) = level {
-                Compression::BROTLI(parquet::basic::BrotliLevel::try_new(lvl as u32)?)
-            } else {
-                Compression::BROTLI(parquet::basic::BrotliLevel::default())
-            }
-        }
-        CompressionAlgorithm::Mixed => {
-            // Mixed compression - Use ZSTD level 3 as default for Parquet
-            // Per-column optimization will be handled at the writer level
-            info!("Using Mixed compression with ZSTD level 3 as base");
-            Compression::ZSTD(parquet::basic::ZstdLevel::try_new(3)?)
-        }
-    };
-
-    Ok(compression)
 }

--- a/src/storage/engines/core/formats/columnar/examples_test.rs
+++ b/src/storage/engines/core/formats/columnar/examples_test.rs
@@ -95,7 +95,7 @@ pub async fn viper_optimization_example() -> Result<()> {
                     values: proximadb_records::EmbeddingValues::Fp32(vector),
                     ..Default::default()
                 }],
-                created_at_ns: i as i64,
+                created_at_ns: i,
                 record_version: 1,
                 ..Default::default()
             };
@@ -357,7 +357,7 @@ pub async fn nova_optimization_example() -> Result<()> {
                     values: proximadb_records::EmbeddingValues::Fp32(vector),
                     ..Default::default()
                 }],
-                created_at_ns: (1_700_000_000 + i) as i64,
+                created_at_ns: (1_700_000_000 + i),
                 record_version: 1,
                 ..Default::default()
             };

--- a/src/storage/engines/core/formats/columnar/serialization.rs
+++ b/src/storage/engines/core/formats/columnar/serialization.rs
@@ -1131,7 +1131,7 @@ mod tests {
 
         let serializer = ColumnarSerializer::new(config).unwrap();
 
-        let vectors = vec![vec![1.0; 128], vec![2.0; 128], vec![3.0; 128]];
+        let vectors = [vec![1.0; 128], vec![2.0; 128], vec![3.0; 128]];
 
         let vector_refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
         let array = serializer.serialize_fp32_vectors(&vector_refs).unwrap();

--- a/src/storage/engines/core/formats/columnar/tests.rs
+++ b/src/storage/engines/core/formats/columnar/tests.rs
@@ -85,7 +85,7 @@ async fn test_id_less_storage_warning() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
     let dir = tempdir().unwrap();
-    let file_name = format!("test_id_less_warning.parquet");
+    let file_name = "test_id_less_warning.parquet".to_string();
     let file_url = format!("file://{}/{}", dir.path().to_str().unwrap(), file_name);
 
     // Test with id_less_storage = true (should trigger warning)
@@ -906,7 +906,7 @@ async fn test_customer_api_compatibility() {
 
     // Single ID lookup
     // Deferred: Implement optimized_batch_id_lookup method
-    let single_result = vec![{
+    let single_result = [{
         let values: Vec<f32> = (0..384).map(|i| (i + 100) as f32 * 0.01).collect();
         let dim = values.len() as u32;
         let mut r = ProximaRecord {
@@ -932,8 +932,7 @@ async fn test_customer_api_compatibility() {
 
     // Batch ID lookup
     // Deferred: Implement optimized_batch_id_lookup method
-    let batch_result = vec![
-        {
+    let batch_result = [{
             let values: Vec<f32> = (0..384).map(|i| i as f32 * 0.01).collect();
             let dim = values.len() as u32;
             let mut r = ProximaRecord {
@@ -968,8 +967,7 @@ async fn test_customer_api_compatibility() {
                 ..Default::default()
             });
             r
-        },
-    ];
+        }];
 
     assert_eq!(batch_result.len(), 2);
     let ids: Vec<String> = batch_result.iter().map(|r| r.oid.clone()).collect();
@@ -1045,7 +1043,7 @@ async fn test_row_group_offset_optimization() {
     .unwrap();
 
     // Deferred: Implement optimized_batch_id_lookup method
-    let lookup_result = vec![{
+    let lookup_result = [{
         let values: Vec<f32> = (0..128).map(|j| (50 + j) as f32 * 0.01).collect();
         let dim = values.len() as u32;
         let mut r = ProximaRecord {
@@ -1118,8 +1116,7 @@ async fn test_schema_evolution_with_id_column() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
     // Test that schema evolution preserves ID column requirement
-    let quantization_configs = vec![
-        QuantizationConfig {
+    let quantization_configs = [QuantizationConfig {
             enable_binary: Some(false),
             enable_int8: Some(false),
             enable_pq: Some(false),
@@ -1136,8 +1133,7 @@ async fn test_schema_evolution_with_id_column() {
             enable_int8: Some(true),
             enable_pq: Some(true),
             ..Default::default()
-        },
-    ];
+        }];
 
     for (i, quant_config) in quantization_configs.iter().enumerate() {
         let schema = create_columnar_schema(

--- a/src/storage/engines/core/formats/columnar/tests.rs
+++ b/src/storage/engines/core/formats/columnar/tests.rs
@@ -932,7 +932,8 @@ async fn test_customer_api_compatibility() {
 
     // Batch ID lookup
     // Deferred: Implement optimized_batch_id_lookup method
-    let batch_result = [{
+    let batch_result = [
+        {
             let values: Vec<f32> = (0..384).map(|i| i as f32 * 0.01).collect();
             let dim = values.len() as u32;
             let mut r = ProximaRecord {
@@ -967,7 +968,8 @@ async fn test_customer_api_compatibility() {
                 ..Default::default()
             });
             r
-        }];
+        },
+    ];
 
     assert_eq!(batch_result.len(), 2);
     let ids: Vec<String> = batch_result.iter().map(|r| r.oid.clone()).collect();
@@ -1116,7 +1118,8 @@ async fn test_schema_evolution_with_id_column() {
     let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
 
     // Test that schema evolution preserves ID column requirement
-    let quantization_configs = [QuantizationConfig {
+    let quantization_configs = [
+        QuantizationConfig {
             enable_binary: Some(false),
             enable_int8: Some(false),
             enable_pq: Some(false),
@@ -1133,7 +1136,8 @@ async fn test_schema_evolution_with_id_column() {
             enable_int8: Some(true),
             enable_pq: Some(true),
             ..Default::default()
-        }];
+        },
+    ];
 
     for (i, quant_config) in quantization_configs.iter().enumerate() {
         let schema = create_columnar_schema(

--- a/src/storage/engines/core/formats/proximablocks/spatial_traits.rs
+++ b/src/storage/engines/core/formats/proximablocks/spatial_traits.rs
@@ -501,10 +501,12 @@ mod tests {
         let encoder = ZOrderSpatialEncoder::new(4, 8);
 
         // Create some block codes
-        let block_coords = [vec![0.1, 0.1, 0.1, 0.1],
+        let block_coords = [
+            vec![0.1, 0.1, 0.1, 0.1],
             vec![0.5, 0.5, 0.5, 0.5],
             vec![0.9, 0.9, 0.9, 0.9],
-            vec![0.2, 0.2, 0.2, 0.2]];
+            vec![0.2, 0.2, 0.2, 0.2],
+        ];
         let block_codes: Vec<SpatialCode> =
             block_coords.iter().map(|c| encoder.encode(c)).collect();
 

--- a/src/storage/engines/core/formats/proximablocks/spatial_traits.rs
+++ b/src/storage/engines/core/formats/proximablocks/spatial_traits.rs
@@ -501,12 +501,10 @@ mod tests {
         let encoder = ZOrderSpatialEncoder::new(4, 8);
 
         // Create some block codes
-        let block_coords = vec![
-            vec![0.1, 0.1, 0.1, 0.1],
+        let block_coords = [vec![0.1, 0.1, 0.1, 0.1],
             vec![0.5, 0.5, 0.5, 0.5],
             vec![0.9, 0.9, 0.9, 0.9],
-            vec![0.2, 0.2, 0.2, 0.2],
-        ];
+            vec![0.2, 0.2, 0.2, 0.2]];
         let block_codes: Vec<SpatialCode> =
             block_coords.iter().map(|c| encoder.encode(c)).collect();
 

--- a/src/storage/engines/core/formats/proximablocks/swift_metadata.rs
+++ b/src/storage/engines/core/formats/proximablocks/swift_metadata.rs
@@ -614,6 +614,18 @@ impl MetadataSerializer for SwiftMetadataSerializer {
         metadata.estimated_selectivity(query_context)
     }
 }
+// Manual Clone implementation for SwiftMetadata
+impl Clone for SwiftMetadata {
+    fn clone(&self) -> Self {
+        Self {
+            global: self.global,
+            segments: self.segments.clone(),
+            variable_data: self.variable_data.clone(),
+            global_bloom: parking_lot::RwLock::new(self.global_bloom.read().clone()),
+            segment_blooms: parking_lot::RwLock::new(self.segment_blooms.read().clone()),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -716,18 +728,6 @@ mod tests {
                 // - no segments match the query
                 // All are valid outcomes for this test
             }
-        }
-    }
-}
-// Manual Clone implementation for SwiftMetadata
-impl Clone for SwiftMetadata {
-    fn clone(&self) -> Self {
-        Self {
-            global: self.global,
-            segments: self.segments.clone(),
-            variable_data: self.variable_data.clone(),
-            global_bloom: parking_lot::RwLock::new(self.global_bloom.read().clone()),
-            segment_blooms: parking_lot::RwLock::new(self.segment_blooms.read().clone()),
         }
     }
 }

--- a/src/storage/engines/core/matrix_trinity_serializer.rs
+++ b/src/storage/engines/core/matrix_trinity_serializer.rs
@@ -191,7 +191,7 @@ mod tests {
         let footer_size = footer.len() as u64;
 
         let mut data = Vec::new();
-        data.extend_from_slice(&vec![0u8; 100]); // Some file content
+        data.extend_from_slice(&[0u8; 100]); // Some file content
         data.extend_from_slice(footer);
         data.extend_from_slice(&footer_size.to_le_bytes());
 

--- a/src/storage/engines/core/ops/simd_decode/bitpacked_neon.rs
+++ b/src/storage/engines/core/ops/simd_decode/bitpacked_neon.rs
@@ -663,7 +663,7 @@ mod tests {
 
     fn create_bitpacked_data(values: &[u64], bits: u8) -> Vec<u8> {
         let total_bits = values.len() * bits as usize;
-        let byte_count = (total_bits + 7) / 8;
+        let byte_count = total_bits.div_ceil(8);
         let mut result = vec![0u8; byte_count];
 
         let mask = if bits == 64 {

--- a/src/storage/engines/core/ops/simd_decode/bitpacked_scalar.rs
+++ b/src/storage/engines/core/ops/simd_decode/bitpacked_scalar.rs
@@ -281,7 +281,7 @@ mod tests {
 
     fn create_bitpacked_data(values: &[u64], bits: u8) -> Vec<u8> {
         let total_bits = values.len() * bits as usize;
-        let byte_count = (total_bits + 7) / 8;
+        let byte_count = total_bits.div_ceil(8);
         let mut result = vec![0u8; byte_count];
 
         let mask = if bits == 64 {

--- a/src/storage/engines/core/ops/simd_decode/mod.rs
+++ b/src/storage/engines/core/ops/simd_decode/mod.rs
@@ -196,7 +196,7 @@ mod tests {
         // Create test data
         fn create_packed_data(values: &[u64], bits: u8) -> Vec<u8> {
             let total_bits = values.len() * bits as usize;
-            let byte_count = (total_bits + 7) / 8;
+            let byte_count = total_bits.div_ceil(8);
             let mut result = vec![0u8; byte_count];
 
             let mask = if bits == 64 {

--- a/src/storage/engines/core/parquet_format_serializer.rs
+++ b/src/storage/engines/core/parquet_format_serializer.rs
@@ -247,7 +247,7 @@ mod tests {
         // Create mock Parquet file data
         let mut data = Vec::new();
         data.extend_from_slice(b"PAR1"); // Magic bytes at start
-        data.extend_from_slice(&vec![0u8; 100]); // Some data
+        data.extend_from_slice(&[0u8; 100]); // Some data
         let footer = b"footer_content";
         data.extend_from_slice(footer);
         data.extend_from_slice(&(footer.len() as u32).to_le_bytes()); // Footer size

--- a/src/storage/engines/core/proximablocks_compact_serializer.rs
+++ b/src/storage/engines/core/proximablocks_compact_serializer.rs
@@ -269,7 +269,7 @@ mod tests {
         data.extend_from_slice(&256u64.to_le_bytes());
 
         // Fill header to 64 bytes
-        data.extend_from_slice(&vec![0u8; 40]);
+        data.extend_from_slice(&[0u8; 40]);
 
         // Some data content
         data.extend_from_slice(&vec![0xFFu8; 960]); // Up to index start

--- a/src/storage/engines/core/sst_format_serializer.rs
+++ b/src/storage/engines/core/sst_format_serializer.rs
@@ -228,7 +228,7 @@ mod tests {
         assert!(extracted.is_some());
 
         let extracted_bytes = extracted.unwrap();
-        assert!(extracted_bytes.len() > 0);
+        assert!(!extracted_bytes.is_empty());
     }
 
     #[test]

--- a/src/storage/engines/helix/liquid_clustering.rs
+++ b/src/storage/engines/helix/liquid_clustering.rs
@@ -446,6 +446,6 @@ mod tests {
             .calculate_clustering_quality(&records, &hilbert_keys)
             .await;
 
-        assert!(quality >= 0.0 && quality <= 1.0);
+        assert!((0.0..=1.0).contains(&quality));
     }
 }

--- a/src/storage/engines/helix/proxima.rs
+++ b/src/storage/engines/helix/proxima.rs
@@ -1113,56 +1113,6 @@ fn metric_distance(
     distance_compute.distance_with_metric(a, b, metric)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn centroid_pruning_selects_sqrt() {
-        let query = vec![0.0f32, 0.0];
-        let metas = vec![
-            HelixBlockMetadata {
-                proxima_metadata: ProximaBlockMetadata::default(),
-                hilbert_range: None,
-                block_centroid: vec![0.1, 0.1],
-                pca_stats: None,
-                clustering_hints: None,
-            },
-            HelixBlockMetadata {
-                proxima_metadata: ProximaBlockMetadata::default(),
-                hilbert_range: None,
-                block_centroid: vec![3.0, 3.0],
-                pca_stats: None,
-                clustering_hints: None,
-            },
-            HelixBlockMetadata {
-                proxima_metadata: ProximaBlockMetadata::default(),
-                hilbert_range: None,
-                block_centroid: vec![0.2, 0.2],
-                pca_stats: None,
-                clustering_hints: None,
-            },
-            HelixBlockMetadata {
-                proxima_metadata: ProximaBlockMetadata::default(),
-                hilbert_range: None,
-                block_centroid: vec![6.0, 6.0],
-                pca_stats: None,
-                clustering_hints: None,
-            },
-        ];
-
-        let selected = select_blocks_by_centroid(
-            &query,
-            &metas,
-            &proximadb_distance_kernel::DistanceMetric::Euclidean,
-            &crate::core::search::BlockPruneConfig::for_testing(),
-        );
-        // max(3, sqrt(4)) = 3 -> expect the three closest indices 0, 2, 1
-        // Block 0: [0.1, 0.1] - dist 0.141, Block 2: [0.2, 0.2] - dist 0.283, Block 1: [3.0, 3.0] - dist 4.243
-        assert_eq!(selected, vec![0, 1, 2]);
-    }
-}
-
 /// Extract block metadata for HELIX
 pub fn extract_helix_metadata(
     records: &[VectorRecord],
@@ -1221,4 +1171,54 @@ pub fn extract_helix_metadata(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centroid_pruning_selects_sqrt() {
+        let query = vec![0.0f32, 0.0];
+        let metas = vec![
+            HelixBlockMetadata {
+                proxima_metadata: ProximaBlockMetadata::default(),
+                hilbert_range: None,
+                block_centroid: vec![0.1, 0.1],
+                pca_stats: None,
+                clustering_hints: None,
+            },
+            HelixBlockMetadata {
+                proxima_metadata: ProximaBlockMetadata::default(),
+                hilbert_range: None,
+                block_centroid: vec![3.0, 3.0],
+                pca_stats: None,
+                clustering_hints: None,
+            },
+            HelixBlockMetadata {
+                proxima_metadata: ProximaBlockMetadata::default(),
+                hilbert_range: None,
+                block_centroid: vec![0.2, 0.2],
+                pca_stats: None,
+                clustering_hints: None,
+            },
+            HelixBlockMetadata {
+                proxima_metadata: ProximaBlockMetadata::default(),
+                hilbert_range: None,
+                block_centroid: vec![6.0, 6.0],
+                pca_stats: None,
+                clustering_hints: None,
+            },
+        ];
+
+        let selected = select_blocks_by_centroid(
+            &query,
+            &metas,
+            &proximadb_distance_kernel::DistanceMetric::Euclidean,
+            &crate::core::search::BlockPruneConfig::for_testing(),
+        );
+        // max(3, sqrt(4)) = 3 -> expect the three closest indices 0, 2, 1
+        // Block 0: [0.1, 0.1] - dist 0.141, Block 2: [0.2, 0.2] - dist 0.283, Block 1: [3.0, 3.0] - dist 4.243
+        assert_eq!(selected, vec![0, 1, 2]);
+    }
 }

--- a/src/storage/engines/nova/mod.rs
+++ b/src/storage/engines/nova/mod.rs
@@ -612,14 +612,12 @@ mod tests {
 
         #[test]
         fn test_processing_stages() {
-            let stages = vec![
-                ProcessingStage::BloomFilter,
+            let stages = [ProcessingStage::BloomFilter,
                 ProcessingStage::ZoneMapPruning,
                 ProcessingStage::BinaryFilter,
                 ProcessingStage::Int8Filter,
                 ProcessingStage::PQ4Filter,
-                ProcessingStage::FullPrecision,
-            ];
+                ProcessingStage::FullPrecision];
 
             assert_eq!(stages.len(), 6);
             assert_eq!(stages[0], ProcessingStage::BloomFilter);

--- a/src/storage/engines/nova/mod.rs
+++ b/src/storage/engines/nova/mod.rs
@@ -612,12 +612,14 @@ mod tests {
 
         #[test]
         fn test_processing_stages() {
-            let stages = [ProcessingStage::BloomFilter,
+            let stages = [
+                ProcessingStage::BloomFilter,
                 ProcessingStage::ZoneMapPruning,
                 ProcessingStage::BinaryFilter,
                 ProcessingStage::Int8Filter,
                 ProcessingStage::PQ4Filter,
-                ProcessingStage::FullPrecision];
+                ProcessingStage::FullPrecision,
+            ];
 
             assert_eq!(stages.len(), 6);
             assert_eq!(stages[0], ProcessingStage::BloomFilter);

--- a/src/storage/engines/raptor/artus_bloom.rs
+++ b/src/storage/engines/raptor/artus_bloom.rs
@@ -546,7 +546,7 @@ mod tests {
             let fp_rate = manager.estimate_false_positive_rate(bloom.as_ref(), 1000);
             // FP rate should be a valid probability
             assert!(
-                fp_rate >= 0.0 && fp_rate <= 1.0,
+                (0.0..=1.0).contains(&fp_rate),
                 "FP rate {} out of range",
                 fp_rate
             );

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -179,8 +179,8 @@ mod tests {
 
         for (record_id, timestamp, expires_at) in mock_records {
             // This mirrors the logic in compaction methods
-            if let Some(expires_at) = expires_at {
-                if expires_at < current_time {
+            if let Some(expires_at) = expires_at
+                && expires_at < current_time {
                     expired_count += 1;
                     println!(
                         "⏰ Compaction: Skipping expired record {} (expired at {})",
@@ -188,7 +188,6 @@ mod tests {
                     );
                     continue;
                 }
-            }
 
             kept_records.push((record_id, timestamp, expires_at));
         }

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -180,14 +180,15 @@ mod tests {
         for (record_id, timestamp, expires_at) in mock_records {
             // This mirrors the logic in compaction methods
             if let Some(expires_at) = expires_at
-                && expires_at < current_time {
-                    expired_count += 1;
-                    println!(
-                        "⏰ Compaction: Skipping expired record {} (expired at {})",
-                        record_id, expires_at
-                    );
-                    continue;
-                }
+                && expires_at < current_time
+            {
+                expired_count += 1;
+                println!(
+                    "⏰ Compaction: Skipping expired record {} (expired at {})",
+                    record_id, expires_at
+                );
+                continue;
+            }
 
             kept_records.push((record_id, timestamp, expires_at));
         }

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -2510,10 +2510,12 @@ mod compression_tests_unified {
     #[test]
     fn test_unified_compression_mixed_deserialization() {
         // Test that blocks compressed with different algorithms can be deserialized together
-        let algorithms = [UnifiedCompressionAlgorithm::None,
+        let algorithms = [
+            UnifiedCompressionAlgorithm::None,
             UnifiedCompressionAlgorithm::Zstd,
             UnifiedCompressionAlgorithm::Lz4,
-            UnifiedCompressionAlgorithm::Snappy];
+            UnifiedCompressionAlgorithm::Snappy,
+        ];
 
         let mut serialized_blocks = Vec::new();
 
@@ -3574,10 +3576,12 @@ mod compression_tests {
     #[test]
     fn test_mixed_compression_deserialization() {
         // Create blocks with different compression algorithms
-        let blocks_data = [(CompressionAlgorithm::CompressionNone, MARKER_UNCOMPRESSED),
+        let blocks_data = [
+            (CompressionAlgorithm::CompressionNone, MARKER_UNCOMPRESSED),
             (CompressionAlgorithm::CompressionZstd, MARKER_ZSTD),
             (CompressionAlgorithm::CompressionLz4, MARKER_LZ4),
-            (CompressionAlgorithm::CompressionSnappy, MARKER_SNAPPY)];
+            (CompressionAlgorithm::CompressionSnappy, MARKER_SNAPPY),
+        ];
 
         let mut serialized_blocks = Vec::new();
 

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -429,7 +429,7 @@ mod sst_filename_tests {
         let level = 3;
 
         // Test that the generated filename can be properly parsed back
-        let filename = FilenameCodec::new().generate(level as u32, "sst");
+        let filename = FilenameCodec::new().generate(level, "sst");
 
         assert!(FilenameCodec::new().is_tiered_filename(&filename, "sst"));
         assert_eq!(FilenameCodec::new().parse_level(&filename), level);
@@ -2123,7 +2123,7 @@ mod bplustree_tests {
 
         // Check structure
         assert_eq!(tree.fanout, 16);
-        assert_eq!(tree.leaves.len(), (100 + 15) / 16); // Ceiling division
+        assert_eq!(tree.leaves.len(), 100_usize.div_ceil(16)); // Ceiling division
         assert_eq!(tree.root.len(), tree.leaves.len());
 
         // Check leaf ranges
@@ -2198,7 +2198,7 @@ mod bplustree_tests {
 
         // Range within single leaf
         let leaves = tree.range_leaves("key_00000", "key_00010");
-        assert!(leaves.len() >= 1);
+        assert!(!leaves.is_empty());
 
         // Full range
         let leaves = tree.range_leaves("key_00000", "key_00099");
@@ -2262,7 +2262,7 @@ mod bplustree_tests {
         let tree = BPlusTreeIndex::build(&entries, 128);
 
         assert_eq!(tree.fanout, 128);
-        assert_eq!(tree.leaves.len(), (1000 + 127) / 128);
+        assert_eq!(tree.leaves.len(), 1000_usize.div_ceil(128));
 
         // Verify all entries are covered
         let total_covered: usize = tree.leaves.iter().map(|l| l.len).sum();
@@ -2362,7 +2362,7 @@ mod compression_tests_unified {
 
         for (algorithm, expected_marker) in algorithms_and_markers {
             let config = BlockCompressionConfig {
-                algorithm: algorithm.clone(),
+                algorithm,
                 compression_level: 3,
                 enable_vector_compression: false, // Disable to avoid vector decompression complexity
                 enable_metadata_compression: false, // Disable to avoid metadata decompression complexity
@@ -2427,7 +2427,7 @@ mod compression_tests_unified {
 
         for algorithm in compression_algorithms {
             let config = BlockCompressionConfig {
-                algorithm: algorithm.clone(),
+                algorithm,
                 compression_level: 6,
                 enable_vector_compression: false, // Disable to avoid vector decompression complexity
                 enable_metadata_compression: false, // Disable to avoid metadata decompression complexity
@@ -2510,19 +2510,17 @@ mod compression_tests_unified {
     #[test]
     fn test_unified_compression_mixed_deserialization() {
         // Test that blocks compressed with different algorithms can be deserialized together
-        let algorithms = vec![
-            UnifiedCompressionAlgorithm::None,
+        let algorithms = [UnifiedCompressionAlgorithm::None,
             UnifiedCompressionAlgorithm::Zstd,
             UnifiedCompressionAlgorithm::Lz4,
-            UnifiedCompressionAlgorithm::Snappy,
-        ];
+            UnifiedCompressionAlgorithm::Snappy];
 
         let mut serialized_blocks = Vec::new();
 
         for (i, algorithm) in algorithms.iter().enumerate() {
             let records = vec![create_test_record(&format!("test_{}", i), 128)];
             let config = BlockCompressionConfig {
-                algorithm: algorithm.clone(),
+                algorithm: *algorithm,
                 compression_level: 3,
                 enable_vector_compression: false, // Disable to avoid vector decompression complexity
                 enable_metadata_compression: false, // Disable to avoid metadata decompression complexity
@@ -2534,7 +2532,7 @@ mod compression_tests_unified {
             let block = ProximaDataBlock::new(records, config.clone());
 
             let serialized = block.serialize_with_config(&config).unwrap();
-            serialized_blocks.push((serialized, algorithm.clone()));
+            serialized_blocks.push((serialized, *algorithm));
         }
 
         // Deserialize all blocks and verify
@@ -2597,7 +2595,7 @@ mod bloom_filter_tests {
 
         // With 10 bits per key, false positive rate should be approximately 0.0095
         // Note: An empty bloom filter should have 0.0 false positive rate
-        assert!(calculated_rate >= 0.0 && calculated_rate < 0.02);
+        assert!((0.0..0.02).contains(&calculated_rate));
     }
 
     #[test]
@@ -2743,7 +2741,7 @@ mod bloom_filter_tests {
 
         // Serialize
         let serialized_data = filter.serialize().unwrap();
-        assert!(serialized_data.len() > 0);
+        assert!(!serialized_data.is_empty());
 
         // Create SerializedBloomFilter for deserialization
         let serialized = crate::core::bloom::SerializedBloomFilter {
@@ -3170,7 +3168,7 @@ mod decompression_cache_tests {
                 };
 
                 let config = BlockCompressionConfig {
-                    algorithm: algo.clone(),
+                    algorithm: *algo,
                     compression_level: 6,
                     enable_vector_compression: true,
                     enable_metadata_compression: true,
@@ -3576,12 +3574,10 @@ mod compression_tests {
     #[test]
     fn test_mixed_compression_deserialization() {
         // Create blocks with different compression algorithms
-        let blocks_data = vec![
-            (CompressionAlgorithm::CompressionNone, MARKER_UNCOMPRESSED),
+        let blocks_data = [(CompressionAlgorithm::CompressionNone, MARKER_UNCOMPRESSED),
             (CompressionAlgorithm::CompressionZstd, MARKER_ZSTD),
             (CompressionAlgorithm::CompressionLz4, MARKER_LZ4),
-            (CompressionAlgorithm::CompressionSnappy, MARKER_SNAPPY),
-        ];
+            (CompressionAlgorithm::CompressionSnappy, MARKER_SNAPPY)];
 
         let mut serialized_blocks = Vec::new();
 

--- a/src/storage/engines/sst/readers/sst_query_engine.rs
+++ b/src/storage/engines/sst/readers/sst_query_engine.rs
@@ -1527,7 +1527,7 @@ mod vector_bounds_prune_tests {
         // Queue fills (≥ k) → a finite, small provisional L2 threshold.
         let tau = vector_bounds_provisional_threshold(&seed_blocks, &query, 10)
             .expect("threshold is finite once the seed fills the queue");
-        assert!(tau.is_finite() && tau >= 0.0 && tau < 1.0, "tau={tau}");
+        assert!(tau.is_finite() && (0.0..1.0).contains(&tau), "tau={tau}");
 
         // A far bounding box ([100,101]^dim) cannot hold a top-k candidate ⇒ pruned.
         let far = VectorBoundsPruner::from_bounds(vec![100.0; dim], vec![101.0; dim]).unwrap();

--- a/src/storage/engines/sst/writer_tests.rs
+++ b/src/storage/engines/sst/writer_tests.rs
@@ -230,7 +230,7 @@ mod tests {
 
         // Should have at least the vectors we wrote
         assert!(
-            read_vectors.len() >= 1,
+            !read_vectors.is_empty(),
             "Should have read at least 1 vector, got {}",
             read_vectors.len()
         );

--- a/src/storage/engines/universal/tests.rs
+++ b/src/storage/engines/universal/tests.rs
@@ -84,7 +84,7 @@ mod tests {
         let converter = FormatConverter::new().await.unwrap();
 
         // Test FP32 to INT8 conversion
-        let fp32_data = vec![1.0f32, 2.0, 3.0, 4.0];
+        let fp32_data = [1.0f32, 2.0, 3.0, 4.0];
         let fp32_bytes = fp32_data
             .iter()
             .flat_map(|&f| f.to_le_bytes().to_vec())

--- a/src/storage/engines/viper/codebook_sidecar.rs
+++ b/src/storage/engines/viper/codebook_sidecar.rs
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_sidecar_path_generation() {
         let parquet_path = Path::new("/data/collection/segment_001.parquet");
-        let sidecar_path = ViperCodebookSidecarManager::sidecar_path(&parquet_path);
+        let sidecar_path = ViperCodebookSidecarManager::sidecar_path(parquet_path);
         assert_eq!(
             sidecar_path.file_name().unwrap().to_str().unwrap(),
             "segment_001.codebook.json"

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -3255,7 +3255,7 @@ mod minimal_compaction_tests {
 
         // Set up storage assignment
         use tokio::fs;
-        let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+        let data_dir = StoragePath::collection_data_path(base_path, collection_id);
         fs::create_dir_all(&data_dir).await?;
 
         // Storage assignment is now handled internally by CollectionService

--- a/src/storage/engines/viper/tests/compaction_tests.rs
+++ b/src/storage/engines/viper/tests/compaction_tests.rs
@@ -285,28 +285,28 @@ async fn test_insert_flush_compact_flow() {
     // Step 4: Verify compacted file contents
     debug!("\n🔍 Step 4: Verifying compacted file...");
     if let Some(file_url) = compacted_file_url
-        && let Ok(data) = fs.read(&file_url).await {
-            debug!("  📊 File size: {} bytes", data.len());
+        && let Ok(data) = fs.read(&file_url).await
+    {
+        debug!("  📊 File size: {} bytes", data.len());
 
-            use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-            if let Ok(builder) = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(data))
-            {
-                let reader = builder.build().unwrap();
-                let mut total_rows = 0;
-                for (i, batch) in reader.enumerate() {
-                    if let Ok(batch) = batch {
-                        debug!("  📊 Batch {}: {} rows", i, batch.num_rows());
-                        total_rows += batch.num_rows();
-                    }
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        if let Ok(builder) = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(data)) {
+            let reader = builder.build().unwrap();
+            let mut total_rows = 0;
+            for (i, batch) in reader.enumerate() {
+                if let Ok(batch) = batch {
+                    debug!("  📊 Batch {}: {} rows", i, batch.num_rows());
+                    total_rows += batch.num_rows();
                 }
-                debug!("  📊 Total rows in compacted file: {}", total_rows);
-                assert_eq!(
-                    total_rows, 40,
-                    "Expected 40 rows in compacted file, got {}",
-                    total_rows
-                );
             }
+            debug!("  📊 Total rows in compacted file: {}", total_rows);
+            assert_eq!(
+                total_rows, 40,
+                "Expected 40 rows in compacted file, got {}",
+                total_rows
+            );
         }
+    }
 
     // Step 5: Verify data is still searchable
     debug!("\n🔍 Step 5: Verifying search after compaction...");

--- a/src/storage/engines/viper/tests/compaction_tests.rs
+++ b/src/storage/engines/viper/tests/compaction_tests.rs
@@ -36,13 +36,13 @@ async fn setup_test_assignment(collection_id: &str, base_path: &str) {
     use tokio::fs;
 
     // Create necessary directories
-    let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+    let data_dir = StoragePath::collection_data_path(base_path, collection_id);
     fs::create_dir_all(&data_dir)
         .await
         .expect("Failed to create data directory");
 
     // Create temp directory for atomic writes
-    let temp_dir = StoragePath::data_file_path(base_path, &collection_id, "___temp");
+    let temp_dir = StoragePath::data_file_path(base_path, collection_id, "___temp");
     fs::create_dir_all(&temp_dir)
         .await
         .expect("Failed to create temp directory");
@@ -205,7 +205,7 @@ async fn test_insert_flush_compact_flow() {
     let base_path = temp_dir.path().to_str().unwrap();
     let data_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     let fs = engine
         .get_filesystem_factory()
@@ -284,8 +284,8 @@ async fn test_insert_flush_compact_flow() {
 
     // Step 4: Verify compacted file contents
     debug!("\n🔍 Step 4: Verifying compacted file...");
-    if let Some(file_url) = compacted_file_url {
-        if let Ok(data) = fs.read(&file_url).await {
+    if let Some(file_url) = compacted_file_url
+        && let Ok(data) = fs.read(&file_url).await {
             debug!("  📊 File size: {} bytes", data.len());
 
             use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -307,7 +307,6 @@ async fn test_insert_flush_compact_flow() {
                 );
             }
         }
-    }
 
     // Step 5: Verify data is still searchable
     debug!("\n🔍 Step 5: Verifying search after compaction...");
@@ -360,10 +359,8 @@ async fn test_insert_flush_compact_flow() {
                             ) {
                                 let reader = builder.build().unwrap();
                                 let mut total_rows = 0;
-                                for batch in reader {
-                                    if let Ok(batch) = batch {
-                                        total_rows += batch.num_rows();
-                                    }
+                                for batch in reader.flatten() {
+                                    total_rows += batch.num_rows();
                                 }
                                 debug!("      📊 PARQUET FILE CONTAINS {} RECORDS", total_rows);
                                 if total_rows != 40 {
@@ -379,15 +376,13 @@ async fn test_insert_flush_compact_flow() {
                         if temp_path.is_dir() {
                             debug!("    - Checking ___temp directory:");
                             if let Ok(temp_entries) = std::fs::read_dir(&temp_path) {
-                                for temp_entry in temp_entries {
-                                    if let Ok(temp_entry) = temp_entry {
-                                        let temp_file = temp_entry.file_name();
-                                        debug!("      - {:?}", temp_file);
-                                        if temp_file.to_string_lossy().ends_with(".parquet") {
-                                            debug!(
-                                                "        ⚠️ Found parquet file in ___temp directory!"
-                                            );
-                                        }
+                                for temp_entry in temp_entries.flatten() {
+                                    let temp_file = temp_entry.file_name();
+                                    debug!("      - {:?}", temp_file);
+                                    if temp_file.to_string_lossy().ends_with(".parquet") {
+                                        debug!(
+                                            "        ⚠️ Found parquet file in ___temp directory!"
+                                        );
                                     }
                                 }
                             }
@@ -453,7 +448,7 @@ async fn test_basic_compaction() {
     let base_path = temp_dir.path().to_str().unwrap();
     let data_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     debug!("📍 Data directory: {}", data_url);
 
@@ -516,7 +511,7 @@ async fn test_basic_compaction() {
     // Debug: check what files exist in the data directory
     let data_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     let fs = engine
         .get_filesystem_factory()
@@ -654,7 +649,7 @@ async fn test_basic_compaction() {
     // List all parquet files in data directory to debug
     let data_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     let fs = engine
         .get_filesystem_factory()
@@ -752,10 +747,8 @@ async fn test_basic_compaction() {
 
         if let Ok(entries) = std::fs::read_dir(&data_path) {
             debug!("  - Contents of data directory:");
-            for entry in entries {
-                if let Ok(entry) = entry {
-                    debug!("    - {:?}", entry.path());
-                }
+            for entry in entries.flatten() {
+                debug!("    - {:?}", entry.path());
             }
         } else {
             debug!("  - ⚠️ Could not read data directory");
@@ -962,7 +955,7 @@ async fn test_concurrent_compaction_and_reads() {
         let collection_id_owned = collection_id.to_string();
         let storage_url = format!(
             "file://{}",
-            StoragePath::collection_data_path(&temp_dir_path, &collection_id)
+            StoragePath::collection_data_path(&temp_dir_path, collection_id)
         );
         let handle = tokio::spawn(async move {
             let mut successful_reads = 0;
@@ -1381,7 +1374,7 @@ async fn test_size_tiered_compaction_strategy() {
     setup_test_assignment(collection_id, temp_dir.path().to_str().unwrap()).await;
 
     // Create files of different sizes
-    let file_sizes = vec![10, 10, 10, 50, 50, 100];
+    let file_sizes = [10, 10, 10, 50, 50, 100];
 
     for (idx, size) in file_sizes.iter().enumerate() {
         let mut vectors = Vec::new();
@@ -1439,10 +1432,8 @@ async fn test_size_tiered_compaction_strategy() {
     );
     debug!("🔍 DEBUG: Listing files in data directory: {}", data_path);
     if let Ok(entries) = std::fs::read_dir(&data_path) {
-        for entry in entries {
-            if let Ok(e) = entry {
-                debug!("  - File: {:?}", e.path());
-            }
+        for e in entries.flatten() {
+            debug!("  - File: {:?}", e.path());
         }
     }
 
@@ -1766,22 +1757,20 @@ async fn test_incremental_compaction() {
         } // Limit recursion depth
         let indent = "  ".repeat(depth);
         if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries {
-                if let Ok(entry) = entry {
-                    let path = entry.path();
-                    if path.is_dir() {
-                        debug!("🔍 DEBUG: {}📁 {:?}", indent, path.file_name().unwrap());
-                        list_directory_recursive(path.to_str().unwrap(), depth + 1);
-                    } else {
-                        let metadata = std::fs::metadata(&path).ok();
-                        let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
-                        debug!(
-                            "🔍 DEBUG: {}📄 {:?} ({}bytes)",
-                            indent,
-                            path.file_name().unwrap(),
-                            size
-                        );
-                    }
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    debug!("🔍 DEBUG: {}📁 {:?}", indent, path.file_name().unwrap());
+                    list_directory_recursive(path.to_str().unwrap(), depth + 1);
+                } else {
+                    let metadata = std::fs::metadata(&path).ok();
+                    let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+                    debug!(
+                        "🔍 DEBUG: {}📄 {:?} ({}bytes)",
+                        indent,
+                        path.file_name().unwrap(),
+                        size
+                    );
                 }
             }
         } else {

--- a/src/storage/engines/viper/tests/debug_compaction_test.rs
+++ b/src/storage/engines/viper/tests/debug_compaction_test.rs
@@ -57,8 +57,8 @@ async fn debug_parquet_file(file_path: &str, label: &str) -> Result<()> {
                                 }
 
                                 // Print first few IDs if available
-                                if let Some(id_column) = batch.column_by_name("id") {
-                                    if let Some(id_array) = id_column
+                                if let Some(id_column) = batch.column_by_name("id")
+                                    && let Some(id_array) = id_column
                                         .as_any()
                                         .downcast_ref::<arrow_array::StringArray>(
                                     ) {
@@ -71,7 +71,6 @@ async fn debug_parquet_file(file_path: &str, label: &str) -> Result<()> {
                                             }
                                         }
                                     }
-                                }
                             }
                             Err(e) => {
                                 debug!("  ❌ Error reading batch: {}", e);
@@ -203,9 +202,9 @@ async fn test_viper_flush_and_compaction_debug() -> Result<()> {
 
     // Set up storage assignment
     use tokio::fs;
-    let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+    let data_dir = StoragePath::collection_data_path(base_path, collection_id);
     fs::create_dir_all(&data_dir).await?;
-    let temp_dir = StoragePath::data_file_path(base_path, &collection_id, "___temp");
+    let temp_dir = StoragePath::data_file_path(base_path, collection_id, "___temp");
     fs::create_dir_all(&temp_dir).await?;
 
     // Storage assignment is now handled internally by CollectionService
@@ -216,7 +215,7 @@ async fn test_viper_flush_and_compaction_debug() -> Result<()> {
 
     let data_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     debug!("📍 Data directory: {}", data_url);
 
@@ -329,7 +328,7 @@ async fn test_viper_flush_and_compaction_debug() -> Result<()> {
 
     let storage_url = format!(
         "file://{}",
-        StoragePath::collection_data_path(base_path, &collection_id)
+        StoragePath::collection_data_path(base_path, collection_id)
     );
     let search_results = engine
         .search_vectors(collection_id, &storage_url, &vec![0.5; 128], 10)

--- a/src/storage/engines/viper/tests/debug_compaction_test.rs
+++ b/src/storage/engines/viper/tests/debug_compaction_test.rs
@@ -61,16 +61,17 @@ async fn debug_parquet_file(file_path: &str, label: &str) -> Result<()> {
                                     && let Some(id_array) = id_column
                                         .as_any()
                                         .downcast_ref::<arrow_array::StringArray>(
-                                    ) {
-                                        debug!("    📝 First few IDs:");
-                                        for i in 0..std::cmp::min(5, id_array.len()) {
-                                            if id_array.is_valid(i) {
-                                                debug!("      [{}]: {}", i, id_array.value(i));
-                                            } else {
-                                                debug!("      [{}]: NULL", i);
-                                            }
+                                    )
+                                {
+                                    debug!("    📝 First few IDs:");
+                                    for i in 0..std::cmp::min(5, id_array.len()) {
+                                        if id_array.is_valid(i) {
+                                            debug!("      [{}]: {}", i, id_array.value(i));
+                                        } else {
+                                            debug!("      [{}]: NULL", i);
                                         }
                                     }
+                                }
                             }
                             Err(e) => {
                                 debug!("  ❌ Error reading batch: {}", e);

--- a/src/storage/engines/viper/tests/engine_tests.rs
+++ b/src/storage/engines/viper/tests/engine_tests.rs
@@ -79,13 +79,13 @@ mod tests {
         use tokio::fs;
 
         // Create necessary directories
-        let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+        let data_dir = StoragePath::collection_data_path(base_path, collection_id);
         fs::create_dir_all(&data_dir)
             .await
             .expect("Failed to create data directory");
 
         // Create temp directory for atomic writes
-        let temp_dir = StoragePath::data_file_path(base_path, &collection_id, "___temp");
+        let temp_dir = StoragePath::data_file_path(base_path, collection_id, "___temp");
         fs::create_dir_all(&temp_dir)
             .await
             .expect("Failed to create temp directory");
@@ -93,7 +93,7 @@ mod tests {
         // Storage assignment is now handled internally by CollectionService
         // when a collection is created. For test purposes, we just ensure
         // the directory structure exists.
-        let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+        let data_dir = StoragePath::collection_data_path(base_path, collection_id);
         let wal_dir = format!("{}/{}/write_buffer", base_path, collection_id);
         fs::create_dir_all(&data_dir)
             .await
@@ -265,7 +265,7 @@ mod tests {
             has_quantization: false,
             storage_path: base_location, // Match production: just base_location
             dimension: query_vector.len(),
-            distance_metric: distance_metric.into(),
+            distance_metric,
             ..Default::default()
         };
 
@@ -831,7 +831,7 @@ mod tests {
             // VIPER stores files in {base_path}/{collection_id}/data
             let storage_url = format!(
                 "file://{}",
-                StoragePath::collection_data_path(base_path, &collection_id)
+                StoragePath::collection_data_path(base_path, collection_id)
             );
             let results =
                 search_with_context(&engine, collection_id, &storage_url, &vec![0.1; 128], 30)
@@ -1073,8 +1073,7 @@ mod tests {
                                                     // Check for id column
                                                     if let Ok(idx) =
                                                         batch.schema().index_of(FIELD_ID)
-                                                    {
-                                                        if let Some(id_array) = batch
+                                                        && let Some(id_array) = batch
                                                             .column(idx)
                                                             .as_any()
                                                             .downcast_ref::<arrow_array::StringArray>()
@@ -1090,7 +1089,6 @@ mod tests {
                                                                 }
                                                             }
                                                         }
-                                                    }
                                                 }
                                                 Err(e) => {
                                                     debug!("  Error reading batch: {}", e);
@@ -1119,7 +1117,7 @@ mod tests {
         // Debug: Check the directory structure
         {
             let base_path = temp_dir.path().to_str().unwrap();
-            let data_dir = StoragePath::collection_data_path(base_path, &collection_id);
+            let data_dir = StoragePath::collection_data_path(base_path, collection_id);
             let _wal_dir = format!("{}/{}/write_buffer", base_path, collection_id);
             if tokio::fs::metadata(&data_dir).await.is_ok() {
                 debug!("Data directory exists: {}", data_dir);

--- a/src/storage/engines/viper/tests/parquet_storage_tests.rs
+++ b/src/storage/engines/viper/tests/parquet_storage_tests.rs
@@ -188,10 +188,10 @@ async fn test_unified_atomic_operations_lifecycle() -> Result<()> {
 
     // Test begin flush operation
     let flush_metadata = viper_ops
-        .begin_flush_operation(&collection_id.to_string(), &storage_url)
+        .begin_flush_operation(collection_id, &storage_url)
         .await?;
 
-    assert!(flush_metadata.operation_id.len() > 0);
+    assert!(!flush_metadata.operation_id.is_empty());
     assert!(flush_metadata.staging_url.contains("__flush"));
     assert!(flush_metadata.final_url.contains("storage"));
 

--- a/src/storage/engines/viper/tests/test_data_generator.rs
+++ b/src/storage/engines/viper/tests/test_data_generator.rs
@@ -168,7 +168,7 @@ impl TestDataGenerator {
         vectors
             .iter()
             .map(|vector| {
-                let bytes_needed = (self.config.dimension + 7) / 8;
+                let bytes_needed = self.config.dimension.div_ceil(8);
                 let mut binary = vec![0u8; bytes_needed];
 
                 for (i, &value) in vector.iter().enumerate() {
@@ -654,7 +654,7 @@ mod tests {
 
         // Test binary quantization
         debug!("Testing binary quantized distances:");
-        for (_idx, binary_vector) in binary_codes.iter().enumerate() {
+        for binary_vector in binary_codes.iter() {
             // Convert binary back to float for comparison (1 bit per dimension)
             let mut dequantized = vec![0.0f32; dimension];
             for (i, &byte) in binary_vector.iter().enumerate() {

--- a/src/storage/entity_store_legacy.rs
+++ b/src/storage/entity_store_legacy.rs
@@ -1305,6 +1305,9 @@ impl ProvenanceRegistry for InMemoryProvenanceRegistry {
     }
 }
 
+static GLOBAL_ENTITY_STORE: std::sync::OnceLock<Arc<ProximaEntityStore>> =
+    std::sync::OnceLock::new();
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1680,6 +1683,3 @@ mod tests {
         assert!(!store.header_matches_filter(&header, &non_matching_filter));
     }
 }
-
-static GLOBAL_ENTITY_STORE: std::sync::OnceLock<Arc<ProximaEntityStore>> =
-    std::sync::OnceLock::new();

--- a/src/storage/memtable/implementations/global_partitioned.rs
+++ b/src/storage/memtable/implementations/global_partitioned.rs
@@ -1774,7 +1774,7 @@ mod tests {
         assert!(
             !search_results
                 .iter()
-                .any(|(_, record)| record.oid == "test_vector".to_string())
+                .any(|(_, record)| record.oid == "test_vector")
         );
 
         let all_vectors = memtable
@@ -1784,7 +1784,7 @@ mod tests {
         assert!(
             !all_vectors
                 .iter()
-                .any(|record| record.oid == "test_vector".to_string())
+                .any(|record| record.oid == "test_vector")
         );
     }
 
@@ -2409,7 +2409,7 @@ mod tests {
         assert!(
             !search_results
                 .iter()
-                .any(|(_, record)| record.oid == vector_id.to_string())
+                .any(|(_, record)| record.oid == vector_id)
         );
     }
 

--- a/src/storage/memtable/implementations/global_partitioned.rs
+++ b/src/storage/memtable/implementations/global_partitioned.rs
@@ -1781,11 +1781,7 @@ mod tests {
             .get_collection_vectors(collection_id)
             .await
             .unwrap();
-        assert!(
-            !all_vectors
-                .iter()
-                .any(|record| record.oid == "test_vector")
-        );
+        assert!(!all_vectors.iter().any(|record| record.oid == "test_vector"));
     }
 
     #[tokio::test]

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -1296,7 +1296,7 @@ mod tests {
             Ok(data) => data,
             Err(_) => {
                 // If normalized entry URL doesn't work, try the entry URL as-is
-                match fs.read(&entry_url).await {
+                match fs.read(entry_url).await {
                     Ok(data) => data,
                     Err(_) => {
                         // Final fallback: try the original file_url

--- a/src/storage/persistence/write_ahead_log/batch_factory.rs
+++ b/src/storage/persistence/write_ahead_log/batch_factory.rs
@@ -348,7 +348,7 @@ mod tests {
             WriteBufferStrategyType::ProtoBatch,
         ] {
             let strategy = WALBatchFactory::create_batch_serialization_strategy(
-                strategy_type.clone(),
+                *strategy_type,
                 &config,
                 filesystem.clone(),
             )

--- a/src/storage/persistence/write_ahead_log/batch_strategy_tests.rs
+++ b/src/storage/persistence/write_ahead_log/batch_strategy_tests.rs
@@ -564,7 +564,7 @@ mod write_ahead_log_batch_strategy_tests {
             Err(e) => {
                 // Expected failure - verify error message is informative
                 let error_msg = e.to_string();
-                assert!(error_msg.len() > 0);
+                assert!(!error_msg.is_empty());
                 // Could contain "Invalid cloud URL" or "Failed to get filesystem"
                 assert!(error_msg.contains("Invalid") || error_msg.contains("Failed"));
             }
@@ -596,7 +596,7 @@ mod write_ahead_log_batch_strategy_tests {
                 }
                 Err(e) => {
                     // Also acceptable - error due to invalid URL or no credentials
-                    assert!(e.to_string().len() > 0);
+                    assert!(!e.to_string().is_empty());
                 }
             }
         }

--- a/src/storage/persistence/write_ahead_log/config.rs
+++ b/src/storage/persistence/write_ahead_log/config.rs
@@ -819,7 +819,7 @@ mod tests {
         assert_eq!(format!("{:?}", avro_strategy), "AvroBatch");
         assert_eq!(format!("{:?}", bincode_strategy), "BincodeBatch");
 
-        let cloned_avro = avro_strategy.clone();
+        let cloned_avro = avro_strategy;
         assert!(matches!(avro_strategy, WriteBufferStrategyType::AvroBatch));
         assert!(matches!(cloned_avro, WriteBufferStrategyType::AvroBatch));
     }

--- a/src/storage/persistence/write_ahead_log/memtable_manager.rs
+++ b/src/storage/persistence/write_ahead_log/memtable_manager.rs
@@ -291,7 +291,7 @@ mod tests {
 
         let batch = WALVectorBatch {
             batch_id: crate::storage::persistence::write_ahead_log::BatchId::new(),
-            vector_records: Arc::new(vectors.into_iter().map(Into::into).collect()),
+            vector_records: Arc::new(vectors.into_iter().collect()),
             timestamp: std::time::SystemTime::now(),
             total_size_bytes: 1024,
             is_flushed: false,

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -3237,11 +3237,11 @@ mod simple_context_tests {
 
         // Test row group size optimization for VIPER
         let row_group_size = viper_context.row_group_size();
-        assert!(row_group_size >= 1000 && row_group_size <= 50000);
+        assert!((1000..=50000).contains(&row_group_size));
 
         // Test flush threshold optimization
         let flush_threshold = viper_context.flush_threshold();
-        assert!(flush_threshold >= 10000 && flush_threshold <= 100000);
+        assert!((10000..=100000).contains(&flush_threshold));
 
         info!("✅ Context performance configuration test passed");
     }

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -1872,7 +1872,7 @@ mod tests {
         // Zero-padded base62 ⇒ S3 LIST lexicographic order == numeric order.
         use crate::core::stable_id::CollectionIdentity;
         let ids: Vec<u32> = vec![1, 2, 3, 10, 11, 100];
-        let mut prefixes: Vec<String> = ids
+        let prefixes: Vec<String> = ids
             .iter()
             .map(|&c| {
                 DrPathBuilder::build_from_identity(

--- a/src/storage/transaction_coordinator.rs
+++ b/src/storage/transaction_coordinator.rs
@@ -1441,10 +1441,7 @@ mod tests {
 
         // Begin flush operation
         let metadata = viper_ops
-            .begin_flush_operation(
-                "test_collection",
-                &format!("file://{}", temp_path),
-            )
+            .begin_flush_operation("test_collection", &format!("file://{}", temp_path))
             .await
             .unwrap();
 

--- a/src/storage/transaction_coordinator.rs
+++ b/src/storage/transaction_coordinator.rs
@@ -1442,7 +1442,7 @@ mod tests {
         // Begin flush operation
         let metadata = viper_ops
             .begin_flush_operation(
-                &"test_collection".to_string(),
+                "test_collection",
                 &format!("file://{}", temp_path),
             )
             .await

--- a/tests/adaptive_pca_high_dim_test.rs
+++ b/tests/adaptive_pca_high_dim_test.rs
@@ -162,10 +162,8 @@ async fn test_sst_with_bge_768_embeddings() -> anyhow::Result<()> {
         info!("📁 Data directory exists: {:?}", data_dir);
         let entries: Vec<_> = std::fs::read_dir(&data_dir)?.collect();
         info!("📄 Data directory has {} entries", entries.len());
-        for entry in entries {
-            if let Ok(entry) = entry {
-                info!("  - {:?}", entry.path());
-            }
+        for entry in entries.into_iter().flatten() {
+            info!("  - {:?}", entry.path());
         }
     } else {
         info!("⚠️ Data directory does not exist at {:?}", data_dir);
@@ -296,10 +294,8 @@ async fn test_sst_with_openai_1536_embeddings() -> anyhow::Result<()> {
         info!("📁 Data directory exists: {:?}", data_dir);
         let entries: Vec<_> = std::fs::read_dir(&data_dir)?.collect();
         info!("📄 Data directory has {} entries", entries.len());
-        for entry in entries {
-            if let Ok(entry) = entry {
-                info!("  - {:?}", entry.path());
-            }
+        for entry in entries.into_iter().flatten() {
+            info!("  - {:?}", entry.path());
         }
     } else {
         info!("⚠️ Data directory does not exist at {:?}", data_dir);

--- a/tests/all_engines_50k_benchmark.rs
+++ b/tests/all_engines_50k_benchmark.rs
@@ -210,7 +210,7 @@ fn benchmark_engine(
         println!(
             "    Inserted batch {}/{}",
             batch_start / BATCH_SIZE + 1,
-            (vector_count + BATCH_SIZE - 1) / BATCH_SIZE
+            vector_count.div_ceil(BATCH_SIZE)
         );
     }
 

--- a/tests/api_consistency_test.rs
+++ b/tests/api_consistency_test.rs
@@ -13,7 +13,6 @@ use proximadb::proto::proximadb_v1::{
     VectorRecord, VectorSearchRequest, filter_clause, sql_value,
 };
 use std::time::Duration;
-use tokio;
 
 #[cfg(test)]
 mod api_consistency_tests {

--- a/tests/api_v2_integration_test.rs
+++ b/tests/api_v2_integration_test.rs
@@ -82,7 +82,7 @@ impl V2ApiTestHarness {
     /// Check if REST server is available
     async fn check_server(&self) -> bool {
         self.http_client
-            .get(&format!("{}/health", REST_BASE_URL))
+            .get(format!("{}/health", REST_BASE_URL))
             .send()
             .await
             .map(|r| r.status().is_success())
@@ -108,7 +108,7 @@ impl V2ApiTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v2/collections", REST_BASE_URL))
+            .post(format!("{}/api/v2/collections", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -174,7 +174,7 @@ impl V2ApiTestHarness {
     async fn get_collection(&self) -> Result<JsonValue, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .get(&format!(
+            .get(format!(
                 "{}/api/v2/collections/{}",
                 REST_BASE_URL, self.test_collection_name
             ))
@@ -207,7 +207,7 @@ impl V2ApiTestHarness {
 
         let response = self
             .http_client
-            .post(&format!(
+            .post(format!(
                 "{}/api/v2/collections/{}/records/batch",
                 REST_BASE_URL, self.test_collection_name
             ))
@@ -251,7 +251,7 @@ impl V2ApiTestHarness {
 
         let response = self
             .http_client
-            .post(&format!(
+            .post(format!(
                 "{}/api/v2/collections/{}/search",
                 REST_BASE_URL, self.test_collection_name
             ))
@@ -276,7 +276,7 @@ impl V2ApiTestHarness {
     ) -> Result<(reqwest::StatusCode, JsonValue), Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .get(&format!(
+            .get(format!(
                 "{}/api/v2/collections/{}",
                 REST_BASE_URL, identifier
             ))
@@ -295,7 +295,7 @@ impl V2ApiTestHarness {
     ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .post(&format!(
+            .post(format!(
                 "{}/api/v2/collections/{}/records/batch",
                 REST_BASE_URL, identifier
             ))
@@ -314,7 +314,7 @@ impl V2ApiTestHarness {
     ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .post(&format!(
+            .post(format!(
                 "{}/api/v2/collections/{}/search",
                 REST_BASE_URL, identifier
             ))
@@ -331,7 +331,7 @@ impl V2ApiTestHarness {
     ) -> Result<reqwest::StatusCode, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .delete(&format!(
+            .delete(format!(
                 "{}/api/v2/collections/{}",
                 REST_BASE_URL, identifier
             ))
@@ -345,7 +345,7 @@ impl V2ApiTestHarness {
         // Try to delete via V1 API (V2 may not have delete endpoint yet)
         let _ = self
             .http_client
-            .delete(&format!(
+            .delete(format!(
                 "{}/api/v1/collections/{}",
                 REST_BASE_URL, self.test_collection_name
             ))
@@ -697,7 +697,7 @@ async fn test_create_collection_invalid_engine() {
 
     let response = harness
         .http_client
-        .post(&format!("{}/api/v2/collections", REST_BASE_URL))
+        .post(format!("{}/api/v2/collections", REST_BASE_URL))
         .json(&request)
         .send()
         .await;
@@ -744,7 +744,7 @@ async fn test_create_collection_invalid_dimension() {
 
     let response = harness
         .http_client
-        .post(&format!("{}/api/v2/collections", REST_BASE_URL))
+        .post(format!("{}/api/v2/collections", REST_BASE_URL))
         .json(&request)
         .send()
         .await;
@@ -1034,7 +1034,7 @@ async fn test_get_collection_not_found() {
     // Try to get non-existent collection
     let response = harness
         .http_client
-        .get(&format!(
+        .get(format!(
             "{}/api/v2/collections/nonexistent_collection_xyz_123",
             REST_BASE_URL
         ))
@@ -1267,7 +1267,7 @@ async fn test_insert_records_empty_batch() {
 
     let response = harness
         .http_client
-        .post(&format!(
+        .post(format!(
             "{}/api/v2/collections/{}/records/batch",
             REST_BASE_URL, harness.test_collection_name
         ))
@@ -1428,15 +1428,14 @@ async fn test_search_with_eq_filter() {
             // All results should have category_0
             for result in results {
                 let typed_fields = result.get("typed_fields");
-                if let Some(fields) = typed_fields {
-                    if let Some(category) = fields.get("category") {
+                if let Some(fields) = typed_fields
+                    && let Some(category) = fields.get("category") {
                         assert_eq!(
                             category.as_str(),
                             Some("category_0"),
                             "Filtered results should only have category_0"
                         );
                     }
-                }
             }
 
             println!("test_search_with_eq_filter PASSED");
@@ -1561,15 +1560,14 @@ async fn test_search_include_vector() {
 
             for result in results {
                 let vector = result.get("vector");
-                if let Some(v) = vector {
-                    if let Some(arr) = v.as_array() {
+                if let Some(v) = vector
+                    && let Some(arr) = v.as_array() {
                         assert_eq!(
                             arr.len(),
                             TEST_DIMENSION as usize,
                             "Vector should have correct dimension"
                         );
                     }
-                }
             }
 
             println!("test_search_include_vector PASSED");
@@ -1612,7 +1610,7 @@ async fn test_search_empty_vector() {
 
     let response = harness
         .http_client
-        .post(&format!(
+        .post(format!(
             "{}/api/v2/collections/{}/search",
             REST_BASE_URL, harness.test_collection_name
         ))
@@ -1672,7 +1670,7 @@ async fn test_search_invalid_filter_operator() {
 
     let response = harness
         .http_client
-        .post(&format!(
+        .post(format!(
             "{}/api/v2/collections/{}/search",
             REST_BASE_URL, harness.test_collection_name
         ))
@@ -1732,7 +1730,7 @@ async fn test_search_between_filter_missing_upper() {
 
     let response = harness
         .http_client
-        .post(&format!(
+        .post(format!(
             "{}/api/v2/collections/{}/search",
             REST_BASE_URL, harness.test_collection_name
         ))

--- a/tests/api_v2_integration_test.rs
+++ b/tests/api_v2_integration_test.rs
@@ -1429,13 +1429,14 @@ async fn test_search_with_eq_filter() {
             for result in results {
                 let typed_fields = result.get("typed_fields");
                 if let Some(fields) = typed_fields
-                    && let Some(category) = fields.get("category") {
-                        assert_eq!(
-                            category.as_str(),
-                            Some("category_0"),
-                            "Filtered results should only have category_0"
-                        );
-                    }
+                    && let Some(category) = fields.get("category")
+                {
+                    assert_eq!(
+                        category.as_str(),
+                        Some("category_0"),
+                        "Filtered results should only have category_0"
+                    );
+                }
             }
 
             println!("test_search_with_eq_filter PASSED");
@@ -1561,13 +1562,14 @@ async fn test_search_include_vector() {
             for result in results {
                 let vector = result.get("vector");
                 if let Some(v) = vector
-                    && let Some(arr) = v.as_array() {
-                        assert_eq!(
-                            arr.len(),
-                            TEST_DIMENSION as usize,
-                            "Vector should have correct dimension"
-                        );
-                    }
+                    && let Some(arr) = v.as_array()
+                {
+                    assert_eq!(
+                        arr.len(),
+                        TEST_DIMENSION as usize,
+                        "Vector should have correct dimension"
+                    );
+                }
             }
 
             println!("test_search_include_vector PASSED");

--- a/tests/backup_restore_test.rs
+++ b/tests/backup_restore_test.rs
@@ -195,7 +195,7 @@ async fn test_incremental_backup() {
     );
 
     // Verify second backup includes previous backup ID
-    assert!(manifest2.data_files.len() >= 1); // At least the new file
+    assert!(!manifest2.data_files.is_empty()); // At least the new file
 }
 
 /// Test backup retention policy

--- a/tests/cache_consolidation_test.rs
+++ b/tests/cache_consolidation_test.rs
@@ -155,11 +155,13 @@ mod cache_consolidation_tests {
     #[test]
     fn test_cache_id_enumeration() {
         // Verify all cache IDs are defined
-        let cache_ids = [CacheId::VectorData,
+        let cache_ids = [
+            CacheId::VectorData,
             CacheId::Metadata,
             CacheId::QueryResult,
             CacheId::BitmapFilter,
-            CacheId::IndexNode];
+            CacheId::IndexNode,
+        ];
 
         // Should have at least 5 cache types
         assert!(cache_ids.len() >= 5);

--- a/tests/cache_consolidation_test.rs
+++ b/tests/cache_consolidation_test.rs
@@ -142,7 +142,7 @@ mod cache_consolidation_tests {
 
             // Verify stats can be retrieved (may be empty if no caches registered)
             // Just verify the method works and returns a valid HashMap
-            assert!(stats.is_empty() || stats.len() > 0);
+            assert!(stats.is_empty() || !stats.is_empty());
 
             // If there are stats, verify structure
             for (cache_id, cache_stats) in stats {
@@ -155,13 +155,11 @@ mod cache_consolidation_tests {
     #[test]
     fn test_cache_id_enumeration() {
         // Verify all cache IDs are defined
-        let cache_ids = vec![
-            CacheId::VectorData,
+        let cache_ids = [CacheId::VectorData,
             CacheId::Metadata,
             CacheId::QueryResult,
             CacheId::BitmapFilter,
-            CacheId::IndexNode,
-        ];
+            CacheId::IndexNode];
 
         // Should have at least 5 cache types
         assert!(cache_ids.len() >= 5);

--- a/tests/cached_planner_integration_test.rs
+++ b/tests/cached_planner_integration_test.rs
@@ -202,7 +202,7 @@ async fn invalidation_summary_total_reflects_cache_contribution() {
     // Populate plan_cache with two distinct keys (different recall
     // targets → distinct cache entries even with the same predicates).
     let _ = build_for_search_cached_with_collection(&plan_cache, &inputs, "kb").await;
-    let mut inputs2 = CachedPlanInputs {
+    let inputs2 = CachedPlanInputs {
         plan_inputs: PlanBuilderInputs {
             predicates: &preds,
             field_stats: &stats,

--- a/tests/catalog_integration_test.rs
+++ b/tests/catalog_integration_test.rs
@@ -536,7 +536,7 @@ mod iceberg_catalog_tests {
 
         let health = catalog.health_check().await.unwrap();
         assert!(health.is_healthy);
-        assert!(health.latency_ms > 0 || health.latency_ms == 0); // Just checking it exists
+        assert!(health.latency_ms >= 0); // Just checking it exists
 
         cleanup_dir(&temp_dir).await;
     }

--- a/tests/cluster_integration_test.rs
+++ b/tests/cluster_integration_test.rs
@@ -995,7 +995,7 @@ async fn test_retry_policy_jitter() {
     for delay in &delays {
         let ms = delay.as_millis();
         assert!(
-            ms >= 80 && ms <= 120,
+            (80..=120).contains(&ms),
             "Delay {}ms outside expected range 80-120ms",
             ms
         );
@@ -1287,7 +1287,7 @@ async fn test_raft_consensus_random_election_timeout() {
         let timeout = consensus.random_election_timeout();
         let ms = timeout.as_millis() as u64;
         assert!(
-            ms >= 100 && ms <= 200,
+            (100..=200).contains(&ms),
             "Timeout {}ms outside expected range 100-200ms",
             ms
         );

--- a/tests/common/integration_test_helpers.rs
+++ b/tests/common/integration_test_helpers.rs
@@ -346,7 +346,7 @@ impl UnifiedTestEnvironment {
         let entries = std::fs::read_dir(&data_dir)?;
         let sst_files: Vec<_> = entries
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map_or(false, |ext| ext == "sst"))
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
             .collect();
 
         if sst_files.is_empty() {
@@ -372,7 +372,7 @@ impl UnifiedTestEnvironment {
         let entries = std::fs::read_dir(&data_dir)?;
         let parquet_files: Vec<_> = entries
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map_or(false, |ext| ext == "parquet"))
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "parquet"))
             .collect();
 
         if parquet_files.is_empty() {

--- a/tests/common/sks_fixtures.rs
+++ b/tests/common/sks_fixtures.rs
@@ -218,7 +218,7 @@ impl TestKnowledgeGraph {
         let mut entities = Vec::new();
         let mut embeddings = Vec::new();
 
-        let categories = vec!["Electronics", "Clothing", "Books", "Home", "Sports"];
+        let categories = ["Electronics", "Clothing", "Books", "Home", "Sports"];
 
         // Generate products with metadata
         for i in 0..num_products {
@@ -336,7 +336,7 @@ impl TestKnowledgeGraph {
     }
 
     fn random_relation_type(rng: &mut impl Rng) -> String {
-        let types = vec!["related_to", "derived_from", "references", "similar_to"];
+        let types = ["related_to", "derived_from", "references", "similar_to"];
         types[rng.gen_range(0..types.len())].to_string()
     }
 }
@@ -367,7 +367,7 @@ mod tests {
     fn test_research_papers_fixture() {
         let graph = TestKnowledgeGraph::research_papers();
         assert_eq!(graph.entities.len(), 500);
-        assert!(graph.relations.len() > 0);
+        assert!(!graph.relations.is_empty());
 
         // Verify metadata structure
         let paper = &graph.entities[0];
@@ -387,7 +387,7 @@ mod tests {
     fn test_ecommerce_fixture() {
         let graph = TestKnowledgeGraph::ecommerce();
         assert_eq!(graph.entities.len(), 1000);
-        assert!(graph.relations.len() > 0);
+        assert!(!graph.relations.is_empty());
 
         // Verify product metadata
         let product = &graph.entities[0];

--- a/tests/common/test_assignments.rs
+++ b/tests/common/test_assignments.rs
@@ -296,7 +296,7 @@ static TEST_ASSIGNMENTS: std::sync::OnceLock<PersistentTestAssignments> =
 
 /// Get the global test assignments instance
 pub fn get_test_assignments() -> &'static PersistentTestAssignments {
-    TEST_ASSIGNMENTS.get_or_init(|| PersistentTestAssignments::new())
+    TEST_ASSIGNMENTS.get_or_init(PersistentTestAssignments::new)
 }
 
 /// Setup storage assignment for a collection with persistent directory management

--- a/tests/distributed_search_test.rs
+++ b/tests/distributed_search_test.rs
@@ -1196,7 +1196,7 @@ async fn test_partition_records_with_tenant_context() {
     let total: usize = partitioned.values().map(|v| v.len()).sum();
     assert_eq!(total, 2);
 
-    for (_shard_id, shard_records) in &partitioned {
+    for shard_records in partitioned.values() {
         for record in shard_records {
             assert!(record.metadata.contains_key("tenant_id"));
             assert!(record.metadata.contains_key("domain_id"));

--- a/tests/embedded_flush_recovery.rs
+++ b/tests/embedded_flush_recovery.rs
@@ -191,7 +191,7 @@ fn sst_block_serialization_roundtrip() {
         }
 
         db.insert("roundtrip_test", ids, vectors, None)
-            .expect(&format!("insert batch {}", batch_idx));
+            .unwrap_or_else(|_| panic!("insert batch {}", batch_idx));
     }
 
     eprintln!(
@@ -308,7 +308,7 @@ fn test_large_k_search_returns_correct_count() {
     for k in [10, 50, 100, 200, 500, 1000] {
         let results = db
             .search("test_large_k", vectors[0].clone(), k, None)
-            .expect(&format!("search pre-flush k={}", k));
+            .unwrap_or_else(|_| panic!("search pre-flush k={}", k));
         eprintln!("  k={}: got {} results", k, results.len());
     }
     let results_pre_flush = db

--- a/tests/filesystem_integration_test.rs
+++ b/tests/filesystem_integration_test.rs
@@ -3,7 +3,6 @@
 //! This test demonstrates that ProximaDB can work with different filesystem backends.
 
 use anyhow::Result;
-use tokio;
 use tracing::debug;
 
 #[tokio::test]

--- a/tests/filtered_ann_recall_bands.rs
+++ b/tests/filtered_ann_recall_bands.rs
@@ -76,9 +76,10 @@ impl RecallBandsServer {
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
             if let Ok(resp) = http.get(&health_url).send().await
-                && resp.status().is_success() {
-                    break;
-                }
+                && resp.status().is_success()
+            {
+                break;
+            }
             if std::time::Instant::now() > deadline {
                 anyhow::bail!("REST didn't become ready in 20s");
             }

--- a/tests/filtered_ann_recall_bands.rs
+++ b/tests/filtered_ann_recall_bands.rs
@@ -75,11 +75,10 @@ impl RecallBandsServer {
         let health_url = format!("http://127.0.0.1:{}/health", rest_port);
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
-            if let Ok(resp) = http.get(&health_url).send().await {
-                if resp.status().is_success() {
+            if let Ok(resp) = http.get(&health_url).send().await
+                && resp.status().is_success() {
                     break;
                 }
-            }
             if std::time::Instant::now() > deadline {
                 anyhow::bail!("REST didn't become ready in 20s");
             }

--- a/tests/fp16_network_e2e.rs
+++ b/tests/fp16_network_e2e.rs
@@ -403,12 +403,11 @@ async fn rest_insert_into_fp16_collection_increments_canonical_bytes_metric() {
         if !line.contains(&coll_fragment) || !line.contains(r#"precision="fp16""#) {
             continue;
         }
-        if let Some((_, tail)) = line.split_once('}') {
-            if let Ok(value) = tail.trim().parse::<i64>() {
+        if let Some((_, tail)) = line.split_once('}')
+            && let Ok(value) = tail.trim().parse::<i64>() {
                 observed = Some(value);
                 break;
             }
-        }
     }
     assert_eq!(
         observed,

--- a/tests/fp16_network_e2e.rs
+++ b/tests/fp16_network_e2e.rs
@@ -404,10 +404,11 @@ async fn rest_insert_into_fp16_collection_increments_canonical_bytes_metric() {
             continue;
         }
         if let Some((_, tail)) = line.split_once('}')
-            && let Ok(value) = tail.trim().parse::<i64>() {
-                observed = Some(value);
-                break;
-            }
+            && let Ok(value) = tail.trim().parse::<i64>()
+        {
+            observed = Some(value);
+            break;
+        }
     }
     assert_eq!(
         observed,

--- a/tests/fp16_v2_insert_search_e2e.rs
+++ b/tests/fp16_v2_insert_search_e2e.rs
@@ -230,10 +230,11 @@ async fn rest_v2_insert_into_fp16_collection_accumulates_canonical_bytes_metric(
             continue;
         }
         if let Some((_, tail)) = line.split_once('}')
-            && let Ok(v) = tail.trim().parse::<i64>() {
-                observed = Some(v);
-                break;
-            }
+            && let Ok(v) = tail.trim().parse::<i64>()
+        {
+            observed = Some(v);
+            break;
+        }
     }
     assert_eq!(
         observed,

--- a/tests/fp16_v2_insert_search_e2e.rs
+++ b/tests/fp16_v2_insert_search_e2e.rs
@@ -229,12 +229,11 @@ async fn rest_v2_insert_into_fp16_collection_accumulates_canonical_bytes_metric(
         if !line.contains(&coll_label) || !line.contains(r#"precision="fp16""#) {
             continue;
         }
-        if let Some((_, tail)) = line.split_once('}') {
-            if let Ok(v) = tail.trim().parse::<i64>() {
+        if let Some((_, tail)) = line.split_once('}')
+            && let Ok(v) = tail.trim().parse::<i64>() {
                 observed = Some(v);
                 break;
             }
-        }
     }
     assert_eq!(
         observed,

--- a/tests/graph_arrow_integration_test.rs
+++ b/tests/graph_arrow_integration_test.rs
@@ -186,24 +186,28 @@ mod graph_arrow_integration_tests {
         // search results in a federated query using Arrow format
 
         // Simulate graph query results
-        let graph_results = [HashMap::from([
+        let graph_results = [
+            HashMap::from([
                 ("node_id".to_string(), serde_json::json!("node1")),
                 ("label".to_string(), serde_json::json!("Person")),
             ]),
             HashMap::from([
                 ("node_id".to_string(), serde_json::json!("node2")),
                 ("label".to_string(), serde_json::json!("Company")),
-            ])];
+            ]),
+        ];
 
         // Simulate vector search results
-        let vector_results = [HashMap::from([
+        let vector_results = [
+            HashMap::from([
                 ("id".to_string(), serde_json::json!("doc1")),
                 ("score".to_string(), serde_json::json!(0.95)),
             ]),
             HashMap::from([
                 ("id".to_string(), serde_json::json!("doc2")),
                 ("score".to_string(), serde_json::json!(0.87)),
-            ])];
+            ]),
+        ];
 
         // Verify both result sets are compatible for federated processing
         assert_eq!(graph_results.len(), 2);

--- a/tests/graph_arrow_integration_test.rs
+++ b/tests/graph_arrow_integration_test.rs
@@ -186,28 +186,24 @@ mod graph_arrow_integration_tests {
         // search results in a federated query using Arrow format
 
         // Simulate graph query results
-        let graph_results = vec![
-            HashMap::from([
+        let graph_results = [HashMap::from([
                 ("node_id".to_string(), serde_json::json!("node1")),
                 ("label".to_string(), serde_json::json!("Person")),
             ]),
             HashMap::from([
                 ("node_id".to_string(), serde_json::json!("node2")),
                 ("label".to_string(), serde_json::json!("Company")),
-            ]),
-        ];
+            ])];
 
         // Simulate vector search results
-        let vector_results = vec![
-            HashMap::from([
+        let vector_results = [HashMap::from([
                 ("id".to_string(), serde_json::json!("doc1")),
                 ("score".to_string(), serde_json::json!(0.95)),
             ]),
             HashMap::from([
                 ("id".to_string(), serde_json::json!("doc2")),
                 ("score".to_string(), serde_json::json!(0.87)),
-            ]),
-        ];
+            ])];
 
         // Verify both result sets are compatible for federated processing
         assert_eq!(graph_results.len(), 2);

--- a/tests/graph_comprehensive_e2e_test.rs
+++ b/tests/graph_comprehensive_e2e_test.rs
@@ -189,7 +189,7 @@ async fn test_e2e_graph_basic_operations() {
         .get_outgoing_edges(&"AI".to_string(), Some("INCLUDES"))
         .unwrap();
     println!("   AI has {} INCLUDES edges", includes_edges.len());
-    assert!(includes_edges.len() > 0);
+    assert!(!includes_edges.is_empty());
 
     // Test 5: Graph statistics
     println!("5. Testing graph statistics...");
@@ -404,7 +404,7 @@ async fn test_e2e_full_pipeline_integration() {
             &engine,
             start,
             target,
-            &vec![0.9, 0.1, 0.0],
+            &[0.9, 0.1, 0.0],
             0.5,
             Arc::clone(&distance_compute),
             DistanceMetric::Cosine,

--- a/tests/graph_integration_test.rs
+++ b/tests/graph_integration_test.rs
@@ -543,12 +543,12 @@ async fn test_graph_stats() {
         stats.total_edges
     );
     assert!(
-        stats.label_stats.len() > 0,
+        !stats.label_stats.is_empty(),
         "Expected label stats, got {}",
         stats.label_stats.len()
     );
     assert!(
-        stats.edge_type_stats.len() > 0,
+        !stats.edge_type_stats.is_empty(),
         "Expected edge type stats, got {}",
         stats.edge_type_stats.len()
     );

--- a/tests/helix_integration_test.rs
+++ b/tests/helix_integration_test.rs
@@ -50,14 +50,14 @@ mod helix_integration_tests {
         }
 
         // Clean system temp directory (macOS: /var/folders, Linux: /tmp)
-        if cfg!(target_os = "macos") {
-            if let Ok(entries) = fs::read_dir("/var/folders") {
+        if cfg!(target_os = "macos")
+            && let Ok(entries) = fs::read_dir("/var/folders") {
                 for entry in entries.flatten() {
                     let path = entry.path();
                     // Search in /var/folders/*/T/ directories
                     let temp_path = path.join("T");
-                    if temp_path.exists() {
-                        if let Ok(temp_entries) = fs::read_dir(&temp_path) {
+                    if temp_path.exists()
+                        && let Ok(temp_entries) = fs::read_dir(&temp_path) {
                             for temp_entry in temp_entries.flatten() {
                                 let temp_file = temp_entry.path();
                                 if let Some(name) = temp_file.file_name() {
@@ -74,10 +74,8 @@ mod helix_integration_tests {
                                 }
                             }
                         }
-                    }
                 }
             }
-        }
     }
 
     /// Helper to create test vectors

--- a/tests/helix_integration_test.rs
+++ b/tests/helix_integration_test.rs
@@ -51,31 +51,31 @@ mod helix_integration_tests {
 
         // Clean system temp directory (macOS: /var/folders, Linux: /tmp)
         if cfg!(target_os = "macos")
-            && let Ok(entries) = fs::read_dir("/var/folders") {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    // Search in /var/folders/*/T/ directories
-                    let temp_path = path.join("T");
-                    if temp_path.exists()
-                        && let Ok(temp_entries) = fs::read_dir(&temp_path) {
-                            for temp_entry in temp_entries.flatten() {
-                                let temp_file = temp_entry.path();
-                                if let Some(name) = temp_file.file_name() {
-                                    let name_str = name.to_string_lossy();
-                                    if name_str.starts_with("helix_test_")
-                                        || name_str.ends_with(".helix")
-                                    {
-                                        let _ = if temp_file.is_dir() {
-                                            fs::remove_dir_all(&temp_file)
-                                        } else {
-                                            fs::remove_file(&temp_file)
-                                        };
-                                    }
-                                }
+            && let Ok(entries) = fs::read_dir("/var/folders")
+        {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                // Search in /var/folders/*/T/ directories
+                let temp_path = path.join("T");
+                if temp_path.exists()
+                    && let Ok(temp_entries) = fs::read_dir(&temp_path)
+                {
+                    for temp_entry in temp_entries.flatten() {
+                        let temp_file = temp_entry.path();
+                        if let Some(name) = temp_file.file_name() {
+                            let name_str = name.to_string_lossy();
+                            if name_str.starts_with("helix_test_") || name_str.ends_with(".helix") {
+                                let _ = if temp_file.is_dir() {
+                                    fs::remove_dir_all(&temp_file)
+                                } else {
+                                    fs::remove_file(&temp_file)
+                                };
                             }
                         }
+                    }
                 }
             }
+        }
     }
 
     /// Helper to create test vectors

--- a/tests/helix_performance_comparison_test.rs
+++ b/tests/helix_performance_comparison_test.rs
@@ -655,7 +655,7 @@ mod performance_comparison_tests {
         for chunk in vectors.chunks(1000) {
             let flush_params = FlushParameters {
                 collection_id: Some("test_collection".to_string()),
-                vector_records: chunk.iter().map(|v| v.clone().into()).collect(),
+                vector_records: chunk.iter().map(|v| v.clone()).collect(),
                 force: true,
                 synchronous: true,
                 hints: HashMap::new(),

--- a/tests/helix_prune_debug_test.rs
+++ b/tests/helix_prune_debug_test.rs
@@ -437,14 +437,14 @@ mod helix_prune_debug {
         eprintln!("\n🔍 Key differences identified:");
         eprintln!("   SST:   dimension mismatch → distance 0.0 (SAFE fallback, block included)");
         eprintln!("   HELIX: dimension mismatch → distance INFINITY (block PRUNED!)");
-        eprintln!("");
+        eprintln!();
         eprintln!("   SST:   file-level pruning first, then block-level");
         eprintln!("   HELIX: block-level pruning only");
-        eprintln!("");
+        eprintln!();
         eprintln!("   Default BlockPruneConfig:");
         eprintln!("     mode: Sqrt (select sqrt(n) blocks)");
         eprintln!("     min_keep: 1 (too aggressive for random data)");
-        eprintln!("");
+        eprintln!();
         eprintln!("   With 5000 vectors, 128 vectors/block:");
         eprintln!("     ~39 blocks, sqrt(39) = ~6 blocks selected = 16% of data!");
 
@@ -588,7 +588,7 @@ mod helix_prune_debug {
         eprintln!("\n========================================");
         eprintln!("TEST: HELIX with Clustered Data");
         eprintln!("========================================");
-        eprintln!("");
+        eprintln!();
         eprintln!("This test verifies that HELIX's centroid-based pruning");
         eprintln!("works well for spatially clustered data (its design target).");
 

--- a/tests/infrastructure_integration_test.rs
+++ b/tests/infrastructure_integration_test.rs
@@ -26,10 +26,7 @@ fn run_command(command: &str, args: &[&str]) -> Result<String, String> {
 
 /// Test helper to check if a resource exists
 fn resource_exists(resource_type: &str, resource_name: &str) -> bool {
-    match run_command("kubectl", &["get", resource_type, resource_name]) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    run_command("kubectl", &["get", resource_type, resource_name]).is_ok()
 }
 
 /// Test helper to wait for a condition

--- a/tests/multimodal_integration_test.rs
+++ b/tests/multimodal_integration_test.rs
@@ -795,7 +795,7 @@ async fn test_federated_query_via_rest() {
 
     // Check if server is running
     let health_check = client
-        .get(&format!("{}/health", REST_BASE_URL))
+        .get(format!("{}/health", REST_BASE_URL))
         .send()
         .await;
 
@@ -819,7 +819,7 @@ async fn test_federated_query_via_rest() {
     });
 
     let response = client
-        .post(&format!("{}/api/v1/unified/federated", REST_BASE_URL))
+        .post(format!("{}/api/v1/unified/federated", REST_BASE_URL))
         .json(&federated_request)
         .send()
         .await;
@@ -863,7 +863,7 @@ async fn test_multimodel_query_via_rest() {
 
     // Check if server is running
     let health_check = client
-        .get(&format!("{}/health", REST_BASE_URL))
+        .get(format!("{}/health", REST_BASE_URL))
         .send()
         .await;
 
@@ -904,7 +904,7 @@ async fn test_multimodel_query_via_rest() {
     });
 
     let response = client
-        .post(&format!("{}/api/v1/unified/multi-model", REST_BASE_URL))
+        .post(format!("{}/api/v1/unified/multi-model", REST_BASE_URL))
         .json(&multimodel_request)
         .send()
         .await;

--- a/tests/multimodal_integration_test.rs
+++ b/tests/multimodal_integration_test.rs
@@ -794,10 +794,7 @@ async fn test_federated_query_via_rest() {
     };
 
     // Check if server is running
-    let health_check = client
-        .get(format!("{}/health", REST_BASE_URL))
-        .send()
-        .await;
+    let health_check = client.get(format!("{}/health", REST_BASE_URL)).send().await;
 
     match health_check {
         Ok(resp) if resp.status().is_success() => {
@@ -862,10 +859,7 @@ async fn test_multimodel_query_via_rest() {
     };
 
     // Check if server is running
-    let health_check = client
-        .get(format!("{}/health", REST_BASE_URL))
-        .send()
-        .await;
+    let health_check = client.get(format!("{}/health", REST_BASE_URL)).send().await;
 
     match health_check {
         Ok(resp) if resp.status().is_success() => {

--- a/tests/pgwire_null_rendering_e2e.rs
+++ b/tests/pgwire_null_rendering_e2e.rs
@@ -177,7 +177,7 @@ async fn pgwire_renders_sql_null_over_simple_query() {
         .expect("SELECT IS NULL");
     let is_null_ids: Vec<String> = col_ordered(&is_null_rows, "id")
         .into_iter()
-        .filter_map(|v| v)
+        .flatten()
         .collect();
     assert_eq!(
         is_null_ids,
@@ -194,7 +194,7 @@ async fn pgwire_renders_sql_null_over_simple_query() {
         .expect("SELECT IS NOT NULL");
     let not_null_ids: Vec<String> = col_ordered(&not_null_rows, "id")
         .into_iter()
-        .filter_map(|v| v)
+        .flatten()
         .collect();
     assert_eq!(
         not_null_ids,
@@ -213,7 +213,7 @@ async fn pgwire_renders_sql_null_over_simple_query() {
         .expect("SELECT ORDER BY");
     let ordered_ids: Vec<String> = col_ordered(&ordered_rows, "id")
         .into_iter()
-        .filter_map(|v| v)
+        .flatten()
         .collect();
     assert_eq!(
         ordered_ids.len(),

--- a/tests/phase3_integration_test.rs
+++ b/tests/phase3_integration_test.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tempfile::TempDir;
 
 // =============================================================================

--- a/tests/prepared_statement_test.rs
+++ b/tests/prepared_statement_test.rs
@@ -543,9 +543,10 @@ fn test_invalidate_for_collection() {
     for id in product_ids {
         let stmt = cache.get(&id);
         if let Ok(s) = stmt
-            && s.original_sql.contains("products") {
-                cache.drop_statement(&id).ok();
-            }
+            && s.original_sql.contains("products")
+        {
+            cache.drop_statement(&id).ok();
+        }
     }
 
     // products statements should be gone

--- a/tests/prepared_statement_test.rs
+++ b/tests/prepared_statement_test.rs
@@ -542,11 +542,10 @@ fn test_invalidate_for_collection() {
     let product_ids: Vec<String> = vec![id1.clone(), id2.clone()];
     for id in product_ids {
         let stmt = cache.get(&id);
-        if let Ok(s) = stmt {
-            if s.original_sql.contains("products") {
+        if let Ok(s) = stmt
+            && s.original_sql.contains("products") {
                 cache.drop_statement(&id).ok();
             }
-        }
     }
 
     // products statements should be gone

--- a/tests/proximacodec_integration_test.rs
+++ b/tests/proximacodec_integration_test.rs
@@ -137,7 +137,7 @@ fn test_proximadatablock_with_proximacodec() {
             enable_metadata_compression: true,
             compression_threshold_bytes: 256,
             dictionary_compression: false,
-            vector_layout: strategy.clone(),
+            vector_layout: strategy,
             metadata_algorithm: None,
         };
 

--- a/tests/query_cache_test.rs
+++ b/tests/query_cache_test.rs
@@ -818,7 +818,7 @@ fn test_concurrent_cache_access() {
     }
 
     // Cache should have entries (exact count depends on timing)
-    assert!(cache.len() > 0);
+    assert!(!cache.is_empty());
 
     let stats = cache.stats();
     assert!(stats.inserts > 0);

--- a/tests/release_smoke_v2.rs
+++ b/tests/release_smoke_v2.rs
@@ -67,11 +67,10 @@ impl ReleaseSmokeServer {
         let health_url = format!("http://127.0.0.1:{}/health", rest_port);
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
-            if let Ok(resp) = http.get(&health_url).send().await {
-                if resp.status().is_success() {
+            if let Ok(resp) = http.get(&health_url).send().await
+                && resp.status().is_success() {
                     break;
                 }
-            }
             if std::time::Instant::now() > deadline {
                 anyhow::bail!("REST didn't become ready in 20s");
             }

--- a/tests/release_smoke_v2.rs
+++ b/tests/release_smoke_v2.rs
@@ -68,9 +68,10 @@ impl ReleaseSmokeServer {
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
             if let Ok(resp) = http.get(&health_url).send().await
-                && resp.status().is_success() {
-                    break;
-                }
+                && resp.status().is_success()
+            {
+                break;
+            }
             if std::time::Instant::now() > deadline {
                 anyhow::bail!("REST didn't become ready in 20s");
             }

--- a/tests/rest_api_load_test.rs
+++ b/tests/rest_api_load_test.rs
@@ -80,7 +80,7 @@ fn test_json_serialization_performance() {
 
     for _ in 0..iterations {
         let serialized = serde_json::to_vec(&data).unwrap();
-        assert!(serialized.len() > 0);
+        assert!(!serialized.is_empty());
     }
 
     let elapsed = start.elapsed();
@@ -308,7 +308,7 @@ fn test_error_response_serialization_performance() {
     for error_response in &error_responses {
         for _ in 0..(iterations / error_responses.len()) {
             let serialized = serde_json::to_vec(error_response).unwrap();
-            assert!(serialized.len() > 0);
+            assert!(!serialized.is_empty());
         }
     }
 

--- a/tests/rest_grpc_parity_test.rs
+++ b/tests/rest_grpc_parity_test.rs
@@ -295,7 +295,7 @@ impl ParityTestHarness {
         // Check REST server
         let rest_available = self
             .http_client
-            .get(&format!("{}/health", REST_BASE_URL))
+            .get(format!("{}/health", REST_BASE_URL))
             .send()
             .await
             .map(|r| r.status().is_success())
@@ -321,7 +321,7 @@ impl ParityTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v1/collections", REST_BASE_URL))
+            .post(format!("{}/api/v1/collections", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -390,7 +390,7 @@ impl ParityTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v1/vectors/batch", REST_BASE_URL))
+            .post(format!("{}/api/v1/vectors/batch", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -466,7 +466,7 @@ impl ParityTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v1/search", REST_BASE_URL))
+            .post(format!("{}/api/v1/search", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -486,7 +486,7 @@ impl ParityTestHarness {
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|item| NormalizedSearchResult::from_json(item))
+                    .filter_map(NormalizedSearchResult::from_json)
                     .collect()
             })
             .unwrap_or_default();
@@ -544,7 +544,7 @@ impl ParityTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v1/sql/execute", REST_BASE_URL))
+            .post(format!("{}/api/v1/sql/execute", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -603,7 +603,7 @@ impl ParityTestHarness {
 
         let response = self
             .http_client
-            .post(&format!("{}/api/v1/graph/nodes", REST_BASE_URL))
+            .post(format!("{}/api/v1/graph/nodes", REST_BASE_URL))
             .json(&request)
             .send()
             .await?;
@@ -664,7 +664,7 @@ impl ParityTestHarness {
     ) -> Result<Option<NormalizedNode>, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .get(&format!(
+            .get(format!(
                 "{}/api/v1/graph/{}/nodes/{}",
                 REST_BASE_URL, self.test_graph_name, node_id
             ))
@@ -710,7 +710,7 @@ impl ParityTestHarness {
     async fn get_error_rest(&self, collection_id: &str) -> Result<u16, Box<dyn std::error::Error>> {
         let response = self
             .http_client
-            .get(&format!(
+            .get(format!(
                 "{}/api/v1/collections/{}",
                 REST_BASE_URL, collection_id
             ))
@@ -745,7 +745,7 @@ impl ParityTestHarness {
         // Try to delete test collection via REST
         let _ = self
             .http_client
-            .delete(&format!(
+            .delete(format!(
                 "{}/api/v1/collections/{}",
                 REST_BASE_URL, self.test_collection_name
             ))
@@ -980,7 +980,7 @@ async fn test_graph_query_parity() {
     // Create a test node via REST
     let node_id = format!(
         "test_node_{}",
-        uuid::Uuid::new_v4().to_string()[..8].to_string()
+        &uuid::Uuid::new_v4().to_string()[..8]
     );
     let labels = vec!["Person", "Employee"];
     let mut properties = HashMap::new();

--- a/tests/rest_grpc_parity_test.rs
+++ b/tests/rest_grpc_parity_test.rs
@@ -978,10 +978,7 @@ async fn test_graph_query_parity() {
     }
 
     // Create a test node via REST
-    let node_id = format!(
-        "test_node_{}",
-        &uuid::Uuid::new_v4().to_string()[..8]
-    );
+    let node_id = format!("test_node_{}", &uuid::Uuid::new_v4().to_string()[..8]);
     let labels = vec!["Person", "Employee"];
     let mut properties = HashMap::new();
     properties.insert("name".to_string(), "Alice".to_string());

--- a/tests/rl_planner_integration_test.rs
+++ b/tests/rl_planner_integration_test.rs
@@ -130,7 +130,7 @@ async fn test_rl_learning_over_queries() {
 
     // Verify learning happened
     let stats = planner.get_action_stats().await;
-    assert!(stats.len() > 0, "Should have tracked some actions");
+    assert!(!stats.is_empty(), "Should have tracked some actions");
 }
 
 /// Test policy persistence and loading
@@ -220,7 +220,7 @@ async fn test_action_space_coverage() {
 
         // Should see at least some variety (with exploration)
         assert!(
-            actions_seen.len() >= 1,
+            !actions_seen.is_empty(),
             "Should select valid actions for engine {:?}",
             engine
         );

--- a/tests/sks_fixtures_test.rs
+++ b/tests/sks_fixtures_test.rs
@@ -12,14 +12,14 @@ use common::sks_fixtures::TestKnowledgeGraph;
 fn test_small_graph() {
     let graph = TestKnowledgeGraph::small();
     assert_eq!(graph.entities.len(), 100);
-    assert!(graph.relations.len() > 0);
+    assert!(!graph.relations.is_empty());
 }
 
 #[test]
 fn test_medium_graph() {
     let graph = TestKnowledgeGraph::medium();
     assert_eq!(graph.entities.len(), 1000);
-    assert!(graph.relations.len() > 0);
+    assert!(!graph.relations.is_empty());
 }
 
 #[test]

--- a/tests/sks_graph_first_integration_test.rs
+++ b/tests/sks_graph_first_integration_test.rs
@@ -223,13 +223,15 @@ async fn test_relation_management_orion() {
             .and_then(|s| s.parse::<usize>().ok());
 
         if let (Some(src), Some(tgt)) = (source_idx, target_idx)
-            && src < 10 && tgt < 10 {
-                store
-                    .add_relation(relation.clone())
-                    .await
-                    .expect("Failed to add relation");
-                added_relations += 1;
-            }
+            && src < 10
+            && tgt < 10
+        {
+            store
+                .add_relation(relation.clone())
+                .await
+                .expect("Failed to add relation");
+            added_relations += 1;
+        }
     }
 
     // Query relations for first entity

--- a/tests/sks_graph_first_integration_test.rs
+++ b/tests/sks_graph_first_integration_test.rs
@@ -222,15 +222,14 @@ async fn test_relation_management_orion() {
             .strip_prefix("entity-")
             .and_then(|s| s.parse::<usize>().ok());
 
-        if let (Some(src), Some(tgt)) = (source_idx, target_idx) {
-            if src < 10 && tgt < 10 {
+        if let (Some(src), Some(tgt)) = (source_idx, target_idx)
+            && src < 10 && tgt < 10 {
                 store
                     .add_relation(relation.clone())
                     .await
                     .expect("Failed to add relation");
                 added_relations += 1;
             }
-        }
     }
 
     // Query relations for first entity
@@ -983,13 +982,13 @@ fn test_fixtures_validation() {
     // Small graph
     let small = TestKnowledgeGraph::small();
     assert_eq!(small.entities.len(), 100);
-    assert!(small.relations.len() > 0);
+    assert!(!small.relations.is_empty());
     assert_eq!(small.embeddings.len(), 100);
 
     // Medium graph
     let medium = TestKnowledgeGraph::medium();
     assert_eq!(medium.entities.len(), 1000);
-    assert!(medium.relations.len() > 0);
+    assert!(!medium.relations.is_empty());
 
     // Research papers
     let papers = TestKnowledgeGraph::research_papers();

--- a/tests/small_batch_brute_force_test.rs
+++ b/tests/small_batch_brute_force_test.rs
@@ -607,7 +607,7 @@ mod small_batch_tests {
 
             // Calculate expected blocks
             let block_size = 128; // HELIX default proxima_block_size
-            let num_blocks = (BENCHMARK_BATCH_SIZE + block_size - 1) / block_size;
+            let num_blocks = BENCHMARK_BATCH_SIZE.div_ceil(block_size);
             let sqrt_blocks = (num_blocks as f32).sqrt().ceil() as usize;
             eprintln!(
                 "Expected: {} blocks total, sqrt pruning selects ~{} blocks ({:.1}% pruned)",

--- a/tests/spatial_clustering_benchmark.rs
+++ b/tests/spatial_clustering_benchmark.rs
@@ -87,7 +87,7 @@ fn compute_centroid(vectors: &[Vec<f32>]) -> Vec<f32> {
 fn create_blocks_with_centroids(vectors: &[Vec<f32>], block_size: usize) -> Vec<Vec<f32>> {
     vectors
         .chunks(block_size)
-        .map(|chunk| compute_centroid(chunk))
+        .map(compute_centroid)
         .collect()
 }
 

--- a/tests/spatial_clustering_benchmark.rs
+++ b/tests/spatial_clustering_benchmark.rs
@@ -85,10 +85,7 @@ fn compute_centroid(vectors: &[Vec<f32>]) -> Vec<f32> {
 
 /// Create blocks from vectors and compute their centroids
 fn create_blocks_with_centroids(vectors: &[Vec<f32>], block_size: usize) -> Vec<Vec<f32>> {
-    vectors
-        .chunks(block_size)
-        .map(compute_centroid)
-        .collect()
+    vectors.chunks(block_size).map(compute_centroid).collect()
 }
 
 #[test]

--- a/tests/streaming_integration_test.rs
+++ b/tests/streaming_integration_test.rs
@@ -157,7 +157,7 @@ fn test_ring_buffer_concurrent_access() {
         let deadline = Instant::now() + Duration::from_secs(5);
 
         while Instant::now() < deadline {
-            if let Some(_) = buf_consumer.try_pop() {
+            if buf_consumer.try_pop().is_some() {
                 consumed += 1;
             } else {
                 thread::yield_now();

--- a/tests/test_record_store_route.rs
+++ b/tests/test_record_store_route.rs
@@ -1,4 +1,3 @@
-use proximadb_catalog::{CatalogStorageSpecialization, CatalogTableSchema, CatalogWorkloadProfile};
 // Assuming TableRecordStoreRoute will be updated in src/services/record_store.rs
 // We will test the routing logic here.
 

--- a/tests/tst_integration_test.rs
+++ b/tests/tst_integration_test.rs
@@ -297,7 +297,7 @@ async fn test_tst_asof_join_tolerance() {
         .unwrap();
 
     // Should only match the close quote
-    assert!(results.len() >= 1);
+    assert!(!results.is_empty());
 }
 
 //
@@ -330,7 +330,7 @@ fn test_tst_downsample_intervals() {
 
     for interval in intervals {
         let config = DownsampleConfig {
-            interval: interval.clone(),
+            interval: interval,
             aggregation: DownsampleAggregation::OHLC,
         };
 
@@ -487,7 +487,7 @@ async fn test_tst_partition_duration() {
         let temp_dir = TempDir::new().unwrap();
         let config = TimeSeriesConfig {
             base_path: temp_dir.path().to_path_buf(),
-            partition_duration: duration.clone(),
+            partition_duration: duration,
             ..Default::default()
         };
 

--- a/tests/v2_evaluation_chain_integration_test.rs
+++ b/tests/v2_evaluation_chain_integration_test.rs
@@ -35,7 +35,7 @@ use proximadb::query::federated::optimizer::plan_calibration::{
 use proximadb::query::federated::optimizer::plan_v2_inference::{
     LinearV1FallbackInferencer, PlanInference, PlanInferencer,
 };
-use proximadb::query::federated::optimizer::plan_v2_training::{DimBucket, PlanFeatures};
+use proximadb::query::federated::optimizer::plan_v2_training::PlanFeatures;
 use proximadb::query::federated::optimizer::trace_replay::{ReplayInputs, replay, summarize};
 
 fn trace(


### PR DESCRIPTION
Applies `cargo clippy --fix -p proximadb --tests` — the `MachineApplicable`-only style suggestions that are safe to auto-apply. This is the mechanical slice of the clippy-debt reduction (complements #625, which scoped the restriction lints).

## What changed (144 files, +760/−857)
Only behavior-preserving, machine-suggested edits:
- `len() > 0` / `len() >= 1` → `!is_empty()`
- `vec![a, b]` → `[a, b]` **only where slice-coerced** (owned inner `vec!`s correctly retained, e.g. `ColumnValue::Bytes(vec![1,2,3])`)
- `(x + 7) / 8` → `x.div_ceil(8)` (manual_div_ceil)
- `x >= lo && x <= hi` → `(lo..=hi).contains(&x)` (RangeInclusive)
- `for (_, v) in &map` → `for v in map.values()` (for_kv_map)
- `.last()` → `.next_back()`
- needless borrows, redundant closures (`.map(|x| f(x))` → `.map(f)`), collapsible `if`, unused imports, `use tokio;` removal

## Review for incorrect auto-edits
Every edit category reviewed — all behavior-preserving. The one category that can change ownership semantics (`useless_vec`: `vec![]`→`[]`) was checked: clippy only rewrites containers consumed as slices; owned `vec!`s passed by value are left intact.

## Verification (local, 1.95.0)
- `cargo clippy --fix` compiled clean (`Finished`)
- **`cargo test -p proximadb --lib` → 8445 passed, 0 failed** ✅
- `cargo fmt --all` applied (rustfmt-normalized the auto-edits)

## Scope
Root `proximadb` crate tests (the bulk of the mechanical findings). Other crates' mechanical debt + the remaining judgment-call findings (no-op assertions, structural) are separate follow-ups. No behavior change.