### PR TITLE
feat(storage): wire cost-driven read-strategy chooser into both sites (TD-RDSTRAT-1 slice 3b)

### DIFF
--- a/src/storage/engines/core/formats/proximablocks/sst_io_layer.rs
+++ b/src/storage/engines/core/formats/proximablocks/sst_io_layer.rs
@@ -59,6 +59,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::Result;
 use tracing::info;
 
+use crate::storage::engines::core::coalesce_strategy::{
+    CoalesceStrategy, choose_read_strategy, read_strategy_chooser_enabled,
+};
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::smart_io::range_coalescer::DefaultRangeCoalescer;
@@ -933,19 +936,54 @@ impl SharedSstFormatReader {
                 .map(|(b, _)| ByteRange::new(b.offset, b.offset + b.size))
                 .collect();
 
-            // Resolve each block's bytes: coalesced read (default) or per-block read (kill-switch).
-            // Both produce byte-identical bytes; only the GET count differs.
-            let block_bytes: Vec<Vec<u8>> = if pax_range_coalescing_enabled() {
-                self.read_blocks_coalesced(file_path, &ranges).await?
+            // Resolve each block's bytes. Precedence: kill-switch (PROXIMADB_DISABLE_PAX_RANGE_COALESCE)
+            // → per-block; cost-driven chooser (PROXIMADB_READ_STRATEGY_CHOOSER) → choose_read_strategy;
+            // default → always-coalesce. All paths produce byte-identical bytes; only the GET count
+            // differs. (TD-RDSTRAT-1 slice 3b wiring.)
+            let strategy = if !pax_range_coalescing_enabled() {
+                CoalesceStrategy::PerBlock
+            } else if read_strategy_chooser_enabled() {
+                let (coalesced_ranges, _) = DefaultRangeCoalescer::default()
+                    .coalesce_with_mapping(ranges.clone(), PAX_RANGE_COALESCE_THRESHOLD);
+                let coalesced_gets = coalesced_ranges.len() as u64;
+                let coalesced_bytes = coalesced_ranges.iter().map(|r| r.len()).sum::<u64>();
+                let total_bytes = blocks.iter().map(|(b, _)| b.size).sum::<u64>();
+                let is_cloud = self.is_cloud_file(file_path);
+                let strat = choose_read_strategy(
+                    is_cloud,
+                    blocks.len() as u64,
+                    total_bytes,
+                    coalesced_gets,
+                    coalesced_bytes,
+                );
+                tracing::debug!(
+                    target: "rdstrat",
+                    strategy = ?strat,
+                    is_cloud,
+                    n_blocks = blocks.len(),
+                    coalesced_gets,
+                    coalesced_bytes,
+                    total_bytes,
+                    "TD-RDSTRAT-1 PAX batch read-strategy choice (observe)"
+                );
+                strat
             } else {
-                let mut out = Vec::with_capacity(blocks.len());
-                for (b, _) in &blocks {
-                    out.push(
-                        self.read_data_block_smart(file_path, collection_id, b)
-                            .await?,
-                    );
+                CoalesceStrategy::Coalesced
+            };
+            let block_bytes: Vec<Vec<u8>> = match strategy {
+                CoalesceStrategy::Coalesced => {
+                    self.read_blocks_coalesced(file_path, &ranges).await?
                 }
-                out
+                CoalesceStrategy::PerBlock => {
+                    let mut out = Vec::with_capacity(blocks.len());
+                    for (b, _) in &blocks {
+                        out.push(
+                            self.read_data_block_smart(file_path, collection_id, b)
+                                .await?,
+                        );
+                    }
+                    out
+                }
             };
 
             // Process each block's keys against its (byte-identical) bytes.

--- a/src/storage/engines/sst/readers/sst_query_engine.rs
+++ b/src/storage/engines/sst/readers/sst_query_engine.rs
@@ -47,6 +47,9 @@ use super::block_filter::{BlockFilter, IntelligentBlockFilter};
 use crate::core::bloom::BloomFilterConfig;
 use crate::core::bloom::SstableBloomFilter;
 use crate::core::search::SearchParams;
+use crate::storage::engines::core::coalesce_strategy::{
+    CoalesceStrategy, choose_read_strategy, is_cloud_path, read_strategy_chooser_enabled,
+};
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 use crate::storage::engines::core::formats::proximablocks::sst_io_layer::{
     SharedSstFormatReader, SstMmapStrategy, SstRegion,
@@ -948,23 +951,61 @@ impl ModularBlockReader {
         let mut distance_results: Vec<proximadb_distance_kernel::engine::SimilarityResult> =
             Vec::new();
 
-        // Source all data blocks via a coalesced read (TD-RDSTRAT-1 slice 2) — byte-identical to
-        // the per-block path (both parse [4-byte len][ProximaDataBlock::deserialize]); only the GET
-        // count drops (the per-block path is 2 GETs/block: prefix + data). Kill-switch
-        // PROXIMADB_DISABLE_SST_SCAN_COALESCE falls back to per-block.
-        let data_blocks: Vec<ProximaDataBlock> =
-            if std::env::var_os("PROXIMADB_DISABLE_SST_SCAN_COALESCE").is_none() {
-                let all_indices: Vec<usize> = (0..index_entries.len()).collect();
-                let plan = reader_clone.plan_selected_block_ranges(
-                    &index_entries,
-                    &all_indices,
-                    &ObjectRangeCoalescePolicy::default(),
-                )?;
-                let mut loaded = reader_clone.read_blocks_by_range_plan(&plan).await?;
+        // Source all data blocks. Precedence: kill-switch (PROXIMADB_DISABLE_SST_SCAN_COALESCE) →
+        // per-block; cost-driven chooser (PROXIMADB_READ_STRATEGY_CHOOSER) → choose_read_strategy;
+        // default → always-coalesce (slice 2). All paths produce byte-identical ProximaDataBlocks
+        // (both parse [4-byte len][ProximaDataBlock::deserialize]). (TD-RDSTRAT-1 slice 3b wiring.)
+        let kill = std::env::var_os("PROXIMADB_DISABLE_SST_SCAN_COALESCE").is_some();
+        let plan = if !kill {
+            let all_indices: Vec<usize> = (0..index_entries.len()).collect();
+            Some(reader_clone.plan_selected_block_ranges(
+                &index_entries,
+                &all_indices,
+                &ObjectRangeCoalescePolicy::default(),
+            )?)
+        } else {
+            None
+        };
+        let strategy = if kill {
+            CoalesceStrategy::PerBlock
+        } else if read_strategy_chooser_enabled() {
+            match &plan {
+                Some(p) => {
+                    let total_bytes = index_entries.iter().map(|e| u64::from(e.size)).sum::<u64>();
+                    let is_cloud = is_cloud_path(&reader_clone.file_path);
+                    let strat = choose_read_strategy(
+                        is_cloud,
+                        index_entries.len() as u64,
+                        total_bytes,
+                        p.estimated_get_requests as u64,
+                        p.estimated_bytes,
+                    );
+                    tracing::debug!(
+                        target: "rdstrat",
+                        strategy = ?strat,
+                        is_cloud,
+                        n_blocks = index_entries.len(),
+                        coalesced_gets = p.estimated_get_requests,
+                        coalesced_bytes = p.estimated_bytes,
+                        total_bytes,
+                        "TD-RDSTRAT-1 SST scan read-strategy choice (observe)"
+                    );
+                    strat
+                }
+                // Unreachable: kill=false ⇒ plan is Some.
+                None => CoalesceStrategy::Coalesced,
+            }
+        } else {
+            CoalesceStrategy::Coalesced
+        };
+        let data_blocks: Vec<ProximaDataBlock> = match (&strategy, &plan) {
+            (CoalesceStrategy::Coalesced, Some(p)) => {
+                let mut loaded = reader_clone.read_blocks_by_range_plan(p).await?;
                 // Match the original ascending block order (block_id == block index).
                 loaded.sort_by_key(|(block_id, _)| *block_id);
                 loaded.into_iter().map(|(_, block)| block).collect()
-            } else {
+            }
+            (CoalesceStrategy::PerBlock, _) => {
                 let mut out = Vec::with_capacity(index_entries.len());
                 for block_idx in 0..index_entries.len() {
                     out.push(
@@ -974,7 +1015,14 @@ impl ModularBlockReader {
                     );
                 }
                 out
-            };
+            }
+            // Unreachable: Coalesced requires !kill ⇒ plan is Some.
+            (CoalesceStrategy::Coalesced, None) => {
+                return Err(anyhow::anyhow!(
+                    "coalesced strategy selected without a range plan"
+                ));
+            }
+        };
 
         for data_block in data_blocks {
             // Preserve the original counter semantics: every record (including


### PR DESCRIPTION
## What
Wires the `choose_read_strategy` chooser (from #786 / slice 3a) into the two PAX/SST read sites, replacing the hardcoded always-coalesce `if/else` with a **3-mode precedence**:

1. **Kill-switch** (`PROXIMADB_DISABLE_PAX_RANGE_COALESCE` / `…_SST_SCAN_COALESCE`) → force per-block.
2. **Cost-driven chooser** (`PROXIMADB_READ_STRATEGY_CHOOSER=1`) → `choose_read_strategy(is_cloud, n_blocks, total_bytes, coalesced_gets, coalesced_bytes)` — picks per-block vs coalesced from the predicted GET/byte cost + tier.
3. **Default** → always-coalesce (the safe baseline from slices 1+2).

**Default OFF** — the always-coalesce baseline runs unless the chooser is explicitly opted in. When on, it **logs** the chosen strategy + scores + tier (observe mode, per ADR-052's observe→flip gate).

## Sites
- **`sst_io_layer::batch_read_with_filtering`** (PAX point-lookup): estimates coalesced geometry via `DefaultRangeCoalescer`, uses `is_cloud_file` for tier.
- **`sst_query_engine::traditional_search`** (SST full-scan): uses `ObjectRangePlan.estimated_get_requests`/`estimated_bytes`, uses `is_cloud_path` for tier.

Both are **byte-identical** — the chooser only routes between byte-identical paths (verified in slices 1+2).

## Verification
- `cargo clippy --lib --bins -p proximadb` → **clean (0 warnings)**, expect-free.
- `cargo fmt --check` → clean.
- The chooser's 4 unit tests (from #786) pin the crossovers; slices 1+2 tests + recall ratchet stay green (routing only).

## Completes TD-RDSTRAT-1
- Slice 1 (#780 ✅ merged): PAX batch coalesce baseline.
- Slice 2 (#783 ✅ merged): SST scan coalesce baseline.
- Slice 3a (#786 ✅ merged): the cost-driven chooser (pure logic + tests).
- **Slice 3b (this PR): the wiring** — the adaptive layer is now live (default-off, observe).

Follow-ups (out of scope): learned weights from `io_trace` (EWMA `avg_get_bytes` per tier → the true 'consume io_trace' step); full-scan as a distinct strategy (currently subsumed by coalesced-all over contiguous blocks).