### PR TITLE
refactor(arrow): inject runtime ApiHandlersPort into Flight service (TD-104 S3-c)

### DIFF
--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -259,12 +259,14 @@ impl ProximaFlightService {
         self
     }
 
-    /// Boot adapter that derives the injected pieces from a root `UnifiedHandlers`.
-    ///
-    /// The Flight write path is wired to the runtime `RecordOpsService` (via
-    /// `UnifiedHandlers::record_ops`) rather than ROOT's `RecordOpsPort` impl, so
-    /// `do_put` ingest no longer routes through ROOT even via this convenience.
-    pub fn from_unified_handlers(request_handlers: Arc<UnifiedHandlers>) -> Self {
+    /// Boot adapter that injects the runtime `api_port` (TD-104 S3-c: the Flight
+    /// service's API surface is now the runtime handler, not ROOT) while deriving
+    /// the remaining services from the root `UnifiedHandlers` at boot (one-time
+    /// extraction; the service holds ports, not the root handler).
+    pub fn from_services(
+        api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
+        request_handlers: &UnifiedHandlers,
+    ) -> Self {
         let storage_locations = request_handlers
             .storage_config()
             .map(|config| {
@@ -276,7 +278,6 @@ impl ProximaFlightService {
             })
             .unwrap_or_default();
 
-        let api_port: Arc<dyn proximadb_runtime::ApiHandlersPort> = request_handlers.clone();
         let record_port: Arc<dyn proximadb_runtime::RecordOpsPort> = request_handlers.record_ops();
         let vector_operations_service = request_handlers.vector_operations_service.clone();
         let collection_service = request_handlers.collection_service.clone();

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -748,11 +748,13 @@ impl MultiServer {
             // three see identical routing decisions.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
+            let api_handlers = services.api_handlers.clone();
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
-                let flight_service = ProximaFlightService::from_unified_handlers(request_handlers);
+                let flight_service =
+                    ProximaFlightService::from_services(api_handlers, &request_handlers);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
@@ -1143,8 +1145,9 @@ impl MultiServer {
 
             // Arrow Flight service (HTTP/2-based, shares internal gRPC server)
             let flight_service =
-                crate::network::arrow_ipc::service::ProximaFlightService::from_unified_handlers(
-                    services.request_handlers.clone(),
+                crate::network::arrow_ipc::service::ProximaFlightService::from_services(
+                    services.api_handlers.clone(),
+                    &services.request_handlers,
                 )
                 .with_security_coordinator(if self.rest_auth_enabled {
                     self.security_coordinator.clone()
@@ -1668,11 +1671,13 @@ impl MultiServer {
             // three see identical routing decisions.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
+            let api_handlers = services.api_handlers.clone();
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
-                let flight_service = ProximaFlightService::from_unified_handlers(request_handlers);
+                let flight_service =
+                    ProximaFlightService::from_services(api_handlers, &request_handlers);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))


### PR DESCRIPTION
## Summary
TD-104 ROOT-deletion **S3-c** — the Flight service's API surface now uses the runtime handler instead of ROOT.

`ProximaFlightService` already held `Arc<dyn ApiHandlersPort>` + `Arc<dyn RecordOpsPort>` + injected services (NOT `Arc<UnifiedHandlers>`). The only root dependency was the `from_unified_handlers` boot adapter, which sourced the `api_port` from the root handler cast. Rename it `from_services(api_port, &request_handlers)`: the api_port is now the RUNTIME handler (`services.api_handlers`), not ROOT. The root handler is still touched once at boot (for service extraction: record_ops, vops, collection, storage, graph), but the Flight service's API surface no longer depends on ROOT.

## Changes (2 files, +17/−11)
- **service.rs**: `from_unified_handlers` → `from_services(api_port, &request_handlers)`.
- **multi_server.rs** (3 boot sites): pass `services.api_handlers.clone()` as the api_port; 2 spawn-block sites clone api_handlers before the spawn.

## Verification
- `cargo clippy --lib --bins` (`-D warnings`): clean
- `cargo check --tests`: clean

## Tracking
TD-104 ROOT-deletion roadmap — S3-c (Arrow Flight). Phase 0 ✅ (#749), S3-d ✅ (#752), S3-a ✅. Remaining: S3-b (near no-op), S3-e (holders), S3-f (terminal: collapse + delete ROOT).