### PR TITLE
fix(embedded): backport OpenSSL-vendor + native-ARM wheel build to 0.2.2 (publishes proximadb_embedded)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -69,19 +69,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Linux-only: proximadb_embedded links the full Rust engine, which is
+        # Linux-native (unix storage APIs). Windows does not compile
+        # (proximadb-storage-common: E0425/E0433/E0599 — no MSVC port); macOS is
+        # deferred. Linux x86_64 + aarch64 is the embedded / edge / air-gapped
+        # deployment surface for an in-process engine. macOS/Windows embedded
+        # wheels are a tracked follow-up (Windows blocked on engine portability,
+        # not a build-config fix).
         include:
           - os: ubuntu-latest
             target: x86_64
             manylinux: auto
-          - os: ubuntu-latest
+          # Native ARM runner (not cross-compile): the engine's C deps —
+          # aws-lc-sys (rustls crypto) and vendored OpenSSL — fail to
+          # cross-compile to aarch64 (aws-lc bcm.c under aarch64-gcc). Building
+          # natively on an ARM runner compiles them the same way x86_64 does,
+          # avoiding the cross-toolchain entirely.
+          - os: ubuntu-24.04-arm
             target: aarch64
             manylinux: auto
-          - os: macos-13
-            target: x86_64
-          - os: macos-14
-            target: aarch64
-          - os: windows-latest
-            target: x64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -95,6 +101,24 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || '' }}
           args: --release --out dist --features python
+          # `openssl/vendored` (enabled by the python feature — openssl-sys is
+          # transitive via sqlx/reqwest) builds OpenSSL from source inside the
+          # manylinux container. openssl-src's Configure needs Perl's IPC::Cmd,
+          # which the stock manylinux2014 image lacks. Install it (yum or dnf,
+          # whichever the image ships) before the build. Linux-only hook; macOS/
+          # Windows system Perl already carries these modules.
+          before-script-linux: |
+            # perl-core = the full Perl stdlib (IPC::Cmd, Time::Piece,
+            # Data::Dumper, Getopt::Long, File::Compare … all of which
+            # openssl 3.x's Configure needs). Verified in the manylinux2014
+            # container that perl-core supplies every module the build requires.
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y perl-core
+            elif command -v dnf >/dev/null 2>&1; then
+              dnf install -y perl-core
+            elif command -v microdnf >/dev/null 2>&1; then
+              microdnf install -y perl-core
+            fi
       - uses: actions/upload-artifact@v4
         with:
           name: embedded-wheels-${{ matrix.os }}-${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ xz2 = "0.1"
 zstd = "0.13"
 
 # Language bindings
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py38"] }
 numpy = { version = "0.28" }
 
 # TurboQuant numerics (ADR-021, gated by `experimental-turboquant`).
@@ -553,6 +553,14 @@ moka = { version = "0.12", features = ["future"] }
 # Language bindings (optional, for embedded mode)
 # Python bindings via PyO3
 pyo3 = { workspace = true, optional = true }
+# Vendored OpenSSL for the embedded wheel build only (see the `python` feature).
+# `openssl-sys` reaches the tree transitively (sqlx tls-native-tls + reqwest 0.11
+# default-tls). The manylinux wheel container has no system openssl, so the
+# maturin build fails at link time. Declaring openssl here with `vendored` and
+# gating it under `python` makes only the wheel build compile OpenSSL from source
+# (portable, cross-target-safe); the OSS server build never pulls this dep and
+# keeps dynamic system openssl.
+openssl = { version = "0.10", optional = true }
 # Zero-copy NumPy array access (matches PyO3 version)
 # Provides direct buffer access to numpy arrays without Python .tolist() conversion
 numpy = { workspace = true, optional = true }
@@ -779,7 +787,7 @@ experimental-cdc-connectors = ["dep:tokio-postgres"]
 # Enable language-specific bindings for embedded database mode
 
 # Python embedded mode (PyO3 bindings with zero-copy numpy support)
-python = ["dep:pyo3", "dep:numpy", "arrow/pyarrow"]  # Enable Python bindings with zero-copy numpy support (arrow/pyarrow pulls pyo3 → gated here so the OSS server build stays Python-free)
+python = ["dep:pyo3", "dep:numpy", "arrow/pyarrow", "dep:openssl", "openssl/vendored"]  # Enable Python bindings with zero-copy numpy support (arrow/pyarrow pulls pyo3 → gated here so the OSS server build stays Python-free). openssl/vendored statically builds OpenSSL so the manylinux wheel needs no system openssl (transitive via sqlx/reqwest).
 
 # Python cdylib output (for PyO3/FFI builds)
 # When enabled, changes crate-type to include cdylib for Python shared library generation


### PR DESCRIPTION
## What

Cherry-picks the tooling half of #701 onto the **0.2.2 release line** (qa→main), so the `proximadb_embedded` PyPI wheel can be built and published for the already-released 0.2.2.

Two files only — pure build tooling, **no engine change**:
- `.github/workflows/release-python.yml` — perl-core `before-script-linux`, Linux-scoped matrix, native `ubuntu-24.04-arm` runner for aarch64 (avoids the aws-lc-sys cross-compile wall)
- `Cargo.toml` — `openssl` vendored dep gated behind the `python` feature (transitive via sqlx/reqwest; manylinux container has no system openssl), `pyo3` `abi3-py38`

The version-sync parts of #701 dropped out on cherry-pick (qa is already 0.2.2). The Cargo.toml delta is gated behind `--features python`, so the OSS server build is unaffected (resolver-verified; already proven green as #701 on develop).

## Why this path

develop is a full engine release ahead of main; promoting it would drag unreleased work into a 0.2.2 tag. Re-tagging at develop would build a 0.2.2 embedded wheel containing future engine code. This backport keeps `proximadb_embedded==0.2.2` byte-aligned with the released `proximadb==0.2.2` SDK + Docker.

## Validation

Dry-run `28812324409` on the #701 branch: **both** Linux wheels green — x86_64 (manylinux) + aarch64 (native ARM). x86_64 also proven locally end-to-end (manylinux2014 docker → WHEEL_OK).

## After merge

qa→main promotion, then move `python-v0.2.2` tag to the new main HEAD. Publish jobs use `skip-existing: true`, so the re-run publishes only `proximadb_embedded` (new) and skips the already-published `proximadb` SDK.