### PR TITLE
docs(design): v1 retirement roadmap (staged, ratchet-driven)

### DIFF
--- a/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
+++ b/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
@@ -64,15 +64,15 @@ REST surface), `embedded/mod.rs` (~59).
 
 Remaining Tier 1 work is the **cutover** (not the gate), in order:
 
-1. **Migrate the admin dashboard off `/api/v1`.** `src/network/rest/dashboard.html` still calls
-   `/api/v1/collections` (lines 697, 826) — swap to `/api/v2/collections?include_stats=true` (the
-   `include_stats=true` is required: v2 defaults it to `false`, which would zero the "total vectors"
-   card). The dashboard's parsing is defensive (`data.collections || data || []`,
-   `col.config?.name || col.name`), so the shape swap is low-risk. Until this lands, flipping the
-   REST-v1 default off breaks the admin UI.
-2. **Flip the REST-v1 default to OFF** (the breaking cutover — `410`s all `/api/v1` traffic). Gate
-   this on (a) the dashboard migration above and (b) confirming no live `/api/v1` client traffic.
-   Needs explicit sign-off (outward-facing break), per the repo's certify-before-flip posture.
+1. **(done, #756)** The served admin UI (`crates/platform/proximadb-admin-ui/assets/admin.html`,
+   embedded via `include_str!` at `/admin` + `/dashboard`) is **already v2-clean** — only
+   `/api/v2/*` + `/metrics/json`. The only `/api/v1` dashboard caller was the *orphaned*
+   `src/network/rest/dashboard.html` (not embedded, not served by any route), deleted in #756. So
+   the cutover is **not** dashboard-blocked. (An earlier draft of this roadmap assumed a dashboard
+   migration was required — that was based on the orphan file, not the served UI.)
+2. **Flip the REST-v1 default to OFF** (the breaking cutover — `410`s all `/api/v1` traffic). Now
+   gated *only* on confirming there is no live external `/api/v1` client traffic. Needs explicit
+   sign-off (outward-facing break), per the repo's certify-before-flip posture.
 3. **Hard-delete** the v1 REST handlers (`network/rest/v1/*`) and the gRPC v1 services once each has
    been default-off through a sunset window.
 

--- a/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
+++ b/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
@@ -52,15 +52,29 @@ REST surface), `embedded/mod.rs` (~59).
 
 === Tier 1 — Gateable surfaces (kill-switch → measure → remove)
 
-Pattern is proven: gRPC v1 is already behind `enable_grpc_v1_compat`
-(env `PROXIMADB_GRPC_V1_COMPAT`, **default off**) in `network/multi_server.rs` /
-`network/server_builder.rs`. Extend the same default-off runtime gate, confirm no traffic, then
-delete the dead branch.
+**Both kill-switches already exist** (verified 2026-07-08):
 
-* REST v1 endpoints — `src/network/rest/v1/*` (`graph.rs` ~59 refs, `handlers.rs` ~51). REST `/api/v1`
-  is the deprecated-compat adapter (SUPPORTED_SURFACE); gate behind a config flag (default off),
-  then remove.
-* gRPC v1 services — already gated; schedule the hard delete after the sunset window.
+* **REST v1 — DONE (ADR-049 M0-c).** `src/network/middleware/v1_sunset.rs` gates the entire
+  `/api/v1/*` surface behind `PROXIMADB_REST_V1_COMPAT` (**default ON**), wired into both router
+  builders (`src/network/rest/server.rs:490` unified + `:816` multi-port). When off, `/api/v1/*`
+  answers `410 Gone` + RFC 8594 `deprecation`/`Link`/`Sunset` headers; `/api/v2/*` is never affected.
+  Unit-tested. (An earlier draft of this roadmap listed the REST gate as a to-do — that was wrong.)
+* **gRPC v1 — DONE.** Behind `enable_grpc_v1_compat` (`PROXIMADB_GRPC_V1_COMPAT`, default off) in
+  `network/{multi_server,server_builder}.rs`.
+
+Remaining Tier 1 work is the **cutover** (not the gate), in order:
+
+1. **Migrate the admin dashboard off `/api/v1`.** `src/network/rest/dashboard.html` still calls
+   `/api/v1/collections` (lines 697, 826) — swap to `/api/v2/collections?include_stats=true` (the
+   `include_stats=true` is required: v2 defaults it to `false`, which would zero the "total vectors"
+   card). The dashboard's parsing is defensive (`data.collections || data || []`,
+   `col.config?.name || col.name`), so the shape swap is low-risk. Until this lands, flipping the
+   REST-v1 default off breaks the admin UI.
+2. **Flip the REST-v1 default to OFF** (the breaking cutover — `410`s all `/api/v1` traffic). Gate
+   this on (a) the dashboard migration above and (b) confirming no live `/api/v1` client traffic.
+   Needs explicit sign-off (outward-facing break), per the repo's certify-before-flip posture.
+3. **Hard-delete** the v1 REST handlers (`network/rest/v1/*`) and the gRPC v1 services once each has
+   been default-off through a sunset window.
 
 === Tier 2 — Deprecated-engine v1 usage (retires with the engines)
 

--- a/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
+++ b/docs/12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc
@@ -1,0 +1,109 @@
+= v1 Retirement Roadmap
+:toc: left
+:toclevels: 2
+:icons: font
+:last-updated: 2026-07-08
+
+[.lead]
+Sequenced retirement of the v1 surface (REST `/api/v1`, gRPC v1, and the v1 proto types
+`proximadb_v1::*` — `VectorRecord`, `MetadataValue`, etc.) toward the canonical v2 types
+(`ProximaValue` / `ProximaRecord` / `ProximaTree`, ADR-024). Answers the question: *should we
+disable/retire v1 candidates so compilation finds tangled references?* — with a safe, staged plan
+instead of a big-bang break.
+
+[IMPORTANT]
+====
+**The mechanism already exists and is CI-blocking:** the v1-proto ratchet
+(link:../10-quality/TECHNICAL_DEBT.adoc[TD-123], `scripts/check_v1_proto_usage.py`) is downward-only
+and blocks `ci-success`. It *is* "let compilation/tests find tangled references," applied one green,
+forward-only PR at a time. This roadmap sequences what goes through that ratchet, in risk order.
+**Do not** big-bang-disable load-bearing v1 shapes to "discover" coupling — that produces a broken
+build and `cfg`-conditional tangles. Use a throwaway *delete-and-see probe branch* to map coupling
+for TD-104, then discard it.
+====
+
+== Current state (2026-07-08, post #750)
+
+`scripts/check_v1_proto_usage.py`: **2913 references / 482 files** (baseline refreshed in #750).
+
+[cols="1,2", options="header"]
+|===
+| Root | v1 refs
+
+| `src`     | ~2400 (the bulk — v1 proto is still the *internal domain model*)
+| `tests`   | ~374
+| `crates`  | ~99
+| `clients` | ~41
+|===
+
+Top prod files: `api_handlers/request_handlers.rs` (~141, the TD-104 root god-object),
+`core/conversions.rs` (~86, the v1↔v2 bridge), `services/operations/vectors/legacy.rs` (~77, wired —
+not dead), `network/grpc/security_service.rs` (~61), `network/rest/v1/{graph,handlers}.rs` (the v1
+REST surface), `embedded/mod.rs` (~59).
+
+== Classification (verified 2026-07-08)
+
+=== Tier 0 — Free deletes (do now; lands green, zero callers)
+
+* ✅ `TypeSafeFilterEvaluator` (`src/core/search/typesafe_filter.rs`) — **done in #750**. Zero prod
+  callers; operated on v1 `MetadataValue`. Was a frequent source of "extend the v1 path" confusion.
+* 🟠 *Local cleanup (not a PR):* `src/storage/engines/sst/mod.rs.backup` — a 5152-line **untracked**
+  scratch file (not in git, not compiled) that inflates *local* ratchet runs by ~72. `rm` it locally.
+
+=== Tier 1 — Gateable surfaces (kill-switch → measure → remove)
+
+Pattern is proven: gRPC v1 is already behind `enable_grpc_v1_compat`
+(env `PROXIMADB_GRPC_V1_COMPAT`, **default off**) in `network/multi_server.rs` /
+`network/server_builder.rs`. Extend the same default-off runtime gate, confirm no traffic, then
+delete the dead branch.
+
+* REST v1 endpoints — `src/network/rest/v1/*` (`graph.rs` ~59 refs, `handlers.rs` ~51). REST `/api/v1`
+  is the deprecated-compat adapter (SUPPORTED_SURFACE); gate behind a config flag (default off),
+  then remove.
+* gRPC v1 services — already gated; schedule the hard delete after the sunset window.
+
+=== Tier 2 — Deprecated-engine v1 usage (retires with the engines)
+
+`MetadataValue` is used across `storage/engines/{raptor,swift}` (experimental/deprecated) and `axis`.
+These refs retire when the deprecated engines are removed
+(link:../10-quality/td/TD-ENGINE-1-deprecated-engine-removal-entanglement.adoc[TD-ENGINE-1]) — not
+before.
+
+=== Tier 3 — Load-bearing internal domain model (the long pole; NOT disable-able)
+
+The ~2400 `src` refs are v1 proto used as the *internal domain model*. Retire only via the canonical
+migration + phased decomposition — never by disabling:
+
+* `VectorRecord` (~92 prod files) — deeply embedded. Migrates to `ProximaRecord` under
+  link:adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024] (the RichRecord/`ProximaRecord`
+  work; TD-104 Phase 0 "RichRecord* relocate" is the unblocking step).
+* `core/conversions.rs` (~86) — the v1↔v2 bridge. Shrinks as callers move to v2; deletes when v1 is
+  gone.
+* `api_handlers/request_handlers.rs` (~141) — the TD-104 root god-object. Retired by the
+  S3-a..f phased decomposition (root `UnifiedHandlers` collapse + delete).
+
+== Nuance: not all v1-proto names are "deprecated"
+
+`SqlValue` (~68 prod files) is a v1-*proto-package* type but is **actively used by the v2 path**
+(e.g. `crates/foundation/proximadb-search-types/src/sql_value_filter.rs`). When the v1 *proto
+package* is retired, `SqlValue` must either migrate to a v2-package equivalent or be carved out — it
+is not a blanket deletion. Always check callers before assuming a `proximadb_v1::` name is
+retire-able.
+
+== Recommended order (max ratchet reduction per unit risk)
+
+1. **Tier 0 free deletes** — #750 landed (−2 refs, −429 lines). Continue sweeping for zero-caller v1
+   components each cycle.
+2. **Tier 1 surface gating** — extend `enable_grpc_v1_compat`-style kill-switches to REST v1;
+   schedule hard deletes.
+3. **Tier 2** — land TD-ENGINE-1 (deprecated engines) → drops `MetadataValue` engine refs.
+4. **Tier 3** — drive ADR-024 (`VectorRecord`→`ProximaRecord`) + TD-104 (root-handler decomposition);
+   the conversions bridge and the internal-domain-model refs collapse as those land.
+
+== How to use the ratchet
+
+* Each retirement PR removes a bounded slice, lands green, and lowers the count; refresh the baseline
+  with `python3 scripts/check_v1_proto_usage.py --write docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json`.
+* To map hidden coupling before a Tier-3 slice: create a throwaway branch, delete the target, record
+  what breaks (`cargo check --workspace`), discard the branch — feed the coupling graph into TD-104.
+  Never merge a probe.


### PR DESCRIPTION
Sequenced retirement of the v1 surface toward the canonical v2 types (ADR-024), answering *'should we disable/retire v1 candidates so compilation finds tangled references?'*.

**Answer:** the v1-proto ratchet (TD-123, CI-blocking, forward-only) already IS that mechanism — applied safely one green PR at a time. Big-bang disabling of load-bearing v1 shapes is rejected; use the ratchet + TD-104 + ADR-024 instead, and throwaway 'delete-and-see' probe branches (never merged) to map coupling.

Classifies the 2913 v1-proto refs into 4 tiers with a retirement order:
- **Tier 0 — free deletes** (now): TypeSafeFilterEvaluator done in #750 (−429 lines).
- **Tier 1 — gateable surfaces**: REST v1 + gRPC v1 via the proven `enable_grpc_v1_compat` kill-switch pattern → measure → remove.
- **Tier 2 — deprecated-engine usage**: MetadataValue refs in raptor/swift retire with TD-ENGINE-1.
- **Tier 3 — load-bearing internal domain model**: VectorRecord (~92 files) → ProximaRecord (ADR-024), conversions bridge, root UnifiedHandlers (TD-104). The long pole; not disable-able.

Also flags the SqlValue nuance: v1-proto-*named* but actively used by the v2 path — not a blanket deletion.