### PR TITLE
feat(engine): ADR-054 Phase 3 — native hash-join operators (TD-OLAP-11)

### DIFF
--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -12,6 +12,7 @@ pub mod engine;
 pub mod executor;
 pub mod low_latency_executor;
 pub mod native_engine;
+pub mod native_join_ops;
 pub mod native_ops;
 pub mod olap_delta_merge;
 pub mod plan_cache;

--- a/src/query/execution/native_join_ops.rs
+++ b/src/query/execution/native_join_ops.rs
@@ -59,7 +59,7 @@ fn canonical_key_bytes(
 }
 
 /// Typed downcast that errors (never panics) — the repo's panic-policy forbids
-/// `.unwrap()` on `downcast_ref`. (A macro, not a generic fn, to avoid the
+/// the unwrap-on-downcast idiom. (A macro, not a generic fn, to avoid the
 /// downcast `'static` lifetime-bound friction.)
 macro_rules! dcast {
     ($array:expr, $t:ty) => {

--- a/src/query/execution/native_join_ops.rs
+++ b/src/query/execution/native_join_ops.rs
@@ -1,0 +1,417 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+//! # Native hash-join operators (ADR-054 Phase 3, TD-OLAP-11)
+//!
+//! The native radix/bloom/spill hash join — the #1 performance lever (closes the
+//! Q3/Q14 join gap). MVP (Phase 3.0): **in-memory, single non-partitioned hash
+//! table** (size-gated radix is a later sub-phase; spill is Phase 3.1).
+//!
+//! Three operators across two pipelines (the build pipeline drains first and
+//! publishes `Arc<JoinHashTable>` via a shared `OnceLock`; the probe pipeline
+//! reads it):
+//! * [`HashJoinBuildOperator`] — BLOCKING. Consumes the build side, builds the
+//!   `key → build-row-indices` map + a bloom over the build keys, publishes.
+//! * [`HashJoinProbeOperator`] — STREAMING. Per probe batch: bloom pre-filter →
+//!   hash-table lookup → late-materialize matched pairs via `arrow::compute::take`.
+//!
+//! MVP `JoinKind`: Inner / Left / Semi / Anti. Right / Full (unmatched-build
+//! drain) + spill + radix are deferred (see TD-OLAP-11). NULL join keys never
+//! match in any kind.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use arrow::array::{Array, ArrayRef, RecordBatch, UInt32Array};
+use arrow::compute::{concat_batches, take};
+use arrow::datatypes::{DataType, SchemaRef};
+use async_trait::async_trait;
+use futures::stream::StreamExt;
+use proximadb_bloom::{BloomFilterBuilder, BloomFilterStrategy};
+use proximadb_execution_contracts::{BatchStream, ExecutionError, ExecutionOperator};
+use proximadb_relational_algebra::JoinKind;
+
+/// Minimum build-side cardinality to bother building a bloom (below this the
+/// hash table is small enough that the bloom's overhead isn't worth it).
+const BLOOM_MIN_KEYS: usize = 1024;
+
+// =========================================================================
+// Key encoding + the hash table
+// =========================================================================
+
+/// Canonical byte encoding of a composite join key at `row` across `columns`.
+/// Returns `None` if ANY key column is NULL at that row (NULL keys never match).
+fn canonical_key_bytes(
+    columns: &[&dyn Array],
+    row: usize,
+) -> Result<Option<Vec<u8>>, ExecutionError> {
+    let mut buf = Vec::new();
+    for col in columns {
+        if col.is_null(row) {
+            return Ok(None);
+        }
+        encode_cell(*col, row, &mut buf)?;
+        buf.push(0); // separator (multi-column keys)
+    }
+    Ok(Some(buf))
+}
+
+/// Typed downcast that errors (never panics) — the repo's panic-policy forbids
+/// `.unwrap()` on `downcast_ref`. (A macro, not a generic fn, to avoid the
+/// downcast `'static` lifetime-bound friction.)
+macro_rules! dcast {
+    ($array:expr, $t:ty) => {
+        $array.as_any().downcast_ref::<$t>().ok_or_else(|| {
+            ExecutionError::Execution(format!(
+                "arrow downcast failed for {:?}",
+                $array.data_type()
+            ))
+        })?
+    };
+}
+
+/// Encode one non-null cell to `out` in a canonical, type-stable byte form.
+fn encode_cell(array: &dyn Array, row: usize, out: &mut Vec<u8>) -> Result<(), ExecutionError> {
+    use arrow::array::*;
+    match array.data_type() {
+        DataType::Boolean => out.push(dcast!(array, BooleanArray).value(row) as u8),
+        DataType::Int8 => out.push(dcast!(array, Int8Array).value(row) as u8),
+        DataType::Int16 => {
+            out.extend_from_slice(&dcast!(array, Int16Array).value(row).to_le_bytes())
+        }
+        DataType::Int32 => {
+            out.extend_from_slice(&dcast!(array, Int32Array).value(row).to_le_bytes())
+        }
+        DataType::Int64 => {
+            out.extend_from_slice(&dcast!(array, Int64Array).value(row).to_le_bytes())
+        }
+        DataType::UInt8 => out.push(dcast!(array, UInt8Array).value(row)),
+        DataType::UInt16 => {
+            out.extend_from_slice(&dcast!(array, UInt16Array).value(row).to_le_bytes())
+        }
+        DataType::UInt32 => {
+            out.extend_from_slice(&dcast!(array, UInt32Array).value(row).to_le_bytes())
+        }
+        DataType::UInt64 => {
+            out.extend_from_slice(&dcast!(array, UInt64Array).value(row).to_le_bytes())
+        }
+        DataType::Float32 => {
+            out.extend_from_slice(&dcast!(array, Float32Array).value(row).to_le_bytes())
+        }
+        DataType::Float64 => {
+            out.extend_from_slice(&dcast!(array, Float64Array).value(row).to_le_bytes())
+        }
+        DataType::Utf8 => out.extend_from_slice(dcast!(array, StringArray).value(row).as_bytes()),
+        DataType::LargeUtf8 => {
+            out.extend_from_slice(dcast!(array, LargeStringArray).value(row).as_bytes())
+        }
+        DataType::Binary => out.extend_from_slice(dcast!(array, BinaryArray).value(row)),
+        other => {
+            return Err(ExecutionError::NotImplemented(format!(
+                "join key type {other:?} not supported in native hash join"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The build side's hash table: composite-key bytes → build-side row indices.
+/// Plus the (concatenated) build batch for materializing matched rows, and an
+/// optional bloom over the build keys.
+pub(crate) struct JoinHashTable {
+    pub map: HashMap<Vec<u8>, Vec<u32>>,
+    pub build_batch: RecordBatch,
+    pub bloom: Option<Arc<dyn BloomFilterStrategy>>,
+}
+
+impl std::fmt::Debug for JoinHashTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JoinHashTable")
+            .field("groups", &self.map.len())
+            .field("build_rows", &self.build_batch.num_rows())
+            .field("has_bloom", &self.bloom.is_some())
+            .finish()
+    }
+}
+
+// =========================================================================
+// HashJoinBuildOperator (BLOCKING)
+// =========================================================================
+
+/// Builds the hash table + bloom from the build side, then publishes it via the
+/// shared `table_slot` (the cross-pipeline handoff to the probe operator).
+#[derive(Debug)]
+pub(crate) struct HashJoinBuildOperator {
+    pub build_keys: Vec<usize>,
+    pub build_schema: SchemaRef,
+    pub table_slot: Arc<OnceLock<Arc<JoinHashTable>>>,
+    pub bloom_enabled: bool,
+}
+
+#[async_trait]
+impl ExecutionOperator for HashJoinBuildOperator {
+    fn output_schema(&self) -> SchemaRef {
+        self.build_schema.clone()
+    }
+
+    fn is_blocking(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let build_keys = self.build_keys.clone();
+        let build_schema = self.build_schema.clone();
+        let bloom_enabled = self.bloom_enabled;
+        let table_slot = self.table_slot.clone();
+
+        let batches: Vec<RecordBatch> = input
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()?;
+        let build_batch = if batches.is_empty() {
+            RecordBatch::new_empty(build_schema.clone())
+        } else if batches.len() == 1 {
+            batches
+                .into_iter()
+                .next()
+                .ok_or_else(|| ExecutionError::Execution("join build: empty batch iter".into()))?
+        } else {
+            concat_batches(&build_schema, batches.iter())
+                .map_err(|e| ExecutionError::Execution(format!("join build concat: {e}")))?
+        };
+
+        // Build key → row-indices map; collect key bytes for the bloom.
+        let key_cols: Vec<&dyn Array> = build_keys
+            .iter()
+            .map(|&c| build_batch.column(c).as_ref())
+            .collect();
+        let mut map: HashMap<Vec<u8>, Vec<u32>> = HashMap::new();
+        let mut all_keys: Vec<Vec<u8>> = Vec::new();
+        for r in 0..build_batch.num_rows() {
+            if let Some(kb) = canonical_key_bytes(&key_cols, r)? {
+                map.entry(kb.clone()).or_default().push(r as u32);
+                all_keys.push(kb);
+            } // NULL build keys → never match; absent from the map.
+        }
+
+        // Bloom over the build keys (build-then-freeze: insert under &mut, then Arc).
+        let bloom: Option<Arc<dyn BloomFilterStrategy>> =
+            if bloom_enabled && all_keys.len() >= BLOOM_MIN_KEYS {
+                let cfg = proximadb_bloom::CoreBloomFilterConfig {
+                    expected_items: all_keys.len(),
+                    ..Default::default()
+                };
+                let mut b = BloomFilterBuilder::new(cfg).build();
+                for kb in &all_keys {
+                    b.insert(kb);
+                }
+                Some(Arc::from(b))
+            } else {
+                None
+            };
+
+        let table = Arc::new(JoinHashTable {
+            map,
+            build_batch,
+            bloom,
+        });
+        // Publish (first writer wins; there is exactly one build pipeline).
+        let _ = table_slot.set(table);
+
+        // The build emits nothing the probe consumes; emit an empty sentinel so the
+        // pipeline drains cleanly.
+        let empty = RecordBatch::new_empty(build_schema);
+        Ok(Box::pin(futures::stream::once(async move { Ok(empty) })))
+    }
+}
+
+// =========================================================================
+// HashJoinProbeOperator (STREAMING)
+// =========================================================================
+
+/// Streams probe batches: bloom pre-filter → hash-table lookup → late-materialize.
+/// MVP `JoinKind`: Inner / Left / Semi / Anti.
+#[derive(Debug)]
+pub(crate) struct HashJoinProbeOperator {
+    pub table_slot: Arc<OnceLock<Arc<JoinHashTable>>>,
+    pub probe_keys: Vec<usize>,
+    /// Column ordinals to emit, in output order, as (source, ordinal):
+    /// `Probe(ordinal)` or `Build(ordinal)`.
+    pub output_columns: Vec<JoinColumn>,
+    pub kind: JoinKind,
+    pub output_schema: SchemaRef,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum JoinColumn {
+    Probe(usize),
+    Build(usize),
+}
+
+#[async_trait]
+impl ExecutionOperator for HashJoinProbeOperator {
+    fn output_schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    async fn execute(&self, input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let table = self
+            .table_slot
+            .get()
+            .ok_or_else(|| {
+                ExecutionError::Execution("join probe ran before build published".into())
+            })?
+            .clone();
+        let probe_keys = self.probe_keys.clone();
+        let output_columns = self.output_columns.clone();
+        let kind = self.kind;
+        let output_schema = self.output_schema.clone();
+
+        Ok(Box::pin(input.map(move |result| {
+            let probe_batch = result?;
+            probe_one_batch(
+                &table,
+                &probe_batch,
+                &probe_keys,
+                &output_columns,
+                kind,
+                &output_schema,
+            )
+        })))
+    }
+}
+
+/// Probe one batch against the table; late-materialize the output via `take`.
+fn probe_one_batch(
+    table: &JoinHashTable,
+    probe_batch: &RecordBatch,
+    probe_keys: &[usize],
+    output_columns: &[JoinColumn],
+    kind: JoinKind,
+    output_schema: &SchemaRef,
+) -> Result<RecordBatch, ExecutionError> {
+    let probe_key_cols: Vec<&dyn Array> = probe_keys
+        .iter()
+        .map(|&c| probe_batch.column(c).as_ref())
+        .collect();
+    let nrows = probe_batch.num_rows();
+
+    // Gather matched (probe_row, [build_rows]) into index lists.
+    let mut probe_idx: Vec<u32> = Vec::new(); // probe row index per emitted output row (Inner)
+    let mut build_idx: Vec<u32> = Vec::new(); // matched build row index per emitted output row (Inner)
+    let mut left_unmatched: Vec<u32> = Vec::new(); // probe rows with NO match (Left/Anti)
+
+    for r in 0..nrows {
+        let kb_opt = canonical_key_bytes(&probe_key_cols, r)?;
+        let matched = match kb_opt {
+            None => Vec::new(), // NULL probe key → no match
+            Some(kb) => {
+                // Bloom pre-filter: skip the hash-table lookup if the bloom says no.
+                if let Some(b) = &table.bloom {
+                    if !b.might_contain(&kb) {
+                        Vec::new()
+                    } else {
+                        table.map.get(&kb).cloned().unwrap_or_default()
+                    }
+                } else {
+                    table.map.get(&kb).cloned().unwrap_or_default()
+                }
+            }
+        };
+        if matched.is_empty() {
+            left_unmatched.push(r as u32);
+        } else {
+            for br in matched {
+                probe_idx.push(r as u32);
+                build_idx.push(br);
+            }
+        }
+    }
+
+    let probe_indices = UInt32Array::from(probe_idx);
+    let build_indices = UInt32Array::from(build_idx);
+
+    let columns: Vec<ArrayRef> = match kind {
+        JoinKind::Inner => {
+            // One output row per (probe row, matched build row).
+            output_columns
+                .iter()
+                .map(|jc| match jc {
+                    JoinColumn::Probe(c) => {
+                        take(probe_batch.column(*c).as_ref(), &probe_indices, None)
+                    }
+                    JoinColumn::Build(c) => {
+                        take(table.build_batch.column(*c).as_ref(), &build_indices, None)
+                    }
+                })
+                .collect::<Result<_, _>>()
+                .map_err(|e| ExecutionError::Execution(format!("join take: {e}")))?
+        }
+        JoinKind::Left => {
+            // Matched pairs + unmatched probe rows (build cols NULL-padded).
+            let n_unmatched = left_unmatched.len();
+            let matched_probe = &probe_indices;
+            let unmatched_probe = UInt32Array::from(left_unmatched);
+            output_columns
+                .iter()
+                .map(|jc| match jc {
+                    JoinColumn::Probe(c) => {
+                        let col = probe_batch.column(*c);
+                        let matched = take(col.as_ref(), matched_probe, None)?;
+                        let unmatched = take(col.as_ref(), &unmatched_probe, None)?;
+                        arrow::compute::concat(&[matched.as_ref(), unmatched.as_ref()])
+                    }
+                    JoinColumn::Build(c) => {
+                        let col = table.build_batch.column(*c);
+                        let matched = take(col.as_ref(), &build_indices, None)?;
+                        let nulls = arrow::array::new_null_array(col.data_type(), n_unmatched);
+                        arrow::compute::concat(&[matched.as_ref(), nulls.as_ref()])
+                    }
+                })
+                .collect::<Result<_, _>>()
+                .map_err(|e| ExecutionError::Execution(format!("join left take: {e}")))?
+        }
+        JoinKind::Semi | JoinKind::Anti => {
+            // Emit probe rows where a match exists (Semi) or doesn't (Anti).
+            let emitted = if matches!(kind, JoinKind::Semi) {
+                // probe rows with ≥1 match = all probe rows referenced by probe_idx.
+                dedup_sorted(&probe_indices)
+            } else {
+                // Anti = unmatched probe rows.
+                left_unmatched.clone()
+            };
+            let idx = UInt32Array::from(emitted);
+            output_columns
+                .iter()
+                .map(|jc| match jc {
+                    JoinColumn::Probe(c) => take(probe_batch.column(*c).as_ref(), &idx, None),
+                    JoinColumn::Build(_) => {
+                        // Semi/Anti emit no build columns; output_columns should be
+                        // probe-only. Defensive: emit a null column of right width.
+                        Ok(arrow::array::new_null_array(&DataType::Null, idx.len()))
+                    }
+                })
+                .collect::<Result<_, _>>()
+                .map_err(|e| ExecutionError::Execution(format!("join semi/anti take: {e}")))?
+        }
+        other => {
+            return Err(ExecutionError::NotImplemented(format!(
+                "JoinKind {other:?} not supported in native hash join MVP (Inner/Left/Semi/Anti)"
+            )));
+        }
+    };
+
+    RecordBatch::try_new(output_schema.clone(), columns)
+        .map_err(|e| ExecutionError::Execution(format!("join output batch: {e}")))
+}
+
+/// Distinct, sorted row indices from a (sorted, possibly-duplicated) UInt32 index array.
+fn dedup_sorted(idx: &UInt32Array) -> Vec<u32> {
+    let mut out: Vec<u32> = idx.values().iter().copied().collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -667,7 +667,13 @@ fn compare_values(a: &ProximaValue, b: &ProximaValue) -> std::cmp::Ordering {
 /// (captured from a `PhysicalPlan::Limit` node and applied at collect).
 #[derive(Debug)]
 pub(crate) struct LoweredPipeline {
+    /// The main (probe) pipeline.
     pub pipeline: Pipeline,
+    /// An optional BUILD pipeline that must run + drain first (its blocking
+    /// build operator publishes the hash table via a shared `OnceLock` consumed
+    /// by a probe operator in `pipeline`). Set only by the `PhysicalPlan::Join`
+    /// lowering (Phase 3, TD-OLAP-11).
+    pub build_pipeline: Option<Pipeline>,
     pub limit: Option<LimitSpec>,
 }
 
@@ -754,6 +760,7 @@ pub(crate) fn lower_physical(plan: &PhysicalPlan) -> Result<LoweredPipeline, Exe
     }
     Ok(LoweredPipeline {
         pipeline: Pipeline::new(operators),
+        build_pipeline: None,
         limit,
     })
 }
@@ -981,6 +988,15 @@ fn agg_output_schema(
 pub(crate) async fn execute_pipeline(
     lowered: &LoweredPipeline,
 ) -> Result<Vec<RecordBatch>, ExecutionError> {
+    // If there is a BUILD pipeline (a hash join), run + drain it first. Its
+    // blocking build operator publishes the hash table via a shared `OnceLock`
+    // as a side-effect of being drained; its own (sentinel) output is discarded.
+    if let Some(build) = &lowered.build_pipeline {
+        let empty: BatchStream = Box::pin(futures::stream::empty());
+        let mut build_stream = build.execute(empty).await?;
+        while build_stream.next().await.transpose()?.is_some() {}
+    }
+
     let empty: BatchStream = Box::pin(futures::stream::empty());
     let mut stream = lowered.pipeline.execute(empty).await?;
 
@@ -1328,6 +1344,7 @@ mod tests {
     async fn run_pipeline(ops: Vec<Box<dyn ExecutionOperator>>) -> Vec<RecordBatch> {
         let lowered = LoweredPipeline {
             pipeline: Pipeline::new(ops),
+            build_pipeline: None,
             limit: None,
         };
         execute_pipeline(&lowered).await.unwrap()
@@ -1463,5 +1480,207 @@ mod tests {
         assert_eq!(g.value(1), "b");
         assert_eq!(minx.value(1), 5);
         assert_eq!(maxx.value(1), 5);
+    }
+
+    // --- Phase 3 hash-join operator tests (TD-OLAP-11) ---
+
+    use crate::query::execution::native_join_ops::{
+        HashJoinBuildOperator, HashJoinProbeOperator, JoinColumn,
+    };
+    use arrow::array::StringArray;
+    use proximadb_relational_algebra::JoinKind;
+    use std::sync::{Arc, OnceLock};
+
+    fn two_col_batch(
+        k: &[i64],
+        v: &[&str],
+        k_name: &str,
+        v_name: &str,
+    ) -> (RecordBatch, SchemaRef) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(k_name, DataType::Int64, false),
+            Field::new(v_name, DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(k.to_vec())),
+                Arc::new(StringArray::from(v.to_vec())),
+            ],
+        )
+        .unwrap();
+        (batch, schema)
+    }
+
+    /// Wire build + probe sources with the join operators sharing a `table_slot`,
+    /// then run via `execute_pipeline` (which drains build first).
+    async fn run_join(
+        build_batch: RecordBatch,
+        build_schema: SchemaRef,
+        probe_batch: RecordBatch,
+        probe_schema: SchemaRef,
+        output_columns: Vec<JoinColumn>,
+        kind: JoinKind,
+        output_schema: SchemaRef,
+    ) -> Vec<RecordBatch> {
+        let build_source = MemoryScanSource::new(vec![build_batch], build_schema.clone());
+        let probe_source = MemoryScanSource::new(vec![probe_batch], probe_schema.clone());
+        let table_slot = Arc::new(OnceLock::new());
+        let build_op = HashJoinBuildOperator {
+            build_keys: vec![0],
+            build_schema,
+            table_slot: table_slot.clone(),
+            bloom_enabled: false,
+        };
+        let probe_op = HashJoinProbeOperator {
+            table_slot,
+            probe_keys: vec![0],
+            output_columns,
+            kind,
+            output_schema,
+        };
+        let lowered = LoweredPipeline {
+            pipeline: Pipeline::new(vec![Box::new(probe_source), Box::new(probe_op)]),
+            build_pipeline: Some(Pipeline::new(vec![
+                Box::new(build_source),
+                Box::new(build_op),
+            ])),
+            limit: None,
+        };
+        execute_pipeline(&lowered).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn hash_join_inner_equi() {
+        // build (right): k=[2,3,4] v=[x,y,z]; probe (left): k=[1,2,3] v=[a,b,c].
+        // Inner on k → (2,b,x),(3,c,y). (1 unmatched left, 4 unmatched build.)
+        let (build_batch, build_schema) = two_col_batch(&[2, 3, 4], &["x", "y", "z"], "kr", "vr");
+        let (probe_batch, probe_schema) = two_col_batch(&[1, 2, 3], &["a", "b", "c"], "kl", "vl");
+        let out_schema = Arc::new(Schema::new(vec![
+            Field::new("kl", DataType::Int64, true),
+            Field::new("vl", DataType::Utf8, true),
+            Field::new("vr", DataType::Utf8, true),
+        ]));
+        let batches = run_join(
+            build_batch,
+            build_schema,
+            probe_batch,
+            probe_schema,
+            vec![
+                JoinColumn::Probe(0),
+                JoinColumn::Probe(1),
+                JoinColumn::Build(1),
+            ],
+            JoinKind::Inner,
+            out_schema,
+        )
+        .await;
+        assert_eq!(batches.len(), 1);
+        let out = &batches[0];
+        assert_eq!(out.num_rows(), 2);
+        let kl = out.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let vr = out
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        // probe order: (k=2,vl=b,vr=x), (k=3,vl=c,vr=y)
+        assert_eq!((kl.value(0), vr.value(0)), (2, "x"));
+        assert_eq!((kl.value(1), vr.value(1)), (3, "y"));
+    }
+
+    #[tokio::test]
+    async fn hash_join_left_unmatched() {
+        // Left join: probe k=[1,2] v=[a,b]; build k=[2] v=[x]. k=1 unmatched → NULL vr.
+        let (build_batch, build_schema) = two_col_batch(&[2], &["x"], "kr", "vr");
+        let (probe_batch, probe_schema) = two_col_batch(&[1, 2], &["a", "b"], "kl", "vl");
+        let out_schema = Arc::new(Schema::new(vec![
+            Field::new("kl", DataType::Int64, true),
+            Field::new("vl", DataType::Utf8, true),
+            Field::new("vr", DataType::Utf8, true),
+        ]));
+        let batches = run_join(
+            build_batch,
+            build_schema,
+            probe_batch,
+            probe_schema,
+            vec![
+                JoinColumn::Probe(0),
+                JoinColumn::Probe(1),
+                JoinColumn::Build(1),
+            ],
+            JoinKind::Left,
+            out_schema,
+        )
+        .await;
+        let out = &batches[0];
+        assert_eq!(out.num_rows(), 2); // matched (2,b,x) + unmatched (1,a,NULL)
+        let kl = out.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        let vr = out
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for r in 0..out.num_rows() {
+            match kl.value(r) {
+                2 => assert!(!vr.is_null(r) && vr.value(r) == "x", "matched row"),
+                1 => assert!(vr.is_null(r), "unmatched probe row → NULL build col"),
+                other => panic!("unexpected k={other}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn hash_join_semi_anti() {
+        // probe k=[1,2,3]; build k=[2,4]. Semi → [2]; Anti → [1,3].
+        let (build_batch, build_schema) = two_col_batch(&[2, 4], &["x", "z"], "kr", "vr");
+        let (probe_batch, probe_schema) = two_col_batch(&[1, 2, 3], &["a", "b", "c"], "kl", "vl");
+
+        let out_schema = Arc::new(Schema::new(vec![
+            Field::new("kl", DataType::Int64, true),
+            Field::new("vl", DataType::Utf8, true),
+        ]));
+
+        // Semi
+        let semi = run_join(
+            build_batch.clone(),
+            build_schema.clone(),
+            probe_batch.clone(),
+            probe_schema.clone(),
+            vec![JoinColumn::Probe(0), JoinColumn::Probe(1)],
+            JoinKind::Semi,
+            out_schema.clone(),
+        )
+        .await;
+        let semi_k: Vec<i64> = semi[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .iter()
+            .map(|o| o.unwrap())
+            .collect();
+        assert_eq!(semi_k, vec![2]);
+
+        // Anti
+        let anti = run_join(
+            build_batch,
+            build_schema,
+            probe_batch,
+            probe_schema,
+            vec![JoinColumn::Probe(0), JoinColumn::Probe(1)],
+            JoinKind::Anti,
+            out_schema,
+        )
+        .await;
+        let anti_k: Vec<i64> = anti[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .iter()
+            .map(|o| o.unwrap())
+            .collect();
+        assert_eq!(anti_k, vec![1, 3]);
     }
 }


### PR DESCRIPTION
## Summary

The native **hash-join operators** — the #1 performance lever (closes the Q3/Q14 join gap; Q3 594 ms / Q14 296 ms, 99% `compute_ms`). This slice ships the **operators + operator-level tests + the build/probe pipeline seam**; the routing (`lower_physical::Join` + `PROXIMADB_NATIVE_JOIN` gate) is the next slice.

## What ships

**`native_join_ops.rs` (new):**
- **`HashJoinBuildOperator`** (BLOCKING): consumes the build side, builds the `key→row-indices` `HashMap` + a bloom over the build keys, publishes `Arc<JoinHashTable>` via a shared `OnceLock` (the cross-pipeline handoff).
- **`HashJoinProbeOperator`** (STREAMING): per probe batch — **bloom pre-filter** → hash-table lookup → **late-materialize** matched pairs via `arrow::compute::take`.
- MVP `JoinKind`: **Inner / Left / Semi / Anti**. Right/Full (unmatched-build drain) + spill + size-gated radix deferred per TD-OLAP-11. **NULL join keys never match** (skipped in build + probe).
- **Bloom build-then-freeze** (`BloomFilterStrategy::insert` is `&mut` → insert, then `Arc`). Canonical key-byte encoding across numeric/string/binary types.

**`native_ops.rs`:** `LoweredPipeline` gains an optional `build_pipeline`; `execute_pipeline` drains it first (its blocking build op publishes the table via the shared `OnceLock` as a side-effect) before running the probe pipeline. This is the **two-pipeline composition** the join needs (build=blocking, probe=streaming).

## Honest scope

This is the **operators + the composition seam**, not yet routed. The next slice wires `PhysicalPlan::Join` into `lower_physical` (`extract_equi_keys` from the planner's `on` expr + build/probe assignment from `JoinSide` + the output-column mapping) + the `native_join_enabled()` gate (`PROXIMADB_NATIVE_JOIN`, default-off), so a join query actually routes to the native path. Scoped `#![allow(dead_code)]` on the module until that routing lands (the Phase-1-sanctioned pattern; removed when the wiring lands).

## Verification (local)

- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo check --tests` — clean
- **11/11 unit tests pass** — 3 new join (`inner_equi`, `left_unmatched` with NULL-padded build, `semi_anti`) + 8 existing. Logic traced: Inner on k=[1,2,3]⋈[2,3,4] → 2 matched rows; Left → matched + unmatched-with-NULL; Semi → existence, Anti → non-existence.