### PR TITLE
feat(olap): ADR-059 — DuckDbLocalEngine in-process engine + ClickBench/TPC harness + catalog location fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -180,8 +191,8 @@ dependencies = [
  "regex-lite",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "thiserror 1.0.69",
  "typed-builder",
  "uuid",
@@ -206,6 +217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +245,12 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
@@ -268,7 +294,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -467,7 +493,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1467,6 +1493,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1539,30 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1550,6 +1612,28 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -2887,6 +2971,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3087,23 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "duckdb"
+version = "1.10501.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
 
 [[package]]
 name = "dunce"
@@ -3248,6 +3360,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3382,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -3295,6 +3429,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3414,6 +3549,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -3854,6 +3995,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -3889,6 +4039,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4816,6 +4975,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10501.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12096c1694924782b3fe21e790630b77bacb4fcb7ad9d7ee0fec626f985bf248"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
 name = "libflate"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,7 +5327,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "metrics-macros",
  "portable-atomic",
 ]
@@ -5947,7 +6123,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -6300,7 +6476,7 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
@@ -6318,7 +6494,7 @@ dependencies = [
  "array-init",
  "bytes",
  "chrono",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -6360,6 +6536,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6531,6 +6716,7 @@ dependencies = [
  "dashmap",
  "datafusion",
  "datafusion-common",
+ "duckdb",
  "env_logger",
  "flate2",
  "flume 0.11.1",
@@ -8050,6 +8236,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8257,6 +8463,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -8493,6 +8705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8640,6 +8861,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8706,6 +8956,23 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8947,6 +9214,12 @@ dependencies = [
  "ring",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -9413,7 +9686,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.16.1",
- "hashlink",
+ "hashlink 0.11.1",
  "indexmap",
  "log",
  "memchr",
@@ -9634,6 +9907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9643,6 +9925,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.118",
 ]
 
@@ -9925,6 +10219,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10175,7 +10486,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",
@@ -10258,7 +10569,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -10304,6 +10615,18 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -10956,6 +11279,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -11553,6 +11877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x509-certificate"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11589,6 +11922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11611,7 +11954,7 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.11.1",
 ]
 
 [[package]]
@@ -11741,10 +12084,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,6 +448,11 @@ arrow-cast = { version = "58", default-features = false }
 # DataFusion for SQL and compute engine compatibility (Arrow 57 compatible)
 datafusion = { version = "54.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions", "datetime_expressions", "math_expressions"], optional = true }
 datafusion-common = { version = "54.0", optional = true }
+# ADR-059: DuckDB-Local as a plugin OLAP engine (in-process, behind the
+# `duckdb` feature, default OFF). `bundled` builds libduckdb from source so no
+# system DuckDB is required. Used by the perf-ledger harnesses for an
+# in-process, io-traced DuckDB baseline (ADR-059 D1/D2).
+duckdb = { version = "1.1", features = ["bundled", "parquet"], optional = true }
 
 # Advanced compression for recovery-optimized WAL
 lz4_flex = "0.11"        # Faster LZ4 implementation
@@ -779,6 +784,10 @@ graph-first-sks = []
 # DataFusion integration for compute engine compatibility
 # DataFusion 51.x uses Arrow 57.x — versions are aligned as of 2026-04
 datafusion-integration = ["dep:datafusion", "dep:datafusion-common"]
+# ADR-059: in-process DuckDB OLAP engine (default OFF — adds the libduckdb C++
+# build). Enables the perf-ledger harnesses to run DuckDB in-process (io-traced,
+# same parquet/SQL) instead of the CLI subprocess.
+duckdb = ["dep:duckdb"]
 
 # Hardware acceleration features
 gpu = ["metal", "proximadb-hardware-caps/gpu", "proximadb-distance-kernel/gpu"]  # GPU acceleration support (CUDA, ROCm, MPS, OpenCL)

--- a/src/datafusion/engine_adapters/object_store_parquet_reader.rs
+++ b/src/datafusion/engine_adapters/object_store_parquet_reader.rs
@@ -559,18 +559,33 @@ impl ObjectStoreParquetTable {
             IcebergObjectStoreBridge::from_url(location)
                 .map_err(|e| df_err(&format!("object-store bridge({location})"), e))?,
         );
+        // ADR-059 first-principles: scan the location's IMMEDIATE parquet files
+        // (Hive/Unity/Polaris model — location = the directory where parquet is
+        // immediate, skipping commit-style `_`/`.` files via the `.parquet`
+        // extension filter). Mixed-read-safe fallback: if no immediate parquet,
+        // try the legacy `data/` subpath (old materialized tables where location
+        // = table base dir, parquet in `{location}/data/`).
         let mut parquet_paths = bridge
-            .list_objects(&Path::from("data"))
+            .list_objects(&Path::from(""))
             .await
-            .map_err(|e| df_err(&format!("list parquet base {location}"), e))?
+            .unwrap_or_default()
             .into_iter()
             .filter(|path| path.as_ref().ends_with(".parquet"))
             .collect::<Vec<_>>();
+        if parquet_paths.is_empty() {
+            parquet_paths = bridge
+                .list_objects(&Path::from("data"))
+                .await
+                .map_err(|e| df_err(&format!("list parquet data/ fallback {location}"), e))?
+                .into_iter()
+                .filter(|path| path.as_ref().ends_with(".parquet"))
+                .collect::<Vec<_>>();
+        }
         parquet_paths.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
         if parquet_paths.is_empty() {
             return Err(df_err(
                 "open object-store parquet base",
-                format!("no data/*.parquet objects under {location}"),
+                format!("no parquet objects under {location} (immediate or data/)"),
             ));
         }
 

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -221,6 +221,14 @@ pub fn statistics_from_splits(
                 .and_then(|f| f.distinct_estimate)
             {
                 cs.distinct_count = Precision::Inexact(ndv as usize);
+            } else if num_rows > 0 {
+                // TD-OLAP-2 NDV proxy: when no registry NDV is available,
+                // use num_rows as an Inexact upper bound (NDV ≤ num_rows).
+                // Gives DataFusion's EnforceDistribution rule a non-Absent
+                // estimate so it can choose a partitioned (multi-core) join
+                // build instead of falling back to single-partition (1 core).
+                // The HLL fix (A2) replaces this proxy with accurate NDV.
+                cs.distinct_count = Precision::Inexact(num_rows);
             }
             cs
         })

--- a/src/datafusion/schema_inference.rs
+++ b/src/datafusion/schema_inference.rs
@@ -221,14 +221,6 @@ pub fn statistics_from_splits(
                 .and_then(|f| f.distinct_estimate)
             {
                 cs.distinct_count = Precision::Inexact(ndv as usize);
-            } else if num_rows > 0 {
-                // TD-OLAP-2 NDV proxy: when no registry NDV is available,
-                // use num_rows as an Inexact upper bound (NDV ≤ num_rows).
-                // Gives DataFusion's EnforceDistribution rule a non-Absent
-                // estimate so it can choose a partitioned (multi-core) join
-                // build instead of falling back to single-partition (1 core).
-                // The HLL fix (A2) replaces this proxy with accurate NDV.
-                cs.distinct_count = Precision::Inexact(num_rows);
             }
             cs
         })

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -1080,7 +1080,12 @@ async fn try_native_over_parquet(
     };
     // Skip grouped aggregates: native's non-spilling HashAggregate OOMs on
     // high-cardinality GROUP BY at scale. These route to DataFusion.
-    if plan_has_grouped_aggregate(&physical) {
+    // Opt-in gate (PROXIMADB_NATIVE_ALLOW_GROUPED_AGG): allow grouped aggregates
+    // when the caller knows the group cardinality is safe (e.g., SF=0.01 with
+    // low-cardinality GROUP BY like Q1's l_returnflag/l_linestatus → 8 groups).
+    if plan_has_grouped_aggregate(&physical)
+        && std::env::var("PROXIMADB_NATIVE_ALLOW_GROUPED_AGG").is_err()
+    {
         tracing::debug!(target: "proximadb::native_route", "native SKIP grouped-aggregate: {sqlp}");
         return None;
     }

--- a/src/query/execution/duckdb_engine.rs
+++ b/src/query/execution/duckdb_engine.rs
@@ -1,0 +1,90 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! # DuckDB-Local OLAP engine (ADR-059)
+//!
+//! In-process DuckDB behind the `ExecutionEngine` seam, mirroring
+//! [`DataFusionLocalEngine`]. Reads the **SAME materialized parquet** ProximaDB
+//! wrote (via DuckDB's `read_parquet`), executes the SQL, and returns an
+//! [`ExecutionPipelineResult`] built from DuckDB's Arrow output through the same
+//! Arrow→`RelationalRow` bridge DataFusion uses (`record_batches_to_pipeline_result`).
+//!
+//! Used by the perf-ledger harnesses (`tpc_perf_ledger_e2e.rs`,
+//! `clickbench_ledger_e2e.rs`) for an **in-process, io-traced** DuckDB baseline,
+//! so the DataFusion-vs-DuckDB discriminant is engine behavior only (same data,
+//! same SQL, same process) — not the out-of-process CLI subprocess (which carried
+//! no io-trace and used a separate data-load path).
+//!
+//! io-trace is **engine-reported** (ADR-059 / decider-accepted): DuckDB's parquet
+//! reader is internal C++ with no `ObjectStore` hook, so per-GET
+//! `range_gets`/`splits_pruned` aren't available; `compute_ms` (wall) is recorded.
+//! (`bytes_read` from DuckDB's profiling API is a follow-up refinement.)
+
+use super::engine::{
+    ExecutionEngine, ExecutionError, ExecutionPipelineResult, QueryExecutionContext,
+};
+use async_trait::async_trait;
+
+/// In-process DuckDB OLAP engine. Stateless — a fresh in-memory DuckDB is opened
+/// per `execute_sql` (the harness runs one query at a time against the
+/// materialized parquet, registered as views).
+pub struct DuckDbLocalEngine;
+
+#[async_trait]
+impl ExecutionEngine for DuckDbLocalEngine {
+    async fn execute_sql(
+        &self,
+        sql: &str,
+        context: QueryExecutionContext,
+    ) -> Result<ExecutionPipelineResult, ExecutionError> {
+        // DuckDB is synchronous + CPU-bound (CBO + vectorized joins). Run it on
+        // the blocking pool so it never holds a tokio worker thread.
+        let sql = sql.to_string();
+        let (result, compute_ms) = tokio::task::spawn_blocking(move || run_duckdb(&sql, &context))
+            .await
+            .map_err(|e| ExecutionError::Execution(format!("duckdb join/task: {e}")))??;
+        // Record io-trace HERE (async context), not inside spawn_blocking — the
+        // task-local `IO_TRACE` is set in this async scope (the harness wraps the
+        // call in an io-trace scope), but does not propagate to the blocking
+        // thread. DuckDB's reader is internal C++ (no ObjectStore hook), so only
+        // engine-reported compute_ms is available (bytes_read is a follow-up).
+        crate::observability::io_trace::record_compute_ms("duckdb", compute_ms);
+        Ok(result)
+    }
+}
+
+/// Open an in-memory DuckDB, register the parquet tables, run the SQL, and
+/// convert the Arrow result to [`ExecutionPipelineResult`]. Returns the result
+/// + the wall `compute_ms` (recorded by the caller in the async io-trace scope).
+fn run_duckdb(
+    sql: &str,
+    context: &QueryExecutionContext,
+) -> Result<(ExecutionPipelineResult, u64), ExecutionError> {
+    let conn = duckdb::Connection::open_in_memory()
+        .map_err(|e| ExecutionError::Execution(format!("duckdb open: {e}")))?;
+    // Register each parquet table as a view over `read_parquet` — DuckDB reads
+    // the SAME materialized parquet ProximaDB wrote (same data; no re-load).
+    for (name, location) in &context.parquet_tables {
+        // Quote the view name + single-quote the location (object-store URL/path).
+        // `name`/`location` are ProximaDB-controlled (catalog + materialize), not
+        // user input, so interpolation is safe here.
+        let ddl = format!("CREATE VIEW \"{name}\" AS SELECT * FROM read_parquet('{location}')");
+        conn.execute_batch(&ddl)
+            .map_err(|e| ExecutionError::Execution(format!("duckdb register {name}: {e}")))?;
+    }
+    // Prepare + execute + time. DuckDB's CBO (join reorder + broadcast) runs
+    // here — the perf lever that closes the measured 100–700× gap (TD-OLAP-15).
+    let started = std::time::Instant::now();
+    let mut stmt = conn
+        .prepare(sql)
+        .map_err(|e| ExecutionError::Execution(format!("duckdb prepare: {e}")))?;
+    let arrow = stmt
+        .query_arrow(duckdb::params![])
+        .map_err(|e| ExecutionError::Execution(format!("duckdb execute: {e}")))?;
+    let schema = arrow.get_schema();
+    let batches: Vec<arrow_array::RecordBatch> = arrow.collect();
+    let compute_ms = started.elapsed().as_millis() as u64;
+    // Arrow → ExecutionPipelineResult (same bridge DataFusion uses; arrow
+    // versions are unified at 58.x so the RecordBatch type is shared).
+    let result = super::native_engine::record_batches_to_pipeline_result(schema.as_ref(), &batches);
+    Ok((result, compute_ms))
+}

--- a/src/query/execution/duckdb_engine.rs
+++ b/src/query/execution/duckdb_engine.rs
@@ -62,12 +62,14 @@ fn run_duckdb(
     let conn = duckdb::Connection::open_in_memory()
         .map_err(|e| ExecutionError::Execution(format!("duckdb open: {e}")))?;
     // Register each parquet table as a view over `read_parquet` — DuckDB reads
-    // the SAME materialized parquet ProximaDB wrote (same data; no re-load).
+    // the SAME materialized parquet ProximaDB wrote (same data; no re-load). The
+    // `location` is the table's base directory (the catalog API contract — like
+    // Hive/Unity/Polaris: the reader scans immediate parquet files in it,
+    // skipping commit-style files `_`/`.` prefixed; partitioned layouts use
+    // `colname=value/` subdirs). NOT a recursive glob.
     for (name, location) in &context.parquet_tables {
-        // Quote the view name + single-quote the location (object-store URL/path).
-        // `name`/`location` are ProximaDB-controlled (catalog + materialize), not
-        // user input, so interpolation is safe here.
-        let ddl = format!("CREATE VIEW \"{name}\" AS SELECT * FROM read_parquet('{location}')");
+        let base = location.trim_end_matches('/');
+        let ddl = format!("CREATE VIEW \"{name}\" AS SELECT * FROM read_parquet('{base}')");
         conn.execute_batch(&ddl)
             .map_err(|e| ExecutionError::Execution(format!("duckdb register {name}: {e}")))?;
     }

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -222,6 +222,11 @@ pub async fn execute_sql_with_backend(
             let engine = super::datafusion_engine::DataFusionLocalEngine;
             engine.execute_sql(sql, context).await
         }
+        #[cfg(feature = "duckdb")]
+        ComputeBackend::DuckDbCompat => {
+            let engine = super::duckdb_engine::DuckDbLocalEngine;
+            engine.execute_sql(sql, context).await
+        }
         other => Err(ExecutionError::UnsupportedBackend(other)),
     }
 }
@@ -236,6 +241,11 @@ pub async fn execute_sql_stream_with_backend(
     match backend {
         ComputeBackend::DataFusionLocal => {
             let engine = super::datafusion_engine::DataFusionLocalEngine;
+            engine.execute_sql_stream(sql, context).await
+        }
+        #[cfg(feature = "duckdb")]
+        ComputeBackend::DuckDbCompat => {
+            let engine = super::duckdb_engine::DuckDbLocalEngine;
             engine.execute_sql_stream(sql, context).await
         }
         other => Err(ExecutionError::UnsupportedBackend(other)),

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod datafusion_bridge;
 pub mod datafusion_engine;
+#[cfg(feature = "duckdb")]
+pub mod duckdb_engine;
 pub mod engine;
 
 pub mod executor;

--- a/src/services/catalog_introspection.rs
+++ b/src/services/catalog_introspection.rs
@@ -1247,11 +1247,21 @@ fn matches_filter(value: &str, filter: Option<&str>) -> bool {
 }
 
 fn primary_layout(schema: &CatalogTableSchema) -> Option<&crate::catalog::CatalogStorageLayout> {
+    // Prefer the materialized Parquet layout (ProjectionPublication) — it has
+    // the correct `location` (the data dir where parquet is immediate, per
+    // ADR-059). The original "primary" layout may have a stale/empty location.
     schema
         .storage_layouts
         .iter()
         .rev()
-        .find(|layout| layout.name == "primary")
+        .find(|l| l.physical_format == crate::catalog::CatalogPhysicalFormat::Parquet)
+        .or_else(|| {
+            schema
+                .storage_layouts
+                .iter()
+                .rev()
+                .find(|l| l.name == "primary")
+        })
         .or_else(|| schema.storage_layouts.first())
 }
 

--- a/src/services/catalog_introspection.rs
+++ b/src/services/catalog_introspection.rs
@@ -1199,14 +1199,26 @@ impl CatalogIntrospectionService {
         // as an internal `proximadb.<ns>` collection namespace and as the
         // SQL-standard `<ns>` schema (observed: `b` listed twice as
         // `proximadb.default.b` and `public.b`). Collapse by normalized identity
-        // (see `table_identity_key`), preferring the SQL-standard form (no
-        // `proximadb.` prefix) so the surviving row displays the standard schema
-        // name. Same-name tables in different user namespaces stay distinct.
-        tables.sort_by_key(|(_, table_id, _)| {
-            table_id
-                .namespace
-                .first()
-                .is_some_and(|first| first.eq_ignore_ascii_case("proximadb"))
+        // (see `table_identity_key`), preferring:
+        //   1. The catalog with a materialized Parquet layout (the CURRENT
+        //      storage state — `set_storage_layouts` updates only the internal
+        //      `proximadb.` catalog, so the SQL-standard form may be stale).
+        //   2. The SQL-standard form (no `proximadb.` prefix) as a tiebreaker.
+        // Same-name tables in different user namespaces stay distinct.
+        tables.sort_by_key(|(_, table_id, schema)| {
+            let has_parquet = schema
+                .storage_layouts
+                .iter()
+                .any(|l| l.physical_format == crate::catalog::CatalogPhysicalFormat::Parquet);
+            // Sort key: (!has_parquet, is_proximadb) — Parquet layouts first,
+            // then non-proximadb (SQL-standard) within each group.
+            (
+                !has_parquet,
+                table_id
+                    .namespace
+                    .first()
+                    .is_some_and(|first| first.eq_ignore_ascii_case("proximadb")),
+            )
         });
         let mut seen = std::collections::BTreeSet::new();
         tables.retain(|(_, table_id, _)| seen.insert(table_identity_key(table_id)));

--- a/src/services/catalog_introspection.rs
+++ b/src/services/catalog_introspection.rs
@@ -552,6 +552,12 @@ impl CatalogIntrospectionService {
                 property_value(&schema, &["freshness_sla", "projection_freshness"])
                     .unwrap_or_default(),
                 policy_boundary(&schema),
+                // ADR-059: the materialized-parquet location (storage_layout.location)
+                // so the perf-ledger harness can register the SAME parquet with an
+                // in-process DuckDB engine (apples-to-apples vs DataFusion).
+                primary_layout
+                    .and_then(|l| l.location.clone())
+                    .unwrap_or_default(),
             ]);
         }
 
@@ -570,8 +576,10 @@ impl CatalogIntrospectionService {
                 "isolation_profile".to_string(),
                 "freshness_sla".to_string(),
                 "policy_boundary".to_string(),
+                "location".to_string(),
             ],
             column_types: vec![
+                "text".to_string(),
                 "text".to_string(),
                 "text".to_string(),
                 "text".to_string(),

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1506,7 +1506,11 @@ impl DmlService {
             .await?;
 
         // 5. Flip the catalog layout to a published Parquet projection at the location.
-        let location = format!("{}/{prefix}", warehouse_root_url.trim_end_matches('/'));
+        // ADR-059 first-principles: the `location` is the directory where the
+        // parquet files are IMMEDIATE children (Hive/Unity/Polaris model) — NOT the
+        // table base dir with a `data/` subpath. The parquet is written to
+        // `{prefix}/data/part-0.parquet`, so the location = `{root}/{prefix}/data`.
+        let location = format!("{}/{prefix}/data", warehouse_root_url.trim_end_matches('/'));
         let layout = CatalogStorageLayout {
             name: "parquet-snapshot".to_string(),
             authority: proximadb_catalog::CatalogAuthorityMode::ProjectionPublication,

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -2639,17 +2639,18 @@ async fn materialize_table_writes_parquet_and_flips_catalog_layout() {
     // the namespace's own (rename-stable) `namespace_id`, no legacy fork.
     assert!(
         location.starts_with("memory:///warehouse/data/default_tenant/ns_")
-            && location.ends_with("/inv"),
+            && location.ends_with("/inv/data"),
         "embedded materialize must use the canonical DrPath layout: {location}"
     );
 
-    // The Parquet snapshot landed where the OLAP reader lists `{location}/data/*.parquet`,
-    // and reads back all three rows. Derive the prefix from the resolved location
-    // so the read tracks the real (opaque) namespace_id.
+    // The Parquet snapshot landed where the OLAP reader lists `{location}/*.parquet`
+    // (ADR-059: `location` is the dir where the parquet files are IMMEDIATE
+    // children), and reads back all three rows. Derive the prefix from the
+    // resolved location so the read tracks the real (opaque) namespace_id.
     let prefix = location
         .strip_prefix("memory:///warehouse/")
         .expect("location under warehouse root");
-    let data_object = object_store::path::Path::from(format!("{prefix}/data/part-0.parquet"));
+    let data_object = object_store::path::Path::from(format!("{prefix}/part-0.parquet"));
     let mut stream = bridge
         .read_parquet_batches(
             &data_object,
@@ -2910,7 +2911,7 @@ async fn materialize_drpath_layout_uses_opaque_namespace_id() {
         loc.starts_with("memory:///wh/data/acmecorp/ns_"),
         "drpath layout must use the opaque namespace_id: {loc}"
     );
-    assert!(loc.ends_with("/inv"), "loc={loc}");
+    assert!(loc.ends_with("/inv/data"), "loc={loc}");
     assert!(!loc.contains("default_tenant"), "loc={loc}");
 }
 

--- a/tests/clickbench_ledger_e2e.rs
+++ b/tests/clickbench_ledger_e2e.rs
@@ -331,6 +331,9 @@ async fn drain_capture() -> Option<IoTraceSnapshot> {
 }
 
 /// Rewrite `FROM hits` to a DuckDB `read_parquet(...)` over the same object.
+/// Only used by the CLI fallback (when the `duckdb` feature is OFF); the
+/// in-process engine registers a `hits` view, so no rewrite is needed.
+#[cfg(not(feature = "duckdb"))]
 fn duckdb_sql(sql: &str, parquet: &str) -> String {
     sql.replace("FROM hits", &format!("FROM read_parquet('{parquet}')"))
 }
@@ -473,7 +476,75 @@ async fn clickbench_ledger() {
     }
     io_trace::set_billing_observer(None);
 
-    // DuckDB baseline (same Parquet), if a binary is provided.
+    // DuckDB baseline (ADR-059): in-process, same Parquet, io-traced — the
+    // engine-behavior-only discriminant (compute_ms; DF-vs-DuckDB on the same
+    // parquet/SQL/process). Re-arm the billing observer (cleared above after the
+    // ProximaDB route) so the instrument scope's snapshot lands in CAPTURE.
+    #[cfg(feature = "duckdb")]
+    {
+        use proximadb::query::execution::engine::{
+            QueryExecutionContext, execute_sql_with_backend,
+        };
+        use proximadb::query::table_write_plan::ComputeBackend;
+        io_trace::set_billing_observer(Some(Box::new(|snap: &IoTraceSnapshot, _tenant| {
+            CAPTURE.lock().expect("capture lock").push(snap.clone());
+        })));
+        for (id, sql) in &queries {
+            CAPTURE.lock().expect("capture lock").clear();
+            // DuckDbLocalEngine registers `CREATE VIEW hits AS SELECT * FROM
+            // read_parquet('{parquet_uri}')`, so the original `FROM hits` SQL
+            // works — no duckdb_sql rewrite needed.
+            let ctx = QueryExecutionContext {
+                parquet_tables: vec![("hits".to_string(), parquet_uri.clone())],
+                ..Default::default()
+            };
+            let t0 = Instant::now();
+            // instrument sets the IO_TRACE scope; the engine's record_compute_ms
+            // lands in it; instrument emits the snapshot → observer → CAPTURE.
+            let sql_owned = sql.to_string();
+            let res = io_trace::instrument(None, "duckdb".to_string(), async move {
+                execute_sql_with_backend(ComputeBackend::DuckDbCompat, &sql_owned, ctx).await
+            })
+            .await;
+            let wall_ms = t0.elapsed().as_millis();
+            let snap = drain_capture().await;
+            let compute_ms = snap.as_ref().map(|s| s.total_compute_ms());
+            let compute_by_engine = snap.and_then(|s| {
+                if s.compute_ms.is_empty() {
+                    None
+                } else {
+                    Some(s.compute_ms)
+                }
+            });
+            let (ok, rows, error) = match res {
+                Ok(r) => (true, r.rows.len(), None),
+                Err(e) => (false, 0, Some(e.to_string())),
+            };
+            records.push(QueryRecord {
+                query: (*id).into(),
+                engine: "duckdb".into(),
+                ok,
+                rows,
+                wall_ms,
+                bytes_read: None,
+                range_gets: None,
+                setup_ms: None,
+                emit_ms: None,
+                session_ms: None,
+                compute_ms,
+                open_ms: None,
+                plan_ms: None,
+                table_open_hits: None,
+                route: Some("DuckDbCompat".into()),
+                compute_by_engine,
+                error,
+            });
+        }
+        io_trace::set_billing_observer(None);
+    }
+    // Fallback: DuckDB CLI subprocess (only when the `duckdb` feature is OFF —
+    // out-of-process, no io-trace; the in-process path above is the ledger route).
+    #[cfg(not(feature = "duckdb"))]
     if let Ok(duckdb) = std::env::var("DUCKDB_BIN") {
         for (id, sql) in &queries {
             let dsql = duckdb_sql(sql, &parquet);

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -1324,7 +1324,7 @@ fn push_record(
 /// `location` (the catalog-introspection `location` column), so the in-process
 /// DuckDB engine reads the SAME parquet DataFusion reads (apples-to-apples).
 #[cfg(feature = "duckdb")]
-async fn query_parquet_locations(client: &Client) -> Vec<(String, String)> {
+async fn query_parquet_locations(client: &Client, table_names: &[&str]) -> Vec<(String, String)> {
     let mut out = Vec::new();
     let Ok(msgs) = client
         .simple_query("SELECT * FROM xcatalog.table_routing")
@@ -1338,7 +1338,9 @@ async fn query_parquet_locations(client: &Client) -> Vec<(String, String)> {
             // location = col 12 (the last, added by ADR-059).
             let name = row.get(2).unwrap_or_default().to_string();
             let loc = row.get(12).unwrap_or_default().to_string();
-            if !loc.is_empty() {
+            // Only the benchmark's tables (filter out system/internal tables
+            // whose locations may be invalid → would break the DuckDB session).
+            if !loc.is_empty() && table_names.contains(&name.as_str()) {
                 out.push((name, loc));
             }
         }
@@ -1596,7 +1598,8 @@ async fn run_benchmark(
     // (after shutdown, below) runs only when the `duckdb` feature is OFF.
     #[cfg(feature = "duckdb")]
     {
-        let parquet_tables = query_parquet_locations(client).await;
+        let table_names: Vec<&str> = schema.iter().map(|(n, _)| *n).collect();
+        let parquet_tables = query_parquet_locations(client, &table_names).await;
         if parquet_tables.is_empty() {
             eprintln!("[{benchmark}] · DuckDB in-process SKIPPED (no parquet locations)");
         } else {

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -72,6 +72,10 @@ impl PgServer {
         config.server.bind_address = "127.0.0.1".to_string();
         config.server.port = rest_port;
         config.server.data_dir = tmp.path().to_path_buf();
+        // ADR-059: the catalog metadata_url MUST be per-tempdir — the default
+        // ("file://./metadata") is a FIXED relative path that persists across
+        // test runs, carrying stale table locations from previous tempdirs.
+        config.storage.metadata_url = format!("file://{}/metadata", tmp.path().display());
         config.api.rest_port = rest_port;
         config.api.grpc_port = grpc_port;
         config.api.unified_mode = false;

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -33,6 +33,7 @@
 //! integration tests are self-contained by convention; keep them in sync.
 
 use std::net::TcpListener;
+#[cfg(not(feature = "duckdb"))]
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -1319,6 +1320,72 @@ fn push_record(
     out.push(rec);
 }
 
+/// ADR-059: query `xcatalog.table_routing` for each table's materialized-parquet
+/// `location` (the catalog-introspection `location` column), so the in-process
+/// DuckDB engine reads the SAME parquet DataFusion reads (apples-to-apples).
+#[cfg(feature = "duckdb")]
+async fn query_parquet_locations(client: &Client) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let Ok(msgs) = client
+        .simple_query("SELECT * FROM xcatalog.table_routing")
+        .await
+    else {
+        return out;
+    };
+    for m in msgs {
+        if let SimpleQueryMessage::Row(row) = m {
+            // table_name = col 2 (table_catalog, table_schema, table_name);
+            // location = col 12 (the last, added by ADR-059).
+            let name = row.get(2).unwrap_or_default().to_string();
+            let loc = row.get(12).unwrap_or_default().to_string();
+            if !loc.is_empty() {
+                out.push((name, loc));
+            }
+        }
+    }
+    out
+}
+
+/// ADR-059: run one query on the in-process DuckDB engine over the materialized
+/// parquet, io-traced (compute_ms). Mirrors `measure` (clear CAPTURE → run →
+/// drain) but via `execute_sql_with_backend(DuckDbCompat)` in
+/// `io_trace::instrument` instead of pgwire.
+#[cfg(feature = "duckdb")]
+async fn measure_duckdb_inprocess(
+    sql: &str,
+    parquet_tables: &[(String, String)],
+) -> Result<(usize, u128, IoTraceSnapshot), (u128, String)> {
+    use proximadb::query::execution::engine::{QueryExecutionContext, execute_sql_with_backend};
+    use proximadb::query::table_write_plan::ComputeBackend;
+    CAPTURE.lock().expect("lock").clear();
+    let ctx = QueryExecutionContext {
+        parquet_tables: parquet_tables.to_vec(),
+        ..Default::default()
+    };
+    let t0 = Instant::now();
+    // instrument sets the IO_TRACE scope; DuckDbLocalEngine records compute_ms;
+    // instrument emits the snapshot → billing observer → CAPTURE.
+    let sql_owned = sql.to_string();
+    let res = io_trace::instrument(None, "duckdb".to_string(), async move {
+        execute_sql_with_backend(ComputeBackend::DuckDbCompat, &sql_owned, ctx).await
+    })
+    .await;
+    let wall_ms = t0.elapsed().as_millis();
+    // Drain CAPTURE (same 60×5ms poll as `measure`).
+    let mut snap = IoTraceSnapshot::default();
+    for _ in 0..60 {
+        if let Some(s) = CAPTURE.lock().expect("lock").pop() {
+            snap = s;
+            break;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    match res {
+        Ok(r) => Ok((r.rows.len(), wall_ms, snap)),
+        Err(e) => Err((wall_ms, e.to_string())),
+    }
+}
+
 /// DuckDB external baseline (TD-OLAP-4 "external baselines"). When `DUCKDB_BIN`
 /// is set, load the SAME synthetic-tpc data (the `schema` CREATE TABLEs + the
 /// `inserts` — both DuckDB-compatible standard SQL) into a persistent temp
@@ -1336,6 +1403,7 @@ fn push_record(
 /// locate the first depth-0 `WITH (` and drop from there to the end. A `WITH`
 /// inside the column list (depth > 0) is left untouched. DuckDB builds its own
 /// zone maps on load, so the cluster key is irrelevant to the wall-time baseline.
+#[cfg(not(feature = "duckdb"))]
 fn strip_duckdb_incompatible_storage_param(ddl: &str) -> String {
     let lower = ddl.to_ascii_lowercase();
     let Some(rel) = lower.find(" with ") else {
@@ -1354,6 +1422,7 @@ fn strip_duckdb_incompatible_storage_param(ddl: &str) -> String {
     before.trim_end().to_string()
 }
 
+#[cfg(not(feature = "duckdb"))]
 fn run_duckdb_baseline(
     benchmark: &str,
     schema: &[(&str, &str)],
@@ -1520,6 +1589,27 @@ async fn run_benchmark(
             push_record(out, benchmark, id, "datafusion", temperature, r);
         }
     }
+
+    // ADR-059: DuckDB in-process route (post-MATERIALIZE, same parquet, io-traced).
+    // Reads the SAME materialized parquet DataFusion reads (apples-to-apples), via
+    // the in-process DuckDbLocalEngine, io-traced (compute_ms). The CLI fallback
+    // (after shutdown, below) runs only when the `duckdb` feature is OFF.
+    #[cfg(feature = "duckdb")]
+    {
+        let parquet_tables = query_parquet_locations(client).await;
+        if parquet_tables.is_empty() {
+            eprintln!("[{benchmark}] · DuckDB in-process SKIPPED (no parquet locations)");
+        } else {
+            eprintln!(
+                "[{benchmark}] · DuckDB in-process baseline ({} parquet tables)",
+                parquet_tables.len()
+            );
+            for (id, sql) in &queries {
+                let r = measure_duckdb_inprocess(sql, &parquet_tables).await;
+                push_record(out, benchmark, id, "duckdb", "first", r);
+            }
+        }
+    }
 }
 
 async fn connect(server: &PgServer) -> Client {
@@ -1585,13 +1675,16 @@ async fn tpc_perf_ledger_inner() {
         )
         .await;
         server.shutdown().await;
-        run_duckdb_baseline(
-            "tpch",
-            TPCH_SCHEMA,
-            &gen_tpch(scale),
-            &keep_queries(tpch_queries()),
-            &mut records,
-        );
+        #[cfg(not(feature = "duckdb"))]
+        {
+            run_duckdb_baseline(
+                "tpch",
+                TPCH_SCHEMA,
+                &gen_tpch(scale),
+                &keep_queries(tpch_queries()),
+                &mut records,
+            );
+        }
     }
     if benchmark_filter.as_deref().is_none_or(|b| b == "tpcds") {
         let server = PgServer::start().await.expect("server start (tpcds)");
@@ -1606,13 +1699,16 @@ async fn tpc_perf_ledger_inner() {
         )
         .await;
         server.shutdown().await;
-        run_duckdb_baseline(
-            "tpcds",
-            TPCDS_SCHEMA,
-            &gen_tpcds(scale),
-            &keep_queries(tpcds_queries()),
-            &mut records,
-        );
+        #[cfg(not(feature = "duckdb"))]
+        {
+            run_duckdb_baseline(
+                "tpcds",
+                TPCDS_SCHEMA,
+                &gen_tpcds(scale),
+                &keep_queries(tpcds_queries()),
+                &mut records,
+            );
+        }
     }
 
     // Console summary: per benchmark × route, pass count + medians. Native and


### PR DESCRIPTION
## What
Implements ADR-059 (DuckDB-Local plugin OLAP engine) + rewires both perf-ledger harnesses to use it in-process (io-traced, apples-to-apples) + fixes the catalog location model (first-principles, Hive/Unity/Polaris-style).

## 1. DuckDbLocalEngine + dispatch (feature-gated `duckdb`, default OFF)
- In-process DuckDB behind the `ExecutionEngine` seam. Registers parquet as `CREATE VIEW ... read_parquet('{location}')` (same data), executes on the blocking pool, converts Arrow via the shared `record_batches_to_pipeline_result` bridge, records engine-reported io-trace (`compute_ms`).
- `DuckDbCompat` dispatch arm in `execute_sql_with_backend`.
- Arrow versions unify at 58.3.0 (datafusion 54.0 + duckdb 1.10501).

## 2. ClickBench harness — in-process DuckDB (io-traced)
Replaces the CLI subprocess with `execute_sql_with_backend(DuckDbCompat, ...)` in `io_trace::instrument` → `drain_capture` → `QueryRecord` with `compute_ms` + real `rows`. CLI kept as `#[cfg(not(feature="duckdb"))]` fallback.

## 3. TPC harness — in-process DuckDB (apples-to-apples, same parquet)
Replaces the INSERT-based CLI baseline with the in-process engine reading the SAME materialized parquet DF reads. Queries `xcatalog.table_routing` for per-table parquet locations (post-MATERIALIZE), filtered to the benchmark's tables. io-traced via `io_trace::instrument` + `drain_capture`.

## 4. Catalog location model (first-principles — Hive/Unity/Polaris)
- **`location` exposed** in `xcatalog.table_routing` (the table's data dir where parquet is immediate).
- **`primary_layout` prefers Parquet** (the materialized layout, not the stale original).
- **Materialize sets `location = {root}/{prefix}/data`** (where parquet is immediate children, not the table base dir with a `data/` subpath).
- **DF reader mixed-read-safe** (scan `{location}` immediate + fallback to `{location}/data/` for old tables).
- **`cataloged_tables` dedup prefers the Parquet catalog** (fixes the stale-location bug — `set_storage_layouts` updates the internal `proximadb.` catalog, but the dedup was keeping the stale `public.` form).
- **`metadata_url` per-tempdir** in the test (fixes the stale-catalog-across-runs bug — the default `file://./metadata` persists across test runs).

## 5. Native grouped-agg env gate (B2)
`PROXIMADB_NATIVE_ALLOW_GROUPED_AGG=1` opts in to native grouped aggregates (the caller ensures low cardinality, e.g., Q1's 8-group GROUP BY at SF=0.01).

## Verification
- `cargo clippy --lib --bins -- -D warnings` clean (default build).
- `cargo clippy --lib --bins --features duckdb -- -D warnings` clean (libduckdb 1.10501 builds via `bundled`).
- SF=0.001: DuckDB ok 22/22 (tpch) + 63/63 (tpcds); DF 22/22 + 63/63 (conformance unchanged); DuckDB median 9ms/13ms vs DF 63ms/75ms.
- Rebased onto latest develop (10 new commits — no regression).

## Non-goals (follow-ons)
- **A2 (HLL during materialize)** — the proper TD-OLAP-2 NDV fix (the `num_rows`-as-NDV proxy was reverted — it caused a bad DF plan at SF=0.01 due to overestimated NDV for low-cardinality columns).
- **Native morsel scheduling** (B1) — enable `PROXIMADB_NATIVE_MORSEL` + verify parallel scan.
- **Native join + multi-table parquet** (B3) — extend `try_native_over_parquet` for >1 table.
- **Default-location resolution + partitioned layouts** — follow-ons to the catalog location model.