### PR TITLE
docs(td): TD-EMBED-1 + TD-IMG-1 — shipped-release follow-ups

### DIFF
--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-EMBED-1: macOS + Windows embedded wheels for proximadb_embedded (fast-follow)
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** (fast-follow)
+| Severity | Low — Linux x86_64 + aarch64 wheels ship today and cover the overwhelming majority of embedded/edge/air-gapped/server deployments. macOS/Windows are additive reach, not a correctness or release blocker.
+| Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`)
+| Relates to | Vendored-OpenSSL manylinux fix (PR #701 / #707); `TD-IMG-1` (the other shipped-release follow-up)
+| Pillar | PACKAGING
+|===
+
+toc::[]
+
+== Symptom
+
+`proximadb_embedded` (the native in-process PyO3 engine, root maturin package) publishes
+**Linux-only** platform wheels. The `build-embedded-wheels` matrix in `release-python.yml`
+builds exactly two targets:
+
+* `ubuntu-latest` / `x86_64` / manylinux
+* `ubuntu-24.04-arm` / `aarch64` / manylinux (native ARM runner — the engine's C deps,
+  `aws-lc-sys` and vendored OpenSSL, do not cross-compile to aarch64, so it builds natively)
+
+macOS and Windows are **not** in the matrix. macOS is *deferred* (a tooling/runner add, no
+known code blocker); Windows is *blocked on engine portability*, not on build config.
+
+== Why deferred (not a build-config fix)
+
+* **Windows** — `proximadb_embedded` links the full Rust engine, which is Linux-native
+  (unix storage APIs). `proximadb-storage-common` does not compile under MSVC
+  (E0425/E0433/E0599 — no Windows port of the storage syscalls). This is an **engine
+  portability** effort (abstract/port the unix-only storage paths), not a wheel-matrix
+  entry. Do not add a Windows matrix row until the engine compiles for `*-pc-windows-msvc`.
+* **macOS** — no known code blocker; the gap is CI (add `macos-14`/Apple-Silicon +
+  `macos-13`/x86_64 runners, confirm the vendored-OpenSSL/`aws-lc-sys` build the same way it
+  does on Linux, then add the matrix rows). Lower effort than Windows.
+
+The pure-Python SDK `proximadb` (`clients/python`) is a universal wheel and is unaffected —
+this TD is only the native `proximadb_embedded` distribution.
+
+== Fix approach
+
+. **macOS (do first — additive, no engine work).** Add `macos-14` (aarch64/Apple Silicon)
+  and `macos-13` (x86_64) rows to the `build-embedded-wheels` matrix. System Perl on macOS
+  already carries the `IPC::Cmd`/`Time::Piece`/etc. modules openssl-src's Configure needs, so
+  the `before-script-linux` perl-core hook is not required there. Verify the maturin build
+  produces a valid `.whl`, then wire the artifacts into the publish job.
+. **Windows (gated on engine portability).** Blocked until `proximadb-storage-common` (and
+  any other unix-only crate on the embedded link path) compiles for MSVC. Track that as its
+  own engine-portability effort; only then add the Windows matrix row.
+
+== Verification
+
+* `python-v*` release (or `workflow_dispatch` with `dry_run=true`) produces macOS wheels
+  alongside the existing Linux wheels; `twine check` passes; `import proximadb_embedded`
+  succeeds on a macOS runner.
+* Windows step stays out of the matrix until the engine compiles for MSVC — do not add a
+  row that will fail-fast the release.

--- a/docs/10-quality/td/TD-IMG-1-commercial-image-registry-provisioning.adoc
+++ b/docs/10-quality/td/TD-IMG-1-commercial-image-registry-provisioning.adoc
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IMG-1: Commercial image build blocked on operator registry provisioning + cloud creds
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** (blocked — external operator action)
+| Severity | Low — the OSS multi-arch image publishes fine; the commercial overlay is an out-of-band operator/provisioning task, known-red independent of any code in this repo.
+| Component | Release/infra — commercial (AnvaiOps) pipeline that overlays pricing onto the OSS image and pushes to ACR/ECR. OSS base: `.github/workflows/publish-image.yml`, `deploy/docker/Dockerfile` target `runtime`.
+| Relates to | `TD-EMBED-1` (the other shipped-release follow-up); `deploy/docker/IMAGE_PUBLISH.md`
+| Pillar | RELEASE/INFRA
+|===
+
+toc::[]
+
+== Symptom
+
+The **commercial** ProximaDB image build is red, independent of the OSS work. It is not a
+code defect and not automatable from this repo: it requires an operator to **provision the
+target container registry (Azure ACR / AWS ECR) and supply cloud credentials** to the
+commercial pipeline before the overlay build can push.
+
+== Context / boundary
+
+* This repo publishes the **public OSS** image `vjsingh1984/proximadb` to Docker Hub, built
+  multi-arch (`linux/amd64` + `linux/arm64`, native per-arch runners) by
+  `.github/workflows/publish-image.yml`. That path is healthy.
+* The **commercial** pipeline (AnvaiOps) consumes that OSS image as a base, overlays pricing/
+  entitlement, and pushes to a **commercial registry (ACR/ECR)**. Auth for that push is
+  registry credentials the operator holds — not repo secrets, not something a code change
+  here can satisfy.
+* Therefore the red state is an **infra provisioning dependency**, tracked here so it is not
+  mistaken for a build regression in this repo.
+
+== Fix approach (operator action, out-of-band)
+
+. Provision the commercial registry (ACR or ECR) for the target cloud account.
+. Supply the registry credentials to the AnvaiOps commercial pipeline (scoped push token /
+  service principal / OIDC — prefer keyless OIDC over a long-lived token where the registry
+  supports it, mirroring the OSS Docker Hub setup).
+. Re-run the commercial overlay build; confirm the pushed digest resolves and the pricing
+  overlay is present.
+
+No change to this repo's `publish-image.yml` or `Dockerfile` is expected. If the OSS image
+shape needs to change to unblock the overlay (e.g. a new `runtime-*` target), file that as a
+separate, code-scoped TD.
+
+== Verification
+
+* Commercial registry exists and the pipeline authenticates (push succeeds).
+* Commercial image pulls and runs; pricing/entitlement overlay is applied on top of the OSS
+  `runtime` base.
+* OSS `publish-image.yml` remains untouched and green.


### PR DESCRIPTION
Files the two known-out-of-scope items from the Linux embedded-wheel release as tracked TDs so they don't get lost.

## TDs
- **TD-EMBED-1** — macOS + Windows embedded wheels for `proximadb_embedded`. Linux x86_64 + aarch64 already ship (covers the bulk of embedded/edge/server). macOS is a CI/runner add (no code blocker); Windows is blocked on engine portability — `proximadb-storage-common` has no MSVC port — not a build-config fix. Anchors: `.github/workflows/release-python.yml` (`build-embedded-wheels` matrix).
- **TD-IMG-1** — commercial ProximaDB image build blocked on operator ACR/ECR provisioning + cloud creds (out-of-band operator action). OSS `publish-image.yml` (multi-arch Docker Hub) is healthy; the red state is an infra provisioning dependency, not a repo regression.

## Notes
- Topic-scoped ids (collision-free per HOW_TO_FILE_TD_AND_ADR.adoc); `check_td_adr_unique.py` → 0 errors.
- Docs-only change.