### PR TITLE
feat(graph): lazily provision scoped graph collections — named-tenant isolation functional (TD-GRAPH-TENANT-1)

### DIFF
--- a/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
+++ b/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
@@ -4,8 +4,8 @@
 
 [cols="1,3"]
 |===
-|Status|Open
-|Priority|HIGH
+|Status|Core resolved (lazy auto-provision); follow-ons open
+|Priority|MED
 |Scope|FEAT
 |Date|2026-07-05
 |Relates to|Phase 1b of the tenant-isolation program (the `TenantGraphOps`/`for_tenant`/`scoped_graph_id` facade over `GraphOperationsService`; the graph_traverse UDTF). Sibling of [[TD-DOC-TENANT-1]] and [[TD-ENTITY-TENANT-1]] — all three are gated by the SAME unscoped-collection-creation issue. Backing: `src/graph/mod.rs` (`scoped_graph_id`), `src/graph/service_engine_factory.rs` (`get_or_create_graph_engine`), the graph collection-create paths (`src/network/rest/v1/graph.rs`, `src/network/postgres/protocol.rs`, `src/database.rs`, embedded, and any future `POST /api/v2/graphs`).
@@ -42,6 +42,39 @@ scoped create→use fails the existence gate. Two symptoms:
   **not a regression** — before Phase 1b the `{tenant}::{graph_id}` fold had the identical create→use
   break for named tenants (creation never folded either); Phase 1b changed the separator, not the
   functional state.
+
+== Landed (core fix — lazy auto-provision)
+
+Named-tenant graph create→use is now **functional end-to-end** via lazy provisioning, chosen over
+threading scoped creation through every request-scoped create path (which would need `TenantContext`
+added to legacy REST v1, pgwire-create scoping, a facade create forwarder, and `{tenant}/` strip
+logic across many response sites):
+
+* `GraphCollectionService::ensure_or_create_graph(graph_id)` (`src/services/graph_collection.rs`) —
+  race-safe get-or-create; on a miss it registers the collection with defaults (ORION engine,
+  service default storage root) under the passed key.
+* `get_or_create_graph_engine` (`src/graph/service_engine_factory.rs`) now calls it instead of
+  `ensure_graph_exists`. So a tenant-scoped first write (`for_tenant` composes `{tenant}/{graph_id}`)
+  auto-registers its collection under the scoped key — no out-of-band bare create needed. The
+  default tenant stays bare, so its explicitly-created collections are found on the first branch and
+  never double-provisioned.
+* Test: `named_tenant_graph_auto_provisions_on_first_write_and_isolates` (v2 graph_service) — a named
+  tenant writes+reads under a clean logical id with NO explicit create; a second tenant on the same
+  id is isolated (its own empty scoped graph). Ratchet +0; server binary + clippy clean.
+
+== Remaining follow-ons (open)
+
+* **Custom create metadata for named tenants.** Auto-provision uses DEFAULT engine/schema. A
+  named tenant that wants a custom schema/engine still needs a tenant-aware create path (scope
+  pgwire `create_graph_collection` + add `TenantContext` to a REST create, or add a v2 graph-create
+  RPC that routes through `for_tenant().create_graph_collection`).
+* **Default-tenant uniformity.** The default tenant stays bare (its create paths are bare). Once
+  those creates scope, flip `scoped_graph_id` to also scope the default (`default/{graph_id}`).
+* **REST v1 list scoping.** REST v1 `list_graph_collections` is unscoped and would surface named
+  tenants' scoped keys (`{tenant}/{graph_id}`) to a default-tenant/legacy caller — scope + strip
+  when REST v1 gains tenant-awareness.
+
+== Original proposal (superseded by the auto-provision fix above)
 
 == Proposed resolution (make it functional)
 

--- a/src/graph/service_engine_factory.rs
+++ b/src/graph/service_engine_factory.rs
@@ -40,10 +40,14 @@ impl super::GraphOperationsService {
             return Ok(Arc::clone(&engine));
         }
 
-        // Verify graph collection exists first
+        // Get — or lazily provision — the graph collection under this (possibly tenant-scoped)
+        // key. A tenant-scoped first write (`for_tenant` composes `{tenant}/{graph_id}`) thus
+        // auto-registers its collection instead of failing "does not exist", making named-tenant
+        // graph create→use functional without an out-of-band bare create (TD-GRAPH-TENANT-1). The
+        // default tenant stays bare, so its explicitly-created collections are found, not recreated.
         let collection = self
             .collection_service
-            .ensure_graph_exists(graph_id)
+            .ensure_or_create_graph(graph_id)
             .await?;
 
         // Determine engine type and storage ROOT URL

--- a/src/network/grpc/v2/graph_service.rs
+++ b/src/network/grpc/v2/graph_service.rs
@@ -1551,4 +1551,43 @@ mod tests {
         );
         Ok(())
     }
+
+    /// End-to-end functional isolation with NO explicit provisioning (TD-GRAPH-TENANT-1): a named
+    /// tenant's first scoped write auto-provisions its `{tenant}/{graph_id}` collection, so
+    /// create→use works without an out-of-band bare create — and a second tenant using the SAME
+    /// clean logical id is isolated (it auto-provisions its own empty scoped graph). This is the
+    /// flow that was broken before the lazy-provision fix (create scoped nowhere ⇒ "collection
+    /// does not exist").
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn named_tenant_graph_auto_provisions_on_first_write_and_isolates() -> anyhow::Result<()>
+    {
+        // Fresh service — NO `create_graph_collection`; the first scoped write must provision.
+        let graph = GraphOperationsService::new();
+        let node = crate::graph::Node {
+            id: "secret".to_string(),
+            labels: vec!["Doc".to_string()],
+            ..Default::default()
+        };
+        graph.for_tenant("acme").create_node("shared", node).await?;
+
+        // acme reads its own node back through the same clean logical id.
+        assert!(
+            graph
+                .for_tenant("acme")
+                .get_node("shared", &"secret".to_string())
+                .await?
+                .is_some(),
+            "owner reads its own node after auto-provision"
+        );
+        // globex, same clean "shared", sees nothing (its own auto-provisioned empty scoped graph).
+        assert!(
+            graph
+                .for_tenant("globex")
+                .get_node("shared", &"secret".to_string())
+                .await?
+                .is_none(),
+            "cross-tenant read is isolated"
+        );
+        Ok(())
+    }
 }

--- a/src/services/graph_collection.rs
+++ b/src/services/graph_collection.rs
@@ -407,6 +407,33 @@ impl GraphCollectionService {
         })
     }
 
+    /// Get the graph collection for `graph_id`, lazily provisioning it with defaults (ORION
+    /// engine, the service's default storage root) if it does not yet exist — the get-or-create
+    /// counterpart of [`ensure_graph_exists`].
+    ///
+    /// This lets a tenant-scoped first write auto-register its collection under the SCOPED key
+    /// (`{tenant}/{graph_id}`), so named-tenant graph create→use works without an out-of-band bare
+    /// create (the v2 gRPC surface has no create RPC, and the REST v1 / pgwire create paths are not
+    /// tenant-scoped — TD-GRAPH-TENANT-1). The default tenant stays bare, so its existing
+    /// explicitly-created collections are found on the first branch and never double-provisioned.
+    /// Idempotent and race-safe: if a concurrent caller wins the insert, we pick it up on re-fetch.
+    pub async fn ensure_or_create_graph(&self, graph_id: &str) -> Result<Arc<GraphCollection>> {
+        if let Some(existing) = self.get_graph(graph_id).await? {
+            return Ok(existing);
+        }
+        match self
+            .create_graph(CreateGraphRequest {
+                graph_id: graph_id.to_string(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(created) => Ok(created),
+            // Lost a create race (another task registered it first) — re-fetch the winner.
+            Err(_) => self.ensure_graph_exists(graph_id).await,
+        }
+    }
+
     /// Get graph statistics
     pub async fn get_graph_stats(
         &self,


### PR DESCRIPTION
## What & why

Makes **named-tenant graph isolation functional end-to-end**. Phase 1b scoped graph
node/edge ops to `{tenant}/{graph_id}` (via `TenantGraphOps`/`for_tenant`), but graph
collection **creation** was scoped nowhere — the v2 gRPC surface has no create RPC, and
the REST v1 / pgwire create paths write a **bare** `graph_id`. So a named tenant's scoped
write hit `get_or_create_graph_engine → ensure_graph_exists({tenant}/{graph_id})` →
**"Graph collection does not exist"**. Phase 1b's named-tenant scoping was therefore
non-functional (and it had regressed the default-tenant flow, fixed separately).

## Approach: lazy auto-provision (vs threading scoped creation everywhere)

`GraphCollectionService` is keyed by a bare id with no tenant dimension, and the factory
gate needs only `graph_id` — ORION engine + default storage root cover the rest. So instead
of the high-surface alternative (add `TenantContext` to legacy REST v1, scope pgwire create,
add a facade create forwarder, and strip `{tenant}/` across many response sites), the write
path **auto-provisions the scoped collection on first use**:

- `GraphCollectionService::ensure_or_create_graph(graph_id)` — race-safe get-or-create; on a
  miss, registers the collection with defaults under the passed (scoped) key.
- `get_or_create_graph_engine` calls it instead of `ensure_graph_exists`. A tenant-scoped
  first write auto-registers `{tenant}/{graph_id}`; the **default tenant stays bare**, so its
  explicitly-created collections are found on the first branch and never double-provisioned.

No test relied on the prior "does not exist" error (verified), and `get_or_create_graph_engine`
already implies get-or-create semantics.

## Tests
- `named_tenant_graph_auto_provisions_on_first_write_and_isolates` — a named tenant writes+reads
  a node under a clean logical id with **NO explicit create**; a second tenant on the same id is
  isolated (its own empty scoped graph). This is the flow that failed before.
- All existing graph_service + graph_traverse tests still pass (10/10).

## Scope (honest)
This delivers functional named-tenant isolation for the **v2 gRPC graph surface** (the one
scoped surface). Remaining follow-ons, tracked in the updated `TD-GRAPH-TENANT-1`: custom
create-metadata for named tenants (needs a tenant-aware create path), default-tenant scoping
uniformity, and scoping REST v1's unscoped `list_graph_collections`.

## Verification
`cargo build -p proximadb-server` ✅ · `cargo fmt --check` ✅ ·
`cargo clippy -p proximadb -- -D warnings` ✅ · v1-proto ratchet +0 · 10/10 graph tests pass.

Stacked on #681. Retargets to `develop` once #681 merges.