### PR TITLE
fix(security): fail closed when REST auth is enabled but no SecurityCoordinator is wired

### DIFF
--- a/src/network/middleware/auth_failclosed.rs
+++ b/src/network/middleware/auth_failclosed.rs
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Vijaykumar Singh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Fail-closed guard for a security **misconfiguration**.
+//!
+//! When the REST server is built with authentication *enabled* but **no**
+//! `SecurityCoordinator` wired, the old behavior logged a warning and then
+//! served every request **unauthenticated** — i.e. it failed *open* on a
+//! security misconfiguration. This layer is attached only in that case and
+//! **fails closed**: data-plane requests (`/api/*`) are rejected with
+//! `503 Service Unavailable` while non-data-plane paths (health / liveness /
+//! metrics) still pass, so orchestrator probes keep working and the operator
+//! sees an up-but-degraded server rather than a silent auth bypass.
+//!
+//! The fix is scoped to the request layer because the REST router constructor
+//! returns `Self` (cannot return an error) and panicking in a critical module
+//! is disallowed by the panic-policy guard.
+
+use axum::{
+    Json,
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+
+/// Path prefix of the authenticated data plane. Requests outside it (health,
+/// liveness, metrics) are allowed through even when auth is misconfigured.
+const DATA_PLANE_PREFIX: &str = "/api/";
+
+/// Reject data-plane requests with `503` when auth is enabled-but-unconfigured.
+/// This middleware is attached ONLY in the misconfigured case, so its presence
+/// is the signal — it always denies `/api/*` and passes everything else.
+pub async fn auth_misconfigured_deny_data_plane(req: Request, next: Next) -> Response {
+    if req.uri().path().starts_with(DATA_PLANE_PREFIX) {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "service_unavailable",
+                "message": "Authentication is enabled but no SecurityCoordinator is \
+                    configured; the data plane is failing closed. Wire a \
+                    SecurityCoordinator or set auth.enabled=false.",
+            })),
+        )
+            .into_response();
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, routing::get};
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        Router::new()
+            .route("/api/v1/search", get(|| async { "data" }))
+            .route("/health", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(
+                auth_misconfigured_deny_data_plane,
+            ))
+    }
+
+    #[tokio::test]
+    async fn data_plane_is_denied_503() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/search")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn health_still_passes() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/src/network/middleware/mod.rs
+++ b/src/network/middleware/mod.rs
@@ -40,6 +40,7 @@
 //! ```
 
 pub mod auth;
+pub mod auth_failclosed;
 pub mod backpressure;
 pub mod cors;
 pub mod metrics;

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -531,7 +531,12 @@ impl RestServer {
         // Create concurrency limit layer for backpressure (if enabled)
         let concurrency_layer = create_concurrency_limit_layer(&security_config.backpressure);
 
-        // Authentication layer (unified): prefer SecurityCoordinator if available
+        // Authentication layer (unified): prefer SecurityCoordinator if available.
+        // Auth ENABLED with NO coordinator is a security misconfiguration: rather
+        // than serving every request unauthenticated (failing open), we fail
+        // CLOSED — the deny layer applied after the router is built rejects the
+        // data plane with 503. (Computed before the coordinator is moved below.)
+        let auth_misconfigured = security_config.auth.enabled && security_coordinator.is_none();
         let auth_layer = if security_config.auth.enabled {
             if let Some(coordinator) = security_coordinator {
                 Some(middleware::from_fn_with_state(
@@ -539,8 +544,10 @@ impl RestServer {
                     crate::network::auth::middleware::auth_middleware_unified,
                 ))
             } else {
-                tracing::warn!(
-                    "Security enabled but no coordinator available; auth layer disabled"
+                tracing::error!(
+                    "REST auth is enabled but no SecurityCoordinator is configured — \
+                     failing CLOSED: data-plane (/api/*) requests are rejected with 503. \
+                     Wire a SecurityCoordinator or set auth.enabled=false."
                 );
                 None
             }
@@ -650,6 +657,13 @@ impl RestServer {
         // Apply auth layer last so request IDs/backpressure/cors are preserved
         if let Some(auth) = auth_layer {
             router = router.layer(auth);
+        }
+        // Fail closed on an auth misconfiguration (enabled but no coordinator):
+        // deny the data plane with 503 rather than serving it unauthenticated.
+        if auth_misconfigured {
+            router = router.layer(middleware::from_fn(
+                crate::network::middleware::auth_failclosed::auth_misconfigured_deny_data_plane,
+            ));
         }
 
         // Build TLS config if specified


### PR DESCRIPTION
## Secure-defaults: fail closed on an auth misconfiguration

Deferred from the Wave-0 review (the auth-hardening thread). The multi-port REST build path (`with_security_and_config_and_ports`) handled **auth enabled + no `SecurityCoordinator`** by logging a warning and then **serving every request unauthenticated** — failing *open* on a security misconfiguration.

### Change
- New `network::middleware::auth_failclosed` layer, attached **only** in the misconfigured case: rejects data-plane requests (`/api/*`) with **`503 Service Unavailable`** while health / liveness / metrics paths still pass — probes keep working, the operator sees an up-but-degraded server rather than a silent auth bypass. Warning escalated to **error**.
- Scoped to the request layer because the builder returns `Self` (can't return an error) and panicking in the `network_rest` critical module is disallowed by the panic-policy guard.

### Correctly scoped
The **unified production path** (`build_router_for_unified`) is already safe by construction — `multi_server` passes a coordinator **iff** auth is enabled, so `None` there means auth-disabled-by-config, not a misconfig. Verified; no change needed there. So the fix targets the one real hole.

### Not in scope
Flipping auth **ON by default** (the broader secure-default) is a separate, test-heavy change — this PR closes the enabled-but-unconfigured *fail-open* hole.

### Tests / verification
- New: data plane → `503` when misconfigured; `/health` still passes.
- Existing REST auth tests unaffected (3/3: disabled-allows, enabled-requires-header, enabled-accepts-api-key).
- `cargo fmt --check` ✓ · `cargo clippy --lib --bins -- -D warnings` ✓ · 5/5 targeted tests.