### PR TITLE
chore(python): raise embedded packages' minimum Python to 3.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ xz2 = "0.1"
 zstd = "0.13"
 
 # Language bindings
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py38"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }  # abi3 floor = CPython 3.10 (our minimum supported Python); one wheel (cp310-abi3) installs on 3.10+
 numpy = { version = "0.28" }
 
 # TurboQuant numerics (ADR-021, gated by `experimental-turboquant`).

--- a/clients/python-embedded/pyproject.toml
+++ b/clients/python-embedded/pyproject.toml
@@ -11,15 +11,13 @@ authors = [
 ]
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["vector", "database", "embedded", "similarity", "search", "ml", "ai", "embeddings"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -79,7 +77,7 @@ python_functions = ["test_*"]
 addopts = ["-v", "--tb=short"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
@@ -90,10 +88,10 @@ line_length = 88
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]

--- a/clients/python-queue-embedded/pyproject.toml
+++ b/clients/python-queue-embedded/pyproject.toml
@@ -9,7 +9,7 @@ description = "ProximaDB Queue (Embedded) — in-process tiered persistent queue
 authors = [{name = "Vijaykumar Singh", email = "singhvjd@gmail.com"}]
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["queue", "persistent", "pyo3", "tokio", "wal", "lsm"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,13 @@ authors = [
 ]
 license = {text = "Apache-2.0"}
 readme = "README.adoc"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["vector", "database", "embedded", "similarity", "search", "ml", "ai", "embeddings"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -72,13 +70,13 @@ python_functions = ["test_*"]
 addopts = ["-v", "--tb=short"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 88
 select = ["E", "W", "F", "I", "B", "C4", "UP"]
 ignore = ["E501"]


### PR DESCRIPTION
We only support Python 3.10+. The pure SDK (`clients/python`) already declared `requires-python >=3.10` and CI had dropped 3.9, but the **embedded** packages and the **abi3 floor** still said 3.8. This aligns them.

## Changes
- **`Cargo.toml`**: `pyo3` `abi3-py38` → **`abi3-py310`**. The emitted `proximadb_embedded` wheel is now `cp310-abi3` — one wheel installable on CPython 3.10+ (was cp38-abi3).
- **`requires-python` `>=3.8` → `>=3.10`** in the root (canonical embedded) `pyproject.toml`, `clients/python-embedded`, and `clients/python-queue-embedded`.
- Dropped the `Python :: 3.8` / `3.9` trove classifiers (root + embedded).
- Bumped `[tool.mypy] python_version` and `[tool.ruff]`/`[tool.black] target-version` from `3.8`/`py38` → `3.10`/`py310`.

## Verified
- All three embedded `pyproject.toml` parse; `requires-python == >=3.10` everywhere.
- `abi3-py310` confirmed a valid feature in `pyo3 0.28.3`.
- No 3.8/3.9 packaging floor remains in the embedded/root manifests.
- Because `Cargo.toml` changed, CI runs the full Rust suite (build compiles with `abi3-py310`).

## Out of scope (flagged)
`.github/workflows/release.yml` carries stale comments for a **legacy per-Python-version cibuildwheel model** ("5 wheels, 3.8–3.12"), separate from the abi3 `release-python.yml` builder and largely commented-out. Left for a dedicated cleanup rather than churning a dead workflow.