### PR TITLE
docs(decomposition): storage extraction plan — graph-grounded up-edge severance (feeds ROOT_CRATE_DECOMPOSITION_PLAN)

### DIFF
--- a/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_EXTRACTION_PLAN_2026_07_11.adoc
+++ b/docs/12-design/ROOT_CRATE_DECOMPOSITION_STORAGE_EXTRACTION_PLAN_2026_07_11.adoc
@@ -1,0 +1,118 @@
+= Root-Crate Decomposition — Storage Extraction Plan (2026-07-11)
+:toc: macro
+:icons: font
+
+[abstract]
+Graph-grounded plan for severing `src/storage`'s outward coupling so it can be extracted into
+parallel workspace crates — the #1 CI lever from
+`ROOT_CRATE_DECOMPOSITION_CI_BUILD_OPTIMIZATION_2026_07_11.adoc` (#876: `src/storage` is 287K
+symbols, 34% of the root monolith). Complements Slice D (`StorageQuantizationEnginePort` D2b
+landed #845, which handles the *quantization* seam) and the parent plan's edge-class view by
+using the *comprehensive* code-graph coupling data to prioritize *all* storage up-edges.
+
+toc::[]
+
+== Two edge counts — both valid, different scope
+
+* **Layering-check ceiling (parent plan): 271 storage up-edges** (`compute` 239, `index` 12,
+  `query` 10, `services` 10) — from `scripts/check_workspace_boundaries.py`, the *enforced*
+  CI non-regression count. This is a **strict subset** (layer-crossing edges per the boundary
+  rules).
+* **Comprehensive graph count: ~4,500+ storage up-edges** — all `CALLS`/`IMPLEMENTS`/
+  `COMPOSITION`/`IMPORTS`/`INHERITS` from `src/storage/*` to non-storage targets in
+  `.victor/project.db`. This is the **full coupling picture** for prioritization.
+
+The graph count is larger because it includes every coupling edge, not just the
+boundary-violating subset. Use the **graph** to decide *what to sever*; the **layering-check**
+(271) is the ratchet that must reach 0 before storage crates can be extracted.
+
+== Storage up-edges — where the outward coupling concentrates (graph, top targets)
+
+[cols="2,1,1",options="header"]
+|===
+| Target (what storage depends on) | edges | class
+| `services/advisor_observations.rs` | **685** | type hub (Ca=795)
+| `index/axis/` cluster (eventlog_adapter 315, zero_overhead 233, compact 227, dual_store_ivf 182, geo/types 98) | **~1,055** | AXIS index
+| `infrastructure/concurrent_structures.rs` | **458** | infra primitives
+| `cdc/sinks/mod.rs` | 315 | cdc
+| `core/metadata_types.rs` | 245 | type hub (Ca=379)
+| `graph/engines/orion/storage.rs` | 227 | graph
+| `compute/proximacodec/` (registry 124, codec 65) | 189 | compute (quantization/codec — Slice D)
+| `datafusion/scan_executor.rs` | 104 | datafusion
+| `services/queue_fs_adapter.rs` | 101 | services
+| `streaming/metrics.rs`, `embedded/coordination/file_lock.rs` | 98 each | streaming/embedded
+| `observability/query/promql.rs` | 66 | observability
+| `automl/prediction.rs` | 56 | automl
+|===
+
+The coupling concentrates in **five clusters**: AXIS index (~1,055), the two **type hubs**
+(`advisor_observations` 685 + `metadata_types` 245 = 930), infrastructure (458), cdc (315), and
+graph (227). Notably the parent plan's "compute 239" is a smaller piece than the graph reveals —
+the dominant blockers are AXIS index and the type hubs.
+
+== Severance sequence (biggest, lowest-risk leverage first)
+
+=== 1. Stabilize the two type hubs (~930 edges) — do first
+`advisor_observations` (Ca=795) and `metadata_types` (Ca=379) are widely-included *types*
+storage depends on heavily (685 + 245 edges). Pinning them as **stable foundation-crate types**
+(frozen API, depended-upon by reference) severs ~930 storage up-edges at low risk — stabilizing
+a type is far cheaper than port-inverting behavior. This is the same work as CI Lever-2
+(build-cascade hub stabilization), so it pays back twice.
+
+=== 2. Extract `infrastructure/concurrent_structures` (458 edges)
+A self-contained concurrency-primitives module. Extract it to its own crate (or fold into an
+existing `horizontal` crate) so storage depends on a *crate*, not a root module — converting an
+up-edge to a clean crate dependency. Low coordination cost.
+
+=== 3. AXIS index (~1,055 edges) — the biggest cluster, needs `IndexPort`
+Storage reaches deep into AXIS (`zero_overhead_vector`, `compact_vector`, `dual_store_ivf`,
+`eventlog_adapter`, `geo/types`). Promote the AXIS *interfaces/types* storage needs behind an
+`IndexPort` (the parent plan already flags this as "high review cost"). Pre-extracting the leaked
+AXIS types into a foundation crate is the lower-risk first half; full port-inversion is the
+second.
+
+=== 4. Cross-subsystem ports: cdc (315), graph/orion (227)
+Define narrow ports (`CdcSinkPort`, the existing graph seam) so storage depends on traits, not
+concrete root modules. Moderate cost.
+
+=== 5. compute (~189) — Slice D (in progress)
+The `StorageQuantizationEnginePort` (D2b, #845) plus a `proximacodec` codec port cover this
+cluster. Already sequenced under Slice D — no new work here, just track it against this plan.
+
+== CI payoff (ties to #876)
+
+Each class severed drops the layering-check ceiling (271 → 0) and the comprehensive edge count.
+Reaching 0 up-edges is the gate for extracting storage's 287K symbols into crates that build
+**in parallel** and shrink peak memory — removing the `CARGO_BUILD_JOBS=1` throttle (the dominant
+CI cost). The type-hub stabilization (step 1) additionally cuts the build-cascade hubs, cheapening
+*every* incremental CI run, independent of storage extraction.
+
+== Recommended order
+
+. **Stabilize `advisor_observations` + `metadata_types`** as foundation types (~930 edges; dual
+  CI payoff). (Step 1)
+. **Extract `infrastructure/concurrent_structures`** to a crate (458 edges; low risk). (Step 2)
+. **AXIS `IndexPort`** — pre-extract leaked types, then port-invert (~1,055 edges; high cost).
+  (Step 3)
+. **cdc + graph ports** (542 edges). (Step 4)
+. **compute** — continue Slice D (189 edges; already in flight). (Step 5)
+
+Steps 1–2 are high-leverage and low-risk; step 3 is the big structural move that unblocks storage
+extraction.
+
+== Reproducibility — key query
+
+[source,sql]
+----
+-- storage up-edges (comprehensive): what src/storage depends on outside storage
+SELECT dn.file, COUNT(*) edges FROM graph_edge e
+  JOIN graph_node sn ON sn.node_id=e.src
+  JOIN graph_node dn ON dn.node_id=e.dst
+WHERE sn.file LIKE 'src/storage/%'
+  AND dn.file NOT LIKE 'src/storage/%' AND dn.file LIKE 'src/%'
+  AND e.type IN ('CALLS','IMPLEMENTS','COMPOSITION','IMPORTS','INHERITS')
+GROUP BY dn.file ORDER BY edges DESC LIMIT 18;
+
+-- enforced CI ceiling (different scope — strict layer-crossing subset):
+--   python3 scripts/check_workspace_boundaries.py --storage-up-edges
+----


### PR DESCRIPTION
Plan for severing `src/storage`'s outward coupling so it can be extracted into parallel workspace crates — the **#1 CI lever** from #876 (storage = 287K symbols, 34% of the root monolith). Complements Slice D (`StorageQuantizationEnginePort` D2b, #845) and the parent plan's edge-class view.

**Key insight (graph-grounded):** the comprehensive code-graph coupling data shows storage's up-edges concentrate in **5 clusters** the coarser “compute 239” categorization understated:
- **AXIS index ~1,055 edges** (`zero_overhead`/`compact_vector`, `dual_store_ivf`, `eventlog_adapter`, `geo`)
- **type hubs ~930**: `advisor_observations` (685, Ca=795) + `metadata_types` (245, Ca=379)
- **infrastructure/concurrent_structures** 458
- **cdc/sinks** 315
- **graph/orion** 227

Two edge counts, both valid: the **layering-check ceiling (271)** is the enforced CI ratchet; the **graph count (~4,500+)** is the full coupling picture for prioritization.

**Severance sequence (biggest, lowest-risk first):**
1. **Stabilize `advisor_observations` + `metadata_types`** as foundation types (~930 edges) — dual payoff (also the build-cascade hubs from #876).
2. **Extract `infrastructure/concurrent_structures`** to a crate (458; low risk).
3. **AXIS `IndexPort`** — pre-extract leaked types, then port-invert (~1,055; high cost).
4. **cdc + graph ports** (542).
5. **compute** — continue Slice D (189; in flight).

Reaching 0 up-edges gates storage's 287K-symbol extraction → parallel builds + removes the `CARGO_BUILD_JOBS=1` throttle (dominant CI cost). Repro query in the doc.