### PR TITLE
refactor(storage): migrate production callers to point_lookup

### DIFF
--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2017,10 +2017,10 @@ impl VectorOperationsService {
             .unwrap_or("");
         let engine = self.get_engine_for_collection(collection_id).await?;
 
-        Ok(engine
-            .vector_by_id(collection_id, base_path, record_id)
+        Ok(!engine
+            .point_lookup(collection_id, base_path, &[record_id.to_string()], None)
             .await?
-            .is_some())
+            .is_empty())
     }
 
     /// Return lightweight, default planning/pruning hints without executing search.

--- a/src/storage/cache/warming.rs
+++ b/src/storage/cache/warming.rs
@@ -359,8 +359,9 @@ impl CacheWarmer {
         // For now, use default path
         let _base_path = "/data/collections";
         engine
-            .vector_by_id(collection_id, _base_path, vector_id)
+            .point_lookup(collection_id, _base_path, &[vector_id.to_string()], None)
             .await
+            .map(|v| v.into_iter().next())
     }
 
     /// Helper: Warm specific collection

--- a/src/storage/formats/adapters.rs
+++ b/src/storage/formats/adapters.rs
@@ -261,11 +261,13 @@ impl<E: UnifiedStorageFormat + 'static> InternalFormat for InternalFormatAdapter
         // Extract collection_id from path (path format: {base}/{collection_id}/data)
         let collection_id = extract_collection_id_from_path(path)?;
 
-        // Use engine's vector_by_id method
+        // Use engine's point_lookup method (batch-capable; identity None for now)
         match self
             .engine
-            .vector_by_id(&collection_id, path, vector_id)
+            .point_lookup(&collection_id, path, &[vector_id.to_string()], None)
             .await?
+            .into_iter()
+            .next()
         {
             Some(record) => {
                 // Convert canonical ProximaRecord to the legacy VectorBatch adapter shape.


### PR DESCRIPTION
Follow-up to #596 (the batch `point_lookup` engine read-trait API, now on `develop`).

## What
Migrates the 3 production call sites from `vector_by_id` (single-ID) to the new batch-capable `point_lookup`, passing a 1-element `&[id]` and `None` identity.

- `src/services/operations/vectors/legacy.rs`
- `src/storage/cache/warming.rs`
- `src/storage/formats/adapters.rs`

## Approach
- **No behavior change** — single-ID semantics preserved via a 1-element batch.
- Sets up the batch path for future multi-ID use and for per-engine overrides (see the SST batch-override PR).
- `vector_by_id` is retained (not deprecated yet — ~100 callers; deprecate after migration per #596).

## Verified
Clean rebase onto `develop`; `point_lookup` signature matches the call sites exactly.