### PR TITLE
docs+chore(documents): P-Retire Phase 1 — deprecate legacy document_wal + file TD-DOC-RETIRE-1 (ADR-055)

### DIFF
--- a/docs/10-quality/td/TD-DOC-RETIRE-1-legacy-document-wal-retirement.adoc
+++ b/docs/10-quality/td/TD-DOC-RETIRE-1-legacy-document-wal-retirement.adoc
@@ -1,0 +1,102 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DOC-RETIRE-1: Retire the legacy document_wal write path (phased, mixed-read-safe)
+
+[cols="1,3"]
+|===
+|Status|Open — Phase 1 (deprecation markers) landing. After the ADR-055 default-ON cutover
+(TD-DOC-CONV-2, #726) + universal canonical provisioning (P-Provision, #765), the legacy
+`document_wal`/`DashMap` document path is **fallback-only**: the canonical `ProximaRecord` store is
+the primary durable authority for every new/converged collection. This TD phases the legacy path out
+across five reversible-until-the-end steps (P1 markers → P5 hard-remove in v0.4).
+|Priority|MEDIUM (operational simplification — one fewer durable write path to maintain)
+|Scope|FEAT
+|Date|2026-07-09
+|Relates to|ADR-055 (canonical document format = ProximaRecord-in-PAX), TD-DOC-CONV-2 (default-ON
+cutover), P-Provision (#765, doc-collection create provisions the canonical collection). The final
+phase of the ADR-055 rollout.
+|===
+
+== Context — why the legacy path is now fallback-only
+
+Documents historically had a store-split: the gRPC `ProximaDocumentService` + `DocumentService`
+wrote to their own `{base}/document_wal` (a row-wise WAL of `DocumentOperation` entries) projected
+into an in-memory `DashMap`, while REST v2 wrote the shared record/vector store. TD-DOC-CONV-2 flipped
+the document route DEFAULT-ON and P-Provision made document-collection creation register a canonical
+collection, so document writes now ride the shared canonical `ProximaRecord` store by default. The
+legacy `document_wal` path survives only as:
+
+* the **mixed-read-safe fallback** for pre-cutover documents (`get_document`/`query_documents` read
+  the canonical store first, fall back to the legacy `DashMap`), and
+* the durable backing for collections that are not (yet) canonical.
+
+The real server still constructs `DocumentService::new_with_wal`
+(`src/network/shared_services.rs`), so the legacy path is still wired even though it is fallback-only.
+
+== The legacy surface (what this TD retires)
+
+* **Constructors** (`src/storage/document/service.rs`): `new_with_wal`, `new_with_wal_and_metrics`
+  (build `{base}/document_wal` + the in-memory `documents: DashMap`). Replacement:
+  `with_canonical_record_store_and_wal`.
+* **`DocumentOperation` DATA-PLANE write variants**
+  (`src/storage/persistence/write_ahead_log/wal_operations.rs`): `InsertDocument`, `UpdateDocument`,
+  `DeleteDocument`, `BatchDocuments`. These are written to the legacy WAL only when the canonical
+  record store is absent (fallback). Replacements on the canonical path:
+  `UpsertCanonicalDocumentRecord` / `DeleteCanonicalDocumentRecord`.
+* **Legacy replay** in `recover_from_wal` for the above data-plane variants.
+
+== Invariants (hold until P5)
+
+* **Keep the read-fallback** (`get_document`/`query_documents` legacy `DashMap` branch) and
+  **`recover_from_wal`** until pre-cutover on-disk `document_wal` files are provably migrated and the
+  fallback is provably unused. Mixed-read-safe, no flag-day (mandate #8).
+* **Keep `CreateCollection` / `DeleteCollection`** WAL ops — they are collection metadata, not
+  per-document data, and are always written.
+* Retirement removes only the **data-plane** ops + the legacy constructors, and only in P5.
+
+== Phased plan
+
+[cols="1,3,2"]
+|===
+|Phase |Work |Reversible?
+
+|P1 (this PR)
+|**Deprecation markers.** `#[deprecated]` on `new_with_wal` / `new_with_wal_and_metrics` (+ a runtime
+`tracing::warn!`); `#[allow(deprecated)]` at the internal call sites that still use them
+(`service.rs` wrapper, `shared_services.rs` server wiring) so `clippy -D warnings` stays green. NO
+behavior change.
+|✅ Yes (purely advisory).
+
+|P2
+|**Feature-gate + server rewire.** Add a `legacy-document-wal` feature; gate the legacy constructors
+behind it; rewire the server (`shared_services.rs`) to `with_canonical_record_store_and_wal` (the
+canonical `RecordStorage` handle is already available at that wiring point, as the graph services
+use). Default the feature OFF for the next minor.
+|❌ Consequential — once the server writes canonical intent, reverting mid-migration risks split
+writes. Guarded by the feature + kept default-reversible for one release.
+
+|P3
+|**One-time migration.** A `document_wal` → canonical replay (reuse `recover_from_wal` →
+`replay_record_recovery_operations`) so any pre-cutover legacy WAL lands in the canonical store;
+idempotent, restart-verified.
+|✅ Yes (idempotent into the immutable canonical store).
+
+|P4
+|**Verify.** Observe production for zero legacy replays / zero legacy-fallback reads; ratchet the
+`document_wal` reference count downward.
+|✅ Yes (operational).
+
+|P5
+|**Hard-remove (v0.4).** Delete the legacy constructors, the data-plane `DocumentOperation` write
+variants + their replay, and finally the read-fallback + the kill-switch once `document_wal` is
+provably dead. Matches the existing `canonical-document-store` "remove the feature flag in v0.4"
+plan (`Cargo.toml`).
+|❌ Destructive — gated on P3/P4 completion across deployments.
+|===
+
+== Gates
+
+* Mixed-read-safe throughout; the kill-switch (`PROXIMADB_DOC_CANONICAL_VECTOR=off`) survives until P5.
+* Net `proximadb_v1` references non-increasing (TD-123).
+* Each phase green on fmt / clippy `-D warnings` / the correctness suites; P3/P5 gated on
+  round-trip + recall parity.

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1692,6 +1692,9 @@ impl SharedServices {
         // Create DocumentService (moved up for UnifiedHandlers)
         debug!("🔧 SharedServices::new - Creating DocumentService for document queries...");
         let document_base_path = storage_config.metadata_url.replace("file://", "");
+        // TD-DOC-RETIRE-1 P2 rewires this to the canonical constructor
+        // (with_canonical_record_store_and_wal); the deprecated call is intentional until then.
+        #[allow(deprecated)]
         let document_service = match DocumentService::new_with_wal(
             sst_engine_for_documents,
             &document_base_path,

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -296,20 +296,36 @@ impl DocumentService {
         Ok(service)
     }
 
-    /// Create a new document service with WAL support
+    /// Create a new document service with WAL support.
+    #[deprecated(
+        since = "0.2.3",
+        note = "legacy document_wal path is fallback-only after the ADR-055 default-ON cutover; use with_canonical_record_store_and_wal. Retirement: TD-DOC-RETIRE-1."
+    )]
     pub async fn new_with_wal(
         storage_engine: Arc<dyn UnifiedStorageFormat>,
         wal_base_path: &str,
     ) -> Result<Self> {
+        // TD-DOC-RETIRE-1 P2 rewires this to the canonical constructor; the deprecated
+        // delegate is intentional until then (the runtime warn fires in the leaf below).
+        #[allow(deprecated)]
         Self::new_with_wal_and_metrics(storage_engine, wal_base_path, None).await
     }
 
-    /// Create a new document service with WAL support and optional metrics
+    /// Create a new document service with WAL support and optional metrics.
+    #[deprecated(
+        since = "0.2.3",
+        note = "legacy document_wal path is fallback-only after the ADR-055 default-ON cutover; use with_canonical_record_store_and_wal. Retirement: TD-DOC-RETIRE-1."
+    )]
     pub async fn new_with_wal_and_metrics(
         storage_engine: Arc<dyn UnifiedStorageFormat>,
         wal_base_path: &str,
         metrics_collector: Option<Arc<DocumentMetricsCollector>>,
     ) -> Result<Self> {
+        tracing::warn!(
+            "DocumentService::new_with_wal[_and_metrics] is deprecated: the legacy document_wal \
+             path is fallback-only after the ADR-055 default-ON cutover. Migrate to \
+             with_canonical_record_store_and_wal (retirement tracked by TD-DOC-RETIRE-1)."
+        );
         let wal_path = format!("{}/document_wal", wal_base_path);
         let wal_writer = UnifiedWALWriter::new(wal_path.clone())
             .await


### PR DESCRIPTION
## What

**P-Retire Phase 1** (ADR-055 final phase, first reversible increment): deprecate the legacy `document_wal` write path — now **fallback-only** after the default-ON cutover (#726) + P-Provision (#765) — and file the retirement TD. **No behavior change, no removal, no rewire.**

## Changes
- **`TD-DOC-RETIRE-1`** (new): the phased, mixed-read-safe plan — P1 markers (this) → P2 `legacy-document-wal` feature-gate + rewire server to `with_canonical_record_store_and_wal` → P3 one-time `document_wal`→canonical replay → P4 verify → P5 hard-remove in **v0.4**. Invariants: read-fallback + `recover_from_wal` + `CreateCollection`/`DeleteCollection` WAL ops **stay until P5**; only data-plane ops (Insert/Update/Delete/Batch) retire.
- `service.rs`: `#[deprecated(note="… Retirement: TD-DOC-RETIRE-1")]` on `new_with_wal` + `new_with_wal_and_metrics` + one runtime `tracing::warn!`.
- Callers: `#[allow(deprecated)]` on the internal wrapper + the server call site (`shared_services.rs`) — the rewire is P2.

## Scope note
`multi_server.rs`'s `new_with_wal` calls are `ObservabilityStorage::new_with_wal` (a **different type**), not `DocumentService` — grep-confirmed, left untouched. The only `DocumentService::new_with_wal` callers are the internal wrapper and the server, both now `#[allow(deprecated)]`'d.

## Verified
`check_td_adr_unique` 0 errors · `cargo fmt --check` · **`cargo clippy --lib --bins -- -D warnings` (exit 0** — deprecation warnings silenced at the call sites, deprecated ctors compile) · TD-123 v1 ratchet **delta −150** · server binary build (running).

Reversible: pure markers + a doc. The consequential steps (feature-gate, rewire, migrate, remove) are documented in the TD and deferred.
