### PR TITLE
docs: hotfix main — first-run image refs, README status honesty, OPEN_CORE (cherry-pick #637)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,7 +33,7 @@ This software may include third-party dependencies with their own licenses.
 See Cargo.toml and package.json files for complete dependency information.
 
 For questions, contributions, or support:
-- GitHub: https://github.com/vijaykumarsingh/proximadb
+- GitHub: https://github.com/vjsingh1984/proximadb
 - Email: singhvjd@gmail.com
 
 Built with Rust for the AI revolution.

--- a/OPEN_CORE.md
+++ b/OPEN_CORE.md
@@ -1,0 +1,59 @@
+# ProximaDB Open-Core Boundary
+
+This document declares, in plain terms, what is free and open source forever
+and what the commercial layer sells. It exists so nobody has to guess where
+the seam is.
+
+## The open-source engine is the whole engine
+
+ProximaDB is licensed under [Apache-2.0](LICENSE). The **full single-node
+engine** is open source with **no feature gates**:
+
+- **Every data model** — vector, graph, document, time-series, and events
+- **Postgres wire protocol** (pgwire), including the pgvector-compatible operator
+- **Hybrid search** (dense + BM25 fusion)
+- **The Web UI dashboard**
+- **All SDKs and client libraries**
+- **The reference MCP server**
+
+There is no "community edition" subset, no enterprise-only flag in this
+repository, and no capability that stops working at scale. **Self-hosting
+ProximaDB at any scale is free, and will remain free.**
+
+(Support tiers — Supported / Beta / Experimental / Planned — describe
+engineering maturity, not licensing. See
+[docs/SUPPORTED_SURFACE.adoc](docs/SUPPORTED_SURFACE.adoc). Nothing is held
+back for payment.)
+
+## What the commercial layer sells: operations, never features
+
+The commercial layer (**AnvaiOps**, a separate private repository) sells
+**operations** around the engine, never engine features:
+
+- Managed multi-tenant hosting
+- Governance and capability entitlements
+- Usage metering and billing
+- Disaster recovery
+- Private connectivity
+- A **governed MCP** that layers entitlement, governance, and economics over
+  the open reference MCP
+
+The principle:
+
+> **The engine measures; the commercial layer adds meaning and money —
+> we gate operations, never features.**
+
+ProximaDB ships mechanism and neutral meters (counts, bytes, durations).
+Pricing, entitlement policy, and billing semantics live entirely outside this
+repository (see
+[docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc](docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc)).
+If a change to this repository would make an engine capability conditional on
+a commercial entitlement, that change is on the wrong side of the seam.
+
+## Trademark
+
+The **ProximaDB** name and logo are trademarks of Vijaykumar Singh. The
+Apache-2.0 license covers the code; it does not grant rights to the name or
+logo. You may state truthfully that your product runs on or is compatible
+with ProximaDB, but do not use the name or logo in a way that implies
+endorsement or official status.

--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ See link:docs/02-guides/platform-packages.md[Platform Packages Guide] for detail
 docker run -it --rm \
   -p 5678:5678 \
   -p 5433:5433 \
-  proximadb/proximadb:latest
+  vjsingh1984/proximadb:latest
 ----
 
 === From Source (Rust)
@@ -313,20 +313,27 @@ JOIN LATERAL GRAPH_QUERY('MATCH (s:Service {name: "' || l.service || '"})-[:DEPE
 
 == Feature Status (Builder View)
 
+Statuses use the support-contract ladder from
+link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`]:
+*Supported* / *Beta* / *Experimental* / *Planned*.
+
 |===
 | Capability | Status | Notes
 
-| Vector search + filters | Stable | 4 supported storage engines (SST/VIPER/HELIX/NOVA) + AXIS (HNSW/IVF) indexes, metadata filters
-| Document store | Stable | WAL‑backed, JSON path queries, full‑text search
-| Graph traversal | Stable | ORION (in‑memory CSR), WAL persistence, algorithms
-| Observability logs | Stable | WAL‑backed, partitioned storage, 6 SIEM adapters
-| Observability metrics | Stable | Time‑series aggregation, downsampling
-| Unified multi‑model query | Stable | Cross‑model joins, parallel execution
-| Postgres wire protocol | Stable | DDL/DML, prepared statements, pgvector compatible
-| Unified port mode | Stable | REST + gRPC + Arrow Flight on single port
-| Web UI dashboard | Stable | SQL editor, graph visualization, dark/light theme
-| Python SDK | Stable | Graph analytics, AutoML, observability, security
+| Vector search + filters | Supported | 4 supported storage engines (SST/VIPER/HELIX/NOVA) + AXIS (HNSW/IVF) indexes, metadata filters
+| Document store | Beta | WAL‑backed, JSON path queries, full‑text search; canonical record storage is the convergence path
+| Graph traversal | Beta | ORION (in‑memory CSR), WAL persistence, algorithms; some v1-only RPCs deferred
+| Observability logs | Beta | WAL‑backed, partitioned storage, 6 SIEM adapters
+| Observability metrics | Beta | Time‑series aggregation, downsampling
+| Unified multi‑model query | Beta | Cross‑model joins, parallel execution; strongest on function-backed sources
+| Postgres wire protocol | Supported | ANSI SQL for SQL clients (psql/JDBC/ORM), transactions, pgvector-compatible operator; full Postgres/SQL parity remains Experimental
+| Unified port mode | Experimental | Arrow Flight / gRPC service multiplexing is an experimental customer-facing transport
+| Web UI dashboard | Beta | SQL editor, graph visualization, dark/light theme; fronts Beta surfaces
+| Python SDK | Beta | Graph analytics, AutoML, observability, security; wraps Beta surfaces
 |===
+
+Authoritative status: link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`] — where
+this table and that contract disagree, the contract wins.
 
 NOTE: Tier detail lives in link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`]. A
 few capabilities in the tree are *not* in the supported surface above: the SWIFT and RAPTOR
@@ -380,3 +387,5 @@ Features:
 == License
 
 Apache License 2.0 - See link:LICENSE[LICENSE]
+
+Open-core boundary: the full single-node engine is free forever with no feature gates — see link:OPEN_CORE.md[OPEN_CORE.md] for what the commercial layer sells (operations, never features).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,7 +54,7 @@ docker run -d \
   -p 5678:5678 \
   -p 5679:5679 \
   -v proximadb-data:/data \
-  proximadb/proximadb:latest
+  vjsingh1984/proximadb:latest
 
 # Or build locally
 cd deploy/docker
@@ -334,5 +334,5 @@ curl http://localhost:5678/health
 ## Support
 
 - Documentation: https://docs.proximadb.io
-- Issues: https://github.com/proximadb/proximadb/issues
-- Discussions: https://github.com/proximadb/proximadb/discussions
+- Issues: https://github.com/vjsingh1984/proximadb/issues
+- Discussions: https://github.com/vjsingh1984/proximadb/discussions

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/Dockerfile
-    image: proximadb/proximadb:latest
+    image: vjsingh1984/proximadb:latest
     container_name: proximadb
     restart: unless-stopped
     ports:

--- a/deploy/helm/legacy-proximadb/Chart.yaml
+++ b/deploy/helm/legacy-proximadb/Chart.yaml
@@ -4,9 +4,9 @@ description: A cloud-native vector database for AI applications
 type: application
 version: 0.2.0
 appVersion: "0.2.0"
-home: https://github.com/proximadb/proximadb
+home: https://github.com/vjsingh1984/proximadb
 sources:
-  - https://github.com/proximadb/proximadb
+  - https://github.com/vjsingh1984/proximadb
 maintainers:
   - name: ProximaDB Team
     email: team@proximadb.ai

--- a/deploy/helm/proximadb/values.yaml
+++ b/deploy/helm/proximadb/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: proximadb/proximadb
+  repository: vjsingh1984/proximadb
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion
   tag: ""

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: proximadb
-          image: proximadb/proximadb:0.2.0
+          image: vjsingh1984/proximadb:0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: rest

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -16,5 +16,5 @@ commonLabels:
   app.kubernetes.io/managed-by: kustomize
 
 images:
-  - name: proximadb/proximadb
+  - name: vjsingh1984/proximadb
     newTag: "0.2.0"

--- a/deploy/terraform/modules/proximadb/main.tf
+++ b/deploy/terraform/modules/proximadb/main.tf
@@ -61,7 +61,7 @@ variable "backup_retention_days" {
 variable "container_image" {
   description = "ProximaDB container image"
   type        = string
-  default     = "proximadb/proximadb:latest"
+  default     = "vjsingh1984/proximadb:latest"
 }
 
 variable "rest_port" {

--- a/docs/00-product/COMPETITIVE_LANDSCAPE.adoc
+++ b/docs/00-product/COMPETITIVE_LANDSCAPE.adoc
@@ -1,0 +1,69 @@
+= ProximaDB Competitive Landscape
+:toc: macro
+:icons: font
+
+[.lead]
+Where ProximaDB sits relative to adjacent systems, and where it honestly does not (yet).
+This is a positioning summary derived from link:VISION.adoc[Vision] and link:PRD.adoc[PRD];
+support claims defer to link:../SUPPORTED_SURFACE.adoc[the support contract].
+
+== The Thesis
+
+AI agents do not operate on a single data model. Assembling context for an agent means
+joining episodic events, semantic vectors, a relational graph, and operational documents —
+today that is four or five specialized stores stitched together with brittle ETL and
+application-side joins. ProximaDB's differentiation is multi-model in *one* engine: one
+deployable binary, one SQL-compatible query interface, cross-model joins in one query
+(see the Positioning Statement in link:PRD.adoc[PRD]).
+
+== Category Comparison
+
+[cols="1,2,2", options="header"]
+|===
+| Category | Representative systems | Limitation ProximaDB addresses
+
+| Vector database
+| Pinecone, Milvus, Weaviate
+| Single data model. Vectors are necessary but insufficient — agents need documents,
+graphs, and temporal data alongside embeddings. Forces application-side joins across
+systems.
+
+| Multi-model database
+| ArangoDB, SurrealDB
+| Generic approach without workload-specialized engines. One storage engine cannot
+optimize for both sub-millisecond vector search and high-throughput time-series
+ingestion simultaneously.
+
+| Data platform
+| Snowflake, Databricks
+| Too broad. Optimized for batch analytics and data warehousing, not for low-latency
+serving, embedded deployment, or real-time event processing at the edge.
+
+| Single-model specialists
+| Neo4j (graphs only), TimescaleDB (time-series only)
+| Best-in-class for their one model, but contextual workloads span models; each added
+store adds an ETL pipeline and an operational surface.
+|===
+
+*Migration path*: ProximaDB speaks the Postgres wire protocol with a pgvector-compatible
+distance operator, so pgvector-shaped workloads have a low-friction on-ramp.
+
+== Honest Positioning
+
+Per the link:../SUPPORTED_SURFACE.adoc[support contract]'s own positioning guidance,
+ProximaDB is currently a *developer-first context database*: one system for vectors,
+operational documents, graph context, and telemetry on the single-node developer path.
+It is "not yet a like-for-like replacement for best-in-class distributed vector, graph,
+document, or observability platforms." For petabyte-scale batch analytics, use a
+warehouse (Snowflake, BigQuery, Databricks) today; for general-purpose OLTP with complex
+multi-table transactions, use PostgreSQL today (see the Non-Goals section of
+link:VISION.adoc[Vision]).
+
+The bet is that agent memory does not need five best-in-class distributed systems — it
+needs episodic events + semantic vectors + relational graph + documents answered from one
+engine, in one query. That is the surface ProximaDB optimizes for.
+
+No benchmark numbers are claimed here; reproducible comparisons against Milvus, Qdrant,
+Weaviate, and Chroma are a stated roadmap milestone in link:VISION.adoc[Vision], and any
+published performance figure must trace to a measured entry in the benchmark evidence
+ledger referenced by the support contract.

--- a/docs/01-quick-start/index.md
+++ b/docs/01-quick-start/index.md
@@ -33,7 +33,7 @@ flowchart LR
 
 ```bash
 # 1. Run ProximaDB
-docker run -d -p 5678:5678 --name proximadb proximadb/proximadb:latest
+docker run -d -p 5678:5678 --name proximadb vjsingh1984/proximadb:latest
 
 # 2. Wait for startup (5 seconds)
 sleep 5

--- a/docs/01-quick-start/install.md
+++ b/docs/01-quick-start/install.md
@@ -111,7 +111,7 @@ docker run -d \
   -p 5678:5678 \
   -p 5433:5433 \
   -v proximadb-data:/var/lib/proximadb \
-  proximadb/proximadb:latest
+  vjsingh1984/proximadb:latest
 
 # Check logs
 docker logs -f proximadb
@@ -127,7 +127,7 @@ curl http://localhost:5678/health
 version: '3.8'
 services:
   proximadb:
-    image: proximadb/proximadb:latest
+    image: vjsingh1984/proximadb:latest
     ports:
       - "5678:5678"  # Unified API
       - "5433:5433"  # PostgreSQL wire
@@ -302,10 +302,10 @@ msiexec /i proximadb-0.2.1-x64.msi
 ### Docker
 
 ```bash
-docker pull proximadb/proximadb:latest
+docker pull vjsingh1984/proximadb:latest
 docker stop proximadb
 docker rm proximadb
-docker run -d ... proximadb/proximadb:latest
+docker run -d ... vjsingh1984/proximadb:latest
 ```
 
 ### From Source

--- a/docs/04-operations/deployment.adoc
+++ b/docs/04-operations/deployment.adoc
@@ -21,7 +21,7 @@ cargo run --release --bin proximadb-server
 docker run -it --rm \
   -p 5678:5678 \
   -p 5679:5679 \
-  proximadb/proximadb:latest
+  vjsingh1984/proximadb:latest
 ----
 
 == Config‑Driven Run

--- a/docs/04-operations/index.md
+++ b/docs/04-operations/index.md
@@ -52,7 +52,7 @@ flowchart TB
 version: '3.8'
 services:
   proximadb:
-    image: proximadb/proximadb:latest
+    image: vjsingh1984/proximadb:latest
     ports:
       - "5678:5678"
       - "5433:5433"

--- a/docs/06-internals/deep-dives/hybrid-columnar-engines.adoc
+++ b/docs/06-internals/deep-dives/hybrid-columnar-engines.adoc
@@ -27,7 +27,7 @@ ProximaDB's intelligent storage engines automatically optimize for your specific
 == Storage Engine Intelligence in Action
 
 .ProximaDB automatically selects the optimal storage engine for your workload
-image::https://raw.githubusercontent.com/proximadb/proximadb/main/docs/assets/storage-engines-hero.svg[Storage Engine Selection,700,align=center]
+image::https://raw.githubusercontent.com/vjsingh1984/proximadb/main/docs/assets/storage-engines-hero.svg[Storage Engine Selection,700,align=center]
 
 [source,mermaid]
 ----

--- a/docs/10-quality/benchmarks/BENCHMARKS.adoc
+++ b/docs/10-quality/benchmarks/BENCHMARKS.adoc
@@ -275,7 +275,7 @@ We welcome community benchmark submissions. To submit your results:
 
 1. Run benchmarks with `--output-json` flag
 2. Include hardware configuration
-3. Submit PR to `https://github.com/proximadb/proximadb`
+3. Submit PR to `https://github.com/vjsingh1984/proximadb`
 4. Results will be verified and added to public leaderboard
 
 == Transparency

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -26,7 +26,7 @@ Developer-first documentation for building multi-model applications on ProximaDB
 
 | link:00-product/VISION.adoc[Vision] | "The Context Database" — category definition, design principles, 3-year horizon
 | link:00-product/PRD.adoc[PRD] | MoSCoW feature requirements, quality targets, release milestones
-| link:00-product/COMPETITIVE_LANDSCAPE.adoc[Competitive Landscape] | Market sizing, competitor matrices, SWOT, positioning
+| link:00-product/COMPETITIVE_LANDSCAPE.adoc[Competitive Landscape] | Category comparison + honest positioning vs. adjacent systems (defers to SUPPORTED_SURFACE)
 |===
 
 ProximaDB development follows four phases:

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ brew services start proximadb
 ### Install (Docker)
 
 ```bash
-docker run -d -p 5678:5678 proximadb/proximadb:latest
+docker run -d -p 5678:5678 vjsingh1984/proximadb:latest
 ```
 
 ### Verify


### PR DESCRIPTION
Clean cherry-pick of 87de059d7 (#637, already on develop) onto main so the funnel fixes are publicly visible now, without a full 747-commit release promotion:

- `docker run` image refs fixed to the real `vjsingh1984/proximadb` org (`:latest` is now published, amd64+arm64 — the quick start works end-to-end)
- README feature-status table reconciled to SUPPORTED_SURFACE.adoc ("the contract wins" line added)
- New: OPEN_CORE.md (gate operations, never features) + docs/00-product/COMPETITIVE_LANDSCAPE.adoc (fixes the dangling VISION/PRD links)
- NOTICE org drift fixed

Direct-to-main fix PRs are precedented (#594, #600). Identical content already on develop, so future promotions won't conflict.