### PR TITLE
docs(agent-rules): add Commands + Architecture map to CLAUDE.md.seed

### DIFF
--- a/docs/agent-rules/CLAUDE.md.seed
+++ b/docs/agent-rules/CLAUDE.md.seed
@@ -55,6 +55,101 @@ When changing a storage format, reader, codec, cache, or engine you MUST:
    buys nothing for our flat-key, immutable, ranged-read workload.
 ====
 
+## 🛠 Commands
+
+Toolchain is pinned by `rust-toolchain.toml` (edition 2024). `.cargo/config.toml` caps build
+jobs at 3 for OOM safety — don't override upward.
+
+### Build / check
+```bash
+cargo check-fast                      # alias: cargo check --all-targets — tightest inner loop
+cargo build                           # dev build
+cargo build --profile release-server  # optimized server binary (make build-server)
+```
+
+### Test (nextest preferred — process-per-test isolation; install: make install-fast-tools)
+```bash
+cargo nxlib                           # unit tests only (--lib, nextest profile "unit", parallel)
+cargo nx                              # all tests (nextest default profile)
+cargo nxint                           # integration tests (sequential, port-safe)
+cargo nextest run <substring>         # single test by name filter
+cargo nextest run --test <file> <substring>   # single test within one integration-test file
+cargo test <test_name> -- --exact     # libtest fallback for a single test
+```
+Integration tests live flat in `tests/` (`*_integration_test.rs`, `*_e2e.rs`); unit tests are
+inline `#[cfg(test)]`. Nextest profiles/test-groups are in `.config/nextest.toml` — anything
+matching `*_e2e`/`*_integration_test` or `datafusion`/`native_volcano` is auto-serialized; don't
+"fix" those by hand. Verify the **server binary** builds, not just `--lib`.
+
+### Lint / format / guardrails
+```bash
+cargo fmt --check                     # CI "Rust Format" gate — run before EVERY push
+cargo clippy -- -D warnings
+make work-commit-check                # all deterministic commit guards: fmt-check, docs-claim,
+                                      # capability-matrix, workspace-boundaries, tenant-path,
+                                      # panic-policy module guard, hygiene
+python3 scripts/check_td_adr_unique.py        # before pushing a TD/ADR filing
+python3 scripts/check_no_agent_attribution.py # commit/PR text must carry no AI attribution
+```
+
+### Run the server
+```bash
+cargo run --release --bin proximadb-server    # flags: -c config (default config/config.toml),
+                                              #        -d data-dir, -p port
+```
+Ports: **5678** = unified multiplexed REST + gRPC + Arrow Flight; **5433** = Postgres wire (pgwire).
+
+### Contract / codegen gates (regenerate in the same PR as the spec change)
+```bash
+make verify-openapi-spec              # spec is GENERATED from axum handlers; fails on drift
+                                      # regen: UPDATE_OPENAPI_SPEC=1 cargo test -p proximadb --test openapi_spec_gen
+make proto-check                      # proto/OpenAPI contract drift
+make gen-python-sdk / gen-go-sdk / gen-ts-sdk / gen-rust-sdk   # spec-driven SDK transports
+```
+
+## 🏗 Architecture (big picture)
+
+**Workspace shape.** Root `src/` is the main library crate `proximadb` (a large monolith being
+decomposed); the server binary is `apps/proximadb-server`. `crates/` is layered — `foundation`
+(leaf types: proto, records, tenant, distance/quantization/index types) → `horizontal`
+(codec, compression, security, telemetry) → `storage` / `query` / `modalities` (vector, graph,
+document, embedding, rank) → `control` (catalog) / `platform` (runtime, api, mcp, admin-ui).
+Layering is CI-enforced (`scripts/check-layering.sh`, `scripts/check_workspace_boundaries.py`) —
+depend on stable crate paths (`proximadb_proto::…`) or port traits, never root-crate internal
+module paths.
+
+**Request flow.** All network surfaces live in `src/network/`: `postgres/` (pgwire, port 5433,
+SELECT lowering in `relational_pipeline.rs`), `rest/` + `grpc/` + `arrow_ipc/` (Arrow Flight)
+multiplexed on port 5678 (`multi_server.rs`, `multiplex/`). Tenant identity enters at
+`src/network/middleware/tenant.rs` and must flow as `TenantContext`
+(crate `proximadb-tenant`) to every I/O boundary.
+
+**Query routing.** The engine owns engine selection — never bypass it. SQL reaches
+`ComputeScheduler::route_select` (`src/query/compute_scheduler.rs`), which picks ONE
+`ComputeBackend` per plan: **DataFusion (OLAP)** for parquet-backed tables (deep integration in
+`src/datafusion/` — table provider, scan exec, pushdown), **native Volcano** otherwise
+(`src/query/execution/engine.rs`). DataFusion is the *interim* OLAP engine behind the
+`ComputeBackend` seam — never assume it is terminal. Vector/ANN work runs on the specialized
+engines in `src/storage/engines/`: **SST**, **HELIX**, **NOVA**, **VIPER** (plus gated
+experimental RAPTOR/SWIFT); graph is **ORION**.
+
+**Storage.** Write path: WAL (`src/storage/persistence/write_ahead_log/`) → memtable → flush
+(`flush_materializer.rs`) into the custom **PAX block format**
+(`crates/storage/proximadb-block-format`) for vector engines, or Parquet+Iceberg
+(`proximadb-iceberg-engine`) for warehouse tables. All object-storage keys are built by
+`DrPathBuilder` (`src/storage/trait_components/path_resolver.rs`) under
+`data/{tenant_id}/{namespace_id}/…` — never raw paths. Object-store abstraction:
+`crates/storage/proximadb-object-store`.
+
+**Feature flags** (root `Cargo.toml` `[features]`): defaults include `sql_frontend`,
+`datafusion-integration`, `canonical-document-store`. Notable opt-ins: `cluster` (Raft),
+`experimental-engines` (RAPTOR/SWIFT), `experimental-turboquant`, `aws`/`azure`/`gcp`,
+`io-trace`, `onnx`.
+
+**Docs.** Architecture index: `docs/12-design/README.adoc`; single-pane system view:
+`docs/12-design/SYSTEM_MAP_2026_05_30.adoc`. Support tiers (what's GA vs Beta vs Experimental):
+`docs/SUPPORTED_SURFACE.adoc`. TD/ADR filing: `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`.
+
 ### Core Directives
 1.  **Workspace Isolation (MANDATORY — this repo is worked on by multiple concurrent sessions):** NEVER edit, commit, `checkout`, `reset`, `stash`, or `branch -f` in the main checkout, and NEVER touch another worktree's branch or uncommitted WIP. Every task gets its own git worktree + branch off `origin/develop`: run `eval "$(scripts/worktree.sh new <type/topic>)"` to create one and `cd` into it. Run `scripts/worktree.sh guard` before editing — if it fails, you are in the shared checkout; stop and make a worktree. Clean up with `scripts/worktree.sh rm <type/topic>` once your PR merges. **Reclaim disk routinely:** worktree `target/` build caches are tens of GB each and are the dominant disk consumer, so run `scripts/worktree.sh clean` (preview with `--dry-run`) at the start/end of a session to drop every worktree whose branch has landed in `develop` — it detects **both** merge-commit and **squash-merged** PRs and reports the space reclaimed. For worktrees you KEEP, the recurring bloat is `target/*/incremental` (multi-GB per crate, never shared) — `eval "$(scripts/worktree.sh new …)"` now disables it (`CARGO_INCREMENTAL=0`) and wires **sccache** when present (`brew install sccache` for fast shared-cache rebuilds); reclaim existing incremental bloat from a kept worktree with `scripts/worktree.sh gc` (`--all` across worktrees, `--dry-run` to preview). Full rationale + commands: `docs/10-quality/WORKSPACE_ISOLATION.md`.
 2.  **Architecture Source Of Truth:** Use `docs/12-design/README.adoc` as the architecture index. Pay special attention to the `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` (strategic pivot) and `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (co-design cost spine) documents. **Filing a TD or ADR:** follow the canonical convention in `docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc` (one file per entry; prefer a topic-scoped id like `TD-CAT-1`; never reuse a number already on `develop`; the `td-adr-unique` CI guard backstops). That in-repo doc is the single source of truth — these per-agent rule files only point to it, so concurrent sessions/machines never drift.

--- a/docs/agent-rules/GEMINI.md.seed
+++ b/docs/agent-rules/GEMINI.md.seed
@@ -59,8 +59,9 @@ When changing a storage format, reader, codec, cache, or engine you MUST:
 - **Multi-Engine Storage:** SST, HELIX, VIPER, SWIFT, NOVA, RAPTOR.
 
 ## 📂 Project Organization
-- `src/`: Core Rust crates (storage, graph, query, vector, api_handlers).
-- `src/bin/`: Main binaries (server, bench, migrate).
+- `src/`: Core Rust library crate (storage, graph, query, vector, api_handlers).
+- `apps/`: Main binaries (proximadb-server, bench, ann-bench, migrate, vectordb-compare).
+- `crates/`: Layered workspace crates (foundation → horizontal → storage/query/modalities → control/platform).
 - `tests/`: Integration, regression, and WAL persistence tests.
 - `benches/`: Performance benchmarks (Criterion).
 - `clients/`: SDKs for Python (PyO3/C FFI), Go, Java, and Node.js.


### PR DESCRIPTION
## What

- **`docs/agent-rules/CLAUDE.md.seed`**: add two lean sections between the co-design mandate and Core Directives:
  - **🛠 Commands** — the real dev workflows: `cargo check-fast`, nextest aliases (`nxlib`/`nx`/`nxint`) + single-test invocation, `cargo fmt --check` / clippy / `make work-commit-check` guardrails, server run command + ports (5678 unified, 5433 pgwire), and the contract/codegen gates (`verify-openapi-spec`, `proto-check`, `gen-*-sdk`).
  - **🏗 Architecture (big picture)** — workspace shape (root lib + `apps/` binaries + layered `crates/`), request flow (`src/network/` surfaces → `ComputeScheduler::route_select` → DataFusion-OLAP vs native Volcano vs SST/HELIX/NOVA/VIPER/ORION), storage spine (WAL → PAX / Parquet+Iceberg, `DrPathBuilder`, `TenantContext`), key feature flags, doc pointers.
- **`docs/agent-rules/GEMINI.md.seed`**: fix stale Project Organization — binaries live in `apps/` (not `src/bin/`), and the layered `crates/` workspace was missing from the list.

## Why

The seed carried the engineering mandates but nothing about how to build, test, or navigate the codebase — every fresh local `CLAUDE.md` copy started blind on the dev loop. Sections are kept lean per Core Directive 12 (static context is paid on every call); detail stays in `docs/12-design/` and the Makefile.

No behavior/code changes — docs only.