### PR TITLE
feat(olap): ADR-058 D5/§9.A path-1 — trust-gate the DataFusion-adapter footer elision

### DIFF
--- a/crates/foundation/proximadb-data-model/src/lib.rs
+++ b/crates/foundation/proximadb-data-model/src/lib.rs
@@ -26,6 +26,34 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
+// Stats Trust (ADR-058 D5 / §9.A)
+// ---------------------------------------------------------------------------
+
+/// Trust level for a parquet table's FOOTER STATISTICS (row_count /
+/// null_count / min-max). Footer-stats elision — answering `COUNT`/`MIN`/`MAX`
+/// from the parquet footer instead of scanning — is only sound when ProximaDB
+/// wrote the footer; an external/federated writer's footer may carry stale or
+/// absent stats, so eliding from it can return a WRONG aggregate.
+///
+/// Lives in the foundation data-model crate so both the network layer
+/// (`relational_pipeline`, which derives it from catalog authority) and the
+/// DataFusion adapter (which consumes it to gate `statistics_from_splits`) can
+/// share it without an ADR-039 layering violation (the adapter is below the
+/// network layer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatsTrust {
+    /// ProximaDB generated the parquet (materialized `ProjectionPublication`,
+    /// `ExportedPublication`, or a WAL-owned authority) ⇒ footer stats are
+    /// authoritative ⇒ elision is sound.
+    Trusted,
+    /// External/federated/imported authority (`FederatedRead` /
+    /// `ExternalAuthoritative` / `ImportedSnapshot`) — the writer is not
+    /// ProximaDB, so footer stats are NOT trusted ⇒ elision is disabled; the
+    /// aggregate is computed by scanning real column data.
+    Untrusted,
+}
+
+// ---------------------------------------------------------------------------
 // Modality Discriminators
 // ---------------------------------------------------------------------------
 

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -536,6 +536,12 @@ pub struct ObjectStoreParquetTable {
     /// key-column materialization because they let pruning happen from metadata
     /// without reading the data column first.
     row_group_bloom_cache: Arc<Mutex<RowGroupBloomCache>>,
+    /// ADR-058 D5/§9.A: trust level for this table's parquet footer stats.
+    /// `Trusted` (default — ProximaDB wrote the footer) ⇒ `statistics_from_splits`
+    /// may surface footer row_count/null_count/min-max as `Precision::Exact` for
+    /// DataFusion's `AggregateStatistics` elision. `Untrusted` (external/federated)
+    /// ⇒ stats are surfaced as `Precision::Absent` so COUNT/MIN/MAX scan.
+    stats_trust: proximadb_data_model::StatsTrust,
 }
 
 impl ObjectStoreParquetTable {
@@ -631,6 +637,7 @@ impl ObjectStoreParquetTable {
             table_name: None,
             split_key_cache: Arc::new(Mutex::new(HashMap::new())),
             row_group_bloom_cache: Arc::new(Mutex::new(HashMap::new())),
+            stats_trust: proximadb_data_model::StatsTrust::Trusted,
         })
     }
 
@@ -664,6 +671,7 @@ impl ObjectStoreParquetTable {
             // Per-query caches start empty (#742) — the table-OPEN cache reuses the
             // immutable footer discovery, not these query-time bloom/key caches.
             row_group_bloom_cache: Arc::new(Mutex::new(HashMap::new())),
+            stats_trust: proximadb_data_model::StatsTrust::Trusted,
         })
     }
 
@@ -693,6 +701,16 @@ impl ObjectStoreParquetTable {
     /// so [`TableProvider::statistics`] can overlay the HLL NDV estimate).
     pub fn with_table_name(mut self, name: impl Into<String>) -> Self {
         self.table_name = Some(name.into());
+        self
+    }
+
+    /// ADR-058 D5/§9.A: set this table's footer-stats trust level. Called at
+    /// registration with the per-table trust derived from the catalog authority
+    /// (`Trusted` for ProximaDB-generated parquet, `Untrusted` for
+    /// external/federated). Controls whether `statistics_from_splits` may
+    /// surface footer stats as `Precision::Exact` for AggregateStatistics elision.
+    pub fn with_stats_trust(mut self, trust: proximadb_data_model::StatsTrust) -> Self {
+        self.stats_trust = trust;
         self
     }
 
@@ -1054,6 +1072,7 @@ impl TableProvider for ObjectStoreParquetTable {
             &self.schema,
             self.table_name.as_deref(),
             df_stats_value_bounds_enabled(),
+            self.stats_trust,
         ))
     }
 
@@ -1085,6 +1104,7 @@ impl TableProvider for ObjectStoreParquetTable {
                 &self.schema,
                 self.table_name.as_deref(),
                 df_stats_value_bounds_enabled(),
+                self.stats_trust,
             ),
             projection.map(|p| p.as_slice()),
         );
@@ -1312,14 +1332,18 @@ pub async fn register_object_store_parquet_location(
     name: &str,
     location: &str,
     tenant: Option<&str>,
+    stats_trust: proximadb_data_model::StatsTrust,
 ) -> DFResult<Arc<ObjectStoreParquetTable>> {
     // Table-OPEN cache (TD-OLAP-4): on a hit, skip LIST + HEAD + footer discovery
     // and rebuild the table from cached metadata + a fresh per-query traced store.
     // Gated default-OFF; the cache is a pure function of the immutable snapshot,
     // invalidated on re-MATERIALIZE.
     if let Some(disc) = super::table_open_cache::get(tenant, location) {
-        let table =
-            Arc::new(ObjectStoreParquetTable::from_cached(&disc, location)?.with_table_name(name));
+        let table = Arc::new(
+            ObjectStoreParquetTable::from_cached(&disc, location)?
+                .with_table_name(name)
+                .with_stats_trust(stats_trust),
+        );
         ctx.register_table(name, table.clone())?;
         crate::observability::io_trace::record_table_open(true);
         return Ok(table);
@@ -1328,7 +1352,8 @@ pub async fn register_object_store_parquet_location(
     let table = Arc::new(
         ObjectStoreParquetTable::open(location)
             .await?
-            .with_table_name(name),
+            .with_table_name(name)
+            .with_stats_trust(stats_trust),
     );
     super::table_open_cache::insert(tenant, location, table.discovery());
     crate::observability::io_trace::record_table_open(false);
@@ -1491,7 +1516,13 @@ mod tests {
         );
 
         // With bounds enabled: min-of-mins / max-of-maxes across row groups.
-        let full = statistics_from_splits(&table.splits, &table.schema, None, true);
+        let full = statistics_from_splits(
+            &table.splits,
+            &table.schema,
+            None,
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
         let k = &full.column_statistics[0];
         assert_eq!(
             k.min_value,
@@ -1526,9 +1557,15 @@ mod tests {
 
         let location = format!("file://{}", tmp.path().display());
         let ctx = SessionContext::new();
-        register_object_store_parquet_location(&ctx, "t", &location, None)
-            .await
-            .unwrap();
+        register_object_store_parquet_location(
+            &ctx,
+            "t",
+            &location,
+            None,
+            proximadb_data_model::StatsTrust::Trusted,
+        )
+        .await
+        .unwrap();
 
         // Row group 1 holds x ∈ {1,2}; row group 2 holds x ∈ {100,101}.
         let df = ctx.sql("SELECT x FROM t WHERE x > 50").await.unwrap();
@@ -1967,9 +2004,15 @@ mod tests {
                 let ctx = SessionContext::new();
                 // Register (wraps the store) INSIDE the scope so the io_trace
                 // handle is captured for spawned-partition reads.
-                register_object_store_parquet_location(&ctx, "t", location, None)
-                    .await
-                    .unwrap();
+                register_object_store_parquet_location(
+                    &ctx,
+                    "t",
+                    location,
+                    None,
+                    proximadb_data_model::StatsTrust::Trusted,
+                )
+                .await
+                .unwrap();
                 let batches = ctx.sql(query).await.unwrap().collect().await.unwrap();
                 let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
                 let snap = io_trace::snapshot().expect("snapshot inside scope");

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -112,7 +112,17 @@ pub fn statistics_from_splits(
     schema: &ArrowSchema,
     collection: Option<&str>,
     include_value_bounds: bool,
+    stats_trust: proximadb_data_model::StatsTrust,
 ) -> Statistics {
+    // ADR-058 D5/§9.A: Untrusted (external/federated) parquet ⇒ do NOT surface
+    // footer stats as Exact. The writer's footer may be stale or absent, so
+    // eliding COUNT/MIN/MAX from it could return a WRONG aggregate. Return all
+    // Absent so DataFusion's AggregateStatistics declines to elide (scans real
+    // column data instead). Trusted (ProximaDB-generated) ⇒ the footer is
+    // authoritative ⇒ fall through to Exact elision.
+    if matches!(stats_trust, proximadb_data_model::StatsTrust::Untrusted) {
+        return Statistics::new_unknown(schema);
+    }
     let mut num_rows = 0usize;
     let mut any_rows = false;
     let mut total_bytes = 0usize;
@@ -626,7 +636,13 @@ mod tests {
             ),
         ];
 
-        let stats = statistics_from_splits(&splits, &schema, None, true);
+        let stats = statistics_from_splits(
+            &splits,
+            &schema,
+            None,
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
 
         assert_eq!(stats.num_rows, Precision::Exact(5));
         assert_eq!(stats.total_byte_size, Precision::Inexact(300));
@@ -674,7 +690,13 @@ mod tests {
             split_with_bounds(2, 10, &[]),
         ];
 
-        let stats = statistics_from_splits(&splits, &schema, None, true);
+        let stats = statistics_from_splits(
+            &splits,
+            &schema,
+            None,
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
         let x = &stats.column_statistics[0];
         assert_eq!(x.min_value, Precision::Absent);
         assert_eq!(x.max_value, Precision::Absent);
@@ -698,7 +720,13 @@ mod tests {
             &[("x", serde_json::json!(0), serde_json::json!(63), 0)],
         )];
 
-        let stats = statistics_from_splits(&splits, &schema, Some(collection), true);
+        let stats = statistics_from_splits(
+            &splits,
+            &schema,
+            Some(collection),
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
         crate::core::statistics::statistics_registry().remove(collection);
 
         match stats.column_statistics[0].distinct_count {
@@ -723,7 +751,13 @@ mod tests {
             &[("x", serde_json::json!(1), serde_json::json!(2), 3)],
         )];
 
-        let stats = statistics_from_splits(&splits, &schema, None, false);
+        let stats = statistics_from_splits(
+            &splits,
+            &schema,
+            None,
+            false,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
         let x = &stats.column_statistics[0];
         // Bounds suppressed (the recursive interval-analysis trigger)…
         assert_eq!(x.min_value, Precision::Absent);
@@ -755,7 +789,13 @@ mod tests {
             ],
         )];
 
-        let stats = statistics_from_splits(&splits, &schema, None, true);
+        let stats = statistics_from_splits(
+            &splits,
+            &schema,
+            None,
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
 
         let f = &stats.column_statistics[0];
         assert_eq!(
@@ -786,7 +826,13 @@ mod tests {
                 ("name", serde_json::json!("a"), serde_json::json!("b"), 0),
             ],
         )];
-        let full = statistics_from_splits(&splits, &schema, None, true);
+        let full = statistics_from_splits(
+            &splits,
+            &schema,
+            None,
+            true,
+            proximadb_data_model::StatsTrust::Trusted,
+        );
 
         let projected = project_statistics(&full, Some(&[1]));
         assert_eq!(projected.column_statistics.len(), 1);

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -30,7 +30,7 @@ use crate::query::execution::{
 };
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
-use proximadb_data_model::{ProximaType, ProximaValue};
+use proximadb_data_model::{ProximaType, ProximaValue, StatsTrust};
 use proximadb_functions::builtins;
 use proximadb_relational_algebra::TableId;
 use proximadb_relational_engine::{
@@ -555,8 +555,20 @@ pub async fn try_run_select(
             .iter()
             .map(|(k, t)| (t.table_name.clone(), parquet_loc_by_key[k].clone()))
             .collect();
+        // ADR-058 D5/§9.A: per-table footer-stats trust, keyed by table_name
+        // (matching `parquet_tables`), derived from `parquet_trust_by_key`
+        // (keyed by the canonical table key). Drives adapter elision gating.
+        let parquet_table_trust: HashMap<String, StatsTrust> = tables
+            .iter()
+            .filter_map(|(k, t)| {
+                parquet_trust_by_key
+                    .get(k)
+                    .map(|tr| (t.table_name.clone(), *tr))
+            })
+            .collect();
         let context = QueryExecutionContext {
             parquet_tables,
+            parquet_table_trust,
             vector_ops,
             graph_ops,
             tenant_id: tenant.map(str::to_string),
@@ -1235,24 +1247,6 @@ fn catalog_table_is_parquet_backed(
             None
         }
     })
-}
-
-/// ADR-058 D5 / §9.A — trust level for a parquet table's FOOTER STATISTICS
-/// (row_count / null_count / min-max). Footer-stats elision (answering
-/// COUNT/MIN/MAX from the footer instead of scanning) is only sound when
-/// ProximaDB wrote the footer; an external/federated writer's footer may carry
-/// stale or absent stats, so eliding from it can return a WRONG aggregate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum StatsTrust {
-    /// ProximaDB generated the parquet (materialized `ProjectionPublication`,
-    /// `ExportedPublication`, or a WAL-owned authority) ⇒ footer stats are
-    /// authoritative ⇒ elision is sound.
-    Trusted,
-    /// External/federated/imported authority (`FederatedRead` /
-    /// `ExternalAuthoritative` / `ImportedSnapshot`) — the writer is not ProximaDB,
-    /// so footer stats are NOT trusted ⇒ elision is disabled; aggregate via the
-    /// trust-safe value-scan path (`ParquetScanOperator::new`).
-    Untrusted,
 }
 
 /// Derive a parquet table's [`StatsTrust`] from its catalog authority. The ONLY

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -121,11 +121,20 @@ impl DataFusionLocalEngine {
                 .await?;
                 continue;
             }
+            // ADR-058 D5/§9.A: per-table footer-stats trust (default Trusted).
+            // Untrusted (external/federated) ⇒ the adapter declines to answer
+            // COUNT/MIN/MAX from the parquet footer and scans instead.
+            let stats_trust = context
+                .parquet_table_trust
+                .get(name)
+                .copied()
+                .unwrap_or(proximadb_data_model::StatsTrust::Trusted);
             let table = crate::datafusion::register_object_store_parquet_location(
                 &ctx,
                 name,
                 location,
                 context.tenant_id.as_deref(),
+                stats_trust,
             )
             .await
             .map_err(|e| {
@@ -653,11 +662,15 @@ async fn register_merged_olap_table(
         .await
         .map_err(|e| ExecutionError::Context(format!("olap-merge delta {name}: {e}")))?;
     if changed.is_empty() {
-        crate::datafusion::register_object_store_parquet_location(ctx, name, location, tenant)
-            .await
-            .map_err(|e| {
-                ExecutionError::Context(format!("olap-merge bare register {name}: {e}"))
-            })?;
+        crate::datafusion::register_object_store_parquet_location(
+            ctx,
+            name,
+            location,
+            tenant,
+            proximadb_data_model::StatsTrust::Trusted,
+        )
+        .await
+        .map_err(|e| ExecutionError::Context(format!("olap-merge bare register {name}: {e}")))?;
         return Ok(());
     }
     let suppress: HashSet<String> = changed.iter().cloned().collect();
@@ -666,9 +679,15 @@ async fn register_merged_olap_table(
     //    registration never leaks into the query's table namespace.
     let base_ctx = crate::datafusion::create_session_context()
         .map_err(|e| ExecutionError::Context(format!("olap-merge base session: {e}")))?;
-    crate::datafusion::register_object_store_parquet_location(&base_ctx, name, location, tenant)
-        .await
-        .map_err(|e| ExecutionError::Context(format!("olap-merge base register {name}: {e}")))?;
+    crate::datafusion::register_object_store_parquet_location(
+        &base_ctx,
+        name,
+        location,
+        tenant,
+        proximadb_data_model::StatsTrust::Trusted,
+    )
+    .await
+    .map_err(|e| ExecutionError::Context(format!("olap-merge base register {name}: {e}")))?;
     let base_schema = base_ctx
         .table_provider(name)
         .await

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -172,6 +172,12 @@ impl ExecutionControls {
 pub struct QueryExecutionContext {
     /// Tables backed by Parquet files (name -> location).
     pub parquet_tables: Vec<(String, String)>,
+    /// ADR-058 D5/§9.A: per-table footer-stats trust, keyed by table name
+    /// (parallel to `parquet_tables`). Drives whether the DataFusion adapter may
+    /// answer COUNT/MIN/MAX from the parquet FOOTER (`Trusted`) or must scan
+    /// (`Untrusted` — external/federated writer's footer is not trusted). Empty
+    /// ⇒ default `Trusted` per-table at registration.
+    pub parquet_table_trust: std::collections::HashMap<String, proximadb_data_model::StatsTrust>,
     /// Optional vector operations service for cross-modal search.
     pub vector_ops: Option<Arc<dyn proximadb_runtime::VectorOpsPort>>,
     /// Optional graph read service for the cross-modal `graph_traverse` table function.

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -8717,9 +8717,15 @@ mod tests {
 
             // Read the published location back through the DataFusion OLAP reader.
             let ctx = create_session_context().expect("session ctx");
-            register_object_store_parquet_location(&ctx, "inv_parquet", &location, None)
-                .await
-                .expect("register parquet location");
+            register_object_store_parquet_location(
+                &ctx,
+                "inv_parquet",
+                &location,
+                None,
+                proximadb_data_model::StatsTrust::Trusted,
+            )
+            .await
+            .expect("register parquet location");
             let batches = ctx
                 .sql("SELECT * FROM inv_parquet")
                 .await


### PR DESCRIPTION
## What
Completes the **§9.A correctness story** (#857). P5-core (#860) trust-gated the native route's two footer paths; this gates the **other, broader path** — the DataFusion adapter's `statistics_from_splits`, which surfaces parquet footer `row_count`/`null_count`/min-max as `Precision::Exact` for DataFusion's `AggregateStatistics` elision. For **external/federated** parquet (`FederatedRead`/`ExternalAuthoritative`/`ImportedSnapshot`) the writer's footer may be stale or absent, so eliding `COUNT`/`MIN`/`MAX` from it could return a **wrong aggregate on the DEFAULT (DataFusion) path** — the broader exposure, since the native route is opt-in default-OFF.

## Changes (7 files)
- **Move `StatsTrust {Trusted, Untrusted}`** from `relational_pipeline.rs` (network layer) → `proximadb-data-model` (foundation), so the DataFusion adapter (below the network layer per ADR-039) can use it without a layering violation.
- **`QueryExecutionContext`** += `parquet_table_trust: HashMap<String, StatsTrust>` (keyed by table name, parallel to `parquet_tables`).
- **`relational_pipeline`** populates it from `parquet_trust_by_key` (built by #860's `parquet_stats_trust`) at the context-construction site.
- **`datafusion_engine`** looks up per-table trust (default `Trusted`) and passes it to `register_object_store_parquet_location`.
- **`ObjectStoreParquetTable`** += `stats_trust` field (default `Trusted` in `open`/`from_cached`) + `.with_stats_trust()` builder; registration applies it.
- **`statistics_from_splits`** takes `stats_trust`; **`Untrusted` ⇒ `Statistics::new_unknown(schema)`** (all `Precision::Absent`) so DataFusion declines to elide and scans real column data. The two production call sites (`statistics()`, `scan()`) pass `self.stats_trust`.

## Scope
The **bare-parquet path** (`register_object_store_parquet_location`) — the external-parquet exposure. The **delta-merge path** (`register_merged_olap_table`) serves materialized parquet (`ProjectionPublication`, trusted, has `snapshot_lsn`) and passes `Trusted`. Tests updated to pass `Trusted` (behavior-preserving).

## Non-goal
**§9.C** — consolidate `try_native_over_parquet`'s scattered predicates into a `parquet_native_supports` descriptor (separate cleanup PR).

## Verification
- `cargo clippy --lib --bins -- -D warnings` clean (the CI gate).
- `cargo check --tests` compiles (test call sites updated).
- `cargo fmt --all` clean.