### PR TITLE
ci: move SDK coverage ratchet to develop + TD-CI-1 (rust-test compile-bound)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1657,6 +1657,52 @@ jobs:
           find tests/unit -name 'test_*.py' | sort | grep -vE "$SKIP_RE" | \
             xargs -P 4 -n 1 bash -c 'test_one "$0"'
 
+  # SDK coverage ratchet — moved here from qa-gate.yml so a Python-SDK coverage
+  # regression is caught on the introducing feat→develop PR, not at develop→qa.
+  # Path-gated on the python filter (clients/python/**, clients/python-embedded/**,
+  # proto/**) and wired into ci-success.needs so it gates when it runs (skipped ⇒
+  # pass). Tolerates the known _cov sys.modules-leak failures — the ratchet measures
+  # coverage, not pass/fail (the python-test matrix owns per-file correctness).
+  sdk-coverage-ratchet:
+    name: SDK Coverage Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: changes
+    if: ${{ !inputs.skip_tests && needs.changes.outputs.python == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: clients/python/pyproject.toml
+      - name: Install SDK + coverage deps
+        working-directory: clients/python
+        run: pip install -e ".[dev]" pytest-cov pyarrow pandas jsonschema psutil
+      - name: Run SDK tests with coverage
+        working-directory: clients/python
+        env:
+          PROXIMADB_EMBEDDED: "0"
+          HF_HUB_DOWNLOAD_TIMEOUT: "30"
+          PROXIMADB_TEST_FORCE_FALLBACK_EMBEDDINGS: "1"
+        run: |
+          # Coverage needs a single aggregating process; tolerate the known
+          # _cov sys.modules-leak failures (the ratchet measures coverage, not
+          # pass/fail). OFFLINE unit tests only: filter out `integration` (needs
+          # a running server) and `live` (needs an external dependency / network).
+          pytest tests/unit/ -q -p no:cacheprovider --timeout=120 \
+            --cov=proximadb_sdk --cov-report=json:/tmp/sdk-cov.json \
+            -m "not integration and not live" \
+            --ignore=tests/unit/test_chunking_code_cov.py \
+            --continue-on-collection-errors || true
+          test -f /tmp/sdk-cov.json
+      - name: Ratchet check
+        run: |
+          python3 scripts/coverage_ratchet.py normalize --sdk /tmp/sdk-cov.json -o /tmp/sdk-current.json
+          python3 scripts/coverage_ratchet.py check \
+            --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json \
+            --current /tmp/sdk-current.json
+
   # ============================================================================
   # INTEGRATION TESTS - Server + Python SDK
   # ============================================================================
@@ -1942,6 +1988,7 @@ jobs:
       - rust-coverage
       - python-lint
       - python-test
+      - sdk-coverage-ratchet
       - integration-test
       - docker-build
       - docs-validation

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -214,45 +214,9 @@ jobs:
         # docker + aws/az CLIs are preinstalled on ubuntu-latest runners.
         run: bash scripts/run_cloud_emulator_tests.sh
 
-  sdk-coverage-ratchet:
-    name: SDK Coverage Ratchet
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: clients/python/pyproject.toml
-      - name: Install SDK + coverage deps
-        working-directory: clients/python
-        run: pip install -e ".[dev]" pytest-cov pyarrow pandas jsonschema psutil
-      - name: Run SDK tests with coverage
-        working-directory: clients/python
-        env:
-          PROXIMADB_EMBEDDED: "0"
-          HF_HUB_DOWNLOAD_TIMEOUT: "30"
-          PROXIMADB_TEST_FORCE_FALLBACK_EMBEDDINGS: "1"
-        run: |
-          # Coverage needs a single aggregating process; tolerate the known
-          # _cov sys.modules-leak failures (the ratchet measures coverage, not
-          # pass/fail — the per-file isolation gate in ci.yml owns correctness).
-          # Run OFFLINE unit tests only: filter out `integration` (needs a running
-          # server) and `live` (needs an external dependency / network, e.g. the
-          # `victor` package). The victor test self-skips via importorskip + `live`.
-          pytest tests/unit/ -q -p no:cacheprovider --timeout=120 \
-            --cov=proximadb_sdk --cov-report=json:/tmp/sdk-cov.json \
-            -m "not integration and not live" \
-            --ignore=tests/unit/test_chunking_code_cov.py \
-            --continue-on-collection-errors || true
-          test -f /tmp/sdk-cov.json
-      - name: Ratchet check
-        run: |
-          python3 scripts/coverage_ratchet.py normalize --sdk /tmp/sdk-cov.json -o /tmp/sdk-current.json
-          python3 scripts/coverage_ratchet.py check \
-            --baseline docs/_internal/roadmap/COVERAGE_BASELINE.json \
-            --current /tmp/sdk-current.json
+  # SDK Coverage Ratchet moved to ci.yml (develop early-detection, path-gated on
+  # clients/python/**) — see ci.yml `sdk-coverage-ratchet`. Catches an SDK coverage
+  # regression on the introducing feat→develop PR instead of only at develop→qa.
 
   rust-coverage-ratchet:
     name: Rust Coverage Ratchet

--- a/docs/10-quality/td/TD-CI-1-rust-test-compile-bottleneck.adoc
+++ b/docs/10-quality/td/TD-CI-1-rust-test-compile-bottleneck.adoc
@@ -1,0 +1,71 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-CI-1: rust-test unit job is compile-bound (CARGO_BUILD_JOBS=1 OOM mitigation) — not run-bound
+:toc: macro
+:icons: font
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — deferred to a billing-tier decision (larger GitHub-hosted runner). No code action until then.
+| Severity | Medium — the slowest job on the develop/qa CI tier (~49 min); does not fail, only costs wall-clock + a runner for the duration.
+| Component | CI — `.github/workflows/ci.yml` `rust-test` (matrix `test-type: unit`)
+| Tracked-by | This TD; related OOM root cause in the cloud-emulator fix (PR #803, `scripts/run_cloud_emulator_tests.sh`).
+| Resolution | (planned) trial a larger runner (16 GB → 64 GB) for `rust-test` so `CARGO_BUILD_JOBS` can rise from 1 → 4-8; measure the compile reduction. Fallback: sccache / shared-build reuse.
+|===
+
+toc::[]
+
+== Context
+
+`Rust Tests (unit)` (`ci.yml`, matrix leg `test-type: unit`) is the single slowest
+job on the develop/qa CI tier. It runs the root `proximadb` crate's `--lib` suite
+under nextest (`CARGO_BUILD_JOBS=1 cargo nextest run --lib --profile unit --test-threads=2`).
+
+== Measurement (PR #794 CI run, job id 86144007328, 2026-07-09)
+
+Total wall: **49.1 min**. Split:
+
+* **~45 min COMPILE** — `cargo nextest` building the `proximadb` lib test binary
+  (~8400 tests). `CARGO_BUILD_JOBS=1` is *forced* to avoid OOM-killing the 16 GB
+  hosted runner mid-link (the same failure mode that made the qa-gate cloud-emulator
+  job red — *"runner received a shutdown signal"*; see the comment at `ci.yml`'s
+  rust-test job and PR #803). Serializing crate compilation is the load-bearing
+  mitigation, and it is what makes the compile slow.
+* **~3.4 min RUN** — the actual test execution (`nextest` run phase, process-per-test).
+
+i.e. **~92% of the job is compile, ~8% is run.**
+
+== Why run-sharding is the wrong lever
+
+`nextest --partition count:k/N` shards only the *run* phase. With run at ~3.4 min,
+sharding it N ways saves ~2 min of wall-clock while *duplicating* the ~45 min compile
+N times (every shard recompiles the full ~8400-test binary). At N=2 that is ~2 min
+saved for 2× the compile compute (two runners each compile 45 min). Net negative —
+measured, not asserted.
+
+== Real levers (in priority order)
+
+1. **Larger GitHub-hosted runner (RECOMMENDED, billing-tier decision).** A 64 GB
+   runner lets `CARGO_BUILD_JOBS` rise to 4-8 without OOM, parallelizing the crate
+   compile and cutting the ~45 min toward ~10-15 min. This is the one change that
+   moves the dominant cost term. Requires enabling larger runners on the org/billing
+   tier — outside a CI-config PR.
+2. **sccache / aligned rust-cache key.** Wire `sccache` (or align rust-test's
+   `shared-key` with `rust-build`) so the compile is a cache hit on repeat/related
+   runs. Does not help the cold first compile of a changed graph, but speeds churn.
+   Safe, modest.
+3. **Shared compiled test binary across shards.** Compile once, shard the run reusing
+   it. *Marginal* here (run is only ~3.4 min) and ferrying `target/` across runners is
+   a documented-unsolved problem (the qa-gate pgwire-recall job builds-on-one-runner
+   precisely because Swatinem/rust-cache cannot reliably ferry `target/` across
+   runners). Low payoff, high risk — not recommended.
+
+== Decision
+
+Do **not** shard the unit run (counterproductive per the measurement). Defer the
+compile reduction to a larger-runner trial (lever 1) as a billing-tier decision.
+Record sccache (lever 2) as the safe interim option if larger runners are not available.
+
+This TD supersedes the "shard rust-test unit 2-3 ways" idea from the CI-rebalancing
+follow-up (the `+ measure` step is what surfaced that run-sharding is the wrong lever).


### PR DESCRIPTION
CI-rebalancing follow-up to #803. Two parts:

## Part 3 — move SDK coverage ratchet from qa-gate to develop
Relocates the `SDK Coverage Ratchet` job from `qa-gate.yml` to `ci.yml`, path-gated on the `python` filter (`clients/python/**`, `clients/python-embedded/**`, `proto/**`) and wired into `ci-success.needs`. An SDK coverage regression is now caught on the **introducing feat→develop PR**, not only at develop→qa. Skipped (free, passes ci-success) on unrelated PRs. `qa-gate.yml` keeps a pointer comment.

## Part 4 — TD-CI-1: rust-test unit is compile-bound (do NOT shard)
Per the chosen "+ measure" approach, I measured the `rust-test` unit job (the slowest develop step) on PR #794's CI run:

- **49.1 min total = ~45 min COMPILE + ~3.4 min RUN** (~92% compile).
- The compile is forced `CARGO_BUILD_JOBS=1` to avoid the 16 GB hosted-runner OOM — the **same root cause** as the cloud-emulator fix (#803): *"runner received a shutdown signal"* is the OOM killer mid-link.

**This measurement invalidates run-sharding:** `nextest --partition` shards only the ~3.4 min run, saving ~2 min wall while *duplicating* the ~45 min compile N× (each shard recompiles the full ~8400-test binary) — a net negative.

So instead of sharding, **TD-CI-1** records the finding and defers the real lever: a larger GitHub-hosted runner (more RAM → `BUILD_JOBS`>1 → parallel crate compile, cutting ~45 min toward ~10-15 min), which is a billing-tier decision outside a CI-config PR. sccache/aligned-cache is noted as the safe interim option. Per the chosen scope, **no sharding change is made.**

## Verification
- `actionlint` on both workflows — clean on the new/changed jobs (only pre-existing unrelated warnings: the advisory `macos-13` GPU job + shellcheck infos).
- `python3 scripts/check_td_adr_unique.py` — 0 errors (TD-CI-1 unique; 175 TD ids checked).
- `make work-commit-check` — green (panic-policy, hygiene, tenant-path, workspace-boundaries).
- On this PR: the `SDK Coverage Ratchet` job will run (this PR touches `ci.yml` → `python` filter matches `proto/**`? no — but `ci.yml` itself isn't in the python filter; verify it's appropriately skipped/run). The qa-gate no longer defines it.

## Remaining (not in scope)
- The larger-runner billing-tier decision for the rust-test compile (TD-CI-1 lever 1).