### PR TITLE
docs(design): TD-OLAP-11 — native radix/bloom/spill hash join (ADR-054 Phase 3 design)

### DIFF
--- a/docs/10-quality/td/TD-OLAP-11-native-radix-bloom-spill-hash-join.adoc
+++ b/docs/10-quality/td/TD-OLAP-11-native-radix-bloom-spill-hash-join.adoc
@@ -1,0 +1,142 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-11: Native radix-partitioned, bloom-pre-filtered, spilling hash join (ADR-054 Phase 3)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — design filed for review (2026-07-08), implementation pending TD-OLAP-10 (Phase 2) landing.** Phase 2 (`FilterProjectOperator` + `HashAggregateOperator`, the `PhysExpr`/`lower_physical`/`Pipeline` substrate this join reuses) is landed (#755/#758/#760/#772). This TD defines the **#1 performance lever**: the native hash join that closes the Q3/Q14 join gap (Q3 594 ms / Q14 296 ms, 99% `compute_ms` — DataFusion 54's hash join does not spill and cannot host the multimodal join semantics that are ProximaDB's wedge).
+| Priority | **P0** — the actual competitive lever. Phases 2/2.1 were foundational (operator set); this is where the measured gap closes. Builds directly on the landed `PhysExpr` (the probe's residual predicate + join-key extractors are `PhysExpr`) and the `Pipeline`/`ExecutionOperator` contracts.
+| Severity | Critical — the join is the binding constraint across TPC-H (Q3/Q5/Q7/Q8/Q9/Q10/Q14) and TPC-DS star queries, and the structural host for the multimodal join wedge (vector+SQL recall loss, ADR-054 §6).
+| Component | *new* `src/query/execution/native_join_ops.rs` (`HashJoinBuildOperator`, `HashJoinProbeOperator`, `JoinHashTable`); extends `native_ops.rs::lower_physical` (`PhysicalPlan::Join` arm) + `native_engine.rs` (`native_join_enabled()` gate, `PROXIMADB_NATIVE_JOIN`); *new* `crates/query/proximadb-execution-contracts/src/memory.rs` (`MemoryPool`/`SpillSink`); reuses `proximadb-bloom` (TD-OLAP-3).
+| Governs | link:../../12-design/adr/ADR-054-native-execution-engine-progressive-cutover.adoc[ADR-054] §5 (the join), §8 Phase 3 row; composes with link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] invariant 4 (measured, not asserted).
+| Relates to | TD-OLAP-3 (runtime filters — bloom primitive, two consumers), TD-OLAP-10 (Phase 2 — `PhysExpr`/`lower_physical`/`Pipeline` substrate), TD-OLAP-4 (the ledger that gates promotion), ADR-050 (CBO — owns build/probe selection), ADR-011 (bloom/ANN pre-filter — the same idea on the vector side). Supersedes nothing; DataFusion stays the floor + fallback.
+|===
+
+== Why this is the lever (and the three cost regimes)
+
+The join moves **three different dominant-cost terms in three regimes** (ADR-052 mandate #1 — name the term):
+
+1. **In-memory hash join (build fits budget):** the binding constraint is *memory-latency on random L2/L3 cache misses during probe*, not CPU. Ailamaki VLDB 1999: ~50% of execution time is stalls, 90% of memory stalls are L2 data misses; Manegold/Boncz VLDB 2000: at zero partitioning, memory access is ~95% of probe time. **Radix partitioning shrinks the per-bucket working set so probes hit L1/L2.** Radix moves the *memory-latency* term.
+2. **Spilling hash join (build > budget):** the cost flips to *I/O bandwidth over spill files* (`total_spill_IO ≈ 2·B(R)·⌈log_F(B(R)/M)⌉`). On cloud object storage that is round-trips + egress — the dominant cloud-OLAP term. **Recursive radix partitioning minimizes passes.** Spill moves the *I/O-passes* term.
+3. **Bloom/range filter pushed to the probe-side scan:** pure *scan-avoidance* (the bytes-scanned term ADR-052 owns). TD-OLAP-3 already measured TPC-DS q42 −44.1% bytes; Spark 3.3 Bloom Filter Joins, Trino dynamic filtering, DuckDB 1.1 dynamic filters all track the probe-side rows/bytes dropped.
+
+The three are **additive**; the ledger (§"Gate") must claim each separately.
+
+== The state-of-the-art split (and the position this TD takes)
+
+The field is **split**, and the design must take an evidence-backed position:
+
+| System | In-memory radix? | Hash table | Spill | Runtime filter |
+| | DuckDB | **Always radix** (fused with materialization; 16 partitions initially) | linear-probing, 48-bit pointer + 16-bit "salt", CAS-parallel insert | page-level (256 KiB) + unified buffer pool | min/max range (v1.1), not bloom |
+| | HyPer | **No radix in-memory** (concurrent CAS insert into one shared lock-free table; argues 97.4% of TPC-H joined tuples fit cache) | lock-free, 64-bit CAS | compiled | (codegen-only) |
+| | Umbra | **No radix** (SIGMOD 2021 best paper: radix wins 1/59 TPC-H joins → "advise against it") | "unchained" adjacency array | architectural (variable pages + pointer swizzling) | — |
+| | Velox | Radix **only for spill** | F14-style (128-byte bucket, tag-SIMD) | recursive `T = M × (2ᴺ)ᴸ` | in-list (primary) + bloom (default OFF) |
+| | Postgres | No radix, no morsel, no runtime-filter pushdown, no NUMA | batch-doubling | re-partition | none |
+
+**Decision — size-gated radix (the synthesis):** unconditional radix is wrong (Shatdal VLDB 1994: radix on hash-join gave only 6.6% — partitioning CPU overhead nearly erased the cache-miss win; Umbra: 1/59 joins). Unconditional no-radix loses spill-for-free (HyPer/Umbra spill is bespoke-architectural, not a reusable Grace path). **MVP: a single non-partitioned linear-probing table with 16-bit salt (DuckDB-shaped) when the build fits comfortably in budget; radix-partition ONLY when build > L3-fit threshold OR when spill triggers (Phase 3.1).** The size-gate is a `MemoryPool`/`estimated_cardinality` decision, never unconditional.
+
+== The three operators + two pipelines
+
+The join is **three contract operators** across **two `Pipeline`s separated by a pipeline break** (ADR-054 §5.2). Build is its own blocking pipeline; probe is the main pipeline.
+
+=== `HashJoinBuildOperator` (BLOCKING)
+Consumes the entire build side (the pipeline break), extracts join keys via `PhysExpr` (reused from Phase 2 — one lowering, two consumers), builds a `JoinHashTable` (linear-probing slots, 16-bit salt), builds a bloom over the build keys (build-then-freeze — see §"Bloom"), and **publishes `Arc<JoinHashTable>` via a `OnceLock`** shared with the probe pipeline. Emits a zero-row sentinel (the build emits nothing; the probe reads the table).
+
+=== `HashJoinProbeOperator` (STREAMING)
+Reads the table from the `OnceLock` (blocks until the build pipeline publishes). Per morsel: extract probe keys (`PhysExpr`), **consult the bloom first** (drops non-matching rows at byte-op cost before the random hash-table lookup), hash → slot lookup → salt-compare → key-compare, producing **selection vectors** (late materialization — no intermediate joined batch), evaluate the residual `PhysExpr` (e.g. `a.y > b.y`) over the selection, then materialize the output per `JoinKind`. After the probe stream ends, for `Right`/`Full` it drains the unmatched build rows (NULL-padded left).
+
+=== Pipeline composition + the `Pipeline` contract change
+```
+Pipeline A (build, blocking):  [build source] → [FilterProject]* → HashJoinBuildOperator  (drains; publishes table; emits nothing)
+Pipeline B (probe, streaming): [probe source] → [FilterProject]* → HashJoinProbeOperator → [Project]* → [Limit]
+```
+The contracts `Pipeline` is a single operator chain; a join needs two pipelines with a dependency. **Additive, non-breaking change:** introduce a single `HashJoinOperator` that internally owns build-then-probe (keeps `Pipeline` a single chain; the two-phase nature is internal to the operator). The `OnceLock<Arc<JoinHashTable>>` is the cross-phase handoff. For MVP (Phase 3, before the Phase 4 morsel scheduler), `execute_pipeline` runs build-then-probe single-threaded — still vectorized per-batch, just not parallel across morsels.
+
+== Bloom integration (one primitive, two consumers — ADR-052 ISP)
+
+**Direction (load-bearing):** bloom over the **build** keys (smaller/dimension, fully consumed first); test **probe** keys against it. (Dremio: build side is smaller + already filtered → small selective bloom; build is fully known before probe streams; probe side is the expensive bytes-scanned term.)
+
+**Build-then-freeze (repo constraint):** `BloomFilterStrategy::insert` takes `&mut self` — you **cannot insert into an `Arc<dyn BloomFilterStrategy>`**. So the build op constructs a `Box<dyn BloomFilterStrategy>` via `BloomFilterFactory::create`, inserts all keys, calls `.build()`, and **only then** wraps in `Arc` for the probe to read. No concurrent insertion (MVP).
+
+**Two integration points:**
+1. **In the probe operator** (MVP) — `might_contain` before each probe row's hash lookup; with `bits_per_key=10` (FPR ~1%) drops ~99% of non-matching rows at byte-op cost instead of random-cache-miss cost. Memory-latency-term win inside the join.
+2. **Pushed to the probe-side scan** (deferred to TD-OLAP-3's full rollout / Phase 2.5 scan) — the bloom published to the probe scan for zone-map/row-group pruning. Bytes-scanned-term win that compounds with (1). The `ExecutionOperator` seam admits a `accepts_runtime_filter()` hook; the scan impl is Phase 2.5.
+
+**API gap to note:** `BloomFilterStrategy` has no batch/Arrow entry point (`might_contain(&[u8])` only). MVP iterates probe keys (acceptable — the bloom internals are byte-SIMD). A follow-up `might_contain_keys(&[&[u8]]) -> BooleanArray` in `proximadb-bloom` vectorizes the outer loop. **Hash consistency:** define one canonical `join_hash(key_bytes) -> u64 = XxHasher::hash_bytes(key_bytes)` for radix bits + bucket index + salt; the bloom's internal two-hash scheme stays internal to the bloom.
+
+== MemoryPool + spill (the ADR-054 §9 gap)
+
+ADR-054 v3 has no "blind spots" section (v2 NR7 promised one; §9 became "evidence justification"). This TD defines `MemoryPool` de novo:
+
+[source,rust]
+----
+pub trait MemoryPool: Send + Sync {
+    fn try_reserve(&self, bytes: usize) -> Result<MemoryReservation, MemoryError>;
+    fn try_grow(&self, r: &MemoryReservation, new_bytes: usize) -> Result<(), MemoryError>;
+    fn release(&self, r: &MemoryReservation);
+    fn used(&self) -> usize;
+    fn capacity(&self) -> usize;
+}
+pub trait SpillSink: Send + Sync { /* spill_partitions / read_partition */ }
+----
+
+**Phase 3.0 (MVP launch, in-memory only):** `MemoryPool` exists; `SpillSink` unimplemented. If `try_reserve` fails → `Err(InsufficientMemory)` → `try_vectorized` returns `Ok(None)` → Volcano fallback (which also has no spill). Honest: the MVP closes the *in-memory parity* gap, not the spill gap.
+
+**Phase 3.1 (Grace spill — the gap-closing claim):** when build > budget → radix-partition **both** sides into N buckets (N so each fits memory); per bucket: in-memory build+probe; **recursive "bucket fission"** if a bucket still exceeds memory (`h2 ≠ h1`); **hybrid** (Shapiro TODS 1986): keep the first partition resident during the partition pass. Target: **local NVMe** first (a temp dir under `data_dir`), object store only as last resort (round-trips + egress). DataFusion 54 has no spill, so even a basic Grace implementation wins the spill regime — but the claim must be measured.
+
+== JoinKind coverage
+
+| JoinKind | MVP? | Behavior |
+| | Inner / Left / Right / Full | **MVP** | matched pairs; unmatched handling per kind (NULL-pad); Right/Full drain unmatched build at probe-end. Planner routes Right/Full to Hash (correctness confirmed at `relational-planner/lib.rs`). |
+| | Semi / Anti | **MVP** | set-lookup (emit/no-emit on existence); reuses TD-OLAP-3's semi-join bloom. |
+| | AntiNullAware | **Deferred** | planner routes to NestedLoop (SQL 3-valued NAAJ); hash NAAJ is a perf follow-up. |
+| | Cross | **Deferred** | no ON → NestedLoop; not a hash-join target. |
+
+**NULL semantics (load-bearing):** a NULL join key **never matches** in any kind. Build + probe **skip NULL keys** (`arrow::compute::is_null`) → NULL keys go to the unmatched set. A dedicated NULL-bearing equi-join conformance test (all 6 hash-kinds, NULL in left/right/both) cross-checked against DataFusion-on-Parquet gates promotion.
+
+== Lowering (extends Phase 2's `lower_physical`)
+
+`PhysicalPlan::Join { left, right, kind, on, strategy }` →
+. **Strategy gate:** only `JoinStrategy::Hash { build_side }` is native-MVP; NLJ/SortMerge/Cross/AntiNullAware → `Err` → `Ok(None)` (Volcano). The planner's `pick_join_strategy` already set `build_side`; the engine executes, does NOT re-pick (ADR-050 CBO owns that).
+. **ON gate:** `extract_equi_keys(on)` → `Vec<(left_col, right_col)>` + optional residual `PhysExpr`; non-equi → fall back.
+. **Build/probe assignment** from `build_side`; build/probe keys + residual lowered to `PhysExpr` (reuse Phase 2).
+. Two pipelines (build over the build side; probe over the probe side) composed via the `HashJoinOperator` wrapper.
+
+**Wire gate:** `try_vectorized` matches `Join` only when `native_join_enabled()` (`PROXIMADB_NATIVE_JOIN`, default OFF — **distinct** from Phase 2's `PROXIMADB_NATIVE_VECTORIZED`), so FilterProject/HashAgg ship without forcing the join on.
+
+== Gate (ADR-052 mandate #4 — measured, not asserted)
+
+Ships behind `PROXIMADB_NATIVE_JOIN` (default OFF) + `PROXIMADB_NATIVE_JOIN_SHADOW` (shadow comparison vs Volcano, demote on >0.1% mismatch). Promotion requires the **TD-OLAP-4 ledger** at the exact configurations:
+
+| Regime | Benchmark | Target |
+| | In-memory parity | TPC-H SF1 Q3/Q5/Q7/Q8/Q9/Q10/Q14 | wall + compute_ms **≤ DataFusion-54** hash join |
+| | Bloom scan-pushdown | TPC-DS SF1 star (q42/q3/q52/q55) | wall **≤ DataFusion**, bytes_read **≤ DataFusion-without-bloom** |
+| | Spill strict-better (Phase 3.1) | TPC-H SF10, build 2× memory | DataFusion OOMs → Grace finishes |
+| | Multimodal recall (Phase 5) | vector+SQL join, k=100, recall@10 | **>99%** (vs the >30% loss cited in arXiv 2506.23071) |
+| | Conformance | TPC-H (22) + TPC-DS (16) pgwire | counts **unchanged** (ratchet only goes up) |
+| | Headline | TPC-H SF1 Q3 + Q14 vs DuckDB | within **3×** (closing the 85–100× gap) |
+
+== Risks + mitigations
+
+* **Hash-table concurrency (morsel build).** MVP: single-thread build, publish via `OnceLock`. Phase 4+: concurrent CAS insert (HyPer 48-bit-pointer + 16-bit-tag) OR partition-local builds + barrier merge (Leis §4 allows both).
+* **Radix CPU cost erasing the cache-miss win** (Shatdal/Umbra). MVP does NOT radix in-memory; radix only when size-gated or spill-triggered.
+* **NULL-semantics correctness** (highest risk). NULL keys never match; build+probe skip them; dedicated NULL conformance test across all 6 hash-kinds; shadow comparison.
+* **Bloom direction.** Bloom over build keys, test probe keys (unit test asserts: bloom over {1,2,3}, probe {4,5,6} → all miss).
+* **Build-side selection (CBO).** MVP accepts the planner's `build_side` heuristic; ADR-050 owns the proper cardinality-based choice; the MemoryPool budget triggers Volcano fallback on mis-estimate.
+* **Key-type dispatch / hash consistency.** Canonical key bytes (LE ints, utf8 bytes, length-prefixed varlen); one `join_hash`.
+* **`Pipeline` contract change.** Additive only (`HashJoinOperator` wrapper); no existing operator changes.
+
+== Sequencing + non-goals
+
+* **Unblocks on:** TD-OLAP-10 (Phase 2) — **landed** (`PhysExpr`/`lower_physical`/`Pipeline` substrate exists).
+* **Non-goals (deferred):** concurrent morsel build (Phase 4 / TD-OLAP-12); multimodal operators (Phase 5 / TD-OLAP-13); NUMA-aware worker pinning (Phase 4); codegen (ADR-052 non-goal). DataFusion stays the floor + fallback at every step.
+
+== Primary-source citations (verified)
+
+* Radix/cache: Boncz/Manegold/Kersten VLDB 1999 (https://www.vldb.org/conf/1999/P5.pdf); Manegold/Boncz/Kersten VLDB 2000 + INS-R9912 (https://ir.cwi.nl/pub/4527/04527D.pdf); Boncz/Kersten/Manegold CACM 2008 (https://cacm.acm.org/research/breaking-the-memory-wall-in-monetdb/); Shatdal/Kant/Naughton VLDB 1994 (https://www.vldb.org/conf/1994/P510.PDF); Ailamaki et al. VLDB 1999 (https://www.vldb.org/conf/1999/P28.pdf); Balkesen et al. SIGMOD 2013 (https://15721.courses.cs.cmu.edu/spring2016/papers/balkesen-icde2013.pdf); Bandle/Giceva/Neumann SIGMOD 2021 best paper (https://www.cs.cmu.edu/~15721-f24/papers/To_Partition_Or_Not_HashJoin.pdf).
+* Morsel: Leis/Boncz/Kemper/Neumann SIGMOD 2014 (https://db.in.tum.de/~leis/papers/morsels.pdf).
+* Systems: DuckDB "Saving Private Hash Join" PVLDB 18(8) 2025 (https://www.vldb.org/pvldb/vol18/p2748-kuiper.pdf); Velox PVLDB 15(12) 2022 (https://www.vldb.org/pvldb/vol15/p3372-pedreira.pdf); Umbra Neumann/Freitag CIDR 2020 (http://cidrdb.org/cidr2020/papers/p29-neumann-cidr20.pdf) + Birler DaMoN 2024 (https://db.in.tum.de/~birler/papers/hashtable.pdf).
+* Grace/spill: Kitsuregawa/Tanaka/Moto-Oka NGC 1983 (https://link.springer.com/article/10.1007/BF03037022); Shapiro TODS 11(3) 1986 (https://dl.acm.org/doi/10.1145/6314.6315).
+* Runtime filters: Spark 3.3 Bloom Filter Joins (SPARK-32268); Trino dynamic filtering (https://trino.io/blog/2019/06/30/dynamic-filtering.html); Dremio (https://www.dremio.com/blog/accelerating-joins-in-dremio-with-runtime-filters/).
+* Multimodal wedge: arXiv 2506.23071 (vector+SQL recall loss).


### PR DESCRIPTION
## Summary

Files **TD-OLAP-11** — the design for the native hash join (ADR-054 Phase 3), the **#1 performance lever**: it closes the Q3/Q14 join gap (Q3 594 ms / Q14 296 ms, 99% `compute_ms`) where DataFusion 54's hash join doesn't spill and can't host the multimodal join wedge. Design only — no code; ready for review (single- or multi-agent, as ADR-054 / TD-OLAP-10 were). Implementation is unblocked now that Phase 2 (`PhysExpr`/`lower_physical`/`Pipeline`) is landed (#755/#758/#760/#772).

## Design position (evidence-backed — the field is split)

**Size-gated radix:** a single non-partitioned linear-probing table (16-bit salt, DuckDB-shaped) when the build fits budget; radix-partition ONLY when size-gated (L3 threshold) or spill-triggered. Unconditional radix is wrong (Shatdal VLDB 1994: 6.6% on hash-join; Umbra SIGMOD 2021 best paper: 1/59 TPC-H joins); unconditional no-radix (HyPer/Umbra) loses spill-for-free.

## Key design points

- **3 operators / 2 pipelines:** `HashJoinBuildOperator` (blocking — builds table + bloom, publishes `Arc<JoinHashTable>` via `OnceLock`); `HashJoinProbeOperator` (streaming — bloom pre-filters before hash lookup, late-materialization selection vectors, residual `PhysExpr`); composed via a `HashJoinOperator` wrapper (additive `Pipeline` change).
- **Bloom build-then-freeze:** `BloomFilterStrategy::insert` is `&mut` → can't insert into `Arc`; build as `Box`, insert all keys, then `Arc`-wrap. One primitive, two consumers (TD-OLAP-3 ISP).
- **MemoryPool + SpillSink defined de novo** (ADR-054 v3 has no §9 blind-spots section). Phase 3.0 = in-memory parity; Phase 3.1 = Grace spill (the gap-closing claim — DataFusion 54 has no spill).
- **JoinKind:** Inner/Left/Right/Full/Semi/Anti MVP; AntiNullAware/Cross deferred. NULL keys never match.
- **Gate:** TD-OLAP-4 ledger — in-memory ≤ DataFusion; spill strict-better; multimodal recall >99%; TPC-H/DS conformance unchanged; within 3× of DuckDB.

All citations primary-source-verified (Boncz/Manegold/Kersten VLDB 1999; Leis SIGMOD 2014; DuckDB PVLDB 2025; Umbra CIDR 2020; Grace NGC 1983; Shapiro TODS 1986). `check_td_adr_unique`: 0 errors, 168 TD ids.

## Next

After review/sign-off: implement TD-OLAP-11 (`native_join_ops.rs` + `MemoryPool` + `lower_physical::Join` arm), behind `PROXIMADB_NATIVE_JOIN` (default-off), gated on the TD-OLAP-4 ledger. Also ready (parallel): Phase 2.5 real-Scan source design (agent findings in hand) — unblocks routing real queries through the vectorized path.