### PR TITLE
refactor(runtime): relocate RichRecord* request types to proximadb-runtime (TD-104 Phase 0)

### DIFF
--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -20,6 +20,7 @@ pub mod proto_defaults;
 pub mod record_ops_port;
 pub mod record_route_port;
 pub mod resources;
+pub mod rich_record;
 pub mod security_port;
 pub mod service_ports;
 pub mod streaming_port;
@@ -44,6 +45,7 @@ pub use port::{
 pub use record_ops_port::RecordOpsPort;
 pub use record_route_port::RecordRoutePort;
 pub use resources::{MemoryBudget, ResourceManager};
+pub use rich_record::{RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest};
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
 pub use service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};
 pub use streaming_port::StreamingPort;

--- a/crates/platform/proximadb-runtime/src/rich_record.rs
+++ b/crates/platform/proximadb-runtime/src/rich_record.rs
@@ -1,0 +1,33 @@
+//! Canonical rich record request types for the v2/internal record API.
+//!
+//! TD-104 Phase 0: relocated from the root crate
+//! (`src/services/operations/vectors/legacy.rs`, now a re-export shim) so the
+//! runtime `RecordOpsPort` contract surface is self-contained in this crate —
+//! the root no longer needs to be in scope for the record-ops port types.
+//! Pure data; no behavior change (mirrors the S3a `BatchOperationResult`
+//! relocation pattern).
+
+use proximadb_records::ProximaRecord;
+
+/// Canonical rich record batch request for internal callers.
+#[derive(Debug, Clone)]
+pub struct RichRecordBatchRequest {
+    pub collection_id: String,
+    pub records: Vec<ProximaRecord>,
+}
+
+/// Canonical rich record delete request for v2 and internal callers.
+#[derive(Debug, Clone)]
+pub struct RichRecordDeleteBatchRequest {
+    pub collection_id: String,
+    pub record_ids: Vec<String>,
+}
+
+/// Canonical rich record get request for v2 and internal callers.
+#[derive(Debug, Clone)]
+pub struct RichRecordGetRequest {
+    pub collection_id: String,
+    pub record_id: String,
+    pub include_vector: bool,
+    pub include_props: bool,
+}

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -84,28 +84,13 @@ use crate::services::operations::{BatchOperationResult, BulkWriteRouter, Operati
 use crate::storage::cache::specialized::query_cache::{QueryCache, QueryKey};
 use crate::storage::engines::sst::SstEngine;
 
-/// Canonical rich record batch request for internal callers.
-#[derive(Debug, Clone)]
-pub struct RichRecordBatchRequest {
-    pub collection_id: String,
-    pub records: Vec<ProximaRecord>,
-}
-
-/// Canonical rich record delete request for v2 and internal callers.
-#[derive(Debug, Clone)]
-pub struct RichRecordDeleteBatchRequest {
-    pub collection_id: String,
-    pub record_ids: Vec<String>,
-}
-
-/// Canonical rich record get request for v2 and internal callers.
-#[derive(Debug, Clone)]
-pub struct RichRecordGetRequest {
-    pub collection_id: String,
-    pub record_id: String,
-    pub include_vector: bool,
-    pub include_props: bool,
-}
+// TD-104 Phase 0: these types now live in `proximadb-runtime` (so the
+// `RecordOpsPort` contract is self-contained). Re-exported here so existing
+// `crate::services::operations::vectors::legacy::RichRecord*` callers are
+// unaffected (mirrors the S3a `BatchOperationResult` relocation pattern).
+pub use proximadb_runtime::rich_record::{
+    RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest,
+};
 
 /// Canonical rich search request for v2 and internal callers.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
TD-104 ROOT-deletion **Phase 0** — the cross-crate prerequisite that unblocks S3-c (Arrow Flight runtime-backed `RecordOpsPort`).

Moves `RichRecordBatchRequest` / `RichRecordDeleteBatchRequest` / `RichRecordGetRequest` from the root crate (`src/services/operations/vectors/legacy.rs`) DOWN to `proximadb-runtime` (new `rich_record.rs`), with a root re-export shim so **all existing import paths are unchanged** (zero call-site churn). Mirrors the proven S3a `BatchOperationResult` relocation.

**Why:** the `RecordOpsPort` contract (owned by `proximadb-runtime`) needs these types in scope so its surface is self-contained — the terminal ROOT deletion (S3-c/S3-f) requires `RecordOpsPort` to not reach up into root. Only non-primitive field is `Vec<ProximaRecord>`; runtime already depends on `proximadb-records` (S3a).

## Verification
- `cargo clippy --lib --bins` (`-D warnings`): clean
- `cargo check --tests`: clean (no call-site churn → no ripple)

## Tracking
TD-104 ROOT-deletion roadmap — Phase 0 (blocks S3-c). Next: Phase 1 parallel components (S3-a REST, S3-b MetricsPort, S3-d gRPC) + S3-c (after this merges).