### PR TITLE
refactor(catalog): neutral tier-config vocabulary — drop the Pricing* names from OSS (Phase B-5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,6 +5769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5776,6 +5785,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6485,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "proximadb"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6555,6 +6565,7 @@ dependencies = [
  "numpy",
  "object_store",
  "once_cell",
+ "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -7608,7 +7619,7 @@ dependencies = [
 
 [[package]]
 name = "proximadb-sdk"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "httpmock",

--- a/src/catalog/tenant_tier.rs
+++ b/src/catalog/tenant_tier.rs
@@ -50,7 +50,7 @@ use tracing::{debug, warn};
 // The numeric defaults (scan_budget_gb, ef_search_cap, freshness_sla_seconds,
 // prom_label) load from the chosen layer at first access. The `Tier` enum
 // variants themselves stay compile-time exhaustive — Rust enums cannot be
-// built from runtime data. The startup assertion `validate_pricing_matches_enum`
+// built from runtime data. The startup assertion `validate_tier_config_matches_enum`
 // panics if the chosen layer's tier set diverges from the enum variants,
 // surfacing the drift at process start rather than at first soft-cap
 // rejection. Validation is alias-aware: overlay JSONs may use any tier id
@@ -63,21 +63,21 @@ const RUNTIME_TIER_CONFIG_ENV: &str = "PROXIMADB_TIER_CONFIG_PATH";
 const DEFAULT_RUNTIME_TIER_CONFIG_PATH: &str = "/config/tier-config.json";
 const LEGACY_RUNTIME_TIER_CONFIG_PATH: &str = "/config/pricing.json";
 
-static PRICING: OnceLock<PricingConfig> = OnceLock::new();
+static TIER_CONFIG: OnceLock<TierConfig> = OnceLock::new();
 
 #[derive(Debug, Deserialize)]
-struct PricingConfig {
+struct TierConfig {
     schema_version: u32,
     #[allow(dead_code)]
     default_tier: String,
-    tiers: Vec<PricingTier>,
+    tiers: Vec<TierSpec>,
 }
 
 #[derive(Debug, Deserialize)]
-struct PricingTier {
+struct TierSpec {
     id: String,
     prom_label: String,
-    soft_caps: PricingSoftCaps,
+    soft_caps: TierSoftCaps,
     /// C5 governance tier-entitlement multiplier (Dimension 5). Authored by the
     /// control plane (anvaiops `tiers.json` → `/config/tier-config.json`); absent
     /// in the OSS baseline overlay → `None` → neutral `1.0`. Other overlay fields
@@ -87,7 +87,7 @@ struct PricingTier {
 }
 
 #[derive(Debug, Deserialize)]
-struct PricingSoftCaps {
+struct TierSoftCaps {
     scan_budget_gb: f64,
     ef_search_cap: u32,
     freshness_sla_seconds: u32,
@@ -151,8 +151,8 @@ fn resolve_tier_config_source() -> TierConfigSource {
 /// because the function's whole point IS to crash early with a clear
 /// operator-facing message rather than degrade silently.
 #[allow(clippy::panic)]
-fn parse_and_validate(source: &TierConfigSource) -> PricingConfig {
-    let parsed: PricingConfig = serde_json::from_str(&source.content).unwrap_or_else(|e| {
+fn parse_and_validate(source: &TierConfigSource) -> TierConfig {
+    let parsed: TierConfig = serde_json::from_str(&source.content).unwrap_or_else(|e| {
         panic!(
             "tier config from {} is malformed — proximaDB cannot start: {e}",
             source.label
@@ -163,12 +163,12 @@ fn parse_and_validate(source: &TierConfigSource) -> PricingConfig {
         "tier config from {} has unsupported schema_version {}",
         source.label, parsed.schema_version
     );
-    validate_pricing_matches_enum(&parsed, &source.label);
+    validate_tier_config_matches_enum(&parsed, &source.label);
     parsed
 }
 
-fn pricing() -> &'static PricingConfig {
-    PRICING.get_or_init(|| {
+fn tier_config() -> &'static TierConfig {
+    TIER_CONFIG.get_or_init(|| {
         let source = resolve_tier_config_source();
         let parsed = parse_and_validate(&source);
         tracing::info!(
@@ -183,9 +183,9 @@ fn pricing() -> &'static PricingConfig {
 // Startup-only invariant check on the loaded tier config. A malformed
 // config means the operator overlay JSON is broken — failing fast at
 // boot is the right answer; downstream code assumes every Tier variant
-// has pricing wired up.
+// has a tier-config row wired up.
 #[allow(clippy::panic)]
-fn validate_pricing_matches_enum(p: &PricingConfig, source_label: &str) {
+fn validate_tier_config_matches_enum(p: &TierConfig, source_label: &str) {
     use std::collections::HashSet;
     // Phase B-4: validation is now alias-aware. Each JSON tier id is parsed
     // through serde (which honors the serde aliases on the Tier enum), and
@@ -218,7 +218,7 @@ fn validate_pricing_matches_enum(p: &PricingConfig, source_label: &str) {
     }
 }
 
-fn pricing_row(tier: Tier) -> &'static PricingTier {
+fn tier_row(tier: Tier) -> &'static TierSpec {
     // Phase B-4: alias-aware lookup. The JSON id may be the canonical id
     // (`tier.id()`) OR any of the serde aliases — both must locate the row.
     // The panic on miss is intentional: the loaded tier config is
@@ -226,7 +226,7 @@ fn pricing_row(tier: Tier) -> &'static PricingTier {
     // (`parse_and_validate`), so a missing tier here is a startup-time
     // invariant violation that should crash, not be silently masked.
     #[allow(clippy::panic)]
-    pricing()
+    tier_config()
         .tiers
         .iter()
         .find(|t| {
@@ -302,7 +302,7 @@ impl Tier {
     }
 
     /// All declared tier variants in increasing-capacity order. Kept in
-    /// sync with the embedded JSON via `validate_pricing_matches_enum()`
+    /// sync with the embedded JSON via `validate_tier_config_matches_enum()`
     /// at startup.
     pub const fn all() -> &'static [Tier] {
         &[
@@ -321,17 +321,17 @@ impl Tier {
     /// avoided because the engine sources its values from the same overlay
     /// the operator publishes.
     pub fn default_scan_budget_gb(self) -> f64 {
-        pricing_row(self).soft_caps.scan_budget_gb
+        tier_row(self).soft_caps.scan_budget_gb
     }
 
     /// Default beam-width / ef_search ceiling — hard ceiling at the router.
     pub fn default_ef_search_cap(self) -> u32 {
-        pricing_row(self).soft_caps.ef_search_cap
+        tier_row(self).soft_caps.ef_search_cap
     }
 
     /// Default freshness SLA for async ingest, in seconds.
     pub fn default_freshness_sla_seconds(self) -> u32 {
-        pricing_row(self).soft_caps.freshness_sla_seconds
+        tier_row(self).soft_caps.freshness_sla_seconds
     }
 
     /// Parse a tier *claim* string (e.g. the `X-Tenant-Tier` header the control
@@ -353,7 +353,7 @@ impl Tier {
     /// fail-safe — a non-positive multiplier could invert the reported cost). The
     /// $ values are control-plane policy; OSS only reads the configured scalar.
     pub fn cost_multiplier(self) -> f64 {
-        match pricing_row(self).cost_multiplier {
+        match tier_row(self).cost_multiplier {
             Some(m) if m.is_finite() && m > 0.0 => m,
             _ => 1.0,
         }
@@ -364,7 +364,7 @@ impl Tier {
     /// add a tier via the runtime overlay (see `config/TIER_CONFIG.md`) widen the
     /// metric label set automatically without a recompile.
     pub fn prometheus_label(self) -> &'static str {
-        pricing_row(self).prom_label.as_str()
+        tier_row(self).prom_label.as_str()
     }
 
     /// Object economy routing configuration for this tier.
@@ -742,10 +742,10 @@ pub fn set_tenant_tier_resolver(resolver: Option<Box<TenantTierFn>>) {
         .unwrap_or_else(|p| p.into_inner()) = resolver;
 }
 
-/// The configured default tier (`pricing().default_tier`, alias-aware), or
+/// The configured default tier (`tier_config().default_tier`, alias-aware), or
 /// [`Tier::default`] if it somehow fails to parse.
 pub fn default_tier() -> Tier {
-    let raw = serde_json::Value::String(pricing().default_tier.clone());
+    let raw = serde_json::Value::String(tier_config().default_tier.clone());
     serde_json::from_value::<Tier>(raw).unwrap_or_default()
 }
 
@@ -851,13 +851,13 @@ mod tests {
     }
 
     #[test]
-    fn pricing_config_loads_without_panic_and_matches_enum() {
-        // First access of `pricing()` deserializes the embedded JSON, asserts
-        // schema_version == 1, and runs `validate_pricing_matches_enum`. If
+    fn tier_config_loads_without_panic_and_matches_enum() {
+        // First access of `tier_config()` deserializes the embedded JSON, asserts
+        // schema_version == 1, and runs `validate_tier_config_matches_enum`. If
         // any of those checks fail we panic here — surfaces a malformed or
         // drifted `config/tier-config.json` at test time rather than first
         // production request.
-        let cfg = pricing();
+        let cfg = tier_config();
         assert_eq!(cfg.schema_version, 1);
         let json_ids: std::collections::HashSet<&str> =
             cfg.tiers.iter().map(|t| t.id.as_str()).collect();
@@ -867,11 +867,11 @@ mod tests {
     }
 
     #[test]
-    fn every_tier_id_round_trips_through_pricing_lookup() {
+    fn every_tier_id_round_trips_through_tier_lookup() {
         for tier in Tier::all() {
             // Every variant must find a matching row, and the loaded numbers
             // must be positive / non-zero — guards against an incomplete
-            // pricing.json that compiles but stalls the router with NaN.
+            // tier-config.json that compiles but stalls the router with NaN.
             assert!(tier.default_scan_budget_gb() > 0.0, "{:?}", tier);
             assert!(tier.default_ef_search_cap() > 0, "{:?}", tier);
             assert!(tier.default_freshness_sla_seconds() > 0, "{:?}", tier);


### PR DESCRIPTION
## Summary

Completes the **Phase B-5** rename flagged in `config/tier-config.json`'s header. The OSS tenant-tier store carried commercial **vocabulary** (`Pricing*` types, `pricing*` fns) over neutral **content** (operational soft-caps only — no $). The content was already neutral and the actual leak vector was closed separately (anvaiops #302 — retiring the commercial-rate-card vendoring); this is the last vocabulary cleanup so the OSS boundary reads clean.

## Change (contained to `src/catalog/tenant_tier.rs` — all private, no external refs)
- `PricingConfig` → `TierConfig`, `PricingTier` → `TierSpec`, `PricingSoftCaps` → `TierSoftCaps`
- `static PRICING` → `TIER_CONFIG`; `pricing()` → `tier_config()`, `pricing_row()` → `tier_row()`, `validate_pricing_matches_enum()` → `validate_tier_config_matches_enum()`
- two test fns + one comment neutralized

## Kept intentionally
- `LEGACY_RUNTIME_TIER_CONFIG_PATH = "/config/pricing.json"` — back-compat path for existing deployments (mixed-read-safe).
- Comments that correctly point to **anvaiops** as the commercial-pricing source, and the neutral `cost_multiplier` field (matches the anvaiops JSON key; a scalar, no $).

## Validation
- **18/18 `tenant_tier` tests pass** (incl. the renamed `tier_config_loads_without_panic_and_matches_enum`).
- fmt ✓, clippy `--lib --bins -D warnings` (+ server binary) ✓, ratchet net-zero. No stray `Pricing*` identifiers remain in the tree.