### PR TITLE
fix(pgwire): stop psql \d/\dt client crash + dedup dual-registered tables

### DIFF
--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -235,6 +235,77 @@ fn pg_type_for_catalog_column(column_type: &str) -> PgType {
     }
 }
 
+/// Enforce the pgwire width-safety invariant on a catalog-introspection result
+/// before any frame is written: the RowDescription field count MUST equal every
+/// DataRow cell count. `RowDescription` and `DataRow` widths are encoded
+/// independently on the wire (`send_row_description` writes `fields.len()`;
+/// `send_data_row*` writes `values.len()`), so a mismatch emits a desync'd
+/// frame that crashes psql with libpq's `"column number N is out of range 0..M"`.
+///
+/// Rules, in order:
+/// 1. If the client's parsed SELECT aliases are present and their count differs
+///    from the result's column count, dispatch routed the query to a wrong-shape
+///    builder → return a safe EMPTY result (the client's alias names, all `text`,
+///    zero rows) so the client renders nothing instead of crashing.
+/// 2. Pad `column_types` to `columns.len()` with `"text"` (or truncate if longer).
+/// 3. Drop any row whose cell count ≠ column count.
+fn sanitize_catalog_result(
+    mut result: crate::services::CatalogIntrospectionResult,
+    select_aliases: Option<&[String]>,
+    query_for_logs: &str,
+) -> crate::services::CatalogIntrospectionResult {
+    // (1) Dispatch-vs-SELECT shape mismatch → graceful empty.
+    if let Some(aliases) = select_aliases
+        && aliases.len() != result.columns.len()
+    {
+        tracing::warn!(
+            target: "proximadb::pgwire::catalog",
+            query = %query_for_logs,
+            expected_columns = aliases.len(),
+            got_columns = result.columns.len(),
+            "catalog introspection shape mismatch; returning empty result to avoid a width-desync'd pgwire frame"
+        );
+        return crate::services::CatalogIntrospectionResult {
+            columns: aliases.to_vec(),
+            column_types: aliases.iter().map(|_| "text".to_string()).collect(),
+            rows: Vec::new(),
+        };
+    }
+
+    // (2) Make column_types exactly columns.len().
+    let ncols = result.columns.len();
+    if result.column_types.len() < ncols {
+        let missing = ncols - result.column_types.len();
+        result
+            .column_types
+            .extend(std::iter::repeat_n("text".to_string(), missing));
+        tracing::warn!(
+            target: "proximadb::pgwire::catalog",
+            query = %query_for_logs,
+            padded_to = ncols,
+            "padded catalog-introspection column_types with text"
+        );
+    } else if result.column_types.len() > ncols {
+        result.column_types.truncate(ncols);
+    }
+
+    // (3) Drop width-mismatched rows.
+    let before = result.rows.len();
+    result.rows.retain(|row| row.len() == ncols);
+    let dropped = before - result.rows.len();
+    if dropped > 0 {
+        tracing::warn!(
+            target: "proximadb::pgwire::catalog",
+            query = %query_for_logs,
+            dropped,
+            expected_width = ncols,
+            "dropped catalog-introspection rows with mismatched cell count"
+        );
+    }
+
+    result
+}
+
 fn pg_type_for_catalog_data_type(data_type: &ProximaType) -> PgType {
     match data_type {
         ProximaType::Boolean => PgType::Bool,
@@ -1442,6 +1513,14 @@ impl PostgresProtocol {
         let Some(result) = result else {
             return self.send_empty_result().await;
         };
+
+        // Width-safety: guarantee the RowDescription field count equals every
+        // DataRow cell count. If dispatch routed this query to a builder whose
+        // shape doesn't match the client's SELECT list, substitute a safe empty
+        // result rather than emit a desync'd frame (which crashes psql with
+        // libpq's "column number N is out of range"). See `sanitize_catalog_result`.
+        let select_aliases = crate::query::sql_frontend::parse_select_aliases(query);
+        let result = sanitize_catalog_result(result, select_aliases.as_deref(), query);
 
         let fields = result
             .columns

--- a/src/query/sql_frontend/mod.rs
+++ b/src/query/sql_frontend/mod.rs
@@ -8,3 +8,4 @@ mod tests;
 
 pub use parser::SqlFrontendParser;
 pub use parser::parse_explain_kind;
+pub use parser::parse_select_aliases;

--- a/src/query/sql_frontend/parser.rs
+++ b/src/query/sql_frontend/parser.rs
@@ -62,6 +62,53 @@ pub fn parse_explain_kind(query: &str) -> Option<(bool, &str)> {
     Some((false, after_explain))
 }
 
+/// Best-effort output-column label for a single SELECT projection item: the
+/// explicit alias when present, else the trailing identifier of the expression
+/// (`a.attname` → `attname`), else the raw expression text. Used to mirror the
+/// client's expected result shape for catalog introspection.
+fn projection_label(item: &SelectItem) -> String {
+    match item {
+        SelectItem::ExprWithAlias { alias, .. } => alias.value.clone(),
+        SelectItem::UnnamedExpr(expr) => {
+            let text = expr.to_string();
+            text.rsplit_once('.')
+                .map(|(_, last)| last.trim().to_string())
+                .unwrap_or(text)
+        }
+        SelectItem::Wildcard(_) => "*".to_string(),
+        _ => item.to_string(),
+    }
+}
+
+/// Parse a single SELECT's projection list and return the output-column labels
+/// the client expects (explicit alias, else a label derived from the
+/// expression). Returns `None` for anything that isn't a single SELECT, for any
+/// projection containing a wildcard (whose width we cannot determine from our
+/// side), or on parse failure — callers fall back to substring-based dispatch
+/// and the width-safety net. This lets catalog introspection answer psql-style
+/// queries (`SELECT ... AS "Name" ... FROM pg_catalog.pg_class ...`) with a
+/// result whose columns match the client's SELECT list by construction.
+pub fn parse_select_aliases(sql: &str) -> Option<Vec<String>> {
+    let statements = Parser::parse_sql(&GenericDialect, sql).ok()?;
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+    let Statement::Query(query) = statement else {
+        return None;
+    };
+    let SetExpr::Select(select) = &*query.body else {
+        return None;
+    };
+    if select
+        .projection
+        .iter()
+        .any(|item| matches!(item, SelectItem::Wildcard(_)))
+    {
+        return None;
+    }
+    Some(select.projection.iter().map(projection_label).collect())
+}
+
 /// SQL frontend parser that converts SQL text into internal AST nodes
 pub struct SqlFrontendParser {
     dialect: GenericDialect,

--- a/src/services/catalog_introspection.rs
+++ b/src/services/catalog_introspection.rs
@@ -101,6 +101,22 @@ impl CatalogIntrospectionService {
             && !normalized.contains("pg_attribute")
             && !normalized.contains("pg_namespace")
         {
+            // A rich psql-style probe (`SELECT ... AS "Name" ... FROM pg_class`)
+            // selects many columns; the narrow `sqlalchemy_table_names` builder
+            // returns one and would trip libpq's "column number out of range".
+            // Route multi-column queries to the shape-aware builder; keep the
+            // 1-column builder for genuine ORM probes that select `relname` only.
+            if let Some(aliases) =
+                crate::query::sql_frontend::parse_select_aliases(sql).filter(|a| a.len() > 1)
+            {
+                let relname = extract_string_filter(sql, "relname")
+                    .or_else(|| extract_string_filter(sql, "c.relname"))
+                    .or(table_filter.clone());
+                return Ok(Some(
+                    self.psql_shaped_table_list(&aliases, relname.as_deref())
+                        .await?,
+                ));
+            }
             return Ok(Some(self.sqlalchemy_table_names(None).await?));
         }
         if normalized.contains(" from xcatalog.columns")
@@ -135,6 +151,18 @@ impl CatalogIntrospectionService {
                 .or_else(|| extract_string_filter(sql, "ct.relname"))
                 .or_else(|| extract_string_filter(sql, "pg_class.relname"))
                 .or(table_filter);
+            // psql's `\d` column probe aliases columns (`AS "Column"`, `AS "Type"`,
+            // ...); the fixed-shape `sqlalchemy_columns` builder returns different
+            // names and psql fails to resolve them. Route multi-column queries to
+            // the shape-aware column builder; keep the ORM builder otherwise.
+            if let Some(aliases) =
+                crate::query::sql_frontend::parse_select_aliases(sql).filter(|a| a.len() > 1)
+            {
+                return Ok(Some(
+                    self.psql_shaped_columns(&aliases, relname_filter.as_deref())
+                        .await?,
+                ));
+            }
             return Ok(Some(
                 self.sqlalchemy_columns(relname_filter.as_deref()).await?,
             ));
@@ -152,6 +180,18 @@ impl CatalogIntrospectionService {
             let relname_filter = extract_string_filter(sql, "c.relname")
                 .or_else(|| extract_string_filter(sql, "pg_class.relname"))
                 .or(table_filter);
+            // psql `\dt` reaches this branch; route rich multi-column probes to
+            // the shape-aware builder so the returned columns match the SELECT
+            // list. The 1-column `sqlalchemy_table_names` path stays for ORM
+            // probes that select only `relname`.
+            if let Some(aliases) =
+                crate::query::sql_frontend::parse_select_aliases(sql).filter(|a| a.len() > 1)
+            {
+                return Ok(Some(
+                    self.psql_shaped_table_list(&aliases, relname_filter.as_deref())
+                        .await?,
+                ));
+            }
             return Ok(Some(
                 self.sqlalchemy_table_names(relname_filter.as_deref())
                     .await?,
@@ -1028,9 +1068,115 @@ impl CatalogIntrospectionService {
         })
     }
 
+    /// Shape-aware `\dt`/relation-list builder: return exactly the columns the
+    /// client's SELECT list named (the parsed aliases), one row per deduped
+    /// table, populating the aliases we recognize and leaving the rest empty.
+    /// This is what makes psql `\dt` show correct data instead of receiving a
+    /// 1-column shape (from the narrow `sqlalchemy_table_names` builder) that
+    /// triggers libpq's "column number N is out of range" and a client crash.
+    /// All cells are text-encoded (psql/ORMs treat pg_catalog probe columns as
+    /// text), so all `column_types` are `text`.
+    async fn psql_shaped_table_list(
+        &self,
+        aliases: &[String],
+        table_filter: Option<&str>,
+    ) -> Result<CatalogIntrospectionResult> {
+        let mut rows = Vec::new();
+        for (catalog_name, table_id, schema) in self.cataloged_tables().await? {
+            if !matches_filter(&table_id.name, table_filter) {
+                continue;
+            }
+            let row = aliases
+                .iter()
+                .map(|label| {
+                    let stripped = label.trim_matches('"');
+                    match stripped.to_ascii_lowercase().as_str() {
+                        "schema" | "nspname" | "table_schema" | "namespace" => {
+                            namespace_name(&table_id)
+                        }
+                        "name" | "relname" | "table_name" | "relation" => table_id.name.clone(),
+                        "owner" => "postgres".to_string(),
+                        "type" => "ordinary table".to_string(),
+                        "relkind" => "r".to_string(),
+                        "relowner" => "10".to_string(),
+                        "relnamespace" => namespace_oid(&namespace_name(&table_id)).to_string(),
+                        "relnatts" | "natts" => schema.columns.len().to_string(),
+                        "oid" | "relid" => table_oid(&catalog_name, &table_id).to_string(),
+                        "relhasindex" => bool_str(!schema.indexes.is_empty()).to_string(),
+                        "relpersistence" => "p".to_string(),
+                        "relrowsecurity" | "relforcerowsecurity" => "f".to_string(),
+                        _ => String::new(),
+                    }
+                })
+                .collect();
+            rows.push(row);
+        }
+        rows.sort();
+        Ok(CatalogIntrospectionResult {
+            columns: aliases.to_vec(),
+            column_types: aliases.iter().map(|_| "text".to_string()).collect(),
+            rows,
+        })
+    }
+
+    /// Shape-aware `\d` (column) builder: return exactly the columns the
+    /// client's SELECT list named, one row per column of matching tables. Maps
+    /// the common pg_attribute aliases (`Column`/`Type`/`Default`/`Nullable`/
+    /// ...) to catalog values and leaves unrecognized aliases empty.
+    async fn psql_shaped_columns(
+        &self,
+        aliases: &[String],
+        table_filter: Option<&str>,
+    ) -> Result<CatalogIntrospectionResult> {
+        let mut rows = Vec::new();
+        for (_catalog_name, table_id, schema) in self.cataloged_tables().await? {
+            if !matches_filter(&table_id.name, table_filter) {
+                continue;
+            }
+            for (idx, column) in schema.columns.iter().enumerate() {
+                let row = aliases
+                    .iter()
+                    .map(|label| {
+                        let stripped = label.trim_matches('"');
+                        match stripped.to_ascii_lowercase().as_str() {
+                            "column" | "attname" | "field" | "column_name" => column.name.clone(),
+                            "type" | "format_type" | "data_type" | "udt_name" => {
+                                postgres_format_type(&column.data_type, &column.properties)
+                                    .to_string()
+                            }
+                            "default" | "column_default" | "default_value" => {
+                                column.default_value.clone().unwrap_or_default()
+                            }
+                            "atthasdef" => bool_str(column.default_value.is_some()).to_string(),
+                            "nullable" | "is_nullable" => {
+                                if column.nullable {
+                                    "YES".to_string()
+                                } else {
+                                    "NO".to_string()
+                                }
+                            }
+                            "not_null" | "notnull" | "attnotnull" => (!column.nullable).to_string(),
+                            "ordinal" | "attnum" | "ordinal_position" | "attposition" => {
+                                (idx as i32 + 1).to_string()
+                            }
+                            "comment" => column.comment.clone().unwrap_or_default(),
+                            _ => String::new(),
+                        }
+                    })
+                    .collect();
+                rows.push(row);
+            }
+        }
+        rows.sort();
+        Ok(CatalogIntrospectionResult {
+            columns: aliases.to_vec(),
+            column_types: aliases.iter().map(|_| "text".to_string()).collect(),
+            rows,
+        })
+    }
+
     async fn cataloged_tables(&self) -> Result<Vec<(String, TableIdentifier, CatalogTableSchema)>> {
         let mut tables = Vec::new();
-
         for catalog_name in self.catalog_manager.list_catalogs().await {
             let catalog = self.catalog_manager.get_catalog(&catalog_name).await?;
             for namespace in catalog.list_namespaces(None).await? {
@@ -1040,6 +1186,22 @@ impl CatalogIntrospectionService {
                 }
             }
         }
+
+        // Dedup dual-registered tables. A table created via SQL surfaces both
+        // as an internal `proximadb.<ns>` collection namespace and as the
+        // SQL-standard `<ns>` schema (observed: `b` listed twice as
+        // `proximadb.default.b` and `public.b`). Collapse by normalized identity
+        // (see `table_identity_key`), preferring the SQL-standard form (no
+        // `proximadb.` prefix) so the surviving row displays the standard schema
+        // name. Same-name tables in different user namespaces stay distinct.
+        tables.sort_by_key(|(_, table_id, _)| {
+            table_id
+                .namespace
+                .first()
+                .is_some_and(|first| first.eq_ignore_ascii_case("proximadb"))
+        });
+        let mut seen = std::collections::BTreeSet::new();
+        tables.retain(|(_, table_id, _)| seen.insert(table_identity_key(table_id)));
 
         Ok(tables)
     }
@@ -1119,6 +1281,45 @@ fn namespace_name(table_id: &TableIdentifier) -> String {
         "public".to_string()
     } else {
         namespace
+    }
+}
+
+/// Fully-qualified logical identity for a catalog table, used to dedup
+/// `cataloged_tables()` across the catalog × namespace cross-product. Uses the
+/// normalized [`identity_namespace`] (NOT the raw display namespace) so the
+/// same logical table — which surfaces both as an internal `proximadb.<ns>`
+/// collection namespace and as the SQL-standard `<ns>` schema (e.g.
+/// `proximadb.default` and `public`) — collapses to one identity. Two same-name
+/// tables in DIFFERENT user namespaces (`analytics.events` vs `audit.events`)
+/// remain distinct.
+fn table_identity_key(table_id: &TableIdentifier) -> String {
+    format!("{}|{}", identity_namespace(table_id), table_id.name)
+}
+
+/// Normalized namespace used for dedup identity. Strips a leading `proximadb`
+/// segment — the collection/relational duality surfaces one namespace both as
+/// `proximadb.<ns>` and as `<ns>` — and maps `default`/empty → `public`, so
+/// `proximadb.default` and `public` (and bare `default`) all identify the same
+/// logical namespace.
+fn identity_namespace(table_id: &TableIdentifier) -> String {
+    let levels = &table_id.namespace;
+    let levels = if levels
+        .first()
+        .is_some_and(|first| first.eq_ignore_ascii_case("proximadb"))
+    {
+        &levels[1..]
+    } else {
+        levels
+    };
+    let joined = levels
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join(".");
+    if joined.is_empty() || joined == "default" {
+        "public".to_string()
+    } else {
+        joined
     }
 }
 
@@ -1334,6 +1535,44 @@ mod tests {
     use super::*;
     use crate::query::sql_frontend::SqlFrontendParser;
     use crate::services::{DdlService, DdlStatement};
+
+    /// The dedup key must collapse the SAME logical table surfacing under two
+    /// namespace forms — the internal `proximadb.<ns>` collection namespace and
+    /// the SQL-standard `<ns>` schema (the user's `b` listed twice by `\dt` as
+    /// `proximadb.default.b` and `public.b`) — while keeping same-name tables in
+    /// DIFFERENT user namespaces distinct.
+    #[test]
+    fn table_identity_key_collapses_duplicates_keeps_cross_namespace() {
+        // The observed duality: `proximadb.default.b` and `public.b` are the
+        // same logical table and must collapse.
+        let via_proximadb_ns =
+            TableIdentifier::new(vec!["proximadb".to_string(), "default".to_string()], "b");
+        let via_public = TableIdentifier::new(vec!["public".to_string()], "b");
+        assert_eq!(
+            table_identity_key(&via_proximadb_ns),
+            table_identity_key(&via_public)
+        );
+
+        // default/empty roots also normalize to "public".
+        let via_default = TableIdentifier::new(vec!["default".to_string()], "b");
+        let via_empty_root = TableIdentifier::new(Vec::new(), "b");
+        assert_eq!(
+            table_identity_key(&via_default),
+            table_identity_key(&via_empty_root)
+        );
+        assert_eq!(
+            table_identity_key(&via_default),
+            table_identity_key(&via_public)
+        );
+
+        // Same name, different user namespaces → distinct (must NOT collapse).
+        let events_analytics = TableIdentifier::new(vec!["analytics".to_string()], "events");
+        let events_audit = TableIdentifier::new(vec!["audit".to_string()], "events");
+        assert_ne!(
+            table_identity_key(&events_analytics),
+            table_identity_key(&events_audit)
+        );
+    }
 
     #[tokio::test]
     async fn test_catalog_introspection_projects_agentic_mixed_schema() {

--- a/tests/pgwire_psql_introspection_e2e.rs
+++ b/tests/pgwire_psql_introspection_e2e.rs
@@ -1,0 +1,234 @@
+//! End-to-end regression for the psql `\dt` / `\d` crash class.
+//!
+//! Symptoms this guards against (observed 2026-07-07):
+//! 1. `psql \dt` listed the same table `b` **twice**.
+//! 2. `psql \d b` crashed the client with SIGSEGV after libpq printed
+//!    `column number N is out of range 0..M`.
+//!
+//! Root cause: pgwire catalog-introspection dispatch routed psql's rich
+//! multi-column `pg_catalog` probes to narrow synthetic builders, so the
+//! RowDescription field count didn't match the client's SELECT list and psql
+//! dereferenced missing data. Compounded by `cataloged_tables()` enumerating
+//! the catalog × namespace cross-product without dedup, surfacing `b` twice.
+//!
+//! This test boots an in-process ProximaDB, connects a real `tokio-postgres`
+//! client over TCP, and reproduces the user's exact flow: CREATE TABLE →
+//! reconnect → `\dt`-equivalent (assert each table once) → `\d`-equivalent
+//! (assert no error, correct column shape). `tokio_postgres::simple_query`'s
+//! `Row::get(idx)` exercises the same indexed column access that crashes psql,
+//! so it is a faithful in-process proxy for the real client without needing the
+//! `psql` binary.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::SimpleQueryMessage;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct PgwireTestServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl PgwireTestServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        // Isolate the catalog WAL + global manifest to the temp dir so the test
+        // is reproducible across runs (otherwise the default `./metadata`
+        // persists tables like `b` and CREATE fails with "already exists").
+        config.storage.metadata_url = format!("file://{}/metadata", tmp_data.path().display());
+        config.storage.wal_config.global_manifest_url =
+            Some(format!("file://{}/manifest", tmp_data.path().display()));
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{}/health", rest_port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            match http_client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!("REST not ready on port {}", rest_port);
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn pg_connection_string(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgwireTestServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Collect `SimpleQueryMessage::Row`s from a `simple_query` result.
+fn rows_of(messages: Vec<SimpleQueryMessage>) -> Vec<tokio_postgres::SimpleQueryRow> {
+    messages
+        .into_iter()
+        .filter_map(|m| match m {
+            SimpleQueryMessage::Row(row) => Some(row),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pgwire_dt_dedup_and_d_shape_contract() {
+    let server = PgwireTestServer::start().await.expect("server start");
+
+    // --- Session 1: create two distinct tables (mirrors the user's CREATE). ---
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+            .await
+            .expect("connect");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+        .simple_query("CREATE TABLE b (id INT PRIMARY KEY, v VARCHAR)")
+        .await
+        .expect("create b");
+    client
+        .simple_query("CREATE TABLE c2 (id INT PRIMARY KEY)")
+        .await
+        .expect("create c2");
+    drop(client);
+
+    // --- Session 2: reconnect, then run psql-style introspection probes. ---
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_connection_string(), tokio_postgres::NoTls)
+            .await
+            .expect("reconnect");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    // `\dt`-equivalent: a multi-column pg_catalog probe with aliases (the shape
+    // psql sends). Must hit the shape-aware table-list builder and return each
+    // table exactly once (Bug A: dedup contract).
+    let dt = client
+        .simple_query(
+            "SELECT n.nspname AS \"Schema\", c.relname AS \"Name\", \
+             'postgres' AS \"Owner\", 'ordinary table' AS \"Type\" \
+             FROM pg_catalog.pg_class c \
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+             WHERE c.relname IN ('b', 'c2')",
+        )
+        .await
+        .expect("\\dt-equivalent must not error");
+    let dt_rows = rows_of(dt);
+    // RowDescription must carry the client's SELECT-list column names.
+    assert!(!dt_rows.is_empty(), "\\dt should list the created tables");
+    let col_names: Vec<&str> = dt_rows[0].columns().iter().map(|c| c.name()).collect();
+    assert_eq!(
+        col_names,
+        vec!["Schema", "Name", "Owner", "Type"],
+        "\\dt columns must match the client's SELECT aliases (shape-aware contract)"
+    );
+    let listed_names: Vec<&str> = dt_rows.iter().map(|r| r.get(1).unwrap_or("")).collect();
+    let b_count = listed_names.iter().filter(|n| **n == "b").count();
+    let c2_count = listed_names.iter().filter(|n| **n == "c2").count();
+    assert_eq!(
+        b_count, 1,
+        "Bug A: table b must appear exactly once in \\dt"
+    );
+    assert_eq!(
+        c2_count, 1,
+        "distinct tables must each appear exactly once (dedup not over-collapsing)"
+    );
+
+    // `\d b`-equivalent: a multi-column pg_attribute probe with aliases. Must
+    // not error/crash and must return the table's columns with the right shape
+    // (Bug B: width-safety + shape-aware contract).
+    let d = client
+        .simple_query(
+            "SELECT a.attname AS \"Column\", \
+             pg_catalog.format_type(a.atttypid, a.atttypmod) AS \"Type\" \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_class c ON a.attrelid = c.oid \
+             WHERE c.relname = 'b' AND a.attnum > 0",
+        )
+        .await
+        .expect("\\d b must not error or crash the client");
+    let d_rows = rows_of(d);
+    // Regression contract: `\d b` must NOT crash (the original SIGSEGV) and
+    // must return rows whose shape matches the client's SELECT list. The
+    // specific column VALUES reflect the backing collection's canonical schema
+    // (ADR-047 collection≡table) rather than the DDL's `(id, v)`; surfacing the
+    // user-defined columns in `\d` is a deeper schema-authority follow-up
+    // (tracked as a TD), not part of this crash/shape fix.
+    assert!(
+        !d_rows.is_empty(),
+        "\\d b should describe the table's columns without crashing"
+    );
+    let d_col_names: Vec<&str> = d_rows[0].columns().iter().map(|c| c.name()).collect();
+    assert_eq!(
+        d_col_names,
+        vec!["Column", "Type"],
+        "\\d columns must match the client's SELECT aliases (shape-aware contract)"
+    );
+    // Every DataRow cell count must equal the RowDescription field count — the
+    // width-safety invariant whose violation crashed psql.
+    for row in &d_rows {
+        assert_eq!(
+            row.columns().len(),
+            2,
+            "\\d rows must carry exactly the SELECT-list width"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Observed against a long-running server: `psql \\dt` listed table `b` **twice**, and `psql \\d b` **crashed the client** (SIGSEGV) after libpq printed `column number 1 is out of range 0..0` and `column number 7 is out of range 0..6`.

## Root cause (pinned by direct code reading)

1. **Duplicate table.** `cataloged_tables()` enumerated `list_catalogs() × list_namespaces(None) × list_tables()` with **no dedup**. A SQL table surfaces under two namespace forms — the internal `proximadb.<ns>` collection namespace and the SQL-standard `<ns>` schema (diagnosed live: `b` appeared as both `proximadb.default.b` and `public.b`).
2. **Segfault.** `execute_select` dispatch uses coarse substring matching and routed psql's rich multi-column `pg_catalog` probes to **narrow 1-column synthetic builders** (e.g. `from pg_class` → `sqlalchemy_table_names` = 1 col). The wire seam encodes `RowDescription` and `DataRow` widths independently (`send_row_description` writes `fields.len()`; `send_data_row_*` writes `values.len()`) with no invariant, so the client got a 1-field result for a 7-column expectation → libpq `PQgetvalue` returns the out-of-range error → psql dereferences the missing data and segfaults.

## Fix

- **Dedup** `cataloged_tables()` by a normalized identity (strip a leading `proximadb.` prefix + map `default`/empty → `public`), preferring the SQL-standard namespace form so the surviving row displays the standard schema name. Same-name tables in different user namespaces stay distinct.
- **Width-safety invariant** at the protocol seam (`sanitize_catalog_result`): on any `RowDescription`/`DataRow` mismatch, emit a safe empty result with the client's SELECT aliases instead of a desync'd frame — making the segfault class impossible.
- **Shape-aware dispatch** for `\\dt`/`\\d`: parse the SELECT aliases (`parse_select_aliases`) and return columns matching the client's SELECT list by construction. Gated on `aliases.len() > 1` so genuine 1-column ORM probes keep the existing path.

## Tests

- New `tests/pgwire_psql_introspection_e2e.rs`: boots in-process ProximaDB, `tokio-postgres` over TCP, reproduces create → reconnect → `\\dt` (assert each table once, columns match SELECT aliases) → `\\d` (assert no error/crash, correct shape). `tokio_postgres::simple_query`'s indexed `Row::get` exercises the same access that crashes psql.
- Unit test `table_identity_key_collapses_duplicates_keeps_cross_namespace` for the dedup key (collapses the `proximadb.<ns>` ↔ `<ns>` duality, keeps `analytics.events` ≠ `audit.events`).
- Existing `catalog_introspection` tests still pass.

Verified: `cargo clippy -p proximadb --lib --bins` clean (CI gate), e2e + unit tests green.

## Out of scope (follow-up)

`\\d` returns the backing collection's canonical schema columns (ADR-047 collection≡table) rather than the DDL's `(id, v)`; surfacing the user-defined columns is a deeper schema-authority question to be tracked separately, as is investigating the write-side cause of the dual registration.