### PR TITLE
feat(pax): Stage B footer-prune on shredded user columns (TD-DOC-PUSHDOWN-1 L2)

### DIFF
--- a/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
+++ b/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
@@ -4,17 +4,22 @@
 
 [cols="1,3"]
 |===
-|Status|Open — **Layer 1 (reader ranged read) LANDED; Layer 2 + adapter remain.** Owning the
-reader (rather than waiting on the OLAP workstream) is underway. **Layer 1** — `PaxSplitReader` now
-fetches a segment via ranged reads (locate the index from a tail suffix → prune whole blocks against
-the index **zone summary** → `read_ranges` only survivors → decode to Arrow), default-OFF
-(`PROXIMADB_DF_PAX_RANGED`), mixed-read-safe (falls back to the whole-file read for any segment
-without a v2 zone index). Verified against the gate shape: a selective predicate reads
-`bytes_read < whole segment` with `range_gets > 0` and returns rows identical to the whole-file path.
-**Layer 2** (shredded user-column ranged pruning) + the **documents adapter** remain — see
-"Remaining". The write-side (P-Shred), universal provisioning (P-Provision), the
-`documents(collection)` DataFusion SQL surface (P-DFSource), the io_trace evidence gate (P-Trace),
-and legacy retirement (P-Retire) all landed previously.
+|Status|Open — **Reader ranged read (Layer 1 + Layer 2) LANDED; documents adapter remains.** Owning
+the reader (rather than waiting on the OLAP workstream) is done. **Layer 1** — `PaxSplitReader`
+fetches a segment via ranged reads: locate the index from a tail suffix → **Stage A** prunes whole
+blocks against the index **zone summary** (canonical columns, no per-block GET) → `read_ranges` only
+survivors → decode to Arrow. **Layer 2** — **Stage B**: when a predicate targets a shredded
+`props__<key>` user column the index summary can't evaluate, each survivor's **footer/metadata** is
+range-read into a `BlockLayout` (carries every column's bounds) and pruned on ALL columns *before* its
+body is fetched, so a pruned block costs only its footer. Both reuse the SAME `BlockZoneSource` prune
+logic as the decode path. Default-OFF (`PROXIMADB_DF_PAX_RANGED`), mixed-read-safe (falls back to the
+whole-file read for any segment without a v2 zone index). Verified against the gate shape: selective
+predicates on BOTH a canonical column (Layer 1) AND a shredded user column (Layer 2) read
+`bytes_read < whole segment` with `range_gets > 0` and return rows identical to the whole-file path.
+The only remaining piece is the **documents adapter** (`documents()` → `PaxTableProvider`) — see
+"Design". The write-side (P-Shred), universal provisioning (P-Provision), the `documents(collection)`
+DataFusion SQL surface (P-DFSource), the io_trace evidence gate (P-Trace), and legacy retirement
+(P-Retire) all landed previously.
 |Priority|MEDIUM (the co-design payoff phase — turns the declared shredded format into a *measured*
 `bytes_read` reduction; but the byte win is gated on reader-level ranged/pruned PAX reads owned by
 the OLAP workstream, not on document code).
@@ -101,14 +106,18 @@ DataFusion `FilesystemFactory`/`PhysicalExpr`/Arrow path). So "own the reader" s
   (`PROXIMADB_DF_PAX_RANGED`), mixed-read-safe fallback to whole-file. io_trace records
   `fetch_pax_ranged` + `bytes_read` + `range_gets`. This is **general** — every DataFusion PAX scan
   with a temporal/canonical predicate now prunes blocks off the wire, not just documents.
-* **Layer 2 — shredded user-column ranged pruning (REMAINING).** The v2 index `BlockZoneSummary`
+* **Layer 2 — shredded user-column ranged pruning (LANDED).** The v2 index `BlockZoneSummary`
   carries **canonical-column** bounds only (`created_at`/`updated_at`/`valid_from`/`valid_to`/
   `edge_weight`); shredded `props__<key>` user columns hit the `_ => {}` arm of `from_column_metas`,
-  so a *document-field* predicate cannot prune from the index alone. Pruning on shredded columns
-  without a full block GET needs **per-block footer ranged reads** — exactly what `RangedSegmentReader`
-  (`BlockLayout` + `metadata_ranges`) already does. Wire `PaxSplitReader` to consume that (adapt
-  `FilesystemFactory`→`ObjectStoreBridge`), or hoist user-column bounds into the index summary
-  (versioned format change). This is what closes the *document-field* `bytes_read` gate.
+  so a *document-field* predicate cannot prune from the index alone. `PaxSplitReader::block_layout_ranged`
+  now range-reads each surviving block's footer + metadata extent (NO stripe bytes) into a
+  `BlockLayout` — reusing the public block-format primitives (`BlockFooter::from_bytes`,
+  `metadata_ranges`, `BlockLayout::assemble`), the `FilesystemFactory` twin of
+  `RangedSegmentReader::build_block_layout` — and `Stage B` prunes on ALL columns before the body is
+  fetched. Engaged only when `needs_footer_prune()` (a predicate on a non-summarized column). This
+  closes the *document-field* `bytes_read` gate. (A separate fix removed a double-count: the
+  filesystem layer already feeds io_trace `bytes_read`/`range_gets` per `read_range`, so `load_ranged`
+  records none itself.)
 * **Adapter — `documents()` → `PaxTableProvider` (REMAINING).** The thin document-side wiring below.
 
 == Design (documents adapter — rides on the ranged reader)

--- a/src/datafusion/engine_adapters/pax_adapter.rs
+++ b/src/datafusion/engine_adapters/pax_adapter.rs
@@ -45,9 +45,14 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use tracing::trace;
 
-use proximadb_block_format::{BlockZoneSource, ColumnRole, PaxBlockReader};
+use proximadb_block_format::{
+    BLOCK_FOOTER_SIZE, BlockFooter, BlockLayout, BlockZoneSource, ColumnRole, PaxBlockReader,
+    metadata_ranges,
+};
 use proximadb_storage_common::format_splits::{ScalarPredicate, ScalarValue};
-use proximadb_storage_common::pax_block::{PaxSegmentScanner, ScanPredicate, SegmentIndex};
+use proximadb_storage_common::pax_block::{
+    BlockIndexEntry, PaxSegmentScanner, ScanPredicate, SegmentIndex,
+};
 
 use crate::observability::io_trace;
 
@@ -88,9 +93,10 @@ pub fn pax_ranged_read_enabled() -> bool {
 const SEGMENT_INDEX_TRAILER_MIN: u64 = 16;
 
 /// Initial tail suffix GET size when locating the segment index; grown ×4 on a
-/// short suffix. 64 KiB holds a typical multi-block segment's index in one GET
-/// (matches `RangedSegmentReader::INITIAL_SUFFIX`).
-const RANGED_INITIAL_SUFFIX: u64 = 64 * 1024;
+/// short suffix. 8 KiB holds a typical segment's index (~93 B/block ⇒ ~85 blocks)
+/// in one GET while staying a small fraction of a modest segment — a large,
+/// many-block segment grows one extra step (rare, cheap vs the body reads).
+const RANGED_INITIAL_SUFFIX: u64 = 8 * 1024;
 
 /// PAX-native OLAP split reader. Loads a PAX **segment** and iterates its blocks
 /// via the canonical [`PaxSegmentScanner`] (each yielded block is a
@@ -159,9 +165,14 @@ impl PaxSplitReader {
     /// Returns `Ok(None)` — signalling the caller to fall back to the whole-file
     /// path — when the segment has no locatable/zone-bearing index (legacy v1
     /// segments, tiny single-block segments), so it is mixed-read-safe with no
-    /// flag-day. Only the shared v2 index zone summary (canonical columns) prunes
-    /// here; shredded user-column pruning needs per-block footer ranged reads
-    /// (`RangedSegmentReader`) — the next slice.
+    /// flag-day.
+    ///
+    /// Two prune stages (TD-DOC-PUSHDOWN-1): **Stage A** prunes against the index
+    /// zone summary (canonical columns, no per-block GET); **Stage B** — engaged only
+    /// when a predicate targets a shredded/user column the summary can't evaluate —
+    /// range-reads each surviving block's footer/metadata (NOT its body) into a
+    /// [`BlockLayout`] and prunes on ALL columns, so a `props__<key>`-pruned block
+    /// costs only its footer, never its body.
     async fn load_ranged(
         &self,
         split: &FileSplit,
@@ -175,9 +186,11 @@ impl PaxSplitReader {
         if len < SEGMENT_INDEX_TRAILER_MIN {
             return Ok(None);
         }
-        // Probe the tail for the segment index, growing on a short suffix.
+        // Probe the tail for the segment index, growing ×4 on a short suffix. Every
+        // physical read (here and below) is accounted by the filesystem layer's own
+        // io_trace hooks (`record_range_gets` + `record_bytes_read`), so this method
+        // records none itself — it would double-count.
         let mut probe = RANGED_INITIAL_SUFFIX.min(len);
-        let mut suffix_bytes: u64 = 0;
         let index = loop {
             let start = len - probe;
             let suffix = self
@@ -185,7 +198,6 @@ impl PaxSplitReader {
                 .read_range(path, start, probe)
                 .await
                 .map_err(|e| DataFusionError::Execution(format!("PAX ranged tail read: {e}")))?;
-            suffix_bytes += suffix.len() as u64;
             match SegmentIndex::locate_in_suffix(&suffix) {
                 Ok(Some(idx)) => break idx,
                 Ok(None) if probe < len => probe = (probe.saturating_mul(4)).min(len),
@@ -194,37 +206,59 @@ impl PaxSplitReader {
                 Ok(None) | Err(_) => return Ok(None),
             }
         };
-        // Prune blocks against the index zone summary (v1 entries carry no zone ⇒
-        // cannot prune from the index ⇒ conservatively keep).
-        let mut survivors: Vec<&proximadb_storage_common::pax_block::BlockIndexEntry> = Vec::new();
+        // Stage A — prune against the index zone summary (canonical columns; v1
+        // entries carry no zone ⇒ conservatively keep). No per-block GET.
+        let mut stage_a: Vec<&BlockIndexEntry> = Vec::new();
         for entry in &index.blocks {
             let pruned = match &entry.zone {
                 Some(zone) => self.pruned_by(zone as &dyn BlockZoneSource),
                 None => false,
             };
             if !pruned {
-                survivors.push(entry);
+                stage_a.push(entry);
             }
         }
         io_trace::record_op_str("fetch_pax_ranged");
-        if survivors.is_empty() {
-            // Every block pruned off the wire — only the tail suffix was read.
-            io_trace::record_bytes_read(suffix_bytes);
+
+        // Stage B — shredded/user-column prune (Layer 2). Only when a predicate targets
+        // a column the index summary can't evaluate: range-read each survivor's footer +
+        // metadata into a `BlockLayout` (carries every column's bounds) and prune on ALL
+        // columns before its body is fetched. A pruned block costs only its footer.
+        // (io_trace `bytes_read`/`range_gets` accrue automatically per `read_range`.)
+        let kept: Vec<&BlockIndexEntry> = if self.needs_footer_prune() {
+            let mut kept = Vec::new();
+            for entry in stage_a {
+                match self
+                    .block_layout_ranged(path, entry.offset, entry.size as u64)
+                    .await
+                {
+                    Ok(layout) => {
+                        if self.pruned_by(&layout as &dyn BlockZoneSource) {
+                            continue; // pruned on a user column — never fetch the body
+                        }
+                        kept.push(entry);
+                    }
+                    // Footer read/parse failed ⇒ conservatively keep (decode re-prunes).
+                    Err(_) => kept.push(entry),
+                }
+            }
+            kept
+        } else {
+            stage_a
+        };
+
+        if kept.is_empty() {
             return Ok(Some(Vec::new()));
         }
-        let ranges: Vec<std::ops::Range<u64>> = survivors
+        let ranges: Vec<std::ops::Range<u64>> = kept
             .iter()
             .map(|e| e.offset..e.offset + e.size as u64)
             .collect();
-        let block_bytes: u64 = ranges.iter().map(|r| r.end - r.start).sum();
         let bufs = self
             .filesystem_factory
             .read_ranges(path, ranges)
             .await
             .map_err(|e| DataFusionError::Execution(format!("PAX ranged block read: {e}")))?;
-        // Each surviving block is fetched with one ranged GET; add the tail probe.
-        io_trace::record_range_gets(survivors.len() as u64 + 1);
-        io_trace::record_bytes_read(block_bytes + suffix_bytes);
         let mut batches = Vec::with_capacity(bufs.len());
         for buf in &bufs {
             let reader = PaxBlockReader::open(buf)
@@ -245,6 +279,70 @@ impl PaxSplitReader {
             batches.push(batch);
         }
         Ok(Some(batches))
+    }
+
+    /// `true` when any prune predicate targets a column the index zone summary does
+    /// NOT carry (a shredded/user column, or a non-summarized canonical column) — the
+    /// case where a per-block footer read (Stage B) can prune beyond the index summary.
+    /// When every predicate is on a summarized canonical column, Stage A suffices and
+    /// no footer GETs are issued.
+    fn needs_footer_prune(&self) -> bool {
+        self.prune_predicates.iter().any(|(name, _)| {
+            self.name_to_col_id
+                .get(name)
+                .is_some_and(|&cid| !is_canonical_zone_col(cid))
+        })
+    }
+
+    /// Range-read one block's footer + metadata extent (NO stripe/body bytes) and
+    /// assemble a [`BlockLayout`] — per-block statistics carrying EVERY column's bounds
+    /// (incl. shredded user columns), so a body-free prune can run. Mirrors
+    /// `RangedSegmentReader::build_block_layout` in the `FilesystemFactory` world:
+    /// one GET for the trailing footer, one for the contiguous metadata extent (both
+    /// accounted by the filesystem layer's io_trace hooks).
+    async fn block_layout_ranged(
+        &self,
+        path: &str,
+        block_offset: u64,
+        block_size: u64,
+    ) -> DFResult<BlockLayout> {
+        let footer_start = block_size - BLOCK_FOOTER_SIZE as u64;
+        let tail = self
+            .filesystem_factory
+            .read_range(path, block_offset + footer_start, BLOCK_FOOTER_SIZE as u64)
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("PAX footer read: {e}")))?;
+        let footer = BlockFooter::from_bytes(&tail)
+            .map_err(|e| DataFusionError::Execution(format!("PAX footer parse: {e}")))?;
+        // The col-meta / vparam / rgdir regions are contiguous below the footer; one
+        // ranged read of [meta_start, footer_start) covers them (no stripe bytes).
+        let mr = metadata_ranges(&footer, block_size);
+        let mut meta_start = mr.col_meta.start;
+        if let Some(r) = &mr.vparam {
+            meta_start = meta_start.min(r.start);
+        }
+        if let Some(r) = &mr.rgdir {
+            meta_start = meta_start.min(r.start);
+        }
+        let meta_buf = if footer_start > meta_start {
+            self.filesystem_factory
+                .read_range(path, block_offset + meta_start, footer_start - meta_start)
+                .await
+                .map_err(|e| DataFusionError::Execution(format!("PAX meta read: {e}")))?
+        } else {
+            Vec::new()
+        };
+        let col_meta = slice_meta(&meta_buf, meta_start, &mr.col_meta)?;
+        let vparam = match &mr.vparam {
+            Some(r) => Some(slice_meta(&meta_buf, meta_start, r)?),
+            None => None,
+        };
+        let rgdir = match &mr.rgdir {
+            Some(r) => Some(slice_meta(&meta_buf, meta_start, r)?),
+            None => None,
+        };
+        BlockLayout::assemble(footer, col_meta, vparam, rgdir)
+            .map_err(|e| DataFusionError::Execution(format!("PAX assemble layout: {e}")))
     }
 
     /// Core decode (no I/O): segment bytes → [`PaxSegmentScanner`] → per-block
@@ -443,6 +541,35 @@ fn block_may_contain(src: &dyn BlockZoneSource, cid: i32, pred: &ScalarPredicate
     }
 }
 
+/// `true` for the canonical columns whose bounds the index [`BlockZoneSummary`]
+/// carries inline (so Stage A can prune them with no per-block GET). Predicates on
+/// any other column need the Stage-B footer read to prune.
+fn is_canonical_zone_col(cid: i32) -> bool {
+    use proximadb_block_format::col_id;
+    matches!(
+        cid,
+        col_id::CREATED_AT
+            | col_id::UPDATED_AT
+            | col_id::VALID_FROM
+            | col_id::VALID_TO
+            | col_id::EDGE_WEIGHT
+    )
+}
+
+/// Slice a block-relative metadata `range` from a buffer that begins at block-relative
+/// `base`. Bounds-checked so a corrupt footer offset is a clean error, not a panic
+/// (mirrors `RangedSegmentReader::slice_meta`).
+fn slice_meta<'a>(buf: &'a [u8], base: u64, range: &std::ops::Range<u64>) -> DFResult<&'a [u8]> {
+    let start = (range.start.saturating_sub(base)) as usize;
+    let end = (range.end.saturating_sub(base)) as usize;
+    buf.get(start..end).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "PAX meta slice {range:?} outside buffer (base {base}, len {})",
+            buf.len()
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,6 +755,114 @@ mod tests {
         assert_eq!(
             ranged_rows, baseline_rows,
             "ranged rows must equal whole-file rows (block-prune parity)"
+        );
+    }
+
+    /// Write a MULTI-block SHREDDED `.pax` segment: each record carries a props
+    /// `age = (i+1)*1000` shredded to a typed i64 user column (`USER_BASE`), tiny target
+    /// block ⇒ blocks span disjoint age ranges. Returns the discovered split + size.
+    async fn multiblock_shredded_split(
+        dir: &std::path::Path,
+        n: i64,
+        target_block: usize,
+        fs: &Arc<FilesystemFactory>,
+    ) -> (crate::storage::formats::FileSplit, u64) {
+        use proximadb_block_format::{BlockCompression, BlockMode};
+        use proximadb_data_model::ProximaValue as PV;
+        use proximadb_records::ProximaTreeNode as Node;
+        use proximadb_storage_common::pax_block::PaxSegmentWriter;
+
+        let path = dir.join("shred.pax");
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            0, // embedding_count — pure document/relational segment (no vectors)
+            Some(target_block),
+        )
+        .with_shred_spec(vec![("age".to_string(), col_id::USER_BASE)]);
+        for i in 0..n {
+            let mut rec = record(&format!("r{i:04}"), "t", (i + 1) * 1000);
+            rec.props
+                .insert("age".into(), Node::Value(PV::Int64((i + 1) * 1000)));
+            w.add_record(&rec).unwrap();
+        }
+        w.finish().unwrap();
+        let file_len = std::fs::metadata(&path).unwrap().len();
+        let base = format!("{}", dir.display());
+        let splits =
+            crate::datafusion::engine_adapters::pax_segment_locator::discover_pax_segments(
+                &base, fs,
+            )
+            .await
+            .unwrap();
+        let split = splits
+            .into_iter()
+            .find(|s| s.file_path.ends_with("shred.pax"))
+            .expect("discovered shred.pax split");
+        (split, file_len)
+    }
+
+    /// Layer 2 (TD-DOC-PUSHDOWN-1): a predicate on a SHREDDED user column — which the
+    /// index zone summary cannot evaluate — prunes block BODIES via the per-block footer
+    /// read (Stage B). `bytes_read < whole segment` with `range_gets > 0`, rows identical
+    /// to the whole-file path.
+    #[tokio::test]
+    async fn ranged_footer_prune_skips_bodies_on_user_column() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = Arc::new(FilesystemFactory::create_default().await.unwrap());
+        // Realistically LARGE blocks (~130 rows/block): per-block metadata is a small
+        // fraction of the body, so pruning a block's body off the wire is a clear net
+        // win over the footer read — the regime real document segments live in.
+        let (split, file_len) = multiblock_shredded_split(tmp.path(), 2000, 16384, &fs).await;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("age", DataType::Int64, true)]));
+        let map = HashMap::from([(String::from("age"), col_id::USER_BASE)]);
+        // age = (i+1)*1000 ∈ [1000, 2_000_000]; keep only the top ~25% of blocks.
+        let filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            col("age", schema.as_ref()).unwrap(),
+            Operator::GtEq,
+            lit(1_500_000i64),
+        ));
+        let reader = PaxSplitReader::new(schema.clone(), fs.clone(), map, vec![filter]);
+        assert!(
+            reader.needs_footer_prune(),
+            "a shredded user-column predicate must engage Stage B footer pruning"
+        );
+
+        let (rows, snap) = io_trace::scope(async {
+            let batches = reader
+                .load_ranged(&split, &schema)
+                .await
+                .unwrap()
+                .expect("v2 zone index present ⇒ ranged path taken");
+            (collect_created_at(&batches), io_trace::snapshot().unwrap())
+        })
+        .await;
+
+        assert!(
+            snap.range_gets > 0,
+            "ranged GETs issued: {}",
+            snap.range_gets
+        );
+        assert!(
+            snap.bytes_read < file_len,
+            "footer-prune bytes_read {} must be < whole segment {file_len} (user-column pruning)",
+            snap.bytes_read
+        );
+
+        let disk = split
+            .file_path
+            .strip_prefix("file://")
+            .unwrap_or(&split.file_path);
+        let whole = std::fs::read(disk).expect("read segment back");
+        let baseline = collect_created_at(&reader.decode_segment(&whole, &schema).unwrap());
+        assert!(!rows.is_empty(), "some upper age blocks survive the filter");
+        assert_eq!(
+            rows, baseline,
+            "footer-prune rows must equal whole-file rows (user-column prune parity)"
         );
     }
 


### PR DESCRIPTION
## What

Layer 1 (#835) pruned blocks off the wire via the index **zone summary** — but that summary carries **canonical-column** bounds only, so a predicate on a shredded `props__<key>` user column couldn't prune from it (all blocks survived, bodies fetched). This adds **Stage B**:

When a predicate targets a column the index summary can't evaluate (`needs_footer_prune`), range-read each surviving block's **footer + metadata extent** (NO stripe/body bytes) into a `BlockLayout` — which carries EVERY column's bounds, incl. user columns — and prune on all columns **before** the body is fetched. A block pruned on a user column then costs only its small footer, never its body.

- `block_layout_ranged` mirrors `RangedSegmentReader::build_block_layout` in the `FilesystemFactory` world, reusing the **public** block-format primitives (`BlockFooter::from_bytes`, `metadata_ranges`, `BlockLayout::assemble`) — no hand-rolled decode. `BlockLayout` implements `BlockZoneSource`, so Stage B reuses the **exact same** `pruned_by`/`block_may_contain` logic as Stage A and the decode path.

## Bug fix (bonus)
Removes a **double-count** in Layer 1: the filesystem layer already feeds io_trace `bytes_read`/`range_gets` per `read_range` (`local.rs:739`), so `load_ranged` was reporting ~2× actual bytes. It now records none itself. Also lowers the index tail probe 64 KiB → 8 KiB (small fraction of a modest segment; a many-block segment grows one extra step) and counts only the final probe.

## Verified — document-field gate shape
`ranged_footer_prune_skips_bodies_on_user_column`: a multi-block **shredded** segment (2000 rows, `age` shredded to a typed i64 user column) with a predicate on `age` reads **`bytes_read` < whole segment** with **`range_gets` > 0** and returns rows **byte-identical** to the whole-file path. Full `pax_adapter` suite: **5/5**. `cargo fmt --check`, `clippy --lib --bins -D warnings`: clean.

## Scope
Closes the **reader half** of TD-DOC-PUSHDOWN-1 (Layer 1 + Layer 2). The `documents()` → `PaxTableProvider` **adapter** (pax-scan-inputs port + `filesystem_factory()` singleton + provider delegation) is the remaining piece — TD updated.

Relates to TD-DOC-PUSHDOWN-1, ADR-055, #835, TD-OLAP-1/#736.