### PR TITLE
feat(rest): ADR-049 M0-c — gate /api/v1/* behind PROXIMADB_REST_V1_COMPAT (v1 sunset clock)

### DIFF
--- a/docs/12-design/adr/ADR-049-v1-to-v2-migration-to-native-model.adoc
+++ b/docs/12-design/adr/ADR-049-v1-to-v2-migration-to-native-model.adoc
@@ -64,7 +64,7 @@ So the migration is **convergence, not a rewrite** — finish the spokes that st
 
 * **M0-a (this PR):** revive `scripts/check_v1_proto_usage.py` (TD-123 downward-only ratchet), wire `v1-proto-usage-no-regression` into `ci-success.needs`, and refresh the baseline once to the post-ADR-048 floor (the prior open ratchet was red only because its baseline predated the catalog-authoritative PRs #606/#609/#612 — drift, not regression). This refresh is the *only* non-ratcheted refresh; subsequent ones require explicit justification or the gate loses meaning.
 * **M0-b (follow-on PR):** proto-deprecate all 17 v1 services (`option deprecated = true` + this ADR / TD-121 comment) — advisory only; v1 stays working through M4.
-* **M0-c (follow-on PR):** gate REST `/api/v1/*` behind `PROXIMADB_REST_V1_COMPAT` (on-default for now; off → 410 Gone + `Deprecation`/`Sunset`), mirroring the gRPC v1 gate.
+* **M0-c (✅ landed):** REST `/api/v1/*` is gated behind `PROXIMADB_REST_V1_COMPAT` (on by default; off → `410 Gone` + RFC 8594 `Deprecation`/`Link`/optional `Sunset` headers), mirroring the gRPC v1 gate. Implemented as `network::middleware::v1_sunset` applied at both REST router-assembly sites; `/api/v2/*` is never affected. Optional `PROXIMADB_REST_V1_SUNSET` sets the `Sunset` HTTP-date.
 
 == Consequences
 

--- a/src/network/middleware/mod.rs
+++ b/src/network/middleware/mod.rs
@@ -48,6 +48,7 @@ pub mod request_id;
 pub mod tenant;
 pub mod timeout;
 pub mod tls;
+pub mod v1_sunset;
 
 pub use auth::{AuthLayer, MiddlewareAuthConfig, UserInfo};
 pub use backpressure::{BackpressureConfig, create_concurrency_limit_layer};

--- a/src/network/middleware/v1_sunset.rs
+++ b/src/network/middleware/v1_sunset.rs
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 Vijaykumar Singh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! REST `/api/v1/*` sunset gate (ADR-049 M0-c).
+//!
+//! ProximaDB is retiring the v1 wire model in favor of the native `proximadb.v2`
+//! surface (ADR-049, closes TD-121). This middleware is the *enabling slice* for
+//! that retirement on the REST edge: when the `PROXIMADB_REST_V1_COMPAT` flag is
+//! off, requests to the deprecated `/api/v1/*` surface are answered with
+//! `410 Gone` + RFC 8594 deprecation headers instead of being served — mirroring
+//! the gRPC v1 compat gate (`PROXIMADB_GRPC_V1_COMPAT`).
+//!
+//! The flag is **on by default**, so behavior is unchanged until an operator
+//! explicitly disables v1 (starting the sunset clock without a flag-day). The
+//! `/api/v2/*` surface is never affected.
+
+use axum::{
+    Json,
+    extract::{Request, State},
+    http::{HeaderValue, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+
+/// Env flag gating the deprecated REST v1 surface. Default ON (v1 served); set
+/// to `0` / `false` / `off` / `no` (case-insensitive) to disable v1 and return
+/// `410 Gone`.
+pub const REST_V1_COMPAT_ENV: &str = "PROXIMADB_REST_V1_COMPAT";
+
+/// Optional RFC 8594 `Sunset` HTTP-date advertised when v1 is disabled (e.g.
+/// `Wed, 01 Jul 2026 00:00:00 GMT`). Emitted verbatim; unset ⇒ no `Sunset`
+/// header.
+pub const REST_V1_SUNSET_ENV: &str = "PROXIMADB_REST_V1_SUNSET";
+
+/// Whether the deprecated `/api/v1/*` surface should still be served. Defaults
+/// to `true` (on) when the env var is unset.
+pub fn rest_v1_compat_enabled() -> bool {
+    parse_compat_flag(std::env::var(REST_V1_COMPAT_ENV).ok().as_deref())
+}
+
+/// Pure parser for the compat flag (testable without touching the environment).
+fn parse_compat_flag(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => {
+            let v = v.trim();
+            !(v == "0"
+                || v.eq_ignore_ascii_case("false")
+                || v.eq_ignore_ascii_case("off")
+                || v.eq_ignore_ascii_case("no"))
+        }
+        None => true,
+    }
+}
+
+/// Middleware that answers `/api/v1/*` with `410 Gone` + deprecation headers when
+/// the v1 compat gate (`compat_enabled`) is off. Every other path — and every
+/// path when the gate is on — passes through unchanged.
+pub async fn v1_sunset_middleware(
+    State(compat_enabled): State<bool>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if !compat_enabled && req.uri().path().starts_with("/api/v1/") {
+        return v1_gone_response(req.uri().path());
+    }
+    next.run(req).await
+}
+
+fn v1_gone_response(path: &str) -> Response {
+    let body = Json(json!({
+        "error": "gone",
+        "message": format!(
+            "REST {path} is part of the deprecated /api/v1 surface, which is disabled \
+             ({REST_V1_COMPAT_ENV} is off). Migrate to /api/v2. See ADR-049."
+        ),
+        "successor_version": "/api/v2",
+    }));
+    let mut resp = (StatusCode::GONE, body).into_response();
+    let headers = resp.headers_mut();
+    // RFC 8594 deprecation signalling.
+    headers.insert("deprecation", HeaderValue::from_static("true"));
+    headers.insert(
+        header::LINK,
+        HeaderValue::from_static("</api/v2>; rel=\"successor-version\""),
+    );
+    if let Ok(sunset) = std::env::var(REST_V1_SUNSET_ENV)
+        && let Ok(val) = HeaderValue::from_str(sunset.trim())
+    {
+        headers.insert("sunset", val);
+    }
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, routing::get};
+    use tower::ServiceExt;
+
+    fn app(compat: bool) -> Router {
+        Router::new()
+            .route("/api/v1/ping", get(|| async { "v1" }))
+            .route("/api/v2/ping", get(|| async { "v2" }))
+            .layer(axum::middleware::from_fn_with_state(
+                compat,
+                v1_sunset_middleware,
+            ))
+    }
+
+    #[test]
+    fn compat_flag_parsing() {
+        assert!(parse_compat_flag(None)); // default on
+        assert!(parse_compat_flag(Some("1")));
+        assert!(parse_compat_flag(Some("true")));
+        assert!(parse_compat_flag(Some("on")));
+        assert!(!parse_compat_flag(Some("0")));
+        assert!(!parse_compat_flag(Some("false")));
+        assert!(!parse_compat_flag(Some("OFF")));
+        assert!(!parse_compat_flag(Some(" no ")));
+    }
+
+    #[tokio::test]
+    async fn v1_returns_410_with_headers_when_gate_off() {
+        let resp = app(false)
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/ping")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::GONE);
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+        assert!(
+            resp.headers()
+                .get(header::LINK)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("successor-version")
+        );
+    }
+
+    #[tokio::test]
+    async fn v2_unaffected_when_gate_off() {
+        let resp = app(false)
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v2/ping")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn v1_served_when_gate_on() {
+        let resp = app(true)
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/ping")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -487,6 +487,16 @@ impl RestServer {
         let state_for_v2 = state.clone();
         let mut base_router = create_router(state.clone());
 
+        // ADR-049 M0-c: gate the deprecated /api/v1/* surface behind
+        // PROXIMADB_REST_V1_COMPAT (on by default). When off, /api/v1/* is
+        // answered with 410 Gone + RFC 8594 deprecation headers; /api/v2/* is
+        // never affected. This starts the v1 sunset clock without a flag-day.
+        let rest_v1_compat = crate::network::middleware::v1_sunset::rest_v1_compat_enabled();
+        base_router = base_router.layer(middleware::from_fn_with_state(
+            rest_v1_compat,
+            crate::network::middleware::v1_sunset::v1_sunset_middleware,
+        ));
+
         // Nest metrics router if available
         if let Some(metrics) = metrics_router {
             base_router = base_router.nest("/metrics", metrics);
@@ -788,6 +798,16 @@ impl RestServer {
         // Build base router with all endpoints
         let state_for_v2 = state.clone();
         let mut base_router = create_router(state.clone());
+
+        // ADR-049 M0-c: gate the deprecated /api/v1/* surface behind
+        // PROXIMADB_REST_V1_COMPAT (on by default). When off, /api/v1/* is
+        // answered with 410 Gone + RFC 8594 deprecation headers; /api/v2/* is
+        // never affected. This starts the v1 sunset clock without a flag-day.
+        let rest_v1_compat = crate::network::middleware::v1_sunset::rest_v1_compat_enabled();
+        base_router = base_router.layer(middleware::from_fn_with_state(
+            rest_v1_compat,
+            crate::network::middleware::v1_sunset::v1_sunset_middleware,
+        ));
 
         // Nest metrics router if available
         if let Some(metrics) = metrics_router {


### PR DESCRIPTION
## Wave 2B — v1 sunset gate (ADR-049 M0-c)

The original PR-B target (delete "inert query stacks" / custom Raft) was **reconsidered after recon**: the federated optimizer (~22.6k LOC), unified executor (2.3k), and RL planner (~7.2k) are **not dead** — they serve the REST `/api/v1/unified/*` facade — and the custom Raft is entangled with the `cluster`-feature `ClusterManager`. The map is documented; the real subtraction is **v1 retirement**, which is a staged ADR-049 migration (M0→M4), not a delete.

This PR lands **ADR-049 M0-c** — the clean, bounded enabling slice that also satisfies the review's "REST v1 sunset clock" item.

### Change
- New `network::middleware::v1_sunset`: when `PROXIMADB_REST_V1_COMPAT` is **off**, `/api/v1/*` is answered with **`410 Gone`** + RFC 8594 `Deprecation: true` + `Link: </api/v2>; rel="successor-version"` (optional `Sunset` HTTP-date via `PROXIMADB_REST_V1_SUNSET`). `/api/v2/*` is never affected.
- **On by default** — zero behavior change until an operator flips it off (no flag-day), mirroring the gRPC `PROXIMADB_GRPC_V1_COMPAT` gate.
- Applied at both REST router-assembly sites (`rest/server.rs`).
- ADR-049 M0-c marked landed.

### Why this is the right move
It starts the v1 sunset clock and is the prerequisite for eventually dropping v1 + its REST-facade backers (federated/unified, ~25k LOC) at ADR-049 M3/M4 — a far bigger and *legitimate* subtraction than the entangled candidates. Those stacks stay for now because they're load-bearing for the still-default v1 surface.

### Tests / verification
- Unit: compat-flag parsing (pure); `/api/v1 → 410` + headers when off; `/api/v1` served when on; `/api/v2` unaffected when off.
- `cargo fmt --check` ✓ · `cargo clippy --lib --bins -- -D warnings` ✓ · v1_sunset 4/4 ✓ (server binary compiles via `--bins`).

### Follow-ups (ADR-049)
- M0-a/M0-b: revive the TD-123 v1-proto ratchet + proto-deprecate the 17 v1 gRPC services.
- M1 (keystone, ~60%): storage engines off v1 `VectorRecord`. M3: v1 API edge → v2 (then federated/unified become removable). M4: delete `proto/proximadb/v1/`.