### PR TITLE
test(tpc-perf): fix the perf-ledger harness — 8MB stack (TD-EXEC-1) + unblock DuckDB baseline

### DIFF
--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -957,9 +957,20 @@ async fn connect(server: &PgServer) -> Client {
     client
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// 8 MB stack — same fix as tpch_pgwire_e2e.rs (planner recursion on deep plans).
+#[test]
 #[ignore = "perf evidence-ledger harness (TD-OLAP-4) — advisory; run with --ignored --nocapture"]
-async fn tpc_perf_ledger() {
+fn tpc_perf_ledger() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    rt.block_on(tpc_perf_ledger_inner());
+}
+
+async fn tpc_perf_ledger_inner() {
     let scale: f64 = std::env::var("TPC_PERF_SCALE")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -783,6 +783,32 @@ fn push_record(
 /// ledger stays ProximaDB-self). Mirrors `tests/clickbench_ledger_e2e.rs`. No
 /// new dependency (uses `std::process` + the operator-provided binary); the
 /// result cache (#708) is default-OFF so ProximaDB's latency is already fair.
+
+/// Strip a terminal `WITH (…) ` storage-parameter clause from a `CREATE TABLE`
+/// DDL. ProximaDB accepts `WITH (cluster_key = '<col>')` (the TD-OLAP-6
+/// sort-on-materialize hint); DuckDB's parser rejects it. The clause is always
+/// at the end of the DDL and at paren depth 0 (after the column-list `)`), so we
+/// locate the first depth-0 `WITH (` and drop from there to the end. A `WITH`
+/// inside the column list (depth > 0) is left untouched. DuckDB builds its own
+/// zone maps on load, so the cluster key is irrelevant to the wall-time baseline.
+fn strip_duckdb_incompatible_storage_param(ddl: &str) -> String {
+    let lower = ddl.to_ascii_lowercase();
+    let Some(rel) = lower.find(" with ") else {
+        return ddl.to_string();
+    };
+    // Only a depth-0 WITH (after the column list closes) is the storage param.
+    let before = &ddl[..rel];
+    let depth: i32 = before.matches('(').count() as i32 - before.matches(')').count() as i32;
+    if depth != 0 {
+        return ddl.to_string();
+    }
+    let after = lower[rel..].trim_start();
+    if !after.starts_with("with (") && !after.starts_with("with(") {
+        return ddl.to_string();
+    }
+    before.trim_end().to_string()
+}
+
 fn run_duckdb_baseline(
     benchmark: &str,
     schema: &[(&str, &str)],
@@ -796,10 +822,14 @@ fn run_duckdb_baseline(
     eprintln!("[{benchmark}] · DuckDB baseline (DUCKDB_BIN={duckdb})");
 
     // Loader SQL: schema.1 is the full `CREATE TABLE` DDL; inserts are standard
-    // `INSERT INTO … VALUES`. DuckDB accepts both.
+    // `INSERT INTO … VALUES`. DuckDB accepts both — EXCEPT ProximaDB's
+    // `WITH (cluster_key = …)` storage param (the TD-OLAP-6 sort-on-materialize
+    // hint), which DuckDB's parser rejects ("WITH clause is not supported for
+    // tables"). Strip it for the baseline: DuckDB builds its own zone maps on
+    // load, so the declared cluster key is irrelevant to the wall-time comparison.
     let mut loader = String::new();
     for (_, ddl) in schema {
-        loader.push_str(ddl);
+        loader.push_str(&strip_duckdb_incompatible_storage_param(ddl));
         loader.push_str(";\n");
     }
     for ins in inserts {
@@ -1040,21 +1070,23 @@ async fn tpc_perf_ledger_inner() {
         );
     }
 
-    // Console summary: per benchmark × route, pass count + medians.
+    // Console summary: per benchmark × route, pass count + medians. Native and
+    // DataFusion report the `repeat` (warm) temperature; DuckDB is out-of-process
+    // (loaded once, no warm/cold distinction) so it records only `first` — match
+    // that temperature or the DuckDB row silently shows 0/0.
     for benchmark in ["tpch", "tpcds"] {
         for route in ["native", "datafusion", "duckdb"] {
+            let temp = if route == "duckdb" { "first" } else { "repeat" };
             let mut rows: Vec<&LedgerRecord> = records
                 .iter()
-                .filter(|r| {
-                    r.benchmark == benchmark && r.route == route && r.temperature == "repeat"
-                })
+                .filter(|r| r.benchmark == benchmark && r.route == route && r.temperature == temp)
                 .collect();
             rows.sort_by_key(|r| r.wall_ms);
             let ok = rows.iter().filter(|r| r.ok).count();
             let median = rows.get(rows.len() / 2).map(|r| r.wall_ms).unwrap_or(0);
             let bytes: u64 = rows.iter().map(|r| r.snapshot.bytes_read).sum();
             eprintln!(
-                "[{benchmark}/{route}] ok {ok}/{} · median repeat wall {median} ms · total bytes_read {bytes}",
+                "[{benchmark}/{route}] ok {ok}/{} · median {temp} wall {median} ms · total bytes_read {bytes}",
                 rows.len()
             );
         }
@@ -1093,11 +1125,34 @@ async fn tpc_perf_ledger_inner() {
     // Skipped for filtered diagnostic runs — the fixed count is only meaningful
     // for the full ledger.
     if !filtered {
+        // Uniqueness invariant (the real check): one record per
+        // (benchmark, query, route, temperature). The DuckDB baseline
+        // (DUCKDB_BIN set) adds a variable record count depending on load
+        // success, so a fixed magic number no longer holds — check uniqueness,
+        // and that the native+datafusion baseline is always fully measured.
+        use std::collections::HashSet;
+        let mut seen: HashSet<(&str, &str, &str, &str)> = HashSet::new();
+        for r in &ledger.records {
+            assert!(
+                seen.insert((
+                    r.benchmark.as_str(),
+                    r.query.as_str(),
+                    r.route.as_str(),
+                    r.temperature.as_str()
+                )),
+                "duplicate (benchmark, query, route, temperature) record"
+            );
+        }
         let n_queries = 22 + 16;
+        let baseline = ledger
+            .records
+            .iter()
+            .filter(|r| r.route != "duckdb")
+            .count();
         assert_eq!(
-            ledger.records.len(),
-            n_queries * 2 /* routes */ * 2, /* temperatures */
-            "one record per query x route x temperature"
+            baseline,
+            n_queries * 2 /* native + datafusion */ * 2, /* first + repeat */
+            "native+datafusion baseline incomplete (expected one record per query x route x temperature)"
         );
     }
 }


### PR DESCRIPTION
## What

Two coherent fixes to `tests/tpc_perf_ledger_e2e.rs` (the TD-OLAP-4 perf evidence-ledger harness) so it runs end-to-end and produces a usable DuckDB baseline. Found while running the SF=0.01 native-vs-DataFusion comparison that grounds **TD-OLAP-15**.

### 1. 8 MB worker stack (completes TD-EXEC-1)
PR #843 applied the 8 MB tokio worker-stack fix to `tpch_pgwire_e2e.rs` + `tpcds_pgwire_e2e.rs` (the planner-recursion stack overflow on Q2/Q7 deep plans). This applies the **same fix to the third TPC test** — `tpc_perf_ledger_e2e.rs` was still on the 2 MB default and would SIGABRT on Q2/Q7 at SF≥0.01. Test stays `#[ignore]`d (advisory).

### 2. Unblock the DuckDB baseline (3 latent bugs — `DUCKDB_BIN` had never been set)
- **TPC-DS load failed** — `store_sales` DDL carries `WITH (cluster_key = …)` (the TD-OLAP-6 hint) which DuckDB rejects. Strip the storage param in the DuckDB loader only (ProximaDB keeps the cluster_key).
- **Hard-coded 152-record assertion** broke when DuckDB added its route → replaced with a uniqueness check + native/datafusion baseline-count.
- **Console summary filtered `temperature=="repeat"`** but DuckDB records only `"first"` → DuckDB row silently showed `0/0`. Match temperature per route.

## Why
The harness is the TD-OLAP-4 measurement instrument. Without the stack fix it can't run the full TPC-H set; without the DuckDB fixes the absolute gap is invisible. With both, the SF=0.01 gap is grounded: **TPC-H joins 25–70× slower than DuckDB** (Q8 70×, Q5 60×), simple agg/filter queries DataFusion wins (in-process at toy scale). Full analysis + the `splits_pruned=0` scale-artifact caveat in TD-OLAP-15.

## Verification
- `cargo check --tests -p proximadb --test tpc_perf_ledger_e2e` clean.
- `cargo test --release --test tpc_perf_ledger_e2e -- --ignored --nocapture` with `DUCKDB_BIN` + `TPC_PERF_SCALE=0.01`: test passes, full 22+16 set completes, DuckDB loads both benchmarks, ledger carries 38 DuckDB records.
- Identical 8 MB change-pattern to the two tests merged in #843.