### PR TITLE
fix(query): execute RANGE and GROUPS window frames as declared, not as ROWS

### DIFF
--- a/src/query/execution/datafusion_bridge.rs
+++ b/src/query/execution/datafusion_bridge.rs
@@ -12,7 +12,7 @@ use super::QueryRow;
 #[cfg(feature = "datafusion-integration")]
 use super::window_executor::WindowFunction;
 use super::window_executor::{
-    FrameBound, FrameDefinition, SortDirection, WindowFunctionCall, WindowSpec,
+    FrameBound, FrameDefinition, FrameUnit, SortDirection, WindowFunctionCall, WindowSpec,
 };
 use anyhow::Result;
 #[cfg(feature = "datafusion-integration")]
@@ -111,8 +111,17 @@ fn map_frame_bound(
 fn map_window_frame(frame: &FrameDefinition) -> datafusion::logical_expr::WindowFrame {
     use datafusion::logical_expr::{WindowFrame, WindowFrameUnits};
 
+    // Thread the declared frame unit through instead of hardcoding `Rows` — a
+    // RANGE/GROUPS frame must execute as declared, otherwise ties produce
+    // silently wrong results.
+    let units = match frame.unit {
+        FrameUnit::Rows => WindowFrameUnits::Rows,
+        FrameUnit::Range => WindowFrameUnits::Range,
+        FrameUnit::Groups => WindowFrameUnits::Groups,
+    };
+
     WindowFrame::new_bounds(
-        WindowFrameUnits::Rows,
+        units,
         map_frame_bound(&frame.start, true),
         map_frame_bound(&frame.end, false),
     )
@@ -315,9 +324,14 @@ pub struct WindowSpecDescription {
 
 /// Describe a frame definition as a human-readable string.
 fn describe_frame(frame: &FrameDefinition) -> String {
+    let unit = match frame.unit {
+        FrameUnit::Rows => "ROWS",
+        FrameUnit::Range => "RANGE",
+        FrameUnit::Groups => "GROUPS",
+    };
     let start = describe_bound(&frame.start, "PRECEDING");
     let end = describe_bound(&frame.end, "FOLLOWING");
-    format!("ROWS BETWEEN {} AND {}", start, end)
+    format!("{} BETWEEN {} AND {}", unit, start, end)
 }
 
 /// Describe a single frame bound.
@@ -404,6 +418,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Unbounded,
                     end: FrameBound::Unbounded,
                 },
@@ -433,6 +448,7 @@ mod tests {
                 },
             ],
             frame: FrameDefinition {
+                unit: FrameUnit::Rows,
                 start: FrameBound::Offset(3),
                 end: FrameBound::CurrentRow,
             },
@@ -455,6 +471,7 @@ mod tests {
 
         // Full frame
         let full_frame = FrameDefinition {
+            unit: FrameUnit::Rows,
             start: FrameBound::Unbounded,
             end: FrameBound::Unbounded,
         };
@@ -466,11 +483,55 @@ mod tests {
 
         // Offset frame
         let offset_frame = FrameDefinition {
+            unit: FrameUnit::Rows,
             start: FrameBound::Offset(2),
             end: FrameBound::Offset(1),
         };
         let desc = describe_frame(&offset_frame);
         assert_eq!(desc, "ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING");
+
+        // RANGE / GROUPS units must be reflected, not collapsed to ROWS.
+        let range_frame = FrameDefinition {
+            unit: FrameUnit::Range,
+            start: FrameBound::Offset(1),
+            end: FrameBound::CurrentRow,
+        };
+        assert_eq!(
+            describe_frame(&range_frame),
+            "RANGE BETWEEN 1 PRECEDING AND CURRENT ROW"
+        );
+        let groups_frame = FrameDefinition {
+            unit: FrameUnit::Groups,
+            start: FrameBound::Unbounded,
+            end: FrameBound::CurrentRow,
+        };
+        assert_eq!(
+            describe_frame(&groups_frame),
+            "GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
+        );
+    }
+
+    /// The DataFusion route must carry the declared frame unit through to the
+    /// DataFusion `WindowFrame` — the bug was hardcoding `Rows` regardless.
+    #[cfg(feature = "datafusion-integration")]
+    #[test]
+    fn map_window_frame_threads_declared_unit() {
+        use datafusion::logical_expr::WindowFrameUnits;
+
+        let cases = [
+            (FrameUnit::Rows, WindowFrameUnits::Rows),
+            (FrameUnit::Range, WindowFrameUnits::Range),
+            (FrameUnit::Groups, WindowFrameUnits::Groups),
+        ];
+        for (unit, expected) in cases {
+            let frame = FrameDefinition {
+                unit,
+                start: FrameBound::Offset(1),
+                end: FrameBound::CurrentRow,
+            };
+            let df_frame = map_window_frame(&frame);
+            assert_eq!(df_frame.units, expected, "unit {unit:?} must map through");
+        }
     }
 
     #[test]

--- a/src/query/execution/window_executor.rs
+++ b/src/query/execution/window_executor.rs
@@ -99,13 +99,34 @@ pub enum FrameBound {
     Unbounded,
     /// CURRENT ROW
     CurrentRow,
-    /// N PRECEDING / N FOLLOWING
+    /// N PRECEDING / N FOLLOWING. Interpreted per the frame's [`FrameUnit`]:
+    /// a physical row count for `Rows`, a logical value offset on the ORDER BY
+    /// key for `Range`, and a peer-group count for `Groups`.
     Offset(u64),
 }
 
-/// Window frame definition (ROWS-based).
+/// How a window frame's bounds are interpreted.
+///
+/// This mirrors the SQL `ROWS | RANGE | GROUPS` frame units and the AST
+/// `WindowFrameUnit`. It is threaded through so a `RANGE`/`GROUPS` frame that
+/// parses and lowers correctly also *executes* as declared instead of silently
+/// collapsing to `ROWS` (which produces wrong results in the presence of ties).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FrameUnit {
+    /// Bounds count physical rows (ROWS).
+    #[default]
+    Rows,
+    /// Bounds are logical value offsets on the single ORDER BY key (RANGE).
+    Range,
+    /// Bounds count peer groups — maximal runs of rows equal on ORDER BY (GROUPS).
+    Groups,
+}
+
+/// Window frame definition.
 #[derive(Debug, Clone)]
 pub struct FrameDefinition {
+    /// How the bounds are interpreted (ROWS / RANGE / GROUPS).
+    pub unit: FrameUnit,
     pub start: FrameBound,
     pub end: FrameBound,
 }
@@ -114,6 +135,7 @@ impl Default for FrameDefinition {
     /// Default frame: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
     fn default() -> Self {
         Self {
+            unit: FrameUnit::Rows,
             start: FrameBound::Unbounded,
             end: FrameBound::CurrentRow,
         }
@@ -395,7 +417,12 @@ impl WindowExecutor {
         let len = partition.len();
 
         for current_pos in 0..len {
-            let (start, end) = Self::resolve_frame(&call.spec.frame, current_pos, len);
+            let (start, end) = Self::resolve_frame(
+                &call.spec.frame,
+                partition,
+                &call.spec.order_by,
+                current_pos,
+            )?;
 
             let frame_values: Vec<f64> = (start..=end)
                 .filter_map(|i| {
@@ -456,8 +483,32 @@ impl WindowExecutor {
         Ok(())
     }
 
-    /// Resolve a `FrameDefinition` into concrete start/end indices.
-    fn resolve_frame(frame: &FrameDefinition, current: usize, len: usize) -> (usize, usize) {
+    /// Resolve a `FrameDefinition` into concrete inclusive start/end indices
+    /// within the (already sorted) `partition`, honouring the frame unit.
+    ///
+    /// The three units differ precisely on rows that are *peers* (equal on the
+    /// ORDER BY key), which is why `ROWS` alone is a correctness bug:
+    ///
+    /// - `ROWS` — bounds count physical rows.
+    /// - `RANGE` — bounds are value offsets on the single ORDER BY key; the frame
+    ///   spans every row whose key is within the value window.
+    /// - `GROUPS` — bounds count peer groups; the frame spans whole groups.
+    fn resolve_frame(
+        frame: &FrameDefinition,
+        partition: &[(usize, QueryRow)],
+        order_by: &[WindowOrderBy],
+        current: usize,
+    ) -> Result<(usize, usize)> {
+        let len = partition.len();
+        match frame.unit {
+            FrameUnit::Rows => Ok(Self::resolve_rows_frame(frame, current, len)),
+            FrameUnit::Groups => Self::resolve_groups_frame(frame, partition, order_by, current),
+            FrameUnit::Range => Self::resolve_range_frame(frame, partition, order_by, current),
+        }
+    }
+
+    /// ROWS: bounds are physical row offsets from the current row.
+    fn resolve_rows_frame(frame: &FrameDefinition, current: usize, len: usize) -> (usize, usize) {
         let start = match &frame.start {
             FrameBound::Unbounded => 0,
             FrameBound::CurrentRow => current,
@@ -469,6 +520,184 @@ impl WindowExecutor {
             FrameBound::Offset(n) => (current + *n as usize).min(len.saturating_sub(1)),
         };
         (start, end)
+    }
+
+    /// GROUPS: bounds count peer groups (maximal runs of rows equal on ORDER BY).
+    /// The partition is pre-sorted in ORDER BY direction, so "preceding" groups
+    /// are simply lower-indexed groups regardless of ASC/DESC.
+    fn resolve_groups_frame(
+        frame: &FrameDefinition,
+        partition: &[(usize, QueryRow)],
+        order_by: &[WindowOrderBy],
+        current: usize,
+    ) -> Result<(usize, usize)> {
+        let len = partition.len();
+        if len == 0 {
+            return Ok((0, 0));
+        }
+        // Assign each row a peer-group id and record each group's first row index.
+        let mut group_id = vec![0usize; len];
+        let mut group_starts: Vec<usize> = vec![0];
+        for i in 1..len {
+            if Self::rows_equal_on_order_by(&partition[i - 1].1, &partition[i].1, order_by) {
+                group_id[i] = group_id[i - 1];
+            } else {
+                group_id[i] = group_id[i - 1] + 1;
+                group_starts.push(i);
+            }
+        }
+        let n_groups = group_starts.len();
+        // Last row index of group `g` (groups are contiguous).
+        let group_last = |g: usize| -> usize {
+            if g + 1 < n_groups {
+                group_starts[g + 1] - 1
+            } else {
+                len - 1
+            }
+        };
+        let cur = group_id[current];
+        let start_g = match &frame.start {
+            FrameBound::Unbounded => 0,
+            FrameBound::CurrentRow => cur,
+            FrameBound::Offset(n) => cur.saturating_sub(*n as usize),
+        };
+        let end_g = match &frame.end {
+            FrameBound::Unbounded => n_groups - 1,
+            FrameBound::CurrentRow => cur,
+            FrameBound::Offset(n) => (cur + *n as usize).min(n_groups - 1),
+        };
+        Ok((group_starts[start_g], group_last(end_g)))
+    }
+
+    /// RANGE: bounds are logical value offsets on the ORDER BY key. With an
+    /// explicit numeric offset the frame spans every row whose key is within the
+    /// value window; with only UNBOUNDED/CURRENT ROW bounds it spans whole peer
+    /// groups (which needs no numeric key).
+    fn resolve_range_frame(
+        frame: &FrameDefinition,
+        partition: &[(usize, QueryRow)],
+        order_by: &[WindowOrderBy],
+        current: usize,
+    ) -> Result<(usize, usize)> {
+        let len = partition.len();
+        if len == 0 {
+            return Ok((0, 0));
+        }
+        // No ORDER BY: the whole partition is a single peer group.
+        if order_by.is_empty() {
+            return Ok((0, len - 1));
+        }
+
+        let has_offset = matches!(frame.start, FrameBound::Offset(_))
+            || matches!(frame.end, FrameBound::Offset(_));
+
+        if !has_offset {
+            // Peer-based RANGE (only UNBOUNDED / CURRENT ROW bounds): CURRENT ROW
+            // means the current peer group, not the current physical row.
+            let mut group_start = current;
+            while group_start > 0
+                && Self::rows_equal_on_order_by(
+                    &partition[group_start - 1].1,
+                    &partition[current].1,
+                    order_by,
+                )
+            {
+                group_start -= 1;
+            }
+            let mut group_end = current;
+            while group_end + 1 < len
+                && Self::rows_equal_on_order_by(
+                    &partition[group_end + 1].1,
+                    &partition[current].1,
+                    order_by,
+                )
+            {
+                group_end += 1;
+            }
+            // Only UNBOUNDED / CURRENT ROW reach here (Offset ⇒ the value path
+            // below). Map defensively rather than assuming, so an unexpected
+            // bound fails loud instead of silently mis-framing.
+            let peer_bound = |bound: &FrameBound, unbounded_idx: usize, peer_idx: usize| match bound
+            {
+                FrameBound::Unbounded => Ok(unbounded_idx),
+                FrameBound::CurrentRow => Ok(peer_idx),
+                FrameBound::Offset(_) => Err(anyhow!(
+                    "internal error: value-offset RANGE bound reached the peer-based path"
+                )),
+            };
+            let start = peer_bound(&frame.start, 0, group_start)?;
+            let end = peer_bound(&frame.end, len - 1, group_end)?;
+            return Ok((start, end));
+        }
+
+        // Value-based RANGE requires exactly one numeric ORDER BY key.
+        if order_by.len() != 1 {
+            return Err(anyhow!(
+                "RANGE frame with a value offset requires exactly one ORDER BY column (got {})",
+                order_by.len()
+            ));
+        }
+        let ob = &order_by[0];
+        let asc = matches!(ob.direction, SortDirection::Asc);
+        let value_at = |i: usize| -> Result<f64> {
+            partition
+                .get(i)
+                .and_then(|(_, row)| row.fields.get(&ob.field))
+                .and_then(|v| v.as_f64())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "RANGE frame with a value offset requires a numeric ORDER BY key; \
+                         column '{}' is null or non-numeric",
+                        ob.field
+                    )
+                })
+        };
+        let cur_val = value_at(current)?;
+
+        // Inclusive value window [lo, hi]. For ASC the start bound is the low
+        // side and the end bound the high side; for DESC the roles flip because
+        // preceding rows carry larger keys.
+        let (lo, hi) = if asc {
+            let lo = match &frame.start {
+                FrameBound::Unbounded => f64::NEG_INFINITY,
+                FrameBound::CurrentRow => cur_val,
+                FrameBound::Offset(n) => cur_val - *n as f64,
+            };
+            let hi = match &frame.end {
+                FrameBound::Unbounded => f64::INFINITY,
+                FrameBound::CurrentRow => cur_val,
+                FrameBound::Offset(n) => cur_val + *n as f64,
+            };
+            (lo, hi)
+        } else {
+            let hi = match &frame.start {
+                FrameBound::Unbounded => f64::INFINITY,
+                FrameBound::CurrentRow => cur_val,
+                FrameBound::Offset(n) => cur_val + *n as f64,
+            };
+            let lo = match &frame.end {
+                FrameBound::Unbounded => f64::NEG_INFINITY,
+                FrameBound::CurrentRow => cur_val,
+                FrameBound::Offset(n) => cur_val - *n as f64,
+            };
+            (lo, hi)
+        };
+
+        // The partition is sorted on the key, so the in-window rows are
+        // contiguous; scan for the first and last that fall inside [lo, hi].
+        let mut start = None;
+        let mut end = current;
+        for i in 0..len {
+            let v = value_at(i)?;
+            if v >= lo && v <= hi {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                end = i;
+            }
+        }
+        // The current row always satisfies its own window, so `start` is set.
+        Ok((start.unwrap_or(current), end))
     }
 
     // -- Navigation helpers -------------------------------------------------
@@ -540,7 +769,12 @@ impl WindowExecutor {
         let len = partition.len();
 
         for current_pos in 0..len {
-            let (start, end) = Self::resolve_frame(&call.spec.frame, current_pos, len);
+            let (start, end) = Self::resolve_frame(
+                &call.spec.frame,
+                partition,
+                &call.spec.order_by,
+                current_pos,
+            )?;
             let target = if is_first { start } else { end };
 
             let val = partition
@@ -747,6 +981,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Unbounded,
                     end: FrameBound::Unbounded,
                 },
@@ -807,6 +1042,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Unbounded,
                     end: FrameBound::Unbounded,
                 },
@@ -824,6 +1060,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Unbounded,
                     end: FrameBound::Unbounded,
                 },
@@ -863,6 +1100,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Offset(1),
                     end: FrameBound::Offset(1),
                 },
@@ -997,6 +1235,7 @@ mod tests {
                     direction: SortDirection::Asc,
                 }],
                 frame: FrameDefinition {
+                    unit: FrameUnit::Rows,
                     start: FrameBound::Unbounded,
                     end: FrameBound::Unbounded,
                 },
@@ -1125,5 +1364,257 @@ mod tests {
         assert!(WindowFunction::FirstValue.is_navigation());
         assert!(WindowFunction::LastValue.is_navigation());
         assert!(!WindowFunction::Count.is_navigation());
+    }
+
+    // -- Frame unit tests (ROWS vs RANGE vs GROUPS) -------------------------
+    //
+    // Ties on the ORDER BY key are exactly what distinguishes the three frame
+    // units, so every case here is built on an ORDERED dataset WITH TIES and
+    // the expected sums are hand-verified. These guard the correctness bug
+    // where a RANGE/GROUPS frame silently executed as ROWS.
+
+    fn frame(unit: FrameUnit, start: FrameBound, end: FrameBound) -> FrameDefinition {
+        FrameDefinition { unit, start, end }
+    }
+
+    /// Run `SUM(x) OVER (ORDER BY x <dir> <frame>)` over `x` (already in the
+    /// given sort direction) and return the per-row result in input order.
+    fn run_sum(x: &[f64], dir: SortDirection, frame: FrameDefinition) -> Result<Vec<f64>> {
+        let rows: Vec<QueryRow> = x.iter().map(|&v| make_row(vec![("x", json!(v))])).collect();
+        let call = WindowFunctionCall {
+            function: WindowFunction::Sum,
+            args: vec!["x".to_string()],
+            spec: WindowSpec {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    field: "x".to_string(),
+                    direction: dir,
+                }],
+                frame,
+            },
+            output_field: "s".to_string(),
+        };
+        let out = WindowExecutor::new().execute_window_functions(rows, &[call])?;
+        Ok(out
+            .iter()
+            .map(|r| {
+                r.fields
+                    .get("s")
+                    .and_then(|v| v.as_f64())
+                    .expect("sum present")
+            })
+            .collect())
+    }
+
+    #[test]
+    fn frame_units_diverge_with_value_offset_and_ties() {
+        // x = [1, 3, 3, 4]; SUM(x) OVER (ORDER BY x <unit> BETWEEN 1 PRECEDING
+        // AND CURRENT ROW). Hand-verified, all three distinct at the tie rows:
+        //   ROWS   — physical rows:  [1], [1,3], [3,3], [3,4]           = 1, 4, 6, 7
+        //   RANGE  — value in [x-1,x]: [1], [3,3], [3,3], [3,3,4]       = 1, 6, 6, 10
+        //   GROUPS — whole peer groups: [1], [1,3,3], [1,3,3], [3,3,4]  = 1, 7, 7, 10
+        let x = [1.0, 3.0, 3.0, 4.0];
+        let asc = SortDirection::Asc;
+
+        let rows = run_sum(
+            &x,
+            asc.clone(),
+            frame(
+                FrameUnit::Rows,
+                FrameBound::Offset(1),
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(rows, vec![1.0, 4.0, 6.0, 7.0], "ROWS");
+
+        let range = run_sum(
+            &x,
+            asc.clone(),
+            frame(
+                FrameUnit::Range,
+                FrameBound::Offset(1),
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(range, vec![1.0, 6.0, 6.0, 10.0], "RANGE");
+
+        let groups = run_sum(
+            &x,
+            asc,
+            frame(
+                FrameUnit::Groups,
+                FrameBound::Offset(1),
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(groups, vec![1.0, 7.0, 7.0, 10.0], "GROUPS");
+
+        // The whole point of the fix: the three are NOT equal.
+        assert_ne!(rows, range);
+        assert_ne!(range, groups);
+    }
+
+    #[test]
+    fn range_and_groups_current_row_span_peers_not_the_single_row() {
+        // x = [1, 2, 2, 3]; UNBOUNDED PRECEDING AND CURRENT ROW.
+        //   ROWS   running total per row:      1, 3, 5, 8
+        //   RANGE  through current peer group: 1, 5, 5, 8
+        //   GROUPS through current peer group: 1, 5, 5, 8
+        let x = [1.0, 2.0, 2.0, 3.0];
+        let asc = SortDirection::Asc;
+
+        let rows = run_sum(
+            &x,
+            asc.clone(),
+            frame(
+                FrameUnit::Rows,
+                FrameBound::Unbounded,
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(rows, vec![1.0, 3.0, 5.0, 8.0], "ROWS running total");
+
+        let range = run_sum(
+            &x,
+            asc.clone(),
+            frame(
+                FrameUnit::Range,
+                FrameBound::Unbounded,
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(range, vec![1.0, 5.0, 5.0, 8.0], "RANGE peers");
+
+        let groups = run_sum(
+            &x,
+            asc,
+            frame(
+                FrameUnit::Groups,
+                FrameBound::Unbounded,
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(groups, vec![1.0, 5.0, 5.0, 8.0], "GROUPS peers");
+    }
+
+    #[test]
+    fn range_offset_respects_desc_ordering() {
+        // ORDER BY x DESC, sorted input [4, 3, 3, 1].
+        // RANGE BETWEEN 1 PRECEDING AND CURRENT ROW: preceding = higher value,
+        // so the window is [x, x+1].
+        //   x=4 -> [4]        = 4
+        //   x=3 -> [4,3,3]    = 10
+        //   x=3 -> [4,3,3]    = 10
+        //   x=1 -> [1]        = 1
+        let x = [4.0, 3.0, 3.0, 1.0];
+        let range = run_sum(
+            &x,
+            SortDirection::Desc,
+            frame(
+                FrameUnit::Range,
+                FrameBound::Offset(1),
+                FrameBound::CurrentRow,
+            ),
+        )
+        .unwrap();
+        assert_eq!(range, vec![4.0, 10.0, 10.0, 1.0]);
+    }
+
+    #[test]
+    fn groups_following_spans_following_peer_groups() {
+        // x = [1, 3, 3, 4]; GROUPS BETWEEN CURRENT ROW AND 1 FOLLOWING.
+        //   g0={1}, g1={3,3}, g2={4}
+        //   pos0 -> g0..g1 = [1,3,3] = 7
+        //   pos1 -> g1..g2 = [3,3,4] = 10
+        //   pos2 -> g1..g2 = [3,3,4] = 10
+        //   pos3 -> g2..g2 = [4]     = 4
+        let x = [1.0, 3.0, 3.0, 4.0];
+        let groups = run_sum(
+            &x,
+            SortDirection::Asc,
+            frame(
+                FrameUnit::Groups,
+                FrameBound::CurrentRow,
+                FrameBound::Offset(1),
+            ),
+        )
+        .unwrap();
+        assert_eq!(groups, vec![7.0, 10.0, 10.0, 4.0]);
+    }
+
+    #[test]
+    fn range_value_offset_fails_loud_on_non_numeric_key() {
+        // A value-based RANGE offset needs a numeric ORDER BY key; a text key
+        // must fail loudly rather than silently returning a wrong number.
+        let rows = vec![
+            make_row(vec![("x", json!("a"))]),
+            make_row(vec![("x", json!("b"))]),
+        ];
+        let call = WindowFunctionCall {
+            function: WindowFunction::Sum,
+            args: vec!["x".to_string()],
+            spec: WindowSpec {
+                partition_by: vec![],
+                order_by: vec![WindowOrderBy {
+                    field: "x".to_string(),
+                    direction: SortDirection::Asc,
+                }],
+                frame: frame(
+                    FrameUnit::Range,
+                    FrameBound::Offset(1),
+                    FrameBound::CurrentRow,
+                ),
+            },
+            output_field: "s".to_string(),
+        };
+        let err = WindowExecutor::new()
+            .execute_window_functions(rows, &[call])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("numeric ORDER BY"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn range_value_offset_fails_loud_on_multiple_order_by_keys() {
+        // SQL forbids a value-offset RANGE with more than one ORDER BY column.
+        let rows = vec![make_row(vec![("x", json!(1.0)), ("y", json!(2.0))])];
+        let call = WindowFunctionCall {
+            function: WindowFunction::Sum,
+            args: vec!["x".to_string()],
+            spec: WindowSpec {
+                partition_by: vec![],
+                order_by: vec![
+                    WindowOrderBy {
+                        field: "x".to_string(),
+                        direction: SortDirection::Asc,
+                    },
+                    WindowOrderBy {
+                        field: "y".to_string(),
+                        direction: SortDirection::Asc,
+                    },
+                ],
+                frame: frame(
+                    FrameUnit::Range,
+                    FrameBound::Offset(1),
+                    FrameBound::CurrentRow,
+                ),
+            },
+            output_field: "s".to_string(),
+        };
+        let err = WindowExecutor::new()
+            .execute_window_functions(rows, &[call])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("exactly one ORDER BY"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/tests/tpcds_pgwire_e2e.rs
+++ b/tests/tpcds_pgwire_e2e.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 use tokio::time::sleep;
 
 /// TPC-DS subset queries expected to execute cleanly over pgwire (the ratchet).
-const TPCDS_RATCHET: usize = 16;
+const TPCDS_RATCHET: usize = 18;
 
 fn free_port() -> u16 {
     let l = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -200,6 +200,10 @@ fn tpcds_queries() -> Vec<(&'static str, String)> {
         ("win_rank", "select i_category, i_brand, sum(ss_ext_sales_price) as rev, rank() over (partition by i_category order by sum(ss_ext_sales_price) desc) as rnk from store_sales, item where ss_item_sk = i_item_sk group by i_category, i_brand order by i_category, rnk".to_string()),
         // WINDOW: running sum (frame).
         ("win_running", "select d_date, sum(ss_ext_sales_price) as daily, sum(sum(ss_ext_sales_price)) over (order by d_date rows between unbounded preceding and current row) as running from store_sales, date_dim where ss_sold_date_sk = d_date_sk group by d_date order by d_date".to_string()),
+        // WINDOW: RANGE value-offset frame (must NOT execute as ROWS).
+        ("win_range", "select ss_quantity, sum(ss_net_profit) over (order by ss_quantity range between 1 preceding and current row) as s from store_sales order by ss_quantity".to_string()),
+        // WINDOW: GROUPS peer-group frame (must NOT execute as ROWS).
+        ("win_groups", "select ss_quantity, sum(ss_net_profit) over (order by ss_quantity groups between 1 preceding and current row) as s from store_sales order by ss_quantity".to_string()),
         // ROLLUP.
         ("rollup", "select i_category, i_class, sum(ss_net_profit) as profit from store_sales, item where ss_item_sk = i_item_sk group by rollup(i_category, i_class) order by i_category, i_class".to_string()),
         // GROUPING SETS.
@@ -383,4 +387,48 @@ async fn tpcds_pgwire_conformance() {
         "rank() window: per-category brand revenue ranking"
     );
     eprintln!("✓ value-correctness: ROLLUP / CUBE / rank() window anchored");
+
+    // Window FRAME-UNIT correctness (RANGE vs GROUPS) on a key WITH TIES — a
+    // frame that silently executed as ROWS would give wrong numbers here.
+    // ORDER BY ss_quantity is [1,1,2,3,5] (the two q=1 rows carry profits 8 and
+    // 6). BETWEEN 1 PRECEDING AND CURRENT ROW over sum(ss_net_profit):
+    //   RANGE  — value window [q-1, q]:  q1→8+6=14, q2→8+6+12=26, q3→12+10=22, q5→20
+    //   GROUPS — whole peer groups:      q1→14,      q2→26,        q3→22,       q5→10+20=30
+    // The two units agree everywhere except q=5 (20 vs 30) — proof the declared
+    // unit is honoured, not collapsed. (ROWS is order-sensitive on ties, so its
+    // per-row values are non-deterministic here; the ROWS frame is anchored by
+    // the deterministic `win_running` ratchet query above.)
+    let mut exp_range = vec![
+        row(&["1", "14"]),
+        row(&["1", "14"]),
+        row(&["2", "26"]),
+        row(&["3", "22"]),
+        row(&["5", "20"]),
+    ];
+    exp_range.sort();
+    assert_eq!(
+        canon_rows(&client, "select ss_quantity, sum(ss_net_profit) over (order by ss_quantity range between 1 preceding and current row) as s from store_sales").await,
+        exp_range,
+        "RANGE frame: value-window sums over a tied ORDER BY key"
+    );
+
+    let mut exp_groups = vec![
+        row(&["1", "14"]),
+        row(&["1", "14"]),
+        row(&["2", "26"]),
+        row(&["3", "22"]),
+        row(&["5", "30"]),
+    ];
+    exp_groups.sort();
+    assert_eq!(
+        canon_rows(&client, "select ss_quantity, sum(ss_net_profit) over (order by ss_quantity groups between 1 preceding and current row) as s from store_sales").await,
+        exp_groups,
+        "GROUPS frame: peer-group sums over a tied ORDER BY key"
+    );
+
+    assert_ne!(
+        exp_range, exp_groups,
+        "RANGE and GROUPS must differ on ties — else the frame unit was collapsed to ROWS"
+    );
+    eprintln!("✓ value-correctness: RANGE vs GROUPS frame units honoured on ties");
 }


### PR DESCRIPTION
## Problem

A `RANGE` or `GROUPS` window frame that parsed and lowered correctly was **silently executed as `ROWS`** — a wrong-results bug (not an error) whenever the `ORDER BY` key has ties, which is exactly the case that distinguishes the three frame units. The AST already carried `WindowFrameUnit {Rows, Range, Groups}` and lowering was done; only execution ignored it.

Two ROWS-only spots:
- `datafusion_bridge::map_window_frame` hardcoded `WindowFrameUnits::Rows`, discarding the declared unit (DataFusion route).
- `window_executor::resolve_frame` only understood physical row offsets — no value-based `RANGE` peers, no `GROUPS` peer groups (native route).

## Fix

- Add `FrameUnit {Rows, Range, Groups}` and thread it through `FrameDefinition`; `map_window_frame` now emits the declared unit.
- `resolve_frame` gains:
  - **RANGE** — value-offset peer semantics on the single numeric `ORDER BY` key, honouring `ASC`/`DESC`; `CURRENT ROW`/`UNBOUNDED`-only frames use peer groups (no numeric key needed).
  - **GROUPS** — peer-group offset semantics.
- **Fail loud, not wrong**: a value-offset `RANGE` over a non-numeric key or more than one `ORDER BY` column now returns a clear error instead of mis-framing.

This is a default-behavior correctness fix (not flag-gated) — results become correct.

## Tests (deterministic ratchets)

The distinguishing dataset is an **ordered key WITH TIES**; all expecteds are hand-verified.

- **Native route** (`window_executor`): `SUM(x) OVER (ORDER BY x <unit> BETWEEN 1 PRECEDING AND CURRENT ROW)` on `x=[1,3,3,4]` yields mutually-distinct `ROWS=[1,4,6,7]`, `RANGE=[1,6,6,10]`, `GROUPS=[1,7,7,10]`; plus peer-span, DESC, `FOLLOWING`, and both fail-loud cases.
- **DataFusion route**: `map_window_frame` maps each unit through; TPC-DS pgwire e2e gains RANGE vs GROUPS value-correctness anchors that differ on ties (q5: RANGE=20 vs GROUPS=30) and two ratchet queries (**TPC-DS ratchet 16 → 18**), validated end-to-end through pgwire → DataFusion.

## Scope note

Per the strategic guidance, this is a clean fix on the current window paths — no large native-Volcano rewrite. `window_executor.rs`/`datafusion_bridge.rs` are disjoint from PR #760's native-engine files.

## Verification

- `cargo fmt --check` ✅ · `cargo clippy --lib --bins -D warnings` ✅ (server binary builds)
- `cargo test --lib window_` → 39 passed ✅
- `cargo test --test tpcds_pgwire_e2e` → 18/18 ratchet + all value anchors ✅
- panic-policy / tenant-path / workspace-boundary guards: pass (query delta +0)