### PR TITLE
feat(ddl): fail-closed allowlist for external parquet tables + e2e verify (TD-OLAP-4)

### DIFF
--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -1958,6 +1958,29 @@ fn add_open_table_layouts(schema: &mut CatalogTableSchema) -> Result<()> {
         .and_then(|value| parse_authority_mode(value))
         .unwrap_or(CatalogAuthorityMode::ProjectionPublication);
 
+    // Path Isolation (CRITICAL mandate): a table that reads an operator/tenant
+    // supplied external `location` reaches outside `DrPathBuilder`'s
+    // `data/{tenant}/{namespace}/…` tree. Gate it fail-closed behind an operator
+    // allowlist of URI-prefix roots (`PROXIMADB_EXTERNAL_TABLE_ROOTS`) so a
+    // tenant cannot point a table at an arbitrary path. The publication
+    // authorities below synthesize an internal `proximadb://…` location and are
+    // exempt; only the externally-located authorities are validated.
+    let reads_external_location = matches!(
+        ownership,
+        CatalogAuthorityMode::ExternalAuthoritative
+            | CatalogAuthorityMode::ImportedSnapshot
+            | CatalogAuthorityMode::FederatedRead
+    );
+    if reads_external_location && !external_location_allowed(&location) {
+        return Err(anyhow!(
+            "external table '{}': location '{}' is not within an allowlisted root — \
+             set PROXIMADB_EXTERNAL_TABLE_ROOTS to a comma-separated list of permitted \
+             URI-prefix roots to opt in (Path Isolation, fail-closed default)",
+            schema.name,
+            location
+        ));
+    }
+
     let mut layout = match ownership {
         CatalogAuthorityMode::ExternalAuthoritative => {
             if location.is_empty() {
@@ -2022,6 +2045,40 @@ fn add_open_table_layouts(schema: &mut CatalogTableSchema) -> Result<()> {
 
     schema.storage_layouts.push(layout);
     Ok(())
+}
+
+/// Fail-closed allowlist for external-table `location`s (Path Isolation mandate).
+///
+/// A location is permitted only when the operator has set
+/// `PROXIMADB_EXTERNAL_TABLE_ROOTS` to a comma-separated list of URI-prefix roots
+/// and the location falls under one of them. Empty/unset allowlist ⇒ every
+/// external location is rejected (the feature is off by default). Locations
+/// containing `..` are always rejected (no traversal-escape). Matching is on a
+/// path boundary — a root `file:///data/ext` matches `file:///data/ext/a.parquet`
+/// but NOT `file:///data/ext-evil/…`.
+fn external_location_allowed(location: &str) -> bool {
+    let loc = location.trim();
+    if loc.is_empty() || loc.contains("..") {
+        return false;
+    }
+    let Ok(roots) = std::env::var("PROXIMADB_EXTERNAL_TABLE_ROOTS") else {
+        return false;
+    };
+    roots
+        .split(',')
+        .map(str::trim)
+        .filter(|root| !root.is_empty())
+        .any(|root| {
+            if loc == root {
+                return true;
+            }
+            let with_slash = if root.ends_with('/') {
+                root.to_string()
+            } else {
+                format!("{root}/")
+            };
+            loc.starts_with(&with_slash)
+        })
 }
 
 fn parse_physical_format(value: &str) -> Option<CatalogPhysicalFormat> {
@@ -2098,6 +2155,44 @@ mod tests {
         let result = DdlResult::success("Operation completed");
         assert!(result.success);
         assert_eq!(result.affected_count, 1);
+    }
+
+    // External-location allowlist (Path Isolation, fail-closed). Serialized by
+    // the shared env var; nextest's process-per-test isolation keeps these from
+    // racing other tests.
+    #[test]
+    fn external_location_allowlist_is_fail_closed_and_boundary_aware() {
+        // Unset ⇒ everything rejected (feature off by default).
+        unsafe { std::env::remove_var("PROXIMADB_EXTERNAL_TABLE_ROOTS") };
+        assert!(!external_location_allowed("file:///data/ext/a.parquet"));
+
+        unsafe {
+            std::env::set_var(
+                "PROXIMADB_EXTERNAL_TABLE_ROOTS",
+                "file:///data/ext/, s3://bucket/warehouse/",
+            )
+        };
+        // Within an allowlisted root.
+        assert!(external_location_allowed("file:///data/ext/a.parquet"));
+        assert!(external_location_allowed(
+            "s3://bucket/warehouse/hits/part-0.parquet"
+        ));
+        // Exact-root match is allowed.
+        assert!(external_location_allowed("file:///data/ext"));
+        // Path-boundary escape must NOT match a prefix of a sibling dir.
+        assert!(!external_location_allowed(
+            "file:///data/ext-evil/secret.parquet"
+        ));
+        // Outside any root.
+        assert!(!external_location_allowed("file:///etc/passwd"));
+        // Traversal is always rejected, even under an allowlisted root.
+        assert!(!external_location_allowed(
+            "file:///data/ext/../../etc/passwd"
+        ));
+        // Empty is rejected.
+        assert!(!external_location_allowed("  "));
+
+        unsafe { std::env::remove_var("PROXIMADB_EXTERNAL_TABLE_ROOTS") };
     }
 
     #[test]

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -2069,15 +2069,11 @@ fn external_location_allowed(location: &str) -> bool {
         .map(str::trim)
         .filter(|root| !root.is_empty())
         .any(|root| {
-            if loc == root {
-                return true;
-            }
-            let with_slash = if root.ends_with('/') {
-                root.to_string()
-            } else {
-                format!("{root}/")
-            };
-            loc.starts_with(&with_slash)
+            // Normalize the root's trailing slash so `file:///x/` and `file:///x`
+            // both denote the same directory: a location is allowed when it IS
+            // the root or sits strictly beneath it (path boundary).
+            let root_norm = root.trim_end_matches('/');
+            loc == root_norm || loc.starts_with(&format!("{root_norm}/"))
         })
 }
 

--- a/tests/external_table_pgwire_e2e.rs
+++ b/tests/external_table_pgwire_e2e.rs
@@ -138,6 +138,13 @@ async fn external_parquet_table_registers_and_reads_via_datafusion() {
     let server = PgServer::start(tmp).await.expect("server");
     let client = connect(&server).await;
 
+    // The native catalog persists outside this test's tempdir, so clear any
+    // entry a prior run left behind (mirrors the tpc harness's DROP-first).
+    client
+        .simple_query("DROP TABLE IF EXISTS ext_hits")
+        .await
+        .ok();
+
     // Register the existing Parquet object as a read-only external table.
     client
         .simple_query(&format!(
@@ -148,8 +155,14 @@ async fn external_parquet_table_registers_and_reads_via_datafusion() {
         .expect("create external table");
 
     // SELECT routes to the DataFusion OLAP engine and reads the object directly.
+    // NOTE: the query must "engage" the relational pipeline (join / GROUP BY /
+    // aggregate) — pgwire keeps a *simple* single-table SELECT on the legacy path
+    // that reads the (empty) backing collection, so a bare `SELECT * FROM ext`
+    // returns no rows today. Parquet-backed / external tables always routing to
+    // DataFusion is a separate follow-up; ClickBench's queries are aggregates and
+    // engage naturally. GROUP BY here both engages and preserves the row values.
     let rows = client
-        .simple_query("SELECT id, name FROM ext_hits ORDER BY id")
+        .simple_query("SELECT id, name FROM ext_hits GROUP BY id, name ORDER BY id")
         .await
         .expect("select");
     let data: Vec<_> = rows
@@ -187,6 +200,7 @@ async fn external_location_outside_allowlist_is_rejected() {
     };
     let server = PgServer::start(tmp).await.expect("server");
     let client = connect(&server).await;
+    client.simple_query("DROP TABLE IF EXISTS bad").await.ok();
 
     let err = client
         .simple_query(
@@ -196,7 +210,12 @@ async fn external_location_outside_allowlist_is_rejected() {
         .await
         .err()
         .expect("CREATE must be rejected when the location is outside the allowlist");
-    let msg = err.to_string().to_lowercase();
+    // tokio-postgres' Display is the terse "db error"; the real message is on
+    // the DbError cause.
+    let msg = err
+        .as_db_error()
+        .map(|e| e.message().to_lowercase())
+        .unwrap_or_else(|| err.to_string().to_lowercase());
     assert!(
         msg.contains("allowlist") || msg.contains("external"),
         "rejection should cite the external-location allowlist, got: {msg}"

--- a/tests/external_table_pgwire_e2e.rs
+++ b/tests/external_table_pgwire_e2e.rs
@@ -1,0 +1,206 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! External parquet table over pgwire — TD-OLAP-4 (external-table hardening).
+//!
+//! Proves the end-to-end path for registering an existing Parquet object as a
+//! read-only table WITHOUT ingestion:
+//!   CREATE TABLE t (...) WITH (format='parquet', external_location='…', authority='external')
+//! is persisted in the native catalog as an external-authoritative Parquet
+//! layout, and `SELECT` over it routes to the DataFusion OLAP engine and reads
+//! the object directly.
+//!
+//! Also pins the Path-Isolation guardrail: an `external_location` outside the
+//! operator allowlist (`PROXIMADB_EXTERNAL_TABLE_ROOTS`) is rejected fail-closed.
+//!
+//! Gated on `datafusion-integration` (the external read routes to DataFusion).
+//!   cargo test --features datafusion-integration --test external_table_pgwire_e2e -- --nocapture
+#![cfg(feature = "datafusion-integration")]
+
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow_array::{Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use parquet::arrow::ArrowWriter;
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::NoTls;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    _db: ProximaDB,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start(tmp: TempDir) -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            _db: db,
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+/// Write a tiny two-column Parquet object and return its `file://` URI.
+fn write_parquet(dir: &std::path::Path) -> String {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ],
+    )
+    .expect("batch");
+    let path = dir.join("ext.parquet");
+    let file = std::fs::File::create(&path).expect("create parquet");
+    let mut w = ArrowWriter::try_new(file, schema, None).expect("writer");
+    w.write(&batch).expect("write");
+    w.close().expect("close");
+    format!("file://{}", path.display())
+}
+
+async fn connect(server: &PgServer) -> tokio_postgres::Client {
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn external_parquet_table_registers_and_reads_via_datafusion() {
+    let tmp = TempDir::new().expect("tmp");
+    // Allowlist the server data dir (which holds the external object).
+    let root = format!("file://{}", tmp.path().display());
+    unsafe { std::env::set_var("PROXIMADB_EXTERNAL_TABLE_ROOTS", &root) };
+
+    let ext_dir = tmp.path().join("external");
+    std::fs::create_dir_all(&ext_dir).expect("mkdir");
+    let location = write_parquet(&ext_dir);
+
+    let server = PgServer::start(tmp).await.expect("server");
+    let client = connect(&server).await;
+
+    // Register the existing Parquet object as a read-only external table.
+    client
+        .simple_query(&format!(
+            "CREATE TABLE ext_hits (id INT, name VARCHAR) \
+             WITH (format='parquet', external_location='{location}', authority='external')"
+        ))
+        .await
+        .expect("create external table");
+
+    // SELECT routes to the DataFusion OLAP engine and reads the object directly.
+    let rows = client
+        .simple_query("SELECT id, name FROM ext_hits ORDER BY id")
+        .await
+        .expect("select");
+    let data: Vec<_> = rows
+        .iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some((
+                r.get("id").unwrap().to_string(),
+                r.get("name").unwrap().to_string(),
+            )),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        data,
+        vec![
+            ("1".to_string(), "a".to_string()),
+            ("2".to_string(), "b".to_string()),
+            ("3".to_string(), "c".to_string()),
+        ],
+        "external parquet rows must be read back via the DataFusion route"
+    );
+
+    unsafe { std::env::remove_var("PROXIMADB_EXTERNAL_TABLE_ROOTS") };
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn external_location_outside_allowlist_is_rejected() {
+    let tmp = TempDir::new().expect("tmp");
+    // Allowlist ONLY the server dir; the table below points outside it.
+    unsafe {
+        std::env::set_var(
+            "PROXIMADB_EXTERNAL_TABLE_ROOTS",
+            format!("file://{}", tmp.path().display()),
+        )
+    };
+    let server = PgServer::start(tmp).await.expect("server");
+    let client = connect(&server).await;
+
+    let err = client
+        .simple_query(
+            "CREATE TABLE bad (id INT) \
+             WITH (format='parquet', external_location='file:///etc/', authority='external')",
+        )
+        .await
+        .err()
+        .expect("CREATE must be rejected when the location is outside the allowlist");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("allowlist") || msg.contains("external"),
+        "rejection should cite the external-location allowlist, got: {msg}"
+    );
+
+    unsafe { std::env::remove_var("PROXIMADB_EXTERNAL_TABLE_ROOTS") };
+}


### PR DESCRIPTION
## What

Hardens ProximaDB's **external parquet table** capability with a fail-closed
Path-Isolation guardrail, and adds the first end-to-end test proving the path
works.

## Background

External parquet tables already existed but were undocumented and untested:
`add_open_table_layouts` turns

```sql
CREATE TABLE hits (cols…) WITH (format='parquet',
  external_location='file:///…/hits.parquet', authority='external')
```

into an `external_authoritative` Parquet catalog layout at that location, which
`catalog_table_is_parquet_backed` already routes to the DataFusion OLAP engine —
no ingestion. The native catalog persists it like any other table.

The gap: the `external_location` was **unrestricted**. A tenant could point a
table at any `file:///` / `s3://` path, reaching outside `DrPathBuilder`'s
`data/{tenant}/{namespace}/…` tree — a violation of the CRITICAL Path Isolation
mandate.

## Changes

- **Fail-closed allowlist** (`external_location_allowed`): external / imported /
  federated locations are rejected unless they fall under an operator-set
  `PROXIMADB_EXTERNAL_TABLE_ROOTS` URI-prefix root. Path-boundary matched
  (`…/ext` matches `…/ext/a.parquet` but not `…/ext-evil/…`), trailing-slash
  normalized, `..`-traversal rejected, empty/unset allowlist ⇒ feature off.
  Publication authorities that synthesize an internal `proximadb://…` location
  are exempt.
- **Tests**: a unit test for the allowlist policy (boundary / traversal /
  fail-closed / trailing-slash), and a pgwire e2e (`external_table_pgwire_e2e`)
  proving `CREATE` external parquet + `SELECT` reads it back via DataFusion, and
  that an out-of-allowlist location is rejected. All three pass.

## Follow-ups (found by finally testing this e2e, out of scope here)

- **Simple `SELECT * FROM ext` returns empty.** pgwire keeps a *simple*
  single-table SELECT on the legacy path (reads the empty backing collection);
  external / parquet-backed tables only read via DataFusion for *engaging*
  queries (join / GROUP BY / aggregate). The e2e uses a GROUP BY to verify the
  read. Making parquet-backed tables always route to DataFusion is a broader
  pgwire change.
- **Dead PAX primary layout.** An external table still gets a writable PAX
  primary layout pushed beside the external one; a read-only external table
  shouldn't carry a writable primary.

Enables the TD-OLAP-4 ClickBench ledger (next PR): register the pre-built
ClickBench parquet as an external table and run the aggregate queries + a DuckDB
baseline, no ingestion.
