### PR TITLE
chore(clippy): final mechanical --fix pass (field_reassign + stragglers)

### DIFF
--- a/apps/proximadb-vectordb-compare/src/main.rs
+++ b/apps/proximadb-vectordb-compare/src/main.rs
@@ -327,6 +327,22 @@ impl ComparisonRunner {
     }
 }
 
+fn main() {
+    println!("VectorDB Comparison Runner");
+    println!("========================");
+    println!();
+    println!("This binary compares ProximaDB performance against competitors.");
+    println!("It requires external databases to be running with default configurations.");
+    println!();
+    println!("Usage: cargo run --bin vectordb_comparison -- <command>");
+    println!();
+    println!("Commands:");
+    println!("  benchmark    Run comparison benchmarks");
+    println!("  compare     Compare against specific competitor");
+    println!();
+    println!("Note: This is a development tool for performance analysis.");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,20 +442,4 @@ mod tests {
         let speedup = runner.calculate_speedup(&results);
         assert_eq!(speedup.get("Qdrant"), Some(&2.0));
     }
-}
-
-fn main() {
-    println!("VectorDB Comparison Runner");
-    println!("========================");
-    println!();
-    println!("This binary compares ProximaDB performance against competitors.");
-    println!("It requires external databases to be running with default configurations.");
-    println!();
-    println!("Usage: cargo run --bin vectordb_comparison -- <command>");
-    println!();
-    println!("Commands:");
-    println!("  benchmark    Run comparison benchmarks");
-    println!("  compare     Compare against specific competitor");
-    println!();
-    println!("Note: This is a development tool for performance analysis.");
 }

--- a/crates/control/proximadb-catalog/src/cache.rs
+++ b/crates/control/proximadb-catalog/src/cache.rs
@@ -447,7 +447,7 @@ mod tests {
         cache.put_statistics("default", &id, CatalogTableStatistics::default());
         cache.put_namespace(
             "default",
-            &vec!["db".into()],
+            &["db".into()],
             CatalogNamespace::new(vec!["db".into()]),
         );
         assert_eq!(cache.size(), 4);
@@ -460,7 +460,7 @@ mod tests {
         expired.put_statistics("default", &id, CatalogTableStatistics::default());
         expired.put_namespace(
             "default",
-            &vec!["db".into()],
+            &["db".into()],
             CatalogNamespace::new(vec!["db".into()]),
         );
         std::thread::sleep(Duration::from_millis(1));

--- a/crates/control/proximadb-catalog/src/dr_reconciler.rs
+++ b/crates/control/proximadb-catalog/src/dr_reconciler.rs
@@ -2117,7 +2117,7 @@ mod tests {
 
     use crate::collection_dr_policy::MockDrProviderAdapter;
     use crate::dr_reconciler::testing::MockDrPolicyStore;
-    use parking_lot::Mutex;
+
     use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
     fn make_driver(

--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -1368,9 +1368,8 @@ mod tests {
         for raw in [
             "true", "TRUE", "True", "1", "yes", "YES", "on", "ON", " true ",
         ] {
-            assert_eq!(
+            assert!(
                 parse_bool_flag(raw, "X").unwrap(),
-                true,
                 "expected {raw:?} to parse as true"
             );
         }
@@ -1379,9 +1378,8 @@ mod tests {
     #[test]
     fn parse_bool_flag_accepts_canonical_false_forms() {
         for raw in ["false", "FALSE", "0", "no", "NO", "off", "OFF", " false "] {
-            assert_eq!(
-                parse_bool_flag(raw, "X").unwrap(),
-                false,
+            assert!(
+                !parse_bool_flag(raw, "X").unwrap(),
                 "expected {raw:?} to parse as false"
             );
         }

--- a/crates/foundation/proximadb-records/src/lib.rs
+++ b/crates/foundation/proximadb-records/src/lib.rs
@@ -1386,7 +1386,7 @@ mod tests {
         // strictly dominates fp16. This is the compaction read+rewrite
         // case: source block is fp16, intermediate flattens to fp32,
         // writer coerces back to fp16 — must match the original bits.
-        let src_fp32 = vec![1.0_f32, -2.5, 65504.0, 0.0001, 100.25, -0.5, 42.0, 7.125];
+        let src_fp32 = [1.0_f32, -2.5, 65504.0, 0.0001, 100.25, -0.5, 42.0, 7.125];
         let original_fp16: Vec<half::f16> =
             src_fp32.iter().map(|&x| half::f16::from_f32(x)).collect();
 

--- a/crates/foundation/proximadb-records/src/store.rs
+++ b/crates/foundation/proximadb-records/src/store.rs
@@ -499,7 +499,7 @@ mod tests {
         }
 
         // Predicate selects even record_version (r0,r2,r4 = 3 matches); limit 2.
-        let pred = |r: &ProximaRecord| r.record_version % 2 == 0;
+        let pred = |r: &ProximaRecord| r.record_version.is_multiple_of(2);
         let got = store
             .scan_records_filtered(RecordScanOptions::limit(2), Some(&pred))
             .await

--- a/crates/foundation/proximadb-records/src/wire_v2.rs
+++ b/crates/foundation/proximadb-records/src/wire_v2.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn batch_of_mixed_precision_records_round_trips_each_variant() {
-        let recs = vec![
+        let recs = [
             ProximaRecord {
                 oid: "fp32-rec".to_string(),
                 embeddings: vec![EmbeddingCell {

--- a/crates/horizontal/proximadb-serialization/src/lib.rs
+++ b/crates/horizontal/proximadb-serialization/src/lib.rs
@@ -713,8 +713,7 @@ mod tests {
 
         let all_results: Vec<_> = handles
             .into_iter()
-            .map(|h| h.join().unwrap())
-            .flatten()
+            .flat_map(|h| h.join().unwrap())
             .collect();
 
         assert_eq!(all_results.len(), num_threads * vectors_per_thread);

--- a/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
@@ -2218,7 +2218,7 @@ mod tests {
         let quantized = engine.quantize(&test_vector, &level).await?;
 
         // Binary quantization: 1 bit per value, packed into bytes
-        let expected_bytes = (test_vector.len() + 7) / 8;
+        let expected_bytes = test_vector.len().div_ceil(8);
         assert_eq!(quantized.data.len(), expected_bytes);
 
         // Test sign-based binary quantization
@@ -2440,7 +2440,7 @@ mod tests {
                 sign_based: true,
             })),
         };
-        assert_eq!(binary.bytes_per_vector(dimension), (dimension + 7) / 8);
+        assert_eq!(binary.bytes_per_vector(dimension), dimension.div_ceil(8));
 
         // Product Quantization
         let pq = UnifiedQuantizationLevel::pq8(16);

--- a/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
@@ -1172,7 +1172,7 @@ mod tests {
         // Test with even number of values
         let (packed, min, max, num_values) = engine.quantize_to_u4(&distances);
         assert_eq!(num_values, distances.len());
-        assert_eq!(packed.len(), (distances.len() + 1) / 2);
+        assert_eq!(packed.len(), distances.len().div_ceil(2));
 
         let reconstructed = engine.dequantize_u4(&packed, min, max, num_values);
         assert_eq!(reconstructed.len(), distances.len());
@@ -1200,7 +1200,7 @@ mod tests {
         // Test with multiple of 4 values
         let (packed, min, max, num_values) = engine.quantize_to_u6(&distances);
         assert_eq!(num_values, distances.len());
-        assert_eq!(packed.len(), (distances.len() * 6 + 7) / 8); // Ceiling division
+        assert_eq!(packed.len(), (distances.len() * 6).div_ceil(8)); // Ceiling division
 
         let reconstructed = engine.dequantize_u6(&packed, min, max, num_values);
         assert_eq!(reconstructed.len(), distances.len());

--- a/crates/modalities/proximadb-queue/tests/metrics_emit.rs
+++ b/crates/modalities/proximadb-queue/tests/metrics_emit.rs
@@ -125,7 +125,7 @@ async fn backpressure_emits_counter_on_hard_pressure() {
     // Either "hard" or "soft" counter must have moved; check both.
     let soft_counter = QUEUE_BACKPRESSURE.with_label_values(&[topic, "soft"]);
     let total_after = hard_counter.get() + soft_counter.get();
-    let total_before = before + 0; // soft started at 0 too (distinct topic name)
+    let total_before = before; // soft started at 0 too (distinct topic name)
     assert!(
         total_after > total_before,
         "QUEUE_BACKPRESSURE (hard+soft) must increment when sends are rejected"

--- a/crates/platform/proximadb-api/src/rest/v1/catalog.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/catalog.rs
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn catalog_legacy_stubs_construct() {
-        let _catalog = CatalogHandler::default();
+        let _catalog = CatalogHandler;
         let _collection = CollectionHandler::new();
     }
 }

--- a/crates/platform/proximadb-api/src/rest/v1/document.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/document.rs
@@ -1159,7 +1159,7 @@ mod tests {
         assert_eq!(aggregate.results[0]["name"], "doc");
 
         let _router = create_document_router();
-        let _handler = DocumentHandler::default();
+        let _handler = DocumentHandler;
         let _query_handler = DocumentQueryHandler::new();
         assert_eq!(default_limit(), 100);
         assert_eq!(default_index_type(), "btree");

--- a/crates/platform/proximadb-api/src/rest/v1/graph.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/graph.rs
@@ -2650,7 +2650,7 @@ mod tests {
         );
 
         let _router = create_graph_router();
-        let _graph_handler = GraphHandler::default();
+        let _graph_handler = GraphHandler;
         let _traversal_handler = GraphTraversalHandler::new();
     }
 }

--- a/crates/platform/proximadb-api/src/rest/v1/hybrid.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/hybrid.rs
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn default_top_k_and_legacy_handler_stubs_construct() {
         assert_eq!(default_top_k(), 10);
-        let _hybrid = HybridSearchHandler::default();
+        let _hybrid = HybridSearchHandler;
         let _progressive = ProgressiveSearchHandler::new();
         let _hybrid_router = create_hybrid_search_router();
     }

--- a/crates/platform/proximadb-api/src/rest/v1/observability.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/observability.rs
@@ -1084,7 +1084,7 @@ mod tests {
         assert_eq!(query.total, 0);
 
         let _router = create_observability_router();
-        let _logs = LogsHandler::default();
+        let _logs = LogsHandler;
         let _metrics = MetricsHandler::new();
     }
 }

--- a/crates/platform/proximadb-runtime/src/bootstrap_config.rs
+++ b/crates/platform/proximadb-runtime/src/bootstrap_config.rs
@@ -838,7 +838,7 @@ mod tests {
         assert_eq!(config.postgres_config.active_bind_address().port(), 5433);
 
         // Verify all ports are distinct
-        let ports = vec![
+        let ports = [
             http_addr.port(),
             grpc_addr.port(),
             config.arrow_ipc_config.port,

--- a/crates/query/proximadb-graph-query/src/parser.rs
+++ b/crates/query/proximadb-graph-query/src/parser.rs
@@ -1487,7 +1487,7 @@ mod tests {
 
         assert_eq!(compiled.return_spec.order_by.len(), 1);
         assert_eq!(compiled.return_spec.order_by[0].0, "p");
-        assert_eq!(compiled.return_spec.order_by[0].1, true); // ASC
+        assert!(compiled.return_spec.order_by[0].1); // ASC
     }
 
     #[test]

--- a/crates/query/proximadb-relational-engine/src/lib.rs
+++ b/crates/query/proximadb-relational-engine/src/lib.rs
@@ -509,7 +509,7 @@ impl RelationalReader for InMemoryReader {
 mod tests {
     use super::*;
     use proximadb_data_model::ProximaType;
-    use proximadb_relational_algebra::{LogicalNode, TableId};
+    use proximadb_relational_algebra::TableId;
     use proximadb_relational_executor::{ExecutionContext, build_executor, collect};
     use proximadb_relational_planner::{Planner, StaticCapabilities};
     use proximadb_relational_reader::ReaderCapabilities as RC;

--- a/crates/storage/proximadb-storage-common/src/auto_scheduler.rs
+++ b/crates/storage/proximadb-storage-common/src/auto_scheduler.rs
@@ -1215,7 +1215,7 @@ mod tests {
         let stats = scheduler.get_stats().await;
         assert!(stats.completed >= 1);
         assert!(stats.avg_duration_ms >= 0.0);
-        assert!(scheduler.completed_history.read().await.len() >= 1);
+        assert!(!scheduler.completed_history.read().await.is_empty());
 
         assert_eq!(
             scheduler

--- a/crates/storage/proximadb-storage-common/src/native_metadata.rs
+++ b/crates/storage/proximadb-storage-common/src/native_metadata.rs
@@ -850,8 +850,8 @@ mod tests {
             .as_any()
             .downcast_ref::<BooleanArray>()
             .unwrap();
-        assert_eq!(active.value(0), true);
-        assert_eq!(active.value(1), false);
+        assert!(active.value(0));
+        assert!(!active.value(1));
 
         let counts = arrays["count"]
             .as_any()

--- a/crates/storage/proximadb-storage-common/src/storage_error.rs
+++ b/crates/storage/proximadb-storage-common/src/storage_error.rs
@@ -805,10 +805,7 @@ mod tests {
         assert!(display.contains("/data/file"));
         assert!(display.contains("LSN: 7"));
 
-        let sourced = StorageError::io(
-            "read failed",
-            Some(io::Error::new(io::ErrorKind::Other, "disk said no")),
-        );
+        let sourced = StorageError::io("read failed", Some(io::Error::other("disk said no")));
         let display = sourced.to_string();
         assert!(display.contains("caused by: disk said no"));
         assert!(std::error::Error::source(&sourced).is_none());
@@ -830,7 +827,7 @@ mod tests {
         let storage_err: StorageError = io::Error::new(io::ErrorKind::WouldBlock, "busy").into();
         assert_eq!(storage_err.kind, StorageErrorKind::LockFailed);
 
-        let storage_err: StorageError = io::Error::new(io::ErrorKind::Other, "other").into();
+        let storage_err: StorageError = io::Error::other("other").into();
         assert_eq!(storage_err.kind, StorageErrorKind::Io);
     }
 
@@ -913,10 +910,8 @@ mod tests {
             assert_eq!(storage_err.message, expected_message);
         }
 
-        let storage_err: StorageError = proximadb_kernel::error::StorageError::DiskIO(
-            io::Error::new(io::ErrorKind::Other, "disk"),
-        )
-        .into();
+        let storage_err: StorageError =
+            proximadb_kernel::error::StorageError::DiskIO(io::Error::other("disk")).into();
         assert_eq!(storage_err.kind, StorageErrorKind::Io);
         assert_eq!(storage_err.source.as_deref(), Some("disk"));
 

--- a/crates/storage/proximadb-storage-common/src/two_phase_commit.rs
+++ b/crates/storage/proximadb-storage-common/src/two_phase_commit.rs
@@ -671,26 +671,17 @@ mod tests {
         }
 
         fn with_prepare(self, results: impl IntoIterator<Item = PrepareResult>) -> Self {
-            self.prepare_results
-                .lock()
-                .unwrap()
-                .extend(results.into_iter());
+            self.prepare_results.lock().unwrap().extend(results);
             self
         }
 
         fn with_commit(self, results: impl IntoIterator<Item = CommitResult>) -> Self {
-            self.commit_results
-                .lock()
-                .unwrap()
-                .extend(results.into_iter());
+            self.commit_results.lock().unwrap().extend(results);
             self
         }
 
         fn with_abort(self, results: impl IntoIterator<Item = CommitResult>) -> Self {
-            self.abort_results
-                .lock()
-                .unwrap()
-                .extend(results.into_iter());
+            self.abort_results.lock().unwrap().extend(results);
             self
         }
     }

--- a/crates/storage/proximadb-storage-optimization/src/metadata_sorter.rs
+++ b/crates/storage/proximadb-storage-optimization/src/metadata_sorter.rs
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_sortable_value_ordering() {
-        let mut values = vec![
+        let mut values = [
             SortableValue::String("zebra".to_string()),
             SortableValue::Number(10),
             SortableValue::Null,

--- a/tests/helix_performance_comparison_test.rs
+++ b/tests/helix_performance_comparison_test.rs
@@ -655,7 +655,7 @@ mod performance_comparison_tests {
         for chunk in vectors.chunks(1000) {
             let flush_params = FlushParameters {
                 collection_id: Some("test_collection".to_string()),
-                vector_records: chunk.iter().map(|v| v.clone()).collect(),
+                vector_records: chunk.iter().cloned().collect(),
                 force: true,
                 synchronous: true,
                 hints: HashMap::new(),

--- a/tests/tst_integration_test.rs
+++ b/tests/tst_integration_test.rs
@@ -330,7 +330,7 @@ fn test_tst_downsample_intervals() {
 
     for interval in intervals {
         let config = DownsampleConfig {
-            interval: interval,
+            interval,
             aggregation: DownsampleAggregation::OHLC,
         };
 


### PR DESCRIPTION
The MachineApplicable remainder after #625 (lint scoping) + #629 (root-crate --fix). `cargo clippy --fix --workspace --tests` — 26 files, +54/−63, compiled clean. Catches the other crates + the leftover `field_reassign_with_default` (two_phase_commit, metadata_sorter) + a few test-site fixes. No behavior change; follow-up to the clippy-debt reduction.