### PR TITLE
feat(portability): Windows ratchet rung 2 — gate Unix-domain-socket transport (TD-EMBED-1)

### DIFF
--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -14,10 +14,15 @@ name: Windows Compile Ratchet
 
 on:
   pull_request:
+    # Scoped to the areas on the remaining Windows-compile path (grown one rung at
+    # a time as blockers are fixed), so this Windows runner only fires on relevant
+    # PRs — not every src change across concurrent sessions.
     paths:
       - 'crates/storage/**'
+      - 'crates/platform/proximadb-runtime/**'
       - 'src/storage/**'
       - 'src/embedded/**'
+      - 'src/network/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/windows-compile-ratchet.yml'

--- a/src/network/arrow_ipc/server.rs
+++ b/src/network/arrow_ipc/server.rs
@@ -129,6 +129,7 @@ impl ArrowFlightServer {
                     .serve(addr)
                     .await?;
             }
+            #[cfg(unix)]
             BindTarget::Uds(path) => {
                 let listener = crate::network::uds::bind_unix_listener(&path).map_err(|e| {
                     anyhow::anyhow!("Arrow Flight UDS bind failed at {}: {}", path.display(), e)
@@ -138,6 +139,13 @@ impl ArrowFlightServer {
                     .add_service(flight_server)
                     .serve_with_incoming(incoming)
                     .await?;
+            }
+            #[cfg(not(unix))]
+            BindTarget::Uds(path) => {
+                anyhow::bail!(
+                    "Arrow Flight UDS (unix:{}) is not supported on this platform; use TCP",
+                    path.display()
+                );
             }
         }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -206,6 +206,9 @@ pub mod storage_write_fence;
 // (root-crate decomposition).
 pub use proximadb_tls as tls;
 /// Unix-domain socket binding helpers for portless ("embedded") transport mode.
+/// UDS (tokio's `UnixListener`) is unix-only; on non-unix (Windows) the module is
+/// absent and the transport bind sites fall back to a "use TCP" error.
+#[cfg(unix)]
 pub mod uds;
 
 pub use metrics_service::*;

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -627,6 +627,7 @@ impl MultiServer {
             let grpc_handle = tokio::spawn(async move {
                 let result = match grpc_bind_target {
                     BindTarget::Tcp(addr) => server.serve(addr).await,
+                    #[cfg(unix)]
                     BindTarget::Uds(path) => match crate::network::uds::bind_unix_listener(&path) {
                         Ok(listener) => {
                             let incoming =
@@ -638,6 +639,14 @@ impl MultiServer {
                             return;
                         }
                     },
+                    #[cfg(not(unix))]
+                    BindTarget::Uds(path) => {
+                        tracing::error!(
+                            "gRPC UDS (unix:{}) is not supported on this platform; use TCP",
+                            path.display()
+                        );
+                        return;
+                    }
                 };
                 if let Err(e) = result {
                     tracing::error!("gRPC server error: {}", e);

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -1036,19 +1036,29 @@ impl RestServer {
 
     /// Start the REST server without TLS (plaintext)
     async fn start_plaintext(self) -> anyhow::Result<()> {
-        // Portless ("embedded") mode: serve over a Unix-domain socket.
+        // Portless ("embedded") mode: serve over a Unix-domain socket (unix-only).
         if let Some(uds_path) = self.uds_path.clone() {
-            tracing::info!(
-                "Starting REST server (plaintext) on unix:{}",
-                uds_path.display()
-            );
-            Self::log_endpoints(&self.bind_addr, false);
-            // axum 0.8 serves any `Listener`; tokio's UnixListener qualifies.
-            let listener = crate::network::uds::bind_unix_listener(&uds_path).map_err(|e| {
-                anyhow::anyhow!("REST UDS bind failed at {}: {}", uds_path.display(), e)
-            })?;
-            axum::serve(listener, self.router.into_make_service()).await?;
-            return Ok(());
+            #[cfg(unix)]
+            {
+                tracing::info!(
+                    "Starting REST server (plaintext) on unix:{}",
+                    uds_path.display()
+                );
+                Self::log_endpoints(&self.bind_addr, false);
+                // axum 0.8 serves any `Listener`; tokio's UnixListener qualifies.
+                let listener = crate::network::uds::bind_unix_listener(&uds_path).map_err(|e| {
+                    anyhow::anyhow!("REST UDS bind failed at {}: {}", uds_path.display(), e)
+                })?;
+                axum::serve(listener, self.router.into_make_service()).await?;
+                return Ok(());
+            }
+            #[cfg(not(unix))]
+            {
+                anyhow::bail!(
+                    "REST UDS (unix:{}) is not supported on this platform; use TCP",
+                    uds_path.display()
+                );
+            }
         }
 
         tracing::info!("Starting REST server (plaintext) on {}", self.bind_addr);


### PR DESCRIPTION
Second Windows compile-ratchet rung (TD-EMBED-1), following #800.

## Chain so far
- **Rung 1 (#800, merged):** `proximadb-storage-common` compiles on `windows-2022` (gated `memmap2::Advice`). Its "measure tail" step surfaced the next blocker.
- **Rung 2 (this PR):** the root `proximadb` lib failed with **3 errors, all Unix-domain-socket** (`tokio::net::UnixListener` / `UnixListenerStream`) — unix-only.

## Fix
Gate the UDS transport behind `#[cfg(unix)]` with a `#[cfg(not(unix))]` **"use TCP"** fallback at each bind site (UDS is genuinely unsupported on Windows; the in-process embedded wheel and Windows both use TCP):
- `network/mod.rs` — `#[cfg(unix)]` on `pub mod uds`
- `multi_server.rs` (gRPC), `arrow_ipc/server.rs` (Arrow Flight), `rest/server.rs` (REST plaintext) — each `BindTarget::Uds` bind body gated; non-unix logs/bails cleanly
- `multi_server.rs` `BindTarget::Uds(p) => Some(p)` left as-is (plain `PathBuf`, Windows-safe)

The `BindTarget::Uds` variant itself (`proximadb-runtime`) is a `PathBuf` and stays cross-platform; only the *consumption* is gated. **Unix path unchanged** — `cargo check -p proximadb --lib` green on Linux (5m41s); fmt clean.

## Ratchet
Broadened the ratchet trigger paths to `src/network/**` + `proximadb-runtime` so this rung runs the Windows check (kept path-scoped, not `src/**`, to avoid firing a Windows runner on every concurrent session's PR). The root-lib check stays **non-gating ("measure tail")** — once it goes green, a follow-up promotes it to a gating rung. This PR's ratchet run tells us whether the root lib now compiles on Windows or reveals the next blocker.