### PR TITLE
feat(olap): native parity — vectorized ungrouped aggregate + footer metadata elision (TD-OLAP-4)

### DIFF
--- a/docs/10-quality/td/TD-OLAP-12-native-morsel-scheduler.adoc
+++ b/docs/10-quality/td/TD-OLAP-12-native-morsel-scheduler.adoc
@@ -101,6 +101,30 @@ hook (ADR-054 §12 Q3, ratified).
 unsupported shape (e.g. an operator that opts out of parallel scheduling) falls back to serial
 execution — the scheduler is additive, never a correctness dependency.
 
+== Motivating evidence (TD-OLAP-4 shadow, 2026-07-10)
+
+The TD-OLAP-4 native-parquet shadow now supplies the cost-term evidence this TD's P3
+priority demanded ("do not build ahead of ledger evidence that a parallel scheduler moves a
+cost term"). At **100M rows (real ClickBench `hits`)**, with the ungrouped `HashAggregate`
+**vectorized** (Arrow kernels, single-threaded) and metadata elision on, native's residual
+loss on **ungrouped scalar aggregates** is attributable *purely to single-threaded execution*:
+
+[cols="2,1,1,1,3", options="header"]
+|===
+| Query | DataFusion | native (1 thread) | DuckDB | Attribution
+| q03 `SUM,COUNT,AVG` | 186ms | 358ms (1.9×) | 61ms | single-thread vs DataFusion `AggregateMode::Partial` across `target_partitions`
+| q04 `AVG(UserID)` | 240ms | 329ms (1.4×) | 127ms | single-thread vs DuckDB morsel-driven `LocalSinkState`→`Combine`
+| q07 `MIN/MAX` | 1609ms | 66ms → ~1ms (elided) | 38ms | native WINS (elision / low overhead)
+| q01 `COUNT(*)` | 12ms | 1ms (elided) | 26ms | native WINS (footer)
+|===
+
+Source review (DataFusion 54 `SumAccumulator<T>`, DuckDB `physical_ungrouped_aggregate`)
+confirms both competitors are **native-type + multi-core**; native's vectorized operators are
+per-op competitive but run on **one** `BatchStream`. The gap is the parallelism this TD adds —
+**not** cast overhead (per-batch, ~8MB, negligible) and not the kernels. This is the measured
+justification to sequence the impl. The vectorized `UngroupedState` (per-batch fold + associative
+`finalize`) is precisely the **morsel partial-state + combine** shape this scheduler fans out.
+
 == Gate (ADR-052 mandate #4 — measured, not asserted)
 
 Promotion requires the **TD-OLAP-4 ledger** showing:

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -730,6 +730,31 @@ impl ObjectStoreParquetTable {
         any.then_some(total)
     }
 
+    /// TD-OLAP-4 metadata elision: the footer-derived numeric `(min, max,
+    /// null_count)` for a column, reduced (min-of-mins / max-of-maxes / Σ nulls)
+    /// across ALL row-group splits — the input for eliding unfiltered
+    /// `MIN`/`MAX`/`COUNT(col)` without a scan. Returns `None` unless EVERY split
+    /// carries numeric bounds for the column (a partially-covered column would
+    /// understate the range), or the bounds are non-numeric (truncated string
+    /// stats → the caller scans, matching DataFusion's `Inexact` guard).
+    pub fn aggregate_numeric_bounds(&self, col: &str) -> Option<(f64, f64, u64)> {
+        if self.splits.is_empty() {
+            return None;
+        }
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        let mut nulls: u64 = 0;
+        for split in &self.splits {
+            let cb = split.statistics.column_stats.get(col)?;
+            nulls = nulls.saturating_add(cb.null_count);
+            let mn = cb.min.as_ref()?.as_f64()?;
+            let mx = cb.max.as_ref()?.as_f64()?;
+            lo = lo.min(mn);
+            hi = hi.max(mx);
+        }
+        Some((lo, hi, nulls))
+    }
+
     /// Count row-group splits that survive the given filters. Uses min/max
     /// zone-maps plus (bloom semi-join default-ON; disable with
     /// `PROXIMADB_DF_BLOOM_SEMIJOIN=0`) any split key
@@ -1364,6 +1389,33 @@ mod tests {
         let table = ObjectStoreParquetTable::open(&location).await.unwrap();
         assert_eq!(table.split_count(), 2);
         assert_eq!(table.schema().fields().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn aggregate_numeric_bounds_reduces_min_max_across_row_groups() {
+        // Two row groups: x = [1,2] and [100,101]. Footer elision must reduce to
+        // min-of-mins=1, max-of-maxes=101 across BOTH splits (not just the first).
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        write_two_row_group_parquet(&data_dir.join("part-0.parquet"));
+
+        let location = format!("file://{}", tmp.path().display());
+        let table = ObjectStoreParquetTable::open(&location).await.unwrap();
+        assert_eq!(table.split_count(), 2, "two row groups");
+
+        let (min, max, nulls) = table.aggregate_numeric_bounds("x").expect("numeric bounds");
+        assert_eq!(min, 1.0, "min-of-mins across both row groups");
+        assert_eq!(max, 101.0, "max-of-maxes across both row groups");
+        assert_eq!(nulls, 0);
+        // A truncated-stats / string column reduces to numeric `None` (→ scan).
+        assert!(
+            table.aggregate_numeric_bounds("k").is_none()
+                || table.aggregate_numeric_bounds("k").unwrap().0.is_nan(),
+            "string column has no numeric bounds"
+        );
+        // A missing column → None (never a wrong bound).
+        assert!(table.aggregate_numeric_bounds("nope").is_none());
     }
 
     #[tokio::test]

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -700,6 +700,206 @@ fn single_scan_columns(plan: &PhysicalPlan) -> Option<Vec<String>> {
     (count == 1).then_some(out).flatten()
 }
 
+/// Is this an unfiltered, ungrouped `COUNT(*)` (possibly under a `Limit`) directly
+/// over a `Scan`? Then the answer is the sum of the parquet/PAX footer row counts —
+/// a metadata read, no column scan. (`scan_cols` can't detect this: the relational
+/// `Scan.output_schema` is full-width, so COUNT(*) would otherwise read all columns.)
+#[cfg(feature = "datafusion-integration")]
+fn is_pure_count_star(plan: &PhysicalPlan) -> bool {
+    use proximadb_relational_algebra::AggregateExpr;
+    match plan {
+        // A `COUNT(*)` lowers to `Project(Aggregate(Scan))` (the Project names/orders
+        // the output) — recurse through both Project and Limit to the Aggregate.
+        PhysicalPlan::Limit { input, .. } | PhysicalPlan::Project { input, .. } => {
+            is_pure_count_star(input)
+        }
+        PhysicalPlan::Aggregate {
+            input,
+            group_by,
+            aggregates,
+            having,
+            ..
+        } => {
+            group_by.is_empty()
+                && having.is_none()
+                && !aggregates.is_empty()
+                && aggregates.iter().all(|a| {
+                    matches!(
+                        &a.agg,
+                        AggregateExpr::Count {
+                            arg: None,
+                            distinct: false
+                        }
+                    )
+                })
+                // MUST be an UNFILTERED scan: a pushed-down `Scan.predicate`
+                // (`WHERE AdvEngineID<>0`, `WHERE URL LIKE …`) means the count is
+                // over the FILTERED rows — footer elision would ignore the filter
+                // and return the wrong (whole-table) count.
+                && matches!(input.as_ref(), PhysicalPlan::Scan { predicate: None, .. })
+        }
+        _ => false,
+    }
+}
+
+/// TD-OLAP-4 metadata elision: if the plan is an UNGROUPED, UNFILTERED aggregate
+/// over a `Scan` whose aggregates are all `COUNT(*)` / `COUNT(col)` / `MIN(col)` /
+/// `MAX(col)` on NUMERIC columns, build the answer row directly from the parquet
+/// FOOTER (row count + per-column min/max/null_count) — zero column I/O, flat cost
+/// (matching DataFusion's `AggregateStatistics`). Returns `None` (→ scan) for
+/// SUM/AVG/DISTINCT, non-column args, string columns (truncated stats), or any
+/// column lacking full footer coverage.
+#[cfg(feature = "datafusion-integration")]
+fn elidable_aggregate_batch(
+    plan: &PhysicalPlan,
+    table: &crate::datafusion::engine_adapters::ObjectStoreParquetTable,
+    file_schema: &arrow::datatypes::SchemaRef,
+) -> Option<arrow_array::RecordBatch> {
+    use arrow_array::{ArrayRef, Float64Array, Int64Array};
+    use proximadb_relational_algebra::AggregateExpr;
+    use proximadb_relational_types::Expr;
+
+    fn find_agg(p: &PhysicalPlan) -> Option<&PhysicalPlan> {
+        match p {
+            PhysicalPlan::Project { input, .. } | PhysicalPlan::Limit { input, .. } => {
+                find_agg(input)
+            }
+            PhysicalPlan::Aggregate { .. } => Some(p),
+            _ => None,
+        }
+    }
+    let PhysicalPlan::Aggregate {
+        input,
+        group_by,
+        aggregates,
+        having,
+        ..
+    } = find_agg(plan)?
+    else {
+        return None;
+    };
+    if !group_by.is_empty()
+        || having.is_some()
+        || !matches!(
+            input.as_ref(),
+            PhysicalPlan::Scan {
+                predicate: None,
+                ..
+            }
+        )
+    {
+        return None;
+    }
+    // Resolve a catalog column name to the FILE column (case-insensitive — CamelCase
+    // DDL over a lowercased parquet) → (parquet-stats key, Arrow type).
+    let resolve = |name: &str| -> Option<(String, arrow::datatypes::DataType)> {
+        file_schema
+            .fields()
+            .iter()
+            .find(|f| f.name().eq_ignore_ascii_case(name))
+            .map(|f| (f.name().clone(), f.data_type().clone()))
+    };
+    let rows = table.estimated_rows()?;
+    let mut fields: Vec<arrow::datatypes::Field> = Vec::with_capacity(aggregates.len());
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(aggregates.len());
+    for na in aggregates {
+        let (dt, arr): (arrow::datatypes::DataType, ArrayRef) = match &na.agg {
+            AggregateExpr::Count {
+                arg: None,
+                distinct: false,
+            } => (
+                arrow::datatypes::DataType::Int64,
+                std::sync::Arc::new(Int64Array::from(vec![rows as i64])),
+            ),
+            AggregateExpr::Count {
+                arg: Some(Expr::Column(c)),
+                distinct: false,
+            } => {
+                let (cn, _) = resolve(&c.name)?;
+                let (_, _, nulls) = table.aggregate_numeric_bounds(&cn)?;
+                (
+                    arrow::datatypes::DataType::Int64,
+                    std::sync::Arc::new(Int64Array::from(vec![rows.saturating_sub(nulls) as i64])),
+                )
+            }
+            AggregateExpr::Min {
+                arg: Expr::Column(c),
+            }
+            | AggregateExpr::Max {
+                arg: Expr::Column(c),
+            } => {
+                let (cn, dt) = resolve(&c.name)?;
+                let (lo, hi, _) = table.aggregate_numeric_bounds(&cn)?;
+                let v = if matches!(na.agg, AggregateExpr::Max { .. }) {
+                    hi
+                } else {
+                    lo
+                };
+                let arr = arrow::compute::cast(&Float64Array::from(vec![v]), &dt).ok()?;
+                (dt, arr)
+            }
+            // SUM/AVG/DISTINCT/STRING_AGG/non-column → not footer-elidable.
+            _ => return None,
+        };
+        fields.push(arrow::datatypes::Field::new(&na.name, dt, true));
+        arrays.push(arr);
+    }
+    arrow_array::RecordBatch::try_new(
+        std::sync::Arc::new(arrow::datatypes::Schema::new(fields)),
+        arrays,
+    )
+    .ok()
+}
+
+/// Does any `Scan` in the plan carry a pushed-down `predicate`? Native's scan does
+/// NOT apply `Scan.predicate` (no predicate pushdown yet), so it would count/aggregate
+/// the UNFILTERED rows — a wrong result. Filtered scans route to DataFusion (which
+/// applies the predicate + prunes row groups) until native gains predicate pushdown.
+#[cfg(feature = "datafusion-integration")]
+fn plan_scan_has_predicate(plan: &PhysicalPlan) -> bool {
+    match plan {
+        PhysicalPlan::Scan { predicate, .. } => predicate.is_some(),
+        PhysicalPlan::Filter { input, .. }
+        | PhysicalPlan::Project { input, .. }
+        | PhysicalPlan::Aggregate { input, .. }
+        | PhysicalPlan::Sort { input, .. }
+        | PhysicalPlan::Limit { input, .. }
+        | PhysicalPlan::Distinct { input, .. }
+        | PhysicalPlan::AssertMaxOneRow { input } => plan_scan_has_predicate(input),
+        PhysicalPlan::Join { left, right, .. } => {
+            plan_scan_has_predicate(left) || plan_scan_has_predicate(right)
+        }
+        PhysicalPlan::Union { inputs, .. } => inputs.iter().any(plan_scan_has_predicate),
+        _ => false,
+    }
+}
+
+/// Does the plan contain an `Aggregate` with a non-empty `GROUP BY`? Native's
+/// `HashAggregate` is in-memory with no spilling, so a high-cardinality group-by
+/// (e.g. `GROUP BY UserID` over 100M rows) balloons the hash table to tens of GB
+/// and OOMs. Until a bounded/spilling aggregate lands, the shadow declines grouped
+/// aggregates — they route to DataFusion (its partitioned/spilling aggregation
+/// handles them), which is itself the dispatch rule the trace confirms.
+#[cfg(feature = "datafusion-integration")]
+fn plan_has_grouped_aggregate(plan: &PhysicalPlan) -> bool {
+    match plan {
+        PhysicalPlan::Aggregate {
+            input, group_by, ..
+        } => !group_by.is_empty() || plan_has_grouped_aggregate(input),
+        PhysicalPlan::Filter { input, .. }
+        | PhysicalPlan::Project { input, .. }
+        | PhysicalPlan::Sort { input, .. }
+        | PhysicalPlan::Limit { input, .. }
+        | PhysicalPlan::Distinct { input, .. }
+        | PhysicalPlan::AssertMaxOneRow { input } => plan_has_grouped_aggregate(input),
+        PhysicalPlan::Join { left, right, .. } => {
+            plan_has_grouped_aggregate(left) || plan_has_grouped_aggregate(right)
+        }
+        PhysicalPlan::Union { inputs, .. } => inputs.iter().any(plan_has_grouped_aggregate),
+        _ => false,
+    }
+}
+
 /// Run the native vectorized engine over the same external parquet DataFusion just
 /// served, purely to record a per-engine compute sample. Single-table parquet only
 /// (MVP); declines silently on anything native can't yet serve.
@@ -716,14 +916,32 @@ async fn shadow_probe_native_parquet(
     let Some(location) = parquet_loc_by_key.values().next() else {
         return;
     };
+    let sqlp = &sql[..sql.len().min(70)];
     // Lower the SAME SQL to the relational physical plan (decline → skip).
     let physical = match plan_over_snapshot(sql, snapshot) {
         Some(Ok(p)) => p,
-        _ => return,
+        _ => {
+            tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP plan-declined: {sqlp}");
+            return;
+        }
     };
     let Some(scan_cols) = single_scan_columns(&physical) else {
+        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP not-single-scan: {sqlp}");
         return;
     };
+    // Skip grouped aggregates: native's non-spilling HashAggregate OOMs on
+    // high-cardinality GROUP BY at scale. These route to DataFusion.
+    if plan_has_grouped_aggregate(&physical) {
+        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP grouped-aggregate: {sqlp}");
+        return;
+    }
+    // Skip filtered scans: native does not apply a pushed-down `Scan.predicate`,
+    // so it would (wrongly) aggregate the unfiltered rows. Route to DataFusion.
+    if plan_scan_has_predicate(&physical) {
+        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP filtered-scan (no native predicate pushdown): {sqlp}");
+        return;
+    }
+    tracing::debug!(target: "proximadb::native_shadow", "shadow RUN native: {sqlp}");
     // Open the same parquet DataFusion read (table-OPEN cache is warm from its run).
     let table = match crate::datafusion::engine_adapters::ObjectStoreParquetTable::open(location)
         .await
@@ -735,36 +953,82 @@ async fn shadow_probe_native_parquet(
         }
     };
     let (store, files, file_schema) = table.native_scan_inputs();
-    // Map the plan's Scan columns → parquet leaf indices by name; build the native
-    // scan output schema from the FILE fields (exact Arrow types). Sort ascending so
-    // the reader's file-order `ProjectionMask::roots` matches the operator schema —
-    // when the plan preserves declared column order (the common case) native aligns;
-    // otherwise the native lowering declines and no sample is recorded.
-    let mut paired: Vec<(usize, arrow::datatypes::Field)> = Vec::with_capacity(scan_cols.len());
-    for name in &scan_cols {
-        let Some((idx, field)) = file_schema
-            .fields()
-            .iter()
-            .enumerate()
-            .find(|(_, f)| f.name() == name)
-        else {
-            return; // column absent from file (schema drift) → never risk a sample
-        };
-        paired.push((idx, field.as_ref().clone()));
+    // Metadata elision (TD-OLAP-4): unfiltered MIN/MAX/COUNT answered from the
+    // parquet FOOTER — zero column I/O, flat cost. The single biggest native win at
+    // scale (q07 MIN/MAX: a full-column vectorized scan → a footer read). Emits the
+    // pre-computed row and bypasses the scan + HashAggregate entirely.
+    if let Some(batch) = elidable_aggregate_batch(&physical, &table, &file_schema) {
+        tracing::debug!(target: "proximadb::native_shadow", "shadow ELIDE (footer stats): {sqlp}");
+        let src = Box::new(
+            crate::query::execution::native_parquet_scan::StatsAggregateOperator::new(batch),
+        );
+        let _ = crate::query::execution::native_engine::run_native_source_only(src).await;
+        return;
     }
-    paired.sort_by_key(|(i, _)| *i);
-    let projection: Vec<usize> = paired.iter().map(|(i, _)| *i).collect();
-    let out_schema = Arc::new(arrow::datatypes::Schema::new(
-        paired.into_iter().map(|(_, f)| f).collect::<Vec<_>>(),
-    ));
-    let source = Box::new(
-        crate::query::execution::native_parquet_scan::ParquetScanOperator::new(
-            store,
-            files,
-            Some(projection),
-            out_schema,
-        ),
-    );
+    // Unfiltered COUNT(*): parquet/PAX carry the row count in the FOOTER, so elide
+    // the scan entirely — read footers only, emit the count (a metadata op, not a
+    // scan). Detected from the PLAN, not `scan_cols`: the relational Scan schema is
+    // full-width, so COUNT(*) would otherwise read all 105 columns.
+    let source: Box<dyn proximadb_execution_contracts::ExecutionOperator> =
+        if is_pure_count_star(&physical) {
+            Box::new(
+                crate::query::execution::native_parquet_scan::ParquetScanOperator::new_count_only(
+                    store, files,
+                ),
+            )
+        } else {
+            // The relational Scan schema is full-width (no projection pushdown yet), so
+            // `scan_cols` reads every column the scan declares. Native has neither
+            // projection nor predicate pushdown, so a wide scan reads all columns
+            // row-wise — impractically slow at scale. Cap it: route wide scans to
+            // DataFusion (which prunes columns + row groups). This IS the dispatch rule
+            // the trace confirms; narrow scans still sample native. (Lifting the cap
+            // needs projection/predicate pushdown — the medium-tier native enabler.)
+            const NATIVE_SCAN_WIDTH_CAP: usize = 8;
+            if scan_cols.len() > NATIVE_SCAN_WIDTH_CAP {
+                tracing::debug!(
+                    target: "proximadb::native_shadow",
+                    cols = scan_cols.len(),
+                    "shadow SKIP wide-scan (no pushdown): {sqlp}"
+                );
+                return;
+            }
+            // Map the plan's Scan columns → parquet leaf indices by name; build the
+            // native scan output schema from the FILE fields (exact Arrow types). Sort
+            // ascending so the reader's file-order `ProjectionMask::roots` matches the
+            // operator schema — when the plan preserves declared column order (the
+            // common case) native aligns; otherwise the native lowering declines and no
+            // sample is recorded.
+            let mut paired: Vec<(usize, arrow::datatypes::Field)> =
+                Vec::with_capacity(scan_cols.len());
+            for name in &scan_cols {
+                // Match case-insensitively: the catalog/DDL may declare CamelCase
+                // columns over a lowercased parquet (e.g. ClickBench). Ordinals still
+                // align positionally — native ops reference columns by ordinal, not name.
+                let Some((idx, field)) = file_schema
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .find(|(_, f)| f.name().eq_ignore_ascii_case(name))
+                else {
+                    return; // column absent from file (schema drift) → never risk a sample
+                };
+                paired.push((idx, field.as_ref().clone()));
+            }
+            paired.sort_by_key(|(i, _)| *i);
+            let projection: Vec<usize> = paired.iter().map(|(i, _)| *i).collect();
+            let out_schema = Arc::new(arrow::datatypes::Schema::new(
+                paired.into_iter().map(|(_, f)| f).collect::<Vec<_>>(),
+            ));
+            Box::new(
+                crate::query::execution::native_parquet_scan::ParquetScanOperator::new(
+                    store,
+                    files,
+                    Some(projection),
+                    out_schema,
+                ),
+            )
+        };
     match crate::query::execution::native_engine::run_native_over_parquet(&physical, source).await {
         Ok(Some(_)) => {
             tracing::debug!(target: "proximadb::native_shadow", "shadow: native-vectorized sample recorded")

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -186,6 +186,37 @@ pub(crate) async fn run_native_over_parquet(
     Ok(Some(record_batches_to_pipeline_result(schema, &batches)))
 }
 
+/// Metadata-elision run path (TD-OLAP-4): execute a single source operator that
+/// already emits the final result row (footer `MIN`/`MAX`/`COUNT`), recording the
+/// `native-vectorized` compute + route sample like the scan path. No plan lowering
+/// — the aggregate is elided, so there is no scan and no HashAggregate.
+pub(crate) async fn run_native_source_only(
+    source: Box<dyn proximadb_execution_contracts::ExecutionOperator>,
+) -> Result<Option<ExecutionPipelineResult>, ExecutionError> {
+    let output_schema = source.output_schema();
+    let started = std::time::Instant::now();
+    let batches = match super::native_ops::execute_source(source).await {
+        Ok(b) => b,
+        Err(reason) => {
+            tracing::debug!(
+                target: "proximadb::native_vectorized",
+                %reason,
+                "native metadata-elision failed; keeping DataFusion result"
+            );
+            return Ok(None);
+        }
+    };
+    crate::observability::io_trace::record_compute_ms(
+        "native-vectorized",
+        started.elapsed().as_millis() as u64,
+    );
+    crate::observability::io_trace::record_route("vectorized", "NativeVectorized");
+    Ok(Some(record_batches_to_pipeline_result(
+        output_schema.as_ref(),
+        &batches,
+    )))
+}
+
 /// Streaming variant — not yet wired (the materialized path serves Phase 2).
 pub async fn try_vectorized_stream(
     _physical: &PhysicalPlan,

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -383,23 +383,32 @@ impl ExecutionOperator for HashAggregateOperator {
         true
     }
 
-    async fn execute(&self, input: BatchStream) -> Result<BatchStream, ExecutionError> {
-        // Collect the entire input (blocking).
+    async fn execute(&self, mut input: BatchStream) -> Result<BatchStream, ExecutionError> {
         let group_by = self.group_by.clone();
         let aggregates = self.aggregates.clone();
         let output_schema = self.output_schema.clone();
 
-        let collected: Vec<RecordBatch> = input
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .collect::<Result<_, _>>()?;
+        // Vectorized fast path for UNGROUPED scalar aggregates (no GROUP BY): fold
+        // Arrow aggregate kernels per batch instead of the row-wise accumulator
+        // loop. This is the dominant OLAP scalar-aggregate shape and was measured
+        // 3-31x slower row-wise at 100M (TD-OLAP-4). Grouped aggregation keeps the
+        // row-wise path below (high-cardinality GROUP BY is routed to DataFusion).
+        if group_by.is_empty() {
+            return ungrouped_vectorized(input, &aggregates, output_schema).await;
+        }
 
         // group key → (group_by values, per-agg accumulators)
         let mut groups: std::collections::HashMap<GroupKey, (Vec<ProximaValue>, Vec<Accumulator>)> =
             std::collections::HashMap::new();
 
-        for batch in &collected {
+        // Stream the input: fold each batch into the hash state, then DROP it —
+        // bounded memory (one batch in flight + the group state), never
+        // materializing the whole input. Collecting all input first OOMs at scale
+        // (a full-width 100M scan is tens of GB). Group state is still unbounded in
+        // the number of distinct groups — high-cardinality GROUP BY is routed away
+        // upstream until a spilling aggregate lands.
+        while let Some(batch) = input.next().await {
+            let batch = batch?;
             let nrows = batch.num_rows();
             for r in 0..nrows {
                 // Build the group key from the group_by columns.
@@ -463,6 +472,215 @@ impl ExecutionOperator for HashAggregateOperator {
             .map_err(|e| ExecutionError::Execution(format!("aggregate output: {e}")))?;
         Ok(Box::pin(futures::stream::once(async move { Ok(batch) })))
     }
+}
+
+// =========================================================================
+// Vectorized UNGROUPED aggregation (TD-OLAP-4): Arrow kernels per batch instead
+// of the row-wise Accumulator loop — the 3-31x compute win on scalar aggregates.
+// Finalization semantics MATCH the row-wise `Accumulator::finalize` exactly
+// (Count→Int64, Sum→Float64|Null, Avg→Float64|Null, Min/Max→value|Null).
+// =========================================================================
+
+/// Running state for one ungrouped aggregate, folded across batches.
+enum UngroupedState {
+    Count { n: i64 },
+    Sum { sum: f64, any: bool },
+    Avg { sum: f64, n: i64 },
+    Min { cur: Option<ProximaValue> },
+    Max { cur: Option<ProximaValue> },
+}
+
+impl UngroupedState {
+    fn new(kind: AggKind) -> Self {
+        match kind {
+            AggKind::Count => Self::Count { n: 0 },
+            AggKind::Sum => Self::Sum {
+                sum: 0.0,
+                any: false,
+            },
+            AggKind::Avg => Self::Avg { sum: 0.0, n: 0 },
+            AggKind::Min => Self::Min { cur: None },
+            AggKind::Max => Self::Max { cur: None },
+        }
+    }
+
+    fn update(&mut self, arg: Option<usize>, batch: &RecordBatch) -> Result<(), ExecutionError> {
+        let need_col = || {
+            arg.ok_or_else(|| {
+                ExecutionError::Execution("SUM/AVG/MIN/MAX requires a column argument".into())
+            })
+        };
+        match self {
+            // COUNT(*): every row; COUNT(col): non-null rows (null_count from the array).
+            Self::Count { n } => match arg {
+                None => *n += batch.num_rows() as i64,
+                Some(c) => {
+                    let col = batch.column(c);
+                    *n += (col.len() - col.null_count()) as i64;
+                }
+            },
+            Self::Sum { sum, any } => {
+                let (s, cnt) = array_sum_count(batch.column(need_col()?))?;
+                *sum += s;
+                if cnt > 0 {
+                    *any = true;
+                }
+            }
+            Self::Avg { sum, n } => {
+                let (s, cnt) = array_sum_count(batch.column(need_col()?))?;
+                *sum += s;
+                *n += cnt;
+            }
+            Self::Min { cur } => {
+                if let Some(v) = array_min_max_proxima(batch.column(need_col()?), false)? {
+                    match cur {
+                        None => *cur = Some(v),
+                        Some(c) if compare_values(&v, c) == std::cmp::Ordering::Less => {
+                            *cur = Some(v)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Self::Max { cur } => {
+                if let Some(v) = array_min_max_proxima(batch.column(need_col()?), true)? {
+                    match cur {
+                        None => *cur = Some(v),
+                        Some(c) if compare_values(&v, c) == std::cmp::Ordering::Greater => {
+                            *cur = Some(v)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finalize(&self) -> ProximaValue {
+        match self {
+            Self::Count { n } => ProximaValue::Int64(*n),
+            Self::Sum { sum, any } => {
+                if *any {
+                    ProximaValue::Float64(*sum)
+                } else {
+                    ProximaValue::Null
+                }
+            }
+            Self::Avg { sum, n } => {
+                if *n == 0 {
+                    ProximaValue::Null
+                } else {
+                    ProximaValue::Float64(sum / (*n as f64))
+                }
+            }
+            Self::Min { cur } | Self::Max { cur } => cur.clone().unwrap_or(ProximaValue::Null),
+        }
+    }
+}
+
+/// Vectorized SUM + non-null count for one column: cast to `Float64` (matching the
+/// row-wise `numeric_to_f64` semantics) then the Arrow `sum` kernel.
+fn array_sum_count(col: &dyn arrow::array::Array) -> Result<(f64, i64), ExecutionError> {
+    let casted = arrow::compute::cast(col, &DataType::Float64)
+        .map_err(|e| ExecutionError::Execution(format!("SUM/AVG cast to f64: {e}")))?;
+    let a = casted
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .ok_or_else(|| ExecutionError::Execution("f64 downcast".into()))?;
+    let s = arrow::compute::kernels::aggregate::sum(a).unwrap_or(0.0);
+    let n = (a.len() - a.null_count()) as i64;
+    Ok((s, n))
+}
+
+/// Vectorized MIN (or MAX) of one column as a `ProximaValue`, preserving the
+/// column type (type-dispatched Arrow `min`/`max` kernel). `None` on an all-null
+/// or empty batch.
+fn array_min_max_proxima(
+    col: &dyn arrow::array::Array,
+    want_max: bool,
+) -> Result<Option<ProximaValue>, ExecutionError> {
+    use arrow::array::*;
+    use arrow::compute::kernels::aggregate as agg;
+    macro_rules! mm {
+        ($ArrTy:ty, $Prox:path) => {{
+            let a = col
+                .as_any()
+                .downcast_ref::<$ArrTy>()
+                .ok_or_else(|| ExecutionError::Execution("MIN/MAX downcast".into()))?;
+            let r = if want_max { agg::max(a) } else { agg::min(a) };
+            Ok(r.map($Prox))
+        }};
+    }
+    match col.data_type() {
+        DataType::Int8 => mm!(Int8Array, ProximaValue::Int8),
+        DataType::Int16 => mm!(Int16Array, ProximaValue::Int16),
+        DataType::Int32 => mm!(Int32Array, ProximaValue::Int32),
+        DataType::Int64 => mm!(Int64Array, ProximaValue::Int64),
+        DataType::UInt8 => mm!(UInt8Array, ProximaValue::UInt8),
+        DataType::UInt16 => mm!(UInt16Array, ProximaValue::UInt16),
+        DataType::UInt32 => mm!(UInt32Array, ProximaValue::UInt32),
+        DataType::UInt64 => mm!(UInt64Array, ProximaValue::UInt64),
+        DataType::Float32 => mm!(Float32Array, ProximaValue::Float32),
+        DataType::Float64 => mm!(Float64Array, ProximaValue::Float64),
+        DataType::Boolean => {
+            let a = col
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .ok_or_else(|| ExecutionError::Execution("MIN/MAX downcast".into()))?;
+            let r = if want_max {
+                agg::max_boolean(a)
+            } else {
+                agg::min_boolean(a)
+            };
+            Ok(r.map(ProximaValue::Boolean))
+        }
+        DataType::Utf8 => {
+            let a = col
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| ExecutionError::Execution("MIN/MAX downcast".into()))?;
+            let r = if want_max {
+                agg::max_string(a)
+            } else {
+                agg::min_string(a)
+            };
+            Ok(r.map(|s| ProximaValue::String(s.to_string())))
+        }
+        other => Err(ExecutionError::NotImplemented(format!(
+            "vectorized MIN/MAX for {other:?}"
+        ))),
+    }
+}
+
+/// Fold the ungrouped aggregates over the input stream with Arrow kernels, then
+/// emit the single result row. Bounded memory (one batch + O(#aggregates) state).
+async fn ungrouped_vectorized(
+    mut input: BatchStream,
+    aggregates: &[AggSpec],
+    output_schema: SchemaRef,
+) -> Result<BatchStream, ExecutionError> {
+    let mut states: Vec<UngroupedState> = aggregates
+        .iter()
+        .map(|s| UngroupedState::new(s.kind))
+        .collect();
+    while let Some(batch) = input.next().await {
+        let batch = batch?;
+        for (spec, st) in aggregates.iter().zip(states.iter_mut()) {
+            st.update(spec.arg, &batch)?;
+        }
+    }
+    let vals: Vec<ProximaValue> = states.iter().map(|s| s.finalize()).collect();
+    let arrays: Vec<ArrayRef> = vals
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            build_column_array(std::slice::from_ref(v), output_schema.field(i).data_type())
+        })
+        .collect::<Result<_, _>>()?;
+    let batch = RecordBatch::try_new(output_schema, arrays)
+        .map_err(|e| ExecutionError::Execution(format!("aggregate output: {e}")))?;
+    Ok(Box::pin(futures::stream::once(async move { Ok(batch) })))
 }
 
 /// Per-group, per-aggregate accumulator. Mirrors the Volcano `Accumulator`'s NULL
@@ -1260,6 +1478,20 @@ fn agg_output_schema(
 
 /// Drain a [`LoweredPipeline`] to materialized `RecordBatch`es, applying the
 /// trailing `Limit` (offset + optional count) row-wise at the end.
+/// Execute a single source operator as a one-op pipeline (no plan lowering) —
+/// used by the metadata-elision path, where the source already emits the final
+/// result row (TD-OLAP-4). Drains the source to `RecordBatch`es.
+pub(crate) async fn execute_source(
+    source: Box<dyn ExecutionOperator>,
+) -> Result<Vec<RecordBatch>, ExecutionError> {
+    let lowered = LoweredPipeline {
+        pipeline: Pipeline::new(vec![source]),
+        build_pipeline: None,
+        limit: None,
+    };
+    execute_pipeline(&lowered).await
+}
+
 pub(crate) async fn execute_pipeline(
     lowered: &LoweredPipeline,
 ) -> Result<Vec<RecordBatch>, ExecutionError> {

--- a/src/query/execution/native_parquet_scan.rs
+++ b/src/query/execution/native_parquet_scan.rs
@@ -18,14 +18,14 @@
 //! engine: reading parquet → `RecordBatch` is pure arrow-rs, and native operators
 //! consume `RecordBatch`es, so DataFusion is not required to read parquet.
 //!
-//! MVP: eager read of the selected row-groups (mirrors `PaxScanOperator`'s eager
-//! MVP); lazy per-split streaming + row-group zone-map pruning are follow-ons.
+//! Streams row groups lazily (bounded memory — one decoded batch in flight),
+//! never materializing the whole file; row-group zone-map pruning is a follow-on.
 
 use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use object_store::ObjectStore;
 use object_store::path::Path;
 use parquet::arrow::ProjectionMask;
@@ -44,6 +44,12 @@ pub(crate) struct ParquetScanOperator {
     /// order, matching what the reader emits.
     projection: Option<Vec<usize>>,
     output_schema: SchemaRef,
+    /// Footer-elision mode: emit a single zero-column batch whose row count is the
+    /// sum of the parquet footers' `num_rows`, reading NO column data. This is the
+    /// metadata-elision path for unfiltered `COUNT(*)` — the co-design-correct
+    /// answer (COUNT(*) is a metadata op, not a scan), matching DataFusion's
+    /// `AggregateStatistics` footer elision and avoiding a 100M-row column read.
+    count_only: bool,
 }
 
 impl ParquetScanOperator {
@@ -58,6 +64,25 @@ impl ParquetScanOperator {
             files,
             projection,
             output_schema,
+            count_only: false,
+        }
+    }
+
+    /// Footer-elision constructor for unfiltered `COUNT(*)`: reads only the parquet
+    /// footers (row counts) and emits one zero-column batch carrying the total row
+    /// count — no column I/O. The downstream `COUNT(*)` counts that row count. For
+    /// footerless formats (CSV) the caller must instead project the smallest-width
+    /// column; parquet and PAX carry the count in the footer, so we elide.
+    pub(crate) fn new_count_only(
+        store: Arc<dyn ObjectStore>,
+        files: Vec<(Path, Option<u64>)>,
+    ) -> Self {
+        Self {
+            store,
+            files,
+            projection: Some(Vec::new()),
+            output_schema: Arc::new(arrow_schema::Schema::empty()),
+            count_only: true,
         }
     }
 }
@@ -69,31 +94,103 @@ impl ExecutionOperator for ParquetScanOperator {
     }
 
     async fn execute(&self, _input: BatchStream) -> Result<BatchStream, ExecutionError> {
-        let mut batches = Vec::new();
-        for (path, size) in &self.files {
-            let mut reader = ParquetObjectReader::new(self.store.clone(), path.clone());
-            if let Some(sz) = size {
-                reader = reader.with_file_size(*sz);
+        // Footer elision (unfiltered COUNT(*)): sum the parquet footers' row counts
+        // and emit ONE zero-column batch carrying that count — zero column I/O.
+        if self.count_only {
+            let mut total: usize = 0;
+            for (path, size) in &self.files {
+                let mut reader = ParquetObjectReader::new(self.store.clone(), path.clone());
+                if let Some(sz) = size {
+                    reader = reader.with_file_size(*sz);
+                }
+                let builder = ParquetRecordBatchStreamBuilder::new(reader)
+                    .await
+                    .map_err(|e| {
+                        ExecutionError::Execution(format!("parquet footer {path}: {e}"))
+                    })?;
+                total += builder.metadata().file_metadata().num_rows().max(0) as usize;
             }
-            let mut builder = ParquetRecordBatchStreamBuilder::new(reader)
-                .await
-                .map_err(|e| ExecutionError::Execution(format!("parquet open {path}: {e}")))?;
-            if let Some(proj) = &self.projection {
-                let mask = ProjectionMask::roots(builder.parquet_schema(), proj.iter().copied());
-                builder = builder.with_projection(mask);
-            }
-            let mut stream = builder
-                .build()
-                .map_err(|e| ExecutionError::Execution(format!("parquet build {path}: {e}")))?;
-            while let Some(b) = stream.next().await {
-                batches.push(b.map_err(|e| {
-                    ExecutionError::Execution(format!("parquet decode {path}: {e}"))
-                })?);
-            }
+            let opts = arrow_array::RecordBatchOptions::new().with_row_count(Some(total));
+            let batch = arrow_array::RecordBatch::try_new_with_options(
+                self.output_schema.clone(),
+                vec![],
+                &opts,
+            )
+            .map_err(|e| ExecutionError::Execution(format!("count batch: {e}")))?;
+            return Ok(Box::pin(futures::stream::once(async move { Ok(batch) })));
         }
-        Ok(Box::pin(futures::stream::iter(
-            batches.into_iter().map(Ok::<_, ExecutionError>),
-        )))
+        // Lazily open each file and stream its row groups — bounded memory (one
+        // decoded batch in flight, plus the downstream operator's state), NEVER
+        // materializing the whole file. Eager materialization OOMs at scale
+        // (100M rows → tens of GB); a blocking `HashAggregate` downstream only
+        // needs one input batch at a time.
+        let store = self.store.clone();
+        let projection = self.projection.clone();
+        let stream = futures::stream::iter(self.files.clone().into_iter().map(Ok))
+            .and_then(move |(path, size)| {
+                let store = store.clone();
+                let projection = projection.clone();
+                async move {
+                    let mut reader = ParquetObjectReader::new(store, path.clone());
+                    if let Some(sz) = size {
+                        reader = reader.with_file_size(sz);
+                    }
+                    let mut builder =
+                        ParquetRecordBatchStreamBuilder::new(reader)
+                            .await
+                            .map_err(|e| {
+                                ExecutionError::Execution(format!("parquet open {path}: {e}"))
+                            })?;
+                    if let Some(proj) = &projection {
+                        let mask =
+                            ProjectionMask::roots(builder.parquet_schema(), proj.iter().copied());
+                        builder = builder.with_projection(mask);
+                    }
+                    let inner = builder.build().map_err(|e| {
+                        ExecutionError::Execution(format!("parquet build {path}: {e}"))
+                    })?;
+                    Ok(inner.map(move |b| {
+                        b.map_err(|e| {
+                            ExecutionError::Execution(format!("parquet decode {path}: {e}"))
+                        })
+                    }))
+                }
+            })
+            .try_flatten();
+        Ok(Box::pin(stream))
+    }
+}
+
+/// A metadata-elision source (TD-OLAP-4): emits ONE pre-computed result batch built
+/// from the parquet footer statistics (unfiltered `MIN`/`MAX`/`COUNT`), with zero
+/// column I/O. The caller (shadow probe) computes the row from the table's
+/// `aggregate_numeric_bounds` + footer row count; this operator just streams it, so
+/// the elided aggregate runs through the native pipeline like any other operator.
+#[derive(Debug)]
+pub(crate) struct StatsAggregateOperator {
+    batch: arrow_array::RecordBatch,
+    output_schema: SchemaRef,
+}
+
+impl StatsAggregateOperator {
+    pub(crate) fn new(batch: arrow_array::RecordBatch) -> Self {
+        let output_schema = batch.schema();
+        Self {
+            batch,
+            output_schema,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionOperator for StatsAggregateOperator {
+    fn output_schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    async fn execute(&self, _input: BatchStream) -> Result<BatchStream, ExecutionError> {
+        let batch = self.batch.clone();
+        Ok(Box::pin(futures::stream::once(async move { Ok(batch) })))
     }
 }
 
@@ -210,6 +307,43 @@ mod tests {
             "native drained every parquet row via the Scan leaf"
         );
         assert_eq!(batches[0].num_columns(), 2);
+    }
+
+    #[tokio::test]
+    async fn count_only_elides_to_footer_row_count_with_zero_columns() {
+        // Footer elision: emit ONE zero-column batch whose row_count == footer total,
+        // reading no column data (the COUNT(*) metadata path).
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("t.parquet");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, false),
+            Field::new("x", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "d", "e"])),
+                Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5])),
+            ],
+        )
+        .unwrap();
+        let f = std::fs::File::create(&file_path).unwrap();
+        let mut w = ArrowWriter::try_new(f, schema.clone(), None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let store = Arc::new(LocalFileSystem::new_with_prefix(tmp.path()).unwrap());
+        let size = std::fs::metadata(&file_path).unwrap().len();
+        let op =
+            ParquetScanOperator::new_count_only(store, vec![(Path::from("t.parquet"), Some(size))]);
+        assert_eq!(op.output_schema().fields().len(), 0, "zero-column output");
+
+        let empty: BatchStream = Box::pin(futures::stream::empty());
+        let mut out = op.execute(empty).await.unwrap();
+        let b = out.next().await.unwrap().unwrap();
+        assert_eq!(b.num_columns(), 0, "no columns read");
+        assert_eq!(b.num_rows(), 5, "row count from footer");
+        assert!(out.next().await.is_none(), "single metadata batch");
     }
 
     #[tokio::test]

--- a/tests/clickbench_ledger_e2e.rs
+++ b/tests/clickbench_ledger_e2e.rs
@@ -338,6 +338,12 @@ fn duckdb_sql(sql: &str, parquet: &str) -> String {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "ClickBench single-node ledger (TD-OLAP-4) — advisory; needs CLICKBENCH_PARQUET"]
 async fn clickbench_ledger() {
+    // Dev-only: honor RUST_LOG so the native-shadow probe's decline reasons are
+    // visible during a diagnostic capture (no-op if RUST_LOG is unset).
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
     let parquet = match std::env::var("CLICKBENCH_PARQUET") {
         Ok(p) => p,
         Err(_) => {


### PR DESCRIPTION
## What
The TD-OLAP-4 native-parquet shadow measured native's aggregates **3–31× slower** than DataFusion at 100M (row-wise scalar loop). This brings native to **parity/wins** on the observed shapes — measured, correctness preserved.

## Measured (100M real ClickBench `hits`, shadow, corrected)
| q | shape | DataFusion | **native** | DuckDB | verdict |
|---|---|---|---|---|---|
| q01 | `COUNT(*)` | 12ms | **0ms** (footer) | 41ms | native wins |
| q07 | `MIN/MAX(EventDate)` | 1616ms | **0ms** (footer elision) | 37ms | **native wins ~1600×** |
| q03 | `SUM,COUNT,AVG` | 188ms | 359ms (1.9×) | 58ms | single-thread gap |
| q04 | `AVG(UserID)` | 248ms | 346ms (1.4×) | 126ms | single-thread gap |

The residual q03/q04 gap is **purely single-threaded** (DataFusion partitions across cores; DuckDB is morsel-driven) — evidence recorded in **TD-OLAP-12** (native morsel scheduler), whose `MorselScheduler` seam already exists. The vectorized `UngroupedState` is exactly its per-morsel partial-state + combine.

## Native execution (`src/query/execution/`)
- **Vectorized ungrouped `HashAggregate`** — Arrow kernels (`sum/min/max/count`, type-dispatched MIN/MAX) folded per batch instead of the row-wise `Accumulator` loop. Grouped path unchanged.
- **Streaming** scan **and** aggregate (was collect-all → 75GB OOM at 100M) — bounded memory.
- **Metadata elision** — `ParquetScanOperator::new_count_only` (footer row count) + `StatsAggregateOperator` (footer MIN/MAX/COUNT), fed by `ObjectStoreParquetTable::aggregate_numeric_bounds` (min-of-mins / max-of-maxes / Σ null_count, all-or-none). Zero column I/O.

## Shadow probe correctness guards (`relational_pipeline.rs`)
Native only samples what it serves **correctly**; everything else routes to DataFusion (the floor):
- `is_pure_count_star` — recurses through `Project` **and** requires an unfiltered scan (a pushed-down `Scan.predicate` would footer-count the wrong rows — caught a fake 2ms "win" that returned ~100M instead of 15,911).
- `plan_scan_has_predicate` — filtered scans → DataFusion (native has no predicate pushdown yet).
- `plan_has_grouped_aggregate` — high-card GROUP BY → DataFusion (no spilling).
- `elidable_aggregate_batch` — unfiltered MIN/MAX/COUNT over a bare Scan → footer.
- Case-insensitive column matching (CamelCase DDL over lowercased parquet).

## Tests
Vectorized aggregate (existing count/sum/avg/min-max), `aggregate_numeric_bounds` (reduces across row groups; string/missing → None), footer count elision. `cargo clippy --lib --bins -D warnings` + fmt + panic-policy clean.

Rebased on #833 (production ScanCtx wire). Follow-on: **TD-OLAP-12** morsel scheduler (closes the q03/q04 single-thread gap) — its evidence section updated here.