### PR TITLE
docs(td): promote Fix C to TD-FLUSH-2 (flush-threshold policy, gated)

### DIFF
--- a/docs/10-quality/td/TD-FLUSH-2-flush-threshold-small-corpora-never-flush.adoc
+++ b/docs/10-quality/td/TD-FLUSH-2-flush-threshold-small-corpora-never-flush.adoc
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FLUSH-2: Flush-threshold policy — small corpora never flush (O(N) linear tail scan)
+
+[cols="1,3"]
+|===
+|Status|Gated
+|Priority|LOW
+|Scope|PERF
+|Date|2026-07-04
+|Gate|**TD-096** (HELIX block-skip on the flushed side) **AND** a corpus-scale trigger (see below) — both must hold.
+|Relates to|TD-STRONG-1 (extracted from its "Fix C"), TD-096 (SST block-skip), TD-FLUSH-1 (sibling flush-lifecycle debt — memtable reap)
+|===
+
+== Context
+
+The memtable flush threshold defaults to `global_memory_limit / 2` = **2 GB**
+(`src/storage/persistence/write_ahead_log/config.rs:284` default 4 GB → `mod.rs`
+`/2`), with a count trigger only at **50 000** records
+(`src/storage/memtable/specialized/wal_behavior.rs:646`). So a small-but-active
+corpus (e.g. 8 000 × 384-dim vectors ≈ 12 MB) **never flushes** — it lives in the
+WAL tail indefinitely, and every Strong search does an O(N) linear scan of the
+tail (`search_unflushed_vectors`). Filed originally as TD-STRONG-1 "Fix C".
+
+== Why this is gated (and why A+B lowered its urgency)
+
+* **Motivation weakened by TD-STRONG-1 Part A.** Fix C existed to *escape* the
+  O(N) tail scan. But Fix A (bloom reuse) + Fix B (defer materialization past
+  top-k) made that scan ~5× cheaper — re-measured 2026-07-04: c16 vector QPS
+  23→115 (x86) / 35→192 (arm), concurrent p99 −76% / −84% (anvaiops
+  `tests/load/results/2026-07-04-arm-vs-x86-postfix/`). The tail scan is no longer
+  the bottleneck at MVP scale, so this is now a *scale* concern, not a hot fix.
+* **Hard dependency on TD-096.** Flushing eagerly *moves* records from the tail
+  to the SST/directory side — which has TD-096's block-skip problem ("≈ full scan
+  on diffuse data") until HELIX PCA→Hilbert ordering lands. Flushing before
+  TD-096 trades a now-fast tail scan for an *unfixed* directory scan: a wash or a
+  regression.
+
+== Gate (both required to unblock)
+
+1. **TD-096 resolved** — HELIX block-skip active, so flushed data is efficiently
+   searchable (ANN, not a full directory scan).
+2. **Corpus-scale trigger** — a corpus large enough that even the post-A+B linear
+   tail scan is the bottleneck (well beyond MVP; a real large-corpus or
+   long-running workload). Do not pre-build for MVP-size data.
+
+== Sketch (when unblocked)
+
+Add a size/count/time flush trigger (or a per-collection knob) so small-but-active
+corpora flush into the indexed directory instead of accumulating in the tail;
+Strong searches then use the HELIX index rather than an O(N) tail scan. Coordinate
+with TD-FLUSH-1 (post-flush memtable reap) so the flushed memory is actually freed.
+
+== Done when
+
+Small corpora flush into the indexed directory on a size/count/time policy, and a
+large-corpus concurrency benchmark shows the linear-tail-scan term removed with
+recall preserved (HELIX block-skip active).

--- a/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
+++ b/docs/10-quality/td/TD-STRONG-1-strong-read-concurrency-followups.adoc
@@ -54,8 +54,9 @@ gain — **dropped**, not merely deferred. (Downstream evidence:
 anvaiops `tests/load/results/2026-07-04-arm-vs-x86-postfix/`.)
 
 *Fix C — flush policy* (the 2GB default keeps small corpora unflushed forever, so
-every Strong search is an O(N) linear tail scan) is a separate structural lever
-that only pays off with TD-096 (HELIX block-skip on the flushed side).
+every Strong search is an O(N) linear tail scan) is promoted to its own gated
+item, **TD-FLUSH-2** (gate: TD-096 + a corpus-scale trigger). A+B lowered its
+urgency to a scale concern; it is not built at MVP size.
 
 == Part B — Close the ungated query-cache read sites (SEC/correctness) — DONE
 


### PR DESCRIPTION
Promotes the flush-policy lever from TD-STRONG-1's inline "Fix C" paragraph into its own tracked, gated TD (**TD-FLUSH-2**) so it's independently visible rather than buried in a mostly-done TD.

**Gate (both required):** TD-096 (HELIX block-skip on the flushed side) **AND** a corpus-scale trigger — flushing eagerly before TD-096 just trades a now-fast tail scan for an unfixed directory scan.

**Key nuance recorded:** TD-STRONG-1 Part A (Fix A+B) made the O(N) tail scan Fix C was meant to escape ~5× cheaper (re-measured 2026-07-04: c16 QPS 23→115 / 35→192, p99 −76%/−84%), so this is now a *scale* concern, not a hot fix — not built at MVP size.

`TD-FLUSH-2` is collision-free (topic-scoped, sibling of the existing TD-FLUSH-1 memtable-reap item). TD-STRONG-1 repointed at it. td-adr guard green.