### PR TITLE
fix(gRPC): route SQL writes (DDL/DML) through a shared adapter dispatch (TD-135)

### DIFF
--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -686,7 +686,12 @@ impl ApiHandlersPort for UnifiedHandlers {
             })
             .collect();
 
-        let rows_returned = rows.len() as u64;
+        // TD-135: a write's affected count is carried in `rows_affected`; reads
+        // carry no such key and report the record count, unchanged.
+        let rows_returned = json_result
+            .get("rows_affected")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(rows.len() as u64);
         let rows_scanned = json_result
             .get("total_count")
             .and_then(|v| v.as_u64())

--- a/src/api_handlers/request_handlers.rs
+++ b/src/api_handlers/request_handlers.rs
@@ -2079,81 +2079,26 @@ impl UnifiedHandlers {
             // DmlService not wired — fall through to legacy path so EXPLAIN degrades gracefully.
         }
 
-        // TD-135: route relational WRITES (DDL + DML) through the same tenant-scoped
-        // service seams pgwire uses, instead of the legacy vector/graph engine which
-        // rejects them. Cheap leading-keyword guards avoid re-parsing read queries.
-        // The request tenant (x-tenant-id, threaded as `tenant_id`) scopes the write
-        // to its partition (TD-064); a None tenant writes unscoped, exactly as pgwire
-        // does for a connection with no `database` — never another tenant's partition.
+        // TD-135: route relational WRITES (DDL + DML) through the SHARED,
+        // tenant-scoped dispatch (also used by QueryFacadeAdapter — the gRPC port
+        // path), so REST and gRPC cannot diverge (TD-104 / seam S1, single SQL
+        // authority). Returns None for reads → fall through to TD-121 SELECT.
+        if let Some(rows_affected) = crate::query::facade::adapter::try_sql_write_dispatch(
+            &query,
+            tenant_id,
+            self.get_dml_service().as_ref(),
+            self.get_ddl_service().as_ref(),
+        )
+        .await?
         {
-            let leading = query.trim_start().get(..7).map(str::to_ascii_uppercase);
-            let leading = leading.as_deref().unwrap_or("");
-            // DDL: CREATE / ALTER / DROP.
-            if (leading.starts_with("CREATE ")
-                || leading.starts_with("ALTER ")
-                || leading.starts_with("DROP "))
-                && let Some(ddl) = self.get_ddl_service()
-            {
-                let parser = crate::query::sql_frontend::SqlFrontendParser::new();
-                match parser.parse_ddl(&query) {
-                    Ok(Some(statement)) => {
-                        let result = ddl
-                            .execute_scoped(statement, tenant_id)
-                            .await
-                            .map_err(|e| anyhow::anyhow!("DDL failed: {e}"))?;
-                        return Ok(crate::proto::proximadb_v1::ExecuteQueryResponse {
-                            rows: vec![],
-                            rows_scanned: 0,
-                            rows_returned: result.affected_count as u64,
-                            execution_time_ms: start_time.elapsed().as_millis() as u64,
-                            columns: vec![],
-                            column_types: vec![],
-                        });
-                    }
-                    Ok(None) => {}
-                    Err(e) => return Err(anyhow::anyhow!("DDL parse error: {e}")),
-                }
-            }
-            // DML writes: INSERT / UPDATE / DELETE (+ UPSERT/MERGE shapes via parse_dml).
-            if (leading.starts_with("INSERT ")
-                || leading.starts_with("UPDATE ")
-                || leading.starts_with("DELETE ")
-                || leading.starts_with("UPSERT ")
-                || leading.starts_with("MERGE "))
-                && let Some(dml) = self.get_dml_service()
-                && let Ok(Some(statement)) =
-                    crate::query::sql_frontend::SqlFrontendParser::new().parse_dml(&query)
-            {
-                use crate::services::dml::DmlStatement;
-                let is_write = matches!(
-                    statement,
-                    DmlStatement::Insert { .. }
-                        | DmlStatement::Update { .. }
-                        | DmlStatement::Delete { .. }
-                        | DmlStatement::Upsert { .. }
-                        | DmlStatement::InsertSelect { .. }
-                        | DmlStatement::InsertOverwrite { .. }
-                );
-                if is_write {
-                    let tenant_ctx = tenant_id
-                        .map(crate::storage::tenant::context::TenantContext::for_tenant_id);
-                    // Use `.context` (NOT `anyhow!("DML failed: {e}")`) so a typed
-                    // ProximaDBError::DmlLockConflict in the chain survives for the
-                    // protocol layer (gRPC/pgwire) to downcast + map to ABORTED/55P03.
-                    let result = dml
-                        .execute_scoped(statement, tenant_ctx.as_ref())
-                        .await
-                        .context("DML failed")?;
-                    return Ok(crate::proto::proximadb_v1::ExecuteQueryResponse {
-                        rows: vec![],
-                        rows_scanned: 0,
-                        rows_returned: result.rows_affected,
-                        execution_time_ms: start_time.elapsed().as_millis() as u64,
-                        columns: vec![],
-                        column_types: vec![],
-                    });
-                }
-            }
+            return Ok(crate::proto::proximadb_v1::ExecuteQueryResponse {
+                rows: vec![],
+                rows_scanned: 0,
+                rows_returned: rows_affected,
+                execution_time_ms: start_time.elapsed().as_millis() as u64,
+                columns: vec![],
+                column_types: vec![],
+            });
         }
 
         // TD-121: route RELATIONAL SQL through the same tenant-scoped relational

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -2115,14 +2115,21 @@ impl SharedServices {
             None => base_dml,
         });
 
+        // TD-135: one DdlService Arc shared by BOTH the adapter (gRPC port path →
+        // adapter.execute_sql) and request_handlers (REST), so DDL writes over
+        // either surface address the same catalog state and execute tenant-scoped.
+        let ddl_service =
+            std::sync::Arc::new(crate::services::DdlService::new(catalog_manager.clone()));
         // Wire QueryFacadeAdapter to UnifiedHandlers for unified SQL routing.
         // This enables SQL queries to flow through the facade when the
         // unified-facade-routing feature is enabled. The adapter carries the
-        // DmlService so the port path (runtime handler → adapter.execute_sql)
-        // reproduces ROOT's EXPLAIN `<DML>` routing (TD-104 / seam S1).
+        // DmlService (EXPLAIN `<DML>`) AND the DdlService (relational DDL) so the
+        // port path (runtime handler → adapter.execute_sql) reproduces ROOT's
+        // SQL behavior (TD-104 / seam S1, single SQL authority).
         let query_adapter = Arc::new(
             QueryFacadeAdapter::new(query_facade.clone())
-                .with_dml_service(dml_service_for_grpc.clone()),
+                .with_dml_service(dml_service_for_grpc.clone())
+                .with_ddl_service(ddl_service.clone()),
         );
         request_handlers.set_query_adapter(query_adapter.clone());
         debug!("✅ SharedServices::new - QueryFacadeAdapter wired to UnifiedHandlers");
@@ -2143,15 +2150,11 @@ impl SharedServices {
             );
         }
 
-        // TD-135: wire a DdlService built from the SAME catalog_manager pgwire uses
-        // (DdlService is a thin wrapper over the shared catalog), so relational
-        // CREATE/ALTER/DROP submitted over the gRPC ExecuteQuery RPC addresses the
-        // same catalog state and executes tenant-scoped.
-        request_handlers.set_ddl_service(std::sync::Arc::new(crate::services::DdlService::new(
-            catalog_manager.clone(),
-        )));
+        // TD-135: the same shared DdlService Arc (built above) drives relational
+        // CREATE/ALTER/DROP on the REST path too.
+        request_handlers.set_ddl_service(ddl_service);
         debug!(
-            "✅ SharedServices::new - DdlService wired to UnifiedHandlers for relational DDL routing"
+            "✅ SharedServices::new - DdlService wired to UnifiedHandlers + adapter for relational DDL routing"
         );
 
         // Build a port-backed runtime handler for collection/vector REST routes.

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -30,7 +30,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use tracing::{debug, info, instrument, warn};
 
 use serde::{Deserialize, Serialize};
@@ -91,6 +91,10 @@ pub struct QueryFacadeAdapter {
     /// degrades gracefully through the facade (parity with ROOT when its
     /// DmlService is unset). Part of TD-104 / seam S1 (single SQL authority).
     dml_service: Option<Arc<crate::services::dml::DmlService>>,
+    /// Optional DdlService for relational DDL (CREATE/ALTER/DROP) on the SQL port
+    /// path (TD-135). Wired in production via `SharedServices`; `None` ⇒ DDL
+    /// falls through. Part of TD-104 / seam S1 (single SQL authority).
+    ddl_service: Option<Arc<crate::services::DdlService>>,
 }
 
 impl QueryFacadeAdapter {
@@ -103,6 +107,7 @@ impl QueryFacadeAdapter {
             validator,
             validation_enabled: true,
             dml_service: None,
+            ddl_service: None,
         }
     }
 
@@ -117,6 +122,7 @@ impl QueryFacadeAdapter {
             validator,
             validation_enabled: false,
             dml_service: None,
+            ddl_service: None,
         }
     }
 
@@ -128,6 +134,13 @@ impl QueryFacadeAdapter {
     /// facade exactly as ROOT does when its DmlService is unwired.
     pub fn with_dml_service(mut self, dml_service: Arc<crate::services::dml::DmlService>) -> Self {
         self.dml_service = Some(dml_service);
+        self
+    }
+
+    /// Attach a `DdlService` so the SQL port path can route relational DDL
+    /// (CREATE/ALTER/DROP) tenant-scoped (TD-135) — parity with the ROOT handler.
+    pub fn with_ddl_service(mut self, ddl_service: Arc<crate::services::DdlService>) -> Self {
+        self.ddl_service = Some(ddl_service);
         self
     }
 
@@ -729,6 +742,29 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
             // degrades gracefully (matches ROOT when its DmlService is unset).
         }
 
+        // TD-135: route relational WRITES (DDL + DML) through the same shared,
+        // tenant-scoped dispatch the ROOT handler uses (TD-104 / seam S1). The
+        // gRPC ExecuteQuery path reaches this adapter (not the ROOT handler), so
+        // without this block CREATE/INSERT fell through to the legacy facade and
+        // was rejected. Returns None for reads / when the service isn't wired →
+        // fall through to TD-121 SELECT routing / sql_query unchanged.
+        if let Some(rows_affected) = try_sql_write_dispatch(
+            &query,
+            tenant_id,
+            self.dml_service.as_ref(),
+            self.ddl_service.as_ref(),
+        )
+        .await?
+        {
+            return Ok(serde_json::json!({
+                "columns": [],
+                "column_types": [],
+                "records": [],
+                // Surfaced as `rows_returned` by the runtime handler (writes).
+                "rows_affected": rows_affected,
+            }));
+        }
+
         // TD-121 relational SELECT routing — parity with the ROOT handler's
         // execute_sql_v1 (src/api_handlers/request_handlers.rs). The gRPC
         // ExecuteQuery path reaches this adapter (not the ROOT handler), so
@@ -785,6 +821,86 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
 
         Ok(shape_sql_records(records))
     }
+}
+
+/// Dispatch a SQL **write** (DDL or DML) through the tenant-scoped service seams.
+///
+/// Shared by the ROOT handler's `execute_sql_v1` and this adapter's
+/// `execute_sql` (TD-104 / seam S1 — single SQL authority) so the two write
+/// paths cannot diverge.
+///
+/// Returns:
+/// - `Ok(Some(rows_affected))` — the statement was a write and was executed
+///   (DDL `affected_count` / DML `rows_affected`).
+/// - `Ok(None)` — not a write keyword, OR the matching service isn't wired → the
+///   caller falls through to read routing / the facade.
+///
+/// `tenant_id` scopes the write to its partition (TD-064); `None` writes
+/// unscoped (as pgwire does for a connection with no `database`), never another
+/// tenant's partition. DML errors use `.context` (NOT `anyhow!`) so a typed
+/// `ProximaDBError::DmlLockConflict` survives in the chain for the protocol
+/// layer (gRPC/pgwire) to downcast + map to ABORTED/55P03.
+pub async fn try_sql_write_dispatch(
+    query: &str,
+    tenant_id: Option<&str>,
+    dml: Option<&Arc<crate::services::dml::DmlService>>,
+    ddl: Option<&Arc<crate::services::DdlService>>,
+) -> Result<Option<u64>> {
+    use crate::query::sql_frontend::SqlFrontendParser;
+    use crate::services::dml::DmlStatement;
+
+    let leading = query.trim_start().get(..7).map(str::to_ascii_uppercase);
+    let leading = leading.as_deref().unwrap_or("");
+
+    // DDL: CREATE / ALTER / DROP.
+    if (leading.starts_with("CREATE ")
+        || leading.starts_with("ALTER ")
+        || leading.starts_with("DROP "))
+        && let Some(ddl) = ddl
+    {
+        match SqlFrontendParser::new().parse_ddl(query) {
+            Ok(Some(statement)) => {
+                let result = ddl
+                    .execute_scoped(statement, tenant_id)
+                    .await
+                    .map_err(|e| anyhow!("DDL failed: {e}"))?;
+                return Ok(Some(result.affected_count as u64));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(anyhow!("DDL parse error: {e}")),
+        }
+    }
+
+    // DML writes: INSERT / UPDATE / DELETE (+ UPSERT/MERGE shapes via parse_dml).
+    if (leading.starts_with("INSERT ")
+        || leading.starts_with("UPDATE ")
+        || leading.starts_with("DELETE ")
+        || leading.starts_with("UPSERT ")
+        || leading.starts_with("MERGE "))
+        && let Some(dml) = dml
+        && let Ok(Some(statement)) = SqlFrontendParser::new().parse_dml(query)
+    {
+        let is_write = matches!(
+            statement,
+            DmlStatement::Insert { .. }
+                | DmlStatement::Update { .. }
+                | DmlStatement::Delete { .. }
+                | DmlStatement::Upsert { .. }
+                | DmlStatement::InsertSelect { .. }
+                | DmlStatement::InsertOverwrite { .. }
+        );
+        if is_write {
+            let tenant_ctx =
+                tenant_id.map(crate::storage::tenant::context::TenantContext::for_tenant_id);
+            let result = dml
+                .execute_scoped(statement, tenant_ctx.as_ref())
+                .await
+                .context("DML failed")?;
+            return Ok(Some(result.rows_affected));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Convert a relational-pipeline (`try_run_select`) result into the SQL


### PR DESCRIPTION
## Summary

Fixes the pre-existing `grpc_td135_relational_write_tenant_isolation_e2e` failure:
gRPC `ExecuteQuery` now routes SQL **writes** (DDL `CREATE/ALTER/DROP` + DML
`INSERT/UPDATE/DELETE/UPSERT/MERGE`), tenant-scoped, instead of rejecting them
("Standard relational SQL execution is not configured in FederatedQueryContext").

## Root cause

The full DDL/DML write dispatch **already existed** in the *root* handler
`UnifiedHandlers::execute_sql_v1` (`src/api_handlers/request_handlers.rs`), which
**REST** uses. But gRPC always serves through the *runtime* handler →
`QueryFacadeAdapter::execute_sql` (the same gap #720 closed for SELECT). The
adapter had EXPLAIN + SELECT routing but **no write dispatch**, so `CREATE TABLE` /
`INSERT` fell through to the legacy facade and were rejected.

## Fix (first-principles / co-design)

The adapter is the gRPC path's SQL authority (TD-104 seam S1). Give it write
authority by **sharing one dispatch implementation** with the root handler — a
single helper both call — so the two write paths cannot diverge:

- **`try_sql_write_dispatch(query, tenant_id, dml, ddl) -> Result<Option<u64>>`**
  (`src/query/facade/adapter.rs`) — leading-keyword guard; `parse_ddl`/`parse_dml`;
  `DdlService::execute_scoped` / `DmlService::execute_scoped` tenant-scoped (TD-064);
  `.context("DML failed")` preserves the typed `DmlLockConflict` for the protocol
  layer to downcast → ABORTED/55P03.
- **Root handler** (`request_handlers.rs`) now calls the helper (DRY, behavior-
  preserving — its inline DDL/DML block is removed).
- **Adapter** `execute_sql` calls the same helper between EXPLAIN and TD-121 SELECT
  routing → gRPC gets writes.
- **One `DdlService` Arc** built in `SharedServices`, shared by the adapter (new
  `with_ddl_service`) and `request_handlers` → both surfaces write the same catalog.
- **Affected count surfaced**: the runtime handler reads `rows_affected` from the
  adapter JSON for writes (reads unchanged — no such key).

## Verification
- `cargo check --lib --bins` + `cargo clippy --lib --bins` (`-D warnings`): clean
- `cargo check --tests`: clean
- **`grpc_td135_relational_write_tenant_isolation_e2e`: now passes** (was failing)
- `grpc_td121_relational_tenant_isolation_e2e` (SELECT): still passes — write
  dispatch is inserted *before* SELECT routing, reads unaffected
- `pgwire_relational_engine_e2e`: still passes
- `rest_grpc_parity_test` (6 tests, incl. `test_sql_query_parity`): still passes —
  covers the root-handler REST refactor + REST/gRPC SQL parity

## Scope
This closes the gRPC SQL write gap. gRPC `ExecuteQuery` now handles full SQL
(SELECT via #720, plus DDL/DML here), at parity with REST/pgwire. No new
behavior behind a flag — write routing is always on (mirroring REST/pgwire).
