### PR TITLE
feat(portability): Windows compile ratchet + first blocker fix (TD-EMBED-1)

### DIFF
--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -1,0 +1,60 @@
+# Windows (MSVC) compile-only ratchet — TD-EMBED-1.
+#
+# proximadb_embedded currently ships Linux + macOS wheels; Windows is blocked
+# only by the Rust engine not yet compiling for x86_64-pc-windows-msvc. This is
+# a COMPILE-ONLY ratchet (no wheel, no C-deps yet): each rung is a crate that
+# now compiles on Windows and MUST stay green. As blockers are fixed the gating
+# scope expands one rung at a time (ratchet only goes up). A separate,
+# non-gating "measure tail" step surfaces the NEXT blocker so the effort is
+# evidence-driven, not speculative.
+#
+# Path-gated + dispatch-only so it costs a Windows runner only when
+# Windows-relevant code changes.
+name: Windows Compile Ratchet
+
+on:
+  pull_request:
+    paths:
+      - 'crates/storage/**'
+      - 'src/storage/**'
+      - 'src/embedded/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/windows-compile-ratchet.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  ratchet:
+    name: cargo check (x86_64-pc-windows-msvc)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+
+      # ---- GATING RUNGS (must stay green; expand as blockers are fixed) --------
+      # Rung 1: proximadb-storage-common compiles on Windows (the memmap2::Advice
+      # madvise gating landed in this PR). Add the next crate here once it's green.
+      - name: Rung 1 — proximadb-storage-common
+        run: cargo check -p proximadb-storage-common
+
+      # ---- MEASURE THE TAIL (non-gating; reveals the next blocker) -------------
+      # The root `proximadb` lib (default features, no `python`) is the engine the
+      # embedded wheel builds minus the PyO3/C-deps. Checking it here surfaces the
+      # next batch of Windows errors without blocking the ratchet. When this goes
+      # green, promote it to a gating rung above; the C-dep (aws-lc-sys/OpenSSL)
+      # story for the actual wheel is a later phase.
+      - name: Measure tail — root proximadb lib (informational)
+        continue-on-error: true
+        run: cargo check -p proximadb --lib

--- a/crates/storage/proximadb-storage-common/src/mmap_file.rs
+++ b/crates/storage/proximadb-storage-common/src/mmap_file.rs
@@ -79,9 +79,20 @@ impl MmapFile {
         })
     }
 
-    /// Advise the kernel about access pattern
+    /// Advise the kernel about access pattern.
+    ///
+    /// `memmap2::Mmap::advise` wraps POSIX `madvise`, which exists only on unix;
+    /// `memmap2::Advice` is not defined on Windows. Advice is a non-binding
+    /// performance hint, so on non-unix this is a correct no-op.
     pub fn advise(&self, advice: Advice) -> Result<()> {
-        self.mmap.advise(advice.into())?;
+        #[cfg(unix)]
+        {
+            self.mmap.advise(advice.into())?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = advice;
+        }
         Ok(())
     }
 }
@@ -212,6 +223,10 @@ pub enum Advice {
     DontNeed,
 }
 
+// `memmap2::Advice` (POSIX `madvise` wrapper) is unix-only, so this conversion
+// is gated to unix; on non-unix the advice is dropped (see `MmapFile::advise`).
+// The public `Advice` enum above stays cross-platform.
+#[cfg(unix)]
 impl From<Advice> for memmap2::Advice {
     fn from(advice: Advice) -> Self {
         match advice {
@@ -443,6 +458,7 @@ mod tests {
             Advice::WillNeed,
             Advice::DontNeed,
         ] {
+            #[cfg(unix)]
             let _: memmap2::Advice = advice.into();
             mmap.advise(advice)?;
         }

--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **macOS: in progress** (wheel matrix wired, CI-validated) · **Windows: Open** (engine-portability effort)
+| Status | **macOS: DONE** (aarch64 wheels shipping, PR #716) · **Windows: in progress** (compile-only ratchet started; first blocker `memmap2::Advice` fixed)
 | Severity | Low — Linux x86_64 + aarch64 wheels ship today and cover the overwhelming majority of embedded/edge/air-gapped/server deployments. macOS/Windows are additive reach, not a correctness or release blocker.
 | Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`); Windows work spans `crates/storage/proximadb-storage-common` + `src/storage`
 | Relates to | Vendored-OpenSSL manylinux fix (PR #701 / #707); `TD-IMG-1` (the other shipped-release follow-up)
@@ -59,46 +59,51 @@ publishing (see the PR that lands this).
 **unix** APIs. Windows/MSVC does not compile it. This is a real port, not a matrix row — do
 **not** add a Windows matrix entry until the engine compiles for `*-pc-windows-msvc`.
 
-=== Enumerated blockers (measured)
+=== First blocker (measured from the real MSVC build — NOT a sweeping port)
 
-The unix-only surface on the embedded link path (grep for `std::os::unix` / `libc::` /
-`mmap` / `memmap2` / `O_DIRECT` / `pread`/`pwrite` / `fcntl`):
+An earlier draft of this TD claimed a "multi-file unix→MSVC port" needing a `PlatformFile`
+seam across dozens of files. **That was a misdiagnosis** — it came from a grep that conflated
+cross-platform `memmap2`/`mmap` with genuine unix-only APIs. Re-measured against `develop`:
 
-* `crates/storage/proximadb-storage-common/src/mmap_file.rs` — mmap-backed file (memmap2 is
-  cross-platform, but the surrounding `std::os::unix` fd/advice plumbing is not).
-* `crates/storage/proximadb-storage-common/src/unified_cache_config.rs`, `.../lib.rs`
-* `crates/storage/proximadb-storage-filesystem-types/src/{lib,counting}.rs`
-* `crates/storage/proximadb-storage-encryption/src/filesystem.rs`
-* `crates/storage/proximadb-block-format/src/prune.rs`
-* `src/storage/` — `mmap_file.rs`, `common/mmap_vectors.rs`,
-  `persistence/filesystem/{local,caching_filesystem,mod}.rs`, and the SST/NOVA/SWIFT/RAPTOR
-  engine writers/readers that call the unix fd/mmap primitives directly.
+* The genuinely unix-only code (`std::os::unix` / `libc` / `nix` / raw fd) is **3 files**, and
+  **all are already `#[cfg(unix)]`-gated** with non-unix fallbacks
+  (`src/embedded/coordination/file_lock.rs`, `src/storage/common/mmap_vectors.rs`,
+  `src/storage/persistence/filesystem/local.rs`). Not blockers.
+* The **actual** first blocker (from the real prerelease-ci `Build x86_64-pc-windows-msvc`
+  log — `E0425`/`E0433`/`E0599`, 7 errors) is entirely **`memmap2::Advice` / `Mmap::advise()`
+  used unconditionally in one file**, `crates/storage/proximadb-storage-common/src/mmap_file.rs`.
+  `memmap2::Advice`/`advise` wrap POSIX `madvise` and are unix-only in `memmap2`. Advice is a
+  non-binding perf hint, so on Windows it is a correct no-op.
 
-The compile errors on MSVC are the expected `E0425/E0433/E0599` (missing unix items).
+Fixed in this PR by `#[cfg(unix)]`-gating the `From<Advice> for memmap2::Advice` impl and the
+`advise()` call (no-op on non-unix). The public `Advice` enum stays cross-platform. The unix
+path is unchanged (verified `cargo check -p proximadb-storage-common` still green on Linux), so
+no risk to the shipped Linux/macOS wheels.
 
-=== Port plan (phased, mixed-platform-safe)
+=== Approach: compile-only ratchet, measure the tail (no seam, no speculation)
 
-. **Introduce a platform seam** for the file/mmap primitives in
-  `proximadb-storage-common` — a `PlatformFile` trait (open, ranged read/write, advise, map)
-  with a `#[cfg(unix)]` impl (current code) and a `#[cfg(windows)]` impl
-  (`FILE_FLAG_*`/`CreateFileMapping`/`MapViewOfFile`). Keep the unix path byte-for-byte to
-  avoid regressing the shipped Linux/macOS wheels.
-. **Gate the advice/`O_DIRECT`-class calls** behind the seam (Windows has no `posix_fadvise`;
-  use `FILE_FLAG_NO_BUFFERING`/no-op fallbacks).
-. **Sweep the engine call sites** (`src/storage/engines/*`) to go through the seam instead of
-  `std::os::unix` directly.
-. **Add a Windows compile-only CI job** (no wheel yet) to ratchet: it must reach `cargo check
-  -p proximadb-storage-common --target x86_64-pc-windows-msvc` green before a wheel row is
-  added.
+No `PlatformFile` seam is needed — the storage code is already cfg-gated; the failures are
+isolated oversights like the `Advice` one. So the plan is a **compile-only ratchet**, not a
+port:
+
+. **`.github/workflows/windows-compile-ratchet.yml`** (added in this PR) — path-gated,
+  compile-only. Rung 1 gates `cargo check -p proximadb-storage-common` on `windows-2022` (green
+  after the `Advice` fix). A non-gating "measure tail" step checks the root `proximadb` lib to
+  surface the **next** Windows blocker.
+. **Fix the next blocker, promote it to a gating rung.** Repeat until the root lib
+  (default features, no `python`) compiles on Windows. Each rung only goes up.
+. **Then** tackle the wheel's C-deps (`aws-lc-sys` / vendored OpenSSL under MSVC) — an
+  unmeasured phase, deferred until the pure-Rust engine compiles.
 . **Only then** add `windows-latest`/`x86_64` to `build-embedded-wheels`.
 
-This is mixed-read/mixed-platform-safe by construction: the seam adds a Windows impl without
-touching the unix one, so no flag-day and no risk to the currently-shipping wheels.
+Mixed-platform-safe by construction: every fix is a `#[cfg]` gate that leaves the unix path
+byte-for-byte, so no flag-day and no risk to the currently-shipping wheels.
 
 == Verification
 
 * **macOS:** `workflow_dispatch` (`dry_run=true`) produces `*.whl` tagged `macosx_*_arm64`;
   `import proximadb_embedded` succeeds on the macos-14 runner. On the next `python-v*` tag the
   wheel publishes to PyPI alongside the Linux wheels.
-* **Windows:** the compile-only CI job goes green first (phase 4); the wheel row is added last
-  (phase 5). Until then, no Windows matrix entry — it would only fail-fast the release.
+* **Windows:** the compile-only ratchet gates the compiling crates and its "measure tail" step
+  reports the next blocker; the wheel row is added last (after the engine compiles + C-deps).
+  Until then, no Windows matrix entry — it would only fail-fast the release.


### PR DESCRIPTION
First rung toward Windows embedded wheels (TD-EMBED-1), evidence-driven.

## The misdiagnosis, corrected
The prior TD framed Windows as a multi-file unix→MSVC port needing a `PlatformFile` seam. Re-measured against the **real** prerelease-ci `Build x86_64-pc-windows-msvc` log:
- Genuinely unix-only code (`std::os::unix`/`libc`/`nix`/raw-fd) = **3 files, all already `#[cfg(unix)]`-gated** with non-unix fallbacks. Not blockers.
- The **actual** first blocker (all 7 `E0425`/`E0433`/`E0599`) = **`memmap2::Advice` / `Mmap::advise()` used unconditionally in one file** (`storage-common/mmap_file.rs`). Those wrap POSIX `madvise`, unix-only in memmap2; advice is a non-binding hint → correct no-op on Windows.

## Changes
- **Fix:** `#[cfg(unix)]`-gate the `From<Advice> for memmap2::Advice` impl + `MmapFile::advise()` (no-op on non-unix). Public `Advice` enum stays cross-platform. Unix path unchanged — `cargo check -p proximadb-storage-common` still green on Linux; `clippy -D warnings` clean.
- **Ratchet:** `.github/workflows/windows-compile-ratchet.yml` — path-gated, compile-only. Rung 1 gates `cargo check -p proximadb-storage-common` on `windows-2022`; a non-gating **"measure tail"** step checks the root `proximadb` lib to surface the *next* blocker. Ratchet only goes up.
- **TD-EMBED-1:** Windows section rewritten to reality (no seam; compile-ratchet + measure-tail; C-deps deferred; wheel row last).

## Not in scope (deferred, sequenced)
Subsequent compile blockers (revealed by the "measure tail" step), the C-dep story (`aws-lc-sys`/OpenSSL under MSVC), and the actual Windows wheel matrix row — each a later rung once the pure-Rust engine compiles.