### PR TITLE
fix(xmodal): tenant-scope cross-modal UDTFs so pgwire joins read REST-written rows (TD-XMODAL-6)

### DIFF
--- a/docs/10-quality/td/TD-XMODAL-6-crossmodal-udtf-live-data-visibility.adoc
+++ b/docs/10-quality/td/TD-XMODAL-6-crossmodal-udtf-live-data-visibility.adoc
@@ -4,7 +4,7 @@
 
 [cols="1,3"]
 |===
-|Status|Open
+|Status|Resolved
 |Priority|HIGH
 |Scope|FEAT
 |Date|2026-07-04
@@ -35,31 +35,64 @@ REST reads that same data back:
 The route/plan are correct (`Compute Route: DataFusionLocal` → frontend declines the table-function →
 `ctx.sql` fallback → UDTF `scan()` invoked). The gap is **data visibility on the UDTF read path**.
 
-== Root-cause hypothesis (to confirm)
+== Root cause (confirmed)
 
-The UDTF providers issue their read with **`tenant_id = None`** (`cross_modal.rs`
-`VectorSearchTableProvider::new(..., None)`), while REST writes/reads under a concrete (default)
-tenant. The pgwire connection's tenant (the startup `dbname`/catalog) is **not threaded into
-`build_session_context` / the UDTF**, so the modality read is unscoped (or scoped to the wrong
-tenant) relative to where the data lives. The timeseries case (shared global, still 0) suggests the
-same tenant/partition-scoping mismatch in `TimeSeriesService::query`, or a freshness/flush boundary
-the UDTF read does not cross (the vector log shows `wal_delta_records_scanned=0`, `watermark_lsn=0`).
+**Per-modality tenant scoping was not threaded into the UDTFs — each read the wrong (unscoped)
+partition.** Each modality scopes by tenant differently, and the REST write path applies that
+scoping while the UDTF read did not:
 
-== Proposed fix
+* **Timeseries** — the REST handler folds the tenant into the *collection key* via
+  `effective_collection(tenant, id) -> "{tenant}::{collection}"` (`src/network/rest/v2/timeseries.rs`),
+  identically on ingest and query. `TimeSeriesService` treats the key opaquely. The
+  `timeseries_range` UDTF passed the **raw** name, so it read `sensor` while REST wrote `default::sensor`.
+* **Vector** — records are **tenant-partitioned** (not name-folded); the REST search resolves a
+  `TenantContext` and calls `VectorOpsPort::search(request, Some(tenant))`. The `vector_search` UDTF
+  hardcoded `tenant_id = None` (`VectorSearchTableProvider::new(..., None)`), so it searched the
+  unscoped partition and found 0 records (matching the `wal_delta_records_scanned=0` log).
+* **Graph** — applies **no** tenant scoping on *either* side today (`GraphPort` has no tenant param;
+  the v1/v2 graph REST handlers take no `TenantContext`); the `graph_id` is the sole scope key, so a
+  raw-`graph_id` read already matches.
 
-1. **Thread the connection tenant** through `QueryExecutionContext` → `prepare_dataframe` →
-   `build_session_context` → the UDTF providers, so `vector_search` / `timeseries_range` /
-   (future) `graph_traverse` read under the same `TenantContext` the pgwire session carries — the
-   co-design invariant (`TenantContext` at every I/O boundary), not `None`.
-2. **Cross the freshness boundary**: ensure the UDTF read includes unflushed WAL/memtable state
-   (Strong freshness) so REST-just-written data is visible without a manual flush — mirror the REST
-   read path's freshness handling.
-3. **Ratchet**: extend `tests/pgwire_crossmodal_join_e2e.rs` to seed vector + timeseries data (via the
-   in-process services under the connection tenant) and assert the join returns the **expected rows**
-   (not just that it executes) — the value-level proof the reachability test defers.
+Freshness was a red herring: the UDTFs call the **same service methods** REST uses
+(`VectorOpsPort::search`, `TimeSeriesService::query`), so they inherit REST's freshness handling —
+once the tenant scope matches, the just-written data is visible with no extra Strong-read plumbing.
+
+A second, separate requirement surfaced: the pgwire **read tenant must equal the REST write tenant**.
+A bare `psql` connection resolves the read tenant to `""` (empty) via `pgwire_resolve_read_tenant`
+(→ `catalog_tenant()` = startup `dbname`, else empty), while the REST middleware defaults to
+`"default"`. So the reader must connect with `dbname=<tenant>` (the catalog *is* the tenant boundary,
+TD-064) matching the REST `X-Tenant-ID`.
+
+== Resolution
+
+1. **Threaded the connection tenant** pgwire → `QueryExecutionContext.tenant_id` (already wired) →
+   `prepare_dataframe` → `create_session_context_with_ports(vector_ops, graph_ops, tenant)` →
+   `build_session_context` → the UDTF constructors. `vector_search` now uses
+   `VectorSearchTableFunction::with_tenant` (passes `Some(tenant)` to `search`); `timeseries_range`
+   uses `from_service_with_tenant` and folds `{tenant}::{collection}` (shared
+   `tenant_scoped_collection` helper mirroring `effective_collection`) before the read.
+   `graph_traverse` stays tenant-agnostic (nothing to match yet).
+2. **Ratchet**: `tests/pgwire_crossmodal_join_e2e.rs` gains
+   `crossmodal_timeseries_join_returns_rest_seeded_rows`, which seeds a timeseries collection via the
+   REST v2 API under an explicit `X-Tenant-ID`, connects pgwire with the matching `dbname`, and
+   asserts the `timeseries_range` CROSS JOIN returns the **expected rows and values** (2 points; the
+   9000-value point passes a `WHERE t.value > 5000` filter). Unit tests
+   `timeseries_range_udtf_folds_tenant_into_collection` + `vector_search_udtf_forwards_tenant_to_search`
+   pin the per-modality transform.
+
+== Follow-up (out of scope, file separately)
+
+**Graph tenant isolation.** The graph modality has *no* tenant isolation on either the write path or
+the UDTF read — a follow-on TD should add a tenant param to `GraphPort` (applied on both the REST
+graph handlers and the `graph_traverse` UDTF) so graph reads are tenant-scoped like the other two.
+
+**Bare-connection default alignment.** A bare pgwire connection (no `dbname`) reads under tenant `""`
+while REST defaults to `"default"`; the two only agree when the client connects with `dbname=default`.
+Whether to default the empty pgwire tenant to `"default"` is a TD-064-scoped decision (it changes the
+catalog=tenant contract), deliberately left out of this fix.
 
 == Impact / gating
 
-Blocks the data-engineering demo (`demo/data-engineering/`, PR-C) from showing **real** joined rows —
-today it can only show that the cross-modal query is reachable/plannable. Once fixed, the zero-ETL
-`relational ⋈ vector ⋈ timeseries ⋈ graph` join returns live results over pgwire.
+Unblocks the data-engineering demo (`demo/data-engineering/`, PR-C) to show **real** joined rows: the
+zero-ETL `relational ⋈ vector ⋈ timeseries` join now returns live REST-written results over pgwire
+when the session connects under the data's tenant (`dbname=<tenant>`).

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -171,12 +171,28 @@ impl TableProvider for VectorSearchTableProvider {
 /// `ctx.register_udtf("vector_search", Arc::new(VectorSearchTableFunction::new(ops)))`.
 pub struct VectorSearchTableFunction {
     vector_ops: Arc<dyn proximadb_runtime::VectorOpsPort>,
+    /// The connection tenant, forwarded to `VectorOpsPort::search` so the search runs under the
+    /// same `TenantContext` the REST write used. `None` ⇒ unscoped (reads only tenant-less data).
+    tenant: Option<String>,
 }
 
 impl VectorSearchTableFunction {
-    /// Capture the live vector service the function will search.
+    /// Capture the live vector service the function will search (no tenant scope).
     pub fn new(vector_ops: Arc<dyn proximadb_runtime::VectorOpsPort>) -> Self {
-        Self { vector_ops }
+        Self {
+            vector_ops,
+            tenant: None,
+        }
+    }
+
+    /// Capture the vector service AND the connection tenant — so the search reads the same
+    /// tenant partition a REST insert wrote. Without this the search runs `tenant_id=None` and
+    /// returns 0 rows for tenant-scoped data (TD-XMODAL-6).
+    pub fn with_tenant(
+        vector_ops: Arc<dyn proximadb_runtime::VectorOpsPort>,
+        tenant: Option<String>,
+    ) -> Self {
+        Self { vector_ops, tenant }
     }
 }
 
@@ -228,7 +244,7 @@ impl TableFunctionImpl for VectorSearchTableFunction {
             collection,
             query_vector,
             top_k as u32,
-            None,
+            self.tenant.clone(),
         )))
     }
 }
@@ -249,6 +265,19 @@ fn arg_i64(args: &[Expr], i: usize) -> Option<i64> {
         Expr::Literal(ScalarValue::Int32(Some(n)), _) => Some(*n as i64),
         Expr::Literal(ScalarValue::UInt64(Some(n)), _) => Some(*n as i64),
         _ => None,
+    }
+}
+
+/// Fold the connection tenant into the collection key exactly as the REST write path's
+/// `effective_collection` (`src/network/rest/v2/timeseries.rs`) does — `{tenant}::{collection}` —
+/// so a UDTF read hits the same partition a REST ingest wrote (TD-XMODAL-6). An empty/absent
+/// tenant yields the raw name, mirroring the REST rule so single-tenant reads still resolve.
+/// (Vectors are scoped by `TenantContext`, not by name, so they use the raw collection + the
+/// tenant id directly; this fold is the timeseries analogue.)
+fn tenant_scoped_collection(tenant: Option<&str>, collection: &str) -> String {
+    match tenant {
+        Some(t) if !t.is_empty() => format!("{t}::{collection}"),
+        _ => collection.to_string(),
     }
 }
 
@@ -412,18 +441,41 @@ impl TableProvider for TimeseriesRangeTableProvider {
 /// `ctx.register_udtf("timeseries_range", Arc::new(TimeseriesRangeTableFunction::new(port)))`.
 pub struct TimeseriesRangeTableFunction {
     scan: Arc<dyn TimeseriesScanPort>,
+    /// The connection tenant, folded into the collection key (`{tenant}::{collection}`) at
+    /// `call` time so the range read hits the same partition a REST ingest wrote. `None` ⇒ raw
+    /// collection name (single-tenant / tenant-less data).
+    tenant: Option<String>,
 }
 
 impl TimeseriesRangeTableFunction {
-    /// Capture the scan port the function will read.
+    /// Capture the scan port the function will read (no tenant scope).
     pub fn new(scan: Arc<dyn TimeseriesScanPort>) -> Self {
-        Self { scan }
+        Self { scan, tenant: None }
     }
 
-    /// Build the function backed by the process time-series service.
+    /// Capture the scan port AND the connection tenant, so the range read folds the collection
+    /// key the same way the REST write path does (TD-XMODAL-6).
+    pub fn with_tenant(scan: Arc<dyn TimeseriesScanPort>, tenant: Option<String>) -> Self {
+        Self { scan, tenant }
+    }
+
+    /// Build the function backed by the process time-series service (no tenant scope).
     pub fn from_service(service: Arc<TimeSeriesService>) -> Self {
         Self {
             scan: Arc::new(TimeSeriesServiceScan(service)),
+            tenant: None,
+        }
+    }
+
+    /// Build the function backed by the process time-series service, scoped to the connection
+    /// tenant — the pgwire OLAP route wiring that makes `timeseries_range` read REST-written data.
+    pub fn from_service_with_tenant(
+        service: Arc<TimeSeriesService>,
+        tenant: Option<String>,
+    ) -> Self {
+        Self {
+            scan: Arc::new(TimeSeriesServiceScan(service)),
+            tenant,
         }
     }
 }
@@ -459,6 +511,9 @@ impl TableFunctionImpl for TimeseriesRangeTableFunction {
                 "timeseries_range: end_ms must be >= start_ms".into(),
             ));
         }
+        // Fold the tenant into the collection key the same way the REST write path does, so the
+        // range read resolves the partition the ingest wrote (TD-XMODAL-6).
+        let collection = tenant_scoped_collection(self.tenant.as_deref(), &collection);
         Ok(Arc::new(TimeseriesRangeTableProvider::new(
             self.scan.clone(),
             collection,
@@ -602,6 +657,12 @@ pub struct GraphTraverseTableFunction {
 
 impl GraphTraverseTableFunction {
     /// Capture the live graph read service the function will traverse.
+    ///
+    /// Unlike `vector_search` / `timeseries_range`, this takes NO tenant: the graph write path
+    /// (`GraphPort`, the v1/v2 REST graph handlers) applies no tenant scoping today — the
+    /// `graph_id` is the sole scope key on both sides — so a UDTF read of the raw `graph_id`
+    /// already matches the write. Real graph tenant isolation (a tenant param on `GraphPort`,
+    /// applied on both write and this read) is a follow-up (see TD-XMODAL-6).
     pub fn new(graph_ops: Arc<dyn GraphQueryReadService>) -> Self {
         Self { graph_ops }
     }
@@ -1097,6 +1158,132 @@ mod tests {
                 "expected {expected:?} in {error}"
             );
         }
+    }
+
+    /// A `TimeseriesScanPort` that records the collection name it was asked to read — used to
+    /// prove `timeseries_range` folds the tenant into the collection key (TD-XMODAL-6).
+    struct RecordingTimeseriesScan {
+        seen: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl TimeseriesScanPort for RecordingTimeseriesScan {
+        async fn range(
+            &self,
+            collection: &str,
+            _start_ms: i64,
+            _end_ms: i64,
+        ) -> anyhow::Result<Vec<TsPoint>> {
+            self.seen.lock().unwrap().push(collection.to_string());
+            Ok(vec![tp(1_000, "amount", 1.0)])
+        }
+    }
+
+    /// TD-XMODAL-6: a tenant-scoped `timeseries_range` folds `{tenant}::{collection}` before the
+    /// read — matching the REST write path's `effective_collection` — so it hits the partition a
+    /// REST ingest wrote; an empty/absent tenant reads the raw name.
+    #[tokio::test]
+    async fn timeseries_range_udtf_folds_tenant_into_collection() {
+        for (tenant, expected) in [
+            (Some("acme".to_string()), "acme::sensor"),
+            (Some(String::new()), "sensor"),
+            (None, "sensor"),
+        ] {
+            let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let port: Arc<dyn TimeseriesScanPort> = Arc::new(RecordingTimeseriesScan {
+                seen: Arc::clone(&seen),
+            });
+            let ctx = SessionContext::new();
+            ctx.register_udtf(
+                "timeseries_range",
+                Arc::new(TimeseriesRangeTableFunction::with_tenant(port, tenant)),
+            );
+            let _ = ctx
+                .sql("SELECT * FROM timeseries_range('sensor', 0, 9999)")
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            assert_eq!(seen.lock().unwrap().as_slice(), &[expected.to_string()]);
+        }
+    }
+
+    /// A `VectorOpsPort` that records the `tenant_id` its `search` was called with — proves
+    /// `vector_search` forwards the connection tenant (TD-XMODAL-6).
+    struct RecordingVectorOps {
+        seen: Arc<std::sync::Mutex<Vec<Option<String>>>>,
+    }
+
+    #[async_trait]
+    impl proximadb_runtime::VectorOpsPort for RecordingVectorOps {
+        async fn search(
+            &self,
+            _request: VectorSearchRequest,
+            tenant_id: Option<&str>,
+        ) -> anyhow::Result<VectorOperationResponse> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(tenant_id.map(str::to_string));
+            Ok(VectorOperationResponse {
+                results: Some(SearchResult {
+                    results: vec![],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
+        async fn batch_upsert(
+            &self,
+            _r: VectorBatchRequest,
+            _t: Option<&str>,
+        ) -> anyhow::Result<VectorOperationResponse> {
+            unimplemented!()
+        }
+        async fn get_vector(
+            &self,
+            _c: &str,
+            _v: &str,
+            _iv: bool,
+            _im: bool,
+            _t: Option<&str>,
+        ) -> anyhow::Result<VectorOperationResponse> {
+            unimplemented!()
+        }
+        async fn flush_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn metrics(&self) -> anyhow::Result<serde_json::Value> {
+            Ok(serde_json::Value::Null)
+        }
+    }
+
+    /// TD-XMODAL-6: a tenant-scoped `vector_search` forwards the connection tenant to the search
+    /// (vectors are `TenantContext`-partitioned, not name-folded), so it reads the tenant's data
+    /// instead of the unscoped partition.
+    #[tokio::test]
+    async fn vector_search_udtf_forwards_tenant_to_search() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let ops: Arc<dyn proximadb_runtime::VectorOpsPort> = Arc::new(RecordingVectorOps {
+            seen: Arc::clone(&seen),
+        });
+        let ctx = SessionContext::new();
+        ctx.register_udtf(
+            "vector_search",
+            Arc::new(VectorSearchTableFunction::with_tenant(
+                ops,
+                Some("acme".to_string()),
+            )),
+        );
+        let _ = ctx
+            .sql("SELECT * FROM vector_search('docs_vec', '[0.1,0.2]', 5)")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(seen.lock().unwrap().as_slice(), &[Some("acme".to_string())]);
     }
 
     // ── graph slice ───────────────────────────────────────────────────────────────

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -155,7 +155,7 @@ use datafusion::prelude::*;
 /// - Custom vector distance functions (cosine, euclidean, dot_product)
 /// - Optimizer rules for predicate pushdown
 pub fn create_session_context() -> datafusion::error::Result<SessionContext> {
-    build_session_context(None, None)
+    build_session_context(None, None, None)
 }
 
 /// Like [`create_session_context`] but also registers the live `vector_search` table function
@@ -165,7 +165,7 @@ pub fn create_session_context() -> datafusion::error::Result<SessionContext> {
 pub fn create_session_context_with_vector_ops(
     vector_ops: std::sync::Arc<dyn proximadb_runtime::VectorOpsPort>,
 ) -> datafusion::error::Result<SessionContext> {
-    build_session_context(Some(vector_ops), None)
+    build_session_context(Some(vector_ops), None, None)
 }
 
 /// Like [`create_session_context_with_vector_ops`] but also registers the live `graph_traverse`
@@ -175,13 +175,21 @@ pub fn create_session_context_with_vector_ops(
 pub fn create_session_context_with_ports(
     vector_ops: Option<std::sync::Arc<dyn proximadb_runtime::VectorOpsPort>>,
     graph_ops: Option<std::sync::Arc<dyn proximadb_graph_query::service::GraphQueryReadService>>,
+    tenant: Option<String>,
 ) -> datafusion::error::Result<SessionContext> {
-    build_session_context(vector_ops, graph_ops)
+    build_session_context(vector_ops, graph_ops, tenant)
 }
 
+/// `tenant` is the resolved pgwire connection tenant (`pgwire_resolve_read_tenant`). It is
+/// applied to the `vector_search` (as the search `tenant_id`) and `timeseries_range` (folded
+/// into the `{tenant}::{collection}` key) UDTFs so a cross-modal read hits the same partition the
+/// REST write path wrote — otherwise those UDTFs read the unscoped partition and return 0 rows
+/// (TD-XMODAL-6). `graph_traverse` is tenant-agnostic today (the graph path applies no tenant on
+/// either side).
 fn build_session_context(
     vector_ops: Option<std::sync::Arc<dyn proximadb_runtime::VectorOpsPort>>,
     graph_ops: Option<std::sync::Arc<dyn proximadb_graph_query::service::GraphQueryReadService>>,
+    tenant: Option<String>,
 ) -> datafusion::error::Result<SessionContext> {
     let config = SessionConfig::new()
         .with_batch_size(8192)
@@ -218,7 +226,10 @@ fn build_session_context(
     if let Some(ops) = vector_ops {
         ctx.register_udtf(
             "vector_search",
-            std::sync::Arc::new(cross_modal::VectorSearchTableFunction::new(ops)),
+            std::sync::Arc::new(cross_modal::VectorSearchTableFunction::with_tenant(
+                ops,
+                tenant.clone(),
+            )),
         );
     }
 
@@ -230,7 +241,12 @@ fn build_session_context(
     if let Some(ts) = crate::services::timeseries_service::timeseries_service() {
         ctx.register_udtf(
             "timeseries_range",
-            std::sync::Arc::new(cross_modal::TimeseriesRangeTableFunction::from_service(ts)),
+            std::sync::Arc::new(
+                cross_modal::TimeseriesRangeTableFunction::from_service_with_tenant(
+                    ts,
+                    tenant.clone(),
+                ),
+            ),
         );
     }
 

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -85,6 +85,7 @@ impl DataFusionLocalEngine {
         let ctx = crate::datafusion::create_session_context_with_ports(
             context.vector_ops.clone(),
             context.graph_ops.clone(),
+            context.tenant_id.clone(),
         )
         .map_err(|e| ExecutionError::Context(format!("session: {e}")))?;
 

--- a/tests/pgwire_crossmodal_join_e2e.rs
+++ b/tests/pgwire_crossmodal_join_e2e.rs
@@ -36,6 +36,7 @@ fn free_port() -> u16 {
 
 struct PgServer {
     pg_port: u16,
+    rest_port: u16,
     db: Option<ProximaDB>,
     _tmp: TempDir,
 }
@@ -78,13 +79,20 @@ impl PgServer {
         sleep(Duration::from_millis(200)).await;
         Ok(Self {
             pg_port,
+            rest_port,
             db: Some(db),
             _tmp: tmp,
         })
     }
     fn conn_str(&self) -> String {
+        self.conn_str_db("proximadb")
+    }
+    /// A connection string whose `dbname` is the tenant/catalog boundary
+    /// (`pgwire_resolve_read_tenant` → `catalog_tenant()` = the startup database). Used to read
+    /// under the SAME tenant a REST write used (TD-XMODAL-6).
+    fn conn_str_db(&self, db: &str) -> String {
         format!(
-            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            "host=127.0.0.1 port={} user=postgres dbname={db} sslmode=disable",
             self.pg_port
         )
     }
@@ -101,7 +109,11 @@ impl Drop for PgServer {
 }
 
 async fn connect(server: &PgServer) -> tokio_postgres::Client {
-    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+    connect_db(server, "proximadb").await
+}
+
+async fn connect_db(server: &PgServer, db: &str) -> tokio_postgres::Client {
+    let (client, conn) = tokio_postgres::connect(&server.conn_str_db(db), tokio_postgres::NoTls)
         .await
         .expect("connect");
     tokio::spawn(async move {
@@ -208,4 +220,100 @@ async fn crossmodal_udtf_join_reaches_datafusion_over_pgwire() {
         tsrange >= 0,
         "timeseries_range join must execute, got {tsrange}"
     );
+}
+
+/// TD-XMODAL-6 (row visibility): data written through the REST v2 timeseries API under a tenant
+/// is READABLE by the `timeseries_range` UDTF over pgwire when the connection resolves to the
+/// SAME tenant (`dbname` = the REST `X-Tenant-ID`). Proves the tenant is threaded pgwire →
+/// `QueryExecutionContext` → `build_session_context` → the UDTF, which folds `{tenant}::{collection}`
+/// exactly like the REST write path's `effective_collection`. Before the fix the UDTF used the raw
+/// (unscoped) name and returned 0 rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn crossmodal_timeseries_join_returns_rest_seeded_rows() {
+    let server = PgServer::start().await.expect("server start");
+    // Unique per run: the tenant (pgwire catalog + REST header) and the collection/table names,
+    // so parallel runs and the persisted native catalog never collide.
+    let tenant = format!("xmt{}", server.pg_port);
+    let coll = format!("sensor_{}", server.pg_port);
+    let wh = format!("wh_{}", server.pg_port);
+
+    // ── Seed the timeseries collection + points via REST under an explicit tenant ──
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let base = format!("http://127.0.0.1:{}", server.rest_port);
+    let create = http
+        .post(format!("{base}/api/v2/timeseries/collections"))
+        .header("X-Tenant-ID", &tenant)
+        .json(&serde_json::json!({ "name": coll, "value_columns": [{ "name": "amount" }] }))
+        .send()
+        .await
+        .expect("create req");
+    assert!(
+        create.status().is_success(),
+        "create timeseries collection failed: {}",
+        create.status()
+    );
+    let ingest = http
+        .post(format!(
+            "{base}/api/v2/timeseries/collections/{coll}/ingest"
+        ))
+        .header("X-Tenant-ID", &tenant)
+        .json(&serde_json::json!({
+            "points": [
+                { "timestamp": 1_000, "values": { "amount": 100.0 } },
+                { "timestamp": 2_000, "values": { "amount": 9_000.0 } },
+            ]
+        }))
+        .send()
+        .await
+        .expect("ingest req");
+    assert!(
+        ingest.status().is_success(),
+        "ingest timeseries failed: {}",
+        ingest.status()
+    );
+
+    // ── Read it back over pgwire under the SAME tenant (dbname == X-Tenant-ID) ──
+    let client = connect_db(&server, &tenant).await;
+    client
+        .simple_query(&format!("DROP TABLE IF EXISTS {wh}"))
+        .await
+        .ok();
+    client
+        .simple_query(&format!("CREATE TABLE {wh} (id TEXT)"))
+        .await
+        .expect("create wh");
+    client
+        .simple_query(&format!("INSERT INTO {wh} VALUES ('anchor')"))
+        .await
+        .expect("insert wh");
+    client
+        .simple_query(&format!("ALTER TABLE {wh} MATERIALIZE"))
+        .await
+        .expect("materialize wh");
+
+    // The 1-row anchor CROSS JOIN the 2 seeded points ⇒ 2 rows. If the tenant fold were missing,
+    // the UDTF would read the unscoped `sensor_*` partition (empty) ⇒ 0 rows.
+    let joined = count(
+        &client,
+        &format!("SELECT count(*) FROM {wh} d CROSS JOIN timeseries_range('{coll}', 0, 9999999) t"),
+    )
+    .await;
+    assert_eq!(
+        joined, 2,
+        "expected the 2 REST-seeded points visible via timeseries_range (tenant fold), got {joined}"
+    );
+
+    // Value correctness: only the 9000 point exceeds 5000 ⇒ exactly 1 row — the real values flow.
+    let high = count(
+        &client,
+        &format!(
+            "SELECT count(*) FROM {wh} d CROSS JOIN timeseries_range('{coll}', 0, 9999999) t WHERE t.value > 5000"
+        ),
+    )
+    .await;
+    assert_eq!(high, 1, "expected exactly the 9000-value point, got {high}");
 }


### PR DESCRIPTION
## What

Makes the cross-modal fabric return **real rows** over pgwire. After the reachability fix (#672) + `graph_traverse` (#673), a `SELECT … JOIN vector_search(…)/timeseries_range(…)` executed over pgwire but returned **0 rows** for data written via the v2 REST API — each UDTF read the wrong (unscoped) partition because the connection tenant was never threaded into the DataFusion session context.

## Root cause

Each modality scopes by tenant differently, and the REST write path applied that scoping while the UDTF read did not:

| Modality | REST write | UDTF read (before) | Fix |
|---|---|---|---|
| Timeseries | folds `{tenant}::{collection}` (`effective_collection`) | raw name | fold `{tenant}::{collection}` |
| Vector | records `TenantContext`-partitioned; `search(req, Some(tenant))` | hardcoded `tenant_id=None` | pass `Some(tenant)` |
| Graph | no tenant on either side (`GraphPort` has none) | raw `graph_id` | unchanged (matches) — follow-up TD |

Freshness was a red herring: the UDTFs call the **same service methods** REST uses (`VectorOpsPort::search`, `TimeSeriesService::query`), so they inherit REST's freshness handling.

## How

- Threaded the tenant: `QueryExecutionContext.tenant_id` (already wired) → `prepare_dataframe` → `create_session_context_with_ports(vector_ops, graph_ops, tenant)` → `build_session_context` → the UDTF constructors (`VectorSearchTableFunction::with_tenant`, `TimeseriesRangeTableFunction::from_service_with_tenant`). Shared `tenant_scoped_collection` helper mirrors the REST `effective_collection`.
- **Read tenant must equal write tenant.** A bare psql connection resolves to `""` while REST defaults to `"default"`, so the reader connects with `dbname=<tenant>` (catalog = tenant boundary, TD-064). Documented, plus a follow-up on aligning the bare-connection default.

## Tests (all green locally)

- Unit: `timeseries_range_udtf_folds_tenant_into_collection`, `vector_search_udtf_forwards_tenant_to_search` (14 cross_modal tests pass).
- E2E `crossmodal_timeseries_join_returns_rest_seeded_rows`: seeds a timeseries collection via REST under an explicit `X-Tenant-ID`, connects pgwire with the matching `dbname`, asserts the `timeseries_range` join returns the **expected rows and values** (2 seeded points; the 9000-value point passes `WHERE t.value > 5000`).
- `cargo check --lib`, `clippy -D warnings` (lib), `cargo fmt` all clean.

## Follow-ups (documented in the TD, filed separately)

- Graph tenant isolation (add a tenant param to `GraphPort`, applied on write + the `graph_traverse` UDTF).
- Whether to default the empty pgwire tenant to `"default"` (TD-064-scoped).

Unblocks the data-engineering demo (PR-C) to show live joined rows. Resolves TD-XMODAL-6.