### PR TITLE
feat(pax): correct storage-inclusive documents() PAX pushdown adapter (TD-DOC-PUSHDOWN-1)

### DIFF
--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -43,7 +43,7 @@ pub use port::{
     CollectionSchemaUpdate, CollectionTextStorage,
 };
 pub use record_ops_port::RecordOpsPort;
-pub use record_route_port::RecordRoutePort;
+pub use record_route_port::{PaxColumnDesc, PaxScanInputs, RecordRoutePort};
 pub use resources::{MemoryBudget, ResourceManager};
 pub use rich_record::{RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest};
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};

--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -15,7 +15,38 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use proximadb_data_model::ProximaType;
 use proximadb_records::ProximaRecord;
+
+/// A PAX-native typed column exposed to a DataFusion scan of a document collection —
+/// the seam that lets `documents(collection)` push predicates into the ranged PAX
+/// reader (TD-DOC-PUSHDOWN-1). Runtime-safe (no arrow, no filesystem): the DataFusion
+/// layer maps `data_type` to Arrow (via `catalog_arrow_type`) and resolves the segment
+/// files under [`PaxScanInputs::base_path`] itself.
+#[derive(Debug, Clone)]
+pub struct PaxColumnDesc {
+    /// DataFusion/SQL-facing column name: the prop key for a shredded column, or the
+    /// canonical field name for a system column (e.g. `id`).
+    pub sql_name: String,
+    /// PAX `column_id` the reader keys the prune + decode on.
+    pub col_id: i32,
+    /// Catalog type, mapped to an Arrow `DataType` at the DataFusion boundary.
+    pub data_type: ProximaType,
+}
+
+/// Inputs to build a `PaxTableProvider` over a document collection's `.pax` segments:
+/// the `DrPathBuilder` base path + the typed columns queryable with predicate pushdown
+/// (the system `id` + the collection's shredded `props__<key>` promoted columns). The
+/// `props` JSON tail is served separately by the document layer, not listed here.
+#[derive(Debug, Clone)]
+pub struct PaxScanInputs {
+    /// Object-store base prefix under which the collection's `.pax` segments live.
+    pub base_path: String,
+    /// The collection's shredded `props__<key>` promoted columns, exposed for typed
+    /// predicate pushdown. The system `id` (col 0) and the `props` JSON tail (col 8)
+    /// are always present and are added by the document layer, not listed here.
+    pub columns: Vec<PaxColumnDesc>,
+}
 
 /// Route for the document facade's canonical branch onto the shared record/vector store.
 ///
@@ -88,4 +119,18 @@ pub trait RecordRoutePort: Send + Sync {
         tenant: Option<&str>,
         promote_keys: &[String],
     ) -> Result<()>;
+
+    /// Resolve the inputs to scan `collection_id`'s canonical `.pax` segments through the
+    /// PAX-native ranged reader with predicate pushdown (TD-DOC-PUSHDOWN-1): the segment
+    /// base path + the typed columns (system `id` + the collection's shredded promoted
+    /// `props__<key>` columns). `None` ⇒ the collection isn't PAX-pushdown-eligible (no
+    /// resolvable catalog schema / not converged), and the caller falls back to the
+    /// in-memory document scan. Default `None` for impls that don't serve documents.
+    async fn pax_scan_inputs(
+        &self,
+        _collection_id: &str,
+        _tenant: Option<&str>,
+    ) -> Option<PaxScanInputs> {
+        None
+    }
 }

--- a/crates/platform/proximadb-runtime/src/record_route_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_route_port.rs
@@ -133,4 +133,20 @@ pub trait RecordRoutePort: Send + Sync {
     ) -> Option<PaxScanInputs> {
         None
     }
+
+    /// Raw unflushed (WAL/memtable) records for `collection_id`, tenant-scoped but
+    /// **NOT** dead-filtered — tombstones and TTL-expired rows are RETAINED. This is the
+    /// unflushed delta of the storage-inclusive document PAX scan (TD-DOC-PUSHDOWN-1): the
+    /// caller merges these with the flushed PAX segments by `oid` (freshest wins, WAL
+    /// priority on ties) and then applies the canonical `is_record_dead` pass on the merged
+    /// set. Retaining tombstones is what lets an unflushed delete suppress a still-flushed
+    /// live copy (invariant #16d) — a dead-filtered scan cannot express that cross-source
+    /// suppression. Default empty for impls that don't serve documents.
+    async fn unflushed_records(
+        &self,
+        _collection_id: &str,
+        _tenant: Option<&str>,
+    ) -> Result<Vec<ProximaRecord>> {
+        Ok(Vec::new())
+    }
 }

--- a/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
+++ b/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
@@ -4,7 +4,9 @@
 
 [cols="1,3"]
 |===
-|Status|Open — **Reader ranged read (Layer 1 + Layer 2) LANDED; documents adapter remains.** Owning
+|Status|In progress — **Reader ranged read (Layer 1 + Layer 2) LANDED; documents adapter now IMPLEMENTED**
+(the correct storage-inclusive merge — `DocumentPaxPushdownProvider`, see "Design (implemented)" below).
+Owning
 the reader (rather than waiting on the OLAP workstream) is done. **Layer 1** — `PaxSplitReader`
 fetches a segment via ranged reads: locate the index from a tail suffix → **Stage A** prunes whole
 blocks against the index **zone summary** (canonical columns, no per-block GET) → `read_ranges` only
@@ -148,6 +150,36 @@ unlanded): `RecordRoutePort::pax_scan_inputs` + impl, the `filesystem_factory()`
 type-directed `props`→JSON decode in `PaxSplitReader` (a `Utf8` props field reconstructs the document
 JSON from the msgpack tail, reusing `proxima_tree_to_json_map`). These are prerequisites for the
 correct adapter but are dead code without the merge layer, so they are NOT landed alone.
+
+== ✅ Resolution — the merge layer is built (`DocumentPaxPushdownProvider`, `src/datafusion/document_pax_provider.rs`)
+
+The correctness blocker above is resolved by a storage-inclusive, record-level merge provider that
+consumes the ranged reader for the flushed half:
+
+* **Flushed, pruned** — `PaxSplitReader` (constructed WITH the query's WHERE predicates lowered to
+  `PhysicalExpr`, so `prune_predicates` actually engage; `PaxTableProvider::reader()` passes empty
+  filters and is therefore NOT reused) reads each `.pax` segment ranged under `PROXIMADB_DF_PAX_RANGED`,
+  decoding `id`(col 0) + `updated_at`(3) + `valid_to`(5) + `props`(8, raw msgpack) + the shredded
+  `props__<key>` columns. Props are read as the msgpack tail and reconstructed to the SAME stripped
+  tree the MemTable path serves (reserved `_document_collection`/`_document_type` keys removed), so
+  output is byte-identical.
+* **Unflushed delta** — a new `RecordRoutePort::unflushed_records` returns the RAW WAL/memtable records
+  INCLUDING tombstones and TTL-expired rows (backed by `get_collection_vectors`, NOT the dead-filtering
+  `stream_unflushed_records` — which drops tombstones and so cannot suppress a still-flushed live copy).
+* **Merge** — by `oid` (= the document id; the converged write stamps `oid = record.id`), freshest
+  `updated_at_ns` winning with WAL priority on ties (dedup-by-oid), then the canonical
+  `is_record_dead(valid_to_ns, now_ns)` pass drops tombstoned/expired survivors — this is where a WAL
+  tombstone suppresses the flushed live copy (#16d). Result rows are byte-identical to the `(id, props)`
+  MemTable path plus the shredded typed columns (Option-A schema).
+* **Freshness (#16c)** — the provider always recomputes the WAL delta and never consults the query
+  cache, so it is `Strong` by construction.
+
+Wired at the `documents()` UDTF (`DocumentsTableFunction::from_service_with_tenant` →
+`try_pax_provider`): when `pax_scan_inputs` resolves it serves this provider; otherwise it falls back
+to the `(id, props)` MemTable path (mixed-read-safe, no flag-day). `supports_filters_pushdown = Inexact`
+so the residual `FilterExec` guarantees exactness. Gates: read-after-write, dead-record/tombstone,
+dedup-freshest and shredded-typed-column tests pass (`document_pax_provider::tests`); the measured
+`bytes_read`/`range_gets` byte gate is inherited from the reader's landed ranged tests.
 
 == Design (documents adapter — rides on the ranged reader + the storage-inclusive merge)
 

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -982,7 +982,6 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
         collection_id: &str,
         tenant: Option<&str>,
     ) -> Option<proximadb_runtime::PaxScanInputs> {
-        use proximadb_catalog::Catalog as _;
         use proximadb_runtime::{PaxColumnDesc, PaxScanInputs};
         // Resolve the collection's catalog schema through the SAME catalog the write
         // path uses, tenant-scoped. Any miss ⇒ None (the caller falls back to the
@@ -1018,6 +1017,24 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
             })
             .collect();
         Some(PaxScanInputs { base_path, columns })
+    }
+
+    async fn unflushed_records(
+        &self,
+        collection_id: &str,
+        tenant: Option<&str>,
+    ) -> Result<Vec<proximadb_records::ProximaRecord>> {
+        let tenant_context = self.collection_service.load_tenant_context(tenant)?;
+        // Unknown collection ⇒ empty (mixed-safe: the caller falls back / merges nothing).
+        let Some(resolved_id) = self
+            .resolve_collection_id_internal(collection_id, tenant_context.as_ref())
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
+        self.vector_operations_service
+            .list_unflushed_raw_with_tenant_context(&resolved_id, tenant_context.as_ref())
+            .await
     }
 
     async fn delete_records(

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -977,6 +977,49 @@ impl proximadb_runtime::RecordRoutePort for RecordOpsService {
             .await
     }
 
+    async fn pax_scan_inputs(
+        &self,
+        collection_id: &str,
+        tenant: Option<&str>,
+    ) -> Option<proximadb_runtime::PaxScanInputs> {
+        use proximadb_catalog::Catalog as _;
+        use proximadb_runtime::{PaxColumnDesc, PaxScanInputs};
+        // Resolve the collection's catalog schema through the SAME catalog the write
+        // path uses, tenant-scoped. Any miss ⇒ None (the caller falls back to the
+        // in-memory document scan — mixed-read-safe).
+        let catalog_manager = self.collection_service.catalog_manager()?;
+        let (catalog, table_id) = catalog_manager
+            .resolve_table_scoped(collection_id, tenant)
+            .await
+            .ok()?;
+        let schema = catalog.get_table(&table_id).await.ok()?;
+        let tenant_context = self.collection_service.load_tenant_context(tenant).ok()?;
+        let base_path = crate::services::record_store::object_store_write_base_path(
+            &schema,
+            tenant_context.as_ref(),
+        );
+        // Shredded promoted columns: prop key (SQL-facing) → the `props__<key>` catalog
+        // column's id + type. Mirrors the write-path shred spec (record_store.rs) so the
+        // reader keys the SAME column ids that were written.
+        let columns = schema
+            .props_auto_promotion
+            .promoted_keys
+            .iter()
+            .filter_map(|(prop_key, col_name)| {
+                schema
+                    .columns
+                    .iter()
+                    .find(|c| &c.name == col_name)
+                    .map(|c| PaxColumnDesc {
+                        sql_name: prop_key.clone(),
+                        col_id: c.id,
+                        data_type: c.data_type.clone(),
+                    })
+            })
+            .collect();
+        Some(PaxScanInputs { base_path, columns })
+    }
+
     async fn delete_records(
         &self,
         collection_id: &str,

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -905,30 +905,79 @@ pub struct DocumentsTableFunction {
     /// The connection tenant, passed structurally to the scan port (which scopes the collection
     /// key) — NOT folded into the collection name. `None` ⇒ the canonical `DEFAULT_TENANT`.
     tenant: Option<String>,
+    /// The canonical record route (TD-DOC-PUSHDOWN-1): when present AND the collection resolves
+    /// `pax_scan_inputs`, `documents()` serves a storage-inclusive PAX-pruned scan (flushed
+    /// segments + unflushed WAL delta + dead-filter/dedup) that also exposes the shredded
+    /// promoted columns as typed columns. `None` ⇒ the `(id, props)` MemTable path only.
+    record_route: Option<Arc<dyn proximadb_runtime::RecordRoutePort>>,
+    /// The process filesystem factory used to read `.pax` segments for the pushdown scan.
+    filesystem_factory: Option<Arc<crate::storage::persistence::filesystem::FilesystemFactory>>,
 }
 
 impl DocumentsTableFunction {
-    /// Capture the scan port the function will read (no tenant scope).
+    /// Capture the scan port the function will read (no tenant scope, no PAX pushdown).
     pub fn new(scan: Arc<dyn DocumentScanPort>) -> Self {
-        Self { scan, tenant: None }
+        Self {
+            scan,
+            tenant: None,
+            record_route: None,
+            filesystem_factory: None,
+        }
     }
 
     /// Capture the scan port AND the connection tenant, so the read scopes the collection key the
-    /// same way the REST write path does (TD-XMODAL-6).
+    /// same way the REST write path does (TD-XMODAL-6). No PAX pushdown (MemTable path only).
     pub fn with_tenant(scan: Arc<dyn DocumentScanPort>, tenant: Option<String>) -> Self {
-        Self { scan, tenant }
+        Self {
+            scan,
+            tenant,
+            record_route: None,
+            filesystem_factory: None,
+        }
     }
 
     /// Build the function backed by the process document service, scoped to the connection tenant —
-    /// the pgwire OLAP route wiring that makes `documents` read REST/gRPC-written data.
+    /// the pgwire OLAP route wiring that makes `documents` read REST/gRPC-written data. Also wires
+    /// the record route + filesystem factory so a converged collection with `.pax` segments is
+    /// served through the correct storage-inclusive PAX pushdown provider (TD-DOC-PUSHDOWN-1),
+    /// falling back to the `(id, props)` MemTable path when neither is available.
     pub fn from_service_with_tenant(
         service: Arc<crate::storage::document::DocumentService>,
         tenant: Option<String>,
     ) -> Self {
+        let record_route = service.record_route_port();
         Self {
             scan: Arc::new(DocumentServiceScan(service)),
             tenant,
+            record_route,
+            filesystem_factory: crate::services::document_service::filesystem_factory(),
         }
+    }
+
+    /// Try to build the storage-inclusive PAX pushdown provider for `collection`. Returns `None`
+    /// (⇒ MemTable fallback) when the record route / filesystem factory is unwired or the
+    /// collection isn't PAX-pushdown-eligible (`pax_scan_inputs` ⇒ `None`). Resolving the scan
+    /// inputs is async but `call()` is sync, so it runs on the current multi-thread runtime via
+    /// `block_in_place` (the server runtime is multi-thread; tests use `flavor = "multi_thread"`).
+    fn try_pax_provider(&self, collection: &str) -> Option<Arc<dyn TableProvider>> {
+        let route = self.record_route.clone()?;
+        let filesystem_factory = self.filesystem_factory.clone()?;
+        let tenant = self.tenant.clone();
+        let collection_owned = collection.to_string();
+        let inputs = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::try_current().ok().and_then(|h| {
+                h.block_on(route.pax_scan_inputs(&collection_owned, tenant.as_deref()))
+            })
+        })?;
+        Some(Arc::new(
+            crate::datafusion::document_pax_provider::DocumentPaxPushdownProvider::new(
+                route,
+                filesystem_factory,
+                self.tenant.clone(),
+                collection.to_string(),
+                inputs,
+            ),
+        ))
     }
 }
 
@@ -951,6 +1000,15 @@ impl TableFunctionImpl for DocumentsTableFunction {
                 "documents: collection must not be empty".into(),
             ));
         }
+        // TD-DOC-PUSHDOWN-1: prefer the storage-inclusive PAX pushdown provider when the
+        // collection is converged (has resolvable `pax_scan_inputs`). It reads the SAME rows the
+        // MemTable path would (byte-identical) plus the shredded typed columns, pruning the
+        // flushed segments off the wire. Any collection that isn't pushdown-eligible falls back to
+        // the `(id, props)` MemTable path below — mixed-read-safe, no flag-day.
+        if let Some(provider) = self.try_pax_provider(&collection) {
+            return Ok(provider);
+        }
+
         // Structural tenant scoping: pass the connection tenant (defaulting to the one canonical
         // DEFAULT_TENANT) + the tenant-CLEAN collection name to the scan port, which scopes the key
         // the same way the REST ingest wrote it. No name-folding at the SQL layer.

--- a/src/datafusion/document_pax_provider.rs
+++ b/src/datafusion/document_pax_provider.rs
@@ -1,0 +1,818 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Correct `documents(collection)` PAX pushdown provider (TD-DOC-PUSHDOWN-1, final phase)
+//!
+//! A raw `documents()` → `PaxTableProvider` delegation is **incorrect** (mandate #16): PAX
+//! segments hold FLUSHED data only, so it misses unflushed writes, and `PaxSplitReader` does
+//! no dead-filtering, so it surfaces tombstoned/TTL-expired documents. This provider is the
+//! storage-inclusive merge that makes a `documents()` scan correct **and** prunes the flushed
+//! portion off the wire:
+//!
+//! 1. **Flushed, pruned** — `PaxSplitReader` (ranged, `PROXIMADB_DF_PAX_RANGED`) over the
+//!    collection's `.pax` segments, with the query's WHERE predicates translated to physical
+//!    filters so whole blocks are skipped (the byte win; emits the `fetch_pax_ranged` /
+//!    `bytes_read` / `range_gets` io_trace). Props are read as the raw msgpack tail (col 8).
+//! 2. **Unflushed delta** — `RecordRoutePort::unflushed_records` returns the raw WAL/memtable
+//!    records INCLUDING tombstones and TTL-expired rows (NOT dead-filtered), so an unflushed
+//!    delete can suppress a still-flushed live copy (#16d).
+//! 3. **Merge** — by `oid` (= the document id, since the converged write stamps `oid = doc_id`),
+//!    freshest `updated_at_ns` winning, WAL taking priority on ties (dedup-by-oid), then the
+//!    canonical `is_record_dead(valid_to_ns, now_ns)` pass (#16a) drops the survivors that are
+//!    tombstoned/expired — this is where a WAL tombstone suppresses the flushed live copy.
+//! 4. **Freshness (#16c)** — the provider always recomputes the WAL delta and never consults the
+//!    query-result cache, so it is `Strong` by construction (no cached result can leak).
+//!
+//! The result rows are byte-identical to the `(id, props)` MemTable path (same
+//! `proxima_tree_to_json_map` transform, same reserved-key stripping, same id derivation), plus
+//! the shredded promoted columns as typed columns — Option A schema
+//! `(id, props, <props__key typed cols>)`. `supports_filters_pushdown = Inexact`, so DataFusion
+//! keeps the residual `FilterExec` above the scan and pushdown only reduces I/O.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::builder::{BooleanBuilder, Float64Builder, Int64Builder, StringBuilder};
+use arrow_array::{Array, ArrayRef, BinaryArray, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::common::DFSchema;
+use datafusion::datasource::{MemTable, TableProvider, TableType};
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::StreamExt;
+use proximadb_block_format::col_id;
+use proximadb_data_model::ProximaValue;
+use proximadb_document::{DOCUMENT_COLLECTION_PROP, DOCUMENT_TYPE_PROP};
+use proximadb_records::{ProximaRecord, ProximaTree, ProximaTreeNode, is_record_dead};
+use proximadb_runtime::{PaxColumnDesc, PaxScanInputs, RecordRoutePort};
+
+use crate::datafusion::engine_adapters::pax_adapter::PaxSplitReader;
+use crate::datafusion::engine_adapters::pax_segment_locator::discover_pax_segments;
+use crate::datafusion::proxima_scan_exec::SplitReader;
+use crate::datafusion::schema_inference::proxima_to_arrow_type;
+use crate::storage::persistence::filesystem::FilesystemFactory;
+
+/// A merged, projected document row keyed by its id, before dead-filtering.
+struct MergeEntry {
+    updated_at_ns: i64,
+    valid_to_ns: Option<i64>,
+    /// The stripped document tree (reserved keys removed); `None` for a pure tombstone /
+    /// non-document record kept only to suppress a flushed live copy of the same id.
+    tree: Option<ProximaTree>,
+    from_wal: bool,
+}
+
+/// Storage-inclusive, PAX-pruned `documents(collection)` table provider.
+pub struct DocumentPaxPushdownProvider {
+    record_route: Arc<dyn RecordRoutePort>,
+    filesystem_factory: Arc<FilesystemFactory>,
+    /// Raw connection tenant (None ⇒ default) — passed structurally to the port.
+    tenant: Option<String>,
+    /// Tenant-clean collection name.
+    collection: String,
+    /// Object-store prefix under which the collection's `.pax` segments live.
+    segments_base: String,
+    /// The collection's shredded promoted columns, exposed as typed output columns.
+    shredded: Vec<PaxColumnDesc>,
+    /// Option-A output schema: `(id, props, <shredded typed>)`.
+    output_schema: SchemaRef,
+    /// Schema the PAX reader decodes: id + updated_at + valid_to + props(msgpack) + shredded,
+    /// so predicates can prune on canonical AND shredded columns.
+    pax_read_schema: SchemaRef,
+    /// SQL/field name → PAX `column_id` for the reader (canonical + shredded).
+    name_to_col_id: HashMap<String, i32>,
+}
+
+impl std::fmt::Debug for DocumentPaxPushdownProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DocumentPaxPushdownProvider")
+            .field("tenant", &self.tenant)
+            .field("collection", &self.collection)
+            .field("segments_base", &self.segments_base)
+            .field("shredded", &self.shredded.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl DocumentPaxPushdownProvider {
+    /// Build the provider from resolved [`PaxScanInputs`]. `base_path` (from the record port,
+    /// via `DrPathBuilder`) is where the collection's segments directory lives.
+    pub fn new(
+        record_route: Arc<dyn RecordRoutePort>,
+        filesystem_factory: Arc<FilesystemFactory>,
+        tenant: Option<String>,
+        collection: impl Into<String>,
+        inputs: PaxScanInputs,
+    ) -> Self {
+        let shredded = inputs.columns;
+
+        // Option-A output schema: id, props (JSON), then each shredded promoted column typed.
+        let mut output_fields = vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("props", DataType::Utf8, true),
+        ];
+        for c in &shredded {
+            output_fields.push(Field::new(
+                &c.sql_name,
+                proxima_to_arrow_type(&c.data_type),
+                true,
+            ));
+        }
+        let output_schema = Arc::new(Schema::new(output_fields));
+
+        // Reader schema: canonical columns needed for the merge (id/updated_at/valid_to) + the
+        // raw msgpack props tail + the shredded columns (so a predicate on any of them prunes).
+        let mut read_fields = vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("updated_at", DataType::Int64, true),
+            Field::new("valid_to", DataType::Int64, true),
+            Field::new("props", DataType::Binary, true),
+        ];
+        let mut name_to_col_id = HashMap::from([
+            ("id".to_string(), col_id::OID),
+            ("updated_at".to_string(), col_id::UPDATED_AT),
+            ("valid_to".to_string(), col_id::VALID_TO),
+            ("props".to_string(), col_id::PROPS),
+        ]);
+        for c in &shredded {
+            read_fields.push(Field::new(
+                &c.sql_name,
+                proxima_to_arrow_type(&c.data_type),
+                true,
+            ));
+            name_to_col_id.insert(c.sql_name.clone(), c.col_id);
+        }
+        let pax_read_schema = Arc::new(Schema::new(read_fields));
+
+        // `base_path` ends with `/` (DrPathBuilder); segments live under `<base>segments`.
+        let segments_base = format!("{}segments", inputs.base_path);
+
+        Self {
+            record_route,
+            filesystem_factory,
+            tenant,
+            collection: collection.into(),
+            segments_base,
+            shredded,
+            output_schema,
+            pax_read_schema,
+            name_to_col_id,
+        }
+    }
+
+    /// Read the flushed `.pax` segments through the ranged/pruned reader, translating the
+    /// query's WHERE predicates to physical filters so whole blocks are skipped off the wire.
+    async fn read_flushed(
+        &self,
+        state: &dyn Session,
+        filters: &[Expr],
+    ) -> DFResult<Vec<FlushedRow>> {
+        let splits = discover_pax_segments(&self.segments_base, &self.filesystem_factory)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        if splits.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Translate logical WHERE predicates → physical exprs against the reader schema, so
+        // `PaxSplitReader` can prune blocks on the referenced (canonical or shredded) columns.
+        // A predicate we cannot lower is simply dropped (correctness-safe: the residual
+        // `FilterExec` still applies it exactly; only pruning is skipped for it).
+        let df_schema = DFSchema::try_from(self.pax_read_schema.as_ref().clone())?;
+        let physical_filters: Vec<Arc<dyn PhysicalExpr>> = filters
+            .iter()
+            .filter_map(|e| state.create_physical_expr(e.clone(), &df_schema).ok())
+            .collect();
+
+        let reader = PaxSplitReader::new(
+            self.pax_read_schema.clone(),
+            self.filesystem_factory.clone(),
+            self.name_to_col_id.clone(),
+            physical_filters,
+        );
+
+        let id_idx = self.pax_read_schema.index_of("id")?;
+        let updated_idx = self.pax_read_schema.index_of("updated_at")?;
+        let valid_to_idx = self.pax_read_schema.index_of("valid_to")?;
+        let props_idx = self.pax_read_schema.index_of("props")?;
+
+        let mut rows = Vec::new();
+        for split in &splits {
+            let mut stream = reader.read_split(split, None, 8192).await?;
+            while let Some(batch) = stream.next().await {
+                let batch = batch?;
+                collect_flushed_rows(
+                    &batch,
+                    id_idx,
+                    updated_idx,
+                    valid_to_idx,
+                    props_idx,
+                    &mut rows,
+                )?;
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Merge flushed + unflushed rows and build the Option-A output batch.
+    fn merge_to_batch(
+        &self,
+        flushed: Vec<FlushedRow>,
+        unflushed: Vec<ProximaRecord>,
+        now_ns: i64,
+    ) -> DFResult<RecordBatch> {
+        let mut by_id: HashMap<String, MergeEntry> = HashMap::new();
+
+        // Flushed baseline (segment-resident). WAL overrides below on freshness.
+        for row in flushed {
+            consider(
+                &mut by_id,
+                row.id,
+                MergeEntry {
+                    updated_at_ns: row.updated_at_ns,
+                    valid_to_ns: row.valid_to_ns,
+                    tree: Some(row.tree),
+                    from_wal: false,
+                },
+            );
+        }
+
+        // Unflushed delta (raw WAL, incl. tombstones). A document record yields its stripped
+        // tree; a tombstone / non-document record is kept tree-less, keyed by oid, purely to
+        // suppress the flushed live copy of the same id (#16d).
+        for record in unflushed {
+            let (key, tree) =
+                match crate::storage::document::canonical_adapter::proxima_record_to_legacy_document(
+                    &record,
+                ) {
+                    Some(doc) => (doc.id, Some(doc.props)),
+                    None => (record.oid.clone(), None),
+                };
+            consider(
+                &mut by_id,
+                key,
+                MergeEntry {
+                    updated_at_ns: record.updated_at_ns,
+                    valid_to_ns: record.valid_to_ns,
+                    tree,
+                    from_wal: true,
+                },
+            );
+        }
+
+        // Dead-filter the merged set (#16a) and keep only live document rows. Sort by id for a
+        // deterministic scan order (the MemTable delegation still honors ORDER BY above).
+        let mut live: Vec<(String, ProximaTree)> = by_id
+            .into_iter()
+            .filter(|(_, e)| !is_record_dead(e.valid_to_ns, now_ns))
+            .filter_map(|(id, e)| e.tree.map(|t| (id, t)))
+            .collect();
+        live.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.build_batch(&live)
+    }
+
+    /// Assemble the `(id, props, <shredded>)` Arrow batch from the merged live rows.
+    fn build_batch(&self, rows: &[(String, ProximaTree)]) -> DFResult<RecordBatch> {
+        let ids: Vec<&str> = rows.iter().map(|(id, _)| id.as_str()).collect();
+        let props: Vec<String> = rows
+            .iter()
+            .map(|(_, tree)| {
+                let map: serde_json::Map<String, serde_json::Value> =
+                    crate::core::search::sql_value_filter::proxima_tree_to_json_map(tree)
+                        .into_iter()
+                        .collect();
+                serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_default()
+            })
+            .collect();
+
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(2 + self.shredded.len());
+        arrays.push(Arc::new(StringArray::from(ids)));
+        arrays.push(Arc::new(StringArray::from(props)));
+
+        for c in &self.shredded {
+            let field = self
+                .output_schema
+                .field_with_name(&c.sql_name)
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "documents: output field {}: {e}",
+                        c.sql_name
+                    ))
+                })?;
+            arrays.push(build_shredded_array(field.data_type(), &c.sql_name, rows));
+        }
+
+        RecordBatch::try_new(self.output_schema.clone(), arrays)
+            .map_err(|e| DataFusionError::Execution(format!("documents batch build failed: {e}")))
+    }
+}
+
+#[async_trait]
+impl TableProvider for DocumentPaxPushdownProvider {
+    fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    /// `Inexact`: WHERE predicates are pushed to the flushed PAX reader for block pruning, but
+    /// the residual `FilterExec` stays above so the merged result is filtered exactly.
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let flushed = self.read_flushed(state, filters).await?;
+        let unflushed = self
+            .record_route
+            .unflushed_records(&self.collection, self.tenant.as_deref())
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("documents unflushed scan: {e}")))?;
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0);
+        let batch = self.merge_to_batch(flushed, unflushed, now_ns)?;
+
+        // Delegate to a MemTable so projection/filter/limit are honored uniformly (the residual
+        // FilterExec guarantees exactness; the pushdown above only reduced I/O).
+        let mem = MemTable::try_new(self.output_schema.clone(), vec![vec![batch]])?;
+        mem.scan(state, projection, filters, limit).await
+    }
+}
+
+/// One decoded flushed document row (id + merge keys + stripped tree).
+struct FlushedRow {
+    id: String,
+    updated_at_ns: i64,
+    valid_to_ns: Option<i64>,
+    tree: ProximaTree,
+}
+
+/// Extract flushed document rows from one PAX reader batch (id/updated_at/valid_to/props cols).
+fn collect_flushed_rows(
+    batch: &RecordBatch,
+    id_idx: usize,
+    updated_idx: usize,
+    valid_to_idx: usize,
+    props_idx: usize,
+    out: &mut Vec<FlushedRow>,
+) -> DFResult<()> {
+    let ids = batch
+        .column(id_idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| DataFusionError::Execution("documents: id column not Utf8".into()))?;
+    let updated = batch
+        .column(updated_idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| DataFusionError::Execution("documents: updated_at not Int64".into()))?;
+    let valid_to = batch
+        .column(valid_to_idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| DataFusionError::Execution("documents: valid_to not Int64".into()))?;
+    let props = batch
+        .column(props_idx)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| DataFusionError::Execution("documents: props not Binary".into()))?;
+
+    for i in 0..batch.num_rows() {
+        if ids.is_null(i) {
+            continue;
+        }
+        let mut tree: ProximaTree = if props.is_null(i) {
+            ProximaTree::default()
+        } else {
+            // A row whose msgpack fails to parse yields an empty tree (defensive; never panics).
+            rmp_serde::from_slice::<ProximaTree>(props.value(i)).unwrap_or_default()
+        };
+        // Match the MemTable path: the document body is props minus the reserved facade keys.
+        tree.remove(DOCUMENT_COLLECTION_PROP);
+        tree.remove(DOCUMENT_TYPE_PROP);
+        out.push(FlushedRow {
+            id: ids.value(i).to_string(),
+            updated_at_ns: if updated.is_null(i) {
+                0
+            } else {
+                updated.value(i)
+            },
+            valid_to_ns: if valid_to.is_null(i) {
+                None
+            } else {
+                Some(valid_to.value(i))
+            },
+            tree,
+        });
+    }
+    Ok(())
+}
+
+/// Insert `entry` for `key`, keeping the freshest version (WAL priority on `updated_at` ties).
+fn consider(by_id: &mut HashMap<String, MergeEntry>, key: String, entry: MergeEntry) {
+    match by_id.get(&key) {
+        Some(existing)
+            if existing.updated_at_ns > entry.updated_at_ns
+                || (existing.updated_at_ns == entry.updated_at_ns && !entry.from_wal) => {}
+        _ => {
+            by_id.insert(key, entry);
+        }
+    }
+}
+
+/// Build one shredded output column, extracting `key` from each row's tree into the Arrow type.
+fn build_shredded_array(
+    data_type: &DataType,
+    key: &str,
+    rows: &[(String, ProximaTree)],
+) -> ArrayRef {
+    let value_of = |tree: &ProximaTree| -> Option<ProximaValue> {
+        match tree.get(key) {
+            Some(ProximaTreeNode::Value(v)) => Some(v.clone()),
+            _ => None,
+        }
+    };
+    match data_type {
+        DataType::Int64 => {
+            let mut b = Int64Builder::with_capacity(rows.len());
+            for (_, tree) in rows {
+                b.append_option(value_of(tree).and_then(proxima_value_as_i64));
+            }
+            Arc::new(b.finish())
+        }
+        DataType::Float64 => {
+            let mut b = Float64Builder::with_capacity(rows.len());
+            for (_, tree) in rows {
+                b.append_option(value_of(tree).and_then(proxima_value_as_f64));
+            }
+            Arc::new(b.finish())
+        }
+        DataType::Boolean => {
+            let mut b = BooleanBuilder::with_capacity(rows.len());
+            for (_, tree) in rows {
+                b.append_option(match value_of(tree) {
+                    Some(ProximaValue::Boolean(v)) => Some(v),
+                    _ => None,
+                });
+            }
+            Arc::new(b.finish())
+        }
+        // Utf8 and any type we don't specialize: render as string (null when absent/mismatched).
+        _ => {
+            let mut b = StringBuilder::new();
+            for (_, tree) in rows {
+                b.append_option(value_of(tree).and_then(proxima_value_as_string));
+            }
+            Arc::new(b.finish())
+        }
+    }
+}
+
+fn proxima_value_as_i64(v: ProximaValue) -> Option<i64> {
+    match v {
+        ProximaValue::Int8(x) => Some(x as i64),
+        ProximaValue::Int16(x) => Some(x as i64),
+        ProximaValue::Int32(x) => Some(x as i64),
+        ProximaValue::Int64(x) => Some(x),
+        ProximaValue::UInt8(x) => Some(x as i64),
+        ProximaValue::UInt16(x) => Some(x as i64),
+        ProximaValue::UInt32(x) => Some(x as i64),
+        ProximaValue::UInt64(x) => i64::try_from(x).ok(),
+        _ => None,
+    }
+}
+
+fn proxima_value_as_f64(v: ProximaValue) -> Option<f64> {
+    match v {
+        ProximaValue::Float16(x) | ProximaValue::Float32(x) => Some(x as f64),
+        ProximaValue::Float64(x) => Some(x),
+        ProximaValue::Int8(x) => Some(x as f64),
+        ProximaValue::Int16(x) => Some(x as f64),
+        ProximaValue::Int32(x) => Some(x as f64),
+        ProximaValue::Int64(x) => Some(x as f64),
+        _ => None,
+    }
+}
+
+fn proxima_value_as_string(v: ProximaValue) -> Option<String> {
+    match v {
+        ProximaValue::String(s) | ProximaValue::Symbol(s) => Some(s),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::prelude::SessionContext;
+
+    use crate::storage::document::DocumentRecord;
+    use crate::storage::document::canonical_adapter::legacy_document_to_proxima_record;
+
+    /// A record route whose flushed segments are empty (no `.pax` under `base`) and whose
+    /// unflushed delta is a fixed set — exercises the storage-inclusive merge (read-after-write,
+    /// dead-filter, dedup, tombstone-suppress) end-to-end through the real `scan()` + MemTable.
+    struct FakeRoute {
+        base: String,
+        columns: Vec<PaxColumnDesc>,
+        unflushed: Vec<ProximaRecord>,
+    }
+
+    #[async_trait]
+    impl RecordRoutePort for FakeRoute {
+        async fn insert_records(
+            &self,
+            _c: &str,
+            _r: Vec<ProximaRecord>,
+            _t: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+        async fn get_record(
+            &self,
+            _c: &str,
+            _r: &str,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Option<ProximaRecord>> {
+            Ok(None)
+        }
+        async fn scan_records(
+            &self,
+            _c: &str,
+            _l: usize,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Vec<ProximaRecord>> {
+            Ok(Vec::new())
+        }
+        async fn delete_records(
+            &self,
+            _c: &str,
+            _r: Vec<String>,
+            _t: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+        async fn collection_exists(&self, _c: &str, _t: Option<&str>) -> bool {
+            true
+        }
+        async fn ensure_collection(
+            &self,
+            _c: &str,
+            _d: u32,
+            _t: Option<&str>,
+            _p: &[String],
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn pax_scan_inputs(&self, _c: &str, _t: Option<&str>) -> Option<PaxScanInputs> {
+            Some(PaxScanInputs {
+                base_path: self.base.clone(),
+                columns: self.columns.clone(),
+            })
+        }
+        async fn unflushed_records(
+            &self,
+            _c: &str,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Vec<ProximaRecord>> {
+            Ok(self.unflushed.clone())
+        }
+    }
+
+    /// Build a document `ProximaRecord` the way the converged write path does: labeled `document`,
+    /// `oid = local_id = id`, props carrying the reserved collection key + the user fields.
+    fn doc(
+        id: &str,
+        coll: &str,
+        fields: &[(&str, ProximaValue)],
+        updated_at_ns: i64,
+        valid_to_ns: Option<i64>,
+    ) -> ProximaRecord {
+        let tree: ProximaTree = fields
+            .iter()
+            .map(|(k, v)| (k.to_string(), ProximaTreeNode::Value(v.clone())))
+            .collect();
+        let dr = DocumentRecord::from_tree(id.to_string(), tree, coll.to_string(), None, None);
+        let mut pr = legacy_document_to_proxima_record(&dr);
+        pr.oid = id.to_string();
+        pr.updated_at_ns = updated_at_ns;
+        pr.valid_to_ns = valid_to_ns;
+        pr
+    }
+
+    /// A bare tombstone that does NOT carry the document facade label — keyed only by oid so it
+    /// can suppress a flushed live copy (#16d).
+    fn tombstone(id: &str, updated_at_ns: i64) -> ProximaRecord {
+        ProximaRecord {
+            oid: id.to_string(),
+            updated_at_ns,
+            valid_to_ns: Some(0),
+            ..Default::default()
+        }
+    }
+
+    fn cols() -> Vec<PaxColumnDesc> {
+        use proximadb_data_model::ProximaType;
+        vec![
+            PaxColumnDesc {
+                sql_name: "region".into(),
+                col_id: col_id::USER_BASE,
+                data_type: ProximaType::String,
+            },
+            PaxColumnDesc {
+                sql_name: "amount".into(),
+                col_id: col_id::USER_BASE + 1,
+                data_type: ProximaType::Int64,
+            },
+        ]
+    }
+
+    async fn provider_with(unflushed: Vec<ProximaRecord>) -> DocumentPaxPushdownProvider {
+        // A base path with no `.pax` segments ⇒ the flushed read is empty (discover returns []),
+        // so the scan is driven purely by the unflushed delta — the read-after-write path.
+        let base = "file:///nonexistent-doc-pax-test-dir/".to_string();
+        let ff = crate::storage::persistence::filesystem::FilesystemFactory::create_default_arc()
+            .await
+            .expect("filesystem factory");
+        let route: Arc<dyn RecordRoutePort> = Arc::new(FakeRoute {
+            base: "file:///nonexistent-doc-pax-test-dir/".to_string(),
+            columns: cols(),
+            unflushed,
+        });
+        DocumentPaxPushdownProvider::new(
+            route,
+            ff,
+            None,
+            "docs",
+            PaxScanInputs {
+                base_path: base,
+                columns: cols(),
+            },
+        )
+    }
+
+    async fn ids(provider: DocumentPaxPushdownProvider, sql: &str) -> Vec<String> {
+        let ctx = SessionContext::new();
+        ctx.register_table("documents", Arc::new(provider)).unwrap();
+        let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+        let mut out = Vec::new();
+        for b in &batches {
+            if let Some(c) = b.column(0).as_any().downcast_ref::<StringArray>() {
+                for i in 0..b.num_rows() {
+                    out.push(c.value(i).to_string());
+                }
+            }
+        }
+        out
+    }
+
+    /// Gate 1 — read-after-write: an inserted-but-unflushed document is visible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unflushed_write_is_visible() {
+        let p = provider_with(vec![
+            doc(
+                "d1",
+                "docs",
+                &[("region", ProximaValue::String("US".into()))],
+                10,
+                None,
+            ),
+            doc(
+                "d2",
+                "docs",
+                &[("region", ProximaValue::String("EU".into()))],
+                20,
+                None,
+            ),
+        ])
+        .await;
+        assert_eq!(
+            ids(p, "SELECT id FROM documents ORDER BY id").await,
+            vec!["d1", "d2"]
+        );
+    }
+
+    /// Gate 2 — dead-record ratchet: a TTL-expired doc and a tombstone are both absent.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_and_tombstoned_records_absent() {
+        let p = provider_with(vec![
+            doc(
+                "live",
+                "docs",
+                &[("region", ProximaValue::String("US".into()))],
+                10,
+                None,
+            ),
+            // TTL-expired (valid_to in the past).
+            doc(
+                "expired",
+                "docs",
+                &[("region", ProximaValue::String("US".into()))],
+                10,
+                Some(1),
+            ),
+            // Tombstone (valid_to == 0).
+            tombstone("deleted", 30),
+        ])
+        .await;
+        assert_eq!(
+            ids(p, "SELECT id FROM documents ORDER BY id").await,
+            vec!["live"]
+        );
+    }
+
+    /// Gate 3 — dedup-by-oid, freshest wins: two versions of the same id collapse to the newest.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dedup_keeps_freshest_version() {
+        let p = provider_with(vec![
+            doc(
+                "d1",
+                "docs",
+                &[("region", ProximaValue::String("OLD".into()))],
+                10,
+                None,
+            ),
+            doc(
+                "d1",
+                "docs",
+                &[("region", ProximaValue::String("NEW".into()))],
+                20,
+                None,
+            ),
+        ])
+        .await;
+        let ctx = SessionContext::new();
+        ctx.register_table("documents", Arc::new(p)).unwrap();
+        let batches = ctx
+            .sql("SELECT region FROM documents")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        let region = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert_eq!(region, "NEW");
+    }
+
+    /// Shredded promoted fields are exposed as typed columns and predicable in SQL.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shredded_columns_are_typed_and_filterable() {
+        let p = provider_with(vec![
+            doc(
+                "d1",
+                "docs",
+                &[
+                    ("region", ProximaValue::String("US".into())),
+                    ("amount", ProximaValue::Int64(100)),
+                ],
+                10,
+                None,
+            ),
+            doc(
+                "d2",
+                "docs",
+                &[
+                    ("region", ProximaValue::String("EU".into())),
+                    ("amount", ProximaValue::Int64(50)),
+                ],
+                20,
+                None,
+            ),
+        ])
+        .await;
+        // Typed predicate over shredded columns (residual FilterExec applies it exactly).
+        assert_eq!(
+            ids(
+                p,
+                "SELECT id FROM documents WHERE region = 'US' AND amount > 60 ORDER BY id"
+            )
+            .await,
+            vec!["d1"]
+        );
+    }
+}

--- a/src/datafusion/document_pax_provider.rs
+++ b/src/datafusion/document_pax_provider.rs
@@ -815,4 +815,139 @@ mod tests {
             vec!["d1"]
         );
     }
+
+    /// Gate 4 — the measured pushdown byte gate (ADR-052 invariant 4). A real multi-block PAX
+    /// segment with a shredded `amount` column is scanned through the provider under
+    /// `PROXIMADB_DF_PAX_RANGED`; a selective `amount >= N` predicate must (a) issue ranged GETs
+    /// and read materially FEWER bytes than the whole segment (blocks pruned off the wire), and
+    /// (b) return exactly the matching rows (the residual `FilterExec` guarantees exactness). Run
+    /// under nextest so the `PROXIMADB_DF_PAX_RANGED` OnceLock is process-isolated.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ranged_pushdown_prunes_bytes_and_matches() {
+        use proximadb_block_format::{BlockCompression, BlockMode};
+        use proximadb_data_model::ProximaType;
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        use proximadb_storage_common::pax_block::PaxSegmentWriter;
+
+        // SAFETY (edition 2024): under nextest each test owns its process, so this env mutation is
+        // single-threaded and read before any other `pax_ranged_read_enabled()` call in-process.
+        unsafe { std::env::set_var("PROXIMADB_DF_PAX_RANGED", "1") };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let seg_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&seg_dir).expect("segments dir");
+        let seg_path = seg_dir.join("data.pax");
+
+        // 600 doc-shaped records with a monotonically increasing `amount`, shredded at USER_BASE,
+        // packed into many small blocks (2 KiB target) so each block owns a contiguous amount
+        // range that Stage-B footer pruning can exclude.
+        let n = 600usize;
+        let mut writer = PaxSegmentWriter::new(
+            &seg_path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "docs",
+            0,
+            1,
+            Some(2048),
+        )
+        .with_shred_spec(vec![("amount".to_string(), col_id::USER_BASE)]);
+        for i in 0..n {
+            let mut props: ProximaTree = HashMap::new();
+            props.insert(
+                "amount".to_string(),
+                ProximaTreeNode::Value(ProximaValue::Int64(i as i64)),
+            );
+            let ts = 1_700_000_000_000_000_000 + i as i64;
+            let mut r = ProximaRecord {
+                oid: format!("v{i:04}"),
+                tenant_id: "t".into(),
+                created_at_ns: ts,
+                updated_at_ns: ts,
+                valid_to_ns: Some(i64::MAX),
+                props,
+                ..Default::default()
+            };
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: 8,
+                values: EmbeddingValues::Fp32(vec![i as f32 * 0.001; 8]),
+                ..Default::default()
+            });
+            writer.add_record(&r).expect("add record");
+        }
+        let meta = writer.finish().expect("finish segment");
+        assert!(
+            meta.block_count >= 2,
+            "need multiple blocks to prune; got {}",
+            meta.block_count
+        );
+        let file_len = std::fs::metadata(&seg_path).expect("seg meta").len();
+
+        let base = format!("file://{}/", dir.path().display());
+        let ff = crate::storage::persistence::filesystem::FilesystemFactory::create_default_arc()
+            .await
+            .expect("filesystem factory");
+        let columns = vec![PaxColumnDesc {
+            sql_name: "amount".into(),
+            col_id: col_id::USER_BASE,
+            data_type: ProximaType::Int64,
+        }];
+        let route: Arc<dyn RecordRoutePort> = Arc::new(FakeRoute {
+            base: base.clone(),
+            columns: columns.clone(),
+            unflushed: Vec::new(),
+        });
+        let provider = DocumentPaxPushdownProvider::new(
+            route,
+            ff,
+            None,
+            "docs",
+            PaxScanInputs {
+                base_path: base,
+                columns,
+            },
+        );
+
+        let ctx = SessionContext::new();
+        ctx.register_table("documents", Arc::new(provider)).unwrap();
+
+        let (rows, snap) = crate::observability::io_trace::scope(async {
+            let batches = ctx
+                .sql("SELECT id FROM documents WHERE amount >= 580 ORDER BY id")
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            let mut ids = Vec::new();
+            for b in &batches {
+                if let Some(c) = b.column(0).as_any().downcast_ref::<StringArray>() {
+                    for i in 0..b.num_rows() {
+                        ids.push(c.value(i).to_string());
+                    }
+                }
+            }
+            (
+                ids,
+                crate::observability::io_trace::snapshot().expect("io_trace scope active"),
+            )
+        })
+        .await;
+
+        // Correctness/parity: exactly amounts 580..=599 survive the residual exact filter.
+        assert_eq!(rows.len(), 20, "amount>=580 ⇒ 20 rows, got {rows:?}");
+        assert_eq!(rows.first().map(String::as_str), Some("v0580"));
+        // Byte win: ranged GETs issued AND fewer bytes read than the whole segment.
+        assert!(
+            snap.range_gets > 0,
+            "expected ranged GETs, got {}",
+            snap.range_gets
+        );
+        assert!(
+            snap.bytes_read < file_len,
+            "pruned bytes_read {} must be < whole segment {file_len}",
+            snap.bytes_read
+        );
+    }
 }

--- a/src/datafusion/engine_adapters/pax_adapter.rs
+++ b/src/datafusion/engine_adapters/pax_adapter.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
 use arrow_array::{ArrayRef, BinaryArray, Float64Array, Int64Array, RecordBatch, StringArray};
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, Field, SchemaRef};
 use async_trait::async_trait;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::SendableRecordBatchStream;
@@ -271,7 +271,7 @@ impl PaxSplitReader {
             let arrays: Vec<ArrayRef> = out_schema
                 .fields()
                 .iter()
-                .map(|f| self.decode_column(&reader, f.name()))
+                .map(|f| self.decode_column(&reader, f))
                 .collect::<DFResult<_>>()?;
             let batch = RecordBatch::try_new(out_schema.clone(), arrays).map_err(|e| {
                 DataFusionError::Execution(format!("PAX ranged batch build failed: {e}"))
@@ -365,7 +365,7 @@ impl PaxSplitReader {
             let arrays: Vec<ArrayRef> = out_schema
                 .fields()
                 .iter()
-                .map(|f| self.decode_column(&reader, f.name()))
+                .map(|f| self.decode_column(&reader, f))
                 .collect::<DFResult<_>>()?;
             let batch = RecordBatch::try_new(out_schema.clone(), arrays)
                 .map_err(|e| DataFusionError::Execution(format!("PAX batch build failed: {e}")))?;
@@ -392,8 +392,12 @@ impl PaxSplitReader {
         self.pruned_by(reader)
     }
 
-    /// Decode one column by its DataFusion name → PAX column_id → typed stripe.
-    fn decode_column(&self, reader: &PaxBlockReader, name: &str) -> DFResult<ArrayRef> {
+    /// Decode one column by its DataFusion field (name → PAX column_id → typed stripe).
+    /// The target Arrow type is type-directed for the `props` tail: a `Utf8` field
+    /// reconstructs the document JSON object from the msgpack tail (the `documents()`
+    /// surface, TD-DOC-PUSHDOWN-1); a `Binary` field emits the raw msgpack bytes.
+    fn decode_column(&self, reader: &PaxBlockReader, field: &Field) -> DFResult<ArrayRef> {
+        let name = field.name();
         let cid = *self
             .name_to_col_id
             .get(name)
@@ -410,6 +414,9 @@ impl PaxSplitReader {
         Ok(match meta.data_type_id {
             0x03 => Arc::new(Int64Array::from(decode_i64(reader, cid, name)?)),
             0x02 => Arc::new(Float64Array::from(decode_f64(reader, cid, name)?)),
+            0xff if meta.role == ColumnRole::Props && field.data_type() == &DataType::Utf8 => {
+                Arc::new(StringArray::from(decode_props_json(reader, cid, name)?))
+            }
             0xff if meta.role == ColumnRole::Props => {
                 Arc::new(BinaryArray::from_iter(decode_bytes(reader, cid, name)?))
             }
@@ -506,6 +513,34 @@ fn decode_bytes(reader: &PaxBlockReader, cid: i32, name: &str) -> DFResult<Vec<O
     reader.decode_bytes_stripe(cid).ok_or_else(|| {
         DataFusionError::Execution(format!("PAX: bytes decode failed for {name} (id {cid})"))
     })
+}
+
+/// Decode the `props` tail (msgpack-serialized [`proximadb_records::ProximaTree`] per row)
+/// into JSON-object strings — the `documents()` surface (TD-DOC-PUSHDOWN-1). Reuses the SAME
+/// `ProximaTree → JSON` mapping the in-memory document scan uses (`proxima_tree_to_json_map`),
+/// so a document read is identical whether served by the PAX scan or the MemTable path. A row
+/// whose msgpack fails to parse yields an empty object (defensive; never panics).
+fn decode_props_json(
+    reader: &PaxBlockReader,
+    cid: i32,
+    name: &str,
+) -> DFResult<Vec<Option<String>>> {
+    use proximadb_records::ProximaTree;
+    Ok(decode_bytes(reader, cid, name)?
+        .into_iter()
+        .map(|opt| {
+            opt.map(|bytes| match rmp_serde::from_slice::<ProximaTree>(&bytes) {
+                Ok(tree) => {
+                    let map: serde_json::Map<String, serde_json::Value> =
+                        crate::core::search::sql_value_filter::proxima_tree_to_json_map(&tree)
+                            .into_iter()
+                            .collect();
+                    serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_default()
+                }
+                Err(_) => "{}".to_string(),
+            })
+        })
+        .collect())
 }
 
 /// `true` iff the block MAY contain a row satisfying `pred` (i.e. NOT pruned).

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -74,6 +74,10 @@ pub mod logical_lowering;
 // DataFusion-joinable table so one SQL plan joins vector similarity with relational data.
 pub mod cross_modal;
 
+// TD-DOC-PUSHDOWN-1 (ADR-055 P-Pushdown): correct, storage-inclusive `documents(collection)` PAX
+// pushdown provider — flushed PAX-pruned scan + unflushed WAL delta + dead-filter/tombstone merge.
+pub mod document_pax_provider;
+
 // F2: registry -> DataFusion scalar-UDF adapter. Binds engine-neutral ProximaFunctionRegistry
 // kernels into DataFusion as ScalarUDFs (native builtins stay the fast path).
 pub mod registry_udf;

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -844,6 +844,12 @@ impl SharedServices {
         );
         debug!("✅ SharedServices::new - Filesystem factory for engines created successfully");
 
+        // TD-DOC-PUSHDOWN-1: publish the storage filesystem factory as a process singleton so the
+        // DataFusion `documents(collection)` UDTF can build a `PaxTableProvider` over a collection's
+        // `.pax` segments for predicate pushdown. Idempotent (first wins); mirrors the
+        // document/timeseries service singletons.
+        crate::services::document_service::set_filesystem_factory(filesystem_factory.clone());
+
         // Create VIPER engine
         debug!("🔧 SharedServices::new - Creating VIPER engine...");
         let viper_config = crate::core::config::ViperConfig::default();

--- a/src/services/document_service.rs
+++ b/src/services/document_service.rs
@@ -22,3 +22,23 @@ pub fn set_document_service(service: Arc<DocumentService>) {
 pub fn document_service() -> Option<Arc<DocumentService>> {
     DOCUMENT_SERVICE.get().cloned()
 }
+
+static FILESYSTEM_FACTORY: OnceLock<
+    Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
+> = OnceLock::new();
+
+/// Register the process-global filesystem factory (idempotent — first wins). Called once at
+/// server bootstrap. The DataFusion `documents()` UDTF reads it to build a `PaxTableProvider`
+/// over a collection's `.pax` segments for predicate pushdown (TD-DOC-PUSHDOWN-1), rather than
+/// threading an `Arc<FilesystemFactory>` through every session construction.
+pub fn set_filesystem_factory(
+    factory: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
+) {
+    let _ = FILESYSTEM_FACTORY.set(factory);
+}
+
+/// The process-global filesystem factory, if registered.
+pub fn filesystem_factory()
+-> Option<Arc<crate::storage::persistence::filesystem::FilesystemFactory>> {
+    FILESYSTEM_FACTORY.get().cloned()
+}

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -800,6 +800,33 @@ impl VectorOperationsService {
         Ok(records)
     }
 
+    /// Raw unflushed (WAL/memtable) records for `collection_id`, tenant-filtered but
+    /// **NOT** dead-filtered — tombstones and TTL-expired rows are RETAINED. This is the
+    /// unflushed half of the storage-inclusive document PAX scan (TD-DOC-PUSHDOWN-1): the
+    /// caller merges these with the flushed PAX scan by `oid` (freshest wins, WAL priority)
+    /// and applies the canonical `is_record_dead` pass on the merged set. Retaining
+    /// tombstones here is what lets an unflushed delete suppress a still-flushed live copy
+    /// (invariant #16d) — `stream_unflushed_records` drops tombstones internally and so
+    /// cannot express that cross-source suppression.
+    pub async fn list_unflushed_raw_with_tenant_context(
+        &self,
+        collection_id: &str,
+        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+    ) -> Result<Vec<ProximaRecord>> {
+        self.validate_tenant_collection_access(collection_id, tenant_context)
+            .await?;
+        let mut records = self
+            .wal_manager
+            .get_collection_vectors(collection_id)
+            .await?;
+        if let Some(tenant_context) = tenant_context {
+            records.retain(|record| {
+                record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
+            });
+        }
+        Ok(records)
+    }
+
     /// Paginated record scan (TD-099(3d) push-down). Returns up to `limit`
     /// records with canonical key `(updated_at_ns, oid)` strictly greater than
     /// `cursor`, in ascending order, plus the next cursor (when the page is

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -274,7 +274,7 @@ fn sanitize_object_path_segment(value: &str) -> String {
 }
 
 #[allow(clippy::expect_used)] // DrPathBuilder::build is infallible for this internally-constructed namespace
-fn object_store_write_base_path(
+pub(crate) fn object_store_write_base_path(
     schema: &CatalogTableSchema,
     tenant_context: Option<&TenantContext>,
 ) -> String {

--- a/src/storage/document/service.rs
+++ b/src/storage/document/service.rs
@@ -363,6 +363,15 @@ impl DocumentService {
         let _ = self.record_route.set(record_route);
     }
 
+    /// The canonical record route port, if registered (ungated) — the DataFusion
+    /// `documents()` UDTF uses it to resolve PAX scan inputs for predicate pushdown
+    /// (TD-DOC-PUSHDOWN-1). Unlike [`Self::canonical_route`], this is not gated on the
+    /// per-collection canonical-vector flag: pushdown-eligibility is decided by whether
+    /// `pax_scan_inputs` resolves, and the caller falls back to the in-memory scan.
+    pub fn record_route_port(&self) -> Option<Arc<dyn proximadb_runtime::RecordRoutePort>> {
+        self.record_route.get().cloned()
+    }
+
     /// Select the canonical-vector route for `collection`, else `None` ⇒ legacy path. The single
     /// decision point for the store-split cutover — every write/read branches on this. Three
     /// conditions, all required (mixed-safe under the DEFAULT-ON gate, TD-DOC-CONV-2):


### PR DESCRIPTION
## TD-DOC-PUSHDOWN-1 — correct `documents()` PAX pushdown adapter (final phase)

Completes ADR-055 P-Pushdown: a `documents(collection)` scan whose **flushed** portion is PAX-pruned, resolving the "adapter correctness blocker" in the TD. A raw `documents()` → `PaxTableProvider` delegation is **incorrect** (mandate #16) — PAX segments are flushed-only (misses unflushed writes) and unfiltered (returns dead/tombstoned rows). The fix is a storage-inclusive, record-level merge.

### `DocumentPaxPushdownProvider` (`src/datafusion/document_pax_provider.rs`)
- **Flushed, pruned** — `PaxSplitReader` built *with* the query's WHERE predicates lowered to `PhysicalExpr` so block pruning actually engages (`PaxTableProvider::reader()` passes empty filters and is deliberately not reused). Reads `id`/`updated_at`/`valid_to` + the raw msgpack `props` tail + shredded `props__<key>` columns under `PROXIMADB_DF_PAX_RANGED`; props reconstruct the **same** reserved-key-stripped tree the MemTable path serves, so output is byte-identical.
- **Unflushed delta** — new `RecordRoutePort::unflushed_records` returns the **raw** WAL/memtable records incl. tombstones/TTL-expired (`get_collection_vectors`, not the dead-filtering `stream_unflushed_records`, which drops tombstones and so cannot suppress a still-flushed live copy — #16d).
- **Merge** — by `oid` (= doc id; the converged write stamps `oid = record.id`), freshest `updated_at_ns` wins with WAL priority on ties (dedup-by-oid), then `is_record_dead(valid_to_ns, now_ns)` drops tombstoned/expired survivors (#16a/#16d). Always recomputes the WAL delta and never consults the query cache → `Strong` by construction (#16c).
- Output = Option-A `(id, props-JSON, <shredded typed cols>)`; `supports_filters_pushdown = Inexact` so the residual `FilterExec` guarantees exactness. Wired at the `documents()` UDTF (`DocumentsTableFunction::try_pax_provider`), falling back to the `(id, props)` MemTable path when `pax_scan_inputs` is unresolvable (mixed-read-safe, no flag-day).

This PR also lands the previously-preserved foundation (`pax_scan_inputs` + impl, `filesystem_factory()` singleton, type-directed props→JSON decode) — it was dead code without this merge layer, so it lands together here.

### Gates (measured, not asserted — `document_pax_provider::tests`, multi-thread)
- read-after-write visibility, dead-record/tombstone absence, dedup-freshest, shredded-typed-column filtering — all pass.
- **Byte gate**: a real multi-block shredded PAX segment scanned under `PROXIMADB_DF_PAX_RANGED` with `amount >= 580` issues ranged GETs (`range_gets > 0`), reads **fewer bytes than the whole segment** (`bytes_read < file_len`), and returns exactly the 20 matching rows (residual `FilterExec` exact) — ADR-052 invariant 4 verified end-to-end through the provider.

### Verification
`cargo fmt --check`, `cargo clippy -p proximadb --lib --bins -- -D warnings`, runtime-crate clippy, and the `proximadb-server` binary build all clean; 5/5 gate tests pass. Rebased onto current `develop`.
