### PR TITLE
feat(documents): P-Shred follow-up — populate promoted_keys so shredding fires (ADR-055)

### DIFF
--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -77,10 +77,15 @@ pub trait RecordRoutePort: Send + Sync {
     /// this at collection-create so a document collection CONVERGES on the canonical store
     /// (P-Provision, ADR-055) instead of the legacy `document_wal`/DashMap path. Callers treat it
     /// best-effort (a failure leaves the legacy path intact — mixed-safe).
+    ///
+    /// `promote_keys` are declared hot prop keys (from the document collection's indexes) to seed
+    /// as props-auto-promotion columns, so those fields shred into typed user-columns at flush
+    /// (P-Shred follow-up, ADR-055). Empty ⇒ no seeded shredding.
     async fn ensure_collection(
         &self,
         collection_id: &str,
         dimension: u32,
         tenant: Option<&str>,
+        promote_keys: &[String],
     ) -> Result<()>;
 }

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -959,14 +959,21 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
         collection_id: &str,
         dimension: u32,
         tenant: Option<&str>,
+        promote_keys: &[String],
     ) -> Result<()> {
         // Idempotent create-if-not-exists so a document collection becomes a resolvable canonical
         // collection (P-Provision, ADR-055). Delegates to the CollectionService helper (which owns
         // the v1 `CollectionConfig` construction) — this keeps `record_ops_service` v1-proto-free
         // (TD-123 ratchet). `dimension == 0` ⇒ a vectorless (pure-document) collection.
+        // `promote_keys` seed props-auto-promotion so declared hot fields shred (P-Shred follow-up).
         let tenant_context = self.collection_service.load_tenant_context(tenant)?;
         self.collection_service
-            .get_or_create_by_name(collection_id, dimension, tenant_context.as_ref())
+            .get_or_create_by_name(
+                collection_id,
+                dimension,
+                tenant_context.as_ref(),
+                promote_keys,
+            )
             .await
     }
 

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -586,12 +586,28 @@ impl CollectionService {
         name: &str,
         dimension: u32,
         tenant_context: Option<&crate::storage::tenant::TenantContext>,
+        promote_keys: &[String],
     ) -> Result<()> {
+        // P-Shred follow-up (ADR-055): declared hot keys become filterable columns (typed, id >= 100
+        // in the catalog schema), which `catalog_schema_from_collection` then registers as
+        // props-auto-promotion `promoted_keys` for document collections — so those props shred into
+        // typed user-columns at flush. Default type Text/String; the shred writer coerces per value.
+        let filterable_columns = promote_keys
+            .iter()
+            .filter(|k| !k.is_empty())
+            .map(|k| crate::proto::proximadb_v1::FilterableColumnSpec {
+                name: k.clone(),
+                indexed: true,
+                supports_range: true,
+                ..Default::default()
+            })
+            .collect();
         let config = CollectionConfig {
             name: name.to_string(),
             dimension,
             storage_engine: Some(StorageEngine::Sst as i32),
             enable_proxima_record: Some(true),
+            filterable_columns,
             ..Default::default()
         };
         let resp = self

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -971,7 +971,26 @@ impl DocumentService {
         // covered without a second hook.
         if let Some(route) = self.record_route.get() {
             let (tenant, clean_collection) = unscope_document_collection(name);
-            if let Err(e) = route.ensure_collection(clean_collection, 0, tenant).await {
+            // P-Shred follow-up (ADR-055): seed props-auto-promotion from the collection's declared
+            // indexes so those hot fields shred into typed columns at flush. Only simple top-level
+            // SCALAR keys shred usefully (a nested `$.user.email` top-level is a Map, not a scalar);
+            // skip nested/array paths rather than promoting a column that would never populate.
+            let promote_keys: Vec<String> = config
+                .indexes
+                .iter()
+                .filter_map(|idx| {
+                    let key = idx.path.trim_start_matches('$').trim_start_matches('.');
+                    if key.is_empty() || key.contains('.') || key.contains('[') {
+                        None
+                    } else {
+                        Some(key.to_string())
+                    }
+                })
+                .collect();
+            if let Err(e) = route
+                .ensure_collection(clean_collection, 0, tenant, &promote_keys)
+                .await
+            {
                 warn!(
                     "P-Provision: canonical collection provision for '{}' failed (staying on legacy path): {}",
                     name, e
@@ -2880,6 +2899,9 @@ mod tests {
         /// to the legacy path). Empty ⇒ every collection is treated as an existing canonical
         /// collection — the common case for the convergence tests.
         non_canonical: std::sync::Mutex<std::collections::HashSet<String>>,
+        /// Per-collection promote keys captured from `ensure_collection` (P-Shred follow-up):
+        /// lets a test assert the document facade forwarded the declared index fields.
+        promoted: std::sync::Mutex<HashMap<String, Vec<String>>>,
     }
 
     #[async_trait::async_trait]
@@ -2956,13 +2978,19 @@ mod tests {
             collection_id: &str,
             _dimension: u32,
             _tenant: Option<&str>,
+            promote_keys: &[String],
         ) -> anyhow::Result<()> {
             // Provisioning makes a (possibly previously non-canonical) collection canonical —
-            // idempotent (removing an absent entry is a no-op).
+            // idempotent (removing an absent entry is a no-op). Record the seeded promote keys so
+            // tests can assert the document facade forwarded the declared index fields.
             self.non_canonical
                 .lock()
                 .expect("mock route lock")
                 .remove(collection_id);
+            self.promoted
+                .lock()
+                .expect("mock route lock")
+                .insert(collection_id.to_string(), promote_keys.to_vec());
             Ok(())
         }
     }
@@ -3191,6 +3219,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_collection_forwards_top_level_index_keys_as_promote_keys() {
+        // P-Shred follow-up (ADR-055): the document facade extracts the TOP-LEVEL scalar key from
+        // each declared index path and forwards it to `ensure_collection` as a promote key (which
+        // the catalog then seeds as a props-auto-promotion column). Nested/array paths are skipped.
+        let svc = create_test_service();
+        let route = Arc::new(MockRecordRoute::default());
+        svc.set_record_route(route.clone());
+
+        svc.create_collection(
+            "idxdocs",
+            DocumentCollectionConfig {
+                name: "idxdocs".to_string(),
+                indexes: vec![
+                    IndexDefinition {
+                        path: "$.status".to_string(),
+                        index_type: DocIndexType::Btree as i32,
+                        ..Default::default()
+                    },
+                    IndexDefinition {
+                        path: "priority".to_string(),
+                        index_type: DocIndexType::Btree as i32,
+                        ..Default::default()
+                    },
+                    IndexDefinition {
+                        path: "$.user.email".to_string(), // nested ⇒ skipped for promotion
+                        index_type: DocIndexType::Btree as i32,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create document collection");
+
+        let promoted = route.promoted.lock().expect("lock");
+        let keys = promoted.get("idxdocs").expect("promote keys captured");
+        assert!(
+            keys.contains(&"status".to_string()),
+            "top-level $.status promoted"
+        );
+        assert!(keys.contains(&"priority".to_string()), "bare key promoted");
+        assert!(
+            !keys
+                .iter()
+                .any(|k| k.contains("email") || k.contains("user")),
+            "nested $.user.email is skipped (would shred nothing useful)"
+        );
+    }
+
+    #[tokio::test]
     async fn ensure_collection_is_idempotent() {
         let route = MockRecordRoute::default();
         route
@@ -3199,11 +3278,11 @@ mod tests {
             .expect("lock")
             .insert("c".to_string());
         route
-            .ensure_collection("c", 0, None)
+            .ensure_collection("c", 0, None, &[])
             .await
             .expect("first ensure");
         route
-            .ensure_collection("c", 0, None)
+            .ensure_collection("c", 0, None, &[])
             .await
             .expect("second ensure is idempotent");
         assert!(route.collection_exists("c", None).await);

--- a/src/storage/metadata/collection_mapping.rs
+++ b/src/storage/metadata/collection_mapping.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use proximadb_catalog::{
     CatalogColumn, CatalogIndex, CatalogIndexType, CatalogPhysicalFormat, CatalogProjection,
     CatalogProjectionKind, CatalogStorageLayout, CatalogStorageLayoutKind, CatalogTableSchema,
-    ProjectionFreshness, TableIdentifier,
+    ProjectionFreshness, PropsAutoPromotionPolicy, TableIdentifier,
 };
 use proximadb_data_model::ProximaType;
 
@@ -410,6 +410,24 @@ pub(crate) fn catalog_schema_from_collection(
         }
     }
 
+    // P-Shred follow-up (ADR-055): for document / canonical-record collections, turn on the
+    // props-auto-promotion policy AND register each declared filterable column (id >= 100) as a
+    // promoted props key. This is what makes hybrid shredding actually FIRE: the flush path
+    // (`write_mutations` -> `with_shred_spec`) reads `promoted_keys` to route those hot props into
+    // typed user-columns. The msgpack `props` tail stays authoritative (clone-not-remove, #767).
+    // `document_default()` also flips `enabled` on for adaptive promotion of additional hot keys
+    // once the compaction-time evaluator is wired (a separate follow-up; today only these declared
+    // keys shred). Gated on `enable_proxima_record` so non-document collections are unaffected.
+    if config.enable_proxima_record == Some(true) {
+        let mut policy = PropsAutoPromotionPolicy::document_default();
+        for col in schema.columns.iter().filter(|c| c.id >= 100) {
+            policy
+                .promoted_keys
+                .insert(col.name.clone(), col.name.clone());
+        }
+        schema.props_auto_promotion = policy;
+    }
+
     for index in &config.index_configs {
         let index_type = catalog_index_type(index.algorithm);
         schema = schema.with_index(CatalogIndex::new(
@@ -650,5 +668,72 @@ fn storage_engine_from_catalog(engine: &str) -> i32 {
         "TITAN" => StorageEngine::Titan as i32,
         "CHRONO" => StorageEngine::Chrono as i32,
         _ => StorageEngine::Sst as i32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc_collection_with_filterable(name: &str, field: &str, document: bool) -> Collection {
+        Collection {
+            id: name.to_string(),
+            config: Some(CollectionConfig {
+                name: name.to_string(),
+                dimension: 0,
+                enable_proxima_record: if document { Some(true) } else { None },
+                filterable_columns: vec![FilterableColumnSpec {
+                    name: field.to_string(),
+                    indexed: true,
+                    supports_range: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn document_collection_seeds_promoted_keys_from_filterable_columns() {
+        // P-Shred follow-up (ADR-055): a document collection's declared filterable column becomes a
+        // promoted props key at create time, so the flush shred path (write_mutations →
+        // with_shred_spec, #767) routes props.<field> into a typed user-column (id ≥ 100). This is
+        // the create-time population that makes shredding FIRE (was empty before).
+        let schema =
+            catalog_schema_from_collection(&doc_collection_with_filterable("docs", "status", true))
+                .expect("schema");
+        assert!(
+            schema.props_auto_promotion.enabled,
+            "props-auto-promotion enabled (document_default) for document collections"
+        );
+        assert_eq!(
+            schema
+                .props_auto_promotion
+                .promoted_keys
+                .get("status")
+                .map(String::as_str),
+            Some("status"),
+            "declared index field seeded as a promoted props key"
+        );
+        assert!(
+            schema
+                .columns
+                .iter()
+                .any(|c| c.name == "status" && c.id >= 100),
+            "promoted column present at id ≥ USER_BASE"
+        );
+    }
+
+    #[test]
+    fn non_document_collection_is_unaffected() {
+        // Gated on enable_proxima_record: a plain vector collection with filterable columns must NOT
+        // get props-auto-promotion (its PAX layout is unchanged — mixed-safe).
+        let schema = catalog_schema_from_collection(&doc_collection_with_filterable(
+            "vecs", "status", false,
+        ))
+        .expect("schema");
+        assert!(!schema.props_auto_promotion.enabled);
+        assert!(schema.props_auto_promotion.promoted_keys.is_empty());
     }
 }


### PR DESCRIPTION
## What

**P-Shred follow-up** (ADR-055): make hybrid props shredding actually **fire** for document collections. P-Shred (#767) shredded based on `schema.props_auto_promotion.promoted_keys` — but that map was empty at create time, so nothing shredded. This populates it via **both** mechanisms you chose:

1. **Adaptive default** — document collections (`enable_proxima_record`) now get `PropsAutoPromotionPolicy::document_default()` (`enabled: true`) at create, so hot keys promote over time.
2. **Seed from declared indexes** — each declared index's top-level scalar key (`$.status` → `status`; nested `$.user.email` skipped) is forwarded through `ensure_collection` → a `FilterableColumnSpec` → a catalog column (id ≥ 100) → seeded into `promoted_keys`.

## The chain (each link unit-tested)

`index → promote_key → filterable column (id≥100) → promoted_key → with_shred_spec → shredded typed column (tail intact)`. So a declared-indexed field genuinely becomes both a typed column **and** a promoted key that `write_mutations` resolves into the shred spec at flush.

## Changes
- `collection_mapping.rs`: enable `document_default()` + seed `promoted_keys` from id≥100 columns (document collections only).
- `service.rs`: extract top-level index keys, forward as promote-keys.
- `record_route_port.rs` / `record_ops_service.rs` / `manager.rs`: thread `promote_keys` → `FilterableColumnSpec`.

## Verified
- lib tests **6/6** (seed-from-columns, forward-index-keys, non-document-unaffected, + existing provision/idempotent/kill-switch).
- TD-123 v1 ratchet **delta −150** · `cargo fmt --check` · `cargo clippy --lib --bins -- -D warnings` (exit 0) · **server binary builds**.

Note: the single end-to-end pruning proof lands in **P-Pushdown** (measuring the `bytes_read` reduction vs the 329 KB P-Trace baseline inherently requires shredding to have fired). The adaptive evaluator (`structural_projection::promotion_candidate`) exists; wiring its output to update `promoted_keys` at compaction is a separate follow-up beyond the `enabled:true` flip here.
