### PR TITLE
fix(build): correct rg pattern quoting in Makefile hygiene-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ clippy:
 
 hygiene-check:
 	@echo "🧹 Running tracked artifact hygiene check..."
-	@bad_files=$$(git ls-files | rg '(^|/)\\.victor($|/)|\\.bak[0-9]*$|\\.disabled$'); \
+	@bad_files=$$(git ls-files | rg '(^|/)\.victor($$|/)|\.bak[0-9]*$$|\.disabled$$'); \
 	if [ -n "$$bad_files" ]; then \
 		echo "❌ Forbidden tracked artifacts detected:"; \
 		echo "$$bad_files"; \


### PR DESCRIPTION
## Problem

The `hygiene-check` Makefile recipe aborted under `/bin/sh` (dash) with:

```
/bin/sh: 7: Syntax error: Unterminated quoted string
make: *** [Makefile:100: hygiene-check] Error 2
```

so `make check` / `make work-commit-check` could not complete locally.

## Root cause — two quoting defects in the single `rg` pattern

1. **Unescaped `$` in a recipe.** Make treats `$` as a variable reference. The trailing `$'` in `\\.disabled$'` was parsed by Make as a `$(')` reference that *consumed the pattern's closing quote*, leaving the single-quoted string unterminated — exactly the dash error. Fixed by escaping every shell-bound `$` as `$$` (`$$|`, `$$'`), so the `$` end-anchors and the `($|/)` alternation survive Make expansion.
2. **Over-escaped `\\.`.** Mid-line backslashes are not special to Make, so `\\.` reached `rg` as *escaped-backslash + any-char* rather than a literal dot — the `.victor` / `.bak` / `.disabled` dots never matched. Corrected to `\.`.

## Diff

```
-	@bad_files=$$(git ls-files | rg '(^|/)\\.victor($|/)|\\.bak[0-9]*$|\\.disabled$'); \
+	@bad_files=$$(git ls-files | rg '(^|/)\.victor($$|/)|\.bak[0-9]*$$|\.disabled$$'); \
```

## Verification

- `make hygiene-check` → exits 0, no shell error.
- The corrected pattern was tested against sample paths: it matches the forbidden artifacts (`foo/.victor/x`, `.victor/y`, `a.bak`, `a.bak2`, `mod.rs.disabled`) and ignores safe names (`victor.rs`, `a.backup`, `notes.txt`, `src/main.rs`) — so it fails loud on real artifacts rather than silently passing.

Build-tooling-only change (no source touched).