### PR TITLE
feat(observability): engine dimension in the io-trace + ledger (TD-OLAP-4 Slice 0)

### DIFF
--- a/src/observability/io_trace.rs
+++ b/src/observability/io_trace.rs
@@ -396,6 +396,7 @@ impl IoTrace {
             plan_ms: self.plan_ms.load(Ordering::Relaxed),
             table_open_hits: self.table_open_hits.load(Ordering::Relaxed),
             table_open_misses: self.table_open_misses.load(Ordering::Relaxed),
+            route: self.route(),
         }
     }
 }
@@ -436,7 +437,15 @@ pub struct IoTraceSnapshot {
     pub embedding_calls: u64,
     pub embedding_input_tokens: u64,
     pub embedding_output_tokens: u64,
+    /// Compute wall ms attributed **per engine** — the engine dimension of the
+    /// geometry-dependent dispatch (TD-OLAP-4). Keys distinguish `datafusion`,
+    /// `native`/`native-vectorized`, and `volcano`, so the route cost model can
+    /// learn which engine wins per query shape.
     pub compute_ms: BTreeMap<String, u64>,
+    /// The route this query was served on, `(shape_class, backend_label)` — the
+    /// top dispatch dimension (which engine). `None` if no route was stamped.
+    #[serde(default)]
+    pub route: Option<(String, String)>,
     /// pgwire relational-pipeline setup wall ms — pre-execution xCatalog schema
     /// resolution + route classification, DataFusion route only (TD-OLAP-4).
     #[serde(default)]

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -75,6 +75,10 @@ pub async fn try_vectorized(
             return Ok(None);
         }
     };
+    // TD-OLAP-4 Slice 0 (engine dimension): time + label the native-vectorized
+    // engine DISTINCTLY from the Volcano and DataFusion, so the io-trace carries
+    // a per-engine compute sample the route cost model can compare on.
+    let started = std::time::Instant::now();
     let batches = match super::native_ops::execute_pipeline(&lowered).await {
         Ok(b) => b,
         Err(reason) => {
@@ -86,6 +90,11 @@ pub async fn try_vectorized(
             return Ok(None);
         }
     };
+    crate::observability::io_trace::record_compute_ms(
+        "native-vectorized",
+        started.elapsed().as_millis() as u64,
+    );
+    crate::observability::io_trace::record_route("vectorized", "NativeVectorized");
     let schema = lowered.pipeline.output_schema.as_ref();
     Ok(Some(record_batches_to_pipeline_result(schema, &batches)))
 }

--- a/tests/clickbench_ledger_e2e.rs
+++ b/tests/clickbench_ledger_e2e.rs
@@ -294,6 +294,16 @@ struct QueryRecord {
     /// Execution (compute) wall ms attributed by the engine (TD-OLAP-4).
     #[serde(skip_serializing_if = "Option::is_none")]
     compute_ms: Option<u64>,
+    /// Engine/route this query was served on — `(shape_class, backend_label)`, the
+    /// engine dimension of the geometry-dependent dispatch (TD-OLAP-4 Slice 0).
+    /// For external-parquet ClickBench this is `DataFusionLocal` (native cannot
+    /// serve external parquet yet), making the current engine coverage explicit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<String>,
+    /// Full per-engine compute breakdown (`{engine: ms}`) — distinguishes
+    /// `datafusion` / `native-vectorized` / `volcano` for the cost-model tensor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compute_by_engine: Option<std::collections::BTreeMap<String, u64>>,
     /// Table-OPEN floor (discovery + footer) wall ms — TD-OLAP-4. Drops to ~0 on a
     /// warm table-open cache hit; the direct signal for the cache lever.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -383,6 +393,8 @@ async fn clickbench_ledger() {
             open_ms,
             plan_ms,
             table_open_hits,
+            route,
+            compute_by_engine,
         ) = snap
             .map(|s| {
                 (
@@ -395,9 +407,13 @@ async fn clickbench_ledger() {
                     Some(s.open_ms),
                     Some(s.plan_ms),
                     Some(s.table_open_hits),
+                    s.route.as_ref().map(|(_, backend)| backend.clone()),
+                    Some(s.compute_ms.clone()),
                 )
             })
-            .unwrap_or((None, None, None, None, None, None, None, None, None));
+            .unwrap_or((
+                None, None, None, None, None, None, None, None, None, None, None,
+            ));
         match res {
             Ok(msgs) => {
                 let rows = msgs
@@ -419,6 +435,8 @@ async fn clickbench_ledger() {
                     open_ms,
                     plan_ms,
                     table_open_hits,
+                    route,
+                    compute_by_engine,
                     error: None,
                 });
             }
@@ -437,6 +455,8 @@ async fn clickbench_ledger() {
                 open_ms,
                 plan_ms,
                 table_open_hits,
+                route,
+                compute_by_engine,
                 error: Some(
                     e.as_db_error()
                         .map(|d| d.message().to_string())
@@ -473,6 +493,8 @@ async fn clickbench_ledger() {
                 open_ms: None,
                 plan_ms: None,
                 table_open_hits: None,
+                route: None,
+                compute_by_engine: None,
                 error: (!ok).then(|| {
                     out.as_ref()
                         .map(|o| String::from_utf8_lossy(&o.stderr).trim().to_string())


### PR DESCRIPTION
Slice 0 of the geometry-dependent dispatch: make the execution ENGINE a first-class trace dimension — the prerequisite for routing native vs DataFusion per shape.

- io_trace snapshot carries `route` (shape_class, backend_label) + exposes per-engine `compute_ms`.
- **native-vectorized** (ADR-054) is now labeled DISTINCTLY (`compute_ms["native-vectorized"]` + route `NativeVectorized`) when `try_vectorized` serves a plan — so a native sample is finally distinguishable.
- ClickBench ledger records `route` + `compute_by_engine`; for external parquet it truthfully shows `DataFusionLocal` (native can't serve external parquet yet — the honest current coverage).

Next: native `ParquetScanOperator` (reuse the arrow-rs reader) → native serves ClickBench → shadow → route. Design: #809.