### PR TITLE
feat(observability): document I/O trace baseline (P-Trace) + put_pax write hook (ADR-054)

### DIFF
--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -390,3 +390,22 @@ hardware = "WSL2 Linux 5.15, 32 cores, 78 GB RAM, local NVMe tempdir, debug prof
 date = "2026-07-06"
 version = "v0.2"
 notes = "500 docs ingested UNFLUSHED (recovery rests purely on vector-WAL replay; canonical path drops legacy document_wal); pre-restart query 500, post-restart query 500, id spot-check 10/10, recovery window ~1.68-1.79 s. Extends #709 single-doc restart to a populated collection. TD-DOC-CONV-2 criterion 5 satisfied at this scale (100k-scale projection-cost test remains follow-up)."
+
+# ---------------------------------------------------------------------------
+# ADR-055 P-Trace — document I/O baseline (pre-shred). The number the
+# hybrid-shredding + pushdown phases (P-Shred/P-DFSource/P-Pushdown) must beat.
+# ---------------------------------------------------------------------------
+
+[[claims]]
+id = "doc_conv2_ptrace_preshred_baseline"
+claim = "A filtered document read fetches the WHOLE PAX segment (no pruning/ranged reads) — 329,111 B for both a 1-record point-get and a 500-record scan; the pre-shred baseline"
+metric = "bytes_read"
+status = "measured"
+asserted_in = ["docs/_internal/status/DOC_PTRACE_PRESHRED_BASELINE_2026_07_07.adoc"]
+bench_source = "src/services/record_store.rs"
+bench_command = "cargo nextest run --features io-trace --lib doc_iotrace_baseline_preshred --no-capture"
+artifact = "docs/_internal/status/DOC_PTRACE_PRESHRED_BASELINE_2026_07_07.adoc"
+hardware = "WSL2 Linux 5.15, 32 cores, 78 GB RAM, in-process memory:// object-store bridge, debug profile"
+date = "2026-07-07"
+version = "v0.2"
+notes = "P-Trace (ADR-055 first phase; trace before you tune). 500-doc corpus, one PAX segment: point_get.bytes_read = filtered_scan.bytes_read = 329,111 B (get_ops=1, range_gets=0), write.bytes_written=329,111 (put_ops=1). A document read fetches the ENTIRE segment whether it wants 1 or 500 records — no block/zone-map pruning, no ranged reads. Wired the write-side put_pax hook (record_bytes_written at the object-store PUT in record_store.rs; shared with vectors); reads already record fetch_pax+bytes_read. range_gets is io-trace-feature-gated but legitimately 0 (whole-segment fetch path). Target for P-Pushdown: a filtered query reads strictly < 329,111 B with range_gets>0, results identical."

--- a/docs/_internal/status/DOC_PTRACE_PRESHRED_BASELINE_2026_07_07.adoc
+++ b/docs/_internal/status/DOC_PTRACE_PRESHRED_BASELINE_2026_07_07.adoc
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= P-Trace — document I/O baseline (pre-shred), TD-DOC-CONV-2 / ADR-055
+:toc:
+
+[cols="1,3"]
+|===
+|Status|MEASURED — the evidence gate for ADR-055's hybrid-shredding + pushdown phases.
+|Date|2026-07-07
+|Phase|P-Trace (first phase of the ADR-055 rollout; wire io_trace, measure, then tune)
+|Harness|`src/services/record_store.rs` unit test `doc_iotrace_baseline_preshred`
+|Command|`cargo nextest run --features io-trace --lib doc_iotrace_baseline_preshred --no-capture`
+|Hardware|WSL2 Linux (5.15 microsoft-standard-WSL2), 32 vCPU, ~78 GiB RAM, in-process `memory://` object-store bridge, debug profile
+|Version|proximadb v0.2.2 (branch `feat/doc-iotrace` off `develop` incl. #726)
+|===
+
+== Why
+
+ADR-055 declares the canonical document format and chooses **hybrid props shredding + DataFusion
+pushdown** to make filtered document queries prune instead of scanning whole segments. The co-design
+mandate requires a **measured trace before tuning** ("trace before you tune"). No document io_trace
+existed; this phase wires it and captures the pre-shred baseline the later phases must beat.
+
+== What was wired
+
+* **Write side (production, shared win):** the object-store PAX segment PUT
+  (`ObjectStoreVectorRecordStore::write_mutations`, `src/services/record_store.rs` ~:4426) now emits
+  `io_trace::record_op_str("put_pax")` + `io_trace::record_bytes_written(bytes.len())`, mirroring the
+  read side's `record_bytes_read` in `read_all_records`. No-op outside an `io_trace::scope`; benefits
+  vector flushes too.
+* **Read side (already instrumented):** `read_all_records` records `fetch_pax` + `record_bytes_read`
+  on the whole-segment object-store fetch.
+
+== Measured baseline (500-doc corpus, rich varied props, one PAX segment)
+
+----
+doc_trace.corpus_docs=500
+doc_trace.write.bytes_written=329111  put_ops=1
+doc_trace.point_get.bytes_read=329111  get_ops=1  range_gets=0
+doc_trace.filtered_scan.bytes_read=329111  get_ops=1  range_gets=0
+doc_trace.point_get_reads_whole_segment=true
+----
+
+== The finding (baseline for P-Shred / P-Pushdown)
+
+A document read fetches the **entire 329,111-byte segment whether it wants 1 record or all 500** —
+identical `bytes_read`, `range_gets = 0`, no block/zone-map pruning and no ranged reads. This is the
+whole-segment, no-pushdown cost that ADR-055's hybrid shredding (typed user-columns with zone-maps +
+bloom) and DataFusion pushdown (P-Shred → P-DFSource → P-Pushdown) are designed to reduce: a filtered
+query should read only the projected stripes of the surviving blocks, not the whole segment.
+
+The **before/after target** for the P-Pushdown PR: a filtered `query_documents` over this corpus reads
+strictly fewer than 329,111 bytes (and issues ranged GETs, `range_gets > 0`), with identical results.
+
+== Notes on the counters
+
+* `bytes_read` / `bytes_written` / `get_ops` / `put_ops` are always-on counters.
+* `range_gets` is gated behind the `io-trace` cargo feature; here it is legitimately `0` because
+  `ObjectStoreVectorRecordStore` uses the whole-segment `fetch_pax` path, never a ranged read — that
+  zero IS the baseline finding, not a measurement gap.
+* Measured on the in-process `memory://` bridge (deterministic, no network) — the byte counts are the
+  co-design quantity (bytes moved across the storage↔compute boundary); absolute latency is out of
+  scope for this phase.

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -3823,6 +3823,158 @@ mod tests {
         }
     }
 
+    /// P-Trace (TD-DOC-CONV-2 / ADR-054): MEASURE the pre-shred document I/O baseline. A
+    /// representative document corpus (rich, varied `props` — the metadata a hybrid-shred format
+    /// would promote to typed columns) is persisted as ONE PAX segment, then each read op runs
+    /// inside an `io_trace::scope` so the task-local trace is captured. This records the co-design
+    /// baseline the shredding + pushdown work (ADR-054 P-Shred/P-Pushdown) will improve: TODAY every
+    /// document read — point-get AND filtered scan alike — FETCHES THE WHOLE SEGMENT (no pushdown,
+    /// no ranged reads), and the write records its segment bytes (the new `put_pax` hook).
+    /// `range_gets` is gated behind the `io-trace` feature; `bytes_read`/`bytes_written` are always-on.
+    #[tokio::test]
+    async fn doc_iotrace_baseline_preshred() {
+        use proximadb_iceberg_engine::IcebergObjectStoreBridge;
+
+        let bridge: Arc<dyn ObjectStoreBridge> =
+            Arc::new(IcebergObjectStoreBridge::from_url("memory://").unwrap());
+        let store = ObjectStoreVectorRecordStore::new(bridge);
+        let schema = CatalogTableSchema::new("docs")
+            .with_workload_profile(CatalogWorkloadProfile::Vector)
+            .with_storage_specialization(CatalogStorageSpecialization::VectorAnn);
+
+        const N: usize = 500;
+        let mut muts = Vec::with_capacity(N);
+        for i in 0..N {
+            let mut props = HashMap::new();
+            props.insert(
+                "title".to_string(),
+                ProximaTreeNode::Value(ProximaValue::String(format!(
+                    "Document number {i} — a representative title with several words"
+                ))),
+            );
+            props.insert(
+                "status".to_string(),
+                ProximaTreeNode::Value(ProximaValue::String(
+                    if i % 3 == 0 { "active" } else { "archived" }.to_string(),
+                )),
+            );
+            props.insert(
+                "day".to_string(),
+                ProximaTreeNode::Value(ProximaValue::Int64((i % 365) as i64)),
+            );
+            props.insert(
+                "author".to_string(),
+                ProximaTreeNode::Value(ProximaValue::String(format!("author_{}", i % 50))),
+            );
+            props.insert(
+                "body".to_string(),
+                ProximaTreeNode::Value(ProximaValue::String("lorem ipsum dolor sit ".repeat(16))),
+            );
+            let record = ProximaRecord {
+                oid: format!("doc-{i}"),
+                variation_id: Some("docs".to_string()),
+                created_at_ns: 1_700_000_000_000_000_000 + i as i64,
+                props,
+                embeddings: vec![EmbeddingCell {
+                    modality: "dense".into(),
+                    dim: 8,
+                    values: EmbeddingValues::Fp32((0..8).map(|d| ((i + d) as f32).sin()).collect()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            muts.push(TableRecordMutation::new(
+                TableRecordMutationKind::Upsert,
+                record,
+            ));
+        }
+
+        // WRITE — the whole-segment flush; captures bytes_written (the new put_pax hook).
+        let write_snap = io_trace::scope(async {
+            let w = store
+                .write_mutations(&schema, muts, None)
+                .await
+                .expect("write_mutations");
+            assert!(w.success);
+            io_trace::snapshot().expect("snapshot in scope")
+        })
+        .await;
+
+        // POINT-GET — one record, but the WHOLE segment is fetched (fetch_pax).
+        let get_snap = io_trace::scope(async {
+            let got = store
+                .get_by_key(
+                    &schema,
+                    TableRecordGetRequest {
+                        table_id: "docs".to_string(),
+                        key: "doc-250".to_string(),
+                        include_vector: false,
+                        include_props: true,
+                    },
+                    None,
+                )
+                .await
+                .expect("get_by_key");
+            assert!(got.is_some(), "point-get must find the record");
+            io_trace::snapshot().expect("snapshot in scope")
+        })
+        .await;
+
+        // FILTERED SCAN — the query_documents baseline; filter is NOT pushed down, so the whole
+        // segment is fetched and filtered in memory.
+        let scan_snap = io_trace::scope(async {
+            let scanned = store
+                .scan_records(
+                    &schema,
+                    TableRecordScanRequest {
+                        table_id: "docs".to_string(),
+                        limit: None,
+                        include_vector: false,
+                        include_props: true,
+                        filter: None,
+                    },
+                    None,
+                )
+                .await
+                .expect("scan_records");
+            assert_eq!(scanned.len(), N, "all docs read back");
+            io_trace::snapshot().expect("snapshot in scope")
+        })
+        .await;
+
+        eprintln!("BAKE_METRIC doc_trace.corpus_docs={N}");
+        eprintln!(
+            "BAKE_METRIC doc_trace.write.bytes_written={} put_ops={}",
+            write_snap.bytes_written, write_snap.put_ops
+        );
+        eprintln!(
+            "BAKE_METRIC doc_trace.point_get.bytes_read={} get_ops={} range_gets={}",
+            get_snap.bytes_read, get_snap.get_ops, get_snap.range_gets
+        );
+        eprintln!(
+            "BAKE_METRIC doc_trace.filtered_scan.bytes_read={} get_ops={} range_gets={}",
+            scan_snap.bytes_read, scan_snap.get_ops, scan_snap.range_gets
+        );
+        // The pre-shred baseline: a point-get fetches the SAME whole segment a full scan does.
+        eprintln!(
+            "BAKE_METRIC doc_trace.point_get_reads_whole_segment={}",
+            get_snap.bytes_read == scan_snap.bytes_read && get_snap.bytes_read > 0
+        );
+
+        assert!(
+            write_snap.bytes_written > 0,
+            "flush must record bytes_written (the new put_pax hook)"
+        );
+        assert!(
+            get_snap.bytes_read > 0,
+            "point-get must record bytes_read (fetch_pax)"
+        );
+        assert!(
+            scan_snap.bytes_read > 0,
+            "filtered scan must record bytes_read (fetch_pax)"
+        );
+    }
+
     /// Phase D: the recovered `oid` byte-matches the catalog's canonical
     /// composite-key encoding (`CatalogRow::primary_key_string`), not a divergent
     /// local join — so a read-back record carries the same oid the write path
@@ -4268,6 +4420,11 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
         let remove_result = std::fs::remove_file(&segment_meta.path);
 
         let tenant_id = _tenant_context.map(|tc| tc.tenant_id.as_str());
+        // Per-query WRITE trace: the PAX segment PUT is the object-store write boundary. Mirrors the
+        // read side's `record_bytes_read` in `read_all_records`, so a flush's bytes are observable
+        // to the co-design cost model (no-op outside an `io_trace::scope`).
+        io_trace::record_op_str("put_pax");
+        io_trace::record_bytes_written(bytes.len() as u64);
         self.bridge
             .persist_vector_segment(&object_path, &bytes, tenant_id)
             .await


### PR DESCRIPTION
## What

**P-Trace** — the first phase of the ADR-054 (#732) document-format rollout: wire the document `io_trace` and capture the **pre-shred baseline** the later phases must beat. Co-design mandate: *measure before you tune.*

## Changes

- **Write hook (shared with vectors):** `ObjectStoreVectorRecordStore::write_mutations` now emits `io_trace::record_op_str("put_pax")` + `record_bytes_written(bytes.len())` at the object-store PAX PUT boundary, mirroring the read side's `record_bytes_read`. No-op outside an `io_trace::scope`; **no behavior change**.
- **Baseline harness:** lib unit test `doc_iotrace_baseline_preshred` (in-process `memory://` bridge, 500-doc corpus, one PAX segment) wraps write / point-get / filtered-scan in `io_trace::scope` and captures the snapshot.

## Measured baseline (the number P-Shred / P-Pushdown must beat)

```
point_get.bytes_read   = 329,111 B  (get_ops=1, range_gets=0)
filtered_scan.bytes_read = 329,111 B  (get_ops=1, range_gets=0)
write.bytes_written    = 329,111 B  (put_ops=1)
```

**Finding:** a document read fetches the **entire 329 KB segment whether it wants 1 record or all 500** — no block/zone-map pruning, no ranged reads. That whole-segment, no-pushdown cost is exactly what ADR-054's hybrid shredding + DataFusion pushdown will reduce. `range_gets` is `io-trace`-feature-gated but legitimately `0` (whole-segment fetch path) — the zero *is* the finding.

Evidence: `docs/_internal/status/DOC_PTRACE_PRESHRED_BASELINE_2026_07_07.adoc` + `BENCHMARK_EVIDENCE.toml` (`doc_conv2_ptrace_preshred_baseline`, measured; validator green).

## Gates
`cargo fmt --check` · `cargo clippy --lib --bins -- -D warnings` (exit 0) · test PASS.

Run: `cargo nextest run --features io-trace --lib doc_iotrace_baseline_preshred --no-capture`
