### PR TITLE
docs(td): file TD-OLAP-14 — native PAX-backed scan source (ADR-054 Phase 2.5)

### DIFF
--- a/docs/10-quality/td/TD-OLAP-14-native-pax-scan-source.adoc
+++ b/docs/10-quality/td/TD-OLAP-14-native-pax-scan-source.adoc
@@ -1,0 +1,243 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-14: Native PAX-backed scan source for the vectorized pipeline (ADR-054 Phase 2.5)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — design filed for review (2026-07-08), implementation pending sign-off.** Phase 2 (FilterProjectOperator + HashAggregateOperator + pipeline executor, TD-OLAP-10) landed on in-memory `PhysicalPlan::Values` sources (#755/#758/#772); this TD defines the first real-storage scan operator (`PaxScanOperator`) that feeds actual `.pax`-backed tables into the vectorized pipeline, the `lower_physical` extension that builds it from `PhysicalPlan::Scan`, the `ScanPredicate` bridge from `Expr`, and the `ReaderFactory`/`FilesystemFactory` threading — then benchmarks against the Volcano on PAX-backed shapes per the ADR-054 §8 Phase 2.5 gate.
+| Priority | **P1** — the production-feasibility phase. The vectorized path's entire value proposition is the Arrow-native PAX scan (TD-OLAP-10 §"Honest scope": *"the vectorized path's value is the Arrow-native PAX scan"*); until `try_vectorized` can serve real storage, the pipeline mechanics proven in Phase 2 are exercised only by `PhysicalPlan::Values` literal tables (in-memory, no I/O, no predicate pruning). This phase is what makes the native vectorized engine *serveable* on the workload shape it was designed for: scan/filter/project/aggregate over PAX-backed collections. It is NOT the join (TD-OLAP-11), the morsel scheduler (TD-OLAP-12), or the fused multimodal operator (TD-OLAP-13) — it is the storage seam that all three will consume.
+| Severity | Medium-high — unblocks the ClickBench comparison (deferred from Phase 2's §8 row), and is the precondition for TD-OLAP-11's join having a real probe-side source rather than a `MemoryScanSource` harness. Honest target: parity-or-better vs the Volcano on scan/filter/project/aggregate over PAX-backed tables, with the zone-map/bloom predicate pruning the PAX format already provides; the win is serveability + the reusable scan leaf, not a join-gap closure.
+| Component | *new* `src/query/execution/native_pax_scan.rs` (`PaxScanOperator`, `build_scan_predicate`, `lower_scan`); `src/query/execution/native_engine.rs` (thread `ReaderFactory`/`FilesystemFactory` into `try_vectorized`); `src/query/execution/native_ops.rs` (`Walked.source` generalized from `MemoryScanSource` to `Box<dyn ExecutionOperator>`, `lower_physical` Scan arm); `src/query/execution/engine.rs` (pass `factory` into `try_vectorized`). Reuses (no change): `crates/storage/proximadb-storage-common/src/pax_block.rs` (`PaxSegmentScanner`, `ScanPredicate`), `src/datafusion/engine_adapters/pax_segment_locator.rs` (`discover_pax_segments` — used as a free function, NOT as a DataFusion import), `crates/storage/proximadb-block-format/src/record.rs` (`col_id` constants for projection pushdown).
+| Governs | link:../../12-design/adr/ADR-054-native-execution-engine-progressive-cutover.adoc[ADR-054] §8 Phase 2.5 row ("scan source + ClickBench comparison"); composes with link:../../10-quality/td/TD-OLAP-10-native-filterproject-pipeline.adoc[TD-OLAP-10] (the pipeline mechanics + `PhysExpr` lowering this builds on), link:TD-OLAP-3-runtime-filters-dpp-bloom-semijoin.adoc[TD-OLAP-3] (runtime filters — the deferred scan-pushdown), ADR-039 (the DataFusion leakage boundary this respects), link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] invariant 4 (measured, not asserted).
+| Relates to | TD-OLAP-10 (Phase 2 — the operator substrate this extends with a real source), TD-OLAP-1 (the PAX scan was the DataFusion wedge; this is its native-vectorized twin), TD-OLAP-11 (native hash join — consumes this scan as its probe-side source), TD-OLAP-3 (runtime-filter/bloom scan-pushdown — deferred from this MVP), TD-OLAP-4 (ledger that gates promotion).
+|===
+
+== Why
+
+ADR-054 §8 ships the native vectorized engine in non-breaking, flag-gated phases. Phase 2 (TD-OLAP-10) proved the pipeline mechanics — `ExecutionOperator` contracts, fused `FilterProjectOperator`, blocking `HashAggregateOperator`, the zero-DataFusion `PhysExpr` IR, the `lower_physical` walker, and the Arrow→`RelationalRow` output bridge — but only on `PhysicalPlan::Values` (in-memory literal tables). `PhysicalPlan::Scan` reaches the catch-all arm of `walk` (`native_ops.rs:882`) and returns `Err(NotImplemented)`, which `try_vectorized` maps to `Ok(None)` → Volcano fallback (the experimental path never fails a query).
+
+That was deliberate (TD-OLAP-10 §"Honest scope"): a `Values` source proves the pipeline without coupling to storage. But it means the vectorized path serves *zero production queries today* — every real query has a `Scan` at its leaf, and the Volcano (row-at-a-time, per-cell `Expr::eval`) handles all of them. The vectorized path's value is the Arrow-native PAX scan: `PaxSegmentScanner` decodes PAX block stripes directly into typed Arrow arrays (zero ProximaValue→Arrow conversion), and the pipeline's vectorized `filter_record_batch` / column-project / hash-aggregate operate on those arrays in tight SIMD-friendly loops. That value is unrealized until `try_vectorized` can read a `.pax` file.
+
+This TD defines the storage seam: a `PaxScanOperator` that calls the already-DataFusion-free `PaxSegmentScanner` + `discover_pax_segments`, threads `TenantContext` + `DrPathBuilder` (the co-design mandate: structural isolation + billing at every I/O boundary), translates `PhysicalPlan::Scan.predicate` (`Expr`) into `ScanPredicate` (tenant hash + time range) for block-level zone-map pruning, and emits `RecordBatch`es into the same `BatchStream` the existing operators already consume. The scan is the last missing piece before the vectorized engine is serveable on the workload shape it was designed for.
+
+== Honest scope (what this phase does NOT move)
+
+* It does **not** close the Q3/Q14 join gap (that is TD-OLAP-11). A scan/filter/project/aggregate pipeline has no join; the Volcano is already competitive on Q1/Q6-shaped scans (ADR-054 §1.3.4: *"the scan path is already competitive on Q1/Q6"*). Phase 2.5 targets **parity-or-better vs the Volcano on PAX-backed scan/filter/project/aggregate**, and the ledger gate says so explicitly. The win is serveability + the reusable scan leaf, not ms on a join.
+* It does **not** include TD-OLAP-3 runtime-filter/bloom scan-pushdown. The MVP predicate pushdown is the `ScanPredicate` zone-map pruning (tenant hash + time range) that `PaxSegmentScanner` already applies at block granularity (`pax_block.rs:831 next_block`). Full bloom/range-filter scan-pushdown from a join build (the TD-OLAP-3 dynamic filter pushed into the probe-side scan) is deferred — the `PaxScanOperator` carries an `accepts_runtime_filter()`-style hook (the `ExecutionOperator` contract already names it in ADR-054 §3.2) so the wiring is non-breaking when TD-OLAP-3 lands.
+* It does **not** vectorize non-PAX tables. A row-based Volcano source (e.g. `InMemoryReader` snapshots) converting row→Arrow→row is wasteful (TD-OLAP-10 §"Honest scope" stated this directly); the vectorized path's value is the Arrow-native PAX scan, so a non-PAX `Scan` declines to `Ok(None)` and the Volcano handles it. This respects ADR-054 §8: *"At every phase, the Volcano remains the floor and the fallback."*
+* It does **not** include multi-segment parallel scans (the morsel scheduler is TD-OLAP-12). The MVP scans segments sequentially within one `PaxScanOperator::execute` stream; `next_block()` yields blocks one at a time. Parallel segment scans (one morsel per `.pax` file, scheduled across workers) land with TD-OLAP-12's `MorselScheduler`.
+
+== Design
+
+=== The leakage boundary (the ADR-039 invariant)
+
+The native execution path MUST stay DataFusion-free (ADR-054 BLOCKER-2, §3.3: *"`proximadb-execution-contracts` has zero DataFusion dependency"*, and the contracts crate is `#![forbid(unsafe_code)]` at `lib.rs:23`). The scan wiring is where this is most fragile, because the existing PAX-read infrastructure is split across two layers with different dependency profiles:
+
+[cols="3,4,2",options="header"]
+|===
+| Artifact | Dependency profile | Usable from native path?
+| `PaxSegmentScanner` + `ScanPredicate` (`crates/storage/proximadb-storage-common/src/pax_block.rs`) | **DataFusion-free** — imports only `proximadb_block_format`, `proximadb_records`, `anyhow`, `serde`, std (`pax_block.rs:38-49`). | **YES** — call directly.
+| `discover_pax_segments` (`src/datafusion/engine_adapters/pax_segment_locator.rs`) | **DataFusion-free** — imports only `std::sync::Arc`, `crate::storage::formats::FileSplit`, `crate::storage::persistence::filesystem::{FilesystemError, FilesystemFactory}` (`pax_segment_locator.rs:19-23`). The file lives under `src/datafusion/` for organizational proximity to `PaxSplitReader`, but it carries NO `datafusion::` import. | **YES** — call as a free function (the `crate::storage::` import path is the stable crate-internal API, not a DataFusion type).
+| `PaxSplitReader` (`src/datafusion/engine_adapters/pax_adapter.rs`) | **DataFusion-typed** — imports `datafusion::error::{DataFusionError, Result as DFResult}`, `datafusion::execution::SendableRecordBatchStream`, `datafusion::physical_expr::PhysicalExpr`, `datafusion::physical_plan::stream::RecordBatchStreamAdapter` (`pax_adapter.rs:41-44`). This is the ADR-039 leakage boundary: it implements the DataFusion `SplitReader` trait and carries `SendableRecordBatchStream`. | **NO** — the native path MUST NOT import it. It would re-leak `datafusion::` into the native engine, regressing BLOCKER-2.
+|===
+
+The design consequence: **the `PaxScanOperator` calls `PaxSegmentScanner::from_bytes` + `next_block()` directly** (the DataFusion-free layer), and replicates the ~30-line decode loop that `PaxSplitReader::decode_segment` (`pax_adapter.rs:131-153`) already contains — but emitting into the contracts-crate `BatchStream` (Arrow `RecordBatch`), not `SendableRecordBatchStream`. This is deliberate duplication, not a missed reuse: the `PaxSplitReader` decode loop is fused to DataFusion error types (`DFResult`) and the `SplitReader` trait signature; extracting it into a shared DataFusion-free helper is a refactor that can land later, but the MVP keeps the boundary clean by reusing only the *leaf* primitives (`PaxSegmentScanner`, `PaxBlockReader`, `col_id`) that are already DataFusion-free. The decode logic (dispatch on `meta.data_type_id` → typed `decode_i64`/`decode_f64`/`decode_str`/`decode_bytes` stripe) is identical; the difference is the error type (`ExecutionError` vs `DataFusionError`) and the stream type (`BatchStream` vs `SendableRecordBatchStream`).
+
+=== The operator: `PaxScanOperator`
+
+A new `impl ExecutionOperator` in `src/query/execution/native_pax_scan.rs`. It is the storage-backed twin of `MemoryScanSource` (`native_ops.rs:250`): where `MemoryScanSource` emits pre-built in-memory `RecordBatch`es, `PaxScanOperator` reads `.pax` segment files lazily and decodes each block into a `RecordBatch` on demand.
+
+[source,rust]
+----
+/// A scan source backed by real `.pax` segment files. Reads segments under
+/// `base_path` (a `DrPathBuilder` tenant-scoped path), applies `ScanPredicate`
+/// zone-map pruning at block granularity, and decodes surviving blocks' stripes
+/// into Arrow `RecordBatch`es — the same `BatchStream` shape `MemoryScanSource`
+/// emits. Non-breaking: replaces `MemoryScanSource` at the same
+/// `ExecutionOperator` seam when the plan's leaf is `PhysicalPlan::Scan`.
+///
+/// MVP: sequential segment scan (no morsel parallelism — that is TD-OLAP-12);
+/// predicate = tenant hash + optional time range (full bloom/range scan-pushdown
+/// is TD-OLAP-3); projection = column-name → `col_id` selection.
+#[derive(Debug)]
+pub(crate) struct PaxScanOperator {
+    /// Tenant-scoped base path from `DrPathBuilder::root_prefix()`
+    /// (`data/{tenant_id}/{namespace_id}/{collection_id}/`). The I/O boundary.
+    base_path: String,
+    /// Block-level predicate for zone-map pruning (tenant hash + time range).
+    scan_predicate: ScanPredicate,
+    /// Column names → PAX `column_id` (`col_id` constants + schema-derived).
+    /// Projection pushdown: only these columns are decoded from each block.
+    projection_col_ids: Vec<i32>,
+    /// Output schema (the projected Arrow columns the pipeline expects).
+    output_schema: SchemaRef,
+    /// Filesystem factory — how the operator reads `.pax` bytes. Obtained from
+    /// the `FilesystemFactory` threaded through `try_vectorized` (see below).
+    filesystem_factory: Arc<FilesystemFactory>,
+}
+----
+
+`execute` (the `ExecutionOperator` contract method at `lib.rs:84`):
+. `discover_pax_segments(&self.base_path, &self.filesystem_factory).await` → `Vec<FileSplit>` (the DataFusion-free locator, one split per `.pax` file).
+. For each `FileSplit`: `filesystem_factory.read(&split.file_path).await` → `Vec<u8>` (the same I/O call `PaxSplitReader::load_bytes` makes at `pax_adapter.rs:113`).
+. `PaxSegmentScanner::from_bytes(bytes, self.scan_predicate)` (`pax_block.rs:802`) — validates the segment magic (`[blocks][index][SEGMENT_MAGIC]`) and parses the block index.
+. `while let Some(reader) = scanner.next_block()` (`pax_block.rs:831`) — `next_block` already applies the `ScanPredicate` zone-map pruning (tenant hash via `reader.tenant_matches(th)`, time range via `reader.time_overlaps(from, to)`), so only blocks that *might* contain matching rows are yielded.
+. For each surviving block: decode the projected columns (`projection_col_ids`) into typed Arrow arrays via `PaxBlockReader`'s stripe-decode API (`decode_i64_stripe`, `decode_f64_stripe`, `decode_str_stripe`, `decode_bytes_stripe` — the same APIs `PaxSplitReader::decode_column` calls at `pax_adapter.rs:165`), build a `RecordBatch`, emit it into the `BatchStream`.
+
+The decode dispatch is on `ColumnMeta.data_type_id` (the `0x03`=I64/`0x02`=F64/`0xff`=varlen convention documented at `pax_adapter.rs:178-185`); the MVP covers the same type set `PaxSplitReader` slice 1 covers (i64/f64/str/bytes — the relational column types). f32 vector-tier decode is slice-2 work for both paths.
+
+=== The predicate bridge: `Expr` → `ScanPredicate`
+
+`PhysicalPlan::Scan` carries `predicate: Option<Expr>` (`proximadb-relational-planner/src/lib.rs:155`) — the full relational predicate, which the planner pushes down for block skipping. `PaxSegmentScanner` consumes `ScanPredicate` (`pax_block.rs:749-758`):
+
+[source,rust]
+----
+/// Predicate context for block-level pruning during segment scans.
+pub struct ScanPredicate {
+    /// If set, skip blocks whose tenant hash doesn't match.
+    pub tenant_hash: Option<u64>,
+    /// If set, skip blocks with no overlap with `[from_ns, to_ns]`.
+    pub time_range: Option<(i64, i64)>,
+}
+----
+
+
+`build_scan_predicate(&Expr, &TenantContext) -> ScanPredicate` translates the pushdown-compatible subset:
+
+. `tenant_hash` ← `ScanPredicate::for_tenant(&tenant_context.tenant_id)` (`pax_block.rs:768`) — always set (the co-design mandate: tenant isolation is structural, not a per-query predicate; every scan under `DrPathBuilder` is tenant-scoped, and the block-level hash prune enforces it at the storage layer as defense-in-depth).
+. `time_range` ← extracted from the `Expr` predicate if it contains a top-level conjunct comparing the `CREATED_AT` column (`col_id::CREATED_AT = 2`, `record.rs:26`) to a literal range (`>`, `>=`, `<`, `<=`, `BETWEEN`). This is the same shape `PaxSplitReader::block_pruned` (`pax_adapter.rs:155`) recognizes; the MVP extracts only the time-range conjunct, leaving the rest of the predicate for the `FilterProjectOperator` to evaluate per-row (correctness-safe: the executor always re-applies the predicate).
+. Any `Expr` not matching the time-range pattern → `ScanPredicate::default()` with only the tenant hash set; the full predicate still applies downstream via `FilterProjectOperator`. This is the ADR-054 §7 contract: *"`ScanPredicate` wiring and the route flip remain follow-up work"* — this phase wires the MVP, not the full TD-OLAP-3 dynamic-filter pushdown.
+
+=== Projection pushdown: column names → `col_id`
+
+`PhysicalPlan::Scan` carries `projection: Option<Vec<String>>` (`lib.rs:151`) — the column names to emit. The PAX format keys stripes by `column_id: i32` (`pax_adapter.rs:79-80`). The translation:
+
+. The canonical `ProximaRecord` columns have stable IDs in the `col_id` module (`record.rs:23-27`): `OID=0`, `TENANT_ID=1`, `CREATED_AT=2`, `UPDATED_AT=3`, `VALID_FROM=4`, `VALID_TO=5`, `ACTOR=6`, `ORIGIN=7`, `PROPS=8`.
+. User-defined columns (the collection's `CatalogTableSchema`) have `column_id`s assigned at write time and recorded in the block's `ColumnMeta`. The `PaxScanOperator` obtains the name→id map from the collection's schema (the same source `PaxSplitReader::new` receives its `name_to_col_id: HashMap<String, i32>` from at `pax_adapter.rs:94`).
+. `projection_col_ids` ← for each name in `Scan.projection`, look up its `col_id`; only those stripes are decoded from each block (the decode loop at step 5 above iterates `projection_col_ids`, not all `ColumnMeta`).
+
+=== `TenantContext` + `DrPathBuilder` (the co-design mandate)
+
+The scan reads under `DrPathBuilder` (`data/{tenant_id}/{namespace_id}/{collection_id}/...`) and carries `TenantContext` (isolation + billing) to the I/O boundary. This is non-negotiable (CLAUDE.md mandate #16a + the co-design mandate #3: *"Isolation is structural, never a per-query predicate"*).
+
+. `base_path` ← `DrPathBuilder::build(namespace, collection_id)?.root_prefix()` (`path_resolver.rs:382, 873`). The `root_prefix()` method produces `data/{tenant_id}/{namespace_id}/{collection_id}/` (or the typed-path variant under ADR-031 when enabled).
+. `tenant_hash` ← `fnv1a_hash(&tenant_context.tenant_id)` (the hash function `ScanPredicate::for_tenant` uses at `pax_block.rs:768`), set on every `ScanPredicate` for the block-level tenant prune.
+. The `FilesystemFactory` is obtained from the engine's storage handle (the same `FilesystemFactory` `PaxSplitReader::new` receives at `pax_adapter.rs:94`), threaded through `try_vectorized` (see below).
+
+=== Threading `ReaderFactory`/`FilesystemFactory` into `try_vectorized`
+
+The current `try_vectorized` signature (`native_engine.rs:47`) takes only `&PhysicalPlan`:
+
+[source,rust]
+----
+pub async fn try_vectorized(
+    physical: &PhysicalPlan,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError>;
+----
+
+
+This is sufficient for Phase 2 (`Values` needs no storage), but Phase 2.5's `PaxScanOperator` needs:
+. The `FilesystemFactory` (to call `discover_pax_segments` + `read`).
+. The `TenantContext` (to build the `DrPathBuilder` path + the `ScanPredicate` tenant hash).
+. The collection's schema / name→`col_id` map (for projection pushdown).
+
+The call site (`engine.rs:293`) already has the `factory: &F` (`F: ReaderFactory`, `engine.rs:281`). The signature extension:
+
+[source,rust]
+----
+pub async fn try_vectorized<F: ReaderFactory>(
+    physical: &PhysicalPlan,
+    factory: &F,
+    tenant: &TenantContext,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError>;
+----
+
+
+The `FilesystemFactory` is obtained from the engine's storage infrastructure (the same handle `PaxSplitReader` receives — the `NativeVolcanoEngine` or its caller has access to the `FilesystemFactory` via the storage engine). The MVP threads it through; the exact plumbing (whether via `ReaderFactory` extension or a separate `StorageContext` struct) is an implementation detail settled at PR time, but the contract is: `try_vectorized` receives the storage access it needs to build a `PaxScanOperator`, and declines (`Ok(None)`) if the storage shape is not PAX-backed.
+
+=== `lower_physical`: the `PhysicalPlan::Scan` arm
+
+The `walk` function (`native_ops.rs:761`) currently matches `Values`, `Filter`, `Project`, `Aggregate`, `Limit`, and falls through to `other => Err(NotImplemented)` at line 882 for everything else (including `Scan`). Phase 2.5 adds a `PhysicalPlan::Scan` arm.
+
+The structural change: `Walked.source` (`native_ops.rs:700`) is currently hardcoded to `MemoryScanSource`. To accept either source type, it must become `Box<dyn ExecutionOperator>` (the contracts trait both `MemoryScanSource` and `PaxScanOperator` implement). This is the non-breaking seam TD-OLAP-10 §"Components" anticipated: *"Phase 2.5 swaps [MemoryScanSource] for a real scan operator behind the same `ExecutionOperator` seam (non-breaking)."*
+
+[source,rust]
+----
+struct Walked {
+    source: Box<dyn ExecutionOperator>,   // was: MemoryScanSource
+    ops: Vec<OpSpec>,
+    cur_schema: SchemaRef,
+    limit: Option<LimitSpec>,
+}
+----
+
+The new `Scan` arm in `walk`:
+
+[source,rust]
+----
+PhysicalPlan::Scan {
+    table, output_schema, projection, predicate, access, ..
+} => {
+    // Decline non-PAX tables (the vectorized path's value is the Arrow-native
+    // PAX scan; a row-based Volcano source converting row→Arrow is wasteful).
+    if !is_pax_backed(table, factory) {
+        return Err(ExecutionError::NotImplemented("non-PAX Scan".into()));
+    }
+    let base_path = dr_path_for(table, tenant)?;
+    let scan_predicate = build_scan_predicate(predicate.as_ref(), tenant);
+    let projection_col_ids = resolve_projection(projection, table, factory)?;
+    let output_schema = relational_schema_to_arrow(output_schema);
+    let source = Box::new(PaxScanOperator::new(
+        base_path, scan_predicate, projection_col_ids,
+        output_schema.clone(), filesystem_factory,
+    ));
+    Ok(Walked { source, ops: Vec::new(), cur_schema: output_schema, limit: None })
+}
+----
+
+The `is_pax_backed` check: a table is PAX-backed when its storage layout uses the PAX block format (SST engine `.pax` segments per ADR-049 M1). The MVP uses the engine type / collection config to decide; non-PAX (e.g. in-memory snapshots served by `InMemoryReader`, Parquet/Iceberg tables served by DataFusion) → decline → `Ok(None)` → Volcano (or DataFusion for Parquet-backed, per the coarse router).
+
+== Rollout (default-off, flag-gated, ledger-gated)
+
+. Gate: `PROXIMADB_NATIVE_VECTORIZED` (default OFF — unchanged from Phase 2; the same flag). `try_vectorized` is a no-op until set. The `PaxScanOperator` path is reached only when the flag is ON AND the plan has a PAX-backed `Scan` leaf.
+. Shadow: `PROXIMADB_NATIVE_VECTORIZED_SHADOW` (default OFF — the Phase 2 shadow harness, TD-OLAP-10 §"Shadow comparison"). Runs the vectorized path, then also runs the Volcano, compares row sets, logs the mismatch rate. A PAX-scan shape with mismatch rate > 0.1% auto-demotes. This is the promotion gate once the scan wiring lands.
+. Promotion (per ADR-054 §8 Phase 2.5 gate): the vectorized scan path is eligible to default-on only when the TD-OLAP-4 ledger shows **≥ parity vs the Volcano on PAX-backed scan/filter/project/aggregate, with TPC-H/TPC-DS conformance unchanged and ClickBench q07 not regressed**. Phase 2.5 itself does not flip the default — it lands the capability + the benchmark harness; the flip is a separate, evidence-gated decision.
+
+== Verification
+
+*Unit (in `native_pax_scan.rs`):*
+* `pax_scan_decodes_segment_to_record_batch` — write a small `.pax` segment via `PaxSegmentWriter` (the test helper `pax_adapter.rs:307` already uses), `PaxScanOperator::execute` reads it, assert the emitted `RecordBatch` column values match. Exercises the decode loop without a filesystem (in-memory bytes).
+* `scan_predicate_prunes_by_tenant_hash` — a 2-block segment where one block's tenant hash does not match; assert `next_block` skips it (the `ScanPredicate` zone-map prune at `pax_block.rs:831`).
+* `scan_predicate_prunes_by_time_range` — a 2-block segment where one block's `CREATED_AT` range is outside the predicate window; assert it is skipped.
+* `projection_pushdown_decodes_only_requested_columns` — a segment with columns A/B/C; `projection_col_ids = [A]`; assert only column A is decoded (B/C stripes are not touched).
+* `build_scan_predicate_extracts_time_range` — an `Expr` with `CREATED_AT > 1000 AND CREATED_AT < 2000` → `ScanPredicate { time_range: Some((1000, 2000)), .. }`.
+* `non_pax_scan_declines` — a `PhysicalPlan::Scan` whose table is not PAX-backed → `lower_physical` returns `Err(NotImplemented)` → `try_vectorized` returns `Ok(None)`.
+
+*Integration (`try_vectorized` wire):*
+* `vectorized_serves_pax_scan_filter_project` — `PROXIMADB_NATIVE_VECTORIZED=1`, a PAX-backed collection with N rows, plan `Project{Filter{Scan}}`; assert result rows equal the Volcano's on the same plan. This is the serveability proof.
+* `vectorized_serves_pax_scan_aggregate` — `PROXIMADB_NATIVE_VECTORIZED=1`, a PAX-backed collection, plan `Aggregate{Scan}` (COUNT/SUM/GROUP BY); assert result rows equal the Volcano's (exercises the Phase 2 `HashAggregateOperator` over a real scan source, not just `MemoryScanSource`).
+
+*Benchmark (#[ignore], run on demand, feeds the ledger):*
+* `pax_scan_filter_project_throughput` — a 1M-row PAX-backed collection, `Filter{x>500000}`+`Project{[x]}`; wall-time the vectorized path vs `NativeVolcanoEngine::execute_physical` on the identical `PhysicalPlan`. Target: parity-or-better (the zone-map prune + Arrow-native decode should not be slower than the Volcano's row-at-a-time path). The number goes into the TD-OLAP-4 ledger as the Phase 2.5 evidence row.
+* `pax_scan_aggregate_throughput` — same collection, `COUNT(*)` + `GROUP BY`; exercises the blocking aggregate over a real scan.
+
+*Gates (local, before push):* `rustup run 1.95.0 cargo fmt --all --check` (pre-push hook); `cargo clippy --lib --bins`; `check_td_adr_unique.py`; **the zero-DataFusion-leakage ratchet**: `grep -rn "datafusion::" src/query/execution/native_pax_scan.rs src/query/execution/native_ops.rs src/query/execution/native_engine.rs` → empty. The `PaxScanOperator` imports `proximadb_block_format`, `proximadb_storage_common`, and `arrow` — never `datafusion::`.
+
+== Risks + mitigations
+
+* **DataFusion leakage regression (BLOCKER-2).** The existing `PaxSplitReader` is the leakage boundary; copying its decode loop into `PaxScanOperator` risks pulling `datafusion::` types along. Mitigation: the `PaxScanOperator` imports only `PaxSegmentScanner` + `PaxBlockReader` + `col_id` (all in DataFusion-free crates) and `arrow` (the data plane, not DataFusion). The `grep` gate above is the CI ratchet. If a shared decode helper is later extracted, it must live in `proximadb-storage-common` (DataFusion-free), not `src/datafusion/`.
+* **Decode-loop duplication.** `PaxSplitReader::decode_segment` and `PaxScanOperator::execute` will share ~30 lines of identical decode dispatch. Mitigation: this is deliberate (the error-type + stream-type boundary forces it for the MVP); extracting a shared helper is a follow-up that must land in the DataFusion-free crate, not as a cross-boundary import. The duplication is bounded (one decode loop, well-tested on both sides).
+* **Path/isolation correctness.** A bug in `DrPathBuilder` path construction or `tenant_hash` computation would break isolation (read the wrong tenant's data) or correctness (prune all blocks). Mitigation: the `scan_predicate_prunes_by_tenant_hash` test pins the hash behavior; the integration test cross-checks against the Volcano (which already reads under `DrPathBuilder`); the shadow comparison catches any row-set mismatch at runtime.
+* **Over-claiming a win.** The temptation is to present Phase 2.5 as "the native engine is now faster on real storage." The Volcano is already competitive on Q1/Q6-shaped scans (ADR-054 §1.3.4). Mitigation: the TD + the ledger row state parity-or-better explicitly; the win is serveability (the vectorized path now handles real queries) + the reusable scan leaf (for TD-OLAP-11's join), not a latency win on scan-only shapes. Promotion is gated on parity-or-better, and the narrative in any status doc must say "serveable, the scan is competitive."
+* **Scope creep into TD-OLAP-3 (bloom/range scan-pushdown).** Full dynamic-filter scan-pushdown (a join build's bloom filter pushed into the probe-side scan) is structurally tempting to add here. Mitigation: the MVP predicate is the static `ScanPredicate` (tenant + time); the `PaxScanOperator` carries the hook for TD-OLAP-3's runtime filter but does not implement it. TD-OLAP-3 is a separate, dependency-ordered TD.
+* **`try_vectorized` signature change ripple.** Adding `F: ReaderFactory` + `&TenantContext` to `try_vectorized` changes the signature at `native_engine.rs:47` and the call site at `engine.rs:293`. Mitigation: the call site already has both (`factory: &F` at `engine.rs:282`, and the tenant context is available in the request scope). The change is local (one caller). Test callers that exercise `try_vectorized` directly must update — verify with `cargo check --tests` (the standard signature-change gotcha).
+
+== Non-goals (deferred)
+
+* **TD-OLAP-3 runtime-filter/bloom scan-pushdown** — the dynamic filter from a join build pushed into the probe-side scan. The MVP carries the hook (`ExecutionOperator`'s `accepts_runtime_filter()` per ADR-054 §3.2); the implementation is TD-OLAP-3.
+* **Multi-segment parallel scans (morsel scheduler)** — TD-OLAP-12. The MVP scans segments sequentially within one stream; parallel segment scans (one morsel per `.pax` file) land with the `MorselScheduler`.
+* **Non-PAX vectorization** — row-based sources (in-memory snapshots, Parquet) stay on the Volcano / DataFusion respectively. Converting row→Arrow for the vectorized path is wasteful (TD-OLAP-10 stated this); the vectorized path's value is the Arrow-native PAX scan.
+* **f32 vector-tier decode** — the MVP covers the relational column types (i64/f64/str/bytes, matching `PaxSplitReader` slice 1). f32 vector-tier stripe decode is slice-2 work for both the DataFusion and native paths (it is not a regression — neither path decodes f32 vector tiers today).
+* **The hash join (TD-OLAP-11)** — this phase provides the scan leaf the join will consume, but does not implement the join itself.
+* **Default-on flip** — separate, ledger-gated.


### PR DESCRIPTION
Design TD for wiring REAL storage into the native vectorized execution path (`try_vectorized` serves actual PAX-backed tables, not just `PhysicalPlan::Values`).

## Summary

Phase 2 (TD-OLAP-10) proved the pipeline mechanics — `FilterProjectOperator` + `HashAggregateOperator` + `PhysExpr` lowering — but only on `PhysicalPlan::Values` (in-memory literal tables). `PhysicalPlan::Scan` falls through to the catch-all `Err(NotImplemented)` at `native_ops.rs:882` → `Ok(None)` → Volcano fallback. The vectorized path serves **zero production queries today** — every real query has a `Scan` leaf.

Phase 2.5 defines the storage seam: `PaxScanOperator`, a new `impl ExecutionOperator` that calls the already-DataFusion-free `PaxSegmentScanner` + `discover_pax_segments` directly, threads `TenantContext` + `DrPathBuilder`, translates `Scan.predicate` (`Expr`) into `ScanPredicate` for block-level zone-map pruning, and emits `RecordBatch`es into the same `BatchStream`.

## Design highlights (all verified against develop, cited file:line)

- **`PaxSegmentScanner`** (`pax_block.rs:787,802,831`) + **`ScanPredicate`** (`:749`) are DataFusion-free — the native fit (Arrow in, Arrow out, zero conversion).
- **`discover_pax_segments`** (`pax_segment_locator.rs:27`) is DataFusion-free (imports only `FileSplit` + `FilesystemFactory`) despite living under `src/datafusion/` — usable directly.
- **`PaxSplitReader`** (`pax_adapter.rs:41-44`) is the ADR-039 leakage boundary — the native scan MUST NOT import it (carries `SendableRecordBatchStream`/`PhysicalExpr`); instead replicate the ~30-line decode loop in `ExecutionError` space (deliberate duplication at the type boundary).
- **`Walked.source`** (`native_ops.rs:700`) generalized `MemoryScanSource` → `Box<dyn ExecutionOperator>` (the non-breaking seam TD-OLAP-10 anticipated).
- **`try_vectorized`** signature extends to accept `ReaderFactory` + `TenantContext` (the call site at `engine.rs:293` already has both).

## MVP scope vs deferred

**MVP:** PAX-backed Scan only; predicate = tenant hash + time range (zone-map prune); projection via `col_id`.

**Deferred:** TD-OLAP-3 bloom/range scan-pushdown, TD-OLAP-12 morsel parallel segments, non-PAX vectorization, f32 vector-tier decode (slice-2 for both paths).

## Gates

- `check_td_adr_unique.py`: 0 errors (169 TD ids)
- `cargo fmt --all --check` (1.95.0): clean
- Doc-only PR (no code changes)

Relates to: ADR-054 §8 Phase 2.5, TD-OLAP-10 (the substrate), TD-OLAP-1 (PAX scan wedge), TD-OLAP-11 (join — consumes this scan), TD-OLAP-3 (runtime filters — deferred).