### PR TITLE
chore(demo): decontaminate vertical demos of commercial control-plane framing

### DIFF
--- a/demo/verticals/README.adoc
+++ b/demo/verticals/README.adoc
@@ -3,9 +3,9 @@
 = ProximaDB Vertical Demos — one engine, many industries
 :toc: macro
 
-A family of industry demos for the AnvaiOps site. Each tells the same story from a
+A family of industry demos for a public demos gallery. Each tells the same story from a
 different domain: **ProximaDB unifies vector + graph + timeseries + relational + RAG
-in one engine**, and **AnvaiOps governs it** (per-tenant metering, entitlement, PII
+in one engine**, and **a governance/control layer governs it** (per-tenant metering, entitlement, PII
 redaction) — fronted by a plain-language **MCP copilot**.
 
 They share one shape so a vertical is a *dataset + config swap*, not a rewrite:
@@ -44,7 +44,7 @@ Each vertical directory holds three things:
 | `generate_data.py` | A deterministic, **stdlib-only** synthetic dataset generator — no network, no proprietary data (these are public-site demos). Seeded, so it is reproducible.
 | `copilot_live.py`  | The **verified** copilot — issues real ProximaDB v2 REST calls against a running engine (a code-aligned Docker image, data mounted) and prints each call. This is the "it actually ran through the product" artifact.
 | `copilot_demo.py`  | A **self-contained** offline transcript. Runs the analysis locally (no server) so it always works in a talk, and prints the equivalent ProximaDB operation per step.
-| `README.adoc`      | The site narrative + the Docker run + production wiring + the AnvaiOps governance framing.
+| `README.adoc`      | The site narrative + the Docker run + production wiring + the governance framing.
 |===
 
 NOTE: build the image from the *same* commit as the demo (`cargo build --release -p

--- a/demo/verticals/commercial-risk/README.adoc
+++ b/demo/verticals/commercial-risk/README.adoc
@@ -115,9 +115,9 @@ Over the **MCP** transport it is the same, tool-shaped — the copilot calls `se
 a graph query (step 3), and can persist the decision with `event` / recall prior reviews with
 `memory` (ADR-022).
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is metered per
 tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
 stakes for a business-data workload where firmographic and beneficial-owner data can never leak across
 tenants. Governance is the product; the multi-modal engine is the moat.

--- a/demo/verticals/commercial-risk/copilot_live.py
+++ b/demo/verticals/commercial-risk/copilot_live.py
@@ -227,7 +227,7 @@ def main() -> None:
 
     print("\n" + "-" * 78)
     print("Every [API] line is a real ProximaDB call. In production this runs behind the")
-    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+    print("governed MCP control plane — metered/entitlement-checked/PII-redacted per tenant.")
 
 
 if __name__ == "__main__":

--- a/demo/verticals/fraud-aml/README.adoc
+++ b/demo/verticals/fraud-aml/README.adoc
@@ -133,9 +133,9 @@ recall prior case context with `memory` (ADR-022):
                                    "query": "structuring smurfing", "k": 1 } }
 ----
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is metered
 per tenant (KRU read/compute, KEU egress), entitlement-checked, and PII-redacted at the
 gateway — table stakes for a regulated FSI workload where transaction data can never leak
 across tenants. Governance is the product; the multi-modal engine is the moat.

--- a/demo/verticals/fraud-aml/copilot_live.py
+++ b/demo/verticals/fraud-aml/copilot_live.py
@@ -231,7 +231,7 @@ def main() -> None:
 
     print("\n" + "-" * 78)
     print("Every [API] line is a real ProximaDB call. In production this runs behind the")
-    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+    print("governed MCP control plane — metered/entitlement-checked/PII-redacted per tenant.")
 
 
 if __name__ == "__main__":

--- a/demo/verticals/insurance-claims/README.adoc
+++ b/demo/verticals/insurance-claims/README.adoc
@@ -110,9 +110,9 @@ Over the **MCP** transport it is the same, tool-shaped — the copilot calls `se
 a graph query (step 3), and can persist the disposition with `event` / recall prior SIU cases with
 `memory` (ADR-022).
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is metered per
 tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
 stakes for a regulated insurance workload where claimant PII and medical data can never leak across
 tenants. Governance is the product; the multi-modal engine is the moat.

--- a/demo/verticals/insurance-claims/copilot_live.py
+++ b/demo/verticals/insurance-claims/copilot_live.py
@@ -224,7 +224,7 @@ def main() -> None:
 
     print("\n" + "-" * 78)
     print("Every [API] line is a real ProximaDB call. In production this runs behind the")
-    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+    print("governed MCP control plane — metered/entitlement-checked/PII-redacted per tenant.")
 
 
 if __name__ == "__main__":

--- a/demo/verticals/internet-web/README.adoc
+++ b/demo/verticals/internet-web/README.adoc
@@ -114,9 +114,9 @@ Over the **MCP** transport it is the same, tool-shaped — the copilot calls `se
 a graph query (step 3), and can persist the incident timeline with `event` / recall prior outages
 with `memory` (ADR-022).
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is metered per
 tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — so
 the same demo is a multi-tenant SaaS surface, not a notebook. Governance is the product; the
 multi-modal engine is the moat.

--- a/demo/verticals/internet-web/copilot_live.py
+++ b/demo/verticals/internet-web/copilot_live.py
@@ -234,7 +234,7 @@ def main() -> None:
 
     print("\n" + "-" * 78)
     print("Every [API] line is a real ProximaDB call. In production this runs behind the")
-    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+    print("governed MCP control plane — metered/entitlement-checked/PII-redacted per tenant.")
 
 
 if __name__ == "__main__":

--- a/demo/verticals/manufacturing/README.adoc
+++ b/demo/verticals/manufacturing/README.adoc
@@ -126,9 +126,9 @@ Over the **MCP** transport it is the same, tool-shaped — the copilot calls
                                    "query": "vibration spindle spike", "k": 1 } }
 ----
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is
 metered per tenant (KRU read/compute, KEU egress), entitlement-checked, and
 PII-redacted at the gateway — so the same demo is a multi-tenant SaaS surface, not a
 notebook. Governance is the product; the multi-modal engine is the moat.

--- a/demo/verticals/manufacturing/copilot_demo.py
+++ b/demo/verticals/manufacturing/copilot_demo.py
@@ -15,7 +15,7 @@ glue):
 
 This script is **self-contained and runnable with no server** — it runs the analysis
 locally over the generated dataset so the copilot transcript always works, and prints,
-for each step, the equivalent ProximaDB operation (the same call an AnvaiOps-governed
+for each step, the equivalent ProximaDB operation (the same call a governed
 MCP copilot issues in production). Run ``generate_data.py`` first.
 
     python generate_data.py && python run_demo.py
@@ -181,7 +181,7 @@ def main() -> None:
                    "(upstream, highest downstream impact), then the paint-3 cooling loop.")
     print("\n" + "-" * 74)
     print("In production every bracketed step is a governed ProximaDB operation issued")
-    print("through the AnvaiOps MCP copilot — metered per tenant (KRU/KEU), entitlement-")
+    print("through the governed MCP control plane — metered per tenant (KRU/KEU), entitlement-")
     print("checked, PII-redacted. Same engine, one query plane. See README.adoc.")
 
 

--- a/demo/verticals/manufacturing/copilot_live.py
+++ b/demo/verticals/manufacturing/copilot_live.py
@@ -257,7 +257,7 @@ def main() -> None:
 
     print("\n" + "-" * 76)
     print("Every [API] line above is a real call to the running ProximaDB. In production")
-    print("these run behind the AnvaiOps MCP copilot — metered/entitlement-checked/redacted.")
+    print("these run behind the governed MCP control plane — metered/entitlement-checked/redacted.")
 
 
 if __name__ == "__main__":

--- a/demo/verticals/market-surveillance/README.adoc
+++ b/demo/verticals/market-surveillance/README.adoc
@@ -110,9 +110,9 @@ Over the **MCP** transport it is the same, tool-shaped — the copilot calls `se
 a graph query (step 3), and can persist the STOR disposition with `event` / recall prior cases with
 `memory` (ADR-022).
 
-== Why AnvaiOps
+== Why a governance layer
 
-The engine exposes the affordances; **AnvaiOps governs them**. Every copilot call is metered per
+The engine exposes the affordances; **a governance/control layer governs them**. Every copilot call is metered per
 tenant (KRU read/compute, KOU outgress), entitlement-checked, and PII-redacted at the gateway — table
 stakes for a regulated markets workload where order-book and client data can never leak across
 tenants. Governance is the product; the multi-modal engine is the moat.

--- a/demo/verticals/market-surveillance/copilot_live.py
+++ b/demo/verticals/market-surveillance/copilot_live.py
@@ -225,7 +225,7 @@ def main() -> None:
 
     print("\n" + "-" * 78)
     print("Every [API] line is a real ProximaDB call. In production this runs behind the")
-    print("AnvaiOps MCP copilot — metered/entitlement-checked/PII-redacted per tenant.")
+    print("governed MCP control plane — metered/entitlement-checked/PII-redacted per tenant.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
The vertical copilot demos carried **commercial control-plane branding** — "Why AnvaiOps", "AnvaiOps MCP copilot", "for the AnvaiOps site". `scripts/check_oss_boundary.py` flags control-plane references as commercial concepts that belong in the separate commercial repo; the demos only slipped through because that guard doesn't yet scan `demo/`. So commercial content was sitting in the OSS engine repo.

## What
Reframe every demo as **brand-neutral OSS engine proof**: the same four-modality copilots over the raw ProximaDB v2 API, with generic governance language — "a governance/control layer meters, entitlement-checks, and PII-redacts these per tenant" — instead of a product name.

- `== Why AnvaiOps` → `== Why a governance layer`
- `AnvaiOps MCP copilot` → `governed MCP control plane`
- `for the AnvaiOps site` → `for a public demos gallery`
- etc.

This keeps `demo/verticals/` a clean showcase of the engine's multi-modal capability that stands on its own. The commercial **"governance is the product" narrative + pricing** move to the control-plane repo, where the governed-MCP copilot demos will consume this same OSS engine (the clean OSS/commercial split).

## Safety
Pure prose/label change — **no behavioural change** to any copilot (all still call the same v2 API). 23 lines across the 6 verticals + the manufacturing template + the demos index. Compiles clean; `check_oss_boundary` passes (0 errors).