### PR TITLE
fix(search): Strong reads bypass the query cache on the secondary search paths (TD-STRONG-1 Part B)

### DIFF
--- a/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
+++ b/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
@@ -49,24 +49,28 @@ via the `query_changes` CI filter.
 an O(N) linear tail scan) is a separate structural lever that only pays off with
 TD-096 (HELIX block-skip on the flushed side).
 
-== Part B — Close the ungated query-cache read sites (SEC/correctness)
+== Part B — Close the ungated query-cache read sites (SEC/correctness) — DONE
 
-Two query-cache read sites carry **no freshness gate** — they serve any
-TTL-fresh entry regardless of `VectorFreshnessMode`, so a Strong read routed
-through them could be served a result that predates a write:
+**Reachability confirmed:** `unified_search` is called live from the RAG engine
+(`src/graph/rag/engine_impls.rs`) and forwards to `unified_search_with_tenant_context`,
+so a Strong read *can* reach the ungated cache — a real read-after-write gap, not
+just a doc note. The audit found **three** ungated `get_if_fresh` read sites (a
+third beyond the two originally listed):
 
-* `unified_search_with_tenant_context` — `src/services/operations/vectors/legacy.rs:2071`
-  (`get_if_fresh`, no gate).
-* `unified_search_with_hints` — `src/services/operations/vectors/legacy.rs:2640`
-  (`get_if_fresh`, no gate).
+* `unified_search_with_tenant_context`
+* `unified_search_with_hints`
+* `execute_search_internal`
 
-This is **pre-existing** (independent of ADR-051; the v1 core path
-`unified_search_v1_inner` is the one that gates). Action:
-1. Audit whether either path actually receives Strong reads on a live route (if
-   neither does, downgrade to a doc note).
-2. If so, extend the same LSN gate (`get_if_fresh_v1_at_lsn` +
-   `cache_with_dependencies_v1_at_lsn`, added in ADR-051 D2) to those sites, or
-   route them through the gated core.
+**Fix (landed):** each now gates the cache read on freshness — **Strong reads
+bypass the query cache** (recompute); only `StaleOk` / `BoundedStale` may be
+served a cached entry. Same invariant the ADR-051 D2 primary path enforces.
+Minimal-correct over full D2 LSN-caching: these are secondary paths, and bypass
+is the obviously-safe close of the gap (LSN-caching them for the repeated-query
+benefit is a possible later perf follow-up, not correctness).
+
+Test: `strong_read_bypasses_query_cache_on_tenant_context_path` seeds the cache
+with a sentinel and asserts a `StaleOk` read is served it while a `Strong` read
+bypasses it (runs via `cargo nextest run --lib` — gated on any `src/` change).
 
 == Done when
 

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2067,8 +2067,19 @@ impl VectorOperationsService {
             filter_str.as_deref(),
         );
 
-        // Check cache first
-        if let Some(cached) = self.query_cache.get_if_fresh(&cache_key, 300).await {
+        // Only non-Strong (StaleOk / BoundedStale) reads may use the query
+        // cache — a Strong read could be served an entry that predates a
+        // concurrent write, violating read-after-write. Gate the cache read on
+        // freshness (mirrors unified_search_v1_inner); Strong reads recompute.
+        let freshness_mode = config
+            .as_ref()
+            .and_then(|c| c.freshness_mode.clone())
+            .unwrap_or_default();
+        if !matches!(
+            freshness_mode,
+            crate::core::search::VectorFreshnessMode::Strong
+        ) && let Some(cached) = self.query_cache.get_if_fresh(&cache_key, 300).await
+        {
             debug!(
                 "✅ Cache hit for unified search in collection {}",
                 collection_id
@@ -2662,7 +2673,17 @@ impl VectorOperationsService {
             filter_str.as_deref(),
         );
         let mut hints = SearchPlanHints::default();
-        if let Some(cached) = self.query_cache.get_if_fresh(&cache_key, 300).await {
+        // Strong reads bypass the query cache (read-after-write); only
+        // StaleOk / BoundedStale may be served a cached entry.
+        let freshness_mode = config
+            .as_ref()
+            .and_then(|c| c.freshness_mode.clone())
+            .unwrap_or_default();
+        if !matches!(
+            freshness_mode,
+            crate::core::search::VectorFreshnessMode::Strong
+        ) && let Some(cached) = self.query_cache.get_if_fresh(&cache_key, 300).await
+        {
             hints.cache_hit = true;
             return Ok((cached, hints));
         }
@@ -2791,8 +2812,14 @@ impl VectorOperationsService {
             filter_str.as_deref(),
         );
 
-        // Check cache first (5 minute TTL)
-        if let Some(cached_results) = self.query_cache.get_if_fresh(&cache_key, 300).await {
+        // Check cache first (5 minute TTL). Strong reads bypass the cache —
+        // a cached entry could predate a concurrent write (read-after-write);
+        // only StaleOk / BoundedStale may be served from it.
+        if !matches!(
+            freshness_mode,
+            crate::core::search::VectorFreshnessMode::Strong
+        ) && let Some(cached_results) = self.query_cache.get_if_fresh(&cache_key, 300).await
+        {
             debug!("✅ Cache hit for query in collection {}", collection_id);
             return Ok(cached_results);
         }
@@ -4846,6 +4873,98 @@ mod index_first_search_tests {
         assert!(
             err.to_string()
                 .contains("Query vector has dimension 2 but collection 'validation-collection' expects dimension 3")
+        );
+    }
+
+    // Part B (TD-STRONG-1): the secondary search entry points must respect
+    // freshness — a Strong read must NOT be served a query-cache entry that
+    // predates a write. Seed a sentinel the real search never returns: a StaleOk
+    // read is served it (proving the cache is consulted), a Strong read bypasses
+    // it (read-after-write). Same gate now applies to unified_search_with_hints
+    // and execute_search_internal.
+    #[tokio::test]
+    async fn strong_read_bypasses_query_cache_on_tenant_context_path() {
+        let (service, _temp_dir) = create_test_service().await.unwrap();
+        cache_test_collection(&service, "freshness-coll", 3);
+        service
+            .insert_records_with_tenant_context(
+                "freshness-coll",
+                vec![record_with_vector("real-1", vec![1.0, 2.0, 3.0])],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let qv = vec![1.0f32, 2.0, 3.0];
+        let k = 5usize;
+        let cache_key = crate::storage::cache::specialized::query_cache::QueryKey::new(
+            "freshness-coll".to_string(),
+            &qv,
+            k as u32,
+            None,
+        );
+        // A sentinel the real search can never produce — marked via the
+        // response wrapper's `collection_id` field (v1 SearchResult is a
+        // {results, total_found, collection_id} envelope, not a record).
+        let stale = crate::proto::proximadb_v1::SearchResult {
+            results: Vec::new(),
+            total_found: 0,
+            collection_id: Some("SENTINEL-MARKER".to_string()),
+        };
+        service
+            .query_cache
+            .cache_with_dependencies(cache_key, vec![stale], Vec::new())
+            .await;
+
+        let mut stale_ok =
+            crate::services::operations::vectors::config::UnifiedSearchConfig::default();
+        stale_ok.freshness_mode = Some(crate::core::search::VectorFreshnessMode::StaleOk);
+        let mut strong =
+            crate::services::operations::vectors::config::UnifiedSearchConfig::default();
+        strong.freshness_mode = Some(crate::core::search::VectorFreshnessMode::Strong);
+
+        // StaleOk is served the seeded (stale) cache entry.
+        let served = service
+            .unified_search_with_tenant_context(
+                "freshness-coll",
+                qv.clone(),
+                k,
+                None,
+                Some(stale_ok),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            served
+                .iter()
+                .any(|r| r.collection_id.as_deref() == Some("SENTINEL-MARKER")),
+            "StaleOk read should be served the cached entry (proves the cache is consulted)"
+        );
+
+        // Strong bypasses the cache. It then runs the real search, which may
+        // error in this minimal harness — that's fine: the invariant is that a
+        // Strong read must NOT be served the seeded sentinel. If the gate were
+        // broken, `fresh` would be Ok([sentinel]); a bypass yields either Err or
+        // Ok(real-results-without-sentinel).
+        let fresh = service
+            .unified_search_with_tenant_context(
+                "freshness-coll",
+                qv.clone(),
+                k,
+                None,
+                Some(strong),
+                None,
+            )
+            .await;
+        let served_stale = matches!(
+            &fresh,
+            Ok(v) if v.iter().any(|r| r.collection_id.as_deref() == Some("SENTINEL-MARKER"))
+        );
+        assert!(
+            !served_stale,
+            "Strong read must bypass the stale cache entry (read-after-write); got Ok len {:?}",
+            fresh.as_ref().map(|v| v.len())
         );
     }
 


### PR DESCRIPTION
## The gap (pre-existing, read-after-write / SEC)

Three query-cache read sites served **any** TTL-fresh entry regardless of `VectorFreshnessMode`, so a **Strong** read routed through them could be served a result that predates a concurrent write. The ADR-051 **D2** gate only covered the v1 core path (`unified_search_v1_inner`).

**Reachability confirmed** (not just a doc note): `unified_search` is called live from the **RAG engine** (`graph/rag/engine_impls.rs`) and forwards to `unified_search_with_tenant_context` — so Strong reads *do* reach the ungated cache. The audit found a **third** site beyond the two originally flagged.

## The fix

Gate each site on freshness — **Strong reads bypass the cache and recompute**; only `StaleOk`/`BoundedStale` may be served a cached entry (the invariant the primary path already enforces):

- `unified_search_with_tenant_context`
- `unified_search_with_hints`
- `execute_search_internal` (already takes `freshness_mode`)

**Minimal-correct** (Strong bypasses) over full D2 LSN-caching: these are secondary paths, and bypass is the obviously-safe close of the gap. LSN-caching them for the repeated-query perf benefit is a possible later follow-up, not correctness.

## TDD

`strong_read_bypasses_query_cache_on_tenant_context_path` — deterministic read-after-write test: seed the cache with a sentinel, then assert a `StaleOk` read **is** served it (cache consulted) while a `Strong` read does **not** return it (bypass). It correctly detects a broken gate (Strong would return `Ok([sentinel])`) while tolerating the minimal harness's real-search error on the bypass path. Runs via `cargo nextest run --lib` → gates any `src/` change.

## Verification

`cargo test --lib` (new test **green**) · `cargo fmt` · v1→v2 ratchet **-2** (down) · td-adr guard 0 errors. Worktree workflow; pre-push gates passed.

Completes **TD-STRONG-1**: Part A (distinct-query alloc, #645) + Part B (this) done; D2 (LSN cache, #640) done. Review-required.