### PR TITLE
feat(olap): runtime filters — static pushdown fix + DF dynamic-filter absorption + skip-ratio trace (TD-OLAP-3 P2a)

### DIFF
--- a/docs/10-quality/TPC_PERF_LEDGER.adoc
+++ b/docs/10-quality/TPC_PERF_LEDGER.adoc
@@ -79,8 +79,10 @@ temperature_semantics, routes}, records: [{benchmark, query, route,
 temperature, ok, error?, rows, wall_ms, ...IoTraceSnapshot}] }`
 
 The `IoTraceSnapshot` fields are flattened per record: `get_ops`, `bytes_read`,
-`range_gets`, `bytes_written`, `footer_hits/misses`, `egress_bytes`,
-`compute_ms` (per-engine map).
+`range_gets`, `splits_total`/`splits_pruned` (TD-OLAP-3 skip ratio — the
+runtime-filter promotion gate's evidence; totals accumulate across the static
+and runtime pruning stages), `bytes_written`, `footer_hits/misses`,
+`egress_bytes`, `compute_ms` (per-engine map).
 
 == Relation to the evidence ledger
 

--- a/docs/10-quality/td/TD-OLAP-3-runtime-filters-dpp-bloom-semijoin.adoc
+++ b/docs/10-quality/td/TD-OLAP-3-runtime-filters-dpp-bloom-semijoin.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open (design; depends on TD-OLAP-2 stats + DataFusion runtime-filter support)
+| Status | Open (slices A–C **landed 2026-07-04**: mechanism RESOLVED — DataFusion 54 natively builds join runtime filters (min/max bounds + in-list over HashJoin build keys, `enable_join_dynamic_filter_pushdown` on by default), so the custom-wrapper fallback is NOT needed. Landed: (A) `supports_filters_pushdown` on `ObjectStoreParquetTable` — static WHERE predicates finally reach `scan()` and prune row-group splits (was dormant), default ON, correctness-neutral (Inexact keeps the FilterExec); (B) `ProximaScanExec` absorbs `DynamicFilterPhysicalExpr` in Post-phase pushdown and prunes splits at stream-open via a conservative PhysicalExpr→`ScalarPredicate` translator, gated `PROXIMADB_DF_RUNTIME_FILTER_PRUNE=1` default OFF; (C) `splits_total`/`splits_pruned` io_trace counters — the skip ratio lands in the TD-OLAP-4 ledger automatically. Remaining: gate promotion on ledger evidence, bloom consumer for high-NDV in-lists, partition-level DPP once Iceberg tables are partitioned)
 | Priority | **P2a** in the ADR-052 execution order — blocked by TD-OLAP-2 (P0a) stats for costing when to build a filter. ISP: one `proximadb-bloom` primitive, two consumers (ANN pre-filter ADR-011 + OLAP semi-join)
 | Severity | High — the single largest warehouse-class lever; 5–50× on star-schema joins (Databricks AQE / Snowflake SOS)
 | Component | `src/query/query_optimizer.rs`, `src/query/federated/{optimizer,execution}`, PAX/Iceberg scan pruning, `proximadb-bloom`

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -10,12 +10,11 @@ use std::sync::Arc;
 use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::ScalarValue as DfScalarValue;
 use datafusion::common::Statistics;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::SendableRecordBatchStream;
-use datafusion::logical_expr::{Expr, Operator};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::SessionContext;
@@ -33,6 +32,7 @@ use proximadb_storage_common::format_splits::{
 use proximadb_storage_common::object_store_bridge::ObjectStoreBridge;
 use url::Url;
 
+use super::super::physical_filter_translate::df_scalar_value;
 use super::super::proxima_scan_exec::{ProximaScanExec, SplitReader};
 use super::super::proxima_table_provider::EngineType;
 use super::super::schema_inference::{
@@ -322,6 +322,19 @@ impl TableProvider for ObjectStoreParquetTable {
         TableType::Base
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        // TD-OLAP-3 slice A: without this override DataFusion's optimizer
+        // keeps every WHERE predicate in a FilterExec and hands `scan()` an
+        // EMPTY filter list — the split-pruning machinery below never fires.
+        // `Inexact` = predicates are passed to `scan()` for best-effort
+        // row-group pruning AND the FilterExec stays above for exact
+        // row-level filtering, so results cannot regress.
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+
     fn statistics(&self) -> Option<Statistics> {
         // ADR-050 D2 / TD-DFR-1: footer-derived, zero-new-scan column
         // statistics so the planner stops planning blind. Typed min/max value
@@ -343,6 +356,12 @@ impl TableProvider for ObjectStoreParquetTable {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let target_partitions = state.config().target_partitions();
         let pruned = self.prune_splits(filters);
+        // Skip-ratio evidence for the runtime-filter promotion gate
+        // (TD-OLAP-3/TD-OLAP-4): candidate vs pruned splits, per query.
+        crate::observability::io_trace::record_splits(
+            self.splits.len() as u64,
+            (self.splits.len() - pruned.len()) as u64,
+        );
         // Post-prune stats, narrowed to the projection: `partition_statistics`
         // requires the vector to match the exec's PROJECTED schema width.
         let scan_stats = project_statistics(
@@ -547,27 +566,6 @@ fn literal_value(expr: &Expr) -> Option<ScalarValue> {
     }
 }
 
-fn df_scalar_value(value: &DfScalarValue) -> Option<ScalarValue> {
-    match value {
-        DfScalarValue::Null => Some(ScalarValue::Null),
-        DfScalarValue::Boolean(Some(v)) => Some(ScalarValue::Bool(*v)),
-        DfScalarValue::Int8(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::Int16(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::Int32(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::Int64(Some(v)) => Some(ScalarValue::Int64(*v)),
-        DfScalarValue::UInt8(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::UInt16(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::UInt32(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
-        DfScalarValue::UInt64(Some(v)) => i64::try_from(*v).ok().map(ScalarValue::Int64),
-        DfScalarValue::Float32(Some(v)) => Some(ScalarValue::Float64(*v as f64)),
-        DfScalarValue::Float64(Some(v)) => Some(ScalarValue::Float64(*v)),
-        DfScalarValue::Utf8(Some(v))
-        | DfScalarValue::Utf8View(Some(v))
-        | DfScalarValue::LargeUtf8(Some(v)) => Some(ScalarValue::String(v.clone())),
-        _ => None,
-    }
-}
-
 /// Register an object_store-backed Parquet location as a DataFusion table.
 pub async fn register_object_store_parquet_location(
     ctx: &SessionContext,
@@ -701,6 +699,51 @@ mod tests {
             Precision::Inexact(DfScalarValue::Int64(Some(101)))
         );
         assert_eq!(x.null_count, Precision::Inexact(0));
+    }
+
+    /// TD-OLAP-3 slice A: with `supports_filters_pushdown` (Inexact), a WHERE
+    /// predicate planned through a real DataFusion session reaches `scan()`
+    /// and prunes row-group splits — previously the optimizer kept it in a
+    /// FilterExec and `scan()` saw an empty filter list (dormant pruning).
+    #[tokio::test]
+    async fn where_predicate_reaches_scan_and_prunes_splits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        write_two_row_group_parquet(&data_dir.join("part-0.parquet"));
+
+        let location = format!("file://{}", tmp.path().display());
+        let ctx = SessionContext::new();
+        register_object_store_parquet_location(&ctx, "t", &location)
+            .await
+            .unwrap();
+
+        // Row group 1 holds x ∈ {1,2}; row group 2 holds x ∈ {100,101}.
+        let df = ctx.sql("SELECT x FROM t WHERE x > 50").await.unwrap();
+        let plan = df.create_physical_plan().await.unwrap();
+
+        fn find_scan(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
+            if let Some(scan) = plan.downcast_ref::<ProximaScanExec>() {
+                return Some(scan.total_split_count());
+            }
+            plan.children().iter().find_map(|c| find_scan(c))
+        }
+        let splits = find_scan(&plan).expect("plan contains a ProximaScanExec");
+        assert_eq!(
+            splits, 1,
+            "the WHERE predicate must reach scan() and prune the disjoint row group"
+        );
+
+        // Correctness: the FilterExec above still applies exact semantics.
+        let rows = ctx
+            .sql("SELECT x FROM t WHERE x > 50")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let total: usize = rows.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 2, "exactly the two rows with x > 50");
     }
 
     #[tokio::test]

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -53,6 +53,10 @@ pub mod scan_executor;
 pub mod schema_inference;
 pub mod table_provider;
 
+// TD-OLAP-3: resolved PhysicalExpr → split-pruning predicate translation
+// (consumes DataFusion 54's join runtime filters at stream-open).
+pub(crate) mod physical_filter_translate;
+
 // New split-based table provider and execution plan modules
 pub mod proxima_scan_exec;
 pub mod proxima_table_provider;

--- a/src/datafusion/physical_filter_translate.rs
+++ b/src/datafusion/physical_filter_translate.rs
@@ -1,0 +1,229 @@
+//! Translate a resolved DataFusion [`PhysicalExpr`] into the engine-neutral
+//! split-pruning vocabulary (TD-OLAP-3 slice B).
+//!
+//! DataFusion 54's join runtime filter (`DynamicFilterPhysicalExpr`) resolves
+//! at stream-open time to a conjunction of per-column min/max bounds and/or an
+//! IN-list over the HashJoin build keys. This module walks that resolved
+//! expression and extracts `(column, ScalarPredicate)` pairs that
+//! `FileSplit::can_prune_scalar` understands — turning the join's build-side
+//! knowledge into row-group skips *before* fetch.
+//!
+//! **Conservative by construction**: any expression shape this walker does not
+//! recognize (OR trees, casts, non-column operands, negated lists, …)
+//! contributes NO predicates — a miss can only cost bytes, never correctness.
+//! The pruning consumer additionally re-applies exact filtering above the scan.
+
+use std::sync::Arc;
+
+use datafusion::common::ScalarValue as DfScalarValue;
+use datafusion::logical_expr::Operator;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, Literal};
+use proximadb_storage_common::format_splits::{ScalarPredicate, ScalarValue};
+
+/// Extract conjunctive `(column, predicate)` pruning pairs from a resolved
+/// physical expression. Unrecognized shapes yield nothing (never a wrong skip).
+pub(crate) fn pruning_predicates(expr: &Arc<dyn PhysicalExpr>) -> Vec<(String, ScalarPredicate)> {
+    let mut out = Vec::new();
+    collect(expr.as_ref(), &mut out);
+    out
+}
+
+fn collect(expr: &dyn PhysicalExpr, out: &mut Vec<(String, ScalarPredicate)>) {
+    if let Some(binary) = expr.downcast_ref::<BinaryExpr>() {
+        match binary.op() {
+            // A conjunction prunes if ANY side prunes — recurse both.
+            Operator::And => {
+                collect(binary.left().as_ref(), out);
+                collect(binary.right().as_ref(), out);
+            }
+            // A disjunction cannot be decomposed into independent per-column
+            // predicates without risking a wrong skip — contribute nothing.
+            Operator::Or => {}
+            op => {
+                if let Some(pair) = comparison(binary.left(), *op, binary.right()) {
+                    out.push(pair);
+                }
+            }
+        }
+        return;
+    }
+    if let Some(in_list) = expr.downcast_ref::<InListExpr>()
+        && !in_list.negated()
+        && let Some(column) = column_name(in_list.expr())
+    {
+        let values: Vec<ScalarValue> = in_list.list().iter().filter_map(literal_value).collect();
+        // Only prune when EVERY list element translated — a partial list
+        // would wrongly skip splits containing the untranslated values.
+        if !values.is_empty() && values.len() == in_list.list().len() {
+            out.push((column, ScalarPredicate::In(values)));
+        }
+    }
+    // `lit(true)` (the dynamic filter's pre-build placeholder), columns,
+    // casts, and anything else: no contribution.
+}
+
+fn comparison(
+    left: &Arc<dyn PhysicalExpr>,
+    op: Operator,
+    right: &Arc<dyn PhysicalExpr>,
+) -> Option<(String, ScalarPredicate)> {
+    if let (Some(column), Some(value)) = (column_name(left), literal_value(right)) {
+        return scalar_predicate(op, value).map(|p| (column, p));
+    }
+    if let (Some(value), Some(column)) = (literal_value(left), column_name(right)) {
+        return scalar_predicate(reverse_operator(op), value).map(|p| (column, p));
+    }
+    None
+}
+
+fn scalar_predicate(op: Operator, value: ScalarValue) -> Option<ScalarPredicate> {
+    match op {
+        Operator::Eq => Some(ScalarPredicate::Equal(value)),
+        Operator::NotEq => Some(ScalarPredicate::NotEqual(value)),
+        Operator::Lt => Some(ScalarPredicate::LessThan(value)),
+        Operator::LtEq => Some(ScalarPredicate::LessThanOrEqual(value)),
+        Operator::Gt => Some(ScalarPredicate::GreaterThan(value)),
+        Operator::GtEq => Some(ScalarPredicate::GreaterThanOrEqual(value)),
+        _ => None,
+    }
+}
+
+fn reverse_operator(op: Operator) -> Operator {
+    match op {
+        Operator::Lt => Operator::Gt,
+        Operator::LtEq => Operator::GtEq,
+        Operator::Gt => Operator::Lt,
+        Operator::GtEq => Operator::LtEq,
+        other => other,
+    }
+}
+
+fn column_name(expr: &Arc<dyn PhysicalExpr>) -> Option<String> {
+    expr.downcast_ref::<Column>().map(|c| c.name().to_string())
+}
+
+fn literal_value(expr: &Arc<dyn PhysicalExpr>) -> Option<ScalarValue> {
+    expr.downcast_ref::<Literal>()
+        .and_then(|l| df_scalar_value(l.value()))
+}
+
+/// Convert a DataFusion scalar into the engine-neutral pruning scalar.
+/// Shared with the logical-side pruning in `object_store_parquet_reader`.
+pub(crate) fn df_scalar_value(value: &DfScalarValue) -> Option<ScalarValue> {
+    match value {
+        DfScalarValue::Null => Some(ScalarValue::Null),
+        DfScalarValue::Boolean(Some(v)) => Some(ScalarValue::Bool(*v)),
+        DfScalarValue::Int8(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::Int16(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::Int32(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::Int64(Some(v)) => Some(ScalarValue::Int64(*v)),
+        DfScalarValue::UInt8(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::UInt16(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::UInt32(Some(v)) => Some(ScalarValue::Int64(*v as i64)),
+        DfScalarValue::UInt64(Some(v)) => i64::try_from(*v).ok().map(ScalarValue::Int64),
+        DfScalarValue::Float32(Some(v)) => Some(ScalarValue::Float64(*v as f64)),
+        DfScalarValue::Float64(Some(v)) => Some(ScalarValue::Float64(*v)),
+        DfScalarValue::Utf8(Some(v))
+        | DfScalarValue::Utf8View(Some(v))
+        | DfScalarValue::LargeUtf8(Some(v)) => Some(ScalarValue::String(v.clone())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{col, lit};
+
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("k", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ])
+    }
+
+    fn binary(
+        l: Arc<dyn PhysicalExpr>,
+        op: Operator,
+        r: Arc<dyn PhysicalExpr>,
+    ) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(l, op, r))
+    }
+
+    #[test]
+    fn bounds_conjunction_translates_to_range_predicates() {
+        let s = schema();
+        // k >= 5 AND k <= 10 — the shape DF's join dynamic filter resolves to.
+        let expr = binary(
+            binary(col("k", &s).unwrap(), Operator::GtEq, lit(5i64)),
+            Operator::And,
+            binary(col("k", &s).unwrap(), Operator::LtEq, lit(10i64)),
+        );
+        let preds = pruning_predicates(&expr);
+        assert_eq!(preds.len(), 2);
+        assert_eq!(preds[0].0, "k");
+        assert!(matches!(
+            preds[0].1,
+            ScalarPredicate::GreaterThanOrEqual(ScalarValue::Int64(5))
+        ));
+        assert!(matches!(
+            preds[1].1,
+            ScalarPredicate::LessThanOrEqual(ScalarValue::Int64(10))
+        ));
+    }
+
+    #[test]
+    fn in_list_translates_and_reversed_comparison_flips() {
+        use datafusion::physical_expr::expressions::in_list;
+
+        let s = schema();
+        let in_expr = in_list(
+            col("name", &s).unwrap(),
+            vec![lit("a"), lit("b")],
+            &false,
+            &s,
+        )
+        .unwrap();
+        let preds = pruning_predicates(&in_expr);
+        assert_eq!(preds.len(), 1);
+        match &preds[0].1 {
+            ScalarPredicate::In(values) => {
+                assert_eq!(values.len(), 2);
+                assert!(matches!(&values[0], ScalarValue::String(v) if v == "a"));
+                assert!(matches!(&values[1], ScalarValue::String(v) if v == "b"));
+            }
+            other => panic!("expected In predicate, got {other:?}"),
+        }
+
+        // 5 < k (literal on the left) flips to k > 5.
+        let flipped = binary(lit(5i64), Operator::Lt, col("k", &s).unwrap());
+        let preds = pruning_predicates(&flipped);
+        assert!(matches!(
+            preds[0].1,
+            ScalarPredicate::GreaterThan(ScalarValue::Int64(5))
+        ));
+    }
+
+    #[test]
+    fn unrecognized_shapes_contribute_nothing() {
+        use datafusion::physical_expr::expressions::in_list;
+
+        let s = schema();
+        // OR cannot be decomposed conjunctively.
+        let or_expr = binary(
+            binary(col("k", &s).unwrap(), Operator::Eq, lit(1i64)),
+            Operator::Or,
+            binary(col("k", &s).unwrap(), Operator::Eq, lit(2i64)),
+        );
+        assert!(pruning_predicates(&or_expr).is_empty());
+        // The dynamic filter's pre-build placeholder.
+        let placeholder: Arc<dyn PhysicalExpr> = lit(true);
+        assert!(pruning_predicates(&placeholder).is_empty());
+        // Negated IN-list must not prune.
+        let negated = in_list(col("k", &s).unwrap(), vec![lit(1i64)], &true, &s).unwrap();
+        assert!(pruning_predicates(&negated).is_empty());
+    }
+}

--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -54,10 +54,17 @@ use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::common::Statistics;
+use datafusion::common::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::expressions::DynamicFilterPhysicalExpr;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalExpr};
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
+};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+use super::physical_filter_translate::pruning_predicates;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use futures::{Stream, StreamExt, TryStreamExt};
 use tracing::debug;
@@ -140,6 +147,24 @@ pub struct ProximaScanExec {
     properties: Arc<PlanProperties>,
     /// Cached statistics
     statistics: Option<Statistics>,
+    /// Absorbed join runtime filters (TD-OLAP-3): DataFusion 54's HashJoin
+    /// pushes a `DynamicFilterPhysicalExpr` over the probe keys in the
+    /// Post-phase filter pushdown; `execute()` snapshots it at stream-open
+    /// (after the build side completed) and prunes splits before fetch.
+    dynamic_filters: Vec<Arc<dyn PhysicalExpr>>,
+}
+
+/// Opt-in gate for absorbing DataFusion's join runtime filters into the scan
+/// (default **off**, per the TD-OLAP-3 "default-off, trace-gated" rollout).
+/// Enable with `PROXIMADB_DF_RUNTIME_FILTER_PRUNE=1`; promote once the
+/// TD-OLAP-4 ledger evidences the skip ratio.
+pub fn runtime_filter_prune_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_DF_RUNTIME_FILTER_PRUNE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
 }
 
 impl ProximaScanExec {
@@ -201,6 +226,67 @@ impl ProximaScanExec {
         self.limit
     }
 
+    /// TD-OLAP-3 slice B: runtime split pruning. The absorbed join filter is
+    /// a `DynamicFilterPhysicalExpr` — `snapshot()` re-resolves it NOW
+    /// (stream-open, after the HashJoin build side completed) to per-column
+    /// bounds / an in-list over the build keys. Translation is conservative:
+    /// unrecognized shapes prune nothing, and the join above re-applies exact
+    /// semantics regardless.
+    fn apply_runtime_filters(
+        &self,
+        mut splits: Vec<FileSplit>,
+        partition: usize,
+    ) -> Vec<FileSplit> {
+        if self.dynamic_filters.is_empty() {
+            return splits;
+        }
+        let mut predicates = Vec::new();
+        for dynamic in &self.dynamic_filters {
+            if let Ok(Some(resolved)) = dynamic.snapshot() {
+                predicates.extend(pruning_predicates(&resolved));
+            }
+        }
+        if predicates.is_empty() {
+            return splits;
+        }
+        let before = splits.len();
+        splits.retain(|split| {
+            !predicates
+                .iter()
+                .any(|(column, predicate)| split.can_prune_scalar(column, predicate))
+        });
+        crate::observability::io_trace::record_splits(
+            before as u64,
+            (before - splits.len()) as u64,
+        );
+        debug!(
+            "Runtime filter pruned {}/{} splits for collection '{}' partition {}",
+            before - splits.len(),
+            before,
+            self.collection_name,
+            partition
+        );
+        splits
+    }
+
+    /// Copy of this scan with absorbed runtime filters attached (TD-OLAP-3).
+    fn with_dynamic_filters(&self, dynamic_filters: Vec<Arc<dyn PhysicalExpr>>) -> Self {
+        Self {
+            schema: self.schema.clone(),
+            original_schema: self.original_schema.clone(),
+            partitions: self.partitions.clone(),
+            projection: self.projection.clone(),
+            filters: self.filters.clone(),
+            limit: self.limit,
+            reader: self.reader.clone(),
+            batch_size: self.batch_size,
+            collection_name: self.collection_name.clone(),
+            properties: self.properties.clone(),
+            statistics: self.statistics.clone(),
+            dynamic_filters,
+        }
+    }
+
     /// Apply schema projection.
     fn project_schema(schema: &SchemaRef, projection: &Option<Vec<usize>>) -> SchemaRef {
         if let Some(proj) = projection {
@@ -237,13 +323,14 @@ impl DisplayAs for ProximaScanExec {
             | DisplayFormatType::TreeRender => {
                 write!(
                     f,
-                    "ProximaScanExec: collection={}, engine={}, partitions={}, splits={}, projection={:?}, filters={}, limit={:?}",
+                    "ProximaScanExec: collection={}, engine={}, partitions={}, splits={}, projection={:?}, filters={}, runtime_filters={}, limit={:?}",
                     self.collection_name,
                     self.reader.engine_type(),
                     self.partitions.len(),
                     self.total_split_count(),
                     self.projection,
                     self.filters.len(),
+                    self.dynamic_filters.len(),
                     self.limit
                 )
             }
@@ -285,7 +372,7 @@ impl ExecutionPlan for ProximaScanExec {
             self.partitions.get(partition).map(|p| p.len()).unwrap_or(0)
         );
 
-        let splits = self
+        let mut splits = self
             .partitions
             .get(partition)
             .ok_or_else(|| {
@@ -297,6 +384,8 @@ impl ExecutionPlan for ProximaScanExec {
                 ))
             })?
             .clone();
+
+        splits = self.apply_runtime_filters(splits, partition);
 
         let reader = self.reader.clone();
         let projection = self.projection.clone();
@@ -343,6 +432,50 @@ impl ExecutionPlan for ProximaScanExec {
         });
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, limited)))
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> DFResult<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        // TD-OLAP-3 slice B: absorb ONLY runtime (dynamic) join filters, and
+        // only in the Post phase where HashJoin pushes them. Static predicates
+        // must stay in the FilterExec above — split pruning is inexact, so
+        // claiming support for them would drop rows. Absorbing a dynamic
+        // filter is safe: it is purely an optimization hint (the join still
+        // applies exact semantics).
+        if !matches!(phase, FilterPushdownPhase::Post) || !runtime_filter_prune_enabled() {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+        let mut absorbed: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
+        let statuses: Vec<PushedDown> = child_pushdown_result
+            .parent_filters
+            .iter()
+            .map(|parent| {
+                if parent
+                    .filter
+                    .downcast_ref::<DynamicFilterPhysicalExpr>()
+                    .is_some()
+                {
+                    absorbed.push(Arc::clone(&parent.filter));
+                    PushedDown::Yes
+                } else {
+                    PushedDown::No
+                }
+            })
+            .collect();
+        if absorbed.is_empty() {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+        let mut dynamic_filters = self.dynamic_filters.clone();
+        dynamic_filters.extend(absorbed);
+        let updated: Arc<dyn ExecutionPlan> = Arc::new(self.with_dynamic_filters(dynamic_filters));
+        Ok(
+            FilterPushdownPropagation::with_parent_pushdown_result(statuses)
+                .with_updated_node(updated),
+        )
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
@@ -491,6 +624,7 @@ impl ProximaScanExecBuilder {
             collection_name: self.collection_name,
             properties: Arc::new(properties),
             statistics: self.statistics,
+            dynamic_filters: Vec::new(),
         })
     }
 }
@@ -776,5 +910,85 @@ mod tests {
         let schema = test_schema();
         let stream = EmptyRecordBatchStream::new(schema.clone());
         assert_eq!(stream.schema().fields().len(), 3);
+    }
+
+    /// TD-OLAP-3 slice B: an absorbed `DynamicFilterPhysicalExpr`, once the
+    /// build side resolves it to key bounds, prunes non-overlapping splits at
+    /// stream-open — the whole snapshot → translate → `can_prune_scalar` chain.
+    #[test]
+    fn runtime_filter_prunes_splits_at_execute() {
+        use datafusion::logical_expr::Operator;
+        use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
+        use proximadb_storage_common::format_splits::{ColumnBounds, SplitStatistics};
+
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+
+        let split_with_bounds = |file: &str, min: i64, max: i64| {
+            let mut split = FileSplit::new_row_group(file.to_string(), 0, 0, 1000, 100);
+            let mut stats = SplitStatistics {
+                row_count: Some(100),
+                byte_size: Some(1000),
+                ..Default::default()
+            };
+            stats.column_stats.insert(
+                "x".to_string(),
+                ColumnBounds {
+                    min: Some(serde_json::json!(min)),
+                    max: Some(serde_json::json!(max)),
+                    null_count: 0,
+                    distinct_count: None,
+                },
+            );
+            split.statistics = stats;
+            split
+        };
+
+        let exec = ProximaScanExec::builder()
+            .schema(schema.clone())
+            .splits(vec![])
+            .reader(Arc::new(NullSplitReader::new(
+                schema.clone(),
+                EngineType::Viper,
+            )))
+            .collection_name("t".to_string())
+            .target_partitions(1)
+            .build()
+            .unwrap();
+
+        // The join build side resolved to keys in [50, 300].
+        let dynamic = DynamicFilterPhysicalExpr::new(vec![col("x", &schema).unwrap()], lit(true));
+        dynamic
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(BinaryExpr::new(
+                    col("x", &schema).unwrap(),
+                    Operator::GtEq,
+                    lit(50i64),
+                )),
+                Operator::And,
+                Arc::new(BinaryExpr::new(
+                    col("x", &schema).unwrap(),
+                    Operator::LtEq,
+                    lit(300i64),
+                )),
+            )))
+            .unwrap();
+        let exec = exec.with_dynamic_filters(vec![Arc::new(dynamic)]);
+
+        let splits = vec![
+            split_with_bounds("a.parquet", 1, 10),    // disjoint → pruned
+            split_with_bounds("b.parquet", 100, 200), // overlaps → kept
+            split_with_bounds("c.parquet", 250, 400), // overlaps → kept
+        ];
+        let survivors = exec.apply_runtime_filters(splits, 0);
+        assert_eq!(survivors.len(), 2, "disjoint split pruned before fetch");
+        assert!(survivors.iter().all(|s| s.file_path != "a.parquet"));
+
+        // Unresolved placeholder (`lit(true)`) prunes nothing.
+        let placeholder =
+            DynamicFilterPhysicalExpr::new(vec![col("x", &schema).unwrap()], lit(true));
+        let exec = exec.with_dynamic_filters(vec![Arc::new(placeholder)]);
+        let splits = vec![split_with_bounds("a.parquet", 1, 10)];
+        assert_eq!(exec.apply_runtime_filters(splits, 0).len(), 1);
     }
 }

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -127,6 +127,12 @@ pub struct IoTrace {
     /// the ~8-16 MiB S3 optimum, or fragmented into per-request-fee-dominated
     /// small GETs?
     range_gets: AtomicU64,
+    /// Split-pruning outcome (TD-OLAP-3): candidate row-group splits
+    /// considered by scans, and how many were skipped BEFORE fetch.
+    /// `splits_pruned / splits_total` is the runtime-filter skip ratio the
+    /// promotion gate consumes.
+    splits_total: AtomicU64,
+    splits_pruned: AtomicU64,
     /// Bytes written to object storage (ingest/flush — KIU).
     bytes_written: AtomicU64,
     /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
@@ -193,6 +199,14 @@ impl IoTrace {
     /// Add to the count of ranged GET requests issued.
     pub fn record_range_gets(&self, gets: u64) {
         self.range_gets.fetch_add(gets, Ordering::Relaxed);
+    }
+
+    /// Record a split-pruning outcome (TD-OLAP-3): `total` candidate
+    /// row-group splits considered by a scan, of which `pruned` were skipped
+    /// before fetch.
+    pub fn record_splits(&self, total: u64, pruned: u64) {
+        self.splits_total.fetch_add(total, Ordering::Relaxed);
+        self.splits_pruned.fetch_add(pruned, Ordering::Relaxed);
     }
 
     /// Add to bytes written to object storage.
@@ -263,6 +277,8 @@ impl IoTrace {
             delete_ops: self.delete_ops.load(Ordering::Relaxed),
             bytes_read: self.bytes_read.load(Ordering::Relaxed),
             range_gets: self.range_gets.load(Ordering::Relaxed),
+            splits_total: self.splits_total.load(Ordering::Relaxed),
+            splits_pruned: self.splits_pruned.load(Ordering::Relaxed),
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
@@ -293,6 +309,12 @@ pub struct IoTraceSnapshot {
     pub delete_ops: u64,
     pub bytes_read: u64,
     pub range_gets: u64,
+    /// Candidate row-group splits considered by scans (TD-OLAP-3).
+    #[serde(default)]
+    pub splits_total: u64,
+    /// Splits skipped before fetch — with `splits_total`, the skip ratio.
+    #[serde(default)]
+    pub splits_pruned: u64,
     pub bytes_written: u64,
     pub footer_hits: u64,
     pub footer_misses: u64,
@@ -432,6 +454,14 @@ pub fn record_bytes_read(bytes: u64) {
 /// exists to remove. Silently no-ops outside an active scope.
 pub fn record_range_gets(gets: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_range_gets(gets));
+}
+
+/// Record a scan's split-pruning outcome for the active query (TD-OLAP-3).
+/// Core counter (always-on, like `record_range_gets`): the runtime-filter
+/// promotion gate reads `splits_pruned / splits_total` from the billing
+/// snapshot. Silently no-ops outside an active scope.
+pub fn record_splits(total: u64, pruned: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_splits(total, pruned));
 }
 
 /// Add to bytes written to object storage for the active query.


### PR DESCRIPTION
## Summary

**ADR-052 execution-order P2a** (TD-OLAP-3). Deep inspection of vendored DataFusion 54 resolved the TD's open mechanism question: **DF natively builds join runtime filters** (min/max bounds + in-list over HashJoin build keys, on by default) and pushes them through the Post-phase filter-pushdown protocol — the custom-wrapper fallback is not needed. What was missing was entirely on our side of the seam:

### Slice A — dormant static pruning fixed (default ON, correctness-neutral)
`ObjectStoreParquetTable` never implemented `supports_filters_pushdown`, so DF kept every WHERE in a `FilterExec` and `scan()` got an **empty filter list** — the split-pruning machinery (and P0a's post-prune statistics) never fired. Now `Inexact` per filter: predicates reach `scan()` for row-group pruning AND the FilterExec stays for exact semantics. Proven end-to-end: `WHERE x > 50` through a real DF session prunes the disjoint row group (2→1 splits), identical results.

### Slice B — join runtime-filter absorption (default OFF, `PROXIMADB_DF_RUNTIME_FILTER_PRUNE=1`)
`ProximaScanExec` implements `handle_child_pushdown_result`, absorbing **only** filters that downcast to `DynamicFilterPhysicalExpr` (static predicates are never claimed — split pruning is inexact; the dynamic filter is a pure optimization hint, the join re-applies exact semantics). At `execute()` the filter is `snapshot()`-resolved (post-build), translated by the new conservative `physical_filter_translate` walker (And/cmp/InList → `ScalarPredicate`; unrecognized shapes prune **nothing**), and splits are pruned before fetch. Default-off per the TD's trace-gated rollout; promote on ledger evidence.

### Slice C — skip-ratio evidence
`splits_total`/`splits_pruned` io_trace counters (additive) emitted from both prune stages; the TPC perf ledger picks them up automatically via its flattened `IoTraceSnapshot` — the promotion gate's evidence lands in the TD-OLAP-4 artifact for free.

### Verification
- TPC-H **22/22** + TPC-DS **16/16** conformance green with the gate **off and on**; `pgwire_olap_delta_merge_e2e` green.
- 9 new unit tests: translator (bounds conjunction, in-list + reversed comparison, OR/placeholder/negated-list conservatism), end-to-end dynamic-filter prune at execute (snapshot→translate→`can_prune_scalar`), WHERE-reaches-scan proof with result-correctness check.
- Clippy gate clean, fmt clean, server binary builds, td-adr-unique + evidence-ledger + attribution guards green.
- TD-OLAP-3 status updated: mechanism resolved; remaining = gate promotion on ledger evidence, bloom consumer for high-NDV in-lists, partition-level DPP once Iceberg partitioning lands.

Refs: ADR-052 (P2a), TD-OLAP-3, TD-OLAP-4, TD-DFR-1, TD-158/ADR-030.