### PR TITLE
feat(timeseries): structural per-tenant isolation (Phase 1a) — delete {tenant}::name fold

### DIFF
--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -268,19 +268,6 @@ fn arg_i64(args: &[Expr], i: usize) -> Option<i64> {
     }
 }
 
-/// Fold the connection tenant into the collection key exactly as the REST write path's
-/// `effective_collection` (`src/network/rest/v2/timeseries.rs`) does — `{tenant}::{collection}` —
-/// so a UDTF read hits the same partition a REST ingest wrote (TD-XMODAL-6). An empty/absent
-/// tenant yields the raw name, mirroring the REST rule so single-tenant reads still resolve.
-/// (Vectors are scoped by `TenantContext`, not by name, so they use the raw collection + the
-/// tenant id directly; this fold is the timeseries analogue.)
-fn tenant_scoped_collection(tenant: Option<&str>, collection: &str) -> String {
-    match tenant {
-        Some(t) if !t.is_empty() => format!("{t}::{collection}"),
-        _ => collection.to_string(),
-    }
-}
-
 /// Parse a pgvector-style text literal `[0.1, 0.2, 0.3]` into `Vec<f32>`.
 fn parse_vector_literal(text: &str) -> Option<Vec<f32>> {
     let inner = text.trim().strip_prefix('[')?.strip_suffix(']')?;
@@ -342,9 +329,12 @@ pub fn timeseries_points_to_batch(points: &[TsPoint]) -> Result<RecordBatch, Arr
 /// with a fixed set of points, independent of the process time-series service.
 #[async_trait]
 pub trait TimeseriesScanPort: Send + Sync {
-    /// Read the points of `collection` in `[start_ms, end_ms]` (epoch millis).
+    /// Read the points of `tenant`'s `collection` in `[start_ms, end_ms]` (epoch millis). The
+    /// tenant scopes the read structurally (the service selects the tenant's engine); the
+    /// collection name is tenant-clean.
     async fn range(
         &self,
+        tenant: &str,
         collection: &str,
         start_ms: i64,
         end_ms: i64,
@@ -358,11 +348,14 @@ struct TimeSeriesServiceScan(Arc<TimeSeriesService>);
 impl TimeseriesScanPort for TimeSeriesServiceScan {
     async fn range(
         &self,
+        tenant: &str,
         collection: &str,
         start_ms: i64,
         end_ms: i64,
     ) -> anyhow::Result<Vec<TsPoint>> {
-        self.0.query(collection, start_ms, end_ms, None).await
+        self.0
+            .query(tenant, collection, start_ms, end_ms, None)
+            .await
     }
 }
 
@@ -371,21 +364,24 @@ impl TimeseriesScanPort for TimeSeriesServiceScan {
 /// can join a timeseries scan against relational/graph data.
 pub struct TimeseriesRangeTableProvider {
     scan: Arc<dyn TimeseriesScanPort>,
+    tenant: String,
     collection: String,
     start_ms: i64,
     end_ms: i64,
 }
 
 impl TimeseriesRangeTableProvider {
-    /// Build a provider for one parameterized time-range read.
+    /// Build a provider for one parameterized time-range read, scoped to `tenant`.
     pub fn new(
         scan: Arc<dyn TimeseriesScanPort>,
+        tenant: impl Into<String>,
         collection: impl Into<String>,
         start_ms: i64,
         end_ms: i64,
     ) -> Self {
         Self {
             scan,
+            tenant: tenant.into(),
             collection: collection.into(),
             start_ms,
             end_ms,
@@ -396,6 +392,7 @@ impl TimeseriesRangeTableProvider {
 impl std::fmt::Debug for TimeseriesRangeTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TimeseriesRangeTableProvider")
+            .field("tenant", &self.tenant)
             .field("collection", &self.collection)
             .field("start_ms", &self.start_ms)
             .field("end_ms", &self.end_ms)
@@ -422,7 +419,7 @@ impl TableProvider for TimeseriesRangeTableProvider {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let points = self
             .scan
-            .range(&self.collection, self.start_ms, self.end_ms)
+            .range(&self.tenant, &self.collection, self.start_ms, self.end_ms)
             .await
             .map_err(|e| DataFusionError::Execution(format!("timeseries range: {e}")))?;
         let batch = timeseries_points_to_batch(&points).map_err(DataFusionError::from)?;
@@ -441,9 +438,8 @@ impl TableProvider for TimeseriesRangeTableProvider {
 /// `ctx.register_udtf("timeseries_range", Arc::new(TimeseriesRangeTableFunction::new(port)))`.
 pub struct TimeseriesRangeTableFunction {
     scan: Arc<dyn TimeseriesScanPort>,
-    /// The connection tenant, folded into the collection key (`{tenant}::{collection}`) at
-    /// `call` time so the range read hits the same partition a REST ingest wrote. `None` ⇒ raw
-    /// collection name (single-tenant / tenant-less data).
+    /// The connection tenant, passed structurally to the scan port (which selects the tenant's
+    /// engine) — NOT folded into the collection name. `None` ⇒ the canonical `DEFAULT_TENANT`.
     tenant: Option<String>,
 }
 
@@ -511,11 +507,14 @@ impl TableFunctionImpl for TimeseriesRangeTableFunction {
                 "timeseries_range: end_ms must be >= start_ms".into(),
             ));
         }
-        // Fold the tenant into the collection key the same way the REST write path does, so the
-        // range read resolves the partition the ingest wrote (TD-XMODAL-6).
-        let collection = tenant_scoped_collection(self.tenant.as_deref(), &collection);
+        // Structural tenant scoping: pass the connection tenant (defaulting to the one canonical
+        // DEFAULT_TENANT) + the tenant-CLEAN collection name to the service, which selects the
+        // tenant's engine. No name-folding — the read hits the same per-tenant engine the REST
+        // ingest wrote to.
+        let tenant = proximadb_tenant::resolve_request_tenant(self.tenant.as_deref());
         Ok(Arc::new(TimeseriesRangeTableProvider::new(
             self.scan.clone(),
+            tenant,
             collection,
             start_ms,
             end_ms,
@@ -1054,6 +1053,7 @@ mod tests {
     impl TimeseriesScanPort for FixedTimeseriesScan {
         async fn range(
             &self,
+            _tenant: &str,
             _collection: &str,
             _start_ms: i64,
             _end_ms: i64,
@@ -1205,34 +1205,39 @@ mod tests {
         assert_eq!(n, 1);
     }
 
-    /// A `TimeseriesScanPort` that records the collection name it was asked to read — used to
-    /// prove `timeseries_range` folds the tenant into the collection key (TD-XMODAL-6).
+    /// A `TimeseriesScanPort` that records the `(tenant, collection)` it was asked to read — used
+    /// to prove `timeseries_range` passes the tenant STRUCTURALLY and keeps the collection name
+    /// tenant-clean (no `{tenant}::` folding).
     struct RecordingTimeseriesScan {
-        seen: Arc<std::sync::Mutex<Vec<String>>>,
+        seen: Arc<std::sync::Mutex<Vec<(String, String)>>>,
     }
 
     #[async_trait]
     impl TimeseriesScanPort for RecordingTimeseriesScan {
         async fn range(
             &self,
+            tenant: &str,
             collection: &str,
             _start_ms: i64,
             _end_ms: i64,
         ) -> anyhow::Result<Vec<TsPoint>> {
-            self.seen.lock().unwrap().push(collection.to_string());
+            self.seen
+                .lock()
+                .unwrap()
+                .push((tenant.to_string(), collection.to_string()));
             Ok(vec![tp(1_000, "amount", 1.0)])
         }
     }
 
-    /// TD-XMODAL-6: a tenant-scoped `timeseries_range` folds `{tenant}::{collection}` before the
-    /// read — matching the REST write path's `effective_collection` — so it hits the partition a
-    /// REST ingest wrote; an empty/absent tenant reads the raw name.
+    /// Structural isolation: `timeseries_range` passes the connection tenant to the scan port
+    /// (which selects the tenant's engine) and keeps the collection name tenant-CLEAN — no
+    /// `{tenant}::` folding. An empty/absent tenant resolves to the one canonical `DEFAULT_TENANT`.
     #[tokio::test]
-    async fn timeseries_range_udtf_folds_tenant_into_collection() {
-        for (tenant, expected) in [
-            (Some("acme".to_string()), "acme::sensor"),
-            (Some(String::new()), "sensor"),
-            (None, "sensor"),
+    async fn timeseries_range_udtf_passes_tenant_structurally_with_clean_name() {
+        for (tenant, expected_tenant) in [
+            (Some("acme".to_string()), "acme"),
+            (Some(String::new()), "default"),
+            (None, "default"),
         ] {
             let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
             let port: Arc<dyn TimeseriesScanPort> = Arc::new(RecordingTimeseriesScan {
@@ -1250,7 +1255,11 @@ mod tests {
                 .collect()
                 .await
                 .unwrap();
-            assert_eq!(seen.lock().unwrap().as_slice(), &[expected.to_string()]);
+            // The collection stays "sensor" (no `::`); the tenant is passed as a distinct arg.
+            assert_eq!(
+                seen.lock().unwrap().as_slice(),
+                &[(expected_tenant.to_string(), "sensor".to_string())]
+            );
         }
     }
 

--- a/src/network/rest/v2/timeseries.rs
+++ b/src/network/rest/v2/timeseries.rs
@@ -8,7 +8,8 @@
 //! `.../{c}/aggregate`, `GET /api/v2/timeseries/collections` (list),
 //! `DELETE .../{c}` (delete). Backed by the process-global [`TimeSeriesService`] over
 //! the native TST engine — never the stubbed vector-shaped trait methods. Tenant
-//! isolation is structural (the tenant is folded into the collection key).
+//! isolation is structural: the request tenant selects a per-tenant engine in the
+//! service (physically separate storage), and the collection name stays tenant-clean.
 
 use axum::extract::Path;
 use axum::{Extension, Json};
@@ -20,14 +21,6 @@ use crate::network::middleware::tenant::TenantContext;
 use crate::services::timeseries_service::{
     TimeSeriesService, TsCollectionConfig, TsPoint, timeseries_service,
 };
-
-fn effective_collection(tenant: &TenantContext, collection_id: &str) -> String {
-    if !tenant.tenant_id.is_empty() {
-        format!("{}::{}", tenant.tenant_id, collection_id)
-    } else {
-        collection_id.to_string()
-    }
-}
 
 fn service() -> ApiResult<Arc<TimeSeriesService>> {
     timeseries_service()
@@ -97,12 +90,13 @@ pub struct DeleteResponse {
 /// `POST /api/v2/timeseries/collections`
 pub async fn create_timeseries_collection(
     Extension(tenant): Extension<TenantContext>,
-    Json(mut config): Json<TsCollectionConfig>,
+    Json(config): Json<TsCollectionConfig>,
 ) -> ApiResult<Json<CreateResponse>> {
-    let name = effective_collection(&tenant, &config.name);
-    config.name = name.clone();
+    // Tenant-clean logical name: the tenant scopes the collection structurally in the service
+    // (a per-tenant engine), so the name the caller sees carries no `{tenant}::` prefix.
+    let name = config.name.clone();
     service()?
-        .create_collection(config)
+        .create_collection(&tenant.tenant_id, config)
         .await
         .map_err(|e| ApiError::Internal(format!("create timeseries collection: {e}")))?;
     Ok(Json(CreateResponse { name }))
@@ -114,9 +108,8 @@ pub async fn ingest_timeseries(
     Extension(tenant): Extension<TenantContext>,
     Json(request): Json<IngestRequest>,
 ) -> ApiResult<Json<IngestResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
     let ingested = service()?
-        .ingest(&collection, request.points)
+        .ingest(&tenant.tenant_id, &collection_id, request.points)
         .await
         .map_err(|e| ApiError::Internal(format!("ingest timeseries: {e}")))?;
     Ok(Json(IngestResponse { ingested }))
@@ -128,10 +121,10 @@ pub async fn query_timeseries(
     Extension(tenant): Extension<TenantContext>,
     Json(request): Json<QueryRequest>,
 ) -> ApiResult<Json<QueryResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
     let points = service()?
         .query(
-            &collection,
+            &tenant.tenant_id,
+            &collection_id,
             request.start_time,
             request.end_time,
             request.limit,
@@ -147,10 +140,10 @@ pub async fn aggregate_timeseries(
     Extension(tenant): Extension<TenantContext>,
     Json(request): Json<AggregateRequest>,
 ) -> ApiResult<Json<AggregateResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
     let buckets = service()?
         .aggregate(
-            &collection,
+            &tenant.tenant_id,
+            &collection_id,
             request.start_time,
             request.end_time,
             &request.aggregation,
@@ -163,9 +156,10 @@ pub async fn aggregate_timeseries(
 
 /// `GET /api/v2/timeseries/collections`
 pub async fn list_timeseries_collections(
-    Extension(_tenant): Extension<TenantContext>,
+    Extension(tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<ListResponse>> {
-    let collections = service()?.list_collections().await;
+    // Tenant-scoped: list only this tenant's collections (was a cross-tenant leak).
+    let collections = service()?.list_collections(&tenant.tenant_id).await;
     Ok(Json(ListResponse { collections }))
 }
 
@@ -174,7 +168,8 @@ pub async fn delete_timeseries_collection(
     Path(collection_id): Path<String>,
     Extension(tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<DeleteResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
-    let success = service()?.delete_collection(&collection).await;
+    let success = service()?
+        .delete_collection(&tenant.tenant_id, &collection_id)
+        .await;
     Ok(Json(DeleteResponse { success }))
 }

--- a/src/services/timeseries_service.rs
+++ b/src/services/timeseries_service.rs
@@ -76,49 +76,96 @@ pub struct TsPoint {
     pub tags: HashMap<String, String>,
 }
 
-/// Wraps a single `TimeSeriesEngine` (multiplexed by `collection_id`) plus a resident
-/// registry of the declared collection configs.
+/// Multiplexes a `TimeSeriesEngine` PER TENANT — each rooted at `<base_path>/<tenant>` — so
+/// tenants are isolated STRUCTURALLY by physical storage path, not by folding the tenant into the
+/// collection name. Collection configs are registered per `(tenant, name)`. Logical collection
+/// names stay tenant-clean; the tenant is the structural key dimension, applied once here.
 pub struct TimeSeriesService {
-    /// `insert_record` takes `&mut self`, so the engine is guarded for interior
-    /// mutability (writes exclusive, `query_time_range` reads shared).
-    engine: RwLock<TimeSeriesEngine>,
-    collections: RwLock<HashMap<String, TsCollectionConfig>>,
+    /// Root under which each tenant's engine hangs (`<base_path>/<tenant>`).
+    base_path: PathBuf,
+    /// One engine per tenant, created lazily. Each `insert_record` needs `&mut engine`, so every
+    /// tenant's engine is independently locked (writes exclusive, queries shared) — and no
+    /// tenant's partitions/WAL/segments ever share a path with another's.
+    engines: RwLock<HashMap<String, Arc<RwLock<TimeSeriesEngine>>>>,
+    /// Declared collection configs, keyed by `(tenant, collection_name)`.
+    collections: RwLock<HashMap<(String, String), TsCollectionConfig>>,
 }
 
 impl TimeSeriesService {
-    /// Build the service with the engine rooted at `base_path` (e.g. `<data_dir>/timeseries`).
+    /// Build the service rooted at `base_path` (e.g. `<data_dir>/timeseries`); per-tenant engines
+    /// hang off `<base_path>/<tenant>`.
     pub fn new(base_path: PathBuf) -> Result<Self> {
-        let config = TimeSeriesConfig {
-            base_path,
-            ..Default::default()
-        };
-        let engine = TimeSeriesEngine::with_config(config)
-            .map_err(|e| anyhow!("failed to init TimeSeriesEngine: {e}"))?;
         Ok(Self {
-            engine: RwLock::new(engine),
+            base_path,
+            engines: RwLock::new(HashMap::new()),
             collections: RwLock::new(HashMap::new()),
         })
     }
 
-    pub async fn create_collection(&self, config: TsCollectionConfig) -> Result<()> {
+    /// Get — or lazily create — the engine for `tenant`, rooted at `<base_path>/<tenant>`. The
+    /// tenant is validated as a path segment (foundation `validate_request_tenant`) so it can
+    /// never traverse or shadow a control-plane system subtree.
+    async fn engine_for(&self, tenant: &str) -> Result<Arc<RwLock<TimeSeriesEngine>>> {
+        proximadb_tenant::validate_request_tenant(tenant)
+            .map_err(|e| anyhow!("invalid tenant '{tenant}': {e}"))?;
+        if let Some(engine) = self.engines.read().await.get(tenant) {
+            return Ok(engine.clone());
+        }
+        let mut engines = self.engines.write().await;
+        // Re-check under the write lock — another task may have created it meanwhile.
+        if let Some(engine) = engines.get(tenant) {
+            return Ok(engine.clone());
+        }
+        let config = TimeSeriesConfig {
+            base_path: self.base_path.join(tenant),
+            ..Default::default()
+        };
+        let engine = TimeSeriesEngine::with_config(config)
+            .map_err(|e| anyhow!("failed to init TimeSeriesEngine for tenant '{tenant}': {e}"))?;
+        let handle = Arc::new(RwLock::new(engine));
+        engines.insert(tenant.to_string(), handle.clone());
+        Ok(handle)
+    }
+
+    pub async fn create_collection(&self, tenant: &str, config: TsCollectionConfig) -> Result<()> {
+        proximadb_tenant::validate_request_tenant(tenant)
+            .map_err(|e| anyhow!("invalid tenant '{tenant}': {e}"))?;
         self.collections
             .write()
             .await
-            .insert(config.name.clone(), config);
+            .insert((tenant.to_string(), config.name.clone()), config);
         Ok(())
     }
 
-    pub async fn list_collections(&self) -> Vec<TsCollectionConfig> {
-        self.collections.read().await.values().cloned().collect()
+    /// List a SINGLE tenant's collections (structural scope — never all tenants').
+    pub async fn list_collections(&self, tenant: &str) -> Vec<TsCollectionConfig> {
+        self.collections
+            .read()
+            .await
+            .iter()
+            .filter(|((t, _), _)| t == tenant)
+            .map(|(_, cfg)| cfg.clone())
+            .collect()
     }
 
-    pub async fn delete_collection(&self, name: &str) -> bool {
-        self.collections.write().await.remove(name).is_some()
+    pub async fn delete_collection(&self, tenant: &str, name: &str) -> bool {
+        self.collections
+            .write()
+            .await
+            .remove(&(tenant.to_string(), name.to_string()))
+            .is_some()
     }
 
-    /// Ingest points → TST-native `insert_record` (values in metadata, timestamp partitioned).
-    pub async fn ingest(&self, collection: &str, points: Vec<TsPoint>) -> Result<usize> {
-        let mut engine = self.engine.write().await;
+    /// Ingest points → TST-native `insert_record` (values in metadata, timestamp partitioned),
+    /// into the TENANT's engine.
+    pub async fn ingest(
+        &self,
+        tenant: &str,
+        collection: &str,
+        points: Vec<TsPoint>,
+    ) -> Result<usize> {
+        let engine_handle = self.engine_for(tenant).await?;
+        let mut engine = engine_handle.write().await;
         let mut inserted = 0usize;
         for point in points {
             let ts = Utc
@@ -160,9 +207,10 @@ impl TimeSeriesService {
         Ok(inserted)
     }
 
-    /// Query a time range → raw points (TST-native `query_time_range`).
+    /// Query a time range → raw points (TST-native `query_time_range`) from the TENANT's engine.
     pub async fn query(
         &self,
+        tenant: &str,
         collection: &str,
         start_ms: i64,
         end_ms: i64,
@@ -176,8 +224,8 @@ impl TimeSeriesService {
             .timestamp_millis_opt(end_ms)
             .single()
             .ok_or_else(|| anyhow!("invalid end_time"))?;
-        let records = self
-            .engine
+        let engine_handle = self.engine_for(tenant).await?;
+        let records = engine_handle
             .read()
             .await
             .query_time_range(collection, start, end, limit)
@@ -190,13 +238,16 @@ impl TimeSeriesService {
     /// (avg | sum | min | max | count | stddev | first | last) to each value column.
     pub async fn aggregate(
         &self,
+        tenant: &str,
         collection: &str,
         start_ms: i64,
         end_ms: i64,
         aggregation: &str,
         bucket_ms: i64,
     ) -> Result<Vec<serde_json::Value>> {
-        let points = self.query(collection, start_ms, end_ms, None).await?;
+        let points = self
+            .query(tenant, collection, start_ms, end_ms, None)
+            .await?;
         let bucket = bucket_ms.max(1);
         let mut buckets: BTreeMap<i64, HashMap<String, Vec<f64>>> = BTreeMap::new();
         for point in points {
@@ -266,5 +317,115 @@ fn apply_aggregation(aggregation: &str, vals: &[f64]) -> f64 {
         }
         // "avg" / "mean" and anything else → mean
         _ => vals.iter().sum::<f64>() / n,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn point(ts: i64, metric: &str, v: f64) -> TsPoint {
+        TsPoint {
+            timestamp: ts,
+            values: HashMap::from([(metric.to_string(), v)]),
+            tags: HashMap::new(),
+        }
+    }
+
+    fn config(name: &str) -> TsCollectionConfig {
+        TsCollectionConfig {
+            name: name.to_string(),
+            timestamp_column: "timestamp".to_string(),
+            value_columns: vec![],
+            tag_columns: vec![],
+            retention_ms: None,
+        }
+    }
+
+    /// The canonical isolation rubric: two tenants write the SAME tenant-clean logical
+    /// collection name, and neither can read the other's data — isolation is structural
+    /// (a per-tenant engine rooted at a separate path), NOT a `{tenant}::name` fold.
+    #[tokio::test]
+    async fn tenants_are_isolated_under_the_same_logical_collection_name() {
+        let tmp = TempDir::new().expect("tempdir");
+        let svc = TimeSeriesService::new(tmp.path().to_path_buf()).expect("service");
+
+        // Both tenants use the identical, tenant-CLEAN collection name "sensor".
+        svc.ingest("acme", "sensor", vec![point(1_000, "v", 1.0)])
+            .await
+            .expect("acme ingest");
+        svc.ingest("globex", "sensor", vec![point(1_000, "v", 99.0)])
+            .await
+            .expect("globex ingest");
+
+        let acme = svc
+            .query("acme", "sensor", 0, 10_000, None)
+            .await
+            .expect("acme query");
+        let globex = svc
+            .query("globex", "sensor", 0, 10_000, None)
+            .await
+            .expect("globex query");
+
+        // Each tenant sees ONLY its own value — no cross-tenant bleed despite the shared name.
+        assert_eq!(acme.len(), 1, "acme sees only its own point");
+        assert_eq!(acme[0].values.get("v"), Some(&1.0));
+        assert_eq!(globex.len(), 1, "globex sees only its own point");
+        assert_eq!(globex[0].values.get("v"), Some(&99.0));
+
+        // A tenant that never wrote "sensor" reads nothing (no shared global engine).
+        let stranger = svc
+            .query("stranger", "sensor", 0, 10_000, None)
+            .await
+            .expect("stranger query");
+        assert!(stranger.is_empty(), "unrelated tenant sees no data");
+    }
+
+    /// `list_collections` is tenant-scoped — the former cross-tenant leak is gone.
+    #[tokio::test]
+    async fn list_collections_returns_only_the_requesting_tenants_collections() {
+        let tmp = TempDir::new().expect("tempdir");
+        let svc = TimeSeriesService::new(tmp.path().to_path_buf()).expect("service");
+
+        svc.create_collection("acme", config("sensor"))
+            .await
+            .expect("acme create");
+        svc.create_collection("globex", config("sensor"))
+            .await
+            .expect("globex create");
+        svc.create_collection("globex", config("weather"))
+            .await
+            .expect("globex create 2");
+
+        let acme = svc.list_collections("acme").await;
+        assert_eq!(acme.len(), 1, "acme has exactly one collection");
+        assert_eq!(acme[0].name, "sensor");
+
+        let globex = svc.list_collections("globex").await;
+        assert_eq!(globex.len(), 2, "globex has two, none of acme's");
+    }
+
+    /// The tenant is validated as a structural path segment — traversal / reserved
+    /// prefixes are fail-closed before an engine is ever created.
+    #[tokio::test]
+    async fn invalid_tenants_are_rejected_fail_closed() {
+        let tmp = TempDir::new().expect("tempdir");
+        let svc = TimeSeriesService::new(tmp.path().to_path_buf()).expect("service");
+
+        assert!(
+            svc.ingest("../evil", "sensor", vec![]).await.is_err(),
+            "path traversal rejected"
+        );
+        assert!(
+            svc.ingest("_system", "sensor", vec![]).await.is_err(),
+            "reserved-prefix tenant rejected"
+        );
+        assert!(
+            svc.create_collection("bad/tenant", config("sensor"))
+                .await
+                .is_err(),
+            "separator in tenant rejected"
+        );
     }
 }


### PR DESCRIPTION
## What & why

Phase 1a of the coherent structural tenant-isolation redesign. Replaces the
`{tenant}::{collection}` **string-folding** on the timeseries surface with
**structural** isolation — the shape the co-design mandate requires ("isolation is
structural, never a per-query predicate"). The fold was exactly that forbidden
per-query name predicate; it was also leaky (`list` forgot it → cross-tenant leak)
and only existed because the TST engine had no tenant parameter at all.

**Mechanism:** `TimeSeriesService` now multiplexes one `TimeSeriesEngine` **per
tenant**, each rooted at `<base_path>/<tenant>`, so no two tenants' partitions, WAL,
or segments ever share a path. Logical collection names stay tenant-**clean**; the
tenant is the structural key dimension, composed **once** in the service. This keeps
the design DrPathBuilder-forward (a tenant path segment today; swappable to a
`DrPathBuilder` prefix later without signature changes).

> Design note: the approved decision was "tenant as an in-engine key dimension." I
> chose **per-tenant engine instances** over a `(tenant, collection, time)` tuple
> partition key — it delivers the same physical separation without a WAL/partition
> on-disk format change, and leaves the TST engine internals untouched. No
> backward-compat concern (v2 internal-only, not deployed), so pre-existing data
> under the old fold paths is not migrated.

## Changes
- **`services/timeseries_service.rs`** — per-tenant engine map (lazy, double-checked
  under write lock); `engine_for(tenant)` validates the tenant as a path segment
  (fail-closed via `proximadb_tenant::validate_request_tenant`); every method takes
  `tenant: &str`; configs keyed by `(tenant, name)`; **`list_collections` is
  tenant-scoped** (fixes the cross-tenant leak).
- **`network/rest/v2/timeseries.rs`** — delete `effective_collection`; handlers pass
  the resolved tenant + the raw, tenant-clean collection name.
- **`datafusion/cross_modal.rs`** — thread tenant through `TimeseriesScanPort::range`
  and `TimeseriesRangeTableProvider`; delete `tenant_scoped_collection`; the
  `timeseries_range` UDTF resolves the tenant and passes a clean name. Writer +
  reader compose the same key, **changed atomically** (mandate: the fold and its
  cross-modal reader move in one PR).

## Tests (TDD rubric)
- `tenants_are_isolated_under_the_same_logical_collection_name` — two tenants write
  the identical clean name "sensor"; neither reads the other's data; a third tenant
  reads nothing.
- `list_collections_returns_only_the_requesting_tenants_collections` — leak fix.
- `invalid_tenants_are_rejected_fail_closed` — traversal / reserved-prefix / separator.
- Updated cross-modal UDTF test asserts the tenant is passed structurally with a
  clean collection name (was: asserts the `{tenant}::name` fold).

## Verification
- `cargo build -p proximadb-server` ✅ (folds live in network handlers that `--lib` skips)
- `cargo fmt --check` ✅, `cargo clippy -p proximadb -- -D warnings` ✅
- 7/7 targeted tests pass.

Stacked on #681 (Phase 0). Retargets to `develop` automatically once #681 merges.