### PR TITLE
fix(pgwire): cross-modal table functions reachable over pgwire + ship datafusion in the server

### DIFF
--- a/apps/proximadb-server/Cargo.toml
+++ b/apps/proximadb-server/Cargo.toml
@@ -14,7 +14,31 @@ name = "proximadb-server"
 path = "src/main.rs"
 
 [features]
-default = []
+# The server ships the engine's PRODUCTION default feature set. The root `proximadb`
+# crate defaults these on, but this crate declares `default-features = false` on it (to
+# keep the cloud backends opt-in), which previously ALSO dropped the core engine features
+# for every `cargo build -p proximadb-server` / `--bin proximadb-server` build (the
+# Dockerfile, CI `_shared-build`, and release workflows) — silently shipping a server with
+# NO DataFusion OLAP route, no SQL frontend, etc. They only linked in under the
+# whole-workspace `--profile release-server` build by feature-unification side-effect.
+# Forward them explicitly so every build path matches the intended production binary.
+default = [
+    "datafusion-integration",
+    "sql_frontend",
+    "canonical-document-store",
+    "graph-first-sks",
+    "unified-facade-routing",
+    "otlp-metering",
+]
+# The cross-modal OLAP query plane (pgwire → DataFusion): the DataFusion engine + the
+# cross-modal table functions (vector_search / timeseries_range). Without it, parquet-backed
+# tables route to the native Volcano engine and the cross-modal UDTFs are not registered.
+datafusion-integration = ["proximadb/datafusion-integration"]
+sql_frontend = ["proximadb/sql_frontend"]
+canonical-document-store = ["proximadb/canonical-document-store"]
+graph-first-sks = ["proximadb/graph-first-sks"]
+unified-facade-routing = ["proximadb/unified-facade-routing"]
+otlp-metering = ["proximadb/otlp-metering"]
 # Build with real ONNX inference. Adds the ort + ndarray runtime, downloads
 # a prebuilt ONNX Runtime binary at build time, and links the resulting
 # native library into the server. Required for production embedding;

--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -828,6 +828,14 @@ fn lower_table_factor(
     catalog: &dyn CatalogLookup,
 ) -> Result<(LogicalNode, Scope), FrontendError> {
     match tf {
+        // A table-valued function `FROM name(args)` (a cross-modal source such as
+        // vector_search / timeseries_range / graph_traverse) is not a catalog table.
+        // Decline it cleanly so the pgwire path falls back to DataFusion's SQL planner
+        // (where the UDTF is registered) instead of mis-lowering it as a bare scan with
+        // its args dropped.
+        TableFactor::Table { args: Some(_), .. } => {
+            Err(FrontendError::Unsupported("table-valued function".into()))
+        }
         TableFactor::Table { name, alias, .. } => {
             let table_name = name.to_string();
             let schema = catalog

--- a/docs/10-quality/td/TD-XMODAL-6-crossmodal-udtf-live-data-visibility.adoc
+++ b/docs/10-quality/td/TD-XMODAL-6-crossmodal-udtf-live-data-visibility.adoc
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-XMODAL-6: cross-modal UDTFs over pgwire return 0 rows for live-written data (tenant/read-path scoping)
+
+[cols="1,3"]
+|===
+|Status|Open
+|Priority|HIGH
+|Scope|FEAT
+|Date|2026-07-04
+|Relates to|ADR-053 (cross-modal query fabric), `src/datafusion/cross_modal.rs` (`VectorSearchTableProvider`, `TimeseriesRangeTableProvider`), `src/datafusion/mod.rs::build_session_context`, the pgwire→DataFusion path (`src/network/postgres/relational_pipeline.rs`, `src/query/execution/datafusion_engine.rs`), `VectorOpsPort` / `timeseries_service()`. Follow-on to the pgwire→UDTF reachability fix.
+|===
+
+== Context
+
+With the reachability fix (table-functions route to the DataFusion `ctx.sql` fallback) and
+`datafusion-integration` in the server's default features, a cross-modal join now **executes**
+over a real pgwire session:
+
+[source,sql]
+----
+SELECT d.id, v.score FROM wh d JOIN vector_search('sig','[0.1,0.2]',5) v ON d.id = v.id;   -- runs
+SELECT count(*)      FROM wh d CROSS JOIN timeseries_range('ts', 0, 9e9) t;                 -- runs
+----
+
+But both return **0 rows** for data written moments earlier via the v2 REST surface, even though
+REST reads that same data back:
+
+* `POST /api/v2/collections/de_vec/records/batch` (3 vectors) → REST `search` returns all 3, but the
+  pgwire `vector_search` UDTF's `scan()` returns 0 (log: search reaches `de_vec` but finds 0 records).
+* `POST /api/v2/timeseries/collections/ts_seeded/ingest` (3 points) → REST `query` returns all 3, but
+  the pgwire `timeseries_range` UDTF returns 0 — **even though both the REST handler and the UDTF use
+  the same process-global `timeseries_service()`**.
+
+The route/plan are correct (`Compute Route: DataFusionLocal` → frontend declines the table-function →
+`ctx.sql` fallback → UDTF `scan()` invoked). The gap is **data visibility on the UDTF read path**.
+
+== Root-cause hypothesis (to confirm)
+
+The UDTF providers issue their read with **`tenant_id = None`** (`cross_modal.rs`
+`VectorSearchTableProvider::new(..., None)`), while REST writes/reads under a concrete (default)
+tenant. The pgwire connection's tenant (the startup `dbname`/catalog) is **not threaded into
+`build_session_context` / the UDTF**, so the modality read is unscoped (or scoped to the wrong
+tenant) relative to where the data lives. The timeseries case (shared global, still 0) suggests the
+same tenant/partition-scoping mismatch in `TimeSeriesService::query`, or a freshness/flush boundary
+the UDTF read does not cross (the vector log shows `wal_delta_records_scanned=0`, `watermark_lsn=0`).
+
+== Proposed fix
+
+1. **Thread the connection tenant** through `QueryExecutionContext` → `prepare_dataframe` →
+   `build_session_context` → the UDTF providers, so `vector_search` / `timeseries_range` /
+   (future) `graph_traverse` read under the same `TenantContext` the pgwire session carries — the
+   co-design invariant (`TenantContext` at every I/O boundary), not `None`.
+2. **Cross the freshness boundary**: ensure the UDTF read includes unflushed WAL/memtable state
+   (Strong freshness) so REST-just-written data is visible without a manual flush — mirror the REST
+   read path's freshness handling.
+3. **Ratchet**: extend `tests/pgwire_crossmodal_join_e2e.rs` to seed vector + timeseries data (via the
+   in-process services under the connection tenant) and assert the join returns the **expected rows**
+   (not just that it executes) — the value-level proof the reachability test defers.
+
+== Impact / gating
+
+Blocks the data-engineering demo (`demo/data-engineering/`, PR-C) from showing **real** joined rows —
+today it can only show that the cross-modal query is reachable/plannable. Once fixed, the zero-ETL
+`relational ⋈ vector ⋈ timeseries ⋈ graph` join returns live results over pgwire.

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -1868,7 +1868,18 @@ fn collect_from_table_with_joins(twj: &TableWithJoins, out: &mut Vec<String>) {
 
 fn collect_from_table_factor(factor: &TableFactor, out: &mut Vec<String>) {
     match factor {
-        TableFactor::Table { name, .. } => out.push(name.to_string()),
+        // A `FROM name(args)` item is a table-valued function (cross-modal source:
+        // vector_search / timeseries_range / graph_traverse), NOT a catalog table.
+        // Collecting it as a table name makes catalog resolution decline the query to
+        // the legacy path AND breaks the parquet-backed route check. Skip it here and
+        // let the DataFusion `ctx.sql` fallback (which has the UDTFs registered) resolve it.
+        // Only a plain `name` (args: None) is a catalog table. A `FROM name(args)` item is a
+        // table-valued function (cross-modal source: vector_search / timeseries_range /
+        // graph_traverse) — it matches neither arm below, falls through to `_`, and is left for
+        // the DataFusion `ctx.sql` fallback (where the UDTFs are registered) to resolve.
+        TableFactor::Table {
+            name, args: None, ..
+        } => out.push(name.to_string()),
         TableFactor::Derived { subquery, .. } => collect_table_names(subquery, out),
         _ => {}
     }

--- a/tests/pgwire_crossmodal_join_e2e.rs
+++ b/tests/pgwire_crossmodal_join_e2e.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-modal table-function reachability over pgwire — e2e.
+//!
+//! Proves the routing fix: a `SELECT … FROM <materialized parquet table>
+//! JOIN vector_search(…) / timeseries_range(…)` executes through the DataFusion
+//! OLAP route over a real pgwire session, instead of declining to the legacy
+//! single-table path (which reported "Column '…' does not exist").
+//!
+//! Two blockers were fixed: (1) `collect_from_table_factor` treated a
+//! table-valued function `name(args)` as a catalog table, so catalog resolution
+//! declined the query AND the parquet-backed route check failed; skipping
+//! args-bearing factors routes it to DataFusion. (2) the shared relational
+//! frontend now cleanly declines a table-function so the existing DataFusion
+//! `ctx.sql` fallback (where the UDTFs are registered) resolves it.
+//!
+//! Gated on `datafusion-integration`: the UDTFs + the OLAP route only exist
+//! there. Run:
+//!   cargo test --features datafusion-integration --test pgwire_crossmodal_join_e2e -- --nocapture
+#![cfg(feature = "datafusion-integration")]
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+async fn connect(server: &PgServer) -> tokio_postgres::Client {
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+}
+
+/// Run a query expected to SUCCEED (no error), returning the first cell as i64.
+async fn count(client: &tokio_postgres::Client, sql: &str) -> i64 {
+    let msgs = client.simple_query(sql).await.unwrap_or_else(|e| {
+        let detail = e
+            .as_db_error()
+            .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+            .unwrap_or_else(|| e.to_string());
+        panic!("cross-modal query declined (reachability regression): `{sql}` -> {detail}");
+    });
+    msgs.into_iter()
+        .find_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => {
+                r.get(0).and_then(|s| s.parse::<i64>().ok())
+            }
+            _ => None,
+        })
+        .unwrap_or(i64::MIN)
+}
+
+/// A materialized (parquet-backed) table JOINed with the `vector_search` and
+/// `timeseries_range` table functions PLANS + EXECUTES through the DataFusion
+/// OLAP route over pgwire — it does not decline to the legacy path. (Row
+/// visibility of live-written UDTF data is covered separately; here the fix is
+/// that the query is *reachable* and returns a well-formed result rather than a
+/// "column does not exist" decline.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn crossmodal_udtf_join_reaches_datafusion_over_pgwire() {
+    let server = PgServer::start().await.expect("server start");
+    let client = connect(&server).await;
+
+    // Unique per run — the native catalog persists table DDL outside the per-test
+    // tempdir, so a fixed name collides across runs.
+    let wh = format!("wh_{}", server.pg_port);
+    client
+        .simple_query(&format!("DROP TABLE IF EXISTS {wh}"))
+        .await
+        .ok();
+    client
+        .simple_query(&format!("CREATE TABLE {wh} (id TEXT, tier TEXT)"))
+        .await
+        .expect("create");
+    client
+        .simple_query(&format!(
+            "INSERT INTO {wh} VALUES ('a','private'),('b','retail'),('z','private')"
+        ))
+        .await
+        .expect("insert");
+    client
+        .simple_query(&format!("ALTER TABLE {wh} MATERIALIZE"))
+        .await
+        .expect("materialize");
+
+    // Baseline: a plain aggregate on the materialized table succeeds (routes OLAP).
+    assert_eq!(
+        count(&client, &format!("SELECT count(*) FROM {wh}")).await,
+        3
+    );
+
+    // The cross-modal join must REACH the DataFusion UDTF, not decline to the legacy
+    // single-table path. Before the fix it declined with "Column 'score' does not exist
+    // in table '{wh}'". After the fix the query routes to DataFusion, resolves the
+    // `vector_search` UDTF, and invokes it — which for a missing collection surfaces a
+    // UDTF-INTERNAL error ("vector search: Collection … not found"). That internal error
+    // is itself the proof the UDTF was reached; only the "does not exist in table" decline
+    // is a reachability regression.
+    let vjoin = format!(
+        "SELECT count(*) FROM {wh} d JOIN vector_search('sig','[0.1,0.2]',5) v ON d.id = v.id"
+    );
+    match client.simple_query(&vjoin).await {
+        Ok(_) => {} // planned + executed (empty/rows) — reachable
+        Err(e) => {
+            let msg = e
+                .as_db_error()
+                .map(|d| d.message().to_string())
+                .unwrap_or_else(|| e.to_string());
+            assert!(
+                !msg.contains("does not exist in table"),
+                "vector_search declined to legacy (reachability regression): {msg}"
+            );
+            assert!(
+                msg.contains("vector search") || msg.to_lowercase().contains("collection"),
+                "expected a UDTF-internal error proving the UDTF was reached, got: {msg}"
+            );
+        }
+    }
+
+    // `timeseries_range` is graceful on a missing collection (empty), so the join executes
+    // cleanly and returns a well-formed count — the end-to-end proof of the DataFusion
+    // route + frontend decline → `ctx.sql` fallback → UDTF resolution.
+    let tsrange = count(
+        &client,
+        &format!("SELECT count(*) FROM {wh} d CROSS JOIN timeseries_range('ts', 0, 9999999) t"),
+    )
+    .await;
+    assert!(
+        tsrange >= 0,
+        "timeseries_range join must execute, got {tsrange}"
+    );
+}


### PR DESCRIPTION
Driving the cross-modal fabric (ADR-053) through a **real pgwire session** surfaced that the fabric worked only *in-process* (the #665 unit test), never over pgwire: `SELECT … FROM <materialized parquet table> JOIN vector_search(…)/timeseries_range(…)` failed with *"Column 'score' does not exist"*. Two root causes, both fixed and verified over a live `psql` session.

## 1. Table-valued functions were mistaken for catalog tables
In `relational_pipeline.rs`, `collect_from_table_factor` pushed `vector_search` as a table **name** (dropping its `args`), which:
- **(a)** failed catalog resolution → the new relational pipeline **declined to the legacy single-table path** (the error source), and
- **(b)** broke the `parquet_backed = tables.keys().all(parquet_loc)` route check → **misrouted to native Volcano**.

**Fix:** skip args-bearing (table-function) factors so the UDTF drops out of name collection. The query then routes to **DataFusionLocal**, `lower_sql` declines the table-function, and the **existing `ctx.sql` fallback** (where the UDTFs are registered) resolves it. Also hardened `lower_table_factor` in the shared relational frontend to decline table-functions cleanly.

## 2. The server binary shipped WITHOUT `datafusion-integration`
`apps/proximadb-server` had `default = []` **and** `proximadb = { default-features = false }`, so `cargo build -p proximadb-server` / `--bin proximadb-server` — i.e. the **Dockerfile, CI `_shared-build`, and release workflows** — silently dropped the **entire DataFusion OLAP route + the cross-modal UDTFs**. It only linked in under the whole-workspace `--profile release-server` build, by feature-unification *side-effect*.

**Fix:** the server crate now forwards the engine's production defaults (`datafusion-integration`, `sql_frontend`, `canonical-document-store`, `graph-first-sks`, `unified-facade-routing`, `otlp-metering`) as its own defaults, so **every build path matches the intended production binary**.

## Verified
- A plain `cargo build -p proximadb-server` now yields a datafusion-baked binary; a materialized-table query routes to **`DataFusionLocal`** (was Native).
- The cross-modal join reaches + invokes the UDTFs over pgwire (`tests/pgwire_crossmodal_join_e2e.rs`, green): `vector_search` surfaces a UDTF-internal error (proving it's *reached*, not declined); `timeseries_range` executes cleanly.

## Follow-up
`TD-XMODAL-6` tracks the remaining **data-visibility gap**: the UDTFs execute but return 0 rows for live-written data (tenant/freshness scoping on the read path — the UDTF passes `tenant_id=None`). That's the next increment before the data-engineering demo (PR-C) can show real joined rows.