### PR TITLE
test(olap): ratchet the stats-trust authority mapping (ADR-058 D5/§9.A)

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -2782,6 +2782,77 @@ mod tests {
         }
     }
 
+    /// ADR-058 D5 / §9.A: the stats-trust derivation is the load-bearing security
+    /// mapping behind the native route's footer-elision gate — an authority that
+    /// wrongly classifies external parquet as `Trusted` would re-open the
+    /// wrong-`COUNT`/`MIN`/`MAX`-on-external-parquet hole #860 closed. This ratchet
+    /// locks the mapping: external parquet authorities ⇒ `Untrusted`; everything
+    /// ProximaDB authored ⇒ `Trusted`; and the gate is parquet-footer-specific (an
+    /// external authority on a non-parquet layout is NOT a footer-trust concern).
+    #[cfg(feature = "datafusion-integration")]
+    #[test]
+    fn parquet_stats_trust_maps_external_authorities_to_untrusted() {
+        use proximadb_catalog::{
+            CatalogAuthorityMode, CatalogPhysicalFormat, CatalogStorageLayout, CatalogTableSchema,
+        };
+        let layout = |authority, physical_format| CatalogStorageLayout {
+            authority,
+            physical_format,
+            ..Default::default()
+        };
+        let schema_with = |layouts: Vec<CatalogStorageLayout>| {
+            let mut s = CatalogTableSchema::new("t");
+            s.storage_layouts = layouts;
+            s
+        };
+
+        // External / federated / imported PARQUET → Untrusted (footer not ours).
+        for authority in [
+            CatalogAuthorityMode::FederatedRead,
+            CatalogAuthorityMode::ExternalAuthoritative,
+            CatalogAuthorityMode::ImportedSnapshot,
+        ] {
+            let s = schema_with(vec![layout(authority, CatalogPhysicalFormat::Parquet)]);
+            assert_eq!(
+                parquet_stats_trust(&s),
+                StatsTrust::Untrusted,
+                "{authority:?} parquet must be Untrusted — its footer stats are not ProximaDB's"
+            );
+        }
+
+        // ProximaDB-authored PARQUET (incl. the `MATERIALIZE` form) → Trusted.
+        for authority in [
+            CatalogAuthorityMode::ProjectionPublication,
+            CatalogAuthorityMode::ExportedPublication,
+        ] {
+            let s = schema_with(vec![layout(authority, CatalogPhysicalFormat::Parquet)]);
+            assert_eq!(
+                parquet_stats_trust(&s),
+                StatsTrust::Trusted,
+                "{authority:?} parquet is ProximaDB-authored ⇒ footer stats are authoritative"
+            );
+        }
+
+        // The gate is parquet-footer-specific: an external authority on a
+        // NON-parquet layout must not taint trust (no parquet footer is trusted).
+        let s = schema_with(vec![layout(
+            CatalogAuthorityMode::FederatedRead,
+            CatalogPhysicalFormat::ProximaBlock,
+        )]);
+        assert_eq!(
+            parquet_stats_trust(&s),
+            StatsTrust::Trusted,
+            "an external authority on a non-parquet layout is not a footer-trust concern"
+        );
+
+        // No storage layouts at all ⇒ nothing external ⇒ Trusted (fail-open is safe
+        // here: with no parquet layout the elision path is never reached).
+        assert_eq!(
+            parquet_stats_trust(&CatalogTableSchema::new("t")),
+            StatsTrust::Trusted
+        );
+    }
+
     #[test]
     fn operation_class_classifies_olap_shapes() {
         use crate::query::compute_scheduler::OperationClass;


### PR DESCRIPTION
## What

Adds the correctness ratchet **#860 shipped without**: a unit test locking `parquet_stats_trust`'s authority→trust mapping — the load-bearing security logic behind the native route's footer-elision trust gate (ADR-058 D5 / §9.A, PR #857).

## Why

#860 closed the wrong-`COUNT`/`MIN`/`MAX`-on-external-parquet hole by gating both footer paths (`elidable_aggregate_batch`, `new_count_only`) on `StatsTrust::Trusted`. But the derivation `parquet_stats_trust` — the mapping from catalog authority to trust — had **no test**. A regression that mis-classifies an external authority as `Trusted` would silently re-open the hole (a wrong answer, not a slow query — invariant #16 territory). This ratchet fails CI instead.

## Coverage

- External parquet authorities (`FederatedRead` / `ExternalAuthoritative` / `ImportedSnapshot`) ⇒ **Untrusted**.
- ProximaDB-authored parquet (`ProjectionPublication` incl. `MATERIALIZE`, `ExportedPublication`) ⇒ **Trusted**.
- Footer-specificity: an external authority on a **non-parquet** layout ⇒ Trusted (not a footer-trust concern).
- No storage layouts ⇒ Trusted (elision path never reached).

## Follow-up (flagged, not in this PR)

An end-to-end "Untrusted-table-does-not-elide" ratchet needs a federated/external-parquet fixture with a deliberately-divergent footer (you can't easily forge a stale footer via normal writers). Deferred as a separate fixture-heavy test; the unit ratchet here locks the decision logic the e2e would exercise.

## Verification
- `cargo nextest run --lib parquet_stats_trust_maps_external` → pass. `cargo fmt --check` clean.