### PR TITLE
refactor(quant): pre-extract quantized data types to foundation (Slice D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7304,6 +7304,7 @@ dependencies = [
  "dashmap",
  "proximadb-distance-kernel",
  "proximadb-hardware",
+ "proximadb-quantization-model",
  "proximadb-quantization-types",
  "proximadb-storage-ports",
  "proximadb-vector",

--- a/crates/foundation/proximadb-quantization-model/src/lib.rs
+++ b/crates/foundation/proximadb-quantization-model/src/lib.rs
@@ -629,3 +629,55 @@ impl QuantizationMethod for UnifiedQuantizationLevel {
         }
     }
 }
+
+// ============================================================================
+// Quantized data types (moved from the modality kernel — Slice D pre-extraction).
+// Foundation-pure (Vec<u8> + the UnifiedQuantizationLevel above + primitive
+// metadata). Shared by storage (data-type refs) + the kernel. Pre-extracting them
+// here makes the upcoming StorageQuantizationEnginePort facade-FREE (the port's
+// return types are these foundation types, not modality types).
+// ============================================================================
+
+/// Metadata for quantized vectors
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct QuantEngineQuantizationMetadata {
+    /// Reference to codebook (for PQ)
+    pub codebook_id: Option<String>,
+    /// Scale factor (for scalar/uniform)
+    pub scale: Option<f32>,
+    /// Offset (for scalar/uniform)
+    pub offset: Option<f32>,
+    /// Original vector norm (useful for some metrics)
+    pub norm: Option<f32>,
+}
+
+/// Backwards-compat alias for [`QuantEngineQuantizationMetadata`].
+pub type QuantizationMetadata = QuantEngineQuantizationMetadata;
+
+/// Quantized vector representation
+#[derive(Debug, Clone)]
+pub struct QuantizedVector {
+    /// The quantized data
+    pub data: Vec<u8>,
+    /// Quantization level used
+    pub quantization_level: UnifiedQuantizationLevel,
+    /// Additional metadata (scale, offset, codebook reference)
+    pub metadata: QuantEngineQuantizationMetadata,
+}
+
+/// Common quantized data structure for storage
+#[derive(Debug, Clone)]
+pub struct StorageQuantizedData {
+    /// Vector ID
+    pub id: String,
+    /// Primary quantization (e.g., PQ codes for ranking)
+    pub primary: Option<QuantizedVector>,
+    /// Filter quantization (e.g., binary sketch for filtering)
+    pub filter: Option<QuantizedVector>,
+    /// Fast quantization (e.g., INT8 for quick distance)
+    pub fast: Option<QuantizedVector>,
+    /// Original dimension
+    pub dimension: usize,
+    /// Metadata about quantization quality
+    pub metadata: QuantizationMetadata,
+}

--- a/crates/modalities/proximadb-quantization-kernel/Cargo.toml
+++ b/crates/modalities/proximadb-quantization-kernel/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { workspace = true }
 proximadb-hardware = { workspace = true }
 proximadb-vector = { workspace = true }
 proximadb-quantization-types = { workspace = true }
+proximadb-quantization-model = { workspace = true }
 proximadb-distance-kernel = { workspace = true }
 # Downward dep (modality→storage-ports): the kernel impls QuantizationEnginePort
 # so storage can depend on the port trait, not on this concrete modality crate.

--- a/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
@@ -44,7 +44,6 @@
 
 use anyhow::{Context, Result};
 use proximadb_storage_ports::QuantizationEnginePort;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -1786,37 +1785,13 @@ impl UnifiedQuantizationEngine {
     }
 }
 
-/// Quantized vector representation
-#[derive(Debug, Clone)]
-pub struct QuantizedVector {
-    /// The quantized data
-    pub data: Vec<u8>,
-
-    /// Quantization level used
-    pub quantization_level: UnifiedQuantizationLevel,
-
-    /// Additional metadata (scale, offset, codebook reference)
-    pub metadata: QuantEngineQuantizationMetadata,
-}
-
-/// Backwards-compat alias for [`QuantEngineQuantizationMetadata`].
-pub type QuantizationMetadata = QuantEngineQuantizationMetadata;
-
-/// Metadata for quantized vectors
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct QuantEngineQuantizationMetadata {
-    /// Reference to codebook (for PQ)
-    pub codebook_id: Option<String>,
-
-    /// Scale factor (for scalar/uniform)
-    pub scale: Option<f32>,
-
-    /// Offset (for scalar/uniform)
-    pub offset: Option<f32>,
-
-    /// Original vector norm (useful for some metrics)
-    pub norm: Option<f32>,
-}
+// Slice D pre-extraction: QuantizedVector + QuantEngineQuantizationMetadata + the
+// QuantizationMetadata alias now live in foundation `proximadb-quantization-model`
+// (foundation-pure: Vec<u8> + UnifiedQuantizationLevel + primitive metadata).
+// Re-exported here so this crate's public API + internal construction are unchanged.
+pub use proximadb_quantization_model::{
+    QuantEngineQuantizationMetadata, QuantizationMetadata, QuantizedVector,
+};
 
 /// In-memory codebook store for testing
 pub struct InMemoryCodebookStore {

--- a/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
@@ -69,27 +69,10 @@ impl Default for StorageQuantizationConfig {
     }
 }
 
-/// Common quantized data structure for storage
-#[derive(Debug, Clone)]
-pub struct StorageQuantizedData {
-    /// Vector ID
-    pub id: String,
-
-    /// Primary quantization (e.g., PQ codes for ranking)
-    pub primary: Option<QuantizedVector>,
-
-    /// Filter quantization (e.g., binary sketch for filtering)
-    pub filter: Option<QuantizedVector>,
-
-    /// Fast quantization (e.g., INT8 for quick distance)
-    pub fast: Option<QuantizedVector>,
-
-    /// Original dimension
-    pub dimension: usize,
-
-    /// Metadata about quantization quality
-    pub metadata: QuantizationMetadata,
-}
+// Slice D pre-extraction: StorageQuantizedData now lives in foundation
+// `proximadb-quantization-model` (foundation-pure). Re-exported here so this crate's
+// public API + internal usage are unchanged.
+pub use proximadb_quantization_model::StorageQuantizedData;
 
 /// Search stages for progressive resolution
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/scripts/check-layering.sh
+++ b/scripts/check-layering.sh
@@ -10,4 +10,4 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT_DIR"
 python3 scripts/check_workspace_boundaries.py --strict
-python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 205
+python3 scripts/check_workspace_boundaries.py --storage-up-edges --max-storage-up-edges 197

--- a/src/storage/engines/core/search/progressive_search.rs
+++ b/src/storage/engines/core/search/progressive_search.rs
@@ -30,12 +30,12 @@ use tracing::{debug, trace};
 use crate::compute::quantization::quantization_engine::{
     QuantizedVector, UnifiedQuantizationEngine,
 };
-use crate::compute::quantization::storage_engine::StorageQuantizedData;
 use crate::core::search::OptimizedSearchRecord;
 use crate::proto::proximadb_v1::VectorRecord;
 use crate::storage::traits::{QuantizationLevel, QuantizationType, StorageQueryContext};
 use proximadb_distance_kernel::DistanceMetric;
 use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+use proximadb_quantization_model::StorageQuantizedData;
 
 /// Progressive search executor that can be used by any storage engine
 pub struct ProgressiveSearchExecutor {

--- a/src/storage/engines/raptor/common.rs
+++ b/src/storage/engines/raptor/common.rs
@@ -1229,7 +1229,7 @@ impl InterCentroidMatrix {
         }
 
         // Create quantized vector wrapper for unified engine processing
-        use crate::compute::quantization::quantization_engine::QuantizationMetadata;
+        use proximadb_quantization_model::QuantizationMetadata;
         let _quantized_vector = QuantizedVector {
             data: quantized_values
                 .iter()

--- a/src/storage/engines/viper/pipeline.rs
+++ b/src/storage/engines/viper/pipeline.rs
@@ -1080,7 +1080,7 @@ impl VectorRecordProcessor {
         &self,
         records: &[VectorRecord],
         quantization_level: proximadb_quantization_model::UnifiedQuantizationLevel,
-    ) -> Result<Vec<crate::compute::quantization::quantization_engine::QuantizedVector>> {
+    ) -> Result<Vec<proximadb_quantization_model::QuantizedVector>> {
         if records.is_empty() {
             return Ok(vec![]);
         }
@@ -1114,12 +1114,11 @@ impl VectorRecordProcessor {
                 );
 
                 // Convert StorageQuantizedData to QuantizedVector
-                let quantized_vectors: Vec<
-                    crate::compute::quantization::quantization_engine::QuantizedVector,
-                > = storage_quantized_data
-                    .into_iter()
-                    .filter_map(|data| data.primary)
-                    .collect();
+                let quantized_vectors: Vec<proximadb_quantization_model::QuantizedVector> =
+                    storage_quantized_data
+                        .into_iter()
+                        .filter_map(|data| data.primary)
+                        .collect();
 
                 // Log quantization success
                 debug!(
@@ -1146,7 +1145,7 @@ impl VectorRecordProcessor {
         records: &[VectorRecord],
     ) -> Result<(
         RecordBatch,
-        Option<Vec<crate::compute::quantization::quantization_engine::QuantizedVector>>,
+        Option<Vec<proximadb_quantization_model::QuantizedVector>>,
     )> {
         if records.is_empty() {
             return Err(anyhow::anyhow!("Cannot process empty record set"));
@@ -2064,9 +2063,7 @@ impl ParquetFlusher {
     pub async fn flush_batch_with_quantization(
         &self,
         batch: RecordBatch,
-        quantized_vectors: Option<
-            Vec<crate::compute::quantization::quantization_engine::QuantizedVector>,
-        >,
+        quantized_vectors: Option<Vec<proximadb_quantization_model::QuantizedVector>>,
         output_path: &str,
     ) -> Result<ViperPipelineFlushResult> {
         // Augment batch with quantized vector columns if available
@@ -2179,7 +2176,7 @@ impl ParquetFlusher {
     fn augment_batch_with_quantized_vectors(
         &self,
         batch: RecordBatch,
-        quantized_vectors: &[crate::compute::quantization::quantization_engine::QuantizedVector],
+        quantized_vectors: &[proximadb_quantization_model::QuantizedVector],
     ) -> Result<RecordBatch> {
         // Quantization types now from unified compute module
         use arrow_array::{BinaryArray, UInt8Array};
@@ -2201,7 +2198,7 @@ impl ParquetFlusher {
         // Group quantized vectors by quantization level for efficient column storage
         let mut quantization_groups: std::collections::HashMap<
             proximadb_quantization_model::UnifiedQuantizationLevel,
-            Vec<&crate::compute::quantization::quantization_engine::QuantizedVector>,
+            Vec<&proximadb_quantization_model::QuantizedVector>,
         > = std::collections::HashMap::new();
 
         for qvec in quantized_vectors {


### PR DESCRIPTION
## What & why
Incremental start of the **factory-as-injection-boundary** (the recommended next step per the Slice D plan, #841). Moves the quantized **data types** down to foundation — the #831 recipe — which both drops storage up-edges AND, importantly, makes the upcoming `StorageQuantizationEnginePort` (D2b) **facade-free**.

## The types
`QuantizedVector` + `QuantEngineQuantizationMetadata` + the `QuantizationMetadata` alias + `StorageQuantizedData`. They were canonically in the modality kernel but are **foundation-pure** (`Vec<u8>` + `UnifiedQuantizationLevel` [foundation via #831] + primitive metadata: `codebook_id`/`scale`/`offset`/`norm` + `String`/`usize`). Moved verbatim into `proximadb-quantization-model` (alongside the #831 cluster); re-exported from the kernel so its public API + internal construction are unchanged.

## Why it matters (beyond the ratchet)
The Slice D plan (#841) assumed `StorageQuantizationEnginePort` would need **facade DTOs** because its methods return `Vec<StorageQuantizedData>` / take `&QuantizedVector` (modality types). With those types now in foundation, the port's signatures are **foundation-typed → no facades**. This materially simplifies D2b (and thus the factory-boundary).

## Changes
- **`proximadb-quantization-model`**: + the 4 data types.
- **`proximadb-quantization-kernel`**: + `quantization-model` dep; the 4 defs → `pub use` re-export; dropped the now-unused `serde` import.
- **`src/storage`** (`progressive_search.rs`, `raptor/common.rs`, `viper/pipeline.rs`): 8 data-type refs → `proximadb_quantization_model::*` (Mechanism A path rewrite).

## Verification
- `cargo check --lib` ✅ · `cargo clippy --lib` ✅ · `cargo fmt --check` ✅
- `bash scripts/check-layering.sh` ✅ (ceiling lowered 205 → 197)
- Storage up-edge ratchet **205 → 197 (−8)**. Behavior-identical type move → recall-neutral (CI storage integration + recall will confirm).
- **No dependency on in-flight #596 or #605** — verified: #596 touches `reader.rs`+`traits/mod.rs`, #605 is docs-only; this PR touches the kernel quantization files + 3 storage files, **0 overlap**.

Per `ROOT_CRATE_DECOMPOSITION_SLICE_D` (the factory-boundary plan, #841).