### PR TITLE
feat(pax): ranged reads for PaxSplitReader — index-zone block pruning (TD-DOC-PUSHDOWN-1 L1)

### DIFF
--- a/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
+++ b/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
@@ -4,12 +4,17 @@
 
 [cols="1,3"]
 |===
-|Status|Open — **blocked-on / coordinated-with the OLAP PAX scan source** (TD-OLAP-14 / TD-OLAP-1).
-Design filed here so the ADR-055 rollout has an honest terminal state: the write-side (P-Shred),
-universal provisioning (P-Provision), the `documents(collection)` DataFusion SQL surface (P-DFSource),
-the io_trace evidence gate (P-Trace), and legacy retirement (P-Retire) all landed; **predicate/
-projection pushdown is the one remaining phase, and it is a single coupled piece with the OLAP
-reader — it does not land as independent document code.**
+|Status|Open — **Layer 1 (reader ranged read) LANDED; Layer 2 + adapter remain.** Owning the
+reader (rather than waiting on the OLAP workstream) is underway. **Layer 1** — `PaxSplitReader` now
+fetches a segment via ranged reads (locate the index from a tail suffix → prune whole blocks against
+the index **zone summary** → `read_ranges` only survivors → decode to Arrow), default-OFF
+(`PROXIMADB_DF_PAX_RANGED`), mixed-read-safe (falls back to the whole-file read for any segment
+without a v2 zone index). Verified against the gate shape: a selective predicate reads
+`bytes_read < whole segment` with `range_gets > 0` and returns rows identical to the whole-file path.
+**Layer 2** (shredded user-column ranged pruning) + the **documents adapter** remain — see
+"Remaining". The write-side (P-Shred), universal provisioning (P-Provision), the
+`documents(collection)` DataFusion SQL surface (P-DFSource), the io_trace evidence gate (P-Trace),
+and legacy retirement (P-Retire) all landed previously.
 |Priority|MEDIUM (the co-design payoff phase — turns the declared shredded format into a *measured*
 `bytes_read` reduction; but the byte win is gated on reader-level ranged/pruned PAX reads owned by
 the OLAP workstream, not on document code).
@@ -80,9 +85,35 @@ avoid a competing ranged-read implementation colliding with the OLAP scan source
 byte win belongs in TD-OLAP-14; document pushdown consumes it.
 ====
 
-== Design (when the OLAP scan source lands)
+== Layered plan (what landed, what remains)
 
-Consume, don't rebuild. The remaining *document-side* work is a thin adapter over the OLAP reader:
+Verifying the prerequisites surfaced that `PaxSplitReader` (#736) still did **one whole-file read** —
+its own comment: *"ranged reads are a follow-up. This is the only I/O path"* (`pax_adapter.rs:111`) —
+and that `RangedSegmentReader` (a footer-first ranged reader with full block pruning) already exists
+but is disconnected (built on `ObjectStoreBridge`/`FilterExpression`/`ProximaRecord`, not the
+DataFusion `FilesystemFactory`/`PhysicalExpr`/Arrow path). So "own the reader" splits cleanly:
+
+* **Layer 1 — reader ranged read + index-zone pruning (LANDED).** `PaxSplitReader::load_ranged`:
+  `metadata` for size → tail-suffix GET → `SegmentIndex::locate_in_suffix` (grow-and-retry) → prune
+  whole blocks against each `BlockIndexEntry.zone` **summary** using the SAME `BlockZoneSource` prune
+  logic as the decode path (`block_may_contain` generalized over `&dyn BlockZoneSource`) →
+  `read_ranges` only survivors → `PaxBlockReader::open` each → decode to Arrow. Default-OFF
+  (`PROXIMADB_DF_PAX_RANGED`), mixed-read-safe fallback to whole-file. io_trace records
+  `fetch_pax_ranged` + `bytes_read` + `range_gets`. This is **general** — every DataFusion PAX scan
+  with a temporal/canonical predicate now prunes blocks off the wire, not just documents.
+* **Layer 2 — shredded user-column ranged pruning (REMAINING).** The v2 index `BlockZoneSummary`
+  carries **canonical-column** bounds only (`created_at`/`updated_at`/`valid_from`/`valid_to`/
+  `edge_weight`); shredded `props__<key>` user columns hit the `_ => {}` arm of `from_column_metas`,
+  so a *document-field* predicate cannot prune from the index alone. Pruning on shredded columns
+  without a full block GET needs **per-block footer ranged reads** — exactly what `RangedSegmentReader`
+  (`BlockLayout` + `metadata_ranges`) already does. Wire `PaxSplitReader` to consume that (adapt
+  `FilesystemFactory`→`ObjectStoreBridge`), or hoist user-column bounds into the index summary
+  (versioned format change). This is what closes the *document-field* `bytes_read` gate.
+* **Adapter — `documents()` → `PaxTableProvider` (REMAINING).** The thin document-side wiring below.
+
+== Design (documents adapter — rides on the ranged reader)
+
+Consume, don't rebuild. The remaining *document-side* work is a thin adapter over the ranged reader:
 
 . **Runtime-safe scan inputs on the record port.** `RecordRoutePort::pax_scan_inputs(collection,
   tenant) -> Option<PaxScanInputs>` returning the `DrPathBuilder` base path + column descriptors

--- a/src/datafusion/engine_adapters/pax_adapter.rs
+++ b/src/datafusion/engine_adapters/pax_adapter.rs
@@ -45,9 +45,11 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use tracing::trace;
 
-use proximadb_block_format::{ColumnRole, PaxBlockReader};
+use proximadb_block_format::{BlockZoneSource, ColumnRole, PaxBlockReader};
 use proximadb_storage_common::format_splits::{ScalarPredicate, ScalarValue};
-use proximadb_storage_common::pax_block::{PaxSegmentScanner, ScanPredicate};
+use proximadb_storage_common::pax_block::{PaxSegmentScanner, ScanPredicate, SegmentIndex};
+
+use crate::observability::io_trace;
 
 use crate::datafusion::physical_filter_translate::pruning_predicates;
 use crate::datafusion::proxima_scan_exec::{EmptyRecordBatchStream, SplitReader};
@@ -65,6 +67,30 @@ pub fn pax_reader_enabled() -> bool {
             .unwrap_or(false)
     })
 }
+
+/// `true` when the PAX-native reader should fetch a segment via **ranged reads**
+/// (index-zone prune → `read_ranges` of surviving blocks only) instead of one
+/// whole-file read (TD-DOC-PUSHDOWN-1). Default OFF — mixed-read-safe: falls back
+/// to the whole-file path for any segment without a locatable v2 zone index, and
+/// the whole-file path stays the default until the ranged path is baked (ADR-052
+/// observe→flip). Gate: `PROXIMADB_DF_PAX_RANGED`.
+pub fn pax_ranged_read_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_DF_PAX_RANGED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
+/// Smallest possible segment tail (`[body_len u32][PAXZ][SEGMENT_MAGIC 8]` at
+/// minimum) — below this a file cannot carry a locatable index, so skip ranged.
+const SEGMENT_INDEX_TRAILER_MIN: u64 = 16;
+
+/// Initial tail suffix GET size when locating the segment index; grown ×4 on a
+/// short suffix. 64 KiB holds a typical multi-block segment's index in one GET
+/// (matches `RangedSegmentReader::INITIAL_SUFFIX`).
+const RANGED_INITIAL_SUFFIX: u64 = 64 * 1024;
 
 /// PAX-native OLAP split reader. Loads a PAX **segment** and iterates its blocks
 /// via the canonical [`PaxSegmentScanner`] (each yielded block is a
@@ -106,9 +132,10 @@ impl PaxSplitReader {
         }
     }
 
-    /// Whole-file read of the split's PAX bytes. Slice-1 simplification: a PAX
-    /// segment is one block ≈ one batch, so `split.offset`/`length` are not
-    /// honored (ranged reads are a follow-up). This is the only I/O path.
+    /// Whole-file read of the split's PAX bytes — the default path and the
+    /// mixed-read-safe fallback for segments without a locatable v2 zone index.
+    /// The pruning ranged path (fetch only surviving blocks) is [`Self::load_ranged`],
+    /// engaged by `PROXIMADB_DF_PAX_RANGED` (TD-DOC-PUSHDOWN-1).
     async fn load_bytes(&self, split: &FileSplit) -> DFResult<Vec<u8>> {
         self.filesystem_factory
             .read(&split.file_path)
@@ -119,6 +146,105 @@ impl PaxSplitReader {
                     split.file_path
                 ))
             })
+    }
+
+    /// Ranged read (TD-DOC-PUSHDOWN-1): locate the segment index from a small tail
+    /// suffix, prune blocks against the **index zone summary** (no block body GET),
+    /// then `read_ranges` only the SURVIVING blocks and decode each to Arrow. This
+    /// is the byte-read win the whole-file [`Self::load_bytes`] path leaves on the
+    /// table: a temporal/canonical-column predicate prunes whole blocks off the
+    /// wire (`bytes_read` < segment, `range_gets` > 0), reusing the SAME
+    /// [`BlockZoneSource`] prune logic as the decode path.
+    ///
+    /// Returns `Ok(None)` — signalling the caller to fall back to the whole-file
+    /// path — when the segment has no locatable/zone-bearing index (legacy v1
+    /// segments, tiny single-block segments), so it is mixed-read-safe with no
+    /// flag-day. Only the shared v2 index zone summary (canonical columns) prunes
+    /// here; shredded user-column pruning needs per-block footer ranged reads
+    /// (`RangedSegmentReader`) — the next slice.
+    async fn load_ranged(
+        &self,
+        split: &FileSplit,
+        out_schema: &SchemaRef,
+    ) -> DFResult<Option<Vec<RecordBatch>>> {
+        let path = &split.file_path;
+        let len = match self.filesystem_factory.metadata(path).await {
+            Ok(m) => m.size,
+            Err(_) => return Ok(None), // no cheap size → fall back
+        };
+        if len < SEGMENT_INDEX_TRAILER_MIN {
+            return Ok(None);
+        }
+        // Probe the tail for the segment index, growing on a short suffix.
+        let mut probe = RANGED_INITIAL_SUFFIX.min(len);
+        let mut suffix_bytes: u64 = 0;
+        let index = loop {
+            let start = len - probe;
+            let suffix = self
+                .filesystem_factory
+                .read_range(path, start, probe)
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("PAX ranged tail read: {e}")))?;
+            suffix_bytes += suffix.len() as u64;
+            match SegmentIndex::locate_in_suffix(&suffix) {
+                Ok(Some(idx)) => break idx,
+                Ok(None) if probe < len => probe = (probe.saturating_mul(4)).min(len),
+                // No index found even reading the whole file, or a corrupt tail:
+                // fall back to the whole-file path (which surfaces real errors).
+                Ok(None) | Err(_) => return Ok(None),
+            }
+        };
+        // Prune blocks against the index zone summary (v1 entries carry no zone ⇒
+        // cannot prune from the index ⇒ conservatively keep).
+        let mut survivors: Vec<&proximadb_storage_common::pax_block::BlockIndexEntry> = Vec::new();
+        for entry in &index.blocks {
+            let pruned = match &entry.zone {
+                Some(zone) => self.pruned_by(zone as &dyn BlockZoneSource),
+                None => false,
+            };
+            if !pruned {
+                survivors.push(entry);
+            }
+        }
+        io_trace::record_op_str("fetch_pax_ranged");
+        if survivors.is_empty() {
+            // Every block pruned off the wire — only the tail suffix was read.
+            io_trace::record_bytes_read(suffix_bytes);
+            return Ok(Some(Vec::new()));
+        }
+        let ranges: Vec<std::ops::Range<u64>> = survivors
+            .iter()
+            .map(|e| e.offset..e.offset + e.size as u64)
+            .collect();
+        let block_bytes: u64 = ranges.iter().map(|r| r.end - r.start).sum();
+        let bufs = self
+            .filesystem_factory
+            .read_ranges(path, ranges)
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("PAX ranged block read: {e}")))?;
+        // Each surviving block is fetched with one ranged GET; add the tail probe.
+        io_trace::record_range_gets(survivors.len() as u64 + 1);
+        io_trace::record_bytes_read(block_bytes + suffix_bytes);
+        let mut batches = Vec::with_capacity(bufs.len());
+        for buf in &bufs {
+            let reader = PaxBlockReader::open(buf)
+                .map_err(|e| DataFusionError::Execution(format!("PAX ranged block open: {e}")))?;
+            // Defence-in-depth: the index summary prunes on canonical columns only;
+            // re-run the full prune on the decoded block (idempotent, cheap).
+            if self.block_pruned(&reader) {
+                continue;
+            }
+            let arrays: Vec<ArrayRef> = out_schema
+                .fields()
+                .iter()
+                .map(|f| self.decode_column(&reader, f.name()))
+                .collect::<DFResult<_>>()?;
+            let batch = RecordBatch::try_new(out_schema.clone(), arrays).map_err(|e| {
+                DataFusionError::Execution(format!("PAX ranged batch build failed: {e}"))
+            })?;
+            batches.push(batch);
+        }
+        Ok(Some(batches))
     }
 
     /// Core decode (no I/O): segment bytes → [`PaxSegmentScanner`] → per-block
@@ -150,15 +276,22 @@ impl PaxSplitReader {
         Ok(batches)
     }
 
-    /// AND-semantics block prune: returns `true` if ANY conjunctive predicate
-    /// provably excludes the block. Unrecognized column/operator ⇒ no prune.
-    fn block_pruned(&self, reader: &PaxBlockReader) -> bool {
+    /// AND-semantics prune over any [`BlockZoneSource`] (a decoded [`PaxBlockReader`]
+    /// or the index [`BlockZoneSummary`]): returns `true` if ANY conjunctive
+    /// predicate provably excludes the block. Unknown column/operator ⇒ no prune.
+    fn pruned_by(&self, src: &dyn BlockZoneSource) -> bool {
         self.prune_predicates.iter().any(|(name, pred)| {
             let Some(&cid) = self.name_to_col_id.get(name) else {
                 return false; // unknown column → cannot prune
             };
-            !block_may_contain(reader, cid, pred)
+            !block_may_contain(src, cid, pred)
         })
+    }
+
+    /// AND-semantics block prune on a decoded block. Unrecognized column/operator
+    /// ⇒ no prune.
+    fn block_pruned(&self, reader: &PaxBlockReader) -> bool {
+        self.pruned_by(reader)
     }
 
     /// Decode one column by its DataFusion name → PAX column_id → typed stripe.
@@ -209,8 +342,20 @@ impl SplitReader for PaxSplitReader {
             ),
             None => self.schema.clone(),
         };
-        let bytes = self.load_bytes(split).await?;
-        let batches = self.decode_segment(&bytes, &out_schema)?;
+        // Ranged path (default-OFF): prune whole blocks off the wire via the index
+        // zone summary, fetch only survivors. Falls back to the whole-file read for
+        // any segment without a locatable v2 zone index (mixed-read-safe).
+        let batches = match if pax_ranged_read_enabled() {
+            self.load_ranged(split, &out_schema).await?
+        } else {
+            None
+        } {
+            Some(batches) => batches,
+            None => {
+                let bytes = self.load_bytes(split).await?;
+                self.decode_segment(&bytes, &out_schema)?
+            }
+        };
         if batches.is_empty() {
             Ok(Box::pin(EmptyRecordBatchStream::new(out_schema)))
         } else {
@@ -266,33 +411,33 @@ fn decode_bytes(reader: &PaxBlockReader, cid: i32, name: &str) -> DFResult<Vec<O
 }
 
 /// `true` iff the block MAY contain a row satisfying `pred` (i.e. NOT pruned).
-/// Conservative: any unrecognized shape returns `true` (cannot prune).
-fn block_may_contain(reader: &PaxBlockReader, cid: i32, pred: &ScalarPredicate) -> bool {
+/// Conservative: any unrecognized shape returns `true` (cannot prune). Operates on
+/// any [`BlockZoneSource`] so the SAME logic prunes a decoded block AND the
+/// index-only zone summary of the ranged read path.
+fn block_may_contain(src: &dyn BlockZoneSource, cid: i32, pred: &ScalarPredicate) -> bool {
     use ScalarPredicate as P;
     use ScalarValue as V;
     match pred {
         // Point equality → i64 zone point / f64 degenerate range / string bloom+hash.
-        P::Equal(V::Int64(v)) => reader.column_may_contain_i64(cid, *v),
-        P::Equal(V::Float64(v)) => reader.column_range_overlaps_f64(cid, *v, *v),
-        P::Equal(V::String(s)) => reader.column_may_contain_str(cid, s),
+        P::Equal(V::Int64(v)) => src.may_contain_i64(cid, *v),
+        P::Equal(V::Float64(v)) => src.range_overlaps_f64(cid, *v, *v),
+        P::Equal(V::String(s)) => src.may_contain_str(cid, s),
         // i64 ranges: Gt/GtEq ⇒ [v, MAX]; Lt/LtEq ⇒ [MIN, v]; Between ⇒ [lo, hi].
         P::GreaterThan(V::Int64(v)) | P::GreaterThanOrEqual(V::Int64(v)) => {
-            reader.column_range_overlaps_i64(cid, *v, i64::MAX)
+            src.range_overlaps_i64(cid, *v, i64::MAX)
         }
         P::LessThan(V::Int64(v)) | P::LessThanOrEqual(V::Int64(v)) => {
-            reader.column_range_overlaps_i64(cid, i64::MIN, *v)
+            src.range_overlaps_i64(cid, i64::MIN, *v)
         }
-        P::Between(V::Int64(lo), V::Int64(hi)) => reader.column_range_overlaps_i64(cid, *lo, *hi),
+        P::Between(V::Int64(lo), V::Int64(hi)) => src.range_overlaps_i64(cid, *lo, *hi),
         // f64 ranges.
         P::GreaterThan(V::Float64(v)) | P::GreaterThanOrEqual(V::Float64(v)) => {
-            reader.column_range_overlaps_f64(cid, *v, f64::INFINITY)
+            src.range_overlaps_f64(cid, *v, f64::INFINITY)
         }
         P::LessThan(V::Float64(v)) | P::LessThanOrEqual(V::Float64(v)) => {
-            reader.column_range_overlaps_f64(cid, f64::NEG_INFINITY, *v)
+            src.range_overlaps_f64(cid, f64::NEG_INFINITY, *v)
         }
-        P::Between(V::Float64(lo), V::Float64(hi)) => {
-            reader.column_range_overlaps_f64(cid, *lo, *hi)
-        }
+        P::Between(V::Float64(lo), V::Float64(hi)) => src.range_overlaps_f64(cid, *lo, *hi),
         // NotEqual / IsNull / IsNotNull / In / Bool / Null / type-mismatched ⇒ cannot prune.
         _ => true,
     }
@@ -370,6 +515,120 @@ mod tests {
             .unwrap();
         assert_eq!(ca.value(0), 1000);
         assert_eq!(ca.value(1), 3000);
+    }
+
+    /// Flatten the `created_at` column of a batch set into a sorted `Vec<i64>` for
+    /// order-independent row-set comparison.
+    fn collect_created_at(batches: &[RecordBatch]) -> Vec<i64> {
+        let mut v = Vec::new();
+        for b in batches {
+            let ca = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("created_at is Int64");
+            for i in 0..b.num_rows() {
+                v.push(ca.value(i));
+            }
+        }
+        v.sort_unstable();
+        v
+    }
+
+    /// Write a MULTI-block `.pax` segment (`n` rows, `created_at = (i+1)*1000`, a
+    /// tiny target block so each block spans a small disjoint `created_at` range)
+    /// and return its discovered [`FileSplit`] + on-disk size.
+    async fn multiblock_split(
+        dir: &std::path::Path,
+        n: i64,
+        target_block: usize,
+        fs: &Arc<FilesystemFactory>,
+    ) -> (crate::storage::formats::FileSplit, u64) {
+        let records: Vec<_> = (0..n)
+            .map(|i| record(&format!("r{i:04}"), "t", (i + 1) * 1000))
+            .collect();
+        let path = dir.join("seg.pax");
+        write_pax_segment(
+            &path,
+            &records,
+            "col",
+            0,
+            VectorQuant::Auto,
+            Some(target_block),
+        )
+        .expect("write_pax_segment");
+        let file_len = std::fs::metadata(&path).unwrap().len();
+        let base = format!("{}", dir.display());
+        let splits =
+            crate::datafusion::engine_adapters::pax_segment_locator::discover_pax_segments(
+                &base, fs,
+            )
+            .await
+            .unwrap();
+        let split = splits
+            .into_iter()
+            .find(|s| s.file_path.ends_with("seg.pax"))
+            .expect("discovered seg.pax split");
+        (split, file_len)
+    }
+
+    /// The P-Pushdown gate (TD-DOC-PUSHDOWN-1): a selective predicate makes the
+    /// ranged reader fetch only surviving blocks — `bytes_read < whole segment`
+    /// with `range_gets > 0` — AND returns EXACTLY the rows the whole-file path
+    /// would (block-level pruning parity).
+    #[tokio::test]
+    async fn ranged_read_prunes_blocks_off_the_wire() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = Arc::new(FilesystemFactory::create_default().await.unwrap());
+        let (split, file_len) = multiblock_split(tmp.path(), 200, 400, &fs).await;
+
+        let (schema, map) = created_at_schema();
+        // created_at >= 150_000 ⇒ only the upper ~quarter of blocks survive; the
+        // lower blocks are pruned from the index zone summary before any body GET.
+        let filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            col("created_at", schema.as_ref()).unwrap(),
+            Operator::GtEq,
+            lit(150_000i64),
+        ));
+        let reader = PaxSplitReader::new(schema.clone(), fs.clone(), map, vec![filter]);
+
+        let (ranged_rows, snap) = io_trace::scope(async {
+            let batches = reader
+                .load_ranged(&split, &schema)
+                .await
+                .unwrap()
+                .expect("v2 zone index present ⇒ ranged path taken (not a fallback)");
+            let rows = collect_created_at(&batches);
+            (rows, io_trace::snapshot().expect("io_trace scope active"))
+        })
+        .await;
+
+        assert!(
+            snap.range_gets > 0,
+            "ranged GETs issued: {}",
+            snap.range_gets
+        );
+        assert!(
+            snap.bytes_read < file_len,
+            "ranged bytes_read {} must be < whole segment {file_len}",
+            snap.bytes_read
+        );
+
+        // Parity vs the whole-file path on the SAME filter.
+        let disk_path = split
+            .file_path
+            .strip_prefix("file://")
+            .unwrap_or(&split.file_path);
+        let whole = std::fs::read(disk_path).expect("read segment back");
+        let baseline_rows = collect_created_at(&reader.decode_segment(&whole, &schema).unwrap());
+        assert!(
+            !ranged_rows.is_empty(),
+            "some upper blocks survive the filter"
+        );
+        assert_eq!(
+            ranged_rows, baseline_rows,
+            "ranged rows must equal whole-file rows (block-prune parity)"
+        );
     }
 
     #[tokio::test]

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -1080,6 +1080,30 @@ impl FilesystemFactory {
         result
     }
 
+    /// Read a single byte range `[offset, offset+length)` from `url`. Convenience
+    /// over `get_filesystem(url).read_range(...)` mirroring [`Self::read`] — used by
+    /// the PAX-native ranged reader to fetch a segment's tail index and individual
+    /// surviving blocks without pulling the whole object (TD-DOC-PUSHDOWN-1).
+    pub async fn read_range(&self, url: &str, offset: u64, length: u64) -> FsResult<Vec<u8>> {
+        let fs = self.get_filesystem(url)?;
+        let path = Self::resolve_path(url)?;
+        fs.read_range(&path, offset, length).await
+    }
+
+    /// Read multiple byte ranges from `url` in one batched call — the object-store
+    /// backend coalesces adjacent ranges into fewer GETs. Mirrors [`Self::read`];
+    /// the ranged PAX reader uses this to fetch all surviving blocks of a pruned
+    /// scan together.
+    pub async fn read_ranges(
+        &self,
+        url: &str,
+        ranges: Vec<std::ops::Range<u64>>,
+    ) -> FsResult<Vec<Vec<u8>>> {
+        let fs = self.get_filesystem(url)?;
+        let path = Self::resolve_path(url)?;
+        fs.read_ranges(&path, ranges).await
+    }
+
     pub async fn write(
         &self,
         url: &str,


### PR DESCRIPTION
## What

`PaxSplitReader` did **one whole-file read** per segment (*"ranged reads are a follow-up. This is the only I/O path"* — `pax_adapter.rs:111`). This adds the **ranged read path**: prune whole blocks off the wire, then fetch only survivors.

`load_ranged`:
1. `metadata` for size → tail-suffix GET → `SegmentIndex::locate_in_suffix` (grow-and-retry).
2. Prune whole blocks against each `BlockIndexEntry.zone` **summary** — the same `BlockZoneSource` prune logic as the decode path (`block_may_contain` generalized over `&dyn BlockZoneSource`, so a decoded `PaxBlockReader` and the index `BlockZoneSummary` share **one** implementation — no duplication).
3. `read_ranges` **only surviving blocks** → `PaxBlockReader::open` each → decode to Arrow.

Supporting: `FilesystemFactory::read_range`/`read_ranges` (mirror `read()`); io_trace records `fetch_pax_ranged` + `bytes_read` + `range_gets`.

## Safety / rollout
- **Default-OFF** (`PROXIMADB_DF_PAX_RANGED`); the whole-file read stays the default until baked (ADR-052 observe→flip).
- **Mixed-read-safe**: falls back to the whole-file read for any segment without a locatable v2 zone index (legacy v1, tiny single-block). No flag-day.

## Verified — the P-Pushdown gate shape
`ranged_read_prunes_blocks_off_the_wire`: a multi-block segment + selective `created_at` predicate reads **`bytes_read` < whole segment** with **`range_gets` > 0**, and returns rows **byte-identical** to the whole-file path (block-prune parity). Full `pax_adapter` suite: 4/4 pass. `cargo fmt --check`, `clippy --lib --bins -D warnings`: clean.

## Scope (honest)
This is **Layer 1** of TD-DOC-PUSHDOWN-1 — **general** to every DataFusion PAX scan with a temporal/canonical predicate, not only documents. The index zone summary carries **canonical-column** bounds only, so shredded document-field (`props__<key>`) pruning needs **Layer 2** (per-block footer ranged reads, à la the existing `RangedSegmentReader`), and the `documents()`→`PaxTableProvider` **adapter** rides on top. Both remain; the TD is updated with the layered plan.

Relates to TD-DOC-PUSHDOWN-1, ADR-055, TD-OLAP-1/#736, TD-OLAP-14.