### PR TITLE
docs(design): geometry-dependent heterogeneous execution dispatch (CUDA/llama.cpp co-design) (TD-OLAP-4)

### DIFF
--- a/docs/12-design/CODESIGN_GEOMETRY_DEPENDENT_EXECUTION_2026_07_09.adoc
+++ b/docs/12-design/CODESIGN_GEOMETRY_DEPENDENT_EXECUTION_2026_07_09.adoc
@@ -117,6 +117,32 @@ cost` becomes populated:**
 Only after Slice 0 is the engine dimension observable; Dimension-0 routing (below)
 then has evidence to act on and grows automatically as native coverage grows.
 
+== Unblock — native CAN serve parquet: the scan source is separable from the engine
+
+A natural objection: "native only reads PAX/`Values`, so it can't compete on the
+external-parquet ClickBench." That is a *sequencing* limit, not an architectural one.
+**Reading parquet and executing operators are two different jobs:**
+
+* Turning parquet bytes → Arrow `RecordBatch` is pure **arrow-rs**
+  (`ParquetRecordBatchStreamBuilder` + `ProjectionMask` — exactly what
+  `object_store_parquet_reader.rs` already uses). No DataFusion required.
+* The native engine's `ExecutionOperator` contract **consumes `RecordBatch`es**
+  (`MemoryScanSource` from `Values`; the Phase-2.5 `PaxScanOperator` from PAX).
+
+So a **native `ParquetScanOperator`** — mirroring `native_scan.rs`'s PAX source but
+driving the *same arrow-rs parquet reader* — feeds parquet `RecordBatch`es straight
+into the native pipeline (`FilterProject` → `HashAggregate` → `HashJoin`). Native
+then serves external-parquet queries wherever its operators are superior. Nothing in
+ADR-052/054 forbids this; parquet was simply DataFusion's lane first because PAX is
+the canonical inside format (ADR-055) and DataFusion gave breadth for free.
+
+**This is the concrete unblock for the whole engine dimension:** with a native
+parquet scan source, native runs the *same* ClickBench queries as DataFusion →
+Slice 0's shadow finally has a real native-vs-DataFusion sample on the actual
+benchmark → Dimension-0 routing has evidence. It moves ahead of "native only on PAX."
+Roadmap: **native `ParquetScanOperator`** (reuse the arrow-rs reader) → shadow on
+ClickBench → route per shape to the measured winner.
+
 == Dimension 0 in depth — engine selection at the router (native vs DataFusion)
 
 Today native (ADR-054) covers few operations (FilterProject, HashAggregate,

--- a/docs/12-design/CODESIGN_GEOMETRY_DEPENDENT_EXECUTION_2026_07_09.adoc
+++ b/docs/12-design/CODESIGN_GEOMETRY_DEPENDENT_EXECUTION_2026_07_09.adoc
@@ -1,0 +1,205 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Co-design: geometry-dependent, heterogeneous execution dispatch (2026-07-09)
+
+TD-OLAP-4 co-design analysis. First-principles proposal: select the execution
+**engine and kernel per operation from the data geometry** — the way CUDA tiles a
+kernel to the matrix/arch geometry and llama.cpp dispatches a quant kernel per
+tensor shape/dtype/backend — calibrated by the per-query io-trace. Grounded in the
+full 100M ClickBench measurement (scale factor 1.0), which produced a decisive
+counter-example to "one strategy fits all" (naive dictionary preservation).
+
+== The first principle (why "always X" is always wrong)
+
+CUDA and llama.cpp share one idea: **there is no single best kernel — only the best
+kernel for THIS geometry.** CUDA picks tile size / kernel per (matrix dims, dtype,
+SM occupancy, roofline position). llama.cpp dispatches per (quant format, tensor
+shape, CPU/GPU backend, SIMD width). The choice is *data-* and *hardware-shaped*,
+resolved from cheap descriptors, and **autotuned/profiled**, not assumed.
+
+ProximaDB's analytics execution is the same problem. The "hardware" is the **data
+geometry** (cardinality, datatype, encoding, selectivity, row-group shape) crossed
+with the **operation** (scan / filter / LIKE / GROUP BY / DISTINCT / MIN / COUNT /
+join). The "kernel" is the execution strategy: which **engine** (native / DataFusion
+/ Volcano), which **tier** (metadata elision / encoded-codes / plain-vectorized /
+native-operator), which **column encoding** (dict codes vs plain values). And the
+io-trace is the profiler that autotunes the dispatch.
+
+== The measured counter-example (dictionary encoding, full 100M)
+
+Preserving on-disk parquet dictionaries is a *kernel variant*. "Always preserve"
+was **net +72% total wall** (66.1 s → 113.9 s) — but the per-shape truth is clean:
+
+[cols="3,1,1",options="header"]
+|===
+| (operation, column geometry) | dict verdict | evidence (100M, off→on ms)
+| GROUP BY, dict-string, **tiny card** (MobilePhoneModel, 31) | **WIN** | q11 983→362, q12 1001→407
+| GROUP BY / DISTINCT, dict-string, **medium card** (SearchPhrase, 18 K) | **LOSE (big)** | q17 2748→16582, q06 1193→9313
+| scan / LIKE / MIN, string (any card) | WIN (codes / less data) | q21 2854→2657, q22 3121→3017
+| GROUP BY, high-card **not dict on disk** (URL, PLAIN) | neutral | q34 7244→7267 (writer already chose PLAIN)
+| MIN/MAX numeric; COUNT(*) | elided (footer) — dict irrelevant | q07 4 ms, q01 19 ms
+|===
+
+The parquet writer's own dictionary decision is itself a cardinality signal (URL is
+PLAIN on disk → nothing to preserve). The decision surface is **operation × card ×
+dtype × encoding** — exactly a geometry-dependent kernel selection. Naive "always
+dict" is using one CUDA tile size for every matrix.
+
+== The dispatch dimensions (cheap descriptors from footer + plan + io-trace)
+
+0. **Engine** — {native vectorized (ADR-054), DataFusion (ADR-052), Volcano (OLTP)}.
+   The *backend*, chosen per operation-shape.
+1. **Operation** — from the plan: scan / filter / substring / GROUP BY / DISTINCT /
+   MIN·MAX / COUNT / SUM·AVG / join. The kernel *family*.
+2. **Cardinality** — per-row-group footer `distinct_count`, else dict-page size, else
+   the ADR-037 HLL sketch. The dominant GROUP-BY/DISTINCT geometry param.
+3. **Datatype + encoding** — numeric / string / **dict-string** / vector-quantized.
+   The "dtype" that selects the code path.
+4. **Selectivity ratio** — predicate selectivity (zone-map + bloom) → PREWHERE
+   ordering, defer-fat-columns. The "sparsity."
+5. **Row-group tile geometry** — rows, byte size, and measured **compute-intensity
+   (ms/MB)** — the roofline position (q23 = 1.2 ms/MB byte-bound; q33 = 4.6 ms/MB
+   compute-bound). Decides tile/morsel sizing and compute-vs-IO-bound handling.
+
+== The dispatch tiers (cheapest first — "the fastest op is the one you never run")
+
+1. **Metadata elision** (answer from the footer, zero execution): COUNT(*) from
+   `num_rows`; MIN/MAX numeric from exact bounds (shipped, #727); **MIN/MAX string
+   from the per-row-group dictionary min-code**; **COUNT(DISTINCT) unfiltered from
+   the ADR-037 HLL sketch**. Top of the dispatch — if the geometry says the footer
+   can answer, skip the engine entirely.
+2. **Encoded-codes kernel** (compute on the compressed form): dict-codes GROUP BY
+   for tiny-card columns; substring/LIKE evaluated over the *dictionary values*
+   (few) then mapped to codes; SQ8/RaBitQ for vectors. The "compressed compute."
+3. **Plain vectorized** (Arrow kernels over materialized values): medium+card
+   GROUP BY/DISTINCT (decode dict first — the measured-correct choice), general
+   filter/agg. DataFusion's strength; the safe default.
+4. **Native operator** (ADR-054): where io-trace proves DataFusion is the binding
+   constraint (join spill, multimodal co-execution, compute pathologies).
+
+== Prerequisite (Slice 0) — make the ENGINE a first-class, shadow-measurable trace dimension
+
+The whole multidimensional dispatch is un-learnable until the trace carries the
+engine dimension *with comparison samples*. Today it does not, in practice:
+
+* The io-trace **has scaffolding** — `IoTrace::record_route(shape_class,
+  backend_label)` and `compute_ms: BTreeMap<engine, ms>` — but no consumer surfaces
+  it: the ClickBench/TPC ledgers record only `total_compute_ms()` (summed, engine
+  erased), and the route cost model isn't fed per-engine samples.
+* The ADR-054 **native-vectorized** engine is **not a distinct backend** — it is a
+  runtime `try_vectorized()` hook inside the Volcano path (`ComputeBackend::Native`
+  == the *row* Volcano), gated `PROXIMADB_NATIVE_VECTORIZED` (off) and fed only
+  in-memory `Values` until Phase 2.5. So it never runs on real queries and, even
+  when it does, its compute is not labeled apart from the Volcano.
+* Result: every ClickBench row is `engine=datafusion`. **There is no native sample
+  anywhere** — exactly the gap observed — so Dimension 0 has nothing to route on.
+
+**Slice 0 fixes the observability so the tensor `(engine × operation × geometry) →
+cost` becomes populated:**
+
+. **Distinctly label native-vectorized.** When `try_vectorized()` serves a plan,
+  stamp `record_compute_ms("native-vectorized", …)` and a route backend
+  `"NativeVectorized"` — separate from `Native(Volcano)` and `DataFusionLocal` — so
+  the trace tells the three engines apart.
+. **Surface engine + route in the ledger.** Add `route`/`backend` and the per-engine
+  `compute_ms` map to `QueryRecord` (ClickBench) and the TPC ledger, so every
+  measurement is engine-tagged and the shadow deltas are visible.
+. **Shadow-execute for supported shapes.** Under a shadow gate (extend
+  ADR-056/TD-OLAP-10's mismatch harness), run DataFusion *and* native-vectorized on
+  the same plan; record both engines' `compute_ms` in the one trace, keyed by
+  engine. DataFusion stays authoritative for the result; native contributes only a
+  *sample*. This is the profiling pass — the analog of llama.cpp benchmarking each
+  backend at load.
+. **Feed the samples to the cost model.** Route the per-engine, per-shape samples
+  into `route_cost_model.rs` (ADR-050) so the debounced learner holds a real
+  `(shape → {engine: cost})` table.
+
+Only after Slice 0 is the engine dimension observable; Dimension-0 routing (below)
+then has evidence to act on and grows automatically as native coverage grows.
+
+== Dimension 0 in depth — engine selection at the router (native vs DataFusion)
+
+Today native (ADR-054) covers few operations (FilterProject, HashAggregate,
+HashJoin, and the Phase-2.5 PAX scan) and is default-off; DataFusion carries breadth.
+That ratio will invert over time. The router (`ComputeScheduler`) must therefore
+choose the **engine per operation-shape from measured evidence**, not a static gate:
+
+* **Measure both, per shape, in shadow.** Extend the ADR-056 / TD-OLAP-10 shadow
+  comparison: for shapes native supports, run native + DataFusion, record each
+  engine's wall/compute in the io-trace keyed by (operation, geometry). No
+  correctness risk (DataFusion result is authoritative until native proves parity).
+* **Route to the winner, actively.** The `ComputeScheduler`'s trace-driven,
+  debounced learn-loop (ADR-050 cost model, `route_cost_model.rs`) already selects a
+  backend per query shape from measured cost. Feed it the per-engine samples so it
+  routes a shape to native the moment native is measurably faster *and* at parity —
+  and back to DataFusion if a regression appears. This makes ADR-054 promotion
+  **continuous and evidence-gated** instead of a manual flag flip.
+* **Coverage grows monotonically.** As native adds operators, more shapes enter the
+  shadow set; the router picks them up automatically. Native is used for exactly
+  what it does well (measured), DataFusion for the long tail — the llama.cpp
+  backend-dispatch pattern.
+
+== Per-row-group (tile) dispatch — the geometry-dependent core
+
+Dictionaries, zone-maps, and blooms are **per-row-group**, so the dispatch is
+naturally **per tile**: each row-group carries its own footer descriptors, so one
+group may elide (min-code answers), another decode-and-vectorize (medium card),
+another be pruned entirely (zone-map/bloom). This is the direct analog of tiling a
+GPU kernel to per-tile geometry — the row-group is the tile, its footer is the tile
+descriptor, and the decision is local and cheap.
+
+== Calibration — the io-trace is the autotuner (profiling-guided execution)
+
+CUDA autotuners benchmark tile sizes; llama.cpp benchmarks kernel variants at load.
+Our equivalent is the **already-emitted per-query io-trace** (bytes, range_gets,
+splits_pruned, compute_ms, ms/MB, per engine). It is the calibration signal that:
+(a) sets the dispatch thresholds (e.g. the dict-GROUP-BY cardinality cutoff observed
+between 31 and 18 K distinct), (b) keeps them current as data/engines change
+(debounced learn-loop), and (c) never asserts — every dispatch rule is a measured
+quantity, matching the co-design mandate (trace before you tune).
+
+== How this resolves the open findings
+
+* **Dictionary paradox → solved by plan-aware + per-row-group dispatch.** Preserve
+  dict codes only for (scan/LIKE/MIN) or (GROUP BY on tiny-card, from footer
+  `distinct_count`); decode before a medium+card hash aggregate. The naive net-72%
+  regression becomes a per-shape win with no regression.
+* **Metadata elision generalized.** Tier 1 extends #727's numeric MIN/MAX to string
+  MIN via dictionary min-code and COUNT(DISTINCT) via HLL — the highest-ROI kernel
+  (zero execution), selected purely from geometry.
+* **Real competitive standing (banked).** At 100M scale-factor-1.0, plain
+  DataFusion (dict-off) is already **1.23× DuckDB total / 1.17× median**; the
+  residual is the kernel gap the tiers above close incrementally, engine-routed.
+
+== Implementation seam (extends existing infra, no new mechanism)
+
+- **Descriptors:** already in the footer (`statistics_from_splits`,
+  `column_bounds_from_parquet`) + ADR-037 HLL registry + the plan (GROUP-BY/agg
+  columns). Add a per-(column, row-group, operation) `ExecKernel` choice.
+- **Elision tier:** the `AggregateStatistics` seam (schema_inference.rs) — extend to
+  string MIN (dict min-code) + COUNT(DISTINCT) (HLL).
+- **Engine routing:** `ComputeScheduler::route_select` + `route_cost_model.rs`
+  (ADR-050) — add per-engine, per-shape samples from the ADR-056 shadow path.
+- **Encoded-codes kernel:** the parquet reader (`object_store_parquet_reader.rs`)
+  preserves dict per-row-group only when the dispatch says so (plan-aware), and
+  decodes otherwise.
+
+== Sequenced slices (each measured on the ClickBench/TPC ledger before promotion)
+
+. **Slice 0 — engine-dimension observability (prerequisite):** distinctly label
+  native-vectorized, surface engine/route + per-engine compute in the ledgers,
+  shadow-execute supported shapes, feed samples to the route cost model. Nothing
+  else in Dimension 0 is learnable without it.
+. **Elision tier** (highest ROI, zero risk): string MIN via dict min-code; COUNT(DISTINCT)
+  via HLL. Generalizes #727. Engine-agnostic — ships in parallel with Slice 0.
+. **Plan-aware dict** (fixes the paradox): preserve dict codes only for non-aggregate
+  or tiny-card-aggregate columns, from footer `distinct_count`.
+. **Engine-routing dimension**: with Slice-0 samples in hand, wire the route cost
+  model to select native where measured-faster (parity-gated), coverage-growing.
+. **Selectivity/PREWHERE + tile sizing**: order predicates + morsel by the io-trace
+  roofline (ms/MB), defer fat columns.
+
+The through-line: **descriptors are cheap, execution is expensive** — spend a footer
+read and a plan inspection to pick the right engine+kernel+tier, and let the io-trace
+autotune the thresholds. That is the CUDA/llama.cpp co-design discipline applied to a
+cloud analytics engine.


### PR DESCRIPTION
First-principles co-design framework: select execution **engine + kernel per operation from data geometry**, calibrated by io-trace — CUDA-tiling / llama.cpp-dispatch applied to OLAP. Grounded in the full 100M ClickBench measurement (naive dict = +72% total, but a clean per-shape win/lose surface).

**Dimensions:** (0) engine {native/DataFusion/Volcano}, (1) operation, (2) cardinality, (3) dtype+encoding, (4) selectivity, (5) row-group tile (ms/MB roofline). **Tiers:** metadata-elision → encoded-codes → plain-vectorized → native-operator, per row-group tile.

**Slice 0 (prerequisite):** make the ENGINE a first-class, shadow-measurable trace dimension — native is default-off/VALUES-only today, so there's no engine sample to route on. Resolves the dict paradox (plan-aware, per-row-group) and generalizes metadata elision (string MIN via dict min-code, COUNT(DISTINCT) via HLL). Informs ADR-050/052/054/056/037.

Design-only; measured evidence from the full 100M run.