### PR TITLE
feat(mcp): MCP-1a — wire the reference-MCP event tool to the ADR-022 EventLogEngine

### DIFF
--- a/crates/platform/proximadb-mcp/src/tools.rs
+++ b/crates/platform/proximadb-mcp/src/tools.rs
@@ -154,8 +154,21 @@ pub fn reference_tools() -> Vec<Tool> {
         },
         Tool {
             name: tool_name::EVENT.to_string(),
-            description: "Agent event log: append or list events (ADR-022).".to_string(),
-            input_schema: json!({ "type": "object", "additionalProperties": true }),
+            description: "Agent event log: append an event to the ADR-022 auditable trail."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["event_type"],
+                "properties": {
+                    "entity_id": { "type": "string", "description": "Entity/stream the event belongs to. Falls back to `collection_id` if omitted." },
+                    "collection_id": { "type": "string", "description": "Used as the entity/stream when `entity_id` is absent." },
+                    "event_type": { "type": "string", "description": "Event type/name." },
+                    "data": { "description": "Event payload (any JSON value)." },
+                    "metadata": { "type": "object", "description": "Optional key/value metadata." },
+                    "causation_id": { "type": "string", "description": "Optional id of the causing event." }
+                },
+                "additionalProperties": true
+            }),
         },
     ]
 }

--- a/src/network/mcp/backend.rs
+++ b/src/network/mcp/backend.rs
@@ -6,23 +6,29 @@
 //! calling them **directly** (no REST/gRPC self-hop): catalog list/describe via
 //! [`ApiHandlersPort`], the statistics envelope via the resident
 //! `statistics_registry`, and explain/search via the [`UnifiedQueryPort`] (which
-//! already returns `serde_json::Value`). The agent-state tools
-//! (`memory`/`checkpoint`/`event`) are deferred to Stage 2 (threading
-//! `AgenticGrpcBackend` into `AppState`) — they return an explicit "not yet
-//! wired in-process" rather than fabricate.
+//! already returns `serde_json::Value`). The `event` tool appends to the ADR-022
+//! auditable `EventLogEngine` (shared from `SharedServices`). The remaining
+//! agent-state tools (`memory`/`checkpoint`) need a wired production agentic
+//! backend (see TD-MCP-1; memory ingest is LLM-gated, TD-101) — they return an
+//! explicit "not yet wired in-process" rather than fabricate.
 
 use crate::core::statistics::{StatisticsSummary, statistics_registry};
 use crate::proto::proximadb_v1::{CollectionOperation, CollectionRequest};
+use crate::storage::engines::eventlog::{Event, EventLogEngine};
 use async_trait::async_trait;
 use proximadb_mcp::{BackendError, ReferenceBackend};
 use proximadb_runtime::{ApiHandlersPort, UnifiedQueryPort};
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A `ReferenceBackend` that calls the engine's in-process services directly.
 pub struct EngineBackend {
     api_handlers: Arc<dyn ApiHandlersPort>,
     query: Option<Arc<dyn UnifiedQueryPort>>,
+    /// ADR-022 auditable event log — backs the `event` tool. `None` disables it
+    /// (the engine failed to initialize), and `event` reports so explicitly.
+    event_log: Option<Arc<EventLogEngine>>,
     /// Tenant the MCP surface operates as. Stage 1 uses a single configured
     /// tenant (or the port default when `None`); per-request tenant scoping from
     /// MCP auth is a later refinement.
@@ -33,11 +39,13 @@ impl EngineBackend {
     pub fn new(
         api_handlers: Arc<dyn ApiHandlersPort>,
         query: Option<Arc<dyn UnifiedQueryPort>>,
+        event_log: Option<Arc<EventLogEngine>>,
         tenant: Option<String>,
     ) -> Self {
         Self {
             api_handlers,
             query,
+            event_log,
             tenant,
         }
     }
@@ -82,8 +90,8 @@ fn query_string(args: &Value) -> Result<String, BackendError> {
 
 fn not_wired(tool: &str) -> BackendError {
     BackendError::internal(format!(
-        "`{tool}` (ADR-022 agent state) is not yet wired in-process; Stage 2 threads \
-         AgenticGrpcBackend into AppState to enable it"
+        "`{tool}` (ADR-022 agent state) is not yet wired in-process — it needs a wired production \
+         agentic backend (see TD-MCP-1); memory ingest is additionally LLM-gated (TD-101)"
     ))
 }
 
@@ -174,7 +182,43 @@ impl ReferenceBackend for EngineBackend {
     async fn checkpoint(&self, _args: &Value) -> Result<Value, BackendError> {
         Err(not_wired("checkpoint"))
     }
-    async fn event(&self, _args: &Value) -> Result<Value, BackendError> {
-        Err(not_wired("event"))
+    async fn event(&self, args: &Value) -> Result<Value, BackendError> {
+        let log = self.event_log.as_ref().ok_or_else(|| {
+            BackendError::internal(
+                "event log unavailable (EventLogEngine failed to initialize)".to_string(),
+            )
+        })?;
+        // The entity/stream the event belongs to (accept `entity_id`, else `collection_id`).
+        let entity_id =
+            require_str(args, "entity_id").or_else(|_| require_str(args, "collection_id"))?;
+        let event_type = require_str(args, "event_type")?;
+        let data = args.get("data").cloned().unwrap_or(Value::Null);
+        let metadata = match args.get("metadata") {
+            Some(Value::Object(m)) => m.clone().into_iter().collect::<HashMap<String, Value>>(),
+            _ => HashMap::new(),
+        };
+        let causation_id = args
+            .get("causation_id")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let event = Event {
+            sequence: 0, // assigned by append_event
+            entity_id,
+            event_type,
+            data,
+            timestamp: chrono::Utc::now(),
+            causation_id,
+            metadata,
+        };
+        let appended = log
+            .append_event(event)
+            .await
+            .map_err(|e| BackendError::internal(format!("append_event failed: {e}")))?;
+        Ok(json!({
+            "sequence": appended.sequence,
+            "entity_id": appended.entity_id,
+            "event_type": appended.event_type,
+            "timestamp": appended.timestamp.to_rfc3339(),
+        }))
     }
 }

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -407,6 +407,7 @@ impl MultiServer {
         let backend = Arc::new(crate::network::mcp::EngineBackend::new(
             svc.api_handlers.clone(),
             Some(query_port),
+            svc.event_log.clone(),
             None,
         ));
         let addr = SocketAddr::new(self.config.http_bind_address().ip(), mcp_port);

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -126,6 +126,11 @@ pub struct SharedServices {
     pub observability_service: Arc<crate::observability::ObservabilityService>,
     /// Unified request handlers shared across all protocol layers
     pub request_handlers: Arc<UnifiedHandlers>,
+    /// ADR-022 auditable event log (append-only trail). The same
+    /// `Arc<EventLogEngine>` handed to the unified handlers; exposed here so
+    /// in-process surfaces (e.g. the reference MCP `event` tool) can append
+    /// directly. `None` when the engine failed to initialize.
+    pub event_log: Option<Arc<crate::storage::engines::eventlog::EventLogEngine>>,
     /// Optional metrics collector for Prometheus/monitoring integration
     pub metrics_collector: Option<Arc<MetricsCollector>>,
     /// Optional internal metrics updater for background metric publishing
@@ -1764,7 +1769,7 @@ impl SharedServices {
             vector_operations_service.clone(),
             document_service.clone(),
             observability_service.clone(),
-            event_log,
+            event_log.clone(),
             graph_collection_service.clone(), // SHARED instance
             graph_service.clone(),            // Concrete native graph operations service
         );
@@ -2385,6 +2390,7 @@ impl SharedServices {
                 document_service: document_service.clone(),
                 observability_service: observability_service.clone(),
                 request_handlers: request_handlers.clone(),
+                event_log,
                 metrics_collector,
                 metrics_updater: metrics_updater.clone(),
                 query_facade,


### PR DESCRIPTION
First slice of **TD-MCP-1** (the deferred agent-state tools from #630). The reference MCP **`event`** tool now appends to the real **ADR-022 auditable `EventLogEngine`** in-process — **no LLM, no extra process** — so 6 of the 8 tools are live.

## Change (4 files, +75)
- **`SharedServices`** exposes the `EventLogEngine` it already builds for audit trails (cloned before it moves into `UnifiedHandlers`) — the same `Arc` the unified handlers use.
- **`EngineBackend.event()`** maps the tool args (`entity_id`|`collection_id`, `event_type`, `data`, `metadata`, `causation_id`) → an `Event` and calls `append_event`; returns the assigned `sequence` + echoed fields.
- **`event` tool schema** now advertises those args (was open `additionalProperties:true`) so agents can discover them.
- Spawn site threads `shared_services.event_log` into `EngineBackend::new`.
- `not_wired` now accurately cites **TD-MCP-1 / TD-101** for the tools that remain deferred.

## Still deferred (per TD-MCP-1)
- `memory` — LLM-gated (`MemoryWriteEngine`, TD-101).
- `checkpoint` — greenfield (embedded-only `save_checkpoint`).

## Verified
Server **lib + binary** build, `cargo fmt` + `clippy` clean; off by default (only bound when `[api].mcp_port` is set).