### PR TITLE
perf(pgwire): TCP_NODELAY kills the ~46ms delayed-ACK floor — beats DuckDB on ClickBench (TD-OLAP-4)

### DIFF
--- a/docs/_internal/status/CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc
+++ b/docs/_internal/status/CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ClickBench: the ~46 ms per-query floor was TCP delayed-ACK — one-line fix beats DuckDB (2026-07-09)
+
+TD-OLAP-4. Resolves the open thread from `CLICKBENCH_FLOOR_DECOMPOSITION_2026_07_07.adoc`:
+the unattributed ~46 ms per-query wall floor. Root cause: **Nagle's algorithm on the
+pgwire socket** (no `TCP_NODELAY`). Fix: one line. Result: **ProximaDB now beats DuckDB
+on the 1M ClickBench single-node track.**
+
+== How it was found (measure-first, six cycles)
+
+The floor decomposition instrumented every server-side span and ruled each out — the
+whole point of measuring rather than guessing:
+
+[cols="2,1",options="header"]
+|===
+| span (per-query median) | ms
+| table open (LIST+HEAD+footer) | ~1 (0 cached)
+| SessionContext + UDF build | ~0
+| lowering + planning | ~0
+| pgwire path-2 setup (xCatalog + route) | ~0
+| path-1 engine-catalog `lower_sql` attempt | ~0
+| result emit (row encode + socket write) | ~0
+| compute (execution) | ~13
+| **unattributed remainder** | **~46**
+|===
+
+A fixed ~40–48 ms **outside every code span**, invariant to bytes/rows/compute, is the
+signature of a **TCP delayed-ACK / Nagle stall** (40 ms is the canonical delayed-ACK
+timer — and it fires even on loopback). The pgwire server never set `TCP_NODELAY` on its
+accepted sockets, so a SELECT response — written as several small segments
+(`RowDescription`, `DataRow`(s), `CommandComplete`) — had its second segment held by
+Nagle until the first was ACKed, while the client delayed its ACK ~40 ms. PostgreSQL's
+own server sets `TCP_NODELAY` for exactly this reason.
+
+== Fix
+
+`src/network/postgres/mod.rs` — `stream.set_nodelay(true)` on each accepted pgwire
+connection (best-effort; a failure only forfeits the latency win). One line.
+
+== Measured (release, 1M ClickBench `cb_hits_1m_lc`, gate + table-cache ON, DuckDB v1.4.4 CLI)
+
+[cols="2,1,1,1",options="header"]
+|===
+| metric | before (Nagle) | after (NODELAY) | DuckDB
+| median wall (35q) | 59 ms | **17 ms** | 34 ms
+| total wall (35q)  | 2,210 ms | **907 ms** | 1,399 ms
+| ProximaDB ≤ DuckDB | 6 / 35 | **32 / 35** | —
+|===
+
+**ProximaDB vs DuckDB: median 0.50× (2× faster), total 0.65×.** Per-query the floor
+vanished exactly as predicted: q07 50→2 ms, q01 49→6 ms, q04 49→7 ms, etc. Correctness
+unchanged (35/35 ok, identical result sets).
+
+The remaining **3 losses** (q21 50/37, q22 53/40, q23 202/52) are the compute-heavy
+wide-`Utf8` scans (`URL LIKE`, `MIN(URL)`/`MIN(Title)`) — the DataFusion-vs-DuckDB
+*kernel* gap, precisely the territory ADR-054's native operators target (not this
+protocol fix).
+
+== Significance
+
+The single highest-leverage OLAP latency change to date, and it is **not** storage,
+planning, session, or compute — it is the **transport**. It applies to EVERY pgwire
+query (OLAP and OLTP), on loopback and over the network. The co-design lesson: the
+dominant cost term was a round-trip stall the whole instrumentation stack had to be
+built to see. Evidence: `ledger_nodelay.json` (after) vs `ledger_emitprobe.json` (before).

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -228,6 +228,18 @@ impl PostgresServer {
             match listener.accept().await {
                 Ok((stream, addr)) => {
                     info!("New PostgreSQL connection from {}", addr);
+                    // Disable Nagle's algorithm on the pgwire socket (as libpq's
+                    // server does): a SELECT response is written as several small
+                    // segments (RowDescription, DataRow(s), CommandComplete), and
+                    // with Nagle on, the second segment waits for the first to be
+                    // ACKed while the client delays its ACK — a ~40 ms delayed-ACK
+                    // stall PER QUERY, even on loopback. Measured as the dominant
+                    // per-query wall floor (TD-OLAP-4 floor decomposition: setup/
+                    // open/plan/compute/emit all ~0, ~46 ms unattributed). Best-
+                    // effort: a failure here only forfeits the latency win.
+                    if let Err(e) = stream.set_nodelay(true) {
+                        warn!("pgwire: failed to set TCP_NODELAY on {}: {}", addr, e);
+                    }
                     let session_manager = self.session_manager.clone();
                     let collection_port = self.collection_port.clone();
                     let vector_ops = self.vector_ops.clone();

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -1557,6 +1557,9 @@ impl PostgresProtocol {
         &mut self,
         result: ExecutionPipelineResult,
     ) -> anyhow::Result<()> {
+        // TD-OLAP-4 result-path probe: time the row encode + socket write, the
+        // last unmeasured span of the per-query wall floor.
+        let emit_start = std::time::Instant::now();
         // RowDescription.
         let fields: Vec<crate::network::postgres::types::FieldDescription> = result
             .schema
@@ -1578,7 +1581,9 @@ impl PostgresProtocol {
             self.send_data_row_nullable(&cells).await?;
         }
         // CommandComplete.
-        self.send_command_complete(&format!("SELECT {n}")).await
+        let done = self.send_command_complete(&format!("SELECT {n}")).await;
+        crate::observability::io_trace::record_emit_ms(emit_start.elapsed().as_millis() as u64);
+        done
     }
 
     /// Try to materialize a SELECT through the relational execution seam.

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -315,6 +315,13 @@ pub async fn try_run_select(
         None
     };
 
+    // TD-OLAP-4 result-path probe: time ALL of `try_run_select` before execution
+    // — including the path-1 engine-catalog `lower_sql` attempt below, which a
+    // DataFusion-routed query pays and fails before reaching the path-2 setup.
+    // The earlier per-query floor decomposition attributed ~0 ms to the path-2
+    // setup alone; starting the clock here tests whether the ~46 ms remainder is
+    // the (previously untimed) path-1 lowering attempt.
+    let setup_start = std::time::Instant::now();
     // 1) Existing in-memory-engine path (preserves the demo table and any
     //    engine-resident tables). Only engages when the SQL lowers against the
     //    engine's own catalog; a catalog miss falls through to the real-data
@@ -350,10 +357,6 @@ pub async fn try_run_select(
     // `CatalogLookup`/`ReaderFactory` traits can't await). Rows are fetched
     // lazily per scan in `DmlTableReader::open`, with the executor's
     // projection/predicate/limit pushed into storage.
-    // TD-OLAP-4: time this pre-execution setup (schema pre-resolution + route
-    // classification) — measurement showed this path-2 setup, not open/session/
-    // plan/compute, is the per-query wall floor the native early-return path skips.
-    let setup_start = std::time::Instant::now();
     let mut names = Vec::new();
     collect_table_names(query, &mut names);
     let mut tables: HashMap<String, PreparedTable> = HashMap::new();

--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -176,6 +176,10 @@ pub struct IoTrace {
     /// collection + xCatalog schema pre-resolution + route classification. Paid
     /// only on the DataFusion (path-2) route, not the native early-return path.
     setup_ms: AtomicU64,
+    /// pgwire result EMIT wall milliseconds (TD-OLAP-4): encoding the materialized
+    /// rows to `RowDescription` + `DataRow` frames and writing them to the socket,
+    /// AFTER execution — the last unmeasured span in the per-query wall floor.
+    emit_ms: AtomicU64,
     /// SessionContext build wall milliseconds (TD-OLAP-4): per-query cost of
     /// creating a fresh DataFusion `SessionContext` and re-registering all
     /// UDFs/UDAFs — paid before table open, reusable across queries.
@@ -296,6 +300,11 @@ impl IoTrace {
         *g.entry(engine.to_string()).or_insert(0) += ms;
     }
 
+    /// Add to the pgwire result-emit wall milliseconds (row encode + socket write).
+    pub fn record_emit_ms(&self, ms: u64) {
+        self.emit_ms.fetch_add(ms, Ordering::Relaxed);
+    }
+
     /// Add to the pgwire relational-pipeline setup wall milliseconds.
     pub fn record_setup_ms(&self, ms: u64) {
         self.setup_ms.fetch_add(ms, Ordering::Relaxed);
@@ -381,6 +390,7 @@ impl IoTrace {
                 .unwrap_or_else(|p| p.into_inner())
                 .clone(),
             setup_ms: self.setup_ms.load(Ordering::Relaxed),
+            emit_ms: self.emit_ms.load(Ordering::Relaxed),
             session_ms: self.session_ms.load(Ordering::Relaxed),
             open_ms: self.open_ms.load(Ordering::Relaxed),
             plan_ms: self.plan_ms.load(Ordering::Relaxed),
@@ -431,6 +441,10 @@ pub struct IoTraceSnapshot {
     /// resolution + route classification, DataFusion route only (TD-OLAP-4).
     #[serde(default)]
     pub setup_ms: u64,
+    /// pgwire result-emit wall ms — row encode + socket write, post-execution
+    /// (TD-OLAP-4).
+    #[serde(default)]
+    pub emit_ms: u64,
     /// SessionContext build wall ms — per-query context+UDF setup (TD-OLAP-4).
     #[serde(default)]
     pub session_ms: u64,
@@ -636,6 +650,11 @@ pub fn record_open_ms(ms: u64) {
 /// Add pgwire relational-pipeline setup wall ms to the active query trace.
 pub fn record_setup_ms(ms: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_setup_ms(ms));
+}
+
+/// Add pgwire result-emit wall ms (row encode + socket write) to the active trace.
+pub fn record_emit_ms(ms: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_emit_ms(ms));
 }
 
 /// Add SessionContext build wall ms to the active query trace.

--- a/tests/clickbench_ledger_e2e.rs
+++ b/tests/clickbench_ledger_e2e.rs
@@ -285,6 +285,9 @@ struct QueryRecord {
     /// resolution + route classification (TD-OLAP-4).
     #[serde(skip_serializing_if = "Option::is_none")]
     setup_ms: Option<u64>,
+    /// pgwire result-emit wall ms — row encode + socket write (TD-OLAP-4).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    emit_ms: Option<u64>,
     /// SessionContext build wall ms — per-query context+UDF setup (TD-OLAP-4).
     #[serde(skip_serializing_if = "Option::is_none")]
     session_ms: Option<u64>,
@@ -374,6 +377,7 @@ async fn clickbench_ledger() {
             bytes_read,
             range_gets,
             setup_ms,
+            emit_ms,
             session_ms,
             compute_ms,
             open_ms,
@@ -385,6 +389,7 @@ async fn clickbench_ledger() {
                     Some(s.bytes_read),
                     Some(s.range_gets),
                     Some(s.setup_ms),
+                    Some(s.emit_ms),
                     Some(s.session_ms),
                     Some(s.total_compute_ms()),
                     Some(s.open_ms),
@@ -392,7 +397,7 @@ async fn clickbench_ledger() {
                     Some(s.table_open_hits),
                 )
             })
-            .unwrap_or((None, None, None, None, None, None, None, None));
+            .unwrap_or((None, None, None, None, None, None, None, None, None));
         match res {
             Ok(msgs) => {
                 let rows = msgs
@@ -408,6 +413,7 @@ async fn clickbench_ledger() {
                     bytes_read,
                     range_gets,
                     setup_ms,
+                    emit_ms,
                     session_ms,
                     compute_ms,
                     open_ms,
@@ -425,6 +431,7 @@ async fn clickbench_ledger() {
                 bytes_read,
                 range_gets,
                 setup_ms,
+                emit_ms,
                 session_ms,
                 compute_ms,
                 open_ms,
@@ -460,6 +467,7 @@ async fn clickbench_ledger() {
                 bytes_read: None,
                 range_gets: None,
                 setup_ms: None,
+                emit_ms: None,
                 session_ms: None,
                 compute_ms: None,
                 open_ms: None,


### PR DESCRIPTION
## What

A **one-line** fix that removes the dominant per-query pgwire latency floor:
`stream.set_nodelay(true)` on each accepted connection. **ProximaDB now beats DuckDB
on the 1M single-node ClickBench track.**

## Root cause (measure-first, six decomposition cycles)

The TD-OLAP-4 floor decomposition left a ~46 ms per-query wall floor unattributed.
Instrumentation ruled out every server-side span — table-open ~1 ms, session/plan ~0,
path-1 + path-2 setup ~0, compute ~13 ms, result-emit ~0 — leaving a **fixed ~40–48 ms
outside all code, invariant to bytes/rows/compute**. That is the signature of a **TCP
delayed-ACK / Nagle stall** (40 ms is the canonical delayed-ACK timer, and it fires even
on loopback). The pgwire server never set `TCP_NODELAY`, so a SELECT response — written
as several small segments (`RowDescription`, `DataRow`(s), `CommandComplete`) — had its
second segment held by Nagle until the first was ACKed, while the client delayed its ACK
~40 ms. PostgreSQL's own server sets `TCP_NODELAY` for exactly this reason.

## Measured (release, 1M ClickBench, DuckDB v1.4.4 baseline, same parquet)

| metric | before (Nagle) | after (NODELAY) | DuckDB |
| --- | --- | --- | --- |
| median wall (35q) | 59 ms | **17 ms** | 34 ms |
| total wall (35q) | 2,210 ms | **907 ms** | 1,399 ms |
| ProximaDB ≤ DuckDB | 6/35 | **32/35** | — |

**vs DuckDB: median 0.50× (2× faster), total 0.65×.** 35/35 ok, identical results. The
3 remaining losses (q21/q22/q23) are compute-bound wide-`Utf8` scans — the DataFusion
kernel gap ADR-054's native operators target, not this transport fix.

## Also in this PR (the instrumentation that found it)

- io_trace `emit_ms` (result encode + socket write) + `setup_ms` widened to include the
  path-1 engine-catalog `lower_sql` attempt — both measured ~0, proving the floor was
  transport, not code. Captured per query in the ClickBench ledger.
- Evidence: `docs/_internal/status/CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc`.

Applies to EVERY pgwire query (OLAP + OLTP), loopback and network.
