### PR TITLE
feat(native): ADR-058 D1 — vectorized_supports capability descriptor + drift guard

### DIFF
--- a/src/query/execution/native_engine.rs
+++ b/src/query/execution/native_engine.rs
@@ -121,6 +121,23 @@ pub async fn try_vectorized(
     if super::native_shadow::is_shape_demoted(physical) {
         return Ok(None);
     }
+    // ADR-058 D1: consult the declared capability descriptor. A `Partial`
+    // verdict GUARANTEES the lowering declines (sound one-way filter — every
+    // reason mirrors a real decline in `walk`/`lower_join`), so decline here
+    // with structured reasons and skip the lowering attempt for clearly-
+    // unsupported shapes. `Full` does NOT guarantee success (deeper constraints
+    // are checked during lowering); fall through and let lower_physical decide.
+    if let super::native_ops::SupportLevel::Partial(reasons) =
+        super::native_ops::vectorized_supports(physical)
+    {
+        let labels: Vec<&'static str> = reasons.iter().map(|r| r.as_label()).collect();
+        tracing::debug!(
+            target: "proximadb::native_vectorized",
+            reasons = ?labels,
+            "vectorized path declined (unsupported plan shape); falling back to Volcano"
+        );
+        return Ok(None);
+    }
     // Any decline (unsupported shape) or failure (execution error) → Volcano.
     let lowered = match super::native_ops::lower_physical(physical, scan_ctx) {
         Ok(l) => l,

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -994,6 +994,103 @@ pub(crate) fn lower_physical(
     })
 }
 
+// ADR-058 D1 — the *declared* capability of the native vectorized path: a
+// shallow classification of which `PhysicalPlan` node variants the engine can
+// lower. This is the single source of truth for "can native-vectorized handle
+// this plan shape?" so the capability is stated once (and re-asserted by the
+// drift test below), rather than re-derived by each caller.
+//
+// **Sound one-way filter:** a [`SupportLevel::Partial`] verdict GUARANTEES
+// [`lower_physical`] declines — every [`SupportReason`] mirrors a concrete
+// decline in `walk`/`lower_join`. [`SupportLevel::Full`] does NOT guarantee
+// success: deeper constraints (distinct aggregates, non-column projections,
+// equi-key extractability, scan-source availability, `MAX_WALK_DEPTH`) are
+// checked only during lowering. Callers may safely short-circuit on `Partial`;
+// on `Full` they must still attempt the lowering.
+#[derive(Debug, Clone)]
+pub(crate) enum SupportLevel {
+    /// Every node variant on every path is in the supported set.
+    Full,
+    /// At least one unsupported node (or structural red-flag); carries the reasons.
+    Partial(Vec<SupportReason>),
+}
+
+/// Why the vectorized path does not support a plan. Each variant mirrors a
+/// concrete decline site in the lowering (`walk`/`lower_join`) — see the drift
+/// test `vectorized_supports_drift_matches_lowering`.
+#[derive(Debug, Clone)]
+pub(crate) enum SupportReason {
+    /// A `PhysicalPlan` variant the vectorized lowering does not handle
+    /// ("Sort", "Distinct", "Union", "SetOp", "AssertMaxOneRow") — `walk`'s
+    /// catch-all declines it.
+    UnsupportedNode(&'static str),
+    /// `Aggregate` with a `HAVING` clause — the native `HashAggregate` has no
+    /// post-filter pass (`walk`'s Aggregate arm declines on `having.is_some()`).
+    AggregateHaving,
+    /// Two `Limit` nodes on one walk-path — the second is nested (`walk`'s Limit
+    /// arm declines when `w.limit` is already set).
+    NestedLimit,
+}
+
+impl SupportReason {
+    /// Short tracing label — reads the carried node name for `UnsupportedNode`
+    /// so the reason is observable in the decline log (not only via `Debug`).
+    pub(crate) fn as_label(&self) -> &'static str {
+        match self {
+            SupportReason::UnsupportedNode(node) => node,
+            SupportReason::AggregateHaving => "AggregateHaving",
+            SupportReason::NestedLimit => "NestedLimit",
+        }
+    }
+}
+
+/// Classify a plan's support for the native vectorized path. Walks the same
+/// node set `walk`/`lower_join` handle. `limit_count` is reset at each `Join`
+/// (each side is lowered independently by `lower_join`, with its own limit slot).
+pub(crate) fn vectorized_supports(plan: &PhysicalPlan) -> SupportLevel {
+    let mut reasons = Vec::new();
+    classify_support(plan, 0, &mut reasons);
+    if reasons.is_empty() {
+        SupportLevel::Full
+    } else {
+        SupportLevel::Partial(reasons)
+    }
+}
+
+fn classify_support(plan: &PhysicalPlan, limit_count: u8, reasons: &mut Vec<SupportReason>) {
+    match plan {
+        PhysicalPlan::Values { .. } | PhysicalPlan::Scan { .. } => {}
+        PhysicalPlan::Filter { input, .. } | PhysicalPlan::Project { input, .. } => {
+            classify_support(input, limit_count, reasons);
+        }
+        PhysicalPlan::Aggregate { input, having, .. } => {
+            if having.is_some() {
+                reasons.push(SupportReason::AggregateHaving);
+            }
+            classify_support(input, limit_count, reasons);
+        }
+        PhysicalPlan::Limit { input, .. } => {
+            if limit_count >= 1 {
+                reasons.push(SupportReason::NestedLimit);
+            }
+            classify_support(input, limit_count + 1, reasons);
+        }
+        // `Join` is lowered by `lower_join`, which walks each side independently
+        // (fresh limit slot per side) — reset the counter at the join boundary.
+        PhysicalPlan::Join { left, right, .. } => {
+            classify_support(left, 0, reasons);
+            classify_support(right, 0, reasons);
+        }
+        PhysicalPlan::Sort { .. } => reasons.push(SupportReason::UnsupportedNode("Sort")),
+        PhysicalPlan::Distinct { .. } => reasons.push(SupportReason::UnsupportedNode("Distinct")),
+        PhysicalPlan::AssertMaxOneRow { .. } => {
+            reasons.push(SupportReason::UnsupportedNode("AssertMaxOneRow"));
+        }
+        PhysicalPlan::Union { .. } => reasons.push(SupportReason::UnsupportedNode("Union")),
+        PhysicalPlan::SetOp { .. } => reasons.push(SupportReason::UnsupportedNode("SetOp")),
+    }
+}
+
 /// Convert a [`Walked`] (source + OpSpec chain) into a concrete operator chain
 /// + the trailing `Limit`. Extracted so `lower_join` can reuse it for each side.
 fn walked_to_operators(walked: Walked) -> (Vec<Box<dyn ExecutionOperator>>, Option<LimitSpec>) {
@@ -2421,6 +2518,53 @@ mod tests {
     }
 
     // --- Join routing through lower_physical (ADR-054 Phase 3 routing) ---
+
+    /// ADR-058 D1 drift guard: `vectorized_supports` must agree with
+    /// `lower_physical` — if the descriptor marks a plan `Partial`, the lowering
+    /// MUST decline (sound one-way filter); if `Full`, the lowering MAY succeed.
+    /// Prevents the declared capability from drifting from the actual lowering.
+    #[test]
+    fn vectorized_supports_drift_matches_lowering() {
+        use proximadb_relational_types::ColumnInfo;
+        let schema = RelationalSchema::new(vec![ColumnInfo::new("k", ProximaType::Int64, true)]);
+        let values_leaf = || PhysicalPlan::Values {
+            rows: vec![vec![Expr::Literal {
+                value: ProximaValue::Int64(1),
+                ty: ProximaType::Int64,
+            }]],
+            output_schema: schema.clone(),
+        };
+
+        // Full: a bare Values leaf is fully supported, and the lowering succeeds.
+        assert!(matches!(
+            vectorized_supports(&values_leaf()),
+            SupportLevel::Full
+        ));
+        assert!(lower_physical(&values_leaf(), None).is_ok());
+
+        // Partial (NestedLimit): two Limits on one path → the descriptor flags
+        // it AND the lowering declines. Proves the one-way invariant.
+        let nested = PhysicalPlan::Limit {
+            input: Box::new(PhysicalPlan::Limit {
+                input: Box::new(values_leaf()),
+                limit: Some(10),
+                offset: 0,
+            }),
+            limit: Some(5),
+            offset: 0,
+        };
+        match vectorized_supports(&nested) {
+            SupportLevel::Partial(rs) => assert!(
+                rs.iter().any(|r| matches!(r, SupportReason::NestedLimit)),
+                "expected NestedLimit reason, got {rs:?}"
+            ),
+            SupportLevel::Full => panic!("nested Limit must be classified Partial"),
+        }
+        assert!(
+            lower_physical(&nested, None).is_err(),
+            "nested Limit must be declined by the lowering"
+        );
+    }
 
     #[tokio::test]
     async fn join_routes_through_lower_physical() {


### PR DESCRIPTION
## What
Implements **ADR-058 D1 (P1-core)**: the native vectorized path's *declared capability* as a single, queryable descriptor, consulted before the lowering attempt so clearly-unsupported shapes decline fast with **structured reasons**. Centralizes what was scattered across N `NotImplemented` returns + a docstring, and is the foundation for routing/probe sites to consult one source of truth.

## Changes
- `vectorized_supports(plan) -> SupportLevel { Full, Partial(Vec<SupportReason>) }` (`native_ops.rs`) — a shallow classifier over the `PhysicalPlan` variants `walk`/`lower_join` handle. Each `SupportReason` mirrors a concrete decline site:
  - `UnsupportedNode("Sort"|"Distinct"|"Union"|"SetOp"|"AssertMaxOneRow")` — `walk` catch-all
  - `AggregateHaving` — `walk` Aggregate arm (`having.is_some()`)
  - `NestedLimit` — `walk` Limit arm (`w.limit` already set)
  - `limit_count` resets at `Join` (each side lowered independently by `lower_join`).
- **Sound one-way filter:** `Partial` **guarantees** `lower_physical` declines (every reason mirrors a real decline); `Full` does **not** guarantee success (deeper constraints — distinct aggregates, non-column projections, equi-key extractability, scan-source, `MAX_WALK_DEPTH` — are checked during lowering). `try_vectorized` short-circuits on `Partial`; falls through to `lower_physical` on `Full`.
- Drift test `vectorized_supports_drift_matches_lowering` — asserts the one-way invariant (nested `Limit` → `Partial` + lowering `Err`; bare `Values` → `Full` + lowering `Ok`), preventing the declared capability from drifting from the actual lowering.

## Coordination with the §9 grounded review (#857) and PR #853
Validated the §9 addendum (A/B/C all sound against the code). Accommodations:
- **§9.A (P5, next PR):** the `StatsTrust::Untrusted → no elision` gate must cover **both** footer-trust paths — `statistics_from_splits` AND `new_count_only` (`ParquetScanOperator`), not just the first.
- **§9.C (this PR):** `vectorized_supports` is D1 site **1 of 3** (the lowering decline via `try_vectorized`). Non-conflicting with #853 — its `native_engine.rs` change is an additive `native_route_enabled()` gate fn, not a `try_vectorized` edit. Full unification (route site + shadow probe consult a shared descriptor) is a follow-up once #853 lands; PAX and parquet have distinct capability sets, so the unified source is **one module** (this descriptor + a future `parquet_native_supports`), not one function.
- **§9.B:** endorse the sound-subset carve (unfiltered scalar agg + footer elision are native-eligible today, trust-gated, opt-in) — #853's domain.

## Verification
- `cargo check --tests -p proximadb --lib` clean (descriptor + drift test compile).
- `cargo fmt --all` clean; pre-push gate green.
- Drift-test execution is trivial by construction; CI runs it authoritatively.