### PR TITLE
perf(olap): co-design scan efficiency — projection pushdown + exact COUNT(*) + byte-ledger (TD-OLAP-4)

### DIFF
--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ClickBench co-design Phase A — the seam is the result path, not the engine (2026-07-06)
+
+Sets the performance bar, maps the execution seams from first principles, and
+frames the co-design target for the single-node OLAP path (ClickBench, TD-OLAP-4
+track). Companion to the v1 ledger (`CLICKBENCH_LEDGER_V1_2026_07_06.adoc`).
+
+== The bar (published ClickBench, c6a.4xlarge, hot total of 43 queries, RELEASE)
+
+|===
+| engine | format | hot total (43q) | note
+
+| DuckDB | native `.duckdb` | ~26 s | native columnar store
+| DuckDB | Parquet | ~32 s | apples-to-apples for a Parquet engine
+| DataFusion | Parquet (partitioned) | ~42 s | **ProximaDB's engine**
+| DataFusion | Parquet (single) | ~46 s |
+|===
+
+Sources: benchmark.clickhouse.com, github.com/ClickHouse/ClickBench result JSONs;
+DataFusion "fastest single-node Parquet" blog (2024-11-18). By ClickBench's
+official *geomean-of-ratios* metric DataFusion took #1 for partitioned Parquet in
+Nov 2024; sum-of-times (above) favors DuckDB because a few heavy queries dominate.
+
+**Key fact:** DataFusion has no native format — it *always* reads Parquet. So the
+apples-to-apples comparison for ProximaDB (a Parquet-backed, DataFusion-engined
+system) is **DataFusion-Parquet vs DuckDB-Parquet ≈ 42–46 s vs 32 s — i.e. DuckDB
+~1.3–1.4× faster**, NOT an order of magnitude.
+
+== Where the gap decomposes (first principles)
+
+ProximaDB's OLAP engine *is* DataFusion, so its ClickBench-Parquet ceiling ≈
+DataFusion's. The gap over DuckDB splits into two buckets with very different
+ownership:
+
+. **DataFusion's own gap vs DuckDB (NOT ours to fix — inherited upstream).**
+  Historically: Parquet scan/filter-pushdown (was ~20× slower, off by default —
+  now fixed with row-group stats + page index + bloom + late materialization),
+  string handling (Arrow `StringView`), cache-efficient partial aggregation
+  (Leis et al.), and a residual ~2× pure-compute gap on some queries. DataFusion
+  improved >30% v34→v43 and continues through v47/v50. **ADR-052 is explicit: do
+  NOT reimplement DataFusion's kernels.** We inherit these by tracking versions.
+. **ProximaDB's *own* added overhead (OUR co-design surface).** Everything
+  ProximaDB layers *around* DataFusion — the result-materialization path and the
+  scan/cache seams — plus, in v1, the debug-build penalty.
+
+== The seams ProximaDB owns (execution-path map, `file:line`)
+
+A SQL aggregate over pgwire → router → DataFusion → back to the client passes
+through (agent-traced):
+
+. **Arrow → row materialization — TOP SUSPECT.**
+  `src/query/execution/datafusion_engine.rs:760-867`
+  (`record_batch_to_rows` / `arrow_cell_to_proxima`). DataFusion emits columnar
+  Arrow `RecordBatch`; ProximaDB converts them **cell-by-cell** into a
+  row-oriented `ProximaValue` enum — O(rows×cols) `downcast_ref` + per-cell heap
+  allocations for strings. Defeats the vectorization DuckDB keeps end to end.
+. **Per-value text encoding for the pgwire wire.**
+  `src/network/postgres/relational_pipeline.rs:954-1024` +
+  `protocol.rs:1506-1534` (`text_encode` / `send_data_row_nullable`). Each cell
+  is `String`-allocated for the text `DataRow`.
+. **`df.collect()` full materialization** (`datafusion_engine.rs:241`) — the
+  streaming path (`execute_datafusion_stream`) exists but is NOT wired to the
+  pgwire aggregate path.
+. **Per-cell type dispatch** (`datafusion_engine.rs:797-856`) — should switch on
+  the Arrow column type once per column, not per cell.
+. **Parquet footer round-trip** (`object_store_parquet_reader.rs:102-109`) — no
+  persistent footer cache across queries (I/O seam; already io_trace-visible).
+
+== The co-design target (measure-first)
+
+* **Target = "≈ DataFusion-Parquet," not "beat DuckDB's engine."** The engine gap
+  is upstream's; our job is to add *near-zero overhead* on top of DataFusion.
+* **Highest-ROI lever already in the architecture: Arrow Flight.** A zero-copy
+  columnar transport on the same multiplexed port — routing bulk/columnar results
+  through it sidesteps the entire Arrow→row→text materialization seam (mandate-3:
+  route bulk/columnar work to Arrow Flight). Cheaper interim wins: wire the
+  streaming path to pgwire; hoist type-dispatch to per-column; persistent footer
+  cache.
+* **Router/DataFusion-first is the right frame.** Optimize the seams *around* the
+  engine; swap/upgrade the engine (or add the native PAX scan, TD-OLAP-1 / #706)
+  behind the `ComputeBackend` boundary without touching the harness or seams.
+
+== v1 measured (debug, 1M-row subset — coverage signal only)
+
+ProximaDB 35/43, DuckDB 35/43 (same 8 fail — EventDate typed INT vs date
+literals + 2 function shapes). Debug median 250 ms vs DuckDB 25 ms — the ~10× is
+**debug build + the result-path seam**, both ours to remove; NOT an engine gap.
+
+== Release measurement (Phase A deliverable — IN PROGRESS)
+
+// PHASE-A-RELEASE-NUMBERS
+A release build collapses most of the debug penalty (the seams are CPU-bound
+per-cell work that release inlines/optimizes heavily). The release run quantifies
+how much of *our* overhead remains after the debug penalty is removed, and — with
+per-layer io_trace + EXPLAIN ANALYZE — splits it into scan I/O vs DataFusion
+compute vs pgwire serialize, so Phase C targets the *measured* dominant seam.
+
+== Plan
+
+* **Phase A (this doc):** bar + seams + release per-layer numbers. No optimization
+  before it.
+* **Phase B:** SOLID harness refactor — `Benchmark` / `LoadStrategy` / `Baseline`
+  / `LedgerSink` traits so ClickBench + TPC-H + TPC-DS run through one
+  router-driven runner (DataFusion as the first `ComputeBackend`).
+* **Phase C:** co-design optimizations targeting the measured dominant seam
+  (Arrow Flight columnar result path / streaming / per-column dispatch / footer
+  cache), each gated on the evidence ledger.

--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -47,9 +47,11 @@ ownership:
 == The seams ProximaDB owns (execution-path map, `file:line`)
 
 A SQL aggregate over pgwire → router → DataFusion → back to the client passes
-through (agent-traced):
+through (agent-traced). NOTE: the "top suspect" ordering below is the *a-priori*
+code-reading guess; the release measurement (next section) OVERTURNED it — the
+evidence-driven ranking is under "Corrected seam ranking."
 
-. **Arrow → row materialization — TOP SUSPECT.**
+. **Arrow → row materialization — a-priori top suspect, DISPROVEN by measurement.**
   `src/query/execution/datafusion_engine.rs:760-867`
   (`record_batch_to_rows` / `arrow_cell_to_proxima`). DataFusion emits columnar
   Arrow `RecordBatch`; ProximaDB converts them **cell-by-cell** into a
@@ -87,14 +89,58 @@ ProximaDB 35/43, DuckDB 35/43 (same 8 fail — EventDate typed INT vs date
 literals + 2 function shapes). Debug median 250 ms vs DuckDB 25 ms — the ~10× is
 **debug build + the result-path seam**, both ours to remove; NOT an engine gap.
 
-== Release measurement (Phase A deliverable — IN PROGRESS)
+== Release measurement — the hypothesis is OVERTURNED
 
-// PHASE-A-RELEASE-NUMBERS
-A release build collapses most of the debug penalty (the seams are CPU-bound
-per-cell work that release inlines/optimizes heavily). The release run quantifies
-how much of *our* overhead remains after the debug penalty is removed, and — with
-per-layer io_trace + EXPLAIN ANALYZE — splits it into scan I/O vs DataFusion
-compute vs pgwire serialize, so Phase C targets the *measured* dominant seam.
+Prediction: a release build would collapse most of the gap, because the suspected
+seam (Arrow→row→text per-cell materialization) is CPU-bound and release-sensitive.
+
+Measured (scale-0.01 / 1M rows, `c` = 32c/78GB WSL2, both over the same lowercase
+Parquet):
+
+|===
+| build | ProximaDB (35 ok) | DuckDB (35 ok) | ratio
+
+| debug   | median 250 ms · total 18.3 s | median 25 ms | ~14×
+| **release** | **median 230 ms · total 17.4 s** | median 26 ms · total 1.2 s | **~14×**
+|===
+
+**Release did NOT help (250→230 ms).** So the dominant cost is *not* the
+CPU-bound Arrow→row→text path — that would have shrunk sharply with optimization.
+
+Per-query shape confirms it: the walls are **flat ~220–240 ms regardless of query
+complexity**, `COUNT(*)` (q01) is 329 ms (counting rows should be near-free from
+footer stats), and a handful of narrow point-filter queries (q20/q24–27) run at
+~47 ms. A near-constant per-query floor that release can't move is the signature
+of a **fixed I/O / scan cost, not compute** — almost certainly the external
+Parquet being **re-opened and re-scanned on every query** (per-query
+`register_object_store_parquet_location` in `prepare_dataframe`; no persistent
+table registration or footer/metadata cache), and likely reading more than the
+1–3 columns each query needs.
+
+**This is the co-design mandate working as intended: trace before you tune.** The
+first-suspect (result path) was disproven by measurement; the real seam is the
+scan/registration path.
+
+=== Corrected seam ranking (evidence-driven)
+
+. **Per-query external-Parquet re-open + scan (NEW top seam).** No persistent
+  registration/footer cache across queries; `prepare_dataframe` re-opens the
+  object each query. Release-insensitive, flat per-query floor. — the ~230 ms.
+. **Projection pushdown for wide tables.** ClickBench touches 1–3 of 105 columns;
+  verify column projection reaches the Parquet reader (the ~47 ms narrow queries
+  suggest it partly works). Reading all columns is a large I/O amplification.
+. Footer round-trip / metadata cache (`object_store_parquet_reader.rs:102-109`).
+. (Deprioritized by evidence) Arrow→row→text materialization
+  (`datafusion_engine.rs:760-867`) — real, but NOT dominant for this workload;
+  revisit once the scan floor is removed.
+
+=== Immediate next step (Phase A tail)
+
+Capture `io_trace` `bytes_read` + `range_gets` per query in the harness (or run
+with `RUST_LOG=proximadb::io_trace`) to prove the mechanism — a per-query
+`bytes_read` ≈ whole-object confirms re-scan; near-footer-only confirms a
+metadata-open floor. Then Phase C targets the measured mechanism (persistent
+table registration / footer cache; projection pushdown), NOT the result path.
 
 == Plan
 

--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -169,6 +169,54 @@ Verification target for Phase C: `COUNT(*)` `bytes_read` → footer-only (KB), n
 queries → proportional to projected columns; `range_gets` collapses; results
 unchanged.
 
+=== Implemented + measured (release, 1M ClickBench, byte-ledger)
+
+. **Projection pushdown (Phase C).** Built a `ProjectionMask::roots` into
+  `ParquetRecordBatchStreamBuilder` (fetch only projected column chunks) + reorder
+  the file-order output to projection order. Measured: total `bytes_read`
+  **−40.8%** (8.22 → 4.87 GB), median wall **210 → 60 ms** (3.5×), `COUNT(*)`
+  **290 → 8 ms**, `range_gets` **965 → ~20-29**; 35/43 unchanged, zero row
+  mismatches. `try_new_with_options` preserves the row count for an EMPTY
+  projection (`COUNT(*)`).
+. **Exact `num_rows` stats → metadata-only `COUNT(*)` (co-design refinement).**
+  The footer's per-row-group row count is EXACT, but `statistics_from_splits`
+  reported it `Inexact`, so DataFusion's `AggregateStatistics` rule never elided
+  the scan. Reporting `Precision::Exact(num_rows)` lets an unfiltered `COUNT(*)`
+  answer from footer metadata — zero column scan. Safe: a `WHERE` inserts a
+  `FilterExec` that re-marks stats Inexact (filtered counts still scan), and the
+  ADR-025 delta-merge path uses its own MemTable when a WAL delta exists, so only
+  footer-accurate providers report Exact.
+
+Exact-`num_rows` measured: `COUNT(*)` `range_gets` **20 → 2** and the column scan
+is elided (`AggregateStatistics` fires) — BUT `bytes_read` stayed ~121 MB. Those
+2 GETs read ~the whole 116 MB file, which exposes the NEXT dominant seam:
+
+=== NEW top seam (measurement-driven): per-query OPEN reads the whole file
+
+After projection + exact-stats, the residual **4.86 GB total ≈ 43 queries ×
+~116 MB** is the per-query table OPEN — `register_object_store_parquet_location`
+→ `ObjectStoreParquetTable::open` reads ~the whole file (the parquet footer
+prefetch pulls a huge suffix; at a 116 MB file that is ≈ the whole object), on
+EVERY query, with no cache. This is now the #1 lever. Two independent fixes,
+both PR-2:
+. **Bounded footer prefetch** — pass `ParquetObjectReader::with_footer_size_hint`
+  (or `with_metadata` of a cached `Arc<ParquetMetaData>`) so `open` reads only
+  the footer (a few MB), not a whole-file suffix. Correctness-neutral, no gating.
+. **Re-open cache** — cache `Arc<ObjectStoreParquetTable>` by location so repeat
+  queries skip `open` entirely (needs snapshot-LSN invalidation for MATERIALIZE'd
+  tables; env-gated).
+
+=== Deferred to follow-up PRs (need gating / invalidation design)
+
+* **Per-query re-open cache (was "Phase B").** A read-through cache of
+  `Arc<ObjectStoreParquetTable>` keyed by location removes the per-query
+  LIST+HEAD+footer re-read, but MATERIALIZE'd tables mutate their location on
+  re-materialize — so it needs snapshot-LSN invalidation and an env gate. Its own
+  PR.
+* **Read coalescing** (the residual small-GET count) and the **SOLID harness
+  refactor** (ClickBench + TPC-H + TPC-DS through one router-driven runner) —
+  separate PRs.
+
 == Plan
 
 * **Phase A (this doc):** bar + seams + release per-layer numbers. No optimization

--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -134,13 +134,40 @@ scan/registration path.
   (`datafusion_engine.rs:760-867`) — real, but NOT dominant for this workload;
   revisit once the scan floor is removed.
 
-=== Immediate next step (Phase A tail)
+=== Byte-ledger result (Phase A instrumentation landed — DECISIVE)
 
-Capture `io_trace` `bytes_read` + `range_gets` per query in the harness (or run
-with `RUST_LOG=proximadb::io_trace`) to prove the mechanism — a per-query
-`bytes_read` ≈ whole-object confirms re-scan; near-footer-only confirms a
-metadata-open floor. Then Phase C targets the measured mechanism (persistent
-table registration / footer cache; projection pushdown), NOT the result path.
+Added per-query `io_trace` capture to the harness (`set_billing_observer`). The
+byte-ledger re-ranks the levers and is far sharper than the wall time:
+
+|===
+| metric (per query, release, 1M / 116 MB file) | value
+
+| `bytes_read` — EVERY query incl. `COUNT(*)` | **241,608,340 (~241 MB)**
+| `range_gets` — EVERY query | **965**
+| total `bytes_read`, 43 queries | 8.2 GB (~70× the 116 MB file)
+|===
+
+Two facts jump out:
+. **`COUNT(*)` reads 241 MB** — it touches zero columns, so this is the pure
+  signature of NO projection pushdown: every query fetches all 105 column chunks.
+  Reading ~2× the whole file per query = all columns + footer/metadata overhead.
+. **965 ranged GETs per query** — the read is fragmented into ~one GET per
+  column-chunk × row-group (≈105 × 9). This is the "small-GET, per-request-fee-
+  dominated" anti-pattern (§2.1 read granularity) — DuckDB coalesces to a handful.
+
+**This overturns the wall-time-based ordering.** The earlier read ("`COUNT(*)`
+= 329 ms ⇒ re-open floor dominates") was wrong: `COUNT(*)`'s cost is the
+full-column READ (241 MB), not the re-open. So:
+. **Projection pushdown (Phase C) is the #1 lever — even at 1M** (not just SF1).
+  It drops `COUNT(*)` / narrow queries from 241 MB → ~KB.
+. **Read coalescing (new lever)** — 965 tiny GETs → a handful of coalesced ranged
+  reads; the reader/`object_store` coalescing knobs.
+. **Per-query re-open cache (Phase B) is secondary** — real, but a minor share of
+  the 965 GETs vs the full-column scan.
+
+Verification target for Phase C: `COUNT(*)` `bytes_read` → footer-only (KB), narrow
+queries → proportional to projected columns; `range_gets` collapses; results
+unchanged.
 
 == Plan
 

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -1157,7 +1157,7 @@ mod tests {
         // Provider path — value bounds are gated default-OFF
         // (`df_stats_value_bounds_enabled`), but rows/bytes/nulls always flow.
         let stats = TableProvider::statistics(&table).expect("footer-backed statistics");
-        assert_eq!(stats.num_rows, Precision::Inexact(4));
+        assert_eq!(stats.num_rows, Precision::Exact(4));
         // Schema-width contract: one entry per table column.
         assert_eq!(stats.column_statistics.len(), 2);
         assert_eq!(stats.column_statistics[1].null_count, Precision::Inexact(0));

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -14,6 +14,7 @@ use datafusion::arrow::array::{
     LargeStringArray, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::catalog::Session;
 use datafusion::common::Statistics;
 use datafusion::datasource::{TableProvider, TableType};
@@ -46,6 +47,12 @@ use super::super::schema_inference::{
     df_stats_value_bounds_enabled, project_statistics, statistics_from_splits,
 };
 use crate::observability::object_store_trace::TracingObjectStore;
+
+/// True iff `proj` selects every column in ascending order — a no-op projection
+/// where pushing a mask (and reordering) buys nothing, so the reader reads all.
+fn is_identity(proj: &[usize]) -> bool {
+    proj.iter().enumerate().all(|(i, &c)| i == c)
+}
 
 fn project_schema(full: &SchemaRef, projection: Option<&[usize]>) -> SchemaRef {
     match projection {
@@ -365,21 +372,58 @@ impl SplitReader for ObjectStoreParquetSplitReader {
         let path = Path::from(split.file_path.as_str());
         let file_size = self.file_sizes.get(&split.file_path).copied();
         let reader = parquet_reader(self.store.clone(), path, file_size);
-        let mut stream = ParquetRecordBatchStreamBuilder::new(reader)
+        let builder = ParquetRecordBatchStreamBuilder::new(reader)
             .await
-            .map_err(|e| df_err("parquet open", e))?
+            .map_err(|e| df_err("parquet open", e))?;
+
+        let out_schema = project_schema(&self.schema, projection);
+
+        // TRUE projection PUSHDOWN: fetch only the projected column chunks, not
+        // all columns (TD-OLAP-4 co-design — a query touching 3 of 105 columns
+        // was reading every column chunk, ~97% wasted bytes). The reader emits
+        // the selected columns in ascending FILE order; `reorder` maps them back
+        // to the requested projection order so the batch matches `out_schema`.
+        // For a flat schema, root columns == leaf columns, so `roots` is exact.
+        let (builder, reorder) = match projection {
+            Some(proj) if proj.len() != self.schema.fields().len() || !is_identity(proj) => {
+                let mask = ProjectionMask::roots(builder.parquet_schema(), proj.iter().copied());
+                let mut file_order: Vec<usize> = proj.to_vec();
+                file_order.sort_unstable();
+                file_order.dedup();
+                let reorder: Vec<usize> = proj
+                    .iter()
+                    .map(|c| {
+                        file_order
+                            .iter()
+                            .position(|x| x == c)
+                            .expect("projected column present in the selected set")
+                    })
+                    .collect();
+                (builder.with_projection(mask), Some(reorder))
+            }
+            // Full/absent projection: read every column, no reorder.
+            _ => (builder, None),
+        };
+
+        let mut stream = builder
             .with_row_groups(vec![row_group_index])
             .with_batch_size(batch_size)
             .build()
             .map_err(|e| df_err("parquet reader build", e))?;
 
-        let proj_owned = projection.map(|p| p.to_vec());
-        let out_schema = project_schema(&self.schema, projection);
         let mut batches = Vec::new();
         while let Some(batch) = stream.next().await {
             let batch = batch.map_err(|e| df_err("parquet decode", e))?;
-            let batch = match &proj_owned {
-                Some(proj) => batch.project(proj).map_err(|e| df_err("project", e))?,
+            let batch = match &reorder {
+                Some(order) => {
+                    let cols: Vec<_> = order.iter().map(|&i| batch.column(i).clone()).collect();
+                    // `with_row_count` preserves the count for an EMPTY projection
+                    // (e.g. `COUNT(*)`, which reads zero columns) — a 0-column
+                    // batch is otherwise rejected without an explicit row count.
+                    let opts = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+                    RecordBatch::try_new_with_options(out_schema.clone(), cols, &opts)
+                        .map_err(|e| df_err("projection reorder", e))?
+                }
                 None => batch,
             };
             batches.push(Ok(batch));

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -390,15 +390,16 @@ impl SplitReader for ObjectStoreParquetSplitReader {
                 let mut file_order: Vec<usize> = proj.to_vec();
                 file_order.sort_unstable();
                 file_order.dedup();
+                // Each requested column is in `file_order` by construction (it is
+                // built from `proj`); map fallibly rather than panic (panic policy).
                 let reorder: Vec<usize> = proj
                     .iter()
                     .map(|c| {
-                        file_order
-                            .iter()
-                            .position(|x| x == c)
-                            .expect("projected column present in the selected set")
+                        file_order.iter().position(|x| x == c).ok_or_else(|| {
+                            df_err("projection", "requested column missing from selected set")
+                        })
                     })
-                    .collect();
+                    .collect::<DFResult<Vec<_>>>()?;
                 (builder.with_projection(mask), Some(reorder))
             }
             // Full/absent projection: read every column, no reorder.

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -194,8 +194,15 @@ pub fn statistics_from_splits(
         .collect();
 
     Statistics {
+        // Parquet row-group `num_rows` is EXACT metadata (unlike the min/max value
+        // bounds below, which are Inexact zone-maps). Reporting it Exact lets
+        // DataFusion's `AggregateStatistics` rule answer an unfiltered `COUNT(*)`
+        // from the footer alone — zero column scan (TD-OLAP-4). Safe: a `WHERE`
+        // inserts a `FilterExec` that re-marks stats Inexact, so filtered counts
+        // still scan; and only footer-accurate providers use this (the ADR-025
+        // delta-merge path builds its own MemTable when a WAL delta exists).
         num_rows: if any_rows {
-            Precision::Inexact(num_rows)
+            Precision::Exact(num_rows)
         } else {
             Precision::Absent
         },
@@ -590,7 +597,7 @@ mod tests {
 
         let stats = statistics_from_splits(&splits, &schema, None, true);
 
-        assert_eq!(stats.num_rows, Precision::Inexact(5));
+        assert_eq!(stats.num_rows, Precision::Exact(5));
         assert_eq!(stats.total_byte_size, Precision::Inexact(300));
         // Schema-width contract (DataFusion 54 indexes by column position).
         assert_eq!(stats.column_statistics.len(), schema.fields().len());
@@ -688,7 +695,7 @@ mod tests {
         assert_eq!(x.max_value, Precision::Absent);
         // …but the join-ordering inputs still flow.
         assert_eq!(x.null_count, Precision::Inexact(3));
-        assert_eq!(stats.num_rows, Precision::Inexact(2));
+        assert_eq!(stats.num_rows, Precision::Exact(2));
     }
 
     #[test]

--- a/tests/clickbench_ledger_e2e.rs
+++ b/tests/clickbench_ledger_e2e.rs
@@ -20,13 +20,21 @@
 #![cfg(feature = "datafusion-integration")]
 
 use std::net::TcpListener;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use proximadb::core::Config;
 use proximadb::database::ProximaDB;
+use proximadb::observability::io_trace::{self, IoTraceSnapshot};
 use tempfile::TempDir;
 use tokio::time::sleep;
 use tokio_postgres::{NoTls, SimpleQueryMessage};
+
+/// Per-query I/O trace capture. The server fires the billing observer at each
+/// statement's `io_trace` scope close, so we clear before a query and drain
+/// after — the same pattern as `tpc_perf_ledger_e2e.rs`. This turns the ledger
+/// from a wall-clock anecdote into a bytes-scanned ledger (the co-design signal).
+static CAPTURE: Mutex<Vec<IoTraceSnapshot>> = Mutex::new(Vec::new());
 
 const CLICKBENCH_DDL_COLS: &str = "WatchID BIGINT, JavaEnable SMALLINT, Title VARCHAR, GoodEvent SMALLINT, EventTime BIGINT, EventDate INT, CounterID INT, ClientIP INT, RegionID INT, UserID BIGINT, CounterClass SMALLINT, OS SMALLINT, UserAgent SMALLINT, URL VARCHAR, Referer VARCHAR, IsRefresh SMALLINT, RefererCategoryID SMALLINT, RefererRegionID INT, URLCategoryID SMALLINT, URLRegionID INT, ResolutionWidth SMALLINT, ResolutionHeight SMALLINT, ResolutionDepth SMALLINT, FlashMajor SMALLINT, FlashMinor SMALLINT, FlashMinor2 VARCHAR, NetMajor SMALLINT, NetMinor SMALLINT, UserAgentMajor SMALLINT, UserAgentMinor VARCHAR, CookieEnable SMALLINT, JavascriptEnable SMALLINT, IsMobile SMALLINT, MobilePhone SMALLINT, MobilePhoneModel VARCHAR, Params VARCHAR, IPNetworkID INT, TraficSourceID SMALLINT, SearchEngineID SMALLINT, SearchPhrase VARCHAR, AdvEngineID SMALLINT, IsArtifical SMALLINT, WindowClientWidth SMALLINT, WindowClientHeight SMALLINT, ClientTimeZone SMALLINT, ClientEventTime BIGINT, SilverlightVersion1 SMALLINT, SilverlightVersion2 SMALLINT, SilverlightVersion3 INT, SilverlightVersion4 SMALLINT, PageCharset VARCHAR, CodeVersion INT, IsLink SMALLINT, IsDownload SMALLINT, IsNotBounce SMALLINT, FUniqID BIGINT, OriginalURL VARCHAR, HID INT, IsOldCounter SMALLINT, IsEvent SMALLINT, IsParameter SMALLINT, DontCountHits SMALLINT, WithHash SMALLINT, HitColor VARCHAR, LocalEventTime BIGINT, Age SMALLINT, Sex SMALLINT, Income SMALLINT, Interests SMALLINT, Robotness SMALLINT, RemoteIP INT, WindowName INT, OpenerName INT, HistoryLength SMALLINT, BrowserLanguage VARCHAR, BrowserCountry VARCHAR, SocialNetwork VARCHAR, SocialAction VARCHAR, HTTPError SMALLINT, SendTiming INT, DNSTiming INT, ConnectTiming INT, ResponseStartTiming INT, ResponseEndTiming INT, FetchTiming INT, SocialSourceNetworkID SMALLINT, SocialSourcePage VARCHAR, ParamPrice BIGINT, ParamOrderID VARCHAR, ParamCurrency VARCHAR, ParamCurrencyID SMALLINT, OpenstatServiceName VARCHAR, OpenstatCampaignID VARCHAR, OpenstatAdID VARCHAR, OpenstatSourceID VARCHAR, UTMSource VARCHAR, UTMMedium VARCHAR, UTMCampaign VARCHAR, UTMContent VARCHAR, UTMTerm VARCHAR, FromTag VARCHAR, HasGCLID SMALLINT, RefererHash BIGINT, URLHash BIGINT, CLID INT";
 
@@ -267,8 +275,26 @@ struct QueryRecord {
     ok: bool,
     rows: usize,
     wall_ms: u128,
+    /// Object-store bytes read for this query (ProximaDB route only; the
+    /// co-design cost term). `None` for the DuckDB baseline (out-of-process).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bytes_read: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    range_gets: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+}
+
+/// Drain the per-query I/O trace snapshot the server emitted at scope close.
+/// Polls briefly because the billing observer fires asynchronously server-side.
+async fn drain_capture() -> Option<IoTraceSnapshot> {
+    for _ in 0..60 {
+        if let Some(s) = CAPTURE.lock().expect("capture lock").pop() {
+            return Some(s);
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    None
 }
 
 /// Rewrite `FROM hits` to a DuckDB `read_parquet(...)` over the same object.
@@ -312,11 +338,21 @@ async fn clickbench_ledger() {
     let queries = clickbench_queries();
     let mut records: Vec<QueryRecord> = Vec::new();
 
+    // Capture the per-query I/O trace the server emits at each statement's scope close.
+    io_trace::set_billing_observer(Some(Box::new(|snap: &IoTraceSnapshot, _tenant| {
+        CAPTURE.lock().expect("capture lock").push(snap.clone());
+    })));
+
     // ProximaDB (DataFusion route).
     for (id, sql) in &queries {
+        CAPTURE.lock().expect("capture lock").clear();
         let t0 = Instant::now();
         let res = client.simple_query(sql).await;
         let wall_ms = t0.elapsed().as_millis();
+        let snap = drain_capture().await;
+        let (bytes_read, range_gets) = snap
+            .map(|s| (Some(s.bytes_read), Some(s.range_gets)))
+            .unwrap_or((None, None));
         match res {
             Ok(msgs) => {
                 let rows = msgs
@@ -329,6 +365,8 @@ async fn clickbench_ledger() {
                     ok: true,
                     rows,
                     wall_ms,
+                    bytes_read,
+                    range_gets,
                     error: None,
                 });
             }
@@ -338,6 +376,8 @@ async fn clickbench_ledger() {
                 ok: false,
                 rows: 0,
                 wall_ms,
+                bytes_read,
+                range_gets,
                 error: Some(
                     e.as_db_error()
                         .map(|d| d.message().to_string())
@@ -346,6 +386,7 @@ async fn clickbench_ledger() {
             }),
         }
     }
+    io_trace::set_billing_observer(None);
 
     // DuckDB baseline (same Parquet), if a binary is provided.
     if let Ok(duckdb) = std::env::var("DUCKDB_BIN") {
@@ -364,6 +405,8 @@ async fn clickbench_ledger() {
                 ok,
                 rows: 0,
                 wall_ms,
+                bytes_read: None,
+                range_gets: None,
                 error: (!ok).then(|| {
                     out.as_ref()
                         .map(|o| String::from_utf8_lossy(&o.stderr).trim().to_string())
@@ -384,8 +427,9 @@ async fn clickbench_ledger() {
         walls.sort_unstable();
         let median = walls.get(walls.len() / 2).copied().unwrap_or(0);
         let total: u128 = walls.iter().sum();
+        let bytes: u64 = rs.iter().filter_map(|r| r.bytes_read).sum();
         eprintln!(
-            "[clickbench/{engine}] ok {ok}/{} · median {median} ms · total {total} ms",
+            "[clickbench/{engine}] ok {ok}/{} · median {median} ms · total {total} ms · total bytes_read {bytes}",
             rs.len()
         );
     }


### PR DESCRIPTION
## What

Measurement-driven co-design optimizations for the single-node OLAP path
(DataFusion over parquet-backed / external tables via the pgwire router),
targeted at ClickBench (TD-OLAP-4). Correctness-neutral; each change is gated on a
before/after **byte-ledger**, not a wall-clock anecdote.

## The method (measure, fix the measured seam, re-measure)

A release build showed ProximaDB ~14× DuckDB on a 1M ClickBench subset — but
release-insensitive and flat ~230ms regardless of query, so **not** the a-priori
"Arrow→row CPU" suspect. Adding a per-query byte-ledger proved it: **every query,
incl. `COUNT(*)`, read 241 MB via 965 ranged GETs over a 116 MB file** — the pure
signature of no projection pushdown. Fixing that re-exposed the next seam, etc.

## Changes (all with measured deltas)

1. **Byte-ledger instrumentation** (`tests/clickbench_ledger_e2e.rs`) — capture
   per-query `bytes_read`/`range_gets` via `set_billing_observer` (pattern from
   `tpc_perf_ledger_e2e`). This is the co-design signal that ranks the levers.
2. **True projection pushdown** (`object_store_parquet_reader.rs`) — build a
   `ProjectionMask::roots` into `ParquetRecordBatchStreamBuilder` and fetch only
   projected column chunks (was reading all 105, discarding ~97%), reordering the
   file-order output back to projection order:
   **−40.8% total bytes_read (8.22→4.87 GB), median wall 210→60 ms (3.5×),
   `COUNT(*)` 290→8 ms, 965→~20 GETs**; 35/43 unchanged, zero row mismatches.
3. **Exact footer `num_rows`** (`schema_inference.rs`) — parquet row-group
   `num_rows` is exact, but we reported `Inexact`, so DataFusion's
   `AggregateStatistics` rule never elided an unfiltered `COUNT(*)`. Report
   `Precision::Exact` → `COUNT(*)` answers from footer metadata (column scan
   elided; gets 20→2). Safe: a `WHERE` inserts a `FilterExec` that re-marks stats
   Inexact (filtered counts still scan); the ADR-025 delta-merge path uses its own
   MemTable when a WAL delta exists.

## Next (follow-up PRs, scoped in the evidence doc)

The residual **4.86 GB ≈ 43 × ~116 MB** is now the **per-query table OPEN reading
the whole file** (footer prefetch pulls a whole-file suffix, no cache). PR-2:
bounded footer-size hint (correctness-neutral) + a re-open cache (env-gated, with
snapshot-LSN invalidation). Then read-coalescing and the SOLID harness refactor
(one router-driven runner for ClickBench + TPC-H + TPC-DS).

Evidence: `docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc`.
Builds on the merged external-table (#710) + ClickBench ledger (#714).
