### PR TITLE
docs(td): file TD-DOCS-1 — public-doc discipline (agent-suitable)

### DIFF
--- a/docs/10-quality/td/TD-DOCS-1-public-doc-discipline.adoc
+++ b/docs/10-quality/td/TD-DOCS-1-public-doc-discipline.adoc
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DOCS-1: Public-doc discipline — honesty-pass positioning/perf claims + complete the ADR README index
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open
+| Severity | Medium (trust / TAM-claim accuracy — public docs must not assert production-ready capabilities or unmeasured perf numbers)
+| Component | Public docs: `README.adoc`, `docs/00-product/{PRD,VISION,COMPETITIVE_LANDSCAPE}.adoc`, `docs/release-notes/*`; ADR index `docs/12-design/adr/README.adoc`
+| Governs | Authority hierarchy in link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] (support contract) + `docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml` (measured-evidence ledger)
+| Relates | link:../REVIEW_RESPONSE_2026_07_07.adoc[REVIEW_RESPONSE_2026_07_07] §2.2 (the loose end this closes), link:TECHNICAL_DEBT.adoc[TD-148] (row_count approximate doc), the `td-adr-unique` guard's ADR-index warnings
+| Suitable for | Autonomous agent execution (docs-only, fully verifiable, low risk). NOTE: `TD-DOCS-` (plural, documentation discipline) is distinct from the `TD-DOC-` (singular, *document modality*) family.
+|===
+
+== Goal
+
+Two independent, docs-only slices. Each is verifiable with a single command. Do them in
+separate commits. This is **documentation only** — no code, no proto, no SDK, no format change.
+
+== Slice A — Honesty-pass public positioning & performance claims
+
+Public docs must not (1) assert a capability as production-ready that
+link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] marks **Beta** or **Experimental**, nor
+(2) quote a performance number that does not trace to a `status = "measured"` entry in
+`docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml`.
+
+=== Known loose ends (verify each against current text; do not blindly edit)
+
+* `docs/00-product/PRD.adoc:34` — positioning line "...sub-millisecond latency in a single Rust
+  binary." Aspirational; soften to low-latency / single-node phrasing or route to a measured
+  ledger entry.
+* `docs/00-product/PRD.adoc:56`, `:109`, `:117` — "sub-millisecond OHLC" / "10x faster" claims
+  for the trading persona. These are not in the measured ledger; qualify or remove the hard
+  numbers.
+* `docs/00-product/VISION.adoc:71`, `docs/00-product/COMPETITIVE_LANDSCAPE.adoc:34` —
+  "sub-millisecond vector search" as a competitive descriptor. Soften to non-numeric language.
+
+=== Authority rules (load-bearing — read before editing)
+
+* link:../../SUPPORTED_SURFACE.adoc[SUPPORTED_SURFACE.adoc] is the **support contract** and wins
+  on any disagreement about what is "supported", "production", or "ready". README's own perf
+  section is already correctly caveated ("headroom indicators, not a published SLA";
+  recall "not an SLA — see SUPPORTED_SURFACE") — **preserve those caveats**, do not weaken them.
+* `VISION.adoc` carries its own banner marking non-SUPPORTED content *aspirational* — keep
+  aspirational language there, but ensure it makes no **Supported-tier** claim. Do not flatten
+  the vision; tighten only hard numeric/production claims.
+* Do **not** edit `BENCHMARK_EVIDENCE.toml` — it is the authority, not a claim. If a number is
+  unmeasured, the fix is to remove/qualify the *doc claim*, not to "measure" it by editing the
+  ledger.
+
+=== Acceptance (Slice A)
+
+* `grep -rniE 'sub.?ms|sub.?millisecond|[0-9]+x faster|^[0-9]+\s*qps|ops/sec' README.adoc docs/00-product docs/release-notes` returns no unqualified hard claims (aspirational VISION copy excepted).
+* No public doc asserts a Beta/Experimental capability (per SUPPORTED_SURFACE) as production-ready.
+* README's existing SLA caveats are intact.
+
+== Slice B — Complete the ADR README index (zero the guard warnings)
+
+`python3 scripts/check_td_adr_unique.py` emits ~15 warnings of the form
+`WARNING: ADR file not listed in the README index: ADR-NNN-*.adoc`. The ADR index at
+`docs/12-design/adr/README.adoc` is how ADRs are discovered; an incomplete index is real debt.
+
+=== Steps
+
+1. Run `python3 scripts/check_td_adr_unique.py 2>&1 | grep 'not listed in the README index'` to
+   derive the current list (do not hard-code it — derive fresh).
+2. For each missing ADR, add an entry to `docs/12-design/adr/README.adoc` **matching the existing
+   entry format** (read the file first; mirror the columns/link style of an already-indexed ADR).
+3. Re-run the guard.
+
+=== Acceptance (Slice B)
+
+* `python3 scripts/check_td_adr_unique.py` reports **0 ADR-index warnings** (the `0 error(s)`
+  TD-unique count must remain 0 — do not introduce a duplicate TD id).
+
+== Constraints / how to land
+
+* Docs-only PR. Target `develop` (never `main`).
+* Two commits: `docs(adr): complete the ADR README index (TD-DOCS-1 slice B)` and
+  `docs(product): honesty-pass positioning/perf claims to SUPPORTED_SURFACE (TD-DOCS-1 slice A)`.
+* No `Co-Authored-By` trailer and no agent-attribution footer — the repo's
+  `check_no_agent_attribution.py` hook rejects them.
+* Work in an isolated worktree off `origin/develop`:
+  `eval "$(scripts/worktree.sh new docs/td-docs-1-public-discipline)"`.
+* Verify before push: `python3 scripts/check_td_adr_unique.py` (0 errors, 0 ADR-index warnings).


### PR DESCRIPTION
Files **TD-DOCS-1**, a docs-only TD intended for autonomous-agent execution (handed to Antigravity). Two verifiable slices:

- **Slice A — claims honesty:** public docs (README/PRD/VISION/COMPETITIVE_LANDSCAPE) must not assert a capability as production-ready that SUPPORTED_SURFACE marks Beta/Experimental, nor quote a perf number not traceable to a `status="measured"` BENCHMARK_EVIDENCE entry. Known loose ends called out (PRD `sub-ms`/`10x faster`, VISION/COMPETITIVE `sub-millisecond vector search`).
- **Slice B — ADR index:** complete `docs/12-design/adr/README.adoc` to zero the ~15 `not listed in the README index` warnings from `check_td_adr_unique.py`.

Each slice has explicit acceptance criteria + authority rules (SUPPORTED_SURFACE wins; BENCHMARK_EVIDENCE is the authority not the claim; don't flatten the aspirational VISION). Closes the R04/B03 loose end from #743's review response.

Verification: `check_td_adr_unique.py` → 0 errors (164 TD ids). Docs only.