### PR TITLE
fix(clippy): real-bug tail — await_holding_lock + tautological assertions

### DIFF
--- a/src/deployment/discovery/environment_detector.rs
+++ b/src/deployment/discovery/environment_detector.rs
@@ -1186,8 +1186,9 @@ mod tests {
         let docker_available = detector.is_docker_available().await.unwrap();
         println!("Docker available: {}", docker_available);
 
-        // Should detect at least one platform
-        assert!(k8s_available || docker_available || true); // Always pass since we might not have either in test
+        // Smoke test only: the contract is that both detectors run without
+        // panicking (asserted via .unwrap() above). We may have neither in CI,
+        // so there is nothing meaningful to assert on the bool results.
     }
 
     #[tokio::test]

--- a/src/query/execution/datafusion_bridge.rs
+++ b/src/query/execution/datafusion_bridge.rs
@@ -475,10 +475,9 @@ mod tests {
 
     #[test]
     fn test_is_datafusion_available() {
-        // Without the feature flag, should return false
-        let available = DataFusionWindowExecutor::is_datafusion_available();
-        // We just check it returns a bool without panicking
-        assert!(available || !available);
+        // Smoke test: the contract is that the probe returns without panicking.
+        // The value is feature-dependent, so there is nothing meaningful to assert.
+        let _ = DataFusionWindowExecutor::is_datafusion_available();
     }
 
     #[test]

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3405,19 +3405,24 @@ mod tests {
             .unwrap();
         assert!(result.success, "vector-bearing insert must succeed");
 
-        let entries = wal.entries.lock().expect("recording WAL read lock");
-        assert_eq!(entries.len(), 1);
-        match &entries[0].operation {
-            CanonicalOperation::RecordUpsert { record, .. } => {
-                assert_eq!(record.embeddings.len(), 1);
-                assert_eq!(
-                    record.embeddings[0].values,
-                    proximadb_records::EmbeddingValues::Fp32(vec![0.1_f32, 0.2, 0.3, 0.4])
-                );
+        // Scope the WAL lock guard so it provably drops before the `get_by_key`
+        // await below (clippy::await_holding_lock): a std Mutex held across an
+        // await would block the runtime if contended. The block end drops the
+        // guard; no explicit `drop` needed.
+        {
+            let entries = wal.entries.lock().expect("recording WAL read lock");
+            assert_eq!(entries.len(), 1);
+            match &entries[0].operation {
+                CanonicalOperation::RecordUpsert { record, .. } => {
+                    assert_eq!(record.embeddings.len(), 1);
+                    assert_eq!(
+                        record.embeddings[0].values,
+                        proximadb_records::EmbeddingValues::Fp32(vec![0.1_f32, 0.2, 0.3, 0.4])
+                    );
+                }
+                other => panic!("expected RecordUpsert WAL entry, got {other:?}"),
             }
-            other => panic!("expected RecordUpsert WAL entry, got {other:?}"),
         }
-        drop(entries);
 
         let fetched = store
             .get_by_key(

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -1058,18 +1058,20 @@ impl FilesystemFile for LocalFile {
 mod tests {
     use super::*;
     use once_cell::sync::Lazy;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use tempfile::TempDir;
     use tracing::{debug, error, info};
 
-    /// Mutex to serialize tests that change the current working directory
-    /// This prevents race conditions when tests run in parallel
-    static CWD_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    /// Async mutex to serialize tests that change the current working directory.
+    /// `tokio::sync::Mutex` so the guard may be held across `.await` without
+    /// blocking the runtime (clears clippy::await_holding_lock); each test is a
+    /// single task, so holding it for the test body serializes the suite safely.
+    static CWD_MUTEX: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));
 
     #[tokio::test]
     async fn test_relative_path_url_handling() {
         // Serialize tests that change the current working directory
-        let _cwd_guard = CWD_MUTEX.lock().unwrap();
+        let _cwd_guard = CWD_MUTEX.lock().await;
 
         // Save current directory to restore later
         let original_dir = std::env::current_dir().unwrap();
@@ -1314,7 +1316,7 @@ mod tests {
     #[tokio::test]
     async fn test_filesystem_without_root_dir() {
         // Serialize tests that change the current working directory
-        let _cwd_guard = CWD_MUTEX.lock().unwrap();
+        let _cwd_guard = CWD_MUTEX.lock().await;
 
         // Test that filesystem without root_dir handles URLs correctly
         let temp_dir = TempDir::new().unwrap();
@@ -1394,7 +1396,7 @@ mod tests {
     #[tokio::test]
     async fn test_prevent_double_relative_path_resolution() {
         // Serialize tests that change the current working directory
-        let _cwd_guard = CWD_MUTEX.lock().unwrap();
+        let _cwd_guard = CWD_MUTEX.lock().await;
 
         // This test verifies that paths are used as-is without root_dir resolution
         // Previously there was a bug where paths were being resolved against root_dir
@@ -1571,7 +1573,7 @@ mod tests {
     #[tokio::test]
     async fn test_exists_method_without_root_dir() {
         // Serialize tests that change the current working directory
-        let _cwd_guard = CWD_MUTEX.lock().unwrap();
+        let _cwd_guard = CWD_MUTEX.lock().await;
 
         // Save current directory to restore later
         let original_dir = std::env::current_dir().unwrap();

--- a/tests/api_consistency_test.rs
+++ b/tests/api_consistency_test.rs
@@ -140,7 +140,6 @@ mod api_consistency_tests {
 
         // Verify REST response structure
         if let Ok(response) = rest_response {
-            assert!(response.success || !response.success); // Response should have success field
             assert!(response.operation >= 0); // Should have valid operation enum
 
             // Check for required fields

--- a/tests/catalog_integration_test.rs
+++ b/tests/catalog_integration_test.rs
@@ -893,11 +893,10 @@ mod hive_catalog_tests {
             .await
             .unwrap();
 
-        // Health check without actual server should indicate unhealthy or handle gracefully
-        let health = catalog.health_check().await.unwrap();
-        // We expect unhealthy since there's no actual Thrift server
-        // But the catalog creation itself should still work
-        assert!(!health.is_healthy || health.is_healthy); // Accept either state
+        // Health check without actual server should indicate unhealthy or handle gracefully.
+        // This is a smoke test — the only contract is that health_check() returns without
+        // panicking (the .unwrap() above asserts no error); the health value is discarded.
+        let _ = catalog.health_check().await.unwrap();
     }
 }
 


### PR DESCRIPTION
The genuinely-valuable slice of the remaining clippy tail (after #625 scoping + #629/#632 mechanical --fix). **9 fixes; no behavior change for green paths.**

## await_holding_lock (5) — real async-correctness
- **`local.rs` `CWD_MUTEX`**: `std::sync::Mutex` → `tokio::sync::Mutex` (4 test sites). The guard is intentionally held across `.await` (it serializes cwd-mutating tests), so the async-aware lock is the correct primitive — it yields instead of blocking the runtime.
- **`record_store.rs:3408`**: scoped the WAL guard in a block so it provably drops before the `get_by_key` await. The code already did `drop(entries)` before the await (correct); the block makes the lifetime unambiguous to clippy.

## logic_bug tautologies (4) — were no-op assertions, not real logic errors
`assert!(x || !x)` / `|| true` — the test always passed trivially. Removed the tautology; the real contract is the preceding `.unwrap()` / smoke-test call. Files: `catalog_integration_test`, `environment_detector`, `datafusion_bridge`, `api_consistency_test`.

## Not included (deferred)
**7 `module_loaded_multiple_times`** — `#[path]` test-harness duplication in `tests/common/`. Deferred: a structural refactor (consolidate into a shared `tests/common` module) across multiple test targets with real breakage risk, for low value (tests compile and pass today; it's build-wastefulness, not correctness). Worth a dedicated follow-up if pursued.

## Verification (local, 1.95.0)
- `cargo clippy -p proximadb --tests` → `logic_bug` 4→0, `await_holding_lock` 5→0; 0 compile errors.
- CI runs the full test suite to confirm the `tokio::sync::Mutex` + block-scope changes behave identically.