### PR TITLE
feat(sst): PAX write bridge for AXIS/tier callers (ADR-049 M1-2)

### DIFF
--- a/src/index/axis/storage/ivf_posting_list_storage.rs
+++ b/src/index/axis/storage/ivf_posting_list_storage.rs
@@ -230,11 +230,10 @@ impl IvfClusterPostingListStorage {
                     );
                 }
 
-                // Write records using streaming approach for production consistency
-                let record_count = records.len();
+                // M1-2 (ADR-049): native PAX segment (no VectorRecord round-trip).
                 let sorted_records_iter = records.into_values(); // Extract values from BTreeMap
                 writer
-                    .write_sorted_proxima_records(sorted_records_iter, record_count)
+                    .write_pax_segment(sorted_records_iter, &format!("ivf_cluster_{cluster_id}"))
                     .await?;
                 debug!("Stored posting list {} to SST at {}", cluster_id, path);
                 Ok(())

--- a/src/index/axis/storage/universal_index_storage.rs
+++ b/src/index/axis/storage/universal_index_storage.rs
@@ -342,12 +342,10 @@ impl<T: IndexData> UniversalIndexStorage<T> {
                         ..proximadb_records::ProximaRecord::default()
                     },
                 );
-                // Write records using streaming approach for production consistency
-                let record_count = records.len();
+                // M1-2 (ADR-049): write a native PAX segment (ProximaRecord→PAX, no
+                // VectorRecord round-trip). Reads stay mixed-format-safe.
                 let sorted_records_iter = records.into_values(); // Extract values from BTreeMap
-                writer
-                    .write_sorted_proxima_records(sorted_records_iter, record_count)
-                    .await?;
+                writer.write_pax_segment(sorted_records_iter, id).await?;
             }
             StorageEngine::VIPER => {
                 // Write as VIPER (Parquet)
@@ -524,12 +522,10 @@ impl<T: IndexData> UniversalIndexStorage<T> {
                     ..proximadb_records::ProximaRecord::default()
                 };
                 records.insert(id.to_string(), record);
-                // Write records using streaming approach for production consistency
-                let record_count = records.len();
+                // M1-2 (ADR-049): write a native PAX segment (ProximaRecord→PAX, no
+                // VectorRecord round-trip). Reads stay mixed-format-safe.
                 let sorted_records_iter = records.into_values(); // Extract values from BTreeMap
-                writer
-                    .write_sorted_proxima_records(sorted_records_iter, record_count)
-                    .await?;
+                writer.write_pax_segment(sorted_records_iter, id).await?;
             }
             StorageEngine::VIPER => {
                 // Write VIPER format

--- a/src/infrastructure/tier_data_movement.rs
+++ b/src/infrastructure/tier_data_movement.rs
@@ -321,10 +321,9 @@ impl TierDataMovement {
                 .unwrap_or_default();
         }
 
-        // Write records using streaming approach for production consistency
-        let record_count = records.len();
+        // M1-2 (ADR-049): native PAX segment (no VectorRecord round-trip).
         writer
-            .write_sorted_proxima_records(records.into_iter(), record_count)
+            .write_pax_segment(records.into_iter(), &self.collection_id)
             .await?;
         Ok(total_bytes)
     }

--- a/src/storage/engines/sst/writer.rs
+++ b/src/storage/engines/sst/writer.rs
@@ -1380,6 +1380,58 @@ impl SstableWriter {
             .await
     }
 
+    /// Write `records` as a native PAX segment (ADR-049 M1-2). ProximaRecord-native:
+    /// no ProximaRecord→VectorRecord→streaming round-trip — records go straight to
+    /// the PAX encoder. PAX encodes via `std::fs` to a local staging file, then we
+    /// promote to the target URL through the filesystem abstraction (handles
+    /// `file://` + object store), mirroring the flush PaxBlock arm. Replaces the
+    /// wrong-way `write_sorted_proxima_records` adapter at the storage/index/tier
+    /// call sites (AXIS stores, tier data movement).
+    pub async fn write_pax_segment<I>(&self, records: I, collection_id: &str) -> Result<()>
+    where
+        I: Iterator<Item = proximadb_records::ProximaRecord> + Send,
+    {
+        use crate::storage::engines::sst::segment_format::write_pax_segment_with_f32_tier;
+        use proximadb_block_format::VectorQuant;
+
+        let recs: Vec<proximadb_records::ProximaRecord> = records.collect();
+        if recs.is_empty() {
+            return Ok(());
+        }
+        let embedding_count = recs.first().map(|r| r.embeddings.len().max(1)).unwrap_or(1);
+
+        // Resolve the target URL (bare path → file://) so the filesystem
+        // abstraction handles both local and object-store destinations.
+        let path_str = self.path.to_string_lossy().to_string();
+        let fs_url = if path_str.contains("://") {
+            path_str
+        } else {
+            format!("file://{}", path_str)
+        };
+        // PAX writes via std::fs to a local staging file, then we promote.
+        let staging = std::env::temp_dir().join(format!(
+            "proximadb-pax-{}.pax",
+            proximadb_kernel::uuid::Uuid::new_v4()
+        ));
+        write_pax_segment_with_f32_tier(
+            &staging,
+            &recs,
+            collection_id,
+            embedding_count,
+            VectorQuant::RaBitQ,
+            false,
+            None,
+        )?;
+        let bytes = std::fs::read(&staging)
+            .map_err(|e| anyhow::anyhow!("read PAX staging {}: {e}", staging.display()))?;
+        let _ = std::fs::remove_file(&staging);
+        self.filesystem
+            .write(&fs_url, &bytes, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("promote PAX segment to {fs_url}: {e}"))?;
+        Ok(())
+    }
+
     /// Legacy v1 wire-record entrypoint - delegates to write_sorted_vector_records.
     pub async fn write_sorted_records<I>(
         &self,


### PR DESCRIPTION
## Context
M1-2 of ADR-049. Migrate the production `write_sorted_proxima_records` callers off the wrong-way adapter (ProximaRecord→VectorRecord→streaming→ProximaRecord) onto a native PAX write. Prepares for M1-3 (retire the streaming path): once these + the flush legacy fallback + tests are migrated, `write_sorted_vector_records` has no callers.

## Change
- **`SstableWriter::write_pax_segment`** — ProximaRecord-native PAX write. PAX encodes via `std::fs` to a local staging file, then promotes to the target URL through the filesystem abstraction (handles `file://` + object store), mirroring the flush PaxBlock arm.
- **4 callers migrated**: `universal_index_storage::demote_to_disk` (×2), `ivf_posting_list_storage::put`, `tier_data_movement::write_to_sst_tier` — now write native PAX (`.pax`) instead of legacy streaming `.sst`.

The streaming path + the `write_sorted_proxima_records` adapter remain (flush legacy fallback + tests) — retired in M1-3. **v1-proto-usage unchanged** here (the adapter + `VectorRecord` import stay until M1-3); M1-2 only removes the callers — the ratchet drop lands in M1-3.

## Verification
- `cargo fmt --all --check` ✓
- `cargo clippy --lib --bins -- -D warnings` ✓
- `cargo check --tests` ✓
- `make v1-proto-usage-no-regression` ✓ (delta +0 — expected; drop is M1-3)
- `make workspace-boundaries-check` ✓ (AXIS/tier → storage are down-edges; no new storage up-edges)