### PR TITLE
fix(documents): support vectorless documents on the ADR-009 canonical route + e2e robustness

### DIFF
--- a/docs/10-quality/td/TD-DOC-CONV-1-canonical-document-point-get-filter-pushdown.adoc
+++ b/docs/10-quality/td/TD-DOC-CONV-1-canonical-document-point-get-filter-pushdown.adoc
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DOC-CONV-1: Canonical-route document point-get uses a bounded scan (push an id predicate down)
+
+[cols="1,3"]
+|===
+|Status|Open (perf follow-up to the ADR-009 document store-convergence, #698)
+|Priority|LOW
+|Scope|FEAT
+|Date|2026-07-06
+|Relates to|ADR-009 document store-convergence (#698). Backing: `src/storage/document/service.rs`
+(`DocumentService::get_document` canonical branch, `CANONICAL_DOC_SCAN_LIMIT`),
+`src/api_handlers/record_ops_service.rs` (`RecordRoutePort::scan_records`),
+`src/services/operations/vectors/legacy.rs` (`scan_records_paginated`).
+|===
+
+== Context (the gap)
+
+The ADR-009 convergence routes the document facade's reads onto the shared record/vector store.
+The shared surface exposes a *scan* (`handle_record_scan_paginated_for_tenant` → full
+`ProximaRecord`s with labels, which the document projection needs) but not a labelled
+*point-get* — the point-get response (`RichSearchResult`) drops `labels`/`variation_id`, so it
+cannot rebuild the document facade.
+
+Consequently `DocumentService::get_document` on the canonical route satisfies a point read by
+scanning up to `CANONICAL_DOC_SCAN_LIMIT` (100k) records and filtering by `id` in memory. That is
+**O(collection)** per get, and silently truncates past the cap (logged, but a very large
+collection could miss a doc on a point read). Correct, but not O(1).
+
+This is acceptable for the beta, default-OFF surface (documents are a beta modality; the gate is
+per-collection opt-in), but should be fixed before the canonical route is a default.
+
+== Proposed resolution (when picked up)
+
+. **Push an `oid`/`local_id` equality predicate into the scan.** `handle_record_scan_paginated_for_tenant`
+  already accepts a `FilterExpression`; add an `id`-keyed variant (or a dedicated
+  `get_record_full` that returns a full labelled `ProximaRecord`, not the search-shaped
+  `RichSearchResult`) so a document point-get is O(1)/O(log n), not a full scan.
+. Route `DocumentService::get_document` through that path; keep the bounded scan only as the
+  `query_documents`/`aggregate_documents` bulk path.
+. Remove the `CANONICAL_DOC_SCAN_LIMIT` truncation risk from the point-get path once it no longer
+  scans.
+
+== Constraints
+
+* Keep net `proximadb_v1` references non-increasing (TD-123 ratchet). Prefer v2 record types.
+* Mixed-read-safe: the legacy `document_wal` read-fallback must remain for pre-cutover docs while
+  the gate is per-collection opt-in.

--- a/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
+++ b/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
@@ -76,10 +76,15 @@ the collection-existence gate rejecting the never-created scoped collection.
 
 == Remaining follow-ons (open)
 
-* **REST v2 documents store-split.** `src/network/rest/v2/documents.rs` writes through a DIFFERENT
-  store (the Flight/record-store path), not `DocumentService` — so this fix does NOT make the REST
-  v2 document ingest surface tenant-isolated the same way. Reconcile the two document write surfaces
-  (or document the split) before claiming cross-surface document coherence.
+* **REST v2 documents store-split — RESOLVED (ADR-009 convergence, #698).** The two document
+  write surfaces are reconciled: `DocumentService`'s canonical branch now routes through the same
+  tenant-scoped record/vector store REST v2 (`src/network/rest/v2/documents.rs`) uses, behind a
+  default-OFF per-collection gate (`PROXIMADB_DOC_CANONICAL_VECTOR`), mixed-read-safe. A document
+  written on either surface is cross-surface visible (verified e2e in
+  `tests/documents_convergence_e2e.rs`), metered, and stored once. Tenant isolation on the canonical
+  path is structural via per-tenant collection resolution + `record.tenant_id`; the legacy
+  `scoped_document_collection` fold is retained on the read-fallback for pre-cutover docs. Follow-up
+  perf item: TD-DOC-CONV-1 (point-get filter pushdown).
 * **pgwire / REST v1 create + default uniformity.** Same shape as the graph follow-ons: those create
   paths are bare; once they scope, flip the default tenant to `default/{collection}` for uniformity.
 * **Entity document leg.** `entity_service.rs` still folds `{tenant}::{collection}` for its document

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -3663,18 +3663,23 @@ impl DmlService {
         let Ok(table_schema) = catalog.get_table(&table_id).await else {
             return Ok(());
         };
-        // v2 vector record API path: when the caller provides at least one
-        // embedding cell on every record, skip relational schema validation.
-        // The v2 records/batch endpoint is the vector ingest surface, not a
-        // SQL DML surface. Relational schema constraints (`reject_unknown_columns`,
-        // missing-required-column, type strictness) reject perfectly valid
-        // vector-API batches — including ones that carry filter metadata in
-        // `props` — because the auto-registered schema is `id` + `vector`
-        // only and treats anything else as unknown. Reconciled 2026-05-28 for
-        // the v0.2 v2 INSERT→SEARCH gap.
-        let all_records_are_vector_shaped =
-            !records.is_empty() && records.iter().all(|r| !r.embeddings.is_empty());
-        if all_records_are_vector_shaped {
+        // v2 record API path: skip relational schema validation for records that are
+        // vector-shaped (carry ≥1 embedding cell) OR document-facade records (labelled
+        // `document`, ADR-009 convergence). Both are v2 record-API shapes — a vector ingest
+        // or a schemaless NF² document projection — NOT SQL DML rows. Relational schema
+        // constraints (`reject_unknown_columns`, missing-required-column, type strictness)
+        // reject perfectly valid vector-API batches — including ones that carry filter/doc
+        // metadata in `props` — because the auto-registered schema is `id` + `vector` only
+        // and treats anything else as unknown. Document records are the vectorless case: a
+        // metadata-only document has no embedding but must not be validated against the
+        // vector-collection's relational schema. (Vector path reconciled 2026-05-28 for the
+        // v0.2 v2 INSERT→SEARCH gap; document label added for ADR-009.)
+        let all_records_are_v2_record_api = !records.is_empty()
+            && records.iter().all(|r| {
+                !r.embeddings.is_empty()
+                    || r.labels.contains(proximadb_document::DOCUMENT_RECORD_LABEL)
+            });
+        if all_records_are_v2_record_api {
             return Ok(());
         }
         // Determine which schema column (if any) maps to the record's canonical

--- a/src/services/operations/vectors/input_validation.rs
+++ b/src/services/operations/vectors/input_validation.rs
@@ -64,18 +64,12 @@ pub(crate) fn validate_records_for_insert(
         None
     };
 
-    let current_time_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as i64)
-        .unwrap_or(0);
-
     for (i, record) in records.iter().enumerate() {
         let dim = record
             .embeddings
             .first()
             .map(|e| e.values.len())
             .unwrap_or(0);
-        let is_tombstone = dim == 0 && record.valid_to_ns.is_some_and(|v| v <= current_time_ns);
 
         for (embedding_idx, embedding) in record.embeddings.iter().enumerate() {
             if let Some((dimension_idx, value)) =
@@ -91,7 +85,13 @@ pub(crate) fn validate_records_for_insert(
             }
         }
 
-        if !is_tombstone && expected_dimension > 0 && dim != expected_dimension as usize {
+        // `dim == 0` ⇒ a vectorless record: a tombstone (delete) OR a metadata-only record
+        // (e.g. an ADR-009 document facade record with no embedding). The engine stores these,
+        // excludes them from the vector index and ANN search (they carry no vector to score),
+        // and still serves them by id/scan — so they are valid in any collection. Only a
+        // *non-zero* dimension that mismatches the collection is a real error (a likely
+        // forgot-to-match-dims bug), which is still rejected.
+        if dim != 0 && expected_dimension > 0 && dim != expected_dimension as usize {
             return Err(anyhow::anyhow!(
                 "Record at index {} has dimension {} but collection '{}' expects dimension {}",
                 i,
@@ -164,4 +164,61 @@ pub(crate) fn validate_query_vector_for_search(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proximadb_records::EmbeddingCell;
+
+    fn dim8_config() -> CollectionConfig {
+        CollectionConfig {
+            dimension: 8,
+            ..Default::default()
+        }
+    }
+
+    fn record_no_vector(oid: &str) -> ProximaRecord {
+        ProximaRecord {
+            oid: oid.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn record_with_dim(oid: &str, dim: usize) -> ProximaRecord {
+        ProximaRecord {
+            oid: oid.to_string(),
+            embeddings: vec![EmbeddingCell {
+                dim: dim as u32,
+                values: EmbeddingValues::Fp32(vec![0.1; dim]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn metadata_only_record_passes_in_a_dimensioned_collection() {
+        // ADR-009: a vectorless (dim-0) record — e.g. a metadata-only document facade record —
+        // is accepted in a dimensioned collection; it simply doesn't participate in the ANN
+        // index/search. Only a *non-zero* dimension mismatch is an error.
+        let out = validate_records_for_insert("c", &dim8_config(), &[record_no_vector("m1")]);
+        assert!(out.is_ok(), "metadata-only record should pass: {out:?}");
+    }
+
+    #[test]
+    fn matching_dimension_record_passes() {
+        let out = validate_records_for_insert("c", &dim8_config(), &[record_with_dim("v1", 8)]);
+        assert!(out.is_ok(), "dim-8 record in a dim-8 collection: {out:?}");
+    }
+
+    #[test]
+    fn wrong_nonzero_dimension_is_still_rejected() {
+        // Regression guard: relaxing dim-0 must NOT relax a genuine (non-zero) dimension bug.
+        let out = validate_records_for_insert("c", &dim8_config(), &[record_with_dim("v1", 2)]);
+        assert!(
+            out.is_err(),
+            "a dim-2 record in a dim-8 collection must be rejected"
+        );
+    }
 }

--- a/tests/documents_convergence_e2e.rs
+++ b/tests/documents_convergence_e2e.rs
@@ -21,7 +21,9 @@ use std::time::Duration;
 use proximadb::core::Config;
 use proximadb::database::ProximaDB;
 use proximadb::proto::proximadb_v2::proxima_document_service_client::ProximaDocumentServiceClient;
-use proximadb::proto::proximadb_v2::{CreateDocumentRequest, GetDocumentRequest};
+use proximadb::proto::proximadb_v2::{
+    CreateDocumentRequest, GetDocumentRequest, QueryDocumentsRequest, TypedValue, typed_value,
+};
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::time::sleep;
@@ -127,9 +129,12 @@ impl Drop for GateGuard {
 /// cross-surface (the headline convergence claim).
 #[tokio::test]
 async fn rest_ingested_document_is_visible_via_grpc_when_gate_on() {
-    let collection = "convdocs";
-    let _gate = GateGuard::on(collection);
     let server = TestServer::start().await.expect("server start");
+    // Port-unique collection name so the shared in-process catalog never collides across runs
+    // (the convention used by grpc_td*_e2e). The gate is read per-call, so setting it after
+    // start — once the port is known — is fine.
+    let collection = format!("convdocs{}", server.grpc_port);
+    let _gate = GateGuard::on(&collection);
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .no_proxy()
@@ -196,6 +201,7 @@ async fn rest_ingested_document_is_visible_via_grpc_when_gate_on() {
 #[tokio::test]
 async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
     let server = TestServer::start().await.expect("server start");
+    let collection = format!("legacydocs{}", server.grpc_port);
     let mut client =
         ProximaDocumentServiceClient::connect(format!("http://127.0.0.1:{}", server.grpc_port))
             .await
@@ -203,7 +209,7 @@ async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
 
     client
         .create_document(CreateDocumentRequest {
-            collection_id: "legacydocs".to_string(),
+            collection_id: collection.clone(),
             id: "doc-1".to_string(),
             ..Default::default()
         })
@@ -212,7 +218,7 @@ async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
 
     let resp = client
         .get_document(GetDocumentRequest {
-            collection_id: "legacydocs".to_string(),
+            collection_id: collection.clone(),
             id: "doc-1".to_string(),
         })
         .await
@@ -220,4 +226,95 @@ async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
         .into_inner();
     let doc = resp.document.expect("document present via legacy path");
     assert_eq!(doc.id, "doc-1");
+}
+
+/// Follow-up validation (PR #698 disclosed limitation): a **pure-metadata** gRPC document —
+/// created with props but NO vector — routes onto the shared record/vector store when the gate is
+/// ON, and is retrievable via gRPC get + query. Confirms documents without embeddings converge
+/// (vector *search* won't surface them, but get/scan/query do).
+#[tokio::test]
+async fn pure_metadata_grpc_document_round_trips_on_canonical_route_when_gate_on() {
+    let server = TestServer::start().await.expect("server start");
+    let collection = format!("metadocs{}", server.grpc_port);
+    let _gate = GateGuard::on(&collection);
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("http client");
+
+    // The canonical route resolves against a real vector collection. A metadata-only document
+    // carries no embedding (dim 0); the vector-insert validation accepts vectorless records in
+    // any collection (they're excluded from the ANN index/search but stored + served by id/scan),
+    // so it converges on the shared store alongside embedded documents.
+    let create = http
+        .post(format!("{}/api/v2/collections", server.rest()))
+        .json(&json!({"name": collection, "dimension": 8, "engine": "sst"}))
+        .send()
+        .await
+        .expect("create collection");
+    let status = create.status();
+    let body = create.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "collection create should succeed, got {status} — body: {body}"
+    );
+
+    let mut client =
+        ProximaDocumentServiceClient::connect(format!("http://127.0.0.1:{}", server.grpc_port))
+            .await
+            .expect("gRPC connect");
+
+    // gRPC CreateDocument with a prop but NO vector — the metadata-only case.
+    let mut props = std::collections::HashMap::new();
+    props.insert(
+        "title".to_string(),
+        TypedValue {
+            declared_type: 0,
+            value: Some(typed_value::Value::TextValue("Gamma".to_string())),
+        },
+    );
+    client
+        .create_document(CreateDocumentRequest {
+            collection_id: collection.to_string(),
+            id: "m1".to_string(),
+            props,
+            ..Default::default()
+        })
+        .await
+        .expect("gRPC CreateDocument (no vector) should route to the shared store");
+
+    // gRPC GetDocument reads it back through the vector-store scan.
+    let got = client
+        .get_document(GetDocumentRequest {
+            collection_id: collection.to_string(),
+            id: "m1".to_string(),
+        })
+        .await
+        .expect("gRPC GetDocument (metadata-only)")
+        .into_inner()
+        .document
+        .expect("metadata-only document present via canonical route");
+    assert_eq!(got.id, "m1");
+    assert!(
+        got.props.contains_key("title"),
+        "props round-trip through the shared store"
+    );
+
+    // gRPC QueryDocuments also surfaces it (sourced from the shared store).
+    let queried = client
+        .query_documents(QueryDocumentsRequest {
+            collection_id: collection.to_string(),
+            limit: 10,
+            ..Default::default()
+        })
+        .await
+        .expect("gRPC QueryDocuments (metadata-only)")
+        .into_inner();
+    assert_eq!(
+        queried.documents.len(),
+        1,
+        "query returns the metadata-only doc"
+    );
+    assert_eq!(queried.documents[0].id, "m1");
 }


### PR DESCRIPTION
## Summary

Follow-up to **#698** (document store-convergence). Resolves the **disclosed limitation** — pure-metadata
gRPC documents (no vector) could not route onto the shared record/vector store — and hardens the
convergence e2e tests.

## Root cause

A metadata-only document record (props, no embedding) hit two vector-native validations on the
canonical write path:

1. **Dimension check** (`input_validation`) rejected it — dim 0 vs the collection's dimension.
2. **DML schema validation** then rejected it — a vectorless record falls through the "v2 vector
   record API" skip and is validated against the auto-registered `id`+`vector` relational schema,
   which treats the document's `title` / `_document_collection` props as unknown columns.

## Fixes (both targeted, well-scoped)

- **`input_validation`**: a `dim == 0` (vectorless) record — a tombstone **or** a metadata-only
  document — skips the dimension check. The engine already stores such records, excludes them from
  the ANN index/search (no vector to score), and serves them by id/scan. A **non-zero** dimension
  mismatch is still rejected (regression-guarded).
- **`dml` schema**: the "v2 record API" validation-skip now also covers **document-facade records**
  (labelled `document`). They're schemaless NF² projections, not SQL DML rows, so relational schema
  constraints must not apply. Real relational inserts (no embedding, no document label) are unaffected.

Net effect: a vectorless document converges on the shared store alongside embedded documents;
vector *search* correctly never surfaces it (no vector), but `get` / `query` / scan do.

## Test robustness

Convergence e2e collection names are now **port-unique** (the `grpc_td*_e2e` convention), fixing
latent re-run flakiness against the shared in-process collection catalog (`COLLECTION_EXISTS`).

## Tests

- **Unit** (`input_validation`): metadata-only record passes in a dimensioned collection; matching
  dim passes; wrong non-zero dim still rejected.
- **e2e** (`documents_convergence_e2e`): a gRPC `CreateDocument` with **no vector** is retrievable
  via gRPC get + query on the canonical route (gate ON). Embedded-doc + gate-OFF tests unchanged.

## Docs

- **TD-DOC-CONV-1** — point-get on the canonical route uses a bounded scan; push an id predicate
  down for O(1) reads (perf follow-up).
- **TD-DOC-TENANT-1** — updated: the REST-v2 store-split follow-on is **resolved** by #698.
