### PR TITLE
feat(storage-ports): QuantizationEnginePort + first adoption (Slice D quant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7304,6 +7304,7 @@ dependencies = [
  "proximadb-distance-kernel",
  "proximadb-hardware",
  "proximadb-quantization-types",
+ "proximadb-storage-ports",
  "proximadb-vector",
  "rand 0.8.6",
  "serde",

--- a/crates/modalities/proximadb-quantization-kernel/Cargo.toml
+++ b/crates/modalities/proximadb-quantization-kernel/Cargo.toml
@@ -26,6 +26,9 @@ proximadb-hardware = { workspace = true }
 proximadb-vector = { workspace = true }
 proximadb-quantization-types = { workspace = true }
 proximadb-distance-kernel = { workspace = true }
+# Downward dep (modality→storage-ports): the kernel impls QuantizationEnginePort
+# so storage can depend on the port trait, not on this concrete modality crate.
+proximadb-storage-ports = { workspace = true }
 
 [features]
 # Mirrors the root crate's TurboQuant gate (ADR-021). The SIMD/store kernels live

--- a/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
@@ -43,6 +43,7 @@
 //! - Centroids: 256 per subquantizer (8-bit codes)
 
 use anyhow::{Context, Result};
+use proximadb_storage_ports::QuantizationEnginePort;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::debug;
@@ -2597,5 +2598,42 @@ mod tests {
         assert_eq!(top_5_quantized[0], top_5_raw[0]);
 
         Ok(())
+    }
+}
+
+// Slice D — QuantizationEnginePort impl: exposes the level-specific quantize_to_*
+// surface (primitive in/out) as a storage dependency-inversion port so `src/storage`
+// can hold `Arc<dyn QuantizationEnginePort>` instead of reaching up into this
+// modality crate. Fully-qualified calls delegate to the inherent methods (no
+// recursion). See crates/storage/proximadb-storage-ports/src/lib.rs.
+impl QuantizationEnginePort for UnifiedQuantizationEngine {
+    fn quantize_to_binary(&self, vector: &[f32]) -> Result<Vec<u8>> {
+        UnifiedQuantizationEngine::quantize_to_binary(self, vector)
+    }
+    fn quantize_to_int8(&self, vector: &[f32]) -> Result<Vec<u8>> {
+        UnifiedQuantizationEngine::quantize_to_int8(self, vector)
+    }
+    fn quantize_to_u4(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32, usize)> {
+        UnifiedQuantizationEngine::quantize_to_u4(self, vector)
+    }
+    fn quantize_to_u6(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32, usize)> {
+        UnifiedQuantizationEngine::quantize_to_u6(self, vector)
+    }
+    fn quantize_to_u8(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32)> {
+        UnifiedQuantizationEngine::quantize_to_u8(self, vector)
+    }
+    fn quantize_to_u16(&self, vector: &[f32]) -> Result<(Vec<u16>, f32, f32)> {
+        UnifiedQuantizationEngine::quantize_to_u16(self, vector)
+    }
+    fn quantize_to_pq(
+        &self,
+        vector: &[f32],
+        num_subvectors: usize,
+        bits_per_code: u32,
+    ) -> Result<Vec<u8>> {
+        UnifiedQuantizationEngine::quantize_to_pq(self, vector, num_subvectors, bits_per_code)
+    }
+    fn calculate_hamming_distance(&self, a: &[u8], b: &[u8]) -> u32 {
+        UnifiedQuantizationEngine::calculate_hamming_distance(self, a, b)
     }
 }

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -62,3 +62,45 @@ pub trait StorageEventLogPort: Send + Sync {
     /// open when the event log is unavailable.
     async fn can_compact(&self, collection_id: &str, file_path: &str) -> Result<bool>;
 }
+
+/// Level-specific vector quantization + Hamming distance that storage's
+/// search/compaction paths need.
+///
+/// Inverts `crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine`
+/// (modality-tier `proximadb-quantization-kernel`, re-exported up through
+/// `compute::quantization`): storage holds an `Arc<dyn QuantizationEnginePort>`
+/// and never names the concrete engine, so the storage→modality up-edge dissolves.
+///
+/// The measured storage-driven surface is the level-specific `quantize_to_*`
+/// encoders plus Hamming distance — every signature is primitive in/out
+/// (`&[f32]` → `Vec<u8>`/`Vec<u16>`/tuples/`u32`), so NO modality type crosses
+/// the seam (no facade DTOs needed). The generic level-based `quantize(level)`
+/// is intentionally NOT here: it would drag the modality `UnifiedQuantizationLevel`
+/// type across the boundary. Callers use the level-specific method instead.
+///
+/// The concrete `UnifiedQuantizationEngine` `impl`s this in its own crate — a
+/// downward dep (modality→storage-ports is layering-allowed; the forbidden
+/// direction is storage→modality). The composition root injects the impl.
+pub trait QuantizationEnginePort: Send + Sync {
+    /// 1-bit sign/threshold quantization → packed bits.
+    fn quantize_to_binary(&self, vector: &[f32]) -> Result<Vec<u8>>;
+    /// 8-bit signed scalar quantization.
+    fn quantize_to_int8(&self, vector: &[f32]) -> Result<Vec<u8>>;
+    /// 4-bit scalar quantization → (codes, min, max, len).
+    fn quantize_to_u4(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32, usize)>;
+    /// 6-bit scalar quantization → (codes, min, max, len).
+    fn quantize_to_u6(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32, usize)>;
+    /// 8-bit unsigned scalar quantization → (codes, min, max).
+    fn quantize_to_u8(&self, vector: &[f32]) -> Result<(Vec<u8>, f32, f32)>;
+    /// 16-bit unsigned scalar quantization → (codes, min, max).
+    fn quantize_to_u16(&self, vector: &[f32]) -> Result<(Vec<u16>, f32, f32)>;
+    /// Product quantization → packed codes.
+    fn quantize_to_pq(
+        &self,
+        vector: &[f32],
+        num_subvectors: usize,
+        bits_per_code: u32,
+    ) -> Result<Vec<u8>>;
+    /// Hamming distance between two bit-packed binary codes.
+    fn calculate_hamming_distance(&self, a: &[u8], b: &[u8]) -> u32;
+}

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -10,4 +10,4 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 python3 scripts/check_workspace_boundaries.py --strict
-python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 250
+python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 248

--- a/src/storage/engines/core/search/search_common.rs
+++ b/src/storage/engines/core/search/search_common.rs
@@ -9,11 +9,11 @@ use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine;
 use crate::core::search::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 use proximadb_filter_expression::FilterExpression;
+use proximadb_storage_ports::QuantizationEnginePort;
 
 /// Backwards-compat alias for [`UniversalSearchConfig`].
 pub type SearchConfig = UniversalSearchConfig;
@@ -153,7 +153,7 @@ pub trait FileSearcher<F: SearchableFile, B: SearchableBlock>: Send + Sync {
 /// Universal search pipeline used by all engines
 pub struct UniversalSearchPipeline {
     distance_compute: Arc<UnifiedDistanceCompute>,
-    quantization_engine: Arc<UnifiedQuantizationEngine>,
+    quantization_engine: Arc<dyn QuantizationEnginePort>,
     #[allow(dead_code)]
     filter_processor: Arc<FilterProcessor>,
     result_manager: Arc<ResultManager>,
@@ -162,7 +162,7 @@ pub struct UniversalSearchPipeline {
 impl UniversalSearchPipeline {
     pub fn new(
         distance_compute: Arc<UnifiedDistanceCompute>,
-        quantization_engine: Arc<UnifiedQuantizationEngine>,
+        quantization_engine: Arc<dyn QuantizationEnginePort>,
     ) -> Self {
         let dc = distance_compute.clone();
         Self {
@@ -370,24 +370,14 @@ impl UniversalSearchPipeline {
         &self,
         records: Vec<VectorRecord>,
         query_vector: &[f32],
-        threshold: f32,
+        _threshold: f32,
     ) -> Result<Vec<VectorRecord>> {
-        // Use quantization engine for binary filtering
-        // Create a binary quantization level
-        use crate::compute::quantization::quantization_engine::{
-            BinaryQuantization, QuantizationLevel, UnifiedQuantizationLevel,
-        };
-        let binary_level = UnifiedQuantizationLevel {
-            level_type: Some(QuantizationLevel::Binary(BinaryQuantization {
-                sign_based: true,
-                threshold: Some(threshold),
-            })),
-        };
-
-        let _binary_query = self
-            .quantization_engine
-            .quantize(query_vector, &binary_level)
-            .await?;
+        // Use the quantization engine for binary filtering via the port's
+        // level-specific method. The generic level-based quantize() is intentionally
+        // NOT on QuantizationEnginePort (it would drag the modality
+        // UnifiedQuantizationLevel type across the storage seam). The result is
+        // currently unused — binary filtering is a passthrough (see the loop below).
+        let _binary_query = self.quantization_engine.quantize_to_binary(query_vector)?;
 
         let mut filtered = Vec::new();
         for record in records {


### PR DESCRIPTION
## What & why
Continues the **root-crate decomposition** (the durable fix for the 45-min compile / test-binary OOM — larger runners were explicitly rejected as masking). The dominant blocker for engine extraction (Slice E = ~245K LOC) is the **`compute::quantization` up-edge class** (~196 of the 250 storage up-edges). This PR introduces the **`QuantizationEnginePort`** — the dependency-inversion port that lets `src/storage` depend DOWN on a trait instead of UP into the modality-tier `UnifiedQuantizationEngine`.

## Analysis → clean design
I mapped all 217 `compute::quantization` refs in `src/storage`. The key finding: **every level-specific `quantize_to_*` method + Hamming distance is primitive in/out** (`&[f32]` → `Vec<u8>`/`Vec<u16>`/tuples/`u32`). So the port needs **no facade DTOs** — no modality type crosses the seam. The generic level-based `quantize(level)` is intentionally excluded (it would drag `UnifiedQuantizationLevel` across — that's the divergent-type-cluster problem, a separate slice).

## Changes
- **`proximadb-storage-ports`**: add `QuantizationEnginePort` — 8 primitive methods (`quantize_to_{binary,int8,u4,u6,u8,u16,pq}` + `calculate_hamming_distance`).
- **`proximadb-quantization-kernel`** (modality): `impl QuantizationEnginePort for UnifiedQuantizationEngine` (delegating). This is a **downward dep** — verified modality→storage-ports is layering-allowed (the forbidden direction is storage→modality).
- **`src/storage/engines/core/search/search_common.rs`**: `UniversalSearchPipeline` now holds `Arc<dyn QuantizationEnginePort>` (field + `new` param); `binary_filter` uses the port's `quantize_to_binary` instead of the generic level-based `quantize` + the modality level-type imports. **First adoption** of the port.

## Verification
- `cargo check --lib` ✅ · `cargo clippy --lib` ✅ (no warnings) · `cargo fmt --check` ✅
- `bash scripts/check-layering.sh` ✅ (kernel→storage-ports dep allowed; ceiling lowered)
- Storage up-edge ratchet **250 → 248** (`search_common.rs` now has 0 `crate::compute::quantization` refs).

## Scope honesty (multi-PR initiative)
This is **D2 (the port contract + impl) + a first D3 adoption**. The ratchet drop here is small (−2) because `search_common`'s field used the short type name — the big ref counts are the **fully-qualified** `crate::compute::quantization::*` paths in the engines. The large ratchet drop (~150 refs) lands when the engines adopt the port — that rewire is the **hot, coordination-window phase** (construction-inversion of `UnifiedQuantizationEngine` across viper/nova/swift/helix/sst/raptor + `progressive_search`, which currently `::new` the concrete engine). It's the next PR; this one lands the contract + proves the injection seam.

Per the repo's coordination protocol (one slice per PR, land fast) and the `ROOT_CRATE_DECOMPOSITION_SLICE_D` doc.