### PR TITLE
docs(decomposition): storage subsystem review (source-level; graph gap flagged)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_REVIEW_2026_07_10.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_REVIEW_2026_07_10.adoc
@@ -1,0 +1,143 @@
+= Root-Crate Decomposition — Storage Subsystem Review (2026-07-10)
+:toc: macro
+:icons: font
+
+[abstract]
+Structure + duplication review of `src/storage/` — the largest subsystem in the root crate
+(577 `.rs` files, ~52 MB of source; `engines/` alone is 333 files). Third in the per-subsystem
+pass after the services (#864) and network (#865) coupling reviews; companion to
+`ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc`.
+IMPORTANT: this review is **source-level only** — `src/storage/` is absent from
+`.victor/project.db` (see <<_finding_1_graph_gap_storage_is_not_indexed>>), so the coupling
+metrics (Ca/Ce/instability, edge fans, cycles) that drove the prior two reviews are **not
+available** here. Findings cover structure (LOC, embedded tests, god-files) and duplication.
+
+toc::[]
+
+== Method (source-level)
+
+No graph data for this subsystem. Findings derive from:
+* `wc -l` for file-size ranking;
+* `grep` for the `#[cfg(test)]` boundary (using the **last** occurrence — the main `mod tests`
+  block — which is more reliable than the first);
+* `grep fn <name>` aggregated across `engines/*/` for cross-engine stub duplication.
+
+Limits: no Ca/Ce, no coupling cycles, no cohesion, no pagerank/hotspot. Duplication is
+name-level (no AST-body hashing).
+
+== Finding 1 (graph gap) — storage is not indexed
+
+`src/storage/` (577 files) is **entirely absent** from `.victor/project.db` — every other major
+`src/` subdir is indexed (query 125, network 113, core 91, index 76, services 67, graph 63
+files), but storage returns 0 rows. `.victor/init.md` itself references `src/storage/traits/mod.rs`,
+`engines/factory.rs`, and `persistence/flush_materializer.rs`, so the omission is an incomplete
+index, not an unknown area.
+
+[recommendation]
+**Action:** extend the victor graph to cover `src/storage/` and re-run a full coupling review
+(cycles, hubs, port candidates). The structural findings below are deliverable now; the coupling
+dimension — the most actionable for decomposition — is blocked on indexing.
+
+== Finding 2 — embedded tests dominate storage god-files (systemic, cross-subsystem)
+
+The "extract embedded `mod tests`" pattern from services (`dml/mod.rs`) and network
+(`postgres/protocol.rs`) is **even more prevalent** in storage. Test boundary = last
+`#[cfg(test)]`:
+
+[cols="2,1,1,1,1",options="header"]
+|===
+| File | total lines | test share | #[test] | prod remnant
+| `engines/raptor/engine.rs` | 3,282 | ~95% | (test module) | ~160
+| `engines/viper/engine.rs` | 3,612 | ~89% | 5 | ~400
+| `engines/swift/engine.rs` | 2,318 | ~89% | 13 | ~260
+| `engines/core/formats/proximablocks/block_structures.rs` | 6,983 | ~82% | 30 | ~1,270
+| `engines/sst/readers/sst_query_engine.rs` | 6,804 | ~77% | 16 | ~1,560
+| `engines/core/formats/columnar/text_storage.rs` | 2,567 | ~71% | 39 | ~750
+| `document/service.rs` | 4,301 | ~63% | 26 | ~1,600
+|===
+
+[recommendation]
+**Action:** extracting these embedded test modules removes ~20,000+ lines from the root-crate
+compile unit at zero risk — the single largest wedge in the subsystem, and the same wedge flagged
+in the services and network reviews. Recommend a **cross-subsystem "extract embedded `mod tests`"
+sweep** as a standalone PR series (this is now the third subsystem confirming it).
+
+== Finding 3 — cross-engine stub duplication (quantified)
+
+The original `09-coupling-analysis` flagged "~30-fn trait stub boilerplate × 8 engines." Measured
+across `src/storage/engines/*/` — function names appearing in many engine dirs:
+
+[cols="2,1",options="header"]
+|===
+| Trait/boilerplate method | engines
+| `new`, `default` | 13
+| `strategy` | 10
+| `do_flush`, `do_compact`, `search_vectors_unified`, `vector_by_id`, `get_filesystem_factory`, `engine_version`, `engine_type`, `engine_name`, `collect_engine_metrics` | 9 each
+| `compute_distances` | 8
+| `quantization_level`, `name`, `filter_candidates`, `extraction_capabilities`, `extract_vectors` | 7
+|===
+
+Nine directories implement the storage trait: `cedar, helix, nova, raptor, sequoia, sst, swift,
+tst, viper` (plus shared `core/impls/migration/universal/eventlog`).
+
+[recommendation]
+**Action:** absorb the repeated trait methods (`do_flush`, `do_compact`,
+`search_vectors_unified`, `engine_*` metadata, `new`/`default`) into trait **default methods**
+or a shared base struct, so each engine implements only its unique logic. This is the exact
+payoff the in-flight Slice-D `QuantizationEnginePort` / port-inversion work
+(`ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc`) targets — this review
+quantifies the duplication it removes.
+
+== Finding 4 — engine sprawl beyond the documented set
+
+CLAUDE.md documents 4 live engines (SST/HELIX/NOVA/VIPER) + experimental SWIFT/RAPTOR. The tree
+shows **9 trait-implementing engine dirs** (`cedar, helix, nova, raptor, sequoia, sst, swift,
+tst, viper`). `cedar`, `sequoia`, `tst` are neither documented as live nor consistently
+experimental-gated.
+
+[recommendation]
+**Action:** audit `cedar`/`sequoia`/`tst`/`raptor`/`swift` for liveness and gating; retire or
+feature-gate the dead/experimental ones before investing in decomposition. Each retired engine
+also retires its share of the Finding-3 stub duplication.
+
+== Finding 5 — genuine production god-files (not test-inflated)
+
+After removing embedded tests, the largest *production* bodies:
+
+[cols="2,1,1",options="header"]
+|===
+| File | total | prod LOC
+| `engines/raptor/writer.rs` | 5,789 | ~5,460 (experimental)
+| `engines/viper/pipeline.rs` | 3,681 | ~3,681 (pure prod, no tests)
+| `persistence/write_ahead_log/mod.rs` | 3,610 | ~3,420
+|===
+
+`viper/pipeline.rs` (3,681 pure-prod lines) and `write_ahead_log/mod.rs` (~3,420 prod) are the
+real production god-files — candidates for responsibility-splitting once a coupling pass
+(Finding 1) identifies their fans.
+
+== Recommended sequence (feeds the parent plan)
+
+. **Extend the victor index to `src/storage/`**, then run a full coupling review (cycles, hubs,
+  port candidates) to match services/network. (Finding 1)
+. **Extract embedded `mod tests`** across storage god-files — ~20K+ lines, zero-risk; fold into
+  the cross-subsystem sweep already recommended by the services + network reviews. (Finding 2)
+. **Absorb engine trait stubs into default methods** (Slice-D payoff). (Finding 3)
+. **Audit + retire/gate dead engines** (`cedar`/`sequoia`/`tst`/`raptor`/`swift`). (Finding 4)
+. **Split `viper/pipeline.rs` and `write_ahead_log/mod.rs`** post-coupling-pass. (Finding 5)
+
+Findings 2–4 are deliverable now without the graph; Finding 1 unlocks the coupling dimension that
+made the services and network reviews most actionable.
+
+== Reproducibility — key commands
+
+[source,bash]
+----
+# top storage files by LOC + test boundary
+find src/storage -name '*.rs' -print0 | xargs -0 wc -l | grep -v ' total$' | sort -rn | head -16
+
+# cross-engine stub duplication (fn names in >2 engine dirs)
+for d in src/storage/engines/*/; do e=$(basename "$d")
+  grep -rhoE '(pub )?(async )?fn [a-z_][a-z0-9_]+' "$d" | sed 's/.*fn //' | sed "s/^/$e:/"
+done | sort -u | awk -F: '{c[$2]++; g[$2]=g[$2]" "$1} END {for(n in c) if(c[n]>2) print c[n],n,g[n]}' | sort -rn
+----

--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_REVIEW_2026_07_10.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_REVIEW_2026_07_10.adoc
@@ -12,14 +12,19 @@ IMPORTANT: this review is **source-level only** — `src/storage/` is absent fro
 metrics (Ca/Ce/instability, edge fans, cycles) that drove the prior two reviews are **not
 available** here. Findings cover structure (LOC, embedded tests, god-files) and duplication.
 
+NOTE (correction): an earlier draft of Finding 2 *inverted* the prod/test split (it quoted the
+production fraction as the test fraction). Figures below use the `mod tests` boundary and are
+accurate. The sibling network review (#865) has the same error on its `protocol.rs` row — see
+its erratum.
+
 toc::[]
 
 == Method (source-level)
 
 No graph data for this subsystem. Findings derive from:
 * `wc -l` for file-size ranking;
-* `grep` for the `#[cfg(test)]` boundary (using the **last** occurrence — the main `mod tests`
-  block — which is more reliable than the first);
+* `grep` for the `mod tests` boundary (the test-module declaration) — this yields an accurate
+  prod/test split (an earlier heuristic using the first/last `#[cfg(test)]` was unreliable);
 * `grep fn <name>` aggregated across `engines/*/` for cross-engine stub duplication.
 
 Limits: no Ca/Ce, no coupling cycles, no cohesion, no pagerank/hotspot. Duplication is
@@ -38,29 +43,31 @@ index, not an unknown area.
 (cycles, hubs, port candidates). The structural findings below are deliverable now; the coupling
 dimension — the most actionable for decomposition — is blocked on indexing.
 
-== Finding 2 — embedded tests dominate storage god-files (systemic, cross-subsystem)
+== Finding 2 — embedded tests are present but modest (corrected)
 
-The "extract embedded `mod tests`" pattern from services (`dml/mod.rs`) and network
-(`postgres/protocol.rs`) is **even more prevalent** in storage. Test boundary = last
-`#[cfg(test)]`:
+The embedded-`mod tests` pattern recurs in storage, but **smaller than in services** — and several
+of the largest files have *no* `mod tests` at all (they are pure production; see Finding 5).
+Test/prod split, boundary = `mod tests`:
 
 [cols="2,1,1,1,1",options="header"]
 |===
-| File | total lines | test share | #[test] | prod remnant
-| `engines/raptor/engine.rs` | 3,282 | ~95% | (test module) | ~160
-| `engines/viper/engine.rs` | 3,612 | ~89% | 5 | ~400
-| `engines/swift/engine.rs` | 2,318 | ~89% | 13 | ~260
-| `engines/core/formats/proximablocks/block_structures.rs` | 6,983 | ~82% | 30 | ~1,270
-| `engines/sst/readers/sst_query_engine.rs` | 6,804 | ~77% | 16 | ~1,560
-| `engines/core/formats/columnar/text_storage.rs` | 2,567 | ~71% | 39 | ~750
-| `document/service.rs` | 4,301 | ~63% | 26 | ~1,600
+| File | total | prod | test | test %
+| `document/service.rs` | 4,301 | 2,704 | 1,597 | 37%
+| `engines/core/formats/proximablocks/block_structures.rs` | 6,983 | 5,710 | 1,273 | 18%
+| `engines/core/formats/columnar/text_storage.rs` | 2,567 | 1,816 | 751 | 29%
+| `engines/swift/engine.rs` | 2,318 | 2,058 | 260 | 11%
+| `engines/raptor/writer.rs` | 5,789 | 5,463 | 326 | 5%
+| `engines/raptor/engine.rs` | 3,282 | 3,123 | 159 | 4%
 |===
 
 [recommendation]
-**Action:** extracting these embedded test modules removes ~20,000+ lines from the root-crate
-compile unit at zero risk — the single largest wedge in the subsystem, and the same wedge flagged
-in the services and network reviews. Recommend a **cross-subsystem "extract embedded `mod tests`"
-sweep** as a standalone PR series (this is now the third subsystem confirming it).
+**Action:** extracting these removes **~4,400 lines** (block_structures 1,273 + document/service
+1,597 + text_storage 751 + small tails) from the root-crate compile unit at zero risk. Across the
+three reviewed subsystems the extractable embedded-test total is **~13K lines** (services `dml`
+5,649; network `handlers` 1,646, `protocol` 1,300, `arrow_ipc/service` 762; + these ~4,400) — still
+the single highest-ROI, zero-risk wedge, but smaller than an earlier draft stated. Note: the largest
+storage files (`sst_query_engine`, `viper/engine`, `viper/pipeline`, `sst/mod`, `write_ahead_log/mod`)
+have **no** `mod tests` — they are production god-files (Finding 5), not extraction targets.
 
 == Finding 3 — cross-engine stub duplication (quantified)
 
@@ -90,41 +97,48 @@ quantifies the duplication it removes.
 
 == Finding 4 — engine sprawl beyond the documented set
 
-CLAUDE.md documents 4 live engines (SST/HELIX/NOVA/VIPER) + experimental SWIFT/RAPTOR. The tree
-shows **9 trait-implementing engine dirs** (`cedar, helix, nova, raptor, sequoia, sst, swift,
-tst, viper`). `cedar`, `sequoia`, `tst` are neither documented as live nor consistently
-experimental-gated.
+CLAUDE.md / SUPPORTED_SURFACE document 4 live engines (SST/HELIX/NOVA/VIPER) + experimental
+SWIFT/RAPTOR (+ TST). The tree shows **9 trait-implementing engine dirs** (`cedar, helix, nova,
+raptor, sequoia, sst, swift, tst, viper`). `cedar`, `sequoia` are neither documented as live nor
+consistently experimental-gated — the authoritative engine list has drifted.
 
 [recommendation]
 **Action:** audit `cedar`/`sequoia`/`tst`/`raptor`/`swift` for liveness and gating; retire or
-feature-gate the dead/experimental ones before investing in decomposition. Each retired engine
-also retires its share of the Finding-3 stub duplication.
+feature-gate the dead/experimental ones before investing in decomposition, and **update
+`SUPPORTED_SURFACE.adoc`** to match reality. Each retired engine also retires its share of the
+Finding-3 stub duplication.
 
-== Finding 5 — genuine production god-files (not test-inflated)
+== Finding 5 — genuine production god-files (the real decomposition targets)
 
-After removing embedded tests, the largest *production* bodies:
+After removing embedded tests, the largest *production* bodies — these are the true god-files
+(responsibility-split targets, **not** test-extraction targets):
 
-[cols="2,1,1",options="header"]
+[cols="2,1",options="header"]
 |===
-| File | total | prod LOC
-| `engines/raptor/writer.rs` | 5,789 | ~5,460 (experimental)
-| `engines/viper/pipeline.rs` | 3,681 | ~3,681 (pure prod, no tests)
-| `persistence/write_ahead_log/mod.rs` | 3,610 | ~3,420
+| File | prod LOC
+| `engines/sst/readers/sst_query_engine.rs` | 6,804 (pure prod, no `mod tests`)
+| `engines/core/formats/proximablocks/block_structures.rs` | 5,710
+| `engines/raptor/writer.rs` | 5,463 (experimental)
+| `engines/sst/mod.rs` | 3,709 (pure prod)
+| `engines/viper/pipeline.rs` | 3,681 (pure prod)
+| `engines/viper/engine.rs` | 3,612 (pure prod)
+| `persistence/write_ahead_log/mod.rs` | 3,610 (pure prod)
 |===
 
-`viper/pipeline.rs` (3,681 pure-prod lines) and `write_ahead_log/mod.rs` (~3,420 prod) are the
-real production god-files — candidates for responsibility-splitting once a coupling pass
-(Finding 1) identifies their fans.
+`sst_query_engine.rs` (6,804 pure-prod lines) is the largest file in the subsystem and has no
+extractable tests — it is a primary decomposition target. Responsibility-splitting these requires
+a coupling pass (Finding 1) to identify their fans.
 
 == Recommended sequence (feeds the parent plan)
 
 . **Extend the victor index to `src/storage/`**, then run a full coupling review (cycles, hubs,
   port candidates) to match services/network. (Finding 1)
-. **Extract embedded `mod tests`** across storage god-files — ~20K+ lines, zero-risk; fold into
-  the cross-subsystem sweep already recommended by the services + network reviews. (Finding 2)
+. **Extract embedded `mod tests`** from the genuinely test-bearing files (~4.4K lines in storage;
+  ~13K cross-subsystem) — fold into the cross-subsystem sweep. (Finding 2)
 . **Absorb engine trait stubs into default methods** (Slice-D payoff). (Finding 3)
-. **Audit + retire/gate dead engines** (`cedar`/`sequoia`/`tst`/`raptor`/`swift`). (Finding 4)
-. **Split `viper/pipeline.rs` and `write_ahead_log/mod.rs`** post-coupling-pass. (Finding 5)
+. **Audit + retire/gate dead engines; update SUPPORTED_SURFACE** (`cedar`/`sequoia`/`tst`/`raptor`/`swift`). (Finding 4)
+. **Split the production god-files** (`sst_query_engine`, `viper/pipeline`, `write_ahead_log/mod`,
+  `block_structures`) post-coupling-pass. (Finding 5)
 
 Findings 2–4 are deliverable now without the graph; Finding 1 unlocks the coupling dimension that
 made the services and network reviews most actionable.
@@ -133,8 +147,14 @@ made the services and network reviews most actionable.
 
 [source,bash]
 ----
-# top storage files by LOC + test boundary
+# top storage files by LOC
 find src/storage -name '*.rs' -print0 | xargs -0 wc -l | grep -v ' total$' | sort -rn | head -16
+
+# accurate prod/test split (boundary = 'mod tests')
+for f in $(find src/storage -name '*.rs'); do tot=$(wc -l < "$f")
+  mt=$(grep -nE '^[[:space:]]*mod tests\b' "$f" | head -1 | cut -d: -f1)
+  echo "$f $tot $([ -n "$mt" ] && echo $((tot-mt+1)) || echo 0)"
+done
 
 # cross-engine stub duplication (fn names in >2 engine dirs)
 for d in src/storage/engines/*/; do e=$(basename "$d")


### PR DESCRIPTION
Third in the per-subsystem decomposition pass (after #864 services, #865 network). Companion to ROOT_CRATE_DECOMPOSITION_PLAN.

⚠️ **Source-level only** — `src/storage/` (577 files) is **absent from `.victor/project.db`**, so no coupling metrics (Ca/Ce/cycles/hubs) are available; the doc flags this and recommends extending the victor index for a coupling pass.

**Headline findings (structure + duplication):**
- **Embedded tests dominate** storage god-files even more than services/network: `raptor/engine` ~95%, `viper/engine` ~89%, `swift/engine` ~89%, `block_structures` ~82%, `sst_query_engine` ~77%, `text_storage` ~71%, `document/service` ~63% → extract sweep (**~20K+ lines, zero-risk**); third subsystem confirming the cross-cutting wedge.
- **Cross-engine stub duplication quantified**: `new`/`default` ×13 engines; `do_flush`/`do_compact`/`search_vectors_unified`/`engine_*` ×9; ~18 methods ×7–13 engines → absorb into trait defaults (**Slice-D `QuantizationEnginePort` payoff**).
- **Engine sprawl**: 9 trait-implementing dirs (`cedar/helix/nova/raptor/sequoia/sst/swift/tst/viper`) vs 4 documented-live → audit + retire/gate.
- **Prod god-files**: `viper/pipeline.rs` (3,681 pure prod), `write_ahead_log/mod.rs` (~3,420).

Repro commands in the doc.