### PR TITLE
feat(cache): wire OLAP result cache into the gRPC/adapter SQL path (TD-104 S4)

### DIFF
--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -766,17 +766,17 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         }
 
         // TD-121 relational SELECT routing — parity with the ROOT handler's
-        // execute_sql_v1 (src/api_handlers/request_handlers.rs). The gRPC
-        // ExecuteQuery path reaches this adapter (not the ROOT handler), so
-        // without this block a standard relational SELECT fell through to the
-        // legacy facade and was rejected ("Standard relational SQL execution is
-        // not configured in FederatedQueryContext"). `require_engagement=false`
+        // execute_sql_v1 (src/api_handlers/request_handlers.rs). Both the gRPC
+        // and REST SQL routes reach this adapter (TD-104 S4 converged REST onto
+        // the runtime handler → adapter), so relational SELECT over EITHER
+        // surface routes through the tenant-scoped pipeline here. `require_engagement=false`
         // routes any resolvable relational SELECT; queries whose tables don't
         // resolve return `None` and fall through to `sql_query` (vector/graph
-        // SQL, unchanged). The OLAP result cache is intentionally NOT consulted
-        // here — the bug fix is routing, not caching; REST/pgwire keep the cache
-        // (wiring it here is a same-crate follow-up, no layering issue).
-        // namespace=None: gRPC ExecuteQuery has no search_path.
+        // SQL, unchanged). The OLAP result cache IS consulted (same-crate call,
+        // no layering issue) — default-OFF behind PROXIMADB_QUERY_RESULT_CACHE,
+        // so this is a no-op unless the flag is set.
+        // namespace=None: SQL port path has no pgwire search_path.
+        let olap_result_cache = crate::network::postgres::relational_pipeline::olap_result_cache();
         if let Some(dml) = self.dml_service.as_ref()
             && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
                 &query,
@@ -787,7 +787,7 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
                 crate::query::execution::ExecutionControls::default(),
                 false,
                 None,
-                None,
+                olap_result_cache.as_deref(),
             )
             .await
         {


### PR DESCRIPTION
## Summary

Completes the cache half of **TD-104 S4** and documents that the routing half was
already shipped. Small, self-contained: the `QueryFacadeAdapter` (the SQL authority
for the gRPC port path — and REST, since corrected-S1) now consults the OLAP result
cache on `SELECT`, so **gRPC SELECT caches like REST/pgwire** (the #720 follow-up).

## Change

`QueryFacadeAdapter::execute_sql` passed `result_cache=None` to `try_run_select`
(#720 left this as a documented same-crate follow-up), so gRPC SELECT never hit the
cache. Wire `olap_result_cache().as_deref()` into the TD-121 SELECT routing.
Same-crate call (no layering issue); **default-OFF** behind
`PROXIMADB_QUERY_RESULT_CACHE`, so a no-op unless the flag is set.

## S4 routing half — already shipped (finding)

Investigating S4's goal ("route REST SQL through the runtime handler → adapter")
showed it's **already done in production** via TD-104 corrected-S1:
- `multi_server.rs:445-455` builds `rest_ports_opt = Some(...)` with the runtime
  `api_handlers` **unconditionally** (outside the gRPC `if`).
- Both REST constructors call `with_api_handlers(p.api_handlers)` when `ports=Some`.
- No production caller uses the `ports=None` legacy constructors that would fall
  back to the root-cast default.

So the twin-handler SQL divergence is already structurally converged for
production; the root-cast survives only as the dev/test/legacy fallback (removing
it is the terminal ROOT-deletion slice, deliberately out of scope). `unified-facade-routing`
is default-on, and both the root handler and the adapter fall back to the **same**
`QueryFacadeAdapter::sql_query` facade — so there was no `execute_sql_frontend`
delta to fold (S4's "fold" clause is a no-op in the default build).

## Verification
- `cargo check --lib --bins` + `cargo clippy --lib --bins` (`-D warnings`): clean
- `rest_grpc_parity_test`: 6/6 (incl. `test_sql_query_parity`)
- `grpc_td121_relational_tenant_isolation_e2e` (exercises the cache-aware adapter)
  + `pgwire_relational_engine_e2e`: pass

## Scope
Cache parity for the gRPC SQL path. Full ROOT deletion (the TD-104 tail) remains
deferred backlog.
