### PR TITLE
demo(verticals): internet / web incident-response copilot (largest-TAM vertical)

### DIFF
--- a/demo/verticals/README.adoc
+++ b/demo/verticals/README.adoc
@@ -23,12 +23,12 @@ toc::[]
 | **Fraud & AML** (FSI, built) | timeseries + vector + graph + RAG | Compliance copilot: transacted-volume burst → AML-typology match → Cypher ring trace → case-note / SAR playbook.
 | **Energy** | timeseries + vector + graph | Grid copilot: meter/sensor anomaly + forecast → topology-aware outage impact → maintenance-log RAG.
 | **Social media** | graph + vector + hybrid RRF | Feed/reco copilot: semantic post search + social-graph proximity + community/influence; taste memory (ADR-022).
-| **Internet / web** | vector + BM25 + Graph-RAG + Text-to-SQL | Knowledge copilot: hybrid retrieval → entity knowledge-graph reasoning → pgwire SQL analytics.
+| **Internet / web** (built) | timeseries + vector + graph + RAG | Incident copilot: 5xx error burst → incident-typology match → Cypher dependency-chain trace ∩ failing set → root cause → postmortem playbook.
 | **Chip / semiconductor** | vector + graph + timeseries + RAG | Design/verification copilot: spec & sim-log RAG + defect/waveform similarity + netlist-graph traversal + yield timeseries.
 |===
 
-**Manufacturing** (the template) and **Fraud & AML** (the first FSI vertical) are built
-out and verified live against a code-aligned engine. The rest reuse their harness — see
+**Manufacturing** (the template), **Fraud & AML** (first FSI vertical), and **Internet / web**
+are built out and verified live against a code-aligned engine. The rest reuse their harness — see
 below.
 
 == The reusable shape

--- a/demo/verticals/internet-web/.gitignore
+++ b/demo/verticals/internet-web/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/demo/verticals/internet-web/README.adoc
+++ b/demo/verticals/internet-web/README.adoc
@@ -1,0 +1,130 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Internet / Web — Incident-Response Copilot (ProximaDB vertical demo)
+:toc: macro
+
+An SRE asks one plain-language question and a copilot answers by chaining **four data
+modalities in a single engine** — no ETL between a metrics store, a vector DB, a graph DB,
+and a search index. That "one engine, one query plane" is the ProximaDB co-design thesis;
+this demo makes it concrete for a web property under a live incident.
+
+toc::[]
+
+== The scenario
+
+> **SRE:** "Traffic to `/pricing` fell off a cliff and 5xx is spiking. What happened?"
+
+A bad deploy on a shared database (`db-primary`) cascades errors *up* the service dependency
+graph until they surface on a user-facing page. The copilot resolves the page in four hops:
+
+[cols="1,2,3", options="header"]
+|===
+| Hop | Modality | What it does
+| 1 | **Timeseries** | Ingest every entity's 5xx-error stream, aggregate per 30-min bucket, and flag the entities breaking out with error **bursts**.
+| 2 | **Vector** | Match the alerting page's error *signature* against a library of known web-incident **typologies** (deploy regression / CDN / bot surge) by cosine similarity → a named root-cause class.
+| 3 | **Graph** | Trace the service **dependency chain** downstream of the page with a **Cypher** multi-hop query, then *join* it with the failing set to pin the **root-cause service**.
+| 4 | **RAG** | Retrieve the matching **postmortem** + on-call runbook with the proven fix.
+|===
+
+...one question, one engine — the SRE gets the incident class, the failing dependency chain,
+the root cause, and the roll-back playbook.
+
+== Run it — live, through ProximaDB (Docker)
+
+Build the image from the *same* code so the v2 API matches (this demo needs the timeseries
+surface and the Cypher variable-length multi-hop traversal), then run the copilot live:
+
+[source,bash]
+----
+# from the repo root — build a ProximaDB image aligned with this code
+cargo build --release -p proximadb-server          # -> target/release/proximadb-server
+docker build -f Dockerfile.prebuilt -t proximadb:develop .
+docker run -d --name proximadb-web -p 5678:5678 proximadb:develop
+
+cd demo/verticals/internet-web
+python generate_data.py && python copilot_live.py
+----
+
+`copilot_live.py` issues **real** v2 REST calls and prints each one — you can *verify* it ran
+through the engine:
+
+[source,text]
+----
+SRE: Traffic to /pricing fell off a cliff and 5xx is spiking. What happened?
+[timeseries] scanned 22 error streams via ProximaDB — 5 with error bursts: /checkout, /pricing, checkout-svc, db-primary, payments-api
+     [API ✓] POST /api/v2/collections/web_incident_typologies/search  (200, 2 ms)
+[vector] /pricing error signature → deploy regression (score 0.998, live ANN)
+     [API ✓] POST /api/v2/graphs/web/query  (200, 1 ms)
+[graph] /pricing reaches 7 deps; failing chain /pricing → checkout-svc → payments-api → db-primary → root cause db-primary
+     [API ✓] POST /api/v2/collections/web_postmortems/search  (200, 2 ms)
+[RAG] pm-deploy-01 → Rolled back the offending deploy; added a canary + error-budget gate to the pipeline.
+----
+
+**All four modalities are live ProximaDB calls** (nothing client-side):
+
+- **timeseries** — each entity's 5xx stream is ingested (`POST /api/v2/timeseries/collections/{c}/ingest`)
+  into its *own* collection and scanned with a per-30-min-bucket `sum` **aggregate**; a
+  single-window burst over threshold flags exactly the failing chain (the engine's
+  per-collection isolation keeps 22 streams from bleeding into each other).
+- **vector** — the incident-typology library as a vector collection; the alerting page's
+  **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` resolves to
+  the nearest typology by cosine ANN. Scaling every feature to a comparable range is what lets
+  cosine separate a *sharp concentrated deploy spike* from a *spread-out bot surge* — magnitude
+  alone would collapse them.
+- **graph** — the page/service `depends_on` graph is built (`/graphs/web/nodes` + `/edges`) and
+  the dependency chain traced by a **Cypher** variable-length query
+  (`MATCH (a:Entity {id:'/pricing'})-[:depends_on*1..4]->(x) RETURN x`). The copilot then
+  **joins graph reachability with the timeseries-failing set** — the root cause is the *sink* of
+  the failing sub-graph (a failing service that depends on no other failing service): `db-primary`.
+- **RAG** — semantic search over the postmortem / runbook corpus returns the roll-back playbook.
+
+That graph∩timeseries join is the co-design payoff: "*which* of this page's dependencies is
+failing, and which is the deepest" is one question to one engine, not a join across three systems.
+
+The demo embedding is a deterministic hash for portability; production uses a real embedder. The
+timeseries + multi-hop Cypher both require a ProximaDB built from the same code — the Docker steps
+above build exactly that engine.
+
+== Production wiring (ProximaDB SDK + the MCP surface)
+
+In production the four hops are ProximaDB operations behind the reference **MCP** copilot (the
+`search` / `stats` / `event` / `memory` tools). Sketch:
+
+[source,python]
+----
+from proximadb import ProximaDBClient
+
+client = ProximaDBClient(url="http://localhost:5678")
+
+# 1. TIMESERIES — 5xx stream per entity; burst via bucket aggregate
+bursts = client.timeseries_aggregate("/pricing", metric="errors", aggregation="sum", bucket="30m")
+
+# 2. VECTOR — incident-typology library; nearest known root-cause class
+typ = client.search("web_incident_typologies", query_vector=burst_shape, top_k=1)
+
+# 3. GRAPH — trace the dependency chain, join with the failing set
+chain = client.graph_query(
+    "web", "MATCH (a:Entity {id:'/pricing'})-[:depends_on*1..4]->(x) RETURN x")
+
+# 4. RAG — semantic search over the postmortem / runbook corpus
+fix = client.search("web_postmortems", query_text="deploy regression 5xx", top_k=1)
+----
+
+Over the **MCP** transport it is the same, tool-shaped — the copilot calls `search` (steps 2 & 4),
+a graph query (step 3), and can persist the incident timeline with `event` / recall prior outages
+with `memory` (ADR-022).
+
+== Why AnvaiOps
+
+The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — so
+the same demo is a multi-tenant SaaS surface, not a notebook. Governance is the product; the
+multi-modal engine is the moat.
+
+== Files
+
+[cols="1,3"]
+|===
+| `generate_data.py` | Deterministic synthetic dataset — the page/service dependency graph, per-entity 5xx-error timeseries (with the embedded deploy-cascade incident), scale-normalised incident-typology signatures, and the postmortem / runbook corpus.
+| `copilot_live.py`  | The live SRE copilot — four real ProximaDB v2 hops (timeseries → vector → graph Cypher → RAG) diagnosing one incident, with the graph∩timeseries root-cause join.
+|===

--- a/demo/verticals/internet-web/copilot_live.py
+++ b/demo/verticals/internet-web/copilot_live.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Internet / web *incident-response copilot* — a ProximaDB internet-vertical demo.
+
+An SRE asks one question — "traffic to /pricing fell off a cliff, what happened?" — and
+the copilot answers by chaining **four modalities in one engine** (no ETL between a
+metrics store, a vector DB, a graph DB, and a search index):
+
+  1. **timeseries** — per-entity 5xx-error streams; flag the error bursts
+  2. **vector**     — match the alerting page's error signature to a known incident *typology*
+  3. **graph**      — trace the service dependency chain to the root cause (Cypher multi-hop)
+  4. **RAG**        — retrieve the postmortem / runbook with the fix
+
+Every hop is a **real ProximaDB v2 API call** (printed with latency). Run it against a
+ProximaDB built from the same code (timeseries + multi-hop Cypher):
+
+    cargo build --release -p proximadb-server
+    docker build -f Dockerfile.prebuilt -t proximadb:develop .
+    docker run -d -p 5678:5678 proximadb:develop
+    python generate_data.py && python copilot_live.py
+
+Env: ``PROXIMADB_URL`` (default ``http://localhost:5678``). Pure stdlib (urllib).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+BASE = os.environ.get("PROXIMADB_URL", "http://localhost:5678").rstrip("/")
+DATA = Path(os.environ.get("DATA", Path(__file__).parent / "data"))
+EMB_DIM = 256
+TYP_COLL = "web_incident_typologies"
+PM_COLL = "web_postmortems"
+BURST_THRESHOLD = 200.0  # a single-bucket 5xx volume this large is an incident, not noise
+ALERT_PAGE = "/pricing"  # the page the SRE was paged about
+
+
+# ── tiny REST client (stdlib) ───────────────────────────────────────────────────
+def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{BASE}{path}", data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def api(method: str, path: str, body: dict | None = None, label: str = "") -> dict:
+    t = time.time()
+    status, resp = _req(method, path, body)
+    ms = (time.time() - t) * 1000
+    if label:
+        print(f"     [API {'✓' if 200 <= status < 300 else '✗'}] {method} {path}  ({status}, {ms:.0f} ms)")
+    return resp
+
+
+def embed(text: str, dim: int = EMB_DIM) -> list[float]:
+    v = [0.0] * dim
+    for tok in text.lower().replace("/", " ").replace(",", " ").replace(".", " ").split():
+        v[int(hashlib.md5(tok.encode()).hexdigest(), 16) % dim] += 1.0
+    norm = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [round(x / norm, 6) for x in v]
+
+
+def unwrap(x):
+    return x["value"] if isinstance(x, dict) and "value" in x else x
+
+
+def iso_ms(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).timestamp() * 1000)
+
+
+def _load(name: str):
+    return json.loads((DATA / name).read_text())
+
+
+# ── setup (real ProximaDB writes) ───────────────────────────────────────────────
+def load_typologies(typologies) -> None:
+    recs = [{"id": t["id"], "vector": t["features"],
+             "props": {"label": t["label"], "case_ref": t["case_ref"] or ""}}
+            for t in typologies if t["label"] != "nominal"]
+    api("POST", "/api/v2/collections", {"name": TYP_COLL, "dimension": 4, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{TYP_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load web-incident typology signatures")
+    print(f"           ↳ {r.get('inserted_count', 0)} typologies")
+
+
+def load_postmortems(postmortems) -> None:
+    recs = [{"id": p["id"], "vector": embed(f"{p['typology']} {p['typology']} {p['text']}"),
+             "props": {"typology": p["typology"], "resolution": p["resolution"]}}
+            for p in postmortems]
+    api("POST", "/api/v2/collections", {"name": PM_COLL, "dimension": EMB_DIM, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{PM_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load postmortems + runbooks")
+    print(f"           ↳ {r.get('inserted_count', 0)} postmortems")
+
+
+def build_topology_graph(topology) -> None:
+    """Pages + services + depends_on edges as a ProximaDB graph (untraced setup calls)."""
+    api("POST", "/api/v2/graphs", {"graph_id": "web"})
+    for n in topology["nodes"]:
+        api("POST", "/api/v2/graphs/web/nodes",
+            {"node": {"id": n["id"], "labels": ["Entity"],
+                      "properties": {"kind": n["kind"], "tier": n["tier"]}}})
+    for e in topology["edges"]:
+        api("POST", "/api/v2/graphs/web/edges",
+            {"edge": {"id": f"{e['from']}->{e['to']}", "from_node_id": e["from"],
+                      "to_node_id": e["to"], "edge_type": "depends_on", "weight": 1.0}})
+    print(f"     [graph] built dependency graph: {len(topology['nodes'])} entities (live)")
+
+
+# ── analysis hops (all live ProximaDB calls) ────────────────────────────────────
+def timeseries_scan(ts_entities) -> list[dict]:
+    """Ingest each entity's 5xx-error stream into ProximaDB time-series, then aggregate SUM
+    per 30-min bucket to flag error bursts. Real /api/v2/timeseries/*."""
+    print(f"     [timeseries] ingesting {len(ts_entities)} error streams + aggregating (live API)…")
+    flagged = []
+    for ent in ts_entities:
+        pts = ent["points"]
+        if len(pts) < 3:
+            continue
+        coll = "ts_" + ent["entity"].strip("/").replace("/", "_").replace("-", "_") or "ts_root"
+        api("POST", "/api/v2/timeseries/collections", {"name": coll})
+        api("POST", f"/api/v2/timeseries/collections/{coll}/ingest",
+            {"points": [{"timestamp": iso_ms(p["ts"]), "values": {"errors": p["errors"]}} for p in pts]})
+        res = api("POST", f"/api/v2/timeseries/collections/{coll}/aggregate",
+                  {"start_time": iso_ms(pts[0]["ts"]) - 1, "end_time": iso_ms(pts[-1]["ts"]) + 1,
+                   "aggregation": "sum", "bucket_ms": 1_800_000})
+        sums = [b["values"]["errors"] for b in res.get("buckets", []) if "errors" in b.get("values", {})]
+        if not sums:
+            continue
+        peak = max(sums)
+        if peak > BURST_THRESHOLD:
+            flagged.append({"entity": ent["entity"], "peak": round(peak, 1),
+                            "features": feature_vector(sums)})
+    return sorted(flagged, key=lambda f: f["peak"], reverse=True)
+
+
+def feature_vector(sums: list[float]) -> list[float]:
+    """Scale-normalised shape of an error burst — must match the typology vectors in
+    generate_data.py. Scaling each dimension to O(1..10) lets cosine discriminate on the
+    burst *shape* (spiky vs spread, concentrated vs diffuse) rather than raw magnitude."""
+    peak = max(sums)
+    total = sum(sums) or 1e-6
+    mean = total / len(sums)
+    spread = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
+    return [round(peak / 100.0, 3), round(peak / (mean or 1e-6), 3),
+            round(spread * 10.0, 3), round(peak / total * 10.0, 3)]
+
+
+def trace_dependency_chain(entity) -> list[str]:
+    """Trace the dependency chain downstream of an entity via a live Cypher multi-hop query."""
+    q = f"MATCH (a:Entity {{id:'{entity}'}})-[:depends_on*1..4]->(x:Entity) RETURN x"
+    res = api("POST", "/api/v2/graphs/web/query", {"query": q, "language": "cypher"},
+              label=f"Cypher trace dependency chain from {entity}")
+    rows = res.get("data", {}).get("rows", [])
+    return [r.get("node_id") or r.get("id") for r in rows]
+
+
+def say(role, text):
+    print(f"\n{'🧑‍💻 SRE' if role == 'sre' else '🛰️  copilot'}: {text}")
+
+
+def main() -> None:
+    if not DATA.exists():
+        raise SystemExit("dataset missing — run `python generate_data.py` first")
+    topology = _load("topology.json")
+    ts_entities = _load("errorstreams.json")
+    typologies = _load("typologies.json")
+    postmortems = _load("postmortems.json")
+
+    print("=" * 78)
+    print(f"  ProximaDB web incident copilot — LIVE against {BASE}")
+    print("  one engine · timeseries + vector + graph + RAG")
+    print("=" * 78)
+    caps = api("GET", "/api/v2/_meta/capabilities")
+    print(f"  engine features: {', '.join(caps.get('features', [])[-4:])}\n")
+
+    print("── setup (real ProximaDB writes across all four modalities) ──")
+    load_typologies(typologies)
+    load_postmortems(postmortems)
+    build_topology_graph(topology)
+
+    print("\n── copilot ──")
+    say("sre", f"Traffic to {ALERT_PAGE} fell off a cliff and 5xx is spiking. What happened?")
+
+    flagged = timeseries_scan(ts_entities)
+    say("copilot", f"[timeseries] scanned {len(ts_entities)} error streams via ProximaDB — "
+                   f"{len(flagged)} with error bursts: " + ", ".join(f["entity"] for f in flagged))
+
+    target = next((f for f in flagged if f["entity"] == ALERT_PAGE), flagged[0] if flagged else None)
+    for f in ([target] if target else []):
+        ent = f["entity"]
+        # VECTOR — match error signature to an incident typology
+        res = api("POST", f"/api/v2/collections/{TYP_COLL}/search",
+                  {"vector": f["features"], "top_k": 1}, label=f"match {ent} to incident typology")
+        hits = res.get("results", [])
+        typ = unwrap(hits[0]["props"].get("label", "?")) if hits else "?"
+        say("copilot", f"[vector] {ent} error signature → **{typ}** (score {hits[0]['score']:.3f}, live ANN)")
+
+        # GRAPH — trace the dependency chain (multi-hop Cypher), then JOIN with the failing
+        # set from timeseries: the root cause is the deepest failing dependency — a sink in
+        # the failing sub-graph (a failing entity that depends on no other failing entity).
+        chain = trace_dependency_chain(ent)
+        flagged_ids = {f["entity"] for f in flagged}
+        dep_edges = {(e["from"], e["to"]) for e in topology["edges"]}
+        failing = [n for n in chain if n in flagged_ids]  # reachable ∩ failing, in depth order
+        root = next((n for n in failing
+                     if not any((n, m) in dep_edges for m in flagged_ids if m != n)),
+                    failing[-1] if failing else "?")
+        say("copilot",
+            f"[graph] {ent} reaches {len(chain)} deps; failing chain "
+            f"{' → '.join([ent] + failing) if failing else 'none'} → root cause **{root}**")
+
+        # RAG — retrieve the matching postmortem + resolution
+        res = api("POST", f"/api/v2/collections/{PM_COLL}/search",
+                  {"vector": embed(f"{typ} {typ} {typ}"), "top_k": 1}, label="retrieve postmortem (RAG)")
+        rhits = res.get("results", [])
+        if rhits:
+            p = rhits[0]["props"]
+            say("copilot", f"[RAG] {rhits[0]['id']} → {unwrap(p.get('resolution', ''))}")
+
+    print("\n" + "-" * 78)
+    print("Every [API] line is a real ProximaDB call. In production this runs behind the")
+    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/verticals/internet-web/generate_data.py
+++ b/demo/verticals/internet-web/generate_data.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Synthetic web-property dataset for the ProximaDB *internet / web* vertical demo.
+
+Deterministic, stdlib-only, no external data — a small content site + its service
+dependency graph, with one embedded incident (a bad deploy on a shared database that
+cascades errors up through the dependency chain to a user-facing page). Exercises all
+four modalities:
+
+  * **graph**       pages + services (nodes) + `depends_on` edges — the incident is a chain
+  * **timeseries**  per-entity 5xx-error-rate series; the failing chain bursts
+  * **vector**      labelled web-incident *typology* signatures for root-cause matching
+  * **text/RAG**    postmortems + runbooks as a retrieval corpus
+
+Outputs JSON under ``--out`` (default ``./data``). Run this before ``copilot_live.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+WINDOW_START = datetime(2026, 3, 2, 8, 0, tzinfo=timezone.utc)
+
+# The dependency chain that fails: a user-facing page resolves through two services to a
+# shared database that gets a bad deploy. Errors cascade UP the chain (dependents of the
+# broken db). The graph query traces DOWN `depends_on` from the page to the root cause.
+INCIDENT = {
+    "page": "/pricing",  # the alerted, user-facing page
+    "chain": ["/pricing", "checkout-svc", "payments-api", "db-primary"],  # depends_on path
+    "cascade": ["/pricing", "/checkout", "checkout-svc", "payments-api", "db-primary"],
+}
+
+# Pages (user-facing URLs) and services (backend). ~40 entities total with background noise.
+PAGES = ["/", "/pricing", "/checkout", "/docs", "/blog", "/login", "/search",
+         "/account", "/support", "/status", "/careers", "/about"]
+SERVICES = ["cdn-edge", "checkout-svc", "payments-api", "db-primary", "db-replica",
+            "auth-svc", "search-svc", "content-svc", "profile-svc", "ledger-svc"]
+
+# depends_on edges: page -> service(s) -> service(s). The incident chain is explicit.
+DEPENDS_ON = [
+    ("/", "cdn-edge"),
+    ("/pricing", "cdn-edge"), ("/pricing", "checkout-svc"),
+    ("/checkout", "checkout-svc"), ("/checkout", "auth-svc"),
+    ("checkout-svc", "payments-api"), ("checkout-svc", "auth-svc"),
+    ("payments-api", "db-primary"), ("payments-api", "ledger-svc"),
+    ("ledger-svc", "db-primary"),
+    ("/account", "profile-svc"), ("profile-svc", "db-replica"),
+    ("/login", "auth-svc"), ("auth-svc", "db-replica"),
+    ("/search", "search-svc"), ("search-svc", "db-replica"),
+    ("/docs", "content-svc"), ("/blog", "content-svc"), ("content-svc", "cdn-edge"),
+    ("/support", "content-svc"), ("/status", "cdn-edge"),
+]
+
+# Labelled web-incident signatures (the vector library). Features are the SCALE-NORMALISED
+# shape of the error burst — [severity, spike_ratio, spread, concentration] — the same vector
+# copilot_live.py derives from the ProximaDB timeseries aggregate (see feature_vector there):
+#   severity      = peak_bucket / 100          (how big)
+#   spike_ratio   = peak / mean                 (how spiky vs baseline)
+#   spread        = burst_fraction * 10         (how many buckets are hot)
+#   concentration = (peak / total) * 10         (how concentrated in one bucket)
+# Scaling keeps every dimension O(1..10) so cosine discriminates on *shape*, not raw magnitude —
+# a sharp concentrated deploy spike separates cleanly from a spread-out bot surge.
+TYPOLOGIES = [
+    {"id": "typ-deploy-regression", "label": "deploy regression", "case_ref": "pm-deploy-01",
+     "features": [6.0, 5.0, 2.5, 6.5]},   # big, spiky, few hot buckets, highly concentrated
+    {"id": "typ-cdn-cache", "label": "CDN cache poisoning", "case_ref": "pm-cdn-01",
+     "features": [2.0, 2.0, 6.0, 2.0]},   # moderate, flat, many hot buckets, diffuse
+    {"id": "typ-bot-surge", "label": "bot / scraper surge", "case_ref": "pm-bot-01",
+     "features": [3.0, 4.0, 6.0, 2.5]},   # moderate, spiky, many hot buckets, diffuse
+    {"id": "typ-nominal", "label": "nominal", "case_ref": None,
+     "features": [0.5, 1.4, 0.5, 3.0]},
+]
+
+POSTMORTEMS = [
+    {"id": "pm-deploy-01", "typology": "deploy regression",
+     "text": "A backend deploy introduced a regression that spiked 5xx errors, cascading up "
+             "the service dependency chain to user-facing pages within minutes of rollout. "
+             "Sudden sharp error spike correlated with a release marker.",
+     "resolution": "Rolled back the offending deploy; added a canary + error-budget gate to the pipeline."},
+    {"id": "pm-cdn-01", "typology": "CDN cache poisoning",
+     "text": "A malformed cache key poisoned the CDN edge, serving errors for a sustained window "
+             "at moderate rate across many pages until the cache was purged.",
+     "resolution": "Purged the edge cache; pinned the cache-key normalization; added a cache-hit-ratio alert."},
+    {"id": "pm-bot-01", "typology": "bot / scraper surge",
+     "text": "A scraper botnet drove a spiky surge of requests to search and listing pages, "
+             "exhausting a connection pool and returning 5xx to real users.",
+     "resolution": "Rate-limited by ASN; moved search behind a queue; added bot-score WAF rules."},
+    {"id": "runbook-oncall-01", "typology": "oncall",
+     "text": "Incident on-call runbook: correlate the error spike to the deploy timeline, trace the "
+             "service dependency graph from the alerting page down to the root service, check the "
+             "release marker, and roll back before mitigating downstream.",
+     "resolution": "Follow trace-to-root then roll-back-first; page the owning team for the root service."},
+]
+
+
+def build_nodes(rng: random.Random) -> list[dict]:
+    chain = set(INCIDENT["cascade"])
+    nodes = []
+    for p in PAGES:
+        nodes.append({"id": p, "kind": "page", "tier": "edge", "in_incident": p in chain})
+    for s in SERVICES:
+        nodes.append({"id": s, "kind": "service",
+                      "tier": "data" if s.startswith("db-") else "app",
+                      "in_incident": s in chain})
+    return nodes
+
+
+def build_error_series(rng: random.Random) -> dict[str, list[dict]]:
+    """Per-entity 5xx-error-count points. Background low noise + the incident burst."""
+    entities = PAGES + SERVICES
+    series: dict[str, list[dict]] = {e: [] for e in entities}
+
+    # ── background: low, time-spread 5xx counts for every entity ──
+    for e in entities:
+        for _ in range(rng.randint(6, 10)):
+            ts = WINDOW_START + timedelta(minutes=rng.randint(0, 300))
+            series[e].append({"ts": ts.isoformat(), "errors": round(rng.uniform(1, 9), 1)})
+
+    # ── the incident: bad deploy on db-primary at hour 3, cascading up the chain ──
+    deploy = WINDOW_START + timedelta(hours=3)
+    for entity in INCIDENT["cascade"]:
+        # sharp error spike concentrated in a ~40-min window after the deploy
+        for _ in range(rng.randint(8, 12)):
+            ts = deploy + timedelta(minutes=rng.randint(0, 40))
+            series[entity].append({"ts": ts.isoformat(), "errors": round(rng.uniform(70, 110), 1)})
+    return series
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate the internet/web demo dataset.")
+    ap.add_argument("--out", default=str(Path(__file__).parent / "data"))
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    nodes = build_nodes(rng)
+    edges = [{"from": a, "to": b, "type": "depends_on"} for (a, b) in DEPENDS_ON]
+    series = build_error_series(rng)
+    ts_out = [{"entity": e, "points": sorted(pts, key=lambda p: p["ts"])}
+              for e, pts in series.items()]
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "topology.json").write_text(json.dumps({"nodes": nodes, "edges": edges}, indent=2))
+    (out / "errorstreams.json").write_text(json.dumps(ts_out, indent=2))
+    (out / "typologies.json").write_text(json.dumps(TYPOLOGIES, indent=2))
+    (out / "postmortems.json").write_text(json.dumps(POSTMORTEMS, indent=2))
+
+    print(f"✅ internet/web dataset written to {out}")
+    print(f"   entities:   {len(nodes)} ({sum(n['in_incident'] for n in nodes)} in the incident chain)")
+    print(f"   depends_on: {len(edges)} edges   ts entities: {len(ts_out)}")
+    print(f"   typologies: {len(TYPOLOGIES)}   postmortems: {len(POSTMORTEMS)}")
+    print(f"   incident: {' → '.join(INCIDENT['chain'])} (bad deploy on db-primary)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The **internet / web** vertical demo for the AnvaiOps site — the largest-TAM vertical, next after fraud-AML. An SRE asks one plain-language question — *"traffic to `/pricing` fell off a cliff and 5xx is spiking, what happened?"* — and a copilot answers by chaining **four modalities in one engine**, every hop a **live ProximaDB v2 API call**:

| Hop | Modality | What runs |
|-----|----------|-----------|
| 1 | **timeseries** | each entity's 5xx-error stream in its *own* ts collection; per-30-min `sum` aggregate flags error **bursts** |
| 2 | **vector** | the alerting page's **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` -> nearest incident **typology** (cosine ANN) |
| 3 | **graph** | a **Cypher** `-[:depends_on*1..4]->` traces the service dependency chain, **joined** with the failing set to pin the root-cause service |
| 4 | **RAG** | semantic search over the postmortem / runbook corpus -> the roll-back **playbook** |

## Verified live (code-aligned image)
```
SRE: Traffic to /pricing fell off a cliff and 5xx is spiking. What happened?
[timeseries] 5 with error bursts: /checkout, /pricing, checkout-svc, db-primary, payments-api
[vector] /pricing error signature -> deploy regression (score 0.998, live ANN)
[graph] /pricing reaches 7 deps; failing chain /pricing -> checkout-svc -> payments-api -> db-primary -> root cause db-primary
[RAG] pm-deploy-01 -> Rolled back the offending deploy; added a canary + error-budget gate to the pipeline.
```
Flags **exactly the 5 incident-chain entities** (zero false positives), matches the correct incident class, and the **multi-hop Cypher ∩ timeseries-failing join** pins the true root cause `db-primary`.

## Notable
- **Exercises the just-merged engine fixes (#658)** end-to-end: per-collection timeseries isolation (22 streams don't bleed) and Cypher variable-length multi-hop traversal (the dependency chain reaches depth 4).
- Introduces **scale-normalised burst features** so cosine discriminates on burst *shape* (spiky vs spread, concentrated vs diffuse) rather than raw magnitude — a reusable pattern for the remaining verticals (insurance, market surveillance, D&B).
- Deterministic + stdlib-only generator; generated `data/` and `__pycache__` gitignored; registers the vertical in `demo/verticals/README.adoc`.

Next in the TAM-ordered roadmap: insurance, then market surveillance & trading, then D&B / commercial risk.