### PR TITLE
demo(verticals): D&B / commercial-risk credit & KYB copilot (final TAM vertical)

### DIFF
--- a/demo/verticals/README.adoc
+++ b/demo/verticals/README.adoc
@@ -23,6 +23,7 @@ toc::[]
 | **Fraud & AML** (FSI, built) | timeseries + vector + graph + RAG | Compliance copilot: transacted-volume burst → AML-typology match → Cypher ring trace → case-note / SAR playbook.
 | **Insurance** (FSI, built) | timeseries + vector + graph + RAG | SIU claims-fraud copilot: claimed-amount burst → fraud-typology match → Cypher staged-ring trace through shared provider → SIU playbook.
 | **Market surveillance & trading** (FSI, built) | timeseries + vector + graph + RAG | Trade-surveillance copilot: order-message burst → manipulation-typology match → Cypher coordination-ring trace through shell → MAR/MiFID STOR playbook.
+| **D&B / commercial risk** (built) | timeseries + vector + graph + RAG | Credit & KYB copilot: delinquency burst → risk-typology match → Cypher related-party cluster trace to UBO → concentration-aware credit playbook.
 | **Energy** | timeseries + vector + graph | Grid copilot: meter/sensor anomaly + forecast → topology-aware outage impact → maintenance-log RAG.
 | **Social media** | graph + vector + hybrid RRF | Feed/reco copilot: semantic post search + social-graph proximity + community/influence; taste memory (ADR-022).
 | **Internet / web** (built) | timeseries + vector + graph + RAG | Incident copilot: 5xx error burst → incident-typology match → Cypher dependency-chain trace ∩ failing set → root cause → postmortem playbook.
@@ -30,7 +31,8 @@ toc::[]
 |===
 
 **Manufacturing** (the template), **Fraud & AML**, **Insurance**, **Market surveillance** (FSI),
-and **Internet / web** are built out and verified live against a code-aligned engine. The rest
+**D&B / commercial risk**, and **Internet / web** are built out and verified live against a
+code-aligned engine. The rest
 reuse their harness — see below.
 
 == The reusable shape

--- a/demo/verticals/commercial-risk/.gitignore
+++ b/demo/verticals/commercial-risk/.gitignore
@@ -1,0 +1,2 @@
+data/
+__pycache__/

--- a/demo/verticals/commercial-risk/README.adoc
+++ b/demo/verticals/commercial-risk/README.adoc
@@ -1,0 +1,131 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= D&B / Commercial Risk — Credit & KYB Copilot (ProximaDB vertical demo)
+:toc: macro
+
+A commercial-credit analyst asks one plain-language question and a copilot answers by chaining
+**four data modalities in a single engine** — no ETL between a metrics store, a vector DB, a
+graph DB, and a search index. That "one engine, one query plane" is the ProximaDB co-design
+thesis; this demo makes it concrete for a business-data / commercial-credit risk desk.
+
+toc::[]
+
+== The scenario
+
+> **Credit analyst:** "Supplier `firm-007` was flagged for elevated credit risk. Is the exposure concentrated?"
+
+The flag looks like one firm in distress — but `firm-007` is quietly controlled, through a holding
+shell, alongside related firms up to one ultimate beneficial owner (UBO). So distress in one is
+**concentration risk across the whole group**. The copilot resolves the flag in four hops:
+
+[cols="1,2,3", options="header"]
+|===
+| Hop | Modality | What it does
+| 1 | **Timeseries** | Ingest each firm's days-beyond-terms (payment-delinquency) stream, aggregate per 7-day bucket, and flag the firms with distress **bursts**.
+| 2 | **Vector** | Match the flagged firm's *delinquency signature* against a library of known risk **typologies** (financial distress / chronic late-payer / over-leverage) by cosine similarity → a named typology.
+| 3 | **Graph** | Trace the related-party (common-control) **cluster** downstream of the firm with a **Cypher** multi-hop path query (`firm → related parties → holding shell → UBO`).
+| 4 | **RAG** | Retrieve the matching **credit-policy / KYB note** + guidance with the recommended action (reduce limit, group-level cap).
+|===
+
+...one question, one engine — the analyst gets a risk typology, the ownership cluster, and the
+concentration-aware credit playbook.
+
+== Run it — live, through ProximaDB (Docker)
+
+Build the image from the *same* code so the v2 API matches (this demo needs the timeseries surface
+and the Cypher variable-length multi-hop traversal), then run the copilot live:
+
+[source,bash]
+----
+# from the repo root — build a ProximaDB image aligned with this code
+cargo build --release -p proximadb-server          # -> target/release/proximadb-server
+docker build -f Dockerfile.prebuilt -t proximadb:develop .
+docker run -d --name proximadb-cr -p 5678:5678 proximadb:develop
+
+cd demo/verticals/commercial-risk
+python generate_data.py && python copilot_live.py
+----
+
+`copilot_live.py` issues **real** v2 REST calls and prints each one — you can *verify* it ran
+through the engine:
+
+[source,text]
+----
+credit: Supplier firm-007 was flagged for elevated credit risk. Is the exposure concentrated?
+[timeseries] scanned 30 delinquency streams via ProximaDB — 4 with distress bursts: firm-011, firm-013, firm-007, firm-012
+     [API ✓] POST /api/v2/collections/cr_risk_typologies/search  (200, 2 ms)
+[vector] firm-007 delinquency signature → financial distress (score 0.984, live ANN)
+     [API ✓] POST /api/v2/graphs/cr/query  (200, 1 ms)
+[graph] related-party cluster of firm-007 → firm-011 → firm-012 → firm-013 → hold-atlas → ubo-nominee  (exposure concentrated behind ubo-nominee)
+     [API ✓] POST /api/v2/collections/cr_casenotes/search  (200, 2 ms)
+[RAG] cr-distress-01 → Reduced the credit limit; required a parent guarantee; set a group-level exposure cap across the UBO cluster.
+----
+
+**All four modalities are live ProximaDB calls** (nothing client-side):
+
+- **timeseries** — each firm's days-beyond-terms stream is ingested into its *own* collection and
+  scanned with a per-7-day-bucket `sum` **aggregate**; a single-window distress burst over threshold
+  flags exactly the cluster firms (the engine's per-collection isolation keeps 30 streams from bleeding).
+- **vector** — the risk-typology library as a vector collection; the flagged firm's
+  **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` resolves to the
+  nearest typology by cosine ANN. Scaling every feature to a comparable range lets cosine separate a
+  *sharp distress event* from a *chronically-late payer* — raw day counts alone would blur them.
+- **graph** — the firm/holding `linked` (common-control) graph is built (`/graphs/cr/nodes` + `/edges`)
+  and the related-party cluster traced by a **Cypher** variable-length path query
+  (`MATCH (a:Firm {id:'firm-007'})-[:linked*1..4]->(x) RETURN x`), walking
+  `firm → related parties → holding shell → UBO` in one hop-bounded traversal — the shared UBO is
+  the link that turns one flagged supplier into a concentrated group exposure.
+- **RAG** — semantic search over the credit-policy / KYB corpus returns the group-level playbook.
+
+The killer move is hop 3: the credit flag was on *one* firm, but the graph reveals the exposure is
+the *whole cluster behind one UBO* — a limit set per-firm would badly understate the real risk. That
+"which firms share control, and who's the UBO" is one question to one engine, not a join across a
+metrics store, a graph DB, and a KYB system.
+
+The demo embedding is a deterministic hash for portability; production uses a real embedder. The
+timeseries + multi-hop Cypher both require a ProximaDB built from the same code — the Docker steps
+above build exactly that engine.
+
+== Production wiring (ProximaDB SDK + the MCP surface)
+
+In production the four hops are ProximaDB operations behind the reference **MCP** copilot (the
+`search` / `stats` / `event` / `memory` tools). Sketch:
+
+[source,python]
+----
+from proximadb import ProximaDBClient
+
+client = ProximaDBClient(url="http://localhost:5678")
+
+# 1. TIMESERIES — days-beyond-terms stream per firm; distress via bucket aggregate
+bursts = client.timeseries_aggregate("firm-007", metric="dbt", aggregation="sum", bucket="7d")
+
+# 2. VECTOR — risk-typology library; nearest known typology to the delinquency signature
+typ = client.search("cr_risk_typologies", query_vector=burst_shape, top_k=1)
+
+# 3. GRAPH — trace the related-party cluster to the UBO with a Cypher path query
+cluster = client.graph_query(
+    "cr", "MATCH (a:Firm {id:'firm-007'})-[:linked*1..4]->(x) RETURN x")
+
+# 4. RAG — semantic search over the credit-policy / KYB corpus
+playbook = client.search("cr_casenotes", query_text="financial distress concentration UBO", top_k=1)
+----
+
+Over the **MCP** transport it is the same, tool-shaped — the copilot calls `search` (steps 2 & 4),
+a graph query (step 3), and can persist the decision with `event` / recall prior reviews with
+`memory` (ADR-022).
+
+== Why AnvaiOps
+
+The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
+stakes for a business-data workload where firmographic and beneficial-owner data can never leak across
+tenants. Governance is the product; the multi-modal engine is the moat.
+
+== Files
+
+[cols="1,3"]
+|===
+| `generate_data.py` | Deterministic synthetic dataset — the firm/holding `linked` common-control graph, per-firm days-beyond-terms timeseries (with the embedded related-party distress cluster), scale-normalised risk-typology signatures, and the credit-policy / KYB corpus.
+| `copilot_live.py`  | The live commercial-credit copilot — four real ProximaDB v2 hops (timeseries → vector → graph Cypher → RAG) resolving one risk flag into a concentration-aware decision.
+|===

--- a/demo/verticals/commercial-risk/copilot_live.py
+++ b/demo/verticals/commercial-risk/copilot_live.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+D&B / commercial-risk *credit & KYB copilot* — a ProximaDB commercial-risk vertical demo.
+
+A commercial-credit analyst asks one question — "supplier firm-007 was flagged for elevated
+risk, is the exposure concentrated?" — and the copilot answers by chaining **four modalities in
+one engine** (no ETL between a metrics store, a vector DB, a graph DB, and a search index):
+
+  1. **timeseries** — per-firm days-beyond-terms (payment-delinquency) streams; flag the distress bursts
+  2. **vector**     — match the flagged firm's delinquency signature to a known risk *typology*
+  3. **graph**      — trace the related-party (common-control) cluster to the UBO (Cypher multi-hop)
+  4. **RAG**        — retrieve the credit-policy / KYB guidance with the recommended action
+
+Every hop is a **real ProximaDB v2 API call** (printed with latency). Run it against a
+ProximaDB built from the same code (timeseries + multi-hop Cypher):
+
+    cargo build --release -p proximadb-server
+    docker build -f Dockerfile.prebuilt -t proximadb:develop .
+    docker run -d -p 5678:5678 proximadb:develop
+    python generate_data.py && python copilot_live.py
+
+Env: ``PROXIMADB_URL`` (default ``http://localhost:5678``). Pure stdlib (urllib).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+BASE = os.environ.get("PROXIMADB_URL", "http://localhost:5678").rstrip("/")
+DATA = Path(os.environ.get("DATA", Path(__file__).parent / "data"))
+EMB_DIM = 256
+TYP_COLL = "cr_risk_typologies"
+CASE_COLL = "cr_casenotes"
+BUCKET_MS = 604_800_000  # 7-day buckets (days-beyond-terms is daily data over a year)
+BURST_THRESHOLD = 150.0  # a single-window delinquency volume this large signals distress
+SEVERITY_SCALE = 100.0   # normalises peak DBT-volume into the O(1..10) feature range
+ALERT_FIRM = "firm-007"  # the supplier the risk model flagged
+
+
+# ── tiny REST client (stdlib) ───────────────────────────────────────────────────
+def _req(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{BASE}{path}", data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def api(method: str, path: str, body: dict | None = None, label: str = "") -> dict:
+    t = time.time()
+    status, resp = _req(method, path, body)
+    ms = (time.time() - t) * 1000
+    if label:
+        print(f"     [API {'✓' if 200 <= status < 300 else '✗'}] {method} {path}  ({status}, {ms:.0f} ms)")
+    return resp
+
+
+def embed(text: str, dim: int = EMB_DIM) -> list[float]:
+    v = [0.0] * dim
+    for tok in text.lower().replace(",", " ").replace(".", " ").replace("-", " ").split():
+        v[int(hashlib.md5(tok.encode()).hexdigest(), 16) % dim] += 1.0
+    norm = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [round(x / norm, 6) for x in v]
+
+
+def unwrap(x):
+    return x["value"] if isinstance(x, dict) and "value" in x else x
+
+
+def iso_ms(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).timestamp() * 1000)
+
+
+def _load(name: str):
+    return json.loads((DATA / name).read_text())
+
+
+def feature_vector(sums: list[float]) -> list[float]:
+    """Scale-normalised shape of a delinquency burst — must match the typology vectors in
+    generate_data.py. Scaling each dimension to O(1..10) lets cosine discriminate on burst
+    *shape* (a sharp distress event vs a chronically-late payer) not raw day counts."""
+    peak = max(sums)
+    total = sum(sums) or 1e-6
+    mean = total / len(sums)
+    spread = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
+    return [round(peak / SEVERITY_SCALE, 3), round(peak / (mean or 1e-6), 3),
+            round(spread * 10.0, 3), round(peak / total * 10.0, 3)]
+
+
+# ── setup (real ProximaDB writes) ───────────────────────────────────────────────
+def load_typologies(typologies) -> None:
+    recs = [{"id": t["id"], "vector": t["features"],
+             "props": {"label": t["label"], "case_ref": t["case_ref"] or ""}}
+            for t in typologies if t["label"] != "nominal"]
+    api("POST", "/api/v2/collections", {"name": TYP_COLL, "dimension": 4, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{TYP_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load risk-typology signatures")
+    print(f"           ↳ {r.get('inserted_count', 0)} typologies")
+
+
+def load_casenotes(cases) -> None:
+    recs = [{"id": c["id"], "vector": embed(f"{c['typology']} {c['typology']} {c['text']}"),
+             "props": {"typology": c["typology"], "resolution": c["resolution"]}}
+            for c in cases]
+    api("POST", "/api/v2/collections", {"name": CASE_COLL, "dimension": EMB_DIM, "distance_metric": "cosine"})
+    r = api("POST", f"/api/v2/collections/{CASE_COLL}/records/batch", {"records": recs, "upsert": True},
+            label="load credit-policy / KYB case notes")
+    print(f"           ↳ {r.get('inserted_count', 0)} case notes")
+
+
+def build_ownership_graph(firms) -> None:
+    """Firms + holding/UBO entities + `linked` (common-control) edges as a ProximaDB graph."""
+    api("POST", "/api/v2/graphs", {"graph_id": "cr"})
+    for n in firms["nodes"]:
+        api("POST", "/api/v2/graphs/cr/nodes",
+            {"node": {"id": n["id"], "labels": ["Firm"], "properties": {"kind": n["kind"]}}})
+    for e in firms["edges"]:
+        api("POST", "/api/v2/graphs/cr/edges",
+            {"edge": {"id": f"{e['from']}->{e['to']}", "from_node_id": e["from"],
+                      "to_node_id": e["to"], "edge_type": "linked", "weight": 1.0}})
+    print(f"     [graph] built ownership graph: {len(firms['nodes'])} firms/entities (live)")
+
+
+# ── analysis hops (all live ProximaDB calls) ────────────────────────────────────
+def timeseries_scan(ts_firms) -> list[dict]:
+    """Ingest each firm's days-beyond-terms stream into ProximaDB time-series, then aggregate SUM
+    per 7-day bucket to flag delinquency bursts. Real /api/v2/timeseries/*."""
+    print(f"     [timeseries] ingesting {len(ts_firms)} delinquency streams + aggregating (live API)…")
+    flagged = []
+    for acc in ts_firms:
+        pts = acc["points"]
+        if len(pts) < 3:
+            continue
+        coll = "ts_" + acc["firm"].replace("-", "_")
+        api("POST", "/api/v2/timeseries/collections", {"name": coll})
+        api("POST", f"/api/v2/timeseries/collections/{coll}/ingest",
+            {"points": [{"timestamp": iso_ms(p["ts"]), "values": {"dbt": p["dbt"]}} for p in pts]})
+        res = api("POST", f"/api/v2/timeseries/collections/{coll}/aggregate",
+                  {"start_time": iso_ms(pts[0]["ts"]) - 1, "end_time": iso_ms(pts[-1]["ts"]) + 1,
+                   "aggregation": "sum", "bucket_ms": BUCKET_MS})
+        sums = [b["values"]["dbt"] for b in res.get("buckets", []) if "dbt" in b.get("values", {})]
+        if not sums:
+            continue
+        peak = max(sums)
+        if peak > BURST_THRESHOLD:
+            flagged.append({"firm": acc["firm"], "peak": round(peak, 1),
+                            "features": feature_vector(sums)})
+    return sorted(flagged, key=lambda f: f["peak"], reverse=True)
+
+
+def trace_cluster(firm) -> list[str]:
+    """Trace the related-party cluster downstream of a firm via a live Cypher multi-hop query."""
+    q = f"MATCH (a:Firm {{id:'{firm}'}})-[:linked*1..4]->(x:Firm) RETURN x"
+    res = api("POST", "/api/v2/graphs/cr/query", {"query": q, "language": "cypher"},
+              label=f"Cypher trace related-party cluster from {firm}")
+    rows = res.get("data", {}).get("rows", [])
+    return [r.get("node_id") or r.get("id") for r in rows]
+
+
+def say(role, text):
+    print(f"\n{'🕵️  credit' if role == 'analyst' else '🤖 copilot'}: {text}")
+
+
+def main() -> None:
+    if not DATA.exists():
+        raise SystemExit("dataset missing — run `python generate_data.py` first")
+    firms = _load("firms.json")
+    ts_firms = _load("dbt.json")
+    typologies = _load("typologies.json")
+    cases = _load("casenotes.json")
+
+    print("=" * 78)
+    print(f"  ProximaDB commercial-risk copilot — LIVE against {BASE}")
+    print("  one engine · timeseries + vector + graph + RAG")
+    print("=" * 78)
+    caps = api("GET", "/api/v2/_meta/capabilities")
+    print(f"  engine features: {', '.join(caps.get('features', [])[-4:])}\n")
+
+    print("── setup (real ProximaDB writes across all four modalities) ──")
+    load_typologies(typologies)
+    load_casenotes(cases)
+    build_ownership_graph(firms)
+
+    print("\n── copilot ──")
+    say("analyst", f"Supplier {ALERT_FIRM} was flagged for elevated credit risk. Is the exposure concentrated?")
+
+    flagged = timeseries_scan(ts_firms)
+    say("copilot", f"[timeseries] scanned {len(ts_firms)} delinquency streams via ProximaDB — "
+                   f"{len(flagged)} with distress bursts: " + ", ".join(f["firm"] for f in flagged))
+
+    target = next((f for f in flagged if f["firm"] == ALERT_FIRM), flagged[0] if flagged else None)
+    for f in ([target] if target else []):
+        firm = f["firm"]
+        # VECTOR — match delinquency signature to a risk typology
+        res = api("POST", f"/api/v2/collections/{TYP_COLL}/search",
+                  {"vector": f["features"], "top_k": 1}, label=f"match {firm} to risk typology")
+        hits = res.get("results", [])
+        typ = unwrap(hits[0]["props"].get("label", "?")) if hits else "?"
+        say("copilot", f"[vector] {firm} delinquency signature → **{typ}** (score {hits[0]['score']:.3f}, live ANN)")
+
+        # GRAPH — trace the related-party cluster to the UBO (multi-hop Cypher)
+        cluster = trace_cluster(firm)
+        ubo = next((n for n in cluster if n.startswith("ubo-")), cluster[-1] if cluster else "?")
+        say("copilot", f"[graph] related-party cluster of {firm} → {' → '.join(cluster) if cluster else 'none'}  "
+                       f"(exposure concentrated behind **{ubo}**)")
+
+        # RAG — retrieve the matching credit-policy note + resolution
+        res = api("POST", f"/api/v2/collections/{CASE_COLL}/search",
+                  {"vector": embed(f"{typ} {typ} {typ}"), "top_k": 1}, label="retrieve credit-policy note (RAG)")
+        rhits = res.get("results", [])
+        if rhits:
+            p = rhits[0]["props"]
+            say("copilot", f"[RAG] {rhits[0]['id']} → {unwrap(p.get('resolution', ''))}")
+
+    print("\n" + "-" * 78)
+    print("Every [API] line is a real ProximaDB call. In production this runs behind the")
+    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/verticals/commercial-risk/generate_data.py
+++ b/demo/verticals/commercial-risk/generate_data.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Synthetic commercial-risk dataset for the ProximaDB *D&B / commercial credit & KYB* vertical demo.
+
+Deterministic, stdlib-only, no external data — a small business-population world with one
+embedded *related-party (common-control) cluster*: a flagged supplier is quietly controlled,
+through a holding shell, alongside a set of related firms up to one ultimate beneficial owner —
+so distress in one is concentration risk across all. Over a sea of independent firms. Exercises
+all four modalities:
+
+  * **graph**       firms + holding/UBO entities (nodes) + `linked` (common-control) edges — the cluster is a path
+  * **timeseries**  per-firm days-beyond-terms (payment-delinquency) series; the cluster firms burst
+  * **vector**      labelled risk *typology* signatures for behaviour matching
+  * **text/RAG**    credit-policy / risk guidance as a retrieval corpus
+
+Outputs JSON under ``--out`` (default ``./data``). Run this before ``copilot_live.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+N_FIRMS = 30
+WINDOW_START = datetime(2026, 1, 5, 0, 0, tzinfo=timezone.utc)
+
+# The related-party cluster: a flagged firm is controlled (via a holding shell) alongside
+# related firms, up to one ultimate beneficial owner. This is the path the graph traces —
+# the exposure to the flagged firm is really exposure to the whole cluster.
+CLUSTER = {
+    "flagged": "firm-007",
+    "related": ["firm-011", "firm-012", "firm-013"],
+    "holding": "hold-atlas",   # the common-control shell
+    "ubo": "ubo-nominee",
+}
+
+# Labelled risk-typology signatures (the vector library). Features are the SCALE-NORMALISED
+# shape of the delinquency burst — [severity, spike_ratio, spread, concentration] — the same
+# vector copilot_live.py derives from the ProximaDB timeseries aggregate (see feature_vector).
+# Scaling keeps every dimension O(1..10) so cosine discriminates on *shape*, not raw day counts.
+TYPOLOGIES = [
+    {"id": "typ-distress", "label": "financial distress", "case_ref": "cr-distress-01",
+     "features": [6.0, 5.0, 2.5, 6.5]},     # sharp deterioration concentrated in a short window
+    {"id": "typ-chronic", "label": "chronic late-payer", "case_ref": "cr-chronic-01",
+     "features": [3.0, 2.2, 6.0, 2.2]},     # persistently late, sustained across the year
+    {"id": "typ-overleverage", "label": "over-leverage", "case_ref": "cr-leverage-01",
+     "features": [3.5, 4.0, 6.0, 2.6]},     # recurring stress spikes (debt-service pressure)
+    {"id": "typ-nominal", "label": "nominal", "case_ref": None,
+     "features": [0.6, 1.4, 0.5, 3.0]},
+]
+
+CASE_NOTES = [
+    {"id": "cr-distress-01", "typology": "financial distress",
+     "text": "A sharp, concentrated deterioration in payment behaviour (days-beyond-terms spiking) "
+             "indicates acute financial distress. When the firm sits in a common-control cluster, the "
+             "distress is correlated across related parties — the true exposure is the whole group, not one firm.",
+     "resolution": "Reduced the credit limit; required a parent guarantee; set a group-level exposure cap across the UBO cluster."},
+    {"id": "cr-chronic-01", "typology": "chronic late-payer",
+     "text": "Persistently elevated days-beyond-terms without a sharp spike — a chronically slow payer "
+             "rather than an acute event. Sustained, low-amplitude delinquency.",
+     "resolution": "Tightened terms (shorter net days); added a late-payment surcharge; kept the limit under review."},
+    {"id": "cr-leverage-01", "typology": "over-leverage",
+     "text": "Recurring delinquency spikes aligned with debt-service dates suggest over-leverage and thin "
+             "liquidity headroom. Repeated stress rather than a single event.",
+     "resolution": "Requested management accounts; covenant-tested; reduced unsecured exposure pending refinancing."},
+    {"id": "cr-indicators-01", "typology": "indicators",
+     "text": "KYB / credit red-flag guidance: correlated delinquency across firms sharing a beneficial owner, "
+             "a holding shell tying suppliers together, and concentration of exposure behind one UBO are "
+             "classic related-party concentration-risk indicators — trace common control before sizing the limit.",
+     "resolution": "Trace the ownership/common-control graph; aggregate exposure to the UBO; cap at the group level."},
+]
+
+
+def build_firms(rng: random.Random) -> list[dict]:
+    cluster_ids = {CLUSTER["flagged"], CLUSTER["ubo"], CLUSTER["holding"], *CLUSTER["related"]}
+    firms = []
+    for i in range(1, N_FIRMS + 1):
+        fid = f"firm-{i:03d}"
+        firms.append({"id": fid, "kind": "firm", "in_cluster": fid in cluster_ids})
+    for name in ["hold-atlas", "hold-orion", "hold-vega", "ubo-nominee"]:
+        firms.append({"id": name, "kind": "entity",
+                      "in_cluster": name in (CLUSTER["holding"], CLUSTER["ubo"])})
+    return firms
+
+
+def build_linked_edges(rng: random.Random) -> list[dict]:
+    """`linked` (common-control) edges. Background firm-holding ties + the cluster path."""
+    edges = []
+    firms = [f"firm-{i:03d}" for i in range(1, N_FIRMS + 1)]
+    holdings = ["hold-orion", "hold-vega"]
+    cluster_ids = {CLUSTER["flagged"], CLUSTER["ubo"], CLUSTER["holding"], *CLUSTER["related"]}
+
+    # ── background: each non-cluster firm tied to an unrelated holding ──
+    for f in firms:
+        if f in cluster_ids:
+            continue
+        edges.append({"from": f, "to": rng.choice(holdings)})
+
+    # ── the cluster: flagged -> related firms -> holding shell -> UBO ──
+    flagged, related, holding, ubo = (CLUSTER["flagged"], CLUSTER["related"],
+                                      CLUSTER["holding"], CLUSTER["ubo"])
+    for f in related:
+        edges.append({"from": flagged, "to": f})    # flagged firm tied to each related party
+        edges.append({"from": f, "to": holding})    # related parties under the common holding
+    edges.append({"from": holding, "to": ubo})      # holding controlled by the UBO
+    return edges
+
+
+def build_dbt_series(rng: random.Random) -> dict[str, list[dict]]:
+    """Per-firm days-beyond-terms points. Healthy low DBT + the cluster distress burst."""
+    firms = [f"firm-{i:03d}" for i in range(1, N_FIRMS + 1)]
+    series: dict[str, list[dict]] = {f: [] for f in firms}
+
+    # ── background: low, occasional days-beyond-terms readings across the year ──
+    for f in firms:
+        for _ in range(rng.randint(4, 7)):
+            ts = WINDOW_START + timedelta(days=rng.randint(0, 300))
+            series[f].append({"ts": ts.isoformat(), "dbt": round(rng.uniform(1, 12), 1)})
+
+    # ── the cluster: a sharp, correlated distress burst over a ~10-day window ──
+    burst = WINDOW_START + timedelta(days=200)
+    for firm in [CLUSTER["flagged"], CLUSTER["ubo"], *CLUSTER["related"]]:
+        if firm.startswith("ubo") or firm.startswith("hold"):
+            continue  # entities carry no payment series
+        for _ in range(rng.randint(5, 7)):
+            ts = burst + timedelta(days=rng.randint(0, 10))
+            series[firm].append({"ts": ts.isoformat(), "dbt": round(rng.uniform(75, 120), 1)})
+    return series
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate the D&B / commercial-risk demo dataset.")
+    ap.add_argument("--out", default=str(Path(__file__).parent / "data"))
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    firms = build_firms(rng)
+    edges = [{"from": e["from"], "to": e["to"], "type": "linked"}
+             for e in build_linked_edges(rng)]
+    series = build_dbt_series(rng)
+    ts_out = [{"firm": f, "points": sorted(pts, key=lambda p: p["ts"])}
+              for f, pts in series.items() if pts]
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "firms.json").write_text(json.dumps({"nodes": firms, "edges": edges}, indent=2))
+    (out / "dbt.json").write_text(json.dumps(ts_out, indent=2))
+    (out / "typologies.json").write_text(json.dumps(TYPOLOGIES, indent=2))
+    (out / "casenotes.json").write_text(json.dumps(CASE_NOTES, indent=2))
+
+    print(f"✅ commercial-risk dataset written to {out}")
+    print(f"   firms/entities: {len(firms)} ({sum(f['in_cluster'] for f in firms)} in the cluster)")
+    print(f"   linked edges: {len(edges)}   ts firms: {len(ts_out)}")
+    print(f"   typologies: {len(TYPOLOGIES)}   case notes: {len(CASE_NOTES)}")
+    print(f"   cluster: {CLUSTER['flagged']} → {CLUSTER['related']} → {CLUSTER['holding']} → {CLUSTER['ubo']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The **D&B / commercial-risk** vertical demo — the final vertical in the TAM-ordered roadmap (internet → insurance → market surveillance → D&B). A credit analyst asks one plain-language question — *"supplier `firm-007` was flagged for elevated risk, is the exposure concentrated?"* — and a copilot answers by chaining **four modalities in one engine**, every hop a **live ProximaDB v2 API call**:

| Hop | Modality | What runs |
|-----|----------|-----------|
| 1 | **timeseries** | each firm's days-beyond-terms stream in its *own* ts collection; per-7-day `sum` aggregate flags distress **bursts** |
| 2 | **vector** | the flagged firm's **scale-normalised burst shape** -> nearest risk **typology** (cosine ANN) |
| 3 | **graph** | a **Cypher** `-[:linked*1..4]->` traces the related-party cluster: firm -> related firms -> holding shell -> UBO |
| 4 | **RAG** | semantic search over the credit-policy / KYB corpus -> the **group-level playbook** |

## Verified live (code-aligned image)
```
credit: Supplier firm-007 was flagged for elevated credit risk. Is the exposure concentrated?
[timeseries] 4 with distress bursts: firm-011, firm-013, firm-007, firm-012
[vector] firm-007 delinquency signature -> financial distress (score 0.984, live ANN)
[graph] related-party cluster of firm-007 -> firm-011 -> firm-012 -> firm-013 -> hold-atlas -> ubo-nominee  (exposure concentrated behind ubo-nominee)
[RAG] cr-distress-01 -> Reduced the credit limit; required a parent guarantee; set a group-level exposure cap across the UBO cluster.
```
**The killer move is hop 3:** the flag was on *one* firm, but the graph reveals the exposure is the *whole cluster behind one UBO* — a per-firm limit would badly understate the real risk. Flags exactly the 4 cluster firms (zero false positives), matches the correct typology, and traces the cluster to the UBO.

## Notable
- Exercises the merged engine fixes (#658): per-collection timeseries isolation (30 streams) + Cypher multi-hop traversal (cluster depth 4).
- Reuses the **scale-normalised burst-feature** pattern across all built verticals — cosine discriminates on burst shape, not raw magnitude.
- Deterministic + stdlib-only generator; `data/` + `__pycache__` gitignored; registers the vertical in `demo/verticals/README.adoc`.

Completes the FSI + internet vertical set. A cross-modal query fabric (ADR-053, #665) will later move the client-side timeseries fan-out + graph∩timeseries join into the engine.