### PR TITLE
chore: remove more dead deprecated aliases (zero callers)

### DIFF
--- a/crates/foundation/proximadb-data-model/src/lib.rs
+++ b/crates/foundation/proximadb-data-model/src/lib.rs
@@ -66,13 +66,6 @@ impl std::fmt::Display for DataModel {
     }
 }
 
-/// Legacy alias for [`DataModel`]. Use `DataModel` in new code.
-#[deprecated(
-    since = "0.2.0",
-    note = "Renamed to DataModel per Overhaul Spec Section 3.3"
-)]
-pub type StoreType = DataModel;
-
 // ---------------------------------------------------------------------------
 // Typed Semantic Memory (Memanto — TD-055)
 // ---------------------------------------------------------------------------

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -20,15 +20,11 @@ pub use federated_delegation_complete::{
 pub use rbac::{EnhancedRBACManager, Permission, TenantRole};
 pub use sso::{EnterpriseUserContext, SSOIntegrationManager, SSOProvider, SSOToken};
 
+use crate::security::rbac_service::{UnifiedAuthMethod, UnifiedPermission, UnifiedUserContext};
 use crate::security::security_coordinator::{
     AuthorizedContext as SecurityAuthorizedContext, SessionMetadata as SecuritySessionMetadata,
 };
 use anyhow::Result;
-#[deprecated(
-    note = "Canonical security result type now lives in crate::security::SecurityAuthenticationResult."
-)]
-pub type SecurityAuthenticationResult = crate::security::SecurityAuthenticationResult;
-use crate::security::rbac_service::{UnifiedAuthMethod, UnifiedPermission, UnifiedUserContext};
 
 /// Enterprise authentication coordinator
 pub struct EnterpriseAuthManager {
@@ -114,13 +110,6 @@ pub enum AuthorizedOperation {
     },
     // Additional operations to be added
 }
-
-#[deprecated(
-    note = "Moved to crate::security::security_coordinator::AuthorizedContext. \
-            Auth shim retained temporarily during consolidation."
-)]
-/// Temporary compatibility alias for phased auth/security migration.
-pub type AuthorizedContext = crate::security::security_coordinator::AuthorizedContext;
 
 fn map_authorized_operation_permission(operation: &AuthorizedOperation) -> UnifiedPermission {
     match operation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,11 +367,6 @@ pub use storage::formats::{
 /// for API-layer conversion (REST status codes, gRPC status).
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Legacy boxed result type kept for gradual migration of call sites
-/// that cannot yet propagate the typed error.
-#[deprecated(note = "Use the typed `Result<T>` alias instead of boxed errors")]
-pub type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
-
 // Re-export the main database instance from the database module
 pub use database::ProximaDB;
 

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -43,9 +43,6 @@ pub use encryption::{
     KeyInfo, KeyStore, KeyStoreConfig, KeyStoreError,
 };
 
-#[allow(deprecated)]
-#[deprecated(note = "Use TypeValidationResult instead.")]
-pub use validation::ValidationResult;
 pub use validation::{
     BinaryValidator, CollectionNameValidator, DecimalValidator, FieldValidationConfig,
     JsonValidator, MetadataValidationConfig, MetadataValidator, TimestampValidator,

--- a/src/security/validation/mod.rs
+++ b/src/security/validation/mod.rs
@@ -57,9 +57,6 @@ pub use text_validator::{
     TextStorageValidationConfig, TextStorageValidationResult, TextValidationError, TextValidator,
     TextValidatorBuilder,
 };
-#[allow(deprecated)]
-#[deprecated(note = "Use TypeValidationResult instead.")]
-pub use type_validators::ValidationResult;
 pub use type_validators::{
     BinaryValidator, DecimalValidator, FieldValidationConfig, JsonValidator, TimestampValidator,
     TypeValidationResult, TypedValueValidator, UuidValidator, ValidationError,

--- a/src/security/validation/type_validators.rs
+++ b/src/security/validation/type_validators.rs
@@ -42,11 +42,6 @@ use std::collections::HashMap;
 /// Canonical validation result type for security field validators.
 pub type TypeValidationResult = Result<(), ValidationError>;
 
-/// Compatibility alias retained for existing imports; prefer `TypeValidationResult` for
-/// explicit type-surface locality.
-#[deprecated(note = "Use TypeValidationResult instead.")]
-pub type ValidationResult = TypeValidationResult;
-
 /// Validation error with details
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ValidationError {


### PR DESCRIPTION
Second pass of dead-deprecated removal (follows #771). Five more deprecated aliases with **zero external callers** — the only refs were the definitions, their re-exports, or unrelated same-named types. Pure deletions, no behavior change. Net **−34 lines**.

## Removed

| Alias | Location | Canonical |
|---|---|---|
| `BoxedResult<T>` | `src/lib.rs` | typed `Result<T>` |
| `StoreType` | `proximadb-data-model` | `DataModel` |
| `auth::SecurityAuthenticationResult` | `auth/mod.rs` | `security::SecurityAuthenticationResult` |
| `auth::AuthorizedContext` | `auth/mod.rs` | `security::security_coordinator::AuthorizedContext` |
| `security::validation::ValidationResult` (+ 2 re-exports) | `type_validators.rs`, `validation/mod.rs`, `security/mod.rs` | `TypeValidationResult` |

## Note on `ValidationResult`

It's a 4-way overloaded name (security / restore / query / sql each define their own `ValidationResult` alias). Only the **security** one was deprecated, and it had zero external callers — the others are active aliases for their domains (not deprecated, not touched).

## Verification

`cargo check --tests` (the gate that caught test-ref breakage in #771), `clippy --lib --bins -D warnings`, and `rustup 1.95.0 fmt --check` — all clean.