### PR TITLE
release: v0.2.2 — version sync + release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to ProximaDB will be documented in this file.
 
+## [0.2.2] - 2026-07-04
+
+### Storage
+- Always-PAX flush/compaction for the SST engine (ADR-049 M1-3); PAX segment compaction; AXIS rebuild from SST on index-store loss.
+
+### Statistics & routing
+- Canonical segment-statistics contract (ADR-042) + neutral envelope (ADR-037) + freshness floor (ADR-038); ADR-050 cost-based routing recorded.
+
+### API
+- gRPC v2 GetRecord Python stubs regenerated to match the proto; two-surface SQL model (pgwire + JWT gRPC ExecuteQuery) documented — neither deprecated.
+
+### OSS adoption
+- First-run funnel fixed (docker refs -> published vjsingh1984/proximadb, :latest live multi-arch); README status reconciled to SUPPORTED_SURFACE ("the contract wins"); OPEN_CORE.md + COMPETITIVE_LANDSCAPE.adoc added.
+
+### Hygiene
+- Clippy real-bug tail + mechanical sweep; attribution/doc-authority CI gates; deterministic-commit contract.
+
 ## [0.2.0] - 2026-02-22
 
 ### 🎉 Major Release: Platform Packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proximadb"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2024"
 autobenches = false
 authors = ["Vijaykumar Singh <singhvjd@gmail.com>"]

--- a/clients/nodejs-embedded/package.json
+++ b/clients/nodejs-embedded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proximadb/client",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "TypeScript/Node.js SDK for ProximaDB vector database",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/python-embedded/pyproject.toml
+++ b/clients/python-embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "proximadb_embedded"
-version = "0.2.0"
+version = "0.2.2"
 description = "ProximaDB Embedded - In-process vector database for Python with zero network overhead"
 authors = [
     {name = "Vijaykumar Singh", email = "singhvjd@gmail.com"}

--- a/clients/python-embedded/src/proximadb_embedded/__init__.py
+++ b/clients/python-embedded/src/proximadb_embedded/__init__.py
@@ -80,7 +80,7 @@ from .notebook import (
 )
 import time
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"
 __all__ = [
     "ProximaDB",
     "DiskConfig",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # the import package stays `proximadb_sdk`). The native in-process engine ships
 # separately as `proximadb_embedded` — install via the `embedded` extra below.
 name = "proximadb"
-version = "0.2.0"
+version = "0.2.2"
 description = "Python client SDK for ProximaDB - Cloud-native vector database engineered for AI-first applications"
 authors = [
     {name = "Vijaykumar Singh", email = "singhvjd@gmail.com"}

--- a/clients/python/src/proximadb_sdk/__init__.py
+++ b/clients/python/src/proximadb_sdk/__init__.py
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0
 """
 
 # Version information
-__version__ = "0.2.0"
+__version__ = "0.2.2"
 __author__ = "ProximaDB Contributors"
 
 # Protocol adapters (TD-126 Phase 3): loaded LAZILY via the package-level

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proximadb-sdk"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2024"
 authors = ["ProximaDB Contributors"]
 description = "Rust SDK for ProximaDB - Native client for agent development"

--- a/deploy/helm/proximadb/Chart.yaml
+++ b/deploy/helm/proximadb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: proximadb
 description: ProximaDB - Cloud-native vector database engineered for AI-first applications
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.2
+appVersion: "0.2.2"
 
 keywords:
   - vector-database

--- a/docs/release-notes/v0.2.2.adoc
+++ b/docs/release-notes/v0.2.2.adoc
@@ -1,0 +1,53 @@
+= ProximaDB v0.2.2 Release Notes
+:toc: left
+:toclevels: 2
+:icons: font
+:last-updated: 2026-07-04
+
+[.lead]
+**Single-node consolidation release.** v0.2.2 lands the always-PAX write path for the SST
+engine, the statistics substrate that feeds catalog and routing decisions, and a repaired
+first-run experience for OSS adopters. Distributed, federated-SQL, and external-format
+surfaces remain Beta or Experimental — `docs/SUPPORTED_SURFACE.adoc` stays the authoritative
+support contract and wins over any other claim.
+
+== Storage engine
+
+* **Always-PAX flush and compaction (ADR-049 M1-3).** The legacy streaming write path for
+  flush/compaction is retired; PAX segments are the single write shape for the SST engine.
+* PAX segment compaction (P3 Phase E) and the per-collection PAX opt-out tag with a global
+  kill-switch precede the cutover, so operators retain an escape hatch.
+* AXIS index rebuild from SST on index-store loss.
+
+== Statistics and routing
+
+* Canonical segment-statistics contract (ADR-042) with the neutral statistics envelope
+  (ADR-037) and freshness/coherence floor (ADR-038) — the substrate for agent-facing
+  catalogs and cost estimation built on top of the engine.
+* Statistics-fed cost-based routing into the DataFusion OLAP arm recorded as ADR-050
+  (design; implementation tracked).
+
+== API surface
+
+* gRPC v2 `GetRecord` servicer stubs regenerated in the Python clients to match
+  `proto/proximadb/v2/record.proto` (codegen staleness fix).
+* SQL remains served by two deliberate surfaces (TD-121/TD-135): pgwire for the PostgreSQL
+  ecosystem and the token-authenticated gRPC `ProximaRecordService.ExecuteQuery` for
+  vector/graph-extension SQL. Neither is deprecated.
+
+== OSS adoption and docs
+
+* **First-run funnel fixed:** every user-facing `docker run` reference now points at the
+  published `vjsingh1984/proximadb` images (`:latest` is live, linux/amd64 + linux/arm64).
+* README feature-status table reconciled to `SUPPORTED_SURFACE.adoc` — where they disagree,
+  the contract wins (stated inline).
+* New `OPEN_CORE.md`: the full single-node engine — every data model, pgwire, hybrid search,
+  the Web UI, all SDKs — is Apache-2.0 and free forever; the commercial layer sells
+  operations, never features.
+* New `docs/00-product/COMPETITIVE_LANDSCAPE.adoc` (fixes dangling VISION/PRD links).
+
+== Hygiene
+
+* Clippy real-bug tail resolved (await-holding-lock, tautological assertions) plus the
+  mechanical `--fix` sweep.
+* Attribution and doc-authority CI gates extended; deterministic-commit contract enforced.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "proximadb_embedded"
-version = "0.2.0"
+version = "0.2.2"
 description = "ProximaDB - High-performance vector database with embedded mode"
 authors = [
     {name = "Vijaykumar Singh", email = "singhvjd@gmail.com"}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proximadb-ui",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "private": true,
   "proxy": "http://localhost:5678",
   "dependencies": {


### PR DESCRIPTION
Release-cut step 1 (of: bump on qa → qa→main promotion → tag v0.2.2 → image publish). `version-sync.sh set 0.2.2` (10 files, check PASSES — qa was still 0.2.0; 0.2.1 only ever landed on main, so 0.2.2 avoids version regression at promotion). Adds `docs/release-notes/v0.2.2.adoc` (a gap 0.2.1 left) + CHANGELOG entry. Content headlines: ADR-049 always-PAX, statistics substrate, OSS funnel fixes + OPEN_CORE.