### PR TITLE
feat(engine): native ParquetScanOperator — external-parquet scan source for the vectorized engine (TD-OLAP-4)

### DIFF
--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -14,6 +14,7 @@ pub mod low_latency_executor;
 pub mod native_engine;
 pub mod native_join_ops;
 pub mod native_ops;
+pub mod native_parquet_scan;
 pub mod native_scan;
 pub mod olap_delta_merge;
 pub mod plan_cache;

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -100,6 +100,57 @@ pub async fn try_vectorized(
     Ok(Some(record_batches_to_pipeline_result(schema, &batches)))
 }
 
+/// TD-OLAP-4 (engine dimension, native-parquet): run `physical` on the native
+/// vectorized engine using `scan_source` — a
+/// [`super::native_parquet_scan::ParquetScanOperator`] built from the SAME
+/// object-store + files + projection the DataFusion adapter reads — as the `Scan`
+/// leaf. This is the shadow entry that lets native serve external-parquet queries
+/// so the io-trace carries a `native-vectorized` compute sample alongside
+/// DataFusion's for the SAME plan and storage.
+///
+/// Returns `Ok(None)` when the path is disabled OR the plan shape is unsupported
+/// (native covers `Filter`/`Project`/`Aggregate`/`Limit` over a `Scan` today) OR
+/// execution failed — the caller keeps DataFusion's result in every such case;
+/// correctness is policed by the shadow-comparison harness.
+pub async fn try_vectorized_over_parquet(
+    physical: &PhysicalPlan,
+    scan_source: Box<dyn proximadb_execution_contracts::ExecutionOperator>,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError> {
+    if !native_vectorized_enabled() {
+        return Ok(None);
+    }
+    let lowered = match super::native_ops::lower_physical_over_source(physical, scan_source) {
+        Ok(l) => l,
+        Err(reason) => {
+            tracing::debug!(
+                target: "proximadb::native_vectorized",
+                %reason,
+                "native-parquet path declined; keeping DataFusion result"
+            );
+            return Ok(None);
+        }
+    };
+    let started = std::time::Instant::now();
+    let batches = match super::native_ops::execute_pipeline(&lowered).await {
+        Ok(b) => b,
+        Err(reason) => {
+            tracing::debug!(
+                target: "proximadb::native_vectorized",
+                %reason,
+                "native-parquet path failed mid-execution; keeping DataFusion result"
+            );
+            return Ok(None);
+        }
+    };
+    crate::observability::io_trace::record_compute_ms(
+        "native-vectorized",
+        started.elapsed().as_millis() as u64,
+    );
+    crate::observability::io_trace::record_route("vectorized", "NativeVectorized");
+    let schema = lowered.pipeline.output_schema.as_ref();
+    Ok(Some(record_batches_to_pipeline_result(schema, &batches)))
+}
+
 /// Streaming variant — not yet wired (the materialized path serves Phase 2).
 pub async fn try_vectorized_stream(
     _physical: &PhysicalPlan,

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -718,11 +718,40 @@ pub struct ScanTableInfo {
 /// The pieces `walk` accumulates while descending a supported plan subtree.
 /// `ops` is bottom-up: the source feeds the first, the last emits the output.
 struct Walked {
+    /// The scan leaf: `MemoryScanSource` for `Values`, a `PaxScanOperator` for a
+    /// `Scan` with a threaded [`ScanCtx`] (PAX segments), or a
+    /// `ParquetScanOperator` injected via [`lower_physical_over_source`] for a
+    /// `Scan` over external parquet (TD-OLAP-4) — generalized so native serves
+    /// real storage, not just literal tables.
     source: Box<dyn ExecutionOperator>,
     ops: Vec<OpSpec>,
     /// Output schema of the last op (or the source if `ops` is empty).
     cur_schema: SchemaRef,
     limit: Option<LimitSpec>,
+}
+
+thread_local! {
+    /// Scan source injected by [`lower_physical_over_source`] for the `Scan` leaf
+    /// (TD-OLAP-4 native-parquet). Set immediately before the sync `walk`, taken
+    /// at the `Scan` arm, cleared after — never held across an await.
+    static INJECTED_SCAN_SOURCE: std::cell::RefCell<Option<Box<dyn ExecutionOperator>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Lower `plan` to a native pipeline using `source` as the `Scan` leaf — the
+/// entry the native-parquet shadow uses to run the SAME plan DataFusion runs, but
+/// over a [`super::native_parquet_scan::ParquetScanOperator`]. Declines (like
+/// `lower_physical`) for any op native does not support.
+pub(crate) fn lower_physical_over_source(
+    plan: &PhysicalPlan,
+    source: Box<dyn ExecutionOperator>,
+) -> Result<LoweredPipeline, ExecutionError> {
+    INJECTED_SCAN_SOURCE.with(|s| *s.borrow_mut() = Some(source));
+    // No `ScanCtx`: the `Scan` leaf resolves to the injected parquet source, which
+    // the `Scan` arm checks before the PAX path.
+    let result = lower_physical(plan, None);
+    INJECTED_SCAN_SOURCE.with(|s| *s.borrow_mut() = None);
+    result
 }
 
 /// Lower a `PhysicalPlan` to a [`LoweredPipeline`]. Returns `Err(NotImplemented)`
@@ -982,6 +1011,18 @@ fn walk(plan: &PhysicalPlan, scan_ctx: Option<&ScanCtx>) -> Result<Walked, Execu
             output_schema,
             ..
         } => {
+            // TD-OLAP-4: a parquet source injected via `lower_physical_over_source`
+            // takes precedence — this is how native serves external parquet for the
+            // shadow probe. Absent an injection, fall through to the PAX path (#807).
+            if let Some(source) = INJECTED_SCAN_SOURCE.with(|s| s.borrow_mut().take()) {
+                let cur_schema = source.output_schema();
+                return Ok(Walked {
+                    source,
+                    ops: Vec::new(),
+                    cur_schema,
+                    limit: None,
+                });
+            }
             use crate::query::execution::native_scan::PaxScanOperator;
             let ctx = scan_ctx.ok_or_else(|| {
                 ExecutionError::NotImplemented(

--- a/src/query/execution/native_parquet_scan.rs
+++ b/src/query/execution/native_parquet_scan.rs
@@ -149,6 +149,69 @@ mod tests {
         assert_eq!(op.output_schema().fields().len(), 2);
     }
 
+    /// End-to-end: a relational `PhysicalPlan::Scan` lowers over an injected
+    /// `ParquetScanOperator` (via `lower_physical_over_source`) and drains all
+    /// rows through the native vectorized engine — proving native serves external
+    /// parquet with ZERO DataFusion (TD-OLAP-4 engine dimension).
+    #[tokio::test]
+    async fn native_lowers_scan_over_parquet_source() {
+        use crate::query::execution::native_ops::{execute_pipeline, lower_physical_over_source};
+        use proximadb_data_model::ProximaType;
+        use proximadb_relational_algebra::TableId;
+        use proximadb_relational_planner::{PhysicalPlan, ScanAccess};
+        use proximadb_relational_types::{ColumnInfo, RelationalSchema};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("t.parquet");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, false),
+            Field::new("x", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "d"])),
+                Arc::new(Int64Array::from(vec![10, 20, 30, 40])),
+            ],
+        )
+        .unwrap();
+        let f = std::fs::File::create(&file_path).unwrap();
+        let mut w = ArrowWriter::try_new(f, schema.clone(), None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let store = Arc::new(LocalFileSystem::new_with_prefix(tmp.path()).unwrap());
+        let size = std::fs::metadata(&file_path).unwrap().len();
+        let source = Box::new(ParquetScanOperator::new(
+            store,
+            vec![(Path::from("t.parquet"), Some(size))],
+            None,
+            schema.clone(),
+        ));
+
+        // Relational plan: a bare Scan whose leaf is the injected parquet source.
+        let plan = PhysicalPlan::Scan {
+            table: TableId::new("hits"),
+            output_schema: RelationalSchema::new(vec![
+                ColumnInfo::new("k", ProximaType::String, false),
+                ColumnInfo::new("x", ProximaType::Int64, false),
+            ]),
+            projection: None,
+            predicate: None,
+            limit: None,
+            access: ScanAccess::FullScan,
+        };
+
+        let lowered = lower_physical_over_source(&plan, source).unwrap();
+        let batches = execute_pipeline(&lowered).await.unwrap();
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            rows, 4,
+            "native drained every parquet row via the Scan leaf"
+        );
+        assert_eq!(batches[0].num_columns(), 2);
+    }
+
     #[tokio::test]
     async fn parquet_scan_projection_narrows_columns() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/query/execution/native_parquet_scan.rs
+++ b/src/query/execution/native_parquet_scan.rs
@@ -1,0 +1,190 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+//! # Native parquet scan operator (ADR-054 / TD-OLAP-4 — engine dimension)
+//!
+//! The arrow-rs analog of [`super::native_scan::PaxScanOperator`]: reads
+//! **external parquet** into Arrow `RecordBatch`es and emits them into the native
+//! vectorized engine's `BatchStream`, with **zero DataFusion dependency** (drives
+//! the `parquet` crate's `ParquetRecordBatchStreamBuilder` directly — the very
+//! same reader `object_store_parquet_reader.rs` uses on the DataFusion side).
+//!
+//! This is the scan source that lets the native vectorized engine
+//! (`FilterProject` → `HashAggregate` → `HashJoin`) serve the SAME external-parquet
+//! queries as DataFusion — the prerequisite for the native-vs-DataFusion shadow
+//! comparison. The scan source is deliberately separable from the execution
+//! engine: reading parquet → `RecordBatch` is pure arrow-rs, and native operators
+//! consume `RecordBatch`es, so DataFusion is not required to read parquet.
+//!
+//! MVP: eager read of the selected row-groups (mirrors `PaxScanOperator`'s eager
+//! MVP); lazy per-split streaming + row-group zone-map pruning are follow-ons.
+
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use futures::StreamExt;
+use object_store::ObjectStore;
+use object_store::path::Path;
+use parquet::arrow::ProjectionMask;
+use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use proximadb_execution_contracts::{BatchStream, ExecutionError, ExecutionOperator};
+
+/// A native scan source that reads external parquet files via arrow-rs and emits
+/// their `RecordBatch`es. Holds only object-store + parquet types — no DataFusion.
+#[derive(Debug)]
+pub(crate) struct ParquetScanOperator {
+    store: Arc<dyn ObjectStore>,
+    /// The parquet files to read, with their (optional) byte sizes.
+    files: Vec<(Path, Option<u64>)>,
+    /// Leaf column indices to fetch (projection pushdown); `None` reads all
+    /// columns. When set, `output_schema` MUST be the projected schema in file
+    /// order, matching what the reader emits.
+    projection: Option<Vec<usize>>,
+    output_schema: SchemaRef,
+}
+
+impl ParquetScanOperator {
+    pub(crate) fn new(
+        store: Arc<dyn ObjectStore>,
+        files: Vec<(Path, Option<u64>)>,
+        projection: Option<Vec<usize>>,
+        output_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            store,
+            files,
+            projection,
+            output_schema,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionOperator for ParquetScanOperator {
+    fn output_schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    async fn execute(&self, _input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let mut batches = Vec::new();
+        for (path, size) in &self.files {
+            let mut reader = ParquetObjectReader::new(self.store.clone(), path.clone());
+            if let Some(sz) = size {
+                reader = reader.with_file_size(*sz);
+            }
+            let mut builder = ParquetRecordBatchStreamBuilder::new(reader)
+                .await
+                .map_err(|e| ExecutionError::Execution(format!("parquet open {path}: {e}")))?;
+            if let Some(proj) = &self.projection {
+                let mask = ProjectionMask::roots(builder.parquet_schema(), proj.iter().copied());
+                builder = builder.with_projection(mask);
+            }
+            let mut stream = builder
+                .build()
+                .map_err(|e| ExecutionError::Execution(format!("parquet build {path}: {e}")))?;
+            while let Some(b) = stream.next().await {
+                batches.push(b.map_err(|e| {
+                    ExecutionError::Execution(format!("parquet decode {path}: {e}"))
+                })?);
+            }
+        }
+        Ok(Box::pin(futures::stream::iter(
+            batches.into_iter().map(Ok::<_, ExecutionError>),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int64Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use object_store::local::LocalFileSystem;
+    use parquet::arrow::ArrowWriter;
+
+    #[tokio::test]
+    async fn parquet_scan_emits_all_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("t.parquet");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, false),
+            Field::new("x", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(Int64Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+        let f = std::fs::File::create(&file_path).unwrap();
+        let mut w = ArrowWriter::try_new(f, schema.clone(), None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let store = Arc::new(LocalFileSystem::new_with_prefix(tmp.path()).unwrap());
+        let size = std::fs::metadata(&file_path).unwrap().len();
+        let op = ParquetScanOperator::new(
+            store,
+            vec![(Path::from("t.parquet"), Some(size))],
+            None,
+            schema.clone(),
+        );
+
+        let empty: BatchStream = Box::pin(futures::stream::empty());
+        let mut out = op.execute(empty).await.unwrap();
+        let mut rows = 0usize;
+        let mut cols = 0usize;
+        while let Some(b) = out.next().await {
+            let b = b.unwrap();
+            rows += b.num_rows();
+            cols = b.num_columns();
+        }
+        assert_eq!(rows, 3, "all rows emitted");
+        assert_eq!(cols, 2, "all columns emitted (no projection)");
+        assert_eq!(op.output_schema().fields().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn parquet_scan_projection_narrows_columns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("t.parquet");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, false),
+            Field::new("x", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(Int64Array::from(vec![1, 2])),
+            ],
+        )
+        .unwrap();
+        let f = std::fs::File::create(&file_path).unwrap();
+        let mut w = ArrowWriter::try_new(f, schema.clone(), None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let store = Arc::new(LocalFileSystem::new_with_prefix(tmp.path()).unwrap());
+        let size = std::fs::metadata(&file_path).unwrap().len();
+        // Project only column 1 ("x").
+        let projected = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+        let op = ParquetScanOperator::new(
+            store,
+            vec![(Path::from("t.parquet"), Some(size))],
+            Some(vec![1]),
+            projected,
+        );
+
+        let empty: BatchStream = Box::pin(futures::stream::empty());
+        let mut out = op.execute(empty).await.unwrap();
+        let b = out.next().await.unwrap().unwrap();
+        assert_eq!(b.num_columns(), 1, "projection kept only 'x'");
+        assert_eq!(b.num_rows(), 2);
+    }
+}


### PR DESCRIPTION
The arrow-rs analog of `PaxScanOperator`: reads external parquet → Arrow `RecordBatch`es → the native vectorized engine's `BatchStream` via the `ExecutionOperator` contract, **zero DataFusion dependency** (drives the `parquet` crate's `ParquetRecordBatchStreamBuilder` directly — the same reader `object_store_parquet_reader.rs` uses on the DataFusion side).

The scan source is separable from the engine: reading parquet → `RecordBatch` is pure arrow-rs, native operators consume `RecordBatch`es → DataFusion isn't required to read parquet. This is the prerequisite for native to serve the SAME external-parquet queries as DataFusion (shadow comparison, engine dimension — design merged in #809).

MVP: eager read + projection pushdown (`ProjectionMask`); unit tests cover all-rows scan + projection narrowing over a real local parquet.

## Shadow wiring (now included)
The native lowering can now execute a relational plan over external parquet:
- `native_ops`: `Walked.source` generalized to `Box<dyn ExecutionOperator>`; a new `Scan` arm in `walk` consumes a source injected by `lower_physical_over_source(plan, source)`. The plain `lower_physical` path still declines `Scan` (no injected source) — existing behavior unchanged; `Values` still lowers to `MemoryScanSource`.
- `native_engine`: `try_vectorized_over_parquet(physical, scan_source)` injects a `ParquetScanOperator` as the `Scan` leaf, executes the pipeline, and records a distinct `native-vectorized` compute sample + route for the io-trace (engine dimension). Same default-OFF gate as `try_vectorized`.
- Test `native_lowers_scan_over_parquet_source`: writes a parquet file, builds a `PhysicalPlan::Scan`, drains every row through the native engine end-to-end.

Native op coverage is still narrow (Filter/Project/Aggregate/Limit over Scan). **Next:** the server-side shadow probe in the DataFusion OLAP path (run native alongside DataFusion for supported shapes) + the 100M ClickBench capture with both engines → the route cost model gets real per-shape engine samples.

Stacked on Slice 0 (#810, engine trace dimension).