### PR TITLE
feat(olap): native shadow probe on the DataFusion OLAP path (TD-OLAP-4)

### DIFF
--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -667,6 +667,28 @@ impl ObjectStoreParquetTable {
         })
     }
 
+    /// TD-OLAP-4 shadow probe: the raw inputs a native
+    /// [`ParquetScanOperator`](crate::query::execution::native_parquet_scan::ParquetScanOperator)
+    /// needs to read the SAME external parquet this DataFusion table reads — the
+    /// traced object store, the distinct files (with footer byte sizes), and the
+    /// file Arrow schema. Whole-file granularity (every row group); the native scan
+    /// does not yet do row-group zone-map pruning, so a native sample built from
+    /// this is an upper bound on selective-filter queries (documented caveat for
+    /// the engine-dimension trace).
+    pub fn native_scan_inputs(
+        &self,
+    ) -> (Arc<dyn ObjectStore>, Vec<(Path, Option<u64>)>, SchemaRef) {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut files: Vec<(Path, Option<u64>)> = Vec::new();
+        for split in &self.splits {
+            if seen.insert(split.file_path.clone()) {
+                let size = self.file_sizes.get(&split.file_path).copied();
+                files.push((Path::from(split.file_path.as_str()), size));
+            }
+        }
+        (self.store.clone(), files, self.schema.clone())
+    }
+
     /// Attach the registered table name (keys the ADR-037 statistics registry
     /// so [`TableProvider::statistics`] can overlay the HLL NDV estimate).
     pub fn with_table_name(mut self, name: impl Into<String>) -> Self {
@@ -1342,6 +1364,33 @@ mod tests {
         let table = ObjectStoreParquetTable::open(&location).await.unwrap();
         assert_eq!(table.split_count(), 2);
         assert_eq!(table.schema().fields().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn native_scan_inputs_yields_distinct_files_with_sizes_and_schema() {
+        // Two row groups live in ONE file → the native scan (whole-file) must see a
+        // single distinct file, with a footer byte size and the full 2-column schema.
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        write_two_row_group_parquet(&data_dir.join("part-0.parquet"));
+
+        let location = format!("file://{}", tmp.path().display());
+        let table = ObjectStoreParquetTable::open(&location).await.unwrap();
+        assert_eq!(table.split_count(), 2, "two row groups");
+
+        let (_store, files, schema) = table.native_scan_inputs();
+        assert_eq!(
+            files.len(),
+            1,
+            "two row groups collapse to one distinct file"
+        );
+        assert!(files[0].0.as_ref().ends_with("part-0.parquet"));
+        assert!(
+            files[0].1.is_some_and(|sz| sz > 0),
+            "footer byte size present"
+        );
+        assert_eq!(schema.fields().len(), 2, "full file schema (k, x)");
     }
 
     #[tokio::test]

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -505,6 +505,20 @@ pub async fn try_run_select(
             &crate::query::compute_scheduler::backend_label(&decision.backend),
             started.elapsed().as_millis() as u64,
         );
+        // TD-OLAP-4 (engine dimension): optional native SHADOW — run the same query
+        // on the native vectorized engine over the same parquet, purely to record a
+        // `native-vectorized` compute sample next to DataFusion's for the trace.
+        // Default-OFF, benchmark-only; the result is discarded (DataFusion's stands)
+        // and any failure is swallowed, so it never affects correctness or latency
+        // of the served query.
+        if crate::query::execution::native_engine::native_shadow_enabled() {
+            let probe_snapshot = SnapshotCatalog {
+                dml: dml.clone(),
+                tables: tables.clone(),
+                tenant: tenant_ctx.clone(),
+            };
+            shadow_probe_native_parquet(sql, &probe_snapshot, &parquet_loc_by_key).await;
+        }
         return Some(match engine_result {
             Ok(result) => {
                 if let Some((skey, lsn)) = &cache_ctx {
@@ -634,6 +648,134 @@ fn plan_over_snapshot(
     };
     let planner = Planner::new(resolver);
     Some(planner.plan(logical).map_err(|e| format!("plan: {e}")))
+}
+
+// =========================================================================
+// TD-OLAP-4 native SHADOW probe (engine dimension). Default-OFF, benchmark-only:
+// run the SAME parquet SELECT on the native vectorized engine alongside DataFusion
+// to record a `native-vectorized` compute sample in the io-trace. The native
+// result is discarded (DataFusion's is authoritative) and all failures are
+// swallowed, so the probe never changes the served result or fails a query.
+// =========================================================================
+
+/// Column names emitted by the plan's sole `Scan` node, or `None` if the plan has
+/// zero or more than one scan (multi-table / no-table). Used to build the native
+/// parquet reader's projection so it reads the same columns DataFusion does.
+#[cfg(feature = "datafusion-integration")]
+fn single_scan_columns(plan: &PhysicalPlan) -> Option<Vec<String>> {
+    fn collect(plan: &PhysicalPlan, count: &mut usize, out: &mut Option<Vec<String>>) {
+        match plan {
+            PhysicalPlan::Scan { output_schema, .. } => {
+                *count += 1;
+                *out = Some(
+                    output_schema
+                        .columns
+                        .iter()
+                        .map(|c| c.name.clone())
+                        .collect(),
+                );
+            }
+            PhysicalPlan::Filter { input, .. }
+            | PhysicalPlan::Project { input, .. }
+            | PhysicalPlan::Aggregate { input, .. }
+            | PhysicalPlan::Sort { input, .. }
+            | PhysicalPlan::Limit { input, .. }
+            | PhysicalPlan::Distinct { input, .. }
+            | PhysicalPlan::AssertMaxOneRow { input } => collect(input, count, out),
+            PhysicalPlan::Join { left, right, .. } => {
+                collect(left, count, out);
+                collect(right, count, out);
+            }
+            PhysicalPlan::Union { inputs, .. } => {
+                for i in inputs {
+                    collect(i, count, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut count = 0usize;
+    let mut out = None;
+    collect(plan, &mut count, &mut out);
+    (count == 1).then_some(out).flatten()
+}
+
+/// Run the native vectorized engine over the same external parquet DataFusion just
+/// served, purely to record a per-engine compute sample. Single-table parquet only
+/// (MVP); declines silently on anything native can't yet serve.
+#[cfg(feature = "datafusion-integration")]
+async fn shadow_probe_native_parquet(
+    sql: &str,
+    snapshot: &SnapshotCatalog,
+    parquet_loc_by_key: &HashMap<String, String>,
+) {
+    // Single-table parquet only — joins are a separately-gated native path.
+    if parquet_loc_by_key.len() != 1 {
+        return;
+    }
+    let Some(location) = parquet_loc_by_key.values().next() else {
+        return;
+    };
+    // Lower the SAME SQL to the relational physical plan (decline → skip).
+    let physical = match plan_over_snapshot(sql, snapshot) {
+        Some(Ok(p)) => p,
+        _ => return,
+    };
+    let Some(scan_cols) = single_scan_columns(&physical) else {
+        return;
+    };
+    // Open the same parquet DataFusion read (table-OPEN cache is warm from its run).
+    let table = match crate::datafusion::engine_adapters::ObjectStoreParquetTable::open(location)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::debug!(target: "proximadb::native_shadow", %e, "shadow: table open declined");
+            return;
+        }
+    };
+    let (store, files, file_schema) = table.native_scan_inputs();
+    // Map the plan's Scan columns → parquet leaf indices by name; build the native
+    // scan output schema from the FILE fields (exact Arrow types). Sort ascending so
+    // the reader's file-order `ProjectionMask::roots` matches the operator schema —
+    // when the plan preserves declared column order (the common case) native aligns;
+    // otherwise the native lowering declines and no sample is recorded.
+    let mut paired: Vec<(usize, arrow::datatypes::Field)> = Vec::with_capacity(scan_cols.len());
+    for name in &scan_cols {
+        let Some((idx, field)) = file_schema
+            .fields()
+            .iter()
+            .enumerate()
+            .find(|(_, f)| f.name() == name)
+        else {
+            return; // column absent from file (schema drift) → never risk a sample
+        };
+        paired.push((idx, field.as_ref().clone()));
+    }
+    paired.sort_by_key(|(i, _)| *i);
+    let projection: Vec<usize> = paired.iter().map(|(i, _)| *i).collect();
+    let out_schema = Arc::new(arrow::datatypes::Schema::new(
+        paired.into_iter().map(|(_, f)| f).collect::<Vec<_>>(),
+    ));
+    let source = Box::new(
+        crate::query::execution::native_parquet_scan::ParquetScanOperator::new(
+            store,
+            files,
+            Some(projection),
+            out_schema,
+        ),
+    );
+    match crate::query::execution::native_engine::run_native_over_parquet(&physical, source).await {
+        Ok(Some(_)) => {
+            tracing::debug!(target: "proximadb::native_shadow", "shadow: native-vectorized sample recorded")
+        }
+        Ok(None) => {
+            tracing::debug!(target: "proximadb::native_shadow", "shadow: native declined (shape/align)")
+        }
+        Err(e) => {
+            tracing::debug!(target: "proximadb::native_shadow", %e, "shadow: native errored")
+        }
+    }
 }
 
 // =========================================================================
@@ -2093,6 +2235,54 @@ mod tests {
             [Statement::Query(query)] => query_engages_relational_engine(query),
             _ => panic!("expected a single SELECT statement"),
         }
+    }
+
+    #[cfg(feature = "datafusion-integration")]
+    fn scan_fixture(cols: &[&str]) -> PhysicalPlan {
+        PhysicalPlan::Scan {
+            table: TableId::new("hits"),
+            output_schema: RelationalSchema::new(
+                cols.iter()
+                    .map(|c| ColumnInfo::new(*c, ProximaType::Int64, false))
+                    .collect(),
+            ),
+            projection: None,
+            predicate: None,
+            limit: None,
+            access: proximadb_relational_planner::ScanAccess::FullScan,
+        }
+    }
+
+    #[cfg(feature = "datafusion-integration")]
+    #[test]
+    fn single_scan_columns_detects_sole_scan_and_rejects_multi_or_none() {
+        // Bare scan → its projected column names.
+        assert_eq!(
+            single_scan_columns(&scan_fixture(&["k", "x"])),
+            Some(vec!["k".to_string(), "x".to_string()])
+        );
+        // Recurses through an intermediate op (Limit) to the sole scan.
+        let limited = PhysicalPlan::Limit {
+            input: Box::new(scan_fixture(&["k", "x"])),
+            limit: Some(10),
+            offset: 0,
+        };
+        assert_eq!(
+            single_scan_columns(&limited),
+            Some(vec!["k".to_string(), "x".to_string()])
+        );
+        // Two scans (Union) → None: the native shadow is single-table only.
+        let two = PhysicalPlan::Union {
+            inputs: vec![scan_fixture(&["k"]), scan_fixture(&["x"])],
+            all: true,
+        };
+        assert_eq!(single_scan_columns(&two), None);
+        // No scan at all → None.
+        let no_scan = PhysicalPlan::Values {
+            rows: vec![],
+            output_schema: RelationalSchema::new(vec![]),
+        };
+        assert_eq!(single_scan_columns(&no_scan), None);
     }
 
     #[test]

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -47,6 +47,21 @@ pub fn native_join_enabled() -> bool {
     })
 }
 
+/// Gate: run the native-parquet SHADOW probe alongside DataFusion on the OLAP
+/// path? Default OFF — this is a benchmark/measurement instrument, not a product
+/// path: when on, a parquet SELECT that DataFusion serves is ALSO re-planned,
+/// re-opened, and re-executed on the native vectorized engine purely to record a
+/// `native-vectorized` compute sample for the engine-dimension trace (TD-OLAP-4).
+/// It roughly doubles the query's work, so it must never be on in production.
+pub fn native_shadow_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_NATIVE_SHADOW")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
 /// Try the native vectorized execution path for an already-planned query.
 /// Called from `NativeVolcanoEngine::execute_physical` (the single native
 /// chokepoint, above the Volcano) when [`native_vectorized_enabled`] is set.
@@ -119,6 +134,18 @@ pub async fn try_vectorized_over_parquet(
     if !native_vectorized_enabled() {
         return Ok(None);
     }
+    run_native_over_parquet(physical, scan_source).await
+}
+
+/// Gate-free core of the native-parquet path: lower `physical` over `scan_source`,
+/// execute, and record the `native-vectorized` compute + route sample. Shared by
+/// [`try_vectorized_over_parquet`] (product-gated) and the shadow probe (which
+/// gates on [`native_shadow_enabled`] instead, so a measurement run needs a single
+/// env switch). Returns `Ok(None)` on decline (unsupported shape) or failure.
+pub(crate) async fn run_native_over_parquet(
+    physical: &PhysicalPlan,
+    scan_source: Box<dyn proximadb_execution_contracts::ExecutionOperator>,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError> {
     let lowered = match super::native_ops::lower_physical_over_source(physical, scan_source) {
         Ok(l) => l,
         Err(reason) => {


### PR DESCRIPTION
## What
Wires the native vectorized engine to run **alongside** DataFusion on the pgwire OLAP path for external-parquet SELECTs, purely to record a `native-vectorized` compute sample in the io-trace next to DataFusion's. This is the per-engine measurement the route cost model needs to "build tiles" (geometry/operation/cardinality/engine dispatch — CODESIGN_GEOMETRY_DEPENDENT_EXECUTION, #809).

**Default-OFF, benchmark-only.** The native result is discarded (DataFusion's stays authoritative), and every failure is swallowed — the probe never changes a served result or fails a query.

## How
- **`native_shadow_enabled()`** gate (`PROXIMADB_NATIVE_SHADOW`, default OFF). The DataFusion arm of `try_run_select`, after DataFusion executes, optionally runs `shadow_probe_native_parquet`.
- **`ObjectStoreParquetTable::native_scan_inputs()`** yields the raw native scan inputs — the traced store, distinct files (+ footer sizes), file Arrow schema — the SAME storage DataFusion reads.
- **`shadow_probe_native_parquet`**: re-lowers the SQL via `plan_over_snapshot`, finds the sole `Scan` (single-table parquet only), opens the same parquet (table-OPEN cache warm from DataFusion's run), maps the plan's Scan columns → parquet leaf indices by name, builds a `ParquetScanOperator`, and runs the plan on native via the new gate-free **`run_native_over_parquet`** (factored out of `try_vectorized_over_parquet`, which now just gate-checks and delegates).
- Projection is mapped in file order; when the plan preserves declared column order (the common case) native aligns and records a sample — otherwise the native lowering declines and **no** sample is recorded (never a wrong sample).

Builds on the enabler from #811 (ParquetScanOperator + `lower_physical_over_source`) and the engine-dimension trace from #810.

## Caveats (honest, for reading the trace)
- The native scan is **whole-file** (no row-group zone-map pruning yet), so native samples on selective-filter queries are an **upper bound** vs DataFusion's pruned read.
- Native op coverage is **Filter/Project/Aggregate/Limit over a single Scan**; anything else declines (no sample).
- Both are documented at the call sites.

## Tests
- `single_scan_columns_detects_sole_scan_and_rejects_multi_or_none` — scan detection (bare / recursed-through-Limit / rejects multi-scan Union / rejects no-scan).
- `native_scan_inputs_yields_distinct_files_with_sizes_and_schema` — the accessor collapses row groups to distinct files with footer sizes + full schema.
- Existing #811 `native_lowers_scan_over_parquet_source` covers the injection path.

End-to-end validation is the **100M ClickBench capture with `PROXIMADB_NATIVE_SHADOW=1`** (next step) — the ledger e2e harness surfaces `compute_by_engine` per query, so the capture will show native-vectorized samples wherever native applies.