### PR TITLE
harden(sql/catalog): tenant-scoped namespace DDL

### DIFF
--- a/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
+++ b/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
@@ -4,14 +4,16 @@
 :icons: font
 :source-highlighter: rouge
 :sectnums:
-:last-updated: 2026-07-02
+:last-updated: 2026-07-07
 
 Status: Apex reference index (active baseline) +
-Date: 2026-07-02 (filename `SYSTEM_MAP_2026_05_30` is the original; content tracks current HEAD) +
+Date: 2026-07-07 (filename `SYSTEM_MAP_2026_05_30` is the original; content tracks current HEAD) +
 Cost spine: the multi-engine routing + cache policy shown here is co-optimized against the *measured
 per-query I/O trace* across the five physical dimensions — see
 `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (the unified cost objective the `ComputeScheduler`
-minimizes) and `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` (the strategic pivot). +
+minimizes), `DATA_WAREHOUSE_AND_ENGINEERING_COURSE_CORRECTION_2026_06_04.adoc` (the strategic pivot),
+and ADR-052 (single-node analytics competitiveness: DataFusion/vectorized OLAP plus PAX-native scans
+before distributed/MPP claims). +
 Scope: One recursive whole-system view — workspace layers, `src/` modules, storage/access-method
 families, the ORION graph runtime, write/read data paths, and the
 protocol-facade-to-canonical-authority convergence. This is also the solution-architecture
@@ -36,12 +38,13 @@ subordinate feeders. New whole-system diagrams belong here or in a feeder linked
 fourth competing map**. That rule is itself a convergence gate (see
 link:CONVERGENCE_AUDIT_2026_05_30.adoc[CONVERGENCE_AUDIT_2026_05_30]).
 
-Production composition is still mostly rooted in the legacy crate (`src/database.rs`,
-`src/network/shared_services.rs`, `src/network/multi_server.rs`). `proximadb-runtime` is the target
-composition boundary and partial shell, not yet the sole owner. Workspace decomposition therefore
-remains a first-principles build-scaling requirement: split ownership only where it reduces compile
-fan-out, enables independent worktrees, and lets CI coverage shards (`cargo llvm-cov`, Tarpaulin, and
-focused `cargo test -p ...`) compile smaller units without timeout or OOM pressure.
+Production composition is still mostly rooted in the root crate (`src/database.rs`,
+`src/network/shared_services.rs`, `src/network/multi_server.rs`). `proximadb-runtime` and
+`proximadb-api` are target extraction boundaries and partial shells, not yet sole owners. Workspace
+decomposition therefore remains a first-principles build-scaling requirement: split ownership only
+where it reduces compile fan-out, enables independent worktrees, and lets CI coverage shards
+(`cargo llvm-cov`, Tarpaulin, and focused `cargo test -p ...`) compile smaller units without timeout
+or OOM pressure.
 ====
 
 == How to use this map
@@ -137,15 +140,16 @@ flowchart TB
 Load-bearing invariants:
 
 * Protocols and modalities are facades. Durable truth converges on `ProximaRecord`, xCatalog,
-canonical WAL/log/manifest state, and tenant-isolated paths. ADR-048 makes the catalog direction
-explicit: typed `CatalogTableSchema`/`CatalogColumn` metadata becomes the native authority, while
-v1 `Collection`/`CollectionConfig` are compatibility read views rather than a second truth.
+canonical WAL/log/manifest state, and tenant-isolated paths. ADR-024/048 make the type/catalog
+direction explicit: typed native schema metadata becomes the authority, while v1
+`Collection`/`CollectionConfig` and proto-v1 DTOs are compatibility views rather than a second truth.
 * Routing happens in the logical plane. Native Volcano, DataFusionLocal, specialized vector engines,
 and modality runtimes are physical execution choices behind one contract. Standard and metered native
 physical plans execute through the query-layer `NativeVolcanoEngine` adapter; pgwire owns wire
 shaping, not executor construction.
 * `TenantContext` and `DrPathBuilder` are SaaS gates, not optional helpers. Any I/O or heavy compute
-boundary that bypasses tenant context or raw-builds paths is architectural debt.
+boundary that bypasses tenant context or raw-builds paths is architectural debt. ADR-032/TD-CAT-2
+make catalog metadata the remaining high-risk tenant-prefix gap.
 * Support level comes from link:../SUPPORTED_SURFACE.adoc[docs/SUPPORTED_SURFACE.adoc], not from the
 existence of modules, feature flags, or demos.
 
@@ -263,7 +267,7 @@ operator visibility.
 |===
 
 [#workspace]
-== Layer 1 — Workspace (79 members, layered)
+== Layer 1 — Workspace (91 members, layered)
 
 The workspace follows the stable map from `CLAUDE.md`:
 `Foundation -> Contracts -> Control -> Horizontal -> Modality -> Storage -> Query/Cross-Model -> Platform -> Apps/Bindings`.
@@ -276,15 +280,15 @@ flowchart TB
   classDef layer fill:#4a90e2,stroke:#2e5c8a,color:#000;
   classDef apps fill:#cfe2f7,stroke:#2e5c8a,color:#000;
 
-  FND["<b>Foundation</b> (20)<br/>kernel · data-model · proto · records · filter-expr<br/>distance-kernel/types · compression/encoding/quantization-types<br/>index-traits/types · cache · memory-pool · hardware(-caps)<br/>config · pipeline-operator · relational-types · functions"]:::layer
+  FND["<b>Foundation</b> (23)<br/>kernel · data-model · proto · records · tenant · search-types · bloom<br/>filter-expr · distance-kernel/types · compression/encoding/quantization-types<br/>index-traits/types · cache · memory-pool · hardware(-caps)<br/>config · pipeline-operator · relational-types · functions"]:::layer
   CTR["<b>Contracts</b> (1)<br/>quantization (behavior + compat gates)"]:::layer
   CTL["<b>Control</b> (1)<br/>proximadb-catalog — xCatalog, 8 backends, route knobs"]:::layer
-  HRZ["<b>Horizontal</b> (7)<br/>codec · compression · security · telemetry<br/>runtime-common · embedded-common · recall-bench"]:::layer
+  HRZ["<b>Horizontal</b> (9)<br/>codec · compression · serialization · security · tls · telemetry<br/>runtime-common · embedded-common · recall-bench"]:::layer
   MOD["<b>Modality Runtime</b> (12)<br/>vector · document · graph · observability · embedding · queue<br/>quantization-kernel · rank-core/features/expr/profile/onnx"]:::layer
-  STG["<b>Storage</b> (8)<br/>storage-common · block-format (PAX) · object-store · iceberg-engine<br/>storage-kv · storage-optimization · storage-strategy · storage-tenant"]:::layer
+  STG["<b>Storage</b> (13)<br/>storage-common/ports/encryption/filesystem-types · block-format (PAX)<br/>object-store · iceberg-engine · storage-kv · storage-operations/optimization<br/>storage-strategy · storage-tenant · storage-transaction"]:::layer
   QRY["<b>Query / Cross-Model</b> (20)<br/>query · uql · multimodel-{query,plan} · relational-{algebra…engine}<br/>{vector,document,graph,observability}-query · graph-{arrow,subset}<br/>query-{capability,clauses,filter,fusion}"]:::layer
-  PLT["<b>Platform</b> (2)<br/>proximadb-api (REST/gRPC/Flight/pgwire surfaces)<br/>proximadb-runtime (composition, PortUserContext)"]:::layer
-  APP["<b>Apps / Bindings</b><br/>workspace: server · migrate · bench · root · rust client · spark JNI<br/>repo clients: python · go · embedded java/node/go/c"]:::apps
+  PLT["<b>Platform</b> (4)<br/>proximadb-api · proximadb-runtime · proximadb-admin-ui · proximadb-mcp"]:::layer
+  APP["<b>Apps / Bindings</b> (7)<br/>server · migrate · bench · ann-bench · vectordb-compare · root crate<br/>workspace rust client · spark JNI; repo clients include python/go/embedded variants"]:::apps
 
   FND --> CTR --> CTL --> HRZ --> MOD --> STG --> QRY --> PLT --> APP
 ----
@@ -294,7 +298,7 @@ link:MODULE_COMPONENT_LLD_2026_05_22.adoc[MODULE_COMPONENT_LLD_2026_05_22]; the 
 link:ARCHITECTURE_ATLAS_2026_05_22.adoc[ARCHITECTURE_ATLAS_2026_05_22]. This map does not restate them.
 
 [#srcmap]
-== Layer 2 — `src/` module map (46 top-level modules)
+== Layer 2 — `src/` module map (42 top-level module directories)
 
 The root crate composes the workspace crates and still hosts the load-bearing runtime implementations
 (handler extraction to `proximadb-api` is in progress — see <<seams>>).
@@ -334,12 +338,12 @@ flowchart TB
   end
 
   subgraph INTG[Integration & AI]
-    CDC2["cdc/ · connectors/ (iceberg·delta·hudi·s3) · ingest/ · streaming/"]:::sub
+    CDC2["cdc/ · connectors/ (spark·duckdb·trino·hadoop pushdown) · ingest/ · streaming/"]:::sub
     AI2["ai/llm_integration · llm/ · embedding/ · automl/"]:::sub
     TXN["transaction/ (mvcc·isolation·locks)"]:::sub
   end
 
-  EMB["embedded/ (PyO3·JNI·NAPI·C FFI)"]:::grp
+  EMB["embedded/ (PyO3/DataFrame · JNI/NAPI/C FFI direction)"]:::grp
 
   NET --> SVC --> DATAEXEC
   SVC --> CTLP
@@ -458,9 +462,10 @@ link:../SUPPORTED_SURFACE.adoc[docs/SUPPORTED_SURFACE.adoc]; this map summarizes
 | Durable authority
 | xCatalog + canonical WAL/log/manifest + `ProximaRecord`/`ProximaType`/`ProximaValue` are the
 target spine. Proto v1 DTOs and legacy `VectorRecord`/`SqlValue`/`SqlObject` remain edge adapters or
-internal migration debt.
-| Ready for narrow v0.2 only when flows stay on the canonical record path. Full internal migration is
-still TD-106/ADR-024 work.
+internal migration debt. ADR-024 is accepted and partially rolled out; ADR-031/048 keep identity and
+native catalog authority separate from compatibility collection views.
+| Ready for narrow v0.2 when flows stay on the canonical record path. Full internal type/schema and
+v1 DTO migration remains TD-106/TD-123/ADR-024 work.
 
 | Vector path
 | REST/gRPC v2 record CRUD and vector search are the supported product path. Multiple vector storage
@@ -468,33 +473,33 @@ engines and AXIS index families exist; v1 vector APIs are compatibility facades.
 `bench_24_recall_at_k_engine` is registered as a real index-vs-ground-truth Recall@k benchmark with
 deterministic vectors, bounded search-readiness probing, and optional `PROXIMADB_BENCH_TOPK=K`
 single-K runs for isolating low-effort Recall@K/latency curves.
-| MVP-ready for single-node vector CRUD/search. Hybrid, filtered ANN policy, recall-gate enforcement,
-and object-economy claims stay Beta/Experimental unless explicitly scoped. The real-engine recall
-benchmark is evidence plumbing, not a published recall SLA until run outputs are captured and
-reviewed.
+| MVP-ready for single-node canonical vector CRUD/search. Hybrid, per-collection filtered-ANN policy,
+recall-gate enforcement, and object-economy claims stay Beta/Experimental unless explicitly scoped.
+The real-engine recall benchmark is evidence plumbing, not a published recall SLA until run outputs
+are captured and reviewed.
 
 | Document / graph / observability
 | Document, ORION graph, and observability runtimes exist and are useful. ORION is the only graph
 runtime; former PULSAR/QUASAR names are retired. These modalities should be treated as projections or
-facades over canonical authority, not separate durable truths.
-| Beta. Good for controlled workflows, not yet the same maturity as the supported vector surface.
+facades over canonical authority, not separate durable truths. The v2 graph service path is live for
+the scoped API set, while deeper graph planner/executor work remains open.
+| Beta at the runtime/product-maturity level. Good for controlled workflows; not yet the same
+maturity as the supported vector surface. Do not infer a separate durable entity/document/graph store
+from compatibility surfaces.
 
 | SQL / pgwire / relational
-| pgwire, relational frontend/algebra/executor, DML routing, `ComputeScheduler`, DataFusionLocal
-route decisions, read-side `RoutedReadPlan`, and query-layer execution seams now exist. pgwire no
-longer constructs DataFusion directly; it dispatches SQL through `execute_sql_with_backend`. Standard
-native physical plans execute through `NativeVolcanoEngine::execute_physical`, and EXPLAIN ANALYZE
-uses `NativeVolcanoEngine::execute_physical_metered`. DataFusion still executes only the all-Parquet
-local route. The execution layer exposes a schema-bearing `ExecutionStreamResult` contract with a
-materialized fallback for engines that have not implemented native row streaming; native Volcano can
-stream rows directly from the executor. pgwire extended `Execute.max_rows` is mapped into
-`ExecutionControls` truncate mode for fallback execution. Relational extended-query portals now keep
-materialized cursor state and emit `PortalSuspended` while rows remain, so clients can resume the
-same portal with another Execute.
-Full PostgreSQL parity, complete
-constraints, MVCC/index state, HTAP delta union, and distributed consistency gates remain in TD-110.
-| Not MVP as a PostgreSQL replacement. Useful Beta/Experimental surface for scoped relational and
-EXPLAIN work. Engine-native streaming portal cursors and backpressure remain scalability work.
+| pgwire is a supported SQL surface for scoped v0.2 use, and gRPC `ExecuteQuery` is supported for
+tenant-scoped relational SQL plus vector/graph-extension SQL. Relational
+frontend/algebra/planner/executor crates, DML routing, `ComputeScheduler`, DataFusionLocal route
+vocabulary, read-side `RoutedReadPlan`, and query-layer execution seams exist. pgwire dispatches
+through `execute_sql_with_backend` rather than constructing DataFusion directly. Native physical
+plans execute through `NativeVolcanoEngine`; DataFusion is fenced as a swappable physical backend
+behind ADR-039 and primarily serves parquet-backed / interop paths. Full PostgreSQL parity, complete
+constraints, MVCC/index state, HTAP delta union, accuracy ratchets, and distributed consistency gates
+remain TD-076/TD-110/TD-115/ADR-040 work.
+| MVP-ready as a scoped SQL/pgwire compatibility surface, not as a PostgreSQL replacement. Keep
+positioning to supported single-node SQL cases; broad ORM/BI parity, full OLTP/HTAP semantics,
+engine-native streaming/backpressure, and distributed SQL are not v0.2 claims.
 
 | DataFusion / distributed execution
 | DataFusion integration, local Parquet registration, shared relational lowering, typed
@@ -511,30 +516,35 @@ long-lived sessions, and returns typed empty PyArrow tables from `to_arrow()`. B
 names, empty aggregate expression lists, keyless joins, and invalid vector-search arguments are
 rejected at the Python and/or DataFusion table-function boundary before execution. Scans still
 require embedded split discovery before collection reads can be claimed row-producing.
-| Local all-Parquet OLAP route is Beta. `DataFusionDistributed` remains route vocabulary only:
-Ballista execution, scheduler/executor deployment, engine-native streaming/backpressure,
-distributed cross-engine joins, embedded row-producing collection scans, and no-overlap/failure tests
-are not complete.
+| Local parquet/interop OLAP route is Beta. ADR-052 narrows the near-term aspiration: win
+single-node/vectorized OLAP and PAX-native scan competitiveness before MPP claims. `DataFusionDistributed`
+remains route vocabulary only: Ballista execution, scheduler/executor deployment, distributed
+cross-engine joins, embedded row-producing collection scans, and no-overlap/failure tests are not
+complete.
 
 | SaaS tenancy and billing boundaries
 | REST and pgwire surfaces propagate tenant identity into service/storage paths; storage has
 `TenantContext`; `DrPathBuilder` owns tenant-isolated physical path construction; telemetry/metrics
-modules provide the billing-observability substrate.
+modules provide the billing-observability substrate. Catalog metadata is the known structural gap:
+ADR-032/TD-CAT-2 require tenant-prefixed catalog object paths and a fail-closed deployment mode.
 | Mandatory architectural gate. New I/O and heavy-compute boundaries must accept or derive tenant
-context deliberately, and physical data paths must flow through `DrPathBuilder`.
+context deliberately, and physical data paths must flow through `DrPathBuilder`. Multi-tenant
+production claims remain scoped until catalog path isolation and fail-closed mode land.
 
 | Open formats and object economy
-| Object-store and Iceberg engine crates are in the workspace; Parquet/Arrow bridge work is the
-analytics/open-format trajectory. Open formats are publications/imports/federated assets unless
-explicitly external-authoritative in xCatalog.
-| Beta/Experimental depending on path. Safe claim is interoperability direction, not default durable
-authority.
+| Object-store and Iceberg engine crates are in the workspace; Parquet/Arrow/Iceberg are the
+interop/publication seam and current local OLAP bridge. ADR-027 proposes PAX as the single internal
+format and ADR-033/052 keep open formats at the boundary unless xCatalog explicitly marks an
+external-authority mode.
+| Beta/Experimental depending on path. Safe claim is interoperability direction and one-way publish
+where tested, not default external-table durable authority or warehouse-scale object economy.
 
 | Security / ops / deployment
 | Security runtime, mTLS/JWT/API key hooks, observability, backup/restore, and deployment assets
 exist. Some admin/status APIs and production runbooks still need hardening.
-| Sufficient for developer/private deployments; enterprise production positioning should remain
-scoped.
+| Sufficient for developer/private deployments and scoped pilots; enterprise production positioning
+should remain constrained by tenant-catalog isolation, operational runbooks, conformance accuracy,
+and release-smoke evidence.
 
 | Deterministic validation guardrails
 | `scripts/check_deterministic_commit_contract.py`, `make work-commit-check`, CI
@@ -547,11 +557,12 @@ codebase evolves.
 |===
 
 MVP posture: ProximaDB is ready to position as a **single-node context database foundation** with a
-supported canonical vector record path and Beta multimodal surfaces. It is not yet ready to position
-as a mature distributed database, full PostgreSQL-compatible OLTP/HTAP system, or warehouse-scale
-MPP engine. The architecture is aligned for that aspiration through xCatalog, route-once planning,
-DataFusion/Ballista contracts, and canonical record convergence, but the implementation is still
-slice-based and must keep support claims narrow.
+supported canonical vector record path, scoped SQL/pgwire compatibility, and Beta multimodal
+surfaces. It is not yet ready to position as a mature distributed database, full PostgreSQL-compatible
+OLTP/HTAP system, or warehouse-scale MPP engine. The architecture is aligned for that aspiration
+through xCatalog, route-once planning, the ADR-039 physical-backend seam, ADR-052's vectorized OLAP
+direction, and canonical record convergence, but the implementation is still slice-based and must
+keep support claims narrow.
 
 [#validation]
 == Validation and guardrail map

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -788,6 +788,13 @@ impl CatalogManager {
         let (catalog, id) = self.resolve_table(fqn).await?;
         match tenant {
             Some(tenant) if !tenant.is_empty() => {
+                if id
+                    .namespace
+                    .first()
+                    .is_some_and(|segment| segment == tenant)
+                {
+                    return Ok((catalog, id));
+                }
                 let mut namespace = Vec::with_capacity(id.namespace.len() + 1);
                 namespace.push(tenant.to_string());
                 namespace.extend(id.namespace.iter().cloned());
@@ -989,6 +996,27 @@ mod tests {
                 "unexpected error for tenant {tenant}: {err}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_table_scoped_does_not_double_prefix_explicit_tenant_namespace() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let manager = CatalogManager::new();
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+
+        let (_, table_id) = manager
+            .resolve_table_scoped("native.acmecorp.analytics.events", Some("acmecorp"))
+            .await
+            .expect("resolve table");
+
+        assert_eq!(
+            table_id.namespace,
+            vec!["acmecorp".to_string(), "analytics".to_string()]
+        );
+        assert_eq!(table_id.name, "events");
     }
 
     #[tokio::test]

--- a/src/query/sql_frontend/parser.rs
+++ b/src/query/sql_frontend/parser.rs
@@ -2299,22 +2299,132 @@ mod tests {
     fn parse_ddl_drop_table_supports_table_name() {
         let parser = SqlFrontendParser::new();
 
-        let statement = parser
-            .parse_ddl("DROP TABLE demo;")
-            .expect("expected ddl parse to succeed")
-            .expect("expected drop table ddl");
+        let cases = [
+            ("DROP TABLE demo;", "demo", false, false),
+            (
+                "DROP TABLE IF EXISTS \"Tenant One\".\"Event Store\";",
+                "Tenant One.Event Store",
+                true,
+                false,
+            ),
+        ];
 
-        if let DdlStatement::DropTable {
-            table_name,
-            if_exists,
-            purge,
-        } = statement
-        {
-            assert_eq!(table_name, "demo");
-            assert!(!if_exists);
-            assert!(!purge);
-        } else {
-            panic!("expected drop table statement");
+        for (sql, expected_table_name, expected_if_exists, expected_purge) in cases {
+            let statement = parser
+                .parse_ddl(sql)
+                .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"))
+                .expect("expected drop table ddl");
+
+            if let DdlStatement::DropTable {
+                table_name,
+                if_exists,
+                purge,
+            } = statement
+            {
+                assert_eq!(
+                    table_name, expected_table_name,
+                    "table mismatch for `{sql}`"
+                );
+                assert_eq!(
+                    if_exists, expected_if_exists,
+                    "IF EXISTS mismatch for `{sql}`"
+                );
+                assert_eq!(purge, expected_purge, "PURGE mismatch for `{sql}`");
+            } else {
+                panic!("expected drop table statement");
+            }
+        }
+    }
+
+    #[test]
+    fn parse_ddl_create_namespace_routes_through_pre_parser() {
+        let parser = SqlFrontendParser::new();
+
+        let cases = [
+            ("CREATE NAMESPACE analytics", vec!["analytics"], false),
+            (
+                "CREATE NAMESPACE IF NOT EXISTS acmecorp.analytics;",
+                vec!["acmecorp", "analytics"],
+                true,
+            ),
+            (
+                "create namespace if not exists \"Tenant One\".\"Event Store\"",
+                vec!["Tenant One", "Event Store"],
+                true,
+            ),
+        ];
+
+        for (sql, expected_namespace, expected_if_not_exists) in cases {
+            let statement = parser
+                .parse_ddl(sql)
+                .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"))
+                .expect("expected create namespace ddl");
+
+            match statement {
+                DdlStatement::CreateNamespace {
+                    namespace,
+                    if_not_exists,
+                    properties,
+                } => {
+                    assert_eq!(
+                        namespace, expected_namespace,
+                        "namespace mismatch for `{sql}`"
+                    );
+                    assert_eq!(
+                        if_not_exists, expected_if_not_exists,
+                        "IF NOT EXISTS mismatch for `{sql}`"
+                    );
+                    assert!(properties.is_empty());
+                }
+                other => panic!("expected CreateNamespace for `{sql}`, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_ddl_drop_namespace_routes_through_pre_parser() {
+        let parser = SqlFrontendParser::new();
+
+        let cases = [
+            ("DROP NAMESPACE analytics", vec!["analytics"], false, false),
+            (
+                "DROP NAMESPACE IF EXISTS acmecorp.analytics CASCADE;",
+                vec!["acmecorp", "analytics"],
+                true,
+                true,
+            ),
+            (
+                "drop namespace if exists \"Tenant One\".\"Event Store\" restrict",
+                vec!["Tenant One", "Event Store"],
+                true,
+                false,
+            ),
+        ];
+
+        for (sql, expected_namespace, expected_if_exists, expected_cascade) in cases {
+            let statement = parser
+                .parse_ddl(sql)
+                .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"))
+                .expect("expected drop namespace ddl");
+
+            match statement {
+                DdlStatement::DropNamespace {
+                    namespace,
+                    if_exists,
+                    cascade,
+                } => {
+                    assert_eq!(
+                        namespace, expected_namespace,
+                        "namespace mismatch for `{sql}`"
+                    );
+                    assert_eq!(
+                        if_exists, expected_if_exists,
+                        "IF EXISTS mismatch for `{sql}`"
+                    );
+                    assert_eq!(cascade, expected_cascade, "CASCADE mismatch for `{sql}`");
+                }
+                other => panic!("expected DropNamespace for `{sql}`, got {:?}", other),
+            }
         }
     }
 
@@ -2349,22 +2459,48 @@ mod tests {
     fn parse_ddl_drop_index_supports_drop_index() {
         let parser = SqlFrontendParser::new();
 
-        let statement = parser
-            .parse_ddl("DROP INDEX demo_payload_idx ON demo;")
-            .expect("expected ddl parse to succeed")
-            .expect("expected drop index ddl");
+        let cases = [
+            (
+                "DROP INDEX demo_payload_idx ON demo;",
+                "demo_payload_idx",
+                "demo",
+                false,
+            ),
+            (
+                "DROP INDEX IF EXISTS \"Payload Index\" ON \"Tenant One\".\"Event Store\";",
+                "Payload Index",
+                "Tenant One.Event Store",
+                true,
+            ),
+        ];
 
-        if let DdlStatement::DropIndex {
-            index_name,
-            table_name,
-            if_exists,
-        } = statement
-        {
-            assert_eq!(index_name, "demo_payload_idx");
-            assert_eq!(table_name, "demo");
-            assert!(!if_exists);
-        } else {
-            panic!("expected drop index statement");
+        for (sql, expected_index_name, expected_table_name, expected_if_exists) in cases {
+            let statement = parser
+                .parse_ddl(sql)
+                .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"))
+                .expect("expected drop index ddl");
+
+            if let DdlStatement::DropIndex {
+                index_name,
+                table_name,
+                if_exists,
+            } = statement
+            {
+                assert_eq!(
+                    index_name, expected_index_name,
+                    "index mismatch for `{sql}`"
+                );
+                assert_eq!(
+                    table_name, expected_table_name,
+                    "table mismatch for `{sql}`"
+                );
+                assert_eq!(
+                    if_exists, expected_if_exists,
+                    "IF EXISTS mismatch for `{sql}`"
+                );
+            } else {
+                panic!("expected drop index statement");
+            }
         }
     }
 
@@ -2585,6 +2721,14 @@ impl SqlFrontendParser {
         }
         // Pattern: CREATE [OR REPLACE] FUNCTION <name>(params) RETURNS <ty> AS '<body>' (F5)
         if let Some(result) = try_parse_create_function(sql)? {
+            return Ok(Some(result));
+        }
+        // Pattern: CREATE NAMESPACE [IF NOT EXISTS] <qualified_namespace>
+        if let Some(result) = try_parse_create_namespace(sql)? {
+            return Ok(Some(result));
+        }
+        // Pattern: DROP NAMESPACE [IF EXISTS] <qualified_namespace> [CASCADE|RESTRICT]
+        if let Some(result) = try_parse_drop_namespace(sql)? {
             return Ok(Some(result));
         }
         // Pattern: ALTER TABLE <name> MATERIALIZE (warehouse publish → Parquet-backed)
@@ -2969,6 +3113,7 @@ impl SqlFrontendParser {
                         .first()
                         .ok_or_else(|| anyhow!("DROP TABLE requires a table name"))?
                         .to_string();
+                    let table_name = unquote_object_name(&table_name);
                     Ok(Some(DdlStatement::DropTable {
                         table_name,
                         if_exists: *if_exists,
@@ -2980,10 +3125,12 @@ impl SqlFrontendParser {
                         .first()
                         .ok_or_else(|| anyhow!("DROP INDEX requires an index name"))?
                         .to_string();
+                    let index_name = unquote_identifier_text(&index_name);
                     let table_name = table
                         .as_ref()
                         .map(|table_name| table_name.to_string())
                         .ok_or_else(|| anyhow!("DROP INDEX requires a table name"))?;
+                    let table_name = unquote_object_name(&table_name);
 
                     Ok(Some(DdlStatement::DropIndex {
                         index_name,
@@ -3332,6 +3479,180 @@ pub fn unquote_identifier_text(value: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn consume_keyword<'a>(input: &'a str, keyword: &str) -> Option<&'a str> {
+    let trimmed = input.trim_start();
+    if trimmed.len() < keyword.len() {
+        return None;
+    }
+
+    let (candidate, rest) = trimmed.split_at(keyword.len());
+    if !candidate.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    if rest.chars().next().is_some_and(|ch| !ch.is_whitespace()) {
+        return None;
+    }
+    Some(rest)
+}
+
+fn parse_qualified_identifier_parts(input: &str, statement_name: &str) -> Result<Vec<String>> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut chars = input.trim().chars().peekable();
+    let mut in_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => {
+                if in_quotes && chars.peek() == Some(&'"') {
+                    current.push('"');
+                    chars.next();
+                } else {
+                    in_quotes = !in_quotes;
+                }
+            }
+            '.' if !in_quotes => {
+                let part = current.trim();
+                if part.is_empty() {
+                    return Err(anyhow!(
+                        "{statement_name} contains an empty identifier part"
+                    ));
+                }
+                parts.push(part.to_string());
+                current.clear();
+            }
+            ch if ch.is_whitespace() && !in_quotes => {
+                return Err(anyhow!(
+                    "{statement_name} expects a single qualified namespace identifier"
+                ));
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if in_quotes {
+        return Err(anyhow!(
+            "{statement_name} has an unterminated quoted identifier"
+        ));
+    }
+
+    let part = current.trim();
+    if part.is_empty() {
+        return Err(anyhow!("{statement_name} requires a namespace name"));
+    }
+    parts.push(part.to_string());
+    Ok(parts)
+}
+
+fn try_parse_create_namespace(sql: &str) -> Result<Option<DdlStatement>> {
+    let normalised = sql.trim().trim_end_matches(';').trim();
+    let Some(rest) = consume_keyword(normalised, "CREATE") else {
+        return Ok(None);
+    };
+    let Some(mut rest) = consume_keyword(rest, "NAMESPACE") else {
+        return Ok(None);
+    };
+
+    let mut if_not_exists = false;
+    if let Some(after_if) = consume_keyword(rest, "IF")
+        && let Some(after_not) = consume_keyword(after_if, "NOT")
+        && let Some(after_exists) = consume_keyword(after_not, "EXISTS")
+    {
+        if_not_exists = true;
+        rest = after_exists;
+    }
+
+    let namespace = parse_qualified_identifier_parts(rest, "CREATE NAMESPACE")?;
+    Ok(Some(DdlStatement::CreateNamespace {
+        namespace,
+        if_not_exists,
+        properties: HashMap::new(),
+    }))
+}
+
+fn split_sql_words_respecting_quotes(input: &str, statement_name: &str) -> Result<Vec<String>> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut chars = input.trim().chars().peekable();
+    let mut in_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => {
+                current.push(ch);
+                if in_quotes && chars.peek() == Some(&'"') {
+                    current.push('"');
+                    chars.next();
+                } else {
+                    in_quotes = !in_quotes;
+                }
+            }
+            ch if ch.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    words.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if in_quotes {
+        return Err(anyhow!(
+            "{statement_name} has an unterminated quoted identifier"
+        ));
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    Ok(words)
+}
+
+fn try_parse_drop_namespace(sql: &str) -> Result<Option<DdlStatement>> {
+    let normalised = sql.trim().trim_end_matches(';').trim();
+    let Some(rest) = consume_keyword(normalised, "DROP") else {
+        return Ok(None);
+    };
+    let Some(mut rest) = consume_keyword(rest, "NAMESPACE") else {
+        return Ok(None);
+    };
+
+    let mut if_exists = false;
+    if let Some(after_if) = consume_keyword(rest, "IF")
+        && let Some(after_exists) = consume_keyword(after_if, "EXISTS")
+    {
+        if_exists = true;
+        rest = after_exists;
+    }
+
+    let mut words = split_sql_words_respecting_quotes(rest, "DROP NAMESPACE")?;
+    if words.is_empty() {
+        return Err(anyhow!("DROP NAMESPACE requires a namespace name"));
+    }
+
+    let mut cascade = false;
+    if let Some(last) = words.last() {
+        if last.eq_ignore_ascii_case("CASCADE") {
+            cascade = true;
+            words.pop();
+        } else if last.eq_ignore_ascii_case("RESTRICT") {
+            words.pop();
+        }
+    }
+
+    if words.len() != 1 {
+        return Err(anyhow!(
+            "DROP NAMESPACE expects a single qualified namespace identifier"
+        ));
+    }
+
+    let namespace = parse_qualified_identifier_parts(&words[0], "DROP NAMESPACE")?;
+    Ok(Some(DdlStatement::DropNamespace {
+        namespace,
+        if_exists,
+        cascade,
+    }))
 }
 
 // =========================================================================

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -536,9 +536,10 @@ impl DdlService {
 
     /// Execute a DDL statement within a tenant scope (TD-064). The tenant
     /// scopes table-targeting DDL (CREATE/DROP/ALTER TABLE, CREATE/DROP INDEX)
-    /// onto the same tenant-prefixed catalog namespace the DML path resolves, so
-    /// a tenant's CREATE-then-INSERT address one schema row. `None` ⇒
-    /// single-tenant, identical to the legacy path.
+    /// and explicit namespace creation onto the same tenant-prefixed catalog
+    /// namespace the DML path resolves, so a tenant's CREATE-then-INSERT
+    /// address one schema row. `None` ⇒ single-tenant, identical to the legacy
+    /// path.
     pub async fn execute_scoped(
         &self,
         statement: DdlStatement,
@@ -613,14 +614,17 @@ impl DdlService {
                 if_not_exists,
                 properties,
             } => {
-                self.create_namespace(&namespace, if_not_exists, properties)
+                self.create_namespace(&namespace, if_not_exists, properties, tenant)
                     .await
             }
             DdlStatement::DropNamespace {
                 namespace,
                 if_exists,
                 cascade,
-            } => self.drop_namespace(&namespace, if_exists, cascade).await,
+            } => {
+                self.drop_namespace(&namespace, if_exists, cascade, tenant)
+                    .await
+            }
             DdlStatement::CreateCollection {
                 collection_name,
                 dimension,
@@ -1060,18 +1064,40 @@ impl DdlService {
     // Namespace Operations
     // ========================
 
+    fn tenant_scoped_namespace(namespace: &[String], tenant: Option<&str>) -> Result<Vec<String>> {
+        let Some(tenant) = tenant.filter(|tenant| !tenant.is_empty()) else {
+            return Ok(namespace.to_vec());
+        };
+        if tenant.starts_with('_') {
+            anyhow::bail!(
+                "tenant '{tenant}' is invalid: tenant identifiers must not begin with '_' \
+                 (reserved for system/control-plane catalog subtrees)"
+            );
+        }
+        if namespace.first().is_some_and(|segment| segment == tenant) {
+            return Ok(namespace.to_vec());
+        }
+
+        let mut scoped = Vec::with_capacity(namespace.len() + 1);
+        scoped.push(tenant.to_string());
+        scoped.extend(namespace.iter().cloned());
+        Ok(scoped)
+    }
+
     /// Create a new namespace (schema grouping) in the default catalog.
     async fn create_namespace(
         &self,
         namespace: &[String],
         if_not_exists: bool,
         properties: HashMap<String, String>,
+        tenant: Option<&str>,
     ) -> Result<DdlResult> {
         let catalog = self.catalog_manager.default_catalog().await?;
+        let namespace = Self::tenant_scoped_namespace(namespace, tenant)?;
         let ns_name = namespace.join(".");
 
         // Check if namespace exists
-        if catalog.namespace_exists(namespace).await? {
+        if catalog.namespace_exists(&namespace).await? {
             if if_not_exists {
                 return Ok(DdlResult::already_exists("Namespace", &ns_name));
             } else {
@@ -1079,8 +1105,20 @@ impl DdlService {
             }
         }
 
-        // Create the namespace
-        catalog.create_namespace(namespace, properties).await?;
+        // Create the namespace. In a tenant-scoped request, persist the owning
+        // tenant so downstream DrPathBuilder users can fail closed on
+        // cross-tenant materialize/read paths instead of treating the namespace
+        // as legacy/unowned.
+        match tenant {
+            Some(tenant) if !tenant.is_empty() => {
+                catalog
+                    .create_namespace_for_tenant(&namespace, properties, Some(tenant))
+                    .await?;
+            }
+            _ => {
+                catalog.create_namespace(&namespace, properties).await?;
+            }
+        }
 
         info!(namespace = %ns_name, "Created namespace");
         Ok(DdlResult::success(format!(
@@ -1095,12 +1133,14 @@ impl DdlService {
         namespace: &[String],
         if_exists: bool,
         cascade: bool,
+        tenant: Option<&str>,
     ) -> Result<DdlResult> {
         let catalog = self.catalog_manager.default_catalog().await?;
+        let namespace = Self::tenant_scoped_namespace(namespace, tenant)?;
         let ns_name = namespace.join(".");
 
         // Check if namespace exists
-        if !catalog.namespace_exists(namespace).await? {
+        if !catalog.namespace_exists(&namespace).await? {
             if if_exists {
                 return Ok(DdlResult::not_found("Namespace", &ns_name));
             } else {
@@ -1109,7 +1149,7 @@ impl DdlService {
         }
 
         // Drop the namespace
-        catalog.drop_namespace(namespace, cascade).await?;
+        catalog.drop_namespace(&namespace, cascade).await?;
 
         info!(namespace = %ns_name, cascade = cascade, "Dropped namespace");
         Ok(DdlResult::success(format!(
@@ -2361,6 +2401,80 @@ mod tests {
             indexes
                 .iter()
                 .any(|index| index.index_type == CatalogIndexType::Hnsw)
+        );
+    }
+
+    #[tokio::test]
+    async fn scoped_create_namespace_records_owning_tenant() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let manager = Arc::new(CatalogManager::new());
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+
+        let ddl = DdlService::new(manager.clone());
+        ddl.execute_scoped(
+            DdlStatement::CreateNamespace {
+                namespace: vec!["analytics".to_string()],
+                if_not_exists: false,
+                properties: HashMap::new(),
+            },
+            Some("acmecorp"),
+        )
+        .await
+        .expect("tenant-scoped create namespace");
+
+        let catalog = manager.default_catalog().await.expect("default catalog");
+        let ns = catalog
+            .get_namespace(&["acmecorp".to_string(), "analytics".to_string()])
+            .await
+            .expect("get tenant-scoped namespace");
+
+        assert_eq!(ns.tenant_id.as_deref(), Some("acmecorp"));
+        assert!(ns.namespace_id.is_some());
+        assert!(ns.is_dr_addressable(), "namespace must be DR-addressable");
+    }
+
+    #[tokio::test]
+    async fn scoped_drop_namespace_uses_tenant_prefixed_namespace() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let manager = Arc::new(CatalogManager::new());
+        manager
+            .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+            .await
+            .expect("native catalog");
+
+        let ddl = DdlService::new(manager.clone());
+        ddl.execute_scoped(
+            DdlStatement::CreateNamespace {
+                namespace: vec!["analytics".to_string()],
+                if_not_exists: false,
+                properties: HashMap::new(),
+            },
+            Some("acmecorp"),
+        )
+        .await
+        .expect("tenant-scoped create namespace");
+
+        ddl.execute_scoped(
+            DdlStatement::DropNamespace {
+                namespace: vec!["analytics".to_string()],
+                if_exists: false,
+                cascade: false,
+            },
+            Some("acmecorp"),
+        )
+        .await
+        .expect("tenant-scoped drop namespace");
+
+        let catalog = manager.default_catalog().await.expect("default catalog");
+        assert!(
+            !catalog
+                .namespace_exists(&["acmecorp".to_string(), "analytics".to_string()])
+                .await
+                .expect("namespace_exists"),
+            "tenant-scoped DROP NAMESPACE must remove the tenant-prefixed namespace"
         );
     }
 


### PR DESCRIPTION
## Summary
- update the system map/MVP posture to match current code reality
- make tenant-scoped CREATE/DROP NAMESPACE use tenant-prefixed catalog namespaces and persist owning tenant metadata
- make resolve_table_scoped idempotent for explicitly tenant-qualified namespaces
- add SQL frontend support for CREATE/DROP NAMESPACE and normalize quoted DROP TABLE / DROP INDEX identifiers

## Validation
- cargo test --lib parse_ddl_drop
- cargo test --lib namespace
- python3 scripts/check_doc_authority.py
- git diff --check HEAD