### PR TITLE
docs(td): TD-DOC-CONV-2 — document-convergence bake + default-ON cutover handoff

### DIFF
--- a/docs/10-quality/td/TD-DOC-CONV-2-canonical-vector-default-on-cutover-bake.adoc
+++ b/docs/10-quality/td/TD-DOC-CONV-2-canonical-vector-default-on-cutover-bake.adoc
@@ -1,0 +1,98 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DOC-CONV-2: Document store-convergence — bake + cutover to default-ON (handoff)
+
+[cols="1,3"]
+|===
+|Status|Open — HANDOFF. Capability complete + merged (default-OFF); production cutover not started.
+|Priority|MEDIUM (the convergence value is unrealized until this lands)
+|Scope|FEAT
+|Date|2026-07-06
+|Relates to|ADR-009 / RELATIONAL_DOCUMENT_GRAPH_CONVERGENCE_2026_05_14.adoc. Landed: #698
+(convergence), #705 (vectorless docs + e2e robustness), #709 (O(log n) point-get + recovery/
+metering verification). Sibling TDs: TD-DOC-CONV-1 (point-get, RESOLVED), TD-DOC-TENANT-1
+(store-split RESOLVED by #698). Backing: `src/storage/document/service.rs`
+(`canonical_route`, `doc_canonical_vector_enabled`), `src/network/rest/v2/documents.rs`,
+`tests/documents_convergence_e2e.rs`.
+|===
+
+== Context — what is done, and what is NOT
+
+The document store-split is **structurally closed** and the capability is merged and green:
+a document written on either surface (REST v2 ingest, gRPC `ProximaDocumentService`) lands in the
+**one** shared record/vector store, is cross-surface visible, durable via the vector WAL
+(restart-verified), rides the metered write path, supports vectorless (metadata-only) documents,
+and reads by id in O(log n) (bloom + B+ tree, TD-DOC-CONV-1).
+
+**BUT it is all behind a default-OFF, per-collection runtime gate**
+(`PROXIMADB_DOC_CANONICAL_VECTOR`). In production, nothing is converged yet: the split still
+exists, the legacy `document_wal` is still the default path, and the three motivating cost wins
+(one store, closed metering/billing gap, no double GB-month) are **latent, not realized**.
+
+Cutover to default-ON was deliberately deferred per the storage-format-migration mandate
+(mixed-read-safe, ship default-OFF until baked). This TD is the handoff to do the bake + cutover.
+
+== The gate (how to enable per-collection during the bake)
+
+`doc_canonical_vector_enabled(collection)` (`src/storage/document/service.rs`) reads env
+`PROXIMADB_DOC_CANONICAL_VECTOR`:
+
+* unset / empty ⇒ OFF (today's legacy behavior, bit-for-bit)
+* `1` / `true` / `on` / `all` / `*` ⇒ ON for every collection
+* a comma-separated list ⇒ ON only for the named collections
+
+The canonical route also requires the collection to exist in the record/vector catalog (created via
+REST v2 / DDL), since it resolves the clean collection per-tenant. Pre-cutover docs stay reachable
+via the legacy `document_wal`/DashMap read-fallback (mixed-read-safe).
+
+== Bake criteria — MEASURE these before flipping the default (the open re-verification gaps)
+
+. **Metering is MEASURED, not just structurally inherited.** #709 proves the gRPC document write
+  rides `handle_record_batch_for_tenant` (the metered path); it does NOT measure a per-tenant
+  billing delta. Before cutover, gate on evidence (`BENCHMARK_EVIDENCE.toml`) that a document
+  write emits the expected per-tenant consumption (KIU/KSU and, at flush/egress, KOU) and that the
+  previously-unmetered gRPC path now bills equivalently to REST v2. NB: per-query io_trace is
+  task-local; meter at the flush / object-store / egress boundaries.
+. **Recall / retrieval quality within tolerance.** Documents that carry embeddings become
+  vector-searchable through the shared store; run the ANN recall@k harness on a
+  canonical-routed collection and hold within tolerance of the f32 baseline (Quality-Ratchet
+  mandate). Metadata-only (vectorless) documents are correctly excluded from ANN and served by
+  id/scan — confirm they do not pollute recall.
+. **Double GB-month reduction is real.** Measure that a converged collection stores each body
+  ONCE (vector store only), not in both the vector store and the legacy `document_wal`. Trace the
+  at-rest bytes per the co-design cost spine — this is the dominant motivating term.
+. **Scale + projection cost.** `query_documents`/`aggregate_documents` still bounded-scan
+  (`CANONICAL_DOC_SCAN_LIMIT`); validate a large canonical collection does not blow the cap or the
+  latency budget. The `DocumentService` DashMap/`IndexManager` becomes a hot projection — bound
+  its rebuild-from-scan cost for large collections.
+. **Recovery at scale.** #709 restart-recovery covers one doc; confirm a populated collection
+  recovers fully from the vector WAL after restart (the canonical path drops the legacy
+  `document_wal`, so durability rests entirely on vector-WAL replay).
+
+== Cutover procedure (when picked up)
+
+. Enable per-collection on a real workload via `PROXIMADB_DOC_CANONICAL_VECTOR=<collection>` and
+  run the bake criteria above; record evidence in `BENCHMARK_EVIDENCE.toml`.
+. Widen to more collections / `all`; watch metering, recall, and GB-month in production telemetry
+  for drift.
+. Only then flip the default: make `doc_canonical_vector_enabled` default-ON (env unset ⇒ ON),
+  mixed-read-safe — the legacy read-fallback MUST remain until every collection is migrated, so
+  pre-cutover docs stay reachable. Ship the default flip default-reversible (a kill-switch to
+  force OFF) until fully baked.
+. Retire the legacy `document_wal` write path only after all collections are converged and the
+  read-fallback is provably unused.
+
+== Constraints
+
+* **Mixed-read-safe, no flag-day.** Old (legacy `document_wal`) and new (vector store) coexist,
+  detected by presence + the `document` label; readers fall back to legacy when absent.
+* **Quality ratchets.** ANN recall@k within f32 tolerance; conformance ratchets only go up.
+* **Measure, don't assert.** Gate the cutover on `BENCHMARK_EVIDENCE.toml`, not indicative
+  microbenchmarks (mandate #6).
+* Keep net `proximadb_v1` references non-increasing (TD-123 ratchet).
+
+== Why this is a separate effort (not a tail on the capability PRs)
+
+Flipping a storage-format-migration default without a bake violates mandate #8. The capability is
+complete and reversible; realizing the convergence in production is a measured rollout
+(per-collection → evidence → default-ON → legacy retirement) that deserves its own scoped pass.


### PR DESCRIPTION
## Summary

Handoff note (as a tracked TD) for the **deferred production cutover** of the document store-convergence.

The capability is complete and merged — #698 (convergence), #705 (vectorless docs), #709 (O(log n) point-get + recovery/metering verification) — but it's behind a **default-OFF** per-collection gate (`PROXIMADB_DOC_CANONICAL_VECTOR`). So the production value (one store, closed billing gap, no double GB-month) is **latent, not realized**. Cutover to default-ON was deliberately deferred per the storage-format-migration mandate (mixed-read-safe, ship default-OFF until baked).

`TD-DOC-CONV-2` captures, so the next session picks it up cleanly:
- **Gate mechanics** — how to enable per-collection during the bake.
- **Bake criteria to MEASURE before flipping the default** — the open re-verification gaps: metering *measured* (not just structurally inherited), ANN recall within f32 tolerance, real double-GB-month reduction, scale (query/projection cost, populated-collection recovery).
- **Mixed-read-safe cutover procedure** — per-collection → evidence → default-ON (reversible) → retire legacy `document_wal` last.
- **Why it's a separate scoped effort** — flipping a storage-format-migration default without a bake violates mandate #8.

Docs-only; links to ADR-009, TD-DOC-CONV-1 (RESOLVED), TD-DOC-TENANT-1 (RESOLVED). TD-unique green.