### PR TITLE
demo(verticals): market-surveillance trade-surveillance copilot (3rd FSI vertical)

### DIFF
--- a/demo/verticals/README.adoc
+++ b/demo/verticals/README.adoc
@@ -22,15 +22,16 @@ toc::[]
 | **Manufacturing / industrial** (template, built) | timeseries + vector + graph + RAG | Factory copilot: sensor anomaly → fault-signature match → downstream-impact traversal → maintenance-log fix.
 | **Fraud & AML** (FSI, built) | timeseries + vector + graph + RAG | Compliance copilot: transacted-volume burst → AML-typology match → Cypher ring trace → case-note / SAR playbook.
 | **Insurance** (FSI, built) | timeseries + vector + graph + RAG | SIU claims-fraud copilot: claimed-amount burst → fraud-typology match → Cypher staged-ring trace through shared provider → SIU playbook.
+| **Market surveillance & trading** (FSI, built) | timeseries + vector + graph + RAG | Trade-surveillance copilot: order-message burst → manipulation-typology match → Cypher coordination-ring trace through shell → MAR/MiFID STOR playbook.
 | **Energy** | timeseries + vector + graph | Grid copilot: meter/sensor anomaly + forecast → topology-aware outage impact → maintenance-log RAG.
 | **Social media** | graph + vector + hybrid RRF | Feed/reco copilot: semantic post search + social-graph proximity + community/influence; taste memory (ADR-022).
 | **Internet / web** (built) | timeseries + vector + graph + RAG | Incident copilot: 5xx error burst → incident-typology match → Cypher dependency-chain trace ∩ failing set → root cause → postmortem playbook.
 | **Chip / semiconductor** | vector + graph + timeseries + RAG | Design/verification copilot: spec & sim-log RAG + defect/waveform similarity + netlist-graph traversal + yield timeseries.
 |===
 
-**Manufacturing** (the template), **Fraud & AML**, **Insurance** (FSI), and **Internet / web**
-are built out and verified live against a code-aligned engine. The rest reuse their harness — see
-below.
+**Manufacturing** (the template), **Fraud & AML**, **Insurance**, **Market surveillance** (FSI),
+and **Internet / web** are built out and verified live against a code-aligned engine. The rest
+reuse their harness — see below.
 
 == The reusable shape
 

--- a/demo/verticals/market-surveillance/.gitignore
+++ b/demo/verticals/market-surveillance/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/demo/verticals/market-surveillance/README.adoc
+++ b/demo/verticals/market-surveillance/README.adoc
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Market Surveillance & Trading — Trade-Surveillance Copilot (ProximaDB vertical demo)
+:toc: macro
+
+A market-surveillance analyst asks one plain-language question and a copilot answers by
+chaining **four data modalities in a single engine** — no ETL between a metrics store, a
+vector DB, a graph DB, and a search index. That "one engine, one query plane" is the
+ProximaDB co-design thesis; this demo makes it concrete for a capital-markets surveillance desk.
+
+toc::[]
+
+== The scenario
+
+> **Surveillance analyst:** "Trader `trd-007` tripped a spoofing alert on ACME. Is it coordinated manipulation?"
+
+A coordinated manipulation ring is embedded in a session of normal order flow — a *principal*
+account coordinates *linked* accounts through a beneficial-owner *shell* to spoof (place-and-cancel)
+and wash-trade the symbol. The copilot resolves the alert in four hops:
+
+[cols="1,2,3", options="header"]
+|===
+| Hop | Modality | What it does
+| 1 | **Timeseries** | Ingest each account's order-message-rate stream, aggregate per 30-min bucket, and flag the accounts with abnormal message **bursts** (place-and-cancel spikes).
+| 2 | **Vector** | Match the flagged account's *burst signature* against a library of known manipulation **typologies** (spoofing / wash trading / momentum ignition) by cosine similarity → a named typology.
+| 3 | **Graph** | Trace the coordination **ring** downstream of the account with a **Cypher** multi-hop path query (`principal → linked accounts → shell → nominee`).
+| 4 | **RAG** | Retrieve the matching **MAR/MiFID surveillance case note** + guidance with the proven resolution (the STOR that was filed).
+|===
+
+...one question, one engine — the analyst gets a typology, the ring, and the regulatory playbook.
+
+== Run it — live, through ProximaDB (Docker)
+
+Build the image from the *same* code so the v2 API matches (this demo needs the timeseries
+surface and the Cypher variable-length multi-hop traversal), then run the copilot live:
+
+[source,bash]
+----
+# from the repo root — build a ProximaDB image aligned with this code
+cargo build --release -p proximadb-server          # -> target/release/proximadb-server
+docker build -f Dockerfile.prebuilt -t proximadb:develop .
+docker run -d --name proximadb-mkt -p 5678:5678 proximadb:develop
+
+cd demo/verticals/market-surveillance
+python generate_data.py && python copilot_live.py
+----
+
+`copilot_live.py` issues **real** v2 REST calls and prints each one — you can *verify* it ran
+through the engine:
+
+[source,text]
+----
+surveillance: Trader trd-007 tripped a spoofing alert on ACME. Is it coordinated manipulation?
+[timeseries] scanned 30 order streams via ProximaDB — 5 with suspicious message bursts: trd-011, trd-020, trd-013, trd-007, trd-012
+     [API ✓] POST /api/v2/collections/mkt_manip_typologies/search  (200, 2 ms)
+[vector] trd-007 order signature → spoofing / layering (score 0.966, live ANN)
+     [API ✓] POST /api/v2/graphs/mkt/query  (200, 1 ms)
+[graph] coordination ring downstream of trd-007 → trd-011 → trd-012 → trd-013 → ent-cayman → trd-020
+     [API ✓] POST /api/v2/collections/mkt_casenotes/search  (200, 2 ms)
+[RAG] mar-spoof-01 → Filed a MAR Article 12 STOR; froze the principal account; escalated the linked cluster and the beneficial-owner shell.
+----
+
+**All four modalities are live ProximaDB calls** (nothing client-side):
+
+- **timeseries** — each account's order-message stream is ingested into its *own* collection and
+  scanned with a per-30-min-bucket `sum` **aggregate**; a single-window burst over threshold flags
+  exactly the ring accounts (the engine's per-collection isolation keeps 30 streams from bleeding).
+- **vector** — the manipulation-typology library as a vector collection; the flagged account's
+  **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` resolves to the
+  nearest typology by cosine ANN. Scaling every feature to a comparable range lets cosine separate a
+  *tight place-and-cancel spoofing spike* from *sustained wash-trading* — raw message counts alone
+  would blur them.
+- **graph** — the account/shell `coordinated` graph is built (`/graphs/mkt/nodes` + `/edges`) and the
+  ring traced by a **Cypher** variable-length path query
+  (`MATCH (a:Actor {id:'trd-007'})-[:coordinated*1..4]->(x) RETURN x`), walking
+  `principal → linked accounts → shell → nominee` in one hop-bounded traversal — the beneficial-owner
+  shell is the link that ties independent-looking accounts into one controlled ring.
+- **RAG** — semantic search over the MAR/MiFID surveillance-case corpus returns the STOR playbook.
+
+The demo embedding is a deterministic hash for portability; production uses a real embedder. The
+timeseries + multi-hop Cypher both require a ProximaDB built from the same code — the Docker steps
+above build exactly that engine.
+
+== Production wiring (ProximaDB SDK + the MCP surface)
+
+In production the four hops are ProximaDB operations behind the reference **MCP** copilot (the
+`search` / `stats` / `event` / `memory` tools). Sketch:
+
+[source,python]
+----
+from proximadb import ProximaDBClient
+
+client = ProximaDBClient(url="http://localhost:5678")
+
+# 1. TIMESERIES — order-message stream per account; burst via bucket aggregate
+bursts = client.timeseries_aggregate("trd-007", metric="messages", aggregation="sum", bucket="30m")
+
+# 2. VECTOR — manipulation-typology library; nearest known typology to the burst signature
+typ = client.search("mkt_manip_typologies", query_vector=burst_shape, top_k=1)
+
+# 3. GRAPH — trace the coordination ring through the shell with a Cypher path query
+ring = client.graph_query(
+    "mkt", "MATCH (a:Actor {id:'trd-007'})-[:coordinated*1..4]->(x) RETURN x")
+
+# 4. RAG — semantic search over the surveillance-case corpus
+playbook = client.search("mkt_casenotes", query_text="spoofing layering order-to-trade", top_k=1)
+----
+
+Over the **MCP** transport it is the same, tool-shaped — the copilot calls `search` (steps 2 & 4),
+a graph query (step 3), and can persist the STOR disposition with `event` / recall prior cases with
+`memory` (ADR-022).
+
+== Why AnvaiOps
+
+The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
+stakes for a regulated markets workload where order-book and client data can never leak across
+tenants. Governance is the product; the multi-modal engine is the moat.
+
+== Files
+
+[cols="1,3"]
+|===
+| `generate_data.py` | Deterministic synthetic dataset — the account/shell `coordinated` graph, per-account order-message timeseries (with the embedded spoofing burst), scale-normalised manipulation-typology signatures, and the MAR/MiFID surveillance-case corpus.
+| `copilot_live.py`  | The live surveillance copilot — four real ProximaDB v2 hops (timeseries → vector → graph Cypher → RAG) resolving one spoofing alert.
+|===

--- a/demo/verticals/market-surveillance/copilot_live.py
+++ b/demo/verticals/market-surveillance/copilot_live.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Market-surveillance *trade-surveillance copilot* — a ProximaDB markets-vertical demo.
+
+A surveillance analyst asks one question — "trader trd-007 tripped a spoofing alert on ACME,
+is it coordinated manipulation?" — and the copilot answers by chaining **four modalities in
+one engine** (no ETL between a metrics store, a vector DB, a graph DB, and a search index):
+
+  1. **timeseries** — per-account order-message-rate streams; flag the message bursts
+  2. **vector**     — match the flagged account's burst signature to a known manipulation *typology*
+  3. **graph**      — trace the coordination ring through the beneficial-owner shell (Cypher multi-hop)
+  4. **RAG**        — retrieve the MAR/MiFID surveillance case note + guidance with the resolution
+
+Every hop is a **real ProximaDB v2 API call** (printed with latency). Run it against a
+ProximaDB built from the same code (timeseries + multi-hop Cypher):
+
+    cargo build --release -p proximadb-server
+    docker build -f Dockerfile.prebuilt -t proximadb:develop .
+    docker run -d -p 5678:5678 proximadb:develop
+    python generate_data.py && python copilot_live.py
+
+Env: ``PROXIMADB_URL`` (default ``http://localhost:5678``). Pure stdlib (urllib).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+BASE = os.environ.get("PROXIMADB_URL", "http://localhost:5678").rstrip("/")
+DATA = Path(os.environ.get("DATA", Path(__file__).parent / "data"))
+EMB_DIM = 256
+TYP_COLL = "mkt_manip_typologies"
+CASE_COLL = "mkt_casenotes"
+BURST_THRESHOLD = 500.0  # a single-window order-message volume this large is suspicious
+SEVERITY_SCALE = 500.0   # normalises peak message-count into the O(1..10) feature range
+ALERT_ACCOUNT = "trd-007"  # the account surveillance flagged
+
+
+# ── tiny REST client (stdlib) ───────────────────────────────────────────────────
+def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{BASE}{path}", data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def api(method: str, path: str, body: dict | None = None, label: str = "") -> dict:
+    t = time.time()
+    status, resp = _req(method, path, body)
+    ms = (time.time() - t) * 1000
+    if label:
+        print(f"     [API {'✓' if 200 <= status < 300 else '✗'}] {method} {path}  ({status}, {ms:.0f} ms)")
+    return resp
+
+
+def embed(text: str, dim: int = EMB_DIM) -> list[float]:
+    v = [0.0] * dim
+    for tok in text.lower().replace(",", " ").replace(".", " ").replace("-", " ").split():
+        v[int(hashlib.md5(tok.encode()).hexdigest(), 16) % dim] += 1.0
+    norm = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [round(x / norm, 6) for x in v]
+
+
+def unwrap(x):
+    return x["value"] if isinstance(x, dict) and "value" in x else x
+
+
+def iso_ms(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).timestamp() * 1000)
+
+
+def _load(name: str):
+    return json.loads((DATA / name).read_text())
+
+
+def feature_vector(sums: list[float]) -> list[float]:
+    """Scale-normalised shape of an order-message burst — must match the typology vectors in
+    generate_data.py. Scaling each dimension to O(1..10) lets cosine discriminate on burst
+    *shape* (a tight place-and-cancel spoofing spike vs sustained wash-trading) not raw counts."""
+    peak = max(sums)
+    total = sum(sums) or 1e-6
+    mean = total / len(sums)
+    spread = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
+    return [round(peak / SEVERITY_SCALE, 3), round(peak / (mean or 1e-6), 3),
+            round(spread * 10.0, 3), round(peak / total * 10.0, 3)]
+
+
+# ── setup (real ProximaDB writes) ───────────────────────────────────────────────
+def load_typologies(typologies) -> None:
+    recs = [{"id": t["id"], "vector": t["features"],
+             "props": {"label": t["label"], "case_ref": t["case_ref"] or ""}}
+            for t in typologies if t["label"] != "nominal"]
+    api("POST", "/api/v2/collections", {"name": TYP_COLL, "dimension": 4, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{TYP_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load manipulation-typology signatures")
+    print(f"           ↳ {r.get('inserted_count', 0)} typologies")
+
+
+def load_casenotes(cases) -> None:
+    recs = [{"id": c["id"], "vector": embed(f"{c['typology']} {c['typology']} {c['text']}"),
+             "props": {"typology": c["typology"], "resolution": c["resolution"]}}
+            for c in cases]
+    api("POST", "/api/v2/collections", {"name": CASE_COLL, "dimension": EMB_DIM, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{CASE_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load MAR/MiFID surveillance case notes")
+    print(f"           ↳ {r.get('inserted_count', 0)} case notes")
+
+
+def build_actor_graph(accounts) -> None:
+    """Accounts + shell entities + `coordinated` edges as a ProximaDB graph (untraced setup calls)."""
+    api("POST", "/api/v2/graphs", {"graph_id": "mkt"})
+    for n in accounts["nodes"]:
+        api("POST", "/api/v2/graphs/mkt/nodes",
+            {"node": {"id": n["id"], "labels": ["Actor"], "properties": {"kind": n["kind"]}}})
+    for e in accounts["edges"]:
+        api("POST", "/api/v2/graphs/mkt/edges",
+            {"edge": {"id": f"{e['from']}->{e['to']}", "from_node_id": e["from"],
+                      "to_node_id": e["to"], "edge_type": "coordinated", "weight": 1.0}})
+    print(f"     [graph] built coordination graph: {len(accounts['nodes'])} actors (live)")
+
+
+# ── analysis hops (all live ProximaDB calls) ────────────────────────────────────
+def timeseries_scan(ts_accounts) -> list[dict]:
+    """Ingest each account's order-message stream into ProximaDB time-series, then aggregate
+    SUM per 30-min bucket to flag message bursts. Real /api/v2/timeseries/*."""
+    print(f"     [timeseries] ingesting {len(ts_accounts)} order streams + aggregating (live API)…")
+    flagged = []
+    for acc in ts_accounts:
+        pts = acc["points"]
+        if len(pts) < 3:
+            continue
+        coll = "ts_" + acc["account"].replace("-", "_")
+        api("POST", "/api/v2/timeseries/collections", {"name": coll})
+        api("POST", f"/api/v2/timeseries/collections/{coll}/ingest",
+            {"points": [{"timestamp": iso_ms(p["ts"]), "values": {"messages": p["messages"]}} for p in pts]})
+        res = api("POST", f"/api/v2/timeseries/collections/{coll}/aggregate",
+                  {"start_time": iso_ms(pts[0]["ts"]) - 1, "end_time": iso_ms(pts[-1]["ts"]) + 1,
+                   "aggregation": "sum", "bucket_ms": 1_800_000})
+        sums = [b["values"]["messages"] for b in res.get("buckets", []) if "messages" in b.get("values", {})]
+        if not sums:
+            continue
+        peak = max(sums)
+        if peak > BURST_THRESHOLD:
+            flagged.append({"account": acc["account"], "peak": round(peak, 1),
+                            "features": feature_vector(sums)})
+    return sorted(flagged, key=lambda f: f["peak"], reverse=True)
+
+
+def trace_ring(actor) -> list[str]:
+    """Trace the coordination ring downstream of an account via a live Cypher multi-hop query."""
+    q = f"MATCH (a:Actor {{id:'{actor}'}})-[:coordinated*1..4]->(x:Actor) RETURN x"
+    res = api("POST", "/api/v2/graphs/mkt/query", {"query": q, "language": "cypher"},
+              label=f"Cypher trace coordination ring from {actor}")
+    rows = res.get("data", {}).get("rows", [])
+    return [r.get("node_id") or r.get("id") for r in rows]
+
+
+def say(role, text):
+    print(f"\n{'🕵️  surveillance' if role == 'analyst' else '🤖 copilot'}: {text}")
+
+
+def main() -> None:
+    if not DATA.exists():
+        raise SystemExit("dataset missing — run `python generate_data.py` first")
+    accounts = _load("accounts.json")
+    ts_accounts = _load("orders.json")
+    typologies = _load("typologies.json")
+    cases = _load("casenotes.json")
+
+    print("=" * 78)
+    print(f"  ProximaDB market-surveillance copilot — LIVE against {BASE}")
+    print("  one engine · timeseries + vector + graph + RAG")
+    print("=" * 78)
+    caps = api("GET", "/api/v2/_meta/capabilities")
+    print(f"  engine features: {', '.join(caps.get('features', [])[-4:])}\n")
+
+    print("── setup (real ProximaDB writes across all four modalities) ──")
+    load_typologies(typologies)
+    load_casenotes(cases)
+    build_actor_graph(accounts)
+
+    print("\n── copilot ──")
+    say("analyst", f"Trader {ALERT_ACCOUNT} tripped a spoofing alert on ACME. Is it coordinated manipulation?")
+
+    flagged = timeseries_scan(ts_accounts)
+    say("copilot", f"[timeseries] scanned {len(ts_accounts)} order streams via ProximaDB — "
+                   f"{len(flagged)} with suspicious message bursts: "
+                   + ", ".join(f["account"] for f in flagged))
+
+    target = next((f for f in flagged if f["account"] == ALERT_ACCOUNT), flagged[0] if flagged else None)
+    for f in ([target] if target else []):
+        acct = f["account"]
+        # VECTOR — match burst signature to a manipulation typology
+        res = api("POST", f"/api/v2/collections/{TYP_COLL}/search",
+                  {"vector": f["features"], "top_k": 1}, label=f"match {acct} to manipulation typology")
+        hits = res.get("results", [])
+        typ = unwrap(hits[0]["props"].get("label", "?")) if hits else "?"
+        say("copilot", f"[vector] {acct} order signature → **{typ}** (score {hits[0]['score']:.3f}, live ANN)")
+
+        # GRAPH — trace the coordination ring through the beneficial-owner shell (multi-hop Cypher)
+        ring = trace_ring(acct)
+        say("copilot", f"[graph] coordination ring downstream of {acct} → {' → '.join(ring) if ring else 'none'}")
+
+        # RAG — retrieve the matching surveillance case note + resolution
+        res = api("POST", f"/api/v2/collections/{CASE_COLL}/search",
+                  {"vector": embed(f"{typ} {typ} {typ}"), "top_k": 1}, label="retrieve surveillance case (RAG)")
+        rhits = res.get("results", [])
+        if rhits:
+            p = rhits[0]["props"]
+            say("copilot", f"[RAG] {rhits[0]['id']} → {unwrap(p.get('resolution', ''))}")
+
+    print("\n" + "-" * 78)
+    print("Every [API] line is a real ProximaDB call. In production this runs behind the")
+    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/verticals/market-surveillance/generate_data.py
+++ b/demo/verticals/market-surveillance/generate_data.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Synthetic markets dataset for the ProximaDB *market-surveillance & trading* vertical demo.
+
+Deterministic, stdlib-only, no external data — a small equities-trading world with one
+embedded *coordinated manipulation ring* (a principal account coordinates linked accounts
+through a shell entity to spoof and wash-trade a symbol) over a sea of normal order flow.
+Exercises all four modalities:
+
+  * **graph**       accounts + shell entities (nodes) + `coordinated` edges — the ring is a path
+  * **timeseries**  per-account order-message-rate series; the ring accounts burst (spoofing)
+  * **vector**      labelled manipulation *typology* signatures for behaviour matching
+  * **text/RAG**    surveillance case notes + MAR/MiFID guidance as a retrieval corpus
+
+Outputs JSON under ``--out`` (default ``./data``). Run this before ``copilot_live.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+N_ACCOUNTS = 30
+WINDOW_START = datetime(2026, 5, 4, 13, 30, tzinfo=timezone.utc)  # a trading session
+
+# The manipulation ring: a principal coordinates linked accounts through a shell entity to
+# spoof (place-and-cancel) and wash-trade the symbol. This is the path the graph traces.
+RING = {
+    "principal": "trd-007",
+    "linked": ["trd-011", "trd-012", "trd-013"],
+    "shell": "ent-cayman",        # the beneficial-owner shell tying them together
+    "nominee": "trd-020",
+}
+
+# Labelled manipulation-typology signatures (the vector library). Features are the
+# SCALE-NORMALISED shape of the order-message burst — [severity, spike_ratio, spread,
+# concentration] — the same vector copilot_live.py derives from the ProximaDB timeseries
+# aggregate (see feature_vector). Scaling keeps every dimension O(1..10) so cosine
+# discriminates on *shape*, not raw message counts.
+TYPOLOGIES = [
+    {"id": "typ-spoofing", "label": "spoofing / layering", "case_ref": "mar-spoof-01",
+     "features": [6.0, 5.0, 2.5, 6.5]},     # big, spiky, few hot windows, concentrated place-and-cancel
+    {"id": "typ-wash", "label": "wash trading", "case_ref": "mar-wash-01",
+     "features": [3.0, 2.2, 6.0, 2.2]},     # moderate, flat, sustained matched trades
+    {"id": "typ-momentum", "label": "momentum ignition", "case_ref": "mar-momentum-01",
+     "features": [3.5, 4.0, 6.0, 2.6]},     # moderate, spiky, many windows (repeated ignition)
+    {"id": "typ-nominal", "label": "nominal", "case_ref": None,
+     "features": [0.6, 1.4, 0.5, 3.0]},
+]
+
+CASE_NOTES = [
+    {"id": "mar-spoof-01", "typology": "spoofing / layering",
+     "text": "A concentrated burst of large non-bona-fide orders placed on one side of the book and "
+             "cancelled before execution to move the price, benefiting real orders on the other side. "
+             "Very high order-to-trade ratio in a tight window; coordinated across linked accounts.",
+     "resolution": "Filed a MAR Article 12 STOR; froze the principal account; escalated the linked cluster and the beneficial-owner shell."},
+    {"id": "mar-wash-01", "typology": "wash trading",
+     "text": "Matched buy/sell orders between accounts under common control creating fake volume with no "
+             "change in beneficial ownership. Sustained self-crossing rather than a single burst.",
+     "resolution": "Suspended the accounts; mapped common beneficial ownership; reported to the venue and regulator."},
+    {"id": "mar-momentum-01", "typology": "momentum ignition",
+     "text": "Aggressive orders fired to ignite a rapid price move and attract algorithmic followers, then "
+             "the instigator reverses into the induced liquidity. Repeated ignition bursts.",
+     "resolution": "Flagged the instigating account; correlated with the reversal fills; opened a manipulation case."},
+    {"id": "mar-indicators-01", "typology": "indicators",
+     "text": "Surveillance red-flag guidance (MAR / MiFID II): abnormal order-to-trade ratio, tight temporal "
+             "clustering of place-and-cancel, coordinated timing across accounts sharing a beneficial owner, "
+             "and price impact around the burst are classic spoofing/layering indicators — trace common control.",
+     "resolution": "Trace beneficial-owner and coordination links; hold and review the cluster; file a STOR if corroborated."},
+]
+
+
+def build_accounts(rng: random.Random) -> list[dict]:
+    ring_ids = {RING["principal"], RING["nominee"], *RING["linked"]}
+    accounts = []
+    for i in range(1, N_ACCOUNTS + 1):
+        aid = f"trd-{i:03d}"
+        accounts.append({"id": aid, "kind": "account", "in_ring": aid in ring_ids})
+    # shell / beneficial-owner entities; ent-cayman is the ring's
+    for name in ["ent-cayman", "ent-onshore", "ent-family", "ent-fund"]:
+        accounts.append({"id": name, "kind": "entity", "in_ring": name == RING["shell"]})
+    return accounts
+
+
+def build_coordinated_edges(rng: random.Random) -> list[dict]:
+    """`coordinated` edges. Background account-entity ties + the ring path."""
+    edges = []
+    accounts = [f"trd-{i:03d}" for i in range(1, N_ACCOUNTS + 1)]
+    entities = ["ent-onshore", "ent-family", "ent-fund"]
+    ring_ids = {RING["principal"], RING["nominee"], *RING["linked"]}
+
+    # ── background: each non-ring account tied to a benign entity ──
+    for a in accounts:
+        if a in ring_ids:
+            continue
+        edges.append({"from": a, "to": rng.choice(entities)})
+
+    # ── the ring: principal -> linked accounts -> shell -> nominee ──
+    principal, linked, shell, nominee = (RING["principal"], RING["linked"],
+                                         RING["shell"], RING["nominee"])
+    for a in linked:
+        edges.append({"from": principal, "to": a})   # principal coordinates each linked account
+        edges.append({"from": a, "to": shell})       # linked accounts controlled via the shell
+    edges.append({"from": shell, "to": nominee})     # shell fronts the nominee account
+    return edges
+
+
+def build_order_series(rng: random.Random) -> dict[str, list[dict]]:
+    """Per-account order-message-count points. Normal low flow + the ring spoofing burst."""
+    accounts = [f"trd-{i:03d}" for i in range(1, N_ACCOUNTS + 1)]
+    series: dict[str, list[dict]] = {a: [] for a in accounts}
+
+    # ── background: modest order-message flow spread across the session ──
+    for a in accounts:
+        for _ in range(rng.randint(3, 6)):
+            ts = WINDOW_START + timedelta(minutes=rng.randint(0, 240))
+            series[a].append({"ts": ts.isoformat(), "messages": round(rng.uniform(2, 20), 1)})
+
+    # ── the ring: a tight burst of place-and-cancel messages in one ~15-min window ──
+    burst = WINDOW_START + timedelta(hours=1)
+    for account in [RING["principal"], RING["nominee"], *RING["linked"]]:
+        for _ in range(rng.randint(5, 7)):
+            ts = burst + timedelta(minutes=rng.randint(0, 15))
+            series[account].append({"ts": ts.isoformat(), "messages": round(rng.uniform(400, 700), 1)})
+    return series
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate the market-surveillance demo dataset.")
+    ap.add_argument("--out", default=str(Path(__file__).parent / "data"))
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    accounts = build_accounts(rng)
+    edges = [{"from": e["from"], "to": e["to"], "type": "coordinated"}
+             for e in build_coordinated_edges(rng)]
+    series = build_order_series(rng)
+    ts_out = [{"account": a, "points": sorted(pts, key=lambda p: p["ts"])}
+              for a, pts in series.items()]
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "accounts.json").write_text(json.dumps({"nodes": accounts, "edges": edges}, indent=2))
+    (out / "orders.json").write_text(json.dumps(ts_out, indent=2))
+    (out / "typologies.json").write_text(json.dumps(TYPOLOGIES, indent=2))
+    (out / "casenotes.json").write_text(json.dumps(CASE_NOTES, indent=2))
+
+    print(f"✅ market-surveillance dataset written to {out}")
+    print(f"   accounts: {len(accounts)} ({sum(a['in_ring'] for a in accounts)} in the ring)")
+    print(f"   coordinated edges: {len(edges)}   ts accounts: {len(ts_out)}")
+    print(f"   typologies: {len(TYPOLOGIES)}   case notes: {len(CASE_NOTES)}")
+    print(f"   ring: {RING['principal']} → {RING['linked']} → {RING['shell']} → {RING['nominee']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The **market-surveillance & trading** vertical demo (3rd FSI vertical in the TAM roadmap). A surveillance analyst asks one plain-language question — *"trader `trd-007` tripped a spoofing alert on ACME, is it coordinated manipulation?"* — and a copilot answers by chaining **four modalities in one engine**, every hop a **live ProximaDB v2 API call**:

| Hop | Modality | What runs |
|-----|----------|-----------|
| 1 | **timeseries** | each account's order-message stream in its *own* ts collection; per-30-min `sum` aggregate flags message **bursts** (place-and-cancel spikes) |
| 2 | **vector** | the flagged account's **scale-normalised burst shape** -> nearest manipulation **typology** (cosine ANN) |
| 3 | **graph** | a **Cypher** `-[:coordinated*1..4]->` traces the ring: principal -> linked accounts -> beneficial-owner shell -> nominee |
| 4 | **RAG** | semantic search over the MAR/MiFID surveillance-case corpus -> the **STOR playbook** |

## Verified live (code-aligned image)
```
surveillance: Trader trd-007 tripped a spoofing alert on ACME. Is it coordinated manipulation?
[timeseries] 5 with suspicious message bursts: trd-011, trd-020, trd-013, trd-007, trd-012
[vector] trd-007 order signature -> spoofing / layering (score 0.966, live ANN)
[graph] coordination ring downstream of trd-007 -> trd-011 -> trd-012 -> trd-013 -> ent-cayman -> trd-020
[RAG] mar-spoof-01 -> Filed a MAR Article 12 STOR; froze the principal account; escalated the linked cluster and the beneficial-owner shell.
```
Flags **exactly the 5 ring accounts** (zero false positives), matches the correct typology, and the multi-hop Cypher traces the **full ring through the beneficial-owner shell** — the link that ties independent-looking accounts into one controlled ring.

## Notable
- Exercises the merged engine fixes (#658) end-to-end: per-collection timeseries isolation (30 streams) + Cypher multi-hop traversal (ring depth 4).
- Reuses the **scale-normalised burst-feature** pattern (internet/insurance) — cosine discriminates on burst shape, not raw message counts.
- Deterministic + stdlib-only generator; `data/` + `__pycache__` gitignored; registers the vertical in `demo/verticals/README.adoc`.

Next in the TAM roadmap: D&B / commercial-risk. A cross-modal query fabric (ADR-053) will later move the client-side timeseries fan-out + graph∩timeseries join into the engine.