### PR TITLE
feat(olap): operation dimension in the route cost model (TD-OLAP-4)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -443,6 +443,7 @@ pub async fn try_run_select(
             pax_backed: false,
             partition_fanout,
             cardinality,
+            operation_class: query_operation_class(query),
         },
         // C4: observe-mode advisory from the trace-driven cost model — augments
         // the reason for telemetry/EXPLAIN, never changes the backend.
@@ -2191,6 +2192,79 @@ fn query_engages_relational_engine(query: &SqlQuery) -> bool {
 /// shape GUARANTEES a tiny result, else `Unknown` (never over-claims). Pure AST
 /// walk — zero route-time I/O (co-design P5: I/O round-trips, not CPU, dominate;
 /// the route path must not probe storage).
+/// TD-OLAP-4 operation dimension: classify the SELECT's OLAP operation from the AST
+/// (syntax-only, zero route-time I/O). Feeds the cost-model shape-class so per-engine
+/// samples accumulate per operation — the geometry the shadow ledger showed engines
+/// win/lose on. Priority: grouped > string-heavy > metadata-elidable > scalar-agg.
+fn query_operation_class(query: &SqlQuery) -> crate::query::compute_scheduler::OperationClass {
+    use crate::query::compute_scheduler::OperationClass;
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return OperationClass::Other;
+    };
+    let has_group_by = match &select.group_by {
+        GroupByExpr::All(_) => true,
+        GroupByExpr::Expressions(exprs, _) => !exprs.is_empty(),
+    };
+    if has_group_by {
+        return OperationClass::Grouped;
+    }
+    // A LIKE/regex predicate → native can't push it down → DataFusion class.
+    if select.selection.as_ref().is_some_and(expr_is_string_heavy) {
+        return OperationClass::StringHeavy;
+    }
+    let has_agg = select.projection.iter().any(select_item_has_aggregate);
+    if has_agg && select.having.is_none() {
+        // Unfiltered + every projection a COUNT/MIN/MAX → footer-elidable.
+        if select.selection.is_none()
+            && select
+                .projection
+                .iter()
+                .all(select_item_is_elidable_aggregate)
+        {
+            return OperationClass::MetadataElidable;
+        }
+        return OperationClass::ScalarAggregate;
+    }
+    OperationClass::Other
+}
+
+/// Does the predicate use a string-matching construct (`LIKE`/`ILIKE`/`SIMILAR TO`
+/// or a `regexp_*` function)? Recursive over boolean structure.
+fn expr_is_string_heavy(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Like { .. } | SqlExpr::ILike { .. } | SqlExpr::SimilarTo { .. } => true,
+        SqlExpr::Function(f) => {
+            let n = f.name.to_string().to_ascii_lowercase();
+            matches!(
+                n.rsplit('.').next().unwrap_or(&n),
+                "regexp_replace" | "regexp_match" | "regexp_matches" | "regexp_like"
+            )
+        }
+        SqlExpr::BinaryOp { left, right, .. } => {
+            expr_is_string_heavy(left) || expr_is_string_heavy(right)
+        }
+        SqlExpr::UnaryOp { expr, .. } | SqlExpr::Nested(expr) | SqlExpr::Cast { expr, .. } => {
+            expr_is_string_heavy(expr)
+        }
+        _ => false,
+    }
+}
+
+/// Is this projection item a `COUNT`/`MIN`/`MAX` aggregate (footer-elidable, unlike
+/// `SUM`/`AVG` which need column data)?
+fn select_item_is_elidable_aggregate(item: &SelectItem) -> bool {
+    let expr = match item {
+        SelectItem::UnnamedExpr(e) | SelectItem::ExprWithAlias { expr: e, .. } => e,
+        _ => return false,
+    };
+    if let SqlExpr::Function(f) = expr {
+        let n = f.name.to_string().to_ascii_lowercase();
+        matches!(n.rsplit('.').next().unwrap_or(&n), "count" | "min" | "max")
+    } else {
+        false
+    }
+}
+
 fn query_cardinality_hint(query: &SqlQuery) -> crate::query::compute_scheduler::CardinalityClass {
     use crate::query::compute_scheduler::CardinalityClass;
     // sqlparser 0.59 carries LIMIT on the Query as a `LimitClause` enum (standard
@@ -2499,6 +2573,47 @@ mod tests {
             [Statement::Query(query)] => query_engages_relational_engine(query),
             _ => panic!("expected a single SELECT statement"),
         }
+    }
+
+    #[test]
+    fn operation_class_classifies_olap_shapes() {
+        use crate::query::compute_scheduler::OperationClass;
+        let op = |sql: &str| {
+            let s = Parser::parse_sql(&GenericDialect {}, sql).expect("parse");
+            match s.as_slice() {
+                [Statement::Query(q)] => query_operation_class(q),
+                _ => panic!("one SELECT"),
+            }
+        };
+        // Unfiltered COUNT(*) / MIN / MAX → footer-elidable (native wins).
+        assert_eq!(
+            op("SELECT COUNT(*) FROM hits"),
+            OperationClass::MetadataElidable
+        );
+        assert_eq!(
+            op("SELECT MIN(eventdate), MAX(eventdate) FROM hits"),
+            OperationClass::MetadataElidable
+        );
+        // SUM/AVG need column data → scalar aggregate.
+        assert_eq!(
+            op("SELECT SUM(advengineid), AVG(resolutionwidth) FROM hits"),
+            OperationClass::ScalarAggregate
+        );
+        // A plain (non-string) filter is still a scalar aggregate.
+        assert_eq!(
+            op("SELECT COUNT(*) FROM hits WHERE advengineid <> 0"),
+            OperationClass::ScalarAggregate
+        );
+        // LIKE predicate → string-heavy (routes to DataFusion).
+        assert_eq!(
+            op("SELECT COUNT(*) FROM hits WHERE url LIKE '%google%'"),
+            OperationClass::StringHeavy
+        );
+        // GROUP BY → grouped.
+        assert_eq!(
+            op("SELECT regionid, COUNT(*) FROM hits GROUP BY regionid"),
+            OperationClass::Grouped
+        );
     }
 
     #[cfg(feature = "datafusion-integration")]

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -118,14 +118,50 @@ impl PartitionFanout {
     }
 }
 
+/// TD-OLAP-4 operation dimension: the OLAP operation class, so the cost model
+/// keys its per-engine samples by *what the query does* (the geometry the shadow
+/// ledger showed engines win/lose on), not just cardinality/partition. Default
+/// `Unknown` preserves the coarse class + warmed cells.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OperationClass {
+    #[default]
+    Unknown,
+    /// Unfiltered scalar aggregate answerable from footer stats — `COUNT(*)`,
+    /// `MIN`/`MAX`. Native wins (metadata elision, flat cost).
+    MetadataElidable,
+    /// Ungrouped scalar aggregate over column data — `SUM`/`AVG`/filtered `COUNT`.
+    /// Native-competitive once vectorized + morsel-parallel (TD-OLAP-12).
+    ScalarAggregate,
+    /// `GROUP BY` aggregate. High-cardinality → DataFusion (native has no spilling).
+    Grouped,
+    /// String-heavy predicate/projection — `LIKE`/regex/string funcs. DataFusion
+    /// (native has no predicate pushdown / wide-string kernels yet).
+    StringHeavy,
+    /// Anything else — joins, window, subquery, plain projection.
+    Other,
+}
+
+impl OperationClass {
+    pub(crate) fn class_suffix(self) -> Option<&'static str> {
+        match self {
+            OperationClass::Unknown => None,
+            OperationClass::MetadataElidable => Some("op=meta"),
+            OperationClass::ScalarAggregate => Some("op=agg"),
+            OperationClass::Grouped => Some("op=grp"),
+            OperationClass::StringHeavy => Some("op=str"),
+            OperationClass::Other => Some("op=other"),
+        }
+    }
+}
+
 /// Shape signals the scheduler routes on.
 ///
 /// P0 used only `engages_relational` — the join / `GROUP BY` / aggregate / set-op
 /// gate (the OLAP-shape signal). P1 added `parquet_backed`. C4 Phase-2b adds the
 /// §5.2 Phase-1 inputs — `cardinality` and `partition_fanout` — which refine the
 /// cost-model shape-class so routing and exploration discriminate beyond
-/// `olap/oltp × native/parquet`. Both default to `Unknown`, preserving the
-/// coarse class (and warmed cells) for planners that cannot estimate them.
+/// `olap/oltp × native/parquet`. TD-OLAP-4 adds `operation_class`. All default to
+/// `Unknown`, preserving the coarse class (and warmed cells).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct QueryShape {
     /// The query lowers against the relational algebra engine for a reason the
@@ -144,6 +180,9 @@ pub struct QueryShape {
     /// TD-OLAP-1 slice 2: tables backed by PAX segments (not Parquet). When
     /// true + `pax_reader_enabled()`, routes to DataFusion via PaxSplitReader.
     pub pax_backed: bool,
+    /// TD-OLAP-4: the OLAP operation class (metadata-elidable / scalar-aggregate /
+    /// grouped / string-heavy) — the geometry dimension the engines win/lose on.
+    pub operation_class: OperationClass,
 }
 
 /// TD-OLAP-1 slice 2: PAX-native OLAP scan gate (inline — not imported from

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -366,6 +366,7 @@ pub fn shape_class(shape: &QueryShape) -> String {
     for suffix in [
         shape.cardinality.class_suffix(),
         shape.partition_fanout.class_suffix(),
+        shape.operation_class.class_suffix(),
     ]
     .into_iter()
     .flatten()
@@ -1249,6 +1250,7 @@ mod tests {
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
+            operation_class: Default::default(),
         });
         assert_eq!(class, "olap/parquet/card=l/part=m");
         // A partially-known shape only appends the known suffix.
@@ -1870,6 +1872,7 @@ mod tests {
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
+            operation_class: Default::default(),
         });
         let small = shape_class(&QueryShape {
             engages_relational: true,
@@ -1877,6 +1880,7 @@ mod tests {
             cardinality: CardinalityClass::Small,
             partition_fanout: PartitionFanout::Single,
             pax_backed: false,
+            operation_class: Default::default(),
         });
         assert_ne!(big, coarse);
         assert_ne!(small, coarse);
@@ -1904,6 +1908,7 @@ mod tests {
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
+            operation_class: Default::default(),
         };
         let class = shape_class(&big);
         // Observe Native as confidently cheaper than DataFusion for THIS fine

--- a/tests/route_cost_offline_eval.rs
+++ b/tests/route_cost_offline_eval.rs
@@ -140,6 +140,7 @@ fn simulate(rounds: u64) -> (Vec<(String, Regret)>, f64, f64) {
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
+            operation_class: Default::default(),
         },
         static_backend: ComputeBackend::DataFusionLocal,
         arms: vec![


### PR DESCRIPTION
## What
Wires **operation** in as a first-class routing/cost dimension. The io-trace already carries **engine** (per-engine `compute_ms`), **cost** (bytes/gets), and **wall/phase**, feeding `route_cost_model` per `(shape_class × backend)`. But `shape_class` keyed only on workload/parquet/cardinality/partition — **not on what the query does**. The shadow ledger showed engines win/lose by *operation*; this closes that loop.

## How
- **`OperationClass`** enum (`MetadataElidable | ScalarAggregate | Grouped | StringHeavy | Other | Unknown`) + `class_suffix()` (`op=meta/agg/grp/str/…`), mirroring `CardinalityClass`/`PartitionFanout`.
- **`QueryShape.operation_class`** field (default `Unknown` — coarse class + warmed cells preserved).
- **`shape_class`** appends the `op=` suffix → cost-model EWMA cells now key on `(workload/parquet/card/part/op × backend)`.
- **`query_operation_class`** — syntax-only AST classifier (zero route-time I/O) wired at the `QueryShape` construction in `try_run_select`: `GROUP BY` → Grouped; `LIKE`/regex → StringHeavy; unfiltered `COUNT`/`MIN`/`MAX` → MetadataElidable; else ScalarAggregate.

## Scope
**Observe dimension only** — does *not* change routing yet (that's the follow-on "favor native by operation"). It makes the same `compute_by_engine` samples the shadow ledger records accumulate **live per operation**, so the router can learn per `(operation × cardinality × engine)` instead of reading the ledger offline.

## Tests
`operation_class_classifies_olap_shapes` over the ClickBench shapes; existing `shape_class` tests pass with the new `op=` suffix. clippy `-D warnings` + fmt clean.

_Note: the integration-test target has a pre-existing `private_interfaces` error in `core_routing_test.rs` (zero references to this change; from the v0.2.0 merge) — unrelated._