### PR TITLE
fix(exec): grow the stack on demand for deep plans; retire MAX_WALK_DEPTH (TD-EXEC-2 §1.a Slice 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6681,6 +6681,7 @@ dependencies = [
  "snap",
  "sqlparser 0.59.0",
  "sqlx",
+ "stacker",
  "sysinfo",
  "tantivy",
  "tempfile",
@@ -7596,6 +7597,7 @@ dependencies = [
  "proximadb-relational-reader",
  "proximadb-relational-types",
  "serde",
+ "stacker",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -7622,6 +7624,7 @@ dependencies = [
  "proximadb-relational-reader",
  "proximadb-relational-types",
  "serde",
+ "stacker",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,10 @@ rand = { version = "0.8", features = ["small_rng"] }
 rayon = "1.10"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
+# On-demand stack growth for the plan-tree recursions (planner lowering, executor
+# build, native lowering) — grows the stack instead of overflowing on deeply
+# nested plans (TD-EXEC-2 §1.a). Same primitive rustc/Servo use.
+stacker = "0.1"
 tempfile = "3.0"
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["full"] }
@@ -487,6 +491,7 @@ raw-cpuid = "11.0"  # CPU feature detection for x86_64
 
 # Random number generation
 rand.workspace = true
+stacker.workspace = true
 rand_chacha = "0.3"
 rand_distr = "0.4"  # For generating realistic probability distributions
 

--- a/crates/query/proximadb-relational-executor/Cargo.toml
+++ b/crates/query/proximadb-relational-executor/Cargo.toml
@@ -22,6 +22,7 @@ proximadb-relational-reader = { workspace = true }
 proximadb-relational-planner = { workspace = true }
 proximadb-functions = { workspace = true }
 serde.workspace = true
+stacker.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/query/proximadb-relational-executor/src/lib.rs
+++ b/crates/query/proximadb-relational-executor/src/lib.rs
@@ -236,7 +236,29 @@ pub async fn collect<E: ExecNode + ?Sized>(node: &mut E) -> Result<Vec<Relationa
 
 /// Build an executor tree from a physical plan. Construction is
 /// sync; reader I/O happens later inside `open`.
+/// Stack red-zone / growth for the executor-build recursion (TD-EXEC-2 §1.a); it
+/// mirrors the plan depth exactly like the planner's lowering. Generous pending
+/// Slice-1 calibration — the check is ~ns, growth fires only when near the limit.
+const BUILD_RED_ZONE: usize = 256 * 1024;
+const BUILD_STACK_GROW: usize = 4 * 1024 * 1024;
+
+/// Build an executor tree from a physical plan.
+///
+/// Guards every recursion level with [`stacker::maybe_grow`] so a deeply nested
+/// plan grows the stack on demand rather than overflowing the worker thread
+/// (TD-EXEC-2 §1.a). The recursive descent goes back through this public entry, so
+/// each level checks its own headroom.
 pub fn build_executor<F: ReaderFactory>(
+    plan: PhysicalPlan,
+    factory: &F,
+    ctx: &ExecutionContext,
+) -> Result<Box<dyn ExecNode>, ExecError> {
+    stacker::maybe_grow(BUILD_RED_ZONE, BUILD_STACK_GROW, || {
+        build_executor_inner(plan, factory, ctx)
+    })
+}
+
+fn build_executor_inner<F: ReaderFactory>(
     plan: PhysicalPlan,
     factory: &F,
     ctx: &ExecutionContext,

--- a/crates/query/proximadb-relational-planner/Cargo.toml
+++ b/crates/query/proximadb-relational-planner/Cargo.toml
@@ -19,4 +19,5 @@ proximadb-relational-types = { workspace = true }
 proximadb-relational-algebra = { workspace = true }
 proximadb-relational-reader = { workspace = true }
 serde.workspace = true
+stacker.workspace = true
 thiserror.workspace = true

--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -739,7 +739,28 @@ pub fn fold_expr(expr: Expr) -> Expr {
 // Pass 2: Lower to physical
 // =========================================================================
 
+/// Stack red-zone / growth for the plan-tree lowering recursion (TD-EXEC-2 §1.a).
+/// Deliberately generous pending Slice-1 frame-cost calibration: the per-frame
+/// check is a TLS read + pointer compare (~ns) and a fresh segment is allocated
+/// only when the descent actually nears the limit — so any plan depth lowers
+/// correctly on any worker stack, retiring the flat-8 MB dependence.
+const LOWER_RED_ZONE: usize = 256 * 1024;
+const LOWER_STACK_GROW: usize = 4 * 1024 * 1024;
+
+/// Lower a logical plan to a physical plan.
+///
+/// Guards every recursion level with [`stacker::maybe_grow`] so a deeply nested
+/// plan (deep join / correlated-subquery trees, e.g. TPC-H Q2/Q7) grows the stack
+/// on demand instead of overflowing the worker thread (TD-EXEC-2 §1.a). The
+/// recursive descent goes back through this public entry, so each level checks its
+/// own headroom.
 pub fn lower_to_physical(node: LogicalNode) -> PhysicalPlan {
+    stacker::maybe_grow(LOWER_RED_ZONE, LOWER_STACK_GROW, || {
+        lower_to_physical_inner(node)
+    })
+}
+
+fn lower_to_physical_inner(node: LogicalNode) -> PhysicalPlan {
     match node {
         LogicalNode::Scan {
             table,
@@ -2358,6 +2379,45 @@ mod tests {
             pk_columns: pk,
             secondary_columns: secondary.into_iter().map(String::from).collect(),
         }
+    }
+
+    // --- Stack safety (TD-EXEC-2 §1.a) --------------------------------
+
+    /// By-construction gate: a pathologically deep plan lowers without a stack
+    /// overflow. `lower_to_physical` recurses once per plan level; on a small
+    /// worker stack a deep enough plan overflows unless `stacker::maybe_grow`
+    /// grows the stack on demand. We run the lowering on a deliberately tiny
+    /// 512 KiB thread stack and a depth far beyond what that stack holds by
+    /// recursion — so a regression that drops the `maybe_grow` guard aborts the
+    /// process (SIGSEGV/SIGABRT → test fails) instead of passing by luck on the
+    /// large default stack. This is the correctness half of TD-EXEC-2's stack
+    /// model, independent of any calibrated estimate.
+    #[test]
+    fn deep_plan_lowers_without_stack_overflow() {
+        // ~20 k levels: a 512 KiB stack holds only ~1 k lowering frames, so this
+        // FORCES `maybe_grow` to fire many times.
+        const DEPTH: usize = 20_000;
+        // Build iteratively (no build-time recursion) so only the LOWERING
+        // recursion is exercised.
+        let mut node = users_scan();
+        for _ in 0..DEPTH {
+            node = LogicalNode::Filter {
+                input: Box::new(node),
+                predicate: Expr::literal(ProximaValue::Int64(1)),
+            };
+        }
+        let handle = std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn(move || {
+                let physical = lower_to_physical(node);
+                // The unit under test (deep lowering) has already succeeded; avoid a
+                // recursive Drop of the deep result overflowing this small stack.
+                std::mem::forget(physical);
+            })
+            .expect("spawn small-stack thread");
+        handle
+            .join()
+            .expect("deep lowering must not overflow the 512 KiB stack (maybe_grow)");
     }
 
     // --- Constant folding ---------------------------------------------

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -983,9 +983,9 @@ pub(crate) fn lower_physical(
 ) -> Result<LoweredPipeline, ExecutionError> {
     // Join is handled specially — it produces two pipelines (build + probe).
     if matches!(plan, PhysicalPlan::Join { .. }) {
-        return lower_join(plan, scan_ctx, 0);
+        return lower_join(plan, scan_ctx);
     }
-    let walked = walk(plan, scan_ctx, 0)?;
+    let walked = walk(plan, scan_ctx)?;
     let (operators, limit) = walked_to_operators(walked);
     Ok(LoweredPipeline {
         pipeline: Pipeline::new(operators),
@@ -1143,7 +1143,6 @@ fn walked_to_operators(walked: Walked) -> (Vec<Box<dyn ExecutionOperator>>, Opti
 fn lower_join(
     plan: &PhysicalPlan,
     scan_ctx: Option<&ScanCtx>,
-    depth: usize,
 ) -> Result<LoweredPipeline, ExecutionError> {
     use crate::query::execution::native_engine::native_join_enabled;
     use crate::query::execution::native_join_ops::{
@@ -1188,8 +1187,8 @@ fn lower_join(
     }
 
     // Walk both subtrees.
-    let left_walked = walk(left, scan_ctx, depth + 1)?;
-    let right_walked = walk(right, scan_ctx, depth + 1)?;
+    let left_walked = walk(left, scan_ctx)?;
+    let right_walked = walk(right, scan_ctx)?;
     let left_schema = left_walked.cur_schema.clone();
     let right_schema = right_walked.cur_schema.clone();
     let (left_ops, _) = walked_to_operators(left_walked);
@@ -1306,23 +1305,27 @@ fn extract_equi_keys(expr: &Expr, left_width: usize) -> Option<Vec<(usize, usize
     }
 }
 
-/// Maximum plan-tree depth the native lowering will attempt before declining
-/// to the Volcano. Prevents stack overflow on deeply nested multi-join plans
-/// (e.g., TPC-H Q2's 5-table join + correlated subquery). 32 is generous for
-/// any realistic OLAP plan (TPC-H's deepest is ~15) while staying well within
-/// tokio's 2 MB worker stack.
-const MAX_WALK_DEPTH: usize = 32;
+/// Stack red-zone / growth for the native lowering recursion (TD-EXEC-2 §1.a).
+/// Retires the former `MAX_WALK_DEPTH=32` depth cap: rather than declining a
+/// deeply nested plan to the Volcano for a stack reason, grow the stack on demand
+/// so native serves any depth correctly on any worker stack. Deliberately generous
+/// pending Slice-1 frame-cost calibration; the per-frame check is a TLS read +
+/// pointer compare (~ns) and a segment allocates only when the descent nears the
+/// limit.
+const WALK_RED_ZONE: usize = 256 * 1024;
+const WALK_STACK_GROW: usize = 4 * 1024 * 1024;
 
-fn walk(
-    plan: &PhysicalPlan,
-    scan_ctx: Option<&ScanCtx>,
-    depth: usize,
-) -> Result<Walked, ExecutionError> {
-    if depth > MAX_WALK_DEPTH {
-        return Err(ExecutionError::NotImplemented(format!(
-            "native lowering exceeded max depth {MAX_WALK_DEPTH} — plan too deeply nested; falling back to Volcano"
-        )));
-    }
+/// Lower a physical-plan subtree to a native pipeline. Guards each recursion level
+/// with [`stacker::maybe_grow`] (TD-EXEC-2 §1.a) so a deep plan grows the stack on
+/// demand rather than overflowing the worker thread; the recursive descent goes
+/// back through this entry, so every level checks its own headroom.
+fn walk(plan: &PhysicalPlan, scan_ctx: Option<&ScanCtx>) -> Result<Walked, ExecutionError> {
+    stacker::maybe_grow(WALK_RED_ZONE, WALK_STACK_GROW, || {
+        walk_inner(plan, scan_ctx)
+    })
+}
+
+fn walk_inner(plan: &PhysicalPlan, scan_ctx: Option<&ScanCtx>) -> Result<Walked, ExecutionError> {
     match plan {
         PhysicalPlan::Values {
             rows,
@@ -1389,7 +1392,7 @@ fn walk(
             })
         }
         PhysicalPlan::Filter { input, predicate } => {
-            let mut w = walk(input, scan_ctx, depth + 1)?;
+            let mut w = walk(input, scan_ctx)?;
             let p = PhysExpr::lower(predicate)?;
             // Fuse into a trailing FilterProject (AND-merge the predicate), else push.
             let fuse = matches!(w.ops.last(), Some(OpSpec::FilterProject { .. }));
@@ -1412,7 +1415,7 @@ fn walk(
             Ok(w) // a filter preserves the column set → cur_schema unchanged
         }
         PhysicalPlan::Project { input, outputs } => {
-            let mut w = walk(input, scan_ctx, depth + 1)?;
+            let mut w = walk(input, scan_ctx)?;
             let indices = lower_column_indices(outputs)?;
             // Output schema of this projection (computed before `indices` is moved
             // into the op below).
@@ -1457,7 +1460,7 @@ fn walk(
                     "HAVING not supported in native HashAggregate".into(),
                 ));
             }
-            let mut w = walk(input, scan_ctx, depth + 1)?;
+            let mut w = walk(input, scan_ctx)?;
             let gb: Vec<usize> = group_by
                 .iter()
                 .map(|ne| lower_col(&ne.expr))
@@ -1481,7 +1484,7 @@ fn walk(
             limit,
             offset,
         } => {
-            let mut w = walk(input, scan_ctx, depth + 1)?;
+            let mut w = walk(input, scan_ctx)?;
             if w.limit.is_some() {
                 return Err(ExecutionError::NotImplemented(
                     "nested Limit not supported in native vectorized path".into(),


### PR DESCRIPTION
## What

Wraps the three depth-∝ plan-tree recursions — the planner's `lower_to_physical`, the executor's `build_executor`, and the native `walk`/`lower_join` — in `stacker::maybe_grow`, so a deeply nested plan **grows the worker stack on demand** instead of overflowing it. Retires the native `MAX_WALK_DEPTH=32` cap and the dependence on a flat oversized worker stack.

This is **Slice 0** of TD-EXEC-2 (per the refinement in #850): stack **safety by construction**, decoupled from — and landing ahead of — the calibrated estimate / geometry routing.

## Why (the production gap #843/#846 didn't close)

- The production server (`apps/proximadb-server/src/main.rs:121`) runs on a bare `#[tokio::main]` runtime = tokio's **default ~2 MB** worker stack. The only 8 MB is `EmbeddedProximaDB::new` (`src/embedded/mod.rs:828`, the PyO3 path); #843/#846 raised the stack **in the three TPC *test harnesses* only**.
- The overflow is **engine-independent**: the planner's `lower_to_physical` recursion runs before any engine and consumes stack ∝ plan depth (the executor build and native walk mirror it). A deep OLAP plan (TPC-H Q2/Q7 at SF ≥ 0.01) **SIGABRTs the production process** — `MAX_WALK_DEPTH=32` only guards the *native* path, so it never covered this.
- `maybe_grow` is how rustc/Servo handle unbounded recursion: `remaining_stack()` is a ~ns TLS read + pointer compare, and a fresh segment allocates **only** when a descent actually nears the limit. Correctness then holds for **any** depth on **any** worker stack, with **zero dependence on a calibrated estimate**.

## Retired heuristics

- **`MAX_WALK_DEPTH=32`** (#843) — deleted. It made native *decline valid deep plans* to the Volcano for a stack reason `maybe_grow` eliminates; native now serves any depth. (The `depth` threading it added is removed too.)
- **Flat oversized worker stack** — no longer a correctness dependency; workers stay at the runtime default and grow on demand.

## Test (by-construction safety gate)

`deep_plan_lowers_without_stack_overflow` (planner): a **20 000-deep** plan lowers on a deliberately **512 KiB** thread stack without overflow — a depth a 512 KiB stack cannot hold by recursion, so a regression that drops the guard aborts the process (test fails) rather than passing by luck on the large default stack. Independent of any calibration.

## Scope / follow-ups

- Leaves the test-harness 8 MB (#843/#846) in place — harmless now, and #846 is in flight; a later cleanup can drop them to the default.
- Slice 1 (observe-only `PlanGeometry` + iterative `measure_geometry` + calibration) and Slice 2/3 (estimate-as-optimization, geometry routing) follow per #850.

## Verification

- `cargo nextest run -p proximadb-relational-planner deep_plan` → pass (512 KiB stack, depth 20 000).
- `cargo clippy --lib --bins -- -D warnings`, `cargo fmt --check`, `make work-commit-check` (panic-policy incl.) → clean.
- `cargo build -p proximadb-server` → builds.