### PR TITLE
feat(engine): ADR-054 Phase 0 — native execution contracts crate + NativeVectorizedEngine skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,6 +6593,7 @@ dependencies = [
  "proximadb-document-query",
  "proximadb-embedded-common",
  "proximadb-embedding",
+ "proximadb-execution-contracts",
  "proximadb-filter-expression",
  "proximadb-functions",
  "proximadb-graph",
@@ -6988,6 +6989,18 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "proximadb-execution-contracts"
+version = "0.2.0"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
+ "futures",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
     "crates/query/proximadb-graph-subset",
     "crates/query/proximadb-multimodel-query",
     "crates/query/proximadb-multimodel-plan",
+    "crates/query/proximadb-execution-contracts",
     "crates/query/proximadb-relational-algebra",
     "crates/query/proximadb-relational-reader",
     "crates/query/proximadb-relational-planner",
@@ -178,6 +179,7 @@ proximadb-index-traits = { path = "crates/foundation/proximadb-index-traits" }
 proximadb-records = { path = "crates/foundation/proximadb-records" }
 proximadb-relational-types = { path = "crates/foundation/proximadb-relational-types" }
 proximadb-functions = { path = "crates/foundation/proximadb-functions" }
+proximadb-execution-contracts = { path = "crates/query/proximadb-execution-contracts" }
 proximadb-relational-algebra = { path = "crates/query/proximadb-relational-algebra" }
 proximadb-relational-reader = { path = "crates/query/proximadb-relational-reader" }
 proximadb-relational-planner = { path = "crates/query/proximadb-relational-planner" }
@@ -298,6 +300,7 @@ proximadb-data-model = { path = "crates/foundation/proximadb-data-model" }
 proximadb-distance-types = { path = "crates/foundation/proximadb-distance-types" }
 proximadb-relational-types = { path = "crates/foundation/proximadb-relational-types" }
 proximadb-functions = { path = "crates/foundation/proximadb-functions" }
+proximadb-execution-contracts = { path = "crates/query/proximadb-execution-contracts" }
 proximadb-relational-algebra = { path = "crates/query/proximadb-relational-algebra" }
 proximadb-relational-reader = { path = "crates/query/proximadb-relational-reader" }
 proximadb-relational-planner = { path = "crates/query/proximadb-relational-planner" }

--- a/crates/query/proximadb-execution-contracts/Cargo.toml
+++ b/crates/query/proximadb-execution-contracts/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "proximadb-execution-contracts"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Native execution engine contracts — morsel-driven vectorized operator traits (ADR-054 Phase 0). Zero DataFusion dependency."
+
+[lib]
+name = "proximadb_execution_contracts"
+path = "src/lib.rs"
+
+[dependencies]
+arrow = { workspace = true }
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/query/proximadb-execution-contracts/src/lib.rs
+++ b/crates/query/proximadb-execution-contracts/src/lib.rs
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Native execution engine contracts (ADR-054 Phase 0)
+//!
+//! Internal SOLID contracts for the `NativeVectorizedEngine`. These traits are
+//! **internal to the native engine** — they do NOT wrap DataFusion and do NOT
+//! cross the `ExecutionEngine` per-query seam (ADR-039). DataFusion stays as-is;
+//! these contracts define how the native engine's own operators are structured.
+//!
+//! ## Design (vectorized + morsel-driven)
+//! * **Vectorized** (X100/DuckDB/Velox lineage) — operators process Arrow
+//!   `RecordBatch`es in tight SIMD-friendly loops, not one row at a time.
+//! * **Morsel-driven** (Leis SIGMOD 2014) — input is split into morsels of
+//!   `MORSEL_SIZE` rows, assigned to worker pipelines.
+//! * **Async stream-based** (the BLOCKER 1 fix from the ADR-054 review) —
+//!   operators transform `SendableRecordBatchStream` → `SendableRecordBatchStream`,
+//!   NOT sync push/poll. This matches DataFusion's async execution model and
+//!   avoids the sync/async mismatch that the v1 draft had.
+//! * **Arrow RecordBatch** as the single data plane — compatible with DataFusion,
+//!   PAX scan, and the existing `ProximaScanExec` infrastructure.
+
+#![forbid(unsafe_code)]
+
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+/// Standard morsel size (rows per batch). DuckDB uses 2048 (`STANDARD_VECTOR_SIZE`);
+/// Velox uses 1024 (`kVectorSize`). We adopt 2048 (tunable per-operator at runtime).
+pub const MORSEL_SIZE: usize = 2048;
+
+/// A stream of Arrow `RecordBatch`es — the data plane for all native operators.
+/// Re-exported as a convenience (the same type DataFusion uses).
+pub type BatchStream = BoxStream<'static, Result<RecordBatch, ExecutionError>>;
+
+/// Error type for native execution. Deliberately separate from DataFusion's
+/// `DataFusionError` — the native engine has zero DataFusion dependency.
+#[derive(Debug, thiserror::Error)]
+pub enum ExecutionError {
+    #[error("native engine: {0}")]
+    NotImplemented(String),
+    #[error("native engine schema error: {0}")]
+    Schema(String),
+    #[error("native engine execution error: {0}")]
+    Execution(String),
+}
+
+/// One physical operator in the native engine's pipeline. Both a scan leaf and
+/// a transform (filter, project, join build, join probe, aggregate, sort)
+/// implement this trait.
+///
+/// The operator is async stream-based (the BLOCKER 1 fix): it takes an input
+/// `BatchStream` and produces an output `BatchStream`. Blocking operators
+/// (hash build, sort) consume the entire input before emitting; pipelined
+/// operators (filter, project) emit as they receive.
+///
+/// SRP: owns ONE relational transform. OCP: new operators are added behind
+/// this trait without modifying the pipeline executor.
+#[async_trait]
+pub trait ExecutionOperator: Send + Sync + std::fmt::Debug {
+    /// Output schema (post-projection, post-join — whatever this operator emits).
+    fn output_schema(&self) -> SchemaRef;
+
+    /// Is this a blocking operator (hash build, sort, aggregate that needs
+    /// to see all input before emitting)? The scheduler uses this to decide
+    /// pipeline breaks.
+    fn is_blocking(&self) -> bool {
+        false
+    }
+
+    /// Estimated output cardinality (feeds the cost router, ADR-050).
+    /// `None` = unknown; the planner falls back to stats.
+    fn estimated_cardinality(&self) -> Option<u64> {
+        None
+    }
+
+    /// Execute: transform an input batch stream into an output batch stream.
+    /// The pipeline executor chains operators by feeding the output of one
+    /// into the input of the next.
+    async fn execute(&self, input: BatchStream) -> Result<BatchStream, ExecutionError>;
+}
+
+/// A pipeline: a chain of fused operators sharing one morsel shape.
+/// The scheduler runs pipelines in parallel (morsel-driven), with pipeline
+/// breaks at blocking operators.
+#[derive(Debug)]
+pub struct Pipeline {
+    /// The operators in execution order (scan → filter → project → ...).
+    pub operators: Vec<Box<dyn ExecutionOperator>>,
+    /// Output schema of the entire pipeline (the last operator's schema).
+    pub output_schema: SchemaRef,
+}
+
+impl Pipeline {
+    /// Create a new pipeline from a chain of operators.
+    pub fn new(operators: Vec<Box<dyn ExecutionOperator>>) -> Self {
+        let output_schema = operators
+            .last()
+            .map(|op| op.output_schema())
+            .unwrap_or_else(|| Arc::new(arrow_schema::Schema::empty()));
+        Self {
+            operators,
+            output_schema,
+        }
+    }
+
+    /// Execute the pipeline: chain the operators (output of each → input of next).
+    pub async fn execute(&self, input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let mut stream = input;
+        for op in &self.operators {
+            stream = op.execute(stream).await?;
+        }
+        Ok(stream)
+    }
+}
+
+/// The morsel scheduler: drives pipelines in parallel using morsel-driven
+/// work-stealing (Leis SIGMOD 2014). Phase 0: trait defined; Phase 4: implemented.
+#[async_trait]
+pub trait MorselScheduler: Send + Sync {
+    /// Schedule a pipeline for parallel execution. Splits the input into
+    /// morsels of `MORSEL_SIZE` rows, assigns them to worker threads, and
+    /// returns the merged output stream.
+    async fn schedule(
+        &self,
+        pipeline: &Pipeline,
+        input: BatchStream,
+    ) -> Result<BatchStream, ExecutionError>;
+}

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -11,6 +11,7 @@ pub mod engine;
 
 pub mod executor;
 pub mod low_latency_executor;
+pub mod native_engine;
 pub mod olap_delta_merge;
 pub mod plan_cache;
 pub mod planner;

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -1,0 +1,56 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Native vectorized execution hook (ADR-054 Phase 0)
+//!
+//! Internal to the `Native` backend — NOT a separate `ComputeBackend` variant.
+//! When the native engine receives an analytical query (relational + not
+//! Parquet-backed), it checks `native_vectorized_enabled()` and, if set, tries
+//! the vectorized pipeline (Phase 1+) before falling back to the Volcano.
+//!
+//! This follows the DuckDB/Velox model: ONE native engine with internal
+//! execution-mode selection (row-at-a-time for OLTP, vectorized for OLAP).
+//! The router always selects `ComputeBackend::Native` for non-Parquet queries;
+//! the execution mode is an engine-internal decision.
+
+use crate::query::execution::engine::{
+    ExecutionError, ExecutionPipelineResult, ExecutionStreamResult, QueryExecutionContext,
+};
+
+/// Gate: is the native vectorized execution path opted in? Default OFF — the
+/// Volcano (row-at-a-time) serves all native-path queries until Phase 1+ lands.
+pub fn native_vectorized_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_NATIVE_VECTORIZED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
+/// Try the native vectorized execution path for an analytical query.
+///
+/// Returns `Ok(Some(result))` if the vectorized engine handled the query.
+/// Returns `Ok(None)` if the vectorized engine doesn't yet support this query
+/// shape (Phase 0: always `None` — fall through to the Volcano).
+/// Returns `Err(...)` if the vectorized engine attempted + failed.
+///
+/// Phase 1+: lower `LogicalNode` → native `Pipeline` (via the
+/// `proximadb_execution_contracts` traits) → morsel-driven execution →
+/// `ExecutionPipelineResult`. This function is the internal seam between the
+/// router's `Native` backend and the vectorized operator pipeline.
+pub async fn try_vectorized(
+    _sql: &str,
+    _context: &QueryExecutionContext,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError> {
+    // Phase 0: not yet implemented — always fall through to the Volcano.
+    Ok(None)
+}
+
+/// Streaming variant (same Phase 0 status).
+pub async fn try_vectorized_stream(
+    _sql: &str,
+    _context: &QueryExecutionContext,
+) -> Result<Option<ExecutionStreamResult>, ExecutionError> {
+    Ok(None)
+}


### PR DESCRIPTION
## What
Phase 0 of the native execution engine (ADR-054): the SOLID contracts crate + the NativeVectorizedEngine skeleton + the per-query routing seam. This does NOT improve performance yet — the skeleton returns NotImplemented for all queries, routing back to DataFusion via the fallback mechanism. Phase 1+ (native operators) build on this.

## Files
- **NEW** `crates/query/proximadb-execution-contracts/` — the internal contracts (`ExecutionOperator`, `Pipeline`, `MorselScheduler`, `BatchStream`, `ExecutionError`). Zero DataFusion dependency. Async stream-based (the BLOCKER 1 fix from ADR-054 review).
- **NEW** `src/query/execution/native_engine.rs` — `NativeVectorizedEngine` skeleton (impl `ExecutionEngine`; returns NotImplemented in Phase 0).
- `ComputeBackend::NativeVectorized` + dispatch arms + route option (`PROXIMADB_NATIVE_ENGINE`, default OFF).

## Architecture (per ADR-054 v2 review)
The native engine is a **per-query ExecutionEngine peer** (NOT per-operator routing). Internal contracts live INSIDE the native engine crate. DataFusion stays as-is. The router selects between `DataFusionLocal` and `NativeVectorized` per query; fallback to DF on error.

## Gates
cargo check --lib clean · clippy --lib --bins clean · fmt clean · td-adr-unique 0 errors · ZERO datafusion refs in contracts crate (CI-ratchet-ready).

## What this enables
Phase 1: native vectorized FilterProject/HashAgg. Phase 3: native hash join (the Q3/Q14 laggard fix — 85-100× gap to DuckDB). Each phase is additive behind the contracts.