### PR TITLE
feat(olap): stats-fed DataFusion planning (TD-DFR-1) + TPC perf evidence-ledger harness (TD-OLAP-4 P0b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1820,6 +1820,53 @@ jobs:
           retention-days: 30
 
   # ============================================================================
+  # TPC PERF EVIDENCE LEDGER (TD-OLAP-4 P0b) — ADVISORY, never a merge gate.
+  # Records latency + bytes-scanned per query x route (native vs DataFusion)
+  # into a JSON ledger artifact on develop pushes / manual dispatch. Gate
+  # (ratchet on a budget) only once variance is bounded — mirror the
+  # pax-recall-ratchet advisory-until-stable pattern. NOT in ci-success needs.
+  # ============================================================================
+  tpc-perf-ledger:
+    name: TPC Perf Evidence Ledger (advisory)
+    runs-on: ubuntu-latest
+    needs: [rust-build]
+    continue-on-error: true
+    timeout-minutes: 60
+    if: |
+      inputs.run_benchmarks ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-tpc-perf"
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+
+      - name: Run TPC perf ledger harness (small scale, advisory)
+        env:
+          TPC_PERF_SCALE: "0.001"
+          TPC_PERF_LEDGER_OUT: target/tpc-perf-ledger/ledger.json
+          # Debug-build planning of join+subquery-heavy TPC shapes runs deep;
+          # 16 MiB thread stacks guard against environment-dependent overflow.
+          RUST_MIN_STACK: "16777216"
+        run: |
+          cargo test --test tpc_perf_ledger_e2e -- --ignored --nocapture 2>&1 | tail -40
+
+      - name: Upload ledger artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tpc-perf-ledger
+          path: target/tpc-perf-ledger/ledger.json
+          retention-days: 30
+
+  # ============================================================================
   # SUMMARY - Final status check
   # ============================================================================
   ci-success:

--- a/docs/10-quality/TPC_PERF_LEDGER.adoc
+++ b/docs/10-quality/TPC_PERF_LEDGER.adoc
@@ -1,0 +1,90 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TPC-H / TPC-DS Performance Evidence Ledger — methodology (TD-OLAP-4)
+
+The harness `tests/tpc_perf_ledger_e2e.rs` promotes the TPC suites from
+count-only *conformance* ratchets (`tests/{tpch,tpcds}_pgwire_e2e.rs`) toward
+*measured* performance evidence (ADR-052 invariant 4). Per query x route x
+temperature it records wall latency and the per-query I/O trace snapshot
+(TD-158: `bytes_read`, `range_gets`, footer hits, per-engine `compute_ms`)
+into a versioned JSON ledger artifact. ProximaDB latency and bytes-scanned on the TPC workloads are measured by this harness per query on both routes.
+
+== How to run
+
+[source,bash]
+----
+TPC_PERF_SCALE=0.001 cargo test --test tpc_perf_ledger_e2e -- --ignored --nocapture
+# artifact: target/tpc-perf-ledger/ledger.json (override: TPC_PERF_LEDGER_OUT)
+# debug builds: RUST_MIN_STACK=16777216 — plan-time recursion on the Q2-class
+# join+subquery shapes overflows default thread stacks on some environments
+# (reproduced on WSL2 debug even without column statistics).
+----
+
+CI: the `tpc-perf-ledger` job in `.github/workflows/ci.yml` runs at small scale
+on develop pushes / manual dispatch, `continue-on-error: true` (ADVISORY — it
+is not in the `ci-success` aggregator and must never gate a merge until
+variance is bounded; mirror the pax-recall-ratchet advisory-until-stable
+pattern when promoting).
+
+== Methodology (pinned per ledger entry; regimes are never averaged)
+
+|===
+| Field | Value / rule
+
+| storage regime
+| `local-tempdir` (file:// object store on local disk). The local-NVMe regime
+  is CPU-bound; the object-store regime is bytes-scanned-bound (ADR-052 first
+  principles). They are separate ledger sections — never average across them.
+  Object-store regimes (MinIO/Azurite/real cloud) are a follow-up section.
+
+| routes
+| `native` (row-wise Volcano, pre-MATERIALIZE) and `datafusion`
+  (Parquet-backed, post-`ALTER TABLE … MATERIALIZE`) — the in-repo baseline
+  pair that TD-OLAP-1 promotion decisions consume. Both routes emit the full
+  I/O trace (the DataFusion Parquet leaf is instrumented via
+  `TracingObjectStore`).
+
+| temperature
+| `first` vs `repeat` against a warm process. This is NOT a cold-page-cache
+  measurement — true cold runs need a server restart per query (future slice).
+
+| datagen
+| `synthetic-tpc-shaped`: deterministic (seeded SplitMix64), TPC-schema
+  row-ratio-scaled, power-law key skew, referentially intact. It is **not**
+  audited dbgen/dsdgen output — no TPC-official or external-comparative claim
+  may cite this ledger until a faithful generator + bulk-load path lands.
+
+| scale
+| `TPC_PERF_SCALE` (1.0 ≡ SF1 row ratios). CI runs 0.001 (~9k TPC-H rows);
+  SF1 over per-row INSERTs is impractical — a bulk-load path is the
+  prerequisite for real SF1/SF10 entries.
+
+| baselines
+| External engines (DuckDB, plain DataFusion-on-Parquet standalone,
+  ClickHouse) are DEFERRED: no CI service-container pattern exists in this
+  repo yet; the dual-route comparison above is the in-repo baseline. When
+  added, each baseline's ledger entry must pin engine version, storage
+  config, and cache state.
+
+| honesty rule
+| The ledger records where ProximaDB *loses* (e.g. DataFusion hash-join
+  no-spill on large joins) — mandate #11: no "competitive" claim is cited in
+  any doc without a ledger entry backing it.
+|===
+
+== Ledger JSON shape
+
+`{ methodology: {engine_version, git_sha, scale, storage_regime, datagen,
+temperature_semantics, routes}, records: [{benchmark, query, route,
+temperature, ok, error?, rows, wall_ms, ...IoTraceSnapshot}] }`
+
+The `IoTraceSnapshot` fields are flattened per record: `get_ops`, `bytes_read`,
+`range_gets`, `bytes_written`, `footer_hits/misses`, `egress_bytes`,
+`compute_ms` (per-engine map).
+
+== Relation to the evidence ledger
+
+Claims derived from this harness are tracked in
+`docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml` (validator-enforced). A run
+artifact must be checked in (dated) before any entry is promoted to
+`measured`.

--- a/docs/10-quality/td/TD-DFR-1-columnstatistics-for-datafusion.adoc
+++ b/docs/10-quality/td/TD-DFR-1-columnstatistics-for-datafusion.adoc
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DFR-1: Feed real `ColumnStatistics` to the DataFusion planner (ADR-050 D2)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Resolved (first slice, 2026-07-04) — footer-derived stats + registry NDV overlay wired to the DataFusion provider; the ADR-042 aggregate-from-segments generalization continues under TD-OLAP-2
+| Severity | High — the DataFusion planner planned blind (`ColumnStatistics::new_unknown()`, `extract_statistics` had no call site, providers defaulted `statistics: None`)
+| Component | `src/datafusion/schema_inference.rs`, `src/datafusion/engine_adapters/object_store_parquet_reader.rs`, `src/datafusion/proxima_scan_exec.rs`
+| Governs | link:../../12-design/adr/ADR-050-statistics-fed-datafusion-route-selection.adoc[ADR-050] D2; first slice of link:TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2] (P0a)
+| Relates to | ADR-042 (SegmentStatistics contract — the intended generalization), ADR-037/038 (statistics substrate + freshness), ADR-039 (the projection lives inside the datafusion adapter allow-list), ADR-052 (execution order P0a)
+|===
+
+== What landed (2026-07-04)
+
+. **Projection core** (`schema_inference.rs`): `statistics_from_splits` merges
+  per-row-group Parquet footer `ColumnBounds` (min-of-mins / max-of-maxes /
+  summed nulls / rows / bytes) into a **schema-width** DataFusion `Statistics`
+  (DataFusion 54 indexes `column_statistics[col.index()]` — a short vector
+  panics under `AggregateExec`). All footer-derived values are
+  `Precision::Inexact` (ADR-050 D3: hints, not truth — post-materialize deltas
+  make the snapshot conservative). `extract_statistics` now also projects
+  min/max (it silently dropped them). `project_statistics` narrows to a scan's
+  projection, preserving the width contract for the exec schema.
+. **Provider wiring** (`object_store_parquet_reader.rs`): `ObjectStoreParquetTable`
+  — the provider that actually serves the `route_select → DataFusionLocal`
+  arm — implements `TableProvider::statistics()` (zero new scan: footers were
+  already read at open for pruning) and passes post-prune, projection-narrowed
+  stats into `ProximaScanExec` (whose `.statistics()` builder slot existed but
+  was never fed).
+. **NDV overlay**: where the ADR-037 resident registry
+  (`statistics_registry().envelope(table)`) has a `distinct_estimate` (HLL),
+  it fills `distinct_count` — Parquet footers rarely carry NDV; the sketch
+  does. Registry absent ⇒ skipped (best-effort).
+. **Value-bounds gate (default OFF)**: typed min/max projection is opt-in via
+  `PROXIMADB_DF_STATS_VALUE_BOUNDS=1` (`df_stats_value_bounds_enabled`).
+  Bounds feed DataFusion's recursive interval/selectivity analysis, deepening
+  plan-time recursion on join+subquery-heavy shapes (TPC-H Q2 class) whose
+  debug-build stack use is already environment-borderline (a Q2 debug stack
+  overflow reproduces on WSL2 *without* bounds; `RUST_MIN_STACK=16777216`
+  clears it). Rows/bytes/nulls/NDV — the join-ordering inputs — always flow;
+  flipping the gate on is a follow-up once the recursion depth is
+  characterized (default-OFF-until-baked posture).
+
+== Not in this slice (tracked under TD-OLAP-2)
+
+* The ADR-042 `SegmentStatistics` canonical type + `SegmentFormat::detect`
+  seam (the type does not exist in code yet); PAX-segment stats feeding.
+* Cardinality estimation in the native/federated planner; histograms.
+* Stats invalidation on compaction / DV application (TD-OLAP-2 step 2);
+  freshness-stamped staleness flag in EXPLAIN.
+
+== Verification
+
+* `schema_inference` unit tests: merge/schema-width/partial-coverage/NDV
+  overlay/projection/typed-bound conversion.
+* `object_store_parquet_reader` unit test: `TableProvider::statistics()`
+  projects real footer bounds from written Parquet.
+* Regression: DataFusion aggregate paths + TPC-H/TPC-DS pgwire conformance
+  ratchets unchanged (guards the schema-width panic).

--- a/docs/10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc
+++ b/docs/10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — ADR-050 D2, filed as **TD-DFR-1** (ColumnStatistics for DataFusion), is the first slice; this TD generalizes it to the native planner + cardinality estimation
+| Status | Open (first slice **landed 2026-07-04**: link:TD-DFR-1-columnstatistics-for-datafusion.adoc[TD-DFR-1] wired footer-derived `ColumnStatistics` + registry NDV to the DataFusion provider); this TD continues with the ADR-042 generalization, native-planner cardinality, histograms, and stats invalidation
 | Priority | **P0a** — cheapest unlock in the ADR-052 execution order; feeds cost routing (ADR-050) and runtime filters (TD-OLAP-3). DIP: the planner consumes the ADR-042 `SegmentStatistics` port, never engine internals
 | Severity | High — without stats the planner is blind; runtime filters (TD-OLAP-3) and cost routing (ADR-050) both depend on it
 | Component | `src/core/statistics/{summary,sketches,registry}`, `src/datafusion/schema_inference.rs`, `src/query/query_optimizer.rs`, `src/query/federated/optimizer/`

--- a/docs/10-quality/td/TD-OLAP-4-tpcds-performance-evidence-ledger.adoc
+++ b/docs/10-quality/td/TD-OLAP-4-tpcds-performance-evidence-ledger.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — the measurement mandate; prerequisite for any "competitive" claim
+| Status | Open (P0b skeleton **landed 2026-07-04**: `tests/tpc_perf_ledger_e2e.rs` dual-route harness + advisory `tpc-perf-ledger` CI job + methodology doc `docs/10-quality/TPC_PERF_LEDGER.adoc`; remaining: faithful datagen + bulk load for real SF1/SF10, object-store regime section, external baselines)
 | Priority | **P0b** in the ADR-052 execution order — the harness skeleton lands *before* any optimization (measure-first); it is the promotion gate for TD-OLAP-1/3/5
 | Severity | High — co-design principle #11: reject component microbenchmarks masquerading as e2e claims; method step 2: capture the trace first
 | Component | `tests/{tpcds,tpch}_pgwire_e2e.rs`, `tools/benchbase/`, `.github/workflows/qa-gate.yml`, new evidence-ledger harness

--- a/docs/12-design/adr/ADR-050-statistics-fed-datafusion-route-selection.adoc
+++ b/docs/12-design/adr/ADR-050-statistics-fed-datafusion-route-selection.adoc
@@ -85,6 +85,16 @@ planning **with zero new scan** (the sketches were produced at flush). The proje
 format-agnostic via ADR-042's `SegmentFormat::detect` seam, so ProximaBlocks and PAX
 segments both feed the same `ColumnStatistics`.
 
+*Status (2026-07-04):* first slice **landed** as
+link:../../10-quality/td/TD-DFR-1-columnstatistics-for-datafusion.adoc[TD-DFR-1] —
+`ObjectStoreParquetTable` (the provider serving the `DataFusionLocal` arm) now
+implements `statistics()` from the already-read Parquet footer bounds
+(schema-width, `Precision::Inexact` per D3) with the ADR-037 registry's HLL NDV
+overlaid, and feeds post-prune projected stats into `ProximaScanExec`. Note the
+canonical `SegmentStatistics` type / `SegmentFormat::detect` seam is not yet in
+code — the ADR-042 generalization (PAX segments feeding the same projection)
+continues under TD-OLAP-2.
+
 === D3 — Treat statistics as freshness-bounded hints (ADR-038)
 
 Each `SegmentStatistics` block carries its own freshness watermark; the envelope floor is

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -314,3 +314,17 @@ hardware = ""
 date = ""
 version = ""
 notes = "Co-design T3.2. The bench measures the raw object-store round-trip floor in isolation (full GET, last-4KiB ranged GET, prefix LIST) at 4KiB/64KiB/1MiB sizes, p50/p95/p99/mean. It ALWAYS runs (defaults to in-process memory://) so CI proves the harness compiles, but memory:// latencies carry NO network RTT and are a smoke check only. Real cloud-latency evidence requires an operator run against s3:// (with --features aws; creds via the standard chain) or a minio endpoint — promote to `measured` with that dated artifact. This is the floor the route cost model and footer/ranged-read decisions must beat."
+
+[[claims]]
+id = "tpc_perf_ledger_dual_route"
+claim = "TPC-H/TPC-DS per-query latency + bytes-scanned on both routes (native Volcano vs DataFusion-on-Parquet), measured into a versioned JSON ledger"
+metric = "wall_ms + bytes_read per query x route x temperature"
+status = "unverified"
+asserted_in = ["docs/10-quality/TPC_PERF_LEDGER.adoc:10"]
+bench_source = "tests/tpc_perf_ledger_e2e.rs"
+bench_command = "TPC_PERF_SCALE=0.001 cargo test --test tpc_perf_ledger_e2e -- --ignored --nocapture"
+artifact = ""
+hardware = ""
+date = ""
+version = ""
+notes = "TD-OLAP-4 P0b skeleton (ADR-052 invariant 4). Datagen is synthetic-tpc-shaped (seeded, deterministic, NON-audited dbgen/dsdgen) at TPC_PERF_SCALE row ratios — no TPC-official or external-comparative claim may cite this until a faithful generator + bulk-load path lands. Storage regime local-tempdir only; regimes are separate ledger sections, never averaged. Advisory `tpc-perf-ledger` CI job (continue-on-error, not in ci-success) uploads the artifact on develop pushes. Promote to `measured` only with a dated, checked-in ledger artifact from a quiet machine."

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -11,6 +11,7 @@ use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::ScalarValue as DfScalarValue;
+use datafusion::common::Statistics;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::SendableRecordBatchStream;
@@ -34,6 +35,10 @@ use url::Url;
 
 use super::super::proxima_scan_exec::{ProximaScanExec, SplitReader};
 use super::super::proxima_table_provider::EngineType;
+use super::super::schema_inference::{
+    df_stats_value_bounds_enabled, project_statistics, statistics_from_splits,
+};
+use crate::observability::object_store_trace::TracingObjectStore;
 
 fn project_schema(full: &SchemaRef, projection: Option<&[usize]>) -> SchemaRef {
     match projection {
@@ -141,6 +146,9 @@ pub struct ObjectStoreParquetTable {
     splits: Vec<FileSplit>,
     file_sizes: HashMap<String, u64>,
     location: String,
+    /// Registered table/collection name — keys the ADR-037 statistics
+    /// registry for the NDV overlay in [`TableProvider::statistics`].
+    table_name: Option<String>,
 }
 
 impl ObjectStoreParquetTable {
@@ -173,7 +181,10 @@ impl ObjectStoreParquetTable {
             ));
         }
 
-        let store = bridge.inner_store();
+        // Wrap the store so footer + row-group reads land in the per-query
+        // I/O trace (ADR-030/TD-158) — the DataFusion route's bytes-scanned
+        // was previously invisible to the co-design cost model.
+        let store = TracingObjectStore::wrap(bridge.inner_store());
         let mut files = Vec::with_capacity(parquet_paths.len());
         for relative in parquet_paths {
             let full = bridge.full_object_path(&relative);
@@ -191,7 +202,7 @@ impl ObjectStoreParquetTable {
         let parsed = Url::parse(location).map_err(|e| df_err("parse object-store url", e))?;
         let (store, path) =
             object_store::parse_url(&parsed).map_err(|e| df_err("object_store parse_url", e))?;
-        let store: Arc<dyn ObjectStore> = Arc::from(store);
+        let store: Arc<dyn ObjectStore> = TracingObjectStore::wrap(Arc::from(store));
         let size = store
             .head(&path)
             .await
@@ -230,7 +241,15 @@ impl ObjectStoreParquetTable {
             splits,
             file_sizes,
             location,
+            table_name: None,
         })
+    }
+
+    /// Attach the registered table name (keys the ADR-037 statistics registry
+    /// so [`TableProvider::statistics`] can overlay the HLL NDV estimate).
+    pub fn with_table_name(mut self, name: impl Into<String>) -> Self {
+        self.table_name = Some(name.into());
+        self
     }
 
     /// Number of row-group splits before runtime filter pruning.
@@ -303,6 +322,18 @@ impl TableProvider for ObjectStoreParquetTable {
         TableType::Base
     }
 
+    fn statistics(&self) -> Option<Statistics> {
+        // ADR-050 D2 / TD-DFR-1: footer-derived, zero-new-scan column
+        // statistics so the planner stops planning blind. Typed min/max value
+        // bounds are opt-in (default OFF) — see `df_stats_value_bounds_enabled`.
+        Some(statistics_from_splits(
+            &self.splits,
+            &self.schema,
+            self.table_name.as_deref(),
+            df_stats_value_bounds_enabled(),
+        ))
+    }
+
     async fn scan(
         &self,
         state: &dyn Session,
@@ -311,9 +342,21 @@ impl TableProvider for ObjectStoreParquetTable {
         limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let target_partitions = state.config().target_partitions();
+        let pruned = self.prune_splits(filters);
+        // Post-prune stats, narrowed to the projection: `partition_statistics`
+        // requires the vector to match the exec's PROJECTED schema width.
+        let scan_stats = project_statistics(
+            &statistics_from_splits(
+                &pruned,
+                &self.schema,
+                self.table_name.as_deref(),
+                df_stats_value_bounds_enabled(),
+            ),
+            projection.map(|p| p.as_slice()),
+        );
         let exec = ProximaScanExec::builder()
             .schema(self.schema.clone())
-            .splits(self.prune_splits(filters))
+            .splits(pruned)
             .reader(self.reader())
             .projection(projection.cloned())
             .filters(filters.to_vec())
@@ -321,6 +364,7 @@ impl TableProvider for ObjectStoreParquetTable {
             .collection_name(self.location.clone())
             .batch_size(8192)
             .target_partitions(target_partitions)
+            .statistics(scan_stats)
             .build()?;
         Ok(Arc::new(exec))
     }
@@ -530,7 +574,11 @@ pub async fn register_object_store_parquet_location(
     name: &str,
     location: &str,
 ) -> DFResult<Arc<ObjectStoreParquetTable>> {
-    let table = Arc::new(ObjectStoreParquetTable::open(location).await?);
+    let table = Arc::new(
+        ObjectStoreParquetTable::open(location)
+            .await?
+            .with_table_name(name),
+    );
     ctx.register_table(name, table.clone())?;
     Ok(table)
 }
@@ -605,6 +653,54 @@ mod tests {
             table.estimated_bytes().unwrap_or(0) > 0,
             "row-group byte sizes are present in the footer"
         );
+    }
+
+    #[tokio::test]
+    async fn table_provider_statistics_projects_footer_bounds() {
+        use datafusion_common::stats::Precision;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        write_two_row_group_parquet(&data_dir.join("part-0.parquet"));
+
+        let location = format!("file://{}", tmp.path().display());
+        let table = ObjectStoreParquetTable::open(&location).await.unwrap();
+
+        // Provider path — value bounds are gated default-OFF
+        // (`df_stats_value_bounds_enabled`), but rows/bytes/nulls always flow.
+        let stats = TableProvider::statistics(&table).expect("footer-backed statistics");
+        assert_eq!(stats.num_rows, Precision::Inexact(4));
+        // Schema-width contract: one entry per table column.
+        assert_eq!(stats.column_statistics.len(), 2);
+        assert_eq!(stats.column_statistics[1].null_count, Precision::Inexact(0));
+        assert_eq!(
+            stats.column_statistics[1].min_value,
+            Precision::Absent,
+            "value bounds stay Absent while the gate is off (default)"
+        );
+
+        // With bounds enabled: min-of-mins / max-of-maxes across row groups.
+        let full = statistics_from_splits(&table.splits, &table.schema, None, true);
+        let k = &full.column_statistics[0];
+        assert_eq!(
+            k.min_value,
+            Precision::Inexact(DfScalarValue::Utf8(Some("a".to_string())))
+        );
+        assert_eq!(
+            k.max_value,
+            Precision::Inexact(DfScalarValue::Utf8(Some("b".to_string())))
+        );
+        let x = &full.column_statistics[1];
+        assert_eq!(
+            x.min_value,
+            Precision::Inexact(DfScalarValue::Int64(Some(1)))
+        );
+        assert_eq!(
+            x.max_value,
+            Precision::Inexact(DfScalarValue::Int64(Some(101)))
+        );
+        assert_eq!(x.null_count, Precision::Inexact(0));
     }
 
     #[tokio::test]

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -8,11 +8,13 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::{
     DataType as ArrowDataType, Field, Schema as ArrowSchema, TimeUnit as ArrowTimeUnit,
 };
-use datafusion::common::{ColumnStatistics, Statistics};
+use datafusion::common::{ColumnStatistics, ScalarValue as DfScalarValue, Statistics};
 use datafusion::error::Result as DFResult;
+use datafusion_common::stats::Precision;
 
 use crate::storage::formats::FormatStatistics;
 use proximadb_data_model::{ProximaType, TimeUnit as DmTimeUnit, VectorElement};
+use proximadb_storage_common::format_splits::FileSplit;
 
 use crate::storage::schema::{ProximaColumn, ProximaSchema};
 
@@ -27,18 +29,19 @@ pub fn infer_schema_from_collection(proxima_schema: &ProximaSchema) -> DFResult<
 /// Extract DataFusion Statistics from ProximaDB format statistics.
 pub fn extract_statistics(format_stats: &FormatStatistics, schema: &ArrowSchema) -> Statistics {
     let num_rows = if format_stats.row_count > 0 {
-        datafusion_common::stats::Precision::Exact(format_stats.row_count as usize)
+        Precision::Exact(format_stats.row_count as usize)
     } else {
-        datafusion_common::stats::Precision::Absent
+        Precision::Absent
     };
 
     let total_byte_size = if format_stats.size_bytes > 0 {
-        datafusion_common::stats::Precision::Exact(format_stats.size_bytes as usize)
+        Precision::Exact(format_stats.size_bytes as usize)
     } else {
-        datafusion_common::stats::Precision::Absent
+        Precision::Absent
     };
 
-    // Create column statistics for each field
+    // Create column statistics for each field (schema-width — DataFusion 54
+    // indexes `column_statistics[col.index()]`, see `proxima_scan_exec.rs`).
     let column_statistics: Vec<ColumnStatistics> = schema
         .fields()
         .iter()
@@ -48,12 +51,24 @@ pub fn extract_statistics(format_stats: &FormatStatistics, schema: &ArrowSchema)
                 // Build column statistics from stored values
                 let mut cs = ColumnStatistics::new_unknown();
                 // null_count is u64 (not Option)
-                cs.null_count =
-                    datafusion_common::stats::Precision::Exact(col_stats.null_count as usize);
+                cs.null_count = Precision::Exact(col_stats.null_count as usize);
                 // distinct_count is Option<u64>
                 if let Some(distinct) = col_stats.distinct_count {
-                    cs.distinct_count =
-                        datafusion_common::stats::Precision::Exact(distinct as usize);
+                    cs.distinct_count = Precision::Exact(distinct as usize);
+                }
+                if let Some(min) = col_stats
+                    .min
+                    .as_ref()
+                    .and_then(|v| json_bound_to_scalar(v, field.data_type()))
+                {
+                    cs.min_value = Precision::Exact(min);
+                }
+                if let Some(max) = col_stats
+                    .max
+                    .as_ref()
+                    .and_then(|v| json_bound_to_scalar(v, field.data_type()))
+                {
+                    cs.max_value = Precision::Exact(max);
                 }
                 cs
             } else {
@@ -66,6 +81,234 @@ pub fn extract_statistics(format_stats: &FormatStatistics, schema: &ArrowSchema)
         num_rows,
         total_byte_size,
         column_statistics,
+    }
+}
+
+/// Project the Parquet-footer split statistics of a table into DataFusion
+/// [`Statistics`] (ADR-050 D2 / TD-DFR-1): min-of-mins / max-of-maxes across
+/// splits, summed null counts, summed rows/bytes.
+///
+/// Everything is [`Precision::Inexact`] — per ADR-050 D3 statistics are
+/// freshness-bounded *hints, not truth* (post-materialize deltas make the
+/// Parquet snapshot conservative). The vector is always **schema-width**
+/// (DataFusion 54 indexes `column_statistics[col.index()]` from parent
+/// operators); columns without footer bounds stay `new_unknown()`.
+///
+/// When `collection` is given and the ADR-037 statistics registry holds a
+/// resident summary for it, its HLL `distinct_estimate` fills
+/// `distinct_count` — Parquet footers rarely carry NDV, the sketch does.
+///
+/// `include_value_bounds` gates min/max projection (see
+/// [`df_stats_value_bounds_enabled`]): typed value bounds feed DataFusion's
+/// recursive interval/selectivity analysis, deepening planner recursion on
+/// join+subquery-heavy plans (TPC-H Q2 class), whose debug-build stack use is
+/// already near the limit on some environments (a Q2 stack overflow reproduces
+/// on WSL2 debug builds even WITHOUT bounds; `RUST_MIN_STACK=16777216` clears
+/// it). Bounds therefore stay opt-in (default-OFF, storage-migration mandate
+/// posture) until that recursion depth is characterized. Row/byte counts, null
+/// counts, and NDV — the inputs that drive join ordering — always flow.
+pub fn statistics_from_splits(
+    splits: &[FileSplit],
+    schema: &ArrowSchema,
+    collection: Option<&str>,
+    include_value_bounds: bool,
+) -> Statistics {
+    let mut num_rows = 0usize;
+    let mut any_rows = false;
+    let mut total_bytes = 0usize;
+    let mut any_bytes = false;
+    for split in splits {
+        if let Some(rows) = split.statistics.row_count {
+            num_rows = num_rows.saturating_add(rows as usize);
+            any_rows = true;
+        }
+        if let Some(bytes) = split.statistics.byte_size {
+            total_bytes = total_bytes.saturating_add(bytes as usize);
+            any_bytes = true;
+        }
+    }
+
+    let registry_fields = collection
+        .and_then(|c| crate::core::statistics::statistics_registry().envelope(c))
+        .map(|env| env.fields)
+        .unwrap_or_default();
+
+    let column_statistics: Vec<ColumnStatistics> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let mut cs = ColumnStatistics::new_unknown();
+            let mut min: Option<DfScalarValue> = None;
+            let mut max: Option<DfScalarValue> = None;
+            let mut nulls = 0usize;
+            let mut covered = 0usize;
+            for split in splits {
+                let Some(bounds) = split.statistics.column_stats.get(field.name()) else {
+                    continue;
+                };
+                covered += 1;
+                nulls = nulls.saturating_add(bounds.null_count as usize);
+                if let Some(v) = bounds
+                    .min
+                    .as_ref()
+                    .and_then(|v| json_bound_to_scalar(v, field.data_type()))
+                {
+                    min = Some(match min.take() {
+                        Some(cur) => scalar_min(cur, v),
+                        None => v,
+                    });
+                }
+                if let Some(v) = bounds
+                    .max
+                    .as_ref()
+                    .and_then(|v| json_bound_to_scalar(v, field.data_type()))
+                {
+                    max = Some(match max.take() {
+                        Some(cur) => scalar_max(cur, v),
+                        None => v,
+                    });
+                }
+            }
+            // Only claim bounds/nulls when EVERY split carries footer stats for
+            // this column — a partially-covered column would understate.
+            if covered == splits.len() && covered > 0 {
+                if include_value_bounds {
+                    if let Some(min) = min {
+                        cs.min_value = Precision::Inexact(min);
+                    }
+                    if let Some(max) = max {
+                        cs.max_value = Precision::Inexact(max);
+                    }
+                }
+                cs.null_count = Precision::Inexact(nulls);
+            }
+            if let Some(ndv) = registry_fields
+                .iter()
+                .find(|f| f.name == *field.name())
+                .and_then(|f| f.distinct_estimate)
+            {
+                cs.distinct_count = Precision::Inexact(ndv as usize);
+            }
+            cs
+        })
+        .collect();
+
+    Statistics {
+        num_rows: if any_rows {
+            Precision::Inexact(num_rows)
+        } else {
+            Precision::Absent
+        },
+        total_byte_size: if any_bytes {
+            Precision::Inexact(total_bytes)
+        } else {
+            Precision::Absent
+        },
+        column_statistics,
+    }
+}
+
+/// Opt-in gate for projecting typed min/max value bounds into DataFusion
+/// `ColumnStatistics` (default **off**, per the default-OFF mandate for
+/// planner-behavior changes): bounds enable DataFusion 54's recursive
+/// interval-based filter-selectivity analysis, deepening plan-time recursion
+/// on join+subquery-heavy shapes (TPC-H Q2 class) whose debug-build stack use
+/// is already borderline on some environments. Enable with
+/// `PROXIMADB_DF_STATS_VALUE_BOUNDS=1` once that recursion depth is
+/// characterized; row/null/NDV statistics flow regardless.
+pub fn df_stats_value_bounds_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_DF_STATS_VALUE_BOUNDS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
+/// Narrow a table-wide [`Statistics`] to a projection, preserving the
+/// schema-width contract for the projected schema.
+pub fn project_statistics(stats: &Statistics, projection: Option<&[usize]>) -> Statistics {
+    match projection {
+        None => stats.clone(),
+        Some(indices) => Statistics {
+            num_rows: stats.num_rows,
+            total_byte_size: stats.total_byte_size.to_inexact(),
+            column_statistics: indices
+                .iter()
+                .map(|&i| {
+                    stats
+                        .column_statistics
+                        .get(i)
+                        .cloned()
+                        .unwrap_or_else(ColumnStatistics::new_unknown)
+                })
+                .collect(),
+        },
+    }
+}
+
+/// Convert a JSON zone-map bound into a typed DataFusion scalar for `field`.
+///
+/// Footer bounds are stored as JSON (`i64`/`f64`/`bool`/string — see
+/// `column_bounds_from_parquet`); only types with a lossless mapping are
+/// projected, everything else stays `Absent`.
+fn json_bound_to_scalar(
+    value: &serde_json::Value,
+    data_type: &ArrowDataType,
+) -> Option<DfScalarValue> {
+    match data_type {
+        ArrowDataType::Boolean => value.as_bool().map(|v| DfScalarValue::Boolean(Some(v))),
+        ArrowDataType::Int8 => value
+            .as_i64()
+            .and_then(|v| i8::try_from(v).ok())
+            .map(|v| DfScalarValue::Int8(Some(v))),
+        ArrowDataType::Int16 => value
+            .as_i64()
+            .and_then(|v| i16::try_from(v).ok())
+            .map(|v| DfScalarValue::Int16(Some(v))),
+        ArrowDataType::Int32 => value
+            .as_i64()
+            .and_then(|v| i32::try_from(v).ok())
+            .map(|v| DfScalarValue::Int32(Some(v))),
+        ArrowDataType::Int64 => value.as_i64().map(|v| DfScalarValue::Int64(Some(v))),
+        ArrowDataType::UInt8 => value
+            .as_u64()
+            .and_then(|v| u8::try_from(v).ok())
+            .map(|v| DfScalarValue::UInt8(Some(v))),
+        ArrowDataType::UInt16 => value
+            .as_u64()
+            .and_then(|v| u16::try_from(v).ok())
+            .map(|v| DfScalarValue::UInt16(Some(v))),
+        ArrowDataType::UInt32 => value
+            .as_u64()
+            .and_then(|v| u32::try_from(v).ok())
+            .map(|v| DfScalarValue::UInt32(Some(v))),
+        ArrowDataType::UInt64 => value.as_u64().map(|v| DfScalarValue::UInt64(Some(v))),
+        ArrowDataType::Float32 => value
+            .as_f64()
+            .map(|v| DfScalarValue::Float32(Some(v as f32))),
+        ArrowDataType::Float64 => value.as_f64().map(|v| DfScalarValue::Float64(Some(v))),
+        ArrowDataType::Utf8 => value
+            .as_str()
+            .map(|v| DfScalarValue::Utf8(Some(v.to_string()))),
+        ArrowDataType::LargeUtf8 => value
+            .as_str()
+            .map(|v| DfScalarValue::LargeUtf8(Some(v.to_string()))),
+        _ => None,
+    }
+}
+
+fn scalar_min(a: DfScalarValue, b: DfScalarValue) -> DfScalarValue {
+    match a.partial_cmp(&b) {
+        Some(std::cmp::Ordering::Greater) => b,
+        _ => a,
+    }
+}
+
+fn scalar_max(a: DfScalarValue, b: DfScalarValue) -> DfScalarValue {
+    match a.partial_cmp(&b) {
+        Some(std::cmp::Ordering::Less) => b,
+        _ => a,
     }
 }
 
@@ -286,5 +529,210 @@ mod tests {
             }
             _ => panic!("Expected FixedSizeList"),
         }
+    }
+
+    use proximadb_storage_common::format_splits::{ColumnBounds, SplitStatistics};
+
+    fn split_with_bounds(
+        rows: u64,
+        bytes: u64,
+        bounds: &[(&str, serde_json::Value, serde_json::Value, u64)],
+    ) -> FileSplit {
+        let mut split = FileSplit::new_row_group("f.parquet".to_string(), 0, 0, bytes, rows as i64);
+        let mut stats = SplitStatistics {
+            row_count: Some(rows),
+            byte_size: Some(bytes),
+            ..Default::default()
+        };
+        for (name, min, max, nulls) in bounds {
+            stats.column_stats.insert(
+                (*name).to_string(),
+                ColumnBounds {
+                    min: Some(min.clone()),
+                    max: Some(max.clone()),
+                    null_count: *nulls,
+                    distinct_count: None,
+                },
+            );
+        }
+        split.statistics = stats;
+        split
+    }
+
+    fn two_col_schema() -> ArrowSchema {
+        ArrowSchema::new(vec![
+            Field::new("x", ArrowDataType::Int64, false),
+            Field::new("name", ArrowDataType::Utf8, true),
+        ])
+    }
+
+    #[test]
+    fn statistics_from_splits_merges_bounds_schema_width() {
+        let schema = two_col_schema();
+        let splits = vec![
+            split_with_bounds(
+                2,
+                100,
+                &[
+                    ("x", serde_json::json!(1), serde_json::json!(10), 0),
+                    ("name", serde_json::json!("a"), serde_json::json!("m"), 1),
+                ],
+            ),
+            split_with_bounds(
+                3,
+                200,
+                &[
+                    ("x", serde_json::json!(-5), serde_json::json!(7), 2),
+                    ("name", serde_json::json!("c"), serde_json::json!("z"), 0),
+                ],
+            ),
+        ];
+
+        let stats = statistics_from_splits(&splits, &schema, None, true);
+
+        assert_eq!(stats.num_rows, Precision::Inexact(5));
+        assert_eq!(stats.total_byte_size, Precision::Inexact(300));
+        // Schema-width contract (DataFusion 54 indexes by column position).
+        assert_eq!(stats.column_statistics.len(), schema.fields().len());
+
+        let x = &stats.column_statistics[0];
+        assert_eq!(
+            x.min_value,
+            Precision::Inexact(DfScalarValue::Int64(Some(-5)))
+        );
+        assert_eq!(
+            x.max_value,
+            Precision::Inexact(DfScalarValue::Int64(Some(10)))
+        );
+        assert_eq!(x.null_count, Precision::Inexact(2));
+
+        let name = &stats.column_statistics[1];
+        assert_eq!(
+            name.min_value,
+            Precision::Inexact(DfScalarValue::Utf8(Some("a".to_string())))
+        );
+        assert_eq!(
+            name.max_value,
+            Precision::Inexact(DfScalarValue::Utf8(Some("z".to_string())))
+        );
+        assert_eq!(name.null_count, Precision::Inexact(1));
+    }
+
+    #[test]
+    fn statistics_from_splits_partial_coverage_stays_unknown() {
+        let schema = two_col_schema();
+        // Second split carries NO bounds for `x` — claiming merged bounds
+        // would understate the true range, so the column must stay unknown.
+        let splits = vec![
+            split_with_bounds(
+                2,
+                10,
+                &[("x", serde_json::json!(1), serde_json::json!(2), 0)],
+            ),
+            split_with_bounds(2, 10, &[]),
+        ];
+
+        let stats = statistics_from_splits(&splits, &schema, None, true);
+        let x = &stats.column_statistics[0];
+        assert_eq!(x.min_value, Precision::Absent);
+        assert_eq!(x.max_value, Precision::Absent);
+        assert_eq!(x.null_count, Precision::Absent);
+    }
+
+    #[test]
+    fn statistics_from_splits_overlays_registry_ndv() {
+        let collection = "schema_inference_ndv_overlay_test";
+        let int64_type = serde_json::to_value(ProximaType::Int64).expect("serde ProximaType");
+        crate::core::statistics::statistics_registry().update(collection, |summary| {
+            for i in 0..64 {
+                summary.observe_field("x", &int64_type, Some(&serde_json::json!(i)));
+            }
+        });
+
+        let schema = two_col_schema();
+        let splits = vec![split_with_bounds(
+            64,
+            10,
+            &[("x", serde_json::json!(0), serde_json::json!(63), 0)],
+        )];
+
+        let stats = statistics_from_splits(&splits, &schema, Some(collection), true);
+        crate::core::statistics::statistics_registry().remove(collection);
+
+        match stats.column_statistics[0].distinct_count {
+            Precision::Inexact(ndv) => {
+                assert!(
+                    (32..=128).contains(&ndv),
+                    "HLL NDV estimate for 64 distinct values, got {ndv}"
+                );
+            }
+            ref other => panic!("expected Inexact NDV from the registry, got {other:?}"),
+        }
+        // Column without a registry field stays absent.
+        assert_eq!(stats.column_statistics[1].distinct_count, Precision::Absent);
+    }
+
+    #[test]
+    fn statistics_from_splits_gates_value_bounds_off() {
+        let schema = two_col_schema();
+        let splits = vec![split_with_bounds(
+            2,
+            10,
+            &[("x", serde_json::json!(1), serde_json::json!(2), 3)],
+        )];
+
+        let stats = statistics_from_splits(&splits, &schema, None, false);
+        let x = &stats.column_statistics[0];
+        // Bounds suppressed (the recursive interval-analysis trigger)…
+        assert_eq!(x.min_value, Precision::Absent);
+        assert_eq!(x.max_value, Precision::Absent);
+        // …but the join-ordering inputs still flow.
+        assert_eq!(x.null_count, Precision::Inexact(3));
+        assert_eq!(stats.num_rows, Precision::Inexact(2));
+    }
+
+    #[test]
+    fn project_statistics_narrows_to_projection() {
+        let schema = two_col_schema();
+        let splits = vec![split_with_bounds(
+            2,
+            10,
+            &[
+                ("x", serde_json::json!(1), serde_json::json!(2), 0),
+                ("name", serde_json::json!("a"), serde_json::json!("b"), 0),
+            ],
+        )];
+        let full = statistics_from_splits(&splits, &schema, None, true);
+
+        let projected = project_statistics(&full, Some(&[1]));
+        assert_eq!(projected.column_statistics.len(), 1);
+        assert_eq!(
+            projected.column_statistics[0].min_value,
+            Precision::Inexact(DfScalarValue::Utf8(Some("a".to_string())))
+        );
+
+        let unprojected = project_statistics(&full, None);
+        assert_eq!(unprojected.column_statistics.len(), 2);
+    }
+
+    #[test]
+    fn json_bounds_convert_per_arrow_type() {
+        assert_eq!(
+            json_bound_to_scalar(&serde_json::json!(7), &ArrowDataType::Int32),
+            Some(DfScalarValue::Int32(Some(7)))
+        );
+        assert_eq!(
+            json_bound_to_scalar(&serde_json::json!(1.5), &ArrowDataType::Float64),
+            Some(DfScalarValue::Float64(Some(1.5)))
+        );
+        assert_eq!(
+            json_bound_to_scalar(&serde_json::json!(true), &ArrowDataType::Boolean),
+            Some(DfScalarValue::Boolean(Some(true)))
+        );
+        // No lossless mapping → None, never a wrong-typed scalar.
+        assert_eq!(
+            json_bound_to_scalar(&serde_json::json!("s"), &ArrowDataType::Date32),
+            None
+        );
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -82,6 +82,10 @@ pub mod metering_event;
 /// standard OTLP collector (ADR-027 dual-sink push half). Feature `otlp-metering`
 /// + runtime-gated by `PROXIMADB_OTLP_ENDPOINT`; compiles to no-ops otherwise.
 pub mod metering_otlp;
+/// [`ObjectStore`](object_store::ObjectStore) decorator feeding the per-query
+/// io_trace (ADR-030/TD-158) — first consumer: the DataFusion Parquet leaf,
+/// closing the "DataFusion route reports zero bytes" trace gap.
+pub mod object_store_trace;
 /// Embedding-precision metrics — Prometheus gauges/counters per
 /// EMBEDDING_PRECISION_LLD_2026_05_22 §"Observability (Q11)" (PR 7b).
 pub mod precision_metrics;

--- a/src/observability/object_store_trace.rs
+++ b/src/observability/object_store_trace.rs
@@ -1,0 +1,198 @@
+//! Query-scoped I/O tracing for `object_store`-backed readers.
+//!
+//! [`TracingObjectStore`] decorates any [`ObjectStore`] and feeds the
+//! per-query [`crate::observability::io_trace`] accumulator (ADR-030 /
+//! TD-158): GET ops, ranged-GET counts, bytes read/written, list/delete ops.
+//! All recording helpers are no-ops outside an `io_trace::scope`, so wrapping
+//! a store is unconditional and free on non-query paths.
+//!
+//! First consumer: the DataFusion Parquet leaf
+//! (`src/datafusion/engine_adapters/object_store_parquet_reader.rs`), whose
+//! footer and row-group reads were previously invisible to the trace — the
+//! documented "DataFusion route reports zero bytes" gap in
+//! `tests/cost_trace_pgwire_multimodal_e2e.rs`.
+
+use std::fmt;
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
+    Result as ObjectStoreResult,
+};
+
+use crate::observability::io_trace::{self, IoOp};
+
+/// An [`ObjectStore`] decorator that records every read/write into the
+/// task-local per-query I/O trace.
+#[derive(Debug)]
+pub struct TracingObjectStore {
+    inner: Arc<dyn ObjectStore>,
+}
+
+impl TracingObjectStore {
+    /// Wrap `inner` so its I/O is attributed to the current query scope.
+    pub fn wrap(inner: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
+        Arc::new(Self { inner })
+    }
+}
+
+impl fmt::Display for TracingObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TracingObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for TracingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        io_trace::record_op(IoOp::Put);
+        io_trace::record_bytes_written(payload.content_length() as u64);
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        io_trace::record_op(IoOp::Put);
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
+        io_trace::record_op(IoOp::Get);
+        let ranged = options.range.is_some();
+        let result = self.inner.get_opts(location, options).await?;
+        if ranged {
+            io_trace::record_range_gets(1);
+        }
+        io_trace::record_bytes_read(result.range.end.saturating_sub(result.range.start));
+        Ok(result)
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &Path,
+        ranges: &[Range<u64>],
+    ) -> ObjectStoreResult<Vec<Bytes>> {
+        io_trace::record_op(IoOp::Get);
+        io_trace::record_range_gets(ranges.len() as u64);
+        io_trace::record_bytes_read(
+            ranges
+                .iter()
+                .map(|r| r.end.saturating_sub(r.start))
+                .sum::<u64>(),
+        );
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, ObjectStoreResult<Path>>,
+    ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+        io_trace::record_op(IoOp::Delete);
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        io_trace::record_op(IoOp::List);
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        io_trace::record_op(IoOp::List);
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        io_trace::record_op(IoOp::List);
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> ObjectStoreResult<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> ObjectStoreResult<()> {
+        self.inner.rename_opts(from, to, options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observability::io_trace::IoTraceSnapshot;
+    use object_store::ObjectStoreExt;
+    use object_store::memory::InMemory;
+    use std::sync::Mutex;
+
+    #[tokio::test]
+    async fn records_ranged_get_bytes_inside_scope() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = TracingObjectStore::wrap(inner);
+        let path = Path::from("t/data.bin");
+        store
+            .put(&path, PutPayload::from_static(&[0u8; 1024]))
+            .await
+            .unwrap();
+
+        static CAPTURED: Mutex<Option<IoTraceSnapshot>> = Mutex::new(None);
+        io_trace::set_billing_observer(Some(Box::new(|snap, _tenant| {
+            *CAPTURED.lock().unwrap_or_else(|p| p.into_inner()) = Some(snap.clone());
+        })));
+
+        io_trace::instrument(None, "test", async {
+            let bytes = store.get_range(&path, 0..256).await.unwrap();
+            assert_eq!(bytes.len(), 256);
+        })
+        .await;
+        io_trace::set_billing_observer(None);
+
+        let snapshot = CAPTURED
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+            .expect("billing observer captured a snapshot");
+        assert_eq!(snapshot.range_gets, 1, "one ranged GET recorded");
+        assert_eq!(snapshot.bytes_read, 256, "ranged bytes attributed");
+        assert!(snapshot.get_ops >= 1, "GET op counted");
+    }
+
+    #[tokio::test]
+    async fn no_ops_outside_scope() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = TracingObjectStore::wrap(inner);
+        let path = Path::from("t/data.bin");
+        // Outside any io_trace scope: must not panic and must not leak state.
+        store
+            .put(&path, PutPayload::from_static(&[0u8; 64]))
+            .await
+            .unwrap();
+        let bytes = store.get_range(&path, 0..8).await.unwrap();
+        assert_eq!(bytes.len(), 8);
+    }
+}

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -1,0 +1,922 @@
+//! TPC-H / TPC-DS performance evidence-ledger harness (TD-OLAP-4, P0b skeleton).
+//!
+//! Promotes the TPC suites from count-only *conformance* (see
+//! `tests/{tpch,tpcds}_pgwire_e2e.rs`) toward *measured* evidence (ADR-052
+//! invariant 4): per query × route × temperature it records wall latency and
+//! the per-query `observability::io_trace` snapshot (bytes read, ranged GETs,
+//! footer hits, per-engine compute_ms), on BOTH routes — native/Volcano
+//! (pre-MATERIALIZE) and DataFusion-on-Parquet (post-MATERIALIZE) — into a
+//! versioned JSON ledger artifact.
+//!
+//! Methodology (pinned per TD-OLAP-4; regimes are reported separately, never
+//! averaged):
+//! - storage regime: `local-tempdir` (file:// object store on local disk).
+//!   Object-store regimes are a separate ledger section when they land.
+//! - datagen: `synthetic-tpc-shaped` — deterministic, seeded, TPC-schema
+//!   row-ratio-scaled with key skew and referential integrity. It is NOT
+//!   audited dbgen/dsdgen output; no TPC-official claim may cite this ledger.
+//! - temperature: `first` vs `repeat` against a warm process (true cold-cache
+//!   runs need a server restart per query — a future slice).
+//! - scale: `TPC_PERF_SCALE` (default 0.001 ≈ 9k TPC-H rows; SF1 ≡ 1.0 —
+//!   impractical over per-row INSERTs until a bulk-load path exists).
+//!
+//! `#[ignore]` — advisory, never a merge gate. Run on demand:
+//!
+//!   TPC_PERF_SCALE=0.001 cargo test --test tpc_perf_ledger_e2e -- --ignored --nocapture
+//!
+//! Output: `TPC_PERF_LEDGER_OUT` (default `target/tpc-perf-ledger/ledger.json`).
+//!
+//! Schemas and query texts are copied verbatim from the conformance suites
+//! (`tests/tpch_pgwire_e2e.rs`, `tests/tpcds_pgwire_e2e.rs`) — the repo's
+//! integration tests are self-contained by convention; keep them in sync.
+
+use std::net::TcpListener;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::observability::io_trace::{self, IoTraceSnapshot};
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::{Client, SimpleQueryMessage};
+
+/// One billing snapshot per query, pushed by the collecting observer at
+/// io_trace scope close (pgwire wraps each statement in its own scope).
+static CAPTURE: Mutex<Vec<IoTraceSnapshot>> = Mutex::new(Vec::new());
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        // Override the process billing observer (installed by db.start()) with
+        // a collector that captures each query's snapshot for this harness.
+        io_trace::set_billing_observer(Some(Box::new(|snap: &IoTraceSnapshot, _tenant| {
+            CAPTURE.lock().expect("capture lock").push(snap.clone());
+        })));
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+
+    async fn shutdown(mut self) {
+        if let Some(mut db) = self.db.take() {
+            let _ = db.shutdown().await;
+        }
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic seeded generator — synthetic-tpc-shaped (NOT dbgen/dsdgen).
+// SplitMix64 keeps every run reproducible; key skew is power-law-ish so join
+// and filter selectivities are non-uniform like real TPC data.
+// ---------------------------------------------------------------------------
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    fn next(&mut self) -> u64 {
+        // SplitMix64.
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n.max(1)
+    }
+    /// Power-law-skewed key in `1..=n` (quadratic bias toward low keys).
+    fn skewed_key(&mut self, n: u64) -> u64 {
+        let u = self.next() as f64 / u64::MAX as f64;
+        ((u * u * n as f64) as u64).min(n.saturating_sub(1)) + 1
+    }
+    fn pick<'a>(&mut self, choices: &[&'a str]) -> &'a str {
+        choices[self.below(choices.len() as u64) as usize]
+    }
+    fn date(&mut self) -> String {
+        let y = 1992 + self.below(7);
+        let m = 1 + self.below(12);
+        let d = 1 + self.below(28);
+        format!("DATE '{y}-{m:02}-{d:02}'")
+    }
+    fn money(&mut self, max: u64) -> String {
+        format!("{}.{:02}", self.below(max), self.below(100))
+    }
+}
+
+fn chunked_inserts(table: &str, cols: &str, values: Vec<String>, chunk: usize) -> Vec<String> {
+    values
+        .chunks(chunk)
+        .map(|c| format!("INSERT INTO {table} ({cols}) VALUES {}", c.join(", ")))
+        .collect()
+}
+
+/// Scale a canonical TPC row count, with a floor so every table joins.
+fn scaled(base: u64, scale: f64, floor: u64) -> u64 {
+    ((base as f64 * scale) as u64).max(floor)
+}
+
+// --- TPC-H (schema copied from tests/tpch_pgwire_e2e.rs) -------------------
+
+const TPCH_SCHEMA: &[(&str, &str)] = &[
+    (
+        "region",
+        "CREATE TABLE region (r_regionkey INT PRIMARY KEY, r_name VARCHAR, r_comment VARCHAR)",
+    ),
+    (
+        "nation",
+        "CREATE TABLE nation (n_nationkey INT PRIMARY KEY, n_name VARCHAR, n_regionkey INT, n_comment VARCHAR)",
+    ),
+    (
+        "supplier",
+        "CREATE TABLE supplier (s_suppkey INT PRIMARY KEY, s_name VARCHAR, s_address VARCHAR, s_nationkey INT, s_phone VARCHAR, s_acctbal DOUBLE PRECISION, s_comment VARCHAR)",
+    ),
+    (
+        "part",
+        "CREATE TABLE part (p_partkey INT PRIMARY KEY, p_name VARCHAR, p_mfgr VARCHAR, p_brand VARCHAR, p_type VARCHAR, p_size INT, p_container VARCHAR, p_retailprice DOUBLE PRECISION, p_comment VARCHAR)",
+    ),
+    (
+        "partsupp",
+        "CREATE TABLE partsupp (ps_partkey INT, ps_suppkey INT, ps_availqty INT, ps_supplycost DOUBLE PRECISION, ps_comment VARCHAR)",
+    ),
+    (
+        "customer",
+        "CREATE TABLE customer (c_custkey INT PRIMARY KEY, c_name VARCHAR, c_address VARCHAR, c_nationkey INT, c_phone VARCHAR, c_acctbal DOUBLE PRECISION, c_mktsegment VARCHAR, c_comment VARCHAR)",
+    ),
+    (
+        "orders",
+        "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_orderstatus VARCHAR, o_totalprice DOUBLE PRECISION, o_orderdate DATE, o_orderpriority VARCHAR, o_clerk VARCHAR, o_shippriority INT, o_comment VARCHAR)",
+    ),
+    (
+        "lineitem",
+        "CREATE TABLE lineitem (l_orderkey INT, l_partkey INT, l_suppkey INT, l_linenumber INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION, l_discount DOUBLE PRECISION, l_tax DOUBLE PRECISION, l_returnflag VARCHAR, l_linestatus VARCHAR, l_shipdate DATE, l_commitdate DATE, l_receiptdate DATE, l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR)",
+    ),
+];
+
+/// 5 regions / 25 nations mapped like the standard, including every nation
+/// name the 22 queries reference by constant.
+const REGIONS: &[&str] = &["AFRICA", "AMERICA", "ASIA", "EUROPE", "MIDDLE EAST"];
+const NATIONS: &[(&str, u64)] = &[
+    ("ALGERIA", 0),
+    ("ARGENTINA", 1),
+    ("BRAZIL", 1),
+    ("CANADA", 1),
+    ("EGYPT", 4),
+    ("ETHIOPIA", 0),
+    ("FRANCE", 3),
+    ("GERMANY", 3),
+    ("INDIA", 2),
+    ("INDONESIA", 2),
+    ("IRAN", 4),
+    ("IRAQ", 4),
+    ("JAPAN", 2),
+    ("JORDAN", 4),
+    ("KENYA", 0),
+    ("MOROCCO", 0),
+    ("MOZAMBIQUE", 0),
+    ("PERU", 1),
+    ("CHINA", 2),
+    ("ROMANIA", 3),
+    ("SAUDI ARABIA", 4),
+    ("VIETNAM", 2),
+    ("RUSSIA", 3),
+    ("UNITED KINGDOM", 3),
+    ("UNITED STATES", 1),
+];
+
+fn gen_tpch(scale: f64) -> Vec<String> {
+    let mut rng = Rng::new(0x7C_0FFE_E5EED);
+    let n_supp = scaled(10_000, scale, 10);
+    let n_part = scaled(200_000, scale, 20);
+    let n_cust = scaled(150_000, scale, 15);
+    let n_ord = scaled(1_500_000, scale, 150);
+
+    let types = [
+        "PROMO BRUSHED STEEL",
+        "STANDARD POLISHED TIN",
+        "SMALL PLATED COPPER",
+        "MEDIUM POLISHED BRASS",
+        "ECONOMY ANODIZED NICKEL",
+    ];
+    let containers = [
+        "SM CASE", "SM BOX", "MED BOX", "MED BAG", "LG BOX", "WRAP PKG",
+    ];
+    let segments = [
+        "BUILDING",
+        "AUTOMOBILE",
+        "MACHINERY",
+        "HOUSEHOLD",
+        "FURNITURE",
+    ];
+    let priorities = ["1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED", "5-LOW"];
+    let shipmodes = ["MAIL", "SHIP", "AIR", "AIR REG", "TRUCK", "RAIL", "FOB"];
+    let instructs = [
+        "DELIVER IN PERSON",
+        "NONE",
+        "TAKE BACK RETURN",
+        "COLLECT COD",
+    ];
+    let name_words = ["forest", "green", "sky", "metal", "ivory", "rose", "navy"];
+    let phone_codes = ["13", "31", "23", "29", "30", "18", "17", "27", "10"];
+
+    let mut out = Vec::new();
+    out.extend(chunked_inserts(
+        "region",
+        "r_regionkey, r_name, r_comment",
+        REGIONS
+            .iter()
+            .enumerate()
+            .map(|(i, r)| format!("({i}, '{r}', 'rc{i}')"))
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "nation",
+        "n_nationkey, n_name, n_regionkey, n_comment",
+        NATIONS
+            .iter()
+            .enumerate()
+            .map(|(i, (n, r))| format!("({i}, '{n}', {r}, 'nc{i}')"))
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "supplier",
+        "s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment",
+        (1..=n_supp)
+            .map(|k| {
+                let nat = rng.below(25);
+                let comment = if rng.below(20) == 0 {
+                    "Customer Complaints"
+                } else {
+                    "sc"
+                };
+                format!(
+                    "({k}, 'Supplier#{k}', 'addr{k}', {nat}, '{}-{k:03}', {}, '{comment}')",
+                    rng.pick(&phone_codes),
+                    rng.money(10_000)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "part",
+        "p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment",
+        (1..=n_part)
+            .map(|k| {
+                format!(
+                    "({k}, '{} part {k}', 'Mfgr#{}', 'Brand#{}{}', '{}', {}, '{}', {}, 'pc{k}')",
+                    rng.pick(&name_words),
+                    1 + rng.below(5),
+                    1 + rng.below(5),
+                    1 + rng.below(5),
+                    rng.pick(&types),
+                    1 + rng.below(50),
+                    rng.pick(&containers),
+                    rng.money(2_000)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    // 4 suppliers per part, like the standard 800k/200k ratio.
+    out.extend(chunked_inserts(
+        "partsupp",
+        "ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment",
+        (1..=n_part)
+            .flat_map(|p| {
+                (0..4)
+                    .map(|_| {
+                        format!(
+                            "({p}, {}, {}, {}, 'psc')",
+                            rng.skewed_key(n_supp),
+                            1 + rng.below(9_999),
+                            rng.money(1_000)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "customer",
+        "c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment",
+        (1..=n_cust)
+            .map(|k| {
+                let comment = if rng.below(15) == 0 {
+                    "special requests noted"
+                } else {
+                    "cc"
+                };
+                format!(
+                    "({k}, 'Customer#{k}', 'caddr{k}', {}, '{}-{k:03}', {}, '{}', '{comment}')",
+                    rng.below(25),
+                    rng.pick(&phone_codes),
+                    rng.money(10_000),
+                    rng.pick(&segments)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    let mut lineitems: Vec<String> = Vec::new();
+    out.extend(chunked_inserts(
+        "orders",
+        "o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment",
+        (1..=n_ord)
+            .map(|o| {
+                let lines = 1 + rng.below(7);
+                for l in 1..=lines {
+                    let ship = rng.date();
+                    lineitems.push(format!(
+                        "({o}, {}, {}, {l}, {}, {}, 0.0{}, 0.0{}, '{}', '{}', {ship}, {}, {}, '{}', '{}', 'lc')",
+                        rng.skewed_key(n_part),
+                        rng.skewed_key(n_supp),
+                        1 + rng.below(50),
+                        rng.money(10_000),
+                        rng.below(11),
+                        rng.below(9),
+                        rng.pick(&["N", "R", "A"]),
+                        rng.pick(&["O", "F"]),
+                        rng.date(),
+                        rng.date(),
+                        rng.pick(&instructs),
+                        rng.pick(&shipmodes),
+                    ));
+                }
+                format!(
+                    "({o}, {}, '{}', {}, {}, '{}', 'Clerk#{}', 0, 'oc')",
+                    rng.skewed_key(n_cust),
+                    rng.pick(&["O", "F", "P"]),
+                    rng.money(100_000),
+                    rng.date(),
+                    rng.pick(&priorities),
+                    1 + rng.below(100)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "lineitem",
+        "l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment",
+        lineitems,
+        200,
+    ));
+    out
+}
+
+// --- TPC-DS star subset (schema copied from tests/tpcds_pgwire_e2e.rs) -----
+
+const TPCDS_SCHEMA: &[(&str, &str)] = &[
+    (
+        "date_dim",
+        "CREATE TABLE date_dim (d_date_sk INT PRIMARY KEY, d_date DATE, d_year INT, d_moy INT, d_qoy INT, d_dom INT, d_dow INT)",
+    ),
+    (
+        "item",
+        "CREATE TABLE item (i_item_sk INT PRIMARY KEY, i_item_id VARCHAR, i_brand_id INT, i_brand VARCHAR, i_class_id INT, i_class VARCHAR, i_category_id INT, i_category VARCHAR, i_manufact_id INT, i_current_price DOUBLE PRECISION)",
+    ),
+    (
+        "store",
+        "CREATE TABLE store (s_store_sk INT PRIMARY KEY, s_store_id VARCHAR, s_store_name VARCHAR, s_state VARCHAR)",
+    ),
+    (
+        "customer",
+        "CREATE TABLE customer (c_customer_sk INT PRIMARY KEY, c_customer_id VARCHAR, c_first_name VARCHAR, c_last_name VARCHAR, c_current_addr_sk INT, c_birth_country VARCHAR)",
+    ),
+    (
+        "customer_address",
+        "CREATE TABLE customer_address (ca_address_sk INT PRIMARY KEY, ca_state VARCHAR, ca_city VARCHAR, ca_zip VARCHAR, ca_country VARCHAR, ca_gmt_offset DOUBLE PRECISION)",
+    ),
+    (
+        "store_sales",
+        "CREATE TABLE store_sales (ss_sold_date_sk INT, ss_item_sk INT, ss_store_sk INT, ss_customer_sk INT, ss_addr_sk INT, ss_ticket_number INT, ss_quantity INT, ss_sales_price DOUBLE PRECISION, ss_ext_sales_price DOUBLE PRECISION, ss_ext_discount_amt DOUBLE PRECISION, ss_net_profit DOUBLE PRECISION)",
+    ),
+];
+
+fn gen_tpcds(scale: f64) -> Vec<String> {
+    let mut rng = Rng::new(0xD5_0FFE_E5EED);
+    let n_item = scaled(18_000, scale, 20);
+    let n_cust = scaled(100_000, scale, 10);
+    let n_sales = scaled(2_880_000, scale, 300);
+    let n_store = 6u64;
+    // Two years of dates, 1999-2000 (the queries filter d_year=2000, d_moy=11).
+    let mut dates = Vec::new();
+    let mut sk = 23_000u64;
+    for y in [1999u64, 2000] {
+        for m in 1..=12u64 {
+            for d in 1..=28u64 {
+                sk += 1;
+                let dow = sk % 7;
+                let qoy = m.div_ceil(3);
+                dates.push(format!(
+                    "({sk}, DATE '{y}-{m:02}-{d:02}', {y}, {m}, {qoy}, {d}, {dow})"
+                ));
+            }
+        }
+    }
+    let n_dates = dates.len() as u64;
+    let first_sk = 23_001u64;
+
+    let categories = [
+        ("Electronics", 1u64),
+        ("Books", 2),
+        ("Home", 3),
+        ("Sports", 4),
+        ("Music", 5),
+    ];
+    let states = ["CA", "NY", "TX", "WA", "IL", "GA"];
+
+    let mut out = Vec::new();
+    out.extend(chunked_inserts(
+        "date_dim",
+        "d_date_sk, d_date, d_year, d_moy, d_qoy, d_dom, d_dow",
+        dates,
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "item",
+        "i_item_sk, i_item_id, i_brand_id, i_brand, i_class_id, i_class, i_category_id, i_category, i_manufact_id, i_current_price",
+        (1..=n_item)
+            .map(|k| {
+                let (cat, cat_id) = categories[rng.below(5) as usize];
+                let brand = 10 * cat_id + 1 + rng.below(5);
+                format!(
+                    "({k}, 'ITEM{k:05}', {brand}, 'brand{brand}', {cat_id}, 'class{}', {cat_id}, '{cat}', {}, {})",
+                    1 + rng.below(3),
+                    100 + rng.below(10),
+                    rng.money(100)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "store",
+        "s_store_sk, s_store_id, s_store_name, s_state",
+        (1..=n_store)
+            .map(|k| {
+                format!(
+                    "({k}, 'STORE{k:02}', 'Store {k}', '{}')",
+                    states[(k - 1) as usize % states.len()]
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "customer_address",
+        "ca_address_sk, ca_state, ca_city, ca_zip, ca_country, ca_gmt_offset",
+        (1..=n_cust)
+            .map(|k| {
+                format!(
+                    "({k}, '{}', 'City{k}', '{:05}', 'United States', -{}.0)",
+                    rng.pick(&states),
+                    10_000 + rng.below(89_999),
+                    5 + rng.below(4)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "customer",
+        "c_customer_sk, c_customer_id, c_first_name, c_last_name, c_current_addr_sk, c_birth_country",
+        (1..=n_cust)
+            .map(|k| {
+                format!(
+                    "({k}, 'CUST{k:05}', 'fn{k}', 'ln{k}', {}, '{}')",
+                    1 + rng.below(n_cust),
+                    rng.pick(&["CANADA", "MEXICO", "BRAZIL", "JAPAN"])
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out.extend(chunked_inserts(
+        "store_sales",
+        "ss_sold_date_sk, ss_item_sk, ss_store_sk, ss_customer_sk, ss_addr_sk, ss_ticket_number, ss_quantity, ss_sales_price, ss_ext_sales_price, ss_ext_discount_amt, ss_net_profit",
+        (1..=n_sales)
+            .map(|t| {
+                let qty = 1 + rng.below(10);
+                let price = 1 + rng.below(100);
+                format!(
+                    "({}, {}, {}, {}, {}, {t}, {qty}, {price}.00, {}.00, {}.00, {}.00)",
+                    first_sk + rng.below(n_dates),
+                    rng.skewed_key(n_item),
+                    1 + rng.below(n_store),
+                    rng.skewed_key(n_cust),
+                    1 + rng.below(n_cust),
+                    qty * price,
+                    rng.below(10),
+                    rng.below(30)
+                )
+            })
+            .collect(),
+        200,
+    ));
+    out
+}
+
+// --- Queries (copied verbatim from the conformance suites) -----------------
+
+fn tpch_queries() -> Vec<(&'static str, String)> {
+    vec![
+        ("Q1", "select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate <= DATE '1998-09-01' group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus".to_string()),
+        ("Q2", "select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%STEEL' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA' and ps_supplycost = (select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA') order by s_acctbal desc, n_name, s_name, p_partkey".to_string()),
+        ("Q3", "select l_orderkey, sum(l_extendedprice*(1-l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < DATE '1995-03-15' and l_shipdate > DATE '1995-03-15' group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate".to_string()),
+        ("Q4", "select o_orderpriority, count(*) as order_count from orders where o_orderdate >= DATE '1993-07-01' and o_orderdate < DATE '1993-10-01' and exists (select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate) group by o_orderpriority order by o_orderpriority".to_string()),
+        ("Q5", "select n_name, sum(l_extendedprice*(1-l_discount)) as revenue from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'AMERICA' and o_orderdate >= DATE '1994-01-01' and o_orderdate < DATE '1995-01-01' group by n_name order by revenue desc".to_string()),
+        ("Q6", "select sum(l_extendedprice*l_discount) as revenue from lineitem where l_shipdate >= DATE '1994-01-01' and l_shipdate < DATE '1995-01-01' and l_discount between 0.05 and 0.07 and l_quantity < 24".to_string()),
+        ("Q7", "select supp_nation, cust_nation, l_year, sum(volume) as revenue from (select n1.n_name as supp_nation, n2.n_name as cust_nation, extract(year from l_shipdate) as l_year, l_extendedprice*(1-l_discount) as volume from supplier, lineitem, orders, customer, nation n1, nation n2 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n2.n_nationkey and ((n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE') or (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')) and l_shipdate between DATE '1995-01-01' and DATE '1996-12-31') as shipping group by supp_nation, cust_nation, l_year order by supp_nation, cust_nation, l_year".to_string()),
+        ("Q8", "select o_year, sum(case when nation = 'GERMANY' then volume else 0 end) / sum(volume) as mkt_share from (select extract(year from o_orderdate) as o_year, l_extendedprice*(1-l_discount) as volume, n2.n_name as nation from part, supplier, lineitem, orders, customer, nation n1, nation n2, region where p_partkey = l_partkey and s_suppkey = l_suppkey and l_orderkey = o_orderkey and o_custkey = c_custkey and c_nationkey = n1.n_nationkey and n1.n_regionkey = r_regionkey and r_name = 'EUROPE' and s_nationkey = n2.n_nationkey and o_orderdate between DATE '1995-01-01' and DATE '1996-12-31' and p_type = 'STANDARD POLISHED TIN') as all_nations group by o_year order by o_year".to_string()),
+        ("Q9", "select nation, o_year, sum(amount) as sum_profit from (select n_name as nation, extract(year from o_orderdate) as o_year, l_extendedprice*(1-l_discount) - ps_supplycost*l_quantity as amount from part, supplier, lineitem, partsupp, orders, nation where s_suppkey = l_suppkey and ps_suppkey = l_suppkey and ps_partkey = l_partkey and p_partkey = l_partkey and o_orderkey = l_orderkey and s_nationkey = n_nationkey and p_name like '%green%') as profit group by nation, o_year order by nation, o_year desc".to_string()),
+        ("Q10", "select c_custkey, c_name, sum(l_extendedprice*(1-l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment from customer, orders, lineitem, nation where c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate >= DATE '1993-10-01' and o_orderdate < DATE '1994-01-01' and l_returnflag = 'R' and c_nationkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment order by revenue desc".to_string()),
+        ("Q11", "select ps_partkey, sum(ps_supplycost*ps_availqty) as value from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY' group by ps_partkey having sum(ps_supplycost*ps_availqty) > (select sum(ps_supplycost*ps_availqty) * 0.0001 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY') order by value desc".to_string()),
+        ("Q12", "select l_shipmode, sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end) as high_line_count, sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count from orders, lineitem where o_orderkey = l_orderkey and l_shipmode in ('MAIL', 'SHIP') and l_commitdate < l_receiptdate and l_shipdate < l_commitdate and l_receiptdate >= DATE '1994-01-01' and l_receiptdate < DATE '1995-01-01' group by l_shipmode order by l_shipmode".to_string()),
+        ("Q13", "select c_count, count(*) as custdist from (select c_custkey, count(o_orderkey) as c_count from customer left outer join orders on c_custkey = o_custkey and o_comment not like '%special%requests%' group by c_custkey) as c_orders group by c_count order by custdist desc, c_count desc".to_string()),
+        ("Q14", "select 100.00 * sum(case when p_type like 'PROMO%' then l_extendedprice*(1-l_discount) else 0 end) / sum(l_extendedprice*(1-l_discount)) as promo_revenue from lineitem, part where l_partkey = p_partkey and l_shipdate >= DATE '1995-09-01' and l_shipdate < DATE '1995-10-01'".to_string()),
+        ("Q15", "select s_suppkey, s_name, s_address, s_phone, total_revenue from supplier, (select l_suppkey as supplier_no, sum(l_extendedprice*(1-l_discount)) as total_revenue from lineitem where l_shipdate >= DATE '1996-01-01' and l_shipdate < DATE '1996-04-01' group by l_suppkey) as revenue0 where s_suppkey = supplier_no order by s_suppkey".to_string()),
+        ("Q16", "select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt from partsupp, part where p_partkey = ps_partkey and p_brand <> 'Brand#45' and p_type not like 'MEDIUM POLISHED%' and p_size in (49, 14, 23, 45, 19, 3, 36, 9) group by p_brand, p_type, p_size order by supplier_cnt desc, p_brand, p_type, p_size".to_string()),
+        ("Q17", "select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < (select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey)".to_string()),
+        ("Q18", "select c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum(l_quantity) from customer, orders, lineitem where o_orderkey in (select l_orderkey from lineitem group by l_orderkey having sum(l_quantity) > 300) and c_custkey = o_custkey and o_orderkey = l_orderkey group by c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice order by o_totalprice desc, o_orderdate".to_string()),
+        ("Q19", "select sum(l_extendedprice*(1-l_discount)) as revenue from lineitem, part where (p_partkey = l_partkey and p_brand = 'Brand#12' and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') and l_quantity >= 1 and l_quantity <= 11 and p_size between 1 and 5 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey and p_brand = 'Brand#23' and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') and l_quantity >= 10 and l_quantity <= 20 and p_size between 1 and 10 and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON')".to_string()),
+        ("Q20", "select s_name, s_address from supplier, nation where s_suppkey in (select ps_suppkey from partsupp where ps_partkey in (select p_partkey from part where p_name like 'forest%') and ps_availqty > (select 0.5 * sum(l_quantity) from lineitem where l_partkey = ps_partkey and l_suppkey = ps_suppkey and l_shipdate >= DATE '1994-01-01' and l_shipdate < DATE '1995-01-01')) and s_nationkey = n_nationkey and n_name = 'CANADA' order by s_name".to_string()),
+        ("Q21", "select s_name, count(*) as numwait from supplier, lineitem l1, orders, nation where s_suppkey = l1.l_suppkey and o_orderkey = l1.l_orderkey and o_orderstatus = 'F' and l1.l_receiptdate > l1.l_commitdate and exists (select * from lineitem l2 where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey <> l1.l_suppkey) and not exists (select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey and l3.l_receiptdate > l3.l_commitdate) and s_nationkey = n_nationkey and n_name = 'SAUDI ARABIA' group by s_name order by numwait desc, s_name".to_string()),
+        ("Q22", "select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal from (select substring(c_phone from 1 for 2) as cntrycode, c_acctbal from customer where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17') and c_acctbal > (select avg(c_acctbal) from customer where c_acctbal > 0.00 and substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17')) and not exists (select * from orders where o_custkey = c_custkey)) as custsale group by cntrycode order by cntrycode".to_string()),
+    ]
+}
+
+fn tpcds_queries() -> Vec<(&'static str, String)> {
+    vec![
+        ("q42", "select dt.d_year, item.i_category_id, item.i_category, sum(ss_ext_sales_price) as revenue from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and item.i_manufact_id = 100 and dt.d_moy = 11 and dt.d_year = 2000 group by dt.d_year, item.i_category_id, item.i_category order by revenue desc, dt.d_year".to_string()),
+        ("q52", "select dt.d_year, item.i_brand_id as brand_id, item.i_brand as brand, sum(ss_ext_sales_price) as ext_price from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and dt.d_moy = 11 and dt.d_year = 2000 group by dt.d_year, item.i_brand, item.i_brand_id order by dt.d_year, ext_price desc, brand_id".to_string()),
+        ("q55", "select i_brand_id as brand_id, i_brand as brand, sum(ss_ext_sales_price) as ext_price from date_dim, store_sales, item where store_sales.ss_sold_date_sk = date_dim.d_date_sk and store_sales.ss_item_sk = item.i_item_sk and i_manufact_id = 100 and d_moy = 11 and d_year = 2000 group by i_brand, i_brand_id order by ext_price desc, i_brand_id".to_string()),
+        ("q3", "select dt.d_year, item.i_brand_id as brand_id, item.i_brand as brand, sum(ss_ext_sales_price) as sum_agg from date_dim dt, store_sales, item where dt.d_date_sk = store_sales.ss_sold_date_sk and store_sales.ss_item_sk = item.i_item_sk and item.i_manufact_id = 100 and dt.d_moy = 11 group by dt.d_year, item.i_brand, item.i_brand_id order by dt.d_year, sum_agg desc, brand_id".to_string()),
+        ("q98", "select i_item_id, i_category, i_class, i_current_price, sum(ss_ext_sales_price) as itemrevenue, sum(ss_ext_sales_price)*100/sum(sum(ss_ext_sales_price)) over (partition by i_class) as revenueratio from store_sales, item, date_dim where ss_item_sk = i_item_sk and i_category in ('Electronics', 'Books') and ss_sold_date_sk = d_date_sk and d_year = 2000 group by i_item_id, i_category, i_class, i_current_price order by i_category, i_class, i_item_id, revenueratio".to_string()),
+        ("win_rank", "select i_category, i_brand, sum(ss_ext_sales_price) as rev, rank() over (partition by i_category order by sum(ss_ext_sales_price) desc) as rnk from store_sales, item where ss_item_sk = i_item_sk group by i_category, i_brand order by i_category, rnk".to_string()),
+        ("win_running", "select d_date, sum(ss_ext_sales_price) as daily, sum(sum(ss_ext_sales_price)) over (order by d_date rows between unbounded preceding and current row) as running from store_sales, date_dim where ss_sold_date_sk = d_date_sk group by d_date order by d_date".to_string()),
+        ("rollup", "select i_category, i_class, sum(ss_net_profit) as profit from store_sales, item where ss_item_sk = i_item_sk group by rollup(i_category, i_class) order by i_category, i_class".to_string()),
+        ("grouping_sets", "select i_category, i_brand, sum(ss_quantity) as qty from store_sales, item where ss_item_sk = i_item_sk group by grouping sets ((i_category), (i_brand), ()) order by i_category, i_brand".to_string()),
+        ("cube", "select d_year, i_category, sum(ss_ext_sales_price) as rev from store_sales, item, date_dim where ss_item_sk = i_item_sk and ss_sold_date_sk = d_date_sk group by cube(d_year, i_category) order by d_year, i_category".to_string()),
+        ("intersect", "select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Electronics' intersect select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Books'".to_string()),
+        ("except", "select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Electronics' except select ss_customer_sk from store_sales, item where ss_item_sk = i_item_sk and i_category = 'Books'".to_string()),
+        ("cte", "with cat_rev as (select i_category, sum(ss_ext_sales_price) as rev from store_sales, item where ss_item_sk = i_item_sk group by i_category) select i_category, rev from cat_rev where rev > 10 order by rev desc".to_string()),
+        ("count_distinct", "select i_category, count(distinct ss_customer_sk) as buyers from store_sales, item where ss_item_sk = i_item_sk group by i_category having count(distinct ss_customer_sk) >= 1 order by buyers desc, i_category".to_string()),
+        ("correlated", "select i_item_sk, i_current_price from item where i_current_price > (select avg(i_current_price) from item i2 where i2.i_category = item.i_category) order by i_item_sk".to_string()),
+        ("case_agg", "select i_category, sum(case when ss_net_profit > 10 then 1 else 0 end) as hi, sum(case when ss_net_profit <= 10 then 1 else 0 end) as lo from store_sales, item where ss_item_sk = i_item_sk group by i_category order by i_category".to_string()),
+    ]
+}
+
+// --- Ledger shape ----------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct Methodology {
+    engine: &'static str,
+    engine_version: &'static str,
+    git_sha: Option<String>,
+    scale: f64,
+    storage_regime: &'static str,
+    datagen: &'static str,
+    temperature_semantics: &'static str,
+    routes: [&'static str; 2],
+}
+
+#[derive(serde::Serialize)]
+struct LedgerRecord {
+    benchmark: String,
+    query: String,
+    route: String,
+    temperature: String,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    rows: usize,
+    wall_ms: u128,
+    #[serde(flatten)]
+    snapshot: IoTraceSnapshot,
+}
+
+#[derive(serde::Serialize)]
+struct Ledger {
+    methodology: Methodology,
+    records: Vec<LedgerRecord>,
+}
+
+/// Run one query: clear the capture, time the client round-trip, drain the
+/// per-query billing snapshot (the observer fires server-side at scope close,
+/// so poll briefly for it).
+async fn measure(
+    client: &Client,
+    sql: &str,
+) -> Result<(usize, u128, IoTraceSnapshot), (u128, String)> {
+    CAPTURE.lock().expect("lock").clear();
+    let t0 = Instant::now();
+    let res = client.simple_query(sql).await;
+    let wall_ms = t0.elapsed().as_millis();
+    match res {
+        Ok(msgs) => {
+            let rows = msgs
+                .iter()
+                .filter(|m| matches!(m, SimpleQueryMessage::Row(_)))
+                .count();
+            let mut snap = IoTraceSnapshot::default();
+            for _ in 0..60 {
+                if let Some(s) = CAPTURE.lock().expect("lock").pop() {
+                    snap = s;
+                    break;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+            Ok((rows, wall_ms, snap))
+        }
+        Err(e) => Err((wall_ms, explain_err(&e))),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_record(
+    out: &mut Vec<LedgerRecord>,
+    benchmark: &str,
+    query: &str,
+    route: &str,
+    temperature: &str,
+    result: Result<(usize, u128, IoTraceSnapshot), (u128, String)>,
+) {
+    let rec = match result {
+        Ok((rows, wall_ms, snapshot)) => LedgerRecord {
+            benchmark: benchmark.into(),
+            query: query.into(),
+            route: route.into(),
+            temperature: temperature.into(),
+            ok: true,
+            error: None,
+            rows,
+            wall_ms,
+            snapshot,
+        },
+        Err((wall_ms, err)) => LedgerRecord {
+            benchmark: benchmark.into(),
+            query: query.into(),
+            route: route.into(),
+            temperature: temperature.into(),
+            ok: false,
+            error: Some(err),
+            rows: 0,
+            wall_ms,
+            snapshot: IoTraceSnapshot::default(),
+        },
+    };
+    out.push(rec);
+}
+
+async fn seed(client: &Client, schema: &[(&str, &str)], inserts: Vec<String>) {
+    for (name, ddl) in schema {
+        let _ = client
+            .simple_query(&format!("DROP TABLE IF EXISTS {name}"))
+            .await;
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("CREATE {name}: {}", explain_err(&e)));
+    }
+    for sql in &inserts {
+        client
+            .simple_query(sql)
+            .await
+            .unwrap_or_else(|e| panic!("INSERT: {}", explain_err(&e)));
+    }
+}
+
+/// Measure every query on both routes, first + repeat run each.
+async fn run_benchmark(
+    client: &Client,
+    benchmark: &str,
+    schema: &[(&str, &str)],
+    inserts: Vec<String>,
+    queries: Vec<(&'static str, String)>,
+    out: &mut Vec<LedgerRecord>,
+) {
+    let n_inserts = inserts.len();
+    seed(client, schema, inserts).await;
+    eprintln!(
+        "[{benchmark}] seeded ({n_inserts} insert batches across {} tables)",
+        schema.len()
+    );
+
+    // Native/Volcano route (pre-MATERIALIZE).
+    for (id, sql) in &queries {
+        for temperature in ["first", "repeat"] {
+            let r = measure(client, sql).await;
+            push_record(out, benchmark, id, "native", temperature, r);
+        }
+    }
+
+    // Flip to parquet-backed → DataFusion route.
+    for (name, _) in schema {
+        if let Err(e) = client
+            .simple_query(&format!("ALTER TABLE {name} MATERIALIZE"))
+            .await
+        {
+            eprintln!("[{benchmark}] · MATERIALIZE {name}: {}", explain_err(&e));
+        }
+    }
+
+    // DataFusion route (post-MATERIALIZE).
+    for (id, sql) in &queries {
+        for temperature in ["first", "repeat"] {
+            let r = measure(client, sql).await;
+            push_record(out, benchmark, id, "datafusion", temperature, r);
+        }
+    }
+}
+
+async fn connect(server: &PgServer) -> Client {
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "perf evidence-ledger harness (TD-OLAP-4) — advisory; run with --ignored --nocapture"]
+async fn tpc_perf_ledger() {
+    let scale: f64 = std::env::var("TPC_PERF_SCALE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.001);
+    eprintln!("=== tpc-perf-ledger harness (TPC_PERF_SCALE={scale}) ===");
+
+    let mut records = Vec::new();
+
+    // Fresh server per benchmark: TPC-H and TPC-DS both define `customer`.
+    {
+        let server = PgServer::start().await.expect("server start (tpch)");
+        let client = connect(&server).await;
+        run_benchmark(
+            &client,
+            "tpch",
+            TPCH_SCHEMA,
+            gen_tpch(scale),
+            tpch_queries(),
+            &mut records,
+        )
+        .await;
+        server.shutdown().await;
+    }
+    {
+        let server = PgServer::start().await.expect("server start (tpcds)");
+        let client = connect(&server).await;
+        run_benchmark(
+            &client,
+            "tpcds",
+            TPCDS_SCHEMA,
+            gen_tpcds(scale),
+            tpcds_queries(),
+            &mut records,
+        )
+        .await;
+        server.shutdown().await;
+    }
+
+    // Console summary: per benchmark × route, pass count + medians.
+    for benchmark in ["tpch", "tpcds"] {
+        for route in ["native", "datafusion"] {
+            let mut rows: Vec<&LedgerRecord> = records
+                .iter()
+                .filter(|r| {
+                    r.benchmark == benchmark && r.route == route && r.temperature == "repeat"
+                })
+                .collect();
+            rows.sort_by_key(|r| r.wall_ms);
+            let ok = rows.iter().filter(|r| r.ok).count();
+            let median = rows.get(rows.len() / 2).map(|r| r.wall_ms).unwrap_or(0);
+            let bytes: u64 = rows.iter().map(|r| r.snapshot.bytes_read).sum();
+            eprintln!(
+                "[{benchmark}/{route}] ok {ok}/{} · median repeat wall {median} ms · total bytes_read {bytes}",
+                rows.len()
+            );
+        }
+    }
+
+    let ledger = Ledger {
+        methodology: Methodology {
+            engine: "proximadb",
+            engine_version: env!("CARGO_PKG_VERSION"),
+            git_sha: std::env::var("GITHUB_SHA").ok(),
+            scale,
+            storage_regime: "local-tempdir",
+            datagen: "synthetic-tpc-shaped (seeded, deterministic, non-audited)",
+            temperature_semantics: "first vs repeat against a warm process (not cold page cache)",
+            routes: [
+                "native (Volcano, pre-MATERIALIZE)",
+                "datafusion (Parquet, post-MATERIALIZE)",
+            ],
+        },
+        records,
+    };
+
+    let out_path = std::env::var("TPC_PERF_LEDGER_OUT")
+        .unwrap_or_else(|_| "target/tpc-perf-ledger/ledger.json".to_string());
+    if let Some(dir) = std::path::Path::new(&out_path).parent() {
+        std::fs::create_dir_all(dir).expect("create ledger dir");
+    }
+    std::fs::write(
+        &out_path,
+        serde_json::to_vec_pretty(&ledger).expect("serialize ledger"),
+    )
+    .expect("write ledger");
+    eprintln!("ledger written: {out_path}");
+
+    // Advisory skeleton: assert only harness integrity, never perf numbers.
+    let n_queries = 22 + 16;
+    assert_eq!(
+        ledger.records.len(),
+        n_queries * 2 /* routes */ * 2, /* temperatures */
+        "one record per query x route x temperature"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **ADR-052 execution-order P0a + P0b** — the first two slices of the analytics-competitiveness plan.

### P0a — statistics into the DataFusion planner (TD-DFR-1 / ADR-050 D2 first slice)
- `schema_inference::statistics_from_splits`: projects the **already-read Parquet footer bounds** (min/max, null counts, rows/bytes per row-group) into schema-width DataFusion `Statistics` — zero new scan; `Precision::Inexact` per ADR-050 D3 (hints, not truth). Registry **HLL NDV overlay** (footers rarely carry NDV; the ADR-037 sketch does). `project_statistics` preserves the DF-54 width contract for the exec's projected schema (a short vector panics under `AggregateExec`).
- `ObjectStoreParquetTable` — the provider that actually serves `route_select → DataFusionLocal` — implements `TableProvider::statistics()` and feeds post-prune projected stats into `ProximaScanExec`'s existing-but-never-fed statistics slot. `extract_statistics` (previously dead + min/max-dropping) fixed.
- **Value bounds gated default-OFF** (`PROXIMADB_DF_STATS_VALUE_BOUNDS=1`): bounds deepen DF's recursive interval/selectivity analysis on Q2-class join+subquery shapes whose debug-build stack use is environment-borderline — a Q2 debug stack overflow reproduces on WSL2 **on clean develop without bounds** (`RUST_MIN_STACK=16MiB` clears it). Rows/bytes/nulls/NDV — the join-ordering inputs — always flow. Default-OFF-until-baked posture; flipping the gate is a follow-up.
- **`TracingObjectStore`** (`src/observability/object_store_trace.rs`): `ObjectStore` decorator feeding the per-query io_trace (ADR-030/TD-158). Wraps the DF parquet reader's store — closes the documented "DataFusion route reports zero bytes" gap (co-design mandate: readers emit the trace).

### P0b — TPC perf evidence-ledger harness (TD-OLAP-4 skeleton, advisory)
- `tests/tpc_perf_ledger_e2e.rs`: all 22 TPC-H + 16 TPC-DS queries measured on **both routes** (native pre-MATERIALIZE, DataFusion post-MATERIALIZE) × first/repeat, capturing wall latency + `IoTraceSnapshot` per query into a JSON ledger with pinned methodology. Datagen is seeded, deterministic, **synthetic-tpc-shaped** (honestly labeled non-audited; faithful datagen + bulk load is the follow-up for real SF1).
- **Advisory `tpc-perf-ledger` CI job**: `continue-on-error`, NOT in `ci-success`, runs on develop pushes/dispatch, uploads the ledger artifact.
- `docs/10-quality/TPC_PERF_LEDGER.adoc` methodology (regimes never averaged; external baselines deferred with rationale); `BENCHMARK_EVIDENCE.toml` `unverified` claim (validator green); **TD-DFR-1 filed** (closes ADR-050's dangling reference); TD-OLAP-2/TD-OLAP-4 statuses updated; ADR-050 D2 landed-note.

### Verification
- **Conformance ratchets unchanged with stats active**: TPC-H 22/22, TPC-DS 16/16; `pgwire_olap_delta_merge_e2e` green (schema-width regression guard).
- 17 new/updated unit tests (projection merge, partial-coverage conservatism, NDV overlay, bounds gate, typed-bound conversion, provider stats, tracing store).
- Harness run at scale 0.001 produced the full ledger; **DF route now reports real bytes_read** (3.7 MB TPC-H / 962 KB TPC-DS) vs 0 before.
- `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean; server binary builds; `check_td_adr_unique` / `validate_benchmark_evidence` / attribution guards green.
- Note: the pre-existing Q2-class debug stack overflow reproduces on WSL2 **on clean develop** (verified by baseline bisect); local e2e runs need `RUST_MIN_STACK=16777216`. The advisory CI job sets it defensively.

Refs: ADR-052 (P0a/P0b), ADR-050 D2, TD-DFR-1, TD-OLAP-2, TD-OLAP-4, TD-158, ADR-030, ADR-037/038/042.