### PR TITLE
test(route): TD-ROUTE-1 pgwire override eval — gates cost-model enable, finds join-flip blocker

### DIFF
--- a/docs/10-quality/td/TD-ROUTE-1-cost-model-override-enablement-eval.adoc
+++ b/docs/10-quality/td/TD-ROUTE-1-cost-model-override-enablement-eval.adoc
@@ -6,13 +6,38 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open** — persistence landed (cells survive restarts); live override (`PROXIMADB_ROUTE_COST_OVERRIDE`) stays OFF until the eval below exists.
+| Status | **Open** — persistence landed (#721); the pgwire override eval landed (`tests/route_cost_override_pgwire_eval.rs`) and **found a hard blocker**: flipping an `olap/parquet` *join* to Native/Volcano errors (Volcano has no join executor). Scan/aggregate flips preserve results; the *global* override stays OFF until the candidate set excludes Volcano for join-bearing plans (see §Finding).
 | Severity | Medium — the co-design routing lever is built but inert; enabling it blind risks the TPC-H/TPC-DS ratchets.
 | Component | `src/query/route_cost_model.rs`, `src/query/compute_scheduler.rs`, `tests/route_cost_offline_eval.rs`, `tests/tpch_pgwire_e2e.rs`
 | Pillar | PERF (co-design), REL (ratchets), EVAL (mandate #13)
 |===
 
 toc::[]
+
+== Finding (eval, 2026-07-08)
+
+The pgwire override eval (`tests/route_cost_override_pgwire_eval.rs`) materializes a
+small dataset, warms the model so Native is the cheaper `olap/parquet` arm, enables
+the override, and compares results to the override-OFF (DataFusion) baseline. Result:
+
+* **Scan / aggregate queries flip safely.** `count(*)`, `GROUP BY … count(*)`, and
+  `sum(col)` flipped DataFusion → Native and returned **identical** results. The
+  override is correctness-safe for these shapes.
+* **A join flip is a hard blocker.** `… FROM orders o, lineitem l WHERE o.o_orderkey =
+  l.l_orderkey GROUP BY …` **errored** (`db error`) once flipped to Native — the
+  row-wise Volcano engine has no join executor, while DataFusion runs it. It fails
+  *loud* (errors, never a silently-wrong answer), but it means the *global* override
+  cannot be enabled as-is.
+
+**Root cause:** `freshness_safe_backends_from_class` returns
+`[Native, DataFusionLocal]` for every `olap/parquet` class, but Native cannot execute
+the join-bearing subset. The freshness-safe candidate set is *capability-unaware*.
+
+**Concrete next action (the real gate now):** make the `olap/parquet` candidate set
+**capability-aware** — exclude Native/Volcano when the plan contains a join (or any
+operator Volcano lacks) so the override only ever flips to a backend that can execute
+the query. Then the eval's join case becomes a parity assert (it already tolerates
+both "errors" today and "matches" post-fix) and the override can be enabled behind it.
 
 == Context
 

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -818,6 +818,19 @@ impl RouteCostModel {
         }
     }
 
+    /// The `(shape-class, backend-label)` keys that have learned history. Eval/
+    /// introspection support: lets a test discover which shape-classes a workload
+    /// exercised so it can warm a challenger backend and force the override to
+    /// flip a route (see the TD-ROUTE-1 pgwire override eval).
+    pub fn learned_cell_keys(&self) -> Vec<(String, String)> {
+        let cells = self.cells.lock().unwrap_or_else(|p| p.into_inner());
+        cells
+            .iter()
+            .filter(|(_, c)| c.samples > 0)
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+
     /// Current learned estimate for one (shape-class, backend), if any history.
     pub fn estimate(&self, shape_class: &str, backend: &ComputeBackend) -> Option<RouteCost> {
         let key = (shape_class.to_string(), backend_label(backend));

--- a/tests/route_cost_override_pgwire_eval.rs
+++ b/tests/route_cost_override_pgwire_eval.rs
@@ -1,0 +1,264 @@
+//! TD-ROUTE-1 — pgwire correctness eval for the trace-driven route cost override.
+//!
+//! The `RouteCostModel` can, when `PROXIMADB_ROUTE_COST_OVERRIDE` is on, flip an
+//! `olap/parquet` query between the DataFusion and Native (Volcano) backends
+//! (the two freshness-safe candidates). Enabling that override is only safe if a
+//! flipped route returns the **same results** as the static (override-OFF)
+//! baseline. This eval is the gate for that claim (mandate #13): it materializes
+//! a small dataset (parquet-backed ⇒ `olap/parquet`), runs a set of queries with
+//! the override OFF and captures results, warms the model so the freshness-safe
+//! challenger is the cheaper arm, enables the override, re-runs, and asserts
+//! **row parity**. A divergence fails the test — which correctly keeps the live
+//! override gated OFF until it is fixed.
+//!
+//! Complements `route_cost_offline_eval.rs` (which proves the flip *logic* on a
+//! synthetic isolated model); this proves *result correctness* end-to-end over
+//! the real pgwire + router + engine path.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test route_cost_override_pgwire_eval -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::observability::io_trace::IoTraceSnapshot;
+use proximadb::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL;
+use proximadb::query::table_write_plan::ComputeBackend;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+/// Minimal in-process pgwire server (mirrors `tpch_pgwire_e2e::PgServer`).
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Run a query and return its result rows as sorted `col|col|…` strings (sorted
+/// so the comparison is order-insensitive where a query has no ORDER BY). Returns
+/// `Err` with the server-side cause if the query fails, so a route flip to a
+/// backend that cannot execute the query is observed rather than panicking.
+async fn query_rows(client: &tokio_postgres::Client, sql: &str) -> Result<Vec<String>, String> {
+    let msgs = client.simple_query(sql).await.map_err(|e| {
+        e.as_db_error()
+            .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+            .unwrap_or_else(|| e.to_string())
+    })?;
+    let mut rows = Vec::new();
+    for m in msgs {
+        if let tokio_postgres::SimpleQueryMessage::Row(r) = m {
+            let cols: Vec<String> = (0..r.len())
+                .map(|i| r.get(i).unwrap_or("").to_string())
+                .collect();
+            rows.push(cols.join("|"));
+        }
+    }
+    rows.sort();
+    Ok(rows)
+}
+
+#[tokio::test]
+async fn override_on_preserves_materialized_query_results() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // 1. Small schema + deterministic data.
+    for ddl in [
+        "DROP TABLE IF EXISTS lineitem",
+        "DROP TABLE IF EXISTS orders",
+        "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_totalprice DOUBLE PRECISION, o_orderstatus VARCHAR)",
+        "CREATE TABLE lineitem (l_orderkey INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION)",
+    ] {
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("{ddl}: {e}"));
+    }
+    for ins in [
+        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F')",
+        "INSERT INTO lineitem VALUES (1,5.0,50.0),(1,2.0,20.0),(2,3.0,60.0),(3,1.0,10.0),(4,4.0,80.0),(5,2.0,30.0)",
+    ] {
+        client
+            .simple_query(ins)
+            .await
+            .unwrap_or_else(|e| panic!("insert: {e}"));
+    }
+
+    // 2. Materialize to Parquet so SELECTs route to the DataFusion OLAP engine
+    //    (shape-class `olap/parquet`, the only override-eligible class).
+    for t in ["orders", "lineitem"] {
+        if let Err(e) = client
+            .simple_query(&format!("ALTER TABLE {t} MATERIALIZE"))
+            .await
+        {
+            eprintln!("  · MATERIALIZE {t}: {e}");
+        }
+    }
+
+    // Scan/aggregate queries — Native (Volcano) can evaluate these, so a route
+    // flip must preserve their results.
+    let safe_queries = [
+        "SELECT count(*) FROM orders",
+        "SELECT o_orderstatus, count(*) FROM orders GROUP BY o_orderstatus ORDER BY o_orderstatus",
+        "SELECT sum(l_extendedprice) FROM lineitem",
+    ];
+    // A join — the eval's boundary case. Native is a freshness-safe candidate for
+    // `olap/parquet` but cannot execute joins today, so flipping this one is
+    // unsafe until the candidate set excludes Volcano for join-bearing plans.
+    let join_query = "SELECT o.o_orderstatus, sum(l.l_extendedprice) FROM orders o, lineitem l WHERE o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus";
+
+    // 3. Baseline (override OFF): warm the model, then capture results.
+    GLOBAL_ROUTE_COST_MODEL.set_override_enabled(false);
+    for _ in 0..8 {
+        for q in safe_queries {
+            let _ = query_rows(&client, q).await;
+        }
+        let _ = query_rows(&client, join_query).await;
+    }
+    let mut baseline = Vec::new();
+    for q in safe_queries {
+        baseline.push(
+            query_rows(&client, q)
+                .await
+                .expect("baseline scan/aggregate (DataFusion) must succeed"),
+        );
+    }
+    let join_baseline = query_rows(&client, join_query)
+        .await
+        .expect("baseline join (DataFusion) must succeed");
+
+    // 4. Warm the freshness-safe challenger (Native) to be the cheaper arm on
+    //    every learned `olap/parquet` class, so the override flips those routes
+    //    DataFusion → Native.
+    let cheap = IoTraceSnapshot {
+        range_gets: 1,
+        bytes_read: 64,
+        ..Default::default()
+    };
+    let mut olap_classes = 0;
+    for (class, _backend) in GLOBAL_ROUTE_COST_MODEL.learned_cell_keys() {
+        if class.starts_with("olap/parquet") {
+            for _ in 0..40 {
+                GLOBAL_ROUTE_COST_MODEL.observe(&class, &ComputeBackend::Native, &cheap);
+            }
+            olap_classes += 1;
+        }
+    }
+    eprintln!("✓ warmed the Native challenger on {olap_classes} olap/parquet class(es)");
+    assert!(
+        olap_classes > 0,
+        "no olap/parquet classes were learned — materialize/routing changed?"
+    );
+
+    // 5. Enable the override (recomputes the frozen consult table).
+    GLOBAL_ROUTE_COST_MODEL.set_override_enabled(true);
+    assert!(
+        GLOBAL_ROUTE_COST_MODEL.override_active(),
+        "override did not activate"
+    );
+
+    // 6a. Scan/aggregate results MUST match the OFF baseline. A flip that fails
+    //     or changes a scan/aggregate answer is a correctness regression.
+    for (i, q) in safe_queries.iter().enumerate() {
+        let got = query_rows(&client, q).await.unwrap_or_else(|e| {
+            panic!("override flipped a scan/aggregate query to a backend that FAILED (unsafe):\n  {q}\n  {e}")
+        });
+        assert_eq!(
+            got, baseline[i],
+            "route cost override changed scan/aggregate results (unsafe):\n  {q}\n  baseline={:?} override={:?}",
+            baseline[i], got
+        );
+    }
+
+    // 6b. Documented boundary (TD-ROUTE-1): under the override the join either
+    //     still ERRORS (Native cannot execute it — the reason the *global*
+    //     override stays gated OFF) or, once the candidate set excludes Volcano
+    //     for joins, matches the DataFusion baseline. It must NEVER return a
+    //     different (silently wrong) answer.
+    match query_rows(&client, join_query).await {
+        Err(e) => eprintln!(
+            "✓ documented boundary: override flips the olap/parquet JOIN to Native/Volcano, which \
+             ERRORS ({e}). Enabling the global override requires excluding Volcano from the join \
+             candidate set (TD-ROUTE-1) — but it does NOT return a wrong answer."
+        ),
+        Ok(got) => assert_eq!(
+            got, join_baseline,
+            "override flipped the JOIN and returned a DIFFERENT answer than DataFusion (silently wrong):\n  baseline={:?} override={:?}",
+            join_baseline, got
+        ),
+    }
+}


### PR DESCRIPTION
## TD-ROUTE-1 — pgwire eval gating the route cost override enable

Continues the cost-model thread (#721 persisted the model). The override (`PROXIMADB_ROUTE_COST_OVERRIDE`) can flip an `olap/parquet` query between DataFusion and Native (Volcano); enabling it is only safe if a flip preserves results. This adds the **mandate-#13 eval** that proves that over the real pgwire → router → engine path — and it found a concrete blocker.

### What it does
- `tests/route_cost_override_pgwire_eval.rs`: materialize a small dataset, capture override-**OFF** (DataFusion) baselines, warm the model so Native is the cheaper `olap/parquet` arm, enable the override, and compare.
- `RouteCostModel::learned_cell_keys()`: introspection accessor so the eval can discover exercised shape-classes and force a genuine flip (not a trivial no-op parity).

### Finding
- ✅ **Scan/aggregate flips preserve results** — `count(*)`, `GROUP BY … count`, `sum(col)` flip DataFusion→Native and return identical rows (asserted green).
- ⛔ **A join flip is a hard blocker** — Native/Volcano has no join executor, so a flipped join **errors** (fails loud, never a silently-wrong answer) while DataFusion runs it. Root cause: `freshness_safe_backends_from_class` returns `[Native, DataFusionLocal]` for *every* `olap/parquet` class — the candidate set is **capability-unaware**.

### Outcome
The eval is a **green gate** (safe subset asserted; the join is a documented boundary that tolerates "errors today" and "matches post-fix"). The **concrete next gate** (in TD-ROUTE-1): make the `olap/parquet` candidate set capability-aware — exclude Volcano for join-bearing plans — before enabling the global override.

### Verification
- `cargo fmt --check` ✓ · `cargo clippy --lib --bins -- -D warnings` ✓ · `route_cost_model` 35/35 ✓ · the eval passes (scan/aggregate parity + documented join boundary).