### PR TITLE
feat(contract): X-Tenant-ID as a formal OpenAPI header + 4-language SDK regen (Phase 2)

### DIFF
--- a/clients/go/proximadb/internal/genrest/genrest.gen.go
+++ b/clients/go/proximadb/internal/genrest/genrest.gen.go
@@ -1330,6 +1330,12 @@ type NotFound = ErrorResponse
 // bug reports.
 type Unauthorized = ErrorResponse
 
+// GetCapabilitiesParams defines parameters for GetCapabilities.
+type GetCapabilitiesParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
 // ListCollectionsParams defines parameters for ListCollections.
 type ListCollectionsParams struct {
 	// Limit Maximum number of collections to return (default: 100)
@@ -1340,6 +1346,75 @@ type ListCollectionsParams struct {
 
 	// IncludeStats Whether to include statistics
 	IncludeStats *bool `form:"include_stats,omitempty" json:"include_stats,omitempty"`
+
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// CreateCollectionParams defines parameters for CreateCollection.
+type CreateCollectionParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// DeleteCollectionParams defines parameters for DeleteCollection.
+type DeleteCollectionParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetCollectionParams defines parameters for GetCollection.
+type GetCollectionParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// IngestDocumentsParams defines parameters for IngestDocuments.
+type IngestDocumentsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// UpsertEntityV2Params defines parameters for UpsertEntityV2.
+type UpsertEntityV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// SearchEntitiesV2Params defines parameters for SearchEntitiesV2.
+type SearchEntitiesV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// DeleteEntityV2Params defines parameters for DeleteEntityV2.
+type DeleteEntityV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetEntityV2Params defines parameters for GetEntityV2.
+type GetEntityV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// InsertRecordsParams defines parameters for InsertRecords.
+type InsertRecordsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ScanRecordsParams defines parameters for ScanRecords.
+type ScanRecordsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// DeleteRecordParams defines parameters for DeleteRecord.
+type DeleteRecordParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
 }
 
 // GetRecordParams defines parameters for GetRecord.
@@ -1349,16 +1424,151 @@ type GetRecordParams struct {
 
 	// IncludeText Whether to include TEXT fields in the response
 	IncludeText *bool `form:"include_text,omitempty" json:"include_text,omitempty"`
+
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetCollectionSchemaParams defines parameters for GetCollectionSchema.
+type GetCollectionSchemaParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// UpdateCollectionSchemaParams defines parameters for UpdateCollectionSchema.
+type UpdateCollectionSchemaParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// SearchRecordsParams defines parameters for SearchRecords.
+type SearchRecordsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ListDocumentCollectionsParams defines parameters for ListDocumentCollections.
+type ListDocumentCollectionsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
 }
 
 // CreateDocumentCollectionJSONBody defines parameters for CreateDocumentCollection.
 type CreateDocumentCollectionJSONBody map[string]interface{}
 
+// CreateDocumentCollectionParams defines parameters for CreateDocumentCollection.
+type CreateDocumentCollectionParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// QueryDocumentsParams defines parameters for QueryDocuments.
+type QueryDocumentsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
 // InsertDocumentJSONBody defines parameters for InsertDocument.
 type InsertDocumentJSONBody map[string]interface{}
 
+// InsertDocumentParams defines parameters for InsertDocument.
+type InsertDocumentParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ListGraphsParams defines parameters for ListGraphs.
+type ListGraphsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// CreateGraphParams defines parameters for CreateGraph.
+type CreateGraphParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// DeleteGraphParams defines parameters for DeleteGraph.
+type DeleteGraphParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetGraphParams defines parameters for GetGraph.
+type GetGraphParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// CreateEdgeParams defines parameters for CreateEdge.
+type CreateEdgeParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// BatchCreateEdgesParams defines parameters for BatchCreateEdges.
+type BatchCreateEdgesParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// FusionSearchV2Params defines parameters for FusionSearchV2.
+type FusionSearchV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ImpactAnalysisV2Params defines parameters for ImpactAnalysisV2.
+type ImpactAnalysisV2Params struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// CreateNodeParams defines parameters for CreateNode.
+type CreateNodeParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// BatchCreateNodesParams defines parameters for BatchCreateNodes.
+type BatchCreateNodesParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// DeleteNodeParams defines parameters for DeleteNode.
+type DeleteNodeParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetNodeParams defines parameters for GetNode.
+type GetNodeParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetGraphStatsParams defines parameters for GetGraphStats.
+type GetGraphStatsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// TraverseGraphParams defines parameters for TraverseGraph.
+type TraverseGraphParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
 // HybridIndexJSONBody defines parameters for HybridIndex.
 type HybridIndexJSONBody map[string]interface{}
+
+// HybridIndexParams defines parameters for HybridIndex.
+type HybridIndexParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
 
 // HybridSearchJSONBody defines parameters for HybridSearch.
 type HybridSearchJSONBody struct {
@@ -1370,11 +1580,59 @@ type HybridSearchJSONBody struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
+// HybridSearchParams defines parameters for HybridSearch.
+type HybridSearchParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
 // IngestLogJSONBody defines parameters for IngestLog.
 type IngestLogJSONBody map[string]interface{}
 
+// IngestLogParams defines parameters for IngestLog.
+type IngestLogParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
 // QueryLogsJSONBody defines parameters for QueryLogs.
 type QueryLogsJSONBody map[string]interface{}
+
+// QueryLogsParams defines parameters for QueryLogs.
+type QueryLogsParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ExecuteQueryParams defines parameters for ExecuteQuery.
+type ExecuteQueryParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// ExplainQueryParams defines parameters for ExplainQuery.
+type ExplainQueryParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetHealthParams defines parameters for GetHealth.
+type GetHealthParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetLivenessParams defines parameters for GetLiveness.
+type GetLivenessParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
+
+// GetReadinessParams defines parameters for GetReadiness.
+type GetReadinessParams struct {
+	// XTenantID Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+	XTenantID *string `json:"X-Tenant-ID,omitempty"`
+}
 
 // CreateCollectionJSONRequestBody defines body for CreateCollection for application/json ContentType.
 type CreateCollectionJSONRequestBody = CreateCollectionV2Request
@@ -3001,188 +3259,188 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// GetCapabilities request
-	GetCapabilities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetCapabilities(ctx context.Context, params *GetCapabilitiesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListCollections request
 	ListCollections(ctx context.Context, params *ListCollectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateCollectionWithBody request with any body
-	CreateCollectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateCollectionWithBody(ctx context.Context, params *CreateCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateCollection(ctx context.Context, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateCollection(ctx context.Context, params *CreateCollectionParams, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteCollection request
-	DeleteCollection(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteCollection(ctx context.Context, collectionId string, params *DeleteCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetCollection request
-	GetCollection(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetCollection(ctx context.Context, collectionId string, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// IngestDocumentsWithBody request with any body
-	IngestDocumentsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	IngestDocumentsWithBody(ctx context.Context, collectionId string, params *IngestDocumentsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	IngestDocuments(ctx context.Context, collectionId string, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	IngestDocuments(ctx context.Context, collectionId string, params *IngestDocumentsParams, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpsertEntityV2WithBody request with any body
-	UpsertEntityV2WithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpsertEntityV2WithBody(ctx context.Context, collectionId string, params *UpsertEntityV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpsertEntityV2(ctx context.Context, collectionId string, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpsertEntityV2(ctx context.Context, collectionId string, params *UpsertEntityV2Params, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SearchEntitiesV2WithBody request with any body
-	SearchEntitiesV2WithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SearchEntitiesV2WithBody(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SearchEntitiesV2(ctx context.Context, collectionId string, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SearchEntitiesV2(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteEntityV2 request
-	DeleteEntityV2(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteEntityV2(ctx context.Context, collectionId string, entityId string, params *DeleteEntityV2Params, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEntityV2 request
-	GetEntityV2(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetEntityV2(ctx context.Context, collectionId string, entityId string, params *GetEntityV2Params, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// InsertRecordsWithBody request with any body
-	InsertRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	InsertRecordsWithBody(ctx context.Context, collectionId string, params *InsertRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	InsertRecords(ctx context.Context, collectionId string, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	InsertRecords(ctx context.Context, collectionId string, params *InsertRecordsParams, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ScanRecordsWithBody request with any body
-	ScanRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ScanRecordsWithBody(ctx context.Context, collectionId string, params *ScanRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	ScanRecords(ctx context.Context, collectionId string, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ScanRecords(ctx context.Context, collectionId string, params *ScanRecordsParams, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteRecord request
-	DeleteRecord(ctx context.Context, collectionId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteRecord(ctx context.Context, collectionId string, recordId string, params *DeleteRecordParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetRecord request
 	GetRecord(ctx context.Context, collectionId string, recordId string, params *GetRecordParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetCollectionSchema request
-	GetCollectionSchema(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetCollectionSchema(ctx context.Context, collectionId string, params *GetCollectionSchemaParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdateCollectionSchemaWithBody request with any body
-	UpdateCollectionSchemaWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateCollectionSchemaWithBody(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpdateCollectionSchema(ctx context.Context, collectionId string, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateCollectionSchema(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SearchRecordsWithBody request with any body
-	SearchRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SearchRecordsWithBody(ctx context.Context, collectionId string, params *SearchRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SearchRecords(ctx context.Context, collectionId string, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SearchRecords(ctx context.Context, collectionId string, params *SearchRecordsParams, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListDocumentCollections request
-	ListDocumentCollections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListDocumentCollections(ctx context.Context, params *ListDocumentCollectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateDocumentCollectionWithBody request with any body
-	CreateDocumentCollectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateDocumentCollectionWithBody(ctx context.Context, params *CreateDocumentCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateDocumentCollection(ctx context.Context, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateDocumentCollection(ctx context.Context, params *CreateDocumentCollectionParams, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// QueryDocuments request
-	QueryDocuments(ctx context.Context, collection string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	QueryDocuments(ctx context.Context, collection string, params *QueryDocumentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// InsertDocumentWithBody request with any body
-	InsertDocumentWithBody(ctx context.Context, collection string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	InsertDocumentWithBody(ctx context.Context, collection string, params *InsertDocumentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	InsertDocument(ctx context.Context, collection string, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	InsertDocument(ctx context.Context, collection string, params *InsertDocumentParams, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListGraphs request
-	ListGraphs(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListGraphs(ctx context.Context, params *ListGraphsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateGraphWithBody request with any body
-	CreateGraphWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateGraphWithBody(ctx context.Context, params *CreateGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateGraph(ctx context.Context, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateGraph(ctx context.Context, params *CreateGraphParams, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteGraph request
-	DeleteGraph(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteGraph(ctx context.Context, graphId GraphId, params *DeleteGraphParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetGraph request
-	GetGraph(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetGraph(ctx context.Context, graphId GraphId, params *GetGraphParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateEdgeWithBody request with any body
-	CreateEdgeWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateEdgeWithBody(ctx context.Context, graphId GraphId, params *CreateEdgeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateEdge(ctx context.Context, graphId GraphId, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateEdge(ctx context.Context, graphId GraphId, params *CreateEdgeParams, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// BatchCreateEdgesWithBody request with any body
-	BatchCreateEdgesWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	BatchCreateEdgesWithBody(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	BatchCreateEdges(ctx context.Context, graphId GraphId, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	BatchCreateEdges(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// FusionSearchV2WithBody request with any body
-	FusionSearchV2WithBody(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	FusionSearchV2WithBody(ctx context.Context, graphId string, params *FusionSearchV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	FusionSearchV2(ctx context.Context, graphId string, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	FusionSearchV2(ctx context.Context, graphId string, params *FusionSearchV2Params, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ImpactAnalysisV2WithBody request with any body
-	ImpactAnalysisV2WithBody(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ImpactAnalysisV2WithBody(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	ImpactAnalysisV2(ctx context.Context, graphId string, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ImpactAnalysisV2(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateNodeWithBody request with any body
-	CreateNodeWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateNodeWithBody(ctx context.Context, graphId GraphId, params *CreateNodeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	CreateNode(ctx context.Context, graphId GraphId, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	CreateNode(ctx context.Context, graphId GraphId, params *CreateNodeParams, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// BatchCreateNodesWithBody request with any body
-	BatchCreateNodesWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	BatchCreateNodesWithBody(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	BatchCreateNodes(ctx context.Context, graphId GraphId, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	BatchCreateNodes(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteNode request
-	DeleteNode(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteNode(ctx context.Context, graphId GraphId, nodeId NodeId, params *DeleteNodeParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetNode request
-	GetNode(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetNode(ctx context.Context, graphId GraphId, nodeId NodeId, params *GetNodeParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetGraphStats request
-	GetGraphStats(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetGraphStats(ctx context.Context, graphId GraphId, params *GetGraphStatsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// TraverseGraphWithBody request with any body
-	TraverseGraphWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	TraverseGraphWithBody(ctx context.Context, graphId GraphId, params *TraverseGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	TraverseGraph(ctx context.Context, graphId GraphId, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	TraverseGraph(ctx context.Context, graphId GraphId, params *TraverseGraphParams, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// HybridIndexWithBody request with any body
-	HybridIndexWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	HybridIndexWithBody(ctx context.Context, params *HybridIndexParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	HybridIndex(ctx context.Context, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	HybridIndex(ctx context.Context, params *HybridIndexParams, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// HybridSearchWithBody request with any body
-	HybridSearchWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	HybridSearchWithBody(ctx context.Context, params *HybridSearchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	HybridSearch(ctx context.Context, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	HybridSearch(ctx context.Context, params *HybridSearchParams, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// IngestLogWithBody request with any body
-	IngestLogWithBody(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	IngestLogWithBody(ctx context.Context, namespace string, params *IngestLogParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	IngestLog(ctx context.Context, namespace string, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	IngestLog(ctx context.Context, namespace string, params *IngestLogParams, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// QueryLogsWithBody request with any body
-	QueryLogsWithBody(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	QueryLogsWithBody(ctx context.Context, namespace string, params *QueryLogsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	QueryLogs(ctx context.Context, namespace string, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	QueryLogs(ctx context.Context, namespace string, params *QueryLogsParams, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExecuteQueryWithBody request with any body
-	ExecuteQueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExecuteQueryWithBody(ctx context.Context, params *ExecuteQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	ExecuteQuery(ctx context.Context, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExecuteQuery(ctx context.Context, params *ExecuteQueryParams, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ExplainQueryWithBody request with any body
-	ExplainQueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExplainQueryWithBody(ctx context.Context, params *ExplainQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	ExplainQuery(ctx context.Context, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ExplainQuery(ctx context.Context, params *ExplainQueryParams, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetHealth request
-	GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetHealth(ctx context.Context, params *GetHealthParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLiveness request
-	GetLiveness(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetLiveness(ctx context.Context, params *GetLivenessParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReadiness request
-	GetReadiness(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetReadiness(ctx context.Context, params *GetReadinessParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) GetCapabilities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetCapabilitiesRequest(c.Server)
+func (c *Client) GetCapabilities(ctx context.Context, params *GetCapabilitiesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCapabilitiesRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3205,8 +3463,8 @@ func (c *Client) ListCollections(ctx context.Context, params *ListCollectionsPar
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateCollectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateCollectionRequestWithBody(c.Server, contentType, body)
+func (c *Client) CreateCollectionWithBody(ctx context.Context, params *CreateCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateCollectionRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3217,8 +3475,8 @@ func (c *Client) CreateCollectionWithBody(ctx context.Context, contentType strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateCollection(ctx context.Context, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateCollectionRequest(c.Server, body)
+func (c *Client) CreateCollection(ctx context.Context, params *CreateCollectionParams, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateCollectionRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3229,8 +3487,8 @@ func (c *Client) CreateCollection(ctx context.Context, body CreateCollectionJSON
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteCollection(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteCollectionRequest(c.Server, collectionId)
+func (c *Client) DeleteCollection(ctx context.Context, collectionId string, params *DeleteCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteCollectionRequest(c.Server, collectionId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3241,8 +3499,8 @@ func (c *Client) DeleteCollection(ctx context.Context, collectionId string, reqE
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetCollection(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetCollectionRequest(c.Server, collectionId)
+func (c *Client) GetCollection(ctx context.Context, collectionId string, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCollectionRequest(c.Server, collectionId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3253,8 +3511,8 @@ func (c *Client) GetCollection(ctx context.Context, collectionId string, reqEdit
 	return c.Client.Do(req)
 }
 
-func (c *Client) IngestDocumentsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewIngestDocumentsRequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) IngestDocumentsWithBody(ctx context.Context, collectionId string, params *IngestDocumentsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestDocumentsRequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3265,8 +3523,8 @@ func (c *Client) IngestDocumentsWithBody(ctx context.Context, collectionId strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) IngestDocuments(ctx context.Context, collectionId string, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewIngestDocumentsRequest(c.Server, collectionId, body)
+func (c *Client) IngestDocuments(ctx context.Context, collectionId string, params *IngestDocumentsParams, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestDocumentsRequest(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3277,8 +3535,8 @@ func (c *Client) IngestDocuments(ctx context.Context, collectionId string, body 
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpsertEntityV2WithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpsertEntityV2RequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) UpsertEntityV2WithBody(ctx context.Context, collectionId string, params *UpsertEntityV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpsertEntityV2RequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3289,8 +3547,8 @@ func (c *Client) UpsertEntityV2WithBody(ctx context.Context, collectionId string
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpsertEntityV2(ctx context.Context, collectionId string, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpsertEntityV2Request(c.Server, collectionId, body)
+func (c *Client) UpsertEntityV2(ctx context.Context, collectionId string, params *UpsertEntityV2Params, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpsertEntityV2Request(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3301,8 +3559,8 @@ func (c *Client) UpsertEntityV2(ctx context.Context, collectionId string, body U
 	return c.Client.Do(req)
 }
 
-func (c *Client) SearchEntitiesV2WithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSearchEntitiesV2RequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) SearchEntitiesV2WithBody(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchEntitiesV2RequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3313,8 +3571,8 @@ func (c *Client) SearchEntitiesV2WithBody(ctx context.Context, collectionId stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) SearchEntitiesV2(ctx context.Context, collectionId string, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSearchEntitiesV2Request(c.Server, collectionId, body)
+func (c *Client) SearchEntitiesV2(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchEntitiesV2Request(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3325,8 +3583,8 @@ func (c *Client) SearchEntitiesV2(ctx context.Context, collectionId string, body
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteEntityV2(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteEntityV2Request(c.Server, collectionId, entityId)
+func (c *Client) DeleteEntityV2(ctx context.Context, collectionId string, entityId string, params *DeleteEntityV2Params, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteEntityV2Request(c.Server, collectionId, entityId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3337,8 +3595,8 @@ func (c *Client) DeleteEntityV2(ctx context.Context, collectionId string, entity
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEntityV2(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetEntityV2Request(c.Server, collectionId, entityId)
+func (c *Client) GetEntityV2(ctx context.Context, collectionId string, entityId string, params *GetEntityV2Params, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEntityV2Request(c.Server, collectionId, entityId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3349,8 +3607,8 @@ func (c *Client) GetEntityV2(ctx context.Context, collectionId string, entityId 
 	return c.Client.Do(req)
 }
 
-func (c *Client) InsertRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInsertRecordsRequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) InsertRecordsWithBody(ctx context.Context, collectionId string, params *InsertRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInsertRecordsRequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3361,8 +3619,8 @@ func (c *Client) InsertRecordsWithBody(ctx context.Context, collectionId string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) InsertRecords(ctx context.Context, collectionId string, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInsertRecordsRequest(c.Server, collectionId, body)
+func (c *Client) InsertRecords(ctx context.Context, collectionId string, params *InsertRecordsParams, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInsertRecordsRequest(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3373,8 +3631,8 @@ func (c *Client) InsertRecords(ctx context.Context, collectionId string, body In
 	return c.Client.Do(req)
 }
 
-func (c *Client) ScanRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewScanRecordsRequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) ScanRecordsWithBody(ctx context.Context, collectionId string, params *ScanRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScanRecordsRequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3385,8 +3643,8 @@ func (c *Client) ScanRecordsWithBody(ctx context.Context, collectionId string, c
 	return c.Client.Do(req)
 }
 
-func (c *Client) ScanRecords(ctx context.Context, collectionId string, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewScanRecordsRequest(c.Server, collectionId, body)
+func (c *Client) ScanRecords(ctx context.Context, collectionId string, params *ScanRecordsParams, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScanRecordsRequest(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3397,8 +3655,8 @@ func (c *Client) ScanRecords(ctx context.Context, collectionId string, body Scan
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteRecord(ctx context.Context, collectionId string, recordId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteRecordRequest(c.Server, collectionId, recordId)
+func (c *Client) DeleteRecord(ctx context.Context, collectionId string, recordId string, params *DeleteRecordParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteRecordRequest(c.Server, collectionId, recordId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3421,8 +3679,8 @@ func (c *Client) GetRecord(ctx context.Context, collectionId string, recordId st
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetCollectionSchema(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetCollectionSchemaRequest(c.Server, collectionId)
+func (c *Client) GetCollectionSchema(ctx context.Context, collectionId string, params *GetCollectionSchemaParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCollectionSchemaRequest(c.Server, collectionId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3433,8 +3691,8 @@ func (c *Client) GetCollectionSchema(ctx context.Context, collectionId string, r
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateCollectionSchemaWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateCollectionSchemaRequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) UpdateCollectionSchemaWithBody(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateCollectionSchemaRequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3445,8 +3703,8 @@ func (c *Client) UpdateCollectionSchemaWithBody(ctx context.Context, collectionI
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateCollectionSchema(ctx context.Context, collectionId string, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateCollectionSchemaRequest(c.Server, collectionId, body)
+func (c *Client) UpdateCollectionSchema(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateCollectionSchemaRequest(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3457,8 +3715,8 @@ func (c *Client) UpdateCollectionSchema(ctx context.Context, collectionId string
 	return c.Client.Do(req)
 }
 
-func (c *Client) SearchRecordsWithBody(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSearchRecordsRequestWithBody(c.Server, collectionId, contentType, body)
+func (c *Client) SearchRecordsWithBody(ctx context.Context, collectionId string, params *SearchRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchRecordsRequestWithBody(c.Server, collectionId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3469,8 +3727,8 @@ func (c *Client) SearchRecordsWithBody(ctx context.Context, collectionId string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) SearchRecords(ctx context.Context, collectionId string, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSearchRecordsRequest(c.Server, collectionId, body)
+func (c *Client) SearchRecords(ctx context.Context, collectionId string, params *SearchRecordsParams, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchRecordsRequest(c.Server, collectionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3481,8 +3739,8 @@ func (c *Client) SearchRecords(ctx context.Context, collectionId string, body Se
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListDocumentCollections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListDocumentCollectionsRequest(c.Server)
+func (c *Client) ListDocumentCollections(ctx context.Context, params *ListDocumentCollectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListDocumentCollectionsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3493,8 +3751,8 @@ func (c *Client) ListDocumentCollections(ctx context.Context, reqEditors ...Requ
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateDocumentCollectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateDocumentCollectionRequestWithBody(c.Server, contentType, body)
+func (c *Client) CreateDocumentCollectionWithBody(ctx context.Context, params *CreateDocumentCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDocumentCollectionRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3505,8 +3763,8 @@ func (c *Client) CreateDocumentCollectionWithBody(ctx context.Context, contentTy
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateDocumentCollection(ctx context.Context, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateDocumentCollectionRequest(c.Server, body)
+func (c *Client) CreateDocumentCollection(ctx context.Context, params *CreateDocumentCollectionParams, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDocumentCollectionRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3517,8 +3775,8 @@ func (c *Client) CreateDocumentCollection(ctx context.Context, body CreateDocume
 	return c.Client.Do(req)
 }
 
-func (c *Client) QueryDocuments(ctx context.Context, collection string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewQueryDocumentsRequest(c.Server, collection)
+func (c *Client) QueryDocuments(ctx context.Context, collection string, params *QueryDocumentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQueryDocumentsRequest(c.Server, collection, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3529,8 +3787,8 @@ func (c *Client) QueryDocuments(ctx context.Context, collection string, reqEdito
 	return c.Client.Do(req)
 }
 
-func (c *Client) InsertDocumentWithBody(ctx context.Context, collection string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInsertDocumentRequestWithBody(c.Server, collection, contentType, body)
+func (c *Client) InsertDocumentWithBody(ctx context.Context, collection string, params *InsertDocumentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInsertDocumentRequestWithBody(c.Server, collection, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3541,8 +3799,8 @@ func (c *Client) InsertDocumentWithBody(ctx context.Context, collection string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) InsertDocument(ctx context.Context, collection string, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewInsertDocumentRequest(c.Server, collection, body)
+func (c *Client) InsertDocument(ctx context.Context, collection string, params *InsertDocumentParams, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInsertDocumentRequest(c.Server, collection, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3553,8 +3811,8 @@ func (c *Client) InsertDocument(ctx context.Context, collection string, body Ins
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListGraphs(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListGraphsRequest(c.Server)
+func (c *Client) ListGraphs(ctx context.Context, params *ListGraphsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListGraphsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3565,8 +3823,8 @@ func (c *Client) ListGraphs(ctx context.Context, reqEditors ...RequestEditorFn) 
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateGraphWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateGraphRequestWithBody(c.Server, contentType, body)
+func (c *Client) CreateGraphWithBody(ctx context.Context, params *CreateGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateGraphRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3577,8 +3835,8 @@ func (c *Client) CreateGraphWithBody(ctx context.Context, contentType string, bo
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateGraph(ctx context.Context, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateGraphRequest(c.Server, body)
+func (c *Client) CreateGraph(ctx context.Context, params *CreateGraphParams, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateGraphRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3589,8 +3847,8 @@ func (c *Client) CreateGraph(ctx context.Context, body CreateGraphJSONRequestBod
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteGraph(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteGraphRequest(c.Server, graphId)
+func (c *Client) DeleteGraph(ctx context.Context, graphId GraphId, params *DeleteGraphParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteGraphRequest(c.Server, graphId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3601,8 +3859,8 @@ func (c *Client) DeleteGraph(ctx context.Context, graphId GraphId, reqEditors ..
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetGraph(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetGraphRequest(c.Server, graphId)
+func (c *Client) GetGraph(ctx context.Context, graphId GraphId, params *GetGraphParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetGraphRequest(c.Server, graphId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3613,8 +3871,8 @@ func (c *Client) GetGraph(ctx context.Context, graphId GraphId, reqEditors ...Re
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEdgeWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEdgeRequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) CreateEdgeWithBody(ctx context.Context, graphId GraphId, params *CreateEdgeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEdgeRequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3625,8 +3883,8 @@ func (c *Client) CreateEdgeWithBody(ctx context.Context, graphId GraphId, conten
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateEdge(ctx context.Context, graphId GraphId, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateEdgeRequest(c.Server, graphId, body)
+func (c *Client) CreateEdge(ctx context.Context, graphId GraphId, params *CreateEdgeParams, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEdgeRequest(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3637,8 +3895,8 @@ func (c *Client) CreateEdge(ctx context.Context, graphId GraphId, body CreateEdg
 	return c.Client.Do(req)
 }
 
-func (c *Client) BatchCreateEdgesWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewBatchCreateEdgesRequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) BatchCreateEdgesWithBody(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBatchCreateEdgesRequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3649,8 +3907,8 @@ func (c *Client) BatchCreateEdgesWithBody(ctx context.Context, graphId GraphId, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) BatchCreateEdges(ctx context.Context, graphId GraphId, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewBatchCreateEdgesRequest(c.Server, graphId, body)
+func (c *Client) BatchCreateEdges(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBatchCreateEdgesRequest(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3661,8 +3919,8 @@ func (c *Client) BatchCreateEdges(ctx context.Context, graphId GraphId, body Bat
 	return c.Client.Do(req)
 }
 
-func (c *Client) FusionSearchV2WithBody(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFusionSearchV2RequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) FusionSearchV2WithBody(ctx context.Context, graphId string, params *FusionSearchV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFusionSearchV2RequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3673,8 +3931,8 @@ func (c *Client) FusionSearchV2WithBody(ctx context.Context, graphId string, con
 	return c.Client.Do(req)
 }
 
-func (c *Client) FusionSearchV2(ctx context.Context, graphId string, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFusionSearchV2Request(c.Server, graphId, body)
+func (c *Client) FusionSearchV2(ctx context.Context, graphId string, params *FusionSearchV2Params, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFusionSearchV2Request(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3685,8 +3943,8 @@ func (c *Client) FusionSearchV2(ctx context.Context, graphId string, body Fusion
 	return c.Client.Do(req)
 }
 
-func (c *Client) ImpactAnalysisV2WithBody(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewImpactAnalysisV2RequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) ImpactAnalysisV2WithBody(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewImpactAnalysisV2RequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3697,8 +3955,8 @@ func (c *Client) ImpactAnalysisV2WithBody(ctx context.Context, graphId string, c
 	return c.Client.Do(req)
 }
 
-func (c *Client) ImpactAnalysisV2(ctx context.Context, graphId string, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewImpactAnalysisV2Request(c.Server, graphId, body)
+func (c *Client) ImpactAnalysisV2(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewImpactAnalysisV2Request(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3709,8 +3967,8 @@ func (c *Client) ImpactAnalysisV2(ctx context.Context, graphId string, body Impa
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateNodeWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateNodeRequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) CreateNodeWithBody(ctx context.Context, graphId GraphId, params *CreateNodeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNodeRequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3721,8 +3979,8 @@ func (c *Client) CreateNodeWithBody(ctx context.Context, graphId GraphId, conten
 	return c.Client.Do(req)
 }
 
-func (c *Client) CreateNode(ctx context.Context, graphId GraphId, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewCreateNodeRequest(c.Server, graphId, body)
+func (c *Client) CreateNode(ctx context.Context, graphId GraphId, params *CreateNodeParams, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNodeRequest(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3733,8 +3991,8 @@ func (c *Client) CreateNode(ctx context.Context, graphId GraphId, body CreateNod
 	return c.Client.Do(req)
 }
 
-func (c *Client) BatchCreateNodesWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewBatchCreateNodesRequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) BatchCreateNodesWithBody(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBatchCreateNodesRequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3745,8 +4003,8 @@ func (c *Client) BatchCreateNodesWithBody(ctx context.Context, graphId GraphId, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) BatchCreateNodes(ctx context.Context, graphId GraphId, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewBatchCreateNodesRequest(c.Server, graphId, body)
+func (c *Client) BatchCreateNodes(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBatchCreateNodesRequest(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3757,8 +4015,8 @@ func (c *Client) BatchCreateNodes(ctx context.Context, graphId GraphId, body Bat
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteNode(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteNodeRequest(c.Server, graphId, nodeId)
+func (c *Client) DeleteNode(ctx context.Context, graphId GraphId, nodeId NodeId, params *DeleteNodeParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteNodeRequest(c.Server, graphId, nodeId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3769,8 +4027,8 @@ func (c *Client) DeleteNode(ctx context.Context, graphId GraphId, nodeId NodeId,
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetNode(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetNodeRequest(c.Server, graphId, nodeId)
+func (c *Client) GetNode(ctx context.Context, graphId GraphId, nodeId NodeId, params *GetNodeParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetNodeRequest(c.Server, graphId, nodeId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3781,8 +4039,8 @@ func (c *Client) GetNode(ctx context.Context, graphId GraphId, nodeId NodeId, re
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetGraphStats(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetGraphStatsRequest(c.Server, graphId)
+func (c *Client) GetGraphStats(ctx context.Context, graphId GraphId, params *GetGraphStatsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetGraphStatsRequest(c.Server, graphId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3793,8 +4051,8 @@ func (c *Client) GetGraphStats(ctx context.Context, graphId GraphId, reqEditors 
 	return c.Client.Do(req)
 }
 
-func (c *Client) TraverseGraphWithBody(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewTraverseGraphRequestWithBody(c.Server, graphId, contentType, body)
+func (c *Client) TraverseGraphWithBody(ctx context.Context, graphId GraphId, params *TraverseGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTraverseGraphRequestWithBody(c.Server, graphId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3805,8 +4063,8 @@ func (c *Client) TraverseGraphWithBody(ctx context.Context, graphId GraphId, con
 	return c.Client.Do(req)
 }
 
-func (c *Client) TraverseGraph(ctx context.Context, graphId GraphId, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewTraverseGraphRequest(c.Server, graphId, body)
+func (c *Client) TraverseGraph(ctx context.Context, graphId GraphId, params *TraverseGraphParams, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTraverseGraphRequest(c.Server, graphId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3817,8 +4075,8 @@ func (c *Client) TraverseGraph(ctx context.Context, graphId GraphId, body Traver
 	return c.Client.Do(req)
 }
 
-func (c *Client) HybridIndexWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewHybridIndexRequestWithBody(c.Server, contentType, body)
+func (c *Client) HybridIndexWithBody(ctx context.Context, params *HybridIndexParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHybridIndexRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3829,8 +4087,8 @@ func (c *Client) HybridIndexWithBody(ctx context.Context, contentType string, bo
 	return c.Client.Do(req)
 }
 
-func (c *Client) HybridIndex(ctx context.Context, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewHybridIndexRequest(c.Server, body)
+func (c *Client) HybridIndex(ctx context.Context, params *HybridIndexParams, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHybridIndexRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3841,8 +4099,8 @@ func (c *Client) HybridIndex(ctx context.Context, body HybridIndexJSONRequestBod
 	return c.Client.Do(req)
 }
 
-func (c *Client) HybridSearchWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewHybridSearchRequestWithBody(c.Server, contentType, body)
+func (c *Client) HybridSearchWithBody(ctx context.Context, params *HybridSearchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHybridSearchRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3853,8 +4111,8 @@ func (c *Client) HybridSearchWithBody(ctx context.Context, contentType string, b
 	return c.Client.Do(req)
 }
 
-func (c *Client) HybridSearch(ctx context.Context, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewHybridSearchRequest(c.Server, body)
+func (c *Client) HybridSearch(ctx context.Context, params *HybridSearchParams, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHybridSearchRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3865,8 +4123,8 @@ func (c *Client) HybridSearch(ctx context.Context, body HybridSearchJSONRequestB
 	return c.Client.Do(req)
 }
 
-func (c *Client) IngestLogWithBody(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewIngestLogRequestWithBody(c.Server, namespace, contentType, body)
+func (c *Client) IngestLogWithBody(ctx context.Context, namespace string, params *IngestLogParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestLogRequestWithBody(c.Server, namespace, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3877,8 +4135,8 @@ func (c *Client) IngestLogWithBody(ctx context.Context, namespace string, conten
 	return c.Client.Do(req)
 }
 
-func (c *Client) IngestLog(ctx context.Context, namespace string, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewIngestLogRequest(c.Server, namespace, body)
+func (c *Client) IngestLog(ctx context.Context, namespace string, params *IngestLogParams, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestLogRequest(c.Server, namespace, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3889,8 +4147,8 @@ func (c *Client) IngestLog(ctx context.Context, namespace string, body IngestLog
 	return c.Client.Do(req)
 }
 
-func (c *Client) QueryLogsWithBody(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewQueryLogsRequestWithBody(c.Server, namespace, contentType, body)
+func (c *Client) QueryLogsWithBody(ctx context.Context, namespace string, params *QueryLogsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQueryLogsRequestWithBody(c.Server, namespace, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3901,8 +4159,8 @@ func (c *Client) QueryLogsWithBody(ctx context.Context, namespace string, conten
 	return c.Client.Do(req)
 }
 
-func (c *Client) QueryLogs(ctx context.Context, namespace string, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewQueryLogsRequest(c.Server, namespace, body)
+func (c *Client) QueryLogs(ctx context.Context, namespace string, params *QueryLogsParams, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQueryLogsRequest(c.Server, namespace, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3913,8 +4171,8 @@ func (c *Client) QueryLogs(ctx context.Context, namespace string, body QueryLogs
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExecuteQueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExecuteQueryRequestWithBody(c.Server, contentType, body)
+func (c *Client) ExecuteQueryWithBody(ctx context.Context, params *ExecuteQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExecuteQueryRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3925,8 +4183,8 @@ func (c *Client) ExecuteQueryWithBody(ctx context.Context, contentType string, b
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExecuteQuery(ctx context.Context, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExecuteQueryRequest(c.Server, body)
+func (c *Client) ExecuteQuery(ctx context.Context, params *ExecuteQueryParams, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExecuteQueryRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3937,8 +4195,8 @@ func (c *Client) ExecuteQuery(ctx context.Context, body ExecuteQueryJSONRequestB
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExplainQueryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExplainQueryRequestWithBody(c.Server, contentType, body)
+func (c *Client) ExplainQueryWithBody(ctx context.Context, params *ExplainQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExplainQueryRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3949,8 +4207,8 @@ func (c *Client) ExplainQueryWithBody(ctx context.Context, contentType string, b
 	return c.Client.Do(req)
 }
 
-func (c *Client) ExplainQuery(ctx context.Context, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewExplainQueryRequest(c.Server, body)
+func (c *Client) ExplainQuery(ctx context.Context, params *ExplainQueryParams, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewExplainQueryRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3961,8 +4219,8 @@ func (c *Client) ExplainQuery(ctx context.Context, body ExplainQueryJSONRequestB
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHealthRequest(c.Server)
+func (c *Client) GetHealth(ctx context.Context, params *GetHealthParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetHealthRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3973,8 +4231,8 @@ func (c *Client) GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetLiveness(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetLivenessRequest(c.Server)
+func (c *Client) GetLiveness(ctx context.Context, params *GetLivenessParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLivenessRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3985,8 +4243,8 @@ func (c *Client) GetLiveness(ctx context.Context, reqEditors ...RequestEditorFn)
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetReadiness(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetReadinessRequest(c.Server)
+func (c *Client) GetReadiness(ctx context.Context, params *GetReadinessParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReadinessRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3998,7 +4256,7 @@ func (c *Client) GetReadiness(ctx context.Context, reqEditors ...RequestEditorFn
 }
 
 // NewGetCapabilitiesRequest generates requests for GetCapabilities
-func NewGetCapabilitiesRequest(server string) (*http.Request, error) {
+func NewGetCapabilitiesRequest(server string, params *GetCapabilitiesParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4019,6 +4277,21 @@ func NewGetCapabilitiesRequest(server string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -4102,22 +4375,37 @@ func NewListCollectionsRequest(server string, params *ListCollectionsParams) (*h
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewCreateCollectionRequest calls the generic CreateCollection builder with application/json body
-func NewCreateCollectionRequest(server string, body CreateCollectionJSONRequestBody) (*http.Request, error) {
+func NewCreateCollectionRequest(server string, params *CreateCollectionParams, body CreateCollectionJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateCollectionRequestWithBody(server, "application/json", bodyReader)
+	return NewCreateCollectionRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewCreateCollectionRequestWithBody generates requests for CreateCollection with any type of body
-func NewCreateCollectionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateCollectionRequestWithBody(server string, params *CreateCollectionParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4142,11 +4430,26 @@ func NewCreateCollectionRequestWithBody(server string, contentType string, body 
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewDeleteCollectionRequest generates requests for DeleteCollection
-func NewDeleteCollectionRequest(server string, collectionId string) (*http.Request, error) {
+func NewDeleteCollectionRequest(server string, collectionId string, params *DeleteCollectionParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4176,11 +4479,26 @@ func NewDeleteCollectionRequest(server string, collectionId string) (*http.Reque
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetCollectionRequest generates requests for GetCollection
-func NewGetCollectionRequest(server string, collectionId string) (*http.Request, error) {
+func NewGetCollectionRequest(server string, collectionId string, params *GetCollectionParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4210,22 +4528,37 @@ func NewGetCollectionRequest(server string, collectionId string) (*http.Request,
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewIngestDocumentsRequest calls the generic IngestDocuments builder with application/json body
-func NewIngestDocumentsRequest(server string, collectionId string, body IngestDocumentsJSONRequestBody) (*http.Request, error) {
+func NewIngestDocumentsRequest(server string, collectionId string, params *IngestDocumentsParams, body IngestDocumentsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewIngestDocumentsRequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewIngestDocumentsRequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewIngestDocumentsRequestWithBody generates requests for IngestDocuments with any type of body
-func NewIngestDocumentsRequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewIngestDocumentsRequestWithBody(server string, collectionId string, params *IngestDocumentsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4257,22 +4590,37 @@ func NewIngestDocumentsRequestWithBody(server string, collectionId string, conte
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewUpsertEntityV2Request calls the generic UpsertEntityV2 builder with application/json body
-func NewUpsertEntityV2Request(server string, collectionId string, body UpsertEntityV2JSONRequestBody) (*http.Request, error) {
+func NewUpsertEntityV2Request(server string, collectionId string, params *UpsertEntityV2Params, body UpsertEntityV2JSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewUpsertEntityV2RequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewUpsertEntityV2RequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewUpsertEntityV2RequestWithBody generates requests for UpsertEntityV2 with any type of body
-func NewUpsertEntityV2RequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewUpsertEntityV2RequestWithBody(server string, collectionId string, params *UpsertEntityV2Params, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4304,22 +4652,37 @@ func NewUpsertEntityV2RequestWithBody(server string, collectionId string, conten
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewSearchEntitiesV2Request calls the generic SearchEntitiesV2 builder with application/json body
-func NewSearchEntitiesV2Request(server string, collectionId string, body SearchEntitiesV2JSONRequestBody) (*http.Request, error) {
+func NewSearchEntitiesV2Request(server string, collectionId string, params *SearchEntitiesV2Params, body SearchEntitiesV2JSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSearchEntitiesV2RequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewSearchEntitiesV2RequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewSearchEntitiesV2RequestWithBody generates requests for SearchEntitiesV2 with any type of body
-func NewSearchEntitiesV2RequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewSearchEntitiesV2RequestWithBody(server string, collectionId string, params *SearchEntitiesV2Params, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4351,11 +4714,26 @@ func NewSearchEntitiesV2RequestWithBody(server string, collectionId string, cont
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewDeleteEntityV2Request generates requests for DeleteEntityV2
-func NewDeleteEntityV2Request(server string, collectionId string, entityId string) (*http.Request, error) {
+func NewDeleteEntityV2Request(server string, collectionId string, entityId string, params *DeleteEntityV2Params) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4392,11 +4770,26 @@ func NewDeleteEntityV2Request(server string, collectionId string, entityId strin
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetEntityV2Request generates requests for GetEntityV2
-func NewGetEntityV2Request(server string, collectionId string, entityId string) (*http.Request, error) {
+func NewGetEntityV2Request(server string, collectionId string, entityId string, params *GetEntityV2Params) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4433,22 +4826,37 @@ func NewGetEntityV2Request(server string, collectionId string, entityId string) 
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewInsertRecordsRequest calls the generic InsertRecords builder with application/json body
-func NewInsertRecordsRequest(server string, collectionId string, body InsertRecordsJSONRequestBody) (*http.Request, error) {
+func NewInsertRecordsRequest(server string, collectionId string, params *InsertRecordsParams, body InsertRecordsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewInsertRecordsRequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewInsertRecordsRequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewInsertRecordsRequestWithBody generates requests for InsertRecords with any type of body
-func NewInsertRecordsRequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewInsertRecordsRequestWithBody(server string, collectionId string, params *InsertRecordsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4480,22 +4888,37 @@ func NewInsertRecordsRequestWithBody(server string, collectionId string, content
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewScanRecordsRequest calls the generic ScanRecords builder with application/json body
-func NewScanRecordsRequest(server string, collectionId string, body ScanRecordsJSONRequestBody) (*http.Request, error) {
+func NewScanRecordsRequest(server string, collectionId string, params *ScanRecordsParams, body ScanRecordsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewScanRecordsRequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewScanRecordsRequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewScanRecordsRequestWithBody generates requests for ScanRecords with any type of body
-func NewScanRecordsRequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewScanRecordsRequestWithBody(server string, collectionId string, params *ScanRecordsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4527,11 +4950,26 @@ func NewScanRecordsRequestWithBody(server string, collectionId string, contentTy
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewDeleteRecordRequest generates requests for DeleteRecord
-func NewDeleteRecordRequest(server string, collectionId string, recordId string) (*http.Request, error) {
+func NewDeleteRecordRequest(server string, collectionId string, recordId string, params *DeleteRecordParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4566,6 +5004,21 @@ func NewDeleteRecordRequest(server string, collectionId string, recordId string)
 	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -4647,11 +5100,26 @@ func NewGetRecordRequest(server string, collectionId string, recordId string, pa
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetCollectionSchemaRequest generates requests for GetCollectionSchema
-func NewGetCollectionSchemaRequest(server string, collectionId string) (*http.Request, error) {
+func NewGetCollectionSchemaRequest(server string, collectionId string, params *GetCollectionSchemaParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4681,22 +5149,37 @@ func NewGetCollectionSchemaRequest(server string, collectionId string) (*http.Re
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewUpdateCollectionSchemaRequest calls the generic UpdateCollectionSchema builder with application/json body
-func NewUpdateCollectionSchemaRequest(server string, collectionId string, body UpdateCollectionSchemaJSONRequestBody) (*http.Request, error) {
+func NewUpdateCollectionSchemaRequest(server string, collectionId string, params *UpdateCollectionSchemaParams, body UpdateCollectionSchemaJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewUpdateCollectionSchemaRequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewUpdateCollectionSchemaRequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewUpdateCollectionSchemaRequestWithBody generates requests for UpdateCollectionSchema with any type of body
-func NewUpdateCollectionSchemaRequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewUpdateCollectionSchemaRequestWithBody(server string, collectionId string, params *UpdateCollectionSchemaParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4728,22 +5211,37 @@ func NewUpdateCollectionSchemaRequestWithBody(server string, collectionId string
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewSearchRecordsRequest calls the generic SearchRecords builder with application/json body
-func NewSearchRecordsRequest(server string, collectionId string, body SearchRecordsJSONRequestBody) (*http.Request, error) {
+func NewSearchRecordsRequest(server string, collectionId string, params *SearchRecordsParams, body SearchRecordsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSearchRecordsRequestWithBody(server, collectionId, "application/json", bodyReader)
+	return NewSearchRecordsRequestWithBody(server, collectionId, params, "application/json", bodyReader)
 }
 
 // NewSearchRecordsRequestWithBody generates requests for SearchRecords with any type of body
-func NewSearchRecordsRequestWithBody(server string, collectionId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewSearchRecordsRequestWithBody(server string, collectionId string, params *SearchRecordsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4775,11 +5273,26 @@ func NewSearchRecordsRequestWithBody(server string, collectionId string, content
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewListDocumentCollectionsRequest generates requests for ListDocumentCollections
-func NewListDocumentCollectionsRequest(server string) (*http.Request, error) {
+func NewListDocumentCollectionsRequest(server string, params *ListDocumentCollectionsParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4800,24 +5313,39 @@ func NewListDocumentCollectionsRequest(server string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
 	}
 
 	return req, nil
 }
 
 // NewCreateDocumentCollectionRequest calls the generic CreateDocumentCollection builder with application/json body
-func NewCreateDocumentCollectionRequest(server string, body CreateDocumentCollectionJSONRequestBody) (*http.Request, error) {
+func NewCreateDocumentCollectionRequest(server string, params *CreateDocumentCollectionParams, body CreateDocumentCollectionJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateDocumentCollectionRequestWithBody(server, "application/json", bodyReader)
+	return NewCreateDocumentCollectionRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewCreateDocumentCollectionRequestWithBody generates requests for CreateDocumentCollection with any type of body
-func NewCreateDocumentCollectionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateDocumentCollectionRequestWithBody(server string, params *CreateDocumentCollectionParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4842,11 +5370,26 @@ func NewCreateDocumentCollectionRequestWithBody(server string, contentType strin
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewQueryDocumentsRequest generates requests for QueryDocuments
-func NewQueryDocumentsRequest(server string, collection string) (*http.Request, error) {
+func NewQueryDocumentsRequest(server string, collection string, params *QueryDocumentsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4874,24 +5417,39 @@ func NewQueryDocumentsRequest(server string, collection string) (*http.Request, 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
 	}
 
 	return req, nil
 }
 
 // NewInsertDocumentRequest calls the generic InsertDocument builder with application/json body
-func NewInsertDocumentRequest(server string, collection string, body InsertDocumentJSONRequestBody) (*http.Request, error) {
+func NewInsertDocumentRequest(server string, collection string, params *InsertDocumentParams, body InsertDocumentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewInsertDocumentRequestWithBody(server, collection, "application/json", bodyReader)
+	return NewInsertDocumentRequestWithBody(server, collection, params, "application/json", bodyReader)
 }
 
 // NewInsertDocumentRequestWithBody generates requests for InsertDocument with any type of body
-func NewInsertDocumentRequestWithBody(server string, collection string, contentType string, body io.Reader) (*http.Request, error) {
+func NewInsertDocumentRequestWithBody(server string, collection string, params *InsertDocumentParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4923,11 +5481,26 @@ func NewInsertDocumentRequestWithBody(server string, collection string, contentT
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewListGraphsRequest generates requests for ListGraphs
-func NewListGraphsRequest(server string) (*http.Request, error) {
+func NewListGraphsRequest(server string, params *ListGraphsParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4950,22 +5523,37 @@ func NewListGraphsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewCreateGraphRequest calls the generic CreateGraph builder with application/json body
-func NewCreateGraphRequest(server string, body CreateGraphJSONRequestBody) (*http.Request, error) {
+func NewCreateGraphRequest(server string, params *CreateGraphParams, body CreateGraphJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateGraphRequestWithBody(server, "application/json", bodyReader)
+	return NewCreateGraphRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewCreateGraphRequestWithBody generates requests for CreateGraph with any type of body
-func NewCreateGraphRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateGraphRequestWithBody(server string, params *CreateGraphParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4990,11 +5578,26 @@ func NewCreateGraphRequestWithBody(server string, contentType string, body io.Re
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewDeleteGraphRequest generates requests for DeleteGraph
-func NewDeleteGraphRequest(server string, graphId GraphId) (*http.Request, error) {
+func NewDeleteGraphRequest(server string, graphId GraphId, params *DeleteGraphParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5024,11 +5627,26 @@ func NewDeleteGraphRequest(server string, graphId GraphId) (*http.Request, error
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetGraphRequest generates requests for GetGraph
-func NewGetGraphRequest(server string, graphId GraphId) (*http.Request, error) {
+func NewGetGraphRequest(server string, graphId GraphId, params *GetGraphParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5058,22 +5676,37 @@ func NewGetGraphRequest(server string, graphId GraphId) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewCreateEdgeRequest calls the generic CreateEdge builder with application/json body
-func NewCreateEdgeRequest(server string, graphId GraphId, body CreateEdgeJSONRequestBody) (*http.Request, error) {
+func NewCreateEdgeRequest(server string, graphId GraphId, params *CreateEdgeParams, body CreateEdgeJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateEdgeRequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewCreateEdgeRequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewCreateEdgeRequestWithBody generates requests for CreateEdge with any type of body
-func NewCreateEdgeRequestWithBody(server string, graphId GraphId, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateEdgeRequestWithBody(server string, graphId GraphId, params *CreateEdgeParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5105,22 +5738,37 @@ func NewCreateEdgeRequestWithBody(server string, graphId GraphId, contentType st
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewBatchCreateEdgesRequest calls the generic BatchCreateEdges builder with application/json body
-func NewBatchCreateEdgesRequest(server string, graphId GraphId, body BatchCreateEdgesJSONRequestBody) (*http.Request, error) {
+func NewBatchCreateEdgesRequest(server string, graphId GraphId, params *BatchCreateEdgesParams, body BatchCreateEdgesJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewBatchCreateEdgesRequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewBatchCreateEdgesRequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewBatchCreateEdgesRequestWithBody generates requests for BatchCreateEdges with any type of body
-func NewBatchCreateEdgesRequestWithBody(server string, graphId GraphId, contentType string, body io.Reader) (*http.Request, error) {
+func NewBatchCreateEdgesRequestWithBody(server string, graphId GraphId, params *BatchCreateEdgesParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5152,22 +5800,37 @@ func NewBatchCreateEdgesRequestWithBody(server string, graphId GraphId, contentT
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewFusionSearchV2Request calls the generic FusionSearchV2 builder with application/json body
-func NewFusionSearchV2Request(server string, graphId string, body FusionSearchV2JSONRequestBody) (*http.Request, error) {
+func NewFusionSearchV2Request(server string, graphId string, params *FusionSearchV2Params, body FusionSearchV2JSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewFusionSearchV2RequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewFusionSearchV2RequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewFusionSearchV2RequestWithBody generates requests for FusionSearchV2 with any type of body
-func NewFusionSearchV2RequestWithBody(server string, graphId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewFusionSearchV2RequestWithBody(server string, graphId string, params *FusionSearchV2Params, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5199,22 +5862,37 @@ func NewFusionSearchV2RequestWithBody(server string, graphId string, contentType
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewImpactAnalysisV2Request calls the generic ImpactAnalysisV2 builder with application/json body
-func NewImpactAnalysisV2Request(server string, graphId string, body ImpactAnalysisV2JSONRequestBody) (*http.Request, error) {
+func NewImpactAnalysisV2Request(server string, graphId string, params *ImpactAnalysisV2Params, body ImpactAnalysisV2JSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewImpactAnalysisV2RequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewImpactAnalysisV2RequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewImpactAnalysisV2RequestWithBody generates requests for ImpactAnalysisV2 with any type of body
-func NewImpactAnalysisV2RequestWithBody(server string, graphId string, contentType string, body io.Reader) (*http.Request, error) {
+func NewImpactAnalysisV2RequestWithBody(server string, graphId string, params *ImpactAnalysisV2Params, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5246,22 +5924,37 @@ func NewImpactAnalysisV2RequestWithBody(server string, graphId string, contentTy
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewCreateNodeRequest calls the generic CreateNode builder with application/json body
-func NewCreateNodeRequest(server string, graphId GraphId, body CreateNodeJSONRequestBody) (*http.Request, error) {
+func NewCreateNodeRequest(server string, graphId GraphId, params *CreateNodeParams, body CreateNodeJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewCreateNodeRequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewCreateNodeRequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewCreateNodeRequestWithBody generates requests for CreateNode with any type of body
-func NewCreateNodeRequestWithBody(server string, graphId GraphId, contentType string, body io.Reader) (*http.Request, error) {
+func NewCreateNodeRequestWithBody(server string, graphId GraphId, params *CreateNodeParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5293,22 +5986,37 @@ func NewCreateNodeRequestWithBody(server string, graphId GraphId, contentType st
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewBatchCreateNodesRequest calls the generic BatchCreateNodes builder with application/json body
-func NewBatchCreateNodesRequest(server string, graphId GraphId, body BatchCreateNodesJSONRequestBody) (*http.Request, error) {
+func NewBatchCreateNodesRequest(server string, graphId GraphId, params *BatchCreateNodesParams, body BatchCreateNodesJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewBatchCreateNodesRequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewBatchCreateNodesRequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewBatchCreateNodesRequestWithBody generates requests for BatchCreateNodes with any type of body
-func NewBatchCreateNodesRequestWithBody(server string, graphId GraphId, contentType string, body io.Reader) (*http.Request, error) {
+func NewBatchCreateNodesRequestWithBody(server string, graphId GraphId, params *BatchCreateNodesParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5340,11 +6048,26 @@ func NewBatchCreateNodesRequestWithBody(server string, graphId GraphId, contentT
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewDeleteNodeRequest generates requests for DeleteNode
-func NewDeleteNodeRequest(server string, graphId GraphId, nodeId NodeId) (*http.Request, error) {
+func NewDeleteNodeRequest(server string, graphId GraphId, nodeId NodeId, params *DeleteNodeParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5381,11 +6104,26 @@ func NewDeleteNodeRequest(server string, graphId GraphId, nodeId NodeId) (*http.
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetNodeRequest generates requests for GetNode
-func NewGetNodeRequest(server string, graphId GraphId, nodeId NodeId) (*http.Request, error) {
+func NewGetNodeRequest(server string, graphId GraphId, nodeId NodeId, params *GetNodeParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5422,11 +6160,26 @@ func NewGetNodeRequest(server string, graphId GraphId, nodeId NodeId) (*http.Req
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetGraphStatsRequest generates requests for GetGraphStats
-func NewGetGraphStatsRequest(server string, graphId GraphId) (*http.Request, error) {
+func NewGetGraphStatsRequest(server string, graphId GraphId, params *GetGraphStatsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5456,22 +6209,37 @@ func NewGetGraphStatsRequest(server string, graphId GraphId) (*http.Request, err
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewTraverseGraphRequest calls the generic TraverseGraph builder with application/json body
-func NewTraverseGraphRequest(server string, graphId GraphId, body TraverseGraphJSONRequestBody) (*http.Request, error) {
+func NewTraverseGraphRequest(server string, graphId GraphId, params *TraverseGraphParams, body TraverseGraphJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewTraverseGraphRequestWithBody(server, graphId, "application/json", bodyReader)
+	return NewTraverseGraphRequestWithBody(server, graphId, params, "application/json", bodyReader)
 }
 
 // NewTraverseGraphRequestWithBody generates requests for TraverseGraph with any type of body
-func NewTraverseGraphRequestWithBody(server string, graphId GraphId, contentType string, body io.Reader) (*http.Request, error) {
+func NewTraverseGraphRequestWithBody(server string, graphId GraphId, params *TraverseGraphParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5503,22 +6271,37 @@ func NewTraverseGraphRequestWithBody(server string, graphId GraphId, contentType
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewHybridIndexRequest calls the generic HybridIndex builder with application/json body
-func NewHybridIndexRequest(server string, body HybridIndexJSONRequestBody) (*http.Request, error) {
+func NewHybridIndexRequest(server string, params *HybridIndexParams, body HybridIndexJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewHybridIndexRequestWithBody(server, "application/json", bodyReader)
+	return NewHybridIndexRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewHybridIndexRequestWithBody generates requests for HybridIndex with any type of body
-func NewHybridIndexRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewHybridIndexRequestWithBody(server string, params *HybridIndexParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5543,22 +6326,37 @@ func NewHybridIndexRequestWithBody(server string, contentType string, body io.Re
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewHybridSearchRequest calls the generic HybridSearch builder with application/json body
-func NewHybridSearchRequest(server string, body HybridSearchJSONRequestBody) (*http.Request, error) {
+func NewHybridSearchRequest(server string, params *HybridSearchParams, body HybridSearchJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewHybridSearchRequestWithBody(server, "application/json", bodyReader)
+	return NewHybridSearchRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewHybridSearchRequestWithBody generates requests for HybridSearch with any type of body
-func NewHybridSearchRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewHybridSearchRequestWithBody(server string, params *HybridSearchParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5583,22 +6381,37 @@ func NewHybridSearchRequestWithBody(server string, contentType string, body io.R
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewIngestLogRequest calls the generic IngestLog builder with application/json body
-func NewIngestLogRequest(server string, namespace string, body IngestLogJSONRequestBody) (*http.Request, error) {
+func NewIngestLogRequest(server string, namespace string, params *IngestLogParams, body IngestLogJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewIngestLogRequestWithBody(server, namespace, "application/json", bodyReader)
+	return NewIngestLogRequestWithBody(server, namespace, params, "application/json", bodyReader)
 }
 
 // NewIngestLogRequestWithBody generates requests for IngestLog with any type of body
-func NewIngestLogRequestWithBody(server string, namespace string, contentType string, body io.Reader) (*http.Request, error) {
+func NewIngestLogRequestWithBody(server string, namespace string, params *IngestLogParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5630,22 +6443,37 @@ func NewIngestLogRequestWithBody(server string, namespace string, contentType st
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewQueryLogsRequest calls the generic QueryLogs builder with application/json body
-func NewQueryLogsRequest(server string, namespace string, body QueryLogsJSONRequestBody) (*http.Request, error) {
+func NewQueryLogsRequest(server string, namespace string, params *QueryLogsParams, body QueryLogsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewQueryLogsRequestWithBody(server, namespace, "application/json", bodyReader)
+	return NewQueryLogsRequestWithBody(server, namespace, params, "application/json", bodyReader)
 }
 
 // NewQueryLogsRequestWithBody generates requests for QueryLogs with any type of body
-func NewQueryLogsRequestWithBody(server string, namespace string, contentType string, body io.Reader) (*http.Request, error) {
+func NewQueryLogsRequestWithBody(server string, namespace string, params *QueryLogsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5677,22 +6505,37 @@ func NewQueryLogsRequestWithBody(server string, namespace string, contentType st
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewExecuteQueryRequest calls the generic ExecuteQuery builder with application/json body
-func NewExecuteQueryRequest(server string, body ExecuteQueryJSONRequestBody) (*http.Request, error) {
+func NewExecuteQueryRequest(server string, params *ExecuteQueryParams, body ExecuteQueryJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewExecuteQueryRequestWithBody(server, "application/json", bodyReader)
+	return NewExecuteQueryRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewExecuteQueryRequestWithBody generates requests for ExecuteQuery with any type of body
-func NewExecuteQueryRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewExecuteQueryRequestWithBody(server string, params *ExecuteQueryParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5717,22 +6560,37 @@ func NewExecuteQueryRequestWithBody(server string, contentType string, body io.R
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewExplainQueryRequest calls the generic ExplainQuery builder with application/json body
-func NewExplainQueryRequest(server string, body ExplainQueryJSONRequestBody) (*http.Request, error) {
+func NewExplainQueryRequest(server string, params *ExplainQueryParams, body ExplainQueryJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewExplainQueryRequestWithBody(server, "application/json", bodyReader)
+	return NewExplainQueryRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewExplainQueryRequestWithBody generates requests for ExplainQuery with any type of body
-func NewExplainQueryRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewExplainQueryRequestWithBody(server string, params *ExplainQueryParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5757,11 +6615,26 @@ func NewExplainQueryRequestWithBody(server string, contentType string, body io.R
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetHealthRequest generates requests for GetHealth
-func NewGetHealthRequest(server string) (*http.Request, error) {
+func NewGetHealthRequest(server string, params *GetHealthParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5784,11 +6657,26 @@ func NewGetHealthRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetLivenessRequest generates requests for GetLiveness
-func NewGetLivenessRequest(server string) (*http.Request, error) {
+func NewGetLivenessRequest(server string, params *GetLivenessParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5811,11 +6699,26 @@ func NewGetLivenessRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
+	}
+
 	return req, nil
 }
 
 // NewGetReadinessRequest generates requests for GetReadiness
-func NewGetReadinessRequest(server string) (*http.Request, error) {
+func NewGetReadinessRequest(server string, params *GetReadinessParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -5836,6 +6739,21 @@ func NewGetReadinessRequest(server string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XTenantID != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Tenant-ID", runtime.ParamLocationHeader, *params.XTenantID)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Tenant-ID", headerParam0)
+		}
+
 	}
 
 	return req, nil
@@ -5885,184 +6803,184 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// GetCapabilitiesWithResponse request
-	GetCapabilitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetCapabilitiesHTTPResp, error)
+	GetCapabilitiesWithResponse(ctx context.Context, params *GetCapabilitiesParams, reqEditors ...RequestEditorFn) (*GetCapabilitiesHTTPResp, error)
 
 	// ListCollectionsWithResponse request
 	ListCollectionsWithResponse(ctx context.Context, params *ListCollectionsParams, reqEditors ...RequestEditorFn) (*ListCollectionsHTTPResp, error)
 
 	// CreateCollectionWithBodyWithResponse request with any body
-	CreateCollectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error)
+	CreateCollectionWithBodyWithResponse(ctx context.Context, params *CreateCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error)
 
-	CreateCollectionWithResponse(ctx context.Context, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error)
+	CreateCollectionWithResponse(ctx context.Context, params *CreateCollectionParams, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error)
 
 	// DeleteCollectionWithResponse request
-	DeleteCollectionWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*DeleteCollectionHTTPResp, error)
+	DeleteCollectionWithResponse(ctx context.Context, collectionId string, params *DeleteCollectionParams, reqEditors ...RequestEditorFn) (*DeleteCollectionHTTPResp, error)
 
 	// GetCollectionWithResponse request
-	GetCollectionWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*GetCollectionHTTPResp, error)
+	GetCollectionWithResponse(ctx context.Context, collectionId string, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*GetCollectionHTTPResp, error)
 
 	// IngestDocumentsWithBodyWithResponse request with any body
-	IngestDocumentsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error)
+	IngestDocumentsWithBodyWithResponse(ctx context.Context, collectionId string, params *IngestDocumentsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error)
 
-	IngestDocumentsWithResponse(ctx context.Context, collectionId string, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error)
+	IngestDocumentsWithResponse(ctx context.Context, collectionId string, params *IngestDocumentsParams, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error)
 
 	// UpsertEntityV2WithBodyWithResponse request with any body
-	UpsertEntityV2WithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error)
+	UpsertEntityV2WithBodyWithResponse(ctx context.Context, collectionId string, params *UpsertEntityV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error)
 
-	UpsertEntityV2WithResponse(ctx context.Context, collectionId string, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error)
+	UpsertEntityV2WithResponse(ctx context.Context, collectionId string, params *UpsertEntityV2Params, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error)
 
 	// SearchEntitiesV2WithBodyWithResponse request with any body
-	SearchEntitiesV2WithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error)
+	SearchEntitiesV2WithBodyWithResponse(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error)
 
-	SearchEntitiesV2WithResponse(ctx context.Context, collectionId string, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error)
+	SearchEntitiesV2WithResponse(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error)
 
 	// DeleteEntityV2WithResponse request
-	DeleteEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*DeleteEntityV2HTTPResp, error)
+	DeleteEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, params *DeleteEntityV2Params, reqEditors ...RequestEditorFn) (*DeleteEntityV2HTTPResp, error)
 
 	// GetEntityV2WithResponse request
-	GetEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*GetEntityV2HTTPResp, error)
+	GetEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, params *GetEntityV2Params, reqEditors ...RequestEditorFn) (*GetEntityV2HTTPResp, error)
 
 	// InsertRecordsWithBodyWithResponse request with any body
-	InsertRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error)
+	InsertRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *InsertRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error)
 
-	InsertRecordsWithResponse(ctx context.Context, collectionId string, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error)
+	InsertRecordsWithResponse(ctx context.Context, collectionId string, params *InsertRecordsParams, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error)
 
 	// ScanRecordsWithBodyWithResponse request with any body
-	ScanRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error)
+	ScanRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *ScanRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error)
 
-	ScanRecordsWithResponse(ctx context.Context, collectionId string, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error)
+	ScanRecordsWithResponse(ctx context.Context, collectionId string, params *ScanRecordsParams, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error)
 
 	// DeleteRecordWithResponse request
-	DeleteRecordWithResponse(ctx context.Context, collectionId string, recordId string, reqEditors ...RequestEditorFn) (*DeleteRecordHTTPResp, error)
+	DeleteRecordWithResponse(ctx context.Context, collectionId string, recordId string, params *DeleteRecordParams, reqEditors ...RequestEditorFn) (*DeleteRecordHTTPResp, error)
 
 	// GetRecordWithResponse request
 	GetRecordWithResponse(ctx context.Context, collectionId string, recordId string, params *GetRecordParams, reqEditors ...RequestEditorFn) (*GetRecordHTTPResp, error)
 
 	// GetCollectionSchemaWithResponse request
-	GetCollectionSchemaWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*GetCollectionSchemaHTTPResp, error)
+	GetCollectionSchemaWithResponse(ctx context.Context, collectionId string, params *GetCollectionSchemaParams, reqEditors ...RequestEditorFn) (*GetCollectionSchemaHTTPResp, error)
 
 	// UpdateCollectionSchemaWithBodyWithResponse request with any body
-	UpdateCollectionSchemaWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error)
+	UpdateCollectionSchemaWithBodyWithResponse(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error)
 
-	UpdateCollectionSchemaWithResponse(ctx context.Context, collectionId string, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error)
+	UpdateCollectionSchemaWithResponse(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error)
 
 	// SearchRecordsWithBodyWithResponse request with any body
-	SearchRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error)
+	SearchRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *SearchRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error)
 
-	SearchRecordsWithResponse(ctx context.Context, collectionId string, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error)
+	SearchRecordsWithResponse(ctx context.Context, collectionId string, params *SearchRecordsParams, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error)
 
 	// ListDocumentCollectionsWithResponse request
-	ListDocumentCollectionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDocumentCollectionsHTTPResp, error)
+	ListDocumentCollectionsWithResponse(ctx context.Context, params *ListDocumentCollectionsParams, reqEditors ...RequestEditorFn) (*ListDocumentCollectionsHTTPResp, error)
 
 	// CreateDocumentCollectionWithBodyWithResponse request with any body
-	CreateDocumentCollectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error)
+	CreateDocumentCollectionWithBodyWithResponse(ctx context.Context, params *CreateDocumentCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error)
 
-	CreateDocumentCollectionWithResponse(ctx context.Context, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error)
+	CreateDocumentCollectionWithResponse(ctx context.Context, params *CreateDocumentCollectionParams, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error)
 
 	// QueryDocumentsWithResponse request
-	QueryDocumentsWithResponse(ctx context.Context, collection string, reqEditors ...RequestEditorFn) (*QueryDocumentsHTTPResp, error)
+	QueryDocumentsWithResponse(ctx context.Context, collection string, params *QueryDocumentsParams, reqEditors ...RequestEditorFn) (*QueryDocumentsHTTPResp, error)
 
 	// InsertDocumentWithBodyWithResponse request with any body
-	InsertDocumentWithBodyWithResponse(ctx context.Context, collection string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error)
+	InsertDocumentWithBodyWithResponse(ctx context.Context, collection string, params *InsertDocumentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error)
 
-	InsertDocumentWithResponse(ctx context.Context, collection string, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error)
+	InsertDocumentWithResponse(ctx context.Context, collection string, params *InsertDocumentParams, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error)
 
 	// ListGraphsWithResponse request
-	ListGraphsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListGraphsHTTPResp, error)
+	ListGraphsWithResponse(ctx context.Context, params *ListGraphsParams, reqEditors ...RequestEditorFn) (*ListGraphsHTTPResp, error)
 
 	// CreateGraphWithBodyWithResponse request with any body
-	CreateGraphWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error)
+	CreateGraphWithBodyWithResponse(ctx context.Context, params *CreateGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error)
 
-	CreateGraphWithResponse(ctx context.Context, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error)
+	CreateGraphWithResponse(ctx context.Context, params *CreateGraphParams, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error)
 
 	// DeleteGraphWithResponse request
-	DeleteGraphWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*DeleteGraphHTTPResp, error)
+	DeleteGraphWithResponse(ctx context.Context, graphId GraphId, params *DeleteGraphParams, reqEditors ...RequestEditorFn) (*DeleteGraphHTTPResp, error)
 
 	// GetGraphWithResponse request
-	GetGraphWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*GetGraphHTTPResp, error)
+	GetGraphWithResponse(ctx context.Context, graphId GraphId, params *GetGraphParams, reqEditors ...RequestEditorFn) (*GetGraphHTTPResp, error)
 
 	// CreateEdgeWithBodyWithResponse request with any body
-	CreateEdgeWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error)
+	CreateEdgeWithBodyWithResponse(ctx context.Context, graphId GraphId, params *CreateEdgeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error)
 
-	CreateEdgeWithResponse(ctx context.Context, graphId GraphId, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error)
+	CreateEdgeWithResponse(ctx context.Context, graphId GraphId, params *CreateEdgeParams, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error)
 
 	// BatchCreateEdgesWithBodyWithResponse request with any body
-	BatchCreateEdgesWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error)
+	BatchCreateEdgesWithBodyWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error)
 
-	BatchCreateEdgesWithResponse(ctx context.Context, graphId GraphId, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error)
+	BatchCreateEdgesWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error)
 
 	// FusionSearchV2WithBodyWithResponse request with any body
-	FusionSearchV2WithBodyWithResponse(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error)
+	FusionSearchV2WithBodyWithResponse(ctx context.Context, graphId string, params *FusionSearchV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error)
 
-	FusionSearchV2WithResponse(ctx context.Context, graphId string, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error)
+	FusionSearchV2WithResponse(ctx context.Context, graphId string, params *FusionSearchV2Params, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error)
 
 	// ImpactAnalysisV2WithBodyWithResponse request with any body
-	ImpactAnalysisV2WithBodyWithResponse(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error)
+	ImpactAnalysisV2WithBodyWithResponse(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error)
 
-	ImpactAnalysisV2WithResponse(ctx context.Context, graphId string, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error)
+	ImpactAnalysisV2WithResponse(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error)
 
 	// CreateNodeWithBodyWithResponse request with any body
-	CreateNodeWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error)
+	CreateNodeWithBodyWithResponse(ctx context.Context, graphId GraphId, params *CreateNodeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error)
 
-	CreateNodeWithResponse(ctx context.Context, graphId GraphId, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error)
+	CreateNodeWithResponse(ctx context.Context, graphId GraphId, params *CreateNodeParams, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error)
 
 	// BatchCreateNodesWithBodyWithResponse request with any body
-	BatchCreateNodesWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error)
+	BatchCreateNodesWithBodyWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error)
 
-	BatchCreateNodesWithResponse(ctx context.Context, graphId GraphId, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error)
+	BatchCreateNodesWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error)
 
 	// DeleteNodeWithResponse request
-	DeleteNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*DeleteNodeHTTPResp, error)
+	DeleteNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, params *DeleteNodeParams, reqEditors ...RequestEditorFn) (*DeleteNodeHTTPResp, error)
 
 	// GetNodeWithResponse request
-	GetNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*GetNodeHTTPResp, error)
+	GetNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, params *GetNodeParams, reqEditors ...RequestEditorFn) (*GetNodeHTTPResp, error)
 
 	// GetGraphStatsWithResponse request
-	GetGraphStatsWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*GetGraphStatsHTTPResp, error)
+	GetGraphStatsWithResponse(ctx context.Context, graphId GraphId, params *GetGraphStatsParams, reqEditors ...RequestEditorFn) (*GetGraphStatsHTTPResp, error)
 
 	// TraverseGraphWithBodyWithResponse request with any body
-	TraverseGraphWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error)
+	TraverseGraphWithBodyWithResponse(ctx context.Context, graphId GraphId, params *TraverseGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error)
 
-	TraverseGraphWithResponse(ctx context.Context, graphId GraphId, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error)
+	TraverseGraphWithResponse(ctx context.Context, graphId GraphId, params *TraverseGraphParams, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error)
 
 	// HybridIndexWithBodyWithResponse request with any body
-	HybridIndexWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error)
+	HybridIndexWithBodyWithResponse(ctx context.Context, params *HybridIndexParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error)
 
-	HybridIndexWithResponse(ctx context.Context, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error)
+	HybridIndexWithResponse(ctx context.Context, params *HybridIndexParams, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error)
 
 	// HybridSearchWithBodyWithResponse request with any body
-	HybridSearchWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error)
+	HybridSearchWithBodyWithResponse(ctx context.Context, params *HybridSearchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error)
 
-	HybridSearchWithResponse(ctx context.Context, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error)
+	HybridSearchWithResponse(ctx context.Context, params *HybridSearchParams, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error)
 
 	// IngestLogWithBodyWithResponse request with any body
-	IngestLogWithBodyWithResponse(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error)
+	IngestLogWithBodyWithResponse(ctx context.Context, namespace string, params *IngestLogParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error)
 
-	IngestLogWithResponse(ctx context.Context, namespace string, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error)
+	IngestLogWithResponse(ctx context.Context, namespace string, params *IngestLogParams, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error)
 
 	// QueryLogsWithBodyWithResponse request with any body
-	QueryLogsWithBodyWithResponse(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error)
+	QueryLogsWithBodyWithResponse(ctx context.Context, namespace string, params *QueryLogsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error)
 
-	QueryLogsWithResponse(ctx context.Context, namespace string, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error)
+	QueryLogsWithResponse(ctx context.Context, namespace string, params *QueryLogsParams, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error)
 
 	// ExecuteQueryWithBodyWithResponse request with any body
-	ExecuteQueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error)
+	ExecuteQueryWithBodyWithResponse(ctx context.Context, params *ExecuteQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error)
 
-	ExecuteQueryWithResponse(ctx context.Context, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error)
+	ExecuteQueryWithResponse(ctx context.Context, params *ExecuteQueryParams, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error)
 
 	// ExplainQueryWithBodyWithResponse request with any body
-	ExplainQueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error)
+	ExplainQueryWithBodyWithResponse(ctx context.Context, params *ExplainQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error)
 
-	ExplainQueryWithResponse(ctx context.Context, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error)
+	ExplainQueryWithResponse(ctx context.Context, params *ExplainQueryParams, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error)
 
 	// GetHealthWithResponse request
-	GetHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthHTTPResp, error)
+	GetHealthWithResponse(ctx context.Context, params *GetHealthParams, reqEditors ...RequestEditorFn) (*GetHealthHTTPResp, error)
 
 	// GetLivenessWithResponse request
-	GetLivenessWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetLivenessHTTPResp, error)
+	GetLivenessWithResponse(ctx context.Context, params *GetLivenessParams, reqEditors ...RequestEditorFn) (*GetLivenessHTTPResp, error)
 
 	// GetReadinessWithResponse request
-	GetReadinessWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetReadinessHTTPResp, error)
+	GetReadinessWithResponse(ctx context.Context, params *GetReadinessParams, reqEditors ...RequestEditorFn) (*GetReadinessHTTPResp, error)
 }
 
 type GetCapabilitiesHTTPResp struct {
@@ -7076,8 +7994,8 @@ func (r GetReadinessHTTPResp) StatusCode() int {
 }
 
 // GetCapabilitiesWithResponse request returning *GetCapabilitiesHTTPResp
-func (c *ClientWithResponses) GetCapabilitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetCapabilitiesHTTPResp, error) {
-	rsp, err := c.GetCapabilities(ctx, reqEditors...)
+func (c *ClientWithResponses) GetCapabilitiesWithResponse(ctx context.Context, params *GetCapabilitiesParams, reqEditors ...RequestEditorFn) (*GetCapabilitiesHTTPResp, error) {
+	rsp, err := c.GetCapabilities(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7094,16 +8012,16 @@ func (c *ClientWithResponses) ListCollectionsWithResponse(ctx context.Context, p
 }
 
 // CreateCollectionWithBodyWithResponse request with arbitrary body returning *CreateCollectionHTTPResp
-func (c *ClientWithResponses) CreateCollectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error) {
-	rsp, err := c.CreateCollectionWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateCollectionWithBodyWithResponse(ctx context.Context, params *CreateCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error) {
+	rsp, err := c.CreateCollectionWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateCollectionHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) CreateCollectionWithResponse(ctx context.Context, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error) {
-	rsp, err := c.CreateCollection(ctx, body, reqEditors...)
+func (c *ClientWithResponses) CreateCollectionWithResponse(ctx context.Context, params *CreateCollectionParams, body CreateCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateCollectionHTTPResp, error) {
+	rsp, err := c.CreateCollection(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7111,8 +8029,8 @@ func (c *ClientWithResponses) CreateCollectionWithResponse(ctx context.Context, 
 }
 
 // DeleteCollectionWithResponse request returning *DeleteCollectionHTTPResp
-func (c *ClientWithResponses) DeleteCollectionWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*DeleteCollectionHTTPResp, error) {
-	rsp, err := c.DeleteCollection(ctx, collectionId, reqEditors...)
+func (c *ClientWithResponses) DeleteCollectionWithResponse(ctx context.Context, collectionId string, params *DeleteCollectionParams, reqEditors ...RequestEditorFn) (*DeleteCollectionHTTPResp, error) {
+	rsp, err := c.DeleteCollection(ctx, collectionId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7120,8 +8038,8 @@ func (c *ClientWithResponses) DeleteCollectionWithResponse(ctx context.Context, 
 }
 
 // GetCollectionWithResponse request returning *GetCollectionHTTPResp
-func (c *ClientWithResponses) GetCollectionWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*GetCollectionHTTPResp, error) {
-	rsp, err := c.GetCollection(ctx, collectionId, reqEditors...)
+func (c *ClientWithResponses) GetCollectionWithResponse(ctx context.Context, collectionId string, params *GetCollectionParams, reqEditors ...RequestEditorFn) (*GetCollectionHTTPResp, error) {
+	rsp, err := c.GetCollection(ctx, collectionId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7129,16 +8047,16 @@ func (c *ClientWithResponses) GetCollectionWithResponse(ctx context.Context, col
 }
 
 // IngestDocumentsWithBodyWithResponse request with arbitrary body returning *IngestDocumentsHTTPResp
-func (c *ClientWithResponses) IngestDocumentsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error) {
-	rsp, err := c.IngestDocumentsWithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) IngestDocumentsWithBodyWithResponse(ctx context.Context, collectionId string, params *IngestDocumentsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error) {
+	rsp, err := c.IngestDocumentsWithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseIngestDocumentsHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) IngestDocumentsWithResponse(ctx context.Context, collectionId string, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error) {
-	rsp, err := c.IngestDocuments(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) IngestDocumentsWithResponse(ctx context.Context, collectionId string, params *IngestDocumentsParams, body IngestDocumentsJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestDocumentsHTTPResp, error) {
+	rsp, err := c.IngestDocuments(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7146,16 +8064,16 @@ func (c *ClientWithResponses) IngestDocumentsWithResponse(ctx context.Context, c
 }
 
 // UpsertEntityV2WithBodyWithResponse request with arbitrary body returning *UpsertEntityV2HTTPResp
-func (c *ClientWithResponses) UpsertEntityV2WithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error) {
-	rsp, err := c.UpsertEntityV2WithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) UpsertEntityV2WithBodyWithResponse(ctx context.Context, collectionId string, params *UpsertEntityV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error) {
+	rsp, err := c.UpsertEntityV2WithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUpsertEntityV2HTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) UpsertEntityV2WithResponse(ctx context.Context, collectionId string, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error) {
-	rsp, err := c.UpsertEntityV2(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) UpsertEntityV2WithResponse(ctx context.Context, collectionId string, params *UpsertEntityV2Params, body UpsertEntityV2JSONRequestBody, reqEditors ...RequestEditorFn) (*UpsertEntityV2HTTPResp, error) {
+	rsp, err := c.UpsertEntityV2(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7163,16 +8081,16 @@ func (c *ClientWithResponses) UpsertEntityV2WithResponse(ctx context.Context, co
 }
 
 // SearchEntitiesV2WithBodyWithResponse request with arbitrary body returning *SearchEntitiesV2HTTPResp
-func (c *ClientWithResponses) SearchEntitiesV2WithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error) {
-	rsp, err := c.SearchEntitiesV2WithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SearchEntitiesV2WithBodyWithResponse(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error) {
+	rsp, err := c.SearchEntitiesV2WithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSearchEntitiesV2HTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) SearchEntitiesV2WithResponse(ctx context.Context, collectionId string, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error) {
-	rsp, err := c.SearchEntitiesV2(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) SearchEntitiesV2WithResponse(ctx context.Context, collectionId string, params *SearchEntitiesV2Params, body SearchEntitiesV2JSONRequestBody, reqEditors ...RequestEditorFn) (*SearchEntitiesV2HTTPResp, error) {
+	rsp, err := c.SearchEntitiesV2(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7180,8 +8098,8 @@ func (c *ClientWithResponses) SearchEntitiesV2WithResponse(ctx context.Context, 
 }
 
 // DeleteEntityV2WithResponse request returning *DeleteEntityV2HTTPResp
-func (c *ClientWithResponses) DeleteEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*DeleteEntityV2HTTPResp, error) {
-	rsp, err := c.DeleteEntityV2(ctx, collectionId, entityId, reqEditors...)
+func (c *ClientWithResponses) DeleteEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, params *DeleteEntityV2Params, reqEditors ...RequestEditorFn) (*DeleteEntityV2HTTPResp, error) {
+	rsp, err := c.DeleteEntityV2(ctx, collectionId, entityId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7189,8 +8107,8 @@ func (c *ClientWithResponses) DeleteEntityV2WithResponse(ctx context.Context, co
 }
 
 // GetEntityV2WithResponse request returning *GetEntityV2HTTPResp
-func (c *ClientWithResponses) GetEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, reqEditors ...RequestEditorFn) (*GetEntityV2HTTPResp, error) {
-	rsp, err := c.GetEntityV2(ctx, collectionId, entityId, reqEditors...)
+func (c *ClientWithResponses) GetEntityV2WithResponse(ctx context.Context, collectionId string, entityId string, params *GetEntityV2Params, reqEditors ...RequestEditorFn) (*GetEntityV2HTTPResp, error) {
+	rsp, err := c.GetEntityV2(ctx, collectionId, entityId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7198,16 +8116,16 @@ func (c *ClientWithResponses) GetEntityV2WithResponse(ctx context.Context, colle
 }
 
 // InsertRecordsWithBodyWithResponse request with arbitrary body returning *InsertRecordsHTTPResp
-func (c *ClientWithResponses) InsertRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error) {
-	rsp, err := c.InsertRecordsWithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) InsertRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *InsertRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error) {
+	rsp, err := c.InsertRecordsWithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseInsertRecordsHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) InsertRecordsWithResponse(ctx context.Context, collectionId string, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error) {
-	rsp, err := c.InsertRecords(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) InsertRecordsWithResponse(ctx context.Context, collectionId string, params *InsertRecordsParams, body InsertRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertRecordsHTTPResp, error) {
+	rsp, err := c.InsertRecords(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7215,16 +8133,16 @@ func (c *ClientWithResponses) InsertRecordsWithResponse(ctx context.Context, col
 }
 
 // ScanRecordsWithBodyWithResponse request with arbitrary body returning *ScanRecordsHTTPResp
-func (c *ClientWithResponses) ScanRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error) {
-	rsp, err := c.ScanRecordsWithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) ScanRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *ScanRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error) {
+	rsp, err := c.ScanRecordsWithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseScanRecordsHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) ScanRecordsWithResponse(ctx context.Context, collectionId string, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error) {
-	rsp, err := c.ScanRecords(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) ScanRecordsWithResponse(ctx context.Context, collectionId string, params *ScanRecordsParams, body ScanRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*ScanRecordsHTTPResp, error) {
+	rsp, err := c.ScanRecords(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7232,8 +8150,8 @@ func (c *ClientWithResponses) ScanRecordsWithResponse(ctx context.Context, colle
 }
 
 // DeleteRecordWithResponse request returning *DeleteRecordHTTPResp
-func (c *ClientWithResponses) DeleteRecordWithResponse(ctx context.Context, collectionId string, recordId string, reqEditors ...RequestEditorFn) (*DeleteRecordHTTPResp, error) {
-	rsp, err := c.DeleteRecord(ctx, collectionId, recordId, reqEditors...)
+func (c *ClientWithResponses) DeleteRecordWithResponse(ctx context.Context, collectionId string, recordId string, params *DeleteRecordParams, reqEditors ...RequestEditorFn) (*DeleteRecordHTTPResp, error) {
+	rsp, err := c.DeleteRecord(ctx, collectionId, recordId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7250,8 +8168,8 @@ func (c *ClientWithResponses) GetRecordWithResponse(ctx context.Context, collect
 }
 
 // GetCollectionSchemaWithResponse request returning *GetCollectionSchemaHTTPResp
-func (c *ClientWithResponses) GetCollectionSchemaWithResponse(ctx context.Context, collectionId string, reqEditors ...RequestEditorFn) (*GetCollectionSchemaHTTPResp, error) {
-	rsp, err := c.GetCollectionSchema(ctx, collectionId, reqEditors...)
+func (c *ClientWithResponses) GetCollectionSchemaWithResponse(ctx context.Context, collectionId string, params *GetCollectionSchemaParams, reqEditors ...RequestEditorFn) (*GetCollectionSchemaHTTPResp, error) {
+	rsp, err := c.GetCollectionSchema(ctx, collectionId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7259,16 +8177,16 @@ func (c *ClientWithResponses) GetCollectionSchemaWithResponse(ctx context.Contex
 }
 
 // UpdateCollectionSchemaWithBodyWithResponse request with arbitrary body returning *UpdateCollectionSchemaHTTPResp
-func (c *ClientWithResponses) UpdateCollectionSchemaWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error) {
-	rsp, err := c.UpdateCollectionSchemaWithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) UpdateCollectionSchemaWithBodyWithResponse(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error) {
+	rsp, err := c.UpdateCollectionSchemaWithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUpdateCollectionSchemaHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) UpdateCollectionSchemaWithResponse(ctx context.Context, collectionId string, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error) {
-	rsp, err := c.UpdateCollectionSchema(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) UpdateCollectionSchemaWithResponse(ctx context.Context, collectionId string, params *UpdateCollectionSchemaParams, body UpdateCollectionSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCollectionSchemaHTTPResp, error) {
+	rsp, err := c.UpdateCollectionSchema(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7276,16 +8194,16 @@ func (c *ClientWithResponses) UpdateCollectionSchemaWithResponse(ctx context.Con
 }
 
 // SearchRecordsWithBodyWithResponse request with arbitrary body returning *SearchRecordsHTTPResp
-func (c *ClientWithResponses) SearchRecordsWithBodyWithResponse(ctx context.Context, collectionId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error) {
-	rsp, err := c.SearchRecordsWithBody(ctx, collectionId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SearchRecordsWithBodyWithResponse(ctx context.Context, collectionId string, params *SearchRecordsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error) {
+	rsp, err := c.SearchRecordsWithBody(ctx, collectionId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSearchRecordsHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) SearchRecordsWithResponse(ctx context.Context, collectionId string, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error) {
-	rsp, err := c.SearchRecords(ctx, collectionId, body, reqEditors...)
+func (c *ClientWithResponses) SearchRecordsWithResponse(ctx context.Context, collectionId string, params *SearchRecordsParams, body SearchRecordsJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchRecordsHTTPResp, error) {
+	rsp, err := c.SearchRecords(ctx, collectionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7293,8 +8211,8 @@ func (c *ClientWithResponses) SearchRecordsWithResponse(ctx context.Context, col
 }
 
 // ListDocumentCollectionsWithResponse request returning *ListDocumentCollectionsHTTPResp
-func (c *ClientWithResponses) ListDocumentCollectionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListDocumentCollectionsHTTPResp, error) {
-	rsp, err := c.ListDocumentCollections(ctx, reqEditors...)
+func (c *ClientWithResponses) ListDocumentCollectionsWithResponse(ctx context.Context, params *ListDocumentCollectionsParams, reqEditors ...RequestEditorFn) (*ListDocumentCollectionsHTTPResp, error) {
+	rsp, err := c.ListDocumentCollections(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7302,16 +8220,16 @@ func (c *ClientWithResponses) ListDocumentCollectionsWithResponse(ctx context.Co
 }
 
 // CreateDocumentCollectionWithBodyWithResponse request with arbitrary body returning *CreateDocumentCollectionHTTPResp
-func (c *ClientWithResponses) CreateDocumentCollectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error) {
-	rsp, err := c.CreateDocumentCollectionWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateDocumentCollectionWithBodyWithResponse(ctx context.Context, params *CreateDocumentCollectionParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error) {
+	rsp, err := c.CreateDocumentCollectionWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateDocumentCollectionHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) CreateDocumentCollectionWithResponse(ctx context.Context, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error) {
-	rsp, err := c.CreateDocumentCollection(ctx, body, reqEditors...)
+func (c *ClientWithResponses) CreateDocumentCollectionWithResponse(ctx context.Context, params *CreateDocumentCollectionParams, body CreateDocumentCollectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocumentCollectionHTTPResp, error) {
+	rsp, err := c.CreateDocumentCollection(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7319,8 +8237,8 @@ func (c *ClientWithResponses) CreateDocumentCollectionWithResponse(ctx context.C
 }
 
 // QueryDocumentsWithResponse request returning *QueryDocumentsHTTPResp
-func (c *ClientWithResponses) QueryDocumentsWithResponse(ctx context.Context, collection string, reqEditors ...RequestEditorFn) (*QueryDocumentsHTTPResp, error) {
-	rsp, err := c.QueryDocuments(ctx, collection, reqEditors...)
+func (c *ClientWithResponses) QueryDocumentsWithResponse(ctx context.Context, collection string, params *QueryDocumentsParams, reqEditors ...RequestEditorFn) (*QueryDocumentsHTTPResp, error) {
+	rsp, err := c.QueryDocuments(ctx, collection, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7328,16 +8246,16 @@ func (c *ClientWithResponses) QueryDocumentsWithResponse(ctx context.Context, co
 }
 
 // InsertDocumentWithBodyWithResponse request with arbitrary body returning *InsertDocumentHTTPResp
-func (c *ClientWithResponses) InsertDocumentWithBodyWithResponse(ctx context.Context, collection string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error) {
-	rsp, err := c.InsertDocumentWithBody(ctx, collection, contentType, body, reqEditors...)
+func (c *ClientWithResponses) InsertDocumentWithBodyWithResponse(ctx context.Context, collection string, params *InsertDocumentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error) {
+	rsp, err := c.InsertDocumentWithBody(ctx, collection, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseInsertDocumentHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) InsertDocumentWithResponse(ctx context.Context, collection string, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error) {
-	rsp, err := c.InsertDocument(ctx, collection, body, reqEditors...)
+func (c *ClientWithResponses) InsertDocumentWithResponse(ctx context.Context, collection string, params *InsertDocumentParams, body InsertDocumentJSONRequestBody, reqEditors ...RequestEditorFn) (*InsertDocumentHTTPResp, error) {
+	rsp, err := c.InsertDocument(ctx, collection, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7345,8 +8263,8 @@ func (c *ClientWithResponses) InsertDocumentWithResponse(ctx context.Context, co
 }
 
 // ListGraphsWithResponse request returning *ListGraphsHTTPResp
-func (c *ClientWithResponses) ListGraphsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListGraphsHTTPResp, error) {
-	rsp, err := c.ListGraphs(ctx, reqEditors...)
+func (c *ClientWithResponses) ListGraphsWithResponse(ctx context.Context, params *ListGraphsParams, reqEditors ...RequestEditorFn) (*ListGraphsHTTPResp, error) {
+	rsp, err := c.ListGraphs(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7354,16 +8272,16 @@ func (c *ClientWithResponses) ListGraphsWithResponse(ctx context.Context, reqEdi
 }
 
 // CreateGraphWithBodyWithResponse request with arbitrary body returning *CreateGraphHTTPResp
-func (c *ClientWithResponses) CreateGraphWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error) {
-	rsp, err := c.CreateGraphWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateGraphWithBodyWithResponse(ctx context.Context, params *CreateGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error) {
+	rsp, err := c.CreateGraphWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateGraphHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) CreateGraphWithResponse(ctx context.Context, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error) {
-	rsp, err := c.CreateGraph(ctx, body, reqEditors...)
+func (c *ClientWithResponses) CreateGraphWithResponse(ctx context.Context, params *CreateGraphParams, body CreateGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateGraphHTTPResp, error) {
+	rsp, err := c.CreateGraph(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7371,8 +8289,8 @@ func (c *ClientWithResponses) CreateGraphWithResponse(ctx context.Context, body 
 }
 
 // DeleteGraphWithResponse request returning *DeleteGraphHTTPResp
-func (c *ClientWithResponses) DeleteGraphWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*DeleteGraphHTTPResp, error) {
-	rsp, err := c.DeleteGraph(ctx, graphId, reqEditors...)
+func (c *ClientWithResponses) DeleteGraphWithResponse(ctx context.Context, graphId GraphId, params *DeleteGraphParams, reqEditors ...RequestEditorFn) (*DeleteGraphHTTPResp, error) {
+	rsp, err := c.DeleteGraph(ctx, graphId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7380,8 +8298,8 @@ func (c *ClientWithResponses) DeleteGraphWithResponse(ctx context.Context, graph
 }
 
 // GetGraphWithResponse request returning *GetGraphHTTPResp
-func (c *ClientWithResponses) GetGraphWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*GetGraphHTTPResp, error) {
-	rsp, err := c.GetGraph(ctx, graphId, reqEditors...)
+func (c *ClientWithResponses) GetGraphWithResponse(ctx context.Context, graphId GraphId, params *GetGraphParams, reqEditors ...RequestEditorFn) (*GetGraphHTTPResp, error) {
+	rsp, err := c.GetGraph(ctx, graphId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7389,16 +8307,16 @@ func (c *ClientWithResponses) GetGraphWithResponse(ctx context.Context, graphId 
 }
 
 // CreateEdgeWithBodyWithResponse request with arbitrary body returning *CreateEdgeHTTPResp
-func (c *ClientWithResponses) CreateEdgeWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error) {
-	rsp, err := c.CreateEdgeWithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateEdgeWithBodyWithResponse(ctx context.Context, graphId GraphId, params *CreateEdgeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error) {
+	rsp, err := c.CreateEdgeWithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateEdgeHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) CreateEdgeWithResponse(ctx context.Context, graphId GraphId, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error) {
-	rsp, err := c.CreateEdge(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) CreateEdgeWithResponse(ctx context.Context, graphId GraphId, params *CreateEdgeParams, body CreateEdgeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEdgeHTTPResp, error) {
+	rsp, err := c.CreateEdge(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7406,16 +8324,16 @@ func (c *ClientWithResponses) CreateEdgeWithResponse(ctx context.Context, graphI
 }
 
 // BatchCreateEdgesWithBodyWithResponse request with arbitrary body returning *BatchCreateEdgesHTTPResp
-func (c *ClientWithResponses) BatchCreateEdgesWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error) {
-	rsp, err := c.BatchCreateEdgesWithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) BatchCreateEdgesWithBodyWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error) {
+	rsp, err := c.BatchCreateEdgesWithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseBatchCreateEdgesHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) BatchCreateEdgesWithResponse(ctx context.Context, graphId GraphId, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error) {
-	rsp, err := c.BatchCreateEdges(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) BatchCreateEdgesWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateEdgesParams, body BatchCreateEdgesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateEdgesHTTPResp, error) {
+	rsp, err := c.BatchCreateEdges(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7423,16 +8341,16 @@ func (c *ClientWithResponses) BatchCreateEdgesWithResponse(ctx context.Context, 
 }
 
 // FusionSearchV2WithBodyWithResponse request with arbitrary body returning *FusionSearchV2HTTPResp
-func (c *ClientWithResponses) FusionSearchV2WithBodyWithResponse(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error) {
-	rsp, err := c.FusionSearchV2WithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) FusionSearchV2WithBodyWithResponse(ctx context.Context, graphId string, params *FusionSearchV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error) {
+	rsp, err := c.FusionSearchV2WithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseFusionSearchV2HTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) FusionSearchV2WithResponse(ctx context.Context, graphId string, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error) {
-	rsp, err := c.FusionSearchV2(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) FusionSearchV2WithResponse(ctx context.Context, graphId string, params *FusionSearchV2Params, body FusionSearchV2JSONRequestBody, reqEditors ...RequestEditorFn) (*FusionSearchV2HTTPResp, error) {
+	rsp, err := c.FusionSearchV2(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7440,16 +8358,16 @@ func (c *ClientWithResponses) FusionSearchV2WithResponse(ctx context.Context, gr
 }
 
 // ImpactAnalysisV2WithBodyWithResponse request with arbitrary body returning *ImpactAnalysisV2HTTPResp
-func (c *ClientWithResponses) ImpactAnalysisV2WithBodyWithResponse(ctx context.Context, graphId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error) {
-	rsp, err := c.ImpactAnalysisV2WithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) ImpactAnalysisV2WithBodyWithResponse(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error) {
+	rsp, err := c.ImpactAnalysisV2WithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseImpactAnalysisV2HTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) ImpactAnalysisV2WithResponse(ctx context.Context, graphId string, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error) {
-	rsp, err := c.ImpactAnalysisV2(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) ImpactAnalysisV2WithResponse(ctx context.Context, graphId string, params *ImpactAnalysisV2Params, body ImpactAnalysisV2JSONRequestBody, reqEditors ...RequestEditorFn) (*ImpactAnalysisV2HTTPResp, error) {
+	rsp, err := c.ImpactAnalysisV2(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7457,16 +8375,16 @@ func (c *ClientWithResponses) ImpactAnalysisV2WithResponse(ctx context.Context, 
 }
 
 // CreateNodeWithBodyWithResponse request with arbitrary body returning *CreateNodeHTTPResp
-func (c *ClientWithResponses) CreateNodeWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error) {
-	rsp, err := c.CreateNodeWithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) CreateNodeWithBodyWithResponse(ctx context.Context, graphId GraphId, params *CreateNodeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error) {
+	rsp, err := c.CreateNodeWithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseCreateNodeHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) CreateNodeWithResponse(ctx context.Context, graphId GraphId, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error) {
-	rsp, err := c.CreateNode(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) CreateNodeWithResponse(ctx context.Context, graphId GraphId, params *CreateNodeParams, body CreateNodeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNodeHTTPResp, error) {
+	rsp, err := c.CreateNode(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7474,16 +8392,16 @@ func (c *ClientWithResponses) CreateNodeWithResponse(ctx context.Context, graphI
 }
 
 // BatchCreateNodesWithBodyWithResponse request with arbitrary body returning *BatchCreateNodesHTTPResp
-func (c *ClientWithResponses) BatchCreateNodesWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error) {
-	rsp, err := c.BatchCreateNodesWithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) BatchCreateNodesWithBodyWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error) {
+	rsp, err := c.BatchCreateNodesWithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseBatchCreateNodesHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) BatchCreateNodesWithResponse(ctx context.Context, graphId GraphId, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error) {
-	rsp, err := c.BatchCreateNodes(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) BatchCreateNodesWithResponse(ctx context.Context, graphId GraphId, params *BatchCreateNodesParams, body BatchCreateNodesJSONRequestBody, reqEditors ...RequestEditorFn) (*BatchCreateNodesHTTPResp, error) {
+	rsp, err := c.BatchCreateNodes(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7491,8 +8409,8 @@ func (c *ClientWithResponses) BatchCreateNodesWithResponse(ctx context.Context, 
 }
 
 // DeleteNodeWithResponse request returning *DeleteNodeHTTPResp
-func (c *ClientWithResponses) DeleteNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*DeleteNodeHTTPResp, error) {
-	rsp, err := c.DeleteNode(ctx, graphId, nodeId, reqEditors...)
+func (c *ClientWithResponses) DeleteNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, params *DeleteNodeParams, reqEditors ...RequestEditorFn) (*DeleteNodeHTTPResp, error) {
+	rsp, err := c.DeleteNode(ctx, graphId, nodeId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7500,8 +8418,8 @@ func (c *ClientWithResponses) DeleteNodeWithResponse(ctx context.Context, graphI
 }
 
 // GetNodeWithResponse request returning *GetNodeHTTPResp
-func (c *ClientWithResponses) GetNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, reqEditors ...RequestEditorFn) (*GetNodeHTTPResp, error) {
-	rsp, err := c.GetNode(ctx, graphId, nodeId, reqEditors...)
+func (c *ClientWithResponses) GetNodeWithResponse(ctx context.Context, graphId GraphId, nodeId NodeId, params *GetNodeParams, reqEditors ...RequestEditorFn) (*GetNodeHTTPResp, error) {
+	rsp, err := c.GetNode(ctx, graphId, nodeId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7509,8 +8427,8 @@ func (c *ClientWithResponses) GetNodeWithResponse(ctx context.Context, graphId G
 }
 
 // GetGraphStatsWithResponse request returning *GetGraphStatsHTTPResp
-func (c *ClientWithResponses) GetGraphStatsWithResponse(ctx context.Context, graphId GraphId, reqEditors ...RequestEditorFn) (*GetGraphStatsHTTPResp, error) {
-	rsp, err := c.GetGraphStats(ctx, graphId, reqEditors...)
+func (c *ClientWithResponses) GetGraphStatsWithResponse(ctx context.Context, graphId GraphId, params *GetGraphStatsParams, reqEditors ...RequestEditorFn) (*GetGraphStatsHTTPResp, error) {
+	rsp, err := c.GetGraphStats(ctx, graphId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7518,16 +8436,16 @@ func (c *ClientWithResponses) GetGraphStatsWithResponse(ctx context.Context, gra
 }
 
 // TraverseGraphWithBodyWithResponse request with arbitrary body returning *TraverseGraphHTTPResp
-func (c *ClientWithResponses) TraverseGraphWithBodyWithResponse(ctx context.Context, graphId GraphId, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error) {
-	rsp, err := c.TraverseGraphWithBody(ctx, graphId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) TraverseGraphWithBodyWithResponse(ctx context.Context, graphId GraphId, params *TraverseGraphParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error) {
+	rsp, err := c.TraverseGraphWithBody(ctx, graphId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseTraverseGraphHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) TraverseGraphWithResponse(ctx context.Context, graphId GraphId, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error) {
-	rsp, err := c.TraverseGraph(ctx, graphId, body, reqEditors...)
+func (c *ClientWithResponses) TraverseGraphWithResponse(ctx context.Context, graphId GraphId, params *TraverseGraphParams, body TraverseGraphJSONRequestBody, reqEditors ...RequestEditorFn) (*TraverseGraphHTTPResp, error) {
+	rsp, err := c.TraverseGraph(ctx, graphId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7535,16 +8453,16 @@ func (c *ClientWithResponses) TraverseGraphWithResponse(ctx context.Context, gra
 }
 
 // HybridIndexWithBodyWithResponse request with arbitrary body returning *HybridIndexHTTPResp
-func (c *ClientWithResponses) HybridIndexWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error) {
-	rsp, err := c.HybridIndexWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) HybridIndexWithBodyWithResponse(ctx context.Context, params *HybridIndexParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error) {
+	rsp, err := c.HybridIndexWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseHybridIndexHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) HybridIndexWithResponse(ctx context.Context, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error) {
-	rsp, err := c.HybridIndex(ctx, body, reqEditors...)
+func (c *ClientWithResponses) HybridIndexWithResponse(ctx context.Context, params *HybridIndexParams, body HybridIndexJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridIndexHTTPResp, error) {
+	rsp, err := c.HybridIndex(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7552,16 +8470,16 @@ func (c *ClientWithResponses) HybridIndexWithResponse(ctx context.Context, body 
 }
 
 // HybridSearchWithBodyWithResponse request with arbitrary body returning *HybridSearchHTTPResp
-func (c *ClientWithResponses) HybridSearchWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error) {
-	rsp, err := c.HybridSearchWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) HybridSearchWithBodyWithResponse(ctx context.Context, params *HybridSearchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error) {
+	rsp, err := c.HybridSearchWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseHybridSearchHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) HybridSearchWithResponse(ctx context.Context, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error) {
-	rsp, err := c.HybridSearch(ctx, body, reqEditors...)
+func (c *ClientWithResponses) HybridSearchWithResponse(ctx context.Context, params *HybridSearchParams, body HybridSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*HybridSearchHTTPResp, error) {
+	rsp, err := c.HybridSearch(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7569,16 +8487,16 @@ func (c *ClientWithResponses) HybridSearchWithResponse(ctx context.Context, body
 }
 
 // IngestLogWithBodyWithResponse request with arbitrary body returning *IngestLogHTTPResp
-func (c *ClientWithResponses) IngestLogWithBodyWithResponse(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error) {
-	rsp, err := c.IngestLogWithBody(ctx, namespace, contentType, body, reqEditors...)
+func (c *ClientWithResponses) IngestLogWithBodyWithResponse(ctx context.Context, namespace string, params *IngestLogParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error) {
+	rsp, err := c.IngestLogWithBody(ctx, namespace, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseIngestLogHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) IngestLogWithResponse(ctx context.Context, namespace string, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error) {
-	rsp, err := c.IngestLog(ctx, namespace, body, reqEditors...)
+func (c *ClientWithResponses) IngestLogWithResponse(ctx context.Context, namespace string, params *IngestLogParams, body IngestLogJSONRequestBody, reqEditors ...RequestEditorFn) (*IngestLogHTTPResp, error) {
+	rsp, err := c.IngestLog(ctx, namespace, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7586,16 +8504,16 @@ func (c *ClientWithResponses) IngestLogWithResponse(ctx context.Context, namespa
 }
 
 // QueryLogsWithBodyWithResponse request with arbitrary body returning *QueryLogsHTTPResp
-func (c *ClientWithResponses) QueryLogsWithBodyWithResponse(ctx context.Context, namespace string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error) {
-	rsp, err := c.QueryLogsWithBody(ctx, namespace, contentType, body, reqEditors...)
+func (c *ClientWithResponses) QueryLogsWithBodyWithResponse(ctx context.Context, namespace string, params *QueryLogsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error) {
+	rsp, err := c.QueryLogsWithBody(ctx, namespace, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseQueryLogsHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) QueryLogsWithResponse(ctx context.Context, namespace string, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error) {
-	rsp, err := c.QueryLogs(ctx, namespace, body, reqEditors...)
+func (c *ClientWithResponses) QueryLogsWithResponse(ctx context.Context, namespace string, params *QueryLogsParams, body QueryLogsJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryLogsHTTPResp, error) {
+	rsp, err := c.QueryLogs(ctx, namespace, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7603,16 +8521,16 @@ func (c *ClientWithResponses) QueryLogsWithResponse(ctx context.Context, namespa
 }
 
 // ExecuteQueryWithBodyWithResponse request with arbitrary body returning *ExecuteQueryHTTPResp
-func (c *ClientWithResponses) ExecuteQueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error) {
-	rsp, err := c.ExecuteQueryWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) ExecuteQueryWithBodyWithResponse(ctx context.Context, params *ExecuteQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error) {
+	rsp, err := c.ExecuteQueryWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseExecuteQueryHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) ExecuteQueryWithResponse(ctx context.Context, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error) {
-	rsp, err := c.ExecuteQuery(ctx, body, reqEditors...)
+func (c *ClientWithResponses) ExecuteQueryWithResponse(ctx context.Context, params *ExecuteQueryParams, body ExecuteQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExecuteQueryHTTPResp, error) {
+	rsp, err := c.ExecuteQuery(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7620,16 +8538,16 @@ func (c *ClientWithResponses) ExecuteQueryWithResponse(ctx context.Context, body
 }
 
 // ExplainQueryWithBodyWithResponse request with arbitrary body returning *ExplainQueryHTTPResp
-func (c *ClientWithResponses) ExplainQueryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error) {
-	rsp, err := c.ExplainQueryWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) ExplainQueryWithBodyWithResponse(ctx context.Context, params *ExplainQueryParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error) {
+	rsp, err := c.ExplainQueryWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseExplainQueryHTTPResp(rsp)
 }
 
-func (c *ClientWithResponses) ExplainQueryWithResponse(ctx context.Context, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error) {
-	rsp, err := c.ExplainQuery(ctx, body, reqEditors...)
+func (c *ClientWithResponses) ExplainQueryWithResponse(ctx context.Context, params *ExplainQueryParams, body ExplainQueryJSONRequestBody, reqEditors ...RequestEditorFn) (*ExplainQueryHTTPResp, error) {
+	rsp, err := c.ExplainQuery(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7637,8 +8555,8 @@ func (c *ClientWithResponses) ExplainQueryWithResponse(ctx context.Context, body
 }
 
 // GetHealthWithResponse request returning *GetHealthHTTPResp
-func (c *ClientWithResponses) GetHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthHTTPResp, error) {
-	rsp, err := c.GetHealth(ctx, reqEditors...)
+func (c *ClientWithResponses) GetHealthWithResponse(ctx context.Context, params *GetHealthParams, reqEditors ...RequestEditorFn) (*GetHealthHTTPResp, error) {
+	rsp, err := c.GetHealth(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7646,8 +8564,8 @@ func (c *ClientWithResponses) GetHealthWithResponse(ctx context.Context, reqEdit
 }
 
 // GetLivenessWithResponse request returning *GetLivenessHTTPResp
-func (c *ClientWithResponses) GetLivenessWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetLivenessHTTPResp, error) {
-	rsp, err := c.GetLiveness(ctx, reqEditors...)
+func (c *ClientWithResponses) GetLivenessWithResponse(ctx context.Context, params *GetLivenessParams, reqEditors ...RequestEditorFn) (*GetLivenessHTTPResp, error) {
+	rsp, err := c.GetLiveness(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7655,8 +8573,8 @@ func (c *ClientWithResponses) GetLivenessWithResponse(ctx context.Context, reqEd
 }
 
 // GetReadinessWithResponse request returning *GetReadinessHTTPResp
-func (c *ClientWithResponses) GetReadinessWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetReadinessHTTPResp, error) {
-	rsp, err := c.GetReadiness(ctx, reqEditors...)
+func (c *ClientWithResponses) GetReadinessWithResponse(ctx context.Context, params *GetReadinessParams, reqEditors ...RequestEditorFn) (*GetReadinessHTTPResp, error) {
+	rsp, err := c.GetReadiness(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/go/proximadb/internal/rest/adapter.go
+++ b/clients/go/proximadb/internal/rest/adapter.go
@@ -387,7 +387,7 @@ func (a *Adapter) CreateCollection(ctx context.Context, req *CreateCollectionReq
 		body.Engine = ptr(req.Engine)
 	}
 
-	resp, err := a.gen.CreateCollection(ctx, body)
+	resp, err := a.gen.CreateCollection(ctx, nil, body)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -452,7 +452,7 @@ func (a *Adapter) ListCollections(ctx context.Context) ([]*CollectionInfo, error
 
 // GetCollection returns information about a specific collection.
 func (a *Adapter) GetCollection(ctx context.Context, name string) (*CollectionInfo, error) {
-	resp, err := a.gen.GetCollection(ctx, name)
+	resp, err := a.gen.GetCollection(ctx, name, nil)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -485,7 +485,7 @@ func (a *Adapter) GetCollection(ctx context.Context, name string) (*CollectionIn
 
 // DeleteCollection deletes a collection.
 func (a *Adapter) DeleteCollection(ctx context.Context, name string) error {
-	resp, err := a.gen.DeleteCollection(ctx, name)
+	resp, err := a.gen.DeleteCollection(ctx, name, nil)
 	if err != nil {
 		return mapTransportError(ctx, err)
 	}
@@ -511,7 +511,7 @@ func (a *Adapter) writeRecords(ctx context.Context, collection string, records [
 		body.Upsert = ptr(true)
 	}
 
-	resp, err := a.gen.InsertRecords(ctx, collection, body)
+	resp, err := a.gen.InsertRecords(ctx, collection, nil, body)
 	if err != nil {
 		return mapTransportError(ctx, err)
 	}
@@ -540,7 +540,7 @@ func (a *Adapter) Search(ctx context.Context, collection string, query *SearchQu
 		IncludeVector: ptr(query.IncludeVectors),
 	}
 
-	resp, err := a.gen.SearchRecords(ctx, collection, body)
+	resp, err := a.gen.SearchRecords(ctx, collection, nil, body)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -584,7 +584,7 @@ func (a *Adapter) Get(ctx context.Context, collection string, ids []string) ([]*
 // Delete removes vectors by their IDs.
 func (a *Adapter) Delete(ctx context.Context, collection string, ids []string) error {
 	for _, id := range ids {
-		resp, err := a.gen.DeleteRecord(ctx, collection, id)
+		resp, err := a.gen.DeleteRecord(ctx, collection, id, nil)
 		if err != nil {
 			return mapTransportError(ctx, err)
 		}
@@ -597,7 +597,7 @@ func (a *Adapter) Delete(ctx context.Context, collection string, ids []string) e
 
 // Health checks the server health.
 func (a *Adapter) Health(ctx context.Context) (*HealthStatus, error) {
-	resp, err := a.gen.GetHealth(ctx)
+	resp, err := a.gen.GetHealth(ctx, nil)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -610,7 +610,7 @@ func (a *Adapter) Health(ctx context.Context) (*HealthStatus, error) {
 
 // HealthLive issues a Kubernetes liveness probe (GET /health/live).
 func (a *Adapter) HealthLive(ctx context.Context) (*ProbeResponse, error) {
-	resp, err := a.gen.GetLiveness(ctx)
+	resp, err := a.gen.GetLiveness(ctx, nil)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -623,7 +623,7 @@ func (a *Adapter) HealthLive(ctx context.Context) (*ProbeResponse, error) {
 
 // HealthReady issues a Kubernetes readiness probe (GET /health/ready).
 func (a *Adapter) HealthReady(ctx context.Context) (*ProbeResponse, error) {
-	resp, err := a.gen.GetReadiness(ctx)
+	resp, err := a.gen.GetReadiness(ctx, nil)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -636,7 +636,7 @@ func (a *Adapter) HealthReady(ctx context.Context) (*ProbeResponse, error) {
 
 // GetCollectionSchema fetches the schema for a collection.
 func (a *Adapter) GetCollectionSchema(ctx context.Context, collectionID string) (*SchemaResponse, error) {
-	resp, err := a.gen.GetCollectionSchema(ctx, collectionID)
+	resp, err := a.gen.GetCollectionSchema(ctx, collectionID, nil)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -658,7 +658,7 @@ func (a *Adapter) UpdateCollectionSchema(ctx context.Context, collectionID strin
 		body.Enforcement = ptr(req.Enforcement)
 	}
 
-	resp, err := a.gen.UpdateCollectionSchema(ctx, collectionID, body)
+	resp, err := a.gen.UpdateCollectionSchema(ctx, collectionID, nil, body)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -683,7 +683,7 @@ func (a *Adapter) ExecuteQuery(ctx context.Context, req *QueryRequest) (QueryRes
 		body.Parameters = toGenQueryParams(req.Parameters)
 	}
 
-	resp, err := a.gen.ExecuteQuery(ctx, body)
+	resp, err := a.gen.ExecuteQuery(ctx, nil, body)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}
@@ -702,7 +702,7 @@ func (a *Adapter) ExplainQuery(ctx context.Context, req *ExplainQueryRequest) (Q
 		Collection: req.Collection,
 	}
 
-	resp, err := a.gen.ExplainQuery(ctx, body)
+	resp, err := a.gen.ExplainQuery(ctx, nil, body)
 	if err != nil {
 		return nil, mapTransportError(ctx, err)
 	}

--- a/clients/nodejs-embedded/src/generated/schema.ts
+++ b/clients/nodejs-embedded/src/generated/schema.ts
@@ -2120,7 +2120,10 @@ export interface operations {
     getCapabilities: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2147,7 +2150,10 @@ export interface operations {
                 /** @description Whether to include statistics */
                 include_stats?: boolean;
             };
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2167,7 +2173,10 @@ export interface operations {
     createCollection: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2200,7 +2209,10 @@ export interface operations {
     getCollection: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2232,7 +2244,10 @@ export interface operations {
     deleteCollection: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2264,7 +2279,10 @@ export interface operations {
     ingestDocuments: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Target collection name/ID. */
                 collection_id: string;
@@ -2309,7 +2327,10 @@ export interface operations {
     upsert_entity_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection backing the entities */
                 collection_id: string;
@@ -2354,7 +2375,10 @@ export interface operations {
     search_entities_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection backing the entities */
                 collection_id: string;
@@ -2399,7 +2423,10 @@ export interface operations {
     get_entity_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection backing the entities */
                 collection_id: string;
@@ -2442,7 +2469,10 @@ export interface operations {
     delete_entity_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection backing the entities */
                 collection_id: string;
@@ -2485,7 +2515,10 @@ export interface operations {
     insertRecords: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2521,7 +2554,10 @@ export interface operations {
     scanRecords: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2571,7 +2607,10 @@ export interface operations {
                 /** @description Whether to include TEXT fields in the response */
                 include_text?: boolean;
             };
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2605,7 +2644,10 @@ export interface operations {
     deleteRecord: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2630,7 +2672,10 @@ export interface operations {
     getCollectionSchema: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2662,7 +2707,10 @@ export interface operations {
     updateCollectionSchema: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2698,7 +2746,10 @@ export interface operations {
     searchRecords: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Collection name/ID. */
                 collection_id: string;
@@ -2734,7 +2785,10 @@ export interface operations {
     listDocumentCollections: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2756,7 +2810,10 @@ export interface operations {
     createDocumentCollection: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2784,7 +2841,10 @@ export interface operations {
     queryDocuments: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 collection: string;
             };
@@ -2808,7 +2868,10 @@ export interface operations {
     insertDocument: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 collection: string;
             };
@@ -2839,7 +2902,10 @@ export interface operations {
     listGraphs: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2859,7 +2925,10 @@ export interface operations {
     createGraph: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2884,7 +2953,10 @@ export interface operations {
     getGraph: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -2907,7 +2979,10 @@ export interface operations {
     deleteGraph: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -2930,7 +3005,10 @@ export interface operations {
     createEdge: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -2958,7 +3036,10 @@ export interface operations {
     batchCreateEdges: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -2986,7 +3067,10 @@ export interface operations {
     fusion_search_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Graph ID for traversal expansion */
                 graph_id: string;
@@ -3031,7 +3115,10 @@ export interface operations {
     impact_analysis_v2: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 /** @description Graph ID */
                 graph_id: string;
@@ -3076,7 +3163,10 @@ export interface operations {
     createNode: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -3104,7 +3194,10 @@ export interface operations {
     batchCreateNodes: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -3132,7 +3225,10 @@ export interface operations {
     getNode: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
                 node_id: components["parameters"]["NodeId"];
@@ -3156,7 +3252,10 @@ export interface operations {
     deleteNode: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
                 node_id: components["parameters"]["NodeId"];
@@ -3180,7 +3279,10 @@ export interface operations {
     getGraphStats: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -3202,7 +3304,10 @@ export interface operations {
     traverseGraph: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 graph_id: components["parameters"]["GraphId"];
             };
@@ -3229,7 +3334,10 @@ export interface operations {
     hybridIndex: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3257,7 +3365,10 @@ export interface operations {
     hybridSearch: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3292,7 +3403,10 @@ export interface operations {
     ingestLog: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 namespace: string;
             };
@@ -3322,7 +3436,10 @@ export interface operations {
     queryLogs: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path: {
                 namespace: string;
             };
@@ -3352,7 +3469,10 @@ export interface operations {
     executeQuery: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3385,7 +3505,10 @@ export interface operations {
     explainQuery: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3418,7 +3541,10 @@ export interface operations {
     getHealth: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3438,7 +3564,10 @@ export interface operations {
     getLiveness: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -3458,7 +3587,10 @@ export interface operations {
     getReadiness: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant. */
+                "X-Tenant-ID"?: string;
+            };
             path?: never;
             cookie?: never;
         };

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/collections/create_collection.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/collections/create_collection.py
@@ -13,14 +13,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_collection_v2_request import CreateCollectionV2Request
 from ...models.create_collection_v2_response import CreateCollectionV2Response
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: CreateCollectionV2Request,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -68,6 +71,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateCollectionV2Request,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[CreateCollectionV2Response, ErrorResponse]]:
     """Create a collection with optional schema.
 
@@ -88,6 +92,7 @@ def sync_detailed(
     - `500 Internal Server Error`: Creation failed
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateCollectionV2Request): Request to create a collection with schema support
 
             ## Example JSON
@@ -120,6 +125,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -133,6 +139,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateCollectionV2Request,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[CreateCollectionV2Response, ErrorResponse]]:
     """Create a collection with optional schema.
 
@@ -153,6 +160,7 @@ def sync(
     - `500 Internal Server Error`: Creation failed
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateCollectionV2Request): Request to create a collection with schema support
 
             ## Example JSON
@@ -186,6 +194,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -193,6 +202,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateCollectionV2Request,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[CreateCollectionV2Response, ErrorResponse]]:
     """Create a collection with optional schema.
 
@@ -213,6 +223,7 @@ async def asyncio_detailed(
     - `500 Internal Server Error`: Creation failed
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateCollectionV2Request): Request to create a collection with schema support
 
             ## Example JSON
@@ -245,6 +256,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -256,6 +268,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateCollectionV2Request,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[CreateCollectionV2Response, ErrorResponse]]:
     """Create a collection with optional schema.
 
@@ -276,6 +289,7 @@ async def asyncio(
     - `500 Internal Server Error`: Creation failed
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateCollectionV2Request): Request to create a collection with schema support
 
             ## Example JSON
@@ -310,5 +324,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/collections/delete_collection.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/collections/delete_collection.py
@@ -12,12 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_collection_v2_response import DeleteCollectionV2Response
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
@@ -26,6 +31,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -61,6 +67,7 @@ def sync_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteCollectionV2Response, ErrorResponse]]:
     """Delete a collection.
 
@@ -70,6 +77,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -81,6 +89,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -94,6 +103,7 @@ def sync(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteCollectionV2Response, ErrorResponse]]:
     """Delete a collection.
 
@@ -103,6 +113,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +126,7 @@ def sync(
     return sync_detailed(
         collection_id=collection_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -122,6 +134,7 @@ async def asyncio_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteCollectionV2Response, ErrorResponse]]:
     """Delete a collection.
 
@@ -131,6 +144,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +156,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -153,6 +168,7 @@ async def asyncio(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteCollectionV2Response, ErrorResponse]]:
     """Delete a collection.
 
@@ -162,6 +178,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -175,5 +192,6 @@ async def asyncio(
         await asyncio_detailed(
             collection_id=collection_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/collections/get_collection.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/collections/get_collection.py
@@ -12,12 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.collection_v2_response import CollectionV2Response
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -26,6 +31,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -61,6 +67,7 @@ def sync_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[CollectionV2Response, ErrorResponse]]:
     """Get collection details.
 
@@ -81,6 +88,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -92,6 +100,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -105,6 +114,7 @@ def sync(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[CollectionV2Response, ErrorResponse]]:
     """Get collection details.
 
@@ -125,6 +135,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -137,6 +148,7 @@ def sync(
     return sync_detailed(
         collection_id=collection_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -144,6 +156,7 @@ async def asyncio_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[CollectionV2Response, ErrorResponse]]:
     """Get collection details.
 
@@ -164,6 +177,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -175,6 +189,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -186,6 +201,7 @@ async def asyncio(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[CollectionV2Response, ErrorResponse]]:
     """Get collection details.
 
@@ -206,6 +222,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -219,5 +236,6 @@ async def asyncio(
         await asyncio_detailed(
             collection_id=collection_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/collections/list_collections.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/collections/list_collections.py
@@ -19,7 +19,11 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     include_stats: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     params: dict[str, Any] = {}
 
@@ -37,6 +41,7 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -70,6 +75,7 @@ def sync_detailed(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     include_stats: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListCollectionsV2Response]:
     """List collections.
 
@@ -93,6 +99,7 @@ def sync_detailed(
         limit (Union[Unset, int]):
         offset (Union[Unset, int]):
         include_stats (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -106,6 +113,7 @@ def sync_detailed(
         limit=limit,
         offset=offset,
         include_stats=include_stats,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -121,6 +129,7 @@ def sync(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     include_stats: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListCollectionsV2Response]:
     """List collections.
 
@@ -144,6 +153,7 @@ def sync(
         limit (Union[Unset, int]):
         offset (Union[Unset, int]):
         include_stats (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -158,6 +168,7 @@ def sync(
         limit=limit,
         offset=offset,
         include_stats=include_stats,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -167,6 +178,7 @@ async def asyncio_detailed(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     include_stats: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListCollectionsV2Response]:
     """List collections.
 
@@ -190,6 +202,7 @@ async def asyncio_detailed(
         limit (Union[Unset, int]):
         offset (Union[Unset, int]):
         include_stats (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -203,6 +216,7 @@ async def asyncio_detailed(
         limit=limit,
         offset=offset,
         include_stats=include_stats,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -216,6 +230,7 @@ async def asyncio(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     include_stats: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListCollectionsV2Response]:
     """List collections.
 
@@ -239,6 +254,7 @@ async def asyncio(
         limit (Union[Unset, int]):
         offset (Union[Unset, int]):
         include_stats (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -254,5 +270,6 @@ async def asyncio(
             limit=limit,
             offset=offset,
             include_stats=include_stats,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/documents/create_document_collection.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/documents/create_document_collection.py
@@ -14,14 +14,17 @@ from ...models.create_document_collection_body import CreateDocumentCollectionBo
 from ...models.create_document_collection_response_200 import (
     CreateDocumentCollectionResponse200,
 )
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: CreateDocumentCollectionBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -65,10 +68,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateDocumentCollectionBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[CreateDocumentCollectionResponse200]:
     """Create a document collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateDocumentCollectionBody):
 
     Raises:
@@ -81,6 +86,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -94,10 +100,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateDocumentCollectionBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[CreateDocumentCollectionResponse200]:
     """Create a document collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateDocumentCollectionBody):
 
     Raises:
@@ -111,6 +119,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -118,10 +127,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateDocumentCollectionBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[CreateDocumentCollectionResponse200]:
     """Create a document collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateDocumentCollectionBody):
 
     Raises:
@@ -134,6 +145,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -145,10 +157,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateDocumentCollectionBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[CreateDocumentCollectionResponse200]:
     """Create a document collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateDocumentCollectionBody):
 
     Raises:
@@ -163,5 +177,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/documents/ingest_documents.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/documents/ingest_documents.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.ingest_documents_request import IngestDocumentsRequest
 from ...models.ingest_documents_response import IngestDocumentsResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: IngestDocumentsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,6 +79,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestDocumentsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, IngestDocumentsResponse]]:
     """Ingest documents for native server-side embedding.
 
@@ -86,6 +90,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestDocumentsRequest):
 
     Raises:
@@ -99,6 +104,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -113,6 +119,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestDocumentsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, IngestDocumentsResponse]]:
     """Ingest documents for native server-side embedding.
 
@@ -123,6 +130,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestDocumentsRequest):
 
     Raises:
@@ -137,6 +145,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -145,6 +154,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestDocumentsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, IngestDocumentsResponse]]:
     """Ingest documents for native server-side embedding.
 
@@ -155,6 +165,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestDocumentsRequest):
 
     Raises:
@@ -168,6 +179,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -180,6 +192,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestDocumentsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, IngestDocumentsResponse]]:
     """Ingest documents for native server-side embedding.
 
@@ -190,6 +203,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestDocumentsRequest):
 
     Raises:
@@ -205,5 +219,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/documents/insert_document.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/documents/insert_document.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.insert_document_body import InsertDocumentBody
 from ...models.insert_document_response_200 import InsertDocumentResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection: str,
     *,
     body: InsertDocumentBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -72,11 +75,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertDocumentBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, InsertDocumentResponse200]]:
     """Insert a document.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertDocumentBody):
 
     Raises:
@@ -90,6 +95,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection=collection,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -104,11 +110,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertDocumentBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, InsertDocumentResponse200]]:
     """Insert a document.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertDocumentBody):
 
     Raises:
@@ -123,6 +131,7 @@ def sync(
         collection=collection,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -131,11 +140,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertDocumentBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, InsertDocumentResponse200]]:
     """Insert a document.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertDocumentBody):
 
     Raises:
@@ -149,6 +160,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection=collection,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -161,11 +173,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertDocumentBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, InsertDocumentResponse200]]:
     """Insert a document.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertDocumentBody):
 
     Raises:
@@ -181,5 +195,6 @@ async def asyncio(
             collection=collection,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/documents/list_document_collections.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/documents/list_document_collections.py
@@ -13,16 +13,23 @@ from ...client import AuthenticatedClient, Client
 from ...models.list_document_collections_response_200 import (
     ListDocumentCollectionsResponse200,
 )
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v2/document-collections",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -53,8 +60,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListDocumentCollectionsResponse200]:
     """List document collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -64,7 +75,9 @@ def sync_detailed(
         Response[ListDocumentCollectionsResponse200]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -76,8 +89,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListDocumentCollectionsResponse200]:
     """List document collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -89,14 +106,19 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListDocumentCollectionsResponse200]:
     """List document collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -106,7 +128,9 @@ async def asyncio_detailed(
         Response[ListDocumentCollectionsResponse200]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -116,8 +140,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListDocumentCollectionsResponse200]:
     """List document collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -130,5 +158,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/documents/query_documents.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/documents/query_documents.py
@@ -11,12 +11,17 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.query_documents_response_200 import QueryDocumentsResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -25,6 +30,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -56,11 +62,13 @@ def sync_detailed(
     collection: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryDocumentsResponse200]:
     """Query documents.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -72,6 +80,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         collection=collection,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -85,11 +94,13 @@ def sync(
     collection: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryDocumentsResponse200]:
     """Query documents.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -102,6 +113,7 @@ def sync(
     return sync_detailed(
         collection=collection,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -109,11 +121,13 @@ async def asyncio_detailed(
     collection: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryDocumentsResponse200]:
     """Query documents.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -125,6 +139,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         collection=collection,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -136,11 +151,13 @@ async def asyncio(
     collection: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryDocumentsResponse200]:
     """Query documents.
 
     Args:
         collection (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,5 +171,6 @@ async def asyncio(
         await asyncio_detailed(
             collection=collection,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/entities/delete_entity_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/entities/delete_entity_v2.py
@@ -12,13 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.upsert_entity_response import UpsertEntityResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     entity_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
@@ -28,6 +33,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -68,11 +74,13 @@ def sync_detailed(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -85,6 +93,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         entity_id=entity_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -99,11 +108,13 @@ def sync(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +128,7 @@ def sync(
         collection_id=collection_id,
         entity_id=entity_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -125,11 +137,13 @@ async def asyncio_detailed(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +156,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         entity_id=entity_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,11 +169,13 @@ async def asyncio(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +190,6 @@ async def asyncio(
             collection_id=collection_id,
             entity_id=entity_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/entities/get_entity_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/entities/get_entity_v2.py
@@ -12,13 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.entity_dto import EntityDto
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     entity_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -28,6 +33,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -68,11 +74,13 @@ def sync_detailed(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[EntityDto, ErrorResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -85,6 +93,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         entity_id=entity_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -99,11 +108,13 @@ def sync(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[EntityDto, ErrorResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +128,7 @@ def sync(
         collection_id=collection_id,
         entity_id=entity_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -125,11 +137,13 @@ async def asyncio_detailed(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[EntityDto, ErrorResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +156,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         entity_id=entity_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,11 +169,13 @@ async def asyncio(
     entity_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[EntityDto, ErrorResponse]]:
     """
     Args:
         collection_id (str):
         entity_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +190,6 @@ async def asyncio(
             collection_id=collection_id,
             entity_id=entity_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/entities/search_entities_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/entities/search_entities_v2.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.search_entities_request import SearchEntitiesRequest
 from ...models.search_entities_response import SearchEntitiesResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: SearchEntitiesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,10 +79,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchEntitiesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, SearchEntitiesResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (SearchEntitiesRequest):
 
     Raises:
@@ -93,6 +98,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -107,10 +113,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchEntitiesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, SearchEntitiesResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (SearchEntitiesRequest):
 
     Raises:
@@ -125,6 +133,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -133,10 +142,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchEntitiesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, SearchEntitiesResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (SearchEntitiesRequest):
 
     Raises:
@@ -150,6 +161,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,10 +174,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: SearchEntitiesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, SearchEntitiesResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (SearchEntitiesRequest):
 
     Raises:
@@ -181,5 +195,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/entities/upsert_entity_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/entities/upsert_entity_v2.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.upsert_entity_request import UpsertEntityRequest
 from ...models.upsert_entity_response import UpsertEntityResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: UpsertEntityRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,10 +79,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpsertEntityRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpsertEntityRequest):
 
     Raises:
@@ -93,6 +98,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -107,10 +113,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpsertEntityRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpsertEntityRequest):
 
     Raises:
@@ -125,6 +133,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -133,10 +142,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpsertEntityRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpsertEntityRequest):
 
     Raises:
@@ -150,6 +161,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,10 +174,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpsertEntityRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpsertEntityResponse]]:
     """
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpsertEntityRequest):
 
     Raises:
@@ -181,5 +195,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/batch_create_edges.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/batch_create_edges.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.batch_create_edges_request import BatchCreateEdgesRequest
 from ...models.batch_edges_response import BatchEdgesResponse
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: BatchCreateEdgesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,6 +79,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateEdgesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[BatchEdgesResponse, ErrorResponse]]:
     """Create multiple edges in a single call.
 
@@ -83,6 +87,7 @@ def sync_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateEdgesRequest): Body for `POST /api/v2/graphs/{id}/edges/batch`.
 
     Raises:
@@ -96,6 +101,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -110,6 +116,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateEdgesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[BatchEdgesResponse, ErrorResponse]]:
     """Create multiple edges in a single call.
 
@@ -117,6 +124,7 @@ def sync(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateEdgesRequest): Body for `POST /api/v2/graphs/{id}/edges/batch`.
 
     Raises:
@@ -131,6 +139,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -139,6 +148,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateEdgesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[BatchEdgesResponse, ErrorResponse]]:
     """Create multiple edges in a single call.
 
@@ -146,6 +156,7 @@ async def asyncio_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateEdgesRequest): Body for `POST /api/v2/graphs/{id}/edges/batch`.
 
     Raises:
@@ -159,6 +170,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -171,6 +183,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateEdgesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[BatchEdgesResponse, ErrorResponse]]:
     """Create multiple edges in a single call.
 
@@ -178,6 +191,7 @@ async def asyncio(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateEdgesRequest): Body for `POST /api/v2/graphs/{id}/edges/batch`.
 
     Raises:
@@ -193,5 +207,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/batch_create_nodes.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/batch_create_nodes.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.batch_create_nodes_request import BatchCreateNodesRequest
 from ...models.batch_nodes_response import BatchNodesResponse
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: BatchCreateNodesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,6 +79,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateNodesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[BatchNodesResponse, ErrorResponse]]:
     """Create multiple nodes in a single call.
 
@@ -84,6 +88,7 @@ def sync_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateNodesRequest): Body for `POST /api/v2/graphs/{id}/nodes/batch`.
 
     Raises:
@@ -97,6 +102,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -111,6 +117,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateNodesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[BatchNodesResponse, ErrorResponse]]:
     """Create multiple nodes in a single call.
 
@@ -119,6 +126,7 @@ def sync(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateNodesRequest): Body for `POST /api/v2/graphs/{id}/nodes/batch`.
 
     Raises:
@@ -133,6 +141,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -141,6 +150,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateNodesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[BatchNodesResponse, ErrorResponse]]:
     """Create multiple nodes in a single call.
 
@@ -149,6 +159,7 @@ async def asyncio_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateNodesRequest): Body for `POST /api/v2/graphs/{id}/nodes/batch`.
 
     Raises:
@@ -162,6 +173,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -174,6 +186,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: BatchCreateNodesRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[BatchNodesResponse, ErrorResponse]]:
     """Create multiple nodes in a single call.
 
@@ -182,6 +195,7 @@ async def asyncio(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (BatchCreateNodesRequest): Body for `POST /api/v2/graphs/{id}/nodes/batch`.
 
     Raises:
@@ -197,5 +211,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_edge.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_edge.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_edge_request import CreateEdgeRequest
 from ...models.edge_response import EdgeResponse
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: CreateEdgeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,11 +79,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateEdgeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[EdgeResponse, ErrorResponse]]:
     """Create an edge in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateEdgeRequest): Wrapped envelope: server expects `{"edge": EdgeInput}`.
 
     Raises:
@@ -94,6 +99,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -108,11 +114,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateEdgeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[EdgeResponse, ErrorResponse]]:
     """Create an edge in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateEdgeRequest): Wrapped envelope: server expects `{"edge": EdgeInput}`.
 
     Raises:
@@ -127,6 +135,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -135,11 +144,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateEdgeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[EdgeResponse, ErrorResponse]]:
     """Create an edge in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateEdgeRequest): Wrapped envelope: server expects `{"edge": EdgeInput}`.
 
     Raises:
@@ -153,6 +164,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -165,11 +177,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateEdgeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[EdgeResponse, ErrorResponse]]:
     """Create an edge in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateEdgeRequest): Wrapped envelope: server expects `{"edge": EdgeInput}`.
 
     Raises:
@@ -185,5 +199,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_graph.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_graph.py
@@ -13,14 +13,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_graph_request import CreateGraphRequest
 from ...models.error_response import ErrorResponse
 from ...models.graph_collection_response import GraphCollectionResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: CreateGraphRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -68,10 +71,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateGraphRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, GraphCollectionResponse]]:
     """Create a graph collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateGraphRequest):
 
     Raises:
@@ -84,6 +89,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,10 +103,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateGraphRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, GraphCollectionResponse]]:
     """Create a graph collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateGraphRequest):
 
     Raises:
@@ -114,6 +122,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -121,10 +130,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateGraphRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, GraphCollectionResponse]]:
     """Create a graph collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateGraphRequest):
 
     Raises:
@@ -137,6 +148,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -148,10 +160,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateGraphRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, GraphCollectionResponse]]:
     """Create a graph collection.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (CreateGraphRequest):
 
     Raises:
@@ -166,5 +180,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_node.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/create_node.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.create_node_request import CreateNodeRequest
 from ...models.error_response import ErrorResponse
 from ...models.node_response import NodeResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: CreateNodeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,11 +79,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateNodeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, NodeResponse]]:
     """Create a node in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateNodeRequest): Wrapped envelope: server expects `{"node": NodeInput}`.
 
     Raises:
@@ -94,6 +99,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -108,11 +114,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateNodeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, NodeResponse]]:
     """Create a node in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateNodeRequest): Wrapped envelope: server expects `{"node": NodeInput}`.
 
     Raises:
@@ -127,6 +135,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -135,11 +144,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateNodeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, NodeResponse]]:
     """Create a node in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateNodeRequest): Wrapped envelope: server expects `{"node": NodeInput}`.
 
     Raises:
@@ -153,6 +164,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -165,11 +177,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: CreateNodeRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, NodeResponse]]:
     """Create a node in a graph.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (CreateNodeRequest): Wrapped envelope: server expects `{"node": NodeInput}`.
 
     Raises:
@@ -185,5 +199,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/delete_graph.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/delete_graph.py
@@ -12,12 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_graph_response import DeleteGraphResponse
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
@@ -26,6 +31,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -61,11 +67,13 @@ def sync_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteGraphResponse, ErrorResponse]]:
     """Delete a graph collection.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,6 +85,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -90,11 +99,13 @@ def sync(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteGraphResponse, ErrorResponse]]:
     """Delete a graph collection.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +118,7 @@ def sync(
     return sync_detailed(
         graph_id=graph_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -114,11 +126,13 @@ async def asyncio_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteGraphResponse, ErrorResponse]]:
     """Delete a graph collection.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -130,6 +144,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -141,11 +156,13 @@ async def asyncio(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteGraphResponse, ErrorResponse]]:
     """Delete a graph collection.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,5 +176,6 @@ async def asyncio(
         await asyncio_detailed(
             graph_id=graph_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/delete_node.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/delete_node.py
@@ -12,13 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_node_response import DeleteNodeResponse
 from ...models.error_response import ErrorResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     node_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
@@ -28,6 +33,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -64,12 +70,14 @@ def sync_detailed(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteNodeResponse, ErrorResponse]]:
     """Delete a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -82,6 +90,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         node_id=node_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -96,12 +105,14 @@ def sync(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteNodeResponse, ErrorResponse]]:
     """Delete a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +126,7 @@ def sync(
         graph_id=graph_id,
         node_id=node_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -123,12 +135,14 @@ async def asyncio_detailed(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[DeleteNodeResponse, ErrorResponse]]:
     """Delete a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +155,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         node_id=node_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -153,12 +168,14 @@ async def asyncio(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[DeleteNodeResponse, ErrorResponse]]:
     """Delete a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +190,6 @@ async def asyncio(
             graph_id=graph_id,
             node_id=node_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/fusion_search_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/fusion_search_v2.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.fusion_search_request import FusionSearchRequest
 from ...models.fusion_search_response import FusionSearchResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: FusionSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,12 +79,14 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: FusionSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, FusionSearchResponse]]:
     """`POST /api/v2/graphs/{graph_id}/fusion-search` — vector seed → graph expand → calibrated fuse-by-
     oid.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (FusionSearchRequest):
 
     Raises:
@@ -95,6 +100,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -109,12 +115,14 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: FusionSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, FusionSearchResponse]]:
     """`POST /api/v2/graphs/{graph_id}/fusion-search` — vector seed → graph expand → calibrated fuse-by-
     oid.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (FusionSearchRequest):
 
     Raises:
@@ -129,6 +137,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -137,12 +146,14 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: FusionSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, FusionSearchResponse]]:
     """`POST /api/v2/graphs/{graph_id}/fusion-search` — vector seed → graph expand → calibrated fuse-by-
     oid.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (FusionSearchRequest):
 
     Raises:
@@ -156,6 +167,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -168,12 +180,14 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: FusionSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, FusionSearchResponse]]:
     """`POST /api/v2/graphs/{graph_id}/fusion-search` — vector seed → graph expand → calibrated fuse-by-
     oid.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (FusionSearchRequest):
 
     Raises:
@@ -189,5 +203,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_graph.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_graph.py
@@ -12,12 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.graph_collection_response import GraphCollectionResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -26,6 +31,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -61,11 +67,13 @@ def sync_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, GraphCollectionResponse]]:
     """Get a graph collection by id.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,6 +85,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -90,11 +99,13 @@ def sync(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, GraphCollectionResponse]]:
     """Get a graph collection by id.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -107,6 +118,7 @@ def sync(
     return sync_detailed(
         graph_id=graph_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -114,11 +126,13 @@ async def asyncio_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, GraphCollectionResponse]]:
     """Get a graph collection by id.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -130,6 +144,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -141,11 +156,13 @@ async def asyncio(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, GraphCollectionResponse]]:
     """Get a graph collection by id.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,5 +176,6 @@ async def asyncio(
         await asyncio_detailed(
             graph_id=graph_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_graph_stats.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_graph_stats.py
@@ -11,12 +11,17 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.graph_stats_response import GraphStatsResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -25,6 +30,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -56,11 +62,13 @@ def sync_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[GraphStatsResponse]:
     """Get graph statistics.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -72,6 +80,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -85,11 +94,13 @@ def sync(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[GraphStatsResponse]:
     """Get graph statistics.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -102,6 +113,7 @@ def sync(
     return sync_detailed(
         graph_id=graph_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -109,11 +121,13 @@ async def asyncio_detailed(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[GraphStatsResponse]:
     """Get graph statistics.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -125,6 +139,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         graph_id=graph_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -136,11 +151,13 @@ async def asyncio(
     graph_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[GraphStatsResponse]:
     """Get graph statistics.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,5 +171,6 @@ async def asyncio(
         await asyncio_detailed(
             graph_id=graph_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_node.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/get_node.py
@@ -12,13 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.node_response import NodeResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     node_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -28,6 +33,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -64,12 +70,14 @@ def sync_detailed(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, NodeResponse]]:
     """Get a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -82,6 +90,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         node_id=node_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -96,12 +105,14 @@ def sync(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, NodeResponse]]:
     """Get a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +126,7 @@ def sync(
         graph_id=graph_id,
         node_id=node_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -123,12 +135,14 @@ async def asyncio_detailed(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, NodeResponse]]:
     """Get a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +155,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         node_id=node_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -153,12 +168,14 @@ async def asyncio(
     node_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, NodeResponse]]:
     """Get a node by id.
 
     Args:
         graph_id (str):
         node_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,5 +190,6 @@ async def asyncio(
             graph_id=graph_id,
             node_id=node_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/impact_analysis_v2.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/impact_analysis_v2.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.impact_analysis_request import ImpactAnalysisRequest
 from ...models.impact_analysis_response import ImpactAnalysisResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: ImpactAnalysisRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,6 +79,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ImpactAnalysisRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, ImpactAnalysisResponse]]:
     """`POST /api/v2/graphs/{graph_id}/impact-analysis` — forward/backward blast radius (TD-131). The
     server-side baseline for the embedded-parity gate; mirrors
@@ -83,6 +87,7 @@ def sync_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ImpactAnalysisRequest):
 
     Raises:
@@ -96,6 +101,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -110,6 +116,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ImpactAnalysisRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, ImpactAnalysisResponse]]:
     """`POST /api/v2/graphs/{graph_id}/impact-analysis` — forward/backward blast radius (TD-131). The
     server-side baseline for the embedded-parity gate; mirrors
@@ -117,6 +124,7 @@ def sync(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ImpactAnalysisRequest):
 
     Raises:
@@ -131,6 +139,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -139,6 +148,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ImpactAnalysisRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, ImpactAnalysisResponse]]:
     """`POST /api/v2/graphs/{graph_id}/impact-analysis` — forward/backward blast radius (TD-131). The
     server-side baseline for the embedded-parity gate; mirrors
@@ -146,6 +156,7 @@ async def asyncio_detailed(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ImpactAnalysisRequest):
 
     Raises:
@@ -159,6 +170,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -171,6 +183,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ImpactAnalysisRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, ImpactAnalysisResponse]]:
     """`POST /api/v2/graphs/{graph_id}/impact-analysis` — forward/backward blast radius (TD-131). The
     server-side baseline for the embedded-parity gate; mirrors
@@ -178,6 +191,7 @@ async def asyncio(
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ImpactAnalysisRequest):
 
     Raises:
@@ -193,5 +207,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/list_graphs.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/list_graphs.py
@@ -11,16 +11,23 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.list_graphs_response import ListGraphsResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v2/graphs",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -51,8 +58,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListGraphsResponse]:
     """List graph collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -62,7 +73,9 @@ def sync_detailed(
         Response[ListGraphsResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -74,8 +87,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListGraphsResponse]:
     """List graph collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,14 +104,19 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ListGraphsResponse]:
     """List graph collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,7 +126,9 @@ async def asyncio_detailed(
         Response[ListGraphsResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -114,8 +138,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ListGraphsResponse]:
     """List graph collections.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -128,5 +156,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/traverse_graph.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/graphs/traverse_graph.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.traverse_request import TraverseRequest
 from ...models.traverse_response import TraverseResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     graph_id: str,
     *,
     body: TraverseRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -72,11 +75,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TraverseRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, TraverseResponse]]:
     """Traverse a graph from a start node.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TraverseRequest): Flat shape (no wrapper). Matches `RestTraversalRequest` in
             proximadb-api.
 
@@ -91,6 +96,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -105,11 +111,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TraverseRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, TraverseResponse]]:
     """Traverse a graph from a start node.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TraverseRequest): Flat shape (no wrapper). Matches `RestTraversalRequest` in
             proximadb-api.
 
@@ -125,6 +133,7 @@ def sync(
         graph_id=graph_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -133,11 +142,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TraverseRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, TraverseResponse]]:
     """Traverse a graph from a start node.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TraverseRequest): Flat shape (no wrapper). Matches `RestTraversalRequest` in
             proximadb-api.
 
@@ -152,6 +163,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         graph_id=graph_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -164,11 +176,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TraverseRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, TraverseResponse]]:
     """Traverse a graph from a start node.
 
     Args:
         graph_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TraverseRequest): Flat shape (no wrapper). Matches `RestTraversalRequest` in
             proximadb-api.
 
@@ -185,5 +199,6 @@ async def asyncio(
             graph_id=graph_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_health.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_health.py
@@ -11,16 +11,23 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.health_response import HealthResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/health",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -51,8 +58,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[HealthResponse]:
     """Get server health.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -62,7 +73,9 @@ def sync_detailed(
         Response[HealthResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -74,8 +87,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[HealthResponse]:
     """Get server health.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,14 +104,19 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[HealthResponse]:
     """Get server health.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,7 +126,9 @@ async def asyncio_detailed(
         Response[HealthResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -114,8 +138,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[HealthResponse]:
     """Get server health.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -128,5 +156,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_liveness.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_liveness.py
@@ -11,16 +11,23 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.probe_response import ProbeResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/health/live",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -51,8 +58,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ProbeResponse]:
     """Kubernetes liveness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -62,7 +73,9 @@ def sync_detailed(
         Response[ProbeResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -74,8 +87,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ProbeResponse]:
     """Kubernetes liveness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,14 +104,19 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ProbeResponse]:
     """Kubernetes liveness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,7 +126,9 @@ async def asyncio_detailed(
         Response[ProbeResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -114,8 +138,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ProbeResponse]:
     """Kubernetes liveness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -128,5 +156,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_readiness.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/health/get_readiness.py
@@ -11,16 +11,23 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.probe_response import ProbeResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/health/ready",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -51,8 +58,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ProbeResponse]:
     """Kubernetes readiness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -62,7 +73,9 @@ def sync_detailed(
         Response[ProbeResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -74,8 +87,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ProbeResponse]:
     """Kubernetes readiness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -87,14 +104,19 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[ProbeResponse]:
     """Kubernetes readiness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,7 +126,9 @@ async def asyncio_detailed(
         Response[ProbeResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -114,8 +138,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[ProbeResponse]:
     """Kubernetes readiness probe.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -128,5 +156,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/hybrid/hybrid_index.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/hybrid/hybrid_index.py
@@ -12,14 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.hybrid_index_body import HybridIndexBody
 from ...models.hybrid_index_response_200 import HybridIndexResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: HybridIndexBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -63,10 +66,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridIndexBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[HybridIndexResponse200]:
     """Index documents for BM25 full-text search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridIndexBody):
 
     Raises:
@@ -79,6 +84,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -92,10 +98,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridIndexBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[HybridIndexResponse200]:
     """Index documents for BM25 full-text search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridIndexBody):
 
     Raises:
@@ -109,6 +117,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -116,10 +125,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridIndexBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[HybridIndexResponse200]:
     """Index documents for BM25 full-text search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridIndexBody):
 
     Raises:
@@ -132,6 +143,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -143,10 +155,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridIndexBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[HybridIndexResponse200]:
     """Index documents for BM25 full-text search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridIndexBody):
 
     Raises:
@@ -161,5 +175,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/hybrid/hybrid_search.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/hybrid/hybrid_search.py
@@ -13,14 +13,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.hybrid_search_body import HybridSearchBody
 from ...models.hybrid_search_response_200 import HybridSearchResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: HybridSearchBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -68,10 +71,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridSearchBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, HybridSearchResponse200]]:
     """BM25 + vector hybrid (fusion) search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridSearchBody):
 
     Raises:
@@ -84,6 +89,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,10 +103,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridSearchBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, HybridSearchResponse200]]:
     """BM25 + vector hybrid (fusion) search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridSearchBody):
 
     Raises:
@@ -114,6 +122,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -121,10 +130,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridSearchBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, HybridSearchResponse200]]:
     """BM25 + vector hybrid (fusion) search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridSearchBody):
 
     Raises:
@@ -137,6 +148,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -148,10 +160,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: HybridSearchBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, HybridSearchResponse200]]:
     """BM25 + vector hybrid (fusion) search.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (HybridSearchBody):
 
     Raises:
@@ -166,5 +180,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/meta/get_capabilities.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/meta/get_capabilities.py
@@ -11,16 +11,23 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.capabilities_response import CapabilitiesResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
-def _get_kwargs() -> dict[str, Any]:
+def _get_kwargs(
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v2/_meta/capabilities",
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -51,11 +58,15 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[CapabilitiesResponse]:
     """Negotiate server capabilities.
 
      Advertises API version, supported features, limits, and the error- envelope contract so SDKs can
     adapt instead of hard-coding assumptions.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -65,7 +76,9 @@ def sync_detailed(
         Response[CapabilitiesResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -77,11 +90,15 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[CapabilitiesResponse]:
     """Negotiate server capabilities.
 
      Advertises API version, supported features, limits, and the error- envelope contract so SDKs can
     adapt instead of hard-coding assumptions.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -93,17 +110,22 @@ def sync(
 
     return sync_detailed(
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[CapabilitiesResponse]:
     """Negotiate server capabilities.
 
      Advertises API version, supported features, limits, and the error- envelope contract so SDKs can
     adapt instead of hard-coding assumptions.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -113,7 +135,9 @@ async def asyncio_detailed(
         Response[CapabilitiesResponse]
     """
 
-    kwargs = _get_kwargs()
+    kwargs = _get_kwargs(
+        x_tenant_id=x_tenant_id,
+    )
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -123,11 +147,15 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[CapabilitiesResponse]:
     """Negotiate server capabilities.
 
      Advertises API version, supported features, limits, and the error- envelope contract so SDKs can
     adapt instead of hard-coding assumptions.
+
+    Args:
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -140,5 +168,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/observability/ingest_log.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/observability/ingest_log.py
@@ -12,15 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.ingest_log_body import IngestLogBody
 from ...models.ingest_log_response_200 import IngestLogResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     namespace: str,
     *,
     body: IngestLogBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -67,11 +70,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestLogBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[IngestLogResponse200]:
     """Ingest a log entry.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestLogBody):
 
     Raises:
@@ -85,6 +90,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         namespace=namespace,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -99,11 +105,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestLogBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[IngestLogResponse200]:
     """Ingest a log entry.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestLogBody):
 
     Raises:
@@ -118,6 +126,7 @@ def sync(
         namespace=namespace,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -126,11 +135,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestLogBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[IngestLogResponse200]:
     """Ingest a log entry.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestLogBody):
 
     Raises:
@@ -144,6 +155,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         namespace=namespace,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -156,11 +168,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: IngestLogBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[IngestLogResponse200]:
     """Ingest a log entry.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (IngestLogBody):
 
     Raises:
@@ -176,5 +190,6 @@ async def asyncio(
             namespace=namespace,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/observability/query_logs.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/observability/query_logs.py
@@ -12,15 +12,18 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.query_logs_body import QueryLogsBody
 from ...models.query_logs_response_200 import QueryLogsResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     namespace: str,
     *,
     body: QueryLogsBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -67,11 +70,13 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryLogsBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryLogsResponse200]:
     """Query logs.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (QueryLogsBody):
 
     Raises:
@@ -85,6 +90,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         namespace=namespace,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -99,11 +105,13 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryLogsBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryLogsResponse200]:
     """Query logs.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (QueryLogsBody):
 
     Raises:
@@ -118,6 +126,7 @@ def sync(
         namespace=namespace,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -126,11 +135,13 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryLogsBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryLogsResponse200]:
     """Query logs.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (QueryLogsBody):
 
     Raises:
@@ -144,6 +155,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         namespace=namespace,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -156,11 +168,13 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryLogsBody,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryLogsResponse200]:
     """Query logs.
 
     Args:
         namespace (str):
+        x_tenant_id (Union[Unset, str]):
         body (QueryLogsBody):
 
     Raises:
@@ -176,5 +190,6 @@ async def asyncio(
             namespace=namespace,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/query/execute_query.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/query/execute_query.py
@@ -13,14 +13,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.query_request import QueryRequest
 from ...models.query_response import QueryResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: QueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -68,6 +71,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, QueryResponse]]:
     """Execute AQL or UQL through the shared query facade.
 
@@ -78,6 +82,7 @@ def sync_detailed(
     only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (QueryRequest):
 
     Raises:
@@ -90,6 +95,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -103,6 +109,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, QueryResponse]]:
     """Execute AQL or UQL through the shared query facade.
 
@@ -113,6 +120,7 @@ def sync(
     only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (QueryRequest):
 
     Raises:
@@ -126,6 +134,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -133,6 +142,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, QueryResponse]]:
     """Execute AQL or UQL through the shared query facade.
 
@@ -143,6 +153,7 @@ async def asyncio_detailed(
     only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (QueryRequest):
 
     Raises:
@@ -155,6 +166,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -166,6 +178,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: QueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, QueryResponse]]:
     """Execute AQL or UQL through the shared query facade.
 
@@ -176,6 +189,7 @@ async def asyncio(
     only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (QueryRequest):
 
     Raises:
@@ -190,5 +204,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/query/explain_query.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/query/explain_query.py
@@ -13,14 +13,17 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.explain_query_request import ExplainQueryRequest
 from ...models.query_response import QueryResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     body: ExplainQueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -68,10 +71,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ExplainQueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, QueryResponse]]:
     """Explain an AQL or UQL query through the shared query facade.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (ExplainQueryRequest):
 
     Raises:
@@ -84,6 +89,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -97,10 +103,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ExplainQueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, QueryResponse]]:
     """Explain an AQL or UQL query through the shared query facade.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (ExplainQueryRequest):
 
     Raises:
@@ -114,6 +122,7 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -121,10 +130,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ExplainQueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, QueryResponse]]:
     """Explain an AQL or UQL query through the shared query facade.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (ExplainQueryRequest):
 
     Raises:
@@ -137,6 +148,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -148,10 +160,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ExplainQueryRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, QueryResponse]]:
     """Explain an AQL or UQL query through the shared query facade.
 
     Args:
+        x_tenant_id (Union[Unset, str]):
         body (ExplainQueryRequest):
 
     Raises:
@@ -166,5 +180,6 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/records/delete_record.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/records/delete_record.py
@@ -11,13 +11,18 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.delete_record_v2_response import DeleteRecordV2Response
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     record_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
@@ -27,6 +32,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -59,6 +65,7 @@ def sync_detailed(
     record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[DeleteRecordV2Response]:
     """Delete a record by ID.
 
@@ -67,6 +74,7 @@ def sync_detailed(
     Args:
         collection_id (str):
         record_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -79,6 +87,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         record_id=record_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -93,6 +102,7 @@ def sync(
     record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[DeleteRecordV2Response]:
     """Delete a record by ID.
 
@@ -101,6 +111,7 @@ def sync(
     Args:
         collection_id (str):
         record_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -114,6 +125,7 @@ def sync(
         collection_id=collection_id,
         record_id=record_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -122,6 +134,7 @@ async def asyncio_detailed(
     record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[DeleteRecordV2Response]:
     """Delete a record by ID.
 
@@ -130,6 +143,7 @@ async def asyncio_detailed(
     Args:
         collection_id (str):
         record_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -142,6 +156,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         record_id=record_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -154,6 +169,7 @@ async def asyncio(
     record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[DeleteRecordV2Response]:
     """Delete a record by ID.
 
@@ -162,6 +178,7 @@ async def asyncio(
     Args:
         collection_id (str):
         record_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -176,5 +193,6 @@ async def asyncio(
             collection_id=collection_id,
             record_id=record_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/records/get_record.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/records/get_record.py
@@ -21,7 +21,11 @@ def _get_kwargs(
     *,
     include_vector: Union[Unset, bool] = UNSET,
     include_text: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     params: dict[str, Any] = {}
 
@@ -40,6 +44,7 @@ def _get_kwargs(
         "params": params,
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -78,6 +83,7 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     include_vector: Union[Unset, bool] = UNSET,
     include_text: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, RecordV2Response]]:
     """Get a record by ID.
 
@@ -107,6 +113,7 @@ def sync_detailed(
         record_id (str):
         include_vector (Union[Unset, bool]):
         include_text (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -121,6 +128,7 @@ def sync_detailed(
         record_id=record_id,
         include_vector=include_vector,
         include_text=include_text,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -137,6 +145,7 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     include_vector: Union[Unset, bool] = UNSET,
     include_text: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, RecordV2Response]]:
     """Get a record by ID.
 
@@ -166,6 +175,7 @@ def sync(
         record_id (str):
         include_vector (Union[Unset, bool]):
         include_text (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -181,6 +191,7 @@ def sync(
         client=client,
         include_vector=include_vector,
         include_text=include_text,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -191,6 +202,7 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     include_vector: Union[Unset, bool] = UNSET,
     include_text: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, RecordV2Response]]:
     """Get a record by ID.
 
@@ -220,6 +232,7 @@ async def asyncio_detailed(
         record_id (str):
         include_vector (Union[Unset, bool]):
         include_text (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -234,6 +247,7 @@ async def asyncio_detailed(
         record_id=record_id,
         include_vector=include_vector,
         include_text=include_text,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -248,6 +262,7 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     include_vector: Union[Unset, bool] = UNSET,
     include_text: Union[Unset, bool] = UNSET,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, RecordV2Response]]:
     """Get a record by ID.
 
@@ -277,6 +292,7 @@ async def asyncio(
         record_id (str):
         include_vector (Union[Unset, bool]):
         include_text (Union[Unset, bool]):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -293,5 +309,6 @@ async def asyncio(
             client=client,
             include_vector=include_vector,
             include_text=include_text,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/records/insert_records.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/records/insert_records.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.insert_records_request import InsertRecordsRequest
 from ...models.insert_records_response import InsertRecordsResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: InsertRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -72,6 +75,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, InsertRecordsResponse]]:
     """Insert or upsert ProximaRecord batches.
 
@@ -93,6 +97,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertRecordsRequest): Request to insert ProximaRecords
 
             ## Example JSON
@@ -138,6 +143,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -152,6 +158,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, InsertRecordsResponse]]:
     """Insert or upsert ProximaRecord batches.
 
@@ -173,6 +180,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertRecordsRequest): Request to insert ProximaRecords
 
             ## Example JSON
@@ -219,6 +227,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -227,6 +236,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, InsertRecordsResponse]]:
     """Insert or upsert ProximaRecord batches.
 
@@ -248,6 +258,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertRecordsRequest): Request to insert ProximaRecords
 
             ## Example JSON
@@ -293,6 +304,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -305,6 +317,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: InsertRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, InsertRecordsResponse]]:
     """Insert or upsert ProximaRecord batches.
 
@@ -326,6 +339,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (InsertRecordsRequest): Request to insert ProximaRecords
 
             ## Example JSON
@@ -373,5 +387,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/records/scan_records.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/records/scan_records.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.scan_records_request import ScanRecordsRequest
 from ...models.scan_records_response import ScanRecordsResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: ScanRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -76,6 +79,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ScanRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, ScanRecordsResponse]]:
     """Paginated scan of records in a collection.
 
@@ -89,6 +93,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ScanRecordsRequest): Body of `POST /records/scan`. Mirrors the OpenAPI
             `ScanRecordsRequest`
             schema; all fields optional so an empty `{}` returns the first page.
@@ -104,6 +109,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -118,6 +124,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ScanRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, ScanRecordsResponse]]:
     """Paginated scan of records in a collection.
 
@@ -131,6 +138,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ScanRecordsRequest): Body of `POST /records/scan`. Mirrors the OpenAPI
             `ScanRecordsRequest`
             schema; all fields optional so an empty `{}` returns the first page.
@@ -147,6 +155,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -155,6 +164,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ScanRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, ScanRecordsResponse]]:
     """Paginated scan of records in a collection.
 
@@ -168,6 +178,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ScanRecordsRequest): Body of `POST /records/scan`. Mirrors the OpenAPI
             `ScanRecordsRequest`
             schema; all fields optional so an empty `{}` returns the first page.
@@ -183,6 +194,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -195,6 +207,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: ScanRecordsRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, ScanRecordsResponse]]:
     """Paginated scan of records in a collection.
 
@@ -208,6 +221,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (ScanRecordsRequest): Body of `POST /records/scan`. Mirrors the OpenAPI
             `ScanRecordsRequest`
             schema; all fields optional so an empty `{}` returns the first page.
@@ -225,5 +239,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/schema/get_collection_schema.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/schema/get_collection_schema.py
@@ -12,12 +12,17 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.schema_response import SchemaResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
+    *,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "get",
@@ -26,6 +31,7 @@ def _get_kwargs(
         ),
     }
 
+    _kwargs["headers"] = headers
     return _kwargs
 
 
@@ -61,6 +67,7 @@ def sync_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, SchemaResponse]]:
     """Get collection schema.
 
@@ -81,6 +88,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -92,6 +100,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -105,6 +114,7 @@ def sync(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, SchemaResponse]]:
     """Get collection schema.
 
@@ -125,6 +135,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -137,6 +148,7 @@ def sync(
     return sync_detailed(
         collection_id=collection_id,
         client=client,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -144,6 +156,7 @@ async def asyncio_detailed(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, SchemaResponse]]:
     """Get collection schema.
 
@@ -164,6 +177,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -175,6 +189,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         collection_id=collection_id,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -186,6 +201,7 @@ async def asyncio(
     collection_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, SchemaResponse]]:
     """Get collection schema.
 
@@ -206,6 +222,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -219,5 +236,6 @@ async def asyncio(
         await asyncio_detailed(
             collection_id=collection_id,
             client=client,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/schema/update_collection_schema.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/schema/update_collection_schema.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.update_schema_request import UpdateSchemaRequest
 from ...models.update_schema_response import UpdateSchemaResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: UpdateSchemaRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "put",
@@ -72,6 +75,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateSchemaRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpdateSchemaResponse]]:
     """Update collection schema.
 
@@ -103,6 +107,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpdateSchemaRequest): Request to update schema
 
             ## Schema Evolution Rules
@@ -137,6 +142,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -151,6 +157,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateSchemaRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpdateSchemaResponse]]:
     """Update collection schema.
 
@@ -182,6 +189,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpdateSchemaRequest): Request to update schema
 
             ## Schema Evolution Rules
@@ -217,6 +225,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -225,6 +234,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateSchemaRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, UpdateSchemaResponse]]:
     """Update collection schema.
 
@@ -256,6 +266,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpdateSchemaRequest): Request to update schema
 
             ## Schema Evolution Rules
@@ -290,6 +301,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -302,6 +314,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: UpdateSchemaRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, UpdateSchemaResponse]]:
     """Update collection schema.
 
@@ -333,6 +346,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (UpdateSchemaRequest): Request to update schema
 
             ## Schema Evolution Rules
@@ -369,5 +383,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/python/src/proximadb_sdk/_generated/rest/api/search/search_records.py
+++ b/clients/python/src/proximadb_sdk/_generated/rest/api/search/search_records.py
@@ -13,15 +13,18 @@ from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
 from ...models.typed_search_request import TypedSearchRequest
 from ...models.typed_search_response import TypedSearchResponse
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     collection_id: str,
     *,
     body: TypedSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
+    if not isinstance(x_tenant_id, Unset):
+        headers["X-Tenant-ID"] = x_tenant_id
 
     _kwargs: dict[str, Any] = {
         "method": "post",
@@ -72,6 +75,7 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TypedSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, TypedSearchResponse]]:
     """Search records with vector similarity and typed filters.
 
@@ -93,6 +97,7 @@ def sync_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TypedSearchRequest): Search request with typed filters
 
             ## Example JSON
@@ -121,6 +126,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = client.get_httpx_client().request(
@@ -135,6 +141,7 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TypedSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, TypedSearchResponse]]:
     """Search records with vector similarity and typed filters.
 
@@ -156,6 +163,7 @@ def sync(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TypedSearchRequest): Search request with typed filters
 
             ## Example JSON
@@ -185,6 +193,7 @@ def sync(
         collection_id=collection_id,
         client=client,
         body=body,
+        x_tenant_id=x_tenant_id,
     ).parsed
 
 
@@ -193,6 +202,7 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TypedSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Response[Union[ErrorResponse, TypedSearchResponse]]:
     """Search records with vector similarity and typed filters.
 
@@ -214,6 +224,7 @@ async def asyncio_detailed(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TypedSearchRequest): Search request with typed filters
 
             ## Example JSON
@@ -242,6 +253,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         collection_id=collection_id,
         body=body,
+        x_tenant_id=x_tenant_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -254,6 +266,7 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     body: TypedSearchRequest,
+    x_tenant_id: Union[Unset, str] = UNSET,
 ) -> Optional[Union[ErrorResponse, TypedSearchResponse]]:
     """Search records with vector similarity and typed filters.
 
@@ -275,6 +288,7 @@ async def asyncio(
 
     Args:
         collection_id (str):
+        x_tenant_id (Union[Unset, str]):
         body (TypedSearchRequest): Search request with typed filters
 
             ## Example JSON
@@ -305,5 +319,6 @@ async def asyncio(
             collection_id=collection_id,
             client=client,
             body=body,
+            x_tenant_id=x_tenant_id,
         )
     ).parsed

--- a/clients/rust/src/genrest.rs
+++ b/clients/rust/src/genrest.rs
@@ -13965,8 +13965,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/_meta/capabilities`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_capabilities()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -13997,11 +14000,13 @@ impl Client {
     /// - `include_stats`: Whether to include statistics
     /// - `limit`: Maximum number of collections to return (default: 100)
     /// - `offset`: Offset for pagination (default: 0)
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.list_collections()
     /// .include_stats(include_stats)
     /// .limit(limit)
     /// .offset(offset)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14028,8 +14033,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/collections`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.create_collection()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14058,9 +14067,11 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_collection()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14077,9 +14088,11 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.delete_collection()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14094,10 +14107,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Target collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.ingest_documents()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14109,10 +14124,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection backing the entities
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.upsert_entity_v2()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14124,10 +14141,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection backing the entities
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.search_entities_v2()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14140,10 +14159,12 @@ impl Client {
     /// Arguments:
     /// - `collection_id`: Collection backing the entities
     /// - `entity_id`: Entity ID
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_entity_v2()
     /// .collection_id(collection_id)
     /// .entity_id(entity_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14155,10 +14176,12 @@ impl Client {
     /// Arguments:
     /// - `collection_id`: Collection backing the entities
     /// - `entity_id`: Entity ID
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.delete_entity_v2()
     /// .collection_id(collection_id)
     /// .entity_id(entity_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14187,10 +14210,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.insert_records()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14212,10 +14237,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.scan_records()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14253,12 +14280,14 @@ impl Client {
     /// - `record_id`: Record ID.
     /// - `include_text`: Whether to include TEXT fields in the response
     /// - `include_vector`: Whether to include the vector in the response
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_record()
     /// .collection_id(collection_id)
     /// .record_id(record_id)
     /// .include_text(include_text)
     /// .include_vector(include_vector)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14274,10 +14303,12 @@ impl Client {
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
     /// - `record_id`: Record ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.delete_record()
     /// .collection_id(collection_id)
     /// .record_id(record_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14305,9 +14336,11 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_collection_schema()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14346,10 +14379,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.update_collection_schema()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14379,10 +14414,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `collection_id`: Collection name/ID.
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.search_records()
     /// .collection_id(collection_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14394,8 +14431,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/document-collections`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.list_document_collections()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14406,8 +14446,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/document-collections`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.create_document_collection()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14419,9 +14463,13 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/document-collections/{collection}/documents`
     ///
+    /// Arguments:
+    /// - `collection`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.query_documents()
     /// .collection(collection)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14432,9 +14480,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/document-collections/{collection}/documents`
     ///
+    /// Arguments:
+    /// - `collection`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.insert_document()
     /// .collection(collection)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14446,8 +14499,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/graphs`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.list_graphs()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14458,8 +14514,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.create_graph()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14471,9 +14531,13 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/graphs/{graph_id}`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_graph()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14484,9 +14548,13 @@ impl Client {
     ///
     /// Sends a `DELETE` request to `/api/v2/graphs/{graph_id}`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.delete_graph()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14497,9 +14565,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs/{graph_id}/edges`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.create_edge()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14514,9 +14587,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs/{graph_id}/edges/batch`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.batch_create_edges()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14530,10 +14608,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `graph_id`: Graph ID for traversal expansion
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.fusion_search_v2()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14548,10 +14628,12 @@ impl Client {
     ///
     /// Arguments:
     /// - `graph_id`: Graph ID
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// - `body`
     /// ```text
     /// let response = client.impact_analysis_v2()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14563,9 +14645,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs/{graph_id}/nodes`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.create_node()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14581,9 +14668,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs/{graph_id}/nodes/batch`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.batch_create_nodes()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14595,10 +14687,15 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/graphs/{graph_id}/nodes/{node_id}`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `node_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_node()
     /// .graph_id(graph_id)
     /// .node_id(node_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14609,10 +14706,15 @@ impl Client {
     ///
     /// Sends a `DELETE` request to `/api/v2/graphs/{graph_id}/nodes/{node_id}`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `node_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.delete_node()
     /// .graph_id(graph_id)
     /// .node_id(node_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14623,9 +14725,13 @@ impl Client {
     ///
     /// Sends a `GET` request to `/api/v2/graphs/{graph_id}/stats`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_graph_stats()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14636,9 +14742,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/graphs/{graph_id}/traverse`
     ///
+    /// Arguments:
+    /// - `graph_id`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.traverse_graph()
     /// .graph_id(graph_id)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14650,8 +14761,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/hybrid/index`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.hybrid_index()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14663,8 +14778,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/hybrid/search`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.hybrid_search()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14676,9 +14795,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/observability/namespaces/{namespace}/logs`
     ///
+    /// Arguments:
+    /// - `namespace`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.ingest_log()
     /// .namespace(namespace)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14690,9 +14814,14 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/observability/namespaces/{namespace}/logs/search`
     ///
+    /// Arguments:
+    /// - `namespace`
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.query_logs()
     /// .namespace(namespace)
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14710,8 +14839,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/query`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.execute_query()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14723,8 +14856,12 @@ impl Client {
     ///
     /// Sends a `POST` request to `/api/v2/query/explain`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+    /// - `body`
     /// ```text
     /// let response = client.explain_query()
+    /// .x_tenant_id(x_tenant_id)
     /// .body(body)
     /// .send()
     /// .await;
@@ -14736,8 +14873,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/health`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_health()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14748,8 +14888,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/health/live`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_liveness()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14760,8 +14903,11 @@ impl Client {
     ///
     /// Sends a `GET` request to `/health/ready`
     ///
+    /// Arguments:
+    /// - `x_tenant_id`: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
     /// ```text
     /// let response = client.get_readiness()
+    /// .x_tenant_id(x_tenant_id)
     /// .send()
     /// .await;
     /// ```
@@ -14784,20 +14930,40 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GetCapabilities<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetCapabilities<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/api/v2/_meta/capabilities`
         pub async fn send(self) -> Result<ResponseValue<types::CapabilitiesResponse>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/_meta/capabilities", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -14830,6 +14996,7 @@ pub mod builder {
         include_stats: Result<Option<bool>, String>,
         limit: Result<Option<i32>, String>,
         offset: Result<Option<i32>, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> ListCollections<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -14838,6 +15005,7 @@ pub mod builder {
                 include_stats: Ok(None),
                 limit: Ok(None),
                 offset: Ok(None),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn include_stats<V>(mut self, value: V) -> Self
@@ -14870,6 +15038,15 @@ pub mod builder {
                 .map_err(|_| "conversion to `i32` for offset failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/collections`
         pub async fn send(
             self,
@@ -14879,16 +15056,21 @@ pub mod builder {
                 include_stats,
                 limit,
                 offset,
+                x_tenant_id,
             } = self;
             let include_stats = include_stats.map_err(Error::InvalidRequest)?;
             let limit = limit.map_err(Error::InvalidRequest)?;
             let offset = offset.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/collections", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -14924,14 +15106,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct CreateCollection<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::CreateCollectionV2Request, String>,
     }
     impl<'a> CreateCollection<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -14961,18 +15154,26 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::CreateCollectionV2Response>, Error<types::ErrorResponse>>
         {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| {
                     types::CreateCollectionV2Request::try_from(v).map_err(|e| e.to_string())
                 })
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/collections", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15007,12 +15208,14 @@ pub mod builder {
     pub struct GetCollection<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetCollection<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15024,6 +15227,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/collections/{collection_id}`
         pub async fn send(
             self,
@@ -15032,18 +15244,23 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15077,12 +15294,14 @@ pub mod builder {
     pub struct DeleteCollection<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> DeleteCollection<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15094,6 +15313,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `DELETE` request to `/api/v2/collections/{collection_id}`
         pub async fn send(
             self,
@@ -15102,18 +15330,23 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15147,6 +15380,7 @@ pub mod builder {
     pub struct IngestDocuments<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::IngestDocumentsRequest, String>,
     }
     impl<'a> IngestDocuments<'a> {
@@ -15154,6 +15388,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -15163,6 +15398,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -15196,9 +15440,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::IngestDocumentsRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -15207,11 +15453,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15249,6 +15498,7 @@ pub mod builder {
     pub struct UpsertEntityV2<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::UpsertEntityRequest, String>,
     }
     impl<'a> UpsertEntityV2<'a> {
@@ -15256,6 +15506,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -15265,6 +15516,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -15296,9 +15556,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::UpsertEntityRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -15307,11 +15569,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15349,6 +15614,7 @@ pub mod builder {
     pub struct SearchEntitiesV2<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::SearchEntitiesRequest, String>,
     }
     impl<'a> SearchEntitiesV2<'a> {
@@ -15356,6 +15622,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -15365,6 +15632,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -15398,9 +15674,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::SearchEntitiesRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -15409,11 +15687,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15452,6 +15733,7 @@ pub mod builder {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
         entity_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetEntityV2<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -15459,6 +15741,7 @@ pub mod builder {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
                 entity_id: Err("entity_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15479,6 +15762,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/collections/{collection_id}/entities/{entity_id}`
         pub async fn send(
             self,
@@ -15487,20 +15779,25 @@ pub mod builder {
                 client,
                 collection_id,
                 entity_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
             let entity_id = entity_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}/entities/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
                 encode_path(&entity_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15538,6 +15835,7 @@ pub mod builder {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
         entity_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> DeleteEntityV2<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -15545,6 +15843,7 @@ pub mod builder {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
                 entity_id: Err("entity_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15565,6 +15864,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `DELETE` request to `/api/v2/collections/{collection_id}/entities/{entity_id}`
         pub async fn send(
             self,
@@ -15574,20 +15882,25 @@ pub mod builder {
                 client,
                 collection_id,
                 entity_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
             let entity_id = entity_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}/entities/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
                 encode_path(&entity_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15624,6 +15937,7 @@ pub mod builder {
     pub struct InsertRecords<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::InsertRecordsRequest, String>,
     }
     impl<'a> InsertRecords<'a> {
@@ -15631,6 +15945,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -15640,6 +15955,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -15673,9 +15997,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::InsertRecordsRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -15684,11 +16010,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15723,6 +16052,7 @@ pub mod builder {
     pub struct ScanRecords<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::ScanRecordsRequest, String>,
     }
     impl<'a> ScanRecords<'a> {
@@ -15730,6 +16060,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -15739,6 +16070,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -15770,9 +16110,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::ScanRecordsRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -15781,11 +16123,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15826,6 +16171,7 @@ pub mod builder {
         record_id: Result<::std::string::String, String>,
         include_text: Result<Option<bool>, String>,
         include_vector: Result<Option<bool>, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetRecord<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -15835,6 +16181,7 @@ pub mod builder {
                 record_id: Err("record_id was not initialized".to_string()),
                 include_text: Ok(None),
                 include_vector: Ok(None),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15875,6 +16222,15 @@ pub mod builder {
                 .map_err(|_| "conversion to `bool` for include_vector failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/collections/{collection_id}/records/{record_id}`
         pub async fn send(
             self,
@@ -15885,22 +16241,27 @@ pub mod builder {
                 record_id,
                 include_text,
                 include_vector,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
             let record_id = record_id.map_err(Error::InvalidRequest)?;
             let include_text = include_text.map_err(Error::InvalidRequest)?;
             let include_vector = include_vector.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}/records/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
                 encode_path(&record_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -15943,6 +16304,7 @@ pub mod builder {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
         record_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> DeleteRecord<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -15950,6 +16312,7 @@ pub mod builder {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
                 record_id: Err("record_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -15970,26 +16333,40 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `DELETE` request to `/api/v2/collections/{collection_id}/records/{record_id}`
         pub async fn send(self) -> Result<ResponseValue<types::DeleteRecordV2Response>, Error<()>> {
             let Self {
                 client,
                 collection_id,
                 record_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
             let record_id = record_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}/records/{}",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
                 encode_path(&record_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16020,12 +16397,14 @@ pub mod builder {
     pub struct GetCollectionSchema<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetCollectionSchema<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection_id<V>(mut self, value: V) -> Self
@@ -16037,6 +16416,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/collections/{collection_id}/schema`
         pub async fn send(
             self,
@@ -16044,18 +16432,23 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/collections/{}/schema",
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16089,6 +16482,7 @@ pub mod builder {
     pub struct UpdateCollectionSchema<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::UpdateSchemaRequest, String>,
     }
     impl<'a> UpdateCollectionSchema<'a> {
@@ -16096,6 +16490,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -16105,6 +16500,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -16136,9 +16540,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::UpdateSchemaRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -16147,11 +16553,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16186,6 +16595,7 @@ pub mod builder {
     pub struct SearchRecords<'a> {
         client: &'a super::Client,
         collection_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::TypedSearchRequest, String>,
     }
     impl<'a> SearchRecords<'a> {
@@ -16193,6 +16603,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection_id: Err("collection_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -16202,6 +16613,15 @@ pub mod builder {
         {
             self.collection_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -16233,9 +16653,11 @@ pub mod builder {
             let Self {
                 client,
                 collection_id,
+                x_tenant_id,
                 body,
             } = self;
             let collection_id = collection_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::TypedSearchRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -16244,11 +16666,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&collection_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16282,10 +16707,23 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ListDocumentCollections<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> ListDocumentCollections<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/api/v2/document-collections`
         pub async fn send(
@@ -16294,13 +16732,20 @@ pub mod builder {
             ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
             Error<()>,
         > {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/document-collections", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16330,14 +16775,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct CreateDocumentCollection<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<::serde_json::Map<::std::string::String, ::serde_json::Value>, String>,
     }
     impl<'a> CreateDocumentCollection<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Err("body was not initialized".to_string()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -16358,14 +16814,22 @@ pub mod builder {
             ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
             Error<()>,
         > {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/document-collections", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16397,12 +16861,14 @@ pub mod builder {
     pub struct QueryDocuments<'a> {
         client: &'a super::Client,
         collection: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> QueryDocuments<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 collection: Err("collection was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn collection<V>(mut self, value: V) -> Self
@@ -16414,6 +16880,15 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/document-collections/{collection}/documents`
         pub async fn send(
             self,
@@ -16421,18 +16896,26 @@ pub mod builder {
             ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
             Error<()>,
         > {
-            let Self { client, collection } = self;
+            let Self {
+                client,
+                collection,
+                x_tenant_id,
+            } = self;
             let collection = collection.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/document-collections/{}/documents",
                 client.baseurl,
                 encode_path(&collection.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16463,6 +16946,7 @@ pub mod builder {
     pub struct InsertDocument<'a> {
         client: &'a super::Client,
         collection: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<::serde_json::Map<::std::string::String, ::serde_json::Value>, String>,
     }
     impl<'a> InsertDocument<'a> {
@@ -16470,6 +16954,7 @@ pub mod builder {
             Self {
                 client: client,
                 collection: Err("collection was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -16479,6 +16964,15 @@ pub mod builder {
         {
             self.collection = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for collection failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -16504,20 +16998,25 @@ pub mod builder {
             let Self {
                 client,
                 collection,
+                x_tenant_id,
                 body,
             } = self;
             let collection = collection.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/document-collections/{}/documents",
                 client.baseurl,
                 encode_path(&collection.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16551,20 +17050,40 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ListGraphs<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> ListGraphs<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/api/v2/graphs`
         pub async fn send(self) -> Result<ResponseValue<types::ListGraphsResponse>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/graphs", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16594,14 +17113,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct CreateGraph<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::CreateGraphRequest, String>,
     }
     impl<'a> CreateGraph<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -16628,16 +17158,24 @@ pub mod builder {
             self,
         ) -> Result<ResponseValue<types::GraphCollectionResponse>, Error<types::ErrorResponse>>
         {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::CreateGraphRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/graphs", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16672,12 +17210,14 @@ pub mod builder {
     pub struct GetGraph<'a> {
         client: &'a super::Client,
         graph_id: Result<types::GetGraphGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetGraph<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn graph_id<V>(mut self, value: V) -> Self
@@ -16689,23 +17229,40 @@ pub mod builder {
                 .map_err(|_| "conversion to `GetGraphGraphId` for graph_id failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/graphs/{graph_id}`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::GraphCollectionResponse>, Error<types::ErrorResponse>>
         {
-            let Self { client, graph_id } = self;
+            let Self {
+                client,
+                graph_id,
+                x_tenant_id,
+            } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/graphs/{}",
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16739,12 +17296,14 @@ pub mod builder {
     pub struct DeleteGraph<'a> {
         client: &'a super::Client,
         graph_id: Result<types::DeleteGraphGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> DeleteGraph<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn graph_id<V>(mut self, value: V) -> Self
@@ -16756,23 +17315,40 @@ pub mod builder {
                 .map_err(|_| "conversion to `DeleteGraphGraphId` for graph_id failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `DELETE` request to `/api/v2/graphs/{graph_id}`
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::DeleteGraphResponse>, Error<types::ErrorResponse>>
         {
-            let Self { client, graph_id } = self;
+            let Self {
+                client,
+                graph_id,
+                x_tenant_id,
+            } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/graphs/{}",
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16806,6 +17382,7 @@ pub mod builder {
     pub struct CreateEdge<'a> {
         client: &'a super::Client,
         graph_id: Result<types::CreateEdgeGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::CreateEdgeRequest, String>,
     }
     impl<'a> CreateEdge<'a> {
@@ -16813,6 +17390,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -16823,6 +17401,15 @@ pub mod builder {
             self.graph_id = value
                 .try_into()
                 .map_err(|_| "conversion to `CreateEdgeGraphId` for graph_id failed".to_string());
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
             self
         }
         pub fn body<V>(mut self, value: V) -> Self
@@ -16852,9 +17439,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::CreateEdgeRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -16863,11 +17452,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -16905,6 +17497,7 @@ pub mod builder {
     pub struct BatchCreateEdges<'a> {
         client: &'a super::Client,
         graph_id: Result<types::BatchCreateEdgesGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::BatchCreateEdgesRequest, String>,
     }
     impl<'a> BatchCreateEdges<'a> {
@@ -16912,6 +17505,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -16921,6 +17515,15 @@ pub mod builder {
         {
             self.graph_id = value.try_into().map_err(|_| {
                 "conversion to `BatchCreateEdgesGraphId` for graph_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -16953,9 +17556,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| {
                     types::BatchCreateEdgesRequest::try_from(v).map_err(|e| e.to_string())
@@ -16966,11 +17571,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17008,6 +17616,7 @@ pub mod builder {
     pub struct FusionSearchV2<'a> {
         client: &'a super::Client,
         graph_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::FusionSearchRequest, String>,
     }
     impl<'a> FusionSearchV2<'a> {
@@ -17015,6 +17624,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -17024,6 +17634,15 @@ pub mod builder {
         {
             self.graph_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for graph_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -17055,9 +17674,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::FusionSearchRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -17066,11 +17687,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17108,6 +17732,7 @@ pub mod builder {
     pub struct ImpactAnalysisV2<'a> {
         client: &'a super::Client,
         graph_id: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::ImpactAnalysisRequest, String>,
     }
     impl<'a> ImpactAnalysisV2<'a> {
@@ -17115,6 +17740,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -17124,6 +17750,15 @@ pub mod builder {
         {
             self.graph_id = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for graph_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -17157,9 +17792,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::ImpactAnalysisRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -17168,11 +17805,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17210,6 +17850,7 @@ pub mod builder {
     pub struct CreateNode<'a> {
         client: &'a super::Client,
         graph_id: Result<types::CreateNodeGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::CreateNodeRequest, String>,
     }
     impl<'a> CreateNode<'a> {
@@ -17217,6 +17858,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -17227,6 +17869,15 @@ pub mod builder {
             self.graph_id = value
                 .try_into()
                 .map_err(|_| "conversion to `CreateNodeGraphId` for graph_id failed".to_string());
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
             self
         }
         pub fn body<V>(mut self, value: V) -> Self
@@ -17256,9 +17907,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::CreateNodeRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -17267,11 +17920,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17309,6 +17965,7 @@ pub mod builder {
     pub struct BatchCreateNodes<'a> {
         client: &'a super::Client,
         graph_id: Result<types::BatchCreateNodesGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::BatchCreateNodesRequest, String>,
     }
     impl<'a> BatchCreateNodes<'a> {
@@ -17316,6 +17973,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -17325,6 +17983,15 @@ pub mod builder {
         {
             self.graph_id = value.try_into().map_err(|_| {
                 "conversion to `BatchCreateNodesGraphId` for graph_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -17357,9 +18024,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| {
                     types::BatchCreateNodesRequest::try_from(v).map_err(|e| e.to_string())
@@ -17370,11 +18039,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17413,6 +18085,7 @@ pub mod builder {
         client: &'a super::Client,
         graph_id: Result<types::GetNodeGraphId, String>,
         node_id: Result<types::GetNodeNodeId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetNode<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -17420,6 +18093,7 @@ pub mod builder {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
                 node_id: Err("node_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn graph_id<V>(mut self, value: V) -> Self
@@ -17440,6 +18114,15 @@ pub mod builder {
                 .map_err(|_| "conversion to `GetNodeNodeId` for node_id failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/graphs/{graph_id}/nodes/{node_id}`
         pub async fn send(
             self,
@@ -17448,20 +18131,25 @@ pub mod builder {
                 client,
                 graph_id,
                 node_id,
+                x_tenant_id,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
             let node_id = node_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/graphs/{}/nodes/{}",
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
                 encode_path(&node_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17496,6 +18184,7 @@ pub mod builder {
         client: &'a super::Client,
         graph_id: Result<types::DeleteNodeGraphId, String>,
         node_id: Result<types::DeleteNodeNodeId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> DeleteNode<'a> {
         pub fn new(client: &'a super::Client) -> Self {
@@ -17503,6 +18192,7 @@ pub mod builder {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
                 node_id: Err("node_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn graph_id<V>(mut self, value: V) -> Self
@@ -17523,6 +18213,15 @@ pub mod builder {
                 .map_err(|_| "conversion to `DeleteNodeNodeId` for node_id failed".to_string());
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `DELETE` request to `/api/v2/graphs/{graph_id}/nodes/{node_id}`
         pub async fn send(
             self,
@@ -17531,20 +18230,25 @@ pub mod builder {
                 client,
                 graph_id,
                 node_id,
+                x_tenant_id,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
             let node_id = node_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/graphs/{}/nodes/{}",
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
                 encode_path(&node_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17578,12 +18282,14 @@ pub mod builder {
     pub struct GetGraphStats<'a> {
         client: &'a super::Client,
         graph_id: Result<types::GetGraphStatsGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetGraphStats<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
             }
         }
         pub fn graph_id<V>(mut self, value: V) -> Self
@@ -17595,20 +18301,37 @@ pub mod builder {
             });
             self
         }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
+        }
         ///Sends a `GET` request to `/api/v2/graphs/{graph_id}/stats`
         pub async fn send(self) -> Result<ResponseValue<types::GraphStatsResponse>, Error<()>> {
-            let Self { client, graph_id } = self;
+            let Self {
+                client,
+                graph_id,
+                x_tenant_id,
+            } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/graphs/{}/stats",
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17639,6 +18362,7 @@ pub mod builder {
     pub struct TraverseGraph<'a> {
         client: &'a super::Client,
         graph_id: Result<types::TraverseGraphGraphId, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::TraverseRequest, String>,
     }
     impl<'a> TraverseGraph<'a> {
@@ -17646,6 +18370,7 @@ pub mod builder {
             Self {
                 client: client,
                 graph_id: Err("graph_id was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
         }
@@ -17655,6 +18380,15 @@ pub mod builder {
         {
             self.graph_id = value.try_into().map_err(|_| {
                 "conversion to `TraverseGraphGraphId` for graph_id failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -17683,9 +18417,11 @@ pub mod builder {
             let Self {
                 client,
                 graph_id,
+                x_tenant_id,
                 body,
             } = self;
             let graph_id = graph_id.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::TraverseRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
@@ -17694,11 +18430,14 @@ pub mod builder {
                 client.baseurl,
                 encode_path(&graph_id.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17732,14 +18471,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct HybridIndex<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::HybridIndexBody, String>,
     }
     impl<'a> HybridIndex<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -17766,16 +18516,24 @@ pub mod builder {
             ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
             Error<()>,
         > {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::HybridIndexBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/hybrid/index", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17806,14 +18564,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct HybridSearch<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::HybridSearchBody, String>,
     }
     impl<'a> HybridSearch<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -17842,16 +18611,24 @@ pub mod builder {
             ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
             Error<types::ErrorResponse>,
         > {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::HybridSearchBody::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/hybrid/search", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17886,6 +18663,7 @@ pub mod builder {
     pub struct IngestLog<'a> {
         client: &'a super::Client,
         namespace: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<::serde_json::Map<::std::string::String, ::serde_json::Value>, String>,
     }
     impl<'a> IngestLog<'a> {
@@ -17893,6 +18671,7 @@ pub mod builder {
             Self {
                 client: client,
                 namespace: Err("namespace was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -17902,6 +18681,15 @@ pub mod builder {
         {
             self.namespace = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for namespace failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -17927,20 +18715,25 @@ pub mod builder {
             let Self {
                 client,
                 namespace,
+                x_tenant_id,
                 body,
             } = self;
             let namespace = namespace.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/observability/namespaces/{}/logs",
                 client.baseurl,
                 encode_path(&namespace.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -17972,6 +18765,7 @@ pub mod builder {
     pub struct QueryLogs<'a> {
         client: &'a super::Client,
         namespace: Result<::std::string::String, String>,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<::serde_json::Map<::std::string::String, ::serde_json::Value>, String>,
     }
     impl<'a> QueryLogs<'a> {
@@ -17979,6 +18773,7 @@ pub mod builder {
             Self {
                 client: client,
                 namespace: Err("namespace was not initialized".to_string()),
+                x_tenant_id: Ok(None),
                 body: Err("body was not initialized".to_string()),
             }
         }
@@ -17988,6 +18783,15 @@ pub mod builder {
         {
             self.namespace = value.try_into().map_err(|_| {
                 "conversion to `:: std :: string :: String` for namespace failed".to_string()
+            });
+            self
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
             });
             self
         }
@@ -18013,20 +18817,25 @@ pub mod builder {
             let Self {
                 client,
                 namespace,
+                x_tenant_id,
                 body,
             } = self;
             let namespace = namespace.map_err(Error::InvalidRequest)?;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body.map_err(Error::InvalidRequest)?;
             let url = format!(
                 "{}/api/v2/observability/namespaces/{}/logs/search",
                 client.baseurl,
                 encode_path(&namespace.to_string()),
             );
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -18057,14 +18866,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ExecuteQuery<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::QueryRequest, String>,
     }
     impl<'a> ExecuteQuery<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -18088,16 +18908,24 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::QueryResponse>, Error<types::ErrorResponse>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::QueryRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/query", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -18131,14 +18959,25 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct ExplainQuery<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
         body: Result<types::builder::ExplainQueryRequest, String>,
     }
     impl<'a> ExplainQuery<'a> {
         pub fn new(client: &'a super::Client) -> Self {
             Self {
                 client: client,
+                x_tenant_id: Ok(None),
                 body: Ok(::std::default::Default::default()),
             }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         pub fn body<V>(mut self, value: V) -> Self
         where
@@ -18164,16 +19003,24 @@ pub mod builder {
         pub async fn send(
             self,
         ) -> Result<ResponseValue<types::QueryResponse>, Error<types::ErrorResponse>> {
-            let Self { client, body } = self;
+            let Self {
+                client,
+                x_tenant_id,
+                body,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let body = body
                 .and_then(|v| types::ExplainQueryRequest::try_from(v).map_err(|e| e.to_string()))
                 .map_err(Error::InvalidRequest)?;
             let url = format!("{}/api/v2/query/explain", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -18207,20 +19054,40 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GetHealth<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetHealth<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/health`
         pub async fn send(self) -> Result<ResponseValue<types::HealthResponse>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/health", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -18250,20 +19117,40 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GetLiveness<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetLiveness<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/health/live`
         pub async fn send(self) -> Result<ResponseValue<types::ProbeResponse>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/health/live", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client
@@ -18293,20 +19180,40 @@ pub mod builder {
     #[derive(Debug, Clone)]
     pub struct GetReadiness<'a> {
         client: &'a super::Client,
+        x_tenant_id: Result<Option<::std::string::String>, String>,
     }
     impl<'a> GetReadiness<'a> {
         pub fn new(client: &'a super::Client) -> Self {
-            Self { client: client }
+            Self {
+                client: client,
+                x_tenant_id: Ok(None),
+            }
+        }
+        pub fn x_tenant_id<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.x_tenant_id = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for x_tenant_id failed".to_string()
+            });
+            self
         }
         ///Sends a `GET` request to `/health/ready`
         pub async fn send(self) -> Result<ResponseValue<types::ProbeResponse>, Error<()>> {
-            let Self { client } = self;
+            let Self {
+                client,
+                x_tenant_id,
+            } = self;
+            let x_tenant_id = x_tenant_id.map_err(Error::InvalidRequest)?;
             let url = format!("{}/health/ready", client.baseurl,);
-            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(2usize);
             header_map.append(
                 ::reqwest::header::HeaderName::from_static("api-version"),
                 ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
             );
+            if let Some(value) = x_tenant_id {
+                header_map.append("X-Tenant-ID", value.to_string().try_into()?);
+            }
             #[allow(unused_mut)]
             let mut request = client
                 .client

--- a/docs/03-api-reference/client-surface-map.adoc
+++ b/docs/03-api-reference/client-surface-map.adoc
@@ -163,6 +163,24 @@ with header `X-Embed-Source: native` (omit `vector` to let the server embed).
 | `Deprecation` / `X-ProximaDB-API-Status` | Set on deprecated v1 responses
 |====
 
+=== Tenant identity per transport
+
+Every transport carries the tenant a different way, but all resolve through the
+single request-tenant resolver — a bare/absent selector maps to the same
+`default` tenant everywhere, and isolation is *structural* (the tenant is composed
+into the storage key at the service boundary, never a per-query predicate). The
+`X-Tenant-ID` REST header is a formal optional parameter on every operation in the
+generated OpenAPI spec (`docs/openapi/proximadb-openapi.yaml`).
+
+[cols="1,2,3", options="header"]
+|====
+| Transport | Tenant carrier | Notes
+| REST v2 | `X-Tenant-ID` header (optional) | Applied only when there is no authenticated context; a JWT tenant claim takes precedence, and a header disagreeing with the authenticated tenant is rejected.
+| gRPC | `x-tenant-id` metadata | Ambient identity (not a per-message field).
+| Arrow Flight | `x-proximadb-tenant-id` metadata | NOTE: key differs from gRPC/REST (`x-tenant-id`) — a naming inconsistency tracked for unification.
+| pgwire | `dbname` (fallback `SET proximadb.write.tenant_id`) | Connection-level; `dbname=proximadb` ⇒ default tenant. See link:./postgres.adoc[Postgres Wire Reference].
+|====
+
 == SDK lowering (Python)
 
 Entry point: `from proximadb_sdk import ProximaDBClient` (the unified client,

--- a/docs/03-api-reference/postgres.adoc
+++ b/docs/03-api-reference/postgres.adoc
@@ -25,6 +25,21 @@ tokio_postgres::connect(
 The pgwire impl accepts any user name in the v0.2 permissive default; mTLS and
 SCRAM-SHA-256 authentication are tracked separately under TD-077.
 
+=== Tenant selection
+
+The connection **`dbname` selects the tenant** — a connection to `dbname=acme`
+scopes every read and write to tenant `acme`; the default `dbname=proximadb`
+resolves to the default tenant. This mirrors the tenant identity carried by the
+other transports (REST `X-Tenant-ID` header, gRPC `x-tenant-id` metadata) — all
+four resolve through the single request-tenant resolver, so a bare/default
+request maps to the same `default` tenant everywhere. A session may also override
+the write tenant with `SET proximadb.write.tenant_id = '<tenant>'`. Tenant
+isolation is *structural* — the tenant is composed into the storage key at the
+service boundary, never applied as a per-query predicate — so a row written under
+one tenant is invisible to another even under an identical logical
+collection/table name. See link:./client-surface-map.adoc[Client Surface Map]
+for the tenant-identity-per-transport table.
+
 == Supported in v0.2
 
 * `CREATE TABLE` with typed columns (BIGINT, VARCHAR, FLOAT, BOOLEAN, JSON,

--- a/docs/openapi/proximadb-openapi.yaml
+++ b/docs/openapi/proximadb-openapi.yaml
@@ -2245,6 +2245,13 @@ paths:
       description: |
         Advertises API version, supported features, limits, and the error- envelope contract so SDKs can adapt instead of hard-coding assumptions.
       operationId: getCapabilities
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2298,6 +2305,12 @@ paths:
         required: false
         schema:
           type: boolean
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2326,6 +2339,13 @@ paths:
         - `409 Conflict`: Collection already exists
         - `500 Internal Server Error`: Creation failed
       operationId: createCollection
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2360,6 +2380,12 @@ paths:
         in: path
         name: collection_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       responses:
@@ -2402,6 +2428,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2427,6 +2459,12 @@ paths:
         in: path
         name: collection_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       requestBody:
@@ -2467,6 +2505,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2502,6 +2546,12 @@ paths:
         in: path
         name: collection_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       requestBody:
@@ -2547,6 +2597,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2581,6 +2637,12 @@ paths:
         in: path
         name: entity_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       responses:
@@ -2630,6 +2692,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2668,6 +2736,12 @@ paths:
         in: path
         name: collection_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       requestBody:
@@ -2713,6 +2787,12 @@ paths:
         in: path
         name: record_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       responses:
@@ -2773,6 +2853,12 @@ paths:
         required: false
         schema:
           type: boolean
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2812,6 +2898,12 @@ paths:
         in: path
         name: collection_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       responses:
@@ -2865,6 +2957,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2913,6 +3011,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2938,6 +3042,13 @@ paths:
   /api/v2/document-collections:
     get:
       operationId: listDocumentCollections
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2951,6 +3062,13 @@ paths:
       - Documents
     post:
       operationId: createDocumentCollection
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -2972,6 +3090,13 @@ paths:
   /api/v2/document-collections/{collection}/documents:
     get:
       operationId: queryDocuments
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -2991,6 +3116,13 @@ paths:
         type: string
     post:
       operationId: insertDocument
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3014,6 +3146,13 @@ paths:
   /api/v2/graphs:
     get:
       operationId: listGraphs
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3026,6 +3165,13 @@ paths:
       - Graphs
     post:
       operationId: createGraph
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3047,6 +3193,13 @@ paths:
   /api/v2/graphs/{graph_id}:
     delete:
       operationId: deleteGraph
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3061,6 +3214,13 @@ paths:
       - Graphs
     get:
       operationId: getGraph
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3080,6 +3240,13 @@ paths:
     - $ref: '#/components/parameters/GraphId'
     post:
       operationId: createEdge
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3107,6 +3274,13 @@ paths:
       description: |
         Batch counterpart to `createEdge`.
       operationId: batchCreateEdges
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3135,6 +3309,12 @@ paths:
         in: path
         name: graph_id
         required: true
+        schema:
+          type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
         schema:
           type: string
       requestBody:
@@ -3175,6 +3355,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3210,6 +3396,13 @@ paths:
     - $ref: '#/components/parameters/GraphId'
     post:
       operationId: createNode
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3238,6 +3431,13 @@ paths:
         Batch counterpart to `createNode`. Use this on bulk-ingest paths
         where individual round-trips would dominate latency.
       operationId: batchCreateNodes
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3261,6 +3461,13 @@ paths:
   /api/v2/graphs/{graph_id}/nodes/{node_id}:
     delete:
       operationId: deleteNode
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3275,6 +3482,13 @@ paths:
       - Graphs
     get:
       operationId: getNode
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3293,6 +3507,13 @@ paths:
   /api/v2/graphs/{graph_id}/stats:
     get:
       operationId: getGraphStats
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3310,6 +3531,13 @@ paths:
     - $ref: '#/components/parameters/GraphId'
     post:
       operationId: traverseGraph
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3331,6 +3559,13 @@ paths:
   /api/v2/hybrid/index:
     post:
       operationId: hybridIndex
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3355,6 +3590,13 @@ paths:
   /api/v2/hybrid/search:
     post:
       operationId: hybridSearch
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3399,6 +3641,13 @@ paths:
         type: string
     post:
       operationId: ingestLog
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3426,6 +3675,13 @@ paths:
         type: string
     post:
       operationId: queryLogs
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3453,6 +3709,13 @@ paths:
         pgwire cannot serve, so this endpoint is their canonical home. (TD-121 retires
         only the plain-SQL gRPC `ExecuteQuery` path, not this UQL/federated surface.)
       operationId: executeQuery
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3478,6 +3741,13 @@ paths:
   /api/v2/query/explain:
     post:
       operationId: explainQuery
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -3503,6 +3773,13 @@ paths:
   /health:
     get:
       operationId: getHealth
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3517,6 +3794,13 @@ paths:
   /health/live:
     get:
       operationId: getLiveness
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -3531,6 +3815,13 @@ paths:
   /health/ready:
     get:
       operationId: getReadiness
+      parameters:
+      - description: Optional explicit tenant selector. Applied only when there is no authenticated tenant context — a JWT tenant claim takes precedence, and a header that disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. Tenant isolation is structural on the server; this header only selects the tenant.
+        in: header
+        name: X-Tenant-ID
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           content:

--- a/src/network/rest/openapi.rs
+++ b/src/network/rest/openapi.rs
@@ -220,7 +220,59 @@ fn openapi_document() -> Result<Value, String> {
     let supplement: Value = serde_yaml::from_str(SUPPLEMENT_YAML)
         .map_err(|e| format!("parse openapi_supplement.yaml: {e}"))?;
     merge_into(&mut doc, &supplement);
+
+    // Formalize the tenant selector as an OPTIONAL `X-Tenant-ID` header on EVERY operation
+    // (generated core ⊕ supplement) — one place, zero per-handler churn, and it sidesteps the
+    // `Option<String>: Display` codegen error that blocks a per-handler `params(...)` header.
+    // Isolation is structural on the server (the tenant is scoped into the storage key); this
+    // header only SELECTS the tenant when there is no authenticated context.
+    inject_tenant_header(&mut doc);
     Ok(doc)
+}
+
+/// Inject the optional `X-Tenant-ID` header parameter into every operation of the merged document.
+///
+/// Runs AFTER the supplement merge so BOTH the generated core paths and the supplement-carried
+/// paths (`/health*`, hybrid, observability, …) carry it. Idempotent — never double-adds. Applied
+/// document-wide because tenant selection is uniform across the REST surface (mirrors the
+/// document-root `security` injection above).
+fn inject_tenant_header(doc: &mut Value) {
+    const METHODS: [&str; 7] = ["get", "put", "post", "delete", "patch", "options", "head"];
+    let header = serde_json::json!({
+        "name": "X-Tenant-ID",
+        "in": "header",
+        "required": false,
+        "description": "Optional explicit tenant selector. Applied only when there is no \
+            authenticated tenant context — a JWT tenant claim takes precedence, and a header that \
+            disagrees with the authenticated tenant is rejected. Absent ⇒ the default tenant. \
+            Tenant isolation is structural on the server; this header only selects the tenant.",
+        "schema": { "type": "string" }
+    });
+    let Some(paths) = doc.get_mut("paths").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for path_item in paths.values_mut() {
+        let Some(item) = path_item.as_object_mut() else {
+            continue;
+        };
+        for method in METHODS {
+            let Some(op) = item.get_mut(method).and_then(Value::as_object_mut) else {
+                continue;
+            };
+            let params = op
+                .entry("parameters".to_string())
+                .or_insert_with(|| serde_json::json!([]));
+            if let Some(arr) = params.as_array_mut() {
+                let already = arr.iter().any(|p| {
+                    p.get("name").and_then(Value::as_str) == Some("X-Tenant-ID")
+                        && p.get("in").and_then(Value::as_str) == Some("header")
+                });
+                if !already {
+                    arr.push(header.clone());
+                }
+            }
+        }
+    }
 }
 
 /// Render the merged OpenAPI document to canonical YAML (the on-disk form of
@@ -251,5 +303,45 @@ mod tests {
         // Supplement-carried operations survive the merge.
         assert!(paths.contains_key("/health/live"));
         assert!(paths.contains_key("/api/v2/graphs"));
+    }
+
+    #[test]
+    fn every_operation_carries_the_optional_tenant_header() {
+        let doc = openapi_document().expect("openapi document builds");
+        let paths = doc
+            .get("paths")
+            .and_then(Value::as_object)
+            .expect("paths object present");
+        const METHODS: [&str; 7] = ["get", "put", "post", "delete", "patch", "options", "head"];
+
+        let mut checked = 0usize;
+        for (route, item) in paths {
+            let Some(item) = item.as_object() else {
+                continue;
+            };
+            for method in METHODS {
+                let Some(op) = item.get(method).and_then(Value::as_object) else {
+                    continue;
+                };
+                let params = op
+                    .get("parameters")
+                    .and_then(Value::as_array)
+                    .unwrap_or_else(|| panic!("{method} {route} should carry parameters"));
+                let tenant = params.iter().find(|p| {
+                    p.get("name").and_then(Value::as_str) == Some("X-Tenant-ID")
+                        && p.get("in").and_then(Value::as_str) == Some("header")
+                });
+                let tenant =
+                    tenant.unwrap_or_else(|| panic!("{method} {route} missing X-Tenant-ID header"));
+                assert_eq!(
+                    tenant.get("required").and_then(Value::as_bool),
+                    Some(false),
+                    "{method} {route}: X-Tenant-ID must be optional"
+                );
+                checked += 1;
+            }
+        }
+        // Covers the generated core (20 ops) + supplement operations.
+        assert!(checked >= 20, "expected many operations, checked {checked}");
     }
 }


### PR DESCRIPTION
## What & why

Final phase of the tenant-isolation program: formalize the tenant selector as an **optional
`X-Tenant-ID` header** on every REST v2 operation in the generated OpenAPI contract, and
regenerate all four spec-driven SDKs so the tenant param is discoverable + typed. Until now the
header was accepted by the server middleware but was prose-only in the spec.

## Approach (spec side)
Injected via the **`openapi_document()` JSON post-processing seam** (not a utoipa `Modify` addon):
- runs **after** the supplement merge, so it covers the FULL published surface (generated core ⊕
  supplement-carried paths like `/health*`, hybrid, observability);
- mirrors the existing document-root `security` injection idiom already in the file;
- sidesteps the `Option<String>: Display` codegen error that blocks a per-handler `params(...)`
  header (documented in `documents.rs`).

Idempotent (never double-adds). Added `every_operation_carries_the_optional_tenant_header` test.

## SDK regen (mandatory — 4 merge-blocking drift gates)
Regenerated all four transports from the updated spec; each generated operation gains the optional
`x-tenant-id` header param (backward-compatible; the hand-written ergonomic facades are unchanged —
auto-send wiring is a tracked follow-up). **All four verified idempotent locally** (re-running the
generator produces no diff — the exact drift-gate check):
- Python (`openapi-python-client 0.24.3`) — 44 files
- Go (`oapi-codegen v2.4.1`)
- TypeScript (`openapi-typescript 7.13.0`)
- Rust (`progenitor`, pinned)

## Docs
- `postgres.adoc` — pgwire `dbname` selects the tenant (+ `SET proximadb.write.tenant_id`).
- `client-surface-map.adoc` — tenant-identity-per-transport table (REST `X-Tenant-ID` / gRPC
  `x-tenant-id` / Flight `x-proximadb-tenant-id` / pgwire `dbname`), flagging the Flight key
  naming inconsistency for future unification.

## Verification
`cargo fmt --check` ✅ · v1-proto ratchet +0 ✅ · `openapi_spec_gen` passed at regen ✅ · all 4
SDK generators idempotent ✅. (`make verify-openapi-spec` + the 4 `*-sdk-codegen-drift` gates run
in CI.)

With this, the tenant-identity contract is formal across all transports — completing the
tenant-isolation program (Phase 0 + timeseries + graph + documents + entities + contract).