### PR TITLE
fix(ci): install the SDK [test] extra so Python SDK Tests lane is green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,11 @@ jobs:
         run: |
           cd clients/python
           python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install pytest grpcio grpcio-tools protobuf pyyaml jsonschema httpx requests
+          # The [test] extra is the single source of truth for the unit-suite
+          # deps (pyproject optional-dependencies.test) — including the optional
+          # data deps some *_cov tests hard-import (pyarrow/pandas/psutil). The
+          # former hand-maintained list drifted and left this lane red.
+          python -m pip install -e ".[test]"
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-proto-compat"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -177,6 +177,18 @@ test = [
     "pytest-xdist>=3.0.0",
     "sentence-transformers>=3.2,<6",
     "requests>=2.28.0",
+    # Complete the "run the unit suite" contract: unit tests hard-import these
+    # optional deps (arrow export/flight, dataframe builders, multi-bert psutil
+    # sizing, grpc codegen, config/openapi validation). Kept here so
+    # `pip install -e ".[test]"` is the single source of truth for CI — the
+    # previously hand-maintained CI dep list drifted and left the SDK lane red.
+    "pyarrow>=14.0.0",
+    "pandas>=2.0.0",
+    "psutil>=5.9.0",
+    "grpcio-tools>=1.60.0",
+    "pyyaml>=6.0",
+    "jsonschema>=4.0.0",
+    "httpx>=0.24.0",
 ]
 
 docs = [


### PR DESCRIPTION
The `Python SDK Tests` job used a hand-maintained dep list that drifted — several `*_cov` tests hard-import `pyarrow`/`pandas`/`psutil` (provided by no extra), so the lane went red (surfaced on the v0.2.2 release CI; engine image unaffected since the SDK is a separate PyPI artifact). Fix: make `[test]` the complete unit-suite extra (adds the data deps + the codegen/validation deps the old list carried) and switch CI to `pip install -e ".[test]"` — one source of truth, no more drift. **Verified locally under the exact CI install: the four previously-failing files pass (37/64/76/42).**