### PR TITLE
demo(verticals): align fraud-AML to the shared scale-normalised burst-feature pattern

### DIFF
--- a/demo/verticals/fraud-aml/README.adoc
+++ b/demo/verticals/fraud-aml/README.adoc
@@ -51,21 +51,22 @@ ran through the engine:
 [source,text]
 ----
 🕵️  analyst: Account acct-007 tripped a transaction-monitoring alert. Is it laundering?
-🤖 copilot: [timeseries] scanned 40 account streams via ProximaDB — 4 with suspicious volume bursts: acct-020, acct-007, acct-030, acct-011
+🤖 copilot: [timeseries] scanned 40 account streams via ProximaDB — 6 with suspicious volume bursts: acct-020, acct-007, acct-030, acct-011, acct-013, acct-012
      [API ✓] POST /api/v2/collections/aml_typologies/search  (200, 2 ms)
-🤖 copilot: [vector] acct-007 behaviour → **rapid layering** (score 1.000, live ANN)
+🤖 copilot: [vector] acct-007 behaviour → **structuring / smurfing** (score 0.939, live ANN)
      [API ✓] POST /api/v2/graphs/aml/query  (200, 1 ms)
 🤖 copilot: [graph] laundering ring downstream of acct-007 → acct-011 → acct-012 → acct-013 → acct-020 → acct-030
      [API ✓] POST /api/v2/collections/aml_casenotes/search  (200, 2 ms)
-🤖 copilot: [RAG] case-layer-01 → Traced the layering chain to a consolidation account; SAR filed on the full ring.
+🤖 copilot: [RAG] case-struct-01 → Filed a SAR; froze the placement account; escalated the fan-out beneficiaries for KYC review.
 ----
 
-The four flagged accounts are **exactly** the ring — `acct-007` (placement/layering head),
-`acct-011` (mule), `acct-020` (consolidation), `acct-030` (cash-out) — with zero false
-positives, because each account's stream is isolated in its own timeseries collection (the
-`(collection, time)` partition-key fix). The single Cypher `*1..4` query then walks the
-*whole* ring — placement → the three mules → consolidation → cash-out — in one hop-bounded
-traversal, so the copilot sees the full laundering topology, not just the first layer.
+The six flagged accounts are **exactly** the ring — `acct-007` (placement head), `acct-011`,
+`acct-012`, `acct-013` (mules), `acct-020` (consolidation), `acct-030` (cash-out) — with zero
+false positives, because each account's stream is isolated in its own timeseries collection (the
+`(collection, time)` partition-key fix). The vector hop reads `acct-007`'s concentrated
+sub-threshold cash-in burst as **structuring / smurfing** (its scale-normalised shape), and the
+single Cypher `*1..4` query walks the *whole* ring — placement → the three mules → consolidation
+→ cash-out — in one hop-bounded traversal, so the copilot sees the full laundering topology.
 
 **All four modalities are live ProximaDB calls** (nothing client-side):
 
@@ -75,8 +76,11 @@ traversal, so the copilot sees the full laundering topology, not just the first 
   account is its *own* timeseries collection, so the engine's per-collection isolation is
   exercised directly (the fix that keys partitions by `(collection, time)`).
 - **vector** — the AML typology library as a vector collection; the flagged account's
-  behaviour features (`[peak, velocity, burst-fraction, mean]`) resolve to the nearest
-  typology by cosine ANN (`records/batch` + typed `search`).
+  **scale-normalised burst shape** `[severity, spike_ratio, spread, concentration]` resolves to
+  the nearest typology by cosine ANN (`records/batch` + typed `search`). Scaling every feature to
+  a comparable range lets cosine separate a *concentrated structuring burst* from *spread-out
+  layering* — raw dollar magnitude alone would blur them. (This is the shared feature pattern
+  across every built vertical.)
 - **graph** — the account/`sent_to` transfer graph is built (`/graphs/aml/nodes` + `/edges`)
   and the whole ring traced by one **Cypher** variable-length path query
   (`MATCH (a:Account {id:'acct-007'})-[:sent_to*1..4]->(x) RETURN x`), which walks

--- a/demo/verticals/fraud-aml/copilot_live.py
+++ b/demo/verticals/fraud-aml/copilot_live.py
@@ -42,6 +42,7 @@ EMB_DIM = 256
 TYP_COLL = "aml_typologies"
 CASE_COLL = "aml_casenotes"
 BURST_THRESHOLD = 5000.0  # a single-bucket transacted volume this large is suspicious
+SEVERITY_SCALE = 2500.0   # normalises peak transacted-volume into the O(1..10) feature range
 
 
 # ── tiny REST client (stdlib) ───────────────────────────────────────────────────
@@ -83,6 +84,19 @@ def iso_ms(iso: str) -> int:
 
 def _load(name: str):
     return json.loads((DATA / name).read_text())
+
+
+def feature_vector(sums: list[float]) -> list[float]:
+    """Scale-normalised shape of a transacted-volume burst — must match the typology vectors in
+    generate_data.py. Scaling each dimension to O(1..10) lets cosine discriminate on burst
+    *shape* (concentrated structuring vs spread layering) rather than raw dollar magnitude —
+    the shared pattern across every built vertical."""
+    peak = max(sums)
+    total = sum(sums) or 1e-6
+    mean = total / len(sums)
+    spread = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
+    return [round(peak / SEVERITY_SCALE, 3), round(peak / (mean or 1e-6), 3),
+            round(spread * 10.0, 3), round(peak / total * 10.0, 3)]
 
 
 # ── setup (real ProximaDB writes) ───────────────────────────────────────────────
@@ -146,13 +160,8 @@ def timeseries_scan(ts_accounts) -> list[dict]:
             continue
         peak = max(sums)
         if peak > BURST_THRESHOLD:  # a large single-window transacted volume
-            mean = sum(sums) / len(sums)
-            burst = sum(1 for s in sums if s > BURST_THRESHOLD) / len(sums)
-            flagged.append({
-                "account": acc["account"], "peak": round(peak, 1),
-                "features": [round(peak, 3), round(peak / (mean or 1e-6), 3),
-                             round(burst, 3), round(mean, 3)],
-            })
+            flagged.append({"account": acc["account"], "peak": round(peak, 1),
+                            "features": feature_vector(sums)})
     return sorted(flagged, key=lambda f: f["peak"], reverse=True)
 
 

--- a/demo/verticals/fraud-aml/generate_data.py
+++ b/demo/verticals/fraud-aml/generate_data.py
@@ -37,18 +37,21 @@ RING = {
     "cashout": "acct-030",
 }
 
-# Labelled AML typology signatures (the vector library). Features are
-# [peak_bucket_amount, velocity_ratio, burst_fraction, avg_bucket_amount] — the same
-# shape copilot_live.py derives from the ProximaDB timeseries aggregate.
+# Labelled AML typology signatures (the vector library). Features are the SCALE-NORMALISED
+# shape of the transacted-volume burst — [severity, spike_ratio, spread, concentration] — the
+# same vector copilot_live.py derives from the ProximaDB timeseries aggregate (see feature_vector).
+# Scaling keeps every dimension O(1..10) so cosine discriminates on burst *shape*, not raw dollars:
+# structuring's concentrated sub-threshold cash-in burst separates cleanly from spread-out layering.
+# This is the shared pattern used by every built vertical (internet/insurance/markets/D&B).
 TYPOLOGIES = [
     {"id": "typ-structuring", "label": "structuring / smurfing", "case_ref": "case-struct-01",
-     "features": [9000.0, 20.0, 0.45, 2200.0]},
+     "features": [6.0, 5.0, 2.5, 6.5]},     # concentrated sub-threshold cash-in burst
     {"id": "typ-layering", "label": "rapid layering", "case_ref": "case-layer-01",
-     "features": [12000.0, 14.0, 0.6, 5000.0]},
+     "features": [3.0, 2.2, 6.0, 2.2]},     # spread across intermediaries, sustained
     {"id": "typ-mule", "label": "money mule", "case_ref": "case-mule-01",
-     "features": [4000.0, 5.0, 0.3, 2500.0]},
+     "features": [3.5, 4.0, 6.0, 2.6]},     # moderate, spiky, many windows (forwarding)
     {"id": "typ-nominal", "label": "nominal", "case_ref": None,
-     "features": [700.0, 1.3, 0.05, 500.0]},
+     "features": [0.6, 1.4, 0.5, 3.0]},
 ]
 
 CASE_NOTES = [
@@ -99,9 +102,10 @@ def build_transactions(rng: random.Random) -> list[dict]:
     burst = WINDOW_START + timedelta(hours=3)
     p, mules, cons, cash = (RING["placement"], RING["mules"],
                             RING["consolidation"], RING["cashout"])
-    # 1. structuring: ~16 sub-threshold cash-ins into the placement account
+    # 1. structuring: ~16 sub-threshold cash-ins into the placement account, in a TIGHT
+    #    window (rapid smurfing) so the placement account's signature is a concentrated burst.
     for k in range(16):
-        ts = burst + timedelta(minutes=rng.randint(0, 80))
+        ts = burst + timedelta(minutes=rng.randint(0, 25))
         txns.append({"from": f"cash-in-{k:02d}", "to": p,
                      "amount": round(rng.uniform(820, 980), 2), "ts": ts.isoformat()})
     # 2. layering: placement -> each mule, several rapid transfers


### PR DESCRIPTION
Refines the fraud-AML vertical (built before the scale-normalised feature pattern) so **all burst-anomaly verticals share one best-practice, magnitude-robust vector-match approach**.

## Problem
fraud-AML used raw `[peak, velocity, burst, mean]` features. Cosine over those is dominated by dollar magnitude, so the placement head `acct-007` (16 sub-threshold cash-ins → textbook **structuring**) drifted to "rapid layering" — a less accurate label for the ring's placement account.

## Fix
- Adopt the shared `feature_vector` — `[severity, spike_ratio, spread, concentration]`, each scaled to O(1..10) so cosine discriminates on burst **shape**, not raw dollars (the pattern internet/insurance/markets/D&B already use).
- Make the placement signal genuinely concentrated: tighten the 16 sub-threshold cash-ins into a rapid ~25-min smurfing window (which is what structuring actually is).

## Verified live (code-aligned image)
```
[timeseries] 6 with suspicious volume bursts: acct-020, acct-007, acct-030, acct-011, acct-013, acct-012
[vector] acct-007 behaviour -> structuring / smurfing (score 0.939, live ANN)
[graph] laundering ring downstream of acct-007 -> acct-011 -> acct-012 -> acct-013 -> acct-020 -> acct-030
[RAG] case-struct-01 -> Filed a SAR; froze the placement account; escalated the fan-out beneficiaries for KYC review.
```
acct-007 now reads as **structuring / smurfing** (the correct typology for a placement head) and RAG returns the SAR playbook written for it; flags exactly the 6 ring accounts (zero false positives); the multi-hop Cypher traces the full ring. README transcript + vector-hop description updated.

## Note on manufacturing
Manufacturing **intentionally** keeps its z-score drift detector. Sensor faults are identified by their physical magnitude (vibration≈3 → bearing wear, temperature≈68 → cooling loss), so the baseline-magnitude feature is correct there — the scale-normalised burst-shape pattern would strip the very signal that picks the fault. Burst-anomaly verticals (fraud/insurance/markets/D&B/internet) share the scaled `feature_vector`; manufacturing uses the detector appropriate to sensor physics. That's alignment by anomaly type, not homogenisation.