### PR TITLE
feat(search): ADR-056 AQE Tier-1 — S2 observability + S11 wait-time dial + ADR acceptance

### DIFF
--- a/docs/12-design/adr/ADR-056-adaptive-execution-predicate-pushdown-first.adoc
+++ b/docs/12-design/adr/ADR-056-adaptive-execution-predicate-pushdown-first.adoc
@@ -5,8 +5,8 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | Proposed (filed 2026-07-09, multi-source research-backed; **claims validated 2026-07-09** — see §10). Decider sign-off pending.
-| Decider | (pending)
+| Status | **Accepted** (filed 2026-07-09; claims validated 2026-07-09 — see §10; **decider sign-off 2026-07-09**).
+| Decider | Vijaykumar Singh (2026-07-09)
 | Date | 2026-07-09
 | Relates to | link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (scan-avoidance is the dominant cloud-OLAP cost term — the spine this decision rests on), link:ADR-054-native-execution-engine-progressive-cutover.adoc[ADR-054] (the native operators the adaptations plug into), link:ADR-050-statistics-fed-datafusion-route-selection.adoc[ADR-050] (the cost router / inter-query learn loop), link:ADR-039-allow-list-no-root-internal-leak.adoc[ADR-039] (the DataFusion leakage boundary the pushdown seam respects).
 | Refines | ADR-052 invariant 3 (scan-avoidance first) — *operationalized* as "predicate-pushdown is the lead adaptive school." Amends ADR-054 §5: the `HashJoinBuild`/`HashJoinProbe` boundary (TD-OLAP-11) MUST be an explicit materialization point from day one to preserve the future re-plan option.

--- a/src/datafusion/proxima_scan_exec.rs
+++ b/src/datafusion/proxima_scan_exec.rs
@@ -210,6 +210,24 @@ pub fn runtime_filter_prune_enabled() -> bool {
     })
 }
 
+/// The probe scan's wait budget for the build-side runtime filter's
+/// `wait_complete()` rendezvous (ADR-056 AQE-S11). Default **1500 ms** —
+/// Impala's effective 1000 ms + margin; on object-storage the wait is *more*
+/// favorable than HDFS (each skipped ranged GET = round-trip + egress $, the
+/// dominant term). Tunable per workload; the arrived-vs-timed-out outcome is
+/// recorded into `IoTrace` so the route cost model learns whether the budget
+/// pays. Set `PROXIMADB_DF_RUNTIME_FILTER_WAIT_MS` to override.
+pub fn runtime_filter_wait_ms() -> u64 {
+    static WAIT_MS: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *WAIT_MS.get_or_init(|| {
+        std::env::var("PROXIMADB_DF_RUNTIME_FILTER_WAIT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&ms| ms > 0)
+            .unwrap_or(1500)
+    })
+}
+
 impl ProximaScanExec {
     /// Create a new ProximaScanExec using the builder pattern.
     pub fn builder() -> ProximaScanExecBuilder {
@@ -408,15 +426,31 @@ impl ExecutionPlan for ProximaScanExec {
         // evaluated — bounded by a timeout so no plan shape can stall a scan
         // (on timeout, splits are read unpruned: conservative). Per-split
         // evaluation below stays as defense-in-depth.
+        //
+        // ADR-056 AQE-S11: the budget is a configurable dial
+        // (`PROXIMADB_DF_RUNTIME_FILTER_WAIT_MS`, default 1500 ms) and the
+        // arrived-vs-timed-out outcome is recorded into `IoTrace` so the route
+        // cost model learns per-workload whether the wait pays.
         let wait_filters = dynamic_filters.clone();
+        let wait_trace = self.trace.clone();
+        let wait_budget_ms = runtime_filter_wait_ms();
         let head = futures::stream::once(async move {
             for dynamic in &wait_filters {
                 if let Some(df) = dynamic.downcast_ref::<DynamicFilterPhysicalExpr>() {
-                    let _ = tokio::time::timeout(
-                        std::time::Duration::from_secs(10),
+                    let started = std::time::Instant::now();
+                    let arrived = tokio::time::timeout(
+                        std::time::Duration::from_millis(wait_budget_ms),
                         df.wait_complete(),
                     )
-                    .await;
+                    .await
+                    .is_ok();
+                    let waited_ms = started.elapsed().as_millis() as u64;
+                    match &wait_trace {
+                        Some(t) => t.record_runtime_filter_wait(arrived, waited_ms),
+                        None => crate::observability::io_trace::record_runtime_filter_wait(
+                            arrived, waited_ms,
+                        ),
+                    }
                 }
             }
             futures::stream::empty::<DFResult<RecordBatch>>()

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -142,6 +142,14 @@ pub struct IoTrace {
     /// promotion gate consumes.
     splits_total: AtomicU64,
     splits_pruned: AtomicU64,
+    /// Runtime-filter wait outcomes (ADR-056 AQE-S11): how often the probe scan's
+    /// `wait_complete()` rendezvous resolved with the filter arrived (pruning
+    /// enabled) vs timed out (filterless, conservative), plus the wall ms spent
+    /// waiting. The route cost model consumes the arrived/(arrived+timed_out)
+    /// ratio to learn per-workload whether the wait budget pays.
+    runtime_filter_arrived: AtomicU64,
+    runtime_filter_timed_out: AtomicU64,
+    runtime_filter_wait_ms: AtomicU64,
     /// Bytes written to object storage (ingest/flush — KIU).
     bytes_written: AtomicU64,
     /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
@@ -238,6 +246,21 @@ impl IoTrace {
     pub fn record_splits(&self, total: u64, pruned: u64) {
         self.splits_total.fetch_add(total, Ordering::Relaxed);
         self.splits_pruned.fetch_add(pruned, Ordering::Relaxed);
+    }
+
+    /// Record a runtime-filter wait outcome (ADR-056 AQE-S11): `arrived` = the
+    /// filter completed within the wait budget (pruning enabled); otherwise it
+    /// timed out (splits read filterless, conservative). `waited_ms` = the wall
+    /// ms actually spent at the rendezvous.
+    pub fn record_runtime_filter_wait(&self, arrived: bool, waited_ms: u64) {
+        if arrived {
+            self.runtime_filter_arrived.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.runtime_filter_timed_out
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.runtime_filter_wait_ms
+            .fetch_add(waited_ms, Ordering::Relaxed);
     }
 
     /// Add to bytes written to object storage.
@@ -342,6 +365,9 @@ impl IoTrace {
             range_gets: self.range_gets.load(Ordering::Relaxed),
             splits_total: self.splits_total.load(Ordering::Relaxed),
             splits_pruned: self.splits_pruned.load(Ordering::Relaxed),
+            runtime_filter_arrived: self.runtime_filter_arrived.load(Ordering::Relaxed),
+            runtime_filter_timed_out: self.runtime_filter_timed_out.load(Ordering::Relaxed),
+            runtime_filter_wait_ms: self.runtime_filter_wait_ms.load(Ordering::Relaxed),
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
@@ -384,6 +410,15 @@ pub struct IoTraceSnapshot {
     /// Splits skipped before fetch — with `splits_total`, the skip ratio.
     #[serde(default)]
     pub splits_pruned: u64,
+    /// Runtime-filter wait outcomes (ADR-056 AQE-S11): arrived vs timed-out +
+    /// the wall ms spent waiting. `arrived / (arrived + timed_out)` is the
+    /// per-workload signal the route cost model learns to tune the wait budget.
+    #[serde(default)]
+    pub runtime_filter_arrived: u64,
+    #[serde(default)]
+    pub runtime_filter_timed_out: u64,
+    #[serde(default)]
+    pub runtime_filter_wait_ms: u64,
     pub bytes_written: u64,
     pub footer_hits: u64,
     pub footer_misses: u64,
@@ -550,6 +585,11 @@ pub fn record_range_gets(gets: u64) {
 /// snapshot. Silently no-ops outside an active scope.
 pub fn record_splits(total: u64, pruned: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_splits(total, pruned));
+}
+
+/// Record a runtime-filter wait outcome for the active query (ADR-056 AQE-S11).
+pub fn record_runtime_filter_wait(arrived: bool, waited_ms: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_runtime_filter_wait(arrived, waited_ms));
 }
 
 /// Add to bytes written to object storage for the active query.

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -431,6 +431,16 @@ struct CostQuantities {
     egress_bytes: f64,
     bytes_written: f64,
     compute_ms: f64,
+    // Diagnostic observability (ADR-056 AQE-S2): the runtime-filter skip ratio
+    // + the wait-outcome ratio. NOT in `score` (pruning already reduced
+    // `range_gets`/`bytes_read` — scoring these double-counts). Recorded per
+    // (shape-class, backend) so promotion/demotion gates + AQE-S4 (build/probe
+    // swap) can read them.
+    splits_total: f64,
+    splits_pruned: f64,
+    runtime_filter_arrived: f64,
+    runtime_filter_timed_out: f64,
+    runtime_filter_wait_ms: f64,
 }
 
 impl CostQuantities {
@@ -441,6 +451,11 @@ impl CostQuantities {
             egress_bytes: snap.egress_bytes as f64,
             bytes_written: snap.bytes_written as f64,
             compute_ms: snap.total_compute_ms() as f64,
+            splits_total: snap.splits_total as f64,
+            splits_pruned: snap.splits_pruned as f64,
+            runtime_filter_arrived: snap.runtime_filter_arrived as f64,
+            runtime_filter_timed_out: snap.runtime_filter_timed_out as f64,
+            runtime_filter_wait_ms: snap.runtime_filter_wait_ms as f64,
         }
     }
 }
@@ -453,6 +468,11 @@ struct Cell {
     egress_bytes: f64,
     bytes_written: f64,
     compute_ms: f64,
+    splits_total: f64,
+    splits_pruned: f64,
+    runtime_filter_arrived: f64,
+    runtime_filter_timed_out: f64,
+    runtime_filter_wait_ms: f64,
     samples: u64,
 }
 
@@ -464,6 +484,11 @@ impl Cell {
             self.egress_bytes = q.egress_bytes;
             self.bytes_written = q.bytes_written;
             self.compute_ms = q.compute_ms;
+            self.splits_total = q.splits_total;
+            self.splits_pruned = q.splits_pruned;
+            self.runtime_filter_arrived = q.runtime_filter_arrived;
+            self.runtime_filter_timed_out = q.runtime_filter_timed_out;
+            self.runtime_filter_wait_ms = q.runtime_filter_wait_ms;
         } else {
             let blend = |old: f64, new: f64| alpha * new + (1.0 - alpha) * old;
             self.range_gets = blend(self.range_gets, q.range_gets);
@@ -471,6 +496,14 @@ impl Cell {
             self.egress_bytes = blend(self.egress_bytes, q.egress_bytes);
             self.bytes_written = blend(self.bytes_written, q.bytes_written);
             self.compute_ms = blend(self.compute_ms, q.compute_ms);
+            self.splits_total = blend(self.splits_total, q.splits_total);
+            self.splits_pruned = blend(self.splits_pruned, q.splits_pruned);
+            self.runtime_filter_arrived =
+                blend(self.runtime_filter_arrived, q.runtime_filter_arrived);
+            self.runtime_filter_timed_out =
+                blend(self.runtime_filter_timed_out, q.runtime_filter_timed_out);
+            self.runtime_filter_wait_ms =
+                blend(self.runtime_filter_wait_ms, q.runtime_filter_wait_ms);
         }
         self.samples += 1;
     }
@@ -482,6 +515,11 @@ impl Cell {
             egress_bytes: self.egress_bytes,
             bytes_written: self.bytes_written,
             compute_ms: self.compute_ms,
+            splits_total: self.splits_total,
+            splits_pruned: self.splits_pruned,
+            runtime_filter_arrived: self.runtime_filter_arrived,
+            runtime_filter_timed_out: self.runtime_filter_timed_out,
+            runtime_filter_wait_ms: self.runtime_filter_wait_ms,
         }
     }
 }
@@ -1159,6 +1197,25 @@ mod tests {
             s.compute_ms.insert("engine".to_string(), compute_ms);
         }
         s
+    }
+
+    #[test]
+    fn cost_quantities_carry_split_and_wait_observability() {
+        // ADR-056 AQE-S2: splits_pruned + the runtime-filter wait outcome flow
+        // from IoTraceSnapshot → CostQuantities (diagnostic observability for
+        // the route model; NOT in the score fn).
+        let mut snap = IoTraceSnapshot::default();
+        snap.splits_total = 100;
+        snap.splits_pruned = 37;
+        snap.runtime_filter_arrived = 4;
+        snap.runtime_filter_timed_out = 1;
+        snap.runtime_filter_wait_ms = 4_200;
+        let q = CostQuantities::from_snapshot(&snap);
+        assert_eq!(q.splits_total, 100.0);
+        assert_eq!(q.splits_pruned, 37.0);
+        assert_eq!(q.runtime_filter_arrived, 4.0);
+        assert_eq!(q.runtime_filter_timed_out, 1.0);
+        assert_eq!(q.runtime_filter_wait_ms, 4_200.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the **predicate-pushdown scan-avoidance stack's adaptive feedback loop** (ADR-056, the AQE Tier-1 slices the decider approved 2026-07-09). Exploration on advanced `develop` found **most of the stack was already built** (TD-OLAP-3 + bloom default-ON #784 + DataFusion 54's build-min/max→probe-scan via `DynamicFilterPhysicalExpr`); this fills the real gaps.

## What ships

**AQE-S2 (observability):** `splits_pruned` was already in `IoTrace` but **NOT in `CostQuantities`** — the route model was blind to the pruning ratio. Wired `splits_total`/`splits_pruned` (+ the S11 wait outcomes) into `CostQuantities::from_snapshot` + `Cell::fold` EWMA. **NOT in `score()`** (pruning already reduced `range_gets`/`bytes_read` — scoring it double-counts). Diagnostic per-(shape,backend) observability; the substrate AQE-S4 (build/probe swap) needs.

**AQE-S11 (wait-time dial + adaptive feedback):** the hardcoded 10s `wait_complete()` timeout → a configurable dial (`PROXIMADB_DF_RUNTIME_FILTER_WAIT_MS`, default **1500ms** — Impala's effective 1000ms + margin). On object-storage the wait is *more* favorable than HDFS (each skipped ranged GET = round-trip + egress $, the dominant term). + **adaptive feedback**: the arrived-vs-timed-out outcome + `waited_ms` recorded into `IoTrace` (always-on counters) → the route cost model **learns per-workload whether the budget pays**.

**AQE-S3 (verify):** the build-min/max→probe-scan mechanism is already complete (`DynamicFilterPhysicalExpr`→`ColumnBounds::can_prune`, default-ON since TD-OLAP-3 v6); covered by `live_join_filter_shape_translates` + the `can_prune` tests. No new prod code.

**ADR-056:** Proposed → **Accepted** (decider sign-off 2026-07-09).

## Verification (local)
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- **35/35 `route_cost_model` tests pass** (incl. the new `cost_quantities_carry_split_and_wait_observability` S2 test; no regressions from the `CostQuantities` field additions).

## Non-goals (next slices)
- **AQE-S4** (runtime build/probe swap + SMJ→BHJ at the rendezvous) — needs S2 (this lands it); riskier join-strategy change → its own plan.
- S5 (sort-on-materialize), S6 (PREWHERE), S7/S8 (MemoryPool/grace_hash) — separate tracks.