### PR TITLE
fix(xmodal): harden cross-modal fabric — worker stack (TD-XMODAL-7) + vector UDTF tenant resolution (TD-XMODAL-8)

### DIFF
--- a/apps/proximadb-server/src/main.rs
+++ b/apps/proximadb-server/src/main.rs
@@ -118,8 +118,23 @@ async fn ensure_required_directories(config: &proximadb::core::Config) -> anyhow
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // ProximaDB's pgwire OLAP path plans through DataFusion, whose SQL planner + optimizer recurse
+    // deeply on nested-subquery / cross-modal plans — e.g. a derived table wrapping a
+    // `vector_search` / `timeseries_range` / `graph_traverse` aggregate that is then JOINed to a
+    // Parquet-backed base table. tokio's default 2 MiB worker stack overflows on that recursion and
+    // aborts the WHOLE server (a single crafted query = DoS; TD-XMODAL-7). Databases routinely run
+    // recursive query planners on a larger stack, so give the runtime workers 32 MiB — deep-but-
+    // bounded planning then completes instead of crashing. (Debug builds have much larger frames,
+    // so this also covers the amplified debug-mode overflow.)
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(32 * 1024 * 1024)
+        .build()?;
+    runtime.block_on(run())
+}
+
+async fn run() -> anyhow::Result<()> {
     // Initialize tracing with rolling file appender
     use tracing_appender::rolling::{RollingFileAppender, Rotation};
     use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};

--- a/docs/10-quality/td/TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc
+++ b/docs/10-quality/td/TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc
@@ -1,0 +1,71 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-XMODAL-7: cross-modal UDTF in an aggregating subquery stack-overflows the server over pgwire
+
+[cols="1,3"]
+|===
+|Status|Resolved
+|Priority|HIGH
+|Scope|FEAT
+|Date|2026-07-04
+|Relates to|ADR-053 (cross-modal query fabric), `apps/proximadb-server/src/main.rs` (runtime), the pgwire→DataFusion fallback (`src/query/execution/datafusion_engine.rs::prepare_dataframe`, `src/network/postgres/relational_pipeline.rs`), `src/datafusion/cross_modal.rs`. Follow-on to TD-XMODAL-6.
+|===
+
+== Context
+
+With TD-XMODAL-6 the cross-modal UDTFs return real rows over pgwire. A **data-engineering** query
+that pre-aggregates one modality in a derived table before joining it — the natural analytical shape
+that avoids CROSS JOIN fan-out — **crashed the whole server**:
+
+[source,sql]
+----
+SELECT o.account_id, ts.peak
+FROM orders o
+CROSS JOIN (SELECT max(value) AS peak FROM timeseries_range('acct_txn', 0, 9999999)) ts
+WHERE o.account_id = 'acct-7'
+GROUP BY o.account_id, ts.peak;
+-- server log: thread 'tokio-rt-worker' has overflowed its stack; fatal runtime error: stack overflow, aborting
+----
+
+A single crafted query aborts the process — a **DoS-class** crash (the pgwire client sees
+"server closed the connection unexpectedly"). Reproduced deterministically on an isolated,
+single-tenant instance.
+
+== Root cause
+
+**Deep (not infinite) recursion in DataFusion's SQL planner + optimizer over the default 2 MiB tokio
+worker stack.** The shape that triggers it is a **derived table (or scalar subquery) wrapping a
+cross-modal UDTF, aggregated, then JOINed to a Parquet-backed base table**, executed on the pgwire
+DataFusion fallback (`ctx.sql`, entered when the shared relational frontend declines the
+table-valued function). Bisection:
+
+* A *top-level* UDTF join — even two UDTFs (`… JOIN graph_traverse(…) g CROSS JOIN timeseries_range(…) t`) — plans fine.
+* The same aggregate over a UDTF wrapped in a **subquery/derived table** joined to `orders` recurses.
+* Pure in-process `ctx.sql` with a `MemTable` base does NOT overflow — the recursion depth only
+  crosses the 2 MiB guard page once the real Parquet table provider (`ProximaScanExec`) + the full
+  session builder (`create_session_context_with_ports`, ~a dozen registered UDF/UDTF) are in the plan.
+
+It is **bounded**: a 32 MiB worker stack lets the identical query complete and return the correct rows,
+so this is stack-frame pressure from deeply nested planning, not a cycle. (Debug builds have much
+larger frames and overflow the most readily, but the fix covers release too.)
+
+== Resolution
+
+`apps/proximadb-server/src/main.rs` replaces `#[tokio::main]` with an explicit multi-thread runtime
+that sets `thread_stack_size(32 * 1024 * 1024)`. Databases routinely run recursive query planners on a
+larger stack; 32 MiB clears the observed depth with headroom while staying negligible against the
+box's memory. After the fix, the previously-crashing single-UDTF-subquery and the combined
+`relational ⋈ timeseries ⋈ graph` subquery form both return correct rows and the server stays up.
+
+A regression test (`src/datafusion/cross_modal.rs::udtf_in_aggregating_subquery_does_not_recurse`)
+pins the in-process planning shape; the pgwire end-to-end shape is exercised by the demo
+(`demo/data-engineering/`) and manual verification.
+
+== Follow-up (out of scope)
+
+* **Bound the planner depth explicitly.** A 32 MiB stack is a safety margin, not a semantic limit; a
+  future change could cap subquery/plan nesting (a `recursion_limit`-style guard) and return a clean
+  SQL error instead of relying on stack size for pathological (adversarial) nesting depths.
+* **Localize the DataFusion interaction.** Narrow which optimizer pass drives the depth (candidate:
+  subquery decorrelation / projection pushdown interacting with the custom `TableProvider`) and, if a
+  DataFusion upstream fix exists, adopt it so the large stack is belt-and-suspenders.

--- a/docs/10-quality/td/TD-XMODAL-8-vector-search-udtf-tenant-resolution.adoc
+++ b/docs/10-quality/td/TD-XMODAL-8-vector-search-udtf-tenant-resolution.adoc
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-XMODAL-8: cross-modal `vector_search` UDTF returns 0 rows — port ignores the tenant
+
+[cols="1,3"]
+|===
+|Status|Resolved
+|Priority|HIGH
+|Scope|FEAT
+|Date|2026-07-04
+|Relates to|ADR-053 (cross-modal query fabric), `src/services/operations/vectors/legacy.rs` (`impl VectorOpsPort for VectorOperationsService`), `src/api_handlers/record_ops_service.rs::resolve_collection_id_internal`, `crates/platform/proximadb-runtime` (`CollectionPort::get_collection`), `src/datafusion/cross_modal.rs`. Follow-on to TD-XMODAL-6.
+|===
+
+== Context
+
+TD-XMODAL-6 threads the pgwire connection tenant into the cross-modal UDTFs. `timeseries_range`
+(name-folded) and `graph_traverse` (no tenant scoping) then read live REST-written data over pgwire.
+`vector_search` still returned **0 rows** for a collection created + populated via the v2 REST API
+under the same tenant, even though a REST `/search` on that collection returned the records.
+
+== Root cause
+
+The `vector_search` UDTF calls `VectorOpsPort::search(request, tenant_id)`. The production impl
+(`impl VectorOpsPort for VectorOperationsService`, `legacy.rs`) took `tenant_id` but **ignored it** —
+it called `search_v1(request)`, which resolves the collection name against the **unscoped** registry.
+
+The REST record path scopes differently: `RecordOpsService::handle_record_search_for_tenant` →
+`resolve_collection_id_internal(name, tenant_context)` → `collection_port.get_collection(name, tenant)`
+→ the tenant-scoped collection's canonical **id**, and searches THAT id. A vector collection is
+tenant-scoped by its (name, tenant) → id mapping, not by a folded name, so resolving the name without
+the tenant misses the collection and the search reads nothing.
+
+== Resolution
+
+`impl VectorOpsPort::search` now resolves the collection under the tenant before searching, mirroring
+the REST path: when `tenant_id` is present it calls `collection_port.get_collection(&collection_id,
+Some(tenant))` and, on a hit, replaces `request.collection_id` with the resolved canonical id, then
+calls `search_v1`. The resolved id is idempotent for `search_v1`'s own resolution, so tenant-less
+callers (`None`) are unaffected. Verified live: `SELECT … JOIN vector_search('patterns', …) v ON
+o.account_id = v.id` over pgwire (under `dbname=<tenant>`) now returns the REST-seeded matches.
+
+== Follow-up (out of scope)
+
+* **Graph tenant isolation** (tracked in TD-XMODAL-6): the graph modality still applies no tenant on
+  either the write path or `graph_traverse`; a tenant param on `GraphPort` would bring it in line with
+  vector + timeseries.
+* **Freshness parity:** the port's `search` uses the `search_v1` leg; confirm it crosses the same
+  WAL/memtable freshness boundary the REST rich-search path (`search_records_with_tenant_context`)
+  does for Strong reads.

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -1160,6 +1160,51 @@ mod tests {
         }
     }
 
+    /// TD-XMODAL-7 repro: a UDTF wrapped in an aggregating derived table that is then JOINed with
+    /// a base table (`FROM base o CROSS JOIN (SELECT max(value) FROM timeseries_range(...)) ts`)
+    /// must not blow the stack. A top-level UDTF (even two joined) plans fine; only the
+    /// join-to-a-derived-table-over-a-UDTF shape recursed over pgwire's DataFusion fallback.
+    #[tokio::test]
+    async fn udtf_in_aggregating_subquery_does_not_recurse() {
+        let port: Arc<dyn TimeseriesScanPort> = Arc::new(FixedTimeseriesScan {
+            points: vec![tp(1, "amount", 5.0), tp(2, "amount", 9.0)],
+        });
+        let ctx = SessionContext::new();
+        ctx.register_udtf(
+            "timeseries_range",
+            Arc::new(TimeseriesRangeTableFunction::new(port)),
+        );
+        // A base relation to join against, mirroring the pgwire `orders` table.
+        let base_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+        let base = RecordBatch::try_new(
+            base_schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["acct-7"]))],
+        )
+        .unwrap();
+        ctx.register_table(
+            "orders",
+            Arc::new(MemTable::try_new(base_schema, vec![vec![base]]).unwrap()),
+        )
+        .unwrap();
+        let n: usize = ctx
+            .sql(
+                "SELECT o.id, ts.peak \
+                 FROM orders o \
+                 CROSS JOIN (SELECT max(value) AS peak FROM timeseries_range('c', 0, 9)) ts \
+                 WHERE o.id = 'acct-7' \
+                 GROUP BY o.id, ts.peak",
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(n, 1);
+    }
+
     /// A `TimeseriesScanPort` that records the collection name it was asked to read — used to
     /// prove `timeseries_range` folds the tenant into the collection key (TD-XMODAL-6).
     struct RecordingTimeseriesScan {

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -5533,9 +5533,25 @@ impl VectorQueryService for VectorOperationsService {
 impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
     async fn search(
         &self,
-        request: crate::proto::proximadb_v1::VectorSearchRequest,
-        _tenant_id: Option<&str>,
+        mut request: crate::proto::proximadb_v1::VectorSearchRequest,
+        tenant_id: Option<&str>,
     ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
+        // TD-XMODAL-8: the cross-modal `vector_search` UDTF reaches this port carrying the pgwire
+        // connection tenant. Resolve the collection UNDER that tenant — the same tenant-scoped
+        // name→canonical-id resolution the REST record path does via
+        // `RecordOpsService::resolve_collection_id_internal` (`collection_port.get_collection`,
+        // TD-XMODAL-6). Without it a tenant-scoped collection name resolves against the unscoped
+        // registry, misses, and the search returns 0 rows even though the data exists. The
+        // resolved id is idempotent for `search_v1`'s own resolution, so tenant-less callers
+        // (`None`) are unaffected.
+        if let Some(tid) = tenant_id.filter(|t| !t.is_empty())
+            && let Ok(Some(collection)) = self
+                .collection_port
+                .get_collection(&request.collection_id, Some(tid))
+                .await
+        {
+            request.collection_id = collection.id;
+        }
         self.search_v1(request).await
     }
 


### PR DESCRIPTION
## What

Two engine bugs found while driving the cross-modal fabric over pgwire from a real **data-engineering** session (`relational ⋈ vector ⋈ timeseries ⋈ graph` in one SQL statement). Follow-on to TD-XMODAL-6 (#675).

## TD-XMODAL-7 — cross-modal UDTF in an aggregating subquery stack-overflows the server (DoS)

A derived table / scalar subquery wrapping a UDTF aggregate — `(SELECT max(value) FROM timeseries_range(...))` — then JOINed to a Parquet-backed table recurses deeply in DataFusion's SQL planner on the pgwire fallback and overflows the **default 2 MiB tokio worker stack**, aborting the whole process. A single crafted query = DoS (`server closed the connection unexpectedly`).

Bisection: top-level UDTF joins (even two — `… JOIN graph_traverse(…) CROSS JOIN timeseries_range(…)`) plan fine; only the **subquery-over-UDTF** shape recurses. It is **deep-but-bounded** — a 32 MiB stack lets the identical query complete and return correct rows.

**Fix:** `apps/proximadb-server/src/main.rs` replaces `#[tokio::main]` with an explicit multi-thread runtime, `thread_stack_size(32 MiB)`. Databases routinely run recursive planners on a larger stack.

## TD-XMODAL-8 — `vector_search` UDTF returned 0 rows for REST-written data

`impl VectorOpsPort::search for VectorOperationsService` accepted `tenant_id` but **ignored it**, resolving the collection against the unscoped registry (a vector collection is tenant-scoped by its (name, tenant)→id mapping). REST search works via a different path (`resolve_collection_id_internal`).

**Fix:** the port now resolves the collection UNDER the tenant (`collection_port.get_collection(id, Some(tenant))`) before `search_v1`, mirroring the REST record path. Tenant-less callers unaffected (idempotent id).

## Verification

Live over pgwire (`dbname=<tenant>`), after seeding vector/timeseries/graph via v2 REST under the same tenant, the four-way join returns **correct rows** and the server stays up:

```
 account_id | order_gross | fraud_pattern_score | peak_txn_rate | downstream_account | hops
------------+-------------+---------------------+---------------+--------------------+------
 acct-7     |        9100 |                   1 |           880 | acct-31            |    1
 acct-7     |        9100 |                   1 |           880 | acct-88            |    2
 acct-7     |        9100 |                   1 |           880 | acct-99            |    3
```

- Adds an in-process planning-shape regression test (`udtf_in_aggregating_subquery_does_not_recurse`).
- `cargo build -p proximadb-server`, `clippy -D warnings` (lib + bin), `cargo fmt` all clean.

## Follow-ups (in the TDs)

- TD-XMODAL-7: an explicit planner recursion/depth limit (clean SQL error for adversarial nesting) vs relying on stack size; localize the exact DataFusion optimizer pass.
- TD-XMODAL-8: graph tenant isolation (still none on either side); confirm `search_v1` freshness parity with the REST rich-search path.