### PR TITLE
refactor(storage): redirect quantization selection/global_cache to compute_bridge (Slice D)

### DIFF
--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -10,4 +10,4 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 python3 scripts/check_workspace_boundaries.py --strict
-python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 271
+python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 250

--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -475,7 +475,7 @@ impl HelixEngine {
         operation_context: &str,
         collection_size: Option<usize>,
     ) -> bool {
-        crate::compute::quantization::selection::QuantizationSelector::should_use_persistent_quantization_simple(
+        crate::storage::compute_bridge::selection::QuantizationSelector::should_use_persistent_quantization_simple(
             operation_context,
             collection_size,
         )
@@ -492,7 +492,7 @@ impl HelixEngine {
         if self.should_use_persistent_quantization(operation_context, collection_size) {
             // Use global quantization cache for persistent operations
             if let Some(global_cache) =
-                crate::compute::quantization::global_cache::GlobalQuantizationCache::instance()
+                crate::storage::compute_bridge::global_cache::GlobalQuantizationCache::instance()
             {
                 Some(
                     global_cache

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -365,7 +365,7 @@ impl RaptorEngine {
         operation_context: &str,
         collection_size: Option<usize>,
     ) -> bool {
-        crate::compute::quantization::selection::QuantizationSelector::should_use_persistent_quantization_simple(
+        crate::storage::compute_bridge::selection::QuantizationSelector::should_use_persistent_quantization_simple(
             operation_context,
             collection_size,
         )
@@ -380,7 +380,7 @@ impl RaptorEngine {
         if self.should_use_persistent_quantization(operation_context, collection_size) {
             // Use global quantization cache for persistent operations
             if let Some(global_cache) =
-                crate::compute::quantization::global_cache::GlobalQuantizationCache::instance()
+                crate::storage::compute_bridge::global_cache::GlobalQuantizationCache::instance()
             {
                 global_cache
                     .get_or_create_engine("default_collection".to_string())

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -1776,7 +1776,7 @@ impl ViperEngine {
         operation_context: &str,
         collection_size: Option<usize>,
     ) -> bool {
-        crate::compute::quantization::selection::QuantizationSelector::should_use_persistent_quantization_simple(
+        crate::storage::compute_bridge::selection::QuantizationSelector::should_use_persistent_quantization_simple(
             operation_context,
             collection_size,
         )
@@ -1791,7 +1791,7 @@ impl ViperEngine {
         if self.should_use_persistent_quantization(operation_context, collection_size) {
             // Use global quantization cache for persistent operations
             if let Some(global_cache) =
-                crate::compute::quantization::global_cache::GlobalQuantizationCache::instance()
+                crate::storage::compute_bridge::global_cache::GlobalQuantizationCache::instance()
             {
                 global_cache
                     .get_or_create_engine("default_collection".to_string())


### PR DESCRIPTION
## What & why
Continues the **root-crate decomposition** (the durable fix for the 45-min compile / test-binary OOM — `ROOT_CRATE_DECOMPOSITION_PLAN` explicitly rejected larger runners as masking). The big LOC/compile payoff is **Slice E** (extract the storage engines, ~245K LOC), but it's blocked until `src/storage` stops reaching *up* into root modules. This PR is a small **Mechanism-A redirect** that lowers that up-edge ratchet.

## The round-trip-up artifact
The helix/raptor/viper engines referenced `crate::compute::quantization::{selection,global_cache}` for `QuantizationSelector` / `GlobalQuantizationCache`. But those modules' **true home is `crate::storage::compute_bridge`** — `src/compute/quantization/mod.rs` just `pub use crate::storage::compute_bridge::{global_cache, selection}`. So storage was reaching **up** to compute only to come **back down** to its own `compute_bridge` — a round-trip that inflated the up-edge count and blocked the ratchet.

## Change (behavior-neutral)
Redirect the **6 refs** (2 per engine × 3 engines) to the storage-local path:
- `crate::compute::quantization::selection::QuantizationSelector::…` → `crate::storage::compute_bridge::selection::…`
- `crate::compute::quantization::global_cache::GlobalQuantizationCache::…` → `crate::storage::compute_bridge::global_cache::…`

Same symbols, same modules — verified the targets are the canonical home (not a divergent-type trap). `cargo check --lib` green.

## Ratchet
- Storage up-edges: **256 → 250** (−6, exactly the redirected refs).
- `scripts/check-layering.sh` ceiling: **271 → 250**. The 271 high-water mark predates develop drifting to 256 (other PRs lowered the real count without re-ratcheting the ceiling); this captures both the drift and this slice.

## Scope honesty
The pure-redirect surface is small (~6 refs). The remaining **~200 quantization refs** (`quantization_engine` 121, `storage_engine` 52, `types` 18, `turboquant_store_registry` 4) resolve to the **modality-tier `proximadb-quantization-kernel`** (storage can't depend on modality) and need the **`QuantizationEnginePort`** (Mechanism B) — the next, bigger slice. The `query`/`index`/`services` edges likewise need port work. This PR is the quick momentum/de-risk step.

## Verification
- `cargo check --lib` ✅ (8m31s, behavior-neutral path rewrite)
- `bash scripts/check-layering.sh` ✅ (green at new ceiling 250)
- `make work-commit-check` ✅