### PR TITLE
docs(decomposition): CI build/test optimization — graph-prioritized extraction (feeds ROOT_CRATE_DECOMPOSITION_PLAN)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_CI_BUILD_OPTIMIZATION_2026_07_11.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_CI_BUILD_OPTIMIZATION_2026_07_11.adoc
@@ -1,0 +1,184 @@
+= Root-Crate Decomposition — CI Build/Test Optimization (2026-07-11)
+:toc: macro
+:icons: font
+
+[abstract]
+A CI-time-framed companion to `ROOT_CRATE_DECOMPOSITION_PLAN_2026_06_21.adoc` and the subsystem
+coupling reviews (#864 services, #865 network, #867 storage). It uses the code-graph centrality
+and coupling data (`.victor/project.db`, 1.41M nodes / now incl. `src/storage`) to **prioritize
+decomposition for maximum CI speedup** — faster rebuilds, parallelization, and a lower memory
+footprint so the build can stop running serial. The single dominant lever: the root crate is one
+850K-symbol compile unit, and `src/storage` is 34% of it.
+
+toc::[]
+
+== Why CI time is gated on the root crate
+
+The root crate `src/` is compiled as a **single unit**: **~850K symbols across 1,382 files
+(~62% of the codebase)**. One giant compilation unit drives the whole CI cost cascade:
+
+* **Peak memory → OOM.** Linking the root crate's (instrumented) test binary OOM-kills — the
+  `Code Coverage` job exits-143 every run, and the unit-test job needs `CARGO_BUILD_JOBS=1` +
+  `--test-threads=2` to survive the compile peak (per the parent plan).
+* **Forced serial build.** `CARGO_BUILD_JOBS=1` means no intra-crate parallelism. The build is
+  *serial* because parallel compilation blows the memory budget — not because the machine lacks
+  cores.
+
+Decomposition is the **unifying lever**: splitting `src/` into workspace crates lets cargo build
+them **in parallel** *and* shrinks each crate's peak memory so `BUILD_JOBS` can rise 1→N. That is
+a multiplicative speedup, not incremental — and it directly removes the `BUILD_JOBS=1` tax.
+
+== Measured monolith split (where the compile weight lives)
+
+[cols="2,1,1",options="header"]
+|===
+| Area | Files | Symbols
+| **`src/` (root crate)** | 1,382 | **849,992**
+| `crates/` (extracted) | 468 | 254,917
+| `clients/` (SDKs) | 467 | 181,955
+| other (tests/benches/demo) | 631 | 210,603
+|===
+
+Within `src/`, one subsystem dominates:
+
+[cols="2,1,1",options="header"]
+|===
+| `src/` subsystem | Files | Symbols
+| **`storage`** | **453** | **286,640 (34% of `src/`)**
+| `query` | 125 | 87,140
+| `network` | 114 | 77,845
+| `services` | 67 | 51,786
+| `index` | 81 | 48,246
+| `graph` | 63 | 40,719
+| `core` | 93 | 37,383
+| `observability` | 49 | 26,342
+| `compute` | 44 | 25,863
+| `catalog` / `cluster` / `cdc` | 29 / 19 / 31 | 21,370 / 17,791 / 16,479
+|===
+
+`storage` is **~3× larger than the next subsystem** and the single biggest compile chunk — the
+highest-ROI extraction target. (It is already partly extracted to `crates/storage/*`; the bulk
+remains in `src/storage`.)
+
+== Lever 1 — extract `src/storage` first (parallel build + memory win)
+
+Pulling storage's 287K symbols out of the root unit removes the dominant compile weight, lets it
+build in parallel with the rest, and shrinks peak memory (the OOM driver).
+
+**Blocker — storage is full of coupling cycles** that resist clean extraction (Ca = afferent,
+Ce = efferent; both high ⇄ can't be carved into separate crates without severing the cycle):
+
+[cols="2,1,1,1",options="header"]
+|===
+| Storage cycle-tangle file | Ca | Ce | syms
+| `storage/engines/raptor/common.rs` | 126 | 24 | 1,440
+| `storage/persistence/write_ahead_log/serialization/mod.rs` | 123 | 16 | 168
+| `storage/engines/sst/object_economy_directory.rs` | 82 | 44 | 1,601
+| `storage/persistence/filesystem/local.rs` | 69 | 42 | 2,232
+| `storage/engines/viper/engine.rs` | 35 | 92 | 2,844
+| `storage/engines/swift/engine.rs` | 34 | 89 | 1,825
+| `storage/engines/raptor/engine.rs` | 33 | 80 | 2,876
+| `storage-common/mmap_file.rs` (crate) | 122 | 22 | 706
+|===
+
+[recommendation]
+**Action (prerequisite):** invert these cycles behind **port traits** (the Slice-D
+`QuantizationEnginePort` pattern, `ROOT_CRATE_DECOMPOSITION_SLICE_D_PORT_INVERSION_2026_06_26.adoc`)
+*before* attempting storage-crate extraction — otherwise the cycles block parallelization. Then
+extract storage's cohesive pieces (engines, persistence, WAL, formats) into crates that build in
+parallel.
+
+== Lever 2 — stabilize the build-cascade hubs (cheaper incremental CI)
+
+These modules have the highest afferent coupling (Ca = # dependents). Every PR that touches one
+recompiles hundreds of modules — the main amplifier of *incremental* CI cost:
+
+[cols="2,1,1,1",options="header"]
+|===
+| Hub | Ca | Ce | pagerank
+| `crates/control/proximadb-catalog/src/lib.rs` | **838** | 4 | 0.0175
+| `src/services/advisor_observations.rs` | **795** | 1 | 0.0171
+| `src/core/metadata_types.rs` | **379** | 5 | 0.0044
+| `src/core/serialization/fixed_length.rs` | 45 | 14 | 0.0057
+|===
+
+[recommendation]
+**Action:** freeze these APIs behind stable crate boundaries (frozen types/ports). Catalog is
+already a crate — the issue is its 838 dependents recompile on any API change; API stability +
+cargo fingerprint hygiene means internal changes stop cascading. `advisor_observations` (795
+dependents on a 256-symbol file) and `metadata_types` (379) are widely-included types that should
+be pinned as stable seams (cf. CLAUDE.md "stable seams not internal paths").
+
+== Lever 3 — split the god-files (smaller per-touch recompile)
+
+The largest compile units — big files mean a larger MIR/type-check surface and a bigger
+incremental recompile per touch:
+
+[cols="2,1",options="header"]
+|===
+| God-file | Symbols
+| `services/dml/mod.rs` | 10,656
+| `network/postgres/protocol.rs` | 7,710
+| `storage/.../block_structures.rs` | 6,326
+| `storage/.../sst_query_engine.rs` | 6,154
+| `index/axis/management/manager.rs` | 5,979
+| `query/federated/execution/mod.rs` | 5,725
+| `storage/.../raptor/writer.rs` | 5,434
+| `index/axis/indexes/dual_store_ivf.rs` | 5,066 (also a cycle hub, Ca=264)
+| `query/sql_frontend/parser.rs` | 4,880
+|===
+
+[recommendation]
+**Action:** responsibility-split these (the coupling reviews #864/#865/#867 already itemize the
+clusters for `dml`, `protocol`, etc.). Smaller files = smaller incremental rebuilds + better
+cache locality. Note: the embedded `mod tests` extraction (#871/#873/#874, ~11.4K lines) already
+removed the test weight from the worst offenders.
+
+== Lever 4 — proto v1 sunset (delete generated weight)
+
+`crates/foundation/proximadb-proto/src/proto/proximadb.v1.rs` is the **single largest file
+(13,088 symbols)**, purely generated. Retiring v1 (TD-V1SUNSET, in flight) deletes it outright —
+the cheapest "deletion" win in the compile budget.
+
+== Lever 5 — unit-test time
+
+* **nextest** process-parallelism: already on (the repo default).
+* **Embedded `mod tests` extraction:** done — ~11.4K lines moved out of the compile unit across
+  7 god-files (#871 `dml`, #873 `document/service`+`protocol`+`text_storage`, #874
+  `block_structures`+`arrow_ipc/service`).
+* Remaining: the next-largest test modules can be extracted the same way.
+
+== Recommended sequence (feeds the parent plan)
+
+. **Break storage cycles via port inversion** (Slice-D pattern) — prerequisite for Lever 1.
+  Targets: `raptor/common`, `viper/engine`, `swift/engine`, `sst/object_economy_directory`,
+  `WAL/serialization`, `filesystem/local`. (Lever 1)
+. **Extract `src/storage` into crates** (287K syms, 34% of the monolith) → biggest parallel +
+  memory win; unblocks raising `BUILD_JOBS`. (Lever 1)
+. **Stabilize the 3 hubs** (`catalog`, `advisor_observations`, `metadata_types`) behind frozen
+  APIs → cheaper incremental CI. (Lever 2)
+. **Split the god-files** per the coupling reviews. (Lever 3)
+. **Proto v1 sunset** (−13K generated syms). (Lever 4)
+
+Steps 1–2 are the structural move that removes the `BUILD_JOBS=1` throttle — the dominant CI
+cost. The coupling data (now complete, incl. storage) lets the extraction be ordered for maximum
+parallelization and minimum cycle-breaking work.
+
+== Reproducibility — key queries
+
+[source,sql]
+----
+-- monolith split
+SELECT CASE WHEN module_path LIKE 'src/%' THEN 'src/' WHEN module_path LIKE 'crates/%' THEN 'crates/'
+  ELSE 'other' END area, COUNT(*) files, SUM(symbol_count) syms
+FROM graph_module_metric GROUP BY area ORDER BY syms DESC;
+
+-- build-cascade hubs (top afferent coupling)
+SELECT module_path, afferent_coupling ca, efferent_coupling ce, pagerank_score
+FROM graph_module_metric ORDER BY pagerank_score DESC LIMIT 12;
+
+-- extraction-blocking cycles (high Ca AND Ce)
+SELECT module_path, afferent_coupling ca, efferent_coupling ce, symbol_count
+FROM graph_module_metric WHERE afferent_coupling>15 AND efferent_coupling>15
+ORDER BY (ca+ce) DESC LIMIT 15;
+----


### PR DESCRIPTION
CI-time companion to ROOT_CRATE_DECOMPOSITION_PLAN and the subsystem coupling reviews (#864/#865/#867). Uses the now-complete code graph (.victor/project.db, incl. `src/storage` after the victor exclude fix) to **prioritize decomposition for maximum CI speedup** — faster rebuilds, parallelization, lower memory.

**The bottleneck (quantified):** root crate `src/` = **850K symbols / 1,382 files in ONE compile unit** (~62% of repo) → peak-memory OOM → forced `CARGO_BUILD_JOBS=1` (serial). Decomposition is the unifying lever: parallel builds **and** lower per-crate memory → `BUILD_JOBS` 1→N (multiplicative).

**Ranked levers:**
1. **Extract `src/storage` first** — **287K symbols, 34% of the monolith, ~3× the next subsystem**. Biggest parallel+memory win. *Blocker:* storage is full of coupling cycles (`raptor/common` Ca126, `viper/engine` 35/92, `swift/engine` 34/89, `sst/object_economy_directory` 82/44, `WAL/serialization` 123, `filesystem/local` 69/42) → need **port inversion first** (Slice-D `QuantizationEnginePort` pattern).
2. **Stabilize the 3 build-cascade hubs** — `catalog` (Ca=838), `advisor_observations` (Ca=795), `metadata_types` (Ca=379) → freeze APIs to stop incremental-recompile cascades.
3. **Split god-files** — `dml/mod` 10.6K, `protocol.rs` 7.7K, `block_structures` 6.3K, `sst_query_engine` 6.2K, `raptor/writer` 5.4K.
4. **Proto v1 sunset** (−13K generated syms — largest single file).
5. **Tests** — nextest on; embedded `mod tests` extraction done (~11.4K lines, #871/#873/#874).

Repro queries in the doc.