### PR TITLE
chore(td-123): refresh v1-proto-usage baseline to post-9b floor (2940→2917)

### DIFF
--- a/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
+++ b/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
@@ -9,8 +9,8 @@
     "/v1_pb2/",
     "check_v1_proto_usage.py"
   ],
-  "file_count": 491,
-  "generated_at": "2026-07-02T03:08:34Z",
+  "file_count": 483,
+  "generated_at": "2026-07-04T21:08:21Z",
   "mode": "report",
   "patterns": [
     "proximadb_v1",
@@ -20,8 +20,8 @@
   "per_root": {
     "clients": 41,
     "crates": 99,
-    "src": 2415,
-    "tests": 385
+    "src": 2403,
+    "tests": 374
   },
   "roots": [
     "src",
@@ -30,5 +30,5 @@
     "tests"
   ],
   "schema_version": 1,
-  "total": 2940
+  "total": 2917
 }


### PR DESCRIPTION
## Summary

Locks in the v1-proto reduction from M1-3 9b (#653 — deleted the streaming writer + `use VectorRecord` import + ~4500 lines of legacy tests). The TD-123 downward-only ratchet was still enforcing the stale 2940 floor; current develop measures **2917**, so this refreshes the baseline so the ratchet enforces 2917 going forward (delta +0).

`docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json`: total 2940→2917 (src 2415→2403 −12, tests 385→374 −11); file_count 491→483.

## Verification
- Regenerated via `make v1-proto-usage-baseline`.
- `make v1-proto-usage-no-regression` passes (delta +0).

Tiny chore — JSON-only. No code change.