### PR TITLE
demo(verticals): insurance SIU claims-fraud copilot (2nd FSI vertical)

### DIFF
--- a/demo/verticals/README.adoc
+++ b/demo/verticals/README.adoc
@@ -21,13 +21,14 @@ toc::[]
 | Vertical | Modalities showcased | Copilot story
 | **Manufacturing / industrial** (template, built) | timeseries + vector + graph + RAG | Factory copilot: sensor anomaly → fault-signature match → downstream-impact traversal → maintenance-log fix.
 | **Fraud & AML** (FSI, built) | timeseries + vector + graph + RAG | Compliance copilot: transacted-volume burst → AML-typology match → Cypher ring trace → case-note / SAR playbook.
+| **Insurance** (FSI, built) | timeseries + vector + graph + RAG | SIU claims-fraud copilot: claimed-amount burst → fraud-typology match → Cypher staged-ring trace through shared provider → SIU playbook.
 | **Energy** | timeseries + vector + graph | Grid copilot: meter/sensor anomaly + forecast → topology-aware outage impact → maintenance-log RAG.
 | **Social media** | graph + vector + hybrid RRF | Feed/reco copilot: semantic post search + social-graph proximity + community/influence; taste memory (ADR-022).
 | **Internet / web** (built) | timeseries + vector + graph + RAG | Incident copilot: 5xx error burst → incident-typology match → Cypher dependency-chain trace ∩ failing set → root cause → postmortem playbook.
 | **Chip / semiconductor** | vector + graph + timeseries + RAG | Design/verification copilot: spec & sim-log RAG + defect/waveform similarity + netlist-graph traversal + yield timeseries.
 |===
 
-**Manufacturing** (the template), **Fraud & AML** (first FSI vertical), and **Internet / web**
+**Manufacturing** (the template), **Fraud & AML**, **Insurance** (FSI), and **Internet / web**
 are built out and verified live against a code-aligned engine. The rest reuse their harness — see
 below.
 

--- a/demo/verticals/insurance-claims/.gitignore
+++ b/demo/verticals/insurance-claims/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/demo/verticals/insurance-claims/README.adoc
+++ b/demo/verticals/insurance-claims/README.adoc
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Insurance — SIU Claims-Fraud Copilot (ProximaDB vertical demo)
+:toc: macro
+
+A Special Investigations Unit (SIU) analyst asks one plain-language question and a copilot
+answers by chaining **four data modalities in a single engine** — no ETL between a metrics
+store, a vector DB, a graph DB, and a search index. That "one engine, one query plane" is the
+ProximaDB co-design thesis; this demo makes it concrete for an auto-insurance fraud desk.
+
+toc::[]
+
+== The scenario
+
+> **SIU analyst:** "Claim from `clmt-007` was flagged by the fraud model. Is it a staged-accident ring?"
+
+A classic staged-accident ring is embedded in a sea of legitimate claims — an *organizer*
+recruits *participants* who all file bodily-injury claims through one *crooked clinic*, which
+bills a phantom *capper*. The copilot resolves the flag in four hops:
+
+[cols="1,2,3", options="header"]
+|===
+| Hop | Modality | What it does
+| 1 | **Timeseries** | Ingest each claimant's claimed-amount stream, aggregate per 30-min bucket, and flag the claimants with suspicious amount **bursts**.
+| 2 | **Vector** | Match the flagged claimant's *burst signature* against a library of known fraud **typologies** (staged ring / provider collusion / claim stacking) by cosine similarity → a named typology.
+| 3 | **Graph** | Trace the fraud **ring** downstream of the claimant with a **Cypher** multi-hop path query (`organizer → participants → clinic → capper`).
+| 4 | **RAG** | Retrieve the matching **SIU case note** + fraud-indicator guidance with the proven resolution.
+|===
+
+...one question, one engine — the analyst gets a typology, the ring, and the SIU playbook.
+
+== Run it — live, through ProximaDB (Docker)
+
+Build the image from the *same* code so the v2 API matches (this demo needs the timeseries
+surface and the Cypher variable-length multi-hop traversal), then run the copilot live:
+
+[source,bash]
+----
+# from the repo root — build a ProximaDB image aligned with this code
+cargo build --release -p proximadb-server          # -> target/release/proximadb-server
+docker build -f Dockerfile.prebuilt -t proximadb:develop .
+docker run -d --name proximadb-ins -p 5678:5678 proximadb:develop
+
+cd demo/verticals/insurance-claims
+python generate_data.py && python copilot_live.py
+----
+
+`copilot_live.py` issues **real** v2 REST calls and prints each one — you can *verify* it ran
+through the engine:
+
+[source,text]
+----
+SIU: Claim from clmt-007 was flagged by the fraud model. Is it a staged-accident ring?
+[timeseries] scanned 30 claim streams via ProximaDB — 5 with suspicious amount bursts: clmt-020, clmt-011, clmt-013, clmt-012, clmt-007
+     [API ✓] POST /api/v2/collections/ins_fraud_typologies/search  (200, 2 ms)
+[vector] clmt-007 claim signature → staged-accident ring (score 0.970, live ANN)
+     [API ✓] POST /api/v2/graphs/ins/query  (200, 1 ms)
+[graph] fraud ring downstream of clmt-007 → clmt-011 → clmt-012 → clmt-013 → prov-briarwood → clmt-020
+     [API ✓] POST /api/v2/collections/ins_casenotes/search  (200, 2 ms)
+[RAG] siu-ring-01 → Denied the cluster; referred the organizer and clinic to SIU + the state fraud bureau; flagged the provider NPI.
+----
+
+**All four modalities are live ProximaDB calls** (nothing client-side):
+
+- **timeseries** — each claimant's claimed-amount stream is ingested into its *own* collection
+  and scanned with a per-30-min-bucket `sum` **aggregate**; a single-window burst over threshold
+  flags exactly the ring claimants (the engine's per-collection isolation keeps 30 streams from
+  bleeding into each other).
+- **vector** — the fraud-typology library as a vector collection; the flagged claimant's
+  **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` resolves to the
+  nearest typology by cosine ANN. Scaling every feature to a comparable range lets cosine separate a
+  *tight staged-ring spike* from *sustained provider collusion* — dollar magnitude alone would blur them.
+- **graph** — the claimant/provider `linked` graph is built (`/graphs/ins/nodes` + `/edges`) and
+  the ring traced by a **Cypher** variable-length path query
+  (`MATCH (a:Party {id:'clmt-007'})-[:linked*1..4]->(x) RETURN x`), walking
+  `organizer → participants → crooked clinic → capper` in one hop-bounded traversal — the shared
+  provider is the link that turns unrelated claimants into a ring.
+- **RAG** — semantic search over the SIU case-note corpus returns the matching playbook.
+
+The demo embedding is a deterministic hash for portability; production uses a real embedder. The
+timeseries + multi-hop Cypher both require a ProximaDB built from the same code — the Docker steps
+above build exactly that engine.
+
+== Production wiring (ProximaDB SDK + the MCP surface)
+
+In production the four hops are ProximaDB operations behind the reference **MCP** copilot (the
+`search` / `stats` / `event` / `memory` tools). Sketch:
+
+[source,python]
+----
+from proximadb import ProximaDBClient
+
+client = ProximaDBClient(url="http://localhost:5678")
+
+# 1. TIMESERIES — claimed-amount stream per claimant; burst via bucket aggregate
+bursts = client.timeseries_aggregate("clmt-007", metric="amount", aggregation="sum", bucket="30m")
+
+# 2. VECTOR — fraud-typology library; nearest known typology to the burst signature
+typ = client.search("ins_fraud_typologies", query_vector=burst_shape, top_k=1)
+
+# 3. GRAPH — trace the fraud ring through the shared provider with a Cypher path query
+ring = client.graph_query(
+    "ins", "MATCH (a:Party {id:'clmt-007'})-[:linked*1..4]->(x) RETURN x")
+
+# 4. RAG — semantic search over the SIU case-note corpus
+playbook = client.search("ins_casenotes", query_text="staged accident ring shared clinic", top_k=1)
+----
+
+Over the **MCP** transport it is the same, tool-shaped — the copilot calls `search` (steps 2 & 4),
+a graph query (step 3), and can persist the disposition with `event` / recall prior SIU cases with
+`memory` (ADR-022).
+
+== Why AnvaiOps
+
+The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
+stakes for a regulated insurance workload where claimant PII and medical data can never leak across
+tenants. Governance is the product; the multi-modal engine is the moat.
+
+== Files
+
+[cols="1,3"]
+|===
+| `generate_data.py` | Deterministic synthetic dataset — the claimant/provider `linked` graph, per-claimant claimed-amount timeseries (with the embedded staged-accident-ring burst), scale-normalised fraud-typology signatures, and the SIU case-note corpus.
+| `copilot_live.py`  | The live SIU copilot — four real ProximaDB v2 hops (timeseries → vector → graph Cypher → RAG) resolving one fraud flag.
+|===

--- a/demo/verticals/insurance-claims/copilot_live.py
+++ b/demo/verticals/insurance-claims/copilot_live.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Insurance *SIU claims-fraud copilot* — a ProximaDB insurance-vertical demo.
+
+A Special Investigations Unit analyst asks one question — "claim from clmt-007 was flagged,
+is it a staged-accident ring?" — and the copilot answers by chaining **four modalities in
+one engine** (no ETL between a metrics store, a vector DB, a graph DB, and a search index):
+
+  1. **timeseries** — per-claimant claimed-amount streams; flag the amount bursts
+  2. **vector**     — match the flagged claimant's burst signature to a known fraud *typology*
+  3. **graph**      — trace the fraud ring through the shared crooked provider (Cypher multi-hop)
+  4. **RAG**        — retrieve the SIU case note + fraud-indicator guidance with the resolution
+
+Every hop is a **real ProximaDB v2 API call** (printed with latency). Run it against a
+ProximaDB built from the same code (timeseries + multi-hop Cypher):
+
+    cargo build --release -p proximadb-server
+    docker build -f Dockerfile.prebuilt -t proximadb:develop .
+    docker run -d -p 5678:5678 proximadb:develop
+    python generate_data.py && python copilot_live.py
+
+Env: ``PROXIMADB_URL`` (default ``http://localhost:5678``). Pure stdlib (urllib).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+BASE = os.environ.get("PROXIMADB_URL", "http://localhost:5678").rstrip("/")
+DATA = Path(os.environ.get("DATA", Path(__file__).parent / "data"))
+EMB_DIM = 256
+TYP_COLL = "ins_fraud_typologies"
+CASE_COLL = "ins_casenotes"
+BURST_THRESHOLD = 8000.0  # a single-window claimed volume this large is suspicious
+ALERT_CLAIMANT = "clmt-007"  # the claimant the fraud model flagged
+
+
+# ── tiny REST client (stdlib) ───────────────────────────────────────────────────
+def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{BASE}{path}", data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def api(method: str, path: str, body: dict | None = None, label: str = "") -> dict:
+    t = time.time()
+    status, resp = _req(method, path, body)
+    ms = (time.time() - t) * 1000
+    if label:
+        print(f"     [API {'✓' if 200 <= status < 300 else '✗'}] {method} {path}  ({status}, {ms:.0f} ms)")
+    return resp
+
+
+def embed(text: str, dim: int = EMB_DIM) -> list[float]:
+    v = [0.0] * dim
+    for tok in text.lower().replace(",", " ").replace(".", " ").replace("-", " ").split():
+        v[int(hashlib.md5(tok.encode()).hexdigest(), 16) % dim] += 1.0
+    norm = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [round(x / norm, 6) for x in v]
+
+
+def unwrap(x):
+    return x["value"] if isinstance(x, dict) and "value" in x else x
+
+
+def iso_ms(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).timestamp() * 1000)
+
+
+def _load(name: str):
+    return json.loads((DATA / name).read_text())
+
+
+def feature_vector(sums: list[float]) -> list[float]:
+    """Scale-normalised shape of a claimed-amount burst — must match the typology vectors in
+    generate_data.py. Scaling each dimension to O(1..10) lets cosine discriminate on burst
+    *shape* (a tight staged-ring spike vs sustained provider collusion) not raw dollars."""
+    peak = max(sums)
+    total = sum(sums) or 1e-6
+    mean = total / len(sums)
+    spread = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
+    return [round(peak / 10000.0, 3), round(peak / (mean or 1e-6), 3),
+            round(spread * 10.0, 3), round(peak / total * 10.0, 3)]
+
+
+# ── setup (real ProximaDB writes) ───────────────────────────────────────────────
+def load_typologies(typologies) -> None:
+    recs = [{"id": t["id"], "vector": t["features"],
+             "props": {"label": t["label"], "case_ref": t["case_ref"] or ""}}
+            for t in typologies if t["label"] != "nominal"]
+    api("POST", "/api/v2/collections", {"name": TYP_COLL, "dimension": 4, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{TYP_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load fraud-typology signatures")
+    print(f"           ↳ {r.get('inserted_count', 0)} typologies")
+
+
+def load_casenotes(cases) -> None:
+    recs = [{"id": c["id"], "vector": embed(f"{c['typology']} {c['typology']} {c['text']}"),
+             "props": {"typology": c["typology"], "resolution": c["resolution"]}}
+            for c in cases]
+    api("POST", "/api/v2/collections", {"name": CASE_COLL, "dimension": EMB_DIM, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{CASE_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load SIU case notes")
+    print(f"           ↳ {r.get('inserted_count', 0)} case notes")
+
+
+def build_party_graph(parties) -> None:
+    """Claimants + providers + `linked` edges as a ProximaDB graph (untraced setup calls)."""
+    api("POST", "/api/v2/graphs", {"graph_id": "ins"})
+    for n in parties["nodes"]:
+        api("POST", "/api/v2/graphs/ins/nodes",
+            {"node": {"id": n["id"], "labels": ["Party"], "properties": {"kind": n["kind"]}}})
+    for e in parties["edges"]:
+        api("POST", "/api/v2/graphs/ins/edges",
+            {"edge": {"id": f"{e['from']}->{e['to']}", "from_node_id": e["from"],
+                      "to_node_id": e["to"], "edge_type": "linked", "weight": 1.0}})
+    print(f"     [graph] built claim network: {len(parties['nodes'])} parties (live)")
+
+
+# ── analysis hops (all live ProximaDB calls) ────────────────────────────────────
+def timeseries_scan(ts_claimants) -> list[dict]:
+    """Ingest each claimant's claimed-amount stream into ProximaDB time-series, then aggregate
+    SUM per 30-min bucket to flag amount bursts. Real /api/v2/timeseries/*."""
+    print(f"     [timeseries] ingesting {len(ts_claimants)} claim streams + aggregating (live API)…")
+    flagged = []
+    for acc in ts_claimants:
+        pts = acc["points"]
+        if len(pts) < 3:
+            continue
+        coll = "ts_" + acc["claimant"].replace("-", "_")
+        api("POST", "/api/v2/timeseries/collections", {"name": coll})
+        api("POST", f"/api/v2/timeseries/collections/{coll}/ingest",
+            {"points": [{"timestamp": iso_ms(p["ts"]), "values": {"amount": p["amount"]}} for p in pts]})
+        res = api("POST", f"/api/v2/timeseries/collections/{coll}/aggregate",
+                  {"start_time": iso_ms(pts[0]["ts"]) - 1, "end_time": iso_ms(pts[-1]["ts"]) + 1,
+                   "aggregation": "sum", "bucket_ms": 1_800_000})
+        sums = [b["values"]["amount"] for b in res.get("buckets", []) if "amount" in b.get("values", {})]
+        if not sums:
+            continue
+        peak = max(sums)
+        if peak > BURST_THRESHOLD:
+            flagged.append({"claimant": acc["claimant"], "peak": round(peak, 1),
+                            "features": feature_vector(sums)})
+    return sorted(flagged, key=lambda f: f["peak"], reverse=True)
+
+
+def trace_ring(party) -> list[str]:
+    """Trace the fraud ring downstream of a claimant via a live Cypher multi-hop query."""
+    q = f"MATCH (a:Party {{id:'{party}'}})-[:linked*1..4]->(x:Party) RETURN x"
+    res = api("POST", "/api/v2/graphs/ins/query", {"query": q, "language": "cypher"},
+              label=f"Cypher trace fraud ring from {party}")
+    rows = res.get("data", {}).get("rows", [])
+    return [r.get("node_id") or r.get("id") for r in rows]
+
+
+def say(role, text):
+    print(f"\n{'🕵️  SIU' if role == 'siu' else '🤖 copilot'}: {text}")
+
+
+def main() -> None:
+    if not DATA.exists():
+        raise SystemExit("dataset missing — run `python generate_data.py` first")
+    parties = _load("parties.json")
+    ts_claimants = _load("claims.json")
+    typologies = _load("typologies.json")
+    cases = _load("casenotes.json")
+
+    print("=" * 78)
+    print(f"  ProximaDB insurance SIU copilot — LIVE against {BASE}")
+    print("  one engine · timeseries + vector + graph + RAG")
+    print("=" * 78)
+    caps = api("GET", "/api/v2/_meta/capabilities")
+    print(f"  engine features: {', '.join(caps.get('features', [])[-4:])}\n")
+
+    print("── setup (real ProximaDB writes across all four modalities) ──")
+    load_typologies(typologies)
+    load_casenotes(cases)
+    build_party_graph(parties)
+
+    print("\n── copilot ──")
+    say("siu", f"Claim from {ALERT_CLAIMANT} was flagged by the fraud model. Is it a staged-accident ring?")
+
+    flagged = timeseries_scan(ts_claimants)
+    say("copilot", f"[timeseries] scanned {len(ts_claimants)} claim streams via ProximaDB — "
+                   f"{len(flagged)} with suspicious amount bursts: "
+                   + ", ".join(f["claimant"] for f in flagged))
+
+    target = next((f for f in flagged if f["claimant"] == ALERT_CLAIMANT), flagged[0] if flagged else None)
+    for f in ([target] if target else []):
+        clmt = f["claimant"]
+        # VECTOR — match burst signature to a fraud typology
+        res = api("POST", f"/api/v2/collections/{TYP_COLL}/search",
+                  {"vector": f["features"], "top_k": 1}, label=f"match {clmt} to fraud typology")
+        hits = res.get("results", [])
+        typ = unwrap(hits[0]["props"].get("label", "?")) if hits else "?"
+        say("copilot", f"[vector] {clmt} claim signature → **{typ}** (score {hits[0]['score']:.3f}, live ANN)")
+
+        # GRAPH — trace the ring through the shared crooked provider (multi-hop Cypher)
+        ring = trace_ring(clmt)
+        say("copilot", f"[graph] fraud ring downstream of {clmt} → {' → '.join(ring) if ring else 'none'}")
+
+        # RAG — retrieve the matching SIU case note + resolution
+        res = api("POST", f"/api/v2/collections/{CASE_COLL}/search",
+                  {"vector": embed(f"{typ} {typ} {typ}"), "top_k": 1}, label="retrieve SIU case note (RAG)")
+        rhits = res.get("results", [])
+        if rhits:
+            p = rhits[0]["props"]
+            say("copilot", f"[RAG] {rhits[0]['id']} → {unwrap(p.get('resolution', ''))}")
+
+    print("\n" + "-" * 78)
+    print("Every [API] line is a real ProximaDB call. In production this runs behind the")
+    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/verticals/insurance-claims/generate_data.py
+++ b/demo/verticals/insurance-claims/generate_data.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Synthetic insurance dataset for the ProximaDB *insurance claims-fraud* vertical demo.
+
+Deterministic, stdlib-only, no external data — a small auto-insurance world with one
+embedded *staged-accident ring* (an organizer recruits participants who all file through a
+single crooked clinic) over a sea of legitimate claims. Exercises all four modalities:
+
+  * **graph**       claimants + providers (nodes) + `linked` edges — the ring is a path
+  * **timeseries**  per-claimant claimed-amount series; the ring claimants burst
+  * **vector**      labelled fraud *typology* signatures for behaviour matching
+  * **text/RAG**    SIU (Special Investigations Unit) case notes as a retrieval corpus
+
+Outputs JSON under ``--out`` (default ``./data``). Run this before ``copilot_live.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+N_CLAIMANTS = 30
+WINDOW_START = datetime(2026, 4, 6, 8, 0, tzinfo=timezone.utc)
+
+# The staged-accident ring: an organizer recruits participants who all file through one
+# crooked clinic, which bills a phantom (capper) claimant. This is the path the graph traces.
+RING = {
+    "organizer": "clmt-007",
+    "participants": ["clmt-011", "clmt-012", "clmt-013"],
+    "provider": "prov-briarwood",   # the colluding clinic
+    "capper": "clmt-020",
+}
+
+# Labelled fraud-typology signatures (the vector library). Features are the SCALE-NORMALISED
+# shape of the claimed-amount burst — [severity, spike_ratio, spread, concentration] — the same
+# vector copilot_live.py derives from the ProximaDB timeseries aggregate (see feature_vector):
+#   severity      = peak_bucket / 10000        (how big the biggest window is)
+#   spike_ratio   = peak / mean                (how spiky vs the claimant baseline)
+#   spread        = burst_fraction * 10        (how many windows are hot)
+#   concentration = (peak / total) * 10        (how concentrated in one window)
+# Scaling keeps every dimension O(1..10) so cosine discriminates on *shape*, not raw magnitude.
+TYPOLOGIES = [
+    {"id": "typ-staged-ring", "label": "staged-accident ring", "case_ref": "siu-ring-01",
+     "features": [6.0, 5.0, 2.5, 6.5]},    # big, spiky, few hot windows, concentrated burst
+    {"id": "typ-provider-collusion", "label": "provider collusion", "case_ref": "siu-collusion-01",
+     "features": [3.0, 2.2, 6.0, 2.2]},    # moderate, flat, sustained over many windows
+    {"id": "typ-claim-stacking", "label": "claim stacking", "case_ref": "siu-stacking-01",
+     "features": [3.5, 4.0, 6.0, 2.6]},    # moderate, spiky, many windows (repeat filer)
+    {"id": "typ-nominal", "label": "nominal", "case_ref": None,
+     "features": [0.6, 1.4, 0.5, 3.0]},
+]
+
+CASE_NOTES = [
+    {"id": "siu-ring-01", "typology": "staged-accident ring",
+     "text": "Multiple bodily-injury claims from a single staged multi-vehicle collision, all "
+             "treated at one clinic within days, organized by a recruiter who signs up participants. "
+             "Tight temporal cluster, shared provider, low prior claim history.",
+     "resolution": "Denied the cluster; referred the organizer and clinic to SIU + the state fraud bureau; flagged the provider NPI."},
+    {"id": "siu-collusion-01", "typology": "provider collusion",
+     "text": "A provider systematically upcodes and bills phantom treatments across many unrelated "
+             "claimants. Sustained abnormal billing volume rather than a single burst.",
+     "resolution": "Audited the provider's billing; suspended direct payment; recovered overpayments."},
+    {"id": "siu-stacking-01", "typology": "claim stacking",
+     "text": "A single claimant files repeated overlapping claims across policies/incidents to stack "
+             "payouts. High personal claim frequency over time.",
+     "resolution": "Consolidated the claims; applied anti-stacking policy terms; opened an EUO."},
+    {"id": "siu-indicators-01", "typology": "indicators",
+     "text": "SIU red-flag guidance: shared provider across unrelated claimants, tight temporal "
+             "clustering of injuries, a recruiter linking participants, and low pre-incident history "
+             "are classic staged-accident-ring indicators — trace the shared entities.",
+     "resolution": "Trace shared-provider and recruiter links; hold payment on the cluster pending SIU review."},
+]
+
+
+def build_parties(rng: random.Random) -> list[dict]:
+    ring_ids = {RING["organizer"], RING["capper"], *RING["participants"]}
+    parties = []
+    for i in range(1, N_CLAIMANTS + 1):
+        cid = f"clmt-{i:03d}"
+        parties.append({"id": cid, "kind": "claimant", "in_ring": cid in ring_ids})
+    # a handful of providers; prov-briarwood is the crooked one
+    for name in ["prov-briarwood", "prov-oakhill", "prov-central", "prov-mercy",
+                 "prov-lakeside", "prov-summit"]:
+        parties.append({"id": name, "kind": "provider", "in_ring": name == RING["provider"]})
+    return parties
+
+
+def build_linked_edges(rng: random.Random) -> list[dict]:
+    """`linked` edges. Background sparse claimant-provider ties + the ring path."""
+    edges = []
+    claimants = [f"clmt-{i:03d}" for i in range(1, N_CLAIMANTS + 1)]
+    providers = ["prov-oakhill", "prov-central", "prov-mercy", "prov-lakeside", "prov-summit"]
+
+    # ── background: each non-ring claimant linked to a legit provider ──
+    ring_ids = {RING["organizer"], RING["capper"], *RING["participants"]}
+    for c in claimants:
+        if c in ring_ids:
+            continue
+        edges.append({"from": c, "to": rng.choice(providers)})
+
+    # ── the ring: organizer -> participants -> crooked provider -> capper ──
+    org, parts, prov, capper = (RING["organizer"], RING["participants"],
+                                RING["provider"], RING["capper"])
+    for p in parts:
+        edges.append({"from": org, "to": p})       # organizer recruited each participant
+        edges.append({"from": p, "to": prov})      # participant filed with the crooked clinic
+    edges.append({"from": prov, "to": capper})     # clinic billed the phantom capper
+    return edges
+
+
+def build_claim_series(rng: random.Random) -> dict[str, list[dict]]:
+    """Per-claimant claimed-amount points. Legit low/occasional + the ring burst."""
+    claimants = [f"clmt-{i:03d}" for i in range(1, N_CLAIMANTS + 1)]
+    series: dict[str, list[dict]] = {c: [] for c in claimants}
+
+    # ── background: sparse, modest claims spread over the window ──
+    for c in claimants:
+        for _ in range(rng.randint(2, 5)):
+            ts = WINDOW_START + timedelta(hours=rng.randint(0, 72))
+            series[c].append({"ts": ts.isoformat(), "amount": round(rng.uniform(200, 1500), 2)})
+
+    # ── the ring: a tight burst of large bodily-injury claims in one ~90-min window ──
+    burst = WINDOW_START + timedelta(hours=30)
+    for claimant in [RING["organizer"], RING["capper"], *RING["participants"]]:
+        for _ in range(rng.randint(5, 7)):
+            ts = burst + timedelta(minutes=rng.randint(0, 90))
+            series[claimant].append({"ts": ts.isoformat(), "amount": round(rng.uniform(9000, 15000), 2)})
+    return series
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate the insurance claims-fraud demo dataset.")
+    ap.add_argument("--out", default=str(Path(__file__).parent / "data"))
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    parties = build_parties(rng)
+    edges = [{"from": e["from"], "to": e["to"], "type": "linked"}
+             for e in build_linked_edges(rng)]
+    series = build_claim_series(rng)
+    ts_out = [{"claimant": c, "points": sorted(pts, key=lambda p: p["ts"])}
+              for c, pts in series.items()]
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "parties.json").write_text(json.dumps({"nodes": parties, "edges": edges}, indent=2))
+    (out / "claims.json").write_text(json.dumps(ts_out, indent=2))
+    (out / "typologies.json").write_text(json.dumps(TYPOLOGIES, indent=2))
+    (out / "casenotes.json").write_text(json.dumps(CASE_NOTES, indent=2))
+
+    print(f"✅ insurance claims-fraud dataset written to {out}")
+    print(f"   parties: {len(parties)} ({sum(p['in_ring'] for p in parties)} in the ring)")
+    print(f"   linked edges: {len(edges)}   ts claimants: {len(ts_out)}")
+    print(f"   typologies: {len(TYPOLOGIES)}   case notes: {len(CASE_NOTES)}")
+    print(f"   ring: {RING['organizer']} → {RING['participants']} → {RING['provider']} → {RING['capper']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The **insurance** vertical demo for the AnvaiOps site (2nd FSI vertical, next in the TAM roadmap after internet). An SIU analyst asks one plain-language question — *"claim from `clmt-007` was flagged by the fraud model, is it a staged-accident ring?"* — and a copilot answers by chaining **four modalities in one engine**, every hop a **live ProximaDB v2 API call**:

| Hop | Modality | What runs |
|-----|----------|-----------|
| 1 | **timeseries** | each claimant's claimed-amount stream in its *own* ts collection; per-30-min `sum` aggregate flags amount **bursts** |
| 2 | **vector** | the flagged claimant's **scale-normalised burst shape** -> nearest fraud **typology** (cosine ANN) |
| 3 | **graph** | a **Cypher** `-[:linked*1..4]->` traces the ring: organizer -> participants -> crooked clinic -> capper |
| 4 | **RAG** | semantic search over the SIU case-note corpus -> the fraud-indicator **playbook** |

## Verified live (code-aligned image)
```
SIU: Claim from clmt-007 was flagged by the fraud model. Is it a staged-accident ring?
[timeseries] 5 with suspicious amount bursts: clmt-020, clmt-011, clmt-013, clmt-012, clmt-007
[vector] clmt-007 claim signature -> staged-accident ring (score 0.970, live ANN)
[graph] fraud ring downstream of clmt-007 -> clmt-011 -> clmt-012 -> clmt-013 -> prov-briarwood -> clmt-020
[RAG] siu-ring-01 -> Denied the cluster; referred the organizer and clinic to SIU + the state fraud bureau; flagged the provider NPI.
```
Flags **exactly the 5 ring claimants** (zero false positives), matches the correct typology, and the multi-hop Cypher traces the **full ring through the shared crooked provider** — the link that turns unrelated claimants into a ring.

## Notable
- Exercises the merged engine fixes (#658) end-to-end: per-collection timeseries isolation (30 streams) + Cypher multi-hop traversal (ring depth 4).
- Reuses the **scale-normalised burst-feature** pattern from the internet vertical (#661) — cosine discriminates on burst shape, not raw dollars.
- Deterministic + stdlib-only generator; `data/` + `__pycache__` gitignored; registers the vertical in `demo/verticals/README.adoc`.

Next in the TAM roadmap: market surveillance & trading, then D&B / commercial risk.