### PR TITLE
fix(ci): correct cancel-in-progress guard — 'development'→'develop' (protected branch)

### DIFF
--- a/.github/workflows/capability-contract-tests.yml
+++ b/.github/workflows/capability-contract-tests.yml
@@ -25,7 +25,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded runs
   # on feature/PR branches, but let protected-branch validation finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -63,7 +63,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Default read-only; jobs that assume an AWS role via OIDC or comment on a PR

--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -10,7 +10,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Default read-only; the single job elevates only what it needs.

--- a/.github/workflows/prerelease-ci-v0.2.1-macos.yml
+++ b/.github/workflows/prerelease-ci-v0.2.1-macos.yml
@@ -7,7 +7,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.

--- a/.github/workflows/prerelease-ci.yml
+++ b/.github/workflows/prerelease-ci.yml
@@ -68,7 +68,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 jobs:
   # ============================================================================

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -16,7 +16,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.

--- a/.github/workflows/tier-config-fingerprint.yml
+++ b/.github/workflows/tier-config-fingerprint.yml
@@ -29,7 +29,7 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded
   # runs on feature/PR branches, but let protected-branch runs finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'development' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
 
 # Least-privilege default GITHUB_TOKEN scope (CodeQL actions/missing-workflow-permissions).
 # Read-only is sufficient: no job here writes to the repo, posts comments, or uses OIDC.


### PR DESCRIPTION
## What
The `cancel-in-progress` concurrency guard in 8 workflows checks `github.ref_name != 'development'`, but the protected integration branch is **`develop`** (no `development` branch exists). So the guard evaluated **true** for `develop` — every new develop push cancelled the in-flight CI run.

The comment above the guard states the intent plainly: *"cancel superseded runs on feature/PR branches, but let protected-branch validation finish."* The typo defeated that on `develop`.

## Impact
`develop`'s combined state has repeatedly failed to get a completed full CI pass — e.g. #832's merge-push CI run (`29097437662`) ran **1h34m and was cancelled** by the next push. With several merges landing since (#837 / #835 / #839 + #832's tenant/config code), `develop` is currently unvalidated end-to-end.

## Fix
`'development'` → `'develop'` in all 8 workflow files:
- `ci.yml`
- `layering-check.yml`
- `capability-contract-tests.yml`
- `tdd.yml`
- `infrastructure-deploy.yml`
- `prerelease-ci-v0.2.1-macos.yml`
- `tier-config-fingerprint.yml`
- `prerelease-ci.yml`

Restores the PR #363 intent (do not cancel validation on `develop` / `main`). Once this lands, the develop CI run triggered by the merge will run to completion and validate the combined state (including #832's tenant/config code).

## Verification
`grep -rn "'development'" .github/workflows/` → 0 hits. 8 files changed, 1 line each.
