### PR TITLE
feat(entity): tenant-aware vector/fusion — named-tenant entity isolation functional (TD-ENTITY-TENANT-1)

### DIFF
--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -3796,6 +3796,8 @@ impl EmbeddedProximaDB {
             let params = GraphFusionParams {
                 route_policy: None,
                 graph_id: graph_id.to_string(),
+                // Embedded stays single-tenant by default (unscoped, byte-identical legacy behavior).
+                tenant: None,
                 vector_collection: vector_collection.to_string(),
                 query_vector,
                 max_depth,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -222,6 +222,13 @@ impl TenantGraphOps<'_> {
     pub async fn query_nodes(&self, graph_id: &str, query: NodeQuery) -> Result<Vec<Arc<Node>>> {
         self.inner.query_nodes(&self.scope(graph_id)?, query).await
     }
+    pub async fn get_nodes(
+        &self,
+        graph_id: &str,
+        ids: &[String],
+    ) -> Result<Vec<Option<Arc<Node>>>> {
+        self.inner.get_nodes(&self.scope(graph_id)?, ids).await
+    }
 
     // ── Edge ops ────────────────────────────────────────────────────────────
     pub async fn create_edge(&self, graph_id: &str, edge: Edge) -> Result<Arc<Edge>> {

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -14,9 +14,10 @@
 //!
 //! This avoids redundant storage: an "entity" is just a graph node with associated
 //! vectors and optional document chunks. Tenant isolation is structural — the
-//! request tenant (`x-tenant-id`) is folded into the backing collection key via
-//! [`grpc_auth::tenant_id`], never a per-query predicate (mirrors the v2 document
-//! service).
+//! request tenant (`x-tenant-id`, resolved via [`grpc_auth::resolved_tenant_id`]) is
+//! applied per-leg with a tenant-CLEAN collection name: graph via `for_tenant`,
+//! vector via `TenantContext`, provenance document via the scoped collection key.
+//! Never a `{tenant}::collection` name fold, never a per-query predicate.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -80,16 +81,6 @@ impl ProximaEntityServiceImpl {
     /// Convert to a tonic server.
     pub fn into_server(self) -> ProximaEntityServiceServer<Self> {
         ProximaEntityServiceServer::new(self)
-    }
-
-    /// Derive the effective backing collection namespace from the request tenant.
-    /// Isolation is structural: the tenant is folded into the storage key, never
-    /// a per-query predicate.
-    fn effective_collection_id<T>(request: &Request<T>, collection_id: &str) -> String {
-        match grpc_auth::tenant_id(request) {
-            Some(tenant) if !tenant.is_empty() => format!("{tenant}::{collection_id}"),
-            _ => collection_id.to_string(),
-        }
     }
 
     /// Generate a unique node ID for this entity in the graph.
@@ -173,8 +164,9 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         &self,
         request: Request<pv2::UpsertEntityRequest>,
     ) -> Result<Response<pv2::UpsertEntityResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
-        let tenant_id = grpc_auth::tenant_id(&request).unwrap_or_default();
+        // Tenant-CLEAN collection name; each leg is scoped structurally by the resolved tenant.
+        let collection = request.get_ref().collection_id.clone();
+        let tenant = grpc_auth::resolved_tenant_id(&request);
         let req = request.into_inner();
         let entity = req
             .entity
@@ -211,12 +203,18 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         // Upsert semantics: try create, fall back to update if the node exists.
         match self
             .graph_service
+            .for_tenant(&tenant)
             .create_node(&collection, node.clone())
             .await
         {
             Ok(_) => debug!("Created graph node {node_id}"),
             Err(create_err) => {
-                if let Err(update_err) = self.graph_service.update_node(&collection, node).await {
+                if let Err(update_err) = self
+                    .graph_service
+                    .for_tenant(&tenant)
+                    .update_node(&collection, node)
+                    .await
+                {
                     error!("Entity node upsert failed: create={create_err}; update={update_err}");
                     return Err(entity_status("upsert entity", update_err));
                 }
@@ -243,7 +241,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
 
             let record = ProximaRecord {
                 oid: vector_id.clone(),
-                tenant_id: tenant_id.clone(),
+                tenant_id: tenant.clone(),
                 local_id: Some(format!("{entity_id}:{}", embedding.model_id)),
                 embeddings: vec![EmbeddingCell {
                     model_id: embedding.model_id.clone(),
@@ -265,7 +263,11 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
 
             match self
                 .vector_service
-                .insert_batch(&collection, vec![record])
+                .insert_batch_with_tenant_context(
+                    &collection,
+                    vec![record],
+                    Some(&crate::storage::tenant::context::TenantContext::for_tenant_id(&tenant)),
+                )
                 .await
             {
                 Ok(result) => {
@@ -319,10 +321,16 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 ProximaTreeNode::Value(ProximaValue::String(collection.clone())),
             );
 
+            // Scope the provenance doc collection to the tenant (both storage key and
+            // record.collection_id key the same OID), matching the document fix. The tenant is
+            // already validated (the graph create above would have failed otherwise).
+            let scoped_doc_collection =
+                crate::storage::document::service::scoped_document_collection(&tenant, &collection)
+                    .map_err(|e| entity_status("scope provenance collection", e))?;
             let doc_record = DocumentRecord::from_tree(
                 doc_id.clone(),
                 tree,
-                collection.clone(),
+                scoped_doc_collection.clone(),
                 None,
                 Some("entity_provenance".to_string()),
             );
@@ -330,7 +338,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
             debug!("Insert provenance document doc_id={doc_id}");
             match self
                 .document_service
-                .insert_document_record(&collection, doc_record)
+                .insert_document_record(&scoped_doc_collection, doc_record)
                 .await
             {
                 Ok(_) => debug!("Provenance document inserted"),
@@ -361,7 +369,12 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 updated_at_ms: now_ms,
             };
 
-            match self.graph_service.create_edge(&collection, edge).await {
+            match self
+                .graph_service
+                .for_tenant(&tenant)
+                .create_edge(&collection, edge)
+                .await
+            {
                 Ok(_) => debug!("Created edge {edge_id}"),
                 Err(e) => warn!("Edge create failed (non-fatal) for {edge_id}: {e}"),
             }
@@ -378,7 +391,8 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         &self,
         request: Request<pv2::GetEntityRequest>,
     ) -> Result<Response<pv2::GetEntityResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let collection = request.get_ref().collection_id.clone();
+        let tenant = grpc_auth::resolved_tenant_id(&request);
         let req = request.into_inner();
 
         debug!(
@@ -389,6 +403,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         let node_id = Self::entity_node_id(&collection, &req.entity_id);
         let node = self
             .graph_service
+            .for_tenant(&tenant)
             .get_node(&collection, &node_id)
             .await
             .map_err(|e| entity_status("get entity", e))?
@@ -403,7 +418,8 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         &self,
         request: Request<pv2::DeleteEntityRequest>,
     ) -> Result<Response<pv2::DeleteEntityResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
+        let collection = request.get_ref().collection_id.clone();
+        let tenant = grpc_auth::resolved_tenant_id(&request);
         let req = request.into_inner();
 
         debug!(
@@ -414,6 +430,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         let node_id = Self::entity_node_id(&collection, &req.entity_id);
         let deleted = self
             .graph_service
+            .for_tenant(&tenant)
             .delete_node(&collection, &node_id)
             .await
             .map_err(|e| entity_status("delete entity", e))?
@@ -436,8 +453,8 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         &self,
         request: Request<pv2::SearchEntitiesRequest>,
     ) -> Result<Response<pv2::SearchEntitiesResponse>, Status> {
-        let collection = Self::effective_collection_id(&request, &request.get_ref().collection_id);
-        let tenant_id = grpc_auth::tenant_id(&request).unwrap_or_default();
+        let collection = request.get_ref().collection_id.clone();
+        let tenant = grpc_auth::resolved_tenant_id(&request);
         let principal = grpc_auth::user_id(&request);
         let req = request.into_inner();
 
@@ -457,9 +474,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         if let Some(similar) = req.similar.as_ref() {
             let query_vector = match similar.query.as_ref() {
                 Some(pv2::similar_query::Query::Vector(v)) => v.values.clone(),
-                Some(pv2::similar_query::Query::Text(t)) => {
-                    Self::embed_query(t, &tenant_id).await?
-                }
+                Some(pv2::similar_query::Query::Text(t)) => Self::embed_query(t, &tenant).await?,
                 Some(pv2::similar_query::Query::RawData(bytes)) => {
                     // Treat raw_data as UTF-8 text to embed.
                     let text = String::from_utf8(bytes.clone()).map_err(|_| {
@@ -467,7 +482,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                             "similar.raw_data must be valid UTF-8 text to embed",
                         )
                     })?;
-                    Self::embed_query(&text, &tenant_id).await?
+                    Self::embed_query(&text, &tenant).await?
                 }
                 None => {
                     return Err(Status::invalid_argument(
@@ -491,6 +506,8 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 route_policy: None,
                 graph_id: collection.clone(),
                 vector_collection: collection.clone(),
+                // Structural tenant boundary — scopes BOTH fusion legs (clean names in, TD-ENTITY-TENANT-1).
+                tenant: Some(tenant.clone()),
                 query_vector,
                 // TD-146 scope B: graph-augmented entity fusion. Entity vectors live under the
                 // auxiliary `{node_id}/{model_id}` oid; `EntityNode` keying normalizes both the
@@ -529,6 +546,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 .collect();
             let nodes = self
                 .graph_service
+                .for_tenant(&tenant)
                 .get_nodes(&collection, &node_ids)
                 .await
                 .map_err(|e| entity_status("materialize search entities", e))?;
@@ -577,6 +595,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
 
         let nodes = self
             .graph_service
+            .for_tenant(&tenant)
             .query_nodes(&collection, query)
             .await
             .map_err(|e| entity_status("search entities", e))?;

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -107,6 +107,8 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
         let params = GraphFusionParams {
             route_policy: None,
             graph_id: req.graph_id.clone(),
+            // Structural tenant boundary — scopes both fusion legs (TD-ENTITY-TENANT-1).
+            tenant: tenant_id.clone(),
             vector_collection: req.vector_collection.clone(),
             query_vector: req.query_vector.clone(),
             max_depth: if req.max_depth == 0 {

--- a/src/network/rest/v2/entities.rs
+++ b/src/network/rest/v2/entities.rs
@@ -5,8 +5,10 @@
 //! optional relations; the orchestration (and fusion-delegating search) lives in
 //! the orchestrator, shared with the gRPC facade. Per
 //! `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`: retrieval delegates to the fusion
-//! seam; this facade owns no ranking. Tenant isolation is structural — the
-//! `TenantContext` tenant is folded into the backing collection key.
+//! seam; this facade owns no ranking. Tenant isolation is structural — the request
+//! tenant is threaded to the orchestrator, which scopes each leg (graph via
+//! `for_tenant`, vector via `TenantContext`, document via the scoped collection key);
+//! collection names stay tenant-clean (never a `{tenant}::name` fold).
 
 use std::collections::HashMap;
 
@@ -163,14 +165,6 @@ fn orchestrator(state: &AppState) -> EntityOrchestrator {
     )
 }
 
-fn effective_collection(tenant: &TenantContext, collection_id: &str) -> String {
-    if !tenant.tenant_id.is_empty() {
-        format!("{}::{}", tenant.tenant_id, collection_id)
-    } else {
-        collection_id.to_string()
-    }
-}
-
 fn node_to_dto(node: &crate::graph::Node, collection: &str) -> EntityDto {
     let mut flexible_metadata = HashMap::new();
     for (k, v) in &node.properties {
@@ -227,7 +221,7 @@ pub async fn upsert_entity_v2(
     Extension(tenant): Extension<TenantContext>,
     Json(request): Json<UpsertEntityRequest>,
 ) -> ApiResult<Json<UpsertEntityResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
+    // Tenant-CLEAN collection name; the orchestrator scopes each leg structurally by the tenant.
     let mut metadata = HashMap::new();
     for (k, v) in &request.flexible_metadata {
         if let Some(pv) = json_to_property_value(v) {
@@ -272,7 +266,7 @@ pub async fn upsert_entity_v2(
     };
 
     let entity_id = orchestrator(&state)
-        .upsert(&collection, &tenant.tenant_id, input)
+        .upsert(&collection_id, &tenant.tenant_id, input)
         .await
         .map_err(|e| err_internal("upsert entity", e))?;
 
@@ -302,13 +296,12 @@ pub async fn get_entity_v2(
     State(state): State<AppState>,
     Extension(tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<EntityDto>> {
-    let collection = effective_collection(&tenant, &collection_id);
     let node = orchestrator(&state)
-        .get(&collection, &entity_id)
+        .get(&collection_id, &tenant.tenant_id, &entity_id)
         .await
         .map_err(|e| err_internal("get entity", e))?
         .ok_or_else(|| ApiError::NotFound(format!("Entity '{entity_id}' not found")))?;
-    Ok(Json(node_to_dto(&node, &collection)))
+    Ok(Json(node_to_dto(&node, &collection_id)))
 }
 
 #[utoipa::path(
@@ -330,9 +323,8 @@ pub async fn delete_entity_v2(
     State(state): State<AppState>,
     Extension(tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<UpsertEntityResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
     let deleted = orchestrator(&state)
-        .delete(&collection, &entity_id)
+        .delete(&collection_id, &tenant.tenant_id, &entity_id)
         .await
         .map_err(|e| err_internal("delete entity", e))?;
     Ok(Json(UpsertEntityResponse {
@@ -366,8 +358,6 @@ pub async fn search_entities_v2(
     Extension(tenant): Extension<TenantContext>,
     Json(request): Json<SearchEntitiesRequest>,
 ) -> ApiResult<Json<SearchEntitiesResponse>> {
-    let collection = effective_collection(&tenant, &collection_id);
-
     let query_vector = if request.query_vector.is_empty() {
         None
     } else {
@@ -387,14 +377,20 @@ pub async fn search_entities_v2(
         .collect::<Vec<_>>();
 
     let hits = orchestrator(&state)
-        .search(&collection, query_vector, filters, request.top_k as usize)
+        .search(
+            &collection_id,
+            &tenant.tenant_id,
+            query_vector,
+            filters,
+            request.top_k as usize,
+        )
         .await
         .map_err(|e| err_internal("search entities", e))?;
 
     let results = hits
         .into_iter()
         .map(|hit| EntitySearchResult {
-            entity: node_to_dto(&hit.node, &collection),
+            entity: node_to_dto(&hit.node, &collection_id),
             score: hit.score,
         })
         .collect::<Vec<_>>();

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -170,6 +170,8 @@ pub async fn fusion_search_v2(
     let service = state.fusion_service.clone();
     let params = GraphFusionParams {
         graph_id,
+        // Structural tenant boundary — scopes both fusion legs (TD-ENTITY-TENANT-1).
+        tenant: Some(tenant.tenant_id.clone()),
         vector_collection: request.vector_collection,
         query_vector: request.query_vector,
         max_depth: request.max_depth,

--- a/src/services/entity_orchestrator.rs
+++ b/src/services/entity_orchestrator.rs
@@ -14,8 +14,10 @@
 //!
 //! Per `SEARCH_SURFACE_CONTRACT_2026_06_24.adoc`: retrieval delegates to the
 //! fusion seam (`FusionService`) — this orchestrator owns no ranking. Tenant
-//! isolation is structural (the caller folds the tenant into the `collection`
-//! key before calling here).
+//! isolation is structural: the caller passes a tenant-CLEAN `collection` + the
+//! request `tenant`, and each leg is scoped here — graph via `for_tenant`, vector
+//! via `TenantContext`, provenance document via the scoped collection key — never a
+//! `{tenant}::collection` name fold.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -159,10 +161,22 @@ impl EntityOrchestrator {
             created_at_ms: now_ms,
             updated_at_ms: now_ms,
         };
-        match self.graph.create_node(collection, node.clone()).await {
+        // Route graph ops through the tenant-scoped handle (structural isolation composed once);
+        // the collection name stays tenant-clean.
+        match self
+            .graph
+            .for_tenant(tenant_id)
+            .create_node(collection, node.clone())
+            .await
+        {
             Ok(_) => debug!("Created graph node {node_id}"),
             Err(create_err) => {
-                if let Err(update_err) = self.graph.update_node(collection, node).await {
+                if let Err(update_err) = self
+                    .graph
+                    .for_tenant(tenant_id)
+                    .update_node(collection, node)
+                    .await
+                {
                     error!("Entity node upsert failed: create={create_err}; update={update_err}");
                     return Err(update_err).context("entity node upsert");
                 }
@@ -201,7 +215,17 @@ impl EntityOrchestrator {
                 props,
                 ..Default::default()
             };
-            match self.vector.insert_batch(collection, vec![record]).await {
+            // Tenant-context write: validates access + stamps tenant_id on the record so the vector
+            // leg isolates by TenantContext (clean collection name), matching the fusion read path.
+            match self
+                .vector
+                .insert_batch_with_tenant_context(
+                    collection,
+                    vec![record],
+                    Some(&crate::storage::tenant::context::TenantContext::for_tenant_id(tenant_id)),
+                )
+                .await
+            {
                 Ok(r) => {
                     if !r.success {
                         warn!(
@@ -250,14 +274,26 @@ impl EntityOrchestrator {
                 "_entity_collection".to_string(),
                 ProximaTreeNode::Value(ProximaValue::String(collection.to_string())),
             );
+            // Scope the provenance doc collection to the tenant (both the storage key and the
+            // record's collection_id — they key the same OID), matching the document fix. The
+            // tenant is already validated (graph create above would have failed otherwise).
+            let scoped_doc_collection =
+                crate::storage::document::service::scoped_document_collection(
+                    tenant_id, collection,
+                )
+                .context("scope provenance document collection")?;
             let doc = DocumentRecord::from_tree(
                 doc_id.clone(),
                 tree,
-                collection.to_string(),
+                scoped_doc_collection.clone(),
                 None,
                 Some("entity_provenance".to_string()),
             );
-            match self.document.insert_document_record(collection, doc).await {
+            match self
+                .document
+                .insert_document_record(&scoped_doc_collection, doc)
+                .await
+            {
                 Ok(_) => debug!("Provenance document inserted doc_id={doc_id}"),
                 Err(e) => warn!("Provenance insert failed (non-fatal) for {doc_id}: {e}"),
             }
@@ -283,7 +319,12 @@ impl EntityOrchestrator {
                 created_at_ms: now_ms,
                 updated_at_ms: now_ms,
             };
-            match self.graph.create_edge(collection, edge).await {
+            match self
+                .graph
+                .for_tenant(tenant_id)
+                .create_edge(collection, edge)
+                .await
+            {
                 Ok(_) => debug!("Created edge {edge_id}"),
                 Err(e) => warn!("Edge create failed (non-fatal) for {edge_id}: {e}"),
             }
@@ -292,10 +333,16 @@ impl EntityOrchestrator {
         Ok(entity_id)
     }
 
-    /// Fetch the entity graph node, if present.
-    pub async fn get(&self, collection: &str, entity_id: &str) -> Result<Option<Arc<Node>>> {
+    /// Fetch the entity graph node, if present. `tenant` scopes the graph read structurally.
+    pub async fn get(
+        &self,
+        collection: &str,
+        tenant: &str,
+        entity_id: &str,
+    ) -> Result<Option<Arc<Node>>> {
         let node_id = Self::entity_node_id(collection, entity_id);
         self.graph
+            .for_tenant(tenant)
             .get_node(collection, &node_id)
             .await
             .context("get entity node")
@@ -303,11 +350,12 @@ impl EntityOrchestrator {
 
     /// Delete the entity graph node. Returns whether it existed. (Associated
     /// vectors/provenance are not cascaded — callers remove them via the
-    /// auxiliary-id convention.)
-    pub async fn delete(&self, collection: &str, entity_id: &str) -> Result<bool> {
+    /// auxiliary-id convention.) `tenant` scopes the graph delete structurally.
+    pub async fn delete(&self, collection: &str, tenant: &str, entity_id: &str) -> Result<bool> {
         let node_id = Self::entity_node_id(collection, entity_id);
         Ok(self
             .graph
+            .for_tenant(tenant)
             .delete_node(collection, &node_id)
             .await
             .context("delete entity node")?
@@ -321,6 +369,7 @@ impl EntityOrchestrator {
     pub async fn search(
         &self,
         collection: &str,
+        tenant: &str,
         query_vector: Option<Vec<f32>>,
         filters: Vec<PropertyFilter>,
         top_k: usize,
@@ -332,6 +381,8 @@ impl EntityOrchestrator {
                 route_policy: None,
                 graph_id: collection.to_string(),
                 vector_collection: collection.to_string(),
+                // Structural tenant boundary — scopes BOTH fusion legs (clean names in, TD-ENTITY-TENANT-1).
+                tenant: Some(tenant.to_string()),
                 query_vector,
                 // TD-146 scope B: graph-augmented entity fusion. `EntityNode` keying normalizes
                 // the auxiliary vector oid + canonical graph oid to the entity `node_id` so the
@@ -357,7 +408,12 @@ impl EntityOrchestrator {
             let mut hits = Vec::with_capacity(items.len());
             for item in items {
                 let node_id = Self::node_id_from_auxiliary_oid(&item.oid).to_owned();
-                if let Ok(Some(node)) = self.graph.get_node(collection, &node_id).await {
+                if let Ok(Some(node)) = self
+                    .graph
+                    .for_tenant(tenant)
+                    .get_node(collection, &node_id)
+                    .await
+                {
                     hits.push(EntitySearchHit {
                         node,
                         score: item.score,
@@ -379,6 +435,7 @@ impl EntityOrchestrator {
         };
         let nodes = self
             .graph
+            .for_tenant(tenant)
             .query_nodes(collection, query)
             .await
             .context("entity node scan")?;

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -427,6 +427,12 @@ pub struct GraphFusionParams {
     pub oid_key: FusionOidKey,
     /// Optional document-modality contribution (TD-138). `None` ⇒ vector+graph only (the default).
     pub document: Option<DocumentFusionSpec>,
+    /// The request tenant — the STRUCTURAL isolation boundary (distinct from `principal`, which is
+    /// within-tenant RBAC). Threads into BOTH legs: the vector leg reads under the tenant's
+    /// `TenantContext` (catalog-resolve + record-stamp), and the graph leg scopes `graph_id` to
+    /// `{tenant}/{graph_id}` (via `scoped_graph_id`) so reads + canonical oids match the graph write
+    /// path. `None`/default tenant ⇒ bare graph_id + unscoped vector read (TD-ENTITY-TENANT-1).
+    pub tenant: Option<String>,
 }
 
 /// Orchestrates the graph instance of the fusion seam over the live vector + graph engines.
@@ -477,6 +483,19 @@ impl FusionService {
 
         let started = Instant::now();
 
+        // Structural tenant scope, composed ONCE and shared by both legs (TD-ENTITY-TENANT-1):
+        // - the graph leg keys reads + canonical oids by `scoped_gid` (`{tenant}/{graph_id}`, bare
+        //   for the default tenant) so it matches the graph write path (`for_tenant`);
+        // - the vector leg reads under the tenant's `TenantContext` (catalog-resolve + record-stamp),
+        //   keeping the collection name clean.
+        let tenant_str = proximadb_tenant::resolve_request_tenant(params.tenant.as_deref());
+        let scoped_gid = crate::graph::scoped_graph_id(&tenant_str, &params.graph_id)?;
+        let tenant_ctx = params
+            .tenant
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .map(crate::storage::tenant::context::TenantContext::for_tenant_id);
+
         // 1. Vector ANN seed with T1.2 retry logic (max 2 retries, exponential backoff).
         let vector = self.vector.clone();
         let collection = params.vector_collection.clone();
@@ -485,7 +504,16 @@ impl FusionService {
 
         let mut hits = retry_vector_search(
             &collection,
-            || vector.unified_search_native(&collection, query_vector.clone(), limit, None, None),
+            || {
+                vector.unified_search_native_with_tenant_context(
+                    &collection,
+                    query_vector.clone(),
+                    limit,
+                    None,
+                    None,
+                    tenant_ctx.as_ref(),
+                )
+            },
             2,
         )
         .await
@@ -516,14 +544,14 @@ impl FusionService {
         // 2. Graph expand from the top seeds (bounded). A seed that is not a node in this graph simply
         //    contributes nothing (its traverse errors are skipped) rather than failing the query.
         // T1.2: Graceful degradation — individual seed failures are logged but don't abort fusion.
-        let seeds = seed_node_ids(&params.graph_id, &hits, params.max_seeds, params.oid_key);
+        let seeds = seed_node_ids(&scoped_gid, &hits, params.max_seeds, params.oid_key);
         let mut nodes: Vec<Node> = Vec::new();
         let mut edges: Vec<Edge> = Vec::new();
         let mut failed_seeds = 0;
 
         for seed in &seeds {
             let request = crate::graph::model::TraversalRequest {
-                graph_id: params.graph_id.clone(),
+                graph_id: scoped_gid.clone(),
                 start_node_id: seed.clone(),
                 max_depth: params.max_depth,
                 edge_types: params.edge_types.clone(),
@@ -534,7 +562,7 @@ impl FusionService {
                 timeout_ms: None,
                 max_frontier: None,
             };
-            match self.graph.traverse(&params.graph_id, request).await {
+            match self.graph.traverse(&scoped_gid, request).await {
                 Ok(response) => {
                     nodes.extend(response.nodes);
                     edges.extend(response.edges);
@@ -564,7 +592,7 @@ impl FusionService {
         //     inaccessible node (never leak a link to a hidden node). Node `oid` = canonical
         //     `graph/{graph_id}/node/{node_id}`, resolved via the graph service's canonical store.
         if let Some(principal) = params.principal.as_deref() {
-            let gid = &params.graph_id;
+            let gid = &scoped_gid;
             let mut kept_nodes = Vec::with_capacity(nodes.len());
             for n in nodes.drain(..) {
                 let oid = GraphNodeKey::new(gid, n.id.clone()).canonical_oid();
@@ -593,13 +621,13 @@ impl FusionService {
         let mut sources = vec![vector_source];
         if matches!(params.grain, GraphGrain::Nodes | GraphGrain::Both) {
             sources.push(normalize_source_keys(
-                traversal_nodes_to_source(&params.graph_id, &nodes, params.graph_weight),
+                traversal_nodes_to_source(&scoped_gid, &nodes, params.graph_weight),
                 params.oid_key,
             ));
         }
         if matches!(params.grain, GraphGrain::Edges | GraphGrain::Both) {
             sources.push(normalize_source_keys(
-                traversal_edges_to_source(&params.graph_id, &edges, params.graph_weight),
+                traversal_edges_to_source(&scoped_gid, &edges, params.graph_weight),
                 params.oid_key,
             ));
         }
@@ -718,6 +746,35 @@ fn truncate_source_to_budget(source: &mut SourceCandidates, budget: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TD-ENTITY-TENANT-1: both fusion legs derive their tenant scope from `params.tenant`.
+    /// The graph leg keys reads + canonical oids by `scoped_graph_id` (named →
+    /// `{tenant}/{graph_id}`, so it matches the graph write path; default/None → bare, matching
+    /// bare-created graphs). The vector leg builds a `TenantContext` whose `tenant_id` isolates
+    /// (catalog-resolve + record-stamp). This asserts the composition both legs use (the full
+    /// fusion path needs the live vector+graph services, exercised by the network e2e suites).
+    #[test]
+    fn fusion_tenant_scopes_both_legs() {
+        // Graph leg: the scope key fusion composes must equal the graph write path's `for_tenant`.
+        let named = proximadb_tenant::resolve_request_tenant(Some("acme"));
+        assert_eq!(
+            crate::graph::scoped_graph_id(&named, "kg").unwrap(),
+            "acme/kg",
+            "named tenant → scoped graph key"
+        );
+        let defaulted = proximadb_tenant::resolve_request_tenant(None);
+        assert_eq!(
+            crate::graph::scoped_graph_id(&defaulted, "kg").unwrap(),
+            "kg",
+            "default tenant → bare graph key (matches bare-created graphs)"
+        );
+        // Vector leg: the tenant stamp that isolates the vector read/write.
+        let tctx = crate::storage::tenant::context::TenantContext::for_tenant_id("acme");
+        assert_eq!(
+            tctx.tenant_id, "acme",
+            "vector leg isolates by TenantContext.tenant_id"
+        );
+    }
 
     fn hit(id: &str, score: f32) -> OptimizedSearchRecord {
         OptimizedSearchRecord {

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2421,6 +2421,41 @@ impl VectorOperationsService {
         Ok((v1_results, explain))
     }
 
+    /// Tenant-aware wrapper over [`unified_search_native`]: validates the tenant's access to the
+    /// collection and resolves it to the tenant's canonical id (mirroring `VectorOpsPort::search`),
+    /// then delegates the actual search. Isolation is clean-name + `TenantContext`
+    /// (catalog-resolve and record-stamp), never a name fold. `None` tenant (or empty tenant_id) ⇒
+    /// plain delegation.
+    /// Lets the fusion vector leg read only the tenant's vectors (TD-ENTITY-TENANT-1) without
+    /// touching the existing `unified_search_native` call sites.
+    pub async fn unified_search_native_with_tenant_context(
+        &self,
+        collection_id: &str,
+        query_vector: Vec<f32>,
+        k: usize,
+        filter: Option<FilterExpression>,
+        config: Option<UnifiedSearchConfig>,
+        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+    ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
+        let resolved = match tenant_context {
+            Some(tc) if !tc.tenant_id.is_empty() => {
+                self.validate_tenant_collection_access(collection_id, tenant_context)
+                    .await?;
+                match self
+                    .collection_port
+                    .get_collection(collection_id, Some(&tc.tenant_id))
+                    .await?
+                {
+                    Some(collection) => collection.id,
+                    None => collection_id.to_string(),
+                }
+            }
+            _ => collection_id.to_string(),
+        };
+        self.unified_search_native(&resolved, query_vector, k, filter, config)
+            .await
+    }
+
     /// Native variant: returns optimized native records for internal callers.
     /// Callers at API boundaries should use v1 adapters.
     pub async fn unified_search_native(


### PR DESCRIPTION
## What & why

Completes named-tenant isolation for the **last** modality — entities — and retires the last
`{tenant}::{collection}` **name-fold**. The entity graph + document write legs already worked
(via the landed `for_tenant`/auto-provision fixes); the remaining blocker was the **vector/fusion
search leg**: `unified_search_native` (which fusion calls) has no tenant parameter, so entity
vector search wasn't tenant-isolated.

Per `TD-ENTITY-TENANT-1`, the fix uses the **already-existing** clean-name + `TenantContext`
mechanism (catalog-resolve + record-stamp) — NOT name-folding — so it's a parameter thread-through,
not an engine rework.

## Changes
- **Vector primitive** (`legacy.rs`): additive `unified_search_native_with_tenant_context` —
  validates tenant access, resolves the collection to the tenant's canonical id (mirroring
  `VectorOpsPort::search`), then delegates to the existing `unified_search_native`. The 8 other
  `unified_search_native` callers are untouched.
- **Fusion** (`fusion_service.rs`): `GraphFusionParams` gains `tenant`. The **vector leg** reads via
  the tenant-aware wrapper with a `TenantContext::for_tenant_id`; the **graph leg** composes
  `scoped_graph_id` once and keys reads + canonical oids by `{tenant}/{graph_id}` (bare for the
  default tenant) — matching the graph write path. No double-scope (raw graph methods take the
  already-scoped id).
- **EntityOrchestrator** (REST path): `upsert` writes via `insert_batch_with_tenant_context`;
  `get`/`delete`/`search` gain a tenant and route graph ops through `for_tenant`; `search` sets
  `params.tenant`. `entity_node_id` stays clean.
- **gRPC `entity_service.rs`**: delete `effective_collection_id` (the `::` fold); resolve the tenant
  and pass clean names + tenant to the tenant-aware graph/vector/document/fusion calls.
- Small: a scoped `get_nodes` forwarder on `TenantGraphOps`; `GraphFusionParams` literals updated.

## Isolation invariant
No `{tenant}::` fold remains in the entity/fusion surfaces (verified). Every entity vector write
goes through `insert_batch_with_tenant_context` (tenant-stamped); every fusion vector read through
`unified_search_native_with_tenant_context` (catalog-resolve); every entity graph op through
`for_tenant`; the fusion graph oid uses `scoped_graph_id` with no double-scope.

## Tests
- `fusion_tenant_scopes_both_legs` — both legs derive scope from `params.tenant`: graph leg
  `scoped_graph_id` (named→`{tenant}/kg`, default→bare), vector leg `TenantContext.tenant_id`.
  (The full live fusion path is exercised by the network e2e suites — the concrete vector/graph
  services are heavy to mock at unit level.)
- 258 entity/fusion unit tests pass.

## Verification
`cargo build -p proximadb-server` ✅ · `cargo fmt --check` ✅ ·
`cargo clippy -p proximadb -- -D warnings` ✅ · v1-proto ratchet +0 · entity/fusion tests green.

With this, **all five modalities** (resolution, timeseries, graph, documents, entities) have
functional named-tenant isolation. Follow-ons remain in the 3 TDs (REST v2 doc store-split,
pgwire/REST-v1 create scoping, default-tenant uniformity).