### PR TITLE
ci(cloud-emulator): fix OOM kill + add develop early-detection (--fast)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       gpu_paths: ${{ steps.filter.outputs.gpu_paths }}
       network_changes: ${{ steps.filter.outputs.network_changes }}
       pgwire_accuracy_changes: ${{ steps.filter.outputs.pgwire_accuracy_changes }}
+      object_store_cloud_changes: ${{ steps.filter.outputs.object_store_cloud_changes }}
       # SDK change detection
       go_sdk: ${{ steps.filter.outputs.go_sdk }}
       nodejs_sdk: ${{ steps.filter.outputs.nodejs_sdk }}
@@ -196,6 +197,16 @@ jobs:
               - 'tests/*storage*'
               - 'tests/*sst*'
               - 'tests/*wal*'
+            # Cloud object-store Cool-tier validation (TD-168). The tier-mapping code
+            # lives in the object-store crate + the cold-payload store; the orchestration
+            # is scripts/run_cloud_emulator_tests.sh. Re-run the (cheap) emulator tier
+            # tests when any of those change — catches a real-cloud-API tier regression
+            # on the introducing PR instead of at develop→qa.
+            object_store_cloud_changes:
+              - 'crates/storage/proximadb-object-store/**'
+              - 'src/graph/cold_payload_store.rs'
+              - 'scripts/run_cloud_emulator_tests.sh'
+              - '.github/workflows/ci.yml'
             graph_changes:
               - 'src/graph/**'
               - 'tests/*graph*'
@@ -1295,6 +1306,37 @@ jobs:
             cargo test ${{ matrix.args }} -- --test-threads=${{ matrix.threads }}
           fi
 
+  # TD-168 develop early-detection: run the CHEAP object-store Cool-tier tests
+  # (scripts/run_cloud_emulator_tests.sh --fast — compiles only the small
+  # object-store crate, ~3-5m; no main-crate compile / no OOM risk) whenever the
+  # tier-mapping code changes. This is the regression coverage for the cloud-tier
+  # path: the same put_with_tier_* validation that runs at develop→qa now also runs
+  # on the introducing feat→develop PR. Path-gated (skipped otherwise) and in
+  # ci-success.needs so it gates when it runs (skipped ⇒ pass). Requires Docker
+  # (Azurite/MinIO/fake-gcs), preinstalled on ubuntu-latest.
+  object-store-emulator-tests:
+    name: Object-store Cool tier (emulators)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [changes]
+    if: |
+      !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
+      needs.changes.outputs.object_store_cloud_changes == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-cloud-emulator-fast"
+      - name: Run object-store tier tests against emulators (--fast)
+        # docker + aws/az CLIs are preinstalled on ubuntu-latest runners.
+        run: bash scripts/run_cloud_emulator_tests.sh --fast
+
   # Targeted integration tests based on changed components
   rust-integration-test-storage:
     name: Rust Integration Tests (storage)
@@ -1896,6 +1938,7 @@ jobs:
       - rust-integration-test-pgwire-accuracy
       - rust-integration-test-graph
       - rust-integration-test-cluster
+      - object-store-emulator-tests
       - rust-coverage
       - python-lint
       - python-test

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -196,7 +196,10 @@ jobs:
   cloud-emulator-object-store:
     name: Cloud object-store emulators (Azurite/MinIO/fake-gcs)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # The --all scope compiles the full main crate under CARGO_BUILD_JOBS=1 (the OOM
+    # mitigation — see scripts/run_cloud_emulator_tests.sh); serialized compile is
+    # ~35-40m, so 60m leaves headroom over the old 45m budget that the OOM-kill hit.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0

--- a/scripts/run_cloud_emulator_tests.sh
+++ b/scripts/run_cloud_emulator_tests.sh
@@ -3,8 +3,17 @@
 # Docker, create the test bucket+container, and run the #[ignore]d object-store
 # tier integration tests against them — the TD-168 "validate the Cool tier on a
 # real cloud API" check. Used by .github/workflows/qa-gate.yml (the develop→qa
-# gate) and `make cloud-emulator-test` (local). Single source of truth so the CI
-# path is exactly the locally-runnable path.
+# gate), .github/workflows/ci.yml (the develop early-detection job, --fast), and
+# `make cloud-emulator-test` (local). Single source of truth so every CI path is
+# exactly the locally-runnable path.
+#
+# Usage: run_cloud_emulator_tests.sh [--fast|--all]
+#   --fast : run ONLY the cheap object-store tier tests (~3-5 min — compiles just
+#            the small object-store crate, no main-crate compile, no OOM risk).
+#            Used by the develop early-detection job so a tier regression is caught
+#            on the introducing feat→develop PR.
+#   --all  : (default) also run cold_graph_record_store_round_trips_on_real_azure,
+#            which compiles the full main crate and runs under CARGO_BUILD_JOBS=1.
 #
 # Requires: docker, cargo, aws CLI (MinIO bucket), az CLI (Azurite container),
 # curl (fake-gcs bucket). On GitHub ubuntu-latest all are preinstalled.
@@ -16,6 +25,18 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
+
+# Scope selection (see header). --fast = object-store tier tests only; --all (default)
+# adds the cold-payload azure round-trip, which compiles the full main crate.
+SCOPE="all"
+for arg in "$@"; do
+  case "$arg" in
+    --fast) SCOPE="fast" ;;
+    --all)  SCOPE="all" ;;
+    *) echo "::error::unknown argument: $arg"; echo "usage: $0 [--fast|--all]"; exit 2 ;;
+  esac
+done
+echo "==> Scope: $SCOPE"
 
 CONTAINER_BUCKET="proximadb-test"
 AZURITE_CONN="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
@@ -59,7 +80,7 @@ curl -sf -X POST "http://127.0.0.1:4443/storage/v1/b?project=proximadb" \
   -H "Content-Type: application/json" -d "{\"name\":\"$CONTAINER_BUCKET\"}" >/dev/null 2>&1 \
   || echo "  (fake-gcs bucket exists)"
 
-echo "==> Running object-store tier integration tests"
+echo "==> Running object-store tier integration tests (scope: $SCOPE)"
 # Azure (Azurite) + S3 (MinIO) through the production from_url + env path; GCS via builder.
 export AZURE_STORAGE_USE_EMULATOR=true AZURE_ALLOW_HTTP=true
 export AWS_ENDPOINT=http://127.0.0.1:9000 AWS_ALLOW_HTTP=true AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
@@ -70,8 +91,15 @@ cargo test -p proximadb-object-store --features aws,azure,gcp -- --ignored --noc
   put_with_tier_accepted_by_azurite \
   put_with_tier_accepted_by_minio \
   put_with_tier_against_fake_gcs
-cargo test -p proximadb --features azure -- --ignored --nocapture \
-  cold_graph_record_store_round_trips_on_real_azure
+
+if [ "$SCOPE" = "all" ]; then
+  # Compiles the full main `proximadb` crate (~8400-test binary). CARGO_BUILD_JOBS=1
+  # serializes crate compilation so the 16GB hosted runner is NOT OOM-killed mid-link
+  # — the exact failure that made the qa-gate job red ("runner received a shutdown
+  # signal"). Same mitigation as ci.yml's rust-test unit job (see its comment).
+  CARGO_BUILD_JOBS=1 cargo test -p proximadb --features azure -- --ignored --nocapture \
+    cold_graph_record_store_round_trips_on_real_azure
+fi
 
 echo "==> Strong read-back: confirm Azurite persisted the Cool tier"
 TIER="$(az storage blob show --container-name "$CONTAINER_BUCKET" --name cold/probe-azure.bin \


### PR DESCRIPTION
## What & why

The `develop → qa` release PR #794 landed **UNSTABLE** because the qa-gate job `Cloud object-store emulators (Azurite/MinIO/fake-gcs)` failed twice with `##[error]The runner has received a shutdown signal … The operation was canceled.` The required `CI Success` gate was green, so it merged — but a red check on a release PR erodes trust in the qa tier.

### Root cause (definitive — and already documented in the repo)
The orchestration script `scripts/run_cloud_emulator_tests.sh` runs two `cargo test` commands:
1. `-p proximadb-object-store` — compiles only the small object-store crate, ~2 min, **passes** (`3 passed; 0 failed`).
2. `cargo test -p proximadb --features azure … cold_graph_record_store_round_trips_on_real_azure` — compiles the **entire main `proximadb` crate** (~8400-test binary) **without `CARGO_BUILD_JOBS=1`** → **OOMs the 16 GB hosted runner and is killed mid-link** with the *identical* "runner received a shutdown signal" message.

This is the **same OOM-kill** the `rust-test` unit job already diagnosed and works around — see `ci.yml:1287-1293`:
> *CARGO_BUILD_JOBS=1: the root proximadb crate's test binary (8400+ tests) is memory-heavy to compile; serializing crate compilation keeps the 16GB hosted runner from OOMing (it was being killed mid-link with exit 143 / "runner received a shutdown signal").*

So it is **not** runner reclamation or self-hosting — it is the OOM killer during main-crate compilation. The cloud-emulator job simply never got the same mitigation.

## Changes

**Part 1 — make the qa-gate job reliable (root-cause fix):**
- `scripts/run_cloud_emulator_tests.sh`: gate the main-crate compile behind `--all` (default) and run it under `CARGO_BUILD_JOBS=1`; add a `--fast` scope (object-store tier tests only — compiles just the small object-store crate, ~3-5 min, **no main-crate compile, no OOM risk**).
- `qa-gate.yml`: bump `cloud-emulator-object-store` `timeout-minutes: 45 → 60` (`BUILD_JOBS=1` serializes the main-crate compile, ~35-40 min).

**Part 2 — develop early-detection + regression coverage (TD-168):**
- `ci.yml`: add an `object-store-emulator-tests` job that runs `--fast` on PRs touching the object-store tier code (path-gated via a new `object_store_cloud_changes` filter), wired into `ci-success.needs` so a cloud-tier regression is **caught on the introducing feat→develop PR**, not at develop→qa. Skipped (free, passes `ci-success`) on unrelated PRs.

The script stays the single source of truth (CI path == `make cloud-emulator-test`).

## Verification
- `bash -n scripts/run_cloud_emulator_tests.sh` ✅; arg-parse (`--fast`/`--all`) ✅.
- `actionlint` on both workflows — clean on the new job (only pre-existing unrelated warnings on the advisory macOS-13 GPU job + shellcheck infos in other jobs).
- `make work-commit-check` ✅ (panic-policy, hygiene, tenant-path, workspace-boundaries).
- Local `bash scripts/run_cloud_emulator_tests.sh --fast`: emulators come up, scope=fast confirmed, object-store crate compiles + the 3 `put_with_tier_*` tests run (no main-crate compile).

## Out of scope (follow-up PR)
- Move more fast qa-gate checks to develop (e.g. `sdk-coverage-ratchet`).
- Shard the slow `rust-test` unit run with `nextest --partition` (2-3 ways) + measure (the bottleneck is compile under `CARGO_BUILD_JOBS=1`, so run-sharding is a modest-but-real win at N× compile cost).