### PR TITLE
feat(documents): converge document store-split onto the canonical record spine (ADR-009, default-OFF)

### DIFF
--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -18,6 +18,7 @@ pub mod observability_port;
 pub mod port;
 pub mod proto_defaults;
 pub mod record_ops_port;
+pub mod record_route_port;
 pub mod resources;
 pub mod security_port;
 pub mod service_ports;
@@ -41,6 +42,7 @@ pub use port::{
     CollectionSchemaUpdate, CollectionTextStorage,
 };
 pub use record_ops_port::RecordOpsPort;
+pub use record_route_port::RecordRoutePort;
 pub use resources::{MemoryBudget, ResourceManager};
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
 pub use service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};

--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -1,0 +1,54 @@
+//! Document-facade record route port (ADR-009 / RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE).
+//!
+//! The document modality is a *projection* over the canonical record/vector spine,
+//! not an independent durable store. This port lets `DocumentService`'s canonical
+//! branch route through the exact tenant-scoped record surface REST v2 already uses
+//! (`RecordOpsService::handle_record_*_for_tenant`) without depending on the concrete
+//! root-crate service — so a document written on either surface is structurally
+//! visible on the other (closes the store-split), metered, and stored once.
+//!
+//! Shapes are facade-simple (`usize` / `Vec<ProximaRecord>`); durable authority stays
+//! in the vector store — no state lives here. Reads use the **scan** surface (not the
+//! point-get), because a full [`ProximaRecord`] — carrying `labels` + `variation_id` —
+//! is required to rebuild the document facade via `canonical_document_from_record`; the
+//! search-shaped point-get response drops those fields.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use proximadb_records::ProximaRecord;
+
+/// Route for the document facade's canonical branch onto the shared record/vector store.
+///
+/// Implemented by the root-crate `RecordOpsService`, delegating to its existing
+/// `handle_record_batch_for_tenant` / `handle_record_scan_paginated_for_tenant`
+/// methods (tenant + collection resolution, WAL lane, lease, metering all inherited).
+#[async_trait]
+pub trait RecordRoutePort: Send + Sync {
+    /// Insert/upsert canonical records into `collection_id` for `tenant`
+    /// (`None` ⇒ default tenant). Returns the number of records persisted.
+    async fn insert_records(
+        &self,
+        collection_id: &str,
+        records: Vec<ProximaRecord>,
+        tenant: Option<&str>,
+    ) -> Result<usize>;
+
+    /// Scan up to `limit` live records from `collection_id`, tenant-scoped. Returns
+    /// full [`ProximaRecord`]s (labels + props intact) so the document facade can be
+    /// rebuilt. Dead/TTL-expired records are filtered by the underlying scan.
+    async fn scan_records(
+        &self,
+        collection_id: &str,
+        limit: usize,
+        tenant: Option<&str>,
+    ) -> Result<Vec<ProximaRecord>>;
+
+    /// Delete records by canonical id from `collection_id`, tenant-scoped (writes a
+    /// tombstone so the delete is visible cross-surface). Returns the number deleted.
+    async fn delete_records(
+        &self,
+        collection_id: &str,
+        record_ids: Vec<String>,
+        tenant: Option<&str>,
+    ) -> Result<usize>;
+}

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -709,3 +709,86 @@ impl proximadb_runtime::RecordOpsPort for RecordOpsService {
         .await
     }
 }
+
+// ADR-009 convergence: the document facade's canonical branch routes here so a
+// document written via gRPC/DocumentService lands in the same tenant-scoped record
+// store REST v2 already uses — closing the store-split. Writes upsert (a re-inserted
+// document id updates in place); reads use the paginated scan, which returns full
+// `ProximaRecord`s (labels + props) needed to rebuild the document facade.
+#[async_trait::async_trait]
+impl proximadb_runtime::RecordRoutePort for RecordOpsService {
+    async fn insert_records(
+        &self,
+        collection_id: &str,
+        records: Vec<proximadb_records::ProximaRecord>,
+        tenant: Option<&str>,
+    ) -> Result<usize> {
+        let result = self
+            .handle_record_batch_for_tenant(
+                RichRecordBatchRequest {
+                    collection_id: collection_id.to_string(),
+                    records,
+                },
+                tenant,
+            )
+            .await?;
+        if result.success {
+            Ok(result.vector_ids.len())
+        } else {
+            Err(anyhow!(
+                "record route insert failed: {}",
+                result.errors.join("; ")
+            ))
+        }
+    }
+
+    async fn scan_records(
+        &self,
+        collection_id: &str,
+        limit: usize,
+        tenant: Option<&str>,
+    ) -> Result<Vec<proximadb_records::ProximaRecord>> {
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let (records, _next_cursor) = self
+            .handle_record_scan_paginated_for_tenant(
+                collection_id,
+                None,
+                limit,
+                false,
+                true,
+                tenant,
+                None,
+                now_ns,
+            )
+            .await?;
+        Ok(records)
+    }
+
+    async fn delete_records(
+        &self,
+        collection_id: &str,
+        record_ids: Vec<String>,
+        tenant: Option<&str>,
+    ) -> Result<usize> {
+        let result = self
+            .handle_record_delete_batch_for_tenant(
+                RichRecordDeleteBatchRequest {
+                    collection_id: collection_id.to_string(),
+                    record_ids,
+                },
+                tenant,
+            )
+            .await?;
+        if result.success {
+            Ok(result.vector_ids.len())
+        } else {
+            Err(anyhow!(
+                "record route delete failed: {}",
+                result.errors.join("; ")
+            ))
+        }
+    }
+}

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -529,25 +529,11 @@ impl MultiServer {
 
             // ── Create backend services (doc + observability need data-dir paths) ──
 
-            let doc_base_path = self.config.data_dir.join("documents");
-            let doc_path_str = doc_base_path.to_string_lossy().to_string();
-            let doc_storage_service = {
-                let engine = services.vector_operations_service.unified_engine();
-                match crate::storage::document::DocumentService::new_with_wal(engine, &doc_path_str)
-                    .await
-                {
-                    Ok(svc) => Arc::new(svc),
-                    Err(e) => {
-                        warn!(
-                            "Failed to create DocumentService with WAL: {}. Using non-durable storage.",
-                            e
-                        );
-                        Arc::new(crate::storage::document::DocumentService::new(
-                            services.vector_operations_service.unified_engine(),
-                        ))
-                    }
-                }
-            };
+            // ADR-009 document convergence: reuse the ONE shared, route-wired DocumentService
+            // instead of building a second WAL-backed instance here — a separate instance would
+            // re-open the store-split (its own document_wal + no canonical route). The shared
+            // instance carries the default-OFF canonical-vector route wired in SharedServices.
+            let doc_storage_service = services.document_service.clone();
 
             let obs_base_path = self.config.data_dir.join("observability");
             let obs_path_str = obs_base_path.to_string_lossy().to_string();
@@ -990,29 +976,10 @@ impl MultiServer {
         // use Arc clones so there is a single WAL-backed instance per service.
         let shared_services_ref = self.shared_services.clone();
 
-        let doc_base_path = self.config.data_dir.join("documents");
-        let doc_path_str = doc_base_path.to_string_lossy().to_string();
-        let doc_storage_service: Arc<crate::storage::document::DocumentService> = {
-            let engine = shared_services_ref
-                .vector_operations_service
-                .unified_engine();
-            match crate::storage::document::DocumentService::new_with_wal(engine, &doc_path_str)
-                .await
-            {
-                Ok(svc) => Arc::new(svc),
-                Err(e) => {
-                    warn!(
-                        "Failed to create DocumentService with WAL: {}. Using non-durable storage.",
-                        e
-                    );
-                    Arc::new(crate::storage::document::DocumentService::new(
-                        shared_services_ref
-                            .vector_operations_service
-                            .unified_engine(),
-                    ))
-                }
-            }
-        };
+        // ADR-009 document convergence: reuse the ONE shared, route-wired DocumentService
+        // rather than a second WAL-backed instance (which would re-open the store-split).
+        let doc_storage_service: Arc<crate::storage::document::DocumentService> =
+            shared_services_ref.document_service.clone();
 
         let obs_base_path = self.config.data_dir.join("observability");
         let obs_path_str = obs_base_path.to_string_lossy().to_string();

--- a/src/network/rest/v2/documents.rs
+++ b/src/network/rest/v2/documents.rs
@@ -193,6 +193,13 @@ async fn ingest_documents_inner(
     // Build ProximaRecords. Reserved column names (text, metadata, etc.) get
     // hoisted into props so the codec-shared embed_text_only_records dispatch
     // can read them out the same way the Arrow Flight path does.
+    //
+    // ADR-009 convergence: when the canonical-vector document route is enabled for this
+    // collection, stamp the same `document` label + `_document_collection` prop that the
+    // DocumentService (gRPC) surface writes, so a REST-v2-ingested doc rebuilds cleanly on a
+    // gRPC read (cross-surface visibility). Gate OFF ⇒ the REST v2 record shape is unchanged.
+    let stamp_document_facade =
+        crate::storage::document::service::doc_canonical_vector_enabled(&collection);
     let mut records: Vec<ProximaRecord> = Vec::with_capacity(request.records.len());
     for doc in request.records {
         let now_ns = chrono::Utc::now()
@@ -221,7 +228,7 @@ async fn ingest_documents_inner(
             _ => vec![],
         };
 
-        records.push(ProximaRecord {
+        let mut record = ProximaRecord {
             oid: doc.id.clone(),
             local_id: Some(doc.id),
             tenant_id: tenant_id.clone(),
@@ -231,7 +238,17 @@ async fn ingest_documents_inner(
             props,
             embeddings,
             ..ProximaRecord::default()
-        });
+        };
+        if stamp_document_facade {
+            record
+                .labels
+                .insert(proximadb_document::DOCUMENT_RECORD_LABEL);
+            record.props.insert(
+                proximadb_document::DOCUMENT_COLLECTION_PROP.to_string(),
+                ProximaTreeNode::Value(ProximaValue::String(collection.clone())),
+            );
+        }
+        records.push(record);
     }
 
     // Phase 2H: async mode + queue available → enqueue to embed-ingest

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1797,6 +1797,18 @@ impl SharedServices {
         let request_handlers = Arc::new(request_handlers_instance);
         debug!("✅ SharedServices::new - UnifiedHandlers created with shared graph services");
 
+        // ADR-009 document convergence: wire the single shared DocumentService onto the same
+        // tenant-scoped record/vector route REST v2 uses (via RecordOpsService, built inside
+        // UnifiedHandlers above). Default-OFF per-collection gate — this only makes the route
+        // *available*; `doc_canonical_vector_enabled` decides per collection at call time. With
+        // this, gRPC/DocumentService and REST v2 writes converge on one store (no store-split).
+        document_service.set_record_route(
+            request_handlers.record_ops() as Arc<dyn proximadb_runtime::RecordRoutePort>
+        );
+        debug!(
+            "✅ SharedServices::new - DocumentService wired to canonical record route (ADR-009, gate default-OFF)"
+        );
+
         // ==================================================================================
         // Create UnifiedQueryFacade - single entry point for all query types
         // This consolidates the 5 parallel query paths into a single unified interface

--- a/src/storage/document/canonical_adapter.rs
+++ b/src/storage/document/canonical_adapter.rs
@@ -206,4 +206,35 @@ mod tests {
     fn ignores_non_document_proxima_records() {
         assert!(proxima_record_to_legacy_document(&ProximaRecord::default()).is_none());
     }
+
+    /// ADR-009 canonical-vector route: a document stored with a RAW-id OID (the `document/`
+    /// prefix dropped) still rebuilds losslessly, because reconstruction reads the id from
+    /// `local_id` and the collection from `DOCUMENT_COLLECTION_PROP` — never from the OID.
+    #[test]
+    fn round_trips_with_raw_id_oid_on_canonical_vector_route() {
+        let legacy = legacy_record();
+        let mut record = legacy_document_to_proxima_record(&legacy);
+
+        // Mirror `DocumentService::canonical_document_record`: raw-id OID + tenant stamp.
+        record.oid = legacy.id.clone();
+        record.tenant_id = "acme".to_string();
+        assert_eq!(record.oid, "doc-1"); // no `document/papers/` prefix
+        assert!(
+            record
+                .labels
+                .contains(proximadb_document::DOCUMENT_RECORD_LABEL)
+        );
+
+        let rebuilt = proxima_record_to_legacy_document(&record).expect("document record");
+        assert_eq!(rebuilt.id, legacy.id);
+        assert_eq!(rebuilt.collection_id, legacy.collection_id);
+        assert_eq!(rebuilt.version, legacy.version);
+        assert_eq!(rebuilt.schema_id, legacy.schema_id);
+        assert_eq!(rebuilt.document_type, legacy.document_type);
+        assert_eq!(rebuilt.props.get("title"), legacy.props.get("title"));
+        assert!(matches!(
+            rebuilt.props.get("author"),
+            Some(ProximaTreeNode::Value(_)) | Some(ProximaTreeNode::Object(_))
+        ));
+    }
 }

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -36,7 +36,6 @@ use proximadb_records::{
 
 use super::DocumentStorageEngine;
 use super::aggregation_extensions::LookupFetcher;
-#[cfg(feature = "canonical-document-store")]
 use super::canonical_adapter::legacy_document_to_proxima_record;
 use super::canonical_adapter::proxima_record_to_legacy_document;
 use super::canonical_adapter::{proxima_tree_to_sql_object, sql_value_to_tree_node};
@@ -66,6 +65,22 @@ pub fn scoped_document_collection(tenant: &str, collection: &str) -> anyhow::Res
         return Ok(collection.to_string());
     }
     Ok(format!("{tenant}/{collection}"))
+}
+
+/// Inverse of [`scoped_document_collection`]: recover `(tenant, clean_collection)` from a
+/// scoped storage key.
+///
+/// The ADR-009 canonical-vector route needs the CLEAN collection name (the shared
+/// record/vector catalog registers bare names, resolved per-tenant via `TenantContext`)
+/// plus the tenant as a separate value — NOT the folded `{tenant}/{collection}` key.
+/// Well-defined because a tenant is a validated path segment (no `/`) and collection
+/// names match `^[a-z][a-z0-9_]*$` (no `/`): the first `/` is unambiguously the fold
+/// separator, and a bare key (DEFAULT tenant) has none ⇒ `(None, key)`.
+pub fn unscope_document_collection(scoped: &str) -> (Option<&str>, &str) {
+    match scoped.split_once('/') {
+        Some((tenant, collection)) => (Some(tenant), collection),
+        None => (None, scoped),
+    }
 }
 
 /// Document service for CRUD operations
@@ -99,6 +114,46 @@ pub struct DocumentService {
     wal_path: String,
     /// Optional metrics collector for observability
     metrics_collector: Option<Arc<DocumentMetricsCollector>>,
+    /// ADR-009 convergence route onto the shared record/vector store. When wired
+    /// AND the runtime gate is ON for a collection (default-OFF), document
+    /// writes/reads flow through the same tenant-scoped record surface REST v2 uses
+    /// — so a document is visible cross-surface, metered, and stored once. When the
+    /// gate is OFF the legacy `document_wal`/`documents` path is used unchanged,
+    /// and pre-cutover docs remain reachable via the legacy read-fallback
+    /// (mixed-read-safe). See `docs/12-design/RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc`.
+    ///
+    /// A `OnceLock` because `RecordOpsService` is constructed *after* this service (it takes
+    /// the shared `document_service` handle), so the route is injected once, post-construction,
+    /// through the already-`Arc`-shared facade — never mutated again.
+    record_route: std::sync::OnceLock<Arc<dyn proximadb_runtime::RecordRoutePort>>,
+}
+
+/// Bound on the canonical-vector read scan for document point/query reads. The point-get
+/// is currently satisfied by a bounded scan (the shared record surface exposes scan, not a
+/// labelled point-get); a follow-up can push an `oid`/`local_id` predicate into the scan for
+/// O(1) point reads. Documents are a beta surface behind a default-OFF gate, so the bound is
+/// generous but finite — a silent truncation past it would drop reads, so it is logged.
+const CANONICAL_DOC_SCAN_LIMIT: usize = 100_000;
+
+/// Runtime gate for the canonical-vector document route (ADR-009), **DEFAULT-OFF**.
+///
+/// The route is enabled for `collection` when env `PROXIMADB_DOC_CANONICAL_VECTOR` is
+/// `1`/`true`/`on`/`all` (all collections), or a comma-separated list containing
+/// `collection`. Unset/empty ⇒ OFF ⇒ today's legacy `document_wal` behavior,
+/// bit-for-bit. Mirrors the graph modality's runtime feature gates; per-collection
+/// opt-in keeps the storage-format migration mixed-read-safe until baked.
+pub fn doc_canonical_vector_enabled(collection: &str) -> bool {
+    match std::env::var("PROXIMADB_DOC_CANONICAL_VECTOR") {
+        Ok(raw) => {
+            let raw = raw.trim();
+            match raw.to_ascii_lowercase().as_str() {
+                "" => false,
+                "1" | "true" | "on" | "all" | "*" => true,
+                _ => raw.split(',').map(str::trim).any(|c| c == collection),
+            }
+        }
+        Err(_) => false,
+    }
 }
 
 impl DocumentService {
@@ -116,6 +171,7 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(None)),
             wal_path: String::new(),
             metrics_collector: None,
+            record_route: std::sync::OnceLock::new(),
         }
     }
 
@@ -139,6 +195,7 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(None)),
             wal_path: String::new(),
             metrics_collector: None,
+            record_route: std::sync::OnceLock::new(),
         }
     }
 
@@ -159,6 +216,7 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(None)),
             wal_path: String::new(),
             metrics_collector: Some(metrics_collector),
+            record_route: std::sync::OnceLock::new(),
         }
     }
 
@@ -184,6 +242,7 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(None)),
             wal_path: String::new(),
             metrics_collector: None,
+            record_route: std::sync::OnceLock::new(),
         }
     }
 
@@ -214,6 +273,7 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(Some(wal_writer))),
             wal_path,
             metrics_collector: None,
+            record_route: std::sync::OnceLock::new(),
         };
 
         service.recover_from_wal().await?;
@@ -252,12 +312,60 @@ impl DocumentService {
             wal_writer: Arc::new(Mutex::new(Some(wal_writer))),
             wal_path,
             metrics_collector,
+            record_route: std::sync::OnceLock::new(),
         };
 
         // Recover from WAL on startup
         service.recover_from_wal().await?;
 
         Ok(service)
+    }
+
+    /// Wire the ADR-009 convergence route onto the shared record/vector store, once.
+    ///
+    /// Called post-construction (the `RecordOpsService` that backs the route is built after
+    /// this service and takes its shared handle), through the already-`Arc`-shared facade.
+    /// Idempotent-safe: a second call is ignored. The legacy `document_wal`/`documents` path
+    /// is retained for the default-OFF gate and as the mixed-read-safe fallback for
+    /// pre-cutover documents.
+    pub fn set_record_route(&self, record_route: Arc<dyn proximadb_runtime::RecordRoutePort>) {
+        let _ = self.record_route.set(record_route);
+    }
+
+    /// Select the canonical-vector route for `collection` iff a route is wired AND the
+    /// runtime gate is ON for it (default-OFF). `None` ⇒ the legacy `document_wal` path.
+    /// The single decision point for the store-split cutover — every write/read branches
+    /// on this so gate-OFF is today's behavior, bit-for-bit.
+    fn canonical_route(
+        &self,
+        collection: &str,
+    ) -> Option<&Arc<dyn proximadb_runtime::RecordRoutePort>> {
+        let route = self.record_route.get()?;
+        if doc_canonical_vector_enabled(collection) {
+            Some(route)
+        } else {
+            None
+        }
+    }
+
+    /// Build the durable canonical envelope for a document on the ADR-009 vector route.
+    ///
+    /// Stamps the CLEAN collection into the label prop (the catalog resolves it per-tenant),
+    /// a raw-id OID (reconstruction reads the id from `local_id`/props, not the OID), and the
+    /// tenant onto the record as structural-isolation defense-in-depth for the scan filter.
+    fn canonical_document_record(
+        record: &DocumentRecord,
+        clean_collection: &str,
+        tenant: Option<&str>,
+    ) -> proximadb_records::ProximaRecord {
+        let mut for_store = record.clone();
+        for_store.collection_id = clean_collection.to_string();
+        let mut proxima = legacy_document_to_proxima_record(&for_store);
+        proxima.oid = record.id.clone();
+        proxima.tenant_id = tenant
+            .unwrap_or(proximadb_tenant::DEFAULT_TENANT)
+            .to_string();
+        proxima
     }
 
     /// Record insert metrics if collector is configured
@@ -950,6 +1058,33 @@ impl DocumentService {
             }
         };
 
+        // ADR-009 canonical-vector route (gate ON, per-collection opt-in): persist to the
+        // shared record/vector store — the exact path REST v2 uses — so the document is
+        // visible cross-surface, metered, and stored once. The legacy `document_wal`/DashMap
+        // is skipped on this path (the vector WAL owns recovery); pre-cutover docs stay
+        // reachable via the read-fallback in `get_document`/`query_documents`.
+        if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let proxima = Self::canonical_document_record(&record, clean_collection, tenant);
+            match route
+                .insert_records(clean_collection, vec![proxima], tenant)
+                .await
+            {
+                Ok(_) => {
+                    debug!(
+                        "Inserted document {} into {} via canonical-vector route",
+                        doc_id, clean_collection
+                    );
+                    self.record_insert_metrics(start, false).await;
+                    return Ok(record);
+                }
+                Err(e) => {
+                    self.record_insert_metrics(start, true).await;
+                    return Err(e.context("canonical-vector document insert failed"));
+                }
+            }
+        }
+
         // Write to WAL first (durability before in-memory update)
         if let Err(e) = self.write_document_upsert_to_wal(collection, &record).await {
             self.record_insert_metrics(start, true).await;
@@ -1034,6 +1169,35 @@ impl DocumentService {
     ) -> Result<Option<DocumentRecord>> {
         debug!("Getting document {} from {}", id, collection);
 
+        // ADR-009 canonical-vector route: the shared vector store is authoritative. Scan it
+        // (full labelled records), rebuild the doc, return on hit. On miss, fall back to the
+        // legacy in-memory map for pre-cutover docs (mixed-read-safe). Note: no `get_collection`
+        // existence gate here — a canonical collection may live only in the record/vector
+        // catalog (e.g. created + written via REST v2), never in this facade's own map.
+        if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let records = route
+                .scan_records(clean_collection, CANONICAL_DOC_SCAN_LIMIT, tenant)
+                .await
+                .context("canonical-vector document scan failed")?;
+            if records.len() == CANONICAL_DOC_SCAN_LIMIT {
+                warn!(
+                    "canonical-vector get scan hit the {} cap for collection {}; a point read may be incomplete",
+                    CANONICAL_DOC_SCAN_LIMIT, clean_collection
+                );
+            }
+            if let Some(mut doc) = records
+                .iter()
+                .find_map(|r| proxima_record_to_legacy_document(r).filter(|d| d.id == id))
+            {
+                if let Some(fields) = projection.as_ref().filter(|f| !f.is_empty()) {
+                    doc.props = self.apply_projection(&doc.props, fields);
+                }
+                return Ok(Some(doc));
+            }
+            return Ok(self.legacy_dashmap_get(collection, id, projection));
+        }
+
         // Verify collection exists
         self.get_collection(collection)
             .await?
@@ -1087,6 +1251,25 @@ impl DocumentService {
         }
 
         Ok(None)
+    }
+
+    /// Legacy in-memory (DashMap) point lookup — the mixed-read-safe fallback for
+    /// pre-cutover documents still keyed under the scoped `collection`. Used only from
+    /// the canonical-vector read path after a store miss; the gate-OFF path keeps its
+    /// own inline lookup unchanged.
+    fn legacy_dashmap_get(
+        &self,
+        collection: &str,
+        id: &str,
+        projection: Option<Vec<String>>,
+    ) -> Option<DocumentRecord> {
+        let documents = &*self.documents;
+        let collection_docs = documents.get(collection)?;
+        let mut result = collection_docs.get(id)?.clone();
+        if let Some(fields) = projection.as_ref().filter(|f| !f.is_empty()) {
+            result.props = self.apply_projection(&result.props, fields);
+        }
+        Some(result)
     }
 
     /// Apply field projection over the canonical props tree (TD-106 Slice 7e).
@@ -1157,6 +1340,30 @@ impl DocumentService {
         let new_version = record.version + 1;
         record.version = new_version;
         record.updated_at_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+
+        // ADR-009 canonical-vector route: write the updated document back to the shared
+        // vector store (upsert on the raw-id OID) so the update is visible cross-surface.
+        if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let proxima = Self::canonical_document_record(&record, clean_collection, tenant);
+            match route
+                .insert_records(clean_collection, vec![proxima], tenant)
+                .await
+            {
+                Ok(_) => {
+                    debug!(
+                        "Updated document {} in {} via canonical-vector route",
+                        id, clean_collection
+                    );
+                    self.record_update_metrics(start, false).await;
+                    return Ok(record);
+                }
+                Err(e) => {
+                    self.record_update_metrics(start, true).await;
+                    return Err(e.context("canonical-vector document update failed"));
+                }
+            }
+        }
 
         // Write to WAL first (durability before in-memory update)
         // Store full updated document for proper recovery replay
@@ -1463,6 +1670,33 @@ impl DocumentService {
         let start = std::time::Instant::now();
         debug!("Deleting document {} from {}", id, collection);
 
+        // ADR-009 canonical-vector route: tombstone in the shared vector store (visible
+        // cross-surface), and also drop any pre-cutover legacy copy under the scoped key so
+        // it cannot resurface (mixed-read-safe). Returns true if either store held the doc.
+        if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let deleted = route
+                .delete_records(clean_collection, vec![id.to_string()], tenant)
+                .await
+                .context("canonical-vector document delete failed")?;
+            let legacy_present = self
+                .documents
+                .get(collection)
+                .is_some_and(|docs| docs.contains_key(id));
+            if legacy_present {
+                if let Err(e) = self.write_document_delete_to_wal(collection, id).await {
+                    self.record_delete_metrics(start, true).await;
+                    return Err(e);
+                }
+                let _ = self.remove_document_projection(collection, id).await;
+                if let Some(mut docs) = self.documents.get_mut(collection) {
+                    docs.remove(id);
+                }
+            }
+            self.record_delete_metrics(start, false).await;
+            return Ok(deleted > 0 || legacy_present);
+        }
+
         // Verify collection exists
         if let Err(e) = self
             .get_collection(collection)
@@ -1559,6 +1793,50 @@ impl DocumentService {
     ) -> Result<DocumentQueryResult> {
         let start = std::time::Instant::now();
         debug!("Querying documents in {}", collection);
+
+        // ADR-009 canonical-vector route: source documents from the shared vector store
+        // (cross-surface visibility), then run the same in-memory query executor. A queried
+        // collection is either opted-in (canonical) or not; pre-cutover point reads stay
+        // served by `get_document`'s legacy fallback.
+        if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let records = route
+                .scan_records(clean_collection, CANONICAL_DOC_SCAN_LIMIT, tenant)
+                .await
+                .context("canonical-vector document scan failed")?;
+            if records.len() == CANONICAL_DOC_SCAN_LIMIT {
+                warn!(
+                    "canonical-vector query scan hit the {} cap for collection {}; results may be incomplete",
+                    CANONICAL_DOC_SCAN_LIMIT, clean_collection
+                );
+            }
+            let documents: Vec<DocumentRecord> = records
+                .iter()
+                .filter_map(proxima_record_to_legacy_document)
+                .collect();
+            let (documents, total_count) = match self
+                .query_executor
+                .execute(collection, &documents, &params, &self.index_manager)
+                .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    self.record_query_metrics(start, true).await;
+                    return Err(e);
+                }
+            };
+            let query_time_ms = start.elapsed().as_millis() as u64;
+            self.record_query_metrics(start, false).await;
+            return Ok(DocumentQueryResult {
+                documents,
+                total_count: if params.include_count {
+                    Some(total_count)
+                } else {
+                    None
+                },
+                query_time_ms,
+            });
+        }
 
         // Verify collection exists
         let _collection_meta = match self
@@ -1657,13 +1935,29 @@ impl DocumentService {
         let start = std::time::Instant::now();
         debug!("Aggregating documents in {}", collection);
 
-        // Verify collection exists
-        self.get_collection(collection)
-            .await?
-            .ok_or_else(|| anyhow!("Collection '{}' not found", collection))?;
-
-        // Get all documents from the collection
-        let documents: Vec<DocumentRecord> = {
+        // Get all documents from the collection — the shared vector store when routed
+        // (ADR-009 cross-surface visibility), else the legacy in-memory map.
+        let documents: Vec<DocumentRecord> = if let Some(route) = self.canonical_route(collection) {
+            let (tenant, clean_collection) = unscope_document_collection(collection);
+            let records = route
+                .scan_records(clean_collection, CANONICAL_DOC_SCAN_LIMIT, tenant)
+                .await
+                .context("canonical-vector document scan failed")?;
+            if records.len() == CANONICAL_DOC_SCAN_LIMIT {
+                warn!(
+                    "canonical-vector aggregate scan hit the {} cap for collection {}; results may be incomplete",
+                    CANONICAL_DOC_SCAN_LIMIT, clean_collection
+                );
+            }
+            records
+                .iter()
+                .filter_map(proxima_record_to_legacy_document)
+                .collect()
+        } else {
+            // Verify collection exists (legacy path only)
+            self.get_collection(collection)
+                .await?
+                .ok_or_else(|| anyhow!("Collection '{}' not found", collection))?;
             let docs = &*self.documents;
             match docs.get(collection) {
                 Some(collection_docs) => collection_docs.values().cloned().collect(),
@@ -2525,6 +2819,195 @@ mod tests {
         .await
         .expect("collection creation should succeed");
         svc
+    }
+
+    // =========================================================================
+    // ADR-009 canonical-vector route (document store convergence)
+    // =========================================================================
+
+    /// In-memory stand-in for the shared record/vector store: proves a document routed onto
+    /// the canonical-vector path lands in — and is served from — the SAME store the REST v2
+    /// record surface uses (cross-surface visibility), without a full network server. Keyed
+    /// by (clean collection, raw-id oid).
+    #[derive(Default)]
+    struct MockRecordRoute {
+        store: std::sync::Mutex<HashMap<String, HashMap<String, proximadb_records::ProximaRecord>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl proximadb_runtime::RecordRoutePort for MockRecordRoute {
+        async fn insert_records(
+            &self,
+            collection_id: &str,
+            records: Vec<proximadb_records::ProximaRecord>,
+            _tenant: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            let mut store = self.store.lock().expect("mock route lock");
+            let coll = store.entry(collection_id.to_string()).or_default();
+            let n = records.len();
+            for r in records {
+                coll.insert(r.oid.clone(), r);
+            }
+            Ok(n)
+        }
+
+        async fn scan_records(
+            &self,
+            collection_id: &str,
+            limit: usize,
+            _tenant: Option<&str>,
+        ) -> anyhow::Result<Vec<proximadb_records::ProximaRecord>> {
+            let store = self.store.lock().expect("mock route lock");
+            Ok(store
+                .get(collection_id)
+                .map(|c| c.values().take(limit).cloned().collect())
+                .unwrap_or_default())
+        }
+
+        async fn delete_records(
+            &self,
+            collection_id: &str,
+            record_ids: Vec<String>,
+            _tenant: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            let mut store = self.store.lock().expect("mock route lock");
+            let mut n = 0;
+            if let Some(coll) = store.get_mut(collection_id) {
+                for id in record_ids {
+                    if coll.remove(&id).is_some() {
+                        n += 1;
+                    }
+                }
+            }
+            Ok(n)
+        }
+    }
+
+    /// Scope the process-global `PROXIMADB_DOC_CANONICAL_VECTOR` gate to one collection for
+    /// the duration of a test; removes it on drop. A unique collection name keeps the gate
+    /// scoped even if the env leaks across a shared-process `cargo test` (nextest — the
+    /// mandated runner — isolates per process, so the set/remove is single-threaded there).
+    struct GateGuard;
+    impl GateGuard {
+        fn on(collection: &str) -> Self {
+            // SAFETY (edition 2024): under nextest each test owns its process, so this env
+            // mutation is single-threaded; the value is a fixed collection name.
+            unsafe { std::env::set_var("PROXIMADB_DOC_CANONICAL_VECTOR", collection) };
+            Self
+        }
+    }
+    impl Drop for GateGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var("PROXIMADB_DOC_CANONICAL_VECTOR") };
+        }
+    }
+
+    fn doc_record(id: &str, collection: &str, title: &str) -> DocumentRecord {
+        DocumentRecord::from_tree(
+            id.to_string(),
+            crate::storage::document::canonical_adapter::sql_object_to_proxima_tree(
+                &make_document(vec![("title", sql_string(title))]),
+            ),
+            collection.to_string(),
+            None,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn canonical_route_insert_is_visible_via_shared_store_and_not_legacy_map() {
+        let _gate = GateGuard::on("conv_docs");
+        let svc = service_with_collection("conv_docs").await;
+        let route = Arc::new(MockRecordRoute::default());
+        svc.set_record_route(route.clone());
+
+        // Insert via the DocumentService (the gRPC surface's entry point).
+        svc.insert_document_record("conv_docs", doc_record("d1", "conv_docs", "Alpha"))
+            .await
+            .expect("canonical insert");
+
+        // It landed in the SHARED store with a raw-id OID + document label — NOT the legacy map.
+        {
+            let store = route.store.lock().expect("lock");
+            let coll = store
+                .get("conv_docs")
+                .expect("collection present in shared store");
+            let stored = coll.get("d1").expect("raw-id OID key");
+            assert_eq!(
+                stored.oid, "d1",
+                "OID is the raw doc id, no document/ prefix"
+            );
+            assert!(
+                stored
+                    .labels
+                    .contains(proximadb_document::DOCUMENT_RECORD_LABEL),
+                "record carries the document facade label"
+            );
+        }
+        assert!(
+            !svc.documents
+                .get("conv_docs")
+                .is_some_and(|d| d.contains_key("d1")),
+            "canonical write must NOT populate the legacy in-memory map"
+        );
+
+        // Read-back via the DocumentService reads THROUGH the shared store (cross-surface).
+        let got = svc
+            .get_document("conv_docs", "d1", None)
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(got.id, "d1");
+        assert_eq!(
+            got.props.get("title"),
+            Some(&ProximaTreeNode::Value(ProximaValue::String(
+                "Alpha".to_string()
+            )))
+        );
+
+        // Query sees it too, sourced from the shared store.
+        let queried = svc
+            .query_documents("conv_docs", DocumentQueryParams::default())
+            .await
+            .expect("query");
+        assert_eq!(queried.documents.len(), 1);
+
+        // Delete tombstones in the shared store.
+        assert!(
+            svc.delete_document("conv_docs", "d1")
+                .await
+                .expect("delete")
+        );
+        assert!(
+            svc.get_document("conv_docs", "d1", None)
+                .await
+                .expect("get2")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_off_keeps_legacy_path_and_ignores_route() {
+        // No GateGuard ⇒ gate OFF ⇒ today's behavior, bit-for-bit.
+        let svc = service_with_collection("legacy_docs").await;
+        let route = Arc::new(MockRecordRoute::default());
+        svc.set_record_route(route.clone());
+
+        svc.insert_document_record("legacy_docs", doc_record("d1", "legacy_docs", "Beta"))
+            .await
+            .expect("legacy insert");
+
+        // The shared store was NOT touched; the legacy map serves the doc.
+        assert!(
+            route.store.lock().expect("lock").is_empty(),
+            "gate OFF must not route to the shared store"
+        );
+        let got = svc
+            .get_document("legacy_docs", "d1", None)
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(got.id, "d1");
     }
 
     /// Set up a canonical-record-backed service with a pre-created collection.

--- a/tests/documents_convergence_e2e.rs
+++ b/tests/documents_convergence_e2e.rs
@@ -1,0 +1,223 @@
+//! ADR-009 document store-convergence — cross-surface visibility, e2e over the real
+//! network transports (REST + gRPC), never calling an engine directly.
+//!
+//! The document modality historically had a **store-split**: REST v2 document ingest wrote
+//! to the per-collection record/vector store, while the gRPC `ProximaDocumentService` +
+//! `DocumentService` wrote to their own `document_wal` — so a document written on one
+//! surface was invisible on the other. This suite proves the convergence:
+//!
+//! - **Gate ON** (`PROXIMADB_DOC_CANONICAL_VECTOR` = collection): a document ingested via
+//!   REST v2 is visible to a gRPC `GetDocument` — one store, cross-surface. This is the
+//!   headline convergence claim.
+//! - **Gate OFF** (default): the gRPC/`DocumentService` legacy path round-trips unchanged
+//!   (create → get), proving the default-OFF gate preserves today's behavior.
+//!
+//! One ProximaDB boot per process (the WAL manifest is a set-once singleton); nextest runs
+//! each test in its own process, so the per-test env gate + boot are isolated.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::proto::proximadb_v2::proxima_document_service_client::ProximaDocumentServiceClient;
+use proximadb::proto::proximadb_v2::{CreateDocumentRequest, GetDocumentRequest};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct TestServer {
+    rest_port: u16,
+    grpc_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl TestServer {
+    async fn start() -> anyhow::Result<Self> {
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let pg_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!("REST server didn't become ready within 20s");
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        sleep(Duration::from_millis(300)).await;
+
+        Ok(Self {
+            rest_port,
+            grpc_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn rest(&self) -> String {
+        format!("http://127.0.0.1:{}", self.rest_port)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Scope the process-global gate to `collection` for the test; removes it on drop.
+struct GateGuard;
+impl GateGuard {
+    fn on(collection: &str) -> Self {
+        // SAFETY (edition 2024): nextest runs each test in its own process, so this env
+        // mutation is single-threaded for the process.
+        unsafe { std::env::set_var("PROXIMADB_DOC_CANONICAL_VECTOR", collection) };
+        Self
+    }
+}
+impl Drop for GateGuard {
+    fn drop(&mut self) {
+        unsafe { std::env::remove_var("PROXIMADB_DOC_CANONICAL_VECTOR") };
+    }
+}
+
+/// Gate ON: a REST-v2-ingested document is visible to a gRPC `GetDocument` — one store,
+/// cross-surface (the headline convergence claim).
+#[tokio::test]
+async fn rest_ingested_document_is_visible_via_grpc_when_gate_on() {
+    let collection = "convdocs";
+    let _gate = GateGuard::on(collection);
+    let server = TestServer::start().await.expect("server start");
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("http client");
+
+    // Create the vector collection the document route resolves against.
+    let create = http
+        .post(format!("{}/api/v2/collections", server.rest()))
+        .json(&json!({"name": collection, "dimension": 8, "engine": "sst"}))
+        .send()
+        .await
+        .expect("create collection");
+    assert!(
+        create.status().is_success(),
+        "collection create should succeed, got {}",
+        create.status()
+    );
+
+    // Ingest a document via REST v2 with an SDK-provided vector (no embedding backend needed).
+    let ingest = http
+        .post(format!(
+            "{}/api/v2/collections/{collection}/documents",
+            server.rest()
+        ))
+        .header("X-Embed-Source", "sdk-vector")
+        .header("X-Ingest-Mode", "sync")
+        .json(&json!({
+            "records": [{
+                "id": "doc-1",
+                "vector": [0.1_f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+                "metadata": {"title": "Alpha"}
+            }]
+        }))
+        .send()
+        .await
+        .expect("ingest document");
+    assert!(
+        ingest.status().is_success(),
+        "document ingest should succeed, got {} body {:?}",
+        ingest.status(),
+        ingest.text().await.ok()
+    );
+
+    // Read it back over gRPC ProximaDocumentService — the other surface.
+    let mut client =
+        ProximaDocumentServiceClient::connect(format!("http://127.0.0.1:{}", server.grpc_port))
+            .await
+            .expect("gRPC connect");
+    let resp = client
+        .get_document(GetDocumentRequest {
+            collection_id: collection.to_string(),
+            id: "doc-1".to_string(),
+        })
+        .await
+        .expect("gRPC GetDocument should find the REST-ingested doc (cross-surface)")
+        .into_inner();
+    let doc = resp.document.expect("document present");
+    assert_eq!(doc.id, "doc-1", "gRPC sees the REST-ingested document id");
+}
+
+/// Gate OFF (default): the gRPC/DocumentService legacy path round-trips unchanged
+/// (create → get), so the default-OFF gate preserves today's behavior bit-for-bit.
+#[tokio::test]
+async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
+    let server = TestServer::start().await.expect("server start");
+    let mut client =
+        ProximaDocumentServiceClient::connect(format!("http://127.0.0.1:{}", server.grpc_port))
+            .await
+            .expect("gRPC connect");
+
+    client
+        .create_document(CreateDocumentRequest {
+            collection_id: "legacydocs".to_string(),
+            id: "doc-1".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("gRPC CreateDocument (legacy path)");
+
+    let resp = client
+        .get_document(GetDocumentRequest {
+            collection_id: "legacydocs".to_string(),
+            id: "doc-1".to_string(),
+        })
+        .await
+        .expect("gRPC GetDocument (legacy path)")
+        .into_inner();
+    let doc = resp.document.expect("document present via legacy path");
+    assert_eq!(doc.id, "doc-1");
+}


### PR DESCRIPTION
## Summary

The document modality had a **store-split**: REST v2 document ingest persisted to the
per-collection record/vector store, while the gRPC `ProximaDocumentService` + `DocumentService`
wrote to their own `document_wal` + in-memory map. A document written on one surface was
**invisible on the other**; the gRPC path was **unmetered** (billing gap); and bodies were
**double-stored** (double GB-month).

This converges both surfaces on the shared record/vector store — the architectural intent of
`RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc` / ADR-009 (graph already converged;
documents were the flagged remaining gap) — behind a **default-OFF, per-collection runtime gate**,
mixed-read-safe.

## What changed

- **`RecordRoutePort`** (`insert`/`scan`/`delete`) in `proximadb-runtime`, implemented on
  `RecordOpsService` — delegating to the *same* tenant-scoped `handle_record_*_for_tenant` path
  REST v2 already uses (reuses the live `RecordOpsPort` write surface rather than duplicating it).
- **`DocumentService`** routes `insert`/`get`/`query`/`delete`/`update`/`aggregate` through the
  route when the gate is ON (`PROXIMADB_DOC_CANONICAL_VECTOR`, per-collection); the legacy
  `document_wal`/map path is retained for gate-OFF **and** as a read-fallback for pre-cutover docs
  (mixed-read-safe, no flag-day). Identity = **raw `doc.id` OID** (reconstruction reads
  `local_id`/props, not the OID) + `record.tenant_id` stamp for structural-isolation defense.
- **Instance fold**: the three `DocumentService` instances (one in `shared_services`, two in
  `multi_server`) collapse to one shared, route-wired instance — closing the second split axis.
- **REST v2** stamps the `document` label + `_document_collection` prop (gated) so a REST-ingested
  doc rebuilds cleanly on a gRPC read — cross-surface visibility.
- Metering (io_trace + consumption), `DrPathBuilder` key discipline, and canonical WAL recovery are
  inherited from the vector path.

**Gate OFF = today's behavior, bit-for-bit.** Cutover to default-ON is deferred until baked, per the
storage-format-migration mandate.

## Tests

- **Unit round-trip** (`canonical_adapter`): raw-id OID + `document` label reconstructs losslessly.
- **Mock-route integration** (`document/service`): insert→get→query→delete through the shared store;
  canonical write does NOT touch the legacy map; **gate-OFF parity** (legacy path unchanged).
- **Network e2e** (`documents_convergence_e2e`): REST-ingested doc visible via gRPC `GetDocument`
  when the gate is ON (cross-surface); gRPC create→get round-trips on the legacy path when OFF.

## Known limitation (bake-period validation)

Pure-metadata documents (gRPC `CreateDocument` with no vector) on the canonical route depend on the
vector engine accepting embedding-less records. Embedded documents (the primary convergence case)
are covered end-to-end; metadata-only routing is to be validated during the default-OFF bake.
