### PR TITLE
chore(grpc): remove inert enable_grpc_v1_compat config + stale comments

### DIFF
--- a/crates/platform/proximadb-runtime/src/bootstrap_config.rs
+++ b/crates/platform/proximadb-runtime/src/bootstrap_config.rs
@@ -425,17 +425,6 @@ pub struct GrpcHttpServerConfig {
     /// Allows dynamic service discovery (grpcurl, etc)
     pub enable_reflection: bool,
 
-    /// Enable deprecated gRPC v1 compatibility services.
-    ///
-    /// When `false` (default) only the canonical `proximadb.v2.ProximaRecordService`,
-    /// `grpc.health.v1.Health`, and reflection are registered. When `true`, the
-    /// deprecated v1 compatibility adapter services (vector/sql/collection/graph/
-    /// hybrid-search/security/document/entity/observability/streaming) are also
-    /// registered. Post-sunset these v1 services are removed entirely.
-    ///
-    /// Env override: `PROXIMADB_GRPC_V1_COMPAT` (set to `1`/`true` to enable).
-    pub enable_grpc_v1_compat: bool,
-
     /// Enable gRPC compression for Avro payloads
     /// Further reduces already-compact protobuf
     pub compression: bool,
@@ -450,20 +439,6 @@ pub struct GrpcHttpServerConfig {
 }
 
 impl GrpcHttpServerConfig {
-    /// Resolve the deprecated gRPC v1 compatibility flag from the
-    /// `PROXIMADB_GRPC_V1_COMPAT` environment variable. Defaults to `false`
-    /// (v1 compat services not registered) when unset or unparseable.
-    /// Accepts `1`/`true`/`yes`/`on` (case-insensitive) as truthy.
-    pub fn v1_compat_from_env() -> bool {
-        std::env::var("PROXIMADB_GRPC_V1_COMPAT")
-            .ok()
-            .map(|v| {
-                let v = v.trim().to_ascii_lowercase();
-                matches!(v.as_str(), "1" | "true" | "yes" | "on")
-            })
-            .unwrap_or(false)
-    }
-
     /// Check if TLS is enabled
     pub fn is_tls_enabled(&self) -> bool {
         self.tls_cert_file.is_some() && self.tls_key_file.is_some()
@@ -580,8 +555,6 @@ impl Default for MultiServerConfig {
                 enable_grpc: true,
                 max_message_size: 64 * 1024 * 1024, // 64MB for bulk vector inserts with Avro
                 enable_reflection: true,
-                // Deprecated v1 compat adapters off by default; env opt-in.
-                enable_grpc_v1_compat: GrpcHttpServerConfig::v1_compat_from_env(),
                 compression: true,
                 tls_cert_file: None,
                 tls_key_file: None,
@@ -929,7 +902,6 @@ mod tests {
             enable_grpc: true,
             max_message_size: 64 * 1024 * 1024,
             enable_reflection: true,
-            enable_grpc_v1_compat: false,
             compression: true,
             tls_cert_file: None,
             tls_key_file: None,

--- a/crates/platform/proximadb-runtime/src/graph_port.rs
+++ b/crates/platform/proximadb-runtime/src/graph_port.rs
@@ -96,7 +96,7 @@ pub trait GraphPort: Send + Sync {
 
     // ── Hybrid query (cross-modal) ────────────────────────────────────────
 
-    /// DEPRECATED (TD-143): v1 hybrid query — dormant (behind `enable_grpc_v1_compat`),
+    /// DEPRECATED (TD-143): v1 hybrid query — dormant (v1 gRPC surface removed, TD-V1SUNSET-1),
     /// not tenant-scoped, owns its own ranking. Use v2 FusionSearch instead.
     #[deprecated(note = "v1 ExecuteHybridQuery is deprecated; use v2 FusionSearch. See TD-143.")]
     async fn execute_hybrid_query(

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -133,7 +133,7 @@ pub trait ApiHandlersPort: Send + Sync {
 
     // ── Hybrid ────────────────────────────────────────────────────────────────
 
-    /// DEPRECATED (TD-143): v1 hybrid query — dormant (behind `enable_grpc_v1_compat`),
+    /// DEPRECATED (TD-143): v1 hybrid query — dormant (v1 gRPC surface removed, TD-V1SUNSET-1),
     /// not tenant-scoped, owns its own ranking. Use v2 FusionSearch instead.
     #[deprecated(note = "v1 ExecuteHybridQuery is deprecated; use v2 FusionSearch. See TD-143.")]
     async fn execute_hybrid_query(

--- a/src/network/grpc/graph_service.rs
+++ b/src/network/grpc/graph_service.rs
@@ -1079,7 +1079,7 @@ impl GraphServiceImpl {
     /// Execute hybrid vector-graph query.
     ///
     /// DEPRECATED (TD-143): v1 entry — delegates to the deprecated inherent impl,
-    /// reachable only when `enable_grpc_v1_compat` is on. Prefer v2
+    /// reachable only via the (now-removed) v1 gRPC compat surface. Prefer v2
     /// `ProximaFusionService.FusionSearch`.
     #[allow(deprecated)]
     async fn execute_hybrid_query(

--- a/src/network/grpc/v2/graph_service.rs
+++ b/src/network/grpc/v2/graph_service.rs
@@ -7,7 +7,7 @@
 //!
 //! This is the canonical, always-registered graph surface (`proximadb.v2.
 //! ProximaGraphService`). It replaces the deprecated `proximadb.v1.GraphService`,
-//! which is only reachable behind `enable_grpc_v1_compat` (default off).
+//! which was removed in TD-V1SUNSET-1 step 4.
 //!
 //! ## Design
 //!

--- a/src/network/middleware/v1_sunset.rs
+++ b/src/network/middleware/v1_sunset.rs
@@ -20,8 +20,8 @@
 //! surface (ADR-049, closes TD-121). This middleware is the *enabling slice* for
 //! that retirement on the REST edge: when the `PROXIMADB_REST_V1_COMPAT` flag is
 //! off, requests to the deprecated `/api/v1/*` surface are answered with
-//! `410 Gone` + RFC 8594 deprecation headers instead of being served — mirroring
-//! the gRPC v1 compat gate (`PROXIMADB_GRPC_V1_COMPAT`).
+//! `410 Gone` + RFC 8594 deprecation headers instead of being served (the gRPC
+//! v1 compat gate was removed in TD-V1SUNSET-1 step 4).
 //!
 //! The flag is **on by default**, so behavior is unchanged until an operator
 //! explicitly disables v1 (starting the sunset clock without a flag-day). The

--- a/src/network/server_builder.rs
+++ b/src/network/server_builder.rs
@@ -312,10 +312,6 @@ pub struct GrpcHttpServerBuilder {
 
     /// Enable gRPC reflection for service discovery
     enable_reflection: bool,
-
-    /// Enable deprecated gRPC v1 compatibility adapter services.
-    /// Default sourced from `PROXIMADB_GRPC_V1_COMPAT` (off when unset).
-    enable_grpc_v1_compat: bool,
 }
 
 impl Default for GrpcHttpServerBuilder {
@@ -330,7 +326,6 @@ impl Default for GrpcHttpServerBuilder {
             tls_key_file: None,
             max_message_size: 64 * 1024 * 1024, // 64MB for bulk vector inserts
             enable_reflection: true,
-            enable_grpc_v1_compat: GrpcHttpServerConfig::v1_compat_from_env(),
         }
     }
 }
@@ -364,12 +359,6 @@ impl GrpcHttpServerBuilder {
     /// Enable/disable gRPC reflection
     pub fn enable_reflection(mut self, enabled: bool) -> Self {
         self.enable_reflection = enabled;
-        self
-    }
-
-    /// Enable/disable deprecated gRPC v1 compatibility adapter services
-    pub fn enable_grpc_v1_compat(mut self, enabled: bool) -> Self {
-        self.enable_grpc_v1_compat = enabled;
         self
     }
 
@@ -433,7 +422,6 @@ impl GrpcHttpServerBuilder {
             enable_grpc: self.enable_grpc,
             max_message_size: self.max_message_size,
             enable_reflection: self.enable_reflection,
-            enable_grpc_v1_compat: self.enable_grpc_v1_compat,
             compression: self.grpc_compression, // Clear mapping to config
             tls_cert_file: self.tls_cert_file,
             tls_key_file: self.tls_key_file,


### PR DESCRIPTION
Follow-up to #792. The `enable_grpc_v1_compat` / `PROXIMADB_GRPC_V1_COMPAT` flag became inert once the v1 gRPC services were deleted (no arm reads it — setting the env var silently did nothing). Removes the dead config knob (`GrpcHttpServerBuilder` + `GrpcHttpServerConfig` fields, the builder method, 2 construction sites, `v1_compat_from_env()`) and sweeps the stale comments that referenced it as a live gate (v1_sunset, graph_service, v2/graph_service, runtime port/graph_port). The 2 references in generated proto/proximadb.v2.rs are left (they regenerate from .proto).

Verified: cargo check --tests, clippy --lib --bins -D warnings, cargo check --features proximadb/cluster --lib, fmt --check — all clean.