### PR TITLE
perf(olap): metadata-first aggregates — elide MIN/MAX/COUNT(col) from parquet footer (TD-OLAP-4)

### DIFF
--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -27,6 +27,52 @@ apples-to-apples comparison for ProximaDB (a Parquet-backed, DataFusion-engined
 system) is **DataFusion-Parquet vs DuckDB-Parquet ≈ 42–46 s vs 32 s — i.e. DuckDB
 ~1.3–1.4× faster**, NOT an order of magnitude.
 
+== FINAL on-this-machine head-to-head (post PR-2+PR-3, 1M ClickBench, RELEASE)
+
+Both engines over the **same** `cb_hits_1m_lc.parquet` on this workstation:
+ProximaDB through the pgwire router → DataFusion external table (value-bounds gate
+ON); DuckDB v1.4.4 CLI `read_parquet(...)`. 35/43 both-ok (the 8 skips are the same
+pre-existing unsupported queries q19/q37–q43).
+
+[cols="2,1,1,1",options="header"]
+|===
+| metric | ProximaDB | DuckDB | ratio
+| median wall (35q) | 59 ms | 32 ms | **1.84×**
+| total wall (35q)  | 2,167 ms | 1,320 ms | **1.64×**
+| q07 `MIN/MAX(EventDate)` | 49 ms (footer, 1 GET) | 14 ms | 3.5× (both tiny)
+|===
+
+**ProximaDB is FASTER than DuckDB on 6/35** (q01/q24/q25/q26/q27/q28): metadata
+elision + fast paths answer these before DuckDB finishes opening the file (e.g.
+q25–q27: 0–1 ms vs 17–27 ms). The 1.84× median is not an engine deficit — DataFusion
+IS the engine — it is the two fixed overheads below.
+
+=== What the io-trace says to fix next (evidence-ranked)
+
+1. **The ~45 ms per-query OPEN+PLAN floor (top median lever).** Footer-only queries
+   read ≤0.5 MB yet still take ~47–49 ms (q07 49 ms/0.5 MB, q01 49 ms, q20 47 ms),
+   while a *26 MB* scan (q28) finishes in **35 ms** — proving the median gap is
+   **fixed per-query cost (external-table LIST+footer open + DataFusion re-plan +
+   pgwire), not I/O bytes**. DuckDB's floor is lower. Fix = the deferred **re-open
+   cache** (cache `Arc<ObjectStoreParquetTable>` — schema+splits+footer-stats — by
+   (tenant, location), env-gated, snapshot-LSN invalidation) **+ a plan cache**, so
+   repeat queries skip the open and the re-plan. This is now the #1 lever (was
+   mis-ranked as a minor S3-RTT optimization; the trace shows it dominates the fast
+   queries where DuckDB wins).
+2. **Read-GET fragmentation (S3-RTT lever).** Even after projection, scans fragment
+   into many small GETs: q31/q32 = 55, q10/q23/q33 = 46. Locally cheap, but on
+   object storage each GET is an RTT + per-request fee. Fix = set the parquet
+   reader's coalescing window toward the 8–16 MiB S3 optimum (codesign §2.1); the
+   arrow-rs default clearly isn't collapsing these.
+3. **q23 wide-string scan (worst single ratio, 4.0×).** 49 MB / 46 GETs / 190 ms vs
+   DuckDB 48 ms — the URL column. Projection already applied (49 MB IS the one
+   column); the residual is genuine wide-`Utf8` compute + fragmentation (overlaps
+   lever 2). Lower priority — real work, not overhead.
+
+Net: PR-2 (metering truth) + PR-3 (metadata elision) closed the outlier and the
+phantom I/O; the **remaining 1.84× median is fixed open+plan overhead**, which the
+re-open+plan cache targets directly — the next PR.
+
 == Where the gap decomposes (first principles)
 
 ProximaDB's OLAP engine *is* DataFusion, so its ClickBench-Parquet ceiling ≈
@@ -219,8 +265,10 @@ elision works), narrow queries ~5 MB (projection works), wide-string queries
 vs DuckDB (~2.2× median) is now clearly **compute + pgwire, not I/O** — dominated
 by the **q07 UInt16 MIN/MAX 10 s outlier** (reads only 5 MB; pure compute). So the
 next levers are the metadata-aggregate elision (MIN/MAX from footer) and the q07
-UInt16 compute pathology — NOT an I/O "open floor" (which never existed). The
-re-open cache drops to a minor S3-RTT optimization (`head` is cheap locally).
+UInt16 compute pathology — NOT an I/O "open floor" (which never existed). [NOTE:
+the head-to-head below revised this — after elision, a *wall* open+plan floor
+(~45 ms, fixed per-query, not I/O) IS the dominant median gap, so the re-open cache
+is promoted to the #1 next lever, joined by a plan cache. See the head-to-head.]
 
 === PR-3 MEASURED — MIN/MAX metadata elision kills the q07 outlier
 

--- a/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
+++ b/docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc
@@ -222,6 +222,36 @@ next levers are the metadata-aggregate elision (MIN/MAX from footer) and the q07
 UInt16 compute pathology — NOT an I/O "open floor" (which never existed). The
 re-open cache drops to a minor S3-RTT optimization (`head` is cheap locally).
 
+=== PR-3 MEASURED — MIN/MAX metadata elision kills the q07 outlier
+
+The parquet footer carries exact per-column min/max/null_count. PR-3 reports them
+`Precision::Exact` from `statistics_from_splits` (numeric min/max only — string
+BYTE_ARRAY stats are truncated, so they stay `Inexact`; `null_count` is exact for
+every type). DataFusion's `AggregateStatistics` rule then answers unfiltered
+`MIN`/`MAX`/`COUNT(col)` from metadata with no column scan.
+
+Measured (release, 1M ClickBench, `cb_hits_1m_lc.parquet`, `eventdate`=UInt16,
+`PROXIMADB_DF_STATS_VALUE_BOUNDS=1`):
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| query | baseline wall | PR-3 wall | PR-3 bytes_read | GETs
+| q07 `MIN/MAX(EventDate)` | 10,059 ms | **50 ms** (201×) | 524 KB (footer only) | 1
+| suite total (43) | 12,462 ms | **2,524 ms** (4.9×) | — | —
+|===
+
+Correctness: **35/43 ok — identical pass set to baseline, zero new failures** (the
+8 failures are pre-existing unsupported queries q19/q37–q43). q07 now reads only
+the footer (1 GET, no column data) and returns the same result. This is the direct
+generalization of the shipped exact-`num_rows` → `COUNT(*)` elision (#722).
+
+Gate posture: `null_count: Exact` (→ `COUNT(col)`) is unconditional. Numeric
+`min`/`max: Exact` (→ `MIN`/`MAX`) is emitted under `PROXIMADB_DF_STATS_VALUE_BOUNDS`
+(default OFF) — the gate exists for the *filter-selectivity recursion* on
+TPC-H-Q2-class plans, unrelated to this non-recursive aggregate elision. Flipping
+the gate default (delivering q07 out-of-the-box) is a follow-up pending that
+recursion characterization; PR-3 wires the mechanism and proves it end-to-end.
+
 === Deferred to follow-up PRs (need gating / invalidation design)
 
 * **Per-query re-open cache (was "Phase B").** A read-through cache of

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -1307,7 +1307,9 @@ mod tests {
         assert_eq!(stats.num_rows, Precision::Exact(4));
         // Schema-width contract: one entry per table column.
         assert_eq!(stats.column_statistics.len(), 2);
-        assert_eq!(stats.column_statistics[1].null_count, Precision::Inexact(0));
+        // `null_count` is exact footer metadata → `Exact` (gate-independent; enables
+        // `COUNT(col)` elision).
+        assert_eq!(stats.column_statistics[1].null_count, Precision::Exact(0));
         assert_eq!(
             stats.column_statistics[1].min_value,
             Precision::Absent,
@@ -1325,16 +1327,16 @@ mod tests {
             k.max_value,
             Precision::Inexact(DfScalarValue::Utf8(Some("b".to_string())))
         );
+        // Numeric column: parquet min/max are exact → `Exact` (elidable MIN/MAX);
+        // null_count exact for every type. (The string column `k` above stays
+        // Inexact — parquet truncates BYTE_ARRAY stats.)
         let x = &full.column_statistics[1];
-        assert_eq!(
-            x.min_value,
-            Precision::Inexact(DfScalarValue::Int64(Some(1)))
-        );
+        assert_eq!(x.min_value, Precision::Exact(DfScalarValue::Int64(Some(1))));
         assert_eq!(
             x.max_value,
-            Precision::Inexact(DfScalarValue::Int64(Some(101)))
+            Precision::Exact(DfScalarValue::Int64(Some(101)))
         );
-        assert_eq!(x.null_count, Precision::Inexact(0));
+        assert_eq!(x.null_count, Precision::Exact(0));
     }
 
     /// TD-OLAP-3 slice A: with `supports_filters_pushdown` (Inexact), a WHERE

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -173,14 +173,37 @@ pub fn statistics_from_splits(
             // this column — a partially-covered column would understate.
             if covered == splits.len() && covered > 0 {
                 if include_value_bounds {
+                    // Parquet min/max are EXACT for numeric columns but TRUNCATED
+                    // for BYTE_ARRAY (string/binary) — a truncated string bound is a
+                    // prefix, not the true value. Report `Exact` only for numeric
+                    // types so DataFusion's `AggregateStatistics` rule can elide
+                    // `MIN`/`MAX` from the footer (e.g. ClickBench q07's
+                    // `MIN/MAX(EventDate)`, a 10 s scan today); keep string bounds
+                    // `Inexact` (zone-map pruning only). A `WHERE` inserts a
+                    // `FilterExec` that re-marks stats Inexact, so filtered
+                    // aggregates still scan; the ADR-025 delta-merge path uses its
+                    // own MemTable, never this provider.
+                    let numeric = field.data_type().is_numeric();
                     if let Some(min) = min {
-                        cs.min_value = Precision::Inexact(min);
+                        cs.min_value = if numeric {
+                            Precision::Exact(min)
+                        } else {
+                            Precision::Inexact(min)
+                        };
                     }
                     if let Some(max) = max {
-                        cs.max_value = Precision::Inexact(max);
+                        cs.max_value = if numeric {
+                            Precision::Exact(max)
+                        } else {
+                            Precision::Inexact(max)
+                        };
                     }
                 }
-                cs.null_count = Precision::Inexact(nulls);
+                // `null_count` from the footer is exact metadata (not a truncatable
+                // bound), so report `Exact` unconditionally — this lets the rule
+                // answer `COUNT(col)` as `num_rows − null_count` with no scan,
+                // independent of the value-bounds gate above.
+                cs.null_count = Precision::Exact(nulls);
             }
             if let Some(ndv) = registry_fields
                 .iter()
@@ -223,6 +246,14 @@ pub fn statistics_from_splits(
 /// is already borderline on some environments. Enable with
 /// `PROXIMADB_DF_STATS_VALUE_BOUNDS=1` once that recursion depth is
 /// characterized; row/null/NDV statistics flow regardless.
+///
+/// When ON, numeric bounds are reported `Exact` (see `statistics_from_splits`),
+/// which additionally unlocks the *non-recursive* `AggregateStatistics` rule to
+/// elide unfiltered `MIN`/`MAX` from the footer (e.g. ClickBench q07's
+/// `MIN/MAX(EventDate)` — a 10 s full scan today answered from metadata). That
+/// aggregate-elision path is unrelated to the filter-selectivity recursion that
+/// keeps the default OFF; `COUNT(col)` elision (via exact `null_count`) is wired
+/// unconditionally and needs no gate.
 pub fn df_stats_value_bounds_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
@@ -602,17 +633,21 @@ mod tests {
         // Schema-width contract (DataFusion 54 indexes by column position).
         assert_eq!(stats.column_statistics.len(), schema.fields().len());
 
+        // Numeric column: parquet min/max are exact → `Exact` (elidable MIN/MAX);
+        // null_count is exact footer metadata → `Exact`.
         let x = &stats.column_statistics[0];
         assert_eq!(
             x.min_value,
-            Precision::Inexact(DfScalarValue::Int64(Some(-5)))
+            Precision::Exact(DfScalarValue::Int64(Some(-5)))
         );
         assert_eq!(
             x.max_value,
-            Precision::Inexact(DfScalarValue::Int64(Some(10)))
+            Precision::Exact(DfScalarValue::Int64(Some(10)))
         );
-        assert_eq!(x.null_count, Precision::Inexact(2));
+        assert_eq!(x.null_count, Precision::Exact(2));
 
+        // String column: parquet BYTE_ARRAY min/max are truncated → stay `Inexact`
+        // (zone-map pruning only); null_count is still exact → `Exact`.
         let name = &stats.column_statistics[1];
         assert_eq!(
             name.min_value,
@@ -622,7 +657,7 @@ mod tests {
             name.max_value,
             Precision::Inexact(DfScalarValue::Utf8(Some("z".to_string())))
         );
-        assert_eq!(name.null_count, Precision::Inexact(1));
+        assert_eq!(name.null_count, Precision::Exact(1));
     }
 
     #[test]
@@ -693,9 +728,51 @@ mod tests {
         // Bounds suppressed (the recursive interval-analysis trigger)…
         assert_eq!(x.min_value, Precision::Absent);
         assert_eq!(x.max_value, Precision::Absent);
-        // …but the join-ordering inputs still flow.
-        assert_eq!(x.null_count, Precision::Inexact(3));
+        // …but the join-ordering inputs still flow — null_count is exact footer
+        // metadata (COUNT(col) elision is independent of the value-bounds gate).
+        assert_eq!(x.null_count, Precision::Exact(3));
         assert_eq!(stats.num_rows, Precision::Exact(2));
+    }
+
+    #[test]
+    fn statistics_from_splits_numeric_bounds_exact_string_inexact() {
+        // The MIN/MAX metadata-elision contract: DataFusion's `AggregateStatistics`
+        // rule elides `MIN`/`MAX` only when the column bound is `Exact`. Parquet
+        // numeric stats are exact, so those must be `Exact` (killing ClickBench
+        // q07's `MIN/MAX(EventDate)` scan); BYTE_ARRAY (string) stats are truncated
+        // prefixes, so they must stay `Inexact` — an elided string MIN/MAX off a
+        // truncated bound would be WRONG.
+        let schema = ArrowSchema::new(vec![
+            Field::new("f", ArrowDataType::Float64, false),
+            Field::new("s", ArrowDataType::Utf8, true),
+        ]);
+        let splits = vec![split_with_bounds(
+            4,
+            40,
+            &[
+                ("f", serde_json::json!(1.5), serde_json::json!(9.5), 0),
+                ("s", serde_json::json!("aaa"), serde_json::json!("zzz"), 2),
+            ],
+        )];
+
+        let stats = statistics_from_splits(&splits, &schema, None, true);
+
+        let f = &stats.column_statistics[0];
+        assert_eq!(
+            f.min_value,
+            Precision::Exact(DfScalarValue::Float64(Some(1.5)))
+        );
+        assert_eq!(
+            f.max_value,
+            Precision::Exact(DfScalarValue::Float64(Some(9.5)))
+        );
+        assert_eq!(f.null_count, Precision::Exact(0));
+
+        let s = &stats.column_statistics[1];
+        assert!(matches!(s.min_value, Precision::Inexact(_)));
+        assert!(matches!(s.max_value, Precision::Inexact(_)));
+        // null_count is exact metadata for every column type.
+        assert_eq!(s.null_count, Precision::Exact(2));
     }
 
     #[test]


### PR DESCRIPTION
## What

Metadata-first aggregates for the single-node OLAP path (DataFusion over
parquet-backed / external tables via the pgwire router), TD-OLAP-4. The parquet
**footer is a materialized statistics index** — exact per-column
`min`/`max`/`null_count` computed once at write time. This reports those exact
values so DataFusion's `AggregateStatistics` physical rule answers aggregates
**from the footer with no column scan**, the same principle as the already-merged
exact-`num_rows` → `COUNT(*)` elision (#722). Correctness-neutral; guarded.

## Changes (`src/datafusion/schema_inference.rs`)

1. **`null_count: Exact` (gate-free).** Footer `null_count` is exact metadata (not
   a truncatable bound), so it is now reported `Precision::Exact` for every column
   type. This lets the rule answer `COUNT(col)` as `num_rows − null_count` with
   **zero scan**, independent of the value-bounds gate.
2. **Numeric `min`/`max: Exact` (under the existing `PROXIMADB_DF_STATS_VALUE_BOUNDS`
   gate).** Parquet numeric stats are exact, so numeric bounds are reported `Exact`
   → the `AggregateStatistics` rule elides unfiltered `MIN`/`MAX` from the footer.
   This is the fix for **ClickBench q07 = `MIN/MAX(EventDate)`**, today a **10 s full
   scan = 82% of the 1M suite wall**, answered from metadata.

## Guards (why this is correct)

- **String bounds stay `Inexact`.** Parquet TRUNCATES `BYTE_ARRAY` (string/binary)
  min/max to a prefix — an elided string `MIN`/`MAX` off a truncated bound would be
  WRONG. Only `is_numeric()` types get `Exact`.
- **Full coverage only.** Bounds/nulls are claimed only when EVERY split carries
  footer stats for the column (pre-existing `covered == splits.len()` guard).
- **Filtered aggregates still scan.** A `WHERE` inserts a `FilterExec` that re-marks
  stats `Inexact`, so `MIN`/`MAX`/`COUNT` over a predicate are unaffected.
- **Delta-merge unaffected.** The ADR-025 delta-merge path builds its own MemTable
  when a WAL delta exists and never uses this footer-accurate provider — same
  reasoning as the shipped exact-`num_rows` change.

## Gate note

The value-bounds gate stays **default-OFF**: it also enables DataFusion's recursive
interval-based *filter-selectivity* analysis (a TPC-H-Q2-class debug-build stack
concern), which is unrelated to the non-recursive `AggregateStatistics` elision.
The `COUNT(col)` win (exact `null_count`) needs no gate and is always on; the
`MIN`/`MAX` win activates when the gate is flipped, which stays a follow-up pending
the recursion characterization.

## Tests

- Updated `statistics_from_splits_merges_bounds_schema_width` /
  `statistics_from_splits_gates_value_bounds_off` for the new `Exact` precision.
- New `statistics_from_splits_numeric_bounds_exact_string_inexact` pins the
  elision contract: numeric bounds `Exact`, string bounds `Inexact`, `null_count`
  `Exact` for both.

Builds on #725 (accurate byte-ledger) + #722. Evidence:
`docs/_internal/status/CLICKBENCH_CODESIGN_PHASE_A_2026_07_06.adoc`.
