### PR TITLE
feat(document): scope collection + lazy auto-provision — named-tenant document isolation functional (TD-DOC-TENANT-1)

### DIFF
--- a/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
+++ b/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
@@ -4,8 +4,8 @@
 
 [cols="1,3"]
 |===
-|Status|Open
-|Priority|MED
+|Status|Core resolved (v2 gRPC scoped + auto-provision); REST-v2 store-split follow-on open
+|Priority|LOW
 |Scope|FEAT
 |Date|2026-07-05
 |Relates to|The coherent structural tenant-isolation program (Phase 0 unified resolution; Phase 1a timeseries per-tenant engines; Phase 1b graph `TenantGraphOps` facade; Phase 1c graph_traverse UDTF). This TD is the deferred **document** slice of that program. Backing: `src/storage/document/service.rs` (`DocumentService`), `src/network/grpc/v2/document_service.rs` (the `{tenant}::{collection}` fold), `src/network/postgres/protocol.rs` (`create_document_collection`), `src/network/rest/v2/documents.rs` (a *different* store path).
@@ -50,6 +50,41 @@ bolting scoping onto it now would be unsafe and incomplete:
   documents are lost on replay**. This must be proven before scoping.
 
 The gRPC `DocumentService` is wired in production (`multi_server.rs:192`), so correctness matters.
+
+== Landed (core fix — v2 gRPC scoped + lazy auto-provision)
+
+Named-tenant document isolation is now **functional on the v2 gRPC document surface**. The
+earlier investigation over-weighted the WAL-recovery risk: the map confirmed recovery replays each
+record by its **embedded canonical OID** (`document/{collection_id}/{doc_id}`), NOT recomputed from
+a WAL frame — so scoping is recovery-safe **provided the storage-key parameter and the record's
+`collection_id` are scoped together** (they were already, on this path). The only real blocker was
+the collection-existence gate rejecting the never-created scoped collection.
+
+* `scoped_document_collection(tenant, collection)` (`src/storage/document/service.rs`) — the
+  document counterpart of `scoped_graph_id`: `{tenant}/{collection}`, DEFAULT tenant bare,
+  fail-closed. Applied to BOTH the storage-key param and `record.collection_id`.
+* `DocumentService::ensure_or_create_collection` — race-safe get-or-create that goes through
+  `create_collection` (so the `CreateCollection` WAL op is logged and the collection is rebuilt on
+  restart). `insert_document_record` now uses it instead of erroring "Collection not found", so a
+  tenant-scoped first write auto-provisions its collection.
+* The v2 gRPC handler replaces the `{tenant}::{collection}` fold with `scoped_document_collection`
+  (`/`, default bare) and strips the scope prefix in responses (`record_to_v2_clean`) so clients see
+  clean names.
+* Tests: `scoped_document_collection` defaults/validation; two tenants, same clean collection +
+  doc id, isolated via auto-provision. Ratchet +0; server binary + clippy + document unit and
+  integration tests green.
+
+== Remaining follow-ons (open)
+
+* **REST v2 documents store-split.** `src/network/rest/v2/documents.rs` writes through a DIFFERENT
+  store (the Flight/record-store path), not `DocumentService` — so this fix does NOT make the REST
+  v2 document ingest surface tenant-isolated the same way. Reconcile the two document write surfaces
+  (or document the split) before claiming cross-surface document coherence.
+* **pgwire / REST v1 create + default uniformity.** Same shape as the graph follow-ons: those create
+  paths are bare; once they scope, flip the default tenant to `default/{collection}` for uniformity.
+* **Entity document leg.** `entity_service.rs` still folds `{tenant}::{collection}` for its document
+  writes; it now auto-provisions (via the shared gate) but uses `::` not `/` — unify when the entity
+  slice (TD-ENTITY-TENANT-1) lands.
 
 == Why deferred (not band-aided)
 

--- a/src/network/grpc/v2/document_service.rs
+++ b/src/network/grpc/v2/document_service.rs
@@ -63,16 +63,22 @@ impl ProximaDocumentServiceImpl {
         ProximaDocumentServiceServer::new(self)
     }
 
-    /// Derive the effective backing collection namespace from the request tenant.
+    /// Resolve the request tenant and compose the `(clean, scoped)` collection pair.
     ///
-    /// Isolation is structural: the tenant is folded into the storage key, never
-    /// applied as a per-query predicate. Embedded / unauthenticated calls (no
-    /// tenant) fall back to the raw `collection_id`.
-    fn effective_collection_id<T>(request: &Request<T>, collection_id: &str) -> String {
-        match grpc_auth::tenant_id(request) {
-            Some(tenant) if !tenant.is_empty() => format!("{tenant}::{collection_id}"),
-            _ => collection_id.to_string(),
-        }
+    /// Isolation is structural: `scoped` is the storage key `{tenant}/{collection}` (default
+    /// tenant ⇒ bare, matching bare-created collections) used for every `DocumentService` call
+    /// AND for the record's `collection_id` (they key the same canonical OID). `clean` is the
+    /// tenant-clean name the caller sent, echoed back in responses so the `{tenant}/` prefix never
+    /// leaks. Fail-closed on an invalid tenant. Replaces the former `{tenant}::` name fold.
+    fn scoped_collection<T>(
+        request: &Request<T>,
+        collection_id: &str,
+    ) -> Result<(String, String), Status> {
+        let tenant = grpc_auth::resolved_tenant_id(request);
+        let scoped =
+            crate::storage::document::service::scoped_document_collection(&tenant, collection_id)
+                .map_err(|e| Status::invalid_argument(format!("invalid tenant: {e}")))?;
+        Ok((collection_id.to_string(), scoped))
     }
 }
 
@@ -128,6 +134,15 @@ mod conv {
             document_type: record.document_type.clone(),
             updated_at_ms: record.updated_at_ns / 1_000_000,
         }
+    }
+
+    /// Like [`record_to_v2`], but echoes the tenant-CLEAN `collection_id` the caller sent instead
+    /// of the record's stored (tenant-scoped `{tenant}/{collection}`) key — so the structural
+    /// scope prefix never leaks back to the client.
+    pub fn record_to_v2_clean(record: &DocumentRecord, clean_collection: &str) -> pv2::Document {
+        let mut doc = record_to_v2(record);
+        doc.collection_id = clean_collection.to_string();
+        doc
     }
 
     /// v2 sort fields -> v1 proto `SortField`. Value-free (path + order only), so
@@ -263,7 +278,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::CreateDocumentRequest>,
     ) -> Result<Response<pv2::DocumentResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!("v2 gRPC CreateDocument collection={collection}");
 
@@ -273,6 +289,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         } else {
             req.id
         };
+        // `record.collection_id` = the SCOPED key (same as the storage-key param): together they
+        // key the canonical OID, so recovery/read agree.
         let record = DocumentRecord::from_tree(
             id,
             props,
@@ -287,7 +305,7 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
             .await
         {
             Ok(stored) => Ok(Response::new(pv2::DocumentResponse {
-                document: Some(conv::record_to_v2(&stored)),
+                document: Some(conv::record_to_v2_clean(&stored, &clean)),
             })),
             Err(e) => {
                 error!("v2 gRPC CreateDocument failed: {e}");
@@ -300,7 +318,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::GetDocumentRequest>,
     ) -> Result<Response<pv2::DocumentResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!("v2 gRPC GetDocument collection={collection} id={}", req.id);
 
@@ -310,7 +329,7 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
             .await
         {
             Ok(Some(record)) => Ok(Response::new(pv2::DocumentResponse {
-                document: Some(conv::record_to_v2(&record)),
+                document: Some(conv::record_to_v2_clean(&record, &clean)),
             })),
             Ok(None) => Err(Status::not_found(format!(
                 "document '{}' not found in collection '{collection}'",
@@ -327,7 +346,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::DeleteDocumentRequest>,
     ) -> Result<Response<pv2::DeleteDocumentResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (_clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!(
             "v2 gRPC DeleteDocument collection={collection} id={}",
@@ -347,7 +367,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::UpdateDocumentRequest>,
     ) -> Result<Response<pv2::DocumentResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!(
             "v2 gRPC UpdateDocument collection={collection} id={} updates={}",
@@ -362,7 +383,7 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
             .await
         {
             Ok(updated) => Ok(Response::new(pv2::DocumentResponse {
-                document: Some(conv::record_to_v2(&updated)),
+                document: Some(conv::record_to_v2_clean(&updated, &clean)),
             })),
             Err(e) => {
                 error!("v2 gRPC UpdateDocument failed: {e}");
@@ -375,7 +396,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::QueryDocumentsRequest>,
     ) -> Result<Response<pv2::QueryDocumentsResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!(
             "v2 gRPC QueryDocuments collection={collection} limit={} offset={}",
@@ -396,7 +418,11 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
 
         match self.documents.query_documents(&collection, params).await {
             Ok(result) => Ok(Response::new(pv2::QueryDocumentsResponse {
-                documents: result.documents.iter().map(conv::record_to_v2).collect(),
+                documents: result
+                    .documents
+                    .iter()
+                    .map(|r| conv::record_to_v2_clean(r, &clean))
+                    .collect(),
                 total_count: result.total_count,
                 query_time_ms: result.query_time_ms,
             })),
@@ -411,7 +437,8 @@ impl ProximaDocumentService for ProximaDocumentServiceImpl {
         &self,
         request: Request<pv2::AggregateDocumentsRequest>,
     ) -> Result<Response<pv2::AggregateDocumentsResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let (_clean, collection) =
+            Self::scoped_collection(&request, &request.get_ref().collection_id)?;
         let req = request.into_inner();
         debug!(
             "v2 gRPC AggregateDocuments collection={} pipeline_len={}",

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -50,6 +50,24 @@ use proximadb_data_model::ProximaValue;
 use proximadb_records::conversions::sql_value_to_proxima;
 use proximadb_records::{ProximaTree, ProximaTreeNode, tree_get};
 
+/// Compose the structural per-tenant document collection key `{tenant}/{collection}` — the
+/// document counterpart of graph's `scoped_graph_id`.
+///
+/// The DEFAULT tenant stays UNSCOPED (bare `collection`), matching the bare collections the
+/// pgwire / REST v1 create paths register; named tenants scope. Validates the tenant as a path
+/// segment (fail-closed) before it becomes part of a storage key. BOTH the storage-key parameter
+/// AND the record's `collection_id` must be composed from this — they key the same canonical OID
+/// (`document/{collection_id}/{doc_id}`), so a scoped write and its recovery/read agree
+/// (TD-DOC-TENANT-1); scoping only one side mis-keys the live read immediately.
+pub fn scoped_document_collection(tenant: &str, collection: &str) -> anyhow::Result<String> {
+    proximadb_tenant::validate_request_tenant(tenant)
+        .map_err(|e| anyhow::anyhow!("invalid tenant '{tenant}': {e}"))?;
+    if tenant == proximadb_tenant::DEFAULT_TENANT {
+        return Ok(collection.to_string());
+    }
+    Ok(format!("{tenant}/{collection}"))
+}
+
 /// Document service for CRUD operations
 pub struct DocumentService {
     /// Storage engine for persistence (vector-centric, used for legacy flush path)
@@ -818,6 +836,31 @@ impl DocumentService {
         Ok(collections.get(name).cloned())
     }
 
+    /// Get the collection metadata for `name`, lazily provisioning it with defaults if absent —
+    /// the get-or-create counterpart of [`get_collection`].
+    ///
+    /// This lets a tenant-scoped first write auto-register its collection under the SCOPED key
+    /// (`{tenant}/{collection}`): the v2 document gRPC path scopes reads/writes, but there is no
+    /// scoped create path (pgwire/REST-v1 create bare), so without this the scoped collection has
+    /// no metadata and the existence gate rejects the insert (TD-DOC-TENANT-1). Provisioning goes
+    /// through [`create_collection`] so the `CreateCollection` WAL op is logged and the collection
+    /// metadata is rebuilt on restart (recovery replays collections only from that op). Idempotent
+    /// and race-safe: a lost create race is resolved by re-fetch.
+    pub async fn ensure_or_create_collection(&self, name: &str) -> Result<DocumentCollection> {
+        if let Some(existing) = self.get_collection(name).await? {
+            return Ok(existing);
+        }
+        let config = DocumentCollectionConfig {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        // On success OR a lost create race, re-fetch the now-registered metadata.
+        let _ = self.create_collection(name, config).await;
+        self.get_collection(name)
+            .await?
+            .ok_or_else(|| anyhow!("Collection '{}' missing after provision", name))
+    }
+
     /// List all collections
     pub async fn list_collections(&self) -> Result<Vec<DocumentCollection>> {
         let collections = self.collections.read().await;
@@ -895,12 +938,11 @@ impl DocumentService {
             doc_id, collection
         );
 
-        // Verify collection exists
-        let _collection_meta = match self
-            .get_collection(collection)
-            .await?
-            .ok_or_else(|| anyhow!("Collection '{}' not found", collection))
-        {
+        // Get — or lazily provision — the collection (get-or-create). A tenant-scoped first write
+        // auto-registers its collection under the scoped key, so named-tenant document create→use
+        // works without an out-of-band scoped create (TD-DOC-TENANT-1). The default tenant's
+        // collections are bare and already exist, so they are found, not recreated.
+        let _collection_meta = match self.ensure_or_create_collection(collection).await {
             Ok(meta) => meta,
             Err(e) => {
                 self.record_insert_metrics(start, true).await;
@@ -3482,5 +3524,74 @@ mod tests {
             .await
             .expect("delete should succeed");
         assert!(!again, "deleting non-existent collection returns false");
+    }
+
+    #[test]
+    fn scoped_document_collection_default_bare_named_scoped_invalid_rejected() {
+        assert_eq!(
+            scoped_document_collection("default", "docs").unwrap(),
+            "docs",
+            "default tenant stays bare (matches bare-created collections)"
+        );
+        assert_eq!(
+            scoped_document_collection("acme", "docs").unwrap(),
+            "acme/docs",
+            "named tenant is path-scoped"
+        );
+        assert!(
+            scoped_document_collection("../evil", "docs").is_err(),
+            "path traversal rejected"
+        );
+        assert!(
+            scoped_document_collection("_system", "docs").is_err(),
+            "reserved-prefix tenant rejected"
+        );
+    }
+
+    /// Named-tenant document isolation with NO explicit provisioning (TD-DOC-TENANT-1): the first
+    /// write to each scoped collection auto-provisions it, and two tenants using the SAME clean
+    /// logical collection + doc id are isolated by their distinct `{tenant}/{collection}` keys.
+    #[tokio::test]
+    async fn scoped_document_collections_isolate_by_tenant_with_auto_provision() {
+        let svc = create_test_service();
+        let acme = scoped_document_collection("acme", "shared").unwrap();
+        let globex = scoped_document_collection("globex", "shared").unwrap();
+
+        // Same clean logical collection ("shared") AND same doc id ("d1"), different tenants.
+        svc.insert_document(
+            &acme,
+            Some("d1"),
+            make_document(vec![("owner", sql_string("acme"))]),
+        )
+        .await
+        .expect("acme insert auto-provisions acme/shared");
+        svc.insert_document(
+            &globex,
+            Some("d1"),
+            make_document(vec![("owner", sql_string("globex"))]),
+        )
+        .await
+        .expect("globex insert auto-provisions globex/shared");
+
+        let a = svc
+            .get_document(&acme, "d1", None)
+            .await
+            .expect("get acme")
+            .expect("acme doc exists");
+        let g = svc
+            .get_document(&globex, "d1", None)
+            .await
+            .expect("get globex")
+            .expect("globex doc exists");
+
+        // Each tenant's doc lives under its own scoped collection — no cross-tenant bleed despite
+        // identical clean collection name + doc id.
+        assert_eq!(a.collection_id, "acme/shared");
+        assert_eq!(g.collection_id, "globex/shared");
+        assert_ne!(
+            tree_get(&a.props, "owner"),
+            tree_get(&g.props, "owner"),
+            "same clean collection + doc id isolate by tenant"
+        );
     }
 }


### PR DESCRIPTION
## What & why

Makes **named-tenant document isolation functional** on the v2 gRPC document surface —
mirroring the graph fix. The handler already scoped reads/writes (folding
`{tenant}::{collection}` into BOTH the storage-key param and `record.collection_id`, which
key the same canonical OID), but the **collection-existence gate** rejected the write because
the scoped collection was never created (no scoped create path exists). So named-tenant
document create→use failed "Collection not found".

## Recovery-safety (the risk that deferred this)

The earlier deferral over-weighted a WAL-recovery concern. The map confirmed recovery replays
each record by its **embedded canonical OID** (`document/{collection_id}/{doc_id}`), *not*
recomputed from a WAL frame — so scoping is recovery-safe **as long as the storage-key param and
`record.collection_id` are scoped together** (they already were). No WAL-frame change needed.

## Changes
- `scoped_document_collection(tenant, collection)` — document counterpart of `scoped_graph_id`:
  `{tenant}/{collection}`, **default tenant bare**, fail-closed. Applied to both the storage key
  and `record.collection_id`.
- `DocumentService::ensure_or_create_collection` — race-safe get-or-create via `create_collection`
  (logs the `CreateCollection` WAL op, so the collection is rebuilt on restart). `insert_document_record`
  uses it instead of erroring — a tenant-scoped first write auto-provisions its collection.
- v2 gRPC handler: replace the `{tenant}::` fold with `scoped_document_collection` (`/`, default bare);
  strip the scope prefix in responses (`record_to_v2_clean`) so clients see clean names.

## Tests
- `scoped_document_collection` defaults (default→bare, named→`t/c`) + fail-closed validation.
- Two tenants, same clean collection + same doc id, isolated via auto-provision (no explicit create).
- Full document unit suite (21) + gRPC document tests + document integration tests pass; no test
  relied on the old "not found on insert" behavior.

## Scope (honest)
Functional for the **v2 gRPC document surface**. Follow-ons in the updated `TD-DOC-TENANT-1`: the
**REST v2 documents store-split** (a different Flight/record store — not covered here), pgwire/REST-v1
create scoping + default uniformity, and unifying the entity document leg's `::` separator.

## Verification
`cargo build -p proximadb-server` ✅ · `cargo fmt --check` ✅ ·
`cargo clippy -p proximadb -- -D warnings` ✅ · v1-proto ratchet +0 · document tests green.

Stacked on #681.