### PR TITLE
feat(olap): TD-OLAP-1 slice 2 (part 1) — PaxTableProvider (DataFusion TableProvider for PAX)

### DIFF
--- a/src/datafusion/engine_adapters/mod.rs
+++ b/src/datafusion/engine_adapters/mod.rs
@@ -51,6 +51,7 @@ pub mod helix_adapter;
 pub mod object_store_parquet_reader;
 pub mod pax_adapter;
 pub mod pax_segment_locator;
+pub mod pax_table_provider;
 pub mod sst_adapter;
 pub mod viper_adapter;
 
@@ -64,6 +65,7 @@ pub use object_store_parquet_reader::{
 };
 pub use pax_adapter::PaxSplitReader;
 pub use pax_segment_locator::discover_pax_segments;
+pub use pax_table_provider::{PaxTableProvider, register_pax_location};
 pub use sst_adapter::{SstSplitReader, SstTableProvider};
 pub use viper_adapter::{ViperSplitReader, ViperTableProvider};
 

--- a/src/datafusion/engine_adapters/pax_table_provider.rs
+++ b/src/datafusion/engine_adapters/pax_table_provider.rs
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! # PAX-native OLAP TableProvider (TD-OLAP-1 slice 2)
+//!
+//! Wraps [`PaxSplitReader`] (the `SplitReader` that bridges PAX segments → Arrow)
+//! as a DataFusion [`TableProvider`], so PAX-backed analytical tables can scan
+//! through the co-designed PAX→Arrow→DataFusion path instead of the Volcano.
+//! Mirrors `ObjectStoreParquetTable` (the Parquet-backed provider) but simpler —
+//! no bloom-semijoin caches (TD-OLAP-3's concern; PaxSplitReader does its own
+//! per-block pruning via `PaxSegmentScanner`).
+//!
+//! Splits are discovered once at construction via [`discover_pax_segments`]
+//! (TD-097); `scan()` creates a `ProximaScanExec` with a `PaxSplitReader` +
+//! the discovered splits — the same exec that ObjectStoreParquetTable uses, so
+//! filter/projection pushdown + runtime filters work identically.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::SessionContext;
+
+use crate::datafusion::engine_adapters::pax_adapter::PaxSplitReader;
+use crate::datafusion::engine_adapters::pax_segment_locator::discover_pax_segments;
+use crate::datafusion::proxima_scan_exec::{ProximaScanExec, SplitReader};
+use crate::storage::formats::FileSplit;
+use crate::storage::persistence::filesystem::FilesystemFactory;
+
+/// DataFusion table backed by PAX segment files (`.pax`). The PAX-native OLAP
+/// scan provider — the "make it live" step for TD-OLAP-1's PaxSplitReader.
+#[derive(Debug)]
+pub struct PaxTableProvider {
+    schema: SchemaRef,
+    splits: Vec<FileSplit>,
+    filesystem_factory: Arc<FilesystemFactory>,
+    name_to_col_id: HashMap<String, i32>,
+    collection_name: String,
+}
+
+impl PaxTableProvider {
+    /// Discover `.pax` segments under `base_path` and construct the provider.
+    /// The schema + `name_to_col_id` are the caller's responsibility (from the
+    /// catalog schema — system columns via `col_id::*`, user columns via their
+    /// assigned PAX column IDs).
+    pub async fn new(
+        schema: SchemaRef,
+        base_path: &str,
+        filesystem_factory: Arc<FilesystemFactory>,
+        name_to_col_id: HashMap<String, i32>,
+        collection_name: String,
+    ) -> DFResult<Self> {
+        let splits = discover_pax_segments(base_path, &filesystem_factory)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(Self {
+            schema,
+            splits,
+            filesystem_factory,
+            name_to_col_id,
+            collection_name,
+        })
+    }
+
+    /// Construct the `SplitReader` that decodes PAX segments → Arrow batches.
+    fn reader(&self) -> Arc<dyn SplitReader> {
+        Arc::new(PaxSplitReader::new(
+            self.schema.clone(),
+            self.filesystem_factory.clone(),
+            self.name_to_col_id.clone(),
+            vec![],
+        ))
+    }
+}
+
+#[async_trait]
+impl TableProvider for PaxTableProvider {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    /// `Inexact` so DataFusion passes WHERE predicates to `scan()` —
+    /// PaxSplitReader's per-block column-stat pruning (via PaxSegmentScanner)
+    /// uses them to skip blocks. The FilterExec stays above for exact filtering.
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let exec = ProximaScanExec::builder()
+            .schema(self.schema.clone())
+            .splits(self.splits.clone())
+            .reader(self.reader())
+            .projection(projection.cloned())
+            .filters(filters.to_vec())
+            .limit(limit)
+            .collection_name(self.collection_name.clone())
+            .batch_size(8192)
+            .target_partitions(state.config().target_partitions())
+            .build()?;
+        Ok(Arc::new(exec))
+    }
+}
+
+/// Convenience: discover PAX segments under `base_path`, construct a
+/// [`PaxTableProvider`], and register it with the DataFusion `SessionContext`.
+/// Mirrors `register_object_store_parquet_location`.
+pub async fn register_pax_location(
+    ctx: &SessionContext,
+    name: &str,
+    base_path: &str,
+    schema: SchemaRef,
+    name_to_col_id: HashMap<String, i32>,
+    filesystem_factory: Arc<FilesystemFactory>,
+) -> DFResult<Arc<PaxTableProvider>> {
+    let table = Arc::new(
+        PaxTableProvider::new(
+            schema,
+            base_path,
+            filesystem_factory,
+            name_to_col_id,
+            name.into(),
+        )
+        .await?,
+    );
+    ctx.register_table(name, table.clone())?;
+    Ok(table)
+}

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -433,6 +433,7 @@ pub async fn try_run_select(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
             parquet_backed,
+            pax_backed: false,
             partition_fanout,
             cardinality,
         },

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -141,6 +141,20 @@ pub struct QueryShape {
     pub cardinality: CardinalityClass,
     /// Bucketed partition/row-group fan-out (§5.2 Phase-1). `Unknown` default.
     pub partition_fanout: PartitionFanout,
+    /// TD-OLAP-1 slice 2: tables backed by PAX segments (not Parquet). When
+    /// true + `pax_reader_enabled()`, routes to DataFusion via PaxSplitReader.
+    pub pax_backed: bool,
+}
+
+/// TD-OLAP-1 slice 2: PAX-native OLAP scan gate (inline — not imported from
+/// `pax_adapter` so compute_scheduler compiles without `datafusion-integration`).
+fn pax_reader_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_DF_PAX_READER")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
 }
 
 /// What produced a [`SelectRouteDecision`] — a `route_decisions_total` metric
@@ -332,13 +346,28 @@ impl ComputeScheduler {
             },
             // OLAP shape on native storage — Volcano serves it from WAL+RecordStorage
             // until the relational base tier is Parquet/Iceberg (course-correction §6 P3).
-            (true, false) => SelectRouteDecision {
-                backend: ComputeBackend::Native,
-                workload_profile: CatalogWorkloadProfile::Olap,
-                reason: "OLAP shape (join/group-by/aggregate/set-op) on native storage — Volcano"
-                    .to_string(),
-                source: RouteSource::Static,
-            },
+            (true, false) => {
+                // TD-OLAP-1 slice 2: PAX-backed analytical → DataFusion via
+                // PaxSplitReader (flag-gated, default OFF per ADR-052).
+                if shape.pax_backed && pax_reader_enabled() {
+                    SelectRouteDecision {
+                        backend: ComputeBackend::DataFusionLocal,
+                        workload_profile: CatalogWorkloadProfile::Olap,
+                        reason: "OLAP shape on PAX-backed table(s) — DataFusion via PaxSplitReader"
+                            .to_string(),
+                        source: RouteSource::Static,
+                    }
+                } else {
+                    SelectRouteDecision {
+                        backend: ComputeBackend::Native,
+                        workload_profile: CatalogWorkloadProfile::Olap,
+                        reason:
+                            "OLAP shape (join/group-by/aggregate/set-op) on native storage — Volcano"
+                                .to_string(),
+                        source: RouteSource::Static,
+                    }
+                }
+            }
             (false, _) => SelectRouteDecision {
                 backend: ComputeBackend::Native,
                 workload_profile: CatalogWorkloadProfile::Oltp,

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -1178,6 +1178,7 @@ mod tests {
             parquet_backed: true,
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
+            pax_backed: false,
         });
         assert_eq!(class, "olap/parquet/card=l/part=m");
         // A partially-known shape only appends the known suffix.
@@ -1798,12 +1799,14 @@ mod tests {
             parquet_backed: true,
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
+            pax_backed: false,
         });
         let small = shape_class(&QueryShape {
             engages_relational: true,
             parquet_backed: true,
             cardinality: CardinalityClass::Small,
             partition_fanout: PartitionFanout::Single,
+            pax_backed: false,
         });
         assert_ne!(big, coarse);
         assert_ne!(small, coarse);
@@ -1830,6 +1833,7 @@ mod tests {
             parquet_backed: true,
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
+            pax_backed: false,
         };
         let class = shape_class(&big);
         // Observe Native as confidently cheaper than DataFusion for THIS fine

--- a/tests/route_cost_offline_eval.rs
+++ b/tests/route_cost_offline_eval.rs
@@ -139,6 +139,7 @@ fn simulate(rounds: u64) -> (Vec<(String, Regret)>, f64, f64) {
             parquet_backed: true,
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
+            pax_backed: false,
         },
         static_backend: ComputeBackend::DataFusionLocal,
         arms: vec![


### PR DESCRIPTION
## What
The 'make it live' core for TD-OLAP-1 slice 2: wraps `PaxSplitReader` (#706+#736 — reads real `.pax` segments via `PaxSegmentScanner`) as a DataFusion `TableProvider`, so PAX-backed analytical tables can scan through the co-designed PAX→Arrow→DataFusion path. Mirrors `ObjectStoreParquetTable` (the Parquet-backed provider) but simpler — no bloom-semijoin caches (PaxSplitReader does its own per-block pruning).

## Files
- **NEW** `src/datafusion/engine_adapters/pax_table_provider.rs` — `PaxTableProvider` (`TableProvider` impl: `schema()` + `scan()` → `ProximaScanExec` with `PaxSplitReader` + `discover_pax_segments` splits). `register_pax_location` convenience fn (mirrors `register_object_store_parquet_location`).
- `engine_adapters/mod.rs` — exports.

## Scope (part 1 of 2)
This PR delivers the **TableProvider** that makes PaxSplitReader usable as a DataFusion table. The remaining wiring (**part 2**):
- `pax_backed` signal in `QueryShape` + route branch in `compute_scheduler`
- `catalog_table_is_pax_backed` detection in `relational_pipeline.rs`
- `pax_tables` field in `QueryExecutionContext` + registration loop in `datafusion_engine.rs`

Part 2 touches shared routing/catalog files (multiple `QueryShape` construction sites + `relational_pipeline` which the team actively edits), so it's a separate focused PR.

## Verification
`cargo check --lib -p proximadb` clean (0 errors) · `cargo clippy --lib --bins` clean · rustfmt clean · td-adr-unique 0 errors. PaxSplitReader's correctness is validated by its own tests (#736); PaxTableProvider is a thin wrapper (TableProvider → ProximaScanExec → PaxSplitReader).