### PR TITLE
feat(cache): wire structurally tenant-keyed result cache onto pgwire OLAP route

### DIFF
--- a/benches/bench_21_query_cache.rs
+++ b/benches/bench_21_query_cache.rs
@@ -14,8 +14,8 @@ use arrow::datatypes::{DataType, Field, Schema};
 use common::benchmark_utils::print_system_info;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use proximadb::query::cache::{
-    CacheInvalidator, ChangeOperation, InvalidationConfig, InvalidationEvent, QueryKey,
-    QueryResultCache, QueryResultCacheConfig,
+    CacheInvalidator, ChangeOperation, FederatedQueryResultCache, InvalidationConfig,
+    InvalidationEvent, QueryKey, QueryResultCacheConfig,
 };
 use proximadb::query::federated::ExecutionResult;
 use std::sync::Arc;
@@ -56,7 +56,7 @@ fn create_test_result(row_count: usize) -> ExecutionResult {
 }
 
 /// Pre-populate a cache with entries (creates a fresh result for each entry)
-fn populate_cache(cache: &QueryResultCache, count: usize, collection: &str) {
+fn populate_cache(cache: &FederatedQueryResultCache, count: usize, collection: &str) {
     for i in 0..count {
         let key = QueryKey::from_sql(&format!("SELECT * FROM {} WHERE id = {}", collection, i));
         let result = create_test_result(10);
@@ -75,7 +75,7 @@ fn bench_cache_hit_latency(c: &mut Criterion) {
     let result_sizes = [10, 100, 1000];
 
     for size in result_sizes {
-        let cache = QueryResultCache::with_defaults();
+        let cache = FederatedQueryResultCache::with_defaults();
         let result = create_test_result(size);
         let key = QueryKey::from_sql("SELECT * FROM products WHERE id = 1");
 
@@ -106,7 +106,7 @@ fn bench_cache_write_overhead(c: &mut Criterion) {
     for size in result_sizes {
         group.throughput(Throughput::Elements(1));
         group.bench_with_input(BenchmarkId::new("result_rows", size), &size, |b, &sz| {
-            let cache = QueryResultCache::with_defaults();
+            let cache = FederatedQueryResultCache::with_defaults();
             let mut counter = 0u64;
             b.iter(|| {
                 counter += 1;
@@ -140,7 +140,7 @@ fn bench_invalidation_cost(c: &mut Criterion) {
                             max_entries: size * 2,
                             ..Default::default()
                         };
-                        let cache = QueryResultCache::new(config);
+                        let cache = FederatedQueryResultCache::new(config);
                         populate_cache(&cache, size, "products");
                         cache
                     },
@@ -164,7 +164,7 @@ fn bench_invalidation_cost(c: &mut Criterion) {
                             max_entries: size * 2,
                             ..Default::default()
                         };
-                        let cache = QueryResultCache::new(config);
+                        let cache = FederatedQueryResultCache::new(config);
                         // Populate with entries from different collections
                         for i in 0..size {
                             let collection = if i % 10 == 0 { "target" } else { "other" };
@@ -198,7 +198,7 @@ fn bench_invalidator_events(c: &mut Criterion) {
     group.bench_function("direct_invalidation", |b| {
         b.iter_with_setup(
             || {
-                let cache = Arc::new(QueryResultCache::with_defaults());
+                let cache = Arc::new(FederatedQueryResultCache::with_defaults());
                 populate_cache(&cache, 1000, "products");
                 let config = InvalidationConfig {
                     batch_invalidations: false,
@@ -218,7 +218,7 @@ fn bench_invalidator_events(c: &mut Criterion) {
     group.bench_function("batched_invalidation", |b| {
         b.iter_with_setup(
             || {
-                let cache = Arc::new(QueryResultCache::with_defaults());
+                let cache = Arc::new(FederatedQueryResultCache::with_defaults());
                 populate_cache(&cache, 1000, "products");
                 let config = InvalidationConfig {
                     batch_invalidations: true,
@@ -252,7 +252,7 @@ fn bench_concurrent_reads(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(15));
 
     for &thread_count in THREAD_COUNTS {
-        let cache = Arc::new(QueryResultCache::with_defaults());
+        let cache = Arc::new(FederatedQueryResultCache::with_defaults());
 
         // Pre-populate with entries
         for i in 0..1000 {
@@ -300,7 +300,7 @@ fn bench_concurrent_read_write(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(15));
 
     for &thread_count in THREAD_COUNTS {
-        let cache = Arc::new(QueryResultCache::new(QueryResultCacheConfig {
+        let cache = Arc::new(FederatedQueryResultCache::new(QueryResultCacheConfig {
             max_entries: 50000,
             ..Default::default()
         }));
@@ -405,7 +405,7 @@ fn bench_cache_lookup_patterns(c: &mut Criterion) {
     let mut group = c.benchmark_group("cache_lookup_patterns");
     group.measurement_time(Duration::from_secs(10));
 
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Populate cache
     for i in 0..1000 {
@@ -454,7 +454,7 @@ fn bench_cache_cleanup(c: &mut Criterion) {
                             default_ttl: Duration::from_millis(1), // Very short TTL
                             ..Default::default()
                         };
-                        let cache = QueryResultCache::new(config);
+                        let cache = FederatedQueryResultCache::new(config);
                         populate_cache(&cache, size, "products");
                         // Wait for entries to expire
                         std::thread::sleep(Duration::from_millis(5));
@@ -479,7 +479,7 @@ fn bench_cache_cleanup(c: &mut Criterion) {
                             max_entries: size * 2,
                             ..Default::default()
                         };
-                        let cache = QueryResultCache::new(config);
+                        let cache = FederatedQueryResultCache::new(config);
                         populate_cache(&cache, size, "products");
                         cache
                     },
@@ -500,7 +500,7 @@ fn bench_cache_stats(c: &mut Criterion) {
     let mut group = c.benchmark_group("cache_stats");
     group.measurement_time(Duration::from_secs(5));
 
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
     populate_cache(&cache, 5000, "products");
 
     // Simulate some operations for realistic stats

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -2162,6 +2162,7 @@ impl UnifiedHandlers {
         // which rejects relational plans. `require_engagement = false` routes any
         // resolvable relational SELECT here; queries whose tables don't resolve
         // (vector/graph SQL) return None and fall through to the legacy engine.
+        let olap_result_cache = crate::network::postgres::relational_pipeline::olap_result_cache();
         if let Some(dml) = self.get_dml_service()
             && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
                 &query,
@@ -2171,6 +2172,10 @@ impl UnifiedHandlers {
                 tenant_id,
                 crate::query::execution::ExecutionControls::default(),
                 false,
+                // REST ExecuteQuery has no pgwire search_path; namespace=None
+                // keys under the default (empty) namespace.
+                None,
+                olap_result_cache.as_deref(),
             )
             .await
         {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -1218,6 +1218,22 @@ impl PostgresProtocol {
                     // CREATE-then-INSERT address one tenant-prefixed schema row.
                     let ddl_tenant = self.pgwire_resolve_write_tenant().await;
                     let ddl_scope = (!ddl_tenant.is_empty()).then_some(ddl_tenant);
+                    // Capture the target table BEFORE the statement is moved into
+                    // execute_scoped, so the success branch can invalidate the
+                    // tenant-scoped OLAP result cache for it.
+                    let ddl_table: Option<String> = match &statement {
+                        crate::services::DdlStatement::CreateTable { table_name, .. }
+                        | crate::services::DdlStatement::DropTable { table_name, .. }
+                        | crate::services::DdlStatement::AlterTable { table_name, .. }
+                        | crate::services::DdlStatement::CreateIndex { table_name, .. }
+                        | crate::services::DdlStatement::DropIndex { table_name, .. } => {
+                            Some(table_name.clone())
+                        }
+                        crate::services::DdlStatement::MaterializeTable { name, .. } => {
+                            Some(name.clone())
+                        }
+                        _ => None,
+                    };
                     match ddl_service
                         .execute_scoped(statement, ddl_scope.as_deref())
                         .await
@@ -1246,6 +1262,15 @@ impl PostgresProtocol {
                             } else {
                                 "OK"
                             };
+                            // Mandate #16b: invalidate the tenant-scoped OLAP
+                            // result cache for the DDL'd table (default-OFF no-op).
+                            if let Some(table) = &ddl_table {
+                                super::relational_pipeline::invalidate_olap_result_cache_for(
+                                    ddl_scope.as_deref().unwrap_or(""),
+                                    table,
+                                )
+                                .await;
+                            }
                             info!(message = %result.message, "DDL executed via catalog service");
                             return self.send_command_complete(tag).await;
                         }
@@ -1484,6 +1509,12 @@ impl PostgresProtocol {
         controls: ExecutionControls,
     ) -> Option<Result<ExecutionPipelineResult, String>> {
         let read_tenant = self.pgwire_resolve_read_tenant().await;
+        // Namespace (pgwire `search_path`) + the shared OLAP result cache are a
+        // structural key component / a short-circuit. The cache is default-OFF
+        // (`PROXIMADB_QUERY_RESULT_CACHE`); `None` ⇒ this path is byte-identical
+        // to the pre-cache behavior.
+        let namespace = self.session.read().await.current_schema();
+        let olap_cache = super::relational_pipeline::olap_result_cache();
         super::relational_pipeline::try_run_select(
             query,
             self.dml_service.as_ref(),
@@ -1500,6 +1531,8 @@ impl PostgresProtocol {
             // pgwire keeps simple single-table SELECTs on its hardened legacy
             // path; only relational-engaging shapes go through this pipeline.
             true,
+            Some(namespace.as_str()),
+            olap_cache.as_deref(),
         )
         .await
     }
@@ -3606,6 +3639,13 @@ impl PostgresProtocol {
                             rows_affected = result.rows_affected,
                             "INSERT executed via DmlService"
                         );
+                        // Mandate #16b: invalidate the tenant-scoped OLAP result
+                        // cache for the written table (default-OFF no-op).
+                        super::relational_pipeline::invalidate_olap_result_cache_for(
+                            &write_tenant,
+                            &table,
+                        )
+                        .await;
                         self.send_command_complete(&format!("INSERT 0 {}", result.rows_affected))
                             .await
                     }
@@ -3721,6 +3761,13 @@ impl PostgresProtocol {
                             rows_affected = result.rows_affected,
                             "DELETE executed via DmlService"
                         );
+                        // Mandate #16b: invalidate the tenant-scoped OLAP result
+                        // cache for the written table (default-OFF no-op).
+                        super::relational_pipeline::invalidate_olap_result_cache_for(
+                            &write_tenant,
+                            &table,
+                        )
+                        .await;
                         self.send_command_complete(&format!("DELETE {}", result.rows_affected))
                             .await
                     }
@@ -3830,6 +3877,13 @@ impl PostgresProtocol {
                             rows_affected = result.rows_affected,
                             "UPDATE executed via DmlService"
                         );
+                        // Mandate #16b: invalidate the tenant-scoped OLAP result
+                        // cache for the written table (default-OFF no-op).
+                        super::relational_pipeline::invalidate_olap_result_cache_for(
+                            &write_tenant,
+                            &table,
+                        )
+                        .await;
                         self.send_command_complete(&format!("UPDATE {}", result.rows_affected))
                             .await
                     }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -52,6 +52,9 @@ use sqlparser::parser::Parser;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::core::search::VectorFreshnessMode;
+use crate::query::cache::invalidation_coordinator::CacheInvalidationCoordinator;
+use crate::query::cache::query_result_cache::{QueryKey, QueryResultCache, StructuralKey};
 use crate::services::dml::DmlService;
 use crate::storage::tenant::context::TenantContext;
 
@@ -105,6 +108,114 @@ fn bootstrap_demo_table(engine: &Arc<InMemoryRelationalEngine>) {
 }
 
 // =========================================================================
+// Process-wide OLAP result cache (default-OFF; ADR-051 D2 / mandate #16)
+// =========================================================================
+
+/// Master switch for the pgwire OLAP result cache. **Default-OFF.** Set
+/// `PROXIMADB_QUERY_RESULT_CACHE` to a truthy token (`1`/`true`/`on`/`yes`,
+/// case-insensitive) to enable structurally tenant-keyed caching of OLAP SELECT
+/// results with Strong LSN-pinned freshness. Pure + split out so it is
+/// unit-testable without mutating the process environment.
+fn olap_result_cache_on(var: Option<&str>) -> bool {
+    match var.map(str::trim) {
+        Some(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
+        None => false,
+    }
+}
+
+fn olap_result_cache_enabled() -> bool {
+    olap_result_cache_on(
+        std::env::var("PROXIMADB_QUERY_RESULT_CACHE")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Process-wide OLAP result cache, keyed structurally on
+/// `(tenant, namespace, query)`. Shared across every pgwire + REST/gRPC
+/// connection (mirrors [`GLOBAL_ENGINE`]'s singleton pattern).
+pub static GLOBAL_OLAP_RESULT_CACHE: Lazy<Arc<QueryResultCache<ExecutionPipelineResult>>> =
+    Lazy::new(|| Arc::new(QueryResultCache::with_defaults()));
+
+/// Process-wide invalidation coordinator with the OLAP result cache attached,
+/// so writes/DDL drop tenant-scoped entries in one fan-out call (mandate #16b).
+pub static GLOBAL_OLAP_CACHE_COORDINATOR: Lazy<Arc<CacheInvalidationCoordinator>> =
+    Lazy::new(|| {
+        Arc::new(
+            CacheInvalidationCoordinator::empty()
+                .with_result_cache(GLOBAL_OLAP_RESULT_CACHE.clone()),
+        )
+    });
+
+/// Returns the shared OLAP result cache only when the feature is enabled
+/// (default-OFF). Callers pass `.as_deref()` of this as the `result_cache`
+/// argument to [`try_run_select`].
+pub fn olap_result_cache() -> Option<Arc<QueryResultCache<ExecutionPipelineResult>>> {
+    if olap_result_cache_enabled() {
+        Some(GLOBAL_OLAP_RESULT_CACHE.clone())
+    } else {
+        None
+    }
+}
+
+/// The shared invalidation coordinator (always reachable; its result-cache arm
+/// is a no-op when the flag is off because nothing was ever inserted).
+pub fn olap_cache_coordinator() -> Arc<CacheInvalidationCoordinator> {
+    GLOBAL_OLAP_CACHE_COORDINATOR.clone()
+}
+
+/// Tenant-scoped invalidation of the OLAP result cache after a write/DDL. Drops
+/// every cached entry registered under `(tenant, normalize_table_key(table))`.
+/// The table name is normalized here (matching the read-side dependency keys,
+/// which are `snapshot.tables` keys) so callers can pass the raw parsed name.
+/// Default-OFF: a cheap no-op when the cache flag is unset. Call from the
+/// pgwire INSERT/UPDATE/DELETE/DDL success paths (mandate #16b).
+pub async fn invalidate_olap_result_cache_for(tenant: &str, table: &str) {
+    if olap_result_cache().is_some() {
+        let normalized = normalize_table_key(table);
+        olap_cache_coordinator()
+            .invalidate_collection(tenant, &normalized, &[])
+            .await;
+    }
+}
+
+/// Cheap canonical-WAL LSN read — the Strong-freshness anchor (ADR-051 D2 /
+/// ADR-046). Returns `0` when WAL-manifest tracking is unavailable, which makes
+/// Strong lookups bypass (never serve) — the safe default. Same source as the
+/// vector-search path (`services::operations::vectors::legacy`).
+async fn current_canonical_lsn() -> u64 {
+    match crate::storage::persistence::write_ahead_log::manifest::get_service() {
+        Some(svc) => svc.current_lsn().await,
+        None => 0,
+    }
+}
+
+/// Stamp a freshly-executed OLAP result into the result cache under its
+/// structural key, with the LSN it was computed at. No-op when the cache is
+/// disabled or LSN tracking is unavailable (`current_lsn == 0` → never
+/// Strong-eligible, so don't waste a slot).
+fn populate_olap_result_cache(
+    cache: Option<&QueryResultCache<ExecutionPipelineResult>>,
+    skey: &StructuralKey,
+    lsn: u64,
+    result: ExecutionPipelineResult,
+    deps_table_keys: &HashMap<String, PreparedTable>,
+) {
+    let Some(cache) = cache else {
+        return;
+    };
+    let computed_at_lsn = (lsn != 0).then_some(lsn);
+    let deps: Vec<String> = deps_table_keys.keys().cloned().collect();
+    if let Err(e) = cache.insert_fresh(skey.clone(), result, deps, computed_at_lsn) {
+        tracing::debug!(
+            target: "proximadb::pgwire::result_cache",
+            error = ?e,
+            "failed to cache OLAP result"
+        );
+    }
+}
+
+// =========================================================================
 // Public entry point
 // =========================================================================
 
@@ -141,6 +252,14 @@ pub async fn try_run_select(
     // whose tables don't resolve return `None` and fall back to the caller's
     // vector/graph engine.
     require_engagement: bool,
+    // Namespace / schema (pgwire `search_path`) — a structural key component so
+    // identical SQL under different namespaces never collides.
+    namespace: Option<&str>,
+    // Shared OLAP result cache (default-OFF — `None` when
+    // `PROXIMADB_QUERY_RESULT_CACHE` is unset). A hit short-circuits routing +
+    // execution; a miss falls through normally and the result is stamped on the
+    // real-data success paths.
+    result_cache: Option<&QueryResultCache<ExecutionPipelineResult>>,
 ) -> Option<Result<ExecutionPipelineResult, String>> {
     // TD-064: the connection's tenant scopes every snapshot read to the tenant's
     // record partition (carried into the SnapshotCatalog → DmlTableReader).
@@ -159,6 +278,32 @@ pub async fn try_run_select(
         );
         return None;
     }
+
+    // OLAP result cache lookup (ADR-051 D2 / mandate #16c). Strong freshness:
+    // a hit is served ONLY when the entry was computed at the current canonical
+    // WAL LSN, so any write since → guaranteed miss → read-after-write correct.
+    // `cache_ctx` carries the (key, lsn) pair so the real-data success paths
+    // below can stamp the result without recomputing it.
+    let cache_ctx: Option<(StructuralKey, u64)> = if let Some(cache) = result_cache {
+        let current_lsn = current_canonical_lsn().await;
+        let skey = StructuralKey::new(
+            tenant.unwrap_or(""),
+            namespace.unwrap_or(""),
+            QueryKey::from_sql(sql),
+        );
+        if let Some(cached) = cache.get_fresh(&skey, &VectorFreshnessMode::Strong, current_lsn) {
+            tracing::debug!(
+                target: "proximadb::pgwire::result_cache",
+                tenant = tenant.unwrap_or(""),
+                lsn = current_lsn,
+                "OLAP result cache hit — short-circuiting route + execution"
+            );
+            return Some(Ok(cached.result.clone()));
+        }
+        Some((skey, current_lsn))
+    } else {
+        None
+    };
 
     // 1) Existing in-memory-engine path (preserves the demo table and any
     //    engine-resident tables). Only engages when the SQL lowers against the
@@ -341,7 +486,15 @@ pub async fn try_run_select(
             &crate::query::compute_scheduler::backend_label(&decision.backend),
             started.elapsed().as_millis() as u64,
         );
-        return Some(engine_result.map_err(|e| e.to_string()));
+        return Some(match engine_result {
+            Ok(result) => {
+                if let Some((skey, lsn)) = &cache_ctx {
+                    populate_olap_result_cache(result_cache, skey, *lsn, result.clone(), &tables);
+                }
+                Ok(result)
+            }
+            Err(e) => Err(e.to_string()),
+        });
     }
 
     let snapshot = SnapshotCatalog {
@@ -356,7 +509,21 @@ pub async fn try_run_select(
         Ok(p) => p,
         Err(e) => return Some(Err(e)),
     };
-    Some(execute_physical(physical, &snapshot, controls).await)
+    match execute_physical(physical, &snapshot, controls).await {
+        Ok(result) => {
+            if let Some((skey, lsn)) = &cache_ctx {
+                populate_olap_result_cache(
+                    result_cache,
+                    skey,
+                    *lsn,
+                    result.clone(),
+                    &snapshot.tables,
+                );
+            }
+            Some(Ok(result))
+        }
+        Err(e) => Some(Err(e)),
+    }
 }
 
 /// Plan + build + drain an executor for `logical` against `factory`, using

--- a/src/query/cache/invalidation.rs
+++ b/src/query/cache/invalidation.rs
@@ -46,7 +46,7 @@ use std::time::Duration;
 use dashmap::DashMap;
 use tracing::{debug, info};
 
-use super::query_result_cache::QueryResultCache;
+use super::query_result_cache::FederatedQueryResultCache;
 
 /// Types of change operations that trigger invalidation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -209,7 +209,7 @@ pub struct InvalidationStatsSnapshot {
 /// 2. Event-driven mode: Subscribe to CDC/WAL events and call `on_change_event`
 pub struct CacheInvalidator {
     /// Reference to the query result cache
-    cache: Arc<QueryResultCache>,
+    cache: Arc<FederatedQueryResultCache>,
     /// Configuration
     config: InvalidationConfig,
     /// Collections to watch (empty = watch all)
@@ -224,12 +224,12 @@ pub struct CacheInvalidator {
 
 impl CacheInvalidator {
     /// Create a new cache invalidator
-    pub fn new(cache: Arc<QueryResultCache>) -> Self {
+    pub fn new(cache: Arc<FederatedQueryResultCache>) -> Self {
         Self::with_config(cache, InvalidationConfig::default())
     }
 
     /// Create a new cache invalidator with custom configuration
-    pub fn with_config(cache: Arc<QueryResultCache>, config: InvalidationConfig) -> Self {
+    pub fn with_config(cache: Arc<FederatedQueryResultCache>, config: InvalidationConfig) -> Self {
         Self {
             cache,
             config,
@@ -441,7 +441,7 @@ impl CacheInvalidator {
     }
 
     /// Get the underlying cache reference
-    pub fn cache(&self) -> &Arc<QueryResultCache> {
+    pub fn cache(&self) -> &Arc<FederatedQueryResultCache> {
         &self.cache
     }
 }
@@ -524,14 +524,14 @@ impl BroadcastInvalidator {
 mod tests {
     use super::*;
 
-    fn create_test_cache() -> Arc<QueryResultCache> {
+    fn create_test_cache() -> Arc<FederatedQueryResultCache> {
         use super::super::query_result_cache::{QueryKey, QueryResultCacheConfig};
         use crate::query::federated::ExecutionResult;
         use arrow::array::{ArrayRef, RecordBatch, StringArray};
         use arrow::datatypes::{DataType, Field, Schema};
 
         let config = QueryResultCacheConfig::default();
-        let cache = Arc::new(QueryResultCache::new(config));
+        let cache = Arc::new(FederatedQueryResultCache::new(config));
 
         // Pre-populate with some entries
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));

--- a/src/query/cache/invalidation_coordinator.rs
+++ b/src/query/cache/invalidation_coordinator.rs
@@ -21,9 +21,38 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
 use crate::query::cache::batch_group::BatchGroupCache;
 use crate::query::cache::plan_cache::PlanCache;
+use crate::query::cache::query_result_cache::{CacheableResult, QueryResultCache};
 use crate::storage::cache::specialized::query_cache::QueryCache;
+
+/// Trait-object seam so [`CacheInvalidationCoordinator`] can fan invalidation
+/// out to a structurally tenant-keyed [`QueryResultCache<T>`] without itself
+/// being generic over the cached result type `T`.
+///
+/// The pgwire OLAP result cache (`QueryResultCache<ExecutionPipelineResult>`)
+/// is attached via [`CacheInvalidationCoordinator::with_result_cache`]; writes
+/// and DDL then call [`CacheInvalidationCoordinator::invalidate_collection`],
+/// which drops every entry registered under `(tenant, collection)` — never
+/// touching another tenant's entries (mandate #16b).
+#[async_trait]
+pub trait TenantResultCacheInvalidation: Send + Sync {
+    /// Drop every cached entry registered under `(tenant, collection)`.
+    /// Returns the number of entries invalidated.
+    async fn invalidate_tenant(&self, tenant: &str, collection: &str) -> u64;
+}
+
+#[async_trait]
+impl<T> TenantResultCacheInvalidation for QueryResultCache<T>
+where
+    T: Clone + CacheableResult + Send + Sync + 'static,
+{
+    async fn invalidate_tenant(&self, tenant: &str, collection: &str) -> u64 {
+        QueryResultCache::invalidate_tenant_collection(self, tenant, collection) as u64
+    }
+}
 
 /// Per-call result — how many entries each cache dropped. Useful in
 /// observability dashboards and in tests that need to assert fan-out.
@@ -32,6 +61,9 @@ pub struct InvalidationSummary {
     pub plan_cache_entries: u64,
     pub batch_groups_closed: u64,
     pub query_cache_entries: u64,
+    /// Entries dropped from the structurally tenant-keyed OLAP result cache
+    /// (the [`TenantResultCacheInvalidation`] arm).
+    pub result_cache_entries: u64,
     /// Corpus version after the bump that fired during this call —
     /// `None` only if the registry wasn't reachable. The observability
     /// dashboard reports this so an SRE can correlate "the version
@@ -41,7 +73,10 @@ pub struct InvalidationSummary {
 
 impl InvalidationSummary {
     pub fn total(&self) -> u64 {
-        self.plan_cache_entries + self.batch_groups_closed + self.query_cache_entries
+        self.plan_cache_entries
+            + self.batch_groups_closed
+            + self.query_cache_entries
+            + self.result_cache_entries
     }
 }
 
@@ -52,6 +87,10 @@ pub struct CacheInvalidationCoordinator {
     plan_cache: Option<Arc<PlanCache>>,
     batch_group: Option<Arc<BatchGroupCache>>,
     query_cache: Option<Arc<QueryCache>>,
+    /// Structurally tenant-keyed result cache (e.g. the pgwire OLAP result
+    /// cache), held as a trait object so the coordinator stays
+    /// non-generic over the cached value type.
+    result_cache: Option<Arc<dyn TenantResultCacheInvalidation>>,
 }
 
 impl CacheInvalidationCoordinator {
@@ -63,6 +102,7 @@ impl CacheInvalidationCoordinator {
             plan_cache: None,
             batch_group: None,
             query_cache: None,
+            result_cache: None,
         }
     }
 
@@ -81,6 +121,17 @@ impl CacheInvalidationCoordinator {
     /// Attach the query-results cache.
     pub fn with_query_cache(mut self, cache: Arc<QueryCache>) -> Self {
         self.query_cache = Some(cache);
+        self
+    }
+
+    /// Attach the structurally tenant-keyed OLAP result cache. Writes/DDL
+    /// routed through [`Self::invalidate_collection`] will then drop every
+    /// entry registered under `(tenant, collection)` for this cache too.
+    pub fn with_result_cache<T>(mut self, cache: Arc<QueryResultCache<T>>) -> Self
+    where
+        T: Clone + CacheableResult + Send + Sync + 'static,
+    {
+        self.result_cache = Some(cache);
         self
     }
 
@@ -108,6 +159,10 @@ impl CacheInvalidationCoordinator {
 
         if let Some(cache) = &self.query_cache {
             summary.query_cache_entries = cache.invalidate_collection(collection).await as u64;
+        }
+
+        if let Some(cache) = &self.result_cache {
+            summary.result_cache_entries = cache.invalidate_tenant(tenant_id, collection).await;
         }
 
         if let Some(cache) = &self.batch_group {
@@ -296,9 +351,116 @@ mod tests {
             plan_cache_entries: 3,
             batch_groups_closed: 5,
             query_cache_entries: 2,
+            result_cache_entries: 2,
             corpus_version_after: None,
         };
-        assert_eq!(s.total(), 10);
+        assert_eq!(s.total(), 12);
+    }
+
+    #[tokio::test]
+    async fn result_cache_invalidation_is_tenant_scoped() {
+        // Attach a structurally tenant-keyed result cache and confirm the
+        // coordinator fan-out drops only the (tenant, collection) entries.
+        use crate::core::search::VectorFreshnessMode;
+        use crate::query::cache::query_result_cache::{
+            CacheableResult, QueryKey, QueryResultCache, StructuralKey,
+        };
+
+        #[derive(Clone)]
+        struct DummyCacheable;
+        impl CacheableResult for DummyCacheable {
+            fn estimated_size_bytes(&self) -> usize {
+                1
+            }
+        }
+
+        let cache = Arc::new(QueryResultCache::<DummyCacheable>::with_defaults());
+        let key_a = StructuralKey::new("tenant-a", "public", QueryKey::from_sql("SELECT 1"));
+        let key_b = StructuralKey::new("tenant-b", "public", QueryKey::from_sql("SELECT 1"));
+        cache
+            .insert_fresh(
+                key_a.clone(),
+                DummyCacheable,
+                vec!["orders".to_string()],
+                Some(1),
+            )
+            .expect("insert a");
+        cache
+            .insert_fresh(
+                key_b.clone(),
+                DummyCacheable,
+                vec!["orders".to_string()],
+                Some(1),
+            )
+            .expect("insert b");
+
+        let coord = CacheInvalidationCoordinator::empty().with_result_cache(cache.clone());
+        let s = coord.invalidate_collection("tenant-a", "orders", &[]).await;
+        // Only tenant-a's entry counted + dropped; tenant-b survives.
+        assert_eq!(s.result_cache_entries, 1);
+        assert!(
+            cache
+                .get_fresh(&key_a, &VectorFreshnessMode::StaleOk, 0)
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_fresh(&key_b, &VectorFreshnessMode::StaleOk, 0)
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn write_side_table_name_normalizes_to_read_side_dep() {
+        // Pin the read↔write normalization match-up: the read path registers a
+        // cached entry's dependency under `normalize_table_key(raw)` (the
+        // `snapshot.tables` keys); the write path
+        // (`invalidate_olap_result_cache_for`) must apply the SAME
+        // `normalize_table_key` to the raw parsed table name or invalidation
+        // silently never fires for any quoted/qualified/mixed-case table.
+        use crate::core::search::VectorFreshnessMode;
+        use crate::query::cache::query_result_cache::{
+            CacheableResult, QueryKey, QueryResultCache, StructuralKey,
+        };
+        use crate::query::execution::normalize_table_key;
+
+        #[derive(Clone)]
+        struct DummyCacheable;
+        impl CacheableResult for DummyCacheable {
+            fn estimated_size_bytes(&self) -> usize {
+                1
+            }
+        }
+
+        // Sanity: the normalizer lowercases + de-qualifies (the contract the
+        // match-up depends on).
+        assert_eq!(normalize_table_key(r#""public"."Orders""#), "orders");
+
+        let cache = Arc::new(QueryResultCache::<DummyCacheable>::with_defaults());
+        // Read side registers the dependency under the NORMALIZED name.
+        let key = StructuralKey::new("t", "public", QueryKey::from_sql("SELECT * FROM Orders"));
+        cache
+            .insert_fresh(
+                key.clone(),
+                DummyCacheable,
+                vec![normalize_table_key("Orders")],
+                Some(1),
+            )
+            .expect("insert");
+
+        let coord = CacheInvalidationCoordinator::empty().with_result_cache(cache.clone());
+        // Write side passes the RAW parsed name; the production helper
+        // normalizes before reaching the coordinator. Simulate that here.
+        let raw_write_name = r#""public"."Orders""#;
+        let s = coord
+            .invalidate_collection("t", &normalize_table_key(raw_write_name), &[])
+            .await;
+        assert_eq!(s.result_cache_entries, 1, "raw write name must evict");
+        assert!(
+            cache
+                .get_fresh(&key, &VectorFreshnessMode::StaleOk, 0)
+                .is_none()
+        );
     }
 
     // Bind one cache key digest to a stable u64 so the coordinator tests

--- a/src/query/cache/mod.rs
+++ b/src/query/cache/mod.rs
@@ -133,8 +133,9 @@ pub use adaptive_cache::{
     AccessPattern, AdaptiveCacheConfig, AdaptiveCacheEntry, AdaptiveCacheStats, AdaptiveQueryCache,
 };
 pub use query_result_cache::{
-    CachedResult, QueryCacheError, QueryCacheKey, QueryCacheResult, QueryCacheStats, QueryKey,
-    QueryResultCache, QueryResultCacheConfig,
+    CacheableResult, CachedResult, CompositeMapKey, FederatedQueryResultCache, QueryCacheError,
+    QueryCacheKey, QueryCacheResult, QueryCacheStats, QueryKey, QueryResultCache,
+    QueryResultCacheConfig, StructuralKey, freshness_eligible,
 };
 
 pub use invalidation::{

--- a/src/query/cache/query_result_cache.rs
+++ b/src/query/cache/query_result_cache.rs
@@ -1,7 +1,34 @@
 //! # Query Result Cache Implementation
 //!
-//! Core types and cache implementation for query result caching.
-//! This cache benefits agentic AI workloads with repetitive queries.
+//! Core types and cache implementation for query result caching. The cache is
+//! generic over the cached result type `T` (any [`CacheableResult`]) so the
+//! same machinery serves both the federated query path (caching
+//! `ExecutionResult`) and the pgwire OLAP path (caching
+//! `ExecutionPipelineResult`).
+//!
+//! ## Multi-tenant structural keying
+//!
+//! The cache is keyed STRUCTURALLY on `(tenant, namespace, query)` — tenant is
+//! a *leading* key component, never a predicate on the value (multi-tenant
+//! co-design mandate). [`StructuralKey`] folds all three into a
+//! [`CompositeMapKey`] used as the DashMap key, and every stored
+//! [`CachedResult`] additionally records the full `(tenant, namespace,
+//! query_fingerprint)` triple which is re-verified on lookup. A cross-tenant
+//! collision would require a simultaneous 192-bit hash collision; the
+//! stored-triple check defends against it regardless.
+//!
+//! ## Read-after-write freshness
+//!
+//! [`QueryResultCache::get_fresh`] gates serving on [`VectorFreshnessMode`]:
+//!
+//! - **Strong** (ADR-051 D2): serve iff `computed_at_lsn == Some(current_lsn)`
+//!   and `current_lsn != 0`. Any write bumps the canonical-WAL LSN → guaranteed
+//!   miss → read-after-write correct (mandate #16c).
+//! - **BoundedStale**: serve iff `age <= max_staleness_ms`.
+//! - **StaleOk**: serve iff not TTL-expired.
+//!
+//! TTL is the universal entry lifetime: an entry older than its TTL is dead for
+//! every mode and is evicted. See [`freshness_eligible`].
 
 use std::collections::HashSet;
 use std::collections::hash_map::DefaultHasher;
@@ -14,6 +41,7 @@ use dashmap::DashMap;
 use thiserror::Error;
 use tracing::{debug, info};
 
+use crate::core::search::VectorFreshnessMode;
 use crate::query::federated::ExecutionResult;
 
 /// Unique identifier for a cached query result
@@ -31,7 +59,7 @@ pub enum QueryCacheError {
     Expired(QueryCacheKey),
 
     /// Cache is full and cannot accept new entries
-    #[error("Query cache is full (max: {0})")]
+    #[error("Cache is full (max: {0})")]
     CacheFull(usize),
 
     /// Failed to compute query key
@@ -45,6 +73,28 @@ pub enum QueryCacheError {
 
 /// Result type for query cache operations
 pub type QueryCacheResult<T> = Result<T, QueryCacheError>;
+
+/// What the cache requires of a cached result type so it can estimate the
+/// in-memory footprint of an entry (for size limits / eviction). Implemented
+/// by the concrete result types that instantiate [`QueryResultCache`].
+pub trait CacheableResult: Send + Sync {
+    /// Rough estimated size of this result in bytes.
+    fn estimated_size_bytes(&self) -> usize;
+}
+
+impl CacheableResult for ExecutionResult {
+    fn estimated_size_bytes(&self) -> usize {
+        // Rough estimation based on row count and schema width — same heuristic
+        // the old hardcoded estimator used.
+        let row_count = self.row_count();
+        let field_count = self.schema.fields().len();
+        // Assume average of 100 bytes per field per row.
+        let estimated_data = row_count * field_count * 100;
+        // Add overhead for schema and metadata.
+        let schema_overhead = field_count * 64;
+        estimated_data + schema_overhead + 256 // Base overhead
+    }
+}
 
 /// Configuration for the query result cache
 #[derive(Debug, Clone)]
@@ -122,15 +172,68 @@ impl QueryKey {
     }
 }
 
+/// Composite DashMap key folding tenant + namespace + query fingerprint.
+/// Deriving `Hash`/`Eq` over all three makes tenant a STRUCTURAL key
+/// component (not a predicate on the value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CompositeMapKey {
+    pub tenant_hash: u64,
+    pub ns_hash: u64,
+    pub query_hash: u64,
+}
+
+/// Structural cache key: tenant and namespace are the LEADING components; the
+/// query is last. This is the multi-tenant isolation surface — tenant is part
+/// of the key, never a predicate.
+#[derive(Debug, Clone)]
+pub struct StructuralKey {
+    /// Tenant identifier (structural leading component).
+    pub tenant: String,
+    /// Namespace / schema identifier (structural component).
+    pub namespace: String,
+    /// The query fingerprint + SQL.
+    pub query: QueryKey,
+}
+
+impl StructuralKey {
+    /// Build a structural key from its three components.
+    pub fn new(tenant: impl Into<String>, namespace: impl Into<String>, query: QueryKey) -> Self {
+        Self {
+            tenant: tenant.into(),
+            namespace: namespace.into(),
+            query,
+        }
+    }
+
+    fn hash_str(s: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        s.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Fold the three components into the DashMap composite key.
+    pub fn composite(&self) -> CompositeMapKey {
+        CompositeMapKey {
+            tenant_hash: Self::hash_str(&self.tenant),
+            ns_hash: Self::hash_str(&self.namespace),
+            query_hash: self.query.fingerprint,
+        }
+    }
+}
+
 /// A cached query result with metadata
 #[derive(Debug)]
-pub struct CachedResult {
+pub struct CachedResult<T> {
     /// The cached execution result
-    pub result: ExecutionResult,
-    /// Collections/tables that this result depends on
+    pub result: T,
+    /// Collections/tables that this result depends on (normalized table keys)
     pub dependencies: Vec<String>,
     /// Query fingerprint for verification
     pub query_fingerprint: u64,
+    /// Tenant this entry belongs to (structural isolation re-check).
+    pub tenant: String,
+    /// Namespace this entry belongs to (structural isolation re-check).
+    pub namespace: String,
     /// Time-to-live for this entry
     pub ttl: Duration,
     /// Creation timestamp
@@ -141,18 +244,15 @@ pub struct CachedResult {
     pub access_count: AtomicU64,
     /// Estimated size in bytes
     pub size_bytes: usize,
+    /// Canonical-WAL LSN the result was computed at — the Strong-freshness
+    /// anchor (ADR-051 D2). `None` = LSN not tracked (never served to Strong).
+    pub computed_at_lsn: Option<u64>,
 }
 
-impl CachedResult {
-    /// Check if this cached result has expired
+impl<T> CachedResult<T> {
+    /// Check if this cached result has expired (age > TTL).
     pub fn is_expired(&self) -> bool {
         self.created_at.elapsed() > self.ttl
-    }
-
-    /// Update the last access time and increment access count
-    pub fn touch(&mut self) {
-        self.last_accessed = Instant::now();
-        self.access_count.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Get the age of this cached result
@@ -166,22 +266,50 @@ impl CachedResult {
     }
 }
 
-/// Thread-safe cache for query results
+/// Decide whether a cached entry is eligible to serve under the given
+/// freshness mode. Pure + deterministic so it is unit-tested directly.
 ///
-/// This cache provides high-performance caching of query results for
-/// agentic AI workloads with repetitive queries. It features:
+/// Policy (ADR-051 D2 / mandate #16c):
+/// - TTL is the universal entry lifetime — an expired entry is never eligible.
+/// - **Strong**: eligible iff `computed_at_lsn == Some(current_lsn)` and
+///   `current_lsn != 0`. Any write bumps the LSN → guaranteed miss.
+/// - **BoundedStale**: eligible iff `age <= max_staleness_ms`.
+/// - **StaleOk**: eligible (within TTL, already checked above).
+pub fn freshness_eligible(
+    mode: &VectorFreshnessMode,
+    age: Duration,
+    ttl: Duration,
+    computed_at_lsn: Option<u64>,
+    current_lsn: u64,
+) -> bool {
+    // Universal expiry: an entry older than its TTL is dead for every mode.
+    if age > ttl {
+        return false;
+    }
+    match mode {
+        VectorFreshnessMode::Strong => current_lsn != 0 && computed_at_lsn == Some(current_lsn),
+        VectorFreshnessMode::BoundedStale { max_staleness_ms } => {
+            age <= Duration::from_millis(*max_staleness_ms)
+        }
+        VectorFreshnessMode::StaleOk => true,
+    }
+}
+
+/// Thread-safe cache for query results, generic over the result type.
 ///
-/// - Thread-safe concurrent access using DashMap
-/// - TTL-based expiration
-/// - Dependency tracking for invalidation
-/// - LRU-like eviction when full
-/// - Metrics for monitoring cache performance
-pub struct QueryResultCache {
+/// This cache provides high-performance caching of query results with:
+///
+/// - Structural `(tenant, namespace, query)` keying for multi-tenant isolation
+/// - TTL-based expiration + LRU-like eviction
+/// - Tenant-scoped dependency tracking for invalidation
+/// - Freshness gating via [`VectorFreshnessMode`] (Strong LSN-pinning)
+pub struct QueryResultCache<T: Clone + CacheableResult + Send + Sync + 'static> {
     /// The result cache using DashMap for concurrent access
-    cache: DashMap<QueryCacheKey, Arc<CachedResult>>,
-    /// Registry mapping collection names to affected cache keys
-    /// Used for efficient invalidation when a collection is modified
-    invalidation_registry: DashMap<String, HashSet<QueryCacheKey>>,
+    cache: DashMap<CompositeMapKey, Arc<CachedResult<T>>>,
+    /// Registry mapping `(tenant, collection)` to affected cache keys.
+    /// Tenant-scoped so invalidating `(tenant-A, coll)` never touches
+    /// tenant-B's entries.
+    invalidation_registry: DashMap<(String, String), HashSet<CompositeMapKey>>,
     /// Configuration
     config: QueryResultCacheConfig,
     /// Cache statistics
@@ -219,7 +347,7 @@ impl QueryResultCacheStatistics {
     }
 }
 
-impl QueryResultCache {
+impl<T: Clone + CacheableResult + Send + Sync + 'static> QueryResultCache<T> {
     /// Create a new query result cache with the given configuration
     pub fn new(config: QueryResultCacheConfig) -> Self {
         Self {
@@ -235,36 +363,56 @@ impl QueryResultCache {
         Self::new(QueryResultCacheConfig::default())
     }
 
-    /// Get a cached result by query key
-    ///
-    /// Returns `Some(result)` if found and not expired, `None` otherwise.
-    pub fn get(&self, key: &QueryKey) -> Option<Arc<CachedResult>> {
-        let cache_key = key.cache_key();
+    /// Freshness-gated lookup honoring [`VectorFreshnessMode`] (ADR-051 D2 /
+    /// mandate #16c). Returns the cached entry only when the structural key
+    /// matches AND the entry is fresh enough for the requested mode.
+    pub fn get_fresh(
+        &self,
+        key: &StructuralKey,
+        mode: &VectorFreshnessMode,
+        current_lsn: u64,
+    ) -> Option<Arc<CachedResult<T>>> {
+        let map_key = key.composite();
 
-        if let Some(entry) = self.cache.get_mut(&cache_key) {
-            // Check expiration
+        if let Some(entry) = self.cache.get(&map_key) {
+            // Check expiration first.
             if entry.is_expired() {
                 drop(entry);
-                self.remove_entry(cache_key);
+                self.remove_entry(map_key);
                 self.stats.expirations.fetch_add(1, Ordering::Relaxed);
                 self.stats.misses.fetch_add(1, Ordering::Relaxed);
                 return None;
             }
 
-            // Verify fingerprint matches (collision check)
-            if entry.query_fingerprint != key.fingerprint {
+            // Structural isolation re-check: tenant + namespace + query must
+            // ALL match the stored entry. Defends against a composite-key
+            // collision and documents the cross-tenant guarantee explicitly.
+            if entry.tenant != key.tenant
+                || entry.namespace != key.namespace
+                || entry.query_fingerprint != key.query.fingerprint
+            {
                 debug!(
-                    expected = key.fingerprint,
-                    actual = entry.query_fingerprint,
-                    "Cache key collision detected"
+                    expected_tenant = %key.tenant,
+                    stored_tenant = %entry.tenant,
+                    "Cache structural-key mismatch (cross-tenant guard)"
                 );
                 self.stats.misses.fetch_add(1, Ordering::Relaxed);
                 return None;
             }
 
-            // Update access tracking (need to get mutable reference)
+            // Freshness gate.
+            if !freshness_eligible(
+                mode,
+                entry.age(),
+                entry.ttl,
+                entry.computed_at_lsn,
+                current_lsn,
+            ) {
+                self.stats.misses.fetch_add(1, Ordering::Relaxed);
+                return None;
+            }
+
             let result = Arc::clone(&*entry);
-            // We cannot call touch() on Arc directly, but we track access via stats
             drop(entry);
 
             self.stats.hits.fetch_add(1, Ordering::Relaxed);
@@ -275,31 +423,36 @@ impl QueryResultCache {
         }
     }
 
-    /// Insert a query result into the cache
-    ///
-    /// # Arguments
-    /// * `key` - The query key
-    /// * `result` - The execution result to cache
-    /// * `dependencies` - Collection names that this result depends on
-    pub fn insert(
+    /// Insert a query result with a structural key + the LSN it was computed at
+    /// (the Strong-freshness anchor). Dependencies are registered under
+    /// `(key.tenant, dep)` for tenant-scoped invalidation.
+    pub fn insert_fresh(
         &self,
-        key: QueryKey,
-        result: ExecutionResult,
+        key: StructuralKey,
+        result: T,
         dependencies: Vec<String>,
+        computed_at_lsn: Option<u64>,
     ) -> QueryCacheResult<()> {
-        self.insert_with_ttl(key, result, dependencies, self.config.default_ttl)
+        self.insert_entry(
+            key,
+            result,
+            dependencies,
+            self.config.default_ttl,
+            computed_at_lsn,
+        )
     }
 
-    /// Insert a query result with a custom TTL
-    pub fn insert_with_ttl(
+    /// Core insert worker shared by the freshness-aware and legacy APIs.
+    fn insert_entry(
         &self,
-        key: QueryKey,
-        result: ExecutionResult,
+        key: StructuralKey,
+        result: T,
         dependencies: Vec<String>,
         ttl: Duration,
+        computed_at_lsn: Option<u64>,
     ) -> QueryCacheResult<()> {
         // Estimate result size
-        let size_bytes = self.estimate_result_size(&result);
+        let size_bytes = result.estimated_size_bytes();
 
         // Check size limit
         if size_bytes > self.config.max_result_size_bytes {
@@ -332,35 +485,38 @@ impl QueryResultCache {
             }
         }
 
-        let cache_key = key.cache_key();
+        let map_key = key.composite();
         let now = Instant::now();
 
         let cached = Arc::new(CachedResult {
             result,
             dependencies: dependencies.clone(),
-            query_fingerprint: key.fingerprint,
+            query_fingerprint: key.query.fingerprint,
+            tenant: key.tenant.clone(),
+            namespace: key.namespace.clone(),
             ttl,
             created_at: now,
             last_accessed: now,
             access_count: AtomicU64::new(0),
             size_bytes,
+            computed_at_lsn,
         });
 
         // Insert into cache
-        self.cache.insert(cache_key, cached);
+        self.cache.insert(map_key, cached);
 
-        // Register dependencies for invalidation
+        // Register dependencies for tenant-scoped invalidation
         for dep in dependencies {
             self.invalidation_registry
-                .entry(dep)
+                .entry((key.tenant.clone(), dep))
                 .or_default()
-                .insert(cache_key);
+                .insert(map_key);
         }
 
         self.stats.inserts.fetch_add(1, Ordering::Relaxed);
 
         debug!(
-            key = cache_key,
+            key = ?map_key,
             ttl_secs = ttl.as_secs(),
             size_bytes,
             "Cached query result"
@@ -369,33 +525,56 @@ impl QueryResultCache {
         Ok(())
     }
 
-    /// Remove a cached entry by key
+    // ---------------------------------------------------------------------
+    // Backward-compatible legacy API (no tenant, no freshness).
+    //
+    // These delegate to the structural/freshness API with `tenant=""`,
+    // `namespace=""`, `computed_at_lsn=None`, and `StaleOk` eligibility,
+    // preserving the original TTL-only semantics. Kept so the federated
+    // query path and its existing tests compile unchanged.
+    // ---------------------------------------------------------------------
+
+    /// Legacy TTL-only lookup (no tenant context). Delegates with the empty
+    /// tenant and `StaleOk` eligibility.
+    pub fn get(&self, key: &QueryKey) -> Option<Arc<CachedResult<T>>> {
+        let skey = StructuralKey::new("", "", key.clone());
+        self.get_fresh(&skey, &VectorFreshnessMode::StaleOk, 0)
+    }
+
+    /// Insert a query result into the cache (legacy, no tenant context).
+    pub fn insert(
+        &self,
+        key: QueryKey,
+        result: T,
+        dependencies: Vec<String>,
+    ) -> QueryCacheResult<()> {
+        self.insert_with_ttl(key, result, dependencies, self.config.default_ttl)
+    }
+
+    /// Insert a query result with a custom TTL (legacy, no tenant context).
+    pub fn insert_with_ttl(
+        &self,
+        key: QueryKey,
+        result: T,
+        dependencies: Vec<String>,
+        ttl: Duration,
+    ) -> QueryCacheResult<()> {
+        let skey = StructuralKey::new("", "", key);
+        self.insert_entry(skey, result, dependencies, ttl, None)
+    }
+
+    /// Remove a cached entry by key (legacy).
     pub fn remove(&self, key: &QueryKey) -> bool {
-        self.remove_entry(key.cache_key())
+        let skey = StructuralKey::new("", "", key.clone());
+        self.remove_entry(skey.composite())
     }
 
-    /// Internal method to remove an entry and clean up invalidation registry
-    fn remove_entry(&self, cache_key: QueryCacheKey) -> bool {
-        if let Some((_, cached)) = self.cache.remove(&cache_key) {
-            // Remove from invalidation registry
-            for dep in &cached.dependencies {
-                if let Some(mut keys) = self.invalidation_registry.get_mut(dep) {
-                    keys.remove(&cache_key);
-                }
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Invalidate all cached results that depend on a collection
-    ///
-    /// This should be called when data in a collection is modified.
-    pub fn invalidate_collection(&self, collection: &str) -> usize {
-        let keys_to_remove: Vec<QueryCacheKey> = self
+    /// Tenant-scoped invalidation: drop every entry registered under
+    /// `(tenant, collection)`. Never touches another tenant's entries.
+    pub fn invalidate_tenant_collection(&self, tenant: &str, collection: &str) -> usize {
+        let keys_to_remove: Vec<CompositeMapKey> = self
             .invalidation_registry
-            .get(collection)
+            .get(&(tenant.to_string(), collection.to_string()))
             .map(|keys| keys.iter().copied().collect())
             .unwrap_or_default();
 
@@ -406,13 +585,15 @@ impl QueryResultCache {
         }
 
         // Clean up the registry entry
-        self.invalidation_registry.remove(collection);
+        self.invalidation_registry
+            .remove(&(tenant.to_string(), collection.to_string()));
 
         if count > 0 {
             self.stats
                 .invalidations
                 .fetch_add(count as u64, Ordering::Relaxed);
             info!(
+                tenant,
                 collection,
                 invalidated = count,
                 "Invalidated cached query results"
@@ -422,7 +603,13 @@ impl QueryResultCache {
         count
     }
 
-    /// Invalidate all cached results that depend on any of the given collections
+    /// Legacy: invalidate by collection name under the empty tenant.
+    pub fn invalidate_collection(&self, collection: &str) -> usize {
+        self.invalidate_tenant_collection("", collection)
+    }
+
+    /// Invalidate cached results for any of the given collections (legacy,
+    /// empty-tenant scope).
     pub fn invalidate_collections(&self, collections: &[&str]) -> usize {
         let mut total = 0;
         for collection in collections {
@@ -431,9 +618,27 @@ impl QueryResultCache {
         total
     }
 
+    /// Internal method to remove an entry and clean up invalidation registry
+    fn remove_entry(&self, map_key: CompositeMapKey) -> bool {
+        if let Some((_, cached)) = self.cache.remove(&map_key) {
+            // Remove from invalidation registry (tenant-scoped)
+            for dep in &cached.dependencies {
+                if let Some(mut keys) = self
+                    .invalidation_registry
+                    .get_mut(&(cached.tenant.clone(), dep.clone()))
+                {
+                    keys.remove(&map_key);
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Cleanup expired entries
     pub fn cleanup_expired(&self) -> usize {
-        let expired_keys: Vec<QueryCacheKey> = self
+        let expired_keys: Vec<CompositeMapKey> = self
             .cache
             .iter()
             .filter(|entry| entry.value().is_expired())
@@ -459,7 +664,7 @@ impl QueryResultCache {
     /// Evict the oldest entries to make room
     fn evict_oldest(&self, count: usize) -> usize {
         // Collect entries with their creation times
-        let mut entries: Vec<(QueryCacheKey, Instant)> = self
+        let mut entries: Vec<(CompositeMapKey, Instant)> = self
             .cache
             .iter()
             .map(|entry| (*entry.key(), entry.value().created_at))
@@ -510,11 +715,15 @@ impl QueryResultCache {
         self.cache.is_empty()
     }
 
-    /// Check if a query is cached
+    /// Check if a query is cached (legacy, empty-tenant scope)
     pub fn contains(&self, key: &QueryKey) -> bool {
-        let cache_key = key.cache_key();
-        if let Some(entry) = self.cache.get(&cache_key) {
-            !entry.is_expired() && entry.query_fingerprint == key.fingerprint
+        let skey = StructuralKey::new("", "", key.clone());
+        let map_key = skey.composite();
+        if let Some(entry) = self.cache.get(&map_key) {
+            !entry.is_expired()
+                && entry.tenant.is_empty()
+                && entry.namespace.is_empty()
+                && entry.query_fingerprint == key.fingerprint
         } else {
             false
         }
@@ -537,21 +746,6 @@ impl QueryResultCache {
         }
     }
 
-    /// Estimate the size of an execution result
-    fn estimate_result_size(&self, result: &ExecutionResult) -> usize {
-        // Rough estimation based on row count and schema
-        let row_count = result.row_count();
-        let field_count = result.schema.fields().len();
-
-        // Assume average of 100 bytes per field per row
-        let estimated_data = row_count * field_count * 100;
-
-        // Add overhead for schema and metadata
-        let schema_overhead = field_count * 64;
-
-        estimated_data + schema_overhead + 256 // Base overhead
-    }
-
     /// Get total size of all cached entries
     fn total_size_bytes(&self) -> usize {
         self.cache
@@ -566,11 +760,16 @@ impl QueryResultCache {
     }
 }
 
-impl Default for QueryResultCache {
+impl<T: Clone + CacheableResult + Send + Sync + 'static> Default for QueryResultCache<T> {
     fn default() -> Self {
         Self::with_defaults()
     }
 }
+
+/// Alias for the cache instantiation used by the federated query path.
+/// Letting `CacheInvalidator` / `FederatedQueryContext` reference the alias
+/// keeps the generic-ization from rippling through every call site.
+pub type FederatedQueryResultCache = QueryResultCache<ExecutionResult>;
 
 /// Public cache statistics.
 ///
@@ -600,7 +799,7 @@ pub struct QueryCacheStats {
     pub expirations: u64,
     /// Total size of cached data in bytes
     pub total_size_bytes: usize,
-    /// Number of tracked collections for invalidation
+    /// Number of tracked (tenant, collection) pairs for invalidation
     pub tracked_collections: usize,
 }
 
@@ -670,7 +869,9 @@ mod tests {
 
     #[test]
     fn test_cache_miss() {
-        let cache = QueryResultCache::with_defaults();
+        // Type-annotate via the alias so the bare `with_defaults()` (no insert
+        // to infer `T`) resolves to the federated result type.
+        let cache = FederatedQueryResultCache::with_defaults();
         let key = QueryKey::from_sql("SELECT * FROM nonexistent");
 
         assert!(!cache.contains(&key));
@@ -880,5 +1081,266 @@ mod tests {
         // Invalidating any dependency should remove the entry
         cache.invalidate_collection("b");
         assert!(!cache.contains(&key));
+    }
+
+    // =====================================================================
+    // Structural keying + freshness tests (pgwire OLAP wiring, ADR-051 D2).
+    // =====================================================================
+
+    fn skey(tenant: &str, namespace: &str, sql: &str) -> StructuralKey {
+        StructuralKey::new(tenant, namespace, QueryKey::from_sql(sql))
+    }
+
+    #[test]
+    fn structural_key_folds_all_three_components() {
+        // Same query + namespace, different tenant → different composite.
+        let a = skey("tenant-a", "public", "SELECT 1");
+        let b = skey("tenant-b", "public", "SELECT 1");
+        assert_ne!(a.composite(), b.composite());
+        // Same query + tenant, different namespace → different composite.
+        let c = skey("tenant-a", "other", "SELECT 1");
+        assert_ne!(a.composite(), c.composite());
+        // Identical → same composite.
+        let a2 = skey("tenant-a", "public", "SELECT 1");
+        assert_eq!(a.composite(), a2.composite());
+    }
+
+    #[test]
+    fn cross_tenant_key_isolation() {
+        // Tenant A's write must NEVER serve tenant B, even with identical SQL
+        // and namespace. Insert under A, lookup under B → miss.
+        let cache = QueryResultCache::with_defaults();
+        let key_a = skey("tenant-a", "public", "SELECT * FROM orders");
+        let key_b = skey("tenant-b", "public", "SELECT * FROM orders");
+
+        cache
+            .insert_fresh(
+                key_a.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                Some(42),
+            )
+            .expect("insert");
+
+        // A hits (Strong at the pinned LSN).
+        assert!(
+            cache
+                .get_fresh(&key_a, &VectorFreshnessMode::Strong, 42)
+                .is_some()
+        );
+        // B never hits A's entry — Strong or otherwise.
+        assert!(
+            cache
+                .get_fresh(&key_b, &VectorFreshnessMode::Strong, 42)
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_fresh(&key_b, &VectorFreshnessMode::StaleOk, 0)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cross_tenant_invalidation_does_not_touch_other_tenant() {
+        let cache = QueryResultCache::with_defaults();
+        let key_a = skey("tenant-a", "public", "SELECT * FROM orders");
+        let key_b = skey("tenant-b", "public", "SELECT * FROM orders");
+
+        cache
+            .insert_fresh(
+                key_a.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                Some(42),
+            )
+            .expect("insert a");
+        cache
+            .insert_fresh(
+                key_b.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                Some(42),
+            )
+            .expect("insert b");
+
+        // Invalidate (tenant-a, orders) — must drop only A.
+        let dropped = cache.invalidate_tenant_collection("tenant-a", "orders");
+        assert_eq!(dropped, 1);
+        assert!(
+            cache
+                .get_fresh(&key_a, &VectorFreshnessMode::Strong, 42)
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_fresh(&key_b, &VectorFreshnessMode::Strong, 42)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn strong_lsn_pinned_serve() {
+        // Strong serves iff computed_at_lsn == current_lsn && lsn != 0.
+        let cache = QueryResultCache::with_defaults();
+        let key = skey("t", "public", "SELECT * FROM orders");
+        cache
+            .insert_fresh(
+                key.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                Some(42),
+            )
+            .expect("insert");
+
+        // Matching LSN → serve.
+        assert!(
+            cache
+                .get_fresh(&key, &VectorFreshnessMode::Strong, 42)
+                .is_some()
+        );
+        // Advanced LSN (simulates a write) → bypass.
+        assert!(
+            cache
+                .get_fresh(&key, &VectorFreshnessMode::Strong, 43)
+                .is_none()
+        );
+        // current_lsn == 0 (LSN tracking unavailable) → never serve Strong.
+        assert!(
+            cache
+                .get_fresh(&key, &VectorFreshnessMode::Strong, 0)
+                .is_none()
+        );
+        // An entry written without an LSN anchor is never Strong-eligible.
+        let key2 = skey("t", "public", "SELECT * FROM other");
+        cache
+            .insert_fresh(
+                key2.clone(),
+                create_test_result(),
+                vec!["other".to_string()],
+                None,
+            )
+            .expect("insert no-lsn");
+        assert!(
+            cache
+                .get_fresh(&key2, &VectorFreshnessMode::Strong, 42)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn strong_serves_until_ttl_even_with_stable_lsn() {
+        // TTL is the universal entry lifetime: even a stable LSN cannot serve
+        // an expired entry.
+        let config = QueryResultCacheConfig {
+            default_ttl: Duration::from_millis(1),
+            ..Default::default()
+        };
+        let cache = QueryResultCache::new(config);
+        let key = skey("t", "public", "SELECT * FROM orders");
+        cache
+            .insert_fresh(
+                key.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                Some(42),
+            )
+            .expect("insert");
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(
+            cache
+                .get_fresh(&key, &VectorFreshnessMode::Strong, 42)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn bounded_stale_window() {
+        let cache = QueryResultCache::with_defaults();
+        let key = skey("t", "public", "SELECT * FROM orders");
+        cache
+            .insert_fresh(
+                key.clone(),
+                create_test_result(),
+                vec!["orders".to_string()],
+                None,
+            )
+            .expect("insert");
+
+        // Within the staleness window → serve.
+        let within = VectorFreshnessMode::BoundedStale {
+            max_staleness_ms: 60_000,
+        };
+        assert!(cache.get_fresh(&key, &within, 0).is_some());
+
+        // Past the window → bypass (age > max_staleness_ms).
+        let past = VectorFreshnessMode::BoundedStale {
+            max_staleness_ms: 0,
+        };
+        std::thread::sleep(Duration::from_millis(2));
+        assert!(cache.get_fresh(&key, &past, 0).is_none());
+    }
+
+    #[test]
+    fn freshness_eligible_predicate_units() {
+        // Pure predicate: exercise each branch without a cache.
+        let ttl = Duration::from_secs(60);
+        // Strong
+        assert!(freshness_eligible(
+            &VectorFreshnessMode::Strong,
+            Duration::from_secs(1),
+            ttl,
+            Some(7),
+            7
+        ));
+        assert!(!freshness_eligible(
+            &VectorFreshnessMode::Strong,
+            Duration::from_secs(1),
+            ttl,
+            Some(7),
+            8
+        ));
+        assert!(!freshness_eligible(
+            &VectorFreshnessMode::Strong,
+            Duration::from_secs(1),
+            ttl,
+            Some(7),
+            0
+        ));
+        // BoundedStale
+        assert!(freshness_eligible(
+            &VectorFreshnessMode::BoundedStale {
+                max_staleness_ms: 1_000
+            },
+            Duration::from_millis(500),
+            ttl,
+            None,
+            0
+        ));
+        assert!(!freshness_eligible(
+            &VectorFreshnessMode::BoundedStale {
+                max_staleness_ms: 1_000
+            },
+            Duration::from_millis(2_000),
+            ttl,
+            None,
+            0
+        ));
+        // StaleOk
+        assert!(freshness_eligible(
+            &VectorFreshnessMode::StaleOk,
+            Duration::from_secs(1),
+            ttl,
+            None,
+            0
+        ));
+        // Universal TTL expiry overrides every mode.
+        assert!(!freshness_eligible(
+            &VectorFreshnessMode::StaleOk,
+            Duration::from_secs(120),
+            ttl,
+            Some(7),
+            7
+        ));
     }
 }

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -16,12 +16,26 @@ use std::sync::{
 };
 
 /// Result of a successful query execution.
-#[derive(Debug)]
+///
+/// `Clone` is required so the pgwire OLAP result cache
+/// (`QueryResultCache<ExecutionPipelineResult>`) can retain + serve a copy of
+/// a result without re-executing the query.
+#[derive(Debug, Clone)]
 pub struct ExecutionPipelineResult {
     /// Ordered result schema.
     pub schema: RelationalSchema,
     /// Fully materialized rows.
     pub rows: Vec<RelationalRow>,
+}
+
+impl crate::query::cache::query_result_cache::CacheableResult for ExecutionPipelineResult {
+    fn estimated_size_bytes(&self) -> usize {
+        // Same heuristic the cache historically used for ExecutionResult:
+        // ~100 bytes per field per row + per-field schema overhead.
+        let row_count = self.rows.len();
+        let field_count = self.schema.columns.len();
+        row_count * field_count * 100 + field_count * 64 + 256
+    }
 }
 
 impl ExecutionPipelineResult {

--- a/src/query/federated/mod.rs
+++ b/src/query/federated/mod.rs
@@ -132,7 +132,7 @@ use anyhow::Result;
 use std::sync::Arc;
 use tracing::debug;
 
-use super::cache::{CacheInvalidator, QueryKey, QueryResultCache};
+use super::cache::{CacheInvalidator, FederatedQueryResultCache, QueryKey};
 use crate::catalog::CatalogManager;
 use crate::storage::MultiModelStorageFacade;
 
@@ -147,7 +147,7 @@ pub struct FederatedQueryContext {
     /// Federated executor
     pub executor: FederatedExecutor,
     /// Query result cache for repetitive queries
-    pub cache: Option<Arc<QueryResultCache>>,
+    pub cache: Option<Arc<FederatedQueryResultCache>>,
     /// Cache invalidator for real-time invalidation
     pub invalidator: Option<Arc<CacheInvalidator>>,
     /// Catalog manager for external table resolution
@@ -218,7 +218,10 @@ impl FederatedQueryContext {
     }
 
     /// Create a new federated query context with caching enabled
-    pub fn with_cache(storage: Arc<MultiModelStorageFacade>, cache: Arc<QueryResultCache>) -> Self {
+    pub fn with_cache(
+        storage: Arc<MultiModelStorageFacade>,
+        cache: Arc<FederatedQueryResultCache>,
+    ) -> Self {
         let invalidator = Arc::new(CacheInvalidator::new(cache.clone()));
         Self {
             storage: storage.clone(),
@@ -248,14 +251,14 @@ impl FederatedQueryContext {
     }
 
     /// Enable caching on an existing context
-    pub fn enable_cache(&mut self, cache: Arc<QueryResultCache>) {
+    pub fn enable_cache(&mut self, cache: Arc<FederatedQueryResultCache>) {
         let invalidator = Arc::new(CacheInvalidator::new(cache.clone()));
         self.cache = Some(cache);
         self.invalidator = Some(invalidator);
     }
 
     /// Get the cache if enabled
-    pub fn get_cache(&self) -> Option<&Arc<QueryResultCache>> {
+    pub fn get_cache(&self) -> Option<&Arc<FederatedQueryResultCache>> {
         self.cache.as_ref()
     }
 
@@ -399,7 +402,7 @@ mod tests {
         MetricAggregation, MetricSample, ObservabilityNamespaceConfig, RetentionConfig, Severity,
         SqlArray, SqlObject, SqlValue, TraceData, sql_value,
     };
-    use crate::query::federated::{FederatedQueryContext, QueryResultCache};
+    use crate::query::federated::{FederatedQueryContext, FederatedQueryResultCache};
     use crate::storage::MultiModelStorageFacade;
     use crate::storage::multimodel::stores::{
         DocumentStore, DocumentStoreConfig, GraphStore, GraphStoreConfig, ObservabilityStore,
@@ -1013,7 +1016,7 @@ mod tests {
     #[test]
     fn test_federated_context_with_cache() {
         let storage = Arc::new(MultiModelStorageFacade::new());
-        let cache = Arc::new(QueryResultCache::with_defaults());
+        let cache = Arc::new(FederatedQueryResultCache::with_defaults());
         let ctx = FederatedQueryContext::with_cache(storage, cache);
 
         assert!(ctx.cache.is_some());
@@ -1177,7 +1180,7 @@ mod tests {
 
         assert!(ctx.cache.is_none());
 
-        let cache = Arc::new(QueryResultCache::with_defaults());
+        let cache = Arc::new(FederatedQueryResultCache::with_defaults());
         ctx.enable_cache(cache);
 
         assert!(ctx.cache.is_some());
@@ -1187,7 +1190,7 @@ mod tests {
     #[test]
     fn test_cache_stats() {
         let storage = Arc::new(MultiModelStorageFacade::new());
-        let cache = Arc::new(QueryResultCache::with_defaults());
+        let cache = Arc::new(FederatedQueryResultCache::with_defaults());
         let ctx = FederatedQueryContext::with_cache(storage, cache);
 
         let stats = ctx.cache_stats();
@@ -1202,7 +1205,7 @@ mod tests {
     #[test]
     fn test_invalidate_collection() {
         let storage = Arc::new(MultiModelStorageFacade::new());
-        let cache = Arc::new(QueryResultCache::with_defaults());
+        let cache = Arc::new(FederatedQueryResultCache::with_defaults());
         let ctx = FederatedQueryContext::with_cache(storage, cache);
 
         // With no cached entries, invalidation returns 0

--- a/tests/query_cache_test.rs
+++ b/tests/query_cache_test.rs
@@ -11,8 +11,8 @@ use arrow::array::{ArrayRef, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 
 use proximadb::query::cache::{
-    CacheInvalidator, ChangeOperation, InvalidationConfig, InvalidationEvent, QueryKey,
-    QueryResultCache, QueryResultCacheConfig,
+    CacheInvalidator, ChangeOperation, FederatedQueryResultCache, InvalidationConfig,
+    InvalidationEvent, QueryKey, QueryResultCacheConfig,
 };
 use proximadb::query::federated::ExecutionResult;
 
@@ -46,7 +46,7 @@ fn create_simple_result() -> ExecutionResult {
 /// Test that cache hit returns the cached result
 #[test]
 fn test_cache_hit_returns_cached_result() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
     let key = QueryKey::from_sql("SELECT * FROM products WHERE id = 1");
     let result = create_simple_result();
 
@@ -71,7 +71,7 @@ fn test_cache_hit_returns_cached_result() {
 /// Test that cache miss for unknown query
 #[test]
 fn test_cache_miss_for_unknown_query() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
     let key = QueryKey::from_sql("SELECT * FROM unknown_table");
 
     let cached = cache.get(&key);
@@ -88,7 +88,7 @@ fn test_cache_miss_for_unknown_query() {
 /// Test multiple cache hits for the same query
 #[test]
 fn test_multiple_cache_hits() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
     let key = QueryKey::from_sql("SELECT name FROM users LIMIT 10");
 
     cache
@@ -121,7 +121,7 @@ fn test_ttl_expiration_removes_entries() {
         default_ttl: Duration::from_millis(50),
         ..Default::default()
     };
-    let cache = QueryResultCache::new(config);
+    let cache = FederatedQueryResultCache::new(config);
 
     let key = QueryKey::from_sql("SELECT * FROM products");
     cache
@@ -157,7 +157,7 @@ fn test_cleanup_expired_batch_removal() {
         default_ttl: Duration::from_millis(20),
         ..Default::default()
     };
-    let cache = QueryResultCache::new(config);
+    let cache = FederatedQueryResultCache::new(config);
 
     // Insert multiple entries
     for i in 0..5 {
@@ -181,7 +181,7 @@ fn test_cleanup_expired_batch_removal() {
 /// Test custom TTL per entry
 #[test]
 fn test_custom_ttl_per_entry() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Insert with short TTL
     let short_key = QueryKey::from_sql("SELECT * FROM short_lived");
@@ -224,7 +224,7 @@ fn test_custom_ttl_per_entry() {
 /// Test invalidation on collection write removes affected entries
 #[test]
 fn test_invalidation_on_collection_write() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false, // Direct invalidation
         ..Default::default()
@@ -268,7 +268,7 @@ fn test_invalidation_on_collection_write() {
 /// Test direct collection invalidation
 #[test]
 fn test_direct_collection_invalidation() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let invalidator = CacheInvalidator::new(cache.clone());
 
     // Insert entries
@@ -295,7 +295,7 @@ fn test_direct_collection_invalidation() {
 /// Test invalidation of multiple collections
 #[test]
 fn test_invalidate_multiple_collections() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let invalidator = CacheInvalidator::new(cache.clone());
 
     for i in 0..5 {
@@ -322,7 +322,7 @@ fn test_invalidate_multiple_collections() {
 /// Test different change operations trigger invalidation
 #[test]
 fn test_change_operations_trigger_invalidation() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false,
         ..Default::default()
@@ -363,7 +363,7 @@ fn test_change_operations_trigger_invalidation() {
 /// Test multi-collection query invalidation on any dependency change
 #[test]
 fn test_multi_collection_query_invalidation() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Query depends on multiple collections (join query)
     let join_key =
@@ -398,7 +398,7 @@ fn test_multi_collection_query_invalidation() {
 /// Test query with three dependencies invalidates correctly
 #[test]
 fn test_triple_dependency_invalidation() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Query depends on three collections
     let key = QueryKey::from_sql("SELECT * FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id");
@@ -420,7 +420,7 @@ fn test_triple_dependency_invalidation() {
 /// Test that independent queries are not affected by unrelated invalidation
 #[test]
 fn test_independent_queries_not_affected() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Insert independent queries
     let key1 = QueryKey::from_sql("SELECT * FROM table_a");
@@ -460,7 +460,7 @@ fn test_lru_eviction_on_capacity() {
         max_entries: 3,
         ..Default::default()
     };
-    let cache = QueryResultCache::new(config);
+    let cache = FederatedQueryResultCache::new(config);
 
     // Insert 3 entries (at capacity)
     for i in 0..3 {
@@ -506,7 +506,7 @@ fn test_eviction_prioritizes_expired() {
         default_ttl: Duration::from_millis(50),
         ..Default::default()
     };
-    let cache = QueryResultCache::new(config);
+    let cache = FederatedQueryResultCache::new(config);
 
     // Insert entries
     for i in 0..3 {
@@ -605,7 +605,7 @@ fn test_fingerprint_whitespace_sensitivity() {
 /// Test transaction-aware invalidation defers until commit
 #[test]
 fn test_transaction_aware_invalidation_deferred() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false,
         transaction_aware: true,
@@ -635,7 +635,7 @@ fn test_transaction_aware_invalidation_deferred() {
 /// Test transaction commit triggers deferred invalidation
 #[test]
 fn test_transaction_commit_triggers_invalidation() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false,
         transaction_aware: true,
@@ -673,7 +673,7 @@ fn test_transaction_commit_triggers_invalidation() {
 /// Test transaction rollback discards pending invalidation
 #[test]
 fn test_transaction_rollback_discards_invalidation() {
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false,
         transaction_aware: true,
@@ -713,7 +713,7 @@ fn test_transaction_rollback_discards_invalidation() {
 /// Test cache statistics accuracy
 #[test]
 fn test_cache_statistics_accuracy() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Insert
     let key1 = QueryKey::from_sql("SELECT 1");
@@ -754,7 +754,7 @@ fn test_cache_statistics_accuracy() {
 /// Test cache clear functionality
 #[test]
 fn test_cache_clear() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Insert multiple entries
     for i in 0..10 {
@@ -783,7 +783,7 @@ fn test_cache_clear() {
 fn test_concurrent_cache_access() {
     use std::thread;
 
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let mut handles = vec![];
 
     // Spawn multiple threads doing inserts
@@ -829,7 +829,7 @@ fn test_concurrent_cache_access() {
 fn test_concurrent_invalidation() {
     use std::thread;
 
-    let cache = Arc::new(QueryResultCache::with_defaults());
+    let cache = Arc::new(FederatedQueryResultCache::with_defaults());
     let config = InvalidationConfig {
         batch_invalidations: false,
         ..Default::default()
@@ -878,7 +878,7 @@ fn test_concurrent_invalidation() {
 /// Test empty query string
 #[test]
 fn test_empty_query_string() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
     let key = QueryKey::from_sql("");
 
     cache
@@ -892,7 +892,7 @@ fn test_empty_query_string() {
 /// Test very long query string
 #[test]
 fn test_long_query_string() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     // Create a very long query
     let mut long_query = "SELECT * FROM t WHERE ".to_string();
@@ -914,7 +914,7 @@ fn test_long_query_string() {
 /// Test cache with no dependencies
 #[test]
 fn test_query_with_no_dependencies() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     let key = QueryKey::from_sql("SELECT 1 + 1");
     cache
@@ -931,7 +931,7 @@ fn test_query_with_no_dependencies() {
 /// Test cache remove functionality
 #[test]
 fn test_cache_remove() {
-    let cache = QueryResultCache::with_defaults();
+    let cache = FederatedQueryResultCache::with_defaults();
 
     let key = QueryKey::from_sql("SELECT * FROM removable");
     cache


### PR DESCRIPTION
## Summary

`QueryResultCache` existed but was only instantiated in the federated path — and
with `cache=None` in production, so it was dead code. This wires it onto the
**live pgwire OLAP SELECT route**, structurally tenant-keyed, **default-OFF**
behind `PROXIMADB_QUERY_RESULT_CACHE`.

## Changes

**Structural tenant keying** (multi-tenant co-design mandate — isolation is
structural, never a predicate):
- Re-keyed on `(tenant, namespace, query)`. `CompositeMapKey` hashes all three
  and the stored entry re-verifies the full triple on lookup, so a cross-tenant
  hash collision (192-bit) cannot leak.
- Generalized `QueryResultCache<T>` so the same machinery serves the federated
  path (`ExecutionResult`) and pgwire (`ExecutionPipelineResult`); a
  `FederatedQueryResultCache` alias keeps `CacheInvalidator` /
  `FederatedQueryContext` and their tests compiling unchanged.

**Read-after-write correctness** (ADR-051 D2 / mandate #16c):
- `get_fresh` gates on `VectorFreshnessMode`. **Strong** serves iff
  `computed_at_lsn == current_lsn && lsn != 0` (any write bumps the canonical-WAL
  LSN → guaranteed miss → read-after-write correct); **BoundedStale** by
  `max_staleness_ms`; **StaleOk** by TTL. LSN read from the manifest singleton
  (same source as the vector-search path). TTL is the universal entry lifetime.

**Wire-in** (`relational_pipeline.rs`):
- `try_run_select` gains `namespace` + `result_cache` params; a Strong LSN-pinned
  lookup short-circuits routing/execution, and the result is stamped on both
  real-data success paths (DataFusion OLAP + Volcano). The cache lives in a
  process-wide `Lazy` singleton (mirrors `GLOBAL_ENGINE`); pgwire and REST/gRPC
  callers share it. Flag off ⇒ byte-identical to the pre-cache behavior.

**Tenant-scoped invalidation** (mandate #16b):
- New result-cache arm on `CacheInvalidationCoordinator`
  (`TenantResultCacheInvalidation` trait + `with_result_cache` builder).
  `INSERT/UPDATE/DELETE/DDL` success paths invalidate `(tenant, table)`. The raw
  parsed table name is normalized via `normalize_table_key` to match the
  read-side dependency keys (`snapshot.tables` keys) — without this, invalidation
  silently never fires for quoted/qualified/mixed-case tables.

## Tests (deterministic)
cross-tenant key isolation, cross-tenant invalidation isolation, Strong
LSN-pinned serve/bypass, Strong-TTL interaction, BoundedStale window,
`freshness_eligible` predicate units, coordinator tenant-scoped fan-out, and the
raw→normalized table match-up.

## Verification
- `cargo check --lib --bins` + `cargo clippy --lib --bins` (`-D warnings`): clean
- `cargo check --tests`: clean; `bench_21_query_cache` compiles
- `query::cache` (110) / `query::federated` (317) / `invalidation_coordinator`
  (11, 2 new) unit tests + `query_cache_test` integration (29): pass
- `pgwire_relational_engine_e2e`: identical results with the flag **on** and **off**

## Notes
- Default-OFF: zero behavior change unless `PROXIMADB_QUERY_RESULT_CACHE` is set.
- `grpc_td121_relational_tenant_isolation_e2e` fails on this branch **and** on
  clean develop (verified via stash) — pre-existing, unrelated (the test's gRPC
  `ExecuteQuery` has no `DmlService`, so it never reaches `try_run_select`).
