### PR TITLE
fix(pgwire,pax): Wave 1 correctness — format-aware $N binding, RaBitQ quant-id, PAX v1/v2 doc

### DIFF
--- a/crates/storage/proximadb-block-format/src/header.rs
+++ b/crates/storage/proximadb-block-format/src/header.rs
@@ -16,8 +16,15 @@ pub const BLOCK_MAGIC: [u8; 4] = *b"PBLK";
 /// v2 (this build) is a clean break from v1: SQ8-quantized vector stripes, a
 /// per-column dimension carried in the [`crate::writer::VectorParamBlock`]
 /// side region (no more per-row dim prefix), and a row-group sub-index. v1
-/// blocks are rejected outright by [`BlockHeader::from_bytes`] — there is no
-/// migration path.
+/// blocks are rejected outright by [`BlockHeader::from_bytes`].
+///
+/// **Mixed-read-safety (mandate #8).** The v1→v2 clean break is safe *because v1
+/// was a pre-release development format that never persisted in any released
+/// build* — there are no v1 blocks on disk to migrate, so rejecting them loses
+/// no data. This exception applies only to that pre-1.0 transition. From v2
+/// onward this version byte is the compatibility gate: any future `v3` MUST be
+/// mixed-read-safe — readers dispatch on the byte and keep decoding v2 rather
+/// than flag-day rejecting it. See `docs/12-design/adr/ADR-010-pax-block-format.adoc`.
 pub const FORMAT_VERSION: u8 = 2;
 /// Fixed header size in bytes.
 pub const HEADER_SIZE: usize = 64;

--- a/crates/storage/proximadb-block-format/src/lib.rs
+++ b/crates/storage/proximadb-block-format/src/lib.rs
@@ -98,7 +98,6 @@ pub use row_dir::{ROW_ENTRY_SIZE, RowDirectory, RowEntry, row_flags};
 pub use rowgroup::{ROW_GROUP_SIZE, RowGroupBlock, RowGroupEntry};
 pub use stripe::{BlockStats, COLUMN_META_SIZE, ColumnMeta, ColumnRole, ColumnStripe};
 pub use vparam::{
-    QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
-    VectorParamEntry,
+    QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock, VectorParamEntry,
 };
 pub use writer::{BLOCK_FOOTER_SIZE, BlockFooter, PaxBlockWriter, VectorQuant};

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -24,9 +24,7 @@ use crate::{
     row_dir::{ROW_ENTRY_SIZE, RowDirectory},
     rowgroup::RowGroupBlock,
     stripe::{COLUMN_META_SIZE, ColumnMeta},
-    vparam::{
-        QUANT_FP16, QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
-    },
+    vparam::{QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock},
     writer::{BLOCK_FOOTER_SIZE, BlockFooter},
 };
 use proximadb_codec::functions::{rabitq, sq8};
@@ -315,7 +313,7 @@ impl<'a> PaxBlockReader<'a> {
         let raw = self.read_stripe_raw(column_id)?;
         let n = self.row_count() as usize;
         let entry = self.vparams.get(column_id)?;
-        if entry.quant_kind == QUANT_RABITQ_RESERVED {
+        if entry.quant_kind == QUANT_RABITQ {
             // RaBitQ is a search representation; reconstruction is coarse (direction
             // preserved, magnitude approximate). Exact rerank uses a full-f32 tier.
             let col = self.vparams.rabitq_column(column_id)?;
@@ -333,7 +331,7 @@ impl<'a> PaxBlockReader<'a> {
         column_id: i32,
     ) -> Option<(RaBitQParams, Vec<Option<RaBitQCode>>)> {
         let entry = self.vparams.get(column_id)?;
-        if entry.quant_kind != QUANT_RABITQ_RESERVED {
+        if entry.quant_kind != QUANT_RABITQ {
             return None;
         }
         let col = self.vparams.rabitq_column(column_id)?;
@@ -1472,7 +1470,7 @@ mod tests {
                 .get(col_id::EMBED_BASE)
                 .unwrap()
                 .quant_kind,
-            crate::vparam::QUANT_RABITQ_RESERVED
+            crate::vparam::QUANT_RABITQ
         );
         assert_eq!(
             reader
@@ -1540,7 +1538,7 @@ mod tests {
                 .get(crate::col_id::EMBED_BASE)
                 .unwrap()
                 .quant_kind,
-            crate::vparam::QUANT_RABITQ_RESERVED
+            crate::vparam::QUANT_RABITQ
         );
 
         // Rerank the full candidate set against a query; FP16 distances must
@@ -1815,7 +1813,7 @@ mod tests {
 
         // Both vector columns present and correctly quantized.
         let emb = reader.vector_params().get(col_id::EMBED_BASE).unwrap();
-        assert_eq!(emb.quant_kind, crate::vparam::QUANT_RABITQ_RESERVED);
+        assert_eq!(emb.quant_kind, crate::vparam::QUANT_RABITQ);
         let rer = reader
             .vector_params()
             .get(crate::col_id::RERANK_BASE)
@@ -1870,7 +1868,7 @@ mod tests {
 
         // The cosine path uses the same RaBitQ + SQ8 columns as L2.
         let emb = reader.vector_params().get(col_id::EMBED_BASE).unwrap();
-        assert_eq!(emb.quant_kind, crate::vparam::QUANT_RABITQ_RESERVED);
+        assert_eq!(emb.quant_kind, crate::vparam::QUANT_RABITQ);
         assert_eq!(
             reader
                 .vector_params()

--- a/crates/storage/proximadb-block-format/src/vparam.rs
+++ b/crates/storage/proximadb-block-format/src/vparam.rs
@@ -33,8 +33,14 @@ use proximadb_codec::Sq8Params;
 pub const QUANT_RAW_F32: u8 = 0;
 /// Vector stripe is SQ8-quantized (1 byte/value).
 pub const QUANT_SQ8: u8 = 1;
-/// Reserved for a future binary RaBitQ scheme (not yet implemented).
-pub const QUANT_RABITQ_RESERVED: u8 = 2;
+/// Vector stripe is RaBitQ binary-quantized: per-row sign bits + corrective
+/// scalars live in the stripe, with the centroid and rotation seed in the
+/// [`RaBitQColumn`] trailer. The writer emits this id under the
+/// `PROXIMADB_VECTOR_RABITQ` gate (default-OFF until recall-baked); readers key
+/// off it to run the RaBitQ candidate/rerank cascade. (Formerly mislabeled
+/// `QUANT_RABITQ_RESERVED` "not yet implemented" while the writer already
+/// emitted it — the id and its on-wire meaning are unchanged; value stays 2.)
+pub const QUANT_RABITQ: u8 = 2;
 /// Vector stripe is stored as FP16 (2 bytes/value, near-lossless).
 pub const QUANT_FP16: u8 = 3;
 
@@ -254,7 +260,7 @@ mod tests {
             entries: vec![VectorParamEntry {
                 column_id: 20,
                 dim: 4,
-                quant_kind: QUANT_RABITQ_RESERVED,
+                quant_kind: QUANT_RABITQ,
                 params: Sq8Params {
                     scale: 0.0,
                     offset: 0.0,

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -35,8 +35,8 @@ use crate::{
     rowgroup::{RowGroupBlock, RowGroupEntry, f64_bounds, i64_bounds},
     stripe::{COLUMN_META_SIZE, ColumnMeta, ColumnRole, ColumnStripe},
     vparam::{
-        QUANT_FP16, QUANT_RABITQ_RESERVED, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn,
-        VectorParamBlock, VectorParamEntry,
+        QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
+        VectorParamEntry,
     },
 };
 
@@ -729,12 +729,7 @@ impl PaxBlockWriter {
         };
         let (data, scheme, quant_kind, rabitq_col) = if use_rabitq {
             let (bytes, col) = encode_f32_vec_rabitq(vals, dim, id);
-            (
-                bytes,
-                ProximaScheme::RaBitQ,
-                QUANT_RABITQ_RESERVED,
-                Some(col),
-            )
+            (bytes, ProximaScheme::RaBitQ, QUANT_RABITQ, Some(col))
         } else if use_sq8 {
             (
                 encode_f32_vec_sq8(vals, dim, &params),

--- a/docs/12-design/adr/ADR-010-pax-block-format.adoc
+++ b/docs/12-design/adr/ADR-010-pax-block-format.adoc
@@ -311,3 +311,16 @@ contract and Iceberg type coercion impact.
   PAX co-locates filter + vector attributes in one page with no storage penalty and no I/O beyond the
   page — validating that the ANN cascade (filter → RaBitQ → SQ8 rerank) must keep filter + vector
   stripes together in the durable core. Source: https://www.vldb.org/conf/2001/P169.pdf.
+* **Format versioning, integrity & quant-id clarifications (2026-07-06).**
+  ** The header `format_version` byte is the block-format compatibility gate. The historical
+     **v1→v2 clean break** (v2 rejects v1 outright, `header.rs::from_bytes`) is a permitted exception
+     to the mixed-read-safety mandate (CLAUDE.md #8) *only because v1 was a pre-release development
+     format that never persisted in any released build* — there are no v1 blocks on disk to migrate.
+     From v2 onward the mandate applies in full: any future `v3` MUST be mixed-read-safe (readers
+     dispatch on the version byte and keep decoding v2), never a flag-day rejection.
+  ** The header `checksum` is **crc32 (IEEE)** over `[64..block_size]` (the block body) and is now
+     **verified on read** by `PaxBlockReader::open` — a mismatch or truncation is rejected rather than
+     decoded, closing a silent-corruption gap where the writer stamped a checksum the reader ignored.
+  ** The `quant_kind == 2` vector id is **RaBitQ** (`QUANT_RABITQ`), not "reserved": the writer emits
+     it (under the `PROXIMADB_VECTOR_RABITQ` gate, default-OFF) and readers key off it for the RaBitQ
+     cascade. The wire value is unchanged; only the mislabeled `_RESERVED` name/doc was corrected.

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -4457,10 +4457,12 @@ impl PostgresProtocol {
         // Read statement name (source prepared statement)
         let statement_name = self.read_cstring(&mut cursor)?;
 
-        // Read format codes count (currently ignored - we use text format)
+        // Read parameter format codes. Per the PG protocol: 0 codes → all params
+        // are text; 1 code → it applies to every param; N codes → one per param.
         let format_code_count = cursor.get_i16() as usize;
+        let mut format_codes: Vec<i16> = Vec::with_capacity(format_code_count);
         for _ in 0..format_code_count {
-            let _format_code = cursor.get_i16();
+            format_codes.push(cursor.get_i16());
         }
 
         // Read parameter values count
@@ -4485,13 +4487,22 @@ impl PostgresProtocol {
             let _ = cursor.get_i16();
         }
 
+        // Normalize parameter format codes to one-per-parameter.
+        let param_formats: Vec<i16> = (0..param_count)
+            .map(|i| match format_codes.len() {
+                0 => 0,
+                1 => format_codes[0],
+                _ => format_codes.get(i).copied().unwrap_or(0),
+            })
+            .collect();
+
         // Get the prepared statement data (extract to avoid borrow conflicts)
         let stmt_data = self
             .prepared_statements
             .get(&statement_name)
-            .map(|s| (s.query.clone(), s.translated.clone()));
+            .map(|s| (s.query.clone(), s.translated.clone(), s.param_types.clone()));
 
-        let (stmt_query, stmt_translated) = match stmt_data {
+        let (stmt_query, stmt_translated, stmt_param_types) = match stmt_data {
             Some(data) => data,
             None => {
                 // If unnamed statement (""), use the query directly
@@ -4508,8 +4519,19 @@ impl PostgresProtocol {
             }
         };
 
-        // Bind parameters to the query
-        let bound_query = self.bind_parameters(&stmt_query, &param_values)?;
+        // Bind parameters to the query (format- and type-aware).
+        let bound_query = match self.bind_parameters(
+            &stmt_query,
+            &param_values,
+            &param_formats,
+            &stmt_param_types,
+        ) {
+            Ok(q) => q,
+            Err(e) => {
+                // 22P03 = invalid_binary_representation.
+                return self.send_error("ERROR", "22P03", &format!("{}", e)).await;
+            }
+        };
 
         // Create portal
         let portal = Portal {
@@ -4525,25 +4547,44 @@ impl PostgresProtocol {
         self.send_bind_complete().await
     }
 
-    /// Bind parameter values to a query string
-    fn bind_parameters(&self, query: &str, param_values: &[Option<Vec<u8>>]) -> Result<String> {
-        let mut result = query.to_string();
-
+    /// Bind parameter values into a query by substituting `$N` placeholders.
+    ///
+    /// Fixes two long-standing bugs in the old ordered `str::replace` approach:
+    /// (1) replacing `$1` before `$10` corrupted every placeholder ≥ 10 (and any
+    /// injected value that happened to contain a later `$N`); (2) every parameter
+    /// was decoded as UTF-8 text, silently mangling **binary-format** params
+    /// (int/float/vector sent with format code 1). Substitution is now a single
+    /// left-to-right pass ([`substitute_placeholders`]) and binary params are
+    /// decoded per their type ([`decode_binary_param`]) before rendering.
+    ///
+    /// `param_formats[i]` is the wire format code for parameter i (0 = text,
+    /// 1 = binary); `param_types[i]` is its type (from Parse / inferred).
+    fn bind_parameters(
+        &self,
+        query: &str,
+        param_values: &[Option<Vec<u8>>],
+        param_formats: &[i16],
+        param_types: &[PgType],
+    ) -> Result<String> {
+        let mut rendered: Vec<Option<String>> = Vec::with_capacity(param_values.len());
         for (i, value) in param_values.iter().enumerate() {
-            let placeholder = format!("${}", i + 1);
-            let replacement = match value {
-                Some(v) => {
-                    // Convert bytes to string (assuming UTF-8 text format)
-                    let s = String::from_utf8_lossy(v);
-                    // Escape single quotes
-                    format!("'{}'", s.replace('\'', "''"))
+            match value {
+                None => rendered.push(None),
+                Some(bytes) => {
+                    let is_binary = param_formats.get(i).copied().unwrap_or(0) == 1;
+                    let text = if is_binary {
+                        let ty = param_types.get(i).cloned().unwrap_or(PgType::Unknown);
+                        decode_binary_param(bytes, &ty).map_err(|e| {
+                            anyhow::anyhow!("parameter ${} binary decode failed: {}", i + 1, e)
+                        })?
+                    } else {
+                        String::from_utf8_lossy(bytes).into_owned()
+                    };
+                    rendered.push(Some(text));
                 }
-                None => "NULL".to_string(),
-            };
-            result = result.replace(&placeholder, &replacement);
+            }
         }
-
-        Ok(result)
+        Ok(substitute_placeholders(query, &rendered))
     }
 
     /// Handle Execute message - executes a portal
@@ -4999,6 +5040,165 @@ impl PostgresProtocol {
     }
 }
 
+/// Substitute `$N` placeholders in `query` with the rendered parameter values in
+/// a single left-to-right pass. `rendered[N-1]` is the parameter's textual value
+/// (`None` = SQL NULL); present values are emitted as quoted, `''`-escaped string
+/// literals (implicit-cast in the SQL layer, matching the historical behavior).
+///
+/// Correctness properties the old ordered `str::replace` lacked:
+/// - Each `$N` is matched by its **full digit run**, so `$10` is never clobbered
+///   by the `$1` substitution, and a substituted value that itself contains a
+///   `$K` sequence is never re-substituted (single forward pass).
+/// - `$N` inside single-quoted string literals is left untouched.
+/// - UTF-8 is preserved (verbatim spans are copied as `&str` slices).
+///
+/// An out-of-range or unparsable `$N` is passed through verbatim.
+fn substitute_placeholders(query: &str, rendered: &[Option<String>]) -> String {
+    let bytes = query.as_bytes();
+    let mut out = String::with_capacity(query.len() + 16);
+    let mut last = 0usize; // start of the not-yet-copied verbatim span
+    let mut i = 0usize;
+    let mut in_squote = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_squote {
+            if c == b'\'' {
+                // '' is an escaped quote inside the literal — stay inside.
+                if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                    i += 2;
+                    continue;
+                }
+                in_squote = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' => {
+                in_squote = true;
+                i += 1;
+            }
+            b'$' if i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() => {
+                let mut j = i + 1;
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    j += 1;
+                }
+                if let Ok(num) = query[i + 1..j].parse::<usize>()
+                    && num >= 1
+                    && num <= rendered.len()
+                {
+                    out.push_str(&query[last..i]);
+                    match &rendered[num - 1] {
+                        Some(v) => {
+                            out.push('\'');
+                            out.push_str(&v.replace('\'', "''"));
+                            out.push('\'');
+                        }
+                        None => out.push_str("NULL"),
+                    }
+                    last = j;
+                }
+                i = j;
+            }
+            _ => i += 1,
+        }
+    }
+    out.push_str(&query[last..]);
+    out
+}
+
+/// Decode a **binary-format** (format code 1) bound parameter into its textual
+/// representation, per the parameter's PostgreSQL type. Integers/floats are
+/// big-endian per the wire protocol; text-like types pass through as UTF-8.
+/// Returns an error (surfaced to the client as SQLSTATE 22P03) for types whose
+/// binary layout we do not decode — better than silently mangling the value,
+/// which the previous UTF-8-only path did.
+fn decode_binary_param(bytes: &[u8], ty: &PgType) -> std::result::Result<String, String> {
+    let fixed = |n: usize| -> std::result::Result<(), String> {
+        if bytes.len() == n {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} expects {n} bytes, got {}",
+                ty.name(),
+                bytes.len()
+            ))
+        }
+    };
+    match ty {
+        PgType::Bool => {
+            fixed(1)?;
+            Ok(if bytes[0] == 0 { "false" } else { "true" }.to_string())
+        }
+        PgType::Int2 => {
+            fixed(2)?;
+            Ok(i16::from_be_bytes([bytes[0], bytes[1]]).to_string())
+        }
+        PgType::Int4 => {
+            fixed(4)?;
+            Ok(i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]).to_string())
+        }
+        PgType::Int8 => {
+            fixed(8)?;
+            let mut a = [0u8; 8];
+            a.copy_from_slice(bytes);
+            Ok(i64::from_be_bytes(a).to_string())
+        }
+        PgType::Float4 => {
+            fixed(4)?;
+            Ok(f32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]).to_string())
+        }
+        PgType::Float8 => {
+            fixed(8)?;
+            let mut a = [0u8; 8];
+            a.copy_from_slice(bytes);
+            Ok(f64::from_be_bytes(a).to_string())
+        }
+        PgType::Text | PgType::Varchar | PgType::Json | PgType::Jsonb | PgType::Uuid => {
+            Ok(String::from_utf8_lossy(bytes).into_owned())
+        }
+        PgType::Vector => decode_binary_vector(bytes),
+        other => Err(format!(
+            "binary format for parameter type '{}' is not supported",
+            other.name()
+        )),
+    }
+}
+
+/// Decode a pgvector binary parameter (`int16 dim`, `int16 unused`, then
+/// `dim × big-endian float4`) into the `[a,b,c]` text literal the SQL layer
+/// parses.
+fn decode_binary_vector(bytes: &[u8]) -> std::result::Result<String, String> {
+    if bytes.len() < 4 {
+        return Err("vector binary too short for header".to_string());
+    }
+    let dim = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+    let expected = 4 + dim * 4;
+    if bytes.len() < expected {
+        return Err(format!(
+            "vector binary: expected {expected} bytes for dim {dim}, got {}",
+            bytes.len()
+        ));
+    }
+    let mut vals = Vec::with_capacity(dim);
+    let mut off = 4;
+    for _ in 0..dim {
+        vals.push(f32::from_be_bytes([
+            bytes[off],
+            bytes[off + 1],
+            bytes[off + 2],
+            bytes[off + 3],
+        ]));
+        off += 4;
+    }
+    let joined = vals
+        .iter()
+        .map(|f| f.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    Ok(format!("[{joined}]"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5010,6 +5210,80 @@ mod tests {
     fn test_frontend_message() {
         assert_eq!(FrontendMessage::Query as u8, b'Q');
         assert_eq!(FrontendMessage::Terminate as u8, b'X');
+    }
+
+    #[test]
+    fn substitute_placeholders_handles_two_digit_indices() {
+        // The old ordered str::replace turned "$10" into "<val1>0"; verify each
+        // placeholder is matched by its full digit run.
+        let rendered: Vec<Option<String>> = (1..=12).map(|n| Some(format!("v{n}"))).collect();
+        let out = substitute_placeholders("a=$1 b=$10 c=$11 d=$2 e=$12", &rendered);
+        assert_eq!(out, "a='v1' b='v10' c='v11' d='v2' e='v12'");
+    }
+
+    #[test]
+    fn substitute_placeholders_null_and_escaping_and_literals() {
+        let rendered = vec![None, Some("O'Brien".to_string())];
+        // $1 -> NULL (unquoted); $2 -> quoted with '' escaping.
+        let out = substitute_placeholders("x=$1, y=$2", &rendered);
+        assert_eq!(out, "x=NULL, y='O''Brien'");
+
+        // A `$1` inside a single-quoted string literal must NOT be substituted.
+        let out2 = substitute_placeholders("SELECT '$1', $2", &rendered);
+        assert_eq!(out2, "SELECT '$1', 'O''Brien'");
+
+        // A substituted value that itself contains `$2` is not re-substituted.
+        let rendered2 = vec![
+            Some("has $2 inside".to_string()),
+            Some("second".to_string()),
+        ];
+        let out3 = substitute_placeholders("$1 | $2", &rendered2);
+        assert_eq!(out3, "'has $2 inside' | 'second'");
+    }
+
+    #[test]
+    fn decode_binary_param_integers_and_floats_are_big_endian() {
+        assert_eq!(
+            decode_binary_param(&258i16.to_be_bytes(), &PgType::Int2).unwrap(),
+            "258"
+        );
+        assert_eq!(
+            decode_binary_param(&70000i32.to_be_bytes(), &PgType::Int4).unwrap(),
+            "70000"
+        );
+        assert_eq!(
+            decode_binary_param(&5_000_000_000i64.to_be_bytes(), &PgType::Int8).unwrap(),
+            "5000000000"
+        );
+        assert_eq!(
+            decode_binary_param(&1.5f32.to_be_bytes(), &PgType::Float4).unwrap(),
+            "1.5"
+        );
+        assert_eq!(
+            decode_binary_param(&2.25f64.to_be_bytes(), &PgType::Float8).unwrap(),
+            "2.25"
+        );
+        assert_eq!(decode_binary_param(&[1], &PgType::Bool).unwrap(), "true");
+        assert_eq!(decode_binary_param(&[0], &PgType::Bool).unwrap(), "false");
+    }
+
+    #[test]
+    fn decode_binary_param_rejects_bad_width_and_unsupported() {
+        // Wrong byte width is rejected rather than mis-decoded.
+        assert!(decode_binary_param(&[0, 0, 0], &PgType::Int4).is_err());
+        // Unsupported binary type errors instead of silently mangling.
+        assert!(decode_binary_param(&[0x01, 0x02], &PgType::Timestamp).is_err());
+    }
+
+    #[test]
+    fn decode_binary_vector_roundtrips_pgvector_layout() {
+        // [int16 dim=2][int16 unused=0][f32 be * 2]
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&2u16.to_be_bytes());
+        buf.extend_from_slice(&0u16.to_be_bytes());
+        buf.extend_from_slice(&0.5f32.to_be_bytes());
+        buf.extend_from_slice(&(-1.0f32).to_be_bytes());
+        assert_eq!(decode_binary_vector(&buf).unwrap(), "[0.5,-1]");
     }
 
     // pgvector WHERE-filter + extended-protocol param tests (TD-100/TD-102)

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -238,7 +238,7 @@ pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
 /// filesystem trait (object-store-safe) and calls this. Mirrors
 /// [`pax_inputs_have_f32_tier`]'s `PaxSegmentScanner` block-0 metadata read.
 pub fn pax_segment_is_coarse_rabitq_without_f32_tier(bytes: &[u8]) -> bool {
-    use proximadb_block_format::vparam::QUANT_RABITQ_RESERVED;
+    use proximadb_block_format::vparam::QUANT_RABITQ;
     if SegmentFormat::detect(bytes) != SegmentFormat::Pax {
         return false;
     }
@@ -256,7 +256,7 @@ pub fn pax_segment_is_coarse_rabitq_without_f32_tier(bytes: &[u8]) -> bool {
     let Some(embed) = vparams.get(col_id::EMBED_BASE) else {
         return false;
     };
-    embed.quant_kind == QUANT_RABITQ_RESERVED && vparams.get(col_id::F32_TIER_BASE).is_none()
+    embed.quant_kind == QUANT_RABITQ && vparams.get(col_id::F32_TIER_BASE).is_none()
 }
 
 /// Detect the tier-2 rerank quant strategy of the source `.pax` segments, so


### PR DESCRIPTION
## Wave 1 — Correctness quick wins

Second remediation batch (stacked on #699 / Wave 0). Fixes data-corrupting bugs on live paths and reconciles format wire-doc drift. **Retarget to `develop` once #699 merges.**

### pgwire prepared-statement binding (`src/network/postgres/protocol.rs`)
The Bind path had two correctness bugs:
1. **`$N` substitution corrupted `$10`+** — the old ordered `str::replace("$1", …)` also matched the `$1` *inside* `$10`/`$11`/…, and could re-substitute a value that itself contained a later `$N`. Replaced with a **single left-to-right pass** (`substitute_placeholders`) that matches each `$N` by its full digit run, skips `$N` inside single-quoted string literals, and is UTF-8-safe.
2. **Binary-format params were mangled** — format codes were read and discarded; every param went through `from_utf8_lossy`, silently corrupting binary int/float/vector bind params. Now the Bind format codes are honored (PG `0`/`1`/`N`-codes fan-out) and binary params are decoded by type (`decode_binary_param`: big-endian int2/4/8, float4/8, bool, text, pgvector). Unsupported binary types return **SQLSTATE 22P03** instead of silently corrupting.

### PAX block format (`crates/storage/proximadb-block-format`, ADR-010)
- **`QUANT_RABITQ_RESERVED` → `QUANT_RABITQ`** (wire value unchanged = 2). The writer already emits this id and readers decode it for the RaBitQ cascade, so "reserved / not yet implemented" was wrong. Pure rename + doc; mixed-read-safe.
- **v1→v2 clean break documented** as a bounded, explicit exception to mixed-read-safety mandate #8 (v1 never persisted in a released build → nothing to migrate), with a forward commitment that any `v3` must be mixed-read-safe. ADR-010 amended (also records the read-side CRC + RaBitQ id from Wave 0/1).

### Tests
- `substitute_placeholders_*`: `$1` vs `$10`, NULL, `''` escaping, string-literal skip, value-injection safety.
- `decode_binary_param_*`: big-endian int/float/bool, bad-width rejection, unsupported-type error.
- `decode_binary_vector_roundtrips_pgvector_layout`.

### Verification
- Server binary builds; `cargo fmt --check` ✓; `clippy -D warnings` (root lib) ✓.
- block-format 46/46 ✓; new pgwire tests 5/5 ✓.

### Follow-up (not in this PR)
- Wiring an end-to-end prepared-statement e2e over the wire (this PR covers the binding logic with unit tests; a full protocol-level e2e with ≥10 params + binary formats belongs with the pgwire integration suite).