### PR TITLE
docs(olap): 10M scale caveat + io-trace co-design analysis — what closes the DuckDB gap (TD-OLAP-4)

### DIFF
--- a/docs/_internal/status/CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc
+++ b/docs/_internal/status/CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc
@@ -64,3 +64,29 @@ planning, session, or compute — it is the **transport**. It applies to EVERY p
 query (OLAP and OLTP), on loopback and over the network. The co-design lesson: the
 dominant cost term was a round-trip stall the whole instrumentation stack had to be
 built to see. Evidence: `ledger_nodelay.json` (after) vs `ledger_emitprobe.json` (before).
+
+== Scale check — 10M (0.1) rows: the win is scale-dependent (banked 2026-07-09)
+
+Re-ran at 10M rows (10× replicate of the 1M set — same schema/distribution; note
+`COUNT(DISTINCT)` sees 10× rows but the same distinct set, so it understates true-10M
+cardinality while still scaling the scan/hash *compute* 10×).
+
+[cols="2,1,1",options="header"]
+|===
+| metric | ProximaDB | DuckDB
+| median wall (35q) | 81 ms | 40 ms
+| total wall (35q)  | 5,078 ms | 2,221 ms
+| ProximaDB ≤ DuckDB | 15 / 35 | —
+|===
+
+**At 10M, DuckDB wins (ProximaDB 2.0× median).** The NODELAY fix still holds (`emit_ms`
+= 0 — transport floor gone, a scale-independent ~40 ms/query win). But the 1M win was
+partly the fixed per-query floor dominating; at scale, **compute dominates and DataFusion's
+kernels trail DuckDB's** on the wide-`Utf8`/DISTINCT tail: q23 1,510 ms vs 62 ms (24×),
+q21/q22 ~9×, and even plain aggregates 2–3×.
+
+Conclusion: TCP_NODELAY is a real, universal latency win, but a "beats DuckDB" claim only
+holds at toy scale (1M). At realistic scale the gap is **DataFusion kernel compute** —
+precisely the territory ADR-054's native operators target. The honest headline is
+"one-line transport fix + native compute engine", pending Phase 2.5 (real native scan).
+Ledgers: `ledger_final.json` (1M), `ledger_10m.json` (10M).

--- a/docs/_internal/status/CLICKBENCH_SCALE_CODESIGN_ANALYSIS_2026_07_09.adoc
+++ b/docs/_internal/status/CLICKBENCH_SCALE_CODESIGN_ANALYSIS_2026_07_09.adoc
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ClickBench 10M — io-trace-driven co-design analysis: what must change to match DuckDB (2026-07-09)
+
+TD-OLAP-4. After the TCP_NODELAY fix (#801) removed the per-query transport floor, the
+1M ClickBench win did NOT survive to 10M (0.1 scale): ProximaDB is **2.0× DuckDB at the
+median** there. This doc reads the per-query io-trace to say *exactly which components,
+modules, and storage↔compute co-design changes* close the gap — ranked by measured impact.
+
+== The decisive fact: at scale it is ALL compute
+
+At 10M, **28 / 35 queries spend ≥ 90 % of wall in `compute_ms`.** `emit_ms`, `open_ms`,
+`setup_ms`, `session_ms` are all ~0 (the NODELAY fix holds; the table-OPEN cache holds).
+I/O bytes are secondary — the wide-column queries read 24–54 MB, the rest 5–10 MB. **The
+gap to DuckDB is DataFusion kernel throughput on specific query shapes**, not storage,
+planning, or transport. (Caveat: the 10M set is a 10× replicate, so `COUNT(DISTINCT)`
+sees 10× rows over the same distinct set — the scan/hash compute scales 10×, cardinality
+is understated; conclusions below are about *compute shape*, which holds.)
+
+== Where the gap is (io-trace, ProximaDB ÷ DuckDB wall, 10M)
+
+[cols="1,1,3",options="header"]
+|===
+| shape | median ratio | worst offenders (pdb ms / duck ms)
+| **string `LIKE` + `MIN(Utf8)`** | **~9×** | q23 1510/62 (24×), q22 317/40, q21 289/31
+| **`GROUP BY` on string key** | ~3× | q35 289/79, q34 254/80, q13 125/38, q33 138/104
+| **`COUNT(DISTINCT)`** | ~2.3× | q11 92/37, q12 98/43, q06 83/35 (8 queries)
+| **plain scan+agg** (COUNT/SUM/AVG) | ~2–3× | q02 52/16, q03 62/19, q04 38/20
+| **point / `LIMIT` / metadata** | **0.0–0.4× (we WIN)** | q07 2/16, q20 0/14, q24 16/116, q25 1/34, q01 5/14
+|===
+
+Two things stand out. **(1)** The queries we already **beat** DuckDB on are precisely the
+ones answered from metadata or short-circuited — `MIN/MAX` and `COUNT(*)` from the footer
+(the elision we shipped), and `SELECT … LIMIT`/point lookups. This validates the co-design
+principle: *answer from metadata, don't scan/compute.* **(2)** The queries we **lose** are
+raw DataFusion string/hash kernels over materialized Arrow.
+
+== Co-design changes needed, ranked by measured impact
+
+=== Lever 1 (biggest: 8–24×) — dictionary-encode wide string columns end-to-end
+`URL`/`Title`/`SearchPhrase` are high-cardinality wide `Utf8`. DuckDB stores them
+dictionary-encoded and runs `LIKE`, `GROUP BY`, and `MIN` on the *codes*; we materialize
+full strings and run per-value kernels. This is a **storage↔compute co-design** change,
+not a kernel tweak:
+
+* **Storage (PAX / ADR-055 P-Shred):** dictionary-encode the promoted string user-columns
+  in the PAX block; carry the dictionary in the segment.
+* **Scan (TD-OLAP-1 `PaxSplitReader` / `PaxTableProvider`):** expose `Dictionary(_, Utf8)`
+  Arrow arrays to the engine so `GROUP BY`/`MIN`/`LIKE` operate on codes (Arrow + DataFusion
+  both have dictionary-aware kernels; today the external-parquet path decodes to full Utf8).
+* **`MIN(Utf8)` from the dictionary/zone-map:** parquet truncates string stats, so `MIN(URL)`
+  can't elide today; a per-segment dictionary min-code (or an untruncated PAX zone-map) makes
+  `MIN(str)` a metadata answer — the same win we already have for numeric `MIN/MAX`.
+
+Attacks q21/q22/q23/q34/q35/q13/q33 — the entire top of the loss table.
+
+=== Lever 2 (8 queries, ~2.3×) — COUNT(DISTINCT) from the ADR-037 HLL sketch
+ProximaDB already maintains an HLL NDV sketch per column (ADR-037 statistics registry;
+it already overlays `distinct_count` in `statistics_from_splits`). Unfiltered
+`COUNT(DISTINCT col)` is then a **metadata elision** (same class as our `COUNT(*)`/`MIN/MAX`
+wins) when approximate-distinct is acceptable, or a fast-path via the resident sketch.
+Filtered/grouped distinct still needs a real operator (Lever 3). Component:
+`src/core/statistics` + the `AggregateStatistics`-style elision seam in `schema_inference.rs`.
+
+=== Lever 3 (general 2–3×) — native vectorized operators over a real scan (ADR-054)
+Plain scan+agg (q02/q03/q04) and grouped/distinct aggregates are ~2–3× off raw DataFusion
+throughput. ADR-054's `FilterProjectOperator` + `HashAggregateOperator` are landed but
+**default-OFF and fed only by in-memory `Values`** (`native_ops.rs` `MemoryScanSource`).
+The unlock is **TD-OLAP-14 Phase 2.5 — a real PAX scan source** feeding the native pipeline
+(and #802's join routing), then evidence-gated promotion on this ledger. This is the
+general-throughput lever; Levers 1–2 are the shape-specific wins that compound with it.
+
+=== Lever 4 (S3 cost, not local wall) — read coalescing
+`range_gets` stays high on the multi-column GROUP BYs (q31/q32 = 60, q10/q23/q33 = 50).
+Locally these are dwarfed by compute, but each GET is an S3 RTT + fee. The
+`ParquetObjectReader`/`PaxSplitReader` coalescing knob (TD-151 / TD-RDSTRAT-1, already in
+flight for PAX/SST) should extend to the DataFusion parquet path. Lower priority than 1–3
+for *wall*, real for *cloud cost*.
+
+== Sequencing (compounding, evidence-gated on this ledger)
+
+. **Lever 1 (dictionary string path)** — biggest measured gap; storage+scan co-design.
+. **Lever 2 (HLL COUNT(DISTINCT) elision)** — cheap, reuses ADR-037; 8 queries.
+. **Lever 3 (native ops + Phase 2.5 scan)** — general throughput; unblocks the rest.
+. **Lever 4 (coalescing)** — S3 cost.
+
+Each is measured on the ClickBench + TPC ledgers (TD-OLAP-4) before promotion; none is
+asserted. The two we already win (metadata elision, LIMIT/point) are the template: the
+fastest query is the one you never compute. Ledgers: `ledger_final.json` (1M),
+`ledger_10m.json` (10M).
+EOF


### PR DESCRIPTION
## What

Two honest, measured docs following the TCP_NODELAY win (#801):

1. **Scale caveat** on the NODELAY evidence doc — the "beats DuckDB" claim holds at 1M
   but **not at 10M** (ProximaDB 2.0× DuckDB median there). Corrects the record so
   develop isn't left overstated.
2. **io-trace-driven co-design analysis** — what components/modules/design changes bring
   us in line with DuckDB at scale.

## The finding (measured, 1M vs 10M, DuckDB v1.4.4 baseline)

| scale | ProximaDB median | DuckDB median | verdict |
| --- | --- | --- | --- |
| 1M (0.001) | 14 ms | 32 ms | ProximaDB wins (0.44×) |
| 10M (0.1) | 81 ms | 40 ms | DuckDB wins (2.0×) |

The NODELAY fix holds at scale (`emit_ms`=0). But at 10M, **28/35 queries are ≥90%
compute** — the gap is DataFusion kernel throughput, not transport/storage/planning.

## Co-design levers (ranked by measured impact)

1. **Dictionary-encode wide string columns end-to-end** (PAX P-Shred + PAX scan exposing
   `Dictionary` arrays + `MIN(str)` from dictionary/zone-map) — attacks the **8–24×**
   string `LIKE`/`GROUP BY`/`MIN` tail (q21/q22/q23/q34/q35).
2. **`COUNT(DISTINCT)` from the ADR-037 HLL sketch** as a metadata elision (reuses the
   existing NDV overlay) — 8 queries at ~2.3×.
3. **Native vectorized operators over a real PAX scan** (ADR-054 Phase 2.5 / TD-OLAP-14)
   — the general 2–3× throughput lever; unblocks the rest.
4. **Read coalescing** (TD-151 / TD-RDSTRAT-1) — S3 RTT cost, not local wall.

The queries we already **beat** DuckDB on (metadata elision `MIN/MAX`/`COUNT(*)`,
`LIMIT`/point) are the template: the fastest query is the one you never compute.

Docs: `CLICKBENCH_NAGLE_ROOTCAUSE_2026_07_09.adoc` (+10M section),
`CLICKBENCH_SCALE_CODESIGN_ANALYSIS_2026_07_09.adoc` (new). No code change.
