### PR TITLE
feat(modalities): real time-series REST surface + graph-query v2 migration (Cypher values)

### DIFF
--- a/crates/platform/proximadb-api/src/rest/v1/graph.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/graph.rs
@@ -47,8 +47,8 @@ use proximadb_proto::v1::PropertyValue;
 use proximadb_proto::v1::{
     BatchEdgeRequest, BatchNodeRequest, CreateEdgeRequest, CreateGraphRequest, CreateNodeRequest,
     DeleteEdgeRequest, DeleteNodeRequest, Edge, EdgeQuery, EmbeddingVersion, GetEdgeRequest,
-    GetNeighborsRequest, GetNodeRequest, GetStatsRequest, GraphQueryRequest, GraphSchema, Node,
-    NodeQuery, PropertyFilter, PropertyFilterOperator, ShortestPathAlgorithm, TraversalAlgorithm,
+    GetNeighborsRequest, GetNodeRequest, GetStatsRequest, GraphSchema, Node, NodeQuery,
+    PropertyFilter, PropertyFilterOperator, ShortestPathAlgorithm, TraversalAlgorithm,
     TraversalRequest, UniqueConstraintRequest, UpdateEdgeRequest, UpdateNodeRequest,
     property_value,
 };
@@ -502,8 +502,13 @@ struct BatchCreateEdgesRequest {
 #[derive(Debug, Deserialize)]
 struct RestGraphQueryRequest {
     query: String,
+    // Accepted for wire compatibility (clients send `language: "cypher"`), but the
+    // query type is inferred by the shared query adapter from the query text; and
+    // `timeout_ms` is reserved for future per-query deadline plumbing (TD-GRAPH-2).
     #[serde(default = "default_query_language")]
+    #[allow(dead_code)]
     language: String,
+    #[allow(dead_code)]
     timeout_ms: Option<u32>,
 }
 
@@ -1130,38 +1135,12 @@ async fn execute_graph_query(
     Path(graph_id): Path<String>,
     Json(req): Json<RestGraphQueryRequest>,
 ) -> impl IntoResponse {
-    use proximadb_proto::v1::QueryLanguage;
-
-    let language = match req.language.to_ascii_lowercase().as_str() {
-        "cypher" => QueryLanguage::Cypher as i32,
-        "gremlin" => QueryLanguage::Gremlin as i32,
-        _ => QueryLanguage::Native as i32,
-    };
-
-    let proto_req = GraphQueryRequest {
-        graph_id,
-        language,
-        query: req.query,
-        parameters: HashMap::new(),
-        timeout_ms: req.timeout_ms,
-        options: None,
-    };
-
-    match s.graph_port.execute_query(proto_req).await {
-        Ok(resp) => {
-            // Convert result rows to JSON
-            let rows: Vec<serde_json::Value> = resp
-                .rows
-                .iter()
-                .map(|row| {
-                    let cols: serde_json::Map<String, serde_json::Value> = row
-                        .columns
-                        .keys()
-                        .map(|k| (k.clone(), serde_json::Value::Null))
-                        .collect();
-                    serde_json::Value::Object(cols)
-                })
-                .collect();
+    // v2-era path (TD-GRAPH-2): the engine yields result rows as `serde_json::Value`
+    // directly, so this REST surface bypasses the legacy v1 `QueryValue` /
+    // `GraphQueryResponse` wrapping entirely. The declarative language (cypher) is
+    // interpreted by the shared query adapter from the query text.
+    match s.graph_port.execute_query_json(&graph_id, &req.query).await {
+        Ok(rows) => {
             #[derive(Serialize)]
             struct QueryResult {
                 rows: Vec<serde_json::Value>,
@@ -1933,7 +1912,7 @@ mod tests {
 
         async fn execute_query(
             &self,
-            _request: GraphQueryRequest,
+            _request: proto::GraphQueryRequest,
         ) -> Result<proto::GraphQueryResponse> {
             let mut columns = HashMap::new();
             columns.insert("n".to_string(), proto::QueryValue::default());
@@ -1943,6 +1922,13 @@ mod tests {
                 query_plan: None,
                 error_message: None,
             })
+        }
+        async fn execute_query_json(
+            &self,
+            _graph_id: &str,
+            _query: &str,
+        ) -> Result<Vec<serde_json::Value>> {
+            self.ok_or_fail(vec![serde_json::json!({"n": {"id": "mock"}})])
         }
 
         async fn get_neighbors(

--- a/crates/platform/proximadb-runtime/src/graph_port.rs
+++ b/crates/platform/proximadb-runtime/src/graph_port.rs
@@ -44,6 +44,15 @@ pub trait GraphPort: Send + Sync {
     async fn query_nodes(&self, request: NodeQuery) -> Result<BatchResponse>;
     async fn query_edges(&self, request: EdgeQuery) -> Result<BatchResponse>;
     async fn execute_query(&self, request: GraphQueryRequest) -> Result<GraphQueryResponse>;
+    /// Execute a declarative graph query and return result rows as raw JSON.
+    /// The engine already yields node/row payloads as `serde_json::Value`, so this
+    /// is the v2-era path for JSON surfaces (REST): it bypasses the legacy v1
+    /// `QueryValue`/`GraphQueryResponse` wrapping entirely. See TD-GRAPH-2.
+    async fn execute_query_json(
+        &self,
+        graph_id: &str,
+        query: &str,
+    ) -> Result<Vec<serde_json::Value>>;
     async fn get_neighbors(&self, request: GetNeighborsRequest) -> Result<BatchResponse>;
 
     // ── Traversal ─────────────────────────────────────────────────────────

--- a/docs/10-quality/td/TD-GRAPH-2-graph-query-v2-proto-migration.adoc
+++ b/docs/10-quality/td/TD-GRAPH-2-graph-query-v2-proto-migration.adoc
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GRAPH-2: Migrate the graph-query surface off the v1 proto (retire v1 QueryValue)
+
+[cols="1,3"]
+|===
+|Status|In Progress
+|Priority|MED
+|Scope|FEAT
+|Date|2026-07-03
+|Relates to|`GraphPort` (`crates/platform/proximadb-runtime/src/graph_port.rs`), the served graph router (`crates/platform/proximadb-api/src/rest/v1/graph.rs`, mounted at `/api/v2/graphs`), the Orion engine + `QueryFacadeAdapter`, the v2 graph proto (`proto/proximadb/v2/graph.proto`)
+|===
+
+== Context
+
+The declarative Cypher surface `POST /api/v2/graphs/{id}/query` (Orion, wired via
+`QueryFacadeAdapter::graph_query`) is live, but the served REST handler ran on the
+**v1 proto** path: `GraphPort::execute_query → v1 GraphQueryResponse` with v1
+`QueryValue`, and the handler discarded every column value
+(`row.columns.keys().map(|k| (k, Value::Null))`) — it returned `row_count` + column
+*names* but `null` for every *value*. Meanwhile a parallel **v2** graph-query stack
+exists (`src/network/grpc/v2/graph_service.rs`, `GraphPropertyValue`/
+`ExecuteGraphQueryRow`) with literal `property_value_to_v1`/`_to_v2` converters — the
+URL was `/api/v2` but the REST wire types were still v1. Both stacks ultimately call
+the same `QueryFacadeAdapter::graph_query`, which already yields
+`Vec<serde_json::Value>` — so for a JSON surface, either proto wrapper is a needless
+round-trip.
+
+== Landed (this PR)
+
+* New `GraphPort::execute_query_json(graph_id, query) -> Vec<serde_json::Value>` — the
+  v2-era JSON path. `GraphServiceImpl` implements it by calling the shared
+  `QueryFacadeAdapter` directly and returning the engine's raw JSON rows; **no v1
+  `QueryValue` wrapping** (mocks stubbed).
+* The REST `execute_graph_query` handler now calls `execute_query_json` and returns the
+  values directly — the value-loss bug is fixed (Cypher `MATCH … RETURN x` returns node
+  properties, not `null`), and the handler no longer touches the v1 proto. The v1
+  `QueryValue`/`PropertyValue` JSON-conversion helpers were deleted.
+
+== Remaining (full v1 retirement)
+
+* Retire `GraphPort::execute_query` (the v1 `GraphQueryResponse` method) once no caller
+  needs it, and drop the v1 `graph.proto` query types + the
+  `property_value_to_v1`/`_to_v2` converters (`src/network/grpc/v2/graph_service.rs`).
+* **Module relocation (TD-GRAPH-1 territory):** the *served* graph router lives in the
+  legacy-named `crates/platform/proximadb-api/src/rest/v1/graph.rs` though mounted at
+  `/api/v2/graphs`; relocate it to a `…/rest/v2/graphs.rs` module and **delete the dead
+  `src/network/rest/v1/graph.rs`** (zero callers).
+* Plumb `parameters` binding through the Cypher REST request (currently ignored), and
+  implement the `/rag` stub.

--- a/docs/10-quality/td/TD-TS-1-timeseries-rest-surface.adoc
+++ b/docs/10-quality/td/TD-TS-1-timeseries-rest-surface.adoc
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-TS-1: First-class time-series REST surface over the native TST engine
+
+[cols="1,3"]
+|===
+|Status|In Progress
+|Priority|MED
+|Scope|FEAT
+|Date|2026-07-03
+|Relates to|the TST storage engine (`src/storage/engines/tst/`), the Python SDK time-series client (`clients/python/src/proximadb_sdk/timeseries.py`), the v2 REST surface conventions (`src/network/rest/v2/`)
+|===
+
+== Context
+
+The `TimeSeriesEngine` (`src/storage/engines/tst/mod.rs`) is a full time-partitioned
+columnar engine — `insert_record`, `query_time_range`, `query_ohlc`, `asof_join`,
+downsampling, retention, WAL + 2PC — but its native methods sit on **no trait**, so
+they were unreachable from the network layer. There was **no `/api/v2/timeseries/*`
+route** and no `"timeseries"` capability. The Python SDK already defines the exact
+contract it expects (`POST /api/v2/timeseries/collections` + `ingest`/`query`/
+`aggregate`) and **silently falls back to in-memory emulation** when the server has
+none. Worse, `engine:"tst"` on a normal collection is a *trap*: records flow through
+the engine's stubbed vector-shaped trait methods (24h hardcoded window,
+`vector_by_id→None`, log-only flush), a degraded vector surface, not the time-series
+API. Co-design principle: **each modality is exposed through its own native contract,
+never forced through the vector-record path.**
+
+== Landed (this PR)
+
+* `TimeSeriesService` (`src/services/timeseries_service.rs`) — a process-global service
+  (like `statistics_registry()`) wrapping a `TimeSeriesEngine`, initialised at
+  bootstrap under `<data_dir>/timeseries` (`SharedServices::new`). It calls the
+  **TST-native** methods (`insert_record`/`query_time_range`), never the stubbed
+  vector methods. Maps SDK points `{timestamp, values, tags}` ↔ `VectorRecord`
+  (values/tags in metadata, timestamp partitioned); `aggregate` buckets by
+  `bucket_ms` with avg/sum/min/max/count/stddev.
+* v2 REST module `src/network/rest/v2/timeseries.rs` matching the SDK contract:
+  `POST /api/v2/timeseries/collections` (create), `.../{c}/ingest`, `.../{c}/query`,
+  `.../{c}/aggregate`, `GET .../collections` (list), `DELETE .../{c}`. Tenant isolation
+  is structural (`effective_collection`).
+* `"timeseries"` added to `/_meta/capabilities` `features`.
+
+== Remaining
+
+* **gRPC + proto service** — a `.proto` time-series service + gRPC handlers on the
+  multiplexed port (the deferred follow-on; REST-only for now).
+* **OpenAPI registration** — add `#[utoipa::path]` annotations + register in
+  `openapi.rs` so the endpoints appear in the spec (currently functional but
+  undocumented; no spec drift because the SDK already assumes them).
+* **Richer engine ops** — surface `insert_ohlc`/`query_ohlc` (OHLC), downsample, and
+  `asof_join` endpoints so the REST surface reflects the full TST engine.
+* **A Rust `TimeSeriesCollectionConfig`** mapping the full SDK shape
+  (`value_columns`/`tag_columns`/`retention`/`downsampling`) for validation +
+  round-trip; the MVP keeps a minimal resident config.
+* Retire the SDK's in-memory emulation fallback once the surface is complete.

--- a/src/network/grpc/graph_service.rs
+++ b/src/network/grpc/graph_service.rs
@@ -1302,6 +1302,29 @@ impl proximadb_runtime::GraphPort for GraphServiceImpl {
             .map_err(|s| anyhow::anyhow!("{}", s.message()))
     }
 
+    /// v2-era JSON path: run the query through the shared `QueryFacadeAdapter` and
+    /// return the engine's raw `serde_json::Value` rows — no v1 `QueryValue`.
+    async fn execute_query_json(
+        &self,
+        graph_id: &str,
+        query: &str,
+    ) -> anyhow::Result<Vec<serde_json::Value>> {
+        let adapter = self
+            .query_adapter
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("graph query adapter not configured"))?;
+        let graph_name = (!graph_id.is_empty()).then_some(graph_id);
+        let result = adapter
+            .graph_query(query, graph_name)
+            .await
+            .map_err(|e| anyhow::anyhow!("graph query failed: {e}"))?;
+        Ok(match result.data {
+            crate::query::QueryResultData::Graph(g) => g.nodes,
+            crate::query::QueryResultData::Rows(rows) => rows,
+            _ => Vec::new(),
+        })
+    }
+
     async fn get_neighbors(&self, request: GetNeighborsRequest) -> anyhow::Result<BatchResponse> {
         self.get_neighbors(tonic::Request::new(request))
             .await

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -2009,6 +2009,13 @@ mod tests {
         ) -> anyhow::Result<crate::proto::v1::GraphQueryResponse> {
             anyhow::bail!("mock")
         }
+        async fn execute_query_json(
+            &self,
+            _graph_id: &str,
+            _query: &str,
+        ) -> anyhow::Result<Vec<serde_json::Value>> {
+            anyhow::bail!("mock")
+        }
         async fn get_neighbors(
             &self,
             _: crate::proto::v1::GetNeighborsRequest,

--- a/src/network/rest/v2/mod.rs
+++ b/src/network/rest/v2/mod.rs
@@ -51,6 +51,7 @@ pub mod graphs;
 pub mod query;
 pub mod records;
 pub mod schema;
+pub mod timeseries;
 
 pub use collections::*;
 pub use query::*;
@@ -86,7 +87,7 @@ use super::v1::handlers::AppState;
 /// - `POST /query` - Execute AQL/UQL through UnifiedQueryPort
 /// - `POST /query/explain` - Explain AQL/UQL through UnifiedQueryPort
 pub fn create_v2_router() -> Router<AppState> {
-    use axum::routing::{get, post, put};
+    use axum::routing::{delete, get, post, put};
 
     Router::new()
         // Collection operations with schema support
@@ -153,6 +154,31 @@ pub fn create_v2_router() -> Router<AppState> {
         // Query facade operations
         .route("/query", post(query::execute_query))
         .route("/query/explain", post(query::explain_query))
+        // Time-series surface (TD-TS-1) — native TST engine over the SDK contract.
+        .route(
+            "/timeseries/collections",
+            post(timeseries::create_timeseries_collection),
+        )
+        .route(
+            "/timeseries/collections",
+            get(timeseries::list_timeseries_collections),
+        )
+        .route(
+            "/timeseries/collections/{collection_id}",
+            delete(timeseries::delete_timeseries_collection),
+        )
+        .route(
+            "/timeseries/collections/{collection_id}/ingest",
+            post(timeseries::ingest_timeseries),
+        )
+        .route(
+            "/timeseries/collections/{collection_id}/query",
+            post(timeseries::query_timeseries),
+        )
+        .route(
+            "/timeseries/collections/{collection_id}/aggregate",
+            post(timeseries::aggregate_timeseries),
+        )
         // Cross-modal fusion seam — graph instance (TD-137): vector seed → graph
         // expand → calibrated fuse-by-oid.
         .route(
@@ -257,7 +283,7 @@ pub async fn capabilities() -> axum::Json<serde_json::Value> {
         "features": [
             "collections", "records", "typed_search", "query_uql", "query_explain",
             "graphs", "hybrid_search", "document_collections", "observability",
-            "index_configs", "tags", "request_id"
+            "index_configs", "tags", "request_id", "timeseries"
         ],
         "limits": {
             "max_batch_records": 10000,

--- a/src/network/rest/v2/timeseries.rs
+++ b/src/network/rest/v2/timeseries.rs
@@ -1,0 +1,180 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! v2 REST time-series surface (TD-TS-1).
+//!
+//! Matches the contract the Python SDK already expects
+//! (`clients/python/src/proximadb_sdk/adapters/rest_adapter.py`):
+//! `POST /api/v2/timeseries/collections` (create), `.../{c}/ingest`, `.../{c}/query`,
+//! `.../{c}/aggregate`, `GET /api/v2/timeseries/collections` (list),
+//! `DELETE .../{c}` (delete). Backed by the process-global [`TimeSeriesService`] over
+//! the native TST engine — never the stubbed vector-shaped trait methods. Tenant
+//! isolation is structural (the tenant is folded into the collection key).
+
+use axum::extract::Path;
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::errors::{ApiError, ApiResult};
+use crate::network::middleware::tenant::TenantContext;
+use crate::services::timeseries_service::{
+    TimeSeriesService, TsCollectionConfig, TsPoint, timeseries_service,
+};
+
+fn effective_collection(tenant: &TenantContext, collection_id: &str) -> String {
+    if !tenant.tenant_id.is_empty() {
+        format!("{}::{}", tenant.tenant_id, collection_id)
+    } else {
+        collection_id.to_string()
+    }
+}
+
+fn service() -> ApiResult<Arc<TimeSeriesService>> {
+    timeseries_service()
+        .ok_or_else(|| ApiError::Internal("timeseries service is not available".to_string()))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IngestRequest {
+    pub points: Vec<TsPoint>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IngestResponse {
+    pub ingested: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct QueryRequest {
+    pub start_time: i64,
+    pub end_time: i64,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct QueryResponse {
+    pub points: Vec<TsPoint>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AggregateRequest {
+    pub start_time: i64,
+    pub end_time: i64,
+    #[serde(default = "default_aggregation")]
+    pub aggregation: String,
+    #[serde(default = "default_bucket_ms")]
+    pub bucket_ms: i64,
+}
+
+fn default_aggregation() -> String {
+    "avg".to_string()
+}
+fn default_bucket_ms() -> i64 {
+    60_000
+}
+
+#[derive(Debug, Serialize)]
+pub struct AggregateResponse {
+    pub buckets: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateResponse {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListResponse {
+    pub collections: Vec<TsCollectionConfig>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeleteResponse {
+    pub success: bool,
+}
+
+/// `POST /api/v2/timeseries/collections`
+pub async fn create_timeseries_collection(
+    Extension(tenant): Extension<TenantContext>,
+    Json(mut config): Json<TsCollectionConfig>,
+) -> ApiResult<Json<CreateResponse>> {
+    let name = effective_collection(&tenant, &config.name);
+    config.name = name.clone();
+    service()?
+        .create_collection(config)
+        .await
+        .map_err(|e| ApiError::Internal(format!("create timeseries collection: {e}")))?;
+    Ok(Json(CreateResponse { name }))
+}
+
+/// `POST /api/v2/timeseries/collections/{collection_id}/ingest`
+pub async fn ingest_timeseries(
+    Path(collection_id): Path<String>,
+    Extension(tenant): Extension<TenantContext>,
+    Json(request): Json<IngestRequest>,
+) -> ApiResult<Json<IngestResponse>> {
+    let collection = effective_collection(&tenant, &collection_id);
+    let ingested = service()?
+        .ingest(&collection, request.points)
+        .await
+        .map_err(|e| ApiError::Internal(format!("ingest timeseries: {e}")))?;
+    Ok(Json(IngestResponse { ingested }))
+}
+
+/// `POST /api/v2/timeseries/collections/{collection_id}/query`
+pub async fn query_timeseries(
+    Path(collection_id): Path<String>,
+    Extension(tenant): Extension<TenantContext>,
+    Json(request): Json<QueryRequest>,
+) -> ApiResult<Json<QueryResponse>> {
+    let collection = effective_collection(&tenant, &collection_id);
+    let points = service()?
+        .query(
+            &collection,
+            request.start_time,
+            request.end_time,
+            request.limit,
+        )
+        .await
+        .map_err(|e| ApiError::Internal(format!("query timeseries: {e}")))?;
+    Ok(Json(QueryResponse { points }))
+}
+
+/// `POST /api/v2/timeseries/collections/{collection_id}/aggregate`
+pub async fn aggregate_timeseries(
+    Path(collection_id): Path<String>,
+    Extension(tenant): Extension<TenantContext>,
+    Json(request): Json<AggregateRequest>,
+) -> ApiResult<Json<AggregateResponse>> {
+    let collection = effective_collection(&tenant, &collection_id);
+    let buckets = service()?
+        .aggregate(
+            &collection,
+            request.start_time,
+            request.end_time,
+            &request.aggregation,
+            request.bucket_ms,
+        )
+        .await
+        .map_err(|e| ApiError::Internal(format!("aggregate timeseries: {e}")))?;
+    Ok(Json(AggregateResponse { buckets }))
+}
+
+/// `GET /api/v2/timeseries/collections`
+pub async fn list_timeseries_collections(
+    Extension(_tenant): Extension<TenantContext>,
+) -> ApiResult<Json<ListResponse>> {
+    let collections = service()?.list_collections().await;
+    Ok(Json(ListResponse { collections }))
+}
+
+/// `DELETE /api/v2/timeseries/collections/{collection_id}`
+pub async fn delete_timeseries_collection(
+    Path(collection_id): Path<String>,
+    Extension(tenant): Extension<TenantContext>,
+) -> ApiResult<Json<DeleteResponse>> {
+    let collection = effective_collection(&tenant, &collection_id);
+    let success = service()?.delete_collection(&collection).await;
+    Ok(Json(DeleteResponse { success }))
+}

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1755,6 +1755,20 @@ impl SharedServices {
             }
         };
 
+        // TD-TS-1: initialise the process-global time-series service over the native
+        // TST engine, rooted under the data dir. Non-fatal on failure (surface stays
+        // unavailable rather than blocking bootstrap).
+        {
+            let ts_base_path = std::path::PathBuf::from(
+                storage_config.metadata_url.replace("file://", "") + "/timeseries",
+            );
+            if let Err(e) =
+                crate::services::timeseries_service::init_timeseries_service(ts_base_path)
+            {
+                warn!("Failed to initialise TimeSeriesService: {}", e);
+            }
+        }
+
         // Derive extracted graph capability views once here so query/orchestration
         // layers depend on explicit contracts rather than the full concrete service.
         let graph_query_service = graph_service.clone();

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -200,6 +200,7 @@ pub mod system_catalog;
 pub mod system_catalog_state;
 #[cfg(feature = "tenant_access")]
 pub mod tenant_access;
+pub mod timeseries_service;
 pub mod transaction;
 pub mod write_intent;
 

--- a/src/services/timeseries_service.rs
+++ b/src/services/timeseries_service.rs
@@ -1,0 +1,270 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! In-process service that surfaces the TST time-series engine (TD-TS-1).
+//!
+//! The `TimeSeriesEngine` (`crate::storage::engines::tst`) is a full time-partitioned
+//! columnar engine, but its native methods sit on no trait and were unreachable from
+//! the network layer. This service wraps it so the v2 REST timeseries surface
+//! (`src/network/rest/v2/timeseries.rs`) can create collections, ingest points, and
+//! query / aggregate — the contract the Python SDK already expects. It calls the
+//! TST-native methods (`insert_record` / `query_time_range`) directly, never the
+//! stubbed vector-shaped trait methods.
+
+use crate::proto::proximadb_v1::{SqlValue, VectorRecord, sql_value};
+use crate::storage::engines::tst::{TimeSeriesConfig, TimeSeriesEngine};
+use anyhow::{Result, anyhow};
+use chrono::{TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+use tokio::sync::RwLock;
+
+static TIMESERIES_SERVICE: OnceLock<Arc<TimeSeriesService>> = OnceLock::new();
+
+/// Initialise the process-global time-series service (idempotent — first wins).
+/// Called once at server bootstrap with `<data_dir>/timeseries` as the base path.
+pub fn init_timeseries_service(base_path: PathBuf) -> Result<()> {
+    if TIMESERIES_SERVICE.get().is_some() {
+        return Ok(());
+    }
+    let service = Arc::new(TimeSeriesService::new(base_path)?);
+    let _ = TIMESERIES_SERVICE.set(service);
+    Ok(())
+}
+
+/// The process-global time-series service, if initialised.
+pub fn timeseries_service() -> Option<Arc<TimeSeriesService>> {
+    TIMESERIES_SERVICE.get().cloned()
+}
+
+/// A value column in a time-series collection (mirrors the SDK `ValueColumn`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TsValueColumn {
+    pub name: String,
+    #[serde(default)]
+    pub unit: Option<String>,
+    #[serde(default)]
+    pub aggregation: Option<String>,
+}
+
+/// Time-series collection config (mirrors the SDK `TimeSeriesCollectionConfig`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TsCollectionConfig {
+    pub name: String,
+    #[serde(default = "default_timestamp_column")]
+    pub timestamp_column: String,
+    #[serde(default)]
+    pub value_columns: Vec<TsValueColumn>,
+    #[serde(default)]
+    pub tag_columns: Vec<String>,
+    #[serde(default)]
+    pub retention_ms: Option<i64>,
+}
+
+fn default_timestamp_column() -> String {
+    "timestamp".to_string()
+}
+
+/// A single time-series point: epoch-millis timestamp + named numeric values + string tags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TsPoint {
+    pub timestamp: i64,
+    #[serde(default)]
+    pub values: HashMap<String, f64>,
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+}
+
+/// Wraps a single `TimeSeriesEngine` (multiplexed by `collection_id`) plus a resident
+/// registry of the declared collection configs.
+pub struct TimeSeriesService {
+    /// `insert_record` takes `&mut self`, so the engine is guarded for interior
+    /// mutability (writes exclusive, `query_time_range` reads shared).
+    engine: RwLock<TimeSeriesEngine>,
+    collections: RwLock<HashMap<String, TsCollectionConfig>>,
+}
+
+impl TimeSeriesService {
+    /// Build the service with the engine rooted at `base_path` (e.g. `<data_dir>/timeseries`).
+    pub fn new(base_path: PathBuf) -> Result<Self> {
+        let config = TimeSeriesConfig {
+            base_path,
+            ..Default::default()
+        };
+        let engine = TimeSeriesEngine::with_config(config)
+            .map_err(|e| anyhow!("failed to init TimeSeriesEngine: {e}"))?;
+        Ok(Self {
+            engine: RwLock::new(engine),
+            collections: RwLock::new(HashMap::new()),
+        })
+    }
+
+    pub async fn create_collection(&self, config: TsCollectionConfig) -> Result<()> {
+        self.collections
+            .write()
+            .await
+            .insert(config.name.clone(), config);
+        Ok(())
+    }
+
+    pub async fn list_collections(&self) -> Vec<TsCollectionConfig> {
+        self.collections.read().await.values().cloned().collect()
+    }
+
+    pub async fn delete_collection(&self, name: &str) -> bool {
+        self.collections.write().await.remove(name).is_some()
+    }
+
+    /// Ingest points → TST-native `insert_record` (values in metadata, timestamp partitioned).
+    pub async fn ingest(&self, collection: &str, points: Vec<TsPoint>) -> Result<usize> {
+        let mut engine = self.engine.write().await;
+        let mut inserted = 0usize;
+        for point in points {
+            let ts = Utc
+                .timestamp_millis_opt(point.timestamp)
+                .single()
+                .ok_or_else(|| anyhow!("invalid timestamp {}", point.timestamp))?;
+            let mut metadata: HashMap<String, SqlValue> = HashMap::new();
+            let mut vector: Vec<f32> = Vec::with_capacity(point.values.len());
+            for (k, v) in &point.values {
+                metadata.insert(
+                    k.clone(),
+                    SqlValue {
+                        value: Some(sql_value::Value::NumberValue(*v)),
+                    },
+                );
+                vector.push(*v as f32);
+            }
+            for (k, v) in &point.tags {
+                metadata.insert(
+                    k.clone(),
+                    SqlValue {
+                        value: Some(sql_value::Value::StringValue(v.clone())),
+                    },
+                );
+            }
+            let record = VectorRecord {
+                id: format!("{collection}:{}", point.timestamp),
+                vector,
+                metadata,
+                timestamp: Some(point.timestamp),
+                ..Default::default()
+            };
+            engine
+                .insert_record(collection, ts, record)
+                .await
+                .map_err(|e| anyhow!("insert_record failed: {e}"))?;
+            inserted += 1;
+        }
+        Ok(inserted)
+    }
+
+    /// Query a time range → raw points (TST-native `query_time_range`).
+    pub async fn query(
+        &self,
+        collection: &str,
+        start_ms: i64,
+        end_ms: i64,
+        limit: Option<usize>,
+    ) -> Result<Vec<TsPoint>> {
+        let start = Utc
+            .timestamp_millis_opt(start_ms)
+            .single()
+            .ok_or_else(|| anyhow!("invalid start_time"))?;
+        let end = Utc
+            .timestamp_millis_opt(end_ms)
+            .single()
+            .ok_or_else(|| anyhow!("invalid end_time"))?;
+        let records = self
+            .engine
+            .read()
+            .await
+            .query_time_range(collection, start, end, limit)
+            .await
+            .map_err(|e| anyhow!("query_time_range failed: {e}"))?;
+        Ok(records.into_iter().map(record_to_point).collect())
+    }
+
+    /// Aggregate a time range into fixed `bucket_ms` buckets, applying `aggregation`
+    /// (avg | sum | min | max | count | stddev | first | last) to each value column.
+    pub async fn aggregate(
+        &self,
+        collection: &str,
+        start_ms: i64,
+        end_ms: i64,
+        aggregation: &str,
+        bucket_ms: i64,
+    ) -> Result<Vec<serde_json::Value>> {
+        let points = self.query(collection, start_ms, end_ms, None).await?;
+        let bucket = bucket_ms.max(1);
+        let mut buckets: BTreeMap<i64, HashMap<String, Vec<f64>>> = BTreeMap::new();
+        for point in points {
+            let key = (point.timestamp / bucket) * bucket;
+            let cols = buckets.entry(key).or_default();
+            for (name, value) in point.values {
+                cols.entry(name).or_default().push(value);
+            }
+        }
+        Ok(buckets
+            .into_iter()
+            .map(|(bucket_start, cols)| {
+                let values: serde_json::Map<String, serde_json::Value> = cols
+                    .into_iter()
+                    .map(|(name, vals)| {
+                        (
+                            name,
+                            serde_json::json!(apply_aggregation(aggregation, &vals)),
+                        )
+                    })
+                    .collect();
+                serde_json::json!({ "bucket_start": bucket_start, "values": values })
+            })
+            .collect())
+    }
+}
+
+fn record_to_point(record: VectorRecord) -> TsPoint {
+    let mut values = HashMap::new();
+    let mut tags = HashMap::new();
+    for (k, sv) in record.metadata {
+        match sv.value {
+            Some(sql_value::Value::NumberValue(n)) => {
+                values.insert(k, n);
+            }
+            Some(sql_value::Value::Int64Value(i)) => {
+                values.insert(k, i as f64);
+            }
+            Some(sql_value::Value::StringValue(s)) => {
+                tags.insert(k, s);
+            }
+            _ => {}
+        }
+    }
+    TsPoint {
+        timestamp: record.timestamp.unwrap_or(0),
+        values,
+        tags,
+    }
+}
+
+fn apply_aggregation(aggregation: &str, vals: &[f64]) -> f64 {
+    if vals.is_empty() {
+        return 0.0;
+    }
+    let n = vals.len() as f64;
+    match aggregation {
+        "sum" => vals.iter().sum(),
+        "min" => vals.iter().cloned().fold(f64::INFINITY, f64::min),
+        "max" => vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
+        "count" => n,
+        "first" => vals[0],
+        "last" => *vals.last().unwrap_or(&0.0),
+        "stddev" => {
+            let mean = vals.iter().sum::<f64>() / n;
+            (vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n).sqrt()
+        }
+        // "avg" / "mean" and anything else → mean
+        _ => vals.iter().sum::<f64>() / n,
+    }
+}

--- a/src/storage/engines/tst/mod.rs
+++ b/src/storage/engines/tst/mod.rs
@@ -633,8 +633,15 @@ impl TimeSeriesEngine {
 
     /// Identify partitions that overlap with the time range
     fn identify_partitions(&self, start: DateTime<Utc>, end: DateTime<Utc>) -> Vec<DateTime<Utc>> {
+        // Partitions are keyed by their truncated start instant and cover the whole
+        // `partition_duration`. A sub-partition query window (e.g. minutes within a Day
+        // partition) must still include the partition that *contains* `start`, whose key
+        // is `<= start` — so widen the lower bound to that partition boundary. Without
+        // this, an intra-partition range like [14:00, 14:05] misses its own partition
+        // (keyed at 00:00) and returns nothing.
+        let start_key = self.config.partition_duration.truncate(start);
         self.partitions
-            .range(start..=end)
+            .range(start_key..=end)
             .map(|(key, _)| *key)
             .collect()
     }


### PR DESCRIPTION
Surfaces two modalities through their **native v2 contracts** instead of the vector-record path — the co-design thread from testing the demo (each modality via its own contract). Verified end-to-end against a code-aligned Docker image.

## Time-series (TD-TS-1)
The native TST engine was network-unreachable (methods on no trait; no route; `engine:"tst"` a degraded-vector trap; the SDK silently emulated in-memory).
- **`TimeSeriesService`** (`src/services/timeseries_service.rs`) — process-global (like `statistics_registry`), wraps `TimeSeriesEngine`, calls the **native** `insert_record`/`query_time_range`; maps SDK points `{timestamp,values,tags}` ↔ `VectorRecord`; `aggregate` buckets by `bucket_ms` (avg/sum/min/max/count/stddev).
- **`/api/v2/timeseries/*`** (`src/network/rest/v2/timeseries.rs`) matching the SDK contract (create/ingest/query/aggregate/list/delete); `"timeseries"` in `/_meta/capabilities`.
- **Engine fix**: `identify_partitions` widened its lower bound to the partition boundary so intra-partition windows (minutes within a Day partition) hit their partition — was returning empty.

## Graph (TD-GRAPH-2)
The Cypher REST surface ran on the **v1 proto** and discarded every column *value* (returned `null`). Migrated to a v2-era JSON path:
- **`GraphPort::execute_query_json`** returns the engine's raw `serde_json` rows (no v1 `QueryValue`); `GraphServiceImpl` calls the shared `QueryFacadeAdapter` directly.
- REST `/api/v2/graphs/{id}/query` now returns **real node values**; v1 `QueryValue` helpers deleted. Full v1 graph-proto retirement + module relocation tracked in **TD-GRAPH-2**.

## Verified (live, code-aligned image)
- timeseries intra-day aggregate → baseline bucket **2.5**, spike bucket **9.05**.
- Cypher `MATCH …-[:feeds_into*1..5]->(x) RETURN x` → real `{node_id, properties}` (not null).
- Server **lib + binary** build; **fmt + clippy** clean.

Follow-ups (in the TDs): gRPC/proto + OpenAPI for timeseries; full v1 graph-proto retirement + dead-file cleanup; wire the manufacturing demo's two client-side hops to these endpoints (PR-C).