### PR TITLE
feat(rest): flip REST v1 sunset default OFF — /api/v1 returns 410 (TD-V1SUNSET-1 step 1)

### DIFF
--- a/src/network/middleware/v1_sunset.rs
+++ b/src/network/middleware/v1_sunset.rs
@@ -23,9 +23,10 @@
 //! `410 Gone` + RFC 8594 deprecation headers instead of being served (the gRPC
 //! v1 compat gate was removed in TD-V1SUNSET-1 step 4).
 //!
-//! The flag is **on by default**, so behavior is unchanged until an operator
-//! explicitly disables v1 (starting the sunset clock without a flag-day). The
-//! `/api/v2/*` surface is never affected.
+//! The flag is **off by default** (TD-V1SUNSET-1 step 1: the breaking cutover —
+//! `/api/v1/*` returns `410 Gone` unless explicitly re-enabled). Set
+//! `PROXIMADB_REST_V1_COMPAT=1` to temporarily re-enable v1 during migration.
+//! The `/api/v2/*` surface is never affected.
 
 use axum::{
     Json,
@@ -47,7 +48,7 @@ pub const REST_V1_COMPAT_ENV: &str = "PROXIMADB_REST_V1_COMPAT";
 pub const REST_V1_SUNSET_ENV: &str = "PROXIMADB_REST_V1_SUNSET";
 
 /// Whether the deprecated `/api/v1/*` surface should still be served. Defaults
-/// to `true` (on) when the env var is unset.
+/// to `false` (off) when the env var is unset (TD-V1SUNSET-1 step 1).
 pub fn rest_v1_compat_enabled() -> bool {
     parse_compat_flag(std::env::var(REST_V1_COMPAT_ENV).ok().as_deref())
 }
@@ -62,7 +63,7 @@ fn parse_compat_flag(value: Option<&str>) -> bool {
                 || v.eq_ignore_ascii_case("off")
                 || v.eq_ignore_ascii_case("no"))
         }
-        None => true,
+        None => false,
     }
 }
 
@@ -123,7 +124,7 @@ mod tests {
 
     #[test]
     fn compat_flag_parsing() {
-        assert!(parse_compat_flag(None)); // default on
+        assert!(!parse_compat_flag(None)); // default off (TD-V1SUNSET-1 step 1)
         assert!(parse_compat_flag(Some("1")));
         assert!(parse_compat_flag(Some("true")));
         assert!(parse_compat_flag(Some("on")));

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -487,10 +487,11 @@ impl RestServer {
         let state_for_v2 = state.clone();
         let mut base_router = create_router(state.clone());
 
-        // ADR-049 M0-c: gate the deprecated /api/v1/* surface behind
-        // PROXIMADB_REST_V1_COMPAT (on by default). When off, /api/v1/* is
-        // answered with 410 Gone + RFC 8594 deprecation headers; /api/v2/* is
-        // never affected. This starts the v1 sunset clock without a flag-day.
+        // ADR-049 M0-c / TD-V1SUNSET-1 step 1: the deprecated /api/v1/*
+        // surface is gated behind PROXIMADB_REST_V1_COMPAT (now OFF by default).
+        // /api/v1/* is answered with 410 Gone + RFC 8594 deprecation headers;
+        // /api/v2/* is never affected. Set PROXIMADB_REST_V1_COMPAT=1 to
+        // temporarily re-enable v1 during migration.
         let rest_v1_compat = crate::network::middleware::v1_sunset::rest_v1_compat_enabled();
         base_router = base_router.layer(middleware::from_fn_with_state(
             rest_v1_compat,
@@ -813,10 +814,11 @@ impl RestServer {
         let state_for_v2 = state.clone();
         let mut base_router = create_router(state.clone());
 
-        // ADR-049 M0-c: gate the deprecated /api/v1/* surface behind
-        // PROXIMADB_REST_V1_COMPAT (on by default). When off, /api/v1/* is
-        // answered with 410 Gone + RFC 8594 deprecation headers; /api/v2/* is
-        // never affected. This starts the v1 sunset clock without a flag-day.
+        // ADR-049 M0-c / TD-V1SUNSET-1 step 1: the deprecated /api/v1/*
+        // surface is gated behind PROXIMADB_REST_V1_COMPAT (now OFF by default).
+        // /api/v1/* is answered with 410 Gone + RFC 8594 deprecation headers;
+        // /api/v2/* is never affected. Set PROXIMADB_REST_V1_COMPAT=1 to
+        // temporarily re-enable v1 during migration.
         let rest_v1_compat = crate::network::middleware::v1_sunset::rest_v1_compat_enabled();
         base_router = base_router.layer(middleware::from_fn_with_state(
             rest_v1_compat,


### PR DESCRIPTION
The breaking cutover: `PROXIMADB_REST_V1_COMPAT` now defaults to **OFF**. `/api/v1/*` → `410 Gone` + RFC 8594 deprecation headers by default. `/api/v2/*` never affected. Set `PROXIMADB_REST_V1_COMPAT=1` to temporarily re-enable.

**Safe:** the project is pre-release with no public `/api/v1` traffic (confirmed by the project owner).

**What changed:** the default (`v1_sunset.rs` `None => false`), module/function docs, the `compat_flag_parsing` test assertion, and the two `server.rs` mount-point comments. 2 files, +17/−14.

**Note:** the v1 REST adapter *handlers* (`proximadb-api/src/rest/v1/`) are still present — their router builders + state types are consumed by the root crate's router construction, so they're **not dead code** (unlike the gRPC v1 services). Hard-deleting them is a follow-up that requires migrating those consumers first.

Verified: `cargo check --tests`, `clippy --lib --bins -D warnings`, `cargo check --features proximadb/cluster --lib`, `fmt --check` — all clean.