### PR TITLE
feat(graph): structural per-tenant isolation via TenantGraphOps facade (Phase 1b) — gRPC + Flight

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -131,8 +131,201 @@ type Result<T> = std::result::Result<T, ProximaDBError>;
 /// Node ID type alias for clarity
 pub type NodeId = String;
 
-/// Edge ID type alias for clarity  
+/// Edge ID type alias for clarity
 pub type EdgeId = String;
+
+/// The ONE structural composition point for graph tenant scoping. The network layer
+/// passes a tenant-CLEAN `graph_id`; the service composes the physical scope key here.
+/// Path-style `{tenant}/{graph_id}` (never `{tenant}::{graph_id}`). Validates the tenant
+/// as a path segment (fail-closed) before it becomes an engine-registry / oid / constraint key.
+///
+/// Isolation is structural, not a per-query name predicate: every read/write path routes
+/// through this one composition so create and read agree, and no network handler bakes the
+/// tenant into a user-visible name. Preserves the prior isolation mechanism (distinct engine
+/// per (tenant, graph)); only the composition location (service, not handler) and separator
+/// (`/` not `::`) change.
+pub fn scoped_graph_id(tenant: &str, graph_id: &str) -> anyhow::Result<String> {
+    proximadb_tenant::validate_request_tenant(tenant)
+        .map_err(|e| anyhow::anyhow!("invalid tenant '{tenant}': {e}"))?;
+    Ok(format!("{tenant}/{graph_id}"))
+}
+
+/// A tenant-scoped view over [`GraphOperationsService`].
+///
+/// The network layer obtains one per request via [`GraphOperationsService::for_tenant`],
+/// passes tenant-CLEAN `graph_id`s, and this handle composes the structural scope
+/// (`{tenant}/{graph_id}`, via [`scoped_graph_id`]) exactly ONCE before delegating to the
+/// untouched raw methods. Isolation is therefore structural and composed at the boundary —
+/// never a per-handler `{tenant}::{graph_id}` name predicate baked into user-visible names.
+///
+/// This is additive: the raw `GraphOperationsService` methods keep taking a bare `graph_id`,
+/// so the ~50 internal/embedded/transaction callers (which have no request tenant) are
+/// unaffected. Only request-scoped network surfaces route through this handle. The isolation
+/// mechanism is preserved verbatim (a distinct engine per `(tenant, graph)` via the engine
+/// registry); only the composition location (here, not each handler) and the separator
+/// (`/` not `::`) change.
+pub struct TenantGraphOps<'a> {
+    inner: &'a GraphOperationsService,
+    tenant: String,
+}
+
+impl GraphOperationsService {
+    /// Obtain a [`TenantGraphOps`] that scopes every operation to `tenant`. Network handlers
+    /// call `self.graph.for_tenant(&tenant).create_node(clean_graph_id, node)` etc.
+    pub fn for_tenant(&self, tenant: &str) -> TenantGraphOps<'_> {
+        TenantGraphOps {
+            inner: self,
+            tenant: tenant.to_string(),
+        }
+    }
+}
+
+impl TenantGraphOps<'_> {
+    /// The single structural composition point for this handle: validate the tenant and
+    /// render `{tenant}/{graph_id}`. Fails closed (invalid tenant → `InvalidInput`).
+    fn scope(&self, graph_id: &str) -> Result<String> {
+        scoped_graph_id(&self.tenant, graph_id)
+            .map_err(|e| ProximaDBError::InvalidInput(e.to_string()))
+    }
+
+    // ── Node ops ────────────────────────────────────────────────────────────
+    pub async fn create_node(&self, graph_id: &str, node: Node) -> Result<Arc<Node>> {
+        self.inner.create_node(&self.scope(graph_id)?, node).await
+    }
+    pub async fn get_node(&self, graph_id: &str, id: &NodeId) -> Result<Option<Arc<Node>>> {
+        self.inner.get_node(&self.scope(graph_id)?, id).await
+    }
+    pub async fn update_node(&self, graph_id: &str, node: Node) -> Result<Arc<Node>> {
+        self.inner.update_node(&self.scope(graph_id)?, node).await
+    }
+    pub async fn delete_node(&self, graph_id: &str, id: &NodeId) -> Result<Option<Arc<Node>>> {
+        self.inner.delete_node(&self.scope(graph_id)?, id).await
+    }
+    pub async fn get_neighbors(&self, graph_id: &str, node_id: &NodeId) -> Result<Vec<Arc<Node>>> {
+        self.inner
+            .get_neighbors(&self.scope(graph_id)?, node_id)
+            .await
+    }
+    pub async fn query_nodes(&self, graph_id: &str, query: NodeQuery) -> Result<Vec<Arc<Node>>> {
+        self.inner.query_nodes(&self.scope(graph_id)?, query).await
+    }
+
+    // ── Edge ops ────────────────────────────────────────────────────────────
+    pub async fn create_edge(&self, graph_id: &str, edge: Edge) -> Result<Arc<Edge>> {
+        self.inner.create_edge(&self.scope(graph_id)?, edge).await
+    }
+    pub async fn update_edge(&self, graph_id: &str, edge: Edge) -> Result<Arc<Edge>> {
+        self.inner.update_edge(&self.scope(graph_id)?, edge).await
+    }
+    pub async fn delete_edge(&self, graph_id: &str, id: &EdgeId) -> Result<Option<Arc<Edge>>> {
+        self.inner.delete_edge(&self.scope(graph_id)?, id).await
+    }
+    pub async fn get_edge(&self, graph_id: &str, id: &EdgeId) -> Result<Option<Arc<Edge>>> {
+        self.inner.get_edge(&self.scope(graph_id)?, id).await
+    }
+    pub async fn query_edges(&self, graph_id: &str, query: EdgeQuery) -> Result<Vec<Arc<Edge>>> {
+        self.inner.query_edges(&self.scope(graph_id)?, query).await
+    }
+
+    // ── Traversal / algorithms ──────────────────────────────────────────────
+    pub async fn traverse(
+        &self,
+        graph_id: &str,
+        request: TraversalRequest,
+    ) -> Result<TraversalResponse> {
+        self.inner.traverse(&self.scope(graph_id)?, request).await
+    }
+    #[allow(clippy::too_many_arguments)]
+    pub async fn shortest_path(
+        &self,
+        graph_id: &str,
+        start_node_id: &NodeId,
+        target_node_id: &NodeId,
+        max_depth: Option<u32>,
+        edge_types: Option<Vec<String>>,
+        algorithm: Option<crate::proto::proximadb_v1::ShortestPathAlgorithm>,
+        k: Option<u32>,
+        override_enable_prefetch: Option<bool>,
+        override_prefetch_budget: Option<usize>,
+    ) -> Result<Option<(Vec<NodeId>, f64)>> {
+        self.inner
+            .shortest_path(
+                &self.scope(graph_id)?,
+                start_node_id,
+                target_node_id,
+                max_depth,
+                edge_types,
+                algorithm,
+                k,
+                override_enable_prefetch,
+                override_prefetch_budget,
+            )
+            .await
+    }
+    pub async fn connected_components(&self, graph_id: &str) -> Result<Vec<Vec<NodeId>>> {
+        self.inner
+            .connected_components(&self.scope(graph_id)?)
+            .await
+    }
+    pub async fn has_cycle(&self, graph_id: &str) -> Result<bool> {
+        self.inner.has_cycle(&self.scope(graph_id)?).await
+    }
+    pub async fn get_stats(&self, graph_id: &str) -> Result<GraphStats> {
+        self.inner.get_stats(&self.scope(graph_id)?).await
+    }
+
+    // ── Batch ───────────────────────────────────────────────────────────────
+    pub async fn batch_create_nodes(
+        &self,
+        graph_id: &str,
+        nodes: Vec<Node>,
+    ) -> Result<Vec<Arc<Node>>> {
+        self.inner
+            .batch_create_nodes(&self.scope(graph_id)?, nodes)
+            .await
+    }
+    pub async fn batch_create_nodes_with_strategy(
+        &self,
+        graph_id: &str,
+        nodes: Vec<Node>,
+        if_exists: &str,
+    ) -> Result<Vec<Arc<Node>>> {
+        self.inner
+            .batch_create_nodes_with_strategy(&self.scope(graph_id)?, nodes, if_exists)
+            .await
+    }
+    pub async fn batch_create_edges(
+        &self,
+        graph_id: &str,
+        edges: Vec<Edge>,
+    ) -> Result<Vec<Arc<Edge>>> {
+        self.inner
+            .batch_create_edges(&self.scope(graph_id)?, edges)
+            .await
+    }
+
+    // ── Constraints ─────────────────────────────────────────────────────────
+    pub async fn add_unique_constraint(
+        &self,
+        graph_id: &str,
+        label: &str,
+        property: &str,
+    ) -> Result<()> {
+        self.inner
+            .add_unique_constraint(&self.scope(graph_id)?, label, property)
+            .await
+    }
+    pub async fn remove_unique_constraint(
+        &self,
+        graph_id: &str,
+        label: &str,
+        property: &str,
+    ) -> Result<()> {
+        self.inner
+            .remove_unique_constraint(&self.scope(graph_id)?, label, property)
+            .await
+    }
+}
 
 /// Graph operation mode for flexible deployment
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -2650,19 +2650,6 @@ impl ProximaFlightService {
         Ok(TonicResponse::new(Box::pin(stream)))
     }
 
-    /// Derive the effective backing graph namespace from the request tenant.
-    ///
-    /// Structural isolation: the tenant is folded into the graph storage key
-    /// (mirrors the gRPC v2 graph surface's `effective_graph_id`), never a
-    /// per-query predicate. Unauthenticated calls (no tenant) fall back to the
-    /// raw graph id.
-    fn effective_graph_id(tenant: Option<&str>, graph_id: &str) -> String {
-        match tenant {
-            Some(t) if !t.is_empty() => format!("{t}::{graph_id}"),
-            _ => graph_id.to_string(),
-        }
-    }
-
     /// Handle the batched columnar graph ingest exchange (`graph_nodes` /
     /// `graph_edges`). Each streamed Arrow `RecordBatch` is decoded via
     /// [`super::graph_codec`] into neutral nodes/edges and upserted through the
@@ -2679,7 +2666,10 @@ impl ProximaFlightService {
         let graph = self.graph_service.as_ref().ok_or_else(|| {
             TonicStatus::unimplemented("graph Flight path requires the graph backing service")
         })?;
-        let effective_graph_id = Self::effective_graph_id(tenant_id.as_deref(), &graph_id);
+        // Structural isolation: resolve the tenant and route through the scoped handle,
+        // which composes `{tenant}/{graph_id}` once. The graph_id stays tenant-clean.
+        let tenant = proximadb_tenant::resolve_request_tenant(tenant_id.as_deref());
+        let ops = graph.for_tenant(&tenant);
 
         let mut total_rows = 0u64;
         let mut total_batches = 0u64;
@@ -2695,15 +2685,13 @@ impl ProximaFlightService {
             let written = if is_nodes {
                 let nodes = super::graph_codec::batch_to_nodes(&batch)
                     .map_err(|e| TonicStatus::invalid_argument(format!("decode nodes: {}", e)))?;
-                graph
-                    .batch_create_nodes_with_strategy(&effective_graph_id, nodes, "update")
+                ops.batch_create_nodes_with_strategy(&graph_id, nodes, "update")
                     .await
                     .map(|created| created.len() as u64)
             } else {
                 let edges = super::graph_codec::batch_to_edges(&batch)
                     .map_err(|e| TonicStatus::invalid_argument(format!("decode edges: {}", e)))?;
-                graph
-                    .batch_create_edges(&effective_graph_id, edges)
+                ops.batch_create_edges(&graph_id, edges)
                     .await
                     .map(|created| created.len() as u64)
             };
@@ -2712,7 +2700,7 @@ impl ProximaFlightService {
                 Ok(n) => (n, true),
                 Err(e) => {
                     all_success = false;
-                    tracing::error!(graph_id = %effective_graph_id, error = %e, "graph Flight ingest batch failed");
+                    tracing::error!(graph_id = %graph_id, error = %e, "graph Flight ingest batch failed");
                     (0, false)
                 }
             };
@@ -2748,7 +2736,7 @@ impl ProximaFlightService {
         }));
 
         info!(
-            graph_id = %effective_graph_id,
+            graph_id = %graph_id,
             kind = if is_nodes { "graph_nodes" } else { "graph_edges" },
             total_batches = total_batches,
             total_rows_written = total_rows,
@@ -2785,7 +2773,10 @@ impl ProximaFlightService {
         let graph = self.graph_service.clone().ok_or_else(|| {
             TonicStatus::unimplemented("graph Flight path requires the graph backing service")
         })?;
-        let gid = Self::effective_graph_id(tenant_id.as_deref(), &ticket.graph_id);
+        // Read the SAME structural key the write path composes (`{tenant}/{graph_id}`).
+        let tenant = proximadb_tenant::resolve_request_tenant(tenant_id.as_deref());
+        let gid = crate::graph::scoped_graph_id(&tenant, &ticket.graph_id)
+            .map_err(|e| TonicStatus::invalid_argument(format!("invalid tenant: {e}")))?;
         let page = ticket
             .limit
             .map(|l| l as usize)

--- a/src/network/grpc/v2/graph_service.rs
+++ b/src/network/grpc/v2/graph_service.rs
@@ -18,11 +18,12 @@
 //!   `UnifiedHandlers::graph_operations_service` the v1 adapter uses — no new
 //!   business logic. v2 messages are mapped to the internal (v1 proto) domain
 //!   types at the handler boundary only; see the `conv` helpers below.
-//! - **Structural tenant isolation.** Each handler derives the effective backing
-//!   graph namespace from the request tenant (`x-tenant-id` / auth context) via
-//!   [`grpc_auth::tenant_id`]. Isolation is a namespace on the storage key, never
-//!   a per-query predicate. The backing `GraphOperationsService` does not yet
-//!   accept a `TenantContext`; deeper plumbing is tracked as a follow-up TD.
+//! - **Structural tenant isolation.** Each handler resolves the request tenant
+//!   (`x-tenant-id` / auth context) via [`grpc_auth::resolved_tenant_id`], then routes
+//!   through [`GraphOperationsService::for_tenant`], which composes the structural scope
+//!   (`{tenant}/{graph_id}`) exactly ONCE at the boundary and delegates to the raw ops.
+//!   Handlers pass tenant-CLEAN `graph_id`s and never bake the tenant into a user-visible
+//!   name — isolation is a namespace on the storage key, never a per-query predicate.
 //!
 //! ## Deferred RPCs
 //!
@@ -77,19 +78,6 @@ impl ProximaGraphServiceImpl {
     /// Convert to a tonic server.
     pub fn into_server(self) -> ProximaGraphServiceServer<Self> {
         ProximaGraphServiceServer::new(self)
-    }
-
-    /// Derive the effective backing graph namespace from the request tenant.
-    ///
-    /// Isolation is structural: the tenant is folded into the storage key (the
-    /// `GraphOperationsService` registry/path key), never applied as a per-query
-    /// predicate. Embedded / unauthenticated calls (no tenant) fall back to the
-    /// raw `graph_id` for backward compatibility.
-    fn effective_graph_id<T>(request: &Request<T>, graph_id: &str) -> String {
-        match grpc_auth::tenant_id(request) {
-            Some(tenant) if !tenant.is_empty() => format!("{tenant}::{graph_id}"),
-            _ => graph_id.to_string(),
-        }
     }
 }
 
@@ -364,7 +352,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::CreateGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC CreateNode graph={graph_id}");
         let node = req
@@ -372,6 +361,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             .ok_or_else(|| Status::invalid_argument("node is required"))?;
         match self
             .graph
+            .for_tenant(&tenant)
             .create_node(&graph_id, conv::node_to_v1(node))
             .await
         {
@@ -389,10 +379,16 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetNode graph={graph_id} node={}", req.node_id);
-        match self.graph.get_node(&graph_id, &req.node_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .get_node(&graph_id, &req.node_id)
+            .await
+        {
             Ok(found) => Ok(Response::new(pv2::GraphNodeResponse {
                 node: found.map(|n| conv::node_to_v2((*n).clone())),
             })),
@@ -404,7 +400,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::UpdateGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC UpdateNode graph={graph_id}");
         let node = req
@@ -412,6 +409,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             .ok_or_else(|| Status::invalid_argument("node is required"))?;
         match self
             .graph
+            .for_tenant(&tenant)
             .update_node(&graph_id, conv::node_to_v1(node))
             .await
         {
@@ -426,10 +424,16 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::DeleteGraphNodeRequest>,
     ) -> Result<Response<pv2::DeleteGraphNodeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC DeleteNode graph={graph_id} node={}", req.node_id);
-        match self.graph.delete_node(&graph_id, &req.node_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .delete_node(&graph_id, &req.node_id)
+            .await
+        {
             Ok(removed) => Ok(Response::new(pv2::DeleteGraphNodeResponse {
                 deleted: removed.is_some(),
                 node: removed.map(|n| conv::node_to_v2((*n).clone())),
@@ -442,7 +446,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::CreateGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC CreateEdge graph={graph_id}");
         let edge = req
@@ -450,6 +455,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             .ok_or_else(|| Status::invalid_argument("edge is required"))?;
         match self
             .graph
+            .for_tenant(&tenant)
             .create_edge(&graph_id, conv::edge_to_v1(edge))
             .await
         {
@@ -464,10 +470,16 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetEdge graph={graph_id} edge={}", req.edge_id);
-        match self.graph.get_edge(&graph_id, &req.edge_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .get_edge(&graph_id, &req.edge_id)
+            .await
+        {
             Ok(found) => Ok(Response::new(pv2::GraphEdgeResponse {
                 edge: found.map(|e| conv::edge_to_v2((*e).clone())),
             })),
@@ -479,7 +491,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::UpdateGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC UpdateEdge graph={graph_id}");
         let edge = req
@@ -487,6 +500,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             .ok_or_else(|| Status::invalid_argument("edge is required"))?;
         match self
             .graph
+            .for_tenant(&tenant)
             .update_edge(&graph_id, conv::edge_to_v1(edge))
             .await
         {
@@ -501,10 +515,16 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::DeleteGraphEdgeRequest>,
     ) -> Result<Response<pv2::DeleteGraphEdgeResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC DeleteEdge graph={graph_id} edge={}", req.edge_id);
-        match self.graph.delete_edge(&graph_id, &req.edge_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .delete_edge(&graph_id, &req.edge_id)
+            .await
+        {
             Ok(removed) => Ok(Response::new(pv2::DeleteGraphEdgeResponse {
                 deleted: removed.is_some(),
                 edge: removed.map(|e| conv::edge_to_v2((*e).clone())),
@@ -517,7 +537,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::QueryGraphNodesRequest>,
     ) -> Result<Response<pv2::QueryGraphNodesResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC QueryNodes graph={graph_id} labels={:?}",
@@ -532,7 +553,12 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             offset,
             continuation_token: None,
         };
-        match self.graph.query_nodes(&graph_id, query).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .query_nodes(&graph_id, query)
+            .await
+        {
             Ok(nodes) => {
                 let nodes: Vec<pv2::GraphNode> = nodes
                     .into_iter()
@@ -552,7 +578,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::QueryGraphEdgesRequest>,
     ) -> Result<Response<pv2::QueryGraphEdgesResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC QueryEdges graph={graph_id}");
         let offset = resolve_offset(req.offset, &req.continuation_token);
@@ -566,7 +593,12 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             offset,
             continuation_token: None,
         };
-        match self.graph.query_edges(&graph_id, query).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .query_edges(&graph_id, query)
+            .await
+        {
             Ok(edges) => {
                 let edges: Vec<pv2::GraphEdge> = edges
                     .into_iter()
@@ -586,10 +618,16 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphNeighborsRequest>,
     ) -> Result<Response<pv2::GetGraphNeighborsResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetNeighbors graph={graph_id} node={}", req.node_id);
-        match self.graph.get_neighbors(&graph_id, &req.node_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .get_neighbors(&graph_id, &req.node_id)
+            .await
+        {
             Ok(nodes) => Ok(Response::new(pv2::GetGraphNeighborsResponse {
                 nodes: nodes
                     .into_iter()
@@ -604,7 +642,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::TraverseGraphRequest>,
     ) -> Result<Response<pv2::TraverseGraphResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         let start = Instant::now();
         debug!(
@@ -612,7 +651,12 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             req.start_node_id
         );
         let internal = conv::traversal_request_to_v1(graph_id.clone(), req);
-        match self.graph.traverse(&graph_id, internal).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .traverse(&graph_id, internal)
+            .await
+        {
             Ok(resp) => {
                 let mut stats = resp.stats.map(conv::traversal_stats_to_v2);
                 if let Some(stats) = stats.as_mut()
@@ -635,7 +679,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphShortestPathRequest>,
     ) -> Result<Response<pv2::GraphShortestPathResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC ShortestPath graph={graph_id} {} -> {}",
@@ -653,6 +698,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         };
         match self
             .graph
+            .for_tenant(&tenant)
             .shortest_path(
                 &graph_id,
                 &req.start_node_id,
@@ -684,9 +730,10 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphStatsRequest>,
     ) -> Result<Response<pv2::GraphStats>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC GetGraphStats graph={graph_id}");
-        match self.graph.get_stats(&graph_id).await {
+        match self.graph.for_tenant(&tenant).get_stats(&graph_id).await {
             Ok(stats) => Ok(Response::new(conv::stats_to_v2(stats))),
             Err(e) => Err(graph_status("get graph statistics", e)),
         }
@@ -704,7 +751,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::TraverseGraphRequest>,
     ) -> Result<Response<Self::StreamTraverseStream>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         let start = Instant::now();
         debug!(
@@ -714,6 +762,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         let internal = conv::traversal_request_to_v1(graph_id.clone(), req);
         let resp = self
             .graph
+            .for_tenant(&tenant)
             .traverse(&graph_id, internal)
             .await
             .map_err(|e| graph_status("traverse graph", e))?;
@@ -746,9 +795,15 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphConnectedComponentsRequest>,
     ) -> Result<Response<pv2::GraphConnectedComponentsResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC GetConnectedComponents graph={graph_id}");
-        match self.graph.connected_components(&graph_id).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .connected_components(&graph_id)
+            .await
+        {
             Ok(comps) => Ok(Response::new(pv2::GraphConnectedComponentsResponse {
                 components: comps
                     .into_iter()
@@ -763,9 +818,10 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphHasCycleRequest>,
     ) -> Result<Response<pv2::GraphHasCycleResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC HasCycle graph={graph_id}");
-        match self.graph.has_cycle(&graph_id).await {
+        match self.graph.for_tenant(&tenant).has_cycle(&graph_id).await {
             Ok(has_cycle) => Ok(Response::new(pv2::GraphHasCycleResponse { has_cycle })),
             Err(e) => Err(graph_status("check for cycles", e)),
         }
@@ -777,7 +833,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphUniqueConstraintRequest>,
     ) -> Result<Response<pv2::GraphUniqueConstraintResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC AddUniqueConstraint graph={graph_id} label={} property={}",
@@ -787,6 +844,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         // adapter) rather than as a gRPC error, so clients can branch on it.
         match self
             .graph
+            .for_tenant(&tenant)
             .add_unique_constraint(&graph_id, &req.label, &req.property)
             .await
         {
@@ -805,7 +863,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphUniqueConstraintRequest>,
     ) -> Result<Response<pv2::GraphUniqueConstraintResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC RemoveUniqueConstraint graph={graph_id} label={} property={}",
@@ -813,6 +872,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         );
         match self
             .graph
+            .for_tenant(&tenant)
             .remove_unique_constraint(&graph_id, &req.label, &req.property)
             .await
         {
@@ -833,14 +893,20 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::BatchCreateGraphNodesRequest>,
     ) -> Result<Response<pv2::BatchCreateGraphNodesResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC BatchCreateNodes graph={graph_id} count={}",
             req.nodes.len()
         );
         let nodes = req.nodes.into_iter().map(conv::node_to_v1).collect();
-        match self.graph.batch_create_nodes(&graph_id, nodes).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .batch_create_nodes(&graph_id, nodes)
+            .await
+        {
             Ok(created) => {
                 let nodes: Vec<pv2::GraphNode> = created
                     .into_iter()
@@ -861,14 +927,20 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::BatchCreateGraphEdgesRequest>,
     ) -> Result<Response<pv2::BatchCreateGraphEdgesResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC BatchCreateEdges graph={graph_id} count={}",
             req.edges.len()
         );
         let edges = req.edges.into_iter().map(conv::edge_to_v1).collect();
-        match self.graph.batch_create_edges(&graph_id, edges).await {
+        match self
+            .graph
+            .for_tenant(&tenant)
+            .batch_create_edges(&graph_id, edges)
+            .await
+        {
             Ok(created) => {
                 let edges: Vec<pv2::GraphEdge> = created
                     .into_iter()
@@ -897,7 +969,8 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::ExecuteGraphQueryRequest>,
     ) -> Result<Response<pv2::ExecuteGraphQueryResponse>, Status> {
-        let graph_id = Self::effective_graph_id(&request, &request.get_ref().graph_id);
+        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
             "v2 gRPC ExecuteQuery graph={graph_id} language={}",
@@ -919,13 +992,18 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
             )
         })?;
 
+        // Scope the graph name so the read hits the SAME structural key the write path
+        // composes (`{tenant}/{graph_id}`) — the adapter resolves the engine by this name.
         let graph_name = if graph_id.is_empty() {
             None
         } else {
-            Some(graph_id.as_str())
+            Some(
+                crate::graph::scoped_graph_id(&tenant, &graph_id)
+                    .map_err(|e| Status::invalid_argument(format!("invalid tenant: {e}")))?,
+            )
         };
 
-        match adapter.graph_query(&req.query, graph_name).await {
+        match adapter.graph_query(&req.query, graph_name.as_deref()).await {
             Ok(result) => {
                 // The graph-subset engine returns node-shaped items as JSON
                 // values; surface each as a single `data` string column. Richer
@@ -1350,13 +1428,16 @@ mod tests {
     /// under tenant A is invisible to tenant B.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tenant_namespacing_isolates_graphs() -> anyhow::Result<()> {
-        // Provision both tenant-namespaced backing graphs on one service.
+        // Provision each tenant's backing graph under its STRUCTURAL scope
+        // (`{tenant}/shared`) — the exact key `for_tenant` composes at the handler, so the
+        // logical graph_id the caller sends stays a tenant-clean `shared`.
         let graph = Arc::new(GraphOperationsService::new());
-        for ns in ["tenantA::shared", "tenantB::shared"] {
+        for tenant in ["tenantA", "tenantB"] {
+            let gid = crate::graph::scoped_graph_id(tenant, "shared")?;
             graph
                 .create_graph_collection(pv1::CreateGraphRequest {
-                    graph_id: ns.to_string(),
-                    name: Some(ns.to_string()),
+                    graph_id: gid.clone(),
+                    name: Some(gid),
                     description: None,
                     schema: None,
                     storage_config: None,
@@ -1405,6 +1486,65 @@ mod tests {
             .metadata_mut()
             .insert("x-tenant-id", "tenantB".parse()?);
         assert!(svc.get_node(get_b).await?.into_inner().node.is_none());
+        Ok(())
+    }
+
+    /// Service-level structural isolation via the `for_tenant` scoped handle (no network):
+    /// two tenants share the SAME clean logical `graph_id`, yet neither reads the other's
+    /// node — the handle composes `{tenant}/{graph_id}` once and the composition carries no
+    /// `::` fold in any user-visible name.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn for_tenant_isolates_the_same_logical_graph_id() -> anyhow::Result<()> {
+        // The composition point is path-style and fold-free.
+        let scoped = crate::graph::scoped_graph_id("tenantA", "shared")?;
+        assert_eq!(scoped, "tenantA/shared");
+        assert!(!scoped.contains("::"), "scope must not fold with `::`");
+
+        let graph = GraphOperationsService::new();
+        // Provision each tenant's backing graph under its structural scope.
+        for tenant in ["tenantA", "tenantB"] {
+            let gid = crate::graph::scoped_graph_id(tenant, "shared")?;
+            graph
+                .create_graph_collection(pv1::CreateGraphRequest {
+                    graph_id: gid.clone(),
+                    name: Some(gid),
+                    description: None,
+                    schema: None,
+                    storage_config: None,
+                    engine_config: None,
+                    access_control: None,
+                })
+                .await?;
+        }
+        let node = crate::graph::Node {
+            id: "secret".to_string(),
+            labels: vec!["Doc".to_string()],
+            ..Default::default()
+        };
+        // Write "secret" into tenant A's clean "shared" graph.
+        graph
+            .for_tenant("tenantA")
+            .create_node("shared", node)
+            .await?;
+
+        // Tenant A reads it back through the same clean logical name.
+        assert!(
+            graph
+                .for_tenant("tenantA")
+                .get_node("shared", &"secret".to_string())
+                .await?
+                .is_some(),
+            "owner reads its own node"
+        );
+        // Tenant B, same clean "shared", cannot see it.
+        assert!(
+            graph
+                .for_tenant("tenantB")
+                .get_node("shared", &"secret".to_string())
+                .await?
+                .is_none(),
+            "cross-tenant read is denied structurally"
+        );
         Ok(())
     }
 }

--- a/src/storage/knowledge_graph/mod.rs
+++ b/src/storage/knowledge_graph/mod.rs
@@ -68,7 +68,9 @@ impl KnowledgeGraphFactory {
         domain_config: DomainConfig,
         rbac_policy: Arc<TenantRBACPolicy>,
     ) -> Result<Arc<DomainKnowledgeGraph>> {
-        let domain_id = format!("{}::{}", tenant_id, domain_name);
+        // Path-style structural scope (`{tenant}/{domain}`), consistent with the graph
+        // engine's `scoped_graph_id`; never a `::`-folded user-visible name.
+        let domain_id = format!("{}/{}", tenant_id, domain_name);
 
         let domain_graph = DomainKnowledgeGraph::new(
             domain_id,


### PR DESCRIPTION
## What & why

Phase 1b of the coherent structural tenant-isolation redesign. Replaces the
`{tenant}::{graph_id}` **string-folding** on the graph **gRPC and Arrow Flight**
surfaces with **structural** isolation, via an additive tenant-scoped handle.

**Why a handle, not threading `tenant` into the service.** The naive plan was to add
`tenant: &str` to `GraphOperationsService`'s methods — but those raw methods have
**50+ callers**, most internal (embedded API, observability graph-linking,
transaction layer, query engine) that carry **no request tenant**. Threading would
cascade-break them and force `default/graph_id` keys that **orphan their existing
data**. Instead:

- `GraphOperationsService::for_tenant(&tenant)` returns a `TenantGraphOps` handle that
  composes the structural scope **once** (`scoped_graph_id` → `{tenant}/{graph_id}`,
  path-style, fail-closed tenant validation) and delegates to the **untouched** raw
  methods. Additive — internal callers are unaffected (no cascade, no orphaning).
- The isolation **mechanism is preserved verbatim** (a distinct engine per
  `(tenant, graph)` via the engine registry); only the composition **location** (the
  handle at the boundary, not each handler) and the **separator** (`/` not `::`)
  change. Network handlers now pass tenant-**clean** graph_ids.

## Changes
- **`src/graph/mod.rs`** — `scoped_graph_id(tenant, graph_id)` (the one composition
  point) + `TenantGraphOps<'a>` handle + `for_tenant`, one forwarder per method the
  graph surfaces use.
- **`src/network/grpc/v2/graph_service.rs`** — delete `effective_graph_id`; all 22
  RPCs resolve the tenant (`grpc_auth::resolved_tenant_id`) and route through
  `for_tenant` with a clean graph_id; `execute_query` scopes the Cypher graph name via
  `scoped_graph_id` to match the write key. Responses return the clean graph_id (no
  scoped-key leak).
- **`src/network/arrow_ipc/service.rs`** — delete `effective_graph_id`; write exchange
  routes via `for_tenant`, export read scopes via `scoped_graph_id` (same key).
- **`src/storage/knowledge_graph/mod.rs`** — domain id `{tenant}::{domain}` →
  `{tenant}/{domain}` (consistent separator).

## Tests (TDD)
- `for_tenant_isolates_the_same_logical_graph_id` (service-level): tenant A writes
  `secret` into clean `shared`; A reads it back; **tenant B with the same clean
  `shared` gets `None`**; asserts the composed key is `tenantA/shared` with no `::`.
- `tenant_namespacing_isolates_graphs` (gRPC, via `x-tenant-id` metadata) evolved to
  provision under the structural scope and drive the `for_tenant` path.

## Scope / non-regression (honest boundary)
This PR covers the graph surfaces that were **folding** today: **gRPC + Flight** (they
must move together — both write the same graphs; splitting separators would re-create a
cross-surface split). The graph_traverse cross-modal UDTF (tenant-agnostic today) and
the **REST v2/v1, pgwire, and fusion** graph surfaces are **unscoped today** (a
pre-existing gap — REST graph never folded), so this PR neither fixes nor **regresses**
them; they are tracked follow-ups. Entities/documents (separate namespaces) likewise
follow-up. No backward-compat concern (v2 internal-only, not deployed).

## Verification
- `cargo build -p proximadb-server` ✅ · `cargo fmt --check` ✅ ·
  `cargo clippy -p proximadb -- -D warnings` ✅ · both isolation tests pass.
- Invariant self-check: zero bare `self.graph.<m>(` outside `for_tenant`; zero `::`
  fold remaining in the touched surfaces; internal raw-method callers untouched.

Stacked on #681 (Phase 0 + 1a). Retargets to `develop` once #681 merges.