### PR TITLE
ci(windows): promote python-feature tail to gating Rung 3 (TD-EMBED-1)

### DIFF
--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -1,12 +1,17 @@
-# Windows (MSVC) compile-only ratchet — TD-EMBED-1.
+# Windows (MSVC) compile ratchet — TD-EMBED-1.
 #
-# proximadb_embedded currently ships Linux + macOS wheels; Windows is blocked
-# only by the Rust engine not yet compiling for x86_64-pc-windows-msvc. This is
-# a COMPILE-ONLY ratchet (no wheel, no C-deps yet): each rung is a crate that
-# now compiles on Windows and MUST stay green. As blockers are fixed the gating
-# scope expands one rung at a time (ratchet only goes up). A separate,
-# non-gating "measure tail" step surfaces the NEXT blocker so the effort is
-# evidence-driven, not speculative.
+# proximadb_embedded now ships Linux + macOS + Windows wheels (release-python.yml
+# builds the x86_64-pc-windows-msvc wheel on every python-v* tag). This ratchet is
+# the FAST, PATH-GATED MSVC regression guard: each rung is a compile scope that
+# now works on Windows and MUST stay green. It fires on develop PRs so an MSVC
+# regression surfaces on the INTRODUCING PR (Mandate #9), not only at release-tag
+# time when the full wheel build runs. The ratchet only goes up.
+#
+# All three rungs are now GATING and the ratchet has reached compile parity with
+# the release wheel (root lib + `python` feature + C-deps all build on MSVC). The
+# end-to-end guard beyond compile — the actual wheel build/link + PyPI publish —
+# lives in release-python.yml; there is no non-gating "measure tail" left because
+# there is no next blocker to reveal.
 #
 # Path-gated + dispatch-only so it costs a Windows runner only when
 # Windows-relevant code changes.
@@ -47,6 +52,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
+      # Deterministic interpreter for the `python`-feature rung (PyO3 needs one at
+      # build time). Pin 3.12 to match release-python.yml's proven env rather than
+      # relying on whatever Python the runner image happens to ship.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       # ---- GATING RUNGS (must stay green; expand as blockers are fixed) --------
       # Rung 1: proximadb-storage-common compiles on Windows (memmap2::Advice
@@ -62,12 +73,14 @@ jobs:
       - name: Rung 2 — root proximadb lib (pure-Rust engine)
         run: cargo check -p proximadb --lib
 
-      # ---- MEASURE THE TAIL (non-gating; reveals the next blocker) -------------
-      # Next frontier toward the actual Windows wheel: the `python` feature, which
-      # pulls PyO3/numpy AND the C-deps (openssl/vendored -> openssl-src needs
-      # NASM+Perl on MSVC; aws-lc-sys already builds on the runner). This surfaces
-      # the C-dep/PyO3 blockers without blocking the ratchet. When it goes green,
-      # promote to a gating rung and add the windows wheel matrix row.
-      - name: Measure tail — root lib with python feature (informational)
-        continue-on-error: true
+      # Rung 3: the root lib WITH the `python` feature — PyO3/numpy plus the C-deps
+      # (openssl/vendored -> openssl-src builds VC-WIN64A via NASM + Strawberry
+      # Perl, both preinstalled on windows-2022; aws-lc-sys already builds on the
+      # runner). This is the exact compile the release wheel (release-python.yml,
+      # windows-2022 row) exercises, minus the link/package step — so once the
+      # wheel builds, this stays green. Promoted from the former non-gating measure
+      # tail to GATING (windows-2022 pinned to match the wheel's proven env) so an
+      # MSVC C-dep/PyO3 regression is caught on the introducing develop PR, not
+      # deferred to the next release tag.
+      - name: Rung 3 — root proximadb lib with python feature (PyO3 + C-deps)
         run: cargo check -p proximadb --lib --features python

--- a/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
+++ b/docs/10-quality/td/TD-EMBED-1-macos-windows-embedded-wheels.adoc
@@ -108,5 +108,9 @@ byte-for-byte, so no flag-day and no risk to the currently-shipping wheels.
   on `windows-2022` (release engine build + `openssl-src` VC-WIN64A + `.pyd` link). The
   `windows-2022`/`x86_64` row is live in `build-embedded-wheels`; `publish-embedded-pypi`'s
   `*embedded-wheels*` glob ships it on the next `python-v*` tag. The `windows-compile-ratchet`
-  workflow stays as the fast, path-gated regression guard (rungs 1-2 gating: storage-common +
-  root lib on MSVC).
+  workflow stays as the fast, path-gated regression guard, now at compile parity with the release
+  wheel — **rungs 1-3 all gating**: storage-common (rung 1), root lib default features (rung 2),
+  and root lib + `python` feature + C-deps (rung 3, promoted from the former non-gating measure
+  tail). The measure tail is retired: there is no next blocker to reveal, so an MSVC C-dep/PyO3
+  regression now fails the introducing develop PR rather than waiting for the release-tag wheel
+  build.


### PR DESCRIPTION
## What

Promotes the `windows-compile-ratchet` workflow's `python`-feature step from a non-gating "measure tail" (`continue-on-error: true`) to a **gating Rung 3**.

- `cargo check -p proximadb --lib --features python` now **fails the PR** on an MSVC C-dep/PyO3 regression instead of only warning.
- Adds `actions/setup-python@v5` pinned to **3.12** so PyO3 gets a deterministic build-time interpreter, matching `release-python.yml`'s proven env (rather than relying on whatever Python the runner image ships).
- Refreshes the workflow header + `TD-EMBED-1` verification note: the ratchet is now at compile parity with the release wheel (rungs 1–3 all gating); the measure tail is retired since there's no next blocker to reveal.

## Why

The identical compile (`--features python`, vendored OpenSSL → `openssl-src` VC-WIN64A, `aws-lc-sys`) already succeeds in `release-python.yml`'s `windows-2022` wheel build — NASM + Strawberry Perl are preinstalled there, no extra setup. `cargo check` is a strict subset of that build, so it is green today.

The value over the release-time wheel build: the ratchet is **path-gated and runs on develop PRs**, so an MSVC regression surfaces on the *introducing* PR (Mandate #9) rather than being deferred to the next `python-v*` release tag. Cost stays bounded — path-gated, so a Windows runner only fires on Windows-relevant changes.

## Test

- YAML validates; `check_td_adr_unique.py` clean (0 errors); `check_no_agent_attribution.py` clean.
- The gating rung's compile is the same one `release-python.yml` already builds/publishes on `windows-2022`.