### PR TITLE
fix(observability): head probe over-counts bytes_read (billing + cost-model) (TD-OLAP-4)

### DIFF
--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -191,20 +191,36 @@ Exact-`num_rows` measured: `COUNT(*)` `range_gets` **20 → 2** and the column s
 is elided (`AggregateStatistics` fires) — BUT `bytes_read` stayed ~121 MB. Those
 2 GETs read ~the whole 116 MB file, which exposes the NEXT dominant seam:
 
-=== NEW top seam (measurement-driven): per-query OPEN reads the whole file
+=== The "121 MB per-query floor" was a METERING ARTIFACT, not real I/O (root-caused)
 
-After projection + exact-stats, the residual **4.86 GB total ≈ 43 queries ×
-~116 MB** is the per-query table OPEN — `register_object_store_parquet_location`
-→ `ObjectStoreParquetTable::open` reads ~the whole file (the parquet footer
-prefetch pulls a huge suffix; at a 116 MB file that is ≈ the whole object), on
-EVERY query, with no cache. This is now the #1 lever. Two independent fixes,
-both PR-2:
-. **Bounded footer prefetch** — pass `ParquetObjectReader::with_footer_size_hint`
-  (or `with_metadata` of a cached `Arc<ParquetMetaData>`) so `open` reads only
-  the footer (a few MB), not a whole-file suffix. Correctness-neutral, no gating.
-. **Re-open cache** — cache `Arc<ObjectStoreParquetTable>` by location so repeat
-  queries skip `open` entirely (needs snapshot-LSN invalidation for MATERIALIZE'd
-  tables; env-gated).
+The residual ~121 MB/query was NOT the footer prefetch and NOT a whole-file read.
+A backtrace pinned it to `ObjectStoreExt::head` (object_store 0.13) — the file-size
+probe in `ObjectStoreParquetTable::open` (`store.head(&path)`). `head` is a
+metadata-only op per backend (local `stat`, S3 `HEAD`, ABFS Get-Blob-Properties,
+GCS metadata) that transfers NO body — but its `GetResult.range` spans
+`0..object_size`, and our `TracingObjectStore::get_opts` recorded
+`range.end − range.start` as `bytes_read`. So EVERY per-query file-size probe
+over-counted `bytes_read` by the whole object size. This is a real metering bug —
+`bytes_read` feeds the co-design cost model AND per-tenant KRU billing, so every
+`head` over-charged the tenant by the object size.
+
+FIX (PR-2): count zero bytes for head-only requests in `TracingObjectStore`
+(`object_store_trace.rs get_opts`, gate on `options.head`). Measured effect:
+total `bytes_read` **4.99 GB → 382 MB (−92%)**, median wall UNCHANGED (~69 ms),
+35/43 unchanged — confirming the bytes were phantom (head is a cheap metadata op).
+Also add `with_footer_size_hint` to the parquet reader (minor: bounds the real
+ranged metadata read; `range_gets` 29→19).
+
+=== Corrected picture — real I/O is small; the gap is COMPUTE
+
+With accurate metering: `COUNT(*)` reads 0.5 MB (footer only — exact-stats
+elision works), narrow queries ~5 MB (projection works), wide-string queries
+(URL/Title) ~30-51 MB. Real total: 382 MB for 43 queries. The remaining wall gap
+vs DuckDB (~2.2× median) is now clearly **compute + pgwire, not I/O** — dominated
+by the **q07 UInt16 MIN/MAX 10 s outlier** (reads only 5 MB; pure compute). So the
+next levers are the metadata-aggregate elision (MIN/MAX from footer) and the q07
+UInt16 compute pathology — NOT an I/O "open floor" (which never existed). The
+re-open cache drops to a minor S3-RTT optimization (`head` is cheap locally).
 
 === Deferred to follow-up PRs (need gating / invalidation design)
 

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -68,12 +68,27 @@ fn project_schema(full: &SchemaRef, projection: Option<&[usize]>) -> SchemaRef {
     }
 }
 
+/// Footer prefetch size (bytes). Without a hint the parquet reader pulls a
+/// whole-file suffix to find the footer on a small object — measured ~116 MB
+/// "open" I/O per query at 1M ClickBench (TD-OLAP-4). 512 KiB covers a
+/// wide-table (105-column) footer in one ranged read; a larger real footer just
+/// costs one extra ranged read (rare). Overridable via
+/// `PROXIMADB_PARQUET_FOOTER_HINT_KB` for tuning at very wide/large scales.
+fn footer_size_hint() -> usize {
+    std::env::var("PROXIMADB_PARQUET_FOOTER_HINT_KB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&kb| kb > 0)
+        .map(|kb| kb * 1024)
+        .unwrap_or(512 * 1024)
+}
+
 fn parquet_reader(
     store: Arc<dyn ObjectStore>,
     path: Path,
     file_size: Option<u64>,
 ) -> ParquetObjectReader {
-    let reader = ParquetObjectReader::new(store, path);
+    let reader = ParquetObjectReader::new(store, path).with_footer_size_hint(footer_size_hint());
     match file_size {
         Some(size) => reader.with_file_size(size),
         None => reader,

--- a/src/observability/object_store_trace.rs
+++ b/src/observability/object_store_trace.rs
@@ -120,11 +120,22 @@ impl ObjectStore for TracingObjectStore {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
         self.rec_op(IoOp::Get);
         let ranged = options.range.is_some();
+        // A `head` request (`ObjectStoreExt::head` → `get_opts(with_head)`) transfers
+        // metadata only, not the body — but its `GetResult.range` spans the whole
+        // object, so recording `range` here would over-count `bytes_read` by the
+        // full object size on every metadata probe (measured: a spurious ~file-size
+        // per query — TD-OLAP-4). Count zero bytes for head-only requests.
+        let is_head = options.head;
         let result = self.inner.get_opts(location, options).await?;
         if ranged {
             self.rec_range_gets(1);
         }
-        self.rec_bytes_read(result.range.end.saturating_sub(result.range.start));
+        let n = if is_head {
+            0
+        } else {
+            result.range.end.saturating_sub(result.range.start)
+        };
+        self.rec_bytes_read(n);
         Ok(result)
     }
 

--- a/src/observability/object_store_trace.rs
+++ b/src/observability/object_store_trace.rs
@@ -242,6 +242,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn head_records_zero_bytes_not_object_size() {
+        // A `head` (metadata) probe transfers no body; its GetResult.range spans
+        // the whole object, so it must NOT be counted as bytes_read (that was a
+        // per-query over-count that inflated the co-design meter + KRU billing).
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = TracingObjectStore::wrap(inner);
+        let path = Path::from("t/data.bin");
+        store
+            .put(&path, PutPayload::from_static(&[0u8; 4096]))
+            .await
+            .unwrap();
+
+        static CAPTURED: Mutex<Option<IoTraceSnapshot>> = Mutex::new(None);
+        io_trace::set_billing_observer(Some(Box::new(|snap, _tenant| {
+            *CAPTURED.lock().unwrap_or_else(|p| p.into_inner()) = Some(snap.clone());
+        })));
+
+        io_trace::instrument(None, "test", async {
+            let meta = store.head(&path).await.unwrap();
+            assert_eq!(meta.size, 4096, "head still reports the true size");
+        })
+        .await;
+        io_trace::set_billing_observer(None);
+
+        let snapshot = CAPTURED
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+            .expect("billing observer captured a snapshot");
+        assert_eq!(
+            snapshot.bytes_read, 0,
+            "a head probe transfers no body — zero bytes_read, not the object size"
+        );
+    }
+
+    #[tokio::test]
     async fn no_ops_outside_scope() {
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let store = TracingObjectStore::wrap(inner);


### PR DESCRIPTION
## What

Fixes a real per-tenant **billing/metering bug** in `TracingObjectStore`: a `head`
(file-size) probe was counted as `bytes_read` equal to the whole object size.

## Root cause

`ObjectStoreExt::head` (object_store 0.13) is `get_opts(with_head(true))` — a
metadata-only op per backend (local `stat`, S3 `HEAD`, ABFS Get-Blob-Properties,
GCS metadata) that transfers **no body**. But its `GetResult.range` spans
`0..object_size`, and `TracingObjectStore::get_opts` recorded `range.end −
range.start` as `bytes_read`. So every per-query file-size probe (in
`ObjectStoreParquetTable::open`) over-charged `bytes_read` by the full object
size. `bytes_read` feeds the **co-design cost model AND per-tenant KRU billing**,
so this over-charged every OLAP query.

## Fix

- Count **zero bytes** for head-only requests (`options.head`) in
  `object_store_trace.rs`; ranged/full reads are unaffected. Unit test added.
- Add `with_footer_size_hint` to the parquet reader (bounds the real ranged
  metadata read; `range_gets` 29→19).

## Measured (1M ClickBench, release byte-ledger)

- total `bytes_read` **4.99 GB → 382 MB (−92%)**, median wall **unchanged** (~69ms),
  35/43 unchanged — confirming the bytes were phantom (head is a cheap metadata op).
- Corrected picture: real per-query I/O is small (`COUNT(*)` 0.5 MB — exact-stats
  elision; narrow queries ~5 MB — projection). The remaining gap vs DuckDB is
  **compute**, dominated by the q07 UInt16 `MIN/MAX` 10 s outlier (reads only 5 MB) —
  which correctly re-points the next work (metadata-aggregate elision + the UInt16
  pathology) at *compute*, not an I/O "open floor" that never existed.

Evidence: `docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc`.
Builds on the merged #722.
