### PR TITLE
feat(storage-ports): StorageQuantizationEnginePort (D2b, facade-free)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7855,6 +7855,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "proximadb-proto",
+ "proximadb-quantization-model",
  "proximadb-storage-common",
 ]
 

--- a/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/storage_engine.rs
@@ -14,6 +14,7 @@ use super::quantization_engine::{
     UnifiedQuantizationEngine, UnifiedQuantizationLevel,
 };
 use proximadb_distance_kernel::engine::{DistanceMetric, UnifiedDistanceCompute};
+use proximadb_storage_ports::StorageQuantizationEnginePort;
 // Note: create_distance_calculator is available but not currently used
 // use proximadb_distance_kernel::create_distance_calculator;
 use proximadb_hardware::{SimdLevel, best_simd_level};
@@ -1521,5 +1522,34 @@ mod tests {
         let original_size = vectors.len() * vectors[0].len() * 4;
         let savings = engine.calculate_savings(original_size, &quantized);
         assert!(savings > 0.2); // Should have at least 20% savings (relaxed for simple test vectors)
+    }
+}
+
+// Slice D — StorageQuantizationEnginePort impl: exposes the collection-aware batch
+// quantize/dequantize surface as a storage dependency-inversion port so `src/storage`
+// can hold `Arc<dyn StorageQuantizationEnginePort>` instead of the concrete engine.
+// Facade-FREE: all return types (Vec<StorageQuantizedData>, Vec<f32>) + params
+// (UnifiedQuantizationLevel, &QuantizedVector) are foundation types (moved by #842).
+// Fully-qualified calls delegate to the inherent methods (no recursion).
+#[async_trait::async_trait]
+impl StorageQuantizationEnginePort for StorageQuantizationEngine {
+    async fn quantize_batch(
+        &self,
+        vectors: &[Vec<f32>],
+        ids: Option<&[String]>,
+    ) -> Result<Vec<StorageQuantizedData>> {
+        StorageQuantizationEngine::quantize_batch(self, vectors, ids).await
+    }
+
+    async fn quantize_batch_with_level(
+        &self,
+        vectors: &[Vec<f32>],
+        level: UnifiedQuantizationLevel,
+    ) -> Result<Vec<StorageQuantizedData>> {
+        StorageQuantizationEngine::quantize_batch_with_level(self, vectors, level).await
+    }
+
+    async fn dequantize(&self, quantized: &QuantizedVector) -> Result<Vec<f32>> {
+        StorageQuantizationEngine::dequantize(self, quantized).await
     }
 }

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -18,6 +18,10 @@ anyhow.workspace = true
 async-trait.workspace = true
 proximadb-proto.workspace = true
 proximadb-storage-common.workspace = true
+# Foundation-tier: the StorageQuantizationEnginePort returns these data types
+# (Vec<StorageQuantizedData>, &QuantizedVector, UnifiedQuantizationLevel) — moved to
+# foundation by #842, so the port is facade-FREE (no DTO/adaptor layer).
+proximadb-quantization-model.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -123,3 +123,40 @@ pub trait GraphOperationsPort: Send + Sync {
         request: proximadb_proto::proximadb_v1::CreateGraphRequest,
     ) -> Result<std::sync::Arc<proximadb_proto::proximadb_v1::GraphCollection>>;
 }
+
+use proximadb_quantization_model::{
+    QuantizedVector, StorageQuantizedData, UnifiedQuantizationLevel,
+};
+
+/// Collection-aware batch quantization + dequantization that storage's
+/// write/compaction/search paths need.
+///
+/// Inverts `StorageQuantizationEngine` (modality-tier kernel): storage holds an
+/// `Arc<dyn StorageQuantizationEnginePort>` and never names the concrete engine.
+/// The return types (`Vec<StorageQuantizedData>`, `Vec<f32>`) and params
+/// (`UnifiedQuantizationLevel`, `&QuantizedVector`) are all foundation types
+/// (moved by #842) → **facade-FREE** (no DTO/adaptor layer).
+///
+/// The concrete `StorageQuantizationEngine` `impl`s this in its own crate (a
+/// downward dep — modality→storage-ports is layering-allowed). The composition
+/// root injects the impl. Training (`train(&mut self)`) is NOT on the port
+/// (it's `&mut self`, not object-safe) — training happens before injection.
+#[async_trait::async_trait]
+pub trait StorageQuantizationEnginePort: Send + Sync {
+    /// Quantize a batch of vectors using the engine's configured levels.
+    async fn quantize_batch(
+        &self,
+        vectors: &[Vec<f32>],
+        ids: Option<&[String]>,
+    ) -> Result<Vec<StorageQuantizedData>>;
+
+    /// Quantize a batch with a specific level override.
+    async fn quantize_batch_with_level(
+        &self,
+        vectors: &[Vec<f32>],
+        level: UnifiedQuantizationLevel,
+    ) -> Result<Vec<StorageQuantizedData>>;
+
+    /// Dequantize a vector back to approximate float values.
+    async fn dequantize(&self, quantized: &QuantizedVector) -> Result<Vec<f32>>;
+}


### PR DESCRIPTION
## What & why
**D2b** — the second DI port for the factory-as-injection-boundary (#841 plan). Defines `StorageQuantizationEnginePort` (the collection-aware engine the engines hold + pass to the write/compaction path) and impls it on the concrete `StorageQuantizationEngine` in the modality kernel.

**Facade-FREE** — thanks to #842 (which pre-extracted `StorageQuantizedData`/`QuantizedVector`/metadata to foundation), every return type + param on this port is a foundation type. No DTO/adaptor layer is needed — this corrects the #841 plan's assumption that D2b would require facades.

## Changes (additive)
- **`proximadb-storage-ports`**: `StorageQuantizationEnginePort` trait — 3 `async &self` methods (`quantize_batch`, `quantize_batch_with_level`, `dequantize`) with foundation-typed returns. + dep on `proximadb-quantization-model`.
- **`proximadb-quantization-kernel`**: `impl StorageQuantizationEnginePort for StorageQuantizationEngine` (delegating via fully-qualified calls).

## Scope
**Additive** — nothing uses the port yet (the ratchet drops in D3/D4 when storage's write path adopts `Arc<dyn StorageQuantizationEnginePort>` instead of the concrete engine). This PR lands the contract + proves the impl, like #822's `QuantizationEnginePort` D2.

## Verification
- `cargo check -p proximadb-storage-ports -p proximadb-quantization-kernel` ✅ (1m18s)
- `cargo fmt --check` ✅ · `make work-commit-check` ✅
- CI will run the full suite (compile, clippy, unit, integration).

Per `ROOT_CRATE_DECOMPOSITION_SLICE_D` (the factory-boundary plan, #841).