### PR TITLE
feat(engine): ADR-054 Phase 2.5 — PaxScanOperator (TD-OLAP-14 slice 1)

### DIFF
--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -14,6 +14,7 @@ pub mod low_latency_executor;
 pub mod native_engine;
 pub mod native_join_ops;
 pub mod native_ops;
+pub mod native_scan;
 pub mod olap_delta_merge;
 pub mod plan_cache;
 pub mod planner;

--- a/src/query/execution/native_scan.rs
+++ b/src/query/execution/native_scan.rs
@@ -1,0 +1,162 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+//! # Native PAX scan operator (ADR-054 Phase 2.5, TD-OLAP-14)
+//!
+//! The real-storage scan source for the native vectorized engine. Mirrors the
+//! DataFusion `PaxSplitReader`'s decode path (PaxSegmentScanner → per-block
+//! decode → RecordBatch) but with **zero DataFusion dependency** — the native
+//! engine works on Arrow `RecordBatch`es directly via the `ExecutionOperator`
+//! contract.
+//!
+//! MVP (Phase 2.5 slice 1): `ScanPredicate::default()` (no block-level zone-map
+//! pruning); correctness via the FilterProject operator above. Block-level
+//! pruning (Expr → ScanPredicate) is slice 2 (the scan-avoidance lever).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, BinaryArray, Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use proximadb_block_format::{ColumnRole, PaxBlockReader};
+use proximadb_execution_contracts::{BatchStream, ExecutionError, ExecutionOperator};
+use proximadb_storage_common::pax_block::{PaxSegmentScanner, ScanPredicate};
+
+use crate::storage::formats::FileSplit;
+use crate::storage::persistence::filesystem::FilesystemFactory;
+
+/// A scan operator that reads PAX-backed storage segments and emits Arrow
+/// `RecordBatch`es into the native engine's `BatchStream`. Mirrors
+/// `PaxSplitReader::decode_segment` but without DataFusion types.
+#[derive(Debug)]
+pub(crate) struct PaxScanOperator {
+    splits: Vec<FileSplit>,
+    filesystem_factory: Arc<FilesystemFactory>,
+    name_to_col_id: HashMap<String, i32>,
+    output_schema: SchemaRef,
+}
+
+impl PaxScanOperator {
+    pub(crate) fn new(
+        splits: Vec<FileSplit>,
+        filesystem_factory: Arc<FilesystemFactory>,
+        name_to_col_id: HashMap<String, i32>,
+        output_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            splits,
+            filesystem_factory,
+            name_to_col_id,
+            output_schema,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionOperator for PaxScanOperator {
+    fn output_schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    async fn execute(&self, _input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let factory = self.filesystem_factory.clone();
+        let splits = self.splits.clone();
+        let name_to_col_id = self.name_to_col_id.clone();
+        let schema = self.output_schema.clone();
+
+        // Eagerly read + decode all segments (MVP; lazy per-segment streaming is a
+        // follow-on for large multi-segment collections).
+        let mut batches = Vec::new();
+        for split in &splits {
+            let bytes = factory.read(&split.file_path).await.map_err(|e| {
+                ExecutionError::Execution(format!("PAX scan read {}: {e}", split.file_path))
+            })?;
+            let decoded = decode_pax_segment(&bytes, &name_to_col_id, &schema)?;
+            batches.extend(decoded);
+        }
+
+        Ok(Box::pin(futures::stream::iter(
+            batches.into_iter().map(Ok::<_, ExecutionError>),
+        )))
+    }
+}
+
+/// Decode one PAX segment file's bytes into `RecordBatch`es — one per block.
+/// Mirrors `PaxSplitReader::decode_segment` but with `ExecutionError` (zero DF).
+fn decode_pax_segment(
+    bytes: &[u8],
+    name_to_col_id: &HashMap<String, i32>,
+    schema: &SchemaRef,
+) -> Result<Vec<RecordBatch>, ExecutionError> {
+    let predicate = ScanPredicate::default(); // MVP: no block-level pruning (slice 2)
+    let mut scanner = PaxSegmentScanner::from_bytes(bytes.to_vec(), predicate)
+        .map_err(|e| ExecutionError::Execution(format!("PAX segment open: {e}")))?;
+
+    let mut batches = Vec::new();
+    while let Some(reader) = scanner.next_block() {
+        let arrays: Vec<ArrayRef> = schema
+            .fields()
+            .iter()
+            .map(|f| decode_column(&reader, f.name(), name_to_col_id))
+            .collect::<Result<_, _>>()?;
+        let batch = RecordBatch::try_new(schema.clone(), arrays)
+            .map_err(|e| ExecutionError::Execution(format!("PAX batch build: {e}")))?;
+        batches.push(batch);
+    }
+    Ok(batches)
+}
+
+/// Decode one column by name → PAX column_id → typed stripe → Arrow array.
+/// Mirrors `PaxSplitReader::decode_column`'s data_type_id dispatch.
+fn decode_column(
+    reader: &PaxBlockReader,
+    name: &str,
+    name_to_col_id: &HashMap<String, i32>,
+) -> Result<ArrayRef, ExecutionError> {
+    let cid = *name_to_col_id
+        .get(name)
+        .ok_or_else(|| ExecutionError::Schema(format!("PAX: no column_id for {name}")))?;
+    let meta = reader
+        .column_metas()
+        .iter()
+        .find(|m| m.column_id == cid)
+        .ok_or_else(|| {
+            ExecutionError::Schema(format!("PAX: column {name} (id {cid}) not in block"))
+        })?;
+
+    // TypeId bytes (proximadb_codec): I64=0x03, F64=0x02; 0xff = variable-length.
+    Ok(match meta.data_type_id {
+        0x03 => {
+            let vals = reader.decode_i64_stripe(cid).ok_or_else(|| {
+                ExecutionError::Execution(format!("PAX: i64 decode failed for {name} (id {cid})"))
+            })?;
+            Arc::new(Int64Array::from(vals))
+        }
+        0x02 => {
+            let vals = reader.decode_f64_stripe(cid).ok_or_else(|| {
+                ExecutionError::Execution(format!("PAX: f64 decode failed for {name} (id {cid})"))
+            })?;
+            Arc::new(Float64Array::from(vals))
+        }
+        0xff if meta.role == ColumnRole::Props => {
+            let vals = reader.decode_bytes_stripe(cid).ok_or_else(|| {
+                ExecutionError::Execution(format!("PAX: bytes decode failed for {name} (id {cid})"))
+            })?;
+            Arc::new(BinaryArray::from_iter(vals))
+        }
+        0xff => {
+            let vals = reader.decode_str_stripe(cid).ok_or_else(|| {
+                ExecutionError::Execution(format!("PAX: str decode failed for {name} (id {cid})"))
+            })?;
+            Arc::new(StringArray::from(vals))
+        }
+        other => {
+            return Err(ExecutionError::NotImplemented(format!(
+                "PAX data_type_id {other:#x} for {name} (MVP: i64/f64/str/bytes)"
+            )));
+        }
+    })
+}


### PR DESCRIPTION
The real-storage scan source for the native engine. Mirrors PaxSplitReader's decode path (PaxSegmentScanner→RecordBatch) without DataFusion types. MVP: ScanPredicate::default(). Scoped #![allow(dead_code)] until the lower_physical::Scan wiring (context threading) lands in the next slice. Compile + clippy clean.