### PR TITLE
demo(montecarlo-sql): ProximaDB as an in-database Monte Carlo compute engine (SQL editor + notebook)

### DIFF
--- a/demo/montecarlo-sql/README.adoc
+++ b/demo/montecarlo-sql/README.adoc
@@ -1,0 +1,109 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Monte Carlo in SQL — ProximaDB as an in-database compute engine
+:toc: macro
+
+ProximaDB is not only a place to *store* vectors and run OLAP — it is a place to *compute*.
+It ships a vectorized **Monte Carlo European-option pricer as a SQL scalar function**,
+`mc_price(spot, strike, vol, rate, t, is_call, n_paths)`, that runs on the DataFusion compute
+engine. So a quant / data engineer prices and stress-tests a whole derivatives book in plain SQL —
+the simulation runs **where the data lives** (compute-to-data), with no extract to a separate
+Spark / pandas cluster. This is a **compute** workload, not a copilot or an MCP call: it is driven
+from the **SQL editor** and from a **notebook**, over the PostgreSQL wire protocol.
+
+toc::[]
+
+== Why in-database Monte Carlo
+
+The default pattern for pricing a book is to pull the positions out of the database into a compute
+cluster (Spark / a pandas notebook), simulate, and push results back — moving the data twice to run
+the CPU next to it. ProximaDB inverts that: the pricer is a SQL function on the engine's own compute
+layer, so the simulation runs *in situ* and only the **aggregates** (a per-underlying book value, a
+risk curve) leave. In co-design terms the dominant cost — moving bytes — collapses: you ship the
+answer, not the book. One SQL surface then serves both personas — the analyst in the SQL editor and
+the data engineer in a notebook — with no second system to learn.
+
+== Run it — over a real pgwire session
+
+This demo needs **only pgwire** (no REST seeding). Build a ProximaDB from *this* code (the `mc_price`
+UDF + the pgwire OLAP route), enable pgwire (`pg_port = 5433` under `[api]`), then:
+
+[source,bash]
+----
+cargo build --release -p proximadb-server
+./target/release/proximadb-server -c config/config.toml          # pgwire :5433
+
+cd demo/montecarlo-sql
+./run.sh                     # runs montecarlo.sql (psql) + montecarlo_notebook.py (psycopg2)
+----
+
+Routing note: `mc_price` is a DataFusion UDF, so a query must engage the OLAP engine — an
+aggregate / GROUP BY over a `MATERIALIZE`'d (Parquet-backed) table. A bare scalar
+`SELECT mc_price(...)` stays on the row-wise path where the UDF isn't bound, so the demo prices
+per-row by grouping on the option id, and the portfolio by underlying.
+
+=== 1. The SQL editor — `montecarlo.sql`
+
+Price every option (200k Monte Carlo paths each), value the book, and stress it — all in SQL:
+
+[source,text]
+----
+ option_id | underlying | mc_price          -- matches Black-Scholes within MC noise
+-----------+------------+----------          --   (ATM call ≈ 10.45, OTM put ≈ 2.31)
+ o1        | ACME       | 10.3804
+ o2        | ACME       |  6.0653
+ o3        | ACME       |  2.3029
+ o4        | GLOBEX     |  3.5022
+
+ underlying | n_options | book_value        -- mark-to-model: sum(mc_price × qty)
+------------+-----------+------------
+ ACME       |         3 |     153.01
+ GLOBEX     |         1 |      70.22
+
+ underlying | base_value | vol_stress_value  -- reprice under a +50% vol shock, one query
+------------+------------+------------------
+ ACME       |     153.19 |           234.79
+ GLOBEX     |      69.95 |           119.32
+----
+
+=== 2. The notebook — `montecarlo_notebook.py`
+
+The same workload from a notebook (a standard `psycopg2` connection to pgwire), plus a **volatility
+sweep** — the whole book repriced across five scenarios in one query, drawn as a risk curve:
+
+[source,text]
+----
+ vol x   book_value  risk curve
+  0.50       103.69  ████████████
+  0.75       160.72  ██████████████████
+  1.00       223.14  █████████████████████████
+  1.25       288.02  █████████████████████████████████
+  1.50       354.10  ████████████████████████████████████████
+----
+
+The file is written as `# %%` cells: run it straight (`python montecarlo_notebook.py`) or open it
+as a notebook (VS Code / Jupyter via jupytext). Only `psycopg2` is required.
+
+== Beyond options
+
+`mc_price` is the reference in-database compute UDF; the same pattern — a vectorized simulation bound
+as a SQL function on the compute engine, driven from SQL or a notebook — generalizes to other
+quantitative workloads (VaR / expected-shortfall by path aggregation, Bayesian posterior sampling,
+scenario/stress grids). The point the demo makes is the *shape*: the simulation runs in the database,
+next to the data.
+
+== Open core
+
+This is engine-neutral and ships in the OSS engine: `mc_price`, the DataFusion compute path, and the
+pgwire surface are all open. The commercial control-plane (the governed **notebook** + **SQL editor**,
+per-tenant compute metering — KPU kernel-time, KRU scan — entitlements, and budget gates) wraps the
+same engine; it is not required to run this demo.
+
+== Files
+
+[cols="1,3"]
+|===
+| `montecarlo.sql`          | the SQL-editor workload — price, value, and vol-stress the book.
+| `montecarlo_notebook.py`  | the notebook workload — same over `psycopg2`, plus a vol-sweep risk curve (`# %%` cells).
+| `run.sh`                  | runs both against a pgwire endpoint.
+|===

--- a/demo/montecarlo-sql/montecarlo.sql
+++ b/demo/montecarlo-sql/montecarlo.sql
@@ -1,0 +1,63 @@
+-- Copyright (C) 2025 ProximaDB
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Monte Carlo option pricing as an IN-DATABASE compute workload, over pgwire.
+--
+-- ProximaDB ships a vectorized Monte Carlo European-option pricer as a SQL scalar
+-- function — `mc_price(spot, strike, vol, rate, t, is_call, n_paths)` — that runs on
+-- the DataFusion compute engine. A quant / data engineer prices and stress-tests a
+-- whole derivatives book with plain SQL: the simulation runs WHERE THE DATA LIVES
+-- (compute-to-data), so nothing is extracted to a separate Spark/pandas cluster.
+--
+-- Routing note: `mc_price` is a DataFusion UDF, so a query must engage the OLAP
+-- engine (an aggregate / GROUP BY over a MATERIALIZE'd, Parquet-backed table). A bare
+-- scalar `SELECT mc_price(...)` stays on the row-wise path where the UDF isn't bound —
+-- so we price per-row by grouping on the option id, and the portfolio by underlying.
+
+DROP TABLE IF EXISTS option_book;
+
+CREATE TABLE option_book (
+    option_id  TEXT,
+    underlying  TEXT,
+    spot       DOUBLE PRECISION,
+    strike     DOUBLE PRECISION,
+    vol        DOUBLE PRECISION,   -- annualized volatility
+    rate       DOUBLE PRECISION,   -- risk-free rate
+    t          DOUBLE PRECISION,   -- time to expiry (years)
+    is_call    BOOLEAN,
+    qty        BIGINT              -- position size (contracts)
+);
+
+INSERT INTO option_book VALUES
+    ('o1', 'ACME',   100.0, 100.0, 0.20, 0.05, 1.0, true,  10),  -- ATM call
+    ('o2', 'ACME',   100.0, 110.0, 0.20, 0.05, 1.0, true,   5),  -- OTM call
+    ('o3', 'ACME',   100.0,  90.0, 0.20, 0.05, 1.0, false,  8),  -- OTM put
+    ('o4', 'GLOBEX',  50.0,  55.0, 0.35, 0.05, 0.5, true,  20);  -- OTM call, higher vol
+
+-- Parquet-backed ⇒ SELECTs route to the DataFusion compute engine (where `mc_price` lives).
+ALTER TABLE option_book MATERIALIZE;
+
+-- 1) Per-option Monte Carlo price (200k paths each) — grouped by id so the UDF engages.
+SELECT option_id,
+       underlying,
+       round(mc_price(spot, strike, vol, rate, t, is_call, 200000)::numeric, 4) AS mc_price
+FROM option_book
+GROUP BY option_id, underlying, spot, strike, vol, rate, t, is_call
+ORDER BY option_id;
+
+-- 2) Portfolio valuation — mark-to-model book value per underlying (price × position).
+SELECT underlying,
+       count(*)                                                                    AS n_options,
+       round(sum(mc_price(spot, strike, vol, rate, t, is_call, 200000) * qty)::numeric, 2) AS book_value
+FROM option_book
+GROUP BY underlying
+ORDER BY book_value DESC;
+
+-- 3) Risk scenario — reprice the whole book under a +50% volatility shock, in ONE query.
+--    (The stress simulation runs in-database; only the two aggregates leave.)
+SELECT underlying,
+       round(sum(mc_price(spot, strike, vol,       rate, t, is_call, 100000) * qty)::numeric, 2) AS base_value,
+       round(sum(mc_price(spot, strike, vol * 1.5, rate, t, is_call, 100000) * qty)::numeric, 2) AS vol_stress_value
+FROM option_book
+GROUP BY underlying
+ORDER BY underlying;

--- a/demo/montecarlo-sql/montecarlo_notebook.py
+++ b/demo/montecarlo-sql/montecarlo_notebook.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monte Carlo option pricing from a NOTEBOOK — in-database compute over pgwire.
+
+This is the notebook persona (the same workload as ``montecarlo.sql`` for the SQL editor):
+a quant/data engineer connects a standard Postgres driver to ProximaDB's pgwire port and
+drives a real Monte Carlo simulation *in the database* via the built-in ``mc_price`` scalar
+UDF — the simulation runs where the data lives (compute-to-data), so there is no extract to
+a separate Spark/pandas cluster.
+
+The file is written as ``# %%`` cells: run it straight (``python montecarlo_notebook.py``)
+or open it as a notebook (VS Code / Jupyter via jupytext). Only ``psycopg2`` is required.
+
+Connection (env-overridable): PROXIMADB_PG_HOST=127.0.0.1  PROXIMADB_PG_PORT=5433
+                              PROXIMADB_DB=quant  (the pgwire database == the tenant/catalog)
+"""
+
+# %% [markdown]
+# ## 1. Connect to ProximaDB over pgwire
+# The database name is the tenant/catalog boundary. Any standard Postgres driver works.
+
+# %%
+import os
+
+import psycopg2
+
+conn = psycopg2.connect(
+    host=os.environ.get("PROXIMADB_PG_HOST", "127.0.0.1"),
+    port=int(os.environ.get("PROXIMADB_PG_PORT", "5433")),
+    dbname=os.environ.get("PROXIMADB_DB", "quant"),
+    user="postgres",
+)
+conn.autocommit = True
+cur = conn.cursor()
+print("connected to ProximaDB pgwire")
+
+
+# %% [markdown]
+# ## 2. Load a derivatives book and MATERIALIZE it
+# `MATERIALIZE` makes the table Parquet-backed, so SELECTs route to the DataFusion compute
+# engine — where the `mc_price` Monte Carlo UDF lives.
+
+# %%
+cur.execute("DROP TABLE IF EXISTS option_book")
+cur.execute(
+    "CREATE TABLE option_book (option_id TEXT, underlying TEXT, spot DOUBLE PRECISION, "
+    "strike DOUBLE PRECISION, vol DOUBLE PRECISION, rate DOUBLE PRECISION, "
+    "t DOUBLE PRECISION, is_call BOOLEAN, qty BIGINT)"
+)
+cur.execute(
+    "INSERT INTO option_book VALUES "
+    "('o1','ACME',100.0,100.0,0.20,0.05,1.0,true,10),"
+    "('o2','ACME',100.0,110.0,0.20,0.05,1.0,true,5),"
+    "('o3','ACME',100.0,90.0,0.20,0.05,1.0,false,8),"
+    "('o4','GLOBEX',50.0,55.0,0.35,0.05,0.5,true,20)"
+)
+cur.execute("ALTER TABLE option_book MATERIALIZE")
+print("book loaded + materialized")
+
+
+# %% [markdown]
+# ## 3. Price every option — 200k Monte Carlo paths each, in the database
+
+# %%
+cur.execute(
+    "SELECT option_id, underlying, "
+    "  round(mc_price(spot,strike,vol,rate,t,is_call,200000)::numeric, 4) AS mc_price "
+    "FROM option_book "
+    "GROUP BY option_id, underlying, spot, strike, vol, rate, t, is_call "
+    "ORDER BY option_id"
+)
+print(f"{'option':8} {'underlying':10} {'mc_price':>10}")
+for opt, und, price in cur.fetchall():
+    print(f"{opt:8} {und:10} {float(price):>10.4f}")
+
+
+# %% [markdown]
+# ## 4. Portfolio valuation — mark-to-model book value per underlying (price × position)
+
+# %%
+cur.execute(
+    "SELECT underlying, count(*) AS n, "
+    "  round(sum(mc_price(spot,strike,vol,rate,t,is_call,200000)*qty)::numeric, 2) AS book_value "
+    "FROM option_book GROUP BY underlying ORDER BY book_value DESC"
+)
+print(f"{'underlying':10} {'n_options':>10} {'book_value':>12}")
+for und, n, val in cur.fetchall():
+    print(f"{und:10} {n:>10} {float(val):>12.2f}")
+
+
+# %% [markdown]
+# ## 5. Risk curve — reprice the WHOLE book across a volatility sweep, in one query
+# Five volatility scenarios (0.5×…1.5× of book vol) repriced in-database — a vega curve
+# for the desk. Only the five aggregates leave the engine.
+
+# %%
+cur.execute(
+    "SELECT v.vol_mult, "
+    "  round(sum(mc_price(spot,strike,vol*v.vol_mult,rate,t,is_call,100000)*qty)::numeric, 2) AS book_value "
+    "FROM option_book "
+    "CROSS JOIN (VALUES (0.5),(0.75),(1.0),(1.25),(1.5)) AS v(vol_mult) "
+    "GROUP BY v.vol_mult ORDER BY v.vol_mult"
+)
+curve = [(float(m), float(val)) for m, val in cur.fetchall()]
+peak = max(val for _, val in curve) or 1.0
+print(f"{'vol x':>6}  {'book_value':>11}  risk curve")
+for mult, val in curve:
+    bar = "█" * int(round(40 * val / peak))
+    print(f"{mult:>6.2f}  {val:>11.2f}  {bar}")
+
+
+# %% [markdown]
+# ## 6. Takeaway
+# The Monte Carlo simulation ran **inside ProximaDB** over pgwire — no data left the engine
+# for a separate compute cluster. One SQL surface serves both a data engineer (this notebook)
+# and an analyst (the SQL editor / `montecarlo.sql`). Compute-to-data: the simulation runs
+# where the book lives.
+
+# %%
+cur.close()
+conn.close()
+print("done — compute ran where the data lives.")

--- a/demo/montecarlo-sql/run.sh
+++ b/demo/montecarlo-sql/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright (C) 2025 ProximaDB
+# SPDX-License-Identifier: Apache-2.0
+#
+# Monte Carlo option pricing as an in-database compute workload — driven two ways over
+# the PostgreSQL wire protocol against a REAL ProximaDB:
+#   1. the SQL editor  (montecarlo.sql,          via psql)
+#   2. a notebook      (montecarlo_notebook.py,  via psycopg2)
+#
+# Prerequisites — a ProximaDB built from THIS code, with pgwire enabled:
+#   cargo build --release -p proximadb-server        # or: make build-server
+#   ./target/release/proximadb-server -c config/config.toml   # pgwire on 5433 (pg_port in [api])
+#
+# Unlike the cross-modal demo this needs ONLY pgwire — no REST seeding. The `mc_price` UDF
+# lives on the DataFusion compute engine, so a query must engage OLAP (an aggregate over a
+# MATERIALIZE'd table); the SQL/notebook do exactly that.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PG_HOST="${PROXIMADB_PG_HOST:-127.0.0.1}"
+PG_PORT="${PROXIMADB_PG_PORT:-5433}"
+DB="${PROXIMADB_DB:-quant}"   # the pgwire database == the tenant/catalog
+CONN="host=${PG_HOST} port=${PG_PORT} user=postgres dbname=${DB} sslmode=disable"
+
+echo "▶ ProximaDB Monte Carlo compute demo (pgwire ${PG_HOST}:${PG_PORT}, db ${DB})"
+
+# The two surfaces run the SAME workload independently; give each its own pgwire database
+# (the database == the tenant/catalog) so they don't share the `option_book` table.
+echo; echo "── montecarlo.sql : the SQL-editor workload (price + value + stress a book) ──"
+psql "host=${PG_HOST} port=${PG_PORT} user=postgres dbname=${DB} sslmode=disable" -f "${HERE}/montecarlo.sql"
+
+echo; echo "── montecarlo_notebook.py : the notebook workload (same pgwire, + a risk curve) ──"
+PROXIMADB_PG_HOST="${PG_HOST}" PROXIMADB_PG_PORT="${PG_PORT}" PROXIMADB_DB="${DB}_nb" \
+    python3 "${HERE}/montecarlo_notebook.py"
+
+echo; echo "✓ done — the Monte Carlo simulation ran in-database (compute-to-data)."


### PR DESCRIPTION
## What

A **compute** workload — not a copilot or MCP call. ProximaDB ships a vectorized Monte Carlo European-option pricer as a SQL scalar UDF — `mc_price(spot, strike, vol, rate, t, is_call, n_paths)` — on the DataFusion compute engine. A quant / data engineer prices and stress-tests a whole derivatives book in plain SQL: the simulation runs **where the data lives** (compute-to-data), with no extract to a separate Spark / pandas cluster. Only the aggregates leave the engine.

Driven two ways over pgwire — the two surfaces AnvaiOps exposes (SQL editor + notebook):

### 1. SQL editor — `montecarlo.sql`
```
 option_id | underlying | mc_price       underlying | n_options | book_value      underlying | base_value | vol_stress_value
-----------+------------+----------      -----------+-----------+------------     -----------+------------+------------------
 o1        | ACME       | 10.3804        ACME       |         3 |     153.80      ACME       |     153.61 |           235.46
 o2        | ACME       |  6.0653        GLOBEX     |         1 |      69.06      GLOBEX     |      69.03 |           117.65
 o3        | ACME       |  2.3029
 o4        | GLOBEX     |  3.5022        (prices match Black-Scholes within MC noise)
```

### 2. Notebook — `montecarlo_notebook.py`
Same over `psycopg2`, plus a **volatility sweep** (the whole book repriced across five scenarios in one query) as a risk curve:
```
 vol x   book_value  risk curve
  0.50       103.55  ████████████
  1.00       222.54  █████████████████████████
  1.50       352.92  ████████████████████████████████████████
```
Written as `# %%` cells — runs as a script, opens as a notebook (VS Code / Jupyter via jupytext).

## Notes

- **Routing:** `mc_price` is a DataFusion UDF, so a query must engage OLAP — an aggregate over a `MATERIALIZE`'d (Parquet-backed) table; a bare scalar `SELECT mc_price(...)` stays row-wise where the UDF isn't bound. The demo groups by option id (per-row) and by underlying (portfolio).
- **Needs only pgwire** — no REST seeding (contrast the cross-modal demo).
- Engine-neutral / open-core: `mc_price`, the DataFusion compute path, and pgwire are all in the OSS engine.
- Verified live end-to-end (both surfaces, isolated pgwire databases).

## Files
`montecarlo.sql`, `montecarlo_notebook.py`, `run.sh`, `README.adoc` under `demo/montecarlo-sql/`.