### PR TITLE
fix(sst): skip coarse AXIS rebuild for RaBitQ-PAX cold reads → cascade

### DIFF
--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -501,6 +501,29 @@ impl SstEngine {
             _ => return,
         };
 
+        // M1-3 cold-read recall: if EVERY durable segment is a RaBitQ-PAX segment
+        // WITHOUT an f32 tier (the default write format), rebuilding AXIS from it
+        // would index COARSE RaBitQ-reconstructed vectors (block-format reader.rs:
+        // "RaBitQ is a search representation; reconstruction is coarse") → ~0.46
+        // recall — WORSE than letting the cold search fall through to the RaBitQ
+        // cascade (~0.93, which ranks the RaBitQ codes properly via
+        // `try_pax_cascade`). Skip the lossy rebuild; the dispatch fallback
+        // reaches the cascade for `.pax` Euclidean/Cosine. Any exact-readable
+        // segment (RawF32/SQ8/RaBitQ-with-tier/`.sst`/`.arrow`) breaks the
+        // `all()` check and rebuilds normally (exact AXIS). See
+        // `pax_segment_is_coarse_rabitq_without_f32_tier`.
+        if self
+            .all_segments_coarse_rabitq_pax_without_f32_tier(&files)
+            .await
+        {
+            tracing::info!(
+                "M1-3 cold-read: RaBitQ-PAX without f32 tier for '{collection_id}' ({} segments) \
+                 — skipping coarse AXIS rebuild; cold reads use the RaBitQ cascade",
+                files.len()
+            );
+            return;
+        }
+
         // Read all records from the durable SST segments via the storage trait's
         // `read_all_records` (UnifiedSSTReader::read_batch). The per-segment
         // `read_segment_records` / `read_all_records_for_compaction` path returned
@@ -538,6 +561,33 @@ impl SstEngine {
                 "TD-112 rebuild: AXIS rebuild-from-SST failed for '{collection_id}': {e}"
             ),
         }
+    }
+
+    /// True iff EVERY file in `files` is a `.pax` segment whose `EMBED_BASE` is
+    /// RaBitQ-coded with no f32 tier (i.e. no exact data — an AXIS rebuild from
+    /// it would be coarse). Used by [`ensure_axis_index_from_sst`] to skip the
+    /// lossy rebuild for default RaBitQ-PAX collections so cold reads use the
+    /// RaBitQ cascade. A non-`.pax` file, a read error, or any exact-readable
+    /// segment (RawF32/SQ8/RaBitQ-with-tier) returns `false` (→ rebuild).
+    /// Short-circuits on the first non-coarse segment. `files` is non-empty when
+    /// called from the rebuild path.
+    async fn all_segments_coarse_rabitq_pax_without_f32_tier(&self, files: &[String]) -> bool {
+        use crate::storage::engines::sst::segment_format::pax_segment_is_coarse_rabitq_without_f32_tier;
+        for file in files {
+            if !file.ends_with(".pax") {
+                return false; // legacy `.sst` / `.arrow` → exact-readable → rebuild
+            }
+            let Ok(fs) = self.filesystem().get_filesystem(file) else {
+                return false; // can't open → don't skip; let the rebuild try
+            };
+            let Ok(bytes) = fs.read(file).await else {
+                return false;
+            };
+            if !pax_segment_is_coarse_rabitq_without_f32_tier(&bytes) {
+                return false; // RawF32/SQ8/RaBitQ-with-tier → rebuild exact
+            }
+        }
+        !files.is_empty()
     }
 
     /// Read all records from one SST segment, dispatching on the engine's block

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -223,6 +223,42 @@ pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
     false
 }
 
+/// True iff `bytes` is a `.pax` SEGMENT whose `EMBED_BASE` column is RaBitQ-coded
+/// AND no `F32_TIER_BASE` column is present — i.e. the segment carries NO exact
+/// vectors, so an AXIS index rebuilt from it (via [`read_segment_records`] →
+/// `decode_rabitq_reconstruct`) would be COARSE (low recall). The reopen-rebuild
+/// path (`ensure_axis_index_from_sst`) uses this to SKIP rebuilding a lossy AXIS
+/// for default RaBitQ-PAX collections, so cold reads fall through to the RaBitQ
+/// cascade (`try_pax_cascade`, which ranks the RaBitQ codes properly, ~0.93
+/// recall) instead of a coarse rebuilt index (~0.46). Returns `false` for non-Pax,
+/// non-RaBitQ quants (RawF32/SQ8/FP16 = exact/near-exact → rebuild), RaBitQ WITH
+/// an f32 tier (exact via the tier → rebuild), or any parse error (→ rebuild).
+///
+/// Pure over `bytes` so it's unit-testable; the engine reads bytes via the
+/// filesystem trait (object-store-safe) and calls this. Mirrors
+/// [`pax_inputs_have_f32_tier`]'s `PaxSegmentScanner` block-0 metadata read.
+pub fn pax_segment_is_coarse_rabitq_without_f32_tier(bytes: &[u8]) -> bool {
+    use proximadb_block_format::vparam::QUANT_RABITQ_RESERVED;
+    if SegmentFormat::detect(bytes) != SegmentFormat::Pax {
+        return false;
+    }
+    // A `.pax` SEGMENT is `[block(s)][segment_index][SEGMENT_MAGIC]`; the scanner
+    // parses the trailing index + magic and yields block 0 (see
+    // [`pax_inputs_have_f32_tier`]).
+    let Ok(mut scanner) = PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())
+    else {
+        return false;
+    };
+    let Some(reader) = scanner.next_block() else {
+        return false;
+    };
+    let vparams = reader.vector_params();
+    let Some(embed) = vparams.get(col_id::EMBED_BASE) else {
+        return false;
+    };
+    embed.quant_kind == QUANT_RABITQ_RESERVED && vparams.get(col_id::F32_TIER_BASE).is_none()
+}
+
 /// Detect the tier-2 rerank quant strategy of the source `.pax` segments, so
 /// compaction PRESERVES it when re-encoding (mirrors [`pax_inputs_have_f32_tier`]
 /// for the f32 tier). Returns the first detected strategy from the co-located
@@ -599,6 +635,68 @@ mod tests {
         let bytes2 = std::fs::read(&path).unwrap();
         let back = read_segment_records(&bytes2, &[], &[], None).unwrap();
         assert_eq!(back.len(), records.len());
+    }
+
+    /// `pax_segment_is_coarse_rabitq_without_f32_tier` classifies a segment by its
+    /// block-0 column metadata: true ONLY for RaBitQ `EMBED_BASE` without an f32
+    /// tier (the default → coarse rebuild → skip AXIS), false for RawF32/SQ8
+    /// (exact / near-exact → rebuild) and RaBitQ-with-tier (exact via tier →
+    /// rebuild). Drives the cold-read recall fix in `ensure_axis_index_from_sst`.
+    #[test]
+    fn pax_segment_is_coarse_rabitq_without_f32_tier_classifies_segments() {
+        let records: Vec<ProximaRecord> = (0..8)
+            .map(|i| {
+                rec(
+                    &format!("v{i}"),
+                    1_700_000_000_000_000_000 + i,
+                    (0..16).map(|d| (i as f32 + d as f32) * 0.1).collect(),
+                )
+            })
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+
+        // RaBitQ, no f32 tier (the default) → coarse → true (skip AXIS rebuild).
+        let path = dir.path().join("rabitq.pax");
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            pax_segment_is_coarse_rabitq_without_f32_tier(&bytes),
+            "RaBitQ-PAX without f32 tier is coarse → skip AXIS rebuild"
+        );
+
+        // RawF32 → exact → false.
+        let path = dir.path().join("rawf32.pax");
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RawF32, None).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            !pax_segment_is_coarse_rabitq_without_f32_tier(&bytes),
+            "RawF32-PAX is exact → rebuild AXIS"
+        );
+
+        // SQ8 → near-exact → false.
+        let path = dir.path().join("sq8.pax");
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::Sq8, None).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            !pax_segment_is_coarse_rabitq_without_f32_tier(&bytes),
+            "SQ8-PAX is near-exact → rebuild AXIS"
+        );
+
+        // RaBitQ WITH f32 tier → exact via tier → false.
+        let path = dir.path().join("rabitq_tier.pax");
+        write_pax_segment_with_f32_tier(&path, &records, "col", 1, VectorQuant::RaBitQ, true, None)
+            .unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(
+            !pax_segment_is_coarse_rabitq_without_f32_tier(&bytes),
+            "RaBitQ-PAX with f32 tier is exact → rebuild AXIS"
+        );
+
+        // Non-PAX bytes → false (treated as exact-readable → rebuild).
+        assert!(
+            !pax_segment_is_coarse_rabitq_without_f32_tier(&[0u8; 64]),
+            "non-PAX bytes → false"
+        );
     }
 
     /// M1 (ADR-049): a `VectorQuant::RawF32` PAX segment carries no RaBitQ codes,


### PR DESCRIPTION
## Summary

Fixes a **cold-read recall regression** (pre-existing since M1-1b's PAX default-on flip, **not** caused by 9a — verified identical on the pre-9a tip `5ff43cc25`). `cold_read_recall_survives_flush_and_reopen` failed: hot (memtable) recall@10 = 1.000 but cold (post-reopen) = **0.460**. This blocked the develop→qa promotion's `pgwire-recall-tests` gate (and thus 9b's recall sign-off), independent of 9a.

## Root cause
On reopen, `ensure_axis_index_from_sst` rebuilt the per-collection AXIS (HNSW) index from on-disk RaBitQ-PAX segments via `read_segment_records` → `EMBED_BASE` → coarse `decode_rabitq_reconstruct` (block-format `reader.rs`: *"RaBitQ is a search representation; reconstruction is coarse"*). The rebuilt AXIS indexed coarse vectors → 0.46 recall — **worse** than the RaBitQ cascade (~0.93, which ranks the RaBitQ codes properly via `try_pax_cascade`). The cold search preferred the coarse AXIS over the cascade. Default RaBitQ-PAX carries no f32 tier, so no exact read exists for it (`search_pax_file_exact` is equally coarse).

## Fix (Approach 1 — no storage cost)
When **every** durable segment is RaBitQ-PAX **without** an f32 tier (the default), **skip the coarse AXIS rebuild** so cold reads fall through to the RaBitQ cascade. New `pax_segment_is_coarse_rabitq_without_f32_tier(bytes)` detects this from block-0 column metadata (`EMBED_BASE` quant == RaBitQ AND no `F32_TIER_BASE`), reusing the `pax_inputs_have_f32_tier` PaxSegmentScanner pattern. RawF32-PAX / `.sst` / `.arrow` / SQ8 / RaBitQ-with-tier all return `false` → rebuild exactly (AXIS stays for those).

## Result
`cold_read_recall`: **0.460 → 1.000** (at N=1000/k=10 the cascade's RaBitQ pool covers all rows → effectively exact; the 0.932 is the N=100k number).

## Behavior change (noted)
Default RaBitQ-PAX cold reads trade AXIS (HNSW) acceleration for cascade-scan latency. Accepted per the chosen approach — mandate-#8 fast+exact (f32-tier default → exact AXIS rebuild) is deferred to a future PR.

## Verification (all green)
- `cold_read_recall_survives_flush_and_reopen`: 0.46 → **1.000**.
- `td112_postflush_recall_e2e` (RawF32-PAX rebuild): still passes (skip is RaBitQ-specific).
- `vector_ann_recall_e2e` (flush-time AXIS): still 1.0 (unaffected — only the reopen-rebuild is gated).
- New unit test `pax_segment_is_coarse_rabitq_without_f32_tier_classifies_segments` (RaBitQ→true, RawF32/SQ8/RaBitQ+tier→false).
- Local gates: `cargo fmt --all --check`, `cargo clippy --lib --bins -- -D warnings`, `cargo check --tests`, `make workspace-boundaries-check`.

## Why no separate RawF32 guard test
An explicit RawF32-PAX guard turned out to assert the wrong thing — RawF32-PAX cold reads route through AXIS HNSW (approximate, ~0.85 top-1 at this scale), not an exact scan, so a `≥0.95` assertion was incorrect. The RawF32 rebuild path is already covered by `td112_postflush_recall_e2e` (integration) and the new unit test (detection).

## Files
- `src/storage/engines/sst/segment_format.rs` — `pax_segment_is_coarse_rabitq_without_f32_tier` + unit test.
- `src/storage/engines/sst/search/mod.rs` — `all_segments_coarse_rabitq_pax_without_f32_tier` + skip in `ensure_axis_index_from_sst`.