### PR TITLE
feat(documents): flip canonical-vector route to DEFAULT-ON with kill-switch, mixed-write-safe (TD-DOC-CONV-2 step 3)

### DIFF
--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -61,4 +61,12 @@ pub trait RecordRoutePort: Send + Sync {
         record_ids: Vec<String>,
         tenant: Option<&str>,
     ) -> Result<usize>;
+
+    /// True when `collection_id` resolves to a canonical (vector) collection for `tenant`
+    /// in the record/vector catalog. The document facade uses this to route mixed-safely
+    /// under the default-ON gate (TD-DOC-CONV-2): a collection that is NOT a canonical
+    /// vector collection (e.g. a pure-document collection never created via REST v2/DDL)
+    /// stays on the legacy path instead of hard-failing the canonical write. Best-effort:
+    /// returns `false` on any resolution error (fail toward the safe legacy path).
+    async fn collection_exists(&self, collection_id: &str, tenant: Option<&str>) -> bool;
 }

--- a/docs/10-quality/td/TD-DOC-CONV-2-canonical-vector-default-on-cutover-bake.adoc
+++ b/docs/10-quality/td/TD-DOC-CONV-2-canonical-vector-default-on-cutover-bake.adoc
@@ -4,14 +4,16 @@
 
 [cols="1,3"]
 |===
-|Status|BAKE COMPLETE 2026-07-06 — all 4 criteria MEASURED-PASS. The metering BLOCKER (a document
-write emitted no per-tenant consumption delta) is CLOSED: `materialize_collection` now emits the
-per-tenant object-store WRITE meter and `/metrics/prometheus` now exports the default registry — a
-canonical document write bills 64,828 B (measured). Cutover MAY proceed via the phased per-collection
-→ widen → default-ON (kill-switch) rollout; follow-ups (not blockers): tenant-attribution audit,
-100k-scale projection test, real access-tier threading. Evidence:
-`docs/_internal/status/TD_DOC_CONV_2_BAKE_RESULTS_2026_07_06.adoc`; harness:
-`tests/documents_convergence_bake.rs`; ledger: `doc_conv2_bake_*` in `BENCHMARK_EVIDENCE.toml`.
+|Status|DEFAULT-ON LANDED 2026-07-07 (cutover step 3). Bake complete (all 4 criteria MEASURED-PASS,
+metering blocker CLOSED). `doc_canonical_vector_enabled` is now DEFAULT-ON with a global kill-switch
+(`PROXIMADB_DOC_CANONICAL_VECTOR=off`), and the flip is made mixed-write-safe by a capability check:
+`canonical_route` routes canonical only when the collection actually EXISTS as a vector collection
+(via new `RecordRoutePort::collection_exists`), so pure-document (non-vector) collections stay on the
+legacy path instead of hard-failing — no flag-day. Legacy read-fallback retained. Remaining:
+production widen/watch, then retire the legacy `document_wal` write path once all collections are
+converged (step 4); follow-ups: tenant-attribution audit, 100k-scale projection test, real
+access-tier threading. Evidence: `docs/_internal/status/TD_DOC_CONV_2_BAKE_RESULTS_2026_07_06.adoc`;
+harness: `tests/documents_convergence_bake.rs`; ledger: `doc_conv2_bake_*` in `BENCHMARK_EVIDENCE.toml`.
 |Priority|MEDIUM (the convergence value is unrealized until this lands)
 |Scope|FEAT
 |Date|2026-07-06

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -800,6 +800,22 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
         Ok(records)
     }
 
+    async fn collection_exists(&self, collection_id: &str, tenant: Option<&str>) -> bool {
+        // Resolve through the SAME catalog path the write path uses (so the answer matches
+        // whether an insert would resolve), tenant-scoped. Any error ⇒ false (fail toward
+        // the safe legacy path) so the default-ON document gate never hard-fails a write to
+        // a non-canonical collection.
+        let tenant_context = match self.collection_service.load_tenant_context(tenant) {
+            Ok(tc) => tc,
+            Err(_) => return false,
+        };
+        matches!(
+            self.resolve_collection_id_internal(collection_id, tenant_context.as_ref())
+                .await,
+            Ok(Some(_))
+        )
+    }
+
     async fn delete_records(
         &self,
         collection_id: &str,

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -135,24 +135,39 @@ pub struct DocumentService {
 /// generous but finite — a silent truncation past it would drop reads, so it is logged.
 const CANONICAL_DOC_SCAN_LIMIT: usize = 100_000;
 
-/// Runtime gate for the canonical-vector document route (ADR-009), **DEFAULT-OFF**.
+/// Runtime gate for the canonical-vector document route (ADR-009), **DEFAULT-ON**
+/// (post-bake cutover, TD-DOC-CONV-2). The bake proved recall / single-store /
+/// restart-recovery, and the write path now meters per-tenant; the default is flipped ON
+/// and shipped default-reversible via a global kill-switch.
 ///
-/// The route is enabled for `collection` when env `PROXIMADB_DOC_CANONICAL_VECTOR` is
-/// `1`/`true`/`on`/`all` (all collections), or a comma-separated list containing
-/// `collection`. Unset/empty ⇒ OFF ⇒ today's legacy `document_wal` behavior,
-/// bit-for-bit. Mirrors the graph modality's runtime feature gates; per-collection
-/// opt-in keeps the storage-format migration mixed-read-safe until baked.
+/// `PROXIMADB_DOC_CANONICAL_VECTOR`:
+/// * unset / empty / `1` / `true` / `on` / `all` / `*` ⇒ **ON** (default)
+/// * `0` / `false` / `off` / `none` ⇒ **OFF** for every collection — the global
+///   **kill-switch** (force back to the legacy path, e.g. to roll the cutover back)
+/// * a comma-separated list ⇒ ON **only** for the named collections (a partial-rollback
+///   scoping: unlisted collections are OFF)
+///
+/// NB this is only HALF the routing decision: the canonical route additionally requires
+/// the collection to actually exist as a canonical/vector collection (see
+/// [`DocumentService::canonical_route`]), so a pure-document (non-vector) collection stays
+/// on the legacy path even with the gate ON — the flip is mixed-read/write-safe, no
+/// flag-day. Legacy pre-cutover docs remain reachable via the read-fallback.
 pub fn doc_canonical_vector_enabled(collection: &str) -> bool {
     match std::env::var("PROXIMADB_DOC_CANONICAL_VECTOR") {
+        // Unset ⇒ ON (default-ON post-cutover).
+        Err(_) => true,
         Ok(raw) => {
             let raw = raw.trim();
             match raw.to_ascii_lowercase().as_str() {
-                "" => false,
-                "1" | "true" | "on" | "all" | "*" => true,
+                // Empty ⇒ treat as unset ⇒ ON.
+                "" | "1" | "true" | "on" | "all" | "*" => true,
+                // Global kill-switch ⇒ OFF for every collection (default-reversible).
+                "0" | "false" | "off" | "none" => false,
+                // Explicit allowlist ⇒ ON only for the listed collections; an explicit
+                // list is a deliberate scoping, so it overrides default-ON for the rest.
                 _ => raw.split(',').map(str::trim).any(|c| c == collection),
             }
         }
-        Err(_) => false,
     }
 }
 
@@ -332,16 +347,28 @@ impl DocumentService {
         let _ = self.record_route.set(record_route);
     }
 
-    /// Select the canonical-vector route for `collection` iff a route is wired AND the
-    /// runtime gate is ON for it (default-OFF). `None` ⇒ the legacy `document_wal` path.
-    /// The single decision point for the store-split cutover — every write/read branches
-    /// on this so gate-OFF is today's behavior, bit-for-bit.
-    fn canonical_route(
+    /// Select the canonical-vector route for `collection`, else `None` ⇒ legacy path. The single
+    /// decision point for the store-split cutover — every write/read branches on this. Three
+    /// conditions, all required (mixed-safe under the DEFAULT-ON gate, TD-DOC-CONV-2):
+    ///
+    /// 1. a canonical route is wired,
+    /// 2. the runtime gate is ON for `collection` (default-ON; kill-switch / allowlist honored),
+    /// 3. `collection` actually EXISTS as a canonical/vector collection.
+    ///
+    /// (3) is what makes default-ON safe: a pure-document (non-vector) collection — one never
+    /// created via REST v2 / DDL — is not resolvable canonically, so it stays on the legacy path
+    /// instead of hard-failing the canonical write (`insert_records` errors on an unresolvable
+    /// collection). Legacy pre-cutover docs stay reachable via the read-fallback.
+    async fn canonical_route(
         &self,
         collection: &str,
     ) -> Option<&Arc<dyn proximadb_runtime::RecordRoutePort>> {
         let route = self.record_route.get()?;
-        if doc_canonical_vector_enabled(collection) {
+        if !doc_canonical_vector_enabled(collection) {
+            return None;
+        }
+        let (tenant, clean_collection) = unscope_document_collection(collection);
+        if route.collection_exists(clean_collection, tenant).await {
             Some(route)
         } else {
             None
@@ -1063,7 +1090,7 @@ impl DocumentService {
         // visible cross-surface, metered, and stored once. The legacy `document_wal`/DashMap
         // is skipped on this path (the vector WAL owns recovery); pre-cutover docs stay
         // reachable via the read-fallback in `get_document`/`query_documents`.
-        if let Some(route) = self.canonical_route(collection) {
+        if let Some(route) = self.canonical_route(collection).await {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             let proxima = Self::canonical_document_record(&record, clean_collection, tenant);
             match route
@@ -1175,7 +1202,7 @@ impl DocumentService {
         // (mixed-read-safe). Note: no `get_collection` existence gate here — a canonical
         // collection may live only in the record/vector catalog (e.g. created + written via
         // REST v2), never in this facade's own map.
-        if let Some(route) = self.canonical_route(collection) {
+        if let Some(route) = self.canonical_route(collection).await {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             if let Some(mut doc) = route
                 .get_record(clean_collection, id, tenant)
@@ -1337,7 +1364,7 @@ impl DocumentService {
 
         // ADR-009 canonical-vector route: write the updated document back to the shared
         // vector store (upsert on the raw-id OID) so the update is visible cross-surface.
-        if let Some(route) = self.canonical_route(collection) {
+        if let Some(route) = self.canonical_route(collection).await {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             let proxima = Self::canonical_document_record(&record, clean_collection, tenant);
             match route
@@ -1667,7 +1694,7 @@ impl DocumentService {
         // ADR-009 canonical-vector route: tombstone in the shared vector store (visible
         // cross-surface), and also drop any pre-cutover legacy copy under the scoped key so
         // it cannot resurface (mixed-read-safe). Returns true if either store held the doc.
-        if let Some(route) = self.canonical_route(collection) {
+        if let Some(route) = self.canonical_route(collection).await {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             let deleted = route
                 .delete_records(clean_collection, vec![id.to_string()], tenant)
@@ -1792,7 +1819,7 @@ impl DocumentService {
         // (cross-surface visibility), then run the same in-memory query executor. A queried
         // collection is either opted-in (canonical) or not; pre-cutover point reads stay
         // served by `get_document`'s legacy fallback.
-        if let Some(route) = self.canonical_route(collection) {
+        if let Some(route) = self.canonical_route(collection).await {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             let records = route
                 .scan_records(clean_collection, CANONICAL_DOC_SCAN_LIMIT, tenant)
@@ -1931,7 +1958,9 @@ impl DocumentService {
 
         // Get all documents from the collection — the shared vector store when routed
         // (ADR-009 cross-surface visibility), else the legacy in-memory map.
-        let documents: Vec<DocumentRecord> = if let Some(route) = self.canonical_route(collection) {
+        let documents: Vec<DocumentRecord> = if let Some(route) =
+            self.canonical_route(collection).await
+        {
             let (tenant, clean_collection) = unscope_document_collection(collection);
             let records = route
                 .scan_records(clean_collection, CANONICAL_DOC_SCAN_LIMIT, tenant)
@@ -2826,6 +2855,10 @@ mod tests {
     #[derive(Default)]
     struct MockRecordRoute {
         store: std::sync::Mutex<HashMap<String, HashMap<String, proximadb_records::ProximaRecord>>>,
+        /// Collections the mock should report as NON-canonical (so `canonical_route` sends them
+        /// to the legacy path). Empty ⇒ every collection is treated as an existing canonical
+        /// collection — the common case for the convergence tests.
+        non_canonical: std::sync::Mutex<std::collections::HashSet<String>>,
     }
 
     #[async_trait::async_trait]
@@ -2887,6 +2920,15 @@ mod tests {
             }
             Ok(n)
         }
+
+        async fn collection_exists(&self, collection_id: &str, _tenant: Option<&str>) -> bool {
+            // Every collection is canonical unless a test explicitly marks it non-canonical.
+            !self
+                .non_canonical
+                .lock()
+                .expect("mock route lock")
+                .contains(collection_id)
+        }
     }
 
     /// Scope the process-global `PROXIMADB_DOC_CANONICAL_VECTOR` gate to one collection for
@@ -2897,8 +2939,14 @@ mod tests {
     impl GateGuard {
         fn on(collection: &str) -> Self {
             // SAFETY (edition 2024): under nextest each test owns its process, so this env
-            // mutation is single-threaded; the value is a fixed collection name.
+            // mutation is single-threaded; the value is a fixed collection name (allowlist mode).
             unsafe { std::env::set_var("PROXIMADB_DOC_CANONICAL_VECTOR", collection) };
+            Self
+        }
+        /// Force the global kill-switch OFF (the gate is DEFAULT-ON, so a test that wants the
+        /// legacy path must explicitly force OFF).
+        fn off() -> Self {
+            unsafe { std::env::set_var("PROXIMADB_DOC_CANONICAL_VECTOR", "off") };
             Self
         }
     }
@@ -2993,8 +3041,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gate_off_keeps_legacy_path_and_ignores_route() {
-        // No GateGuard ⇒ gate OFF ⇒ today's behavior, bit-for-bit.
+    async fn kill_switch_forces_legacy_path_and_ignores_route() {
+        // The gate is DEFAULT-ON, so force the global kill-switch OFF to exercise the legacy path.
+        let _gate = GateGuard::off();
         let svc = service_with_collection("legacy_docs").await;
         let route = Arc::new(MockRecordRoute::default());
         svc.set_record_route(route.clone());
@@ -3006,10 +3055,40 @@ mod tests {
         // The shared store was NOT touched; the legacy map serves the doc.
         assert!(
             route.store.lock().expect("lock").is_empty(),
-            "gate OFF must not route to the shared store"
+            "kill-switch OFF must not route to the shared store"
         );
         let got = svc
             .get_document("legacy_docs", "d1", None)
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(got.id, "d1");
+    }
+
+    #[tokio::test]
+    async fn default_on_but_non_canonical_collection_stays_legacy() {
+        // Gate DEFAULT-ON (no guard), route wired — but the collection is NOT a canonical vector
+        // collection, so the mixed-write-safe capability check must keep it on the legacy path
+        // (a pure-document collection must not hard-fail the canonical write under default-ON).
+        let svc = service_with_collection("plain_docs").await;
+        let route = Arc::new(MockRecordRoute::default());
+        route
+            .non_canonical
+            .lock()
+            .expect("lock")
+            .insert("plain_docs".to_string());
+        svc.set_record_route(route.clone());
+
+        svc.insert_document_record("plain_docs", doc_record("d1", "plain_docs", "Delta"))
+            .await
+            .expect("legacy insert for non-canonical collection");
+
+        assert!(
+            route.store.lock().expect("lock").is_empty(),
+            "a non-canonical collection must stay on the legacy path even with the gate ON"
+        );
+        let got = svc
+            .get_document("plain_docs", "d1", None)
             .await
             .expect("get")
             .expect("present");

--- a/tests/documents_convergence_bake.rs
+++ b/tests/documents_convergence_bake.rs
@@ -760,9 +760,10 @@ async fn bake_single_store_no_double_gb_month() {
         sleep(Duration::from_millis(500)).await;
     }
 
-    // --- Legacy path (gate OFF) — gRPC CreateDocument writes to document_wal ---
+    // --- Legacy path — gRPC CreateDocument on a NON-canonical collection ---
     {
-        // No GateGuard ⇒ gate OFF ⇒ legacy document_wal path.
+        // legacy_coll is never created as a vector collection, so under the DEFAULT-ON gate the
+        // capability check keeps it on the legacy path (mixed-write-safe), not the canonical route.
         let mut client = ProximaDocumentServiceClient::connect(server.grpc())
             .await
             .expect("gRPC connect");

--- a/tests/documents_convergence_e2e.rs
+++ b/tests/documents_convergence_e2e.rs
@@ -9,7 +9,7 @@
 //! - **Gate ON** (`PROXIMADB_DOC_CANONICAL_VECTOR` = collection): a document ingested via
 //!   REST v2 is visible to a gRPC `GetDocument` — one store, cross-surface. This is the
 //!   headline convergence claim.
-//! - **Gate OFF** (default): the gRPC/`DocumentService` legacy path round-trips unchanged
+//! - **Legacy path** (non-canonical collection, or kill-switch): the gRPC/`DocumentService` legacy path round-trips unchanged
 //!   (create → get), proving the default-OFF gate preserves today's behavior.
 //!
 //! One ProximaDB boot per process (the WAL manifest is a set-once singleton); nextest runs
@@ -243,10 +243,12 @@ async fn rest_ingested_document_is_visible_via_grpc_when_gate_on() {
     assert_eq!(doc.id, "doc-1", "gRPC sees the REST-ingested document id");
 }
 
-/// Gate OFF (default): the gRPC/DocumentService legacy path round-trips unchanged
-/// (create → get), so the default-OFF gate preserves today's behavior bit-for-bit.
+/// Legacy path for a NON-canonical collection: the gate is DEFAULT-ON, but `legacydocs*` is never
+/// created as a vector collection, so the mixed-write-safe capability check keeps the
+/// gRPC/DocumentService write on the legacy path (create → get round-trips unchanged). This proves
+/// default-ON does not hard-fail pure-document collections.
 #[tokio::test]
-async fn grpc_document_round_trips_on_legacy_path_when_gate_off() {
+async fn grpc_document_round_trips_on_legacy_path_for_non_canonical_collection() {
     let server = TestServer::start().await.expect("server start");
     let collection = format!("legacydocs{}", server.grpc_port);
     let mut client =


### PR DESCRIPTION
## What

**TD-DOC-CONV-2 cutover step 3**: flip the document canonical-vector route to **DEFAULT-ON**, shipped reversible via a kill-switch, and made **mixed-write-safe** so it does not regress pure-document collections.

Follows #718 (bake + metering fix, merged), which proved recall / single-store / restart-recovery and closed the per-tenant metering blocker.

## Gate semantics (`doc_canonical_vector_enabled`)

| `PROXIMADB_DOC_CANONICAL_VECTOR` | Behavior |
|---|---|
| unset / `""` / `on` / `all` / `1` / `true` | **ON** (default) |
| `0` / `false` / `off` / `none` | **OFF** — global kill-switch (default-reversible) |
| `"colA,colB"` | ON only for listed (partial-rollback scoping) |

## The safety: capability-aware routing (why default-ON doesn't regress)

A naive gate-only flip would break gRPC document writes to **non-vector** collections: `handle_record_batch_for_tenant` returns "Collection not found", and the canonical write branch propagates it (no fallback). So this PR makes `canonical_route` route canonical **only when the collection actually exists as a canonical/vector collection** — via a new `RecordRoutePort::collection_exists` (resolved through the same catalog path a write uses). A pure-document collection (never created via REST v2/DDL) stays on the legacy path instead of hard-failing. Reads already fell back on miss; this makes writes consistent. Legacy read-fallback retained — no flag-day.

## Changes

- `crates/platform/proximadb-runtime/…/record_route_port.rs`: `+ async fn collection_exists`
- `src/api_handlers/record_ops_service.rs`: impl via `resolve_collection_id_internal` (fail-safe ⇒ `false`)
- `src/storage/document/service.rs`: gate default-ON + kill-switch; `canonical_route` async + capability-gated (6 callers `.await`); mock + unit tests
- `tests/…_e2e.rs`, `tests/…_bake.rs`: reflect capability-driven legacy routing under default-ON

## Verified (all under default-ON)

- doc-service unit tests **3/3** (kill-switch forces legacy; default-ON keeps a non-canonical collection on legacy; canonical routing intact)
- bake suite **4/4** — metering write ≈64 KB, recall@10 = 1.000, recovery 500/500, 0 `document_wal` bytes
- `documents_convergence` e2e **5/5** — incl. non-canonical collection staying legacy (mixed-write-safety)
- `fmt` · `clippy --lib --bins -- -D warnings` (exit 0) · workspace-boundaries · layering — green; **server binary builds**

## Remaining (TD-DOC-CONV-2)

Production widen/watch, then retire the legacy `document_wal` write path (step 4). Follow-ups: tenant-attribution audit, 100k-scale projection test, real access-tier threading.
