### PR TITLE
fix(gRPC): route relational SELECT through the TD-121 pipeline on the SQL path

### DIFF
--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -397,6 +397,7 @@ pub(crate) mod test_support {
             &self,
             _query: String,
             _collection: Option<String>,
+            _tenant_id: Option<&str>,
         ) -> Result<JsonValue> {
             Ok(JsonValue::Array(Vec::new()))
         }
@@ -637,7 +638,7 @@ mod tests {
             .unwrap();
         assert!(
             query
-                .execute_sql("select 1".to_string(), Some("docs".to_string()))
+                .execute_sql("select 1".to_string(), Some("docs".to_string()), None)
                 .await
                 .unwrap()
                 .is_array()

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -626,7 +626,7 @@ impl ApiHandlersPort for UnifiedHandlers {
         query: String,
         _parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
-        _tenant_id: Option<&str>,
+        tenant_id: Option<&str>,
     ) -> Result<ExecuteQueryResponse> {
         let adapter = self
             .query_adapter
@@ -634,7 +634,7 @@ impl ApiHandlersPort for UnifiedHandlers {
             .ok_or_else(|| anyhow!("SQL execution requires QueryAdapterPort (not wired)"))?;
 
         let start = Instant::now();
-        let json_result = adapter.execute_sql(query, collection).await?;
+        let json_result = adapter.execute_sql(query, collection, tenant_id).await?;
 
         let records = json_result
             .get("records")
@@ -889,6 +889,7 @@ mod tests {
             &self,
             _query: String,
             _collection: Option<String>,
+            _tenant_id: Option<&str>,
         ) -> Result<serde_json::Value> {
             Ok(json!({
                 "columns": ["id", "score", "flag", "none", "obj"],
@@ -1155,6 +1156,7 @@ mod tests {
                 &self,
                 _query: String,
                 _collection: Option<String>,
+                _tenant_id: Option<&str>,
             ) -> Result<serde_json::Value> {
                 Ok(json!(["text", 7, false, null, {"shape": "object"}]))
             }

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -165,5 +165,14 @@ pub trait QueryAdapterPort: Send + Sync {
     /// Returns rows as protocol-neutral JSON so the protocol layer can convert
     /// to v1 `ExecuteQueryResponse`, v2 `ProximaValue` rows, or any wire format
     /// without the port accumulating v1 surface debt.
-    async fn execute_sql(&self, query: String, collection: Option<String>) -> Result<JsonValue>;
+    ///
+    /// `tenant_id` scopes relational SQL to the tenant's partition (TD-064); the
+    /// adapter routes relational SELECT through the tenant-scoped relational
+    /// pipeline (`try_run_select`, TD-121) before falling back to the facade.
+    async fn execute_sql(
+        &self,
+        query: String,
+        collection: Option<String>,
+        tenant_id: Option<&str>,
+    ) -> Result<JsonValue>;
 }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -139,6 +139,16 @@ pub static GLOBAL_OLAP_RESULT_CACHE: Lazy<Arc<QueryResultCache<ExecutionPipeline
 
 /// Process-wide invalidation coordinator with the OLAP result cache attached,
 /// so writes/DDL drop tenant-scoped entries in one fan-out call (mandate #16b).
+///
+/// Only the `result_cache` arm is attached, deliberately:
+/// - **PlanCache** is already invalidated *lazily* — every
+///   `invalidate_collection` call bumps `CorpusVersionRegistry`, and `PlanCache`
+///   consults that version on lookup → stale entries already miss. An eager
+///   `with_plan_cache` arm would only free memory slightly sooner.
+/// - **BatchGroupCache** has no production instance (test-only) and is keyed on
+///   `(batch_id, group_id)`, not `(tenant, collection)` — there's no
+///   `(tenant, collection) → batch_id` mapping to drive it. Wire it when a live
+///   batch registry lands.
 pub static GLOBAL_OLAP_CACHE_COORDINATOR: Lazy<Arc<CacheInvalidationCoordinator>> =
     Lazy::new(|| {
         Arc::new(

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -693,6 +693,7 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         &self,
         query: String,
         _collection: Option<String>,
+        tenant_id: Option<&str>,
     ) -> anyhow::Result<serde_json::Value> {
         use crate::query::QueryResultData;
 
@@ -728,6 +729,38 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
             // degrades gracefully (matches ROOT when its DmlService is unset).
         }
 
+        // TD-121 relational SELECT routing — parity with the ROOT handler's
+        // execute_sql_v1 (src/api_handlers/request_handlers.rs). The gRPC
+        // ExecuteQuery path reaches this adapter (not the ROOT handler), so
+        // without this block a standard relational SELECT fell through to the
+        // legacy facade and was rejected ("Standard relational SQL execution is
+        // not configured in FederatedQueryContext"). `require_engagement=false`
+        // routes any resolvable relational SELECT; queries whose tables don't
+        // resolve return `None` and fall through to `sql_query` (vector/graph
+        // SQL, unchanged). The OLAP result cache is intentionally NOT consulted
+        // here — the bug fix is routing, not caching; REST/pgwire keep the cache
+        // (wiring it here is a same-crate follow-up, no layering issue).
+        // namespace=None: gRPC ExecuteQuery has no search_path.
+        if let Some(dml) = self.dml_service.as_ref()
+            && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
+                &query,
+                Some(dml),
+                None,
+                None,
+                tenant_id,
+                crate::query::execution::ExecutionControls::default(),
+                false,
+                None,
+                None,
+            )
+            .await
+        {
+            return match outcome {
+                Ok(result) => Ok(pipeline_result_to_json(result)),
+                Err(msg) => Err(anyhow!("Relational query execution failed: {msg}")),
+            };
+        }
+
         let query_result = self.sql_query(&query).await?;
 
         let records: Vec<serde_json::Value> = match query_result.data {
@@ -752,6 +785,37 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
 
         Ok(shape_sql_records(records))
     }
+}
+
+/// Convert a relational-pipeline (`try_run_select`) result into the SQL
+/// port-path JSON envelope (`{ columns, column_types, records }`), reusing
+/// [`shape_sql_records`] so the relational route (TD-121) shapes an identical
+/// response to the facade path (TD-104 parity). Each `ProximaValue` cell is
+/// serialized via its `serde::Serialize` impl.
+fn pipeline_result_to_json(
+    result: crate::query::execution::ExecutionPipelineResult,
+) -> serde_json::Value {
+    let col_names: Vec<String> = result
+        .schema
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    let records: Vec<serde_json::Value> = result
+        .rows
+        .into_iter()
+        .map(|row| {
+            let mut obj = serde_json::Map::new();
+            for (name, cell) in col_names.iter().zip(row.iter()) {
+                obj.insert(
+                    name.clone(),
+                    serde_json::to_value(cell).unwrap_or(serde_json::Value::Null),
+                );
+            }
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+    shape_sql_records(records)
 }
 
 /// Assemble the SQL port-path response envelope that the runtime handler's


### PR DESCRIPTION
## Summary

Fixes the pre-existing `grpc_td121_relational_tenant_isolation_e2e` failure: gRPC
`ExecuteQuery` couldn't run a relational `SELECT` ("Standard relational SQL
execution is not configured in FederatedQueryContext").

## Root cause

The TD-121 `try_run_select` routing lived **only** in the root-crate
`UnifiedHandlers::execute_sql_v1` (`src/api_handlers/request_handlers.rs:2165`),
which the **REST** path uses. gRPC `ExecuteQuery` reaches a *different* handler —
`runtime_api_handlers` (`proximadb_runtime::UnifiedHandlers`) →
`QueryFacadeAdapter::execute_sql` — which had **EXPLAIN** routing but **not**
relational SELECT routing, so standard SELECT fell through to the legacy facade
and was rejected.

## Fix

Bring gRPC to parity with REST by porting the TD-121 routing into the adapter
(the declared "single SQL authority", TD-104 seam S1), which already has
`dml_service` wired:

- **Thread `tenant_id`** through `QueryAdapterPort::execute_sql` (the runtime
  handler already received it as `_tenant_id`; pass it through). Updates the
  trait + adapter impl + 3 test mocks + the single caller.
- **TD-121 routing in `QueryFacadeAdapter::execute_sql`** (mirrors the root
  handler): on a resolvable relational SELECT, route through the tenant-scoped
  `try_run_select` pipeline and return the JSON-shaped result; otherwise fall
  through to `sql_query` (vector/graph SQL unchanged).
- **`pipeline_result_to_json`** helper (reuses `shape_sql_records` for TD-104
  parity; `ProximaValue` cells via serde).
- **#2 follow-up doc**: at `GLOBAL_OLAP_CACHE_COORDINATOR`, document why only the
  result-cache arm is attached (PlanCache is lazy-invalidated via the
  coordinator's corpus-version bump; BatchGroupCache has no production instance).

The OLAP result cache is intentionally **not** consulted on the gRPC path — the
bug fix is routing, not caching; REST/pgwire keep the cache (a same-crate
follow-up).

## Verification
- `cargo check --lib --bins` + `cargo clippy --lib --bins` (`-D warnings`): clean
- `cargo check --tests` (trait-signature ripple): clean
- **`grpc_td121_relational_tenant_isolation_e2e`: now passes** (was failing)
- `pgwire_relational_engine_e2e`: still passes (no regression)

## Out of scope
`grpc_td135_relational_write_tenant_isolation_e2e` (gRPC SQL **DDL/INSERT**) is a
separate, broader pre-existing gap — it fails **identically on clean
`origin/develop`** (verified via stash), so this PR is not a regression and does
not attempt write routing. It deserves its own follow-up.
