### PR TITLE
docs(td): file TD-PGW-1/2 — pgwire catalog follow-ups

### DIFF
--- a/docs/10-quality/td/TD-PGW-1-catalog-double-registration-write-side.adoc
+++ b/docs/10-quality/td/TD-PGW-1-catalog-double-registration-write-side.adoc
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-PGW-1: Catalog double-registration — a SQL table surfaces twice in introspection
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — read-side dedup landed as mitigation (PR #738); the write-side source fix is the remaining work tracked here.
+| Severity | Medium — every SQL table appears twice in `pg_catalog`/`information_schema` probes; cosmetic for `\dt` but doubles `\d` column rows and confuses clients that count relations.
+| Component | `src/services/catalog_introspection.rs` (`cataloged_tables`, `identity_namespace`); the DDL `create_table` registration path; `CatalogManager` + the collection≡table mapping (ADR-047).
+| Relates to | PR #738 (read-side dedup), ADR-047 (collection≡table), link:TD-PGW-2-pg-catalog-as-relational-views.adoc[TD-PGW-2]
+|===
+
+== Symptom
+
+`psql \dt` listed a table `b` created once via `CREATE TABLE b (...)` **twice**.
+Live diagnosis (PR #738 e2e test) showed each table enumerating under two
+distinct namespaces: the internal collection namespace `proximadb.<ns>` and the
+SQL-standard `<ns>` schema — e.g. `proximadb.default.b` and `public.b` for the
+same logical table.
+
+== Root cause (enumeration side — fixed in PR #738)
+
+`cataloged_tables()` walked `list_catalogs() × list_namespaces(None) ×
+list_tables()` and emitted one row per (catalog, namespace, table) with no
+dedup. The same logical table surfaced under both namespace forms, so every
+builder that consumes `cataloged_tables` (`pg_class`, `information_schema.tables`,
+`\d` columns, …) emitted duplicates.
+
+The mitigation dedups by a **normalized** identity (`identity_namespace`: strip a
+leading `proximadb.` segment + map `default`/empty → `public`), preferring the
+SQL-standard namespace form for the surviving row.
+
+== Open work (write side)
+
+The dedup is defense-in-depth at the read boundary. The deeper question — **why
+the table is registered/surfaced under two namespaces in the first place** — is
+unresolved. Likely the collection≡table unification (ADR-047): `CREATE TABLE`
+writes a relational catalog entry (`public.b`) **and** mirrors/backs it as a
+collection (`proximadb.default.b`), and the introspection enumeration unifies
+both stores.
+
+Next action:
+. Trace `CREATE TABLE` end-to-end (`src/services/ddl/`) and confirm whether it
+  writes to two stores (relational catalog + collection registry), or whether
+  `list_catalogs()`/`list_namespaces(None)` returns overlapping roots (twin
+  canonical/legacy catalog).
+. Decide the single source of truth for the SQL surface and stop the second
+  registration (or stop enumerating it), so `cataloged_tables` naturally returns
+  one entry and the read-side dedup becomes redundant.
+. Add a regression that creates a table and asserts `cataloged_tables` returns
+  exactly one entry *without* the dedup (proving the source fix).
+
+Until then, the read-side dedup in PR #738 keeps `\dt`/`\d` correct.

--- a/docs/10-quality/td/TD-PGW-2-pg-catalog-as-relational-views.adoc
+++ b/docs/10-quality/td/TD-PGW-2-pg-catalog-as-relational-views.adoc
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-PGW-2: Serve pg_catalog/information_schema as real relational views
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — Phase 1 (crash-proof + shape-aware dispatch) landed in PR #738; the full relational-view rewrite is the work tracked here.
+| Severity | Medium — `\d` shows the backing collection's canonical schema columns rather than the DDL's user-defined columns; psql/ORM introspection is crash-safe but not yet fully faithful.
+| Component | `src/services/catalog_introspection.rs` (dispatch + synthetic builders); `src/network/postgres/protocol.rs` (`execute_catalog_introspection_query`); the relational engine (`try_run_select`).
+| Relates to | PR #738, ADR-047 (collection≡table / schema authority), link:TD-PGW-1-catalog-double-registration-write-side.adoc[TD-PGW-1]
+|===
+
+== What landed in Phase 1 (PR #738)
+
+. **Width-safety invariant** at the pgwire seam (`sanitize_catalog_result`): a
+  `RowDescription`/`DataRow` width mismatch is converted to a safe empty result,
+  so the libpq `"column number N is out of range"` → psql SIGSEGV class of bug
+  is impossible.
+. **Shape-aware dispatch** for `\dt`/`\d`: parse the client's SELECT aliases and
+  return columns matching that SELECT list by construction (`psql_shaped_table_list`,
+  `psql_shaped_columns`), instead of routing rich multi-column probes to narrow
+  1-column synthetic builders.
+. **Read-side dedup** (see TD-PGW-1).
+
+== Open work (Phase 2)
+
+The introspection layer is still a set of hand-written synthetic builders picked
+by coarse substring matching in `CatalogIntrospectionService::execute_select`.
+This has two gaps Phase 1 did not close:
+
+. **Schema authority**: `\d <t>` returns the backing collection's canonical
+  schema columns (e.g. `oid, tenant_id, created_at_ns, updated_at_ns, props,
+  embedding`) rather than the DDL's user-defined columns (`id, v`). This is the
+  ADR-047 collection≡table schema-authority question — the SQL surface should
+  project the user's relational columns.
+. **Shape fidelity**: every pg_catalog probe must be anticipated by a dispatch
+  arm; anything unhandled degrades to a graceful empty (no crash, but no data).
+
+Next action:
+. Register `pg_class`, `pg_attribute`, `pg_namespace`, `pg_type`, `pg_index`,
+  `pg_constraint` (and the `information_schema.*` views) as real read-only,
+  catalog-backed relations in the relational engine, mirroring the existing
+  `pg_namespace()`/`pg_class()`/`pg_attribute()` builder logic.
+. Route `try_run_select` to answer them natively so the result column shape
+  matches the client's SELECT list by construction (predicate pushdown for
+  `WHERE c.relname = 'b'`; type-OID resolution via `proxima_type_oid`).
+. Retire the synthetic dispatch layer in `execute_select` (keep `xcatalog.*`
+  ProximaDB-specific views for as long as ORMs depend on their fixed shapes).
+. Resolve schema authority so `\d` projects the DDL columns.
+
+The Phase 1 width-safety invariant + shape-aware builder remain correct as
+defense-in-depth under this rewrite.


### PR DESCRIPTION
Tracks the open follow-ups from PR #738 (psql \\d/\\dt crash + dedup fix).

- **TD-PGW-1** — catalog double-registration write-side root cause. PR #738 added a read-side dedup as mitigation; the deeper question (why a SQL table surfaces under both `proximadb.<ns>` and the SQL-standard `<ns>`) stays open.
- **TD-PGW-2** — Phase 2: serve `pg_catalog`/`information_schema` as real relational views so `try_run_select` answers them natively (retire the synthetic substring-dispatch), and resolve schema authority so `\\d` projects the DDL columns (ADR-047).

Docs-only. `check_td_adr_unique.py` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)