### PR TITLE
fix(engine): timeseries per-collection isolation + Cypher variable-length multi-hop traversal

### DIFF
--- a/crates/query/proximadb-graph-query/src/ast.rs
+++ b/crates/query/proximadb-graph-query/src/ast.rs
@@ -74,6 +74,10 @@ pub struct EdgePattern {
     pub direction: EdgeDirection,
     /// Whether this is an optional match
     pub optional: bool,
+    /// Variable-length quantifier `*min..max` (e.g. `-[:KNOWS*1..4]->`).
+    /// `None` is a fixed single hop (equivalent to `Some((1, 1))`); `Some((min, max))`
+    /// expands the relationship over `min..=max` hops via bounded BFS at execution time.
+    pub var_length: Option<(u32, u32)>,
 }
 
 /// Path pattern for variable-length paths

--- a/crates/query/proximadb-graph-query/src/parser.rs
+++ b/crates/query/proximadb-graph-query/src/parser.rs
@@ -177,20 +177,25 @@ fn property_map(input: &str) -> IResult<&str, HashMap<String, PropertyConstraint
     )(input)
 }
 
-// Parse a node pattern (e.g., (n:Label {prop: "val"}))
+// Parse a node pattern (e.g., (n:Label {prop: "val"}), (:Label), or anonymous ())
 fn parse_node_pattern(input: &str) -> IResult<&str, NodePattern> {
+    // Anonymous nodes `()` / `(:Label)` get a synthetic, deterministic variable derived
+    // from this node's source position (the remaining-byte count is unique per node and
+    // stable across re-parses), so chained patterns like `()-[:X]->()` bind consistently
+    // without a global counter.
+    let anon_seed = input.len();
     map(
         delimited(
             char('('),
             tuple((
-                identifier,                               // Variable
+                opt(identifier),                          // Optional variable (anonymous if absent)
                 opt(preceded(char(':'), identifier)),     // Optional Label
                 opt(preceded(multispace0, property_map)), // Optional Properties
             )),
             char(')'),
         ),
-        |(variable, label_opt, properties_opt)| NodePattern {
-            variable,
+        move |(variable_opt, label_opt, properties_opt)| NodePattern {
+            variable: variable_opt.unwrap_or_else(|| format!("__anon_{anon_seed}")),
             labels: label_opt.map(|l| vec![l]).unwrap_or_default(),
             properties: properties_opt.unwrap_or_default(),
             optional: false, // Not handling OPTIONAL MATCH yet
@@ -290,7 +295,7 @@ fn parse_path_segment(input: &str) -> IResult<&str, (NodePattern, EdgePattern, N
         )),
         |(
             from_node,
-            (is_incoming, edge_var, edge_types, edge_props, is_outgoing, _var_length),
+            (is_incoming, edge_var, edge_types, edge_props, is_outgoing, var_length),
             to_node,
         )| {
             let direction = match (is_incoming, is_outgoing) {
@@ -308,6 +313,7 @@ fn parse_path_segment(input: &str) -> IResult<&str, (NodePattern, EdgePattern, N
                 properties: edge_props,
                 direction,
                 optional: false,
+                var_length,
             };
 
             (from_node.clone(), edge_pattern, to_node)
@@ -340,7 +346,7 @@ fn parse_path_chain(input: &str) -> IResult<&str, (Vec<NodePattern>, Vec<EdgePat
         {
             Ok((
                 after_edge,
-                (is_incoming, edge_var, edge_types, edge_props, is_outgoing, _var_length),
+                (is_incoming, edge_var, edge_types, edge_props, is_outgoing, var_length),
             )) => {
                 match preceded(
                     multispace0::<&str, nom::error::Error<&str>>,
@@ -364,6 +370,7 @@ fn parse_path_chain(input: &str) -> IResult<&str, (Vec<NodePattern>, Vec<EdgePat
                             properties: edge_props,
                             direction,
                             optional: false,
+                            var_length,
                         });
                         nodes.push(next_node);
                         rest = after_node;

--- a/crates/query/proximadb-query/src/graph_adapter.rs
+++ b/crates/query/proximadb-query/src/graph_adapter.rs
@@ -964,6 +964,7 @@ mod tests {
             properties: HashMap::new(),
             direction: EdgeDirection::Outgoing,
             optional: false,
+            var_length: None,
         }
     }
 

--- a/crates/query/proximadb-query/src/graph_lowering.rs
+++ b/crates/query/proximadb-query/src/graph_lowering.rs
@@ -202,12 +202,6 @@ fn validate_compiled_query(compiled: &CompiledPattern, normalized_query: &str) -
         }
     }
 
-    if normalized_query.contains("[*") {
-        return Err(anyhow!(
-            "Variable-length graph paths are not supported in the facade/federated graph subset"
-        ));
-    }
-
     if compiled.nodes.is_empty() {
         return Err(anyhow!(
             "Graph query must contain at least one node pattern"

--- a/crates/query/proximadb-query/src/graph_runtime.rs
+++ b/crates/query/proximadb-query/src/graph_runtime.rs
@@ -149,6 +149,12 @@ pub async fn execute_graph_query_expr_with_start_nodes(
     execute_lowered_graph_query_with_start_nodes(graph_ops, expr, start_node_ids).await
 }
 
+/// Hard cap on variable-length `*min..max` expansion depth. Per-source work is already
+/// bounded to O(V + E) by the visited set; this backstops a user-supplied `max` far larger
+/// than any real graph diameter (e.g. `*1..1000000`) so a single query cannot iterate the
+/// depth loop pathologically.
+const MAX_VARIABLE_LENGTH_DEPTH: u32 = 64;
+
 pub async fn execute_supported_graph_query_with_start_nodes(
     graph_ops: &dyn GraphQueryReadService,
     parsed: &ParsedGraphQuery,
@@ -176,46 +182,124 @@ pub async fn execute_supported_graph_query_with_start_nodes(
                 ));
             };
 
-            let candidate_edges =
-                query_candidate_edges(graph_ops, parsed.graph_id(), &current_node.id, edge_pattern)
+            match edge_pattern.var_length {
+                None => {
+                    // Fixed single hop: bind both the traversed edge and the adjacent node.
+                    let candidate_edges = query_candidate_edges(
+                        graph_ops,
+                        parsed.graph_id(),
+                        &current_node.id,
+                        edge_pattern,
+                    )
                     .await?;
 
-            for edge in candidate_edges {
-                let next_node_id = resolve_adjacent_node_id(
-                    &current_node.id,
-                    edge.as_ref(),
-                    edge_pattern.direction,
-                );
-                let Some(next_node) = graph_ops.get_node(parsed.graph_id(), &next_node_id).await?
-                else {
-                    continue;
-                };
+                    for edge in candidate_edges {
+                        let next_node_id = resolve_adjacent_node_id(
+                            &current_node.id,
+                            edge.as_ref(),
+                            edge_pattern.direction,
+                        );
+                        let Some(next_node) =
+                            graph_ops.get_node(parsed.graph_id(), &next_node_id).await?
+                        else {
+                            continue;
+                        };
 
-                if !matches_node_pattern(next_node.as_ref(), next_node_pattern) {
-                    continue;
-                }
+                        if !matches_node_pattern(next_node.as_ref(), next_node_pattern) {
+                            continue;
+                        }
 
-                let mut next_binding = binding.clone();
-                let edge_value = BoundValue::Edge(edge.clone());
-                if let Some(edge_var) = &edge_pattern.variable {
-                    if !binding_is_compatible(next_binding.get(edge_var), &edge_value) {
-                        continue;
+                        let mut next_binding = binding.clone();
+                        let edge_value = BoundValue::Edge(edge.clone());
+                        if let Some(edge_var) = &edge_pattern.variable {
+                            if !binding_is_compatible(next_binding.get(edge_var), &edge_value) {
+                                continue;
+                            }
+                            next_binding.insert(edge_var.clone(), edge_value);
+                        } else {
+                            let synthetic_key = format!("_edge_{}", edge.id);
+                            next_binding.insert(synthetic_key, edge_value);
+                        }
+
+                        let next_node_value = BoundValue::Node(next_node.clone());
+                        if !binding_is_compatible(
+                            next_binding.get(&next_node_pattern.variable),
+                            &next_node_value,
+                        ) {
+                            continue;
+                        }
+                        next_binding.insert(next_node_pattern.variable.clone(), next_node_value);
+                        next_bindings.push(next_binding);
                     }
-                    next_binding.insert(edge_var.clone(), edge_value);
-                } else {
-                    let synthetic_key = format!("_edge_{}", edge.id);
-                    next_binding.insert(synthetic_key, edge_value);
                 }
+                Some((min_hops, max_hops)) => {
+                    // Variable-length `*min..max`: bounded BFS from the current node,
+                    // emitting one binding per DISTINCT node reachable in [min, max] hops
+                    // that matches the terminal pattern. This is *reachability* semantics —
+                    // the cost-bounded default for impact / lineage / ring tracing — rather
+                    // than per-path multiplicity. Each node is expanded at most once, so the
+                    // work is O(V + E) per source regardless of `max`; MAX_VARIABLE_LENGTH_DEPTH
+                    // backstops pathological graphs. Intermediate nodes are unconstrained (only
+                    // the edge type filters each hop); the terminal pattern gates emission.
+                    let max_depth = max_hops.min(MAX_VARIABLE_LENGTH_DEPTH) as usize;
+                    let min_depth = (min_hops.max(1)) as usize;
 
-                let next_node_value = BoundValue::Node(next_node.clone());
-                if !binding_is_compatible(
-                    next_binding.get(&next_node_pattern.variable),
-                    &next_node_value,
-                ) {
-                    continue;
+                    let mut visited: HashSet<String> = HashSet::new();
+                    visited.insert(current_node.id.clone());
+                    let mut emitted: HashSet<String> = HashSet::new();
+                    let mut frontier = vec![current_node.clone()];
+
+                    for depth in 1..=max_depth {
+                        let mut next_frontier = Vec::new();
+                        for node in &frontier {
+                            let candidate_edges = query_candidate_edges(
+                                graph_ops,
+                                parsed.graph_id(),
+                                &node.id,
+                                edge_pattern,
+                            )
+                            .await?;
+                            for edge in candidate_edges {
+                                let adj_id = resolve_adjacent_node_id(
+                                    &node.id,
+                                    edge.as_ref(),
+                                    edge_pattern.direction,
+                                );
+                                let Some(adj_node) =
+                                    graph_ops.get_node(parsed.graph_id(), &adj_id).await?
+                                else {
+                                    continue;
+                                };
+
+                                if depth >= min_depth
+                                    && matches_node_pattern(adj_node.as_ref(), next_node_pattern)
+                                    && emitted.insert(adj_id.clone())
+                                {
+                                    let next_node_value = BoundValue::Node(adj_node.clone());
+                                    if binding_is_compatible(
+                                        binding.get(&next_node_pattern.variable),
+                                        &next_node_value,
+                                    ) {
+                                        let mut next_binding = binding.clone();
+                                        next_binding.insert(
+                                            next_node_pattern.variable.clone(),
+                                            next_node_value,
+                                        );
+                                        next_bindings.push(next_binding);
+                                    }
+                                }
+
+                                if depth < max_depth && visited.insert(adj_id.clone()) {
+                                    next_frontier.push(adj_node.clone());
+                                }
+                            }
+                        }
+                        frontier = next_frontier;
+                        if frontier.is_empty() {
+                            break;
+                        }
+                    }
                 }
-                next_binding.insert(next_node_pattern.variable.clone(), next_node_value);
-                next_bindings.push(next_binding);
             }
         }
 
@@ -1249,6 +1333,107 @@ mod tests {
                 "colleague": "Bob",
                 "company": "Acme"
             })]
+        );
+    }
+
+    // A linear chain n0 -> n1 -> n2 -> n3 -> n4 over edge type LINK, for exercising
+    // variable-length `*min..max` traversal.
+    fn seed_chain() -> MockGraphReadService {
+        let mut service = MockGraphReadService::with_graphs(&["chain"]);
+        for id in ["n0", "n1", "n2", "n3", "n4"] {
+            service.insert_node(
+                "chain",
+                Node {
+                    id: id.to_string(),
+                    labels: vec!["N".to_string()],
+                    properties: HashMap::new(),
+                    embedding: None,
+                    created_at_ms: 0,
+                    updated_at_ms: 0,
+                },
+            );
+        }
+        for (from, to) in [("n0", "n1"), ("n1", "n2"), ("n2", "n3"), ("n3", "n4")] {
+            service.insert_edge(
+                "chain",
+                Edge {
+                    id: format!("{from}->{to}"),
+                    from_node_id: from.to_string(),
+                    to_node_id: to.to_string(),
+                    edge_type: "LINK".to_string(),
+                    properties: HashMap::new(),
+                    weight: None,
+                    created_at_ms: 0,
+                    updated_at_ms: 0,
+                },
+            );
+        }
+        service
+    }
+
+    async fn chain_ids(service: &MockGraphReadService, query: &str) -> Vec<String> {
+        let parsed = crate::graph_lowering::parse_supported_graph_query(query, None, Some("chain"))
+            .expect("parse graph query");
+        let executed = execute_supported_graph_query(service, &parsed)
+            .await
+            .expect("execute graph query");
+        let mut ids = executed
+            .rows
+            .iter()
+            .filter_map(|row| row.get("id").and_then(Value::as_str).map(str::to_string))
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn variable_length_path_expands_every_depth_in_range() {
+        let service = seed_chain();
+
+        // `*1..3` from n0 must reach n1 (depth 1), n2 (depth 2), n3 (depth 3) — not n4 (depth 4).
+        // Before the fix this returned only n1 (depth 1).
+        assert_eq!(
+            chain_ids(
+                &service,
+                "MATCH (a:N {id: \"n0\"})-[:LINK*1..3]->(x:N) RETURN x.id AS id",
+            )
+            .await,
+            vec!["n1", "n2", "n3"],
+        );
+
+        // `*1..1` is a plain single hop.
+        assert_eq!(
+            chain_ids(
+                &service,
+                "MATCH (a:N {id: \"n0\"})-[:LINK*1..1]->(x:N) RETURN x.id AS id",
+            )
+            .await,
+            vec!["n1"],
+        );
+
+        // The lower bound excludes the direct neighbour: `*2..4` starts at depth 2.
+        assert_eq!(
+            chain_ids(
+                &service,
+                "MATCH (a:N {id: \"n0\"})-[:LINK*2..4]->(x:N) RETURN x.id AS id",
+            )
+            .await,
+            vec!["n2", "n3", "n4"],
+        );
+    }
+
+    #[tokio::test]
+    async fn anonymous_chained_pattern_traverses_two_explicit_hops() {
+        let service = seed_chain();
+        // Two explicit hops through an anonymous intermediate node `()` must reach n2.
+        // Before the fix, anonymous nodes failed to parse and the query returned nothing.
+        assert_eq!(
+            chain_ids(
+                &service,
+                "MATCH (a:N {id: \"n0\"})-[:LINK]->()-[:LINK]->(x:N) RETURN x.id AS id",
+            )
+            .await,
+            vec!["n2"],
         );
     }
 

--- a/docs/10-quality/td/TD-GRAPH-3-cypher-variable-length-multihop.adoc
+++ b/docs/10-quality/td/TD-GRAPH-3-cypher-variable-length-multihop.adoc
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GRAPH-3: Cypher variable-length / multi-hop traversal in the shared graph subset
+
+[cols="1,3"]
+|===
+|Status|Landed
+|Priority|MED
+|Scope|FEAT
+|Date|2026-07-04
+|Relates to|The shared graph-query subset (`crates/query/proximadb-graph-query` parser/AST + `crates/query/proximadb-query` `graph_runtime`/`graph_lowering`) behind `QueryFacadeAdapter::graph_query`, served at `POST /api/v2/graphs/{id}/query`. Sibling of [[TD-GRAPH-2]]. Surfaced by the fraud/AML vertical demo.
+|===
+
+== Context (the gap)
+
+The declarative Cypher surface returned real node values (TD-GRAPH-2), but **variable-length
+and multi-hop traversal only resolved the first hop**. Root causes, all in the shared subset:
+
+* The parser recognised the `*min..max` quantifier (`parser.rs::parse_variable_length`) but the
+  `EdgePattern` AST had **no field to carry it** — the range was bound to `_var_length` and
+  discarded, so `-[:r*1..4]->` compiled identically to a single `-[:r]->`.
+* The executor (`graph_runtime::execute_supported_graph_query_with_start_nodes`) did **exactly
+  one neighbour-expansion per `EdgePattern`**, so even had the range survived, it walked depth 1.
+* A `normalized_query.contains("[*")` reject in `graph_lowering` was **ineffective** for the
+  common `[:type*..]` form (which contains `[:`, not `[*`) — it silently degraded to one hop
+  instead of erroring.
+* Anonymous nodes `()` failed to parse (`parse_node_pattern` required a mandatory identifier),
+  so chained patterns `()-[:r]->()-[:r]->(x)` errored out entirely.
+
+Reproduced against a code-aligned engine: `MATCH (a {id:'acct-011'})-[:sent_to*1..2]->(x)` returned
+only the depth-1 neighbour, missing the real depth-2 node.
+
+== Landed (this PR)
+
+* **AST** — `EdgePattern` carries `var_length: Option<(u32, u32)>` (`ast.rs`).
+* **Parser** — `parse_path_segment` / `parse_path_chain` populate `var_length` instead of
+  discarding it; `parse_node_pattern` accepts anonymous / label-only nodes (`()`, `(:L)`),
+  synthesising a deterministic per-position variable so chained patterns bind consistently.
+* **Executor** — for a var-length edge the executor runs a **bounded BFS** over `min..=max`
+  hops from the current node, emitting one binding per DISTINCT terminal node that matches the
+  end pattern (*reachability* semantics — the cost-bounded default for impact / lineage / ring
+  tracing). Each node is expanded at most once, so work is **O(V + E) per source regardless of
+  `max`**; `MAX_VARIABLE_LENGTH_DEPTH` (64) backstops pathological `max` values. Intermediate
+  nodes are unconstrained; only the per-hop edge type filters the walk and the terminal pattern
+  gates emission. The fixed single-hop path is unchanged (still binds the traversed edge).
+* **Lowering** — removed the ineffective `[*` reject; var-length edges pass the linear-chain
+  validator unchanged (`from`/`to` still reference adjacent nodes).
+* **Tests** — `graph_runtime` unit ratchets: `variable_length_path_expands_every_depth_in_range`
+  (`*1..3`, `*1..1`, `*2..4` over a 5-node chain) and
+  `anonymous_chained_pattern_traverses_two_explicit_hops`.
+
+== Co-design notes
+
+Traversal cost is node/edge visits (adjacency-store round-trips), not CPU. The visited-set bound
+keeps a var-length query linear in the reachable subgraph, and the depth cap makes a
+user-supplied `max` non-weaponisable. The seam is unchanged (still `graph_query → Vec<Value>`).
+
+== Remaining (follow-ups)
+
+* Per-path multiplicity + relationship-list binding (`RETURN r` where `r` is a var-length rel
+  list) — currently a var-length edge does not bind an edge variable; only `RETURN <node>` is
+  supported. Reachability semantics are the intended default; strict per-path is opt-in later.
+* Emit the query-scoped traversal I/O trace (nodes/edges visited per depth) so the
+  `ComputeScheduler` can cost multi-hop routes from measured quantities.
+* `*0..N` (zero-length paths, i.e. include the start node) is not handled.

--- a/src/storage/engines/tst/mod.rs
+++ b/src/storage/engines/tst/mod.rs
@@ -300,9 +300,11 @@ pub struct TimeSeriesEngine {
     /// Engine configuration
     config: TimeSeriesConfig,
 
-    /// Time-partitioned data storage
-    /// Key: Partition start time, Value: Columnar partition data
-    partitions: BTreeMap<DateTime<Utc>, TimePartition>,
+    /// Time-partitioned data storage.
+    /// Key: (collection_id, partition start time), Value: columnar partition data.
+    /// The collection_id is part of the key so collections sharing a time window are
+    /// isolated — a query for one collection must never see another collection's rows.
+    partitions: BTreeMap<(String, DateTime<Utc>), TimePartition>,
 
     /// Active partition for writes
     /// Points to the current time partition that accepts new writes
@@ -409,11 +411,10 @@ impl TimeSeriesEngine {
         // Determine partition key from timestamp
         let partition_key = self.config.partition_duration.truncate(timestamp);
 
+        // Composite partition key: (collection, time) — isolates collections in memory.
+        let pkey = (collection_id.to_string(), partition_key);
         // Get partition record count before insert (to check if we should trigger downsampling)
-        let partition_count_before = self
-            .partitions
-            .get(&partition_key)
-            .map_or(0, |p| p.record_count());
+        let partition_count_before = self.partitions.get(&pkey).map_or(0, |p| p.record_count());
 
         // Get or create mutable partition and insert record
         {
@@ -425,15 +426,12 @@ impl TimeSeriesEngine {
 
         // Check if downsampling is needed after inserting
         // Trigger downsampling if partition has grown significantly
-        let partition_count_after = self
-            .partitions
-            .get(&partition_key)
-            .map_or(0, |p| p.record_count());
+        let partition_count_after = self.partitions.get(&pkey).map_or(0, |p| p.record_count());
 
         if partition_count_after > partition_count_before && partition_count_after >= 1000 {
             // Check each downsampler to see if it should trigger
             // First collect which downsamplers need to trigger to avoid borrow conflicts
-            let ohlc_to_downsample = if let Some(partition) = self.partitions.get(&partition_key) {
+            let ohlc_to_downsample = if let Some(partition) = self.partitions.get(&pkey) {
                 let mut results = Vec::new();
                 for downsampler in &self.downsamplers {
                     if downsampler.should_trigger(partition).await? {
@@ -511,13 +509,13 @@ impl TimeSeriesEngine {
     /// Query time-series data with time range
     pub async fn query_time_range(
         &self,
-        _collection_id: &str,
+        collection_id: &str,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
         limit: Option<usize>,
     ) -> Result<Vec<VectorRecord>> {
-        // Identify relevant partitions
-        let relevant_partitions = self.identify_partitions(start, end);
+        // Identify relevant partitions for THIS collection only
+        let relevant_partitions = self.identify_partitions(collection_id, start, end);
 
         // Scan partitions in parallel
         let mut results = Vec::new();
@@ -553,7 +551,7 @@ impl TimeSeriesEngine {
         }
 
         // Otherwise, query raw data and aggregate to OHLC on the fly
-        let relevant_partitions = self.identify_partitions(start, end);
+        let relevant_partitions = self.identify_partitions(collection_id, start, end);
         let mut all_bars = Vec::new();
 
         for partition_key in relevant_partitions {
@@ -588,23 +586,24 @@ impl TimeSeriesEngine {
         collection_id: &str,
         partition_key: DateTime<Utc>,
     ) -> Result<&mut TimePartition> {
-        // Check if partition exists in memory
-        if !self.partitions.contains_key(&partition_key) {
+        // Check if partition exists in memory (keyed by collection + time)
+        let pkey = (collection_id.to_string(), partition_key);
+        if !self.partitions.contains_key(&pkey) {
             // Try to load from disk
             let partition_path = self.partition_path(collection_id, partition_key);
             if partition_path.exists() {
                 let partition = TimePartition::load_from_disk(&partition_path).await?;
-                self.partitions.insert(partition_key, partition);
+                self.partitions.insert(pkey.clone(), partition);
             } else {
                 // Create new partition
                 let partition = TimePartition::new(partition_key, collection_id.to_string())?;
-                self.partitions.insert(partition_key, partition);
+                self.partitions.insert(pkey.clone(), partition);
             }
         }
 
         // Return mutable reference
         self.partitions
-            .get_mut(&partition_key)
+            .get_mut(&pkey)
             .ok_or_else(|| anyhow::anyhow!("Partition not found after creation: {}", partition_key))
     }
 
@@ -616,8 +615,8 @@ impl TimeSeriesEngine {
         collection_id: &str,
         partition_key: DateTime<Utc>,
     ) -> Result<()> {
-        if let std::collections::btree_map::Entry::Vacant(e) = self.partitions.entry(partition_key)
-        {
+        let pkey = (collection_id.to_string(), partition_key);
+        if let std::collections::btree_map::Entry::Vacant(e) = self.partitions.entry(pkey) {
             let partition = TimePartition::new(partition_key, collection_id.to_string())?;
             e.insert(partition);
         }
@@ -628,21 +627,27 @@ impl TimeSeriesEngine {
     ///
     /// Used during WAL recovery to replay DropPartition operations.
     pub fn remove_partition(&mut self, partition_key: &DateTime<Utc>) {
-        self.partitions.remove(partition_key);
+        // Drop the time partition across all collections that hold it.
+        self.partitions.retain(|(_, t), _| t != partition_key);
     }
 
     /// Identify partitions that overlap with the time range
-    fn identify_partitions(&self, start: DateTime<Utc>, end: DateTime<Utc>) -> Vec<DateTime<Utc>> {
-        // Partitions are keyed by their truncated start instant and cover the whole
-        // `partition_duration`. A sub-partition query window (e.g. minutes within a Day
-        // partition) must still include the partition that *contains* `start`, whose key
-        // is `<= start` — so widen the lower bound to that partition boundary. Without
-        // this, an intra-partition range like [14:00, 14:05] misses its own partition
-        // (keyed at 00:00) and returns nothing.
+    fn identify_partitions(
+        &self,
+        collection_id: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Vec<(String, DateTime<Utc>)> {
+        // Partitions are keyed by (collection, truncated start instant) and cover the
+        // whole `partition_duration`. A sub-partition query window (e.g. minutes within a
+        // Day partition) must still include the partition that *contains* `start`, whose
+        // key is `<= start` — so widen the lower bound to that partition boundary. The
+        // collection_id bounds the range so only this collection's partitions are scanned.
         let start_key = self.config.partition_duration.truncate(start);
+        let cid = collection_id.to_string();
         self.partitions
-            .range(start_key..=end)
-            .map(|(key, _)| *key)
+            .range((cid.clone(), start_key)..=(cid, end))
+            .map(|(key, _)| key.clone())
             .collect()
     }
 
@@ -1414,20 +1419,17 @@ impl UnifiedStorageFormat for TimeSeriesEngine {
     #[allow(dead_code)]
     async fn do_compact(&self, params: &CompactionParameters) -> Result<CompactionResult> {
         // Identify partitions to compact based on collection_id
-        let partitions_to_compact: Vec<_> = if let Some(_collection_id) = &params.collection_id {
-            self.partitions
-                .iter()
-                .filter(|(_key, _)| {
-                    // For TST engine, we use simple timestamp-based compaction
-                    // Compact all partitions for the specified collection
-                    true
-                })
-                .map(|(key, _)| *key)
-                .collect()
-        } else {
-            // Global compaction - all partitions
-            self.partitions.keys().copied().collect()
-        };
+        let partitions_to_compact: Vec<(String, DateTime<Utc>)> =
+            if let Some(collection_id) = &params.collection_id {
+                self.partitions
+                    .keys()
+                    .filter(|(cid, _)| cid == collection_id)
+                    .cloned()
+                    .collect()
+            } else {
+                // Global compaction - all partitions
+                self.partitions.keys().cloned().collect()
+            };
 
         if partitions_to_compact.is_empty() {
             return Ok(CompactionResult {
@@ -1450,7 +1452,7 @@ impl UnifiedStorageFormat for TimeSeriesEngine {
         // For each partition, flush to disk
         for partition_key in &partitions_to_compact {
             if let Some(partition) = self.partitions.get(partition_key) {
-                let partition_path = self.partition_path("", *partition_key);
+                let partition_path = self.partition_path(&partition_key.0, partition_key.1);
                 let partition_size = partition.size_bytes();
 
                 // Flush partition to disk
@@ -1500,7 +1502,12 @@ impl UnifiedStorageFormat for TimeSeriesEngine {
             current_partition_key: None,
             current_record_index: 0,
             current_partition_records: None,
-            partition_keys: self.partitions.keys().copied().collect(),
+            partition_keys: self
+                .partitions
+                .keys()
+                .filter(|(c, _)| c.as_str() == collection_id)
+                .cloned()
+                .collect(),
             current_index: 0,
         };
 
@@ -1523,8 +1530,8 @@ struct TimeSeriesScanIterator {
     /// Scan strategy filter
     strategy: crate::storage::scan_strategy::ScanStrategy,
 
-    /// Current partition key being scanned
-    current_partition_key: Option<DateTime<Utc>>,
+    /// Current partition key being scanned (collection_id, partition start)
+    current_partition_key: Option<(String, DateTime<Utc>)>,
 
     /// Current record index within partition
     current_record_index: usize,
@@ -1532,8 +1539,8 @@ struct TimeSeriesScanIterator {
     /// Current partition's records (cached)
     current_partition_records: Option<Vec<crate::proto::proximadb_v1::VectorRecord>>,
 
-    /// List of partition keys to scan
-    partition_keys: Vec<DateTime<Utc>>,
+    /// List of partition keys to scan (collection_id, partition start)
+    partition_keys: Vec<(String, DateTime<Utc>)>,
 
     /// Current index in partition_keys
     current_index: usize,
@@ -1547,13 +1554,11 @@ impl ScanIterator for TimeSeriesScanIterator {
 
         while results.len() < batch_size && self.current_index < self.partition_keys.len() {
             // Get current partition
-            let partition_key = self.partition_keys[self.current_index];
+            let partition_key = self.partition_keys[self.current_index].clone();
 
-            if self.current_partition_key.is_none()
-                || self.current_partition_key != Some(partition_key)
-            {
+            if self.current_partition_key.as_ref() != Some(&partition_key) {
                 // Load new partition
-                self.current_partition_key = Some(partition_key);
+                self.current_partition_key = Some(partition_key.clone());
                 self.current_record_index = 0;
                 self.current_partition_records = None;
 
@@ -1713,5 +1718,71 @@ mod tests {
 
         assert_eq!(stats.total_partitions, 0);
         assert_eq!(stats.total_records, 0);
+    }
+
+    /// Regression: two collections writing into the same time window must not
+    /// cross-contaminate. The partition map is keyed by (collection_id, time);
+    /// before the fix it was keyed by time alone, so a query on one collection
+    /// summed the other's records (observed as acct-014 reading $17,934 vs its
+    /// real $1,734 in the fraud/AML demo).
+    #[tokio::test]
+    async fn test_collections_are_isolated_in_the_same_window() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = TimeSeriesConfig {
+            base_path: temp_dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mut engine = TimeSeriesEngine::with_config(config).unwrap();
+
+        let base = DateTime::parse_from_rfc3339("2026-02-01T11:15:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // Distinct timestamps within the same partition window (a partition stores records
+        // by timestamp, so same-window records must differ in time to coexist).
+        let at = |mins: i64| base + chrono::Duration::minutes(mins);
+        let rec = |id: &str, amount: f32, ts: DateTime<Utc>| VectorRecord {
+            id: id.to_string(),
+            vector: vec![amount],
+            timestamp: Some(ts.timestamp_millis()),
+            ..Default::default()
+        };
+
+        // coll_a gets one record of 100; coll_b two of 999 — all in the same partition window.
+        engine
+            .insert_record("coll_a", at(0), rec("a-1", 100.0, at(0)))
+            .await
+            .unwrap();
+        engine
+            .insert_record("coll_b", at(1), rec("b-1", 999.0, at(1)))
+            .await
+            .unwrap();
+        engine
+            .insert_record("coll_b", at(2), rec("b-2", 999.0, at(2)))
+            .await
+            .unwrap();
+
+        let start = base - chrono::Duration::hours(1);
+        let end = base + chrono::Duration::hours(1);
+
+        let a = engine
+            .query_time_range("coll_a", start, end, None)
+            .await
+            .unwrap();
+        assert_eq!(a.len(), 1, "coll_a must see only its own record");
+        assert_eq!(a[0].vector, vec![100.0]);
+
+        let b = engine
+            .query_time_range("coll_b", start, end, None)
+            .await
+            .unwrap();
+        assert_eq!(b.len(), 2, "coll_b must see only its own two records");
+        assert!(b.iter().all(|r| r.vector == vec![999.0]));
+
+        // A collection that never wrote in this window sees nothing.
+        let empty = engine
+            .query_time_range("coll_c", start, end, None)
+            .await
+            .unwrap();
+        assert!(empty.is_empty(), "coll_c wrote nothing, must read nothing");
     }
 }


### PR DESCRIPTION
Two engine correctness gaps surfaced by — and driven to fix from — the fraud/AML vertical demo. Both are **verified end-to-end against a code-aligned Docker image**, not just unit tests.

## 1. TST timeseries per-collection isolation
The `TimeSeriesEngine` partition map was keyed by **timestamp alone**, so two timeseries collections writing into the same time window **cross-contaminated** — a range query on one collection summed the other's records (observed in the AML demo as an account reading **$17,934 vs its real $1,734**). This affects the timeseries surface shipped in #651.

**Fix:** key partitions by `(collection_id, time)` everywhere — insert, range query, OHLC, compaction, scan iterator, and WAL recovery (`ensure_partition` / `remove_partition`). Adds `test_collections_are_isolated_in_the_same_window`.

## 2. Cypher variable-length / multi-hop traversal (TD-GRAPH-3)
The shared graph subset (`proximadb-graph-query` + `proximadb-query`) **parsed** the `*min..max` quantifier but **discarded** it (the `EdgePattern` AST had no field to carry it), and the executor did a single neighbour-expansion per edge — so `-[:r*1..N]->` only ever reached **depth 1**. Anonymous nodes `()` also failed to parse, so chained `()-->()-->(x)` patterns errored.

**Fix:**
- `EdgePattern` carries `var_length: Option<(u32,u32)>`; the parser populates it and now accepts anonymous / label-only nodes (deterministic per-position variable so chained patterns bind consistently).
- The executor expands a var-length edge via **bounded BFS** over `min..=max` hops — *reachability* semantics (the cost-bounded default for impact / lineage / ring tracing), visited-bounded to **O(V+E) per source** regardless of `max`, with a hard `MAX_VARIABLE_LENGTH_DEPTH` (64) backstop.
- Removed the ineffective `"[*"` lowering reject (it never matched the common `[:type*..]` form).
- Ratchet tests: `variable_length_path_expands_every_depth_in_range` (`*1..3`, `*1..1`, `*2..4`) and `anonymous_chained_pattern_traverses_two_explicit_hops`.

## Verification (live, code-aligned image)
- Timeseries scan flags **exactly the 4 ring accounts** (placement, mule, consolidation, cash-out) with **zero false positives** (was 13/40 before).
- A single Cypher `MATCH (a {id:'acct-007'})-[:sent_to*1..4]->(x) RETURN x` walks the **full ring**: `acct-007 → acct-011/012/013 → acct-020 → acct-030`.

Co-design: traversal cost is adjacency round-trips, not CPU — the visited-set bound keeps a var-length query linear in the reachable subgraph and the depth cap makes a user `max` non-weaponisable. Stable seam unchanged (`graph_query → Vec<Value>`).

The fraud/AML vertical demo that surfaced these lands in a separate PR.