### PR TITLE
feat(search): fail-loud strict metadata filter on v2 ProximaValue seam (TD-FILT-1 slice 1)

### DIFF
--- a/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
+++ b/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
@@ -38,6 +38,32 @@ use proximadb_proto::proximadb_v1::SqlValue;
 use proximadb_proto::proximadb_v1::sql_value::Value as SqlVal;
 use proximadb_records::{ProximaTree, ProximaTreeNode};
 
+/// Fail-loud error from the strict v2 metadata-filter evaluators (TD-FILT-1). The legacy
+/// [`evaluate_filter_resolved`] silently folds an unresolved field into `false` (dropping the row);
+/// the strict variants surface it so a caller can reject the result instead of accepting a silently
+/// wrong set. v2-canonical: this lives on the `ProximaValue`/`ProximaTree` seam (ADR-024), not the
+/// deprecated v1 `MetadataValue` path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterEvalError {
+    /// A value comparison referenced a field the resolver could not lower to a comparable value —
+    /// either absent from the record, or a non-scalar leaf. (`IsNull`/`IsNotNull` are NOT errors:
+    /// field absence is their domain, per SQL semantics.)
+    MissingField { field: String },
+}
+
+impl std::fmt::Display for FilterEvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterEvalError::MissingField { field } => write!(
+                f,
+                "filter field {field:?} could not be resolved to a comparable value (absent or non-scalar leaf)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FilterEvalError {}
+
 /// Evaluate a filter expression against proto `SqlValue` (wire-format) metadata.
 ///
 /// Thin adapter over the canonical [`evaluate_filter_resolved`] seam: each field's
@@ -342,6 +368,69 @@ where
     }
 }
 
+/// Fail-loud variant of [`evaluate_filter_resolved`] (TD-FILT-1, v2-canonical). Returns
+/// `Err(MissingField)` for a value comparison whose field the resolver cannot lower (absent or a
+/// non-scalar leaf), instead of silently returning `false`. `IsNull`/`IsNotNull` keep SQL absence
+/// semantics (`Ok`, never an error). The comparison layer is unchanged (it total-orders by JSON
+/// type precedence, so there is no per-comparison type mismatch to surface on this path).
+///
+/// Callers wanting ADR-043 fail-loud semantics migrate here; the legacy `evaluate_filter*` stay the
+/// silent default until call-sites are migrated slice-by-slice (default-off / behavior-preserving).
+pub fn evaluate_filter_resolved_strict<F>(
+    expr: &FilterExpression,
+    resolve: &F,
+) -> Result<bool, FilterEvalError>
+where
+    F: Fn(&str) -> Option<serde_json::Value>,
+{
+    match expr {
+        FilterExpression::And(exprs) => {
+            // Non-short-circuit: evaluate every child so a MissingField in a later arm surfaces
+            // (fail-loud) rather than being hidden by an earlier Ok(false).
+            let mut acc = true;
+            for e in exprs {
+                acc &= evaluate_filter_resolved_strict(e, resolve)?;
+            }
+            Ok(acc)
+        }
+        FilterExpression::Or(exprs) => {
+            let mut pending_err: Option<FilterEvalError> = None;
+            for e in exprs {
+                match evaluate_filter_resolved_strict(e, resolve) {
+                    Ok(true) => return Ok(true),
+                    Ok(false) => {}
+                    Err(e) => pending_err = pending_err.or(Some(e)),
+                }
+            }
+            // No arm was true; surface a deferred error if any arm failed (fail-loud), else false.
+            match pending_err {
+                Some(e) => Err(e),
+                None => Ok(false),
+            }
+        }
+        FilterExpression::Not(e) => Ok(!evaluate_filter_resolved_strict(e, resolve)?),
+        FilterExpression::Comparison {
+            field,
+            operator,
+            value,
+        } => match operator {
+            // Null tests are decided by presence (SQL: an absent field IS NULL) — never an error.
+            ComparisonOperator::IsNull => {
+                Ok(resolve(field).is_none_or(|json_val| json_val.is_null()))
+            }
+            ComparisonOperator::IsNotNull => {
+                Ok(resolve(field).is_some_and(|json_val| !json_val.is_null()))
+            }
+            _ => match resolve(field) {
+                Some(json_val) => Ok(compare_json_op(operator, &json_val, value)),
+                None => Err(FilterEvalError::MissingField {
+                    field: field.clone(),
+                }),
+            },
+        },
+    }
+}
+
 /// Evaluate a filter expression against a `ProximaTree` (canonical v2 path).
 ///
 /// Thin adapter over [`evaluate_filter_resolved`]: each field resolves to its
@@ -349,6 +438,19 @@ where
 /// absent fields resolve to `None`.
 pub fn evaluate_filter_proxima(expr: &FilterExpression, props: &ProximaTree) -> bool {
     evaluate_filter_resolved(expr, &|field| match props.get(field) {
+        Some(ProximaTreeNode::Value(pv)) => Some(proxima_value_to_json(pv)),
+        _ => None,
+    })
+}
+
+/// Fail-loud variant of [`evaluate_filter_proxima`] (TD-FILT-1) on the canonical `ProximaTree`
+/// path. Mirrors its resolver and surfaces an unresolved field (absent or a non-scalar leaf) as
+/// [`FilterEvalError::MissingField`] instead of silently dropping the row.
+pub fn evaluate_filter_proxima_strict(
+    expr: &FilterExpression,
+    props: &ProximaTree,
+) -> Result<bool, FilterEvalError> {
+    evaluate_filter_resolved_strict(expr, &|field| match props.get(field) {
         Some(ProximaTreeNode::Value(pv)) => Some(proxima_value_to_json(pv)),
         _ => None,
     })
@@ -729,5 +831,87 @@ mod tests {
             },
         ]);
         assert!(evaluate_filter(&filter, &metadata));
+    }
+
+    // ---- TD-FILT-1: evaluate_filter_proxima_strict (fail-loud, v2 ProximaValue path) ----
+
+    fn proxima_props_one(field: &str, pv: ProximaValue) -> ProximaTree {
+        let mut props = ProximaTree::new();
+        props.insert(field.to_string(), ProximaTreeNode::Value(pv));
+        props
+    }
+
+    #[test]
+    fn strict_clean_match_agrees_with_legacy() {
+        let props = proxima_props_one("tier", ProximaValue::Int64(2));
+        let filter = FilterExpression::Comparison {
+            field: "tier".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!(2),
+        };
+        assert_eq!(evaluate_filter_proxima(&filter, &props), true);
+        assert!(evaluate_filter_proxima_strict(&filter, &props).unwrap());
+    }
+
+    #[test]
+    fn strict_missing_field_surfaces_error_legacy_silently_drops() {
+        // No "tier" field in the (empty) props.
+        let props = ProximaTree::new();
+        let filter = FilterExpression::Comparison {
+            field: "tier".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!(2),
+        };
+        // The bug (TD-FILT-1): the legacy path silently drops the row (`None => false`).
+        assert!(
+            !evaluate_filter_proxima(&filter, &props),
+            "legacy evaluate_filter_proxima silently drops the unresolved-field row"
+        );
+        // The fix: strict surfaces it as a typed error.
+        assert_eq!(
+            evaluate_filter_proxima_strict(&filter, &props),
+            Err(FilterEvalError::MissingField {
+                field: "tier".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn strict_isnull_on_missing_is_ok_not_error() {
+        // Absent field IS NULL (SQL semantics) — not a MissingField error.
+        let props = ProximaTree::new();
+        let filter = FilterExpression::Comparison {
+            field: "tier".to_string(),
+            operator: ComparisonOperator::IsNull,
+            value: json!(null),
+        };
+        assert!(evaluate_filter_proxima_strict(&filter, &props).unwrap());
+    }
+
+    #[test]
+    fn strict_and_surfaces_missing_field_even_when_an_earlier_arm_is_false() {
+        // arm1 (a==2) is false (a is 1); arm2 references a missing field. Non-short-circuit strict
+        // must surface the MissingField rather than hide it behind arm1's Ok(false).
+        let mut props = ProximaTree::new();
+        props.insert(
+            "a".to_string(),
+            ProximaTreeNode::Value(ProximaValue::Int64(1)),
+        );
+        let filter = FilterExpression::And(vec![
+            FilterExpression::Comparison {
+                field: "a".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!(2),
+            },
+            FilterExpression::Comparison {
+                field: "missing".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!(1),
+            },
+        ]);
+        assert!(matches!(
+            evaluate_filter_proxima_strict(&filter, &props),
+            Err(FilterEvalError::MissingField { .. })
+        ));
     }
 }

--- a/docs/10-quality/td/TD-FILT-1-metadata-filter-evaluation-fail-loud.adoc
+++ b/docs/10-quality/td/TD-FILT-1-metadata-filter-evaluation-fail-loud.adoc
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FILT-1: v2 metadata-filter silently drops rows on unresolved fields (add a fail-loud strict path on the canonical ProximaValue seam)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | In Progress — slice 1 (typed `FilterEvalError` + `evaluate_filter_resolved_strict` / `evaluate_filter_proxima_strict` on the canonical v2 seam) landed in this PR (2026-07-07). Re-scoped from a v1 `MetadataValue` target the same day (see below).
+| Severity | High (silent correctness loss in results — records whose filter field is absent, or a non-scalar leaf, are silently dropped from every non-null comparison with no error)
+| Component | Canonical v2 filter seam: `crates/foundation/proximadb-search-types/src/sql_value_filter.rs` — `evaluate_filter_resolved` (the shared spine, line ~315), `evaluate_filter_proxima` (ProximaTree/ProximaValue adapter, line ~350), `evaluate_filter` (SqlValue adapter).
+| Governs | link:../../12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024] (single canonical `ProximaValue`/`ProximaRecord` type) + link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (fail-loud predicate evaluation). v2-canonical: only the `ProximaValue`/`ProximaTree` path is extended; the v1 `MetadataValue`/`VectorRecord` path is *not* (see "Re-scope note").
+| Relates | link:TD-186-relational-expr-eval-unification.adoc[TD-186] (relational fail-loud rollout), link:../REVIEW_RESPONSE_2026_07_07.adoc[REVIEW_RESPONSE_2026_07_07] §8/B03, link:TECHNICAL_DEBT.adoc[TD-123] (v1-proto ratchet / v1 sunset), link:TECHNICAL_DEBT.adoc[TD-182] (accuracy harness)
+| Surfaced by | Antigravity architectural recommendations round 2, item B03
+|===
+
+== Re-scope note (2026-07-07) — v2-canonical alignment
+
+The original filing targeted `src/core/search/typesafe_filter.rs` (`TypeSafeFilterEvaluator`),
+which operates on the **v1** `proto::proximadb_v1::MetadataValue`. Two facts make that the wrong
+target:
+
+1. **`TypeSafeFilterEvaluator` is dead** — `grep -rn TypeSafeFilterEvaluator` finds only its own
+   definition + two test sites; **zero production callers**. It is stranded v1-type legacy.
+2. **The canonical v2 filter path already exists on `ProximaValue`/`ProximaTree`** in
+   `crates/foundation/proximadb-search-types/src/sql_value_filter.rs` (`evaluate_filter_resolved`,
+   `evaluate_filter_proxima`), and it has the *same* silent-drop bug. Per ADR-024 + the v2-canonical
+   mandate (only maintain v2 surfaces; v1 sunsets via TD-123), the fix belongs on the `ProximaValue`
+   path. Extending the v1 `MetadataValue` evaluator would build new API on a deprecated, dead
+   component — the same anti-pattern as patching the v1 fusion path.
+
+The v1 `TypeSafeFilterEvaluator` is a **retirement candidate** under v1 sunset (TD-123 / ADR-049),
+not something to harden. (It additionally silent-folds type-mismatches because its
+`compare_typed_values -> Option<Ordering>` folds `None` to `false`/`true`; that dies with the file.)
+
+== Problem (v2 path)
+
+`evaluate_filter_resolved` is the shared spine every `FilterExpression` evaluator funnels through.
+For every operator except the null tests, an unresolved field silently becomes `false`:
+
+```rust
+// sql_value_filter.rs, evaluate_filter_resolved
+_ => match resolve(field) {
+    Some(json_val) => compare_json_op(operator, &json_val, value),
+    None => false,                       // ← silent drop: absent field OR non-scalar leaf
+},
+```
+
+`resolve` returns `None` both when the field is **absent** and when it is a **non-scalar leaf** the
+adapter doesn't lower (e.g. `evaluate_filter_proxima` maps `Object`/non-`Value` nodes to `None`).
+In both cases the record is silently excluded from the result of any `Equals`/`In`/`<`/… predicate
+— no error surfaces, so a query can quietly return fewer rows than it should with no signal. This is
+the B03 failure mode, on the canonical path.
+
+(Note: the v2 comparison layer — `compare_json_op` / `compare_json_values` — *intentionally*
+total-orders across JSON types by type precedence, so unlike the v1 `Option<Ordering>` evaluator
+there is no per-comparison "type mismatch" to surface here. The silent drop on the v2 path is the
+*unresolved-field* case.)
+
+== Plan (behavior-preserving slices)
+
+* **Slice 1 (this PR):** add a typed `FilterEvalError` (`MissingField`) and
+  `evaluate_filter_resolved_strict<F>(expr, resolve) -> Result<bool, FilterEvalError>` plus the
+  `evaluate_filter_proxima_strict` / `evaluate_filter_strict` adapters. A value comparison against
+  an unresolved field returns `Err(MissingField)` instead of silently `false`; `IsNull`/`IsNotNull`
+  keep SQL absence semantics (`Ok`, not an error). The legacy `evaluate_filter*` are **untouched**
+  (zero behavior change) — strict is opt-in.
+* **Slice 2 (wiring):** migrate the live v2 search call-sites that want ADR-043 fail-loud semantics
+  to the strict variants, propagating the error to a query-level failure behind a config flag
+  (default preserve-current). The point at which silent drops become loud in production.
+* **Slice 3 (cleanup):** delete the dead v1 `TypeSafeFilterEvaluator` under v1 sunset (TD-123).
+
+== Why default-off / behavior-preserving
+
+Making the live `evaluate_filter*` fail-loud by default would change query *results* (rows silently
+dropped today would instead error the query). Correct end-state, but must be gated
+(ADR-052 observe→ingest→act) so it is an explicit opt-in. Slice 1 only *adds* a fail-loud path.
+
+== How to apply / verify
+
+Acceptance (slice 1):
+
+* `evaluate_filter_proxima_strict` returns `Err(MissingField)` for a value comparison on an absent
+  field (where `evaluate_filter_proxima` silently returns `false`).
+* `IsNull`/`IsNotNull` return `Ok` (absence is not an error).
+* A clean match returns the same `Ok(bool)` as the legacy path.
+* The legacy `evaluate_filter*` are byte-identical (regression guard).


### PR DESCRIPTION
## What

Implements **slice 1** of [TD-FILT-1](../blob/develop/docs/10-quality/td/TD-FILT-1-metadata-filter-evaluation-fail-loud.adoc) — a fail-loud strict metadata-filter path on the **canonical v2 `ProximaValue`/`ProximaTree` seam**, closing the B03 finding (queries silently dropping rows when a filter field can't be resolved).

## v2-canonical (the key decision)

This was re-scoped mid-PR. The first cut targeted `src/core/search/typesafe_filter.rs` (`TypeSafeFilterEvaluator`) — but that operates on **v1 `MetadataValue`** proto and is **dead** (zero production callers). Per ADR-024 + the "only maintain v2 surfaces" mandate, the fix belongs on the canonical v2 path, which already exists and has the same bug: `crates/foundation/proximadb-search-types/src/sql_value_filter.rs`. The v1 `TypeSafeFilterEvaluator` is now flagged as a retirement candidate under v1 sunset (TD-123), not something to extend.

## Changes

- **`sql_value_filter.rs`** (the v2 seam):
  - `FilterEvalError::MissingField` — typed error for an unresolved field.
  - `evaluate_filter_resolved_strict` (the shared spine) + `evaluate_filter_proxima_strict` (ProximaTree adapter) returning `Result<bool, FilterEvalError>`. A value comparison on an unresolved field (absent or a non-scalar leaf) → `Err(MissingField)` instead of silently `false`. `IsNull`/`IsNotNull` keep SQL absence semantics (`Ok`). Non-short-circuit `And` so a missing-field in a later arm still surfaces.
- **`docs/10-quality/td/TD-FILT-1-…adoc`** — filed, scoped to the v2 path, with the re-scope note.

Legacy `evaluate_filter`/`evaluate_filter_proxima` are **untouched** (zero behavior change); strict is opt-in. Wiring the live search call-sites to the strict variants behind a config flag is slice 2 (default-off, gated — flipping it changes query results).

## Verification

- `cargo clippy --lib -p proximadb-search-types` → clean.
- `cargo test -p proximadb-search-types --lib sql_value_filter::` → **12 passed** (4 new strict tests: clean-match-agrees, missing-field-surfaces-error, isnull-not-error, and-surfaces-later-arm).
- `cargo fmt --check` clean. `check_td_adr_unique.py` → 0 errors.
