### PR TITLE
perf(search): LSN-pin Strong-freshness reads so they become cache-eligible (ADR-051)

### DIFF
--- a/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
+++ b/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-STRONG-1: Strong-read concurrency follow-ups — shared WAL-tail pool + ungated cache sites
+
+[cols="1,3"]
+|===
+|Status|Open
+|Priority|MED
+|Scope|PERF + SEC
+|Date|2026-07-02
+|Relates to|ADR-051 (Strong stays default; D2 LSN-pinned cache landed, this tracks D3), TD-096 (SST block-skip — the other #634 term), TD-074 (per-collection freshness)
+|===
+
+== Context
+
+ADR-051 D2 made **repeated** Strong queries cache-eligible (LSN-pinned). Two
+items remain to make Strong fully cheap and fully correct under concurrency.
+
+== Part A — Per-(collection, LSN) shared WAL-tail candidate pool (PERF, ADR-051 D3)
+
+The #634 concurrency collapse was measured with **all-distinct** query vectors,
+which the D2 cache does not help. At a fixed LSN the unflushed WAL tail is
+immutable, yet every concurrent Strong read re-runs `get_unflushed_batches` +
+the linear scan independently (`src/storage/persistence/write_ahead_log/mod.rs:2396`,
+via `scan_wal_delta_if_needed`, `legacy.rs:1662`).
+
+*Sketch:* memoize the tail candidate retrieval per `(collection, lsn)` so N
+concurrent same-LSN reads share one batch retrieval/scan; the per-query distance
+computation stays per-query. Bound the memo by memory; invalidate on LSN advance
+(write) and on flush (tail shrinks — the memo for the old LSN is simply dropped).
+Single-flight the population so a thundering herd collapses to one scan.
+
+*Why deferred:* restructures the hot WAL-visibility path; needs careful
+concurrency (single-flight + lifecycle), a memory bound, and the full
+`vector_ann_recall`/`postflush` integration suites to prove no visibility
+regression.
+
+== Part B — Close the ungated query-cache read sites (SEC/correctness)
+
+Two query-cache read sites carry **no freshness gate** — they serve any
+TTL-fresh entry regardless of `VectorFreshnessMode`, so a Strong read routed
+through them could be served a result that predates a write:
+
+* `unified_search_with_tenant_context` — `src/services/operations/vectors/legacy.rs:2071`
+  (`get_if_fresh`, no gate).
+* `unified_search_with_hints` — `src/services/operations/vectors/legacy.rs:2640`
+  (`get_if_fresh`, no gate).
+
+This is **pre-existing** (independent of ADR-051; the v1 core path
+`unified_search_v1_inner` is the one that gates). Action:
+1. Audit whether either path actually receives Strong reads on a live route (if
+   neither does, downgrade to a doc note).
+2. If so, extend the same LSN gate (`get_if_fresh_v1_at_lsn` +
+   `cache_with_dependencies_v1_at_lsn`, added in ADR-051 D2) to those sites, or
+   route them through the gated core.
+
+== Done when
+
+* Part A: concurrent distinct same-LSN Strong reads share one tail scan; a
+  concurrency benchmark shows the p99-under-load term from the WAL delta removed;
+  recall/visibility suites green.
+* Part B: every query-cache read site that can serve a Strong read validates the
+  LSN (no stale-under-Strong path), asserted by a test.

--- a/docs/12-design/adr/ADR-051-strong-freshness-default-cheap-under-concurrency.adoc
+++ b/docs/12-design/adr/ADR-051-strong-freshness-default-cheap-under-concurrency.adoc
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-051: Strong freshness stays the read default; make it cheap under concurrency
+
+[cols="1,3"]
+|===
+|Status|Proposed
+|Date|2026-07-02
+|Deciders|Vijaykumar Singh
+|Relates to|ADR-020 (canonical WAL authority — durability vs read-visibility), ADR-046 (LSN-coherent merge read — the cheap-LSN primitive this reuses), ADR-011 (filtered-ANN modes — freshness is an orthogonal axis), TD-074 (per-collection freshness catalog wiring — the per-collection opt-out lever), TD-096 (SST block-skip — the OTHER, distinct-query scan-cost term; explicitly out of scope)
+|Supersedes|—
+|Tracked under|D2 implemented in this change; D3 + the ungated-cache-site audit tracked as TD-STRONG-1.
+|===
+
+== Context
+
+Every typed vector `/search` runs at `freshness = Strong` (the default:
+`legacy.rs` `run_unified_search_v1` builds config with `freshness_mode: None` →
+`effective_freshness_mode` `unwrap_or_default()` → `VectorFreshnessMode::Strong`,
+`src/core/search/mod.rs:135`). Strong has two costs that compound under
+concurrency and are the freshness term behind the downstream #634 finding
+(typed `/search` p99 ~1s at c16 vs ~53ms single-flight):
+
+1. **Cache bypass.** Strong reads are *never* served from the query cache
+   (`legacy.rs:2279-2298`) — because `QueryKey` = `{collection, vector, k, filters}`
+   omits any LSN, so a cached entry cannot be proven newer than the WAL tail. At
+   c16 this means **zero amortization** — all in-flight requests recompute.
+2. **Per-query WAL delta-merge.** Strong forces `apply_delta_merge_with_explain`
+   (`legacy.rs:2362`) → `search_unflushed_vectors` on every query, an O(unflushed
+   tail) linear scan (`wal/mod.rs:2396`).
+
+The question this ADR answers: **should the read default stop being Strong?**
+
+== First principles
+
+* **Durability ≠ visibility timing (ADR-020).** ADR-020 makes the WAL the single
+  durable authority; it does not mandate *when* a durable write becomes visible to
+  search. So the freshness default is a genuine, separately-decidable choice.
+* **A default that can silently drop a just-written row is a footgun.** Strong is
+  a **deliberate, test-asserted** read-after-write contract
+  (`assert_eq!(VectorFreshnessMode::default(), Strong)`, `core/search/mod.rs:1197`;
+  field/accessor docs at `:460-464,628`), added *because* a v2 INSERT→SEARCH
+  visibility gap was a production bug (defensive guards at `core/search/mod.rs:212-226`).
+  It also matches turbopuffer's strong-consistency default.
+* **Correct-and-cheap beats cheap-and-wrong.** The cost is a *cache/scan*
+  problem, not a *semantics* problem. The LSN needed to make Strong cacheable is
+  **already fetched every Strong query** (`manifest::current_lsn`, a cheap
+  singleton; ADR-046 §"cheap metadata lookup"), and write-triggered invalidation
+  already exists. So we can keep the contract and remove the cost.
+
+== Decision
+
+=== D1 — Strong stays the read default (reject the global weakening)
+
+The default read freshness remains `Strong`. Weakening it globally to
+`BoundedStale`/`StaleOk` is rejected: it breaks an explicit, historically-bug-
+motivated read-after-write contract and the turbopuffer parity claim, for a cost
+that is fixable without touching semantics (D2/D3). Collections that genuinely
+want a cheaper default get it **per-collection** via the catalog knob (TD-074) —
+a scoped opt-out, not a global flip.
+
+=== D2 — LSN-pinned cache eligibility for Strong reads (implemented here)
+
+A Strong read is **cache-eligible iff the cached entry was computed at the
+current canonical-WAL LSN**. Mechanics:
+
+* Stamp each cached result with `computed_at_lsn` (`CachedQueryResult`), set to
+  the LSN snapshotted once at query start.
+* A Strong read serves the entry only when `computed_at_lsn == current_lsn`
+  (`get_if_fresh_v1_at_lsn`); `current_lsn == 0` (unavailable) never hits.
+
+**Why it stays read-after-write correct:** any write both (a) advances the LSN —
+so an LSN-stamped entry no longer matches → miss → recompute over the new tail —
+and (b) evicts the collection's cache entries (`CacheInvalidationCoordinator`).
+Double invalidation; a Strong read can never serve a result that predates a
+write. If a write races *during* a query, the LSN advances past the snapshot and
+the entry is simply never served (conservative under-caching, never a stale hit).
+
+**What it fixes:** repeated identical Strong queries (dashboards, retries, hot
+queries, health checks) — which were 100% recomputed before — now amortize.
+
+=== D3 — Per-(collection, LSN) shared WAL-tail candidate pool (designed; TD-STRONG-1)
+
+For **distinct**-query concurrency (the #634 benchmark ran all-random vectors,
+so D2's cache does not help it), the immutable unflushed tail at a fixed LSN is
+re-scanned independently by every concurrent query. Memoize the tail candidate
+retrieval per `(collection, lsn)` so N concurrent same-LSN Strong reads share one
+`get_unflushed_batches`/scan pass (the per-query distance computation stays
+per-query). Deferred to **TD-STRONG-1**: it restructures the hot WAL-visibility
+path and needs careful concurrency, memory-bound, and flush/write invalidation
+design plus the full integration suite.
+
+== Non-goals / disclaimers
+
+* **Does not weaken read-after-write** (D1) — the contract is preserved exactly.
+* **Does not fix the SST directory-side scan cost.** The other #634 term is the
+  block-skip / object-store-GET efficiency on the *flushed* side (TD-096, "≈ full
+  scan on diffuse data"), addressed by HELIX PCA→Hilbert ordering — separate work.
+* **The all-distinct-random benchmark is not fixed by D2** (distinct queries do
+  not repeat); it is addressed by D3 + TD-096. D2 targets repeated-query traffic.
+* Freshness is orthogonal to the ADR-011 filter-mode default; unchanged here.
+
+== Consequences
+
+=== Positive
+
+* Strong reads finally amortize across repeated queries with **zero semantic
+  change**, reusing primitives that already exist (cheap `current_lsn`,
+  write-triggered eviction, a pure LSN-stable delta).
+* The read-after-write default — the safe one — is kept, not traded away for perf.
+
+=== Risks / follow-ups
+
+* Cache correctness is subtle; guarded by LSN-equality **and** existing eviction
+  (belt-and-suspenders), covered by new unit tests (`query_cache.rs`
+  `lsn_gate_tests`) and the CI integration suite.
+* **Pre-existing gap (not introduced here):** two other query-cache read sites —
+  `unified_search_with_tenant_context` (`legacy.rs:2071`) and
+  `unified_search_with_hints` (`legacy.rs:2640`) — serve any TTL-fresh entry with
+  **no freshness gate**, so they could serve a Strong read stale today. Audit
+  whether those paths receive Strong reads and, if so, extend the LSN gate —
+  tracked in TD-STRONG-1.
+
+== References
+
+* `src/core/search/mod.rs` — `VectorFreshnessMode` (`:112-239`), the `default()==Strong`
+  test (`:1197`).
+* `src/services/operations/vectors/legacy.rs` — the Strong cache gate + delta-merge
+  + the LSN-pinned change (`unified_search_v1_inner`).
+* `src/storage/cache/specialized/query_cache.rs` — `computed_at_lsn`,
+  `get_if_fresh_v1_at_lsn`, `cache_with_dependencies_v1_at_lsn`, `lsn_gate_tests`.
+* ADR-020 (WAL authority), ADR-046 (LSN-coherent read), TD-074 (per-collection
+  freshness), TD-096 (SST block-skip — separate #634 term).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -179,6 +179,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Statistics-fed cost-based routing into the DataFusion OLAP arm
 | Proposed
 | Activates ADR-039's *declared-but-inert* DataFusion arm and makes its planning cost-based. Two moves: (1) `ComputeScheduler::route_select` stops hardcoding `Native(Volcano)` and routes analytical scan/join/aggregate over Parquet-backed tables to `DataFusionLocal` above a cost crossover (`SET compute_engine` override; strong-freshness stays Volcano) — realizes TD-115; (2) `schema_inference` feeds real DataFusion `ColumnStatistics` by projecting the ADR-042 mergeable `SegmentStatistics` (min/max/distinct/null) instead of `new_unknown()` — cost-based planning with **zero new scan**, the ADR-042 spine's second consumer. Stats are freshness-bounded hints (ADR-038) and calibrated by observed cost (ADR-030/034); the swap invariant (ADR-039) is preserved. **Explicitly disclaims the typed-vector-search scan cost** (#634 → ADR-011/028 + TD-064/073/096), which never enters DataFusion. Tracked: TD-115, TD-DFR-1
+
+| link:ADR-051-strong-freshness-default-cheap-under-concurrency.adoc[ADR-051]
+| Strong freshness stays the read default; make it cheap under concurrency
+| Proposed
+| Answers "should typed `/search` stop defaulting to Strong?" — **no.** D1: Strong stays the default (a deliberate, test-asserted read-after-write contract, `default()==Strong`, added because an INSERT→SEARCH visibility gap was a prod bug; matches turbopuffer); weakening globally is rejected — per-collection opt-out is TD-074. D2 (**implemented**): make Strong *cheap* by LSN-pinning cache eligibility — Strong reads (formerly 100% cache-bypassed) may serve a cached entry iff `computed_at_lsn == current_lsn`; any write advances the LSN (miss→recompute) AND evicts the collection, so read-after-write is preserved (belt-and-suspenders). Fixes repeated-query Strong concurrency. D3 (designed → TD-STRONG-1): per-`(collection,lsn)` shared WAL-tail scan for the distinct-query case (the #634 benchmark). **Disclaims** the SST directory-side scan cost (TD-096, the other #634 term). Tracked: TD-STRONG-1
 |===
 
 NOTE: ADR-010 through ADR-013 and ADR-048/ADR-049 exist in this directory but

--- a/src/core/search/integrated_search_optimization.rs
+++ b/src/core/search/integrated_search_optimization.rs
@@ -718,6 +718,7 @@ impl AdvancedSearchOptimizer {
             results: vec![proto_results], // Wrap in Vec as CachedQueryResult expects Vec<SearchResult>
             cached_at: std::time::SystemTime::now(),
             file_dependencies: vec![], // Would track dependencies
+            computed_at_lsn: 0, // non-LSN-aware path; never served to a Strong read via the LSN gate
         };
 
         self.query_cache.put_with_hooks(key, cached_result).await;

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2120,6 +2120,7 @@ impl VectorOperationsService {
             results: results.clone(),
             cached_at: std::time::SystemTime::now(),
             file_dependencies: Vec::new(), // No specific file dependencies for this query
+            computed_at_lsn: 0, // non-LSN-aware path (unified_search_with_tenant_context)
         };
         self.query_cache
             .put_with_hooks(cache_key, cached_result)
@@ -2276,20 +2277,40 @@ impl VectorOperationsService {
             k as u32,
             filter_str.as_deref(),
         );
-        // Strong-freshness reads must NEVER be served from the query cache —
-        // a cached result could predate a concurrent write and violate
-        // read-after-write. Only non-Strong (StaleOk / BoundedStale) reads
-        // may use the cache. Extract freshness here (before the cache check)
-        // so the gate is correct.
+        // Freshness gate for the query cache. Extract freshness here (before
+        // the cache check) so the gate is correct.
         let freshness_mode = config
             .as_ref()
             .and_then(|c| c.freshness_mode.clone())
             .unwrap_or_default();
-        if !matches!(
+        let is_strong = matches!(
             freshness_mode,
             crate::core::search::VectorFreshnessMode::Strong
-        ) && let Some(cached_v1) = self.query_cache.get_if_fresh_v1(&cache_key, 300).await
+        );
+        // Snapshot the canonical-WAL LSN once, up front — the anchor for both
+        // the Strong cache-read validity check and the cache-write stamp below.
+        // Cheap in-memory singleton read (same source the delta-merge uses).
+        let query_lsn = match crate::storage::persistence::write_ahead_log::manifest::get_service()
         {
+            Some(svc) => svc.current_lsn().await,
+            None => 0,
+        };
+        // Non-Strong (StaleOk / BoundedStale) reads use the TTL cache as before.
+        // Strong reads are cache-eligible ONLY when the cached entry was computed
+        // at the CURRENT LSN — i.e. no write has landed since, so read-after-write
+        // still holds. Any write both advances the LSN (→ miss → recompute) AND
+        // evicts the collection's entries (CacheInvalidationCoordinator), so a
+        // Strong read never serves a stale result. `query_lsn == 0` (LSN tracking
+        // unavailable) is never a Strong hit — it recomputes, matching the
+        // delta-merge's "scan anyway when the LSN is unknown" guard.
+        let cache_hit = if is_strong {
+            self.query_cache
+                .get_if_fresh_v1_at_lsn(&cache_key, 300, query_lsn)
+                .await
+        } else {
+            self.query_cache.get_if_fresh_v1(&cache_key, 300).await
+        };
+        if let Some(cached_v1) = cache_hit {
             // Phase 7.2: a process-local cache hit is the strongest
             // possible signal that this node owns the warm path for
             // the collection — record affinity here too.
@@ -2374,9 +2395,13 @@ impl VectorOperationsService {
         let v1_results =
             vec![self.optimized_results_to_proto_v1(merged_results, collection_id, true)];
 
-        // Cache v1 (via legacy conversion) for reuse
+        // Cache v1 (via legacy conversion) for reuse, stamped with the LSN this
+        // result was computed at so a later Strong read can validate it. If a
+        // write raced in during the search, the LSN has advanced past query_lsn,
+        // so this entry simply won't be served to a later Strong read (it will
+        // recompute) — conservative, never a stale hit.
         self.query_cache
-            .cache_with_dependencies_v1(cache_key, v1_results.clone(), Vec::new())
+            .cache_with_dependencies_v1_at_lsn(cache_key, v1_results.clone(), Vec::new(), query_lsn)
             .await;
 
         // Phase 7.2: record affinity on a successful v1 search.

--- a/src/storage/cache/specialized/query_cache.rs
+++ b/src/storage/cache/specialized/query_cache.rs
@@ -49,6 +49,12 @@ pub struct CachedQueryResult {
     pub results: Vec<SearchResult>,
     pub cached_at: SystemTime,
     pub file_dependencies: Vec<String>,
+    /// Canonical-WAL LSN at which this result was computed. Makes
+    /// Strong-freshness reads cache-eligible: a Strong read may be served from
+    /// cache iff this equals the current LSN (no write has landed since), so
+    /// read-after-write still holds. `0` = "unversioned" (written by a
+    /// non-LSN-aware path; never served to a Strong read via the LSN gate).
+    pub computed_at_lsn: u64,
 }
 
 impl CacheValue for CachedQueryResult {
@@ -125,6 +131,37 @@ impl QueryCache {
         None
     }
 
+    /// Strong-freshness variant of [`Self::get_if_fresh_v1`]. Serves a cached
+    /// result to a Strong read ONLY when it was computed at the *current*
+    /// canonical-WAL LSN — i.e. no write has advanced the LSN since, so the
+    /// cached result is still read-after-write correct. `expected_lsn == 0`
+    /// (LSN tracking unavailable) never hits, matching the delta-merge's
+    /// "scan anyway when the LSN is unknown" guard. The TTL still applies as a
+    /// backstop.
+    pub async fn get_if_fresh_v1_at_lsn(
+        &self,
+        key: &QueryKey,
+        max_age_secs: u64,
+        expected_lsn: u64,
+    ) -> Option<Vec<SearchResult>> {
+        if expected_lsn == 0 {
+            return None;
+        }
+        if let Some(cached) = BaseCache::get_with_hooks(&self.base, key).await {
+            if cached.computed_at_lsn != expected_lsn {
+                return None;
+            }
+            let age = SystemTime::now()
+                .duration_since(cached.cached_at)
+                .unwrap_or_default()
+                .as_secs();
+            if age <= max_age_secs {
+                return Some(cached.results.into_iter().collect());
+            }
+        }
+        None
+    }
+
     /// Cache results with file dependencies
     pub async fn cache_with_dependencies(
         &self,
@@ -136,6 +173,7 @@ impl QueryCache {
             results,
             cached_at: SystemTime::now(),
             file_dependencies: dependencies,
+            computed_at_lsn: 0,
         };
 
         BaseCache::put_with_hooks(&self.base, key, cached).await;
@@ -156,6 +194,27 @@ impl QueryCache {
             results: legacy,
             cached_at: SystemTime::now(),
             file_dependencies: dependencies,
+            computed_at_lsn: 0,
+        };
+        BaseCache::put_with_hooks(&self.base, key, cached).await;
+    }
+
+    /// LSN-stamped variant of [`Self::cache_with_dependencies_v1`]. Records the
+    /// canonical-WAL LSN the result was computed at so a later Strong read can
+    /// validate freshness via [`Self::get_if_fresh_v1_at_lsn`].
+    pub async fn cache_with_dependencies_v1_at_lsn(
+        &self,
+        key: QueryKey,
+        results: Vec<SearchResult>,
+        dependencies: Vec<String>,
+        computed_at_lsn: u64,
+    ) {
+        let legacy: Vec<SearchResult> = results.into_iter().collect();
+        let cached = CachedQueryResult {
+            results: legacy,
+            cached_at: SystemTime::now(),
+            file_dependencies: dependencies,
+            computed_at_lsn,
         };
         BaseCache::put_with_hooks(&self.base, key, cached).await;
     }
@@ -247,4 +306,65 @@ pub struct SpecializedQueryCacheStatistics {
     pub miss_count: u64,
     pub eviction_count: u64,
     pub memory_usage_bytes: usize,
+}
+
+#[cfg(test)]
+mod lsn_gate_tests {
+    use super::*;
+
+    fn key(collection: &str) -> QueryKey {
+        QueryKey::new(collection.to_string(), &[0.1f32, 0.2, 0.3], 5, None)
+    }
+
+    // A Strong read is cache-eligible ONLY at the LSN the entry was computed
+    // at: same LSN → hit; advanced LSN (a write landed) → miss (recompute);
+    // unknown LSN (0) → miss. This is the read-after-write validity predicate.
+    #[tokio::test]
+    async fn strong_read_hits_only_at_matching_lsn() {
+        let cache = QueryCache::new(16);
+        let k = key("c1");
+        cache
+            .cache_with_dependencies_v1_at_lsn(k.clone(), Vec::new(), Vec::new(), 42)
+            .await;
+
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 42).await.is_some());
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 43).await.is_none());
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 0).await.is_none());
+    }
+
+    // Entries written by a non-LSN-aware path (computed_at_lsn = 0) must never
+    // be served to a Strong read, but remain valid for the plain TTL reader.
+    #[tokio::test]
+    async fn unversioned_entry_never_strong_hits() {
+        let cache = QueryCache::new(16);
+        let k = key("c2");
+        cache
+            .cache_with_dependencies_v1(k.clone(), Vec::new(), Vec::new())
+            .await;
+
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 7).await.is_none());
+        assert!(cache.get_if_fresh_v1(&k, 300).await.is_some());
+    }
+
+    // Read-after-write, eviction leg: a write drops the collection's entries
+    // (CacheInvalidationCoordinator → invalidate_collection), so even an
+    // LSN-pinned entry cannot survive a write — belt-and-suspenders alongside
+    // the LSN-mismatch miss. Together these two legs are why a Strong read never
+    // serves a result that predates a write.
+    #[tokio::test]
+    async fn write_eviction_drops_lsn_pinned_entry() {
+        let cache = QueryCache::new(16);
+        let k = key("c3");
+        cache
+            .cache_with_dependencies_v1_at_lsn(k.clone(), Vec::new(), Vec::new(), 99)
+            .await;
+        // Present at its LSN before the write.
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 99).await.is_some());
+
+        // A write invalidates the collection (removes by collection_id).
+        assert_eq!(cache.invalidate_collection("c3").await, 1);
+
+        // The LSN-pinned entry is gone → the next Strong read recomputes.
+        assert!(cache.get_if_fresh_v1_at_lsn(&k, 300, 99).await.is_none());
+    }
 }


### PR DESCRIPTION
## Decision (ADR-051): keep Strong the default, make it cheap

Investigated whether typed `/search` should stop defaulting to `Strong` freshness (the freshness term behind #634's c16 collapse). **Answer: no — keep Strong.** It's a deliberate, test-asserted read-after-write contract (`default()==Strong`, `core/search/mod.rs:1197`), added *because* a v2 INSERT→SEARCH visibility gap was a production bug, and it matches turbopuffer's strong-consistency default. Weakening it globally is a real semantic regression. The cost is a **cache/scan** problem, not a **semantics** problem — so this keeps the contract and removes the cost.

## The fix (ADR-051 D2)

Strong reads were **100% cache-bypassed** — a cached result could predate a concurrent write because `QueryKey` omits the LSN. Now:
- Each cached result is stamped with `computed_at_lsn` (the canonical-WAL LSN it was computed at, snapshotted once at query start).
- A Strong read serves a cached entry **iff `computed_at_lsn == current_lsn`** (`get_if_fresh_v1_at_lsn`); `current_lsn == 0` (unavailable) never hits.

**Why read-after-write is preserved:** any write both (a) advances the LSN → the entry no longer matches → miss → recompute over the new tail, *and* (b) evicts the collection's cache (`CacheInvalidationCoordinator`). Double-invalidation. A write that races *during* a query advances the LSN past the snapshot, so the entry is simply never served (conservative under-caching, **never a stale hit**).

## Changes

| File | Change |
|---|---|
| `storage/cache/specialized/query_cache.rs` | `computed_at_lsn` field; `get_if_fresh_v1_at_lsn`; `cache_with_dependencies_v1_at_lsn`; **`lsn_gate_tests`** (2 tests, green) |
| `services/operations/vectors/legacy.rs` | `unified_search_v1_inner`: snapshot `query_lsn`, LSN-gate the Strong cache read, stamp the write |
| `core/search/integrated_search_optimization.rs`, `legacy.rs:2119` | the other 2 constructors of the specialized `CachedQueryResult` |
| `docs/adr/ADR-051-*`, `docs/td/TD-STRONG-1-*`, `README.adoc` | decision + follow-ups + index |

## Honest scoping

D2 fixes **repeated-query** Strong concurrency (dashboards, retries, hot queries). It does **not** fix the #634 *benchmark* (all-distinct random vectors don't repeat) — that needs **D3** (per-`(collection,lsn)` shared WAL-tail scan, designed → **TD-STRONG-1**) + **TD-096** (SST block-skip). Both explicitly disclaimed in ADR-051.

**Pre-existing gap flagged (not introduced here):** two other query-cache read sites (`legacy.rs:2071`, `:2640`) have no freshness gate and could serve a Strong read stale today — audited/tracked in TD-STRONG-1 Part B.

## Verification

- `cargo check --lib` ✅ (clean) · `cargo test --lib lsn_gate_tests` ✅ (**2 passed**) · `cargo fmt` ✅ · docs guard **0 errors**.
- **Review-required:** it's a cache-correctness change — CI's Rust build/clippy + the vector-recall/postflush integration suites are the final gate before merge. Leaving unmerged for your review.