### PR TITLE
docs(td): TD-MCP-1 — reference-MCP agent-state tools need a wired ADR-022 agentic backend

### DIFF
--- a/docs/10-quality/td/TD-MCP-1-agent-state-tools-need-wired-agentic-backend.adoc
+++ b/docs/10-quality/td/TD-MCP-1-agent-state-tools-need-wired-agentic-backend.adoc
@@ -1,0 +1,104 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-MCP-1: Reference-MCP agent-state tools (memory / checkpoint / event) require a wired ADR-022 agentic backend
+
+[cols="1,3"]
+|===
+|Status|Open
+|Priority|MED
+|Scope|FEAT
+|Date|2026-07-02
+|Relates to|ADR-037 Decision 5 (reference MCP surface), ADR-022 (agent memory layer), TD-101 (agent memory write surface — In Progress), TD-174 (statistics envelope, feeds `stats`)
+|Depends on|TD-101 (LLM-gated memory ingest) + a wired production agentic backend (see below)
+|===
+
+== Context
+
+The in-process reference MCP surface (ADR-037 Decision 5) shipped through Stage 1
+runnable via `[api].mcp_port`:
+
+* `proximadb-mcp` crate — protocol + tool catalog + dispatch (#440).
+* Stage 1a — `EngineBackend` + HTTP transport + config flag (#470).
+* Stage 1b — gated `spawn_mcp_surface()` in `MultiServer::start` (#630).
+
+Five **data tools** are live in-process by calling the engine's services directly:
+`list_collections` / `describe` (`ApiHandlersPort`), `stats`
+(`statistics_registry`), `explain` / `search` (`UnifiedQueryPort` over the shared
+`QueryFacadeAdapter`).
+
+The three **agent-state tools** — `memory`, `checkpoint`, `event` — return an
+explicit *"not yet wired in-process"* from `EngineBackend`
+(`src/network/mcp/backend.rs`). The original Stage-1 note assumed enabling them was
+a tail-end wire-in ("thread `AgenticGrpcBackend` into `AppState`"). **A thorough
+investigation shows that is not the case** — the backend they would call does not
+exist in production.
+
+== Finding (2026-07-02 investigation)
+
+. **No wired production `AgenticGrpcBackend`.** The trait
+  (`crates/platform/proximadb-api/src/grpc/v2/agentic.rs`) has exactly one impl —
+  a `MockBackend` in a `#[cfg(test)]` module — and `AgentMemoryService` /
+  `AgentCheckpointService` / `AgentEventService` are constructed **only inside a
+  test**. The agentic gRPC service is **not registered** on the running server.
+. **No wired production `AgenticRestBackend` either.** The REST v2 counterpart
+  (`crates/platform/proximadb-api/src/rest/v2/agentic.rs`) is likewise trait +
+  handlers + mock, and is **not mounted** in the REST v2 router
+  (`src/network/rest/v2/mod.rs`).
+. **The real primitives are heterogeneous and partly external-dependent:**
+  * *memory* — `MemoryWriteEngine::ingest` (`src/services/agent_memory.rs`) is
+    **LLM-driven** (`LLMIntegrationEngine`: extraction + consolidation prompts),
+    wired at REST v1 `POST /api/v1/memory/ingest` with a **`501` guard when no LLM
+    is configured**. Tracked as **TD-101 (In Progress)**. Read/search is backed by
+    `VectorMemoryStore` (non-LLM) + the `MemoryAqlSource` AQL read surface.
+  * *checkpoint* — only an **embedded-only** `save_checkpoint`
+    (`src/embedded/agent_memory.rs`); no server-composed checkpoint store.
+  * *event* — a real `EventLogEngine::append_event`
+    (`src/storage/engines/eventlog/mod.rs`) exists, but there is no service
+    composition exposing it as an agent-facing surface.
+
+**Conclusion:** completing the MCP agent-state tools is **real ADR-022 integration
+work** (a wired agentic backend + an LLM dependency for memory + a partly-greenfield
+checkpoint store), not a wiring change against an existing backend. Keeping the
+tools' honest *"not yet wired"* response is correct until that backend lands.
+
+== What "done" requires (prerequisite work)
+
+. A **wired production agentic backend** — one impl (gRPC and/or REST) composed over
+  the real stores and constructed at server boot (registered, not test-only). This
+  is the single missing seam both the gRPC and REST agentic surfaces already assume.
+. **LLM availability** for `memory` put/ingest (TD-101) — the `501`-guard path must
+  resolve, or the MCP `memory` put tool must degrade explicitly when no LLM is set.
+. A **checkpoint store** promoted from embedded-only to a server-composed service.
+. Then `EngineBackend` gains a handle to that backend (threaded through
+  `SharedServices`, like `api_handlers` / `query_adapter`) and its
+  `memory`/`checkpoint`/`event` methods call it directly in-process.
+
+== Suggested phasing (each independently shippable, mixed-read-safe)
+
+* **MCP-1a — event** (non-LLM, bounded): compose `EventLogEngine::append_event`
+  behind the agentic backend + wire the MCP `event` tool. Lowest risk.
+* **MCP-1b — memory search** (non-LLM read): back `search_memory` with
+  `VectorMemoryStore` / `MemoryAqlSource`; wire the MCP `memory` search path.
+* **MCP-1c — memory put** (LLM-gated): compose `MemoryWriteEngine::ingest`; the MCP
+  `memory` put path degrades explicitly when no LLM is configured (TD-101).
+* **MCP-1d — checkpoint** (greenfield): a server-composed checkpoint store from the
+  embedded `save_checkpoint`; wire the MCP `checkpoint` tool.
+
+== Also (small, ride the Stage-2 PR)
+
+Correct the `EngineBackend::not_wired` message
+(`src/network/mcp/backend.rs`) to reference **this TD / ADR-022 / TD-101** as the
+real dependency, instead of "Stage 2 threads `AgenticGrpcBackend` into `AppState`"
+(which implies a ready backend that does not exist).
+
+== References
+
+* `src/network/mcp/backend.rs` (`EngineBackend` — the 5 live data tools + the 3
+  deferred agent-state tools)
+* `crates/platform/proximadb-api/src/grpc/v2/agentic.rs` (`AgenticGrpcBackend` trait +
+  test-only mock)
+* `crates/platform/proximadb-api/src/rest/v2/agentic.rs` (`AgenticRestBackend` trait,
+  unmounted)
+* `src/services/agent_memory.rs` (`MemoryWriteEngine`, `VectorMemoryStore` — TD-101)
+* `src/storage/engines/eventlog/mod.rs` (`EventLogEngine::append_event`)
+* `src/embedded/agent_memory.rs` (embedded-only `save_checkpoint`)


### PR DESCRIPTION
Files the outcome of a thorough investigation into completing the MCP `memory`/`checkpoint`/`event` tools (the deferred Stage-2 items from #630).

**Finding:** they can't be wired in — the backend doesn't exist in production.
- The only `AgenticGrpcBackend` impl is a `#[cfg(test)]` **mock**; the services are constructed **only in a test** and are **never registered** on the server.
- The REST v2 `AgenticRestBackend` is likewise trait + handlers + mock, **unmounted** in the router.
- Real primitives are heterogeneous + partly external-dependent: memory ingest is **LLM-gated** (`MemoryWriteEngine`, **TD-101 In Progress**); checkpoint is **embedded-only**; event has `EventLogEngine::append_event` but no service composition.

So completing these tools is **real ADR-022 integration** (a wired agentic backend + an LLM dependency + a partly-greenfield checkpoint store), **not a tail-end wire-in**. The TD captures the prerequisite + a suggested independently-shippable phasing (event → memory-search → memory-put → checkpoint), and notes the `EngineBackend::not_wired` message should be corrected to point here when Stage 2 is picked up.

Docs-only; `td-adr-unique` guard passes (TD-MCP-1, first in the topic-scoped MCP series). The honest "not yet wired in-process" MCP response stays correct until the backend lands.