### PR TITLE
fix(storage,network): Wave 0 truth & safety — PAX read CRC, mux conn-leak, real fdatasync, honest engine/tenant semantics

### DIFF
--- a/crates/storage/proximadb-block-format/src/header.rs
+++ b/crates/storage/proximadb-block-format/src/header.rs
@@ -111,7 +111,7 @@ pub mod flags {
 /// [8..10]  column_count       u16
 /// [10..14] row_count          u32
 /// [14..18] block_size         u32  (total bytes including header)
-/// [18..22] checksum           u32  crc32c of bytes [22..block_size]
+/// [18..22] checksum           u32  crc32 (IEEE) of bytes [64..block_size]
 /// [22..24] _pad               u16
 /// [24..32] collection_id_hash u64  xxhash64(collection_id)
 /// [32..40] schema_fingerprint u64  schema version fingerprint
@@ -128,7 +128,9 @@ pub struct BlockHeader {
     pub row_count: u32,
     /// Total block size in bytes (including this 64-byte header).
     pub block_size: u32,
-    /// crc32c checksum of bytes [22..block_size] (everything after the checksum field).
+    /// crc32 (IEEE) checksum of bytes [HEADER_SIZE..block_size] (the block body,
+    /// i.e. everything after the 64-byte header). Verified on read by
+    /// `PaxBlockReader::open`.
     pub checksum: u32,
     /// xxhash64 of the UTF-8 collection identifier.
     pub collection_id_hash: u64,
@@ -194,8 +196,15 @@ impl BlockHeader {
 
     /// True if this block may contain rows for the given `tenant_id_hash`.
     ///
-    /// Returns `true` conservatively (when hash is 0, block is multi-tenant
-    /// or tenant hash is not set).
+    /// This is a block-level **pruning hint**, not the tenant-isolation
+    /// boundary: it lets a scan skip blocks that provably hold no rows for the
+    /// querying tenant. A `tenant_id_hash` of 0 means the block is
+    /// **mixed-tenant** — the writer stamps 0 whenever a single block accretes
+    /// records from more than one tenant (see `PaxBlockWriter`) — so such a
+    /// block cannot be pruned by tenant and is conservatively scanned. Tenant
+    /// isolation for mixed blocks is enforced downstream by **row-level**
+    /// tenant filtering, never by this method alone; returning `true` here is
+    /// therefore correct (a superset), not a fail-open leak.
     pub fn tenant_matches(&self, tenant_hash: u64) -> bool {
         self.tenant_id_hash == 0 || self.tenant_id_hash == tenant_hash
     }

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -16,6 +16,7 @@
 //! stripes are read at that index position.
 
 use anyhow::{Result, bail};
+use crc32fast::Hasher as Crc32;
 use proximadb_codec::{ProximaScheme, functions};
 
 use crate::{
@@ -69,6 +70,17 @@ impl<'a> PaxBlockReader<'a> {
             bail!("block too small: {} bytes", data.len());
         }
         let header = BlockHeader::from_bytes(&data[..HEADER_SIZE])?;
+
+        // Verify block integrity before interpreting any footer offsets. The
+        // writer stamps crc32(body) where body = bytes [HEADER_SIZE..block_size]
+        // (everything after the 64-byte header); a mismatch means the block was
+        // silently corrupted on disk or in flight, so we fail closed rather than
+        // decode garbage. This guards the whole-block read path (compaction,
+        // local reads, OLTP full-row reads); the footer-first ranged path
+        // (`ranged.rs`) fetches partial byte ranges and cannot run this
+        // whole-block check — extending integrity to per-stripe/per-range CRCs
+        // for the ranged reader is a known follow-up.
+        verify_block_checksum(data, &header)?;
 
         // Read block footer (last BLOCK_FOOTER_SIZE bytes)
         let footer_start = data.len() - BLOCK_FOOTER_SIZE;
@@ -593,6 +605,32 @@ impl<'a> PaxBlockReader<'a> {
     }
 }
 
+/// Recompute and check the block's CRC32 against the value stamped in its
+/// header. `body` is `data[HEADER_SIZE..block_size]` — exactly the bytes the
+/// writer hashed (see `PaxBlockWriter::flush`). Returns an error on a truncated
+/// buffer or a checksum mismatch (silent corruption), so the reader never
+/// decodes bytes it cannot vouch for.
+fn verify_block_checksum(data: &[u8], header: &BlockHeader) -> Result<()> {
+    let block_size = header.block_size as usize;
+    if block_size < HEADER_SIZE || block_size > data.len() {
+        bail!(
+            "block size {block_size} inconsistent with buffer {} bytes (truncated or corrupt)",
+            data.len()
+        );
+    }
+    let mut hasher = Crc32::new();
+    hasher.update(&data[HEADER_SIZE..block_size]);
+    let actual = hasher.finalize();
+    if actual != header.checksum {
+        bail!(
+            "block checksum mismatch: header {:#010x} != computed {:#010x} (corruption)",
+            header.checksum,
+            actual
+        );
+    }
+    Ok(())
+}
+
 fn scheme_from_encoding_id(encoding_id: u8) -> Option<ProximaScheme> {
     match encoding_id {
         0 => Some(ProximaScheme::Raw),
@@ -1007,6 +1045,46 @@ mod tests {
         assert_eq!(stats.upper_bounds.get(&col_id::CREATED_AT), Some(&3000));
         assert!(stats.hash_lower_bounds.contains_key(&col_id::TENANT_ID));
         assert!(stats.bloom_filter_bytes.contains_key(&col_id::TENANT_ID));
+    }
+
+    #[test]
+    fn open_rejects_corrupted_block() {
+        // A block whose body is mutated after the writer stamped its CRC must be
+        // rejected by `open` — silent corruption is caught, not decoded.
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 0);
+        writer.add_record(&make_record("r1", "t", 1000)).unwrap();
+        writer.add_record(&make_record("r2", "t", 2000)).unwrap();
+        let block = writer.flush().unwrap();
+
+        // Sanity: the pristine block opens.
+        assert!(PaxBlockReader::open(&block).is_ok());
+
+        // Flip one body byte (past the 64-byte header) → checksum must fail.
+        // (`PaxBlockReader` has no Debug impl, so we can't use `unwrap_err`.)
+        let mut corrupt = block.clone();
+        corrupt[HEADER_SIZE + 1] ^= 0xff;
+        let err = match PaxBlockReader::open(&corrupt) {
+            Ok(_) => panic!("expected corrupted block to be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("checksum mismatch"),
+            "expected checksum rejection, got: {err}"
+        );
+
+        // A buffer whose declared block_size exceeds its length is rejected as
+        // truncated before any offset is interpreted.
+        let truncated = &block[..block.len() - 1];
+        let err = match PaxBlockReader::open(truncated) {
+            Ok(_) => panic!("expected truncated block to be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("truncated")
+                || err.to_string().contains("checksum")
+                || err.to_string().contains("too small"),
+            "expected truncation/checksum rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -530,6 +530,16 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// Sync file *data* to disk (fdatasync): flush contents without necessarily
+    /// flushing inode metadata (size/mtime) separately — a cheaper durability
+    /// barrier than [`FileSystem::sync_file`] on local disks. The default
+    /// delegates to `sync_file` (a full fsync, a safe superset), so backends
+    /// without a distinct data-only barrier (object stores, etc.) need not
+    /// override it. `LocalFileSystem` overrides this with a real `fdatasync`.
+    async fn sync_data(&self, path: &str) -> FsResult<()> {
+        self.sync_file(path).await
+    }
+
     /// Append to file
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()>;
 

--- a/src/network/multiplex/tcp_multiplexer.rs
+++ b/src/network/multiplex/tcp_multiplexer.rs
@@ -21,6 +21,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tracing::{debug, error, info, trace, warn};
@@ -152,7 +153,13 @@ impl TcpMultiplexer {
 
         let config = Arc::new(self.config);
         let mut shutdown_rx = self.shutdown_rx;
-        let mut connection_count = 0usize;
+        // Count of *live* connections. Each accepted connection increments this
+        // and holds a `ConnectionGuard` that decrements it when the connection
+        // task finishes, so `max_connections` bounds concurrent connections
+        // rather than lifetime accepts (previously a plain counter only
+        // incremented, wedging the listener after `max_connections` lifetime
+        // connections — an availability bug).
+        let connection_count = Arc::new(AtomicUsize::new(0));
 
         loop {
             tokio::select! {
@@ -166,19 +173,25 @@ impl TcpMultiplexer {
                 accept_result = listener.accept() => {
                     match accept_result {
                         Ok((stream, peer_addr)) => {
-                            if connection_count >= config.max_connections {
+                            let current = connection_count.load(Ordering::Relaxed);
+                            if current >= config.max_connections {
                                 warn!(
-                                    current = connection_count,
+                                    current,
                                     max = config.max_connections,
                                     "Max connections reached"
                                 );
                                 continue;
                             }
 
-                            connection_count += 1;
+                            // Reserve a slot; the guard releases it when the
+                            // connection task completes (RAII), keeping the count
+                            // equal to the number of live connections.
+                            connection_count.fetch_add(1, Ordering::Relaxed);
+                            let guard = ConnectionGuard(Arc::clone(&connection_count));
                             let cfg = Arc::clone(&config);
 
                             tokio::spawn(async move {
+                                let _guard = guard;
                                 if let Err(e) = handle_connection(stream, peer_addr, cfg).await {
                                     debug!(error = %e, peer = %peer_addr, "Connection error");
                                 }
@@ -205,6 +218,18 @@ impl TcpMultiplexer {
 impl Default for TcpMultiplexer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// RAII guard for the multiplexer's live-connection count. Increment happens at
+/// accept time; this guard decrements when the connection task drops, so the
+/// count tracks concurrent connections and the `max_connections` cap can never
+/// be permanently exhausted by connections that have already closed.
+struct ConnectionGuard(Arc<AtomicUsize>);
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -400,5 +425,20 @@ mod tests {
         let config = TcpMultiplexConfig::default();
         assert_eq!(config.max_connections, 10000);
         assert_eq!(config.fallback_protocol, TcpProtocol::Http1);
+    }
+
+    #[test]
+    fn connection_guard_releases_slot_on_drop() {
+        // The live-connection count returns to zero once guards drop, so the
+        // listener never wedges after `max_connections` lifetime accepts.
+        let count = Arc::new(AtomicUsize::new(0));
+        {
+            count.fetch_add(1, Ordering::Relaxed);
+            let _g1 = ConnectionGuard(Arc::clone(&count));
+            count.fetch_add(1, Ordering::Relaxed);
+            let _g2 = ConnectionGuard(Arc::clone(&count));
+            assert_eq!(count.load(Ordering::Relaxed), 2);
+        }
+        assert_eq!(count.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -140,9 +140,18 @@ pub async fn materialize_collection(
         .collect();
     let vector_count = vector_records.len() as u64;
 
-    // Resolve + create the collection's configured engine (proven factory path).
-    let proto_engine =
-        ProtoStorageEngine::try_from(plan.engine_type).unwrap_or(ProtoStorageEngine::Sst);
+    // Resolve the collection's configured engine (proven factory path). An
+    // unrecognized engine id is a misconfiguration — fail loudly rather than
+    // silently substituting SST, which would write the collection's data in a
+    // different on-disk format than it was configured for.
+    let proto_engine = ProtoStorageEngine::try_from(plan.engine_type).map_err(|_| {
+        anyhow::anyhow!(
+            "flush: collection '{}' declares an unrecognized storage engine id {} — \
+             refusing to substitute a default engine",
+            plan.wal_key,
+            plan.engine_type
+        )
+    })?;
     let engine =
         match crate::storage::engines::factory::StorageFormatFactory::create_from_proto_async(
             proto_engine,

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -972,6 +972,39 @@ impl FileSystem for LocalFileSystem {
         Ok(())
     }
 
+    async fn sync_data(&self, path: &str) -> FsResult<()> {
+        // fdatasync: flush the file's data (and only the metadata required to
+        // read it back) without the full inode metadata flush of `sync_all`.
+        // This is the genuine `DurabilityLevel::SyncData` fast-path on local
+        // disks; remote backends fall back to a full `sync_file` via the trait
+        // default.
+        let path_str = self.resolve_path(path)?;
+        let resolved_path = PathBuf::from(path_str);
+
+        if !self.config.sync_enabled {
+            return Ok(());
+        }
+
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&resolved_path)
+            .await
+            .map_err(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    FilesystemError::NotFound(resolved_path.display().to_string())
+                }
+                _ => FilesystemError::Io(e),
+            })?;
+
+        // sync_data() maps to fdatasync(2) — data durability without the extra
+        // metadata barrier of fsync(2)/sync_all().
+        file.sync_data().await.map_err(FilesystemError::Io)?;
+
+        tracing::debug!("✅ File data synced to disk: {}", resolved_path.display());
+        Ok(())
+    }
+
     async fn open_file(&self, path: &str, create: bool) -> FsResult<Box<dyn FilesystemFile>> {
         let path_str = self.resolve_path(path)?;
         let resolved_path = PathBuf::from(path_str);

--- a/src/storage/persistence/write_ahead_log/batch_sync_coordinator.rs
+++ b/src/storage/persistence/write_ahead_log/batch_sync_coordinator.rs
@@ -280,12 +280,13 @@ impl BatchSyncCoordinator {
         // Perform sync based on durability level
         match &self.durability_level {
             DurabilityLevel::SyncData => {
-                // For now, we use sync_file which does fsync
-                // Deferred: Implement fdatasync for metadata-only sync
-                filesystem.sync_file(file_path).await?;
+                // Data-only durability: fdatasync on local disks (flush contents
+                // without the extra inode-metadata barrier); remote backends fall
+                // back to a full sync via the `sync_data` trait default.
+                filesystem.sync_data(file_path).await?;
             }
             DurabilityLevel::SyncFull => {
-                // Full fsync
+                // Full fsync (data + metadata).
                 filesystem.sync_file(file_path).await?;
             }
             _ => {


### PR DESCRIPTION
## Wave 0 — Truth & Safety

First batch of the ROI-ordered architecture-review remediation: small, high-value fixes that close **shipped correctness/availability holes** and make code match its docs. Co-design theme: **correctness-at-the-boundary** + operational trust.

### Changes
- **PAX read-side CRC** — `PaxBlockReader::open` now recomputes the block CRC32 over the body and rejects corrupted/truncated blocks. The writer already stamped the checksum; the reader never verified it, so silent PAX corruption was undetectable on read. Header doc corrected (crc32 IEEE over `[64..block_size]`, not "crc32c over [22..]").
- **Multiplexer connection-counter leak** — replaced the lifetime-only `usize` counter with `AtomicUsize` + an RAII `ConnectionGuard` that decrements when each connection task drops. `max_connections` now bounds *live* connections; previously the counter only incremented and the listener wedged permanently after `max_connections` lifetime accepts (availability bug).
- **SyncData durability honesty** — added `FileSystem::sync_data` (fdatasync) with a safe full-fsync default; `LocalFileSystem` implements the real fast-path. The WAL coordinator's `SyncData` tier no longer silently aliases `SyncFull` (config previously advertised a durability point that didn't exist).
- **Engine-misconfig no longer masked** — `flush_materializer` hard-errors on an unrecognized storage engine id instead of silently substituting SST (which would write a collection's data in the wrong on-disk format).
- **Block RLS semantics documented** — `tenant_id_hash == 0` is the *deliberate mixed-tenant marker* (writer stamps it when a block accretes >1 tenant); `tenant_matches` is a block-**pruning** hint with isolation enforced by row-level filtering downstream. Documented so it isn't misread as a fail-open leak (behavior unchanged — it's correct).

### Tests
- `open_rejects_corrupted_block` (block-format): a mutated body / truncated buffer is rejected by `open`.
- `connection_guard_releases_slot_on_drop` (multiplexer): the live count returns to zero as guards drop.

### Verification
- Server binary builds (`cargo build -p proximadb-server`), not just `--lib`.
- `cargo fmt --check` ✓ · `cargo clippy -D warnings` (leaf crates + root lib) ✓.
- `cargo nextest`: block-format 46/46 ✓; multiplexer guard test ✓.
- Panic-policy module guard: **+0 delta** (no new unwrap/expect/panic). Tenant-path guard ✓.

### Deferred (intentional — tracked for a dedicated PR)
- **Auth-required-by-default + tenant middleware default flip** → a separate **"secure-defaults" PR** (behavior-changing security posture touching the server-builder control flow and many tests; deserves its own review + TD + `--insecure` opt-out). The concrete unsafe branch to fix there is `auth.enabled && no SecurityCoordinator ⇒ serves unauthenticated` (`src/network/rest/server.rs:525`).
- **Per-stripe/per-range CRCs** for the footer-first ranged reader (the whole-block CRC here can't cover partial-range fetches) — noted as a follow-up.

### Note
`make hygiene-check` fails locally due to a pre-existing Makefile recipe bug (the `rg` regex doesn't parse under `dash`/`/bin/sh`); the guard's actual logic passes (no forbidden artifacts). Not addressed here to keep this batch scoped.