### PR TITLE
feat(query): persist the trace-driven route cost model across restarts (Wave 3)

### DIFF
--- a/docs/10-quality/td/TD-ROUTE-1-cost-model-override-enablement-eval.adoc
+++ b/docs/10-quality/td/TD-ROUTE-1-cost-model-override-enablement-eval.adoc
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ROUTE-1: Enabling the live route cost-model override needs a pgwire eval gate
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — persistence landed (cells survive restarts); live override (`PROXIMADB_ROUTE_COST_OVERRIDE`) stays OFF until the eval below exists.
+| Severity | Medium — the co-design routing lever is built but inert; enabling it blind risks the TPC-H/TPC-DS ratchets.
+| Component | `src/query/route_cost_model.rs`, `src/query/compute_scheduler.rs`, `tests/route_cost_offline_eval.rs`, `tests/tpch_pgwire_e2e.rs`
+| Pillar | PERF (co-design), REL (ratchets), EVAL (mandate #13)
+|===
+
+toc::[]
+
+== Context
+
+The trace-driven `RouteCostModel` learns per `(shape-class, backend)` from measured
+I/O and can flip *freshness-safe* routes to the cheaper backend when
+`PROXIMADB_ROUTE_COST_OVERRIDE` is on. Two safety gates already constrain it:
+a hard RTT-budget gate (`route_cost_model.rs`, `PROXIMADB_ROUTE_RTT_BUDGET`;
+applied at `compute_scheduler.rs`) and freshness-safety
+(`freshness_safe_backends_from_class` — only `olap/parquet` exposes two safe
+candidates; OLTP/Strong is pinned to Native, with a regression test at
+`compute_scheduler.rs::override_never_flips_freshness_critical_oltp`).
+
+The model's learned cells are now **persisted** across restarts
+(`{data_dir}/route_cost_cells.json`), which removes the cold-start mislearning
+window that would otherwise face a freshly-enabled override.
+
+== The gap
+
+Override remains OFF by default because there is **no safety net for the one
+behavior it changes**. Enabling it only affects `olap/parquet` queries — but
+TPC-H materializes its tables (`tests/tpch_pgwire_e2e.rs`), so TPC-H queries are
+`olap/parquet` and become eligible to flip DataFusion↔Native. The existing
+`tests/route_cost_offline_eval.rs` gates *routing quality on a synthetic,
+isolated model* (regret vs a static heuristic over 4,000 rounds) — it never
+touches the global model, the pgwire path, or real TPC-H correctness. So a
+flipped route that fails or regresses would only surface at the ratchet, not at
+an eval.
+
+== Decision / plan (do NOT enable override until these land)
+
+1. **pgwire integration eval (mandate #13).** A test that: (a) sets
+   `PROXIMADB_ROUTE_COST_OVERRIDE=1`, (b) warms the global model on a TPC-H
+   trace (or loads a checked-in persisted `route_cost_cells.json` fixture),
+   (c) runs the TPC-H suite over pgwire, and asserts **both output correctness
+   (result parity vs the OFF baseline) and trajectory** (the model does not flip
+   a query to a backend that regresses latency/regret beyond a threshold).
+2. **DataFusion read-path stability audit** — confirm the DataFusion arm is
+   production-ready for every shape the override could route to it (course
+   correction §4 flags it as wired-but-unproven for some paths).
+3. **Only then** flip the default (or ship an ops runbook to enable per
+   deployment), gated on the eval as a downward-only regret ratchet.
+
+== Acceptance
+
+* The pgwire override eval is green and CI-gated; TPC-H/TPC-DS ratchets hold with
+  override ON.
+* No freshness-critical (OLTP/Strong) route is ever flipped (existing guard
+  extended to the pgwire suite).
+* Enabling is documented (env/config) with the eval as the gate.

--- a/src/database.rs
+++ b/src/database.rs
@@ -128,6 +128,9 @@ impl ProximaDB {
         // measured cost of each (shape-class, backend). Observe-mode today —
         // routing is unchanged until a later flag-gated slice.
         crate::query::route_cost_model::install_route_cost_observer();
+        // Warm the cost model from persisted cells so the measured routing
+        // history survives restarts (behavior unchanged while override is off).
+        crate::query::route_cost_model::load_persisted_cost_model(&config.server.data_dir);
         // ADR-030: wire the io_trace flush to the always-on per-tenant billing
         // meters (KRU read-compute from the snapshot's per-engine compute_ms).
         // Same snapshot as the route observer above — billed bytes/ms cannot
@@ -767,6 +770,10 @@ impl ProximaDB {
     /// Shutdown the database instance gracefully.
     pub async fn shutdown(&mut self) -> anyhow::Result<()> {
         info!("Graceful shutdown requested");
+
+        // Persist the learned route cost model so measured history survives the
+        // restart (best-effort; off the hot path, on graceful shutdown only).
+        crate::query::route_cost_model::persist_cost_model(&self._config.server.data_dir);
 
         // 1a. Stop the async-ingest drainer first so it stops consuming
         //     before we shut down the storage layer it inserts into.

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -70,6 +70,144 @@ pub fn install_route_cost_observer() {
     GLOBAL_ROUTE_COST_MODEL.set_override_enabled(on);
 }
 
+// ── Persistence: let the measured cost history survive restarts ─────────────
+//
+// The trace-driven model learns per (shape-class, backend) from measured I/O.
+// In-memory only, it re-learns cold on every boot — so the co-design signal
+// ("route from measured quantities") is thrown away at each restart, and any
+// future live-override slice would face a cold-start mislearning window.
+// Persisting the EWMA cells fixes both: warm advisories across restarts, and a
+// warm model when override is eventually enabled. Behavior is unchanged while
+// the override stays OFF (default). Mirrors the RL-planner policy persistence
+// (`{data_dir}/rl_policy.json`).
+
+/// On-disk snapshot version. Only the EWMA cells are persisted; the frozen
+/// consult table is re-derived on load. Bumping this invalidates older files
+/// (they load nothing and the model re-learns), so a format change is never
+/// mis-read.
+const COST_MODEL_PERSIST_VERSION: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedCostModel {
+    version: u32,
+    cells: Vec<PersistedCell>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistedCell {
+    shape_class: String,
+    backend: String,
+    cell: Cell,
+}
+
+/// Path of the persisted global cost model under a server data dir.
+pub fn cost_model_persist_path(data_dir: &std::path::Path) -> std::path::PathBuf {
+    data_dir.join("route_cost_cells.json")
+}
+
+/// Warm the global cost model from `{data_dir}/route_cost_cells.json` at startup
+/// if present. Best-effort: a missing / unreadable / older-version file loads
+/// nothing and the model re-learns. Routing is unchanged either way (the model
+/// stays observe-only until `PROXIMADB_ROUTE_COST_OVERRIDE`).
+pub fn load_persisted_cost_model(data_dir: &std::path::Path) {
+    let path = cost_model_persist_path(data_dir);
+    let loaded = GLOBAL_ROUTE_COST_MODEL.load_from(&path);
+    if loaded > 0 {
+        tracing::info!(
+            "route cost model: warmed {loaded} learned cell(s) from {}",
+            path.display()
+        );
+    }
+}
+
+/// Persist the global cost model to `{data_dir}/route_cost_cells.json` at
+/// shutdown (best-effort; a write failure is logged, not fatal).
+pub fn persist_cost_model(data_dir: &std::path::Path) {
+    let path = cost_model_persist_path(data_dir);
+    match GLOBAL_ROUTE_COST_MODEL.persist_to(&path) {
+        Ok(n) if n > 0 => tracing::info!(
+            "route cost model: persisted {n} learned cell(s) to {}",
+            path.display()
+        ),
+        Ok(_) => {} // nothing learned yet — nothing to persist
+        Err(e) => tracing::warn!(
+            "route cost model: failed to persist to {}: {e}",
+            path.display()
+        ),
+    }
+}
+
+impl RouteCostModel {
+    /// Persist the learned cells to `path` via an atomic temp+rename. Returns
+    /// the number of cells written (only cells with ≥1 sample are persisted).
+    fn persist_to(&self, path: &std::path::Path) -> std::io::Result<usize> {
+        let snapshot = {
+            let cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+            PersistedCostModel {
+                version: COST_MODEL_PERSIST_VERSION,
+                cells: cells
+                    .iter()
+                    .filter(|(_, c)| c.samples > 0)
+                    .map(|((class, backend), cell)| PersistedCell {
+                        shape_class: class.clone(),
+                        backend: backend.clone(),
+                        cell: *cell,
+                    })
+                    .collect(),
+            }
+        };
+        let n = snapshot.cells.len();
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let bytes = serde_json::to_vec_pretty(&snapshot).map_err(std::io::Error::other)?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(n)
+    }
+
+    /// Replace the learned cells with those persisted at `path`, then warm the
+    /// frozen consult table. Returns the number of cells loaded; 0 on a missing,
+    /// unreadable, or version-mismatched file (the model re-learns from scratch).
+    fn load_from(&self, path: &std::path::Path) -> usize {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(_) => return 0, // no persisted model yet
+        };
+        let snapshot: PersistedCostModel = match serde_json::from_slice(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    "route cost model: ignoring unreadable persisted file {}: {e}",
+                    path.display()
+                );
+                return 0;
+            }
+        };
+        if snapshot.version != COST_MODEL_PERSIST_VERSION {
+            tracing::warn!(
+                "route cost model: ignoring persisted file {} (version {}, expected {})",
+                path.display(),
+                snapshot.version,
+                COST_MODEL_PERSIST_VERSION
+            );
+            return 0;
+        }
+        let n = snapshot.cells.len();
+        {
+            let mut cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+            for pc in snapshot.cells {
+                cells.insert((pc.shape_class, pc.backend), pc.cell);
+            }
+        }
+        // Re-derive the frozen consult table from the loaded cells so advisories
+        // (and a future enabled override) see the warm history immediately.
+        self.recompute_locked();
+        n
+    }
+}
+
 // ── Per-Parquet-location shape stats (route-time classification) ────────────
 
 /// One Parquet table's physical shape, warmed for free wherever the table is
@@ -308,7 +446,7 @@ impl CostQuantities {
 }
 
 /// One (shape-class, backend) cell: EWMA means of the cost-bearing quantities.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
 struct Cell {
     range_gets: f64,
     bytes_read: f64,
@@ -950,6 +1088,53 @@ impl RouteCostModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn persist_load_round_trip_warms_a_fresh_model() {
+        let m = RouteCostModel::new();
+        // Learn two cells from measured snapshots (typed observe so the backend
+        // labels match what `estimate` derives).
+        m.observe(
+            "olap/parquet/large",
+            &ComputeBackend::DataFusionLocal,
+            &snap(12, 4_000_000, 8),
+        );
+        m.observe(
+            "olap/parquet/large",
+            &ComputeBackend::Native,
+            &snap(40, 4_000_000, 30),
+        );
+
+        let dir = std::env::temp_dir().join(format!("pdb_cost_persist_{}", std::process::id()));
+        let path = cost_model_persist_path(&dir);
+        assert_eq!(m.persist_to(&path).expect("persist"), 2);
+
+        // A fresh model has no history until it loads the persisted cells.
+        let fresh = RouteCostModel::new();
+        assert!(
+            fresh
+                .estimate("olap/parquet/large", &ComputeBackend::DataFusionLocal)
+                .is_none()
+        );
+        assert_eq!(fresh.load_from(&path), 2);
+        let est = fresh
+            .estimate("olap/parquet/large", &ComputeBackend::DataFusionLocal)
+            .expect("warmed estimate");
+        assert_eq!(est.range_gets, 12.0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_file_is_a_noop() {
+        let m = RouteCostModel::new();
+        assert_eq!(
+            m.load_from(std::path::Path::new(
+                "/nonexistent/pdb/route_cost_cells.json"
+            )),
+            0
+        );
+    }
 
     fn snap(range_gets: u64, bytes_read: u64, compute_ms: u64) -> IoTraceSnapshot {
         let mut s = IoTraceSnapshot {


### PR DESCRIPTION
## Wave 3 — Convergence: persist the trace-driven cost model

The review's #12 improvement is "turn **on** + **persist**" the trace-driven route cost model. Scoping (read-only, verify-before-cut) split it into two separable changes:

- **(A) Persist** — LOW risk, self-contained, behavior-neutral. **This PR.**
- **(B) Enable the live override** — HIGH risk: it would flip TPC-H queries (materialized → `olap/parquet`) between DataFusion/Native, and there is **no pgwire-level eval** gating correctness+regret (the existing `route_cost_offline_eval` runs on a synthetic, isolated model). **Deferred → TD-ROUTE-1.**

### This PR (A)
The `ComputeScheduler` cost model learns per `(shape-class, backend)` from measured I/O, but was in-memory only — every restart discarded the co-design signal and re-learned cold. Now the learned EWMA cells persist across restarts (`{data_dir}/route_cost_cells.json`, mirroring the RL-planner policy persistence):

- serde on `Cell`; versioned snapshot (only cells persisted — the frozen consult table is re-derived on load).
- `persist_to` (atomic temp+rename) / `load_from` (repopulate + `recompute_locked`). Best-effort + graceful: a missing/unreadable/version-mismatched file loads nothing and the model re-learns — never blocks startup.
- Load at startup (after `install_route_cost_observer`), save on graceful `Database::shutdown` (off the query hot path).

**Behavior unchanged** — the model stays observe-only until `PROXIMADB_ROUTE_COST_OVERRIDE`. Persistence also **de-risks** future enablement: a warm persisted model avoids the cold-start mislearning that's the #1 hazard of flipping the override on.

### Tests / verification
- `persist→load` round-trip warms a fresh model's `estimate`; missing file is a no-op.
- `cargo fmt --check` ✓ · `cargo clippy --lib --bins -- -D warnings` ✓ · route_cost_model **35/35** ✓.

### Follow-up
- **TD-ROUTE-1** — enabling the live override needs a pgwire TPC-H eval (correctness + regret) + a DataFusion read-path stability audit before flipping the default (mandate #13).