### PR TITLE
fix(query): harden native hash join — injective keys, Right/Full, shadow harness (TD-OLAP-11)

### DIFF
--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -291,6 +291,34 @@ impl NativeVolcanoEngine {
         // Default-off; any decline or failure falls back to the Volcano inside
         // `try_vectorized` (the experimental path never fails a query).
         if let Some(result) = super::native_engine::try_vectorized(&physical).await? {
+            // Shadow mode (ADR-054 §7 Phase 0.5, TD-OLAP-11 §Gate): run the
+            // Volcano reference too, compare result multisets, and on divergence
+            // auto-demote the shape + fail safe to the reference. Default-off.
+            if super::native_shadow::native_join_shadow_enabled() {
+                let mut ref_exec = build_executor(
+                    physical.clone(),
+                    factory,
+                    &VolcanoExecutionContext::default(),
+                )
+                .map_err(|e| ExecutionError::Execution(format!("shadow build_executor: {e}")))?;
+                ref_exec
+                    .open()
+                    .await
+                    .map_err(|e| ExecutionError::Execution(format!("shadow open: {e}")))?;
+                let ref_schema = ref_exec.schema().clone();
+                let ref_rows = collect(&mut *ref_exec)
+                    .await
+                    .map_err(|e| ExecutionError::Execution(format!("shadow scan: {e}")))?;
+                let reference = ExecutionPipelineResult {
+                    schema: ref_schema,
+                    rows: ref_rows,
+                };
+                if super::native_shadow::shadow_compare_and_record(&physical, &result, &reference)
+                    .diverged
+                {
+                    return finalize_row_limit(reference, &controls);
+                }
+            }
             return finalize_row_limit(result, &controls);
         }
         let mut exec = build_executor(physical, factory, &VolcanoExecutionContext::default())

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -15,6 +15,7 @@ pub mod native_engine;
 pub mod native_join_ops;
 pub mod native_ops;
 pub mod native_scan;
+pub mod native_shadow;
 pub mod olap_delta_merge;
 pub mod plan_cache;
 pub mod planner;

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -56,11 +56,18 @@ pub fn native_join_enabled() -> bool {
 /// are unsupported (Phase 2: only `Project`/`Filter`/`Limit` over `Values`) OR
 /// execution hit an issue — in every such case the caller falls back to the
 /// Volcano. The experimental, default-off path never fails a query; correctness
-/// is policed by the shadow-comparison harness (TD-OLAP-10 §"Shadow comparison").
+/// is policed by the native-vs-Volcano shadow-comparison harness
+/// ([`super::native_shadow`], ADR-054 §7 Phase 0.5), which auto-demotes a query
+/// shape after a divergence — demoted shapes decline here.
 pub async fn try_vectorized(
     physical: &PhysicalPlan,
 ) -> Result<Option<ExecutionPipelineResult>, ExecutionError> {
     if !native_vectorized_enabled() {
+        return Ok(None);
+    }
+    // A prior shadow run may have demoted this query shape after observing a
+    // native-vs-Volcano divergence (ADR-054 §7 Phase 0.5). Skip native for it.
+    if super::native_shadow::is_shape_demoted(physical) {
         return Ok(None);
     }
     // Any decline (unsupported shape) or failure (execution error) → Volcano.

--- a/src/query/execution/native_join_ops.rs
+++ b/src/query/execution/native_join_ops.rs
@@ -15,12 +15,13 @@
 //! * [`HashJoinProbeOperator`] — STREAMING. Per probe batch: bloom pre-filter →
 //!   hash-table lookup → late-materialize matched pairs via `arrow::compute::take`.
 //!
-//! MVP `JoinKind`: Inner / Left / Semi / Anti. Right / Full (unmatched-build
-//! drain) + spill + radix are deferred (see TD-OLAP-11). NULL join keys never
-//! match in any kind.
+//! MVP `JoinKind`: Inner / Left / Right / Full / Semi / Anti. Right / Full drain
+//! the unmatched build rows after the probe stream ends (probe columns
+//! NULL-padded). Spill + radix are deferred (see TD-OLAP-11). NULL join keys
+//! never match in any kind.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use arrow::array::{Array, ArrayRef, RecordBatch, UInt32Array};
 use arrow::compute::{concat_batches, take};
@@ -41,6 +42,13 @@ const BLOOM_MIN_KEYS: usize = 1024;
 
 /// Canonical byte encoding of a composite join key at `row` across `columns`.
 /// Returns `None` if ANY key column is NULL at that row (NULL keys never match).
+///
+/// The encoding is **self-delimiting** — fixed-width cells occupy their type's
+/// fixed width and variable-length cells are length-prefixed (see
+/// [`encode_cell`]) — so concatenating columns is injective across a fixed key
+/// schema: two distinct key tuples can never encode to the same bytes. (A naïve
+/// trailing `0` separator is NOT injective — a varlen value may itself contain
+/// `0x00`, e.g. `("a\0","b")` and `("a","\0b")` would collide.)
 fn canonical_key_bytes(
     columns: &[&dyn Array],
     row: usize,
@@ -51,7 +59,6 @@ fn canonical_key_bytes(
             return Ok(None);
         }
         encode_cell(*col, row, &mut buf)?;
-        buf.push(0); // separator (multi-column keys)
     }
     Ok(Some(buf))
 }
@@ -101,11 +108,11 @@ fn encode_cell(array: &dyn Array, row: usize, out: &mut Vec<u8>) -> Result<(), E
         DataType::Float64 => {
             out.extend_from_slice(&dcast!(array, Float64Array).value(row).to_le_bytes())
         }
-        DataType::Utf8 => out.extend_from_slice(dcast!(array, StringArray).value(row).as_bytes()),
+        DataType::Utf8 => encode_varlen(dcast!(array, StringArray).value(row).as_bytes(), out),
         DataType::LargeUtf8 => {
-            out.extend_from_slice(dcast!(array, LargeStringArray).value(row).as_bytes())
+            encode_varlen(dcast!(array, LargeStringArray).value(row).as_bytes(), out)
         }
-        DataType::Binary => out.extend_from_slice(dcast!(array, BinaryArray).value(row)),
+        DataType::Binary => encode_varlen(dcast!(array, BinaryArray).value(row), out),
         other => {
             return Err(ExecutionError::NotImplemented(format!(
                 "join key type {other:?} not supported in native hash join"
@@ -113,6 +120,14 @@ fn encode_cell(array: &dyn Array, row: usize, out: &mut Vec<u8>) -> Result<(), E
         }
     }
     Ok(())
+}
+
+/// Append a variable-length cell to `out`, length-prefixed (u32 LE) so that the
+/// concatenated composite key stays injective even when the bytes contain
+/// `0x00`. (Join keys are small; a `u32` length is never the binding limit.)
+fn encode_varlen(bytes: &[u8], out: &mut Vec<u8>) {
+    out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    out.extend_from_slice(bytes);
 }
 
 /// The build side's hash table: composite-key bytes → build-side row indices.
@@ -231,7 +246,9 @@ impl ExecutionOperator for HashJoinBuildOperator {
 // =========================================================================
 
 /// Streams probe batches: bloom pre-filter → hash-table lookup → late-materialize.
-/// MVP `JoinKind`: Inner / Left / Semi / Anti.
+/// MVP `JoinKind`: Inner / Left / Right / Full / Semi / Anti. For Right/Full the
+/// operator appends a final batch of the unmatched build rows once the probe
+/// stream ends (probe columns NULL-padded).
 #[derive(Debug)]
 pub(crate) struct HashJoinProbeOperator {
     pub table_slot: Arc<OnceLock<Arc<JoinHashTable>>>,
@@ -268,17 +285,54 @@ impl ExecutionOperator for HashJoinProbeOperator {
         let kind = self.kind;
         let output_schema = self.output_schema.clone();
 
-        Ok(Box::pin(input.map(move |result| {
+        // Right/Full must emit the unmatched BUILD rows after the probe stream
+        // ends; track which build rows matched (across all probe batches) in a
+        // shared bitmap that the drain tail reads once the probe stream drains.
+        let matched_build: Option<Arc<Mutex<Vec<bool>>>> =
+            if matches!(kind, JoinKind::Right | JoinKind::Full) {
+                Some(Arc::new(Mutex::new(vec![
+                    false;
+                    table.build_batch.num_rows()
+                ])))
+            } else {
+                None
+            };
+
+        let probe_table = table.clone();
+        let probe_mb = matched_build.clone();
+        let probe_cols = output_columns.clone();
+        let probe_out_schema = output_schema.clone();
+        let mapped = input.map(move |result| {
             let probe_batch = result?;
             probe_one_batch(
-                &table,
+                &probe_table,
                 &probe_batch,
                 &probe_keys,
-                &output_columns,
+                &probe_cols,
                 kind,
-                &output_schema,
+                &probe_out_schema,
+                probe_mb.as_deref(),
             )
-        })))
+        });
+
+        match matched_build {
+            None => Ok(Box::pin(mapped)),
+            Some(mb) => {
+                // After the probe stream drains, emit one batch of the unmatched
+                // build rows (or nothing when every build row matched).
+                let tail = futures::stream::once(async move {
+                    drain_unmatched_build(&table, &output_columns, &output_schema, &mb)
+                })
+                .filter_map(|r| async move {
+                    match r {
+                        Ok(Some(batch)) => Some(Ok(batch)),
+                        Ok(None) => None,
+                        Err(e) => Some(Err(e)),
+                    }
+                });
+                Ok(Box::pin(mapped.chain(tail)))
+            }
+        }
     }
 }
 
@@ -290,6 +344,7 @@ fn probe_one_batch(
     output_columns: &[JoinColumn],
     kind: JoinKind,
     output_schema: &SchemaRef,
+    matched_build: Option<&Mutex<Vec<bool>>>,
 ) -> Result<RecordBatch, ExecutionError> {
     let probe_key_cols: Vec<&dyn Array> = probe_keys
         .iter()
@@ -329,11 +384,26 @@ fn probe_one_batch(
         }
     }
 
+    // Record matched build rows for Right/Full's end-of-stream unmatched-build
+    // drain (only tracked when `matched_build` is `Some`, i.e. Right/Full).
+    if let Some(mb) = matched_build {
+        let mut guard = mb
+            .lock()
+            .map_err(|_| ExecutionError::Execution("join matched-build lock poisoned".into()))?;
+        for &br in &build_idx {
+            if let Some(slot) = guard.get_mut(br as usize) {
+                *slot = true;
+            }
+        }
+    }
+
     let probe_indices = UInt32Array::from(probe_idx);
     let build_indices = UInt32Array::from(build_idx);
 
     let columns: Vec<ArrayRef> = match kind {
-        JoinKind::Inner => {
+        // Right's streaming portion == Inner (matched pairs only; unmatched probe
+        // rows are dropped). Its unmatched build rows are appended by the drain.
+        JoinKind::Inner | JoinKind::Right => {
             // One output row per (probe row, matched build row).
             output_columns
                 .iter()
@@ -348,7 +418,9 @@ fn probe_one_batch(
                 .collect::<Result<_, _>>()
                 .map_err(|e| ExecutionError::Execution(format!("join take: {e}")))?
         }
-        JoinKind::Left => {
+        // Full's streaming portion == Left (matched pairs + unmatched probe rows,
+        // build NULL-padded). Its unmatched build rows are appended by the drain.
+        JoinKind::Left | JoinKind::Full => {
             // Matched pairs + unmatched probe rows (build cols NULL-padded).
             let n_unmatched = left_unmatched.len();
             let matched_probe = &probe_indices;
@@ -397,13 +469,59 @@ fn probe_one_batch(
         }
         other => {
             return Err(ExecutionError::NotImplemented(format!(
-                "JoinKind {other:?} not supported in native hash join MVP (Inner/Left/Semi/Anti)"
+                "JoinKind {other:?} not supported in native hash join MVP \
+                 (supported: Inner/Left/Right/Full/Semi/Anti)"
             )));
         }
     };
 
     RecordBatch::try_new(output_schema.clone(), columns)
         .map_err(|e| ExecutionError::Execution(format!("join output batch: {e}")))
+}
+
+/// After the probe stream ends, emit the unmatched BUILD rows for `Right`/`Full`:
+/// build columns taken from the unmatched build indices, probe columns NULL-padded
+/// (using each output column's declared type). Returns `Ok(None)` when every build
+/// row matched (nothing to drain).
+fn drain_unmatched_build(
+    table: &JoinHashTable,
+    output_columns: &[JoinColumn],
+    output_schema: &SchemaRef,
+    matched_build: &Mutex<Vec<bool>>,
+) -> Result<Option<RecordBatch>, ExecutionError> {
+    let unmatched: Vec<u32> = {
+        let guard = matched_build
+            .lock()
+            .map_err(|_| ExecutionError::Execution("join matched-build lock poisoned".into()))?;
+        guard
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &m)| if m { None } else { Some(i as u32) })
+            .collect()
+    };
+    if unmatched.is_empty() {
+        return Ok(None);
+    }
+    let n = unmatched.len();
+    let build_indices = UInt32Array::from(unmatched);
+    let columns: Vec<ArrayRef> = output_columns
+        .iter()
+        .enumerate()
+        .map(|(i, jc)| match jc {
+            JoinColumn::Build(c) => {
+                take(table.build_batch.column(*c).as_ref(), &build_indices, None)
+                    .map_err(|e| ExecutionError::Execution(format!("join build-drain take: {e}")))
+            }
+            // Probe columns are unmatched here → NULL of the output column's type.
+            JoinColumn::Probe(_) => Ok(arrow::array::new_null_array(
+                output_schema.field(i).data_type(),
+                n,
+            )),
+        })
+        .collect::<Result<_, _>>()?;
+    RecordBatch::try_new(output_schema.clone(), columns)
+        .map(Some)
+        .map_err(|e| ExecutionError::Execution(format!("join build-drain batch: {e}")))
 }
 
 /// Distinct, sorted row indices from a (sorted, possibly-duplicated) UInt32 index array.

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -1859,6 +1859,218 @@ mod tests {
         assert_eq!(anti_k, vec![1, 3]);
     }
 
+    fn null_key_batch(
+        k: &[Option<i64>],
+        v: &[&str],
+        k_name: &str,
+        v_name: &str,
+    ) -> (RecordBatch, SchemaRef) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(k_name, DataType::Int64, true),
+            Field::new(v_name, DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(k.to_vec())),
+                Arc::new(StringArray::from(v.to_vec())),
+            ],
+        )
+        .unwrap();
+        (batch, schema)
+    }
+
+    fn int_key_batch(k: &[i64], name: &str) -> (RecordBatch, SchemaRef) {
+        let schema = Arc::new(Schema::new(vec![Field::new(name, DataType::Int64, false)]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(k.to_vec()))])
+                .unwrap();
+        (batch, schema)
+    }
+
+    #[tokio::test]
+    async fn hash_join_null_keys_never_match() {
+        // build (right): k=[Some(2), None]; probe (left): k=[Some(2), None, Some(3)].
+        // A NULL key must never match in ANY kind: NULL build keys are absent from
+        // the map, and a NULL probe key short-circuits to "no match". (TD-OLAP-11
+        // "highest risk" — asserted across all six hash-join kinds.)
+        let out3 = || {
+            Arc::new(Schema::new(vec![
+                Field::new("kl", DataType::Int64, true),
+                Field::new("vl", DataType::Utf8, true),
+                Field::new("vr", DataType::Utf8, true),
+            ]))
+        };
+        let out2 = || {
+            Arc::new(Schema::new(vec![
+                Field::new("kl", DataType::Int64, true),
+                Field::new("vl", DataType::Utf8, true),
+            ]))
+        };
+        let cols3 = || {
+            vec![
+                JoinColumn::Probe(0),
+                JoinColumn::Probe(1),
+                JoinColumn::Build(1),
+            ]
+        };
+        let cols2 = || vec![JoinColumn::Probe(0), JoinColumn::Probe(1)];
+        let bp = || null_key_batch(&[Some(2), None], &["x", "n"], "kr", "vr");
+        let pp = || null_key_batch(&[Some(2), None, Some(3)], &["a", "b", "c"], "kl", "vl");
+        let rows = |bs: Vec<RecordBatch>| bs.iter().map(|b| b.num_rows()).sum::<usize>();
+
+        // Inner: only k=2 matches (NULL never matches).
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols3(), JoinKind::Inner, out3()).await),
+            1
+        );
+        // Left: matched (k=2) + 2 unmatched probe rows (NULL-key, k=3) → 3.
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols3(), JoinKind::Left, out3()).await),
+            3
+        );
+        // Semi: probe rows with a match → only k=2 → 1.
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols2(), JoinKind::Semi, out2()).await),
+            1
+        );
+        // Anti: probe rows without a match → NULL-key row + k=3 → 2.
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols2(), JoinKind::Anti, out2()).await),
+            2
+        );
+        // Right: matched (k=2) + drained unmatched build (the NULL-key build row) → 2.
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols3(), JoinKind::Right, out3()).await),
+            2
+        );
+        // Full: matched (1) + unmatched probe (2) + unmatched build (1) → 4.
+        let (b, bs) = bp();
+        let (p, ps) = pp();
+        assert_eq!(
+            rows(run_join(b, bs, p, ps, cols3(), JoinKind::Full, out3()).await),
+            4
+        );
+    }
+
+    #[tokio::test]
+    async fn hash_join_right_and_full_drain_unmatched_build() {
+        // build (right): k=[2,3,4]; probe (left): k=[1,2,3].
+        let out = || {
+            Arc::new(Schema::new(vec![
+                Field::new("kl", DataType::Int64, true),
+                Field::new("vl", DataType::Utf8, true),
+                Field::new("vr", DataType::Utf8, true),
+            ]))
+        };
+        let cols = || {
+            vec![
+                JoinColumn::Probe(0),
+                JoinColumn::Probe(1),
+                JoinColumn::Build(1),
+            ]
+        };
+
+        // Right: matched (2↔x),(3↔y) + unmatched build {4→z}, probe cols NULL → 3.
+        let (b, bs) = two_col_batch(&[2, 3, 4], &["x", "y", "z"], "kr", "vr");
+        let (p, ps) = two_col_batch(&[1, 2, 3], &["a", "b", "c"], "kl", "vl");
+        let right = run_join(b, bs, p, ps, cols(), JoinKind::Right, out()).await;
+        assert_eq!(right.iter().map(|b| b.num_rows()).sum::<usize>(), 3);
+        // Exactly one row has a NULL probe key — the drained unmatched build row,
+        // which still carries its own value (vr = "z").
+        let mut null_probe_rows = 0;
+        for batch in &right {
+            let kl = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let vr = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            for r in 0..batch.num_rows() {
+                if kl.is_null(r) {
+                    null_probe_rows += 1;
+                    assert_eq!(vr.value(r), "z");
+                }
+            }
+        }
+        assert_eq!(null_probe_rows, 1);
+
+        // Full: matched (2,3) + unmatched probe {1} + unmatched build {4} → 4.
+        let (b, bs) = two_col_batch(&[2, 3, 4], &["x", "y", "z"], "kr", "vr");
+        let (p, ps) = two_col_batch(&[1, 2, 3], &["a", "b", "c"], "kl", "vl");
+        let full = run_join(b, bs, p, ps, cols(), JoinKind::Full, out()).await;
+        assert_eq!(full.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
+    }
+
+    #[tokio::test]
+    async fn hash_join_bloom_prefilter_direction() {
+        // The bloom is built over BUILD keys and tested against PROBE keys. With
+        // ≥ BLOOM_MIN_KEYS build keys the build op constructs the bloom; probe keys
+        // disjoint from the build set must all miss (TD-OLAP-11: bloom over {build},
+        // probe {disjoint} → all miss), and PRESENT probe keys must still match —
+        // no false drops (the dangerous failure mode if the bloom were built over
+        // probe keys and tested against build keys instead).
+        let build_keys: Vec<i64> = (0..1500).collect(); // > 1024 → bloom is built
+        let probe_keys: Vec<i64> = vec![5, 100000, 100, 100001, 900]; // 3 present, 2 absent
+
+        let (build_batch, build_schema) = int_key_batch(&build_keys, "kr");
+        let (probe_batch, probe_schema) = int_key_batch(&probe_keys, "kl");
+
+        let table_slot = Arc::new(OnceLock::new());
+        let build_op = HashJoinBuildOperator {
+            build_keys: vec![0],
+            build_schema: build_schema.clone(),
+            table_slot: table_slot.clone(),
+            bloom_enabled: true,
+        };
+        let probe_op = HashJoinProbeOperator {
+            table_slot,
+            probe_keys: vec![0],
+            output_columns: vec![JoinColumn::Probe(0)],
+            kind: JoinKind::Inner,
+            output_schema: Arc::new(Schema::new(vec![Field::new("kl", DataType::Int64, true)])),
+        };
+        let lowered = LoweredPipeline {
+            pipeline: Pipeline::new(vec![
+                Box::new(MemoryScanSource::new(vec![probe_batch], probe_schema)),
+                Box::new(probe_op),
+            ]),
+            build_pipeline: Some(Pipeline::new(vec![
+                Box::new(MemoryScanSource::new(vec![build_batch], build_schema)),
+                Box::new(build_op),
+            ])),
+            limit: None,
+        };
+        let batches = execute_pipeline(&lowered).await.unwrap();
+        let mut matched: Vec<i64> = Vec::new();
+        for batch in &batches {
+            let kl = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            for r in 0..batch.num_rows() {
+                matched.push(kl.value(r));
+            }
+        }
+        matched.sort_unstable();
+        assert_eq!(matched, vec![5, 100, 900]);
+    }
+
     // --- Join routing through lower_physical (ADR-054 Phase 3 routing) ---
 
     #[tokio::test]

--- a/src/query/execution/native_shadow.rs
+++ b/src/query/execution/native_shadow.rs
@@ -1,0 +1,347 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Native-vs-Volcano shadow comparison + auto-demotion (ADR-054 §7 Phase 0.5)
+//!
+//! The correctness safety-net for the experimental native vectorized/join path
+//! (TD-OLAP-11 §Gate). When `PROXIMADB_NATIVE_JOIN_SHADOW` is set,
+//! `NativeVolcanoEngine::execute_physical` runs BOTH the native path and the
+//! Volcano reference for a query, compares their result multisets, logs any
+//! discrepancy, and — per ADR-054 §7 / TD-OLAP-11 §Gate — **auto-demotes the
+//! query shape** when the row-level mismatch rate exceeds
+//! [`MISMATCH_DEMOTE_THRESHOLD`] (0.1%). A demoted shape skips the native path on
+//! subsequent runs ([`is_shape_demoted`], consulted by `try_vectorized`), and the
+//! diverging run itself fails safe to the Volcano result.
+//!
+//! Comparison is **order-insensitive** (a multiset over per-row canonical
+//! strings): join/aggregate output order is not guaranteed to match between the
+//! two engines, so only row *content and multiplicity* are compared.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use proximadb_relational_planner::PhysicalPlan;
+
+use super::engine::ExecutionPipelineResult;
+
+/// Per-query-shape divergence rate above which the native path is auto-demoted.
+/// ADR-054 §7 Phase 0.5 / TD-OLAP-11 §Gate: "mismatch rate >0.1% → auto-demote".
+pub const MISMATCH_DEMOTE_THRESHOLD: f64 = 0.001;
+
+/// Gate: is native-vs-Volcano shadow comparison opted in? Default OFF — shadow
+/// mode runs every native-handled query twice (native + Volcano), so it is a
+/// validation/CI switch, not a production default (TD-OLAP-11 §Gate flag,
+/// distinct from `PROXIMADB_NATIVE_JOIN`).
+pub fn native_join_shadow_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_NATIVE_JOIN_SHADOW")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
+/// The outcome of one shadow comparison.
+#[derive(Debug, Clone, Copy)]
+pub struct ShadowVerdict {
+    /// Row-level mismatch rate in `[0, 1]` (symmetric multiset difference / rows).
+    pub mismatch_rate: f64,
+    /// `true` when `mismatch_rate` exceeded the threshold — the shape is now
+    /// demoted and the caller MUST fail safe to the reference (Volcano) result.
+    pub diverged: bool,
+}
+
+/// Process-global set of demoted query-shape signatures.
+fn demoted_shapes() -> &'static Mutex<HashSet<u64>> {
+    static REG: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Has a prior shadow run demoted this plan's shape? Consulted by
+/// `try_vectorized` to skip the native path for a known-divergent shape.
+pub fn is_shape_demoted(plan: &PhysicalPlan) -> bool {
+    let sig = plan_shape_signature(plan);
+    demoted_shapes()
+        .lock()
+        .map(|g| g.contains(&sig))
+        .unwrap_or(false)
+}
+
+/// Compare a native result against the Volcano reference, log any discrepancy,
+/// and demote the shape when the mismatch rate exceeds the threshold. Returns the
+/// verdict; on divergence the caller MUST return the reference result.
+pub fn shadow_compare_and_record(
+    plan: &PhysicalPlan,
+    native: &ExecutionPipelineResult,
+    reference: &ExecutionPipelineResult,
+) -> ShadowVerdict {
+    let mismatch_rate = mismatch_rate(native, reference);
+    let diverged = mismatch_rate > MISMATCH_DEMOTE_THRESHOLD;
+    let sig = plan_shape_signature(plan);
+    if diverged {
+        if let Ok(mut g) = demoted_shapes().lock() {
+            g.insert(sig);
+        }
+        tracing::warn!(
+            target: "proximadb::native_shadow",
+            mismatch_rate,
+            shape = sig,
+            native_rows = native.rows.len(),
+            reference_rows = reference.rows.len(),
+            "native path diverged from Volcano reference; auto-demoting shape and failing safe to reference"
+        );
+    } else {
+        tracing::debug!(
+            target: "proximadb::native_shadow",
+            mismatch_rate,
+            shape = sig,
+            rows = native.rows.len(),
+            "native path matched Volcano reference within tolerance"
+        );
+    }
+    ShadowVerdict {
+        mismatch_rate,
+        diverged,
+    }
+}
+
+/// Order-insensitive row-multiset mismatch rate in `[0, 1]`. A schema-shape
+/// mismatch (different column count) is a total mismatch (`1.0`).
+fn mismatch_rate(a: &ExecutionPipelineResult, b: &ExecutionPipelineResult) -> f64 {
+    if a.schema.columns.len() != b.schema.columns.len() {
+        return 1.0;
+    }
+    let total = a.rows.len().max(b.rows.len());
+    if total == 0 {
+        return 0.0;
+    }
+    let mut counts: HashMap<String, i64> = HashMap::new();
+    for row in &a.rows {
+        *counts.entry(canonical_row(row)).or_default() += 1;
+    }
+    for row in &b.rows {
+        *counts.entry(canonical_row(row)).or_default() -= 1;
+    }
+    // Each surplus/deficit row on either side counts once toward the mismatch.
+    let unmatched: i64 = counts.values().map(|c| c.abs()).sum();
+    ((unmatched as f64) / (total as f64)).min(1.0)
+}
+
+/// Canonical, order-stable string for one result row (its column values in
+/// order). Uses `Debug` — good enough to detect content divergence; two
+/// semantically-equal-but-differently-typed cells count as a mismatch, which is
+/// the conservative direction for a correctness net.
+fn canonical_row(row: &[proximadb_data_model::ProximaValue]) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    for cell in row {
+        // Unit-separator between cells so column boundaries can't blur.
+        let _ = write!(s, "{cell:?}\u{1f}");
+    }
+    s
+}
+
+/// A structural signature of a plan that is invariant to literal DATA (Values
+/// payloads, literal values, predicate constants) but captures operator shape,
+/// join kind, arity, and column widths — the "query shape" the demotion registry
+/// keys on (ADR-054 §7: "auto-demote native for that query shape").
+pub fn plan_shape_signature(plan: &PhysicalPlan) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut buf = String::new();
+    shape_into(plan, &mut buf);
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    buf.hash(&mut h);
+    h.finish()
+}
+
+fn shape_into(plan: &PhysicalPlan, out: &mut String) {
+    use std::fmt::Write;
+    match plan {
+        PhysicalPlan::Scan {
+            table,
+            output_schema,
+            projection,
+            predicate,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "Scan[t={table:?},cols={},proj={},pred={}];",
+                output_schema.columns.len(),
+                projection.is_some(),
+                predicate.is_some()
+            );
+        }
+        PhysicalPlan::Filter { input, .. } => {
+            out.push_str("Filter(");
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Project { input, outputs } => {
+            let _ = write!(out, "Project[{}](", outputs.len());
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Join {
+            left,
+            right,
+            kind,
+            on,
+            strategy,
+        } => {
+            let _ = write!(out, "Join[{kind:?},{strategy:?},on={}](", on.is_some());
+            shape_into(left, out);
+            out.push(',');
+            shape_into(right, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Aggregate {
+            input,
+            group_by,
+            aggregates,
+            having,
+            strategy,
+        } => {
+            let _ = write!(
+                out,
+                "Agg[gb={},ag={},hav={},{strategy:?}](",
+                group_by.len(),
+                aggregates.len(),
+                having.is_some()
+            );
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Sort {
+            input,
+            keys,
+            strategy,
+        } => {
+            let _ = write!(out, "Sort[{},{strategy:?}](", keys.len());
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Limit {
+            input,
+            limit,
+            offset,
+        } => {
+            let _ = write!(out, "Limit[{limit:?},{offset}](");
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Distinct { input, strategy } => {
+            let _ = write!(out, "Distinct[{strategy:?}](");
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::AssertMaxOneRow { input } => {
+            out.push_str("AssertMax1(");
+            shape_into(input, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Union { inputs, all } => {
+            let _ = write!(out, "Union[all={all}](");
+            for i in inputs {
+                shape_into(i, out);
+                out.push(',');
+            }
+            out.push_str(");");
+        }
+        PhysicalPlan::SetOp {
+            op,
+            left,
+            right,
+            all,
+        } => {
+            let _ = write!(out, "SetOp[{op:?},all={all}](");
+            shape_into(left, out);
+            out.push(',');
+            shape_into(right, out);
+            out.push_str(");");
+        }
+        PhysicalPlan::Values {
+            rows,
+            output_schema,
+        } => {
+            // DATA-INVARIANT: only the row COUNT + column width, never payloads.
+            let _ = write!(
+                out,
+                "Values[rows={},cols={}];",
+                rows.len(),
+                output_schema.columns.len()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proximadb_data_model::{ProximaType, ProximaValue};
+    use proximadb_relational_types::{ColumnInfo, RelationalSchema};
+
+    fn result(rows: Vec<Vec<ProximaValue>>) -> ExecutionPipelineResult {
+        let schema = RelationalSchema::new(vec![
+            ColumnInfo::new("k", ProximaType::Int64, true),
+            ColumnInfo::new("v", ProximaType::String, true),
+        ]);
+        ExecutionPipelineResult { schema, rows }
+    }
+
+    fn row(k: i64, v: &str) -> Vec<ProximaValue> {
+        vec![ProximaValue::Int64(k), ProximaValue::String(v.to_string())]
+    }
+
+    #[test]
+    fn identical_results_match_regardless_of_order() {
+        let a = result(vec![row(1, "a"), row(2, "b"), row(3, "c")]);
+        // Same multiset, permuted order → must NOT be flagged as divergence.
+        let b = result(vec![row(3, "c"), row(1, "a"), row(2, "b")]);
+        assert_eq!(mismatch_rate(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn one_wrong_row_exceeds_threshold() {
+        let a = result(vec![row(1, "a"), row(2, "b")]);
+        let b = result(vec![row(1, "a"), row(2, "WRONG")]);
+        // Two surplus/deficit rows over a 2-row set → well above 0.1%.
+        assert!(mismatch_rate(&a, &b) > MISMATCH_DEMOTE_THRESHOLD);
+    }
+
+    #[test]
+    fn column_count_mismatch_is_total() {
+        let a = result(vec![row(1, "a")]);
+        let mut b = a.clone();
+        b.schema = RelationalSchema::new(vec![ColumnInfo::new("k", ProximaType::Int64, true)]);
+        assert_eq!(mismatch_rate(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn shape_signature_ignores_values_payload_but_tracks_shape() {
+        use proximadb_relational_planner::PhysicalPlan;
+        let schema = RelationalSchema::new(vec![ColumnInfo::new("k", ProximaType::Int64, true)]);
+        let mk = |vals: &[i64]| PhysicalPlan::Values {
+            rows: vals
+                .iter()
+                .map(|&n| {
+                    vec![proximadb_relational_types::Expr::Literal {
+                        value: ProximaValue::Int64(n),
+                        ty: ProximaType::Int64,
+                    }]
+                })
+                .collect(),
+            output_schema: schema.clone(),
+        };
+        // Same shape (row count + width), different payload → same signature.
+        assert_eq!(
+            plan_shape_signature(&mk(&[1, 2, 3])),
+            plan_shape_signature(&mk(&[7, 8, 9]))
+        );
+        // Different row count → different signature (shape changed).
+        assert_ne!(
+            plan_shape_signature(&mk(&[1, 2, 3])),
+            plan_shape_signature(&mk(&[1, 2]))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fix-forward on the ADR-054 Phase 3 native hash join (default-off, `PROXIMADB_NATIVE_JOIN`), closing the correctness/gate gaps surfaced in review before the operator can be promoted. All four items land as one coherent PR.

## What & why

1. **Composite-key encoding — correctness bug** (`native_join_ops.rs`)
   The key encoder appended a raw `0` separator between columns, which is **not injective** for variable-length keys: `("a\0","b")` and `("a","\0b")` both encoded to the same bytes → false join matches on multi-column varchar/binary keys with an embedded `0x00`. Now varlen cells are **length-prefixed** (`u32` LE) and the separator is dropped — the TD's prescribed "length-prefixed varlen" canonical encoding. Fixed-width cells stay fixed-width, so concatenation is injective across a fixed key schema.

2. **Right / Full joins** (`native_join_ops.rs`)
   The probe operator now tracks matched build rows in a shared bitmap across all probe batches; after the probe stream drains, a chained tail emits the unmatched build rows (probe columns NULL-padded) via `drain_unmatched_build`. `Inner|Right` share the matched-pair path; `Left|Full` share the NULL-padded path. Only `Cross`/`AntiNullAware` remain `NotImplemented` → Volcano.

3. **Shadow harness + auto-demote** (new `native_shadow.rs`, wired in `engine.rs` + `native_engine.rs`)
   ADR-054 §7 Phase 0.5 / TD-OLAP-11 §Gate required a native-vs-Volcano shadow comparison with auto-demotion — previously only a doc-comment referenced a harness that did not exist. This adds: order-insensitive row-multiset comparison, a process-global demotion registry keyed by a **data-invariant plan-shape signature**, and the 0.1% mismatch threshold. Gated by `PROXIMADB_NATIVE_JOIN_SHADOW` (default-off; runs each query twice). Wired at `execute_physical` (compare, demote, **fail safe to the Volcano result on divergence**) and consulted by `try_vectorized` (a demoted shape declines native).

4. **Tests** (`native_ops.rs`, `native_shadow.rs`)
   - NULL keys never match across **all six** hash-join kinds (TD's "highest risk").
   - Right/Full unmatched-build drain (NULL-padded probe columns).
   - Bloom pre-filter **direction** (≥1024 build keys so the bloom is actually built): present keys survive (no false drops — the dangerous reversed-direction bug), absent keys miss.
   - `native_shadow` units: order-insensitivity, divergence detection, schema-count mismatch, shape-signature data-invariance.

## Verification
- `cargo check --all-targets -p proximadb` ✅
- `cargo nextest run` (join + shadow): **13 passed** ✅
- `cargo fmt --check` ✅ · `cargo clippy --lib --bins -- -D warnings` ✅
- No `unwrap`/`expect`/`panic!` in the new non-test paths (Mutex locks map to `ExecutionError`).

## Scope notes
- Everything stays behind the existing default-off flags; the seam is unchanged (zero `datafusion` in `proximadb-execution-contracts`).
- Radix partitioning + Grace spill (Phase 3.1) and the TD-OLAP-14 PAX scan source remain out of scope.