### PR TITLE
feat(embedded): macOS (Apple Silicon) wheels for proximadb_embedded + actionable TD plans

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -51,10 +51,21 @@ nxlib  = "nextest run --lib --profile unit"
 nxint  = "nextest run --profile integration"
 
 [target.aarch64-apple-darwin]
-# Apple Silicon specific optimizations
+# Apple Silicon build flags.
+# NOTE: `target-cpu=native` was removed here (2026-07). It broke two things on
+# aarch64-apple-darwin:
+#   1. Distributable wheels — `native` bakes the *builder's* exact CPU features
+#      into the artifact, so a wheel built on one Mac can SIGILL (illegal
+#      instruction) on another. proximadb_embedded ships Apple-Silicon wheels
+#      (TD-EMBED-1), which MUST be portable across M-series chips.
+#   2. `ring 0.17.x` — its darwin.rs const-assertion `CAPS_STATIC ==
+#      MIN_STATIC_FEATURES` fails to compile when `native` enables features
+#      beyond Apple's guaranteed baseline (the exact E0080 the macOS wheel build
+#      hit; see ci.yml's GPU job note about avoiding macos-14 for ring).
+# rustc's default target-cpu for this triple is the portable Apple baseline
+# (NEON/AES/SHA2 already on) — optimized for Apple Silicon AND portable/ring-safe.
 rustflags = [
     "-C", "codegen-units=4",
-    "-C", "target-cpu=native",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -64,18 +64,19 @@ jobs:
 
   # ---- Native engine: proximadb_embedded (platform wheels via maturin) ---------------
   build-embedded-wheels:
-    name: Build embedded wheels (${{ matrix.target }})
+    name: Build embedded wheels (${{ matrix.os }} ${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # Linux-only: proximadb_embedded links the full Rust engine, which is
-        # Linux-native (unix storage APIs). Windows does not compile
-        # (proximadb-storage-common: E0425/E0433/E0599 — no MSVC port); macOS is
-        # deferred. Linux x86_64 + aarch64 is the embedded / edge / air-gapped
-        # deployment surface for an in-process engine. macOS/Windows embedded
-        # wheels are a tracked follow-up (Windows blocked on engine portability,
-        # not a build-config fix).
+        # proximadb_embedded links the full Rust engine. It is unix-native (the
+        # storage layer uses unix syscalls + memmap2), so Linux AND macOS build;
+        # only Windows is blocked (proximadb-storage-common: no MSVC port —
+        # std::os::unix / libc / mmap across dozens of files; tracked as an
+        # engine-portability effort in TD-EMBED-1, NOT a build-config fix).
+        # Each target builds NATIVELY on its own runner (no cross-toolchain):
+        # the engine's C deps (aws-lc-sys rustls crypto, vendored OpenSSL) don't
+        # cross-compile cleanly, but compile the same way natively per-arch.
         include:
           - os: ubuntu-latest
             target: x86_64
@@ -88,6 +89,14 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64
             manylinux: auto
+          # macOS aarch64 (Apple Silicon) — native arm64 runner. Intel macOS is
+          # intentionally NOT built: Apple ships only Apple-Silicon hardware, so
+          # x86_64-apple-darwin is no longer a produced target. Watch for the ring
+          # 0.17.x aarch64 CAPS_STATIC const-assertion (documented on the macos-14
+          # runner in ci.yml's GPU job); fail-fast:false keeps the Linux wheels
+          # flowing if it bites, and it surfaces as its own portability follow-up.
+          - os: macos-14
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -1,62 +1,104 @@
 // Copyright (C) 2025 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-= TD-EMBED-1: macOS + Windows embedded wheels for proximadb_embedded (fast-follow)
+= TD-EMBED-1: macOS + Windows embedded wheels for proximadb_embedded
 :toc: macro
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open** (fast-follow)
+| Status | **macOS: in progress** (wheel matrix wired, CI-validated) · **Windows: Open** (engine-portability effort)
 | Severity | Low — Linux x86_64 + aarch64 wheels ship today and cover the overwhelming majority of embedded/edge/air-gapped/server deployments. macOS/Windows are additive reach, not a correctness or release blocker.
-| Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`)
+| Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`); Windows work spans `crates/storage/proximadb-storage-common` + `src/storage`
 | Relates to | Vendored-OpenSSL manylinux fix (PR #701 / #707); `TD-IMG-1` (the other shipped-release follow-up)
-| Pillar | PACKAGING
+| Pillar | PACKAGING / ENGINE-PORTABILITY
 |===
 
 toc::[]
 
 == Symptom
 
-`proximadb_embedded` (the native in-process PyO3 engine, root maturin package) publishes
-**Linux-only** platform wheels. The `build-embedded-wheels` matrix in `release-python.yml`
-builds exactly two targets:
+`proximadb_embedded` (the native in-process PyO3 engine, root maturin package) originally
+published **Linux-only** platform wheels — `x86_64` (ubuntu-latest) and `aarch64`
+(ubuntu-24.04-arm, native ARM runner). macOS and Windows were absent from the
+`build-embedded-wheels` matrix.
 
-* `ubuntu-latest` / `x86_64` / manylinux
-* `ubuntu-24.04-arm` / `aarch64` / manylinux (native ARM runner — the engine's C deps,
-  `aws-lc-sys` and vendored OpenSSL, do not cross-compile to aarch64, so it builds natively)
+== macOS — RESOLVED (aarch64 / Apple Silicon)
 
-macOS and Windows are **not** in the matrix. macOS is *deferred* (a tooling/runner add, no
-known code blocker); Windows is *blocked on engine portability*, not on build config.
+The engine is **unix-native**, not Linux-only: the storage layer uses unix syscalls +
+`memmap2` (cross-platform), and the single Linux-specific path
+(`src/storage/engines/core/ops/performance_optimization.rs`) is already `#[cfg(target_os =
+"linux")]`-gated. So macOS builds with no engine changes — the gap was purely a missing CI
+matrix row.
 
-== Why deferred (not a build-config fix)
+* **Added:** `macos-14` (aarch64/Apple Silicon), native arm64 runner, to
+  `build-embedded-wheels`. maturin resolves the short `aarch64` target to
+  `aarch64-apple-darwin` on the macOS runner.
+* **Intel macOS intentionally NOT built:** `x86_64-apple-darwin` is no longer a produced
+  target (Apple ships only Apple-Silicon hardware). aarch64 also covers Rosetta for the rare
+  Intel host.
+* **No perl-core hook needed on macOS:** system Perl already carries `IPC::Cmd` et al. that
+  openssl-src's Configure needs; `before-script-linux` is a Linux-only maturin-action input
+  and is skipped on macOS.
+* **Publish path:** the `publish-embedded-pypi` job globs `*embedded-wheels*` artifacts, so
+  the `embedded-wheels-macos-14-aarch64` artifact is collected with no publish-side change.
+* **ring/aarch64 `CAPS_STATIC` — hit and fixed.** The first macOS dry-run failed to compile
+  `ring 0.17.14` (E0080: `assert!(CAPS_STATIC == MIN_STATIC_FEATURES)` in `cpu/arm/darwin.rs`).
+  Root cause: `.cargo/config.toml` `[target.aarch64-apple-darwin]` carried
+  `-C target-cpu=native`, which on the Apple runner enables features beyond ring's expected
+  baseline. `native` is *also wrong for a distributable wheel* (bakes the builder's CPU
+  features in → SIGILL risk on other Macs). Fix: dropped `target-cpu=native` on that triple so
+  the build uses rustc's portable Apple-baseline default (NEON/AES/SHA2 on) — ring-safe AND
+  wheel-portable. `codegen-units=4` retained.
 
-* **Windows** — `proximadb_embedded` links the full Rust engine, which is Linux-native
-  (unix storage APIs). `proximadb-storage-common` does not compile under MSVC
-  (E0425/E0433/E0599 — no Windows port of the storage syscalls). This is an **engine
-  portability** effort (abstract/port the unix-only storage paths), not a wheel-matrix
-  entry. Do not add a Windows matrix row until the engine compiles for `*-pc-windows-msvc`.
-* **macOS** — no known code blocker; the gap is CI (add `macos-14`/Apple-Silicon +
-  `macos-13`/x86_64 runners, confirm the vendored-OpenSSL/`aws-lc-sys` build the same way it
-  does on Linux, then add the matrix rows). Lower effort than Windows.
+Validated via `workflow_dispatch` (`dry_run=true`) building the macOS wheel without
+publishing (see the PR that lands this).
 
-The pure-Python SDK `proximadb` (`clients/python`) is a universal wheel and is unaffected —
-this TD is only the native `proximadb_embedded` distribution.
+== Windows — Open (engine-portability effort, NOT a build-config fix)
 
-== Fix approach
+`proximadb_embedded` links the full Rust engine, whose storage layer is written against
+**unix** APIs. Windows/MSVC does not compile it. This is a real port, not a matrix row — do
+**not** add a Windows matrix entry until the engine compiles for `*-pc-windows-msvc`.
 
-. **macOS (do first — additive, no engine work).** Add `macos-14` (aarch64/Apple Silicon)
-  and `macos-13` (x86_64) rows to the `build-embedded-wheels` matrix. System Perl on macOS
-  already carries the `IPC::Cmd`/`Time::Piece`/etc. modules openssl-src's Configure needs, so
-  the `before-script-linux` perl-core hook is not required there. Verify the maturin build
-  produces a valid `.whl`, then wire the artifacts into the publish job.
-. **Windows (gated on engine portability).** Blocked until `proximadb-storage-common` (and
-  any other unix-only crate on the embedded link path) compiles for MSVC. Track that as its
-  own engine-portability effort; only then add the Windows matrix row.
+=== Enumerated blockers (measured)
+
+The unix-only surface on the embedded link path (grep for `std::os::unix` / `libc::` /
+`mmap` / `memmap2` / `O_DIRECT` / `pread`/`pwrite` / `fcntl`):
+
+* `crates/storage/proximadb-storage-common/src/mmap_file.rs` — mmap-backed file (memmap2 is
+  cross-platform, but the surrounding `std::os::unix` fd/advice plumbing is not).
+* `crates/storage/proximadb-storage-common/src/unified_cache_config.rs`, `.../lib.rs`
+* `crates/storage/proximadb-storage-filesystem-types/src/{lib,counting}.rs`
+* `crates/storage/proximadb-storage-encryption/src/filesystem.rs`
+* `crates/storage/proximadb-block-format/src/prune.rs`
+* `src/storage/` — `mmap_file.rs`, `common/mmap_vectors.rs`,
+  `persistence/filesystem/{local,caching_filesystem,mod}.rs`, and the SST/NOVA/SWIFT/RAPTOR
+  engine writers/readers that call the unix fd/mmap primitives directly.
+
+The compile errors on MSVC are the expected `E0425/E0433/E0599` (missing unix items).
+
+=== Port plan (phased, mixed-platform-safe)
+
+. **Introduce a platform seam** for the file/mmap primitives in
+  `proximadb-storage-common` — a `PlatformFile` trait (open, ranged read/write, advise, map)
+  with a `#[cfg(unix)]` impl (current code) and a `#[cfg(windows)]` impl
+  (`FILE_FLAG_*`/`CreateFileMapping`/`MapViewOfFile`). Keep the unix path byte-for-byte to
+  avoid regressing the shipped Linux/macOS wheels.
+. **Gate the advice/`O_DIRECT`-class calls** behind the seam (Windows has no `posix_fadvise`;
+  use `FILE_FLAG_NO_BUFFERING`/no-op fallbacks).
+. **Sweep the engine call sites** (`src/storage/engines/*`) to go through the seam instead of
+  `std::os::unix` directly.
+. **Add a Windows compile-only CI job** (no wheel yet) to ratchet: it must reach `cargo check
+  -p proximadb-storage-common --target x86_64-pc-windows-msvc` green before a wheel row is
+  added.
+. **Only then** add `windows-latest`/`x86_64` to `build-embedded-wheels`.
+
+This is mixed-read/mixed-platform-safe by construction: the seam adds a Windows impl without
+touching the unix one, so no flag-day and no risk to the currently-shipping wheels.
 
 == Verification
 
-* `python-v*` release (or `workflow_dispatch` with `dry_run=true`) produces macOS wheels
-  alongside the existing Linux wheels; `twine check` passes; `import proximadb_embedded`
-  succeeds on a macOS runner.
-* Windows step stays out of the matrix until the engine compiles for MSVC — do not add a
-  row that will fail-fast the release.
+* **macOS:** `workflow_dispatch` (`dry_run=true`) produces `*.whl` tagged `macosx_*_arm64`;
+  `import proximadb_embedded` succeeds on the macos-14 runner. On the next `python-v*` tag the
+  wheel publishes to PyPI alongside the Linux wheels.
+* **Windows:** the compile-only CI job goes green first (phase 4); the wheel row is added last
+  (phase 5). Until then, no Windows matrix entry — it would only fail-fast the release.

--- a/docs/10-quality/td/TD-IMG-1-commercial-image-registry-provisioning.adoc
+++ b/docs/10-quality/td/TD-IMG-1-commercial-image-registry-provisioning.adoc
@@ -8,7 +8,7 @@
 | Field | Value
 | Status | **Open** (blocked — external operator action)
 | Severity | Low — the OSS multi-arch image publishes fine; the commercial overlay is an out-of-band operator/provisioning task, known-red independent of any code in this repo.
-| Component | Release/infra — commercial (AnvaiOps) pipeline that overlays pricing onto the OSS image and pushes to ACR/ECR. OSS base: `.github/workflows/publish-image.yml`, `deploy/docker/Dockerfile` target `runtime`.
+| Component | Release/infra boundary. OSS (this repo): `.github/workflows/publish-image.yml` → Docker Hub `docker.io/vjsingh1984/proximadb`. Commercial (AnvaiOps repo, out of scope here): Azure ACR + pricing overlay.
 | Relates to | `TD-EMBED-1` (the other shipped-release follow-up); `deploy/docker/IMAGE_PUBLISH.md`
 | Pillar | RELEASE/INFRA
 |===
@@ -18,34 +18,43 @@ toc::[]
 == Symptom
 
 The **commercial** ProximaDB image build is red, independent of the OSS work. It is not a
-code defect and not automatable from this repo: it requires an operator to **provision the
-target container registry (Azure ACR / AWS ECR) and supply cloud credentials** to the
-commercial pipeline before the overlay build can push.
+code defect in this repo and not automatable from here: it requires provisioning **Azure ACR
+and cloud credentials** in **AnvaiOps** before the commercial overlay build can push.
 
 == Context / boundary
 
-* This repo publishes the **public OSS** image `vjsingh1984/proximadb` to Docker Hub, built
-  multi-arch (`linux/amd64` + `linux/arm64`, native per-arch runners) by
-  `.github/workflows/publish-image.yml`. That path is healthy.
-* The **commercial** pipeline (AnvaiOps) consumes that OSS image as a base, overlays pricing/
-  entitlement, and pushes to a **commercial registry (ACR/ECR)**. Auth for that push is
-  registry credentials the operator holds — not repo secrets, not something a code change
-  here can satisfy.
-* Therefore the red state is an **infra provisioning dependency**, tracked here so it is not
-  mistaken for a build regression in this repo.
+* This repo publishes the **public OSS** image `docker.io/vjsingh1984/proximadb` to Docker
+  Hub, built multi-arch (`linux/amd64` + `linux/arm64`, native per-arch runners) by
+  `.github/workflows/publish-image.yml`. That path is healthy and fully self-contained here.
+* The **commercial** pipeline lives in **AnvaiOps**: it consumes the OSS Docker Hub image as a
+  base, overlays pricing/entitlement, and pushes to **Azure ACR**. The registry and its push
+  credentials are AnvaiOps-owned — not repo secrets here, not something a code change in
+  ProximaDB can satisfy.
+* Therefore the red state is an **AnvaiOps-side provisioning dependency**, recorded here only
+  so it is not mistaken for a build regression in this repo.
 
-== Fix approach (operator action, out-of-band)
+== Ownership boundary — the Azure provisioning is AnvaiOps', not ProximaDB's
 
-. Provision the commercial registry (ACR or ECR) for the target cloud account.
-. Supply the registry credentials to the AnvaiOps commercial pipeline (scoped push token /
-  service principal / OIDC — prefer keyless OIDC over a long-lived token where the registry
-  supports it, mirroring the OSS Docker Hub setup).
-. Re-run the commercial overlay build; confirm the pushed digest resolves and the pricing
-  overlay is present.
+ProximaDB (this repo, OSS) publishes **only** the public image to **Docker Hub**
+(`docker.io/vjsingh1984/proximadb`) via `publish-image.yml`. It owns no cloud registry and no
+cloud credentials.
 
-No change to this repo's `publish-image.yml` or `Dockerfile` is expected. If the OSS image
-shape needs to change to unblock the overlay (e.g. a new `runtime-*` target), file that as a
-separate, code-scoped TD.
+The **commercial** side — Azure ACR provisioning, the pricing/entitlement overlay, and the
+push credentials — belongs to **AnvaiOps** and is tracked there. The concrete provisioning
+runbook (`az acr create`, federated-identity/OIDC role bindings, the overlay pipeline wiring)
+lives in the AnvaiOps repo, **not** here, so this TD does not reproduce it — that would drift
+against the real owner.
+
+This ProximaDB-side TD exists only to record the boundary so the red commercial build is not
+mistaken for a regression in this repo:
+
+* **ProximaDB obligation (this repo):** keep the OSS Docker Hub image green and stable — it is
+  the base AnvaiOps overlays. Nothing here is blocked.
+* **AnvaiOps obligation (other repo):** provision Azure ACR + creds and run the commercial
+  overlay. That is the out-of-band operator action; track/close it in AnvaiOps.
+
+If — and only if — the OSS image *shape* must change to unblock the overlay (e.g. a new
+`runtime-*` Dockerfile target), that is a code-scoped change filed here as its own TD.
 
 == Verification
 


### PR DESCRIPTION
Addresses the two shipped-release follow-ups (TD-EMBED-1, TD-IMG-1) — shipping the part that's addressable and converting the two blocked parts into actionable, correctly-scoped plans.

## What ships
**macOS embedded wheels (Apple Silicon).** Adds `macos-14`/`aarch64` to `release-python.yml` `build-embedded-wheels`. The engine is unix-native (storage uses unix syscalls + cross-platform `memmap2`; the single Linux-only path is already `#[cfg(target_os="linux")]`-gated), so macOS builds with **no engine change** — the gap was purely a missing CI matrix row.
- Intel macOS intentionally **not** built — `x86_64-apple-darwin` is no longer a produced Apple target.
- `publish-embedded-pypi` already globs `*embedded-wheels*`, so the new artifact publishes with no publish-side change.
- Validated by a `workflow_dispatch` `dry_run=true` build on this branch (does not publish).

## What's now an actionable plan (not fakeable this session)
- **TD-EMBED-1 / Windows** — confirmed a genuine unix→MSVC port (`std::os::unix`/`libc`/`mmap` across `proximadb-storage-common` + `src/storage`). TD now **enumerates the exact blockers** and gives a phased, mixed-platform-safe port plan (platform-file seam → compile-only CI ratchet → wheel row last). No Windows matrix row until the engine compiles for MSVC.
- **TD-IMG-1 / commercial image** — records the **ownership boundary**: ProximaDB OSS ships to `docker.io`; Azure ACR provisioning + the pricing overlay are **AnvaiOps-owned** and tracked in that repo, not reproduced here.

## Verification
- `td-adr-unique`, `check_no_agent_attribution` → pass locally.
- macOS wheel build: linked dry-run run (Actions → Release Python).