### PR TITLE
perf(storage): coalesce the SST full-scan read (TD-RDSTRAT-1 slice 2)

### DIFF
--- a/src/storage/engines/sst/readers/sst_query_engine.rs
+++ b/src/storage/engines/sst/readers/sst_query_engine.rs
@@ -948,12 +948,35 @@ impl ModularBlockReader {
         let mut distance_results: Vec<proximadb_distance_kernel::engine::SimilarityResult> =
             Vec::new();
 
-        // Scan all blocks and compute distances
-        for (block_idx, _index_entry) in index_entries.iter().enumerate() {
-            let data_block = reader_clone
-                .read_data_block_async(block_idx as u64, ReadMode::Direct)
-                .await?;
+        // Source all data blocks via a coalesced read (TD-RDSTRAT-1 slice 2) — byte-identical to
+        // the per-block path (both parse [4-byte len][ProximaDataBlock::deserialize]); only the GET
+        // count drops (the per-block path is 2 GETs/block: prefix + data). Kill-switch
+        // PROXIMADB_DISABLE_SST_SCAN_COALESCE falls back to per-block.
+        let data_blocks: Vec<ProximaDataBlock> =
+            if std::env::var_os("PROXIMADB_DISABLE_SST_SCAN_COALESCE").is_none() {
+                let all_indices: Vec<usize> = (0..index_entries.len()).collect();
+                let plan = reader_clone.plan_selected_block_ranges(
+                    &index_entries,
+                    &all_indices,
+                    &ObjectRangeCoalescePolicy::default(),
+                )?;
+                let mut loaded = reader_clone.read_blocks_by_range_plan(&plan).await?;
+                // Match the original ascending block order (block_id == block index).
+                loaded.sort_by_key(|(block_id, _)| *block_id);
+                loaded.into_iter().map(|(_, block)| block).collect()
+            } else {
+                let mut out = Vec::with_capacity(index_entries.len());
+                for block_idx in 0..index_entries.len() {
+                    out.push(
+                        reader_clone
+                            .read_data_block_async(block_idx as u64, ReadMode::Direct)
+                            .await?,
+                    );
+                }
+                out
+            };
 
+        for data_block in data_blocks {
             // Preserve the original counter semantics: every record (including
             // those with empty vectors) is counted as "scanned".
             total_records_scanned += data_block.records.len();


### PR DESCRIPTION
## What
`traditional_search` (the no-quantization fallback that scans **all** blocks — the most severe fragmentation source, one+ GET per block) now sources its blocks through the **existing coalesced path**: `plan_selected_block_ranges(all blocks) → read_blocks_by_range_plan`.

## Byte-identical (verified)
Both paths parse the same on-disk layout `[4-byte len][ProximaDataBlock::deserialize]` — confirmed by reading `read_data_block_async` (reads 4-byte prefix → size → deserialize) and `read_blocks_by_range_plan` (same). Only the GET count changes. Bonus: the per-block path was actually **2 GETs/block** (prefix + data), so the win on object storage is large.

- Default ON (byte-identical). Kill-switch `PROXIMADB_DISABLE_SST_SCAN_COALESCE` → per-block fallback.
- Blocks re-sorted by `block_id` to preserve the original ascending scan order (so top-k tie-breaking is unchanged).
- Reuses the already-tested `read_blocks_by_range_plan` infra (`range_plan_reports_overfetch_and_prune_counts`, `range_plan_keeps_block_slice_offsets_stable`).

## Verification
- `cargo clippy --lib --bins -p proximadb` → clean. `cargo fmt --check` → clean.
- Parse-equivalence confirmed structurally (both `[4-byte len][deserialize]`); the underlying coalesced read is covered by the existing `range_plan_*` tests.
- CI's SST read suites + the recall ratchet validate end-to-end (the routing change produces the same `ProximaDataBlock`s).

## Context
This is **TD-RDSTRAT-1 slice 2** (the highest-value unaddressed fragmentation). Slice 1 (#780) coalesced the PAX point-lookup batch; this coalesces the SST full-scan. Slice 3 (the cost-driven selectivity×tier chooser) layers on top — consuming `io_trace` + ADR-050's cost model to pick per-block/coalesced/full-scan per tier.