### PR TITLE
chore: remove dead deprecated SearchContext alias

### DIFF
--- a/src/storage/engines/core/search/search_modes.rs
+++ b/src/storage/engines/core/search/search_modes.rs
@@ -1076,13 +1076,6 @@ pub struct CandidateRecord {
     pub search_context: Option<SearchStageContext>,
 }
 
-/// Type alias for backward compatibility - DEPRECATED: Use SearchStageContext
-#[deprecated(
-    since = "0.1.4",
-    note = "Use SearchStageContext to avoid confusion with query context"
-)]
-pub type SearchContext = SearchStageContext;
-
 /// Search stage context information - tracks which stage found a candidate
 /// This is NOT the overall search request context (that's UnifiedQueryContext)
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Removes the zero-caller `pub type SearchContext = SearchStageContext` alias in `search_modes.rs` (deprecated since 0.1.4). The name collision that made it look risky is with two *unrelated* symbols (the `SearchContext` trait in `core/search/strategies`, and `storage::engines::core::SearchContext` = `SearchConfig` re-exported) — neither is touched. Pure deletion. Verified: cargo check --tests, clippy --lib --bins -D warnings, fmt.