### PR TITLE
docs(decomposition): services subsystem coupling review (feeds ROOT_CRATE_DECOMPOSITION_PLAN)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_SERVICES_COUPLING_REVIEW_2026_07_10.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_SERVICES_COUPLING_REVIEW_2026_07_10.adoc
@@ -1,0 +1,210 @@
+= Root-Crate Decomposition — Services Subsystem Coupling Review (2026-07-10)
+:toc: macro
+:icons: font
+
+[abstract]
+Evidence-driven coupling/cohesion/duplication review of `src/services/` — the #1
+god-module concentration in the root crate. This is a *companion* to
+`ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`: it supplies the measured coupling
+data and a sequenced extraction list for the services subsystem. All numbers come
+from the code graph in `.victor/project.db` (1,051,256 nodes / 3,232,318 edges;
+per-file Martin metrics in `graph_module_metric`), not from assertion.
+
+toc::[]
+
+== Why services first
+
+`src/services/` holds the write-path core and the single largest file in the repo.
+It is the highest-leverage place to start the per-subsystem decomposition pass: four
+of its files sit in the global hotspot top-20, and they form the write-path coupling
+spine that every other subsystem routes through.
+
+== Method & evidence source
+
+* `graph_module_metric` (2,379 files): pre-computed `afferent_coupling` (Ca),
+  `efferent_coupling` (Ce), `instability`, `pagerank`, `betweenness`, `hotspot_score`,
+  `symbol_count`, `change_frequency`.
+* `graph_edge` (3.2M): file-level coupling fan via
+  `CALLS`/`IMPLEMENTS`/`COMPOSITION`/`IMPORTS`/`INHERITS`
+  (control/data-flow edges `CFG_*`/`DDG_*` excluded as intra-procedural).
+* `graph_node` (1.05M): per-symbol inventory for structural split candidates.
+
+*Caveats (measured limits):* `cohesion_lcom4` is computed at file granularity only and
+reads `0.0` everywhere — type-level cohesion is **not** pre-computed (would require
+deriving from `DDG_DEF_USE` per struct). Duplication is signature/name-level only (the
+graph stores no AST-body hashes); generated `clients/*` code is excluded from dup scans.
+
+== Services hotspot ranking (top, by `hotspot_score`)
+
+[cols="3,1,1,1,1,1,1",options="header"]
+|===
+| File | hot | Ca | Ce | inst | syms | churn
+| `services/dml/mod.rs` | 0.521 | 13 | 43 | 0.77 | 10,656 | 95
+| `services/operations/vectors/legacy.rs` | 0.511 | 13 | 61 | 0.82 | 4,342 | 86
+| `services/collection/manager.rs` | 0.407 | 10 | 55 | 0.85 | 3,919 | 50
+| `services/record_store.rs` | 0.391 | 27 | 97 | 0.78 | 3,968 | 51
+| `services/mod.rs` | 0.386 | 0 | 3 | 1.00 | 454 | 28
+| `services/fusion_service.rs` | 0.334 | 0 | 12 | 1.00 | 1,059 | 11
+|===
+
+`record_store.rs` has the **highest bidirectional coupling** (Ca=27, Ce=97); `dml/mod.rs`
+has the **highest churn (95)** and symbol count.
+
+== Finding 1 — `dml/mod.rs` is half embedded tests (low-risk halving)
+
+`src/services/dml/mod.rs` is a single 11,256-line file. Verified against source:
+
+* Lines 1–5606: production (~5,606 lines).
+* Line 5607: `#[cfg(test)]` → line 5608 `mod tests {` … 11,256: **~5,648 lines of embedded
+  tests (72 `#[test]` functions)**.
+* Public API is narrow: **9 `pub fn`, 8 `pub struct`, 9 `impl`** — the file's *surface* is
+  small; its *body* and embedded test module are the bulk.
+* No submodules extracted (`mod` declarations = only `mod tests`).
+
+[recommendation]
+**Action (low-risk, do first):** extract the `mod tests` block to a sibling file
+(e.g. `src/services/dml/tests.rs` via `#[path]`, or `tests/dml_*`). This halves the file
+with zero behavioural change and immediately shrinks the root-crate compile unit — the
+stated goal of the parent plan. (The plan's "11,256-line god-module" figure counts the
+whole file including tests.)
+
+== Finding 2 — `dml/mod.rs` production body is an unsplit god-module (≥7 clusters)
+
+The 216 functions in the file resolve to at least seven separable responsibility clusters
+(inferred from the `graph_node` function-name inventory):
+
+[cols="2,4",options="header"]
+|===
+| Cluster | Representative functions
+| DML execution core | `execute`, `execute_insert/update/delete/upsert`, `execute_scoped`, `effective_insert_literal`
+| FK / cascade enforcement | `acquire_cascade_child_dml_locks`, `enforce_foreign_keys`, `delete_enforces_*_fk`, `discover_cascade_child_set`, `assert_no_cascade_cycle`
+| Column / corpus stats | `bump_column_minmax/ndv/null_counts`, `compute_column_*_from_records`, `bump_row_count_stats`, `bump_corpus_version_for_stats`
+| Predicate evaluation | `condition_to_predicate_tree`, `eval_predicate_tree`, `eval_predicate_leaf`, `compare_catalog_value`, `combine_conditions`
+| Mutation-record building | `build_mutation_record`, `build_delete_tombstone_record`, `build_updated_proxima_record`, `build_unique_candidate_sets`
+| DDL handling | `alter_table_materialize_via_ddl_flips_catalog_layout`, `ddl_create_table_visible_in_introspection`, `ddl_constraints_surface_as_route_metadata_gaps`
+| CDC / change feed | `cdc_change_feed_reports_ops_since_lsn`, `changed_oids_since`, `changes_since`
+| Explain | `explain_table_write`, `explain_insert_values`, `explain_analyze_executes_*`
+|===
+
+[recommendation]
+**Action:** after extracting tests, split the production body into submodules by cluster
+(`dml/exec.rs`, `dml/fk.rs`, `dml/stats.rs`, `dml/predicate.rs`, `dml/mutation.rs`,
+`dml/ddl.rs`, `dml/cdc.rs`, `dml/explain.rs`). The narrow public API (9 fns) makes this a
+mechanical, low-blast-radius extraction.
+
+== Finding 3 — the write-path coupling triangle (decomposition blocker)
+
+Three files form a cyclic coupling tangle (edge counts, file→file, type-filtered):
+
+[cols="3,3,1",options="header"]
+|===
+| From | To | edges
+| `dml/mod.rs` | `services/record_store.rs` | 15
+| `services/record_store.rs` | `dml/mod.rs` | 11
+| `dml/mod.rs` | `query/table_write_executor.rs` | 6
+| `query/table_write_executor.rs` | `dml/mod.rs` | 8
+| `services/record_store.rs` | `query/table_write_executor.rs` | 45
+|===
+
+`dml ↔ record_store` and `dml ↔ table_write_executor` are **bidirectional (cycles)**; the
+`record_store → table_write_executor` edge (45) is the heaviest single coupling in the
+subsystem. These cycles block clean extraction — you cannot move any of the three into a
+workspace crate without severing the cycle.
+
+== Finding 4 — `record_store.rs` is the write-path hub → port candidate
+
+`record_store.rs` (Ca=27, Ce=97) is the convergence point of the write path. Its efferent
+fan shows where the coupling concentrates:
+
+[cols="3,1",options="header"]
+|===
+| Depends on | edges
+| `observability/io_trace.rs` | 67
+| `query/table_write_executor.rs` | 45
+| `metrics/consumption_metrics.rs` | 27
+| `infrastructure/concurrent_structures.rs` | 21
+| `services/transaction/cross_model_coordinator.rs` | 11
+| `index/axis/{zero_overhead,compact}_vector.rs` | 11 each
+| `graph/engines/orion/storage.rs` | 10
+| `cluster/partition_lease.rs` | 10
+| `crates/modalities/proximadb-rank-core/src/arena.rs` | 10
+|===
+
+[recommendation]
+**Action:** introduce a `RecordStorePort` trait and invert its consumers (the network
+handlers, `dml`, `table_write_executor`) to depend on `Arc<dyn RecordStorePort>`. This
+mirrors the proven `QuantizationEnginePort` / Slice-D port-inversion pattern
+(`ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc`): define the port in
+`storage-ports`, keep the impl in the services kernel, let dependents hold the trait
+object. That single move severs the Finding-3 cycles and makes `record_store` (and the
+storage/index/graph/cluster deps behind it) swappable + extractable.
+
+== Finding 5 — `dml/mod.rs` reaches across six subsystems
+
+`dml/mod.rs` efferent edges reach: `control/proximadb-catalog` (×2: `lib.rs`, `relational.rs`),
+`index/axis` (×2), `graph/engines/orion`, `modalities/proximadb-rank-core`,
+`cluster/partition_lease`, `infrastructure/concurrent_structures`. It is a god-module
+*orchestrator* depending on concretes across the layer cake.
+
+[recommendation]
+**Action:** once the `RecordStorePort` (Finding 4) and cluster/predicate submodules
+(Finding 2) exist, route dml's cross-subsystem reach through ports, not concrete modules —
+the same SOLID-seam discipline the parent plan and ADR-039 enforce.
+
+== Finding 6 — duplication is secondary
+
+Same-named functions across `services/` files (generated `clients/*` excluded):
+
+[cols="2,1",options="header"]
+|===
+| Function name | files
+| `list_all`, `resolve_collection_id` | 4
+| `create_collection`, `from_wal_entries`, `get_by_key`, `scan_records`, `validate_records_for_insert`, `write_mutations`, `resolve_collection_name` | 3
+| `create_test_service`, `append_operations`, `build_unique_candidate_sets`, `bulk_write`, `check_delete_permission`, `convert_distance_metric`, `create_index`, `create_namespace` | 2–3
+|===
+
+Most of this is **test-helper duplication** (`create_test_service`) and a handful of
+operational helpers repeated across collection/record/discovery modules. It is real but
+low-severity relative to Findings 1–5; chase it after the structural splits land.
+
+== Finding 7 — `operations/vectors/legacy.rs` is active debt
+
+`legacy.rs` sits at hot 0.511, churn 86, Ce=61 — second only to `dml/mod.rs`, yet its name
+flags it as legacy. High churn on a "legacy" module is the classic active-debt signature.
+
+[recommendation]
+**Action:** audit whether `legacy.rs` callers can migrate to the current `operations/vectors/`
+path; tie retirement to the v1-sunset work. Do not invest in decomposing a file slated for
+removal.
+
+== Recommended sequence (feeds the parent plan)
+
+. **Extract `dml/mod.rs` `mod tests`** — zero-risk, halves the largest file. (Finding 1)
+. **Split `dml` production body into responsibility submodules.** (Finding 2)
+. **Introduce `RecordStorePort`; invert consumers** — severs the write-path triangle.
+  (Findings 3 & 4)
+. **Route `dml` cross-subsystem reach through ports.** (Finding 5)
+. **Retire `operations/vectors/legacy.rs`** via v1-sunset; defer its decomposition. (Finding 7)
+. **De-duplicate services helpers** post-split. (Finding 6)
+
+Steps 1–2 are mechanical and low-risk; step 3 is the architectural move that unblocks
+extraction (and is the services-subsystem analogue of Slice D).
+
+== Reproducibility — key queries
+
+[source,sql]
+----
+-- services hotspot ranking
+SELECT module_path, hotspot_score, afferent_coupling, efferent_coupling,
+       instability, symbol_count, change_frequency
+FROM graph_module_metric
+WHERE module_path LIKE 'src/services/%' ORDER BY hotspot_score DESC;
+
+-- file→file coupling fan (dml efferent example)
+SELECT dn.file, COUNT(*) FROM graph_edge e
+  JOIN graph_node sn ON sn.node_id=e.src
+  JOIN graph_node dn ON dn.node_id=e.dst
+WHERE sn.file='src/services/dml/mod.rs' AND dn.file<>'src/services/dml/mod.rs'
+  AND e.type IN ('CALLS','IMPLEMENTS','COMPOSITION','IMPORTS','INHERITS')
+GROUP BY dn.file ORDER BY 2 DESC;
+----


### PR DESCRIPTION
Evidence-driven coupling/cohesion/duplication review of `src/services/` from the `.victor/project.db` code graph (1.05M nodes / 3.2M edges). Companion to ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc — supplies a sequenced extraction list for the services subsystem.

**Headline findings:**
- `dml/mod.rs` (11,256 lines) is **half embedded tests** (~5,648 lines / 72 `#[test]`) — extract `mod tests` to halve the file at zero risk.
- `dml` prod body = 216 fns across **≥7 responsibility clusters** — split into submodules.
- **Write-path coupling triangle** (dml ↔ record_store ↔ table_write_executor, cyclic) blocks extraction.
- `record_store.rs` is the write-path **hub** (Ca=27/Ce=97) → `RecordStorePort` candidate (Slice-D pattern).
- `operations/vectors/legacy.rs` = active debt (churn 86) → retire via v1-sunset.

Method (graph metrics, not assertion) + repro queries in the doc.