### PR TITLE
feat(olap): native-over-parquet PRIMARY route by operation (TD-OLAP-4)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -436,6 +436,7 @@ pub async fn try_run_select(
         cardinality
     };
 
+    let operation_class = query_operation_class(query);
     let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         crate::query::compute_scheduler::QueryShape {
             engages_relational: true,
@@ -443,7 +444,7 @@ pub async fn try_run_select(
             pax_backed: false,
             partition_fanout,
             cardinality,
-            operation_class: query_operation_class(query),
+            operation_class,
         },
         // C4: observe-mode advisory from the trace-driven cost model — augments
         // the reason for telemetry/EXPLAIN, never changes the backend.
@@ -462,11 +463,82 @@ pub async fn try_run_select(
     // P1 dispatch driven by the scheduler decision. The DataFusion arm exists only
     // under the feature (and `parquet_backed` — hence a `DataFusionLocal` decision —
     // is only reachable there), so a default build never enters it and stays Volcano.
+    //
+    // The block is entered for the OLAP-over-parquet route: a static `DataFusionLocal`
+    // decision, OR a cost-model override/exploration flip to `Native` on the
+    // `olap/parquet` class (the only class with two freshness-safe engines,
+    // `freshness_safe_backends_from_class`). Routing the override-`Native` case here
+    // rather than to the Volcano keeps a warmed override on the native-over-parquet
+    // path (which reads the external parquet) with DataFusion as the floor — never on
+    // the Volcano, which has no external-parquet scan wired.
     #[cfg(feature = "datafusion-integration")]
-    if matches!(
-        decision.backend,
-        crate::query::table_write_plan::ComputeBackend::DataFusionLocal
-    ) {
+    if parquet_backed
+        && matches!(
+            decision.backend,
+            crate::query::table_write_plan::ComputeBackend::DataFusionLocal
+                | crate::query::table_write_plan::ComputeBackend::Native
+        )
+    {
+        // TD-OLAP-4 "favor native by operation": for the operation classes native
+        // measurably wins — footer-elidable `COUNT(*)`/`MIN`/`MAX` (MetadataElidable)
+        // and narrow unfiltered scalar aggregates (ScalarAggregate) — run the native
+        // vectorized engine over the SAME external parquet as the PRIMARY backend and
+        // return ITS result. DataFusion stays the correctness floor: any decline
+        // (ineligible shape, wide/filtered/grouped scan, native error) falls through
+        // to the DataFusion execution below, so correctness never depends on native.
+        //
+        // Trigger (default-OFF): the explicit `PROXIMADB_NATIVE_ROUTE` master switch,
+        // OR a warmed cost-model override/exploration that advised `Native` for this
+        // operation-keyed `olap/parquet` cell (`PROXIMADB_ROUTE_COST_OVERRIDE`, with
+        // its freshness/RTT/min-advantage gating). Either way the shape gate is the
+        // same measured win-set, and DataFusion is the fallback.
+        let native_advised = matches!(
+            decision.backend,
+            crate::query::table_write_plan::ComputeBackend::Native
+        ) && matches!(
+            decision.source,
+            crate::query::compute_scheduler::RouteSource::OverrideExploit
+                | crate::query::compute_scheduler::RouteSource::OverrideExplore
+        );
+        let native_eligible_op = matches!(
+            operation_class,
+            crate::query::compute_scheduler::OperationClass::MetadataElidable
+                | crate::query::compute_scheduler::OperationClass::ScalarAggregate
+        );
+        if native_eligible_op
+            && (crate::query::execution::native_engine::native_route_enabled() || native_advised)
+        {
+            let native_snapshot = SnapshotCatalog {
+                dml: dml.clone(),
+                tables: tables.clone(),
+                tenant: tenant_ctx.clone(),
+            };
+            // Setup (planning/route) time is attributed here; the native engine records
+            // its own `native-vectorized` compute sample inside the run.
+            crate::observability::io_trace::record_setup_ms(
+                setup_start.elapsed().as_millis() as u64
+            );
+            if let Some(result) =
+                try_native_over_parquet(sql, &native_snapshot, &parquet_loc_by_key).await
+            {
+                tracing::debug!(
+                    target: "proximadb::compute_route",
+                    "native-over-parquet served as PRIMARY (op={:?}); DataFusion floor bypassed",
+                    operation_class
+                );
+                if let Some((skey, lsn)) = &cache_ctx {
+                    populate_olap_result_cache(
+                        result_cache,
+                        skey,
+                        *lsn,
+                        result.clone(),
+                        &native_snapshot.tables,
+                    );
+                }
+                return Some(Ok(result));
+            }
+            // Native declined → fall through to the DataFusion floor below.
+        }
         let parquet_tables: Vec<(String, String)> = tables
             .iter()
             .map(|(k, t)| (t.table_name.clone(), parquet_loc_by_key[k].clone()))
@@ -501,9 +573,15 @@ pub async fn try_run_select(
         // close. `record_compute_ms` no-ops outside an `io_trace` scope.
         crate::observability::io_trace::record_setup_ms(setup_start.elapsed().as_millis() as u64);
         let started = std::time::Instant::now();
-        let engine_result = execute_sql_with_backend(decision.backend.clone(), sql, context).await;
+        // This block IS the DataFusion floor for the OLAP-over-parquet route, so
+        // execute on DataFusion regardless of the scheduler's advised label — a
+        // cost-model override may have set `decision.backend = Native` (routed here
+        // for the native-primary attempt above), but `execute_sql_with_backend` only
+        // serves `DataFusionLocal`; anything else errors `UnsupportedBackend`.
+        let floor_backend = crate::query::table_write_plan::ComputeBackend::DataFusionLocal;
+        let engine_result = execute_sql_with_backend(floor_backend.clone(), sql, context).await;
         crate::observability::io_trace::record_compute_ms(
-            &crate::query::compute_scheduler::backend_label(&decision.backend),
+            &crate::query::compute_scheduler::backend_label(&floor_backend),
             started.elapsed().as_millis() as u64,
         );
         // TD-OLAP-4 (engine dimension): optional native SHADOW — run the same query
@@ -903,54 +981,80 @@ fn plan_has_grouped_aggregate(plan: &PhysicalPlan) -> bool {
 
 /// Run the native vectorized engine over the same external parquet DataFusion just
 /// served, purely to record a per-engine compute sample. Single-table parquet only
-/// (MVP); declines silently on anything native can't yet serve.
+/// (MVP); declines silently on anything native can't yet serve. Thin wrapper over
+/// [`try_native_over_parquet`] that discards the result — the sample it records via
+/// the io-trace is the whole point; DataFusion's answer is the one served.
 #[cfg(feature = "datafusion-integration")]
 async fn shadow_probe_native_parquet(
     sql: &str,
     snapshot: &SnapshotCatalog,
     parquet_loc_by_key: &HashMap<String, String>,
 ) {
+    let _ = try_native_over_parquet(sql, snapshot, parquet_loc_by_key).await;
+}
+
+/// Serve `sql` on the native vectorized engine over the SAME external parquet
+/// DataFusion would read, returning `Some(result)` when native handled it as the
+/// PRIMARY backend (its result is wire-identical to DataFusion's for the routed
+/// shapes) or `None` to route to DataFusion. This is the single native-over-parquet
+/// code path shared by the production route arm ([`try_run_select`], gated on
+/// `native_route_enabled`) and the benchmark shadow probe (gated on
+/// `native_shadow_enabled`) — every eligibility guard and source selection lives
+/// here so the two callers can never diverge (TD-OLAP-4 "favor native by
+/// operation").
+///
+/// Eligibility (any failure → `None`, DataFusion serves): single-table parquet,
+/// a single-scan plan, no grouped aggregate (native's non-spilling HashAggregate
+/// OOMs on high-cardinality `GROUP BY`), no filter predicate (native has no
+/// predicate pushdown, so it would wrongly aggregate unfiltered rows), and a scan
+/// no wider than the width cap. The served shapes are exactly the measured native
+/// wins: footer-elidable `COUNT(*)`/`MIN`/`MAX` and narrow unfiltered scalar
+/// aggregates.
+#[cfg(feature = "datafusion-integration")]
+async fn try_native_over_parquet(
+    sql: &str,
+    snapshot: &SnapshotCatalog,
+    parquet_loc_by_key: &HashMap<String, String>,
+) -> Option<ExecutionPipelineResult> {
     // Single-table parquet only — joins are a separately-gated native path.
     if parquet_loc_by_key.len() != 1 {
-        return;
+        return None;
     }
-    let Some(location) = parquet_loc_by_key.values().next() else {
-        return;
-    };
+    let location = parquet_loc_by_key.values().next()?;
     let sqlp = &sql[..sql.len().min(70)];
     // Lower the SAME SQL to the relational physical plan (decline → skip).
     let physical = match plan_over_snapshot(sql, snapshot) {
         Some(Ok(p)) => p,
         _ => {
-            tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP plan-declined: {sqlp}");
-            return;
+            tracing::debug!(target: "proximadb::native_route", "native SKIP plan-declined: {sqlp}");
+            return None;
         }
     };
     let Some(scan_cols) = single_scan_columns(&physical) else {
-        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP not-single-scan: {sqlp}");
-        return;
+        tracing::debug!(target: "proximadb::native_route", "native SKIP not-single-scan: {sqlp}");
+        return None;
     };
     // Skip grouped aggregates: native's non-spilling HashAggregate OOMs on
     // high-cardinality GROUP BY at scale. These route to DataFusion.
     if plan_has_grouped_aggregate(&physical) {
-        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP grouped-aggregate: {sqlp}");
-        return;
+        tracing::debug!(target: "proximadb::native_route", "native SKIP grouped-aggregate: {sqlp}");
+        return None;
     }
     // Skip filtered scans: native does not apply a pushed-down `Scan.predicate`,
     // so it would (wrongly) aggregate the unfiltered rows. Route to DataFusion.
     if plan_scan_has_predicate(&physical) {
-        tracing::debug!(target: "proximadb::native_shadow", "shadow SKIP filtered-scan (no native predicate pushdown): {sqlp}");
-        return;
+        tracing::debug!(target: "proximadb::native_route", "native SKIP filtered-scan (no native predicate pushdown): {sqlp}");
+        return None;
     }
-    tracing::debug!(target: "proximadb::native_shadow", "shadow RUN native: {sqlp}");
+    tracing::debug!(target: "proximadb::native_route", "native RUN: {sqlp}");
     // Open the same parquet DataFusion read (table-OPEN cache is warm from its run).
     let table = match crate::datafusion::engine_adapters::ObjectStoreParquetTable::open(location)
         .await
     {
         Ok(t) => t,
         Err(e) => {
-            tracing::debug!(target: "proximadb::native_shadow", %e, "shadow: table open declined");
-            return;
+            tracing::debug!(target: "proximadb::native_route", %e, "native: table open declined");
+            return None;
         }
     };
     let (store, files, file_schema) = table.native_scan_inputs();
@@ -959,12 +1063,14 @@ async fn shadow_probe_native_parquet(
     // scale (q07 MIN/MAX: a full-column vectorized scan → a footer read). Emits the
     // pre-computed row and bypasses the scan + HashAggregate entirely.
     if let Some(batch) = elidable_aggregate_batch(&physical, &table, &file_schema) {
-        tracing::debug!(target: "proximadb::native_shadow", "shadow ELIDE (footer stats): {sqlp}");
+        tracing::debug!(target: "proximadb::native_route", "native ELIDE (footer stats): {sqlp}");
         let src = Box::new(
             crate::query::execution::native_parquet_scan::StatsAggregateOperator::new(batch),
         );
-        let _ = crate::query::execution::native_engine::run_native_source_only(src).await;
-        return;
+        return native_result(
+            crate::query::execution::native_engine::run_native_source_only(src).await,
+            sqlp,
+        );
     }
     // Unfiltered COUNT(*): parquet/PAX carry the row count in the FOOTER, so elide
     // the scan entirely — read footers only, emit the count (a metadata op, not a
@@ -988,11 +1094,11 @@ async fn shadow_probe_native_parquet(
             const NATIVE_SCAN_WIDTH_CAP: usize = 8;
             if scan_cols.len() > NATIVE_SCAN_WIDTH_CAP {
                 tracing::debug!(
-                    target: "proximadb::native_shadow",
+                    target: "proximadb::native_route",
                     cols = scan_cols.len(),
-                    "shadow SKIP wide-scan (no pushdown): {sqlp}"
+                    "native SKIP wide-scan (no pushdown): {sqlp}"
                 );
-                return;
+                return None;
             }
             // Map the plan's Scan columns → parquet leaf indices by name; build the
             // native scan output schema from the FILE fields (exact Arrow types). Sort
@@ -1012,7 +1118,7 @@ async fn shadow_probe_native_parquet(
                     .enumerate()
                     .find(|(_, f)| f.name().eq_ignore_ascii_case(name))
                 else {
-                    return; // column absent from file (schema drift) → never risk a sample
+                    return None; // column absent from file (schema drift) → never risk a sample
                 };
                 paired.push((idx, field.as_ref().clone()));
             }
@@ -1030,15 +1136,32 @@ async fn shadow_probe_native_parquet(
                 ),
             )
         };
-    match crate::query::execution::native_engine::run_native_over_parquet(&physical, source).await {
-        Ok(Some(_)) => {
-            tracing::debug!(target: "proximadb::native_shadow", "shadow: native-vectorized sample recorded")
+    native_result(
+        crate::query::execution::native_engine::run_native_over_parquet(&physical, source).await,
+        sqlp,
+    )
+}
+
+/// Interpret a native-engine run result for [`try_native_over_parquet`]: `Ok(Some)`
+/// → native served it (return the result); `Ok(None)` → native declined the shape;
+/// `Err` → native errored. In both non-served cases the caller routes to DataFusion.
+#[cfg(feature = "datafusion-integration")]
+fn native_result(
+    run: Result<Option<ExecutionPipelineResult>, crate::query::execution::engine::ExecutionError>,
+    sqlp: &str,
+) -> Option<ExecutionPipelineResult> {
+    match run {
+        Ok(Some(result)) => {
+            tracing::debug!(target: "proximadb::native_route", "native served: {sqlp}");
+            Some(result)
         }
         Ok(None) => {
-            tracing::debug!(target: "proximadb::native_shadow", "shadow: native declined (shape/align)")
+            tracing::debug!(target: "proximadb::native_route", "native declined (shape/align): {sqlp}");
+            None
         }
         Err(e) => {
-            tracing::debug!(target: "proximadb::native_shadow", %e, "shadow: native errored")
+            tracing::debug!(target: "proximadb::native_route", %e, "native errored: {sqlp}");
+            None
         }
     }
 }

--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -77,6 +77,26 @@ pub fn native_shadow_enabled() -> bool {
     })
 }
 
+/// Gate: route the operation classes native measurably wins to the native
+/// vectorized engine as the PRIMARY backend over external parquet (returning its
+/// result), with DataFusion as the correctness floor. Default OFF (TD-OLAP-4
+/// "favor native by operation"). Distinct from [`native_shadow_enabled`] (which
+/// runs native ALONGSIDE DataFusion and discards the result): when this is on, a
+/// footer-elidable / scalar-aggregate unfiltered parquet SELECT is served by
+/// native and DataFusion is only consulted when native declines the shape.
+/// Correctness is preserved because native's result MUST equal DataFusion's for
+/// the routed shapes (guarded by the eligibility gates in `try_native_over_parquet`
+/// and the native-vs-DataFusion ratchet tests); any decline falls through to
+/// DataFusion.
+pub fn native_route_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("PROXIMADB_NATIVE_ROUTE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
 /// Try the native vectorized execution path for an already-planned query.
 /// Called from `NativeVolcanoEngine::execute_physical` (the single native
 /// chokepoint, above the Volcano) when [`native_vectorized_enabled`] is set.

--- a/tests/native_route_pgwire_e2e.rs
+++ b/tests/native_route_pgwire_e2e.rs
@@ -1,0 +1,270 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native-over-parquet PRIMARY routing — end-to-end correctness ratchet
+//! (TD-OLAP-4 "favor native by operation").
+//!
+//! Exercises the production native-parquet route end-to-end: a real server, the
+//! PostgreSQL wire protocol, and the router — never bypassing pgwire or the engine
+//! selector. The native vectorized + route gates are ON
+//! (`PROXIMADB_NATIVE_VECTORIZED=1`, `PROXIMADB_NATIVE_ROUTE=1`; both default-off in
+//! production), so an UNFILTERED footer-elidable / scalar-aggregate SELECT over a
+//! `MATERIALIZE`d (Parquet-backed) table routes to
+//! `relational_pipeline::try_native_over_parquet` and is served by the native
+//! vectorized engine as the PRIMARY backend — with DataFusion the correctness floor.
+//!
+//! The central correctness property: the native-served result MUST equal
+//! DataFusion's for the routed shapes. We prove this WITHIN one process (so no
+//! `OnceLock` gate flip is needed) by pairing each aggregate with a tautological
+//! filter: the UNFILTERED form routes to native (no `Scan.predicate`, elidable /
+//! narrow scan), while the SAME aggregate under `WHERE id >= <min>` (which every row
+//! satisfies) carries a `Scan.predicate` — native has no predicate pushdown, so it
+//! declines and DataFusion serves it. Equal results ⇒ native == DataFusion. Each is
+//! additionally asserted against the hand-computed ANSI-correct value.
+//!
+//! Run with the real server-side cause behind any opaque pgwire `db error`:
+//!   RUST_LOG=proximadb=debug cargo nextest run --test native_route_pgwire_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::{Client, SimpleQueryMessage};
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        // Turn on the native vectorized path AND the "favor native by operation"
+        // route BEFORE the server (and its `OnceLock`-cached gate reads) come up.
+        // nextest runs each test in its own process, so this env mutation cannot
+        // leak into other tests.
+        // SAFETY: single-threaded test setup, before any server thread starts.
+        unsafe {
+            std::env::set_var("PROXIMADB_NATIVE_VECTORIZED", "1");
+            std::env::set_var("PROXIMADB_NATIVE_ROUTE", "1");
+            // Decode row-groups in parallel too — additive, never a correctness dep.
+            std::env::set_var("PROXIMADB_NATIVE_MORSEL", "1");
+        }
+
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Render a tokio_postgres error including the real server-side DbError cause.
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+/// Run a single-column scalar-aggregate SELECT and return the one cell as text.
+async fn scalar(client: &Client, sql: &str) -> String {
+    let messages = client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)));
+    for m in &messages {
+        if let SimpleQueryMessage::Row(r) = m {
+            return r
+                .get(0)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "NULL".to_string());
+        }
+    }
+    panic!("query `{sql}` returned no row");
+}
+
+/// Parse a numeric scalar cell to f64 (aggregate results may render as `30` or
+/// `30.0` depending on the engine's output type; comparing as f64 is
+/// representation-insensitive).
+fn num(s: &str) -> f64 {
+    s.parse::<f64>()
+        .unwrap_or_else(|_| panic!("expected numeric scalar, got `{s}`"))
+}
+
+/// The native-over-parquet PRIMARY route must return exactly DataFusion's answer for
+/// COUNT(*)/MIN/MAX (footer-elidable) and SUM/AVG (scalar-aggregate). Proven by the
+/// unfiltered (native) vs tautological-filtered (DataFusion) pairing described in the
+/// module docs, plus hand-computed ANSI-correct expected values.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn native_route_aggregates_equal_datafusion_over_pgwire() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    // Unique table name so parallel/repeat runs never collide in the catalog.
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let t = format!("nr_{suffix}");
+
+    client
+        .simple_query(&format!(
+            "CREATE TABLE {t} (id INT PRIMARY KEY, v INT, w INT)"
+        ))
+        .await
+        .unwrap_or_else(|e| panic!("CREATE: {}", explain_err(&e)));
+
+    // Deterministic, NULL-free data with a known min id of 1 so `WHERE id >= 1` is a
+    // tautology (matches every row) — the filtered aggregate DataFusion computes
+    // equals the unfiltered aggregate native computes.
+    //   COUNT(*)=5  MIN(v)=10  MAX(v)=50  SUM(v)=150  AVG(v)=30
+    for (id, v, w) in [
+        (1, 10, 100),
+        (2, 20, 200),
+        (3, 30, 300),
+        (4, 40, 400),
+        (5, 50, 500),
+    ] {
+        client
+            .simple_query(&format!(
+                "INSERT INTO {t} (id, v, w) VALUES ({id}, {v}, {w})"
+            ))
+            .await
+            .unwrap_or_else(|e| panic!("INSERT: {}", explain_err(&e)));
+    }
+
+    // MATERIALIZE → Parquet-backed → OLAP route reaches DataFusion (and, for the
+    // eligible unfiltered shapes, native-over-parquet as PRIMARY).
+    client
+        .simple_query(&format!("ALTER TABLE {t} MATERIALIZE"))
+        .await
+        .unwrap_or_else(|e| panic!("MATERIALIZE: {}", explain_err(&e)));
+    sleep(Duration::from_millis(500)).await;
+
+    // (aggregate, unfiltered→native, tautological-filtered→DataFusion, expected).
+    // The filter `id >= 1` matches all rows, so the DataFusion answer equals the
+    // unfiltered native answer AND the hand-computed value.
+    let cases = [
+        ("COUNT(*)", 5.0_f64),
+        ("MIN(v)", 10.0),
+        ("MAX(v)", 50.0),
+        ("SUM(v)", 150.0),
+        ("AVG(v)", 30.0),
+    ];
+    for (agg, expected) in cases {
+        let native = scalar(&client, &format!("SELECT {agg} FROM {t}")).await;
+        let datafusion = scalar(&client, &format!("SELECT {agg} FROM {t} WHERE id >= 1")).await;
+        assert_eq!(
+            num(&native),
+            expected,
+            "native-routed {agg} must equal the ANSI-correct value"
+        );
+        assert_eq!(
+            num(&native),
+            num(&datafusion),
+            "native-routed {agg} ({native}) must equal DataFusion's ({datafusion})"
+        );
+    }
+
+    // MIN/MAX over a second column via footer elision — same equality property.
+    for (agg, expected) in [("MIN(w)", 100.0_f64), ("MAX(w)", 500.0)] {
+        let native = scalar(&client, &format!("SELECT {agg} FROM {t}")).await;
+        let datafusion = scalar(&client, &format!("SELECT {agg} FROM {t} WHERE id >= 1")).await;
+        assert_eq!(num(&native), expected, "native-routed {agg}");
+        assert_eq!(
+            num(&native),
+            num(&datafusion),
+            "native-routed {agg} ({native}) must equal DataFusion's ({datafusion})"
+        );
+    }
+
+    // Non-vacuity guard: prove the unfiltered aggregates were ACTUALLY served by the
+    // native engine (not silently declined to DataFusion, which would make the
+    // equality checks above pass trivially with DataFusion == DataFusion). The pgwire
+    // query boundary wraps each query in an `io_trace::instrument` scope that feeds
+    // the route observer (installed at startup) the stamped route; the native
+    // over-parquet path stamps `("vectorized", "NativeVectorized")`. So a learned
+    // cost-model cell with the `NativeVectorized` backend label exists iff native
+    // served at least one query as PRIMARY.
+    let served_native = GLOBAL_ROUTE_COST_MODEL
+        .learned_cell_keys()
+        .iter()
+        .any(|(_class, backend)| backend == "NativeVectorized");
+    assert!(
+        served_native,
+        "native-over-parquet route never engaged — the equality checks would be \
+         vacuous (DataFusion == DataFusion). Learned cost-model cells: {:?}",
+        GLOBAL_ROUTE_COST_MODEL.learned_cell_keys()
+    );
+}


### PR DESCRIPTION
## What

Routes the operation classes native measurably wins to the **native vectorized engine as the PRIMARY backend over external parquet** (returning its result), with **DataFusion as the correctness floor / fallback**. Today native-over-parquet exists only as a discarded shadow probe; this makes it a product path, gated default-OFF.

Concretely, in `relational_pipeline::try_run_select`, before the DataFusion arm: for an **unfiltered `MetadataElidable` / `ScalarAggregate`** SELECT over a parquet-backed (`MATERIALIZE`d) table, run native and return its result; any decline (grouped / filtered / wide / multi-table / native error) falls through to DataFusion.

## Why (grounded in measured evidence)

Aligned with **TD-OLAP-15** (#848): native records **zero samples on join/agg-heavy TPC-H/DS** but **beats DataFusion 1.8× on scan-heavy ClickBench**. This PR routes exactly the scan-heavy elidable/scalar-agg shapes native wins to native, and leaves join/agg/grouped/string-heavy on DataFusion. It's the concrete first instance of TD-EXEC-2 Slice 3 ("geometry/operation routing"), scoped to the confirmed-win shapes.

## Design

- **Shared core `try_native_over_parquet`** — the shadow probe now delegates to it, so the production route and the shadow can't diverge. It carries every eligibility guard (single-table, single-scan, not grouped, no `Scan.predicate`, width cap) and the source selection (footer elision / count-star / projected scan).
- **Two triggers, both default-OFF**: the explicit `PROXIMADB_NATIVE_ROUTE` master switch, OR a warmed cost-model override/exploration that advised `Native` for this operation-keyed `olap/parquet` cell (`PROXIMADB_ROUTE_COST_OVERRIDE`, freshness/RTT/min-advantage gating intact).
- **Correctness floor**: the block now also catches the cost-model override→`Native` case (previously it silently fell to the Volcano, which has no external-parquet scan) and always executes DataFusion as the floor — never `UnsupportedBackend`.

## Correctness test (non-vacuous)

`native_route_pgwire_e2e`: over a `MATERIALIZE`d table, each aggregate is run unfiltered (→ native) and with a tautological `WHERE id >= 1` (→ filtered scan declines native → DataFusion). Asserts **native == DataFusion == hand-computed** for COUNT*/MIN/MAX/SUM/AVG, plus a **non-vacuity guard** (a `("vectorized","NativeVectorized")` learned cost-model cell must exist — proving native actually served, not a silent both-DataFusion pass).

## Verification

- `native_route_pgwire_e2e` → pass (native engagement proven).
- Ratchets green on the rebased branch: **TPC-H 22/22 + TPC-DS 18/18** (native OFF default → identical routing to develop); ClickBench ledger `#[ignore]` (advisory).
- `cargo clippy --lib --bins -- -D warnings`, `cargo fmt --check`, `make work-commit-check` (panic-policy incl.) → clean.
- Rebased onto develop (#843/#847/#848); default-OFF, so routing is byte-identical to develop unless the gate/override is set.