### PR TITLE
feat(embedded): Windows x86_64 wheels for proximadb_embedded (TD-EMBED-1 final rung)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -97,6 +97,15 @@ jobs:
           # flowing if it bites, and it surfaces as its own portability follow-up.
           - os: macos-14
             target: aarch64
+          # Windows x86_64 (MSVC). Enabled after the windows-compile-ratchet
+          # (TD-EMBED-1) proved the whole engine + `python` feature + C-deps
+          # compile on x86_64-pc-windows-msvc: two small #[cfg(unix)] gates
+          # (memmap2::Advice #800, Unix-domain sockets #808) were the only
+          # blockers. Pinned to windows-2022 to match the ratchet-proven env —
+          # the runner ships NASM + Strawberry Perl, so openssl/vendored's
+          # openssl-src build (VC-WIN64A) works without extra setup.
+          - os: windows-2022
+            target: x86_64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **macOS: DONE** (aarch64 wheels shipping, PR #716) · **Windows: pure-Rust engine now COMPILES on MSVC** (root lib green, gating rung 2) after two small `#[cfg(unix)]` gates — `memmap2::Advice` (#800) + Unix-domain sockets (#808); next frontier = `--features python` C-deps (NASM/OpenSSL) toward the wheel
+| Status | **macOS: DONE** (aarch64 wheels shipping, PR #716) · **Windows: engine + `python` feature + C-deps all COMPILE on MSVC** (ratchet rungs 1-3 green: `memmap2::Advice` #800, Unix-domain sockets #808, python/C-dep tail #813 — no C-dep wall). Windows `x86_64` wheel row now added to `build-embedded-wheels`; final validation = a `maturin` dry-run exercising the extension-module link.
 | Severity | Low — Linux x86_64 + aarch64 wheels ship today and cover the overwhelming majority of embedded/edge/air-gapped/server deployments. macOS/Windows are additive reach, not a correctness or release blocker.
 | Component | Packaging/CI — `.github/workflows/release-python.yml` (`build-embedded-wheels`), root maturin package (`proximadb_embedded`); Windows work spans `crates/storage/proximadb-storage-common` + `src/storage`
 | Relates to | Vendored-OpenSSL manylinux fix (PR #701 / #707); `TD-IMG-1` (the other shipped-release follow-up)


### PR DESCRIPTION
Final rung of the Windows embedded-wheel effort (TD-EMBED-1).

## Evidence that got us here
The `windows-compile-ratchet` proved, on real `windows-2022` CI, that the **whole embedded engine + `python` feature + C-deps compile on `x86_64-pc-windows-msvc`**:
- Rung 1 (#800): `proximadb-storage-common` — gated `memmap2::Advice`
- Rung 2 (#808): root lib (pure-Rust engine) — gated Unix-domain sockets
- Rung 3 (#813): root lib **+ `--features python`** — `Finished` clean, incl. `openssl-src`/`openssl-sys` (vendored OpenSSL built via NASM+Perl on the runner) and PyO3/numpy. **No C-dep wall.**

Two small `#[cfg(unix)]` gates were the only blockers — the TD's original "multi-week port" was a large overestimate.

## Change
Add `windows-2022` / `x86_64` to `build-embedded-wheels` (pinned to the ratchet-proven runner). `before-script-linux` is Linux-only (ignored on Windows); the shared `setup-python` step covers PyO3. `fail-fast: false` keeps Linux+macOS wheels flowing if Windows regresses. `publish-embedded-pypi` already globs `*embedded-wheels*`, so the `win_amd64` wheel publishes with no publish-side change.

## Validation
`cargo check` (the ratchet) doesn't link. This PR is validated by a **`workflow_dispatch` `dry_run=true` maturin build**, which exercises the extension-module link and produces the actual `.whl`. Merging once that dry-run yields a `cp310-abi3-win_amd64` wheel.