### PR TITLE
docs(td): TD-OLAP-7 (selective GPU OLAP) + TD-OLAP-8 (incremental/MV/streaming)

### DIFF
--- a/docs/10-quality/td/TD-OLAP-7-selective-gpu-olap-vector-fusion-wedge.adoc
+++ b/docs/10-quality/td/TD-OLAP-7-selective-gpu-olap-vector-fusion-wedge.adoc
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-7: Selective GPU OLAP behind the ExecutionEngine seam + the GPU-vector↔OLAP fusion wedge
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open (design; Phase-2/strategic — sequence AFTER the TD-OLAP-1..6 scan-avoidance foundation; does NOT gate current execution)
+| Priority | P3 — every named competitor has a GPU story; ProximaDB's posture (ADR-052) names CPU-SIMD + DataFusion-vectorized but not GPU. A unique unsolved wedge exists.
+| Severity | Medium-High — the only major analytics cohort the current plan doesn't address
+| Component | `ExecutionEngine` trait (ADR-039); a new `gpu-olap` backend crate; the cuVS/`proximadb-quantization-kernel` adjacency; an Arrow↔device-memory bridge
+| Governs | link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (extends to a 4th compute mode alongside SIMD-CPU + DataFusion-vectorized)
+| Relates to | TurboQuant (ADR-021 — CPU SIMD + cuVS vector-GPU), ADR-039 (swappable backend), TD-OLAP-1 (PAX scan → Arrow — the shared host buffer), TD-OLAP-3 (runtime filters — the GPU filter-bitset reuse), ADR-028 (selectivity-aware exact-vs-ANN routing)
+|===
+
+== Why (re-research 2026-07-06, primary-sourced)
+
+Every competitor has a GPU story — as adoption OR as an explicit declination — and the hybrid-vector+OLAP wedge is unsolved:
+
+* **Spark RAPIDS** is the only mature general-purpose GPU-SQL: ~90% of Spark physical ops, 3–7× (vendor) / ~2× (independent) on agg/join-heavy; loses on <100 GB, shuffle, UDFs, and GPU init (~2–3 s/exec amortizes only past ~30 s of work).
+* **Databricks Photon and Snowflake explicitly CHOSE CPU-SIMD for SQL** — Databricks docs verbatim: *"Photon is not supported with GPU instance types"*; Snowflake warehouses are CPU (GPU only via Snowpark Container Services, for ML). **HeavyDB** (GPU-native SQL DB) was acqui-hired by NVIDIA in 2025 — the standalone GPU-SQL-DB market is thin.
+* **cuVS** (NVIDIA RAPIDS) ships an official **Rust crate** (CAGRA / IVF-PQ / brute-force) — ProximaDB's existing cuVS adjacency is on the proven path. **libcudf** is the relational-kernel library; **Polars GPU** = Rust planner → libcudf via FFI (the production pattern). There is NO Rust-native GPU columnar kernel ecosystem — libcudf via FFI is the floor.
+* **The wedge (unsolved):** cuVS fuses filter+ANN *in-kernel* (bitset consulted during graph traversal); MaxVec (ETH, PVLDB'25) shows **77–87% of the GPU speedup in hybrid queries comes from the *relational* operators**, not the search — but **nobody fuses ANN + relational-filter + aggregation in one kernel** (Milvus explicitly excludes GROUP BY on GPU indexes).
+* **Economics now work for the right workload:** post-Jun-2025 AWS pricing — `g6.4xlarge` (L4) \$1.32/hr is *cheaper* than `m8g.8xlarge` (Graviton4) \$1.44/hr; Starburst+cuDF measured 3.4× ClickBench throughput → ~3.4× lower cost/query. **But Shanbhag (SIGMOD'20) is load-bearing:** the GPU-as-coprocessor model (ship data per query over PCIe) FAILS (1.4× *slower* than HyPer); only resident-data + operator-chaining wins (25× on SSB). Wins decisively only when data is GPU-resident and the workload is agg/join-heavy.
+
+== The seam (natural, not a detour)
+
+ProximaDB already has Rust→CUDA FFI (cuVS, vectors) and an Arrow-buffer flow (→ DataFusion + CPU SIMD). Extending to GPU-OLAP reuses **both**:
+
+* Same `ExecutionEngine` trait (ADR-039); a `gpu-olap` backend behind a Cargo feature + env gate.
+* Rust physical plan → IR translation → **libcudf** operators (scan/filter/hash-join/agg/sort) via FFI (mirror `cudf-polars` / `gabotechs/datafusion-gpu`). **Do NOT build Rust-native GPU kernels** — none exist in production; libcudf is the floor.
+* Shared Arrow buffers → **one host→device copy per query, operator-chaining on-device** (the Starburst pattern that compounds gains; eliminates per-op transfers).
+
+== Rollout (Phase 1 — necessary; default-off, recall-gated)
+
+. **Pluggable GPU ExecutionBackend** behind ADR-039's trait, env-gated `PROXIMADB_GPU_OLAP=off` (default). Rust plan → libcudf via FFI; reuse the cuVS Rust crate's build/runtime library management.
+. **Residency-aware dispatch rule** (the load-bearing design decision, per Shanbhag): GPU only when (a) data is already GPU-resident (warm), (b) the operator chain is ≥3–4 ops or contains a heavy agg/join, OR (c) the cuVS vector path already paid the host→device transfer for the same query (the crossover wedge — see #3). Default-deny; opt-in per plan.
+. **GPU-vector ↔ GPU-OLAP fusion (the wedge):** when a hybrid query already routes ANN to cuVS, **reuse the filter bitset as input to a GPU-resident aggregation** — no CPU round-trip. This is the unique differentiator vs Milvus (no GROUP BY on GPU) and MaxVec (separate kernels). Selectivity-aware fallback: graph-ANN (CAGRA) above ~10% surviving vectors, brute-force below (CAGRA recall collapses near 0 at low selectivity — cuVS issue #252), CPU below ~1%.
+
+== Phase 2 (strategic, defer implementation)
+
+. **Single-kernel ANN+filter+aggregation fusion** — research-grade (track MaxVec/ETH, arXiv:2605.15957). Reserve the architectural option (keep the backend trait general enough); do not commit to building.
+. **Vulkan/wgpu vendor-agnostic path** — hedge against CUDA lock-in for embedded portability (Qdrant's Vulkan existence proof; no Apple-Silicon/integrated-GPU story under CUDA). Long-term.
+
+== Non-goals
+* GPU for ML/training (not ProximaDB's business).
+* Building a Rust-native GPU columnar kernel ecosystem (use libcudf via FFI; do not try to replace it).
+* "Build on GPU, serve on CPU" (a vector-side decision; separate TD if pursued — it is the dominant production pattern today: Elastic/OpenSearch/AWS/Milvus `adapt_for_cpu`).
+
+== Verification
+* **Recall-gate** (mirror `pax-recall-ratchet`): any GPU-OLAP path preserves correctness on a TPC-H/DS subset + a vector+OLAP hybrid probe.
+* **Cost-gate:** document the breakeven (≥3× speedup for expensive GPU types; ~1× for L4 post-Jun-2025) — make the dispatch rule explicit and measured (TD-OLAP-4 ledger gains a GPU track).
+* Default-OFF until the residency-aware dispatch is *measured* to beat CPU on the dominant cost term (bytes-moved-over-PCIe when cold; cycles when resident).
+
+== Sources
+Spark RAPIDS (`supported_ops.html`, FAQ, RAPIDS Shuffle); Databricks GPU docs ("Photon not supported with GPU instance types"); Snowflake SPCS overview; HeavyDB acqui-hire (dbdb.io, "Abandoned 2025"); Polars GPU / `cudf-polars` (FFI pattern); `gabotechs/datafusion-gpu` (prototype); cuVS Rust crate + filtering (docs.rapids.ai); CAGRA (arXiv:2308.15136); Meta/Faiss+cuVS (engineering.fb.com, 2.4–4.7× query — independent, smaller than vendor); Shanbhag/Madden/Yu SIGMOD'20 (arXiv:2003.01178 — coprocessor fails / resident-data 25×); Starburst+NVIDIA (4.6× geo, Q13 11.4×, Q17 regression); MaxVec ETH/PVLDB'25 (arXiv:2605.15957 — 77–87% of speedup is relational); VecFlow (arXiv:2506.00812 — CAGRA ≈0% recall on multi-label filters); cuVS issue #252 (filter-recall collapse → brute-force below ~10%).

--- a/docs/10-quality/td/TD-OLAP-8-incremental-materialized-view-streaming-olap.adoc
+++ b/docs/10-quality/td/TD-OLAP-8-incremental-materialized-view-streaming-olap.adoc
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-8: Incremental / materialized-view / streaming-OLAP — attack bytes-RECOMPUTED, not bytes-scanned
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open (design; Phase-2/strategic — sequence AFTER TD-OLAP-1..6; complementary to TD-OLAP-5 slice 3 result cache — NOT a duplicate)
+| Priority | P3 — Quanton's entire competitive wedge; >50% of cloud analytics spend is repetitive ETL / dashboard re-runs that incremental maintenance attacks
+| Severity | Medium-High — a distinct dominant cost term from ADR-052's bytes-SCANNED: bytes RECOMPUTED on refresh
+| Component | Iceberg snapshot-diff planner API; an incremental plan rewriter; MV / aggregate-index catalog + query-rewrite rule; `proximadb-queue` + CDC ingest; PAX zone maps + `proximadb-bloom` (reused across runs)
+| Governs | link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (extends scan-avoidance from per-query to cross-run)
+| Relates to | ADR-025 (deletion vectors / Iceberg snapshots), ADR-007 (Iceberg REST catalog), TD-OLAP-1 (PAX scan), TD-OLAP-2 / TD-DFR-1 (stats — rewrite costing), TD-OLAP-5 slice 3 (result cache — same-row re-run; this TD is different-data-since-last-run; one freshness watermark serves both, ADR-038/051), ADR-027 (metering substrate)
+|===
+
+== Why (re-research 2026-07-06, primary-sourced)
+
+A distinct cost term from ADR-052's bytes-SCANNED: **bytes RECOMPUTED on repetitive ETL / MV refresh.** Onehouse **Quanton** (launched May 2025; Iceberg follow-on Mar 2026) claims 2–3× price/perf and >50% cost reduction by doing work proportional to the data *differential* since the last run, not the table size. Its mechanism — from the Onehouse *Apache Iceberg on Quanton* blog (verbatim) — is the most technical public description:
+
+> "Quanton amortizes execution costs by recognizing patterns like stable target table schemas and recurring SQL plans, **caching metadata, indexing data and reusing intermediates** along with data structures like **Bloom filters or min-max indexes across runs**. For instance, in pipelines with **temporal partitioning or CDC feeds, it automatically rewrites batch queries into incremental operations, slashing full scans to delta merges**…"
+
+Decoded against ProximaDB's substrate, Quanton's "secret sauce" is **shallower than the marketing**: it is the *integration* of four primitives, three of which ProximaDB already has or has designed —
+
+* **(a) cross-run plan/metadata caching** — ProximaDB has plan caching (federated-optimizer LRU).
+* **(b) format-native file-level change detection** — Iceberg snapshots (ADR-007 / ADR-025). **Gap:** no `parent_snapshot_id` / `added_data_files` diff surface exposed to the planner.
+* **(c) bloom / min-max reused across runs** — = PAX zone maps (TD-OLAP-6 cluster keys) + `proximadb-bloom`.
+* **(d) automatic batch → delta-merge rewrite** — **Gap:** no incremental plan rewriter.
+
+The broader IVM state of the art (2026): Snowflake Dynamic Tables (vs single-source MVs), ClickHouse incremental MergeTree MVs + projections + lazy materialization, Databricks streaming tables / DLT, StarRocks/Doris async MVs + query rewrite; and streaming-OLAP engines (Materialize/differential-dataflow, RisingWave, Flink SQL) for continuous refresh.
+
+== The wedge (ProximaDB-specific)
+
+The durable differentiator is **NOT** "we do incremental ETL too" (Feldera's critique: everyone reinvents self-adjusting computation; the formal floor is an algebra like DBSP). It is **where** incremental maintenance is *co-designed with the vector+OLAP substrate* —
+
+* **Continuous vector refresh over streaming OLAP** — ANN indexes that incrementally update as the OLAP MV refreshes (today every system bolts CDC → reindex as a separate, brittle pipeline).
+* **ANN result materialization** — materialize top-k / rerank results *as* the MV, refreshed incrementally on the delta.
+* **Hybrid vector+OLAP correctness under refresh** — the arXiv 2506.23071 "vector+SQL silently discards >30% on JOINs" failure mode, but for *refresh* not just query (extends the correctness wedge ADR-052 already claims for queries).
+
+== Rollout (Phase 1 — the two gaps; default-off)
+
+. **Iceberg snapshot-diff API to the planner:** expose `parent_snapshot_id` / `added_data_files` / `deleted_data_files` so a recurring query knows what changed since its last run. ADR-007/025 already persist the snapshots; the *planner-facing diff* is the gap.
+. **Incremental plan rewriter (the Quanton core):** detect recurring SQL plans over temporally-partitioned / CDC-fed tables and rewrite batch scans → delta-merges over the diff. Flag-gated, default-off; promote only on a measured recompute reduction.
+
+== Phase 2 (strategic)
+
+. **Materialized views / aggregate indexes + query rewrite** — declarative `CREATE MATERIALIZED VIEW` with incremental maintenance (ClickHouse-style), optimizer query-rewrite to the MV. Reuses stats (TD-OLAP-2) for rewrite costing.
+. **Streaming-OLAP over `proximadb-queue` + CDC** — continuous refresh into MVs / PAX; the live-materialized-view model.
+. **Vector-aware incremental maintenance (the wedge)** — ANN index + MV co-refresh; hybrid correctness under refresh.
+
+== Non-goals / de-duplication
+* **NOT a result cache** (that is TD-OLAP-5 slice 3 — same-row, re-run; this TD is *different-data-since-last-run*). Converge: one freshness/invalidation watermark (ADR-038/051) serves both.
+* **NOT a full DBSP / differential-dataflow rewrite** (Feldera's algebra is the formal floor; the *integration wedge with the vector+OLAP substrate* is the value, not the algebra).
+
+== Verification
+* TD-OLAP-4 ledger gains an **incremental-recompute-ratio track**: bytes-computed-on-refresh vs table-size, on a recurring ETL workload.
+* **Correctness:** MV / query-rewrite results identical to recomputed-from-scratch (differential ratchet); conformance ratchets unchanged.
+
+== Sources
+Onehouse Quanton (onehouse.ai launch + *Apache Iceberg on Quanton* 3× blog — the mechanism paragraph); Snowflake Dynamic Tables + persisted result cache; ClickHouse incremental MV + projections + lazy materialization; Databricks DLT / streaming tables; StarRocks/Doris async MV + query rewrite; Materialize (differential dataflow / Timely); RisingWave; Apache Flink SQL; Feldera IVM critique (feldera.com/blog/incremental-computation-deja-vu); arXiv 2506.23071 (vector+SQL post-filter recall loss >30%).


### PR DESCRIPTION
## What
Completeness round (re-research 2026-07-06). Two **new** genuine competitive gaps surfaced by a 5-agent re-research pass that the original ADR-052 set (TD-OLAP-1..6) did not cover. Both are **Phase-2 / strategic (P3)**, sequenced **after** the in-flight scan-avoidance foundation — neither gates current execution.

## TD-OLAP-7 — Selective GPU OLAP + the GPU-vector↔OLAP fusion wedge
Every competitor has a GPU story: Spark RAPIDS is mature; Databricks Photon + Snowflake **explicitly declined** GPU-SQL ("Photon is not supported with GPU instance types"); HeavyDB was acqui-hired by NVIDIA 2025. The seam is natural (ProximaDB already has Rust→CUDA FFI via cuVS + Arrow buffers): a `gpu-olap` backend behind the ADR-039 `ExecutionEngine` trait → **libcudf via FFI** (mirror `cudf-polars`). **Residency-aware dispatch** is load-bearing (Shanbhag SIGMOD'20: the coprocessor model fails; only resident-data + operator-chaining wins). **The unsolved wedge:** fuse ANN + relational-filter + aggregation in one GPU kernel (cuVS filter-bitset reused as aggregation input — Milvus excludes GROUP BY on GPU indexes; MaxVec ETH'25 shows 77–87% of hybrid-query GPU speedup is relational).

## TD-OLAP-8 — Incremental / materialized-view / streaming-OLAP (bytes-RECOMPUTED)
A distinct cost term from ADR-052's bytes-SCANNED. Quanton's entire wedge (>50% of cloud spend = repetitive ETL). Its mechanism (Onehouse blog, verbatim) decodes to **4 primitives ProximaDB mostly already has**: Iceberg snapshot-diff API (the gap), cross-run plan cache, bloom/min-max reuse (= PAX zone maps + `proximadb-bloom`), batch→delta-merge rewriter (the gap). Wedge = vector-aware incremental maintenance. Explicitly **not** a duplicate of TD-OLAP-5 result-cache (same-row re-run vs different-data-since-last-run; one freshness watermark serves both).

## Re-research also CONFIRMED (no new TD)
- **Distributed/elastic:** deferral correct — 0.03% of Redshift queries scan >10 TB; MotherDuck <100 ms per-user tenancy beats ClickHouse Cloud/BigQuery/Snowflake on median latency; Ballista's production footprint is thin (Spice AI had to build HA/mTLS/shuffle themselves). Single-node/elastic is the right 2026 posture.
- **DataFusion limits:** hash-join spill / AQE / stats / codegen all covered by TD-OLAP-1..6.

## Recommended separately (NOT in this PR)
- Small **ADR-052 erratum**: soften "Substrait-ready `LogicalNode`" → "Iceberg REST + Arrow Flight SQL as the federation seam" (an unfalsifiable claim ADR-052's own methodology rejects; Substrait cross-engine fidelity <88% per Bauplan/IBM SAO 2026, Spark/Trino don't natively consume it).
- Minor amendments: ClickBench track in TD-OLAP-4; AQE upstream-watch note (DataFusion #23194); peak-memory ledger column.

## Verification
- `check_td_adr_unique.py`: **0 errors** (52 ADRs, 150 TD ids).
- Docs-only; no code change.

Handoff: leave for the team to merge after green (the TD-OLAP execution sprint owns the ratification cadence).