### PR TITLE
refactor(api): relocate REST v1 deprecation-header util (TD-V1SUNSET-1 step 2)

### DIFF
--- a/crates/platform/proximadb-api/src/rest.rs
+++ b/crates/platform/proximadb-api/src/rest.rs
@@ -2,6 +2,7 @@
 //!
 //! HTTP/JSON API handlers via Axum framework.
 
+pub mod deprecation;
 pub mod errors;
 pub mod state;
 pub mod v1;

--- a/crates/platform/proximadb-api/src/rest/deprecation.rs
+++ b/crates/platform/proximadb-api/src/rest/deprecation.rs
@@ -1,0 +1,126 @@
+//! REST v1 deprecation-header utilities.
+//!
+//! Centralized home for the deprecation headers ProximaDB emits on compatibility
+//! (`/api/v1`) traffic, owned *outside* the deprecated `rest::v1` adapter
+//! directory. This relocation is TD-V1SUNSET-1 step 2 — the prerequisite for
+//! hard-deleting that directory: the live root-crate handler
+//! (`src/network/rest/v1/handlers.rs`) imports `add_rest_v1_deprecation_headers`
+//! from here, so deleting `rest::v1` no longer breaks it. The v1 adapters
+//! re-export `with_v1_compatibility_headers` from here for their per-request
+//! header layer.
+
+use axum::{
+    Router,
+    body::Body,
+    http::{HeaderMap, HeaderValue, Request, header},
+    middleware::Next,
+    response::Response,
+};
+
+pub const REST_V1_REPLACEMENT_SURFACE: &str = "/api/v2, proximadb.v2.ProximaRecordService, pgwire";
+pub const REST_V1_DEPRECATION_MESSAGE: &str =
+    "REST /api/v1 is compatibility-only; use canonical ProximaRecord APIs for new clients";
+
+pub fn apply_v1_deprecation_headers(headers: &mut HeaderMap) {
+    let deprecation = header::HeaderName::from_static("deprecation");
+    if !headers.contains_key(&deprecation) {
+        headers.insert(deprecation, HeaderValue::from_static("true"));
+    }
+
+    if !headers.contains_key(header::LINK) {
+        headers.insert(
+            header::LINK,
+            HeaderValue::from_static("</api/v2>; rel=\"successor-version\""),
+        );
+    }
+
+    let status = header::HeaderName::from_static("x-proximadb-api-status");
+    if !headers.contains_key(&status) {
+        headers.insert(status, HeaderValue::from_static("deprecated-compatibility"));
+    }
+
+    let replacement = header::HeaderName::from_static("x-proximadb-replacement");
+    if !headers.contains_key(&replacement) {
+        headers.insert(
+            replacement,
+            HeaderValue::from_static(REST_V1_REPLACEMENT_SURFACE),
+        );
+    }
+
+    let message = header::HeaderName::from_static("x-proximadb-deprecation-message");
+    if !headers.contains_key(&message) {
+        headers.insert(
+            message,
+            HeaderValue::from_static(REST_V1_DEPRECATION_MESSAGE),
+        );
+    }
+}
+
+/// Path-scoped: stamps deprecation headers only on `/api/v1/` responses. Applied
+/// as an axum middleware layer on the live canonical router.
+pub async fn add_rest_v1_deprecation_headers(request: Request<Body>, next: Next) -> Response {
+    let is_rest_v1 = request.uri().path().starts_with("/api/v1/");
+    let mut response = next.run(request).await;
+
+    if is_rest_v1 {
+        apply_v1_deprecation_headers(response.headers_mut());
+    }
+
+    response
+}
+
+/// Unscoped: stamps deprecation headers on every response. Used by the v1
+/// compatibility adapters that are known to serve only v1 traffic.
+pub async fn add_compatibility_deprecation_headers(request: Request<Body>, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    apply_v1_deprecation_headers(response.headers_mut());
+    response
+}
+
+pub fn with_v1_compatibility_headers<S>(router: Router<S>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    router.layer(axum::middleware::from_fn(
+        add_compatibility_deprecation_headers,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::Request, routing::get};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn compatibility_router_headers_mark_relative_v1_adapters() {
+        let router =
+            with_v1_compatibility_headers(Router::new().route("/relative", get(|| async { "ok" })));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/relative")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get("deprecation")
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-proximadb-replacement")
+                .and_then(|value| value.to_str().ok()),
+            Some(REST_V1_REPLACEMENT_SURFACE)
+        );
+    }
+}

--- a/crates/platform/proximadb-api/src/rest/v1/mod.rs
+++ b/crates/platform/proximadb-api/src/rest/v1/mod.rs
@@ -4,14 +4,10 @@
 //!
 //! These endpoints are compatibility adapters. New clients should use canonical
 //! record/table surfaces instead of targeting v1 vector-shaped payloads.
-
-use axum::{
-    Router,
-    body::Body,
-    http::{HeaderMap, HeaderValue, Request, header},
-    middleware::Next,
-    response::Response,
-};
+//!
+//! The deprecation-header machinery these adapters emit is centralized in
+//! `crate::rest::deprecation` (TD-V1SUNSET-1 step 2) and re-exported below so
+//! the per-adapter `super::with_v1_compatibility_headers` call sites resolve.
 
 pub mod analytics;
 pub mod catalog;
@@ -22,70 +18,14 @@ pub mod hybrid;
 pub mod multimodal_query;
 pub mod observability;
 
-pub const REST_V1_REPLACEMENT_SURFACE: &str = "/api/v2, proximadb.v2.ProximaRecordService, pgwire";
-pub const REST_V1_DEPRECATION_MESSAGE: &str =
-    "REST /api/v1 is compatibility-only; use canonical ProximaRecord APIs for new clients";
-
-pub fn apply_v1_deprecation_headers(headers: &mut HeaderMap) {
-    let deprecation = header::HeaderName::from_static("deprecation");
-    if !headers.contains_key(&deprecation) {
-        headers.insert(deprecation, HeaderValue::from_static("true"));
-    }
-
-    if !headers.contains_key(header::LINK) {
-        headers.insert(
-            header::LINK,
-            HeaderValue::from_static("</api/v2>; rel=\"successor-version\""),
-        );
-    }
-
-    let status = header::HeaderName::from_static("x-proximadb-api-status");
-    if !headers.contains_key(&status) {
-        headers.insert(status, HeaderValue::from_static("deprecated-compatibility"));
-    }
-
-    let replacement = header::HeaderName::from_static("x-proximadb-replacement");
-    if !headers.contains_key(&replacement) {
-        headers.insert(
-            replacement,
-            HeaderValue::from_static(REST_V1_REPLACEMENT_SURFACE),
-        );
-    }
-
-    let message = header::HeaderName::from_static("x-proximadb-deprecation-message");
-    if !headers.contains_key(&message) {
-        headers.insert(
-            message,
-            HeaderValue::from_static(REST_V1_DEPRECATION_MESSAGE),
-        );
-    }
-}
-
-pub async fn add_rest_v1_deprecation_headers(request: Request<Body>, next: Next) -> Response {
-    let is_rest_v1 = request.uri().path().starts_with("/api/v1/");
-    let mut response = next.run(request).await;
-
-    if is_rest_v1 {
-        apply_v1_deprecation_headers(response.headers_mut());
-    }
-
-    response
-}
-
-pub async fn add_compatibility_deprecation_headers(request: Request<Body>, next: Next) -> Response {
-    let mut response = next.run(request).await;
-    apply_v1_deprecation_headers(response.headers_mut());
-    response
-}
-
-pub fn with_v1_compatibility_headers<S>(router: Router<S>) -> Router<S>
-where
-    S: Clone + Send + Sync + 'static,
-{
-    router.layer(axum::middleware::from_fn(
-        add_compatibility_deprecation_headers,
-    ))
-}
+// Deprecation-header utilities live outside this deprecated dir; re-exported
+// here so the adapters' `super::with_v1_compatibility_headers` sites compile.
+// See `crate::rest::deprecation` (TD-V1SUNSET-1 step 2).
+pub use crate::rest::deprecation::{
+    REST_V1_DEPRECATION_MESSAGE, REST_V1_REPLACEMENT_SURFACE,
+    add_compatibility_deprecation_headers, add_rest_v1_deprecation_headers,
+    apply_v1_deprecation_headers, with_v1_compatibility_headers,
+};
 
 // Re-exports — handler types
 pub use analytics::{AnalyticsHandler, AqlHandler};
@@ -117,42 +57,3 @@ pub use observability::create_observability_router;
 // Re-exports — handler functions (for direct registration in existing root-crate routers)
 pub use catalog::{collection_operation, delete_collection, get_collection, list_collections};
 pub use hybrid::{liveness_check, readiness_check};
-
-#[cfg(test)]
-mod tests {
-    use axum::{body::Body, http::Request, routing::get};
-    use tower::ServiceExt;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn compatibility_router_headers_mark_relative_v1_adapters() {
-        let router =
-            with_v1_compatibility_headers(Router::new().route("/relative", get(|| async { "ok" })));
-
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/relative")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            response
-                .headers()
-                .get("deprecation")
-                .and_then(|value| value.to_str().ok()),
-            Some("true")
-        );
-        assert_eq!(
-            response
-                .headers()
-                .get("x-proximadb-replacement")
-                .and_then(|value| value.to_str().ok()),
-            Some(REST_V1_REPLACEMENT_SURFACE)
-        );
-    }
-}

--- a/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
+++ b/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
@@ -8,7 +8,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Planned — gated.** Not executable until (a) REST-v1 default-off has run a sunset window and (b) the breaking REST flip has product/ops sign-off (certify-before-flip). This TD is the *plan*; no behavior change lands with it.
+| Status | **Partially invalidated — see Reconciliation 2026-07-09.** Step 1 (REST flip) ✅ landed (#814, `9c9b0466`). Step 2 (relocate deprecation-header util) ✅ landed. Step 4 (gRPC v1 api-crate delete) ✅ *already complete* on `develop` (found pre-deleted). **Step 3 (hard-delete api-crate `rest/v1/`) is INVALIDATED** — that dir holds LIVE `/api/v2` port-backed routers, not deprecated v1 adapters; it must NOT be deleted (a rename is TD-104). Step 5 (remove `v1_sunset` middleware) remains gated on sunset-window verification.
 | Severity | Medium — outward-facing break (REST flip `410`s all `/api/v1/*`); recovery is a one-line revert.
 | Component | Network: REST v1 sunset (`src/network/middleware/v1_sunset.rs`) + the deprecated v1 surfaces in `crates/platform/proximadb-api/src/{rest,grpc}/v1/`.
 | Tracked-by | link:../../12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc[V1_RETIREMENT_ROADMAP] (strategy, Tier 1); link:../../12-design/adr/ADR-049-v1-to-v2-migration-to-native-model.adoc[ADR-049] (M0-c REST sunset gate); the v1-proto ratchet (`scripts/check_v1_proto_usage.py`).
@@ -49,10 +49,47 @@ the root-crate REST (which is live despite the `v1` path segment):
 [cols="2,4,1", options="header"]
 |===
 | Path | Role | Action
-| `crates/platform/proximadb-api/src/rest/v1/` | **Deprecated** v1 REST adapters (port-backed handlers that forward to v2 + emit deprecation headers). 9 files: `analytics, catalog, document, entities, graph, hybrid, multimodal_query, observability, mod`. | **Delete** (after sunset window + prerequisite below).
-| `src/network/rest/v1/` | **LIVE canonical REST** infrastructure: `AppState`, `RestCoreServices`, `rank`, `rank_backend`, `graph.rs`, `primary_pod`, `progressive_search_handler`. Serves `/api/v2/*` (+ shared router plumbing). | **Keep.** (Touched by TD-104 #761.)
-| `crates/platform/proximadb-api/src/grpc/v1/` | **Deprecated** v1 gRPC services. 11 files: `collection, document, entity, graph, hybrid, observability, security, sql, streaming, vector, mod`. | **Delete** (after sunset window).
+| `crates/platform/proximadb-api/src/rest/v1/` | **LIVE canonical `/api/v2` REST (misnamed)** — port-backed router builders + handlers wired into production at `src/network/rest/v1/handlers.rs:1460-1542`: `create_graph_router` (`/api/v2/graphs/*`), `create_document_router`, `create_observability_router`, `create_multimodal_router`, `create_hybrid_search_router`. 9 files. | **Keep.** Do NOT delete — breaks the build + removes `/api/v2` routes. A module rename/relocate (e.g. `rest::v1`→`rest::canonical`) is TD-104 decomposition, not v1-sunset. |
+| `src/network/rest/v1/` | **LIVE canonical REST** infrastructure: `AppState`, `RestCoreServices`, `rank`, `rank_backend`, `graph.rs`, `primary_pod`, `progressive_search_handler`. Serves `/api/v2/*` (+ shared router plumbing). | **Keep.** (Touched by TD-104 #761.) |
+| `crates/platform/proximadb-api/src/grpc/v1/` | (Was the deprecated v1 gRPC services.) | **Already deleted** on `develop` (pre-existing); `grpc.rs:5-8` records the removal. Nothing remains. |
 |===
+
+== Reconciliation (2026-07-09) — original premise partially invalidated
+
+A fresh `origin/develop` worktree audit (the prompt's "don't trust this blindly"
+step) found the deletion targets are NOT the dead surface this TD assumed:
+
+* **Step 4 (gRPC v1 api-crate) — already complete.**
+  `crates/platform/proximadb-api/src/grpc/v1/` (11 files), `grpc/builder.rs`, and
+  the `lib.rs` `grpc::v1` re-export are all gone; `grpc.rs:5-8` documents the
+  removal. The sole residual `grpc::v1` reference workspace-wide is that
+  historical doc comment. Nothing to land.
+
+* **Step 3 (REST v1 api-crate) — INVALIDATED, do not execute.**
+  `crates/platform/proximadb-api/src/rest/v1/` is **LIVE `/api/v2` code**, not
+  deprecated. `src/network/rest/v1/handlers.rs:1460-1542` wires its
+  `create_{graph,document,observability,multimodal,hybrid_search}_router`
+  builders into production `/api/v2/*` routes (each guarded only by a runtime
+  `if let Some(port)` check — the `use proximadb_api::rest::{...}` imports are
+  compiled unconditionally). The `v1` path segment is a historical misnomer;
+  these are canonical port-backed routers. A blanket `git rm -r` would fail to
+  compile AND delete `/api/v2` routes. Relocating/renaming the module is TD-104
+  (root-crate decomposition) work, out of scope for the v1 sunset.
+
+* **Consequence — the REST v1 sunset is effectively already complete.** The
+  legacy `/api/v1/collections`, `/api/v1/search`, `/api/v1/sql`, and
+  `/api/v1/graph` routes were removed in the "API standardization hard-rename"
+  (see comments at `handlers.rs:1463-1479,1545`), and step 1's `v1_sunset`
+  middleware now `410`s any residual `/api/v1` traffic. No deprecated REST v1
+  *route handlers* remain; only the misnamed live `rest::v1` module dir.
+
+* **Step 2 — landed.** The deprecation-header utility was relocated to a neutral
+  `proximadb_api::rest::deprecation` module (decoupling the live `handlers.rs`
+  from the `rest::v1` namespace). Valid, non-breaking, independent of step 3.
+
+* **Step 5 — unchanged.** Remove `v1_sunset` middleware + mounts only after the
+  flip is proven safe through a sunset window (metrics/access-log/SDK audit).
+  This remains the sole outstanding REST-side action.
 
 == Prerequisite (easy to miss) — relocate the deprecation-header utility
 
@@ -74,14 +111,16 @@ deleted dir, so they go away with it.)
 == Hard-delete scope
 
 * **REST v1 adapters** — `crates/platform/proximadb-api/src/rest/v1/` (9 files).
-* **gRPC v1 services** — `crates/platform/proximadb-api/src/grpc/v1/` (11 files) +
-  the builder arm (`crates/platform/proximadb-api/src/grpc/builder.rs:11-16`,
-  guarded by the `enable_grpc_v1_compat` branch) + the re-export at
-  `crates/platform/proximadb-api/src/lib.rs:42`.
+  ❌ **NOT deletable** — this dir is LIVE `/api/v2` code (see Reconciliation
+  2026-07-09); the original "delete" plan was based on a wrong premise.
+* **gRPC v1 services** — ✅ **already deleted** on `develop`:
+  `crates/platform/proximadb-api/src/grpc/v1/` (11 files) + the builder arm +
+  the `lib.rs:42` re-export are all gone (`grpc.rs:5-8` records it).
 * **v1_sunset middleware** (`src/network/middleware/v1_sunset.rs`) + its two mount
-  points in `rest/server.rs` — delete only **after** the REST default has been off
-  through a sunset window (it's redundant once `/api/v1` is gone and the flip has
-  been observed in prod).
+  points in `rest/server.rs` — ⏳ delete only **after** the REST default has been
+  off through a sunset window (metrics/access-log/SDK audit); it's the escape
+  hatch to re-enable `/api/v1` if a late caller appears. **Sole outstanding
+  REST-side action.**
 
 === Cross-references to update (real breakage, not the live root-crate ones)
 
@@ -118,18 +157,22 @@ traffic:
 
 == Sequenced execution (do NOT collapse into one change)
 
-. **REST default flip** — `v1_sunset.rs:65` `None => true` → `None => false`.
-  One line. Breaking (`410` on `/api/v1/*`). **Requires sign-off.** Observe in
+. ✅ **DONE (#814, `9c9b0466`)** — **REST default flip** — `v1_sunset.rs:65`
+  `None => true` → `None => false`. Breaking (`410` on `/api/v1/*`). Observe in
   prod for the sunset window; revert is trivial if unexpected traffic appears.
-. **Relocate deprecation-header utility** (prerequisite above) — additive,
-  non-breaking, can land before or with step 3.
-. **Hard-delete REST v1 adapters** — remove `crates/platform/proximadb-api/src/rest/v1/`
-  after the window; repoint `handlers.rs:13`.
-. **Hard-delete gRPC v1 services** — remove `grpc/v1/` + builder arm + `lib.rs:42`
-  re-export; rewrite the one integration test.
-. **Remove v1_sunset middleware** + mount points (last; only after the flip is
-  proven safe — it's the escape hatch to re-enable `/api/v1` if a late caller
-  appears).
+. ✅ **DONE** — **Relocate deprecation-header utility** (prerequisite above) —
+  additive, non-breaking; moved to `proximadb_api::rest::deprecation`,
+  `handlers.rs:13` repointed.
+. ❌ **INVALIDATED — DO NOT EXECUTE** — **Hard-delete REST v1 adapters**: the
+  target `crates/platform/proximadb-api/src/rest/v1/` is LIVE `/api/v2` code (see
+  Reconciliation 2026-07-09). Deleting breaks the build + removes `/api/v2`
+  routes. A module rename is TD-104.
+. ✅ **ALREADY COMPLETE on `develop`** — **Hard-delete gRPC v1 services**:
+  `grpc/v1/` + builder arm + `lib.rs:42` re-export were already removed
+  (pre-existing); `grpc.rs:5-8` records it.
+. ⏳ **GATED (sole outstanding REST action)** — **Remove v1_sunset middleware** +
+  mount points (last; only after the flip is proven safe through a sunset window
+  — metrics/access-log/SDK audit — it's the escape hatch to re-enable `/api/v1`).
 . Each step = its own PR, CI-green (incl. `--features cluster` server-bin build +
   the v1-proto ratchet, which must not regress).
 

--- a/src/network/rest/v1/handlers.rs
+++ b/src/network/rest/v1/handlers.rs
@@ -10,7 +10,7 @@ use axum::{
     http::StatusCode,
     response::Json as JsonResponse,
 };
-use proximadb_api::rest::v1::add_rest_v1_deprecation_headers;
+use proximadb_api::rest::deprecation::add_rest_v1_deprecation_headers;
 use proximadb_graph_query::service::GraphExecutionService;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};


### PR DESCRIPTION
## What

Lands **TD-V1SUNSET-1 step 2** (relocate the REST v1 deprecation-header utility out of the `rest::v1` namespace) and reconciles the TD after a worktree audit disproved the rest of the plan's deletion premise.

## Step 2 — relocate deprecation-header util (code, additive / non-breaking)

The deprecation-header family (`add_rest_v1_deprecation_headers`, `with_v1_compatibility_headers`, their `apply_v1_deprecation_headers` helper, and the two consts) lived in `proximadb_api::rest::v1::mod`, but `add_rest_v1_deprecation_headers` is imported by **live** root-crate code (`src/network/rest/v1/handlers.rs:13`, which serves `/api/v2`). This moves the whole family to a new neutral `proximadb_api::rest::deprecation` module, re-exports it back into `rest::v1` (so that dir's internal `super::with_v1_compatibility_headers` call sites compile unchanged), and repoints `handlers.rs:13` at `rest::deprecation`.

## ⚠️ Step 3 is INVALIDATED — do NOT delete `rest/v1/`

The TD's boundary table classified `crates/platform/proximadb-api/src/rest/v1/` as "deprecated v1 adapters → delete." A fresh `origin/develop` audit proves this **wrong**: that directory holds the **live canonical `/api/v2` REST** router builders — `create_{graph,document,observability,multimodal,hybrid_search}_router` — wired into production at `src/network/rest/v1/handlers.rs:1460-1542` (e.g. `router.nest("/api/v2", create_graph_router()...)`, comment: "always wired in production since Phase 9.12"). The `v1` path segment is a historical misnomer. A `git rm -r` would fail to compile and remove `/api/v2/graphs`, `/api/v2/document-collections`, `/api/v2/observability`, `/api/v2/unified`, `/api/v2/hybrid`. **Not done; corrected in the TD.** Renaming the module is TD-104 (decomposition), not v1-sunset.

## Step 4 was already complete

`crates/platform/proximadb-api/src/grpc/v1/` (11 files), `grpc/builder.rs`, and the `lib.rs` `grpc::v1` re-export are already gone on `develop`; `grpc.rs:5-8` records the removal. Nothing to land.

## Net

The REST v1 sunset is effectively complete: legacy `/api/v1` routes were removed in the "API standardization hard-rename" and step 1 (#814) `410`s residual traffic. No deprecated REST v1 route handlers remain — only the misnamed **live** `rest::v1` module dir, which stays. The sole outstanding action is step 5 (remove the `v1_sunset` middleware + mounts), gated on sunset-window ops verification (metrics / access-log / SDK audit) — out of scope here.

## Verification
- `cargo check -p proximadb-api --tests` — green
- `cargo check --lib` (root crate, incl. the `handlers.rs:13` repoint) — green
- `cargo clippy -p proximadb-api --lib --bins -- -D warnings` — green (CI gate is `--lib --bins`; the one `--tests`-only `deprecated` lint at `lib.rs:469` is pre-existing TD-143 test code, untouched)
- `cargo fmt --check` (rustup 1.95.0) — green
- `scripts/check_td_adr_unique.py` — 0 errors
- `scripts/check_no_agent_attribution.py` — clean
- v1-proto ratchet: unaffected (step 2 moves no proto refs; no baseline refresh needed)

Commits: step 2 (`b04410b66`) + TD reconcile (`73ddfe131`).