### PR TITLE
docs(td): file TD-XMODAL-9 + review response to 2026-07-07 architecture review

### DIFF
--- a/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
+++ b/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
@@ -1,0 +1,211 @@
+= Response to Antigravity Architectural Review (2026-07-07)
+:toc: left
+:toclevels: 2
+:icons: font
+:last-updated: 2026-07-07
+
+[.lead]
+This document responds to the comprehensive architectural review produced by Antigravity on
+2026-07-07 (`architectural_review.md`, grade B-). It (1) corrects several load-bearing claims
+that are stale or miscited, (2) maps every "real" finding to the Technical-Debt entry that
+already tracks it, (3) records the one genuinely-new finding filed from the review, and (4)
+separates engineering work from product/strategy decisions that are the maintainer's call, not
+code edits. Predecessor: link:REVIEW_RESPONSE_FEB_2025.adoc[the February 2025 review response].
+
+[IMPORTANT]
+====
+The review is broadly sound in its *themes* (god objects, twin handlers, DataFusion/Volcano
+divergence, single-node-vs-MPP gap, agent-memory wedge). Its *citations* are not: it invents a
+`TD-CAT-2` that does not exist, treats already-tracked TDs as new discoveries, and overstates
+two items that are in fact already resolved or in-flight. **Acting on the review as written
+would duplicate in-flight work and chase ghost items.** This doc is the corrected action plan.
+====
+
+== 1. Executive Summary
+
+* The review's three top risks (vision-vs-reality gap, handler monolith, catalog tenancy) are
+  real in *theme* but two of the three are **already tracked, in-progress TDs** the review
+  filed under wrong/non-existent IDs.
+* **~9 of 11 backlog items map to existing TD entries** (TD-104, TD-151, TD-186/ADR-043,
+  TD-168/ADR-034, TD-123, TD-ENGINE-1, TD-078, ADR-018, the measurement mandate). Filing new
+  TDs for these would violate the collision-free convention and be rejected by the
+  `td-adr-unique` guard.
+* **One genuinely-new finding** — cross-modal fusion streams lack `ExecutionControls` row/byte
+  caps — is filed as link:td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc[TD-XMODAL-9].
+* **Two items are product/strategy decisions**, not code (warehouse positioning, defer
+  multi-table ACID). These are flagged for the maintainer; this doc does not enact them.
+* **No new release blocker is uncovered.** The nearest real SaaS risk — catalog metadata
+  path isolation — is ADR-032 (Proposed) and is already in-flight in the working tree.
+
+== 2. Corrections — stale, miscited, or already-resolved items
+
+=== 2.1. `TD-CAT-2` (cited as a P0 catalog-isolation blocker) does not exist
+
+*Review claim:* "Treat TD-CAT-2 as a P0 release blocker for SaaS multi-tenant."
+
+*Actual state:* There is no `TD-CAT-2` file in `docs/10-quality/td/` or row in the legacy
+`TECHNICAL_DEBT.adoc`. The catalog-isolation gap is real but it is **already documented and
+in-flight**:
+
+* link:../12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc[ADR-032]
+  (status: **Proposed**) names the exact gap — Decision F2: `NativeCatalog` persists flat
+  `base_path/metadata/tables/<namespace>/<table>.json` with no `{tenant_id}` segment, so the
+  catalog metadata authority is the one place tenant data is not path-isolated, even though
+  `DrPathBuilder` handles the data path.
+* `src/catalog/mod.rs` **already ships substantial isolation machinery**: `resolve_table_within_tenant`
+  (TD-064), the reserved-segment denylist guarding `_operator`/`_metering`/`_trace`, ADR-035
+  per-tenant hot cache (TD-SC-1), and a fail-closed `parse_storage_url` (line 298).
+* **`src/catalog/mod.rs` is currently modified in the working tree** — i.e. this is active
+  work, not an undiscovered hole. Per-modality isolation is tracked separately: TD-DOC-TENANT-1,
+  TD-ENTITY-TENANT-1, TD-GRAPH-TENANT-1, TD-IOTRACE-2, TD-XMODAL-8.
+
+*Action:* Do **not** open a new "catalog tenant isolation" TD — it would duplicate ADR-032 +
+collide with the in-flight catalog changes. Drive ADR-032 to Accepted and execute its phased
+rollout (it already specifies fail-closed `DeploymentMode::{SingleTenant, MultiTenant}`).
+
+=== 2.2. "100K QPS / sub-ms in public docs" is largely already handled
+
+*Review claim:* "Scrub the README and marketing docs. Only publish numbers marked
+`status = "measured"`."
+
+*Actual state:* The README perf section is **already explicitly caveated** —
+*"treat as headroom indicators, not a published SLA,"* recall marked
+*"not an SLA — see SUPPORTED_SURFACE,"* plus a NOTE clarifying v0.2 is a narrow single-node cut
+with Beta/Experimental tiers enumerated. The "100K QPS" figure the review flags lives in
+`docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml` marked **unverified** — which is exactly the
+correct placement (internal ledger, not public claim). The only loose thread is positioning
+copy in link:../00-product/PRD.adoc[PRD] / link:../00-product/VISION.adoc[VISION]
+("sub-millisecond latency in a single Rust binary", "sub-ms OHLC") — aspirational product
+descriptors, not benchmark claims.
+
+*Action:* Minor wording tightening in PRD/VISION positioning sentences (swap "sub-millisecond"
+for "low-latency, single-node" or route to a measured ledger entry). Not a scrub.
+
+=== 2.3. "Repo clutter" scratch directories are already gitignored
+
+*Review implication:* scratch top-level dirs (`test_metadata*`, `footer_cache.bin`, …) clutter
+the tree.
+
+*Actual state:* `test_metadata`, `test_metadata_atomic`, `test_schema[2,3,5]`, `log/`,
+`footer_cache.bin`, `pytest_debug.log` are **all gitignored** (`git check-ignore` confirms).
+Only `data/` is tracked. There is no committed clutter to remove.
+
+=== 2.4. "B04 hard-delete v1 = quick win (S effort)" is mislabeled
+
+*Review claim:* v1 deletion is a quick win.
+
+*Actual state:* v1 removal is the **staged v1-proto ratchet** (link:td/../TECHNICAL_DEBT.adoc[TD-123]),
+baseline at `docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json`, enforced downward-only by
+`scripts/check_v1_proto_usage.py`, with thousands of references to retire across catalog /
+query / records. This is a deliberate multi-PR effort, not an `S`. The deprecated-engine
+sibling is link:td/TD-ENGINE-1-deprecated-engine-removal-entanglement.adoc[TD-ENGINE-1].
+
+== 3. Findings → existing TD mapping
+
+Every review item below is already tracked. New TDs were **not** filed (would duplicate).
+
+[cols="1,3,2,1", options="header"]
+|===
+| Review item | Already tracked as | Status | Verdict
+
+| B02 / R03 — god objects, twin `UnifiedHandlers`
+  (`request_handlers.rs` 4273L, `protocol.rs` 6556L, `database.rs` 1439L)
+| link:../12-design/TD104_HANDLER_CONVERGENCE_PLAN_2026_06_03.adoc[TD-104] "Phase 9 handler/service extraction (seam S1)" +
+  design docs: `TD104_HANDLER_CONVERGENCE_PLAN_2026_06_03.adoc`, `ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc`
+| In Progress (D4 / OE)
+| Real. Review accurate on sizes (verified). Drive TD-104 to completion; note `protocol.rs` (6556L) is the largest monolith and was under-emphasized by the review.
+
+| B05 / R10 — PAX ranged-read coalescing / S3 GET fees
+| link:TECHNICAL_DEBT.adoc[TD-151] "PAX ranged-read range-coalescing + block pruning"
+| Open (D1 / COST)
+| Real, exactly tracked. Note TD-167 (PAX read-path depth collapse) is already *Resolved*.
+
+| R08 / B06 — DataFusion/Volcano divergence; capability-registry routing
+| link:td/TD-186-relational-expr-eval-unification.adoc[TD-186] + link:../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (single logical lowering) +
+  link:td/TD-OLAP-1-pax-native-vectorized-scan-feeds-datafusion.adoc[TD-OLAP-1] (retire Volcano-for-OLAP)
+| Open
+| Real. The review's own remedy ("rely on relational-algebra single lowering") *is* ADR-043.
+
+| B08 / R05 — ORION projection drift / WAL LSN-correlation
+| link:TECHNICAL_DEBT.adoc[TD-168] / link:../12-design/adr/ADR-034-objectstore-access-path-codesign.adoc[ADR-034] re-scope (cold-start O(E) rebuild; make graph object-storage-native) + TD-066 (scoped graph WAL replay)
+| Open
+| Real. ADR-034's runtime audit already corrected the original framing (CSR is RAM-resident; the gap is cold-start rebuild + RAM-boundedness).
+
+| B04 / R07 — deprecated v1 REST/gRPC weight
+| TD-123 (v1-proto ratchet) + link:td/TD-ENGINE-1-deprecated-engine-removal-entanglement.adoc[TD-ENGINE-1]
+| Open
+| Real, staged. Not a quick win (see §2.4).
+
+| B07 — distributed MPP (Ballista) unwired
+| link:TECHNICAL_DEBT.adoc[TD-078] federated execution; strategically deferred per the 2026-06-04 course correction
+| Open / deferred
+| Real. Strategic bet, explicitly not MVP.
+
+| B11 — multi-table ACID (BEGIN/COMMIT)
+| pgwire parity roadmap (link:../12-design/adr/ADR-018-pgwire-sql-parity-roadmap.adoc[ADR-018])
+| Planned
+| Review itself tags this **DEFER (P4)**. Agreed.
+
+| B09 — cross-modal fusion latency unverified at scale
+| The ADR-034 measurement mandate (scale + trace harness: SF≥1 dbgen/dsdgen, SIFT1M/768-d N≥1M, real object-store, concurrency, captured io_traces) + link:td/TD-OLAP-4-tpcds-performance-evidence-ledger.adoc[TD-OLAP-4] ledger + link:TECHNICAL_DEBT.adoc[TD-182] accuracy harness
+| Open
+| Real. The substrate to turn "proven" into "measured" is already scoped.
+
+| R06 — in-memory pod-restart rebuild tax
+| TD-168 / ADR-034 (graph O(E) cold-start) + the storage-format decision framework (in-memory-vs-streaming restart tax)
+| Open
+| Real, graph-specific tracked; broader restart tax is the documented in-memory trade-off.
+
+| B03 / R04 — unverified perf claims in public docs
+| README already caveatted; `BENCHMARK_EVIDENCE.toml` ledger exists and is the authority
+| Largely handled
+| See §2.2. Minor positioning-copy tightening only.
+
+| B01 / R01 — catalog tenant isolation "P0 blocker"
+| link:../12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc[ADR-032] (Proposed) + in-flight `src/catalog/mod.rs` + per-modality TDs
+| In-flight
+| Miscited (no `TD-CAT-2`). See §2.1.
+|===
+
+== 4. Genuinely-new finding (filed)
+
+link:td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc[TD-XMODAL-9] — Cross-modal
+fusion streams (`src/core/search/hybrid`, `src/services/operations/vectors/hybrid`,
+`src/graph/hybrid`) lack the `ExecutionControls` row/byte caps that the relational engine
+enforces (`src/query/execution/engine.rs`). Unbounded late-materialization buffers → OOM /
+saturation under wide fan-out or adversarial input. Sibling of TD-XMODAL-7 (heap-side vs
+stack-side). This was the only review finding not already covered by an existing TD.
+
+== 5. Product / strategy decisions (the maintainer's call — not enacted here)
+
+These are business judgments, not code. The review's recommendations are recorded for the
+maintainer; this document does not rewrite `VISION.adoc` or positioning:
+
+* **B10 / thesis** — "Defer the warehouse fight; position as the AI-agent memory layer."
+  Defensible (the supported surface is single-node CRUD today), but reversing the 2026-06-04
+  course correction is a strategic call. Recommendation: narrow *marketing* to the agent-memory
+  wedge while keeping the pgwire/object-store foundation (the code investment holds either way).
+* **B11** — defer multi-table ACID. The review agrees (P4). No action.
+* **G / H** — persona focus on AI/ML Engineer for the near term. A positioning decision.
+
+== 6. Recommended sequencing
+
+* **P0 / release blocker:** none *new*. The real SaaS blocker — ADR-032 F2 catalog path
+  isolation — is already Proposed and in-flight in the working tree. Land it before any
+  multi-tenant claim.
+* **Quick wins (safe, doc-only):** tighten PRD/VISION "sub-millisecond" positioning copy (§2.2).
+  That is the only zero-risk change the review implies.
+* **Real engineering (each its own PR, all already tracked):** TD-104 (decomposition — lead
+  with `protocol.rs` 6556L), TD-151 (range coalescing), TD-186/ADR-043 (expr unification),
+  link:td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc[TD-XMODAL-9] (new — fusion
+  resource bounds).
+* **Strategic / deferred:** TD-078 (distributed MPP), multi-table ACID (ADR-018).
+
+== 7. Filing note
+
+TD-XMODAL-9 was filed per the collision-free per-file convention
+(`docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc`); `td-adr-unique` is green. To land this doc +
+the TD on `develop`, follow the convention: branch off `origin/develop` via
+`scripts/worktree.sh new docs/review-response-2026-07-07` (the main checkout currently carries
+uncommitted catalog/parser/ddl work and must not be used as the PR base). This document and the
+TD are written but **uncommitted** pending that.

--- a/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
+++ b/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
@@ -274,6 +274,11 @@ propagates. ADR-043 (fail-loud, `Result<bool>`) is *Accepted* and TD-186 rolls i
 umbrella covers the *relational* expression path. The bare-`bool` stragglers
 (`typesafe_filter.rs:35`, `storage/engines/core/filter_evaluator.rs:43/49/54/144`,
 `storage/document/query/filter.rs:30`, `storage/engines/sequoia/mod.rs:230`) are the
-*vector-metadata* seam ADR-043 doesn't reach. Filed as TD-FILT-1; slice 1 (typed
-`FilterEvalError` + an `evaluate_strict -> Result<bool, _>` fail-loud path on
-`TypeSafeFilterEvaluator`, behavior-preserving) lands in its own PR.
+*vector-metadata* seam ADR-043 doesn't reach. Filed as TD-FILT-1 and **re-scoped to the v2
+`ProximaValue` path** after discovery: the v1 `TypeSafeFilterEvaluator` (`typesafe_filter.rs`) is
+**dead** (zero callers) on v1 `MetadataValue` — a retirement candidate under v1 sunset (TD-123),
+not something to extend. The canonical v2 filter seam
+(`crates/foundation/proximadb-search-types/src/sql_value_filter.rs`: `evaluate_filter_resolved` /
+`evaluate_filter_proxima`) has the *same* silent-drop (`None => false`) on the `ProximaTree` path.
+Slice 1 (typed `FilterEvalError::MissingField` + `evaluate_filter_resolved_strict` /
+`evaluate_filter_proxima_strict`, behavior-preserving) lands in #747.

--- a/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
+++ b/docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc
@@ -209,3 +209,71 @@ the TD on `develop`, follow the convention: branch off `origin/develop` via
 `scripts/worktree.sh new docs/review-response-2026-07-07` (the main checkout currently carries
 uncommitted catalog/parser/ddl work and must not be used as the PR base). This document and the
 TD are written but **uncommitted** pending that.
+
+== 8. Round 2 — Antigravity's 30 recommendations (2026-07-07)
+
+Antigravity produced a second artifact (`architectural_recommendations.md`, 30 items, P0–P4).
+Same discipline applies — verify before acting. Outcome: **~25/30 are already-tracked ADRs/TDs,
+2 are ghost repeats, 1 is already done, and 1 is a genuinely-new confirmed finding.** No new TDs
+were filed for the tracked majority (would duplicate the `td-adr-unique` guard).
+
+=== Ghosts / already-handled (do NOT chase)
+
+* **B01 — "TD-CAT-2" again.** `find docs -iname '*TD-CAT*'` → nothing. This is the *same phantom
+  TD* from round 1; Antigravity did not learn. Real tracker:
+  link:../12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc[ADR-032]
+  (Proposed) + in-flight `src/catalog/mod.rs` + per-modality TDs (DOC/ENTITY/GRAPH-TENANT-1,
+  IOTRACE-2, XMODAL-8).
+* **B08 — 100K QPS scrub.** Repeat: README is already caveatted; the figure lives correctly in
+  `BENCHMARK_EVIDENCE.toml` unverified. See §2.2.
+* **B20 — Azure HNS-off / `ObjectAccessTier`.** *Already landed* (`azure_blob.rs`, `aws_s3.rs`,
+  `gcs_store.rs` all carry access-tier; ADR-036). Stale.
+* **B21 — "Small" v1 hard-delete.** Mislabeled: the staged TD-123 ratchet (thousands of refs),
+  multi-PR. See §2.4.
+
+=== Already-tracked (mapped, no new TD)
+
+[cols="1,2", options="header"]
+|===
+| Item | Tracked as
+
+| B02 (LSN read-after-write) | ADR-051 (Proposed) / TD-STRONG-1 — LSN-pinning **shipped** on the cached paths (`storage/cache/specialized/query_cache.rs`, `network/postgres/relational_pipeline.rs`); ADR ratification incomplete, not a new hole
+| B04 (canonical ProximaType) | ADR-024
+| B05 / B11 (god object / dissolve UnifiedHandlers) | TD-104 (+ `TD104_HANDLER_CONVERGENCE_PLAN`)
+| B06 (PAX range coalescing) | TD-151
+| B07 (force DataFusion OLAP) | TD-OLAP-1 / ADR-039
+| B09 (retire legacy engines / PAX stacked quant) | ADR-026 (M1 landed)
+| B10 (trace+meter seam) | ADR-030
+| B12 (symbol object_id) | ADR-044
+| B13 (ORION LSN-correlation) | TD-066 / ADR-034
+| B14 (capability registry) | ADR-001 / ADR-043
+| B15 (fusion latency benchmarks) | ADR-034 measurement mandate / TD-OLAP-4
+| B16 (deletion vectors) | ADR-025 (design shipped; impl P4)
+| B17 (3-tier catalog cache) | ADR-035 / TD-SC-1
+| B18 (Parquet interop-only) | ADR-033 / ADR-027 (settled)
+| B19 (cross-modal fabric UDTFs) | ADR-053
+| B22 (SDK codegen) | ADR-041
+| B23 (nextest / flaky tests) | test hygiene (Volcano-flake history)
+| B24 (differential accuracy) | ADR-040 / TD-182
+| B25 (consolidate casts) | ADR-043 / TD-186
+| B26 (SegmentStatistics contract) | ADR-042
+| B27 (distributed MPP) | TD-078 (deferred)
+| B28 (multi-table ACID) | ADR-018 (deferred)
+| B29 (LTAP without CDC) | ADR-046
+| B30 (refocus GTM) | product decision (see §5)
+|===
+
+=== The one genuinely-new, confirmed finding (filed)
+
+**B03 — silent fail-open/fail-closed in the *vector-metadata* filter path.** Verified at
+`src/core/search/typesafe_filter.rs:35` (`evaluate() -> bool`): `compare_typed_values` returns
+`Option<Ordering>`, and on a **type-mismatched stored value** (`None`) the result silently folds —
+positive comparisons (`Equals`/`LessThan`/…) → `false` (row dropped); `NotEquals`/`NotIn` → `true`
+(row kept, fail-open); missing field → the catch-all `_ => false` (line 187, row dropped). No error
+propagates. ADR-043 (fail-loud, `Result<bool>`) is *Accepted* and TD-186 rolls it out — but that
+umbrella covers the *relational* expression path. The bare-`bool` stragglers
+(`typesafe_filter.rs:35`, `storage/engines/core/filter_evaluator.rs:43/49/54/144`,
+`storage/document/query/filter.rs:30`, `storage/engines/sequoia/mod.rs:230`) are the
+*vector-metadata* seam ADR-043 doesn't reach. Filed as TD-FILT-1; slice 1 (typed
+`FilterEvalError` + an `evaluate_strict -> Result<bool, _>` fail-loud path on
+`TypeSafeFilterEvaluator`, behavior-preserving) lands in its own PR.

--- a/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
+++ b/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-XMODAL-9: Cross-modal fusion streams lack `ExecutionControls` row/byte caps (OOM / saturation risk)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open
+| Severity | Medium-High (robustness / reliability — unbounded late-materialization buffers under large fan-out or adversarial inputs)
+| Component | Cross-modal query fusion — `src/core/search/hybrid`, `src/services/operations/vectors/hybrid`, `src/graph/hybrid`; the resource-control contract lives at `src/query/execution/engine.rs` (`ExecutionControls`)
+| Governs | link:../../12-design/adr/ADR-053-cross-modal-query-fabric.adoc[ADR-053] (cross-modal query fabric — modalities as composable SQL relations)
+| Relates | link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7] (sibling resource-bound defect — unbounded recursion), link:TD-186-relational-expr-eval-unification.adoc[TD-186] / link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (unified execution lowering), link:TD-OLAP-1-pax-native-vectorized-scan-feeds-datafusion.adoc[TD-OLAP-1], link:TECHNICAL_DEBT.adoc#td-104[TD-104] (handler convergence)
+| Surfaced by | External architectural review (2026-07-07) — the one genuinely-untracked finding; see link:../REVIEW_RESPONSE_2026_07_07.adoc[review response]
+|===
+
+== Problem
+
+The relational engine has a resource-control contract — `ExecutionControls` (defined at
+`src/query/execution/engine.rs`, threaded through `src/query/execution/datafusion_engine.rs`
+and the pgwire boundary at `src/network/postgres/protocol.rs`) — that is meant to enforce
+row / byte / time ceilings on physical streams so a query cannot grow an unbounded buffer.
+
+That contract is **not wired into the cross-modal fusion streams**. The fusion executors at
+`src/core/search/hybrid`, `src/services/operations/vectors/hybrid`, and `src/graph/hybrid`
+materialize per-leg result sets and the fused output with **no row or byte cap**:
+
+* `grep -r "ExecutionControls\|execution_controls" src/core/search/hybrid src/services/operations/vectors/hybrid src/graph/hybrid` → no hits.
+* `grep -rln "struct ExecutionControls" src crates` → only the relational-execution sites above; nothing in any fusion path.
+
+Consequence: a cross-modal query that fans out a wide vector leg + a high-degree graph
+expansion + a per-record document fetch can buffer arbitrarily many `ScoredRecord`s / fused
+rows in RAM before ranking + projection drain them. Under adversarial input or a fat k / large
+top-k this is an OOM / saturation path — the same class of unbounded-resource defect as
+link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7] (stack), but on the
+heap side of the fusion stream.
+
+This is *not* a correctness bug (results are right); it is a robustness gap that matters the
+moment cross-modal queries leave the single-node developer bench (the ADR-053 fabric is
+intended to compose arbitrarily).
+
+== Next action
+
+Thread `ExecutionControls` (or a shared `StreamLimits { max_rows, max_bytes, deadline }`)
+into the fusion executors' stream adapters, enforced at the **fusion-materialization
+boundary** — i.e. where each leg's output is collected into the fused buffer, not at the leaf
+scan (leaf caps are the engines' job). Concretely:
+
+1. Define one shared limit type (reuse `ExecutionControls` if its shape fits; else a thin
+   `FusionStreamLimits` in `crates/query/proximadb-query-fusion`) so the cap is defined once.
+2. Enforce `max_rows` / `max_bytes` at the collector that buffers leg outputs before RRF /
+   PIT-calibrated fusion (`src/core/search/hybrid`); fail loud (a `ResourceExhausted`-style
+   error with the limit + which leg tripped it), never silent truncation.
+3. Default the caps conservatively (config + env override) so single-node dev workloads are
+   unaffected but a runaway fan-out fails closed instead of OOMing.
+4. Test: an adversarial cross-modal query whose natural fan-out exceeds the cap returns the
+   bounded error, not a kill; a normal query is untouched (regression guard).
+
+== Dependencies / sequencing
+
+* Independent of TD-104 (handler convergence) — can land first; the limit type just needs a
+  stable home.
+* Pairs naturally with TD-XMODAL-7 (both are "the cross-modal fabric needs bounded resource
+  semantics before it's production-safe"); consider a shared `FusionResourcePolicy`.
+* No format/storage change — mixed-read-safe, magic bytes untouched, recall ratchet unaffected.
+
+== How to apply
+
+Start at `src/core/search/hybrid` (the canonical fusion seam per
+`CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`), find the collector that assembles per-leg results
+by `oid`, and bound it. Then propagate the same limit to the graph-leg expander
+(`src/graph/hybrid`) and the vector hybrid path
+(`src/services/operations/vectors/hybrid`). Verify with a fan-out stress test before promoting
+any default.

--- a/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
+++ b/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open (re-scoped 2026-07-07 after implementation-discovery — see below)
+| Status | In Progress — slice 1 landed in #746 (2026-07-07): `PoolCapMode { Truncate, Error }` + `FusionStats.pool_cap_exceeded` on the canonical `Fuser`, and `PROXIMADB_FUSION_POOL_CAP` wired into the live `graph_fusion_search` path (default-off). Re-scoped from the original framing earlier the same day (see below).
 | Severity | Medium-High (robustness / reliability — wide fan-out buffers the full source union in RAM before the output trim)
 | Component | Cross-modal fusion. **Canonical (v2) core:** `src/core/search/cross_modal_fusion.rs` (`Fuser`, `FusionPolicy.pool_cap`) + `src/services/fusion_service.rs` (`fuse_optimized`, entity-orchestrator) + `crates/query/proximadb-query/src/fusion.rs` (`ResultFuser`). **Deprecated v1 (do NOT harden — retire):** `src/core/search/hybrid/fusion.rs` (`HybridFusionEngine`) reached via `execute_hybrid_search` on `proximadb_v1::HybridSearchRequest`. Resource-control contract mirrored from `src/query/execution/engine.rs` (`ExecutionControls`, `RowLimitMode`, `cap_plan`).
 | Governs | link:../../12-design/adr/ADR-053-cross-modal-query-fabric.adoc[ADR-053] (cross-modal query fabric); `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` (`Fuser` is its Phase-1 F-A core)

--- a/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
+++ b/docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc
@@ -1,73 +1,78 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-= TD-XMODAL-9: Cross-modal fusion streams lack `ExecutionControls` row/byte caps (OOM / saturation risk)
+= TD-XMODAL-9: Cross-modal fusion has no fail-loud / default-ON row cap on the materialized oid-union (OOM / saturation risk)
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open
-| Severity | Medium-High (robustness / reliability — unbounded late-materialization buffers under large fan-out or adversarial inputs)
-| Component | Cross-modal query fusion — `src/core/search/hybrid`, `src/services/operations/vectors/hybrid`, `src/graph/hybrid`; the resource-control contract lives at `src/query/execution/engine.rs` (`ExecutionControls`)
-| Governs | link:../../12-design/adr/ADR-053-cross-modal-query-fabric.adoc[ADR-053] (cross-modal query fabric — modalities as composable SQL relations)
-| Relates | link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7] (sibling resource-bound defect — unbounded recursion), link:TD-186-relational-expr-eval-unification.adoc[TD-186] / link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (unified execution lowering), link:TD-OLAP-1-pax-native-vectorized-scan-feeds-datafusion.adoc[TD-OLAP-1], link:TECHNICAL_DEBT.adoc#td-104[TD-104] (handler convergence)
-| Surfaced by | External architectural review (2026-07-07) — the one genuinely-untracked finding; see link:../REVIEW_RESPONSE_2026_07_07.adoc[review response]
+| Status | Open (re-scoped 2026-07-07 after implementation-discovery — see below)
+| Severity | Medium-High (robustness / reliability — wide fan-out buffers the full source union in RAM before the output trim)
+| Component | Cross-modal fusion. **Canonical (v2) core:** `src/core/search/cross_modal_fusion.rs` (`Fuser`, `FusionPolicy.pool_cap`) + `src/services/fusion_service.rs` (`fuse_optimized`, entity-orchestrator) + `crates/query/proximadb-query/src/fusion.rs` (`ResultFuser`). **Deprecated v1 (do NOT harden — retire):** `src/core/search/hybrid/fusion.rs` (`HybridFusionEngine`) reached via `execute_hybrid_search` on `proximadb_v1::HybridSearchRequest`. Resource-control contract mirrored from `src/query/execution/engine.rs` (`ExecutionControls`, `RowLimitMode`, `cap_plan`).
+| Governs | link:../../12-design/adr/ADR-053-cross-modal-query-fabric.adoc[ADR-053] (cross-modal query fabric); `docs/12-design/CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc` (`Fuser` is its Phase-1 F-A core)
+| Relates | link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7] (sibling resource-bound defect — stack), link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043], link:TECHNICAL_DEBT.adoc#td-104[TD-104], link:TECHNICAL_DEBT.adoc[TD-138] (`HybridFusionEngine` retirement onto the neutral seam), link:TECHNICAL_DEBT.adoc[TD-123] (v1-proto ratchet / v1 sunset — REST `/api/v2` + gRPC v2 are the only canonical surfaces)
+| Surfaced by | External architectural review (2026-07-07); see link:../REVIEW_RESPONSE_2026_07_07.adoc[review response]
 |===
 
-== Problem
+== Re-scope note (2026-07-07)
 
-The relational engine has a resource-control contract — `ExecutionControls` (defined at
-`src/query/execution/engine.rs`, threaded through `src/query/execution/datafusion_engine.rs`
-and the pgwire boundary at `src/network/postgres/protocol.rs`) — that is meant to enforce
-row / byte / time ceilings on physical streams so a query cannot grow an unbounded buffer.
+The original filing said the fusion streams "lack `ExecutionControls` row/byte caps." Implementation
+discovery refined this. The **canonical v2 `Fuser` already exposes `pool_cap: Option<usize>`**
+(`cross_modal_fusion.rs:88`, the D5 cost/quality gate) that bounds each source's candidate pool to
+its top-N before fusing (`cross_modal_fusion.rs:172-180`). So the *mechanism* exists. The real,
+precise gaps are:
 
-That contract is **not wired into the cross-modal fusion streams**. The fusion executors at
-`src/core/search/hybrid`, `src/services/operations/vectors/hybrid`, and `src/graph/hybrid`
-materialize per-leg result sets and the fused output with **no row or byte cap**:
+1. **`pool_cap` defaults to `None`** (`cross_modal_fusion.rs:99`) — protective only when a caller
+   opts in.
+2. **Silent truncate only** — there is no fail-loud `RowLimitMode::Error` analog (cf.
+   `engine.rs:132` `RowLimitMode`, `engine.rs:247` `cap_plan`). An over-cap source is silently
+   trimmed; nothing surfaces the saturation.
+3. **Zero production callers of `Fuser`** — `grep -rn 'Fuser::new\|FusionPolicy\|pool_cap:'` outside
+   the module returns nothing. `Fuser` is the converged *target* (contract #280, Phase-1 F-A
+   landed); route integration is ongoing. The **live v2** path (`fusion_service.rs::fuse_optimized`,
+   via the entity-orchestrator) and `ResultFuser` (`proximadb-query/src/fusion.rs`) do **not** use
+   `Fuser`/`pool_cap` — each materializes the full per-`oid` union then `truncate(limit)`
+   (`fusion_service.rs:130-140`, `proximadb-query/src/fusion.rs:114/148`).
 
-* `grep -r "ExecutionControls\|execution_controls" src/core/search/hybrid src/services/operations/vectors/hybrid src/graph/hybrid` → no hits.
-* `grep -rln "struct ExecutionControls" src crates` → only the relational-execution sites above; nothing in any fusion path.
+So: the protective mechanism exists in the canonical v2 core but is unwired, default-off, and
+non-fail-loud; the live v2 paths lack it. A wide fan-out (large vector leg + high-degree graph
+expansion) buffers the entire source union in RAM before the output trim — the OOM / saturation
+path. Sibling of link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7]
+(heap-side vs stack-side).
 
-Consequence: a cross-modal query that fans out a wide vector leg + a high-degree graph
-expansion + a per-record document fetch can buffer arbitrarily many `ScoredRecord`s / fused
-rows in RAM before ranking + projection drain them. Under adversarial input or a fat k / large
-top-k this is an OOM / saturation path — the same class of unbounded-resource defect as
-link:TD-XMODAL-7-crossmodal-udtf-subquery-stack-overflow.adoc[TD-XMODAL-7] (stack), but on the
-heap side of the fusion stream.
+== v2-canonical alignment
 
-This is *not* a correctness bug (results are right); it is a robustness gap that matters the
-moment cross-modal queries leave the single-node developer bench (the ADR-053 fabric is
-intended to compose arbitrarily).
+Per the standing mandate (only maintain v2 surface areas; v1 is deprecated and sunsetting —
+TD-123), this TD **scopes hardening to the v2 path only**. The deprecated v1 fusion entry point
+(`execute_hybrid_search` on `proximadb_v1::HybridSearchRequest` → `HybridFusionEngine`) is **not**
+a seam to add caps to — it is slated for **retirement** (TD-138). Do not invest robustness work in
+v1 fusion; retire it.
 
-== Next action
+== Next action (corrected scope, behavior-preserving — all default-OFF)
 
-Thread `ExecutionControls` (or a shared `StreamLimits { max_rows, max_bytes, deadline }`)
-into the fusion executors' stream adapters, enforced at the **fusion-materialization
-boundary** — i.e. where each leg's output is collected into the fused buffer, not at the leaf
-scan (leaf caps are the engines' job). Concretely:
+1. **Fail-loud mode.** Add `pool_cap_mode: PoolCapMode { Truncate, Error }` to `FusionPolicy`
+   mirroring `RowLimitMode` (`engine.rs:132`); default `Truncate` (today's behavior). In `Error`
+   mode, a source exceeding `pool_cap` surfaces the overflow (the canonical `fuse` returns
+   `(Vec, FusionStats)` — add `pool_cap_exceeded: Option<usize>` to `FusionStats`, or convert
+   `fuse` to `Result` given its caller count is currently zero).
+2. **Wire through the live v2 path.** Thread `pool_cap` + `pool_cap_mode` into
+   `fusion_service.rs::fuse_optimized` (the entity-orchestrator serving path) from `FusionService`
+   config / request, default-off. `Fuser` becomes the single place the cap is enforced once the
+   live path migrates fully onto it (TD-138).
+3. **Test.** Error-mode + an over-cap source fails loud / is bounded; a normal query is
+   byte-identical (regression guard on the existing `fuse_by_oid_dedups_and_counts_sources` test).
 
-1. Define one shared limit type (reuse `ExecutionControls` if its shape fits; else a thin
-   `FusionStreamLimits` in `crates/query/proximadb-query-fusion`) so the cap is defined once.
-2. Enforce `max_rows` / `max_bytes` at the collector that buffers leg outputs before RRF /
-   PIT-calibrated fusion (`src/core/search/hybrid`); fail loud (a `ResourceExhausted`-style
-   error with the limit + which leg tripped it), never silent truncation.
-3. Default the caps conservatively (config + env override) so single-node dev workloads are
-   unaffected but a runaway fan-out fails closed instead of OOMing.
-4. Test: an adversarial cross-modal query whose natural fan-out exceeds the cap returns the
-   bounded error, not a kill; a normal query is untouched (regression guard).
+== Deferred (separate, gated)
+
+* Flipping `pool_cap` to default-ON changes fusion *results* (drops low-ranked candidates), so a
+  default must be gated behind a recall benchmark (ADR-052 observe→ingest→act) — do NOT
+  default-enable blindly.
+* A byte cap (not just row count) and a cooperative cancellation flag (`ExecutionControls` has
+  one) are natural follow-ons once the row cap is wired.
+* Retiring the v1 `HybridFusionEngine` (TD-138) removes the deprecated unbounded seam.
 
 == Dependencies / sequencing
 
-* Independent of TD-104 (handler convergence) — can land first; the limit type just needs a
-  stable home.
-* Pairs naturally with TD-XMODAL-7 (both are "the cross-modal fabric needs bounded resource
-  semantics before it's production-safe"); consider a shared `FusionResourcePolicy`.
-* No format/storage change — mixed-read-safe, magic bytes untouched, recall ratchet unaffected.
-
-== How to apply
-
-Start at `src/core/search/hybrid` (the canonical fusion seam per
-`CROSS_MODAL_FUSION_SEAM_2026_06_22.adoc`), find the collector that assembles per-leg results
-by `oid`, and bound it. Then propagate the same limit to the graph-leg expander
-(`src/graph/hybrid`) and the vector hybrid path
-(`src/services/operations/vectors/hybrid`). Verify with a fan-out stress test before promoting
-any default.
+* Independent of TD-104 (handler convergence). Pairs with TD-XMODAL-7 (both: the cross-modal
+  fabric needs bounded resource semantics before it's production-safe).
+* Mixed-read-safe — no format/storage/proto change, magic bytes untouched, recall ratchet
+  unaffected (default-OFF).


### PR DESCRIPTION
## What

Files the actionable output of the 2026-07-07 Antigravity architectural review.

- **`docs/10-quality/td/TD-XMODAL-9-crossmodal-fusion-stream-resource-bounds.adoc`** — the one genuinely-new finding: cross-modal fusion streams (`src/core/search/hybrid`, `src/services/operations/vectors/hybrid`, `src/graph/hybrid`) lack the `ExecutionControls` row/byte caps the relational engine enforces (`src/query/execution/engine.rs`). Unbounded late-materialization buffers → OOM/saturation under wide fan-out. Sibling of TD-XMODAL-7 (heap-side vs stack-side).
- **`docs/10-quality/REVIEW_RESPONSE_2026_07_07.adoc`** — corrected action plan. Verifies every review claim against the tree and corrects the miscited ones.

## Why this is a *response*, not a batch of new TDs

The review is sound in its themes but its citations are not. ~9 of its 11 backlog items map to **already-tracked TDs** (TD-104, TD-151, TD-186/ADR-043, TD-168/ADR-034, TD-123, TD-ENGINE-1, TD-078, ADR-018). Filing new TDs for those would duplicate and be rejected by the `td-adr-unique` guard. The response doc maps each item to its real TD instead.

Corrections worth flagging:

- **No `TD-CAT-2` exists** (cited as a P0 catalog-isolation blocker). The real gap is ADR-032 (**Proposed**), already in-flight in the working tree's `src/catalog/mod.rs`, plus per-modality TDs (DOC/ENTITY/GRAPH-TENANT-1, IOTRACE-2, XMODAL-8).
- **"100K QPS in public docs" is largely already handled** — the README is already caveated ("headroom, not an SLA"); the unverified figure lives correctly in `BENCHMARK_EVIDENCE.toml`. Only loose end: PRD/VISION "sub-ms" positioning copy.
- **Scratch dirs are already gitignored**; **v1-delete is the staged TD-123 ratchet**, not a quick win.

## Verification

- `python3 scripts/check_td_adr_unique.py` → **0 errors** (164 TD ids, 52 ADRs). The 15 warnings are pre-existing ADR-index housekeeping, unrelated to this PR.
- Docs only — no code, no format/storage change.

## Follow-ups (separate efforts)

- Tighten PRD/VISION positioning copy (R04/B03 loose end).
- Execute TD-XMODAL-9 (taken on separately).
- Drive ADR-032 to Accepted (coordinate with in-flight catalog work).
