### PR TITLE
docs(td): TD-RDSTRAT-1 — cost-driven, tier-aware read-strategy chooser

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-1-read-strategy-chooser.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-1-read-strategy-chooser.adoc
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-1: Cost-driven, tier-aware read-strategy chooser (selectivity × storage tier)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open (design; implementation gated on ADR-050 cost-router + io_trace, default-off → observe → flip)
+| Severity | Medium-High (perf + cloud cost — bytes-scanned/GET-cost is the dominant cloud-OLAP cost per ADR-052)
+| Component | PAX/SST read path (`sst_io_layer.rs`, `sst_query_engine.rs`); the route cost model (`src/query/.../route_metrics` / cost loop); `io_trace` (`TD-IOTRACE-1`, always-on).
+| Governs | link:../../12-design/adr/ADR-050-statistics-fed-datafusion-route-selection.adoc[ADR-050] (cost-based routing) + link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (bytes-scanned thesis) + link:../../12-design/adr/ADR-011-filtered-ann-routing-modes.adoc[ADR-011] (selectivity routing).
+| Relates | TD-151 slice 1 baseline (#780 — always-coalesce); link:TD-ENGINE-1-deprecated-engine-removal-entanglement.adoc[TD-IOTRACE-1/2] (io_trace); link:../../12-design/adr/ADR-034-objectstore-access-path-codesign.adoc[ADR-034] (object-store access path); link:TECHNICAL_DEBT.adoc[TD-159] (adaptive engine consumes io_trace).
+| Surfaced by | The architecture-review follow-up question: "should the read action differ by CBO selectivity (30/50/70%) and by cached-NVMe vs cold-object-store?" Researched against real-world cloud-native query systems.
+|===
+
+== Context
+
+TD-151 slice 1 (#780) ships a safe, byte-identical **baseline**: the PAX multi-block read
+**always coalesces** adjacent ranges into fewer GETs. That already cuts cloud cost everywhere with
+zero risk. The natural next layer — and the intent of this TD — is to make the read strategy
+**adaptive**: choose *per-block ranged* vs *coalesced ranged* vs *full-scan* from the query's
+**selectivity** and the data's **storage tier** (hot NVMe/page-cache vs cold object-store), driven
+by a cost model — **not hardcoded thresholds**.
+
+The thesis (ADR-052): cloud-OLAP's dominant cost is bytes-scanned and GET-round-trips, not CPU.
+So the read-strategy choice should minimize a measured cost, exactly as the cost-based router
+(ADR-050) does for plan selection. This TD is ADR-050/052's "act" applied to the PAX/SST read path.
+
+== Real-world evidence (cloud-native query systems)
+
+The pattern is consistent across mature systems — verified, not asserted:
+
+1. **Selectivity → metadata pruning (the "don't touch non-matching units" layer).** Every major
+   engine prunes at the partition/file/block boundary using per-unit min/max (zone maps), distinct
+   counts, and Bloom filters, *before* any ranged read:
+   * **Snowflake** micro-partitions (~50–500 MB compressed) carry per-column min/max + distinct +
+     null-count metadata; at runtime, *query pruning* skips micro-partitions whose ranges can't
+     contain matching rows; clustering keys co-locate data to raise skip rates. ([Snowflake docs:
+     micro-partitions & clustering](https://docs.snowflake.com/en/user-guide/tables-clustering-micropartitions);
+     [academic survey of Snowflake pruning, arXiv:2504.11540](https://arxiv.org/html/2504.11540v2))
+   * **Delta/Iceberg/ClickHouse** do the same with file/manifest min-max + Bloom + skip indexes.
+   * *ProximaDB already has this*: PAX zone maps + per-collection Bloom + the index block power
+     `batch_read_with_filtering`'s bloom+index filtering (it already prunes to the needed blocks).
+
+2. **Within selected units: avoid many small GETs on object storage.** The exact anti-pattern TD-151
+   measured (+29,900% GETs) is documented across the ecosystem:
+   * **Trino** generates materially more S3 `GetObject` calls than Presto on some Parquet scans, and
+     actively works to batch/coalesce them ([trinodb/trino#18334](https://github.com/trinodb/trino/issues/18334));
+     the Trino Fest 2024 "Best Practices for Trino with S3" talk names "many small files → excessive
+     LIST/GET" as a core challenge.
+   * **AWS Athena** tuning targets file sizes ~128 MB–1 GB to amortize per-request cost
+     ([AWS Athena top-10 tuning](https://aws.amazon.com/blogs/big-data/top-10-performance-tuning-tips-for-amazon-athena/));
+   * S3 charges **per request + per GB**, so N small range GETs cost more (fees + latency) than one
+     covering read — the physics behind TD-151's coalescing ([vantage.sh: S3 bill spikes from
+     Trino/Athena](https://www.vantage.sh/blog/s3-bill-increase-athena-trino-hive-fix-iceberg-caching)).
+
+3. **Runtime cost adaptation (the "observe → act" layer).** The strategy is chosen/re-chosen from
+   *actual* statistics at runtime, not fixed plan-time thresholds:
+   * **Spark/Databricks AQE** re-optimizes mid-execution from runtime stats — dynamically coalescing
+     small partitions, switching join strategy, and handling skew
+     ([Databricks AQE blog](https://www.databricks.com/blog/2020/05/29/adaptive-query-execution-speeding-up-spark-sql-at-runtime.html);
+     [Databricks AQE docs](https://docs.databricks.com/aws/en/optimizations/aqe)).
+   * *ProximaDB's analog*: `io_trace` (always-on, TD-158) exposes measured `range_gets`,
+     `avg_get_bytes`, `bytes_read` — the exact cost signal a chooser should consume (ADR-050's cost
+     loop already prices these; TD-159 wires the adaptive engine to consume io_trace).
+
+4. **Tier asymmetry is real and exploited.** Hot data lives on local SSD/NVMe cache (Snowflake
+   compute-node local disk; Databricks local SSD); cold data on object storage. Engines treat the
+   two differently because **GET round-trips are cheap on local I/O / page cache but expensive
+   (fees + latency) on object storage**.
+
+== The cost model (why not fixed 30/50/70%)
+
+A fixed selectivity threshold (30/50/70%) would repeat the very mistake ADR-052 corrected: it
+ignores the **live GET/byte costs and the tier**. The crossover where *full-scan* beats *coalesced
+ranged* is a function of `GET_cost`, `byte_cost`, `selectivity`, and `cold_start_fixed_cost` — all
+of which `io_trace` measures. The chooser is:
+
+```
+strategy = argmin over { per-block ranged, coalesced ranged, full-scan, skip }
+               of  GET_cost · n_gets + byte_cost · n_bytes + cold_start_fixed_cost · [tier == cold]
+```
+
+with `selectivity` = (blocks-the-query-touches / total-blocks), derived from the index; `tier` =
+cache-hit / file-location signal; and the cost terms from `io_trace` per backend. The thresholds
+*fall out* of the model per deployment/tier — they are not authored.
+
+== Strategies and trigger regions (tier × selectivity)
+
+[cols="1,2,2", options="header"]
+|===
+| Strategy | When it wins | ProximaDB status
+
+| **Skip** (metadata-only prune)
+| Predicate excludes the unit entirely (zone-map/Bloom/index miss)
+| ✅ have it (PAX zone maps + Bloom + index)
+
+| **Per-block ranged**
+| Hot NVMe/page-cache + *very low* selectivity — local I/O is cheap; fetch only the few blocks
+| ⏳ baseline path (pre-#780); keep as the hot-tier low-selectivity arm
+
+| **Coalesced ranged** (≤256 KiB gaps → ~MB GETs)
+| Object-store + low–med selectivity — minimize GETs, bounded over-fetch
+| ✅ TD-151 slice 1 (#780, always-on baseline)
+
+| **Full-scan** (read the contiguous data region / whole file)
+| High selectivity on *either* tier; and **cold-start + high selectivity on object-store** — one GET amortizes the cold metadata fetch and avoids GET amplification
+| ⏳ missing — the key gap this TD adds (SST scan path `traditional_search` + a chooser)
+|===
+
+The tier asymmetry: full-scan crosses over at **lower selectivity on object-store** (GETs are
+expensive, so eating the over-fetch wins earlier) and **higher selectivity on NVMe** (cheap I/O
+keeps fine-grained reads good longer).
+
+== Plan (slices)
+
+* **Slice 1 (design, this TD):** the cost model + chooser spec; the tier×selectivity strategy
+  table. No code.
+* **Slice 2:** route the SST scan path (`traditional_search`, `sst_query_engine.rs:952` — reads ALL
+  blocks, the most severe fragmentation) through the existing coalesced path
+  (`ObjectRangePlan` / `read_blocks_by_range_plan`) as the *full-scan / large-coalesced* arm. Reuses
+  existing infra; byte-identical.
+* **Slice 3 (the chooser):** a cost-driven selector at the read-strategy decision point that, given
+  (index selectivity, tier signal, live `io_trace` GET/byte costs), picks skip / per-block /
+  coalesced / full-scan. Default-off behind a flag → observe (log the chosen strategy + measured
+  cost) → flip once the ADR-052 observe→ingest→act gate is satisfied. Integrates with the ADR-050
+  cost-router and consumes `io_trace` (TD-159).
+* **Slice 4:** tie the chooser's cost terms to the ADR-034 GET-round-trip measurement (the
+  444ms→10ms cliff) so cold-start is priced from real object-store latencies, not guesses.
+
+== Verification (when implemented)
+- Correctness: each strategy returns byte-identical results (parity tests, as in TD-151 slice 1);
+  the chooser only changes *which* strategy runs, not the bytes.
+- Cost: the `io_trace` `range_gets` / `avg_get_bytes` ratchet (TD-151's signal) drops on
+  representative cloud workloads (SF≥1 TPC-DS + SIFT1M, per the ADR-034 measurement mandate).
+- No regression: the recall ratchet (`tests/sift_pax_recall_ratchet_test.rs`) + the SST/PAX read
+  tests stay green.
+- Default-off → observe → flip (ADR-052 pattern); never hardcode a selectivity percentage.
+
+== Non-goals
+- Hardcoded selectivity thresholds (30/50/70%) — rejected; the cost model derives them.
+- Replacing the existing pruning (zone maps/Bloom/index) — that stays; the chooser sits *after*
+  pruning, deciding how to read the surviving units.
+- Mounting the dead `SmartIO` layer end-to-end — separate; the chooser can coalesce inline (as
+  TD-151 slice 1 does) without it.


### PR DESCRIPTION
Files **TD-RDSTRAT-1**: the next layer over TD-151 slice 1 (#780, the always-coalesce baseline) — a **cost-driven chooser** that picks *per-block ranged* vs *coalesced ranged* vs *full-scan* from **query selectivity × storage tier** (hot NVMe/page-cache vs cold object-store).

**Key decision: not hardcoded 30/50/70% thresholds.** The crossover where full-scan beats coalesced ranged-read is a function of `GET_cost·n_gets + byte_cost·n_bytes + cold_start_fixed_cost` — all measured by `io_trace` (TD-158). The chooser derives the thresholds per tier; it does not author them. This is ADR-050/052's 'act' applied to the read path.

**Grounded in verified real-world evidence** (per the ADR-052 'verify before citing' discipline):
- Snowflake micro-partition pruning (~50–500 MB compressed, per-column min/max metadata → runtime query pruning; clustering keys) — [docs](https://docs.snowflake.com/en/user-guide/tables-clustering-micropartitions).
- The many-small-GET anti-pattern TD-151 measured is documented ecosystem-wide: [trinodb/trino#18334](https://github.com/trinodb/trino/issues/18334), [AWS Athena tuning](https://aws.amazon.com/blogs/big-data/top-10-performance-tuning-tips-for-amazon-athena/), [S3 per-request economics](https://www.vantage.sh/blog/s3-bill-increase-athena-trino-hive-fix-iceberg-caching).
- Runtime cost adaptation: [Spark/Databricks AQE](https://www.databricks.com/blog/2020/05/29/adaptive-query-execution-speeding-up-spark-sql-at-runtime.html) — re-optimize from actual stats (ProximaDB's analog: io_trace + ADR-050 cost loop).

(The search corrected a near-miss: Snowflake micro-partitions are **50–500 MB**, not the 16 MB I'd have otherwise cited — caught before writing.)

**Slices:** (1) this design; (2) route the SST scan path (`traditional_search`) through the existing `ObjectRangePlan` coalesced path as the full-scan arm; (3) the chooser behind a default-off flag → observe → flip (ADR-052 gate); (4) price cold-start from ADR-034's measured GET-round-trip cliff.

Verification: `check_td_adr_unique.py` → 0 errors (170 TD ids). Docs only.