### PR TITLE
docs(td): TD-V1SUNSET-1 — v1 REST/gRPC sunset cutover plan

### DIFF
--- a/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
+++ b/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
@@ -1,0 +1,150 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-V1SUNSET-1: v1 REST/gRPC sunset cutover — execution plan
+:toc: macro
+:icons: font
+:last-updated: 2026-07-09
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Planned — gated.** Not executable until (a) REST-v1 default-off has run a sunset window and (b) the breaking REST flip has product/ops sign-off (certify-before-flip). This TD is the *plan*; no behavior change lands with it.
+| Severity | Medium — outward-facing break (REST flip `410`s all `/api/v1/*`); recovery is a one-line revert.
+| Component | Network: REST v1 sunset (`src/network/middleware/v1_sunset.rs`) + the deprecated v1 surfaces in `crates/platform/proximadb-api/src/{rest,grpc}/v1/`.
+| Tracked-by | link:../../12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc[V1_RETIREMENT_ROADMAP] (strategy, Tier 1); link:../../12-design/adr/ADR-049-v1-to-v2-migration-to-native-model.adoc[ADR-049] (M0-c REST sunset gate); the v1-proto ratchet (`scripts/check_v1_proto_usage.py`).
+| Depends-on | Confirmed-zero `/api/v1` production traffic (sunset window) + SDK/client migration off `/api/v1`.
+|===
+
+== Why this exists
+
+Both v1 kill-switches already ship (verified 2026-07-08, see the roadmap §"Current
+state"). What remains is the **cutover** — flip the REST default off, then hard-delete
+the v1 surfaces. The roadmap stages this but does not enumerate the exact files,
+the live-vs-deprecated boundary, or the one prerequisite that is easy to miss (the
+deprecation-header utility imported by *live* handlers). This TD captures that
+execution detail so the cutover is mechanical once the sunset window closes.
+
+== Current state (verified 2026-07-09)
+
+=== Kill-switches
+
+* **REST v1** — `src/network/middleware/v1_sunset.rs`. `rest_v1_compat_enabled()`
+  reads `PROXIMADB_REST_V1_COMPAT`; `parse_compat_flag` at line 65 maps
+  `None => true` (**default ON**). The middleware (`v1_sunset_middleware`, line 72)
+  returns `410 Gone` + RFC 8594 headers for any `/api/v1/` path when compat is off.
+  Mounted at `src/network/rest/server.rs:494-498` (multi-port) and `:820-824`
+  (unified). **Flip = change line 65 `None => true,` → `None => false,`.**
+
+* **gRPC v1** — `enable_grpc_v1_compat` / `PROXIMADB_GRPC_V1_COMPAT`,
+  **default OFF** (`src/core/config/bootstrap_config.rs:454-458`,
+  `unwrap_or(false)`). The v1 services are registered only inside the
+  `if self.config.grpc_config.enable_grpc_v1_compat { ... }` arm at three sites:
+  `src/network/multi_server.rs:669`, `:1218`, `:1600`.
+
+=== CRITICAL: two `rest/v1` dirs — only one is deprecated
+
+Do **not** conflate these. The deletion target is the *api-crate* v1 surface, not
+the root-crate REST (which is live despite the `v1` path segment):
+
+[cols="2,4,1", options="header"]
+|===
+| Path | Role | Action
+| `crates/platform/proximadb-api/src/rest/v1/` | **Deprecated** v1 REST adapters (port-backed handlers that forward to v2 + emit deprecation headers). 9 files: `analytics, catalog, document, entities, graph, hybrid, multimodal_query, observability, mod`. | **Delete** (after sunset window + prerequisite below).
+| `src/network/rest/v1/` | **LIVE canonical REST** infrastructure: `AppState`, `RestCoreServices`, `rank`, `rank_backend`, `graph.rs`, `primary_pod`, `progressive_search_handler`. Serves `/api/v2/*` (+ shared router plumbing). | **Keep.** (Touched by TD-104 #761.)
+| `crates/platform/proximadb-api/src/grpc/v1/` | **Deprecated** v1 gRPC services. 11 files: `collection, document, entity, graph, hybrid, observability, security, sql, streaming, vector, mod`. | **Delete** (after sunset window).
+|===
+
+== Prerequisite (easy to miss) — relocate the deprecation-header utility
+
+`crates/platform/proximadb-api/src/rest/v1/mod.rs` defines
+`add_rest_v1_deprecation_headers` / `with_v1_compatibility_headers`, but these are
+imported by **live** root-crate handlers:
+
+* `src/network/rest/v1/handlers.rs:13` —
+  `use proximadb_api::rest::v1::add_rest_v1_deprecation_headers;` (applied at
+  `:1741`, `:1877`).
+
+Deleting the api-crate `rest/v1/` dir would break that import. **Before deleting**,
+move the deprecation-header helpers to a non-v1 location (e.g.
+`crates/platform/proximadb-api/src/rest/deprecation.rs`, re-exported at
+`rest/mod.rs`) and repoint `handlers.rs:13`. (The `with_v1_compatibility_headers`
+call sites at `rest/v1/{hybrid,observability,analytics}.rs` are *inside* the
+deleted dir, so they go away with it.)
+
+== Hard-delete scope
+
+* **REST v1 adapters** — `crates/platform/proximadb-api/src/rest/v1/` (9 files).
+* **gRPC v1 services** — `crates/platform/proximadb-api/src/grpc/v1/` (11 files) +
+  the builder arm (`crates/platform/proximadb-api/src/grpc/builder.rs:11-16`,
+  guarded by the `enable_grpc_v1_compat` branch) + the re-export at
+  `crates/platform/proximadb-api/src/lib.rs:42`.
+* **v1_sunset middleware** (`src/network/middleware/v1_sunset.rs`) + its two mount
+  points in `rest/server.rs` — delete only **after** the REST default has been off
+  through a sunset window (it's redundant once `/api/v1` is gone and the flip has
+  been observed in prod).
+
+=== Cross-references to update (real breakage, not the live root-crate ones)
+
+External importers of the deprecated surfaces (must migrate/delete together):
+
+* `tests/grpc_hybrid_integration_test.rs:21` —
+  `use proximadb_api::grpc::v1::hybrid::HybridSearchServiceImpl;` (test; rewrite to
+  v2 fusion or delete).
+* `src/network/grpc/graph_service.rs:1082` — comment referencing the v1 adapter
+  reachability (docs only).
+* Any `rest/v1` deprecation-header call sites outside the deleted dir (the
+  prerequisite above resolves `handlers.rs:13`).
+
+The many `src/network/rest/v1/...` references in `multi_server.rs` / `shared_services.rs`
+/ `postgres/` / `arrow_ipc/` reference the **live** root-crate module — **not**
+breakage from this deletion.
+
+== Sunset-window verification (the gate to actually executing)
+
+Before flipping the REST default off / hard-deleting, confirm no live `/api/v1`
+traffic:
+
+. **Metrics** — the `/metrics` endpoint; watch `/api/v1/*` request rate to ~0 over
+  the window.
+. **Access logs** — grep `/api/v1/` in server logs.
+. **Clients/SDKs** — confirm generated SDKs (Python/Go/TS/Rust) target `/api/v2`
+  (they are spec-driven from the canonical OpenAPI; verify no hand-rolled `/api/v1`
+  callers).
+. **Deprecation-signal** — the middleware already emits `deprecation: true` +
+  `Link: </api/v2>; rel="successor-version"` + optional `Sunset` (from
+  `PROXIMADB_REST_V1_SUNSET`). Monitor for clients that do **not** honor these.
+. **gRPC** — confirm no deployment sets `PROXIMADB_GRPC_V1_COMPAT=1` (it's already
+  default-off; a deployment metric/env audit).
+
+== Sequenced execution (do NOT collapse into one change)
+
+. **REST default flip** — `v1_sunset.rs:65` `None => true` → `None => false`.
+  One line. Breaking (`410` on `/api/v1/*`). **Requires sign-off.** Observe in
+  prod for the sunset window; revert is trivial if unexpected traffic appears.
+. **Relocate deprecation-header utility** (prerequisite above) — additive,
+  non-breaking, can land before or with step 3.
+. **Hard-delete REST v1 adapters** — remove `crates/platform/proximadb-api/src/rest/v1/`
+  after the window; repoint `handlers.rs:13`.
+. **Hard-delete gRPC v1 services** — remove `grpc/v1/` + builder arm + `lib.rs:42`
+  re-export; rewrite the one integration test.
+. **Remove v1_sunset middleware** + mount points (last; only after the flip is
+  proven safe — it's the escape hatch to re-enable `/api/v1` if a late caller
+  appears).
+. Each step = its own PR, CI-green (incl. `--features cluster` server-bin build +
+  the v1-proto ratchet, which must not regress).
+
+== Risks
+
+* **Breaking** — step 1 returns `410` for any in-flight `/api/v1` client. Mitigation:
+  the sunset-window checks above + one-line revert.
+* **Deletion of live code by mistake** — the `rest/v1` name collision is the trap;
+  this TD's boundary table is the safeguard. The root-crate `src/network/rest/v1/`
+  is live and must not be touched.
+* **gRPC v1 escape-hatch removal** — step 4 removes the compat feature; confirm no
+  deployment relies on `PROXIMADB_GRPC_V1_COMPAT=1` first.
+
+== References
+
+* link:../../12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc[V1_RETIREMENT_ROADMAP_2026_07_08] — strategy + Tier classification (this TD details Tier 1's cutover).
+* link:../../12-design/adr/ADR-049-v1-to-v2-migration-to-native-model.adoc[ADR-049] — M0-c shipped the REST v1 sunset gate.
+* `scripts/check_v1_proto_usage.py` + `docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json` — v1-proto downward-only ratchet (CI-blocking).


### PR DESCRIPTION
Docs-only (no behavior change). Files TD-V1SUNSET-1: the detailed execution plan for the v1 sunset cutover (Tier 1 of the V1_RETIREMENT_ROADMAP). Lands now, executes later on sunset-window completion + sign-off.

Key detail captured: the two `rest/v1` boundary (deprecated api-crate adapters = DELETE; live root-crate canonical REST = KEEP — the name collision is the trap), exact kill-switch lines, the deprecation-header utility prerequisite (live handlers.rs:13 imports from the to-be-deleted dir), the hard-delete set, sunset-window checklist, sequenced steps, risks.

Verified: td-adr-unique (0 errors), no dead links, docs-claim + capability-matrix guards pass.