### PR TITLE
feat(portability): Windows ratchet rung 3 — promote root-lib to gating + measure python/C-dep tail (TD-EMBED-1)

### DIFF
--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -49,17 +49,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # ---- GATING RUNGS (must stay green; expand as blockers are fixed) --------
-      # Rung 1: proximadb-storage-common compiles on Windows (the memmap2::Advice
-      # madvise gating landed in this PR). Add the next crate here once it's green.
+      # Rung 1: proximadb-storage-common compiles on Windows (memmap2::Advice
+      # madvise gating, #800).
       - name: Rung 1 — proximadb-storage-common
         run: cargo check -p proximadb-storage-common
 
-      # ---- MEASURE THE TAIL (non-gating; reveals the next blocker) -------------
-      # The root `proximadb` lib (default features, no `python`) is the engine the
-      # embedded wheel builds minus the PyO3/C-deps. Checking it here surfaces the
-      # next batch of Windows errors without blocking the ratchet. When this goes
-      # green, promote it to a gating rung above; the C-dep (aws-lc-sys/OpenSSL)
-      # story for the actual wheel is a later phase.
-      - name: Measure tail — root proximadb lib (informational)
-        continue-on-error: true
+      # Rung 2: the ENTIRE root `proximadb` lib (default features, no `python`) —
+      # i.e. the pure-Rust engine — compiles on Windows. Reached after two small
+      # cfg(unix) gates (memmap2::Advice #800, Unix-domain sockets #808); the
+      # earlier "multi-file port" fear was a misdiagnosis. Promoted from the
+      # measure-tail step to GATING here so Windows compilation can't regress.
+      - name: Rung 2 — root proximadb lib (pure-Rust engine)
         run: cargo check -p proximadb --lib
+
+      # ---- MEASURE THE TAIL (non-gating; reveals the next blocker) -------------
+      # Next frontier toward the actual Windows wheel: the `python` feature, which
+      # pulls PyO3/numpy AND the C-deps (openssl/vendored -> openssl-src needs
+      # NASM+Perl on MSVC; aws-lc-sys already builds on the runner). This surfaces
+      # the C-dep/PyO3 blockers without blocking the ratchet. When it goes green,
+      # promote to a gating rung and add the windows wheel matrix row.
+      - name: Measure tail — root lib with python feature (informational)
+        continue-on-error: true
+        run: cargo check -p proximadb --lib --features python

--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **macOS: DONE** (aarch64 wheels shipping, PR #716) · **Windows: in progress** (compile-only ratchet started; first blocker `memmap2::Advice` fixed)
+| Status | **macOS: DONE** (aarch64 wheels shipping, PR #716) · **Windows: pure-Rust engine now COMPILES on MSVC** (root lib green, gating rung 2) after two small `#[cfg(unix)]` gates — `memmap2::Advice` (#800) + Unix-domain sockets (#808); next frontier = `--features python` C-deps (NASM/OpenSSL) toward the wheel
 | Severity | Low — Linux x86_64 + aarch64 wheels ship today and cover the overwhelming majority of embedded/edge/air-gapped/server deployments. macOS/Windows are additive reach, not a correctness or release blocker.
 | Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`); Windows work spans `crates/storage/proximadb-storage-common` + `src/storage`
 | Relates to | Vendored-OpenSSL manylinux fix (PR #701 / #707); `TD-IMG-1` (the other shipped-release follow-up)


### PR DESCRIPTION
Third Windows compile-ratchet step (TD-EMBED-1), following #800 (rung 1) and #808 (rung 2).

## Milestone
After two small `#[cfg(unix)]` gates — `memmap2::Advice` (#800) and Unix-domain sockets (#808) — the **entire pure-Rust `proximadb` lib (default features) compiles on `x86_64-pc-windows-msvc`** (verified: root lib `Finished` on the `windows-2022` runner, 1 pre-existing warning, zero errors). The TD's original "multi-week PlatformFile port" was a misdiagnosis.

## Changes
- **Promote to gating:** `cargo check -p proximadb --lib` moves from the non-gating "measure tail" step to a **gating rung 2**, so Windows compilation of the engine can't silently regress.
- **New measure-tail (non-gating):** `cargo check -p proximadb --lib --features python` — the next frontier toward the actual wheel. Pulls PyO3/numpy + the C-deps (`openssl/vendored` → `openssl-src` needs NASM+Perl on MSVC; `aws-lc-sys` already builds on the runner). This surfaces the C-dep/PyO3 blockers as **evidence**, not speculation.
- **TD-EMBED-1** status updated to record the milestone + next frontier.

## What this run tells us
Rung 2 gating confirms the engine still compiles on Windows; the new python-feature tail reports whether the C-dep hurdle is a small hop or a real wall — driving the next decision on the wheel phase.