### PR TITLE
feat(documents): P-Provision — document-collection create provisions the canonical collection (ADR-055)

### DIFF
--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -69,4 +69,18 @@ pub trait RecordRoutePort: Send + Sync {
     /// stays on the legacy path instead of hard-failing the canonical write. Best-effort:
     /// returns `false` on any resolution error (fail toward the safe legacy path).
     async fn collection_exists(&self, collection_id: &str, tenant: Option<&str>) -> bool;
+
+    /// Idempotently ensure a canonical (record/vector) collection exists for `collection_id`
+    /// (create-if-not-exists; an already-existing collection is treated as success). `dimension`
+    /// is the embedding width — `0` ⇒ vectorless (a pure-document collection: documents are still
+    /// stored, point-gettable and scannable, but excluded from ANN). The document facade calls
+    /// this at collection-create so a document collection CONVERGES on the canonical store
+    /// (P-Provision, ADR-055) instead of the legacy `document_wal`/DashMap path. Callers treat it
+    /// best-effort (a failure leaves the legacy path intact — mixed-safe).
+    async fn ensure_collection(
+        &self,
+        collection_id: &str,
+        dimension: u32,
+        tenant: Option<&str>,
+    ) -> Result<()>;
 }

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -816,6 +816,22 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
         )
     }
 
+    async fn ensure_collection(
+        &self,
+        collection_id: &str,
+        dimension: u32,
+        tenant: Option<&str>,
+    ) -> Result<()> {
+        // Idempotent create-if-not-exists so a document collection becomes a resolvable canonical
+        // collection (P-Provision, ADR-055). Delegates to the CollectionService helper (which owns
+        // the v1 `CollectionConfig` construction) — this keeps `record_ops_service` v1-proto-free
+        // (TD-123 ratchet). `dimension == 0` ⇒ a vectorless (pure-document) collection.
+        let tenant_context = self.collection_service.load_tenant_context(tenant)?;
+        self.collection_service
+            .get_or_create_by_name(collection_id, dimension, tenant_context.as_ref())
+            .await
+    }
+
     async fn delete_records(
         &self,
         collection_id: &str,

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -576,6 +576,38 @@ impl CollectionService {
         Ok(response)
     }
 
+    /// Idempotent get-or-create by name for the document canonical-vector route (ADR-055
+    /// P-Provision): build a minimal `CollectionConfig` and create it, treating an already-existing
+    /// collection as success. `dimension == 0` ⇒ a vectorless (pure-document) collection. The v1
+    /// `CollectionConfig`/`StorageEngine` construction lives HERE (where those types are already in
+    /// scope) so callers (e.g. `RecordOpsService::ensure_collection`) stay v1-proto-free (TD-123).
+    pub async fn get_or_create_by_name(
+        &self,
+        name: &str,
+        dimension: u32,
+        tenant_context: Option<&crate::storage::tenant::TenantContext>,
+    ) -> Result<()> {
+        let config = CollectionConfig {
+            name: name.to_string(),
+            dimension,
+            storage_engine: Some(StorageEngine::Sst as i32),
+            enable_proxima_record: Some(true),
+            ..Default::default()
+        };
+        let resp = self
+            .create_collection_with_tenant_context(&config, tenant_context)
+            .await?;
+        if resp.success || resp.error_code.as_deref() == Some("COLLECTION_EXISTS") {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "get_or_create_by_name '{}' failed: {:?}",
+                name,
+                resp.error_code
+            ))
+        }
+    }
+
     /// Create collection with tenant context validation
     pub async fn create_collection_with_tenant_context(
         &self,

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -961,6 +961,24 @@ impl DocumentService {
             collections.insert(name.to_string(), collection);
         }
 
+        // P-Provision (ADR-055): also provision the canonical (record/vector) collection so this
+        // document collection CONVERGES on the shared store instead of the legacy path — even for
+        // pure-document (vectorless) use. Uses the CLEAN name (the catalog registers bare names,
+        // resolved per-tenant); dimension 0 = vectorless (documents that carry vectors are inserted
+        // through the metered /documents path). Best-effort + mixed-safe: on failure we warn and
+        // keep the legacy path (the canonical route's capability check just stays false).
+        // `ensure_or_create_collection` funnels through here too, so first-write auto-create is
+        // covered without a second hook.
+        if let Some(route) = self.record_route.get() {
+            let (tenant, clean_collection) = unscope_document_collection(name);
+            if let Err(e) = route.ensure_collection(clean_collection, 0, tenant).await {
+                warn!(
+                    "P-Provision: canonical collection provision for '{}' failed (staying on legacy path): {}",
+                    name, e
+                );
+            }
+        }
+
         info!("Created document collection: {}", name);
         Ok(name.to_string())
     }
@@ -2686,6 +2704,8 @@ impl proximadb_runtime::DocumentPort for DocumentService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The convergence tests call `RecordRoutePort` methods (collection_exists / ensure_collection)
+    // directly on the mock, so the trait must be in scope (the impls use the fully-qualified path).
     use crate::proto::proximadb_v1::{
         DocFilterCondition, DocFilterOperator, DocIndexType, DocumentCollectionConfig,
         DocumentFilter, DocumentUpdate, IndexDefinition, SqlObject, SqlValue, UpdateOperation,
@@ -2696,6 +2716,7 @@ mod tests {
         StorageFormatStrategy, UnifiedStorageFormat,
     };
     use async_trait::async_trait;
+    use proximadb_runtime::RecordRoutePort;
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -2929,6 +2950,21 @@ mod tests {
                 .expect("mock route lock")
                 .contains(collection_id)
         }
+
+        async fn ensure_collection(
+            &self,
+            collection_id: &str,
+            _dimension: u32,
+            _tenant: Option<&str>,
+        ) -> anyhow::Result<()> {
+            // Provisioning makes a (possibly previously non-canonical) collection canonical —
+            // idempotent (removing an absent entry is a no-op).
+            self.non_canonical
+                .lock()
+                .expect("mock route lock")
+                .remove(collection_id);
+            Ok(())
+        }
     }
 
     /// Scope the process-global `PROXIMADB_DOC_CANONICAL_VECTOR` gate to one collection for
@@ -3093,6 +3129,106 @@ mod tests {
             .expect("get")
             .expect("present");
         assert_eq!(got.id, "d1");
+    }
+
+    // =========================================================================
+    // P-Provision (ADR-055): document-collection create provisions the canonical collection
+    // =========================================================================
+
+    #[tokio::test]
+    async fn create_collection_provisions_canonical_collection() {
+        // With a route wired, creating a document collection provisions the canonical (record/
+        // vector) collection, so a pure-document collection converges on the shared store.
+        let svc = create_test_service();
+        let route = Arc::new(MockRecordRoute::default());
+        // Start NON-canonical (legacy) so provisioning is observable as a flip.
+        route
+            .non_canonical
+            .lock()
+            .expect("lock")
+            .insert("provdocs".to_string());
+        svc.set_record_route(route.clone());
+
+        assert!(
+            !route.collection_exists("provdocs", None).await,
+            "precondition: collection starts non-canonical (legacy)"
+        );
+
+        svc.create_collection(
+            "provdocs",
+            DocumentCollectionConfig {
+                name: "provdocs".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create document collection");
+
+        assert!(
+            route.collection_exists("provdocs", None).await,
+            "create_collection must provision the canonical collection (P-Provision)"
+        );
+
+        // A subsequent document write now routes CANONICAL (shared store), not the legacy map.
+        svc.insert_document_record("provdocs", doc_record("d1", "provdocs", "Zeta"))
+            .await
+            .expect("canonical insert after provisioning");
+        assert!(
+            route
+                .store
+                .lock()
+                .expect("lock")
+                .get("provdocs")
+                .is_some_and(|c| c.contains_key("d1")),
+            "insert routes canonical after provisioning (lands in the shared store)"
+        );
+        assert!(
+            !svc.documents
+                .get("provdocs")
+                .is_some_and(|d| d.contains_key("d1")),
+            "canonical write must NOT populate the legacy in-memory map"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_collection_is_idempotent() {
+        let route = MockRecordRoute::default();
+        route
+            .non_canonical
+            .lock()
+            .expect("lock")
+            .insert("c".to_string());
+        route
+            .ensure_collection("c", 0, None)
+            .await
+            .expect("first ensure");
+        route
+            .ensure_collection("c", 0, None)
+            .await
+            .expect("second ensure is idempotent");
+        assert!(route.collection_exists("c", None).await);
+    }
+
+    #[tokio::test]
+    async fn create_collection_without_route_stays_legacy_no_panic() {
+        // No route wired ⇒ create provisions nothing and does not panic (pure legacy path).
+        let svc = create_test_service();
+        svc.create_collection(
+            "legacyonly",
+            DocumentCollectionConfig {
+                name: "legacyonly".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create without route");
+        assert!(
+            svc.get_collection("legacyonly")
+                .await
+                .expect("get")
+                .is_some(),
+            "collection created on the legacy path when no route is wired"
+        );
     }
 
     /// Set up a canonical-record-backed service with a pre-created collection.


### PR DESCRIPTION
## What

**P-Provision** (2nd phase of the ADR-055 document-format rollout, #732): make document-collection creation ALSO register a **canonical (record/vector) collection** so pure-document / vectorless collections converge on the shared store instead of the legacy `document_wal`/DashMap. This is what makes the DEFAULT-ON convergence (#726) actually cover non-vector document collections.

## How (SOLID seam — reuse the existing port, no new wiring)

- **`RecordRoutePort`** gains `async fn ensure_collection(collection_id, dimension, tenant)` — idempotent create-if-not-exists. This is the port `DocumentService` already holds (alongside `collection_exists`), so no new dependency/injection.
- **`RecordOpsService`** implements it via `CollectionService::create_collection_with_tenant_context`, treating `COLLECTION_EXISTS` as success. **Dimension 0 ⇒ vectorless** canonical collection (allowed at the CollectionService layer — the pgwire document path already does this).
- **`DocumentService::create_collection`** (and `ensure_or_create_collection` via it): after the metadata/WAL create, best-effort `ensure_collection(clean_name, 0, tenant)` when the route is wired — unscoped name, **warn-and-continue** on failure (stays legacy → mixed-safe).

## Effect

A newly-created document collection is now a resolvable canonical collection ⇒ the capability check (`collection_exists`) passes ⇒ document writes route **canonical** (shared store), not the legacy in-memory map. Vectorless documents converge; they stay excluded from ANN but are point-gettable/scannable.

## Verified

- doc-service tests **6/6**: `create_collection_provisions_canonical_collection` (create → canonical provisioned → next write lands in shared store, not legacy map), `ensure_collection_is_idempotent`, `create_collection_without_route_stays_legacy_no_panic`, + existing `canonical_route_insert` / `kill_switch_forces` / `default_on_but_non_canonical` unchanged.
- `cargo fmt --check` · `cargo clippy --lib --bins -- -D warnings` (exit 0) · **server binary builds**.

Mixed-read-safe: legacy read-fallback unchanged; provisioning is best-effort + idempotent. Next: P-Shred (hybrid props shredding), then P-DFSource/P-Pushdown (reuse `PaxTableProvider`/`PaxSplitReader`).
