### PR TITLE
docs(td): TD-GST-1..4 — engine gaps to run a GST-ASP fully on ProximaDB

### DIFF
--- a/docs/10-quality/td/TD-GST-1-jsonb-nested-column-type-pgwire.adoc
+++ b/docs/10-quality/td/TD-GST-1-jsonb-nested-column-type-pgwire.adoc
@@ -1,0 +1,86 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GST-1: JSONB / nested-struct column type for record props + pgwire SQL
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — enhancement request (external consumer: AnvaiOps GST-ASP vertical)
+| Priority | High — blocks a lossless, aggregatable invoice table; the single biggest schema-fidelity gap for the GST filing workload
+| Severity | Medium — worked around today (JSON-as-string in props), but the workaround forecloses engine-side filter/aggregate
+| Component | record props type system; pgwire SQL surface (`src/network/postgres/`, `crates/query/proximadb-query/`); `crates/foundation/proximadb-functions`
+| Relates to | ADR-018 (pgwire/SQL parity roadmap — Phase 2 aggregation + Phase 2.E JSON/JSONB type + Phase 2.F `->`/`->>`), TD-OLAP-5 (analytics function library), TD-186 (expr-eval unification)
+|===
+
+== Context
+
+The GST-ASP (a GST tax-filing Application Suite Provider built on AnvaiOps) needs
+to store filed invoices as first-class records. A GST invoice is **intrinsically
+nested**: one invoice header carries N HSN line-items, and each line carries
+rate-wise tax splits (CGST/SGST/IGST/cess at a per-HSN rate). The natural shape is
+a list of structs, e.g. `hsn_lines: [{hsn, taxable_value, rate, cgst, sgst, igst}, …]`.
+
+Today ProximaDB records are **dim-1 KV with typed `props`** — a flat property map
+written with an explicit zero vector so the engine skips embedding (this is the
+runtime-record path AnvaiOps already uses for its `anvaiops_invoices` collection).
+There is **no JSONB / STRUCT / LIST column type** in that map, so AnvaiOps is forced
+to serialise `hsn_lines` to a **JSON string** and stuff it in a single prop. That
+is lossy for query purposes: the engine sees an opaque string, not structure.
+
+On the SQL side, ADR-018 Phase 1 (`docs/12-design/adr/ADR-018-pgwire-sql-parity-roadmap.adoc`)
+is basic-DML-only. Aggregation (`COUNT/SUM/GROUP BY`) is **Phase 2, out of scope
+for v0.2** (ADR-018 §"v0.2 Release Status"; the live probe crashed the server on
+`SELECT SUM(...)`/`GROUP BY`). JSON accessors `->`/`->>` are listed under Phase 2.F
+"partially done by the translator today," and `JSONB` is a Phase 2.E type. So there
+is no way to index/filter/aggregate *into* the nested line-items from pgwire — the
+invoice table is neither lossless nor directly aggregatable.
+
+== Proposed enhancement
+
+Add a **native semi-structured column type** to the record props type system and
+expose it through pgwire SQL:
+
+1. **Type.** A `JSONB`-equivalent column, or (preferred, engine-native) an
+   Arrow-native `STRUCT` / `LIST<STRUCT>` prop type, so the engine stores
+   `hsn_lines` as typed nested data rather than a string blob. It must round-trip
+   through the v2 record write/read path (`records/batch` write, `props` on read)
+   without stringification.
+2. **Accessors.** pgwire support for `->` (get JSON object/array element),
+   `->>` (get as text), and a **containment** operator `@>` over the nested column,
+   plus path extraction into a scalar so it can feed a `GROUP BY`/`SUM`.
+3. **Aggregatability.** Extracted scalars (e.g. `props->'hsn_lines'->>'rate'`
+   unnested to rows) participate in `SUM`/`GROUP BY` — which requires ADR-018
+   Phase 2 aggregation to have landed. This TD therefore **depends on ADR-018
+   Phase 2** and should be scheduled behind (or with) it.
+
+== Boundary / interface impact
+
+* **Wire (record path):** the v2 record `props` map gains a semi-structured value
+  type; writes preserve nesting, reads return it structurally (still under `props`).
+* **SQL surface gains:** `props->'hsn_lines'`, `props->>'gstin'`, containment
+  `WHERE props->'hsn_lines' @> '[{"rate": 18}]'`, and path-extract expressions that
+  are valid `GROUP BY`/`SUM` inputs. This makes the invoice table directly
+  aggregatable (rate-wise tax totals) instead of requiring a client-side re-parse.
+
+== Relationship to existing work
+
+* **ADR-018** is the driver: Phase 2 lists the JSONB type (P2.E), the JSON
+  accessors (P2.F), and the aggregation surface (P2.C) this TD needs — but as
+  separate line items with no nested-column-in-props story. This TD names the GST
+  requirement that pulls them together and adds the containment operator + the
+  props-map type extension.
+* **TD-OLAP-5** grows the scalar/function library; JSON path/containment functions
+  are a natural tranche there.
+* **TD-186** (expr-eval unification) is the substrate the accessor expressions lower
+  through.
+
+== Acceptance / done-when
+
+* A record can be written with a native nested prop (`LIST<STRUCT>` or `JSONB`) and
+  read back structurally — no client-side stringify/parse.
+* Over pgwire: `SELECT … WHERE props->'hsn_lines' @> '[{"hsn":"8471"}]'` filters
+  correctly against a live server (no disconnect).
+* `SELECT rate, SUM(taxable_value) … GROUP BY rate` over the extracted per-line rate
+  returns correct rate-wise totals for a multi-line invoice corpus.
+* AnvaiOps can drop its JSON-string workaround for `anvaiops_invoices` and flip the
+  invoice query surface to engine-side aggregation.

--- a/docs/10-quality/td/TD-GST-2-worm-retention-lock-hash-chain.adoc
+++ b/docs/10-quality/td/TD-GST-2-worm-retention-lock-hash-chain.adoc
@@ -1,0 +1,93 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GST-2: Native immutable/WORM records with retention-lock + tamper-evident hash-chain
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — enhancement request (external consumer: AnvaiOps GST-ASP vertical)
+| Priority | High — a legal-retention/audit requirement AnvaiOps can only half-satisfy at the app layer today
+| Severity | Medium/High — app-layer immutability is defeatable (a privileged overwrite/delete leaves no engine-enforced trail)
+| Component | record KV write path; collection policy/metadata; DR/CRR contract (`docs/12-design/COLLECTION_DR_CRR_ENGINE_CONTRACT.adoc`)
+| Relates to | ADR-017 (DR engine surface — collection-level policy is the right home), TD-MANIFEST-1 (manifest retention), the Iceberg v3 row-lineage / `GlobalLsnAllocator` primitives (`docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc` §"Iceberg v3 alignment")
+|===
+
+== Context
+
+Indian GST law mandates **~6-year immutable retention** of filed returns and their
+supporting invoices, plus a **tamper-evident audit trail** an auditor can trust. The
+GST-ASP must be able to prove a filed invoice was neither altered nor deleted within
+the retention window.
+
+Today ProximaDB records are dim-1 KV with typed `props` and **no native WORM /
+retention-lock** surface. AnvaiOps enforces immutability **at the app layer** via
+content-addressed record ids (the id is a hash of the content, so a changed body is a
+different id). That gives *detectability of a changed body under the same logical
+key* only by convention — it does **not** stop a privileged caller from overwriting
+the record at that id, deleting it, or writing a competing id, and it leaves no
+engine-level, auditor-verifiable proof of the sequence. A tamper-evident chain
+(each record's hash committing to the prior) would have to be **hand-rolled in
+AnvaiOps**, duplicating a primitive that belongs in the engine and putting the
+integrity root outside the system of record.
+
+The engine already has the raw materials: a `GlobalLsnAllocator` for a monotonic
+commit order and Iceberg-v3 row-lineage thinking (`_row_id`,
+`_last_updated_sequence_number`) per the format strategy — but neither is exposed as
+a customer-facing immutability guarantee.
+
+== Proposed enhancement
+
+An **engine-level append-only / WORM collection mode**, selected at collection
+creation, with two composable guarantees:
+
+1. **Per-record retention-lock.** A collection created WORM carries a retention
+   policy (`retention_years = N`, or an explicit per-record `retain_until`). Before
+   expiry the engine **refuses** any overwrite (upsert to an existing id) or delete —
+   the write returns a policy error, it does not silently succeed. This is a
+   **collection policy** (ADR-017-shaped), evaluated on the record write path, not an
+   app convention.
+2. **Optional built-in tamper-evident hash-chain.** When enabled, each committed
+   record's stored hash **chains the prior record's hash** (in LSN/commit order,
+   scoped to the collection+tenant), so the chain head is a single value committing
+   to the entire history. The per-record chain hash + prior-link is exposed as
+   **verifiable metadata** (readable prop or a dedicated field), and a
+   **chain-verify call** walks the chain to prove there are no gaps or edits.
+
+WORM mode and the hash-chain are independently selectable (retention-lock without
+chaining is valid; chaining strengthens the audit story).
+
+== Boundary / interface impact
+
+* **Collection API:** create-collection gains a WORM/retention policy block
+  (`mode: worm`, `retention_years`, `hash_chain: on|off`).
+* **Record write path:** overwrite/delete before `retain_until` is rejected with a
+  typed policy error (distinct from a validation error), tenant-scoped.
+* **Read/verify:** each record exposes chain metadata (`chain_hash`, `prev_hash`,
+  commit LSN); a new **verify** operation returns proof-of-integrity for a range or
+  the whole collection (no gaps, no edits, head matches).
+* Inherits the collection's DR/CRR contract — the retention-lock and chain replicate
+  with the data (the guarantee survives failover).
+
+== Relationship to existing work
+
+* **ADR-017 (DR engine surface)** establishes collection-level policy as an
+  engine-owned surface; retention-lock is the same shape (policy in, enforcement in
+  the engine, operator on top).
+* **Iceberg v3 row-lineage + `GlobalLsnAllocator`** (format strategy §"Iceberg v3
+  alignment") supply the monotonic commit order the hash-chain links over — this TD
+  is the customer-facing WORM/verify surface *over* that primitive.
+* **TD-MANIFEST-1 (manifest retention)** is adjacent (retention of physical
+  manifests) but distinct: this TD is a *logical, per-record* retention-lock +
+  integrity contract, not GC policy.
+* Complements the record KV path AnvaiOps already uses for `anvaiops_invoices`.
+
+== Acceptance / done-when
+
+* A collection can be created in WORM mode with `retention_years = N`.
+* An overwrite or delete of a record before its `retain_until` is **refused** with a
+  policy error (verified against a live server); after expiry it is permitted.
+* With hash-chain on, each record carries verifiable `chain_hash`/`prev_hash`
+  metadata, and a **chain-verify** call over the collection proves no gaps and no
+  edits (and detects a deliberately tampered record in a test).
+* AnvaiOps can retire its hand-rolled hash-chaining and rely on the engine guarantee
+  as the integrity root for filed invoices.

--- a/docs/10-quality/td/TD-GST-3-blob-attachment-storage-colocated-records.adoc
+++ b/docs/10-quality/td/TD-GST-3-blob-attachment-storage-colocated-records.adoc
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GST-3: Blob / attachment storage co-located with records
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — enhancement request (external consumer: AnvaiOps GST-ASP vertical)
+| Priority | High — removing the separate object store is the point of "run the entire data layer on ProximaDB"
+| Severity | Medium — an S3/MinIO workaround exists, but it splits the durability, tenancy, and retention story across two systems
+| Component | record KV path; object/blob storage layer (`ObjectStoreBridge`); DR/CRR contract; streaming I/O on the REST v2 surface
+| Relates to | TD-GST-2 (WORM retention-lock the attachment must inherit), ADR-017 (DR engine surface / tenant + DR policy), the `ObjectStoreBridge` object-store abstraction (`docs/12-design/FORMAT_STRATEGY_ICEBERG_DELTA_LANCE_2026_06.adoc`)
+|===
+
+== Context
+
+The GST-ASP must retain, for the same ~6-year window as the filed returns, a set of
+**large binary artifacts** tied to each filing: ARN acknowledgment PDFs (the
+government's filing receipt), GSP receipts, and raw voucher/e-invoice XML dumps.
+These are per-invoice / per-filing blobs that belong *with* the invoice record.
+
+Today ProximaDB records are dim-1 KV with typed `props` and there is **no
+blob/attachment surface** — props are metadata, not a place for multi-MB PDFs.
+So the ASP is forced to stand up a **separate S3 / MinIO** bucket for the receipt
+store. That directly defeats the "run the entire data layer on ProximaDB" goal and,
+worse, **splits the durability and tenancy story**: the blobs live under a different
+DR/CRR policy, a different tenant-isolation model, and a different retention regime
+than the invoice records they belong to. Proving "this filing and its receipt were
+both retained and both untampered" now spans two systems.
+
+== Proposed enhancement
+
+A **large-object / attachment surface that binds a blob to a record id**, tenant-
+scoped, sharing the record's policy envelope:
+
+1. **Binding.** An attachment is addressed by `(collection, record_id, name)` so it
+   is unambiguously owned by one record and one tenant. Listing/enumerating a
+   record's attachments is supported.
+2. **Streaming put/get.** `PUT …/records/{id}/attachments/{name}` streams the blob
+   to storage (O(1) memory — never buffer the full PDF in the request path), and GET
+   streams it back. Range requests are desirable but not required for MVP.
+3. **Policy inheritance.** The attachment inherits the collection's **tenant
+   isolation**, its **DR/CRR** contract (replicates with the record — the receipt
+   survives failover alongside its invoice), and, critically, its **retention-lock**
+   (TD-GST-2): a blob under a WORM collection cannot be overwritten or deleted before
+   the record's `retain_until`.
+4. **Backing store.** Implement over the existing `ObjectStoreBridge` object-store
+   abstraction so the physical bytes land in the same durable, cloud-native object
+   layer the engine already uses — this is a new logical binding + streaming surface,
+   not a new storage backend.
+
+== Boundary / interface impact
+
+* **REST v2 gains an attachment sub-resource** on records:
+  `PUT/GET/DELETE …/collections/{c}/records/{id}/attachments/{name}` and a list
+  endpoint, all streaming, all tenant-scoped.
+* **DELETE** is subject to the same retention-lock as record delete (refused before
+  expiry when the collection is WORM).
+* No change to the record `props`/vector contract — attachments are a sibling
+  sub-resource, not a prop type (contrast TD-GST-1, which is about *structured*
+  props).
+
+== Relationship to existing work
+
+* **TD-GST-2** supplies the retention-lock the attachment inherits — the two together
+  give a single-system, WORM-retained "invoice + its receipt PDF" unit.
+* **ADR-017 (DR engine surface)** supplies the tenant + DR policy the attachment
+  reuses rather than re-implements.
+* **`ObjectStoreBridge`** is the backing abstraction (already used for Iceberg
+  materialization / warehouse publish), so the durable bytes ride the existing
+  object-store path.
+* Replaces the external S3/MinIO receipt store, collapsing the durability/tenancy
+  story back onto ProximaDB.
+
+== Acceptance / done-when
+
+* `PUT …/collections/{c}/records/{id}/attachments/{name}` streams a large (e.g.
+  >10 MB) PDF to storage without buffering it whole; `GET` streams it back
+  byte-identical.
+* An attachment is tenant-scoped — tenant B cannot read/list/overwrite tenant A's
+  attachment for the same logical name.
+* On a WORM collection (TD-GST-2), an attachment DELETE/overwrite before the record's
+  `retain_until` is refused; after expiry it is permitted.
+* An attachment replicates under the collection's DR/CRR policy (present after a
+  simulated failover).
+* AnvaiOps can retire the separate S3/MinIO receipt bucket and store ARN PDFs / GSP
+  receipts / voucher XML on ProximaDB beside the invoice record.

--- a/docs/10-quality/td/TD-GST-4-gstr2b-reconciliation-cross-modal-join.adoc
+++ b/docs/10-quality/td/TD-GST-4-gstr2b-reconciliation-cross-modal-join.adoc
@@ -1,0 +1,92 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-GST-4: GSTR-2B reconciliation as a first-class cross-modal join
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — enhancement request (external consumer: AnvaiOps GST-ASP vertical)
+| Priority | High — reconciliation is the single biggest audit-risk operation in the GST filing workflow (ITC eligibility, Sec 16(2)(aa))
+| Severity | Medium — doable client-side today, but as an N+1 join that ships result sets over the wire (the exact anti-pattern ADR-053 exists to kill)
+| Component | cross-modal query fabric (`src/datafusion/cross_modal.rs`, `crates/query/proximadb-query/`); pgwire SQL surface; a (new) fuzzy-join operator
+| Relates to | ADR-053 (cross-modal query fabric — modalities as composable SQL relations, joins execute data-local), TD-XMODAL-1..5 (the tracked fabric sources), ADR-052 (analytics execution / DataFusion vectorized kernels), TD-OLAP-5 (function/aggregate library)
+|===
+
+== Context
+
+GST input-tax-credit (ITC) reconciliation matches the taxpayer's **purchase register**
+against the government-supplied **GSTR-2B** (the auto-drafted ITC statement) and
+classifies every line into **Matched / Mismatched / Missing**. The exact match key is
+`(supplier GSTIN + invoice-no + invoice-date + amount)`, but real data needs **fuzzy**
+tolerance: party names differ by punctuation/abbreviation, invoice numbers carry
+formatting drift, and amounts differ by rounding/near-values. Under Sec 16(2)(aa) an
+unmatched purchase is **ineligible ITC** — so this is the single most audit-sensitive
+computation the ASP runs.
+
+Today, on ProximaDB, both sides land as records (relational-shaped rows). With no
+engine-side join, AnvaiOps would run reconciliation as a **client-side N+1 join**:
+loop each purchase-register row, query 2B for candidates, compare in Python. That is
+exactly the anti-pattern ADR-053 (`docs/12-design/adr/ADR-053-cross-modal-query-fabric.adoc`)
+was written to eliminate — it maximises the dominant cost terms (I/O round-trips +
+egress / metered KOU) by shipping intermediate result sets over the wire only to
+intersect and discard most. The fuzzy leg is also poorly served client-side: it is a
+similarity problem (party-name / near-amount) that wants a vector-similarity assist,
+which ProximaDB has natively.
+
+== Proposed enhancement
+
+Express GSTR-2B reconciliation as a **single cross-modal join executed data-local**
+on the ADR-053 fabric:
+
+1. **Both inputs as relations.** Purchase register (relational) and GSTR-2B
+   (relational) are table sources in the SQL/relational plane — no client fan-out.
+2. **Exact + fuzzy join.** The join is `purchase_register ⋈ gstr_2b` on the exact key
+   `(gstin, invoice_no, invoice_date, amount)` **with a vector-similarity assist** for
+   the fuzzy leg (party-name embedding similarity + near-amount tolerance), so
+   candidate pairs that miss the exact key but match fuzzily are surfaced rather than
+   dropped. This likely requires a **new fuzzy-join operator** (a similarity-threshold
+   join) alongside the existing equi-join — expressible via the `vector_search` UDTF
+   pattern ADR-053 already establishes.
+3. **Classification + ITC engine-side.** The single query returns rows bucketed
+   **Matched / Mismatched / Missing** with **eligible-ITC computed engine-side** (sum
+   of tax on the Matched bucket), so the client receives the *answer*, not two result
+   sets to join. One round-trip, one metered plan, tenant-isolation structural at the
+   fabric seam.
+
+== Boundary / interface impact
+
+* **SQL surface gains** a reconciliation-shaped query: two relations joined on an
+  exact composite key with a similarity-threshold fallback leg, a `CASE`/bucket
+  projection (Matched/Mismatched/Missing), and an aggregate for eligible ITC — all in
+  one DataFusion/Volcano plan behind the `ComputeBackend` seam.
+* **New operator:** a fuzzy/similarity-threshold join primitive (or a documented UDTF
+  composition) so "near-match on party-name/amount" is expressible in SQL.
+* The engine ships the **buckets + ITC total**, not intermediate candidate sets — no
+  client-side result-set shipping.
+
+== Relationship to existing work
+
+* **ADR-053** is the direct home: modalities as composable SQL relations, the join
+  executed data-local, agentic reasoning stays in the client/MCP layer. This TD is a
+  **concrete GST vertical** for that fabric — the reconciliation join is a real
+  instance of "relational ⋈ relational with a vector-similarity assist."
+* **TD-XMODAL-1..5** are the tracked fabric sources/optimizations this rides; the
+  fuzzy-join operator is a candidate new increment in that series.
+* **ADR-052 / TD-OLAP-5** supply the vectorized execution + aggregate/`CASE` function
+  surface the classification and ITC sum need.
+* Consumes the same tenant-scoped record collections AnvaiOps already uses (the
+  purchase register and 2B import land as records today).
+
+== Acceptance / done-when
+
+* A **single** query (pgwire or the fabric UDTF surface) takes a tenant's purchase
+  register and its GSTR-2B and returns rows classified **Matched / Mismatched /
+  Missing**, with **eligible ITC computed engine-side** for the Matched bucket.
+* The fuzzy leg surfaces a party-name/near-amount match that the pure exact-key join
+  would have dropped (verified on a seeded near-match fixture), without a client-side
+  loop.
+* The plan executes data-local (no intermediate result-set egress between the two
+  legs) and is metered as one unit; tenant isolation is structural (A's register can
+  never join B's 2B).
+* AnvaiOps can flip reconciliation from a client-side N+1 join to this single
+  engine-side query.


### PR DESCRIPTION
## What

Four AnvaiOps-driven **enhancement requests (TD-GST-1..4)** so a GST tax-filing ASP can run its **entire data layer on ProximaDB** instead of Postgres/Redis/S3/OpenSearch. Docs-only; consumed by AnvaiOps ADR-0031 (which lands the Tally invoice connector on the record-KV path today and flips query surfaces onto these when they ship).

| TD | Gap → ask |
|----|-----------|
| **TD-GST-1** | No JSONB/nested column type → native JSONB/STRUCT/LIST prop type + pgwire `->`/`->>`/`@>` + aggregation over nested invoice line-items (depends on ADR-018 Phase 2). |
| **TD-GST-2** | No WORM/retention → engine-level immutable/WORM records + per-record retention-lock + tamper-evident hash-chain (6-yr GST retention + audit). |
| **TD-GST-3** | Receipts force external S3 → streaming blob/attachment surface bound to a record id over `ObjectStoreBridge`, inheriting tenant/DR/retention. |
| **TD-GST-4** | Reconciliation would be a client-side N+1 join → GSTR-2B ⋈ purchase register as an **ADR-053 cross-modal join** (relational + vector-similarity fuzzy leg), data-local, ITC computed engine-side. |

## Grounding
Verified against current engine status: pgwire Phase-1 (ADR-018 — no JOIN/GROUP BY/aggregation), Iceberg v3 experimental/export-only (FORMAT_STRATEGY_ICEBERG_DELTA_LANCE), cross-modal fabric per ADR-053 / TD-XMODAL-1..5. Records today are dim-1 KV with typed props (no JSONB/WORM/blob).

## Convention
Topic-scoped `TD-GST-*` ids (collision-free), one file per entry under `docs/10-quality/td/`, authoritative `= TD-GST-N:` headings, license headers. `scripts/check_td_adr_unique.py` → 0 errors.