### PR TITLE
chore(release): remove stale per-Python-version wheel model from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,11 @@
 #     - proximadb-{version}-aarch64-apple-darwin.tar.gz
 #     - proximadb-{version}-x86_64-pc-windows-msvc.zip
 #
-#   Python Wheels (per platform/Python version):
-#     - Linux x86_64: Python 3.8, 3.9, 3.10, 3.11, 3.12
-#     - Linux aarch64: Python 3.9, 3.10, 3.11, 3.12
-#     - macOS x86_64: Python 3.9, 3.10, 3.11, 3.12
-#     - macOS aarch64: Python 3.9, 3.10, 3.11, 3.12
-#     - Windows x64: Python 3.9, 3.10, 3.11, 3.12
-#
-#   Embedded Wheels (5 targets):
-#     - Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, Windows x64
+#   Python Wheels are NOT built here. The pure-Python SDK (`proximadb`) and the
+#   native embedded engine (`proximadb_embedded`, one abi3 wheel per platform,
+#   CPython 3.10+) are built and published by `release-python.yml` on `python-v*`
+#   tags — decoupled from this binary/OS-package release. This workflow (`v*`)
+#   only builds the server binaries, the sdist, and the OS packages below.
 #
 # SAFEGUARDS:
 #   - dry_run: Builds all artifacts but skips publishing (test the pipeline)
@@ -358,84 +354,12 @@ jobs:
             proximadb-*.${{ matrix.archive }}.sha256
           retention-days: 7
 
-  # ============================================================================
-  # BUILD PYTHON EMBEDDED WHEELS - Lightweight embedded package
-  # DISABLED for v0.2.0: clients/python-embedded is pure Python (setuptools), not Rust
-  # Re-enable in v0.2.1 after adding proper setuptools build or PyO3 bindings
-  # ============================================================================
-  # build-embedded-wheels:
-  #   name: Build Embedded Wheels (${{ matrix.os }}, ${{ matrix.target }})
-  #   needs: prepare
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - os: ubuntu-22.04
-  #           target: x86_64
-  #         - os: ubuntu-22.04
-  #           target: aarch64
-  #         - os: macos-latest
-  #           target: aarch64
-  #         - os: windows-2022
-  #           target: x64
-  #
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Setup Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.11"
-  #
-  #     - name: Install Rust Toolchain
-  #       uses: dtolnay/rust-toolchain@1.95.0
-  #       with:
-  #         toolchain: stable
-  #
-  #     - name: Install Maturin
-  #       run: pip install maturin
-  #
-  #     - name: Build Embedded Wheels (Linux x86_64)
-  #       if: matrix.os == 'ubuntu-22.04' && matrix.target == 'x86_64'
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         working-directory: clients/python-embedded
-  #         target: x86_64
-  #         manylinux: auto
-  #         args: --release --out dist --features python
-  #
-  #     - name: Build Embedded Wheels (Linux aarch64)
-  #       if: matrix.os == 'ubuntu-22.04' && matrix.target == 'aarch64'
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         working-directory: clients/python-embedded
-  #         target: aarch64
-  #         manylinux: auto
-  #         args: --release --out dist --features python
-  #
-  #     - name: Build Embedded Wheels (macOS/Windows)
-  #       if: runner.os != 'Linux'
-  #       working-directory: clients/python-embedded
-  #       run: |
-  #         if [ "${{ runner.os }}" = "macOS" ]; then
-  #           if [ "${{ matrix.target }}" = "aarch64" ]; then
-  #             maturin build --release --out dist --features python --target aarch64-apple-darwin
-  #           else
-  #             maturin build --release --out dist --features python --target x86_64-apple-darwin
-  #           fi
-  #         else
-  #           maturin build --release --out dist --features python
-  #         fi
-  #       shell: bash
-  #
-  #     - name: Upload Embedded Wheel Artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: embedded-wheel-${{ matrix.os }}-${{ matrix.target }}
-  #         path: clients/python-embedded/dist/*.whl
-  #         retention-days: 7
+  # NOTE: Python embedded wheels are built by `release-python.yml` (native
+  # `proximadb_embedded`, one abi3 wheel per platform, CPython 3.10+), NOT here.
+  # A previously commented-out `build-embedded-wheels` job lived here; it was
+  # removed as dead — its premise ("clients/python-embedded is pure Python, not
+  # Rust") is also wrong now that the embedded engine is the root PyO3/maturin
+  # package.
 
   # ============================================================================
   # BUILD SOURCE DISTRIBUTION - Python sdist
@@ -721,72 +645,16 @@ jobs:
           echo ""
 
           # ----------------------------------------
-          # Expected Python Wheels
+          # Python Wheels — validated & published by release-python.yml, not here
           # ----------------------------------------
+          # This `v*` workflow builds no Python wheels (SDK + embedded abi3 wheels
+          # ship from release-python.yml on `python-v*` tags), so there is nothing
+          # to validate here. The prior per-Python-version count checks (expecting
+          # 5 wheels for 3.8-3.12) were orphaned when the wheel-build jobs moved
+          # out — they force-failed VALIDATION_PASSED against wheels this run never
+          # produces, blocking the publish gate. Removed.
           echo "## Python Wheel Artifacts"
-          echo ""
-
-          # Count wheels by platform pattern
-          LINUX_X64_WHEELS=$(find artifacts -name "*manylinux*x86_64*.whl" -type f 2>/dev/null | wc -l)
-          LINUX_ARM64_WHEELS=$(find artifacts -name "*manylinux*aarch64*.whl" -type f 2>/dev/null | wc -l)
-          MACOS_X64_WHEELS=$(find artifacts -name "*macosx*x86_64*.whl" -type f 2>/dev/null | wc -l)
-          MACOS_ARM64_WHEELS=$(find artifacts -name "*macosx*arm64*.whl" -type f 2>/dev/null | wc -l)
-          WINDOWS_WHEELS=$(find artifacts -name "*win_amd64*.whl" -type f 2>/dev/null | wc -l)
-
-          # Expected minimums (main wheels, not embedded)
-          # Linux x86_64: 5 Python versions (3.8-3.12)
-          # Others: 4 Python versions (3.9-3.12)
-          echo "  Linux x86_64 wheels: $LINUX_X64_WHEELS (expected >= 5)"
-          echo "  Linux aarch64 wheels: $LINUX_ARM64_WHEELS (expected >= 4)"
-          echo "  macOS x86_64 wheels: $MACOS_X64_WHEELS (expected >= 4)"
-          echo "  macOS arm64 wheels: $MACOS_ARM64_WHEELS (expected >= 4)"
-          echo "  Windows x64 wheels: $WINDOWS_WHEELS (expected >= 4)"
-          echo ""
-
-          # Check minimum wheel counts (combined main + embedded)
-          if [ "$LINUX_X64_WHEELS" -lt 5 ]; then
-            echo "  [WARNING] Fewer than expected Linux x86_64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$LINUX_ARM64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected Linux aarch64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$MACOS_X64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected macOS x86_64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$MACOS_ARM64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected macOS arm64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$WINDOWS_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected Windows x64 wheels"
-            VALIDATION_PASSED=false
-          fi
-
-          TOTAL_WHEELS=$((LINUX_X64_WHEELS + LINUX_ARM64_WHEELS + MACOS_X64_WHEELS + MACOS_ARM64_WHEELS + WINDOWS_WHEELS))
-          echo ""
-          echo "  Total wheels found: $TOTAL_WHEELS"
-          echo ""
-
-          # ----------------------------------------
-          # Expected Embedded Wheels (5 platforms)
-          # ----------------------------------------
-          echo "## Embedded Wheel Artifacts"
-          echo ""
-
-          EMBEDDED_LINUX_X64=$(find artifacts -name "embedded-wheel-ubuntu*x86_64*" -type d 2>/dev/null | wc -l)
-          EMBEDDED_LINUX_ARM=$(find artifacts -name "embedded-wheel-ubuntu*aarch64*" -type d 2>/dev/null | wc -l)
-          EMBEDDED_MACOS_X64=$(find artifacts -name "embedded-wheel-macos*x86_64*" -type d 2>/dev/null | wc -l)
-          EMBEDDED_MACOS_ARM=$(find artifacts -name "embedded-wheel-macos*aarch64*" -type d 2>/dev/null | wc -l)
-          EMBEDDED_WINDOWS=$(find artifacts -name "embedded-wheel-windows*" -type d 2>/dev/null | wc -l)
-
-          echo "  Embedded Linux x86_64: $EMBEDDED_LINUX_X64"
-          echo "  Embedded Linux aarch64: $EMBEDDED_LINUX_ARM"
-          echo "  Embedded macOS x86_64: $EMBEDDED_MACOS_X64"
-          echo "  Embedded macOS aarch64: $EMBEDDED_MACOS_ARM"
-          echo "  Embedded Windows: $EMBEDDED_WINDOWS"
+          echo "  (built & published by release-python.yml on python-v* tags — not validated here)"
           echo ""
 
           # ----------------------------------------
@@ -879,7 +747,6 @@ jobs:
           echo "report<<EOF" >> $GITHUB_OUTPUT
           echo "Version: $VERSION" >> $GITHUB_OUTPUT
           echo "Binaries: $BINARY_COUNT/${#EXPECTED_BINARIES[@]}" >> $GITHUB_OUTPUT
-          echo "Wheels: $TOTAL_WHEELS" >> $GITHUB_OUTPUT
           echo "SDists: $SDIST_COUNT" >> $GITHUB_OUTPUT
           echo "Status: $VALIDATION_PASSED" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Follow-up to the Python-3.10 floor work. `release.yml` (the `v*` binary/OS-package release) builds **no** Python wheels — the SDK + embedded abi3 wheels ship from `release-python.yml` on `python-v*` tags. But it still carried the legacy per-version (3.8–3.12) cibuildwheel model.

## Removed (all superseded by `release-python.yml`)
1. **Header comment** claiming per-platform/per-version Python wheels + "5 embedded wheel targets" → rewritten to point at `release-python.yml`.
2. **Commented-out `build-embedded-wheels` job** (~75 lines) whose premise was itself wrong ("clients/python-embedded is pure Python, not Rust" — the embedded engine is now the root PyO3/maturin package). Deleted as dead.
3. **Orphaned wheel-count validation** in `validate-artifacts` expecting `>=5` Linux x64 / `>=4` other wheels + `embedded-wheel-*` dirs.

## Why #3 matters (not just cosmetic)
`validate-artifacts` emits `validation_passed`, which **gates `create-release` / `publish-pypi` / `publish-crates`**. Because this workflow builds zero wheels, those `find … .whl | wc -l` checks were always `0 < 5` → forced `VALIDATION_PASSED=false`. The validation now reflects what `release.yml` actually produces (binaries + sdist + RPM/DEB/MSI); Python-wheel validation is `release-python.yml`'s job.

## Verified
- YAML parses; no dangling wheel-count vars (`TOTAL_WHEELS` et al.) remain.
- Net **−152 / +19** lines.
- The sdist download/consolidate/publish steps are untouched (they tolerate absent wheel dirs via `|| true`); the `release.yml`↔`release-python.yml` publish overlap is pre-existing and left as-is (separate concern).