### PR TITLE
refactor(rl-planner): shrink policy file + skip no-op checkpoint rewrites

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -922,12 +922,22 @@ impl ProximaDB {
                 let interval = std::time::Duration::from_secs(RL_CHECKPOINT_INTERVAL_SECS);
                 let mut ticker = tokio::time::interval(interval);
                 ticker.tick().await;
+                // Dirty-flag: only rewrite the policy when learning actually
+                // advanced since the last checkpoint. A long-running idle server
+                // otherwise rewrites an identical multi-KB file every tick.
+                let mut last_saved_updates: Option<u64> = None;
 
                 loop {
                     ticker.tick().await;
                     if let Some(planner) = query::rl_planner::get_rl_planner() {
+                        let updates = planner.total_updates().await;
+                        if last_saved_updates == Some(updates) {
+                            continue;
+                        }
                         if let Err(e) = planner.save_policy(&checkpoint_path).await {
                             tracing::warn!("Failed to save RL policy checkpoint: {}", e);
+                        } else {
+                            last_saved_updates = Some(updates);
                         }
                     } else {
                         break;

--- a/src/query/rl_planner/bandit.rs
+++ b/src/query/rl_planner/bandit.rs
@@ -137,12 +137,16 @@ pub struct ContextualBanditPlanner {
     /// Exploration rate for ε-greedy fallback
     exploration_rate: f32,
     /// Base exploration rate (before decay) — used to reset for new contexts
+    #[serde(skip_serializing, default)]
     base_exploration_rate: f32,
     /// Use Thompson Sampling (true) or ε-greedy (false)
+    #[serde(skip_serializing, default)]
     use_thompson_sampling: bool,
     /// Per-engine action spaces
+    #[serde(skip_serializing, default)]
     engine_action_spaces: HashMap<String, ActionSpace>,
     /// Default action space
+    #[serde(skip_serializing, default)]
     default_action_space: ActionSpace,
     /// Total number of updates
     total_updates: u64,
@@ -155,7 +159,11 @@ impl ContextualBanditPlanner {
     /// Create new contextual bandit planner
     pub fn new(exploration_rate: f32, use_thompson_sampling: bool) -> Self {
         let mut engine_action_spaces = HashMap::new();
-        for engine in &["SST", "HELIX", "VIPER", "SWIFT", "NOVA", "RAPTOR"] {
+        // Only live storage engines get action spaces. SWIFT and RAPTOR are
+        // retired/experimental-off; a query routed to an engine without a space
+        // falls back to `default_action_space` (SST) via the `unwrap_or` in
+        // select/exploit, which is safe.
+        for engine in &["SST", "HELIX", "VIPER", "NOVA"] {
             engine_action_spaces.insert(engine.to_string(), ActionSpace::for_engine(engine));
         }
 
@@ -438,6 +446,10 @@ impl ContextualBanditPlanner {
         self.context_weights = loaded.context_weights;
         self.exploration_rate = loaded.exploration_rate;
         self.total_updates = loaded.total_updates;
+        // Restore per-engine learning maturity too. Without this every engine
+        // looks "new" (0 updates) after restart and exploration is wrongly
+        // boosted via the <50-updates branch in select_action.
+        self.engine_update_counts = loaded.engine_update_counts;
 
         tracing::info!(
             "Loaded RL planner state from {} ({} actions, {} updates)",
@@ -705,6 +717,27 @@ mod tests {
         // Should have same stats
         assert_eq!(planner.total_updates(), loaded.total_updates());
         assert_eq!(planner.action_stats.len(), loaded.action_stats.len());
+
+        // The static action-space config must NOT be persisted (it's regenerated
+        // by `new()` and never read back); only learned state is on disk. This
+        // is what keeps the policy file small.
+        let on_disk = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(
+            !on_disk.contains("engine_action_spaces"),
+            "persisted policy must omit static engine_action_spaces, got: {on_disk}"
+        );
+        assert!(
+            !on_disk.contains("default_action_space"),
+            "persisted policy must omit static default_action_space"
+        );
+
+        // engine_update_counts is learned state and must round-trip (it was
+        // previously dropped on load, making every engine look "new" after a
+        // restart and wrongly boosting exploration).
+        assert_eq!(
+            planner.engine_update_counts, loaded.engine_update_counts,
+            "engine_update_counts must round-trip through save/load"
+        );
 
         // Cleanup
         let _ = tokio::fs::remove_file(path).await;

--- a/src/query/rl_planner/integration.rs
+++ b/src/query/rl_planner/integration.rs
@@ -384,6 +384,11 @@ impl RLPlannerIntegration {
         planner.load_policy(path).await
     }
 
+    /// Total reward updates observed (passthrough for the checkpoint dirty-flag).
+    pub async fn total_updates(&self) -> u64 {
+        self.planner.read().await.total_updates().await
+    }
+
     /// Check if RL planning is enabled
     pub fn is_enabled(&self) -> bool {
         self.config.enabled

--- a/src/query/rl_planner/mod.rs
+++ b/src/query/rl_planner/mod.rs
@@ -264,6 +264,13 @@ impl RLPlanner {
         let bandit = self.bandit.read().await;
         bandit.save_to_file(path).await
     }
+
+    /// Total number of reward updates observed since the planner was created.
+    /// Used by the checkpoint task to skip no-op rewrites when no learning has
+    /// occurred between ticks.
+    pub async fn total_updates(&self) -> u64 {
+        self.bandit.read().await.total_updates()
+    }
 }
 
 impl Default for RLPlanner {


### PR DESCRIPTION
## Problem

The persisted \`rl_policy.json\` was ~95% static config written on every save but **never read back**, and the checkpoint task rewrote the entire file every 300s unconditionally — an idle 6h server did ~70 identical multi-KB rewrites with zero learning. \`engine_update_counts\` (learned state) was also silently dropped on load.

## Changes

- **Stop persisting static config.** \`#[serde(skip_serializing, default)]\` on \`engine_action_spaces\`, \`default_action_space\`, \`base_exploration_rate\`, \`use_thompson_sampling\` — all regenerated by \`new()\` and ignored by \`load_from_file\`. File shrinks ~95%; **old files still deserialize** (no version/migration needed).
- **Restore \`engine_update_counts\` on load** — it's learned state that was dropped, so every engine looked "new" (0 updates) after restart, wrongly boosting exploration.
- **Drop retired SWIFT/RAPTOR** from the seeded engine action spaces; a query routed to an unseeded engine falls back to \`default_action_space\` (SST) via the existing \`unwrap_or\`.
- **Dirty-flag the checkpoint task** — only rewrite when \`total_updates\` advanced since the last save (adds \`RLPlanner\`/\`RLPlannerIntegration::total_updates\` accessors).

## Tests

- \`test_save_and_load\` now asserts the file omits \`engine_action_spaces\`/\`default_action_space\` and that \`engine_update_counts\` round-trips.
- All 9 \`rl_planner_integration_test\` tests pass (incl. \`test_action_space_coverage\`, which exercises SWIFT/RAPTOR and now exercises the fallback path).
- \`cargo clippy -p proximadb --lib --bins\` clean (CI gate).