### PR TITLE
demo(data-engineering): warehouse analytics + the zero-ETL four-way cross-modal join over pgwire

### DIFF
--- a/demo/data-engineering/README.adoc
+++ b/demo/data-engineering/README.adoc
@@ -1,0 +1,119 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Data Engineering — the relational modality drives SQL analytics AND the zero-ETL cross-modal join
+:toc: macro
+
+Every other demo in this repo is **copilot-shaped** (an agent asks, a multi-modal answer comes back).
+This one serves the other persona — the **data engineer / analyst on SQL** — and it is the *spine*
+that makes the modalities joinable. ProximaDB speaks the **PostgreSQL wire protocol**, so the analyst
+connects with `psql` (or any Postgres driver / BI tool) and gets two things no warehouse or vector DB
+gives together:
+
+1. **Ordinary warehouse analytics** — `CREATE` / `INSERT` / `ALTER TABLE … MATERIALIZE` /
+   `GROUP BY`, executed by a real vectorized OLAP engine (DataFusion behind the `ComputeBackend`
+   seam, ADR-052).
+2. **The zero-ETL cross-modal join** — the same SQL statement joins the relational fact table against
+   the **vector**, **timeseries**, and **graph** modalities living in the *same* engine, with **no ETL**
+   between a metrics store, a vector DB, and a graph DB (ADR-053).
+
+toc::[]
+
+== Why this is the moat
+
+The copilot demos resolve a question by making N calls from the client and stitching the results
+together in application code — a client-side fan-out + join. That is the anti-pattern a warehouse
+exists to kill for *relational* data; ProximaDB kills it for **all four modalities at once**. Because
+the vector / timeseries / graph sources are exposed as DataFusion **table-valued functions**
+(`vector_search`, `timeseries_range`, `graph_traverse`), the engine plans and executes the whole join
+**data-local** and ships the client the **answer**, not four intermediate result sets. In co-design
+terms (the dominant cost is I/O round-trips + egress) that collapses N network round-trips and a
+client-side join into one plan — the "one engine, one query plane" thesis, made concrete at the seam
+the data engineer actually uses.
+
+== The scenario
+
+> **Data engineer:** for account `acct-7`, "how fraud-like is its behaviour, how hot is its
+> transaction stream, and where does its money flow?" — in one query.
+
+[cols="1,2,3", options="header"]
+|===
+| Modality | Source | What it contributes
+| **relational** | `orders` (Parquet / DataFusion) | the account's booked orders (the warehouse fact)
+| **vector** | `vector_search('patterns', …)` | cosine similarity of the account's behaviour signature to a library of known fraud typologies (live ANN)
+| **timeseries** | `timeseries_range('acct_txn', …)` | the account's peak per-window transaction rate (live TST)
+| **graph** | `graph_traverse('flows', 'acct-7', 'sent_to', 4)` | the money-flow accounts downstream of it (live ORION traversal)
+|===
+
+== Run it — live, over a real pgwire session
+
+Build a ProximaDB from *this* code (the cross-modal UDTFs + the pgwire OLAP route only exist in a
+same-code build), enable pgwire (`pg_port = 5433` under `[api]`), then:
+
+[source,bash]
+----
+cargo build --release -p proximadb-server
+./target/release/proximadb-server -c config/config.toml          # REST :5678, pgwire :5433
+
+cd demo/data-engineering
+./run.sh
+----
+
+`run.sh` seeds the vector / timeseries / graph data through the **real v2 REST API** under tenant
+`de_demo`, then runs the SQL over `psql` connected with `dbname=de_demo`. (The `dbname` IS the tenant
+boundary and the cross-modal UDTFs read under the connection tenant — so the seed tenant and the psql
+`dbname` must match; TD-XMODAL-6.)
+
+=== What you get
+
+Warehouse analytics (`warehouse.sql`) — plain ANSI SQL, vectorized OLAP:
+
+[source,text]
+----
+ region | n_orders | gross
+--------+----------+-------
+ emea   |        2 |  9100
+ amer   |        2 |   290
+ apac   |        1 |    75
+----
+
+The zero-ETL cross-modal join (`crossmodal.sql`) — relational ⋈ vector ⋈ timeseries ⋈ graph, one
+statement:
+
+[source,text]
+----
+ account_id | region | order_gross | fraud_pattern_score | peak_txn_rate | downstream_account | hops_downstream
+------------+--------+-------------+---------------------+---------------+--------------------+-----------------
+ acct-7     | emea   |        9100 |                   1 |           880 | acct-31            |               1
+ acct-7     | emea   |        9100 |                   1 |           880 | acct-88            |               2
+ acct-7     | emea   |        9100 |                   1 |           880 | acct-99            |               3
+----
+
+One query returns the account's booked revenue (**relational**), its fraud-typology match
+(**vector**, score 1.0), its peak transaction rate (**timeseries**, 880), and the three accounts its
+money flows to (**graph**, acct-31 → acct-88 → acct-99) — no ETL, no client-side join.
+
+== How the routing works
+
+`ALTER TABLE … MATERIALIZE` makes `orders` Parquet-backed, so the `ComputeScheduler` routes SELECTs
+over it to the DataFusion OLAP engine. The cross-modal table-valued functions are registered on that
+same DataFusion session (`vector_search` / `timeseries_range` / `graph_traverse`), so a join across
+them plans and executes in one place. When the shared relational frontend can't lower a table-valued
+function it declines cleanly to DataFusion's own ANSI SQL planner over the same registered tables —
+the query still routes pgwire → `ComputeScheduler` → the DataFusion engine.
+
+== Open core
+
+This demo is engine-neutral and ships in the OSS engine: the modalities, the pgwire surface, and the
+cross-modal fabric are all open. The commercial control-plane (per-tenant metering — KRU read/compute,
+KOU outgress — entitlements, and the governed query gateway) wraps the same engine; it is not required
+to run this demo.
+
+== Files
+
+[cols="1,3"]
+|===
+| `warehouse.sql`  | CREATE / INSERT / MATERIALIZE + a GROUP BY aggregate (the relational modality).
+| `crossmodal.sql` | the four-way `relational ⋈ vector ⋈ timeseries ⋈ graph` join in one statement.
+| `seed.sh`        | seeds the vector / timeseries / graph collections via the v2 REST API under the tenant.
+| `run.sh`         | seeds, then runs both SQL files over `psql` (dbname = tenant).
+|===

--- a/demo/data-engineering/crossmodal.sql
+++ b/demo/data-engineering/crossmodal.sql
@@ -1,0 +1,43 @@
+-- Copyright (C) 2025 ProximaDB
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Step 2 — the zero-ETL cross-modal join (the moat).
+--
+-- ONE SQL statement, over a real PostgreSQL wire connection, joins the relational
+-- warehouse fact table against THREE non-relational modalities living in the SAME
+-- engine — no ETL between a metrics store, a vector DB, and a graph DB:
+--
+--   relational  (orders)              — the warehouse fact table (Parquet / DataFusion)
+--   ⋈ vector    vector_search(...)    — similarity of the account's behaviour to a
+--                                       library of known fraud patterns (live ANN)
+--   ⋈ timeseries timeseries_range(...) — the account's peak transaction rate (live TST)
+--   ⋈ graph     graph_traverse(...)   — the money-flow accounts downstream of it (live ORION)
+--
+-- The cross-modal sources are DataFusion table-valued functions (ADR-053); the
+-- ComputeScheduler routes the whole plan data-local, so what ships to the client is the
+-- ANSWER, not four intermediate result sets glued together in application code.
+--
+-- Scenario: a data engineer triaging high-value orders asks, for account 'acct-7',
+-- "how fraud-like is its behaviour, how hot is its transaction stream, and where does
+--  its money flow?" — resolved in a single query the analyst actually types.
+
+SELECT
+    o.account_id,
+    o.region,
+    sum(o.amount)   AS order_gross,          -- relational: the account's booked orders
+    v.score         AS fraud_pattern_score,  -- vector: cosine similarity to the fraud typology
+    ts.peak_txn_rate,                         -- timeseries: peak per-window transaction rate
+    g.node_id       AS downstream_account,   -- graph: an account money flows to
+    g.depth         AS hops_downstream       -- graph: how many hops away
+FROM orders o
+JOIN vector_search('patterns', '[0.95,0.05]', 5) v
+    ON o.account_id = v.id
+CROSS JOIN (
+    SELECT max(value) AS peak_txn_rate
+    FROM timeseries_range('acct_txn', 0, 9999999)
+) ts
+JOIN graph_traverse('flows', 'acct-7', 'sent_to', 4) g
+    ON true
+WHERE o.account_id = 'acct-7'
+GROUP BY o.account_id, o.region, v.score, ts.peak_txn_rate, g.node_id, g.depth
+ORDER BY g.depth;

--- a/demo/data-engineering/run.sh
+++ b/demo/data-engineering/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data-engineering demo: warehouse analytics + the zero-ETL cross-modal join, driven
+# entirely over the PostgreSQL wire protocol against a REAL running ProximaDB.
+#
+# Prerequisites — a ProximaDB built from THIS code, with pgwire enabled:
+#   cargo build --release -p proximadb-server        # or: make build-server
+#   # run it with pgwire on 5433 and REST on 5678 (pg_port = 5433 in config.toml [api]):
+#   ./target/release/proximadb-server -c config/config.toml
+#   # (Docker: build the image from this code — the cross-modal UDTFs + pgwire OLAP
+#   #  route only exist in a same-code build — then publish 5678 and 5433.)
+#
+# The cross-modal UDTFs read under the pgwire connection's tenant, and the catalog
+# (the psql `dbname`) IS the tenant boundary — so we seed the vector/timeseries/graph
+# data via REST under tenant "de_demo" and connect psql with dbname=de_demo. They MUST
+# match (TD-XMODAL-6).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PROXIMADB_REST="${PROXIMADB_REST:-http://127.0.0.1:5678}"
+export PROXIMADB_TENANT="${PROXIMADB_TENANT:-de_demo}"
+PG_HOST="${PROXIMADB_PG_HOST:-127.0.0.1}"
+PG_PORT="${PROXIMADB_PG_PORT:-5433}"
+CONN="host=${PG_HOST} port=${PG_PORT} user=postgres dbname=${PROXIMADB_TENANT} sslmode=disable"
+
+echo "▶ ProximaDB data-engineering demo (pgwire ${PG_HOST}:${PG_PORT}, REST ${PROXIMADB_REST}, tenant ${PROXIMADB_TENANT})"
+
+# 1) Seed the non-relational modalities via the v2 REST API under the tenant.
+bash "${HERE}/seed.sh"
+
+# 2) Warehouse analytics — CREATE / INSERT / MATERIALIZE / GROUP BY over pgwire.
+echo; echo "── warehouse.sql : relational analytics (routes to the DataFusion OLAP engine) ──"
+psql "${CONN}" -f "${HERE}/warehouse.sql"
+
+# 3) The moat: relational ⋈ vector ⋈ timeseries ⋈ graph in ONE data-local SQL plan.
+echo; echo "── crossmodal.sql : the zero-ETL four-way cross-modal join ──"
+psql "${CONN}" -f "${HERE}/crossmodal.sql"
+
+echo; echo "✓ done — one engine, one query plane, zero ETL."

--- a/demo/data-engineering/seed.sh
+++ b/demo/data-engineering/seed.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+#
+# Seed the non-relational modalities (timeseries + graph) through the REAL v2 REST
+# API, under one tenant, so the pgwire cross-modal join in crossmodal.sql can read
+# them back in a single SQL plan. The tenant here (X-Tenant-ID) MUST match the pgwire
+# `dbname` the SQL connects with — the catalog is the tenant boundary (TD-064), and
+# the UDTFs read under the connection tenant (TD-XMODAL-6).
+set -euo pipefail
+
+REST="${PROXIMADB_REST:-http://127.0.0.1:5678}"
+TENANT="${PROXIMADB_TENANT:-de_demo}"
+CURL=(curl -s --noproxy '*' -H "X-Tenant-ID: ${TENANT}" -H 'content-type: application/json')
+
+echo "→ seeding under tenant '${TENANT}' at ${REST}"
+
+# ── Timeseries: a per-account transaction-rate stream (acct-7 has a burst) ──
+"${CURL[@]}" -X POST "${REST}/api/v2/timeseries/collections" \
+  -d '{"name":"acct_txn","value_columns":[{"name":"rate"}]}' >/dev/null
+"${CURL[@]}" -X POST "${REST}/api/v2/timeseries/collections/acct_txn/ingest" \
+  -d '{"points":[
+        {"timestamp":1000,"values":{"rate":12.0}},
+        {"timestamp":2000,"values":{"rate":880.0}},
+        {"timestamp":3000,"values":{"rate":33.0}}]}' >/dev/null
+echo "  ✓ timeseries acct_txn (3 points)"
+
+# ── Vector: a fraud-typology library; records keyed by account so the join keys on id ──
+# 2-D behavioural signature [place-and-cancel burstiness, steady-flow]; acct-7 sits on the
+# fraud-like axis, the others on the benign axis.
+"${CURL[@]}" -X POST "${REST}/api/v2/collections" \
+  -d '{"name":"patterns","dimension":2,"engine":"sst","distance_metric":"cosine"}' >/dev/null
+"${CURL[@]}" -X POST "${REST}/api/v2/collections/patterns/records/batch" \
+  -d '{"records":[
+        {"id":"acct-7","vector":[0.95,0.05]},
+        {"id":"acct-9","vector":[0.10,0.90]},
+        {"id":"acct-3","vector":[0.20,0.80]}]}' >/dev/null
+echo "  ✓ vector patterns (3 account signatures)"
+
+# ── Graph: a money-flow chain acct-7 → acct-31 → acct-88 → acct-99 ──
+"${CURL[@]}" -X POST "${REST}/api/v2/graphs" \
+  -d '{"graph_id":"flows","name":"money flows"}' >/dev/null
+for n in acct-7 acct-31 acct-88 acct-99; do
+  "${CURL[@]}" -X POST "${REST}/api/v2/graphs/flows/nodes" \
+    -d "{\"node\":{\"id\":\"${n}\",\"labels\":[\"account\"]}}" >/dev/null
+done
+i=0
+for pair in "acct-7:acct-31" "acct-31:acct-88" "acct-88:acct-99"; do
+  i=$((i + 1)); from="${pair%:*}"; to="${pair#*:}"
+  "${CURL[@]}" -X POST "${REST}/api/v2/graphs/flows/edges" \
+    -d "{\"edge\":{\"id\":\"e${i}\",\"from_node_id\":\"${from}\",\"to_node_id\":\"${to}\",\"edge_type\":\"sent_to\"}}" >/dev/null
+done
+echo "  ✓ graph flows (4 nodes, 3 sent_to edges)"
+
+echo "→ seeded. Now run the SQL under the SAME tenant: psql \"dbname=${TENANT}\""

--- a/demo/data-engineering/warehouse.sql
+++ b/demo/data-engineering/warehouse.sql
@@ -1,0 +1,37 @@
+-- Copyright (C) 2025 ProximaDB
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Step 1 — warehouse analytics over pgwire (the data-engineer's bread and butter).
+--
+-- Create a fact table, load it, MATERIALIZE it to Parquet (which routes the table to
+-- the DataFusion OLAP engine behind ProximaDB's ComputeBackend seam), then run a
+-- GROUP BY aggregate. This is plain ANSI SQL on a real PostgreSQL wire connection —
+-- nothing ProximaDB-specific yet. The cross-modal payoff is in crossmodal.sql.
+
+DROP TABLE IF EXISTS orders;
+
+CREATE TABLE orders (
+    order_id   TEXT,
+    account_id TEXT,
+    region     TEXT,
+    amount     DOUBLE PRECISION
+);
+
+INSERT INTO orders VALUES
+    ('o1', 'acct-7', 'emea', 100.0),
+    ('o2', 'acct-7', 'emea', 9000.0),
+    ('o3', 'acct-9', 'amer', 250.0),
+    ('o4', 'acct-3', 'apac', 75.0),
+    ('o5', 'acct-9', 'amer', 40.0);
+
+-- Parquet-backed => the ComputeScheduler routes SELECTs over this table to the
+-- DataFusion OLAP engine (vectorized aggregates), not the row-wise Volcano floor.
+ALTER TABLE orders MATERIALIZE;
+
+-- Pure relational analytics: gross revenue per region.
+SELECT region,
+       count(*)    AS n_orders,
+       sum(amount) AS gross
+FROM orders
+GROUP BY region
+ORDER BY gross DESC;


### PR DESCRIPTION
## What

The **relational modality's** demo — a data engineer on **pgwire (psql)**, not a copilot. Every other demo in the repo is copilot-shaped; this one serves the SQL/analyst persona and shows the spine that makes the modalities joinable.

Two things, over a real PostgreSQL wire connection against a same-code ProximaDB:

1. **Warehouse analytics** (`warehouse.sql`) — `CREATE` / `INSERT` / `ALTER TABLE … MATERIALIZE` / `GROUP BY`, routed to the DataFusion OLAP engine.
2. **The zero-ETL cross-modal join** (`crossmodal.sql`) — ONE SQL statement joins the relational fact table against **vector** (`vector_search`), **timeseries** (`timeseries_range`), and **graph** (`graph_traverse`) in the same engine — no ETL between a metrics store, a vector DB, and a graph DB (ADR-053).

## Verified live

Seeded via v2 REST under tenant `de_demo`, read over pgwire with `dbname=de_demo`:

```
 region | n_orders | gross          account_id | order_gross | fraud_pattern_score | peak_txn_rate | downstream | hops
--------+----------+-------          -----------+-------------+---------------------+---------------+------------+-----
 emea   |        2 |  9100           acct-7     |        9100 |                   1 |           880 | acct-31    |   1
 amer   |        2 |   290           acct-7     |        9100 |                   1 |           880 | acct-88    |   2
 apac   |        1 |    75           acct-7     |        9100 |                   1 |           880 | acct-99    |   3
```

One query returns the account's booked revenue (relational), its fraud-typology match (vector, 1.0), its peak transaction rate (timeseries, 880), and the accounts its money flows to (graph). Zero ETL, no client-side join.

## Notes

- The `dbname` IS the tenant boundary and the cross-modal UDTFs read under the connection tenant — so the REST seed tenant and the psql `dbname` must match (TD-XMODAL-6).
- Engine-neutral / open-core: the modalities, pgwire surface, and cross-modal fabric are all in the OSS engine.
- Depends on the cross-modal fabric landed in #672/#673/#675 and hardened in #677.

## Files
`warehouse.sql`, `crossmodal.sql`, `seed.sh`, `run.sh`, `README.adoc` under `demo/data-engineering/`.