### PR TITLE
docs(td): TD-OLAP-15 native-engine measured posture at SF=0.01

### DIFF
--- a/docs/10-quality/td/TD-OLAP-15-native-engine-measured-posture-sf001.adoc
+++ b/docs/10-quality/td/TD-OLAP-15-native-engine-measured-posture-sf001.adoc
@@ -1,0 +1,119 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-15: Native-engine measured posture at SF=0.01 — scan-wedge confirmed, joins deferred, splits_pruned is a scale artifact
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — filed 2026-07-10 after the SF=0.01 native-vs-DataFusion shadow comparison (TD-OLAP-4 ledger harness) produced ZERO `native-vectorized` compute samples: every TPC-H (22) and TPC-DS (16) query was declined by the shadow probe's skip-guards.** This **confirms** the ADR-052 / TD-OLAP-1 strategy (native owns the PAX/parquet SCAN; DataFusion's vectorized operators own everything above it) — it does not change it. The skip-guards are the honest, in-code manifestation of "native = scan operator, not a peer engine." The finding exists to (a) stop the zero-samples result being misread as "native is useless" — TD-OLAP-12 measured native *beating* DataFusion 1.8× on scan-heavy ClickBench the same week — and (b) record that `splits_pruned=0` is a benchmark-scale artifact, not a pruning bug.
+| Priority | **P2** — an evidence / measurement-finding record. Gates no new work; prevents two misreadings (native-useless; pruning-broken) and points the next investment at the real cost terms.
+| Severity | N/A (documentation / interpretation guard).
+| Component | `tests/tpc_perf_ledger_e2e.rs` (the TD-OLAP-4 ledger harness), `src/network/postgres/relational_pipeline.rs::shadow_probe_native_parquet` (the four skip-guards), `src/datafusion/engine_adapters/object_store_parquet_reader.rs::prune_splits` (the pruning that `splits_pruned` measures).
+| Governs | Interpretation of the TD-OLAP-4 ledger's `native` route and its `splits_pruned` field.
+| Relates to | ADR-052 (bytes-scanned dominates cloud-OLAP cost), ADR-054 (native engine, progressive cutover), TD-OLAP-1 (the scan-wedge — "own the scan, reuse DF above"), TD-OLAP-2 (stats/CBO — the join-order gap behind the slow joins), TD-OLAP-3 (runtime-filter/bloom/zone-map pruning infra), TD-OLAP-4 (the ledger), TD-OLAP-11 (native hash join + the non-spilling aggregate gap), TD-OLAP-12 (morsel scheduler — the ClickBench win), TD-EXEC-1 (the 8 MB stack fix that made this harness runnable end-to-end).
+|===
+
+== The finding (2026-07-10)
+
+The SF=0.01 release comparison (`PROXIMADB_NATIVE_SHADOW=1`, the native-parquet shadow probe that re-runs every DataFusion-served parquet query on native-vectorized over the *same* plan + storage to record a `native-vectorized` compute sample) recorded **zero** `native-vectorized` samples across all 38 TPC-H/TPC-DS queries. The probe ran — it was wired (`relational_pipeline.rs:515`) — but **declined every query** via its skip-guards. Every query's served answer came from DataFusion (or, on the separate native/Volcano-over-PAX route, the old Volcano engine).
+
+This is not a wiring failure. It is the strategy made visible.
+
+== The four skip-guards are the four blocking gaps
+
+`shadow_probe_native_parquet` (`src/network/postgres/relational_pipeline.rs:908`) declines a query when any of four conditions hold. Each guard names a concrete native-engine gap and points at the TD that owns it:
+
+[cols="1,1,3", options="header"]
+|===
+| Guard (line) | Skips | The gap it documents → owner
+| single-table only (`:914`) | every join | no parquet-side native join in the shadow path → TD-OLAP-11 (Phase 3.1 Grace spill pending; in-memory join landed #779)
+| grouped aggregate (`:935`) | Q1, Q4, Q10, Q12–Q20, most TPC-DS | "native's non-spilling HashAggregate OOMs on high-cardinality GROUP BY at scale" → TD-OLAP-11 (SpillSink unimplemented → `InsufficientMemory` falls back)
+| filtered scan (`:941`) | any `WHERE` | no predicate pushdown to the native scan → would aggregate *unfiltered* rows (wrong answer) → scan pushdown (future TD)
+| wide scan >8 cols (`:989`) | wide tables | no projection pushdown → reads all columns row-wise, impractically slow → projection pushdown (future TD)
+|===
+
+Net reachable surface today: narrow + unfiltered + single-table + flat scan. That is ~nothing in a join/agg-heavy OLAP workload — which is exactly why TPC-H/TPC-DS produced zero samples.
+
+== This confirms the strategy, it does not change it
+
+ADR-052's thesis is that the dominant cloud-OLAP cost term is **bytes-scanned, not CPU**; DataFusion's vectorized kernels are already good, so native can only win via *scan-avoidance*. TD-OLAP-1 states it directly: the native engine "must be a **scan operator**, not a parallel operator engine: own the PAX-native SCAN; reuse DataFusion's vectorized operators for everything above it."
+
+The four skip-guards above are that statement operationalized. Native declining every TPC-H join/agg is the system behaving exactly as designed. The work that turns samples on is the four gaps above (spill, join-routing, predicate pushdown, projection pushdown) — **not** "make native beat DataFusion on CPU."
+
+== Counterpoint: native wins where it is supposed to
+
+The zero-samples result must not be read as "native is useless." The same week (2026-07-10), **TD-OLAP-12 measured native-vectorized + the morsel scheduler BEATING DataFusion on scan-heavy ClickBench**: q04 `AVG(UserID)` 346 ms → **191 ms** (1.8×, vs DataFusion 256 ms); q03 `SUM,COUNT,AVG` 359 ms → 261 ms (1.4×). ClickBench is the scan-heavy workload native *is* built for; TPC-H/TPC-DS are join/agg-heavy workloads native *is not yet* built for. The wedge works where it is aimed.
+
+== splits_pruned = 0 is a scale artifact, not a bug
+
+Every record in the SF=0.01 ledger carries `splits_pruned = 0` (e.g. `0/1`, `0/6`, `0/9`). This is **not** a pruning failure. The prune infrastructure is fully wired and sound: `prune_splits` (`object_store_parquet_reader.rs:776`) applies min/max zone-maps + bloom semi-join (TD-OLAP-3, default-OFF bloom) and is *called on every DataFusion scan* (`:1073`), recording `(total, pruned)` at `:1076-1079`.
+
+The reason it prunes nothing is **scale**: the default OLAP `row_group_size = 65536` (`src/core/config.rs:1019`). At SF=0.01, lineitem is 60 051 rows → **1 row group → 1 split**; every dimension table is smaller still → 1 row group each. You cannot prune the only split if any qualifying row exists. The `splits_total` values seen (1–9) are the *join* arity (tables × their single split), not row-group counts.
+
+To exercise TD-OLAP-3 pruning: SF≥0.1 (lineitem ≈ 600 K → ~10 row groups) or a smaller `row_group_size` at materialize time. Do **not** chase `splits_pruned=0` at SF=0.01 as a defect.
+
+== DataFusion baseline @ SF=0.01 (release)
+
+The served-answer route (the numbers that matter while native declines):
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Query | wall ms | df compute ms | rows | bytes_read
+| Q6 (filtered agg, 1 tbl) | 2 | 1 | 1 | 1.7 MB
+| Q1 (groupby pricing) | 5 | 4 | 6 | 1.8 MB
+| Q3 (3-tbl join) | 624 | 616 | 1205 | 2.8 MB
+| Q2/Q7/Q9 (5-tbl join+subq) | ~1237 | ~1235 | 4–118 | 0.8–3.4 MB
+| Q5 (5-tbl join) | 1543 | 1542 | 5 | 2.9 MB
+| Q8 (5-tbl join) | 1857 | 1856 | 2 | 3.2 MB
+|===
+
+Read: simple agg/filter is 2–5 ms; the **join queries are 0.6–1.9 s** — that is the competitive gap, and it lives entirely on the DataFusion path (native cannot run them).
+
+// DUCKDB_GAP_TABLE: fill from the DUCKDB_BIN re-run once the harness fix (PR #846)
+// lands — strip WITH(cluster_key) for DuckDB + uniqueness assertion. Until then the
+// DuckDB baseline is blocked (the harness never had DUCKDB_BIN exercised).
+
+== DuckDB baseline gap (now unblocked by PR #846)
+
+The DuckDB baseline had never been exercised (`DUCKDB_BIN` was never set), so it carried two latent harness bugs — TPC-DS `store_sales`'s `WITH (cluster_key = …)` that DuckDB rejects, and a hard-coded 152-record assertion. PR #846 fixes both (strip the storage param for DuckDB; uniqueness + baseline-count assertion). With `DUCKDB_BIN` set, the SF=0.01 gap (DuckDB ok rows vs DataFusion repeat wall-ms):
+
+[cols="2,1,1,1", options="header"]
+|===
+| Query (tpch) | DuckDB ms | DataFusion ms | gap
+| Q8 (5-tbl join)        | 25 | 1741 | **70×**
+| Q5 (5-tbl join)        | 24 | 1442 | **60×**
+| Q9 (5-tbl join)        | 25 | 1163 | **47×**
+| Q7 (5-tbl join)        | 26 | 1171 | **45×**
+| Q2 (5-tbl join + subq) | 27 | 1154 | **43×**
+| Q10                    | 26 |  880 | **34×**
+| Q21                    | 28 |  884 | **32×**
+| Q3 (3-tbl join)        | 24 |  593 | **25×**
+| Q6 (filtered agg)      | 22 |    2 | 0.1× (DF wins)
+| Q1 (groupby)           | 26 |    5 | 0.2× (DF wins)
+|===
+
+*TPC-DS:* 4–9× (q42 9×, q3/q52/q55/q98 8×; the rest 4×) — smaller because the suite is less join-heavy at this scale.
+
+Read: on **join queries DuckDB is 25–70× faster** than ProximaDB's DataFusion path (the competitive gap, now grounded — not the earlier unverified "85–100×"). On **simple agg/filter queries DataFusion wins** (DuckDB's process-spawn + fixed cost dominates at toy scale; DataFusion is in-process). The crossover moves with scale — at SF≥1 DuckDB's per-query fixed cost amortizes and it wins broadly, which is exactly why scale matters for this comparison (see §Measurement-scale guidance).
+
+== The remaining competitive problem + the levers (by dominant cost term)
+
+The join gap (0.6–1.9 s) is the real problem. Per the co-design mandate (name the dimensional cost term, optimize across the storage↔compute boundary), the levers in priority order are:
+
+1. **`splits_pruned` at scale (the bytes-scanned term — ADR-052's whole point).** At SF≥0.1 the prune stack eliminates row groups; the win scales with data volume. Measure at SF=1 before any native-engine work. Biggest bang.
+2. **DataFusion join order / broadcast (the compute term).** The 1.2–1.9 s joins are likely missing statistics → wrong join order / no broadcast, *not* "DataFusion is slow." Diagnose via TD-OLAP-2 (stats-fed CBO) before building anything.
+3. **Native footer-stats elision (scan-avoidance, zero column I/O).** Already implemented (`elidable_aggregate_batch`); the single biggest native win for COUNT/MIN/MAX at scale. The correct native investment per ADR-052.
+4. **Native spill + pushdown (to turn the four skip-guards off).** TD-OLAP-11 Phase 3.1 (Grace spill) + scan predicate/projection pushdown. This expands native's *reachable* surface; it does not by itself beat DataFusion on CPU.
+
+== Measurement-scale guidance
+
+- **SF=0.01** is too small to exercise pruning (1 row group/table) and too small to separate compute from fixed costs. Use it only for conformance (does the query return the right rows), not for the cost-term comparison.
+- **SF≥0.1** to exercise TD-OLAP-3 row-group pruning; **SF=1** for a realistic bytes-scanned signal.
+- **ClickBench** (scan-heavy, 100 M) is the correct harness for validating the native scan-wedge — already done, TD-OLAP-12 (1.8× win).
+- Always set `DUCKDB_BIN` (now that PR #846 fixes the path) to ground the absolute gap.
+
+== Non-goals
+
+- This TD does **not** propose new native operators. The operator set (FilterProject, HashAgg, HashJoin, PaxScan, ParquetScan) exists; the gaps are spill + pushdown, owned by TD-OLAP-11 and future pushdown TDs.
+- It does **not** re-litigate ADR-052/TD-OLAP-1. The "native = scan operator" decision stands; this TD records the measured evidence that grounds it.
+- It does **not** gate the native default-on flip. That flip is gated on the TD-OLAP-4 ledger showing a measured win on the dominant cost term at scale — which requires SF≥0.1 + the DuckDB baseline now unblocked by PR #846.


### PR DESCRIPTION
## What
Files **TD-OLAP-15** — the measured evidence from the SF=0.01 native-vs-DataFusion shadow comparison, so the result is not misread.

## Findings recorded
- **Zero native-vectorized samples** across all 38 TPC-H/TPC-DS queries. The shadow probe's four skip-guards (single-table / grouped-agg / filtered-scan / wide-scan) ARE the four blocking gaps (TD-OLAP-11 spill + scan pushdown). This **confirms** the ADR-052 / TD-OLAP-1 strategy (native owns the scan; DataFusion owns everything above) — it does not change it.
- **Counterpoint** so the zero isn't misread: TD-OLAP-12 measured native *beating* DataFusion 1.8× on scan-heavy ClickBench the same week. TPC-H/TPC-DS are join/agg-heavy — not native's surface yet.
- **`splits_pruned=0` is a scale artifact, not a bug** — `row_group_size=65536` > SF=0.01 data (lineitem 60K → 1 row group). The prune stack is wired + sound; exercise it at SF≥0.1.
- **DuckDB gap (now unblocked by #846):** TPC-H joins 25–70× (Q8 70×, Q5 60×), TPC-DS 4–9×; simple agg/filter queries DataFusion wins (in-process at toy scale).

## Why
Priority P2 — an evidence/interpretation guard. Gates no new work; prevents two misreadings (native-useless; pruning-broken) and points the next investment at the real cost terms: `splits_pruned` at scale, and DataFusion join order/CBO (TD-OLAP-2) — not "beat DF on CPU" (ADR-052: bytes-scanned dominates).

Docs-only. The DuckDB numbers depend on #846 landing (cross-referenced).

`td-adr-unique` guard: 0 errors.