### PR TITLE
docs(decomposition): network subsystem coupling review (feeds ROOT_CRATE_DECOMPOSITION_PLAN)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_NETWORK_COUPLING_REVIEW_2026_07_10.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_NETWORK_COUPLING_REVIEW_2026_07_10.adoc
@@ -1,0 +1,184 @@
+= Root-Crate Decomposition — Network Subsystem Coupling Review (2026-07-10)
+:toc: macro
+:icons: font
+
+[abstract]
+Evidence-driven coupling/cohesion/duplication review of `src/network/` — the most
+hotspot-dense subsystem in the root crate (9 of the global top-20 hotspots, including the
+#1 file `shared_services.rs`). Second in the per-subsystem pass after
+`ROOT_CRATE_DECOMPOSITION_SERVICES_COUPLING_REVIEW_2026_07_10.adoc`; same method and a
+companion to `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`. All numbers come from the code
+graph in `.victor/project.db` (1.05M nodes / 3.2M edges; `graph_module_metric` Martin metrics).
+
+toc::[]
+
+== Why network second
+
+`src/network/` is the request-entry surface and owns the single highest-hotspot file in the
+repo. It is also where two in-flight efforts converge — the TD-104 legacy-handler retirement
+and the `rest::canonical` rename — so a coupling map here both feeds decomposition and de-risks
+those. See <<_method>> for limits (cohesion not pre-computed; duplication signature-level).
+
+== Method
+
+Same as the services review: `graph_module_metric` for per-file Ca/Ce/instability/hotspot;
+`graph_edge` (`CALLS`/`IMPLEMENTS`/`COMPOSITION`/`IMPORTS`/`INHERITS`, control/data-flow
+edges excluded) for file→file coupling fan; `graph_node` for structural inventory; source
+`grep` for the `#[cfg(test)]` boundary. Open `.victor/project.db` read-only.
+
+== Network hotspot ranking (top, by `hotspot_score`)
+
+[cols="3,1,1,1,1,1,1",options="header"]
+|===
+| File | hot | Ca | Ce | inst | syms | churn
+| `network/shared_services.rs` | 0.591 | 2 | 66 | 0.97 | 2,116 | 98
+| `network/rest/v1/handlers.rs` | 0.552 | 5 | 101 | 0.95 | 2,550 | 87
+| `network/multi_server.rs` | 0.546 | 1 | 36 | 0.97 | 1,742 | 83
+| `network/postgres/protocol.rs` | 0.496 | 1 | 52 | 0.98 | 7,710 | 66
+| `network/rest/v2/records.rs` | 0.465 | 2 | 59 | 0.97 | 3,435 | 57
+| `network/arrow_ipc/service.rs` | 0.439 | 4 | 101 | 0.96 | 3,653 | 49
+| `network/rest/server.rs` | 0.408 | 2 | 67 | 0.97 | 1,103 | 38
+| `network/grpc/v2/record_service.rs` | 0.386 | 0 | 45 | 1.00 | 2,646 | 28
+| `network/postgres/relational_pipeline.rs` | 0.385 | 9 | 26 | 0.74 | 2,091 | 53
+|===
+
+Note `relational_pipeline.rs` is the only file with meaningful **afferent** coupling (Ca=9) —
+the SQL-lowering bridge everything routes through.
+
+== Finding 1 — embedded tests dominate the god-files (systemic, zero-risk win)
+
+The same pattern found in `services/dml/mod.rs` recurs here, more severely. Verified `#[cfg(test)]`
+boundaries against source:
+
+[cols="2,1,1,1,1,1",options="header"]
+|===
+| File | total lines | tests start @ | test share | #[test] | pub/crate fn
+| `postgres/protocol.rs` | 6,635 | 5,335 | **~80%** | 59 | 7
+| `rest/v1/handlers.rs` | 3,458 | 1,812 | ~48% | 35 | 22
+| `arrow_ipc/service.rs` | 3,877 | 3,115 | ~20% | 30 | 3
+| `shared_services.rs` | 3,217 | 2,968 | ~8% (92% prod) | 5 | 8
+| `multi_server.rs` | 1,888 | none | 0% | 0 | 1
+|===
+
+[recommendation]
+**`postgres/protocol.rs` is ~80% embedded tests** (6,635 lines → ~1,300 prod + ~5,335 test / 59
+`#[test]`). Extracting `mod tests` drops it to ~1,300 lines — the single biggest zero-risk
+reduction in the subsystem. This is now a *cross-cutting* finding (services + network): the
+codebase parks huge `#[cfg(test)] mod tests` blocks inside production source, which inflates
+the root-crate compile unit — the exact OOM/compile-peak the parent plan exists to fix.
+**Recommend a dedicated "extract embedded `mod tests`" sweep across the top-N god-files**
+(protocol.rs, dml/mod.rs, handlers.rs, …) as a cheap, high-yield first wedge.
+
+== Finding 2 — `shared_services.rs` is the composition root → must be thinned to wiring
+
+`shared_services.rs` (hot 0.591, the **#1 global hotspot**) is the service-composition / DI hub.
+Efferent reaches ~15 services — `cluster/primary_pod_registry` (8), `record_store` (4),
+`canonical_wal` (4), `graph/service` (4), `function_store` (3), `events/log` (3),
+`discovery/drift` (3), `system_catalog_state` (2), `rank_profile_store` (2),
+`consumption_metrics` (2), `timeseries_service` (1). Afferent is just 2 (`runtime/handlers.rs`,
+`api/lib.rs`) — a narrow top-of-graph surface.
+
+Its high Ce is *partly legitimate* for a wiring file — but it is **2,968 lines of production
+code (92% prod), not thin wiring**, with only 8 `pub`/`pub(crate)` functions.
+
+[recommendation]
+**Action:** this file is the literal target of the parent plan's end-state — *"root crate becomes
+a thin composition layer: bootstrap, wiring, and port composition only — no large module
+bodies."* Thin `shared_services.rs` to pure wiring; move any inline logic into the service
+crates it composes. Low afferent (2 callers) makes this safe.
+
+== Finding 3 — protocol + Arrow-Flight reach across subsystems via concretes (port candidates)
+
+* `postgres/protocol.rs` efferent: `infrastructure/concurrent_structures` (20),
+  `relational_pipeline` (10), `index/axis/{zero_overhead,compact}_vector` (10 each),
+  `graph/engines/orion/storage` (10), `core/metadata_types` (10), `rank-core/arena` (10).
+  The pgwire protocol touches storage/index/graph/rank internals directly.
+* `arrow_ipc/service.rs` efferent: `graph/canonical/mod` (31),
+  `crates/platform/proximadb-api/src/rest/v1/graph.rs` (**31**), `kernel/error` (30),
+  `search/filter_contract` (24), `streaming/subscriptions/result_set` (21),
+  `query-capability` (21), `arrow_ipc/codec` (18), `catalog/iceberg_rest_service` (16).
+
+[recommendation]
+**Two issues:** (a) both transports reach storage/index/graph/rank via concretes — route through
+ports (same recommendation as the services review's `RecordStorePort`). (b) **Layering smell:**
+`arrow_ipc/service.rs` → `platform/api/rest/v1/graph.rs` (31 edges) — an Arrow Flight service
+calling into a *REST* graph handler is transport-crossing shared logic leaking between surfaces
+(the same twin-handler gap behind TD-104 / TD-121). Promote the shared graph logic to a service
+seam both transports call, rather than Flight → REST.
+
+== Finding 4 — `rest/v1/handlers.rs` is TD-104 legacy → retire, don't decompose
+
+`rest/v1/handlers.rs` (hot 0.552, churn 87) is the legacy REST handler surface slated for
+retirement under TD-104. Its efferent coupling is **low** (max 3 edges — `service_types`,
+`canonical_wal`, `iceberg_rest_catalog`, `graph/merge`) — consistent with a thin legacy shell
+that delegates rather than owns logic.
+
+[recommendation]
+**Action:** do not invest in decomposing this file; it is on the TD-104 retirement path (and the
+`rest::canonical` rename is already in motion). Sequence any extraction *after* the v1 sunset so
+the work isn't thrown away.
+
+== Finding 5 — `multi_server.rs` is pure-prod lifecycle orchestration
+
+`multi_server.rs` (1,888 lines, hot 0.546) is **100% production** (no embedded tests) with a
+1-function public surface — the server lifecycle/bootstrap orchestration. Like `shared_services`,
+it is a genuine prod god-file (not test-inflated).
+
+[recommendation]
+**Action:** candidate for splitting lifecycle stages (bind → multiplex → serve → graceful
+shutdown) into submodules; narrow surface makes it low-risk. Lower priority than Findings 1–2.
+
+== Finding 6 — duplication is more significant than in services
+
+Same-named functions across `network/` files:
+
+[cols="2,1",options="header"]
+|===
+| Function name | files
+| `create_router` | 8
+| `execute_query` | 7
+| `create_namespace`, `default_top_k`, `into_server`, `with_catalog_manager`, `with_config`, `with_primary_pod_gate` | 5
+| `add_unique_constraint`, `batch_create_edges/nodes`, `create_edge/node`, `create_graph_collection`, `default_limit` | 4
+|===
+
+Two classes: (a) genuine operational duplication — `create_router` (×8) and `execute_query` (×7)
+are real cross-file repeats worth consolidating into a shared helper; (b) **duplicated test
+builders** (`with_config`, `with_catalog_manager`, `with_primary_pod_gate`, `into_server` — the
+`with_*`/`into_*` pattern) repeated per test module — extract a shared network test-harness
+crate/module. This is more severe than services' duplication.
+
+== Recommended sequence (feeds the parent plan)
+
+. **Extract embedded `mod tests`** across network god-files — `protocol.rs` (−~5,335 lines),
+  `rest/v1/handlers.rs`, `arrow_ipc/service.rs`. Highest-yield, zero-risk; ideally done as a
+  cross-subsystem sweep with the services review's dml extraction. (Finding 1)
+. **Thin `shared_services.rs` to pure wiring** — move inline bodies into service crates; matches
+  the plan's end-state. (Finding 2)
+. **Promote shared graph logic to a service seam**; stop `arrow_ipc → rest/v1/graph` calls.
+  (Finding 3b)
+. **Route transport→storage/index/graph through ports.** (Finding 3a)
+. **Defer `rest/v1/handlers.rs` to TD-104 retirement**; do not decompose. (Finding 4)
+. **Split `multi_server.rs` lifecycle stages.** (Finding 5)
+. **Consolidate `create_router`/`execute_query`; extract a shared network test-harness.** (Finding 6)
+
+Findings 1–2 are mechanical/low-risk and compound directly with the services review; Finding 3
+is the architectural move (ports + seam) that unblocks transport extraction.
+
+== Reproducibility — key queries
+
+[source,sql]
+----
+-- network hotspot ranking
+SELECT module_path, hotspot_score, afferent_coupling, efferent_coupling,
+       instability, symbol_count, change_frequency
+FROM graph_module_metric
+WHERE module_path LIKE 'src/network/%' ORDER BY hotspot_score DESC;
+
+-- file→file coupling fan (protocol.rs efferent example)
+SELECT dn.file, COUNT(*) FROM graph_edge e
+  JOIN graph_node sn ON sn.node_id=e.src
+  JOIN graph_node dn ON dn.node_id=e.dst
+WHERE sn.file='src/network/postgres/protocol.rs' AND dn.file<>sn.file
+  AND e.type IN ('CALLS','IMPLEMENTS','COMPOSITION','IMPORTS','INHERITS')
+GROUP BY dn.file ORDER BY 2 DESC;
+----


### PR DESCRIPTION
Evidence-driven coupling/duplication review of `src/network/` from `.victor/project.db` (1.05M nodes / 3.2M edges). Second in the per-subsystem pass (after #864 services); companion to ROOT_CRATE_DECOMPOSITION_PLAN.

**Headline findings:**
- **Embedded tests dominate the god-files** — `postgres/protocol.rs` is **~80% tests** (6,635 → ~1,300 prod + ~5,335 test / 59 `#[test]`); `rest/v1/handlers.rs` ~half; `arrow_ipc/service.rs` ~762 test lines. Cross-cutting with services `dml` → recommend a dedicated **'extract embedded `mod tests`' sweep** (zero-risk, shrinks the compile unit — the plan's core motivation).
- `shared_services.rs` (#1 global hotspot) is the **composition root** (2,968 prod lines, 8-fn surface) → **thin to pure wiring** (the plan's end-state).
- `protocol.rs` + `arrow_ipc/service.rs` reach storage/index/graph via **concretes** → ports; `arrow_ipc → platform/api/rest/v1/graph` (31 edges) is a **transport-crossing layering smell**.
- `rest/v1/handlers.rs` = **TD-104 legacy** → retire, don't decompose.
- `multi_server.rs` = pure-prod lifecycle (1,888 lines, 1 `pub fn`) → split stages.
- **Duplication > services**: `create_router` ×8, `execute_query` ×7, plus `with_*`/`into_*` test builders.

Method (graph metrics) + repro queries in the doc.