### PR TITLE
test(pgwire): ratchet native relational scan storage-inclusiveness + dead-filter (TD-REL-SCAN-1)

### DIFF
--- a/docs/10-quality/td/TD-REL-SCAN-1-relational-native-scan-storage-inclusive-correctness.adoc
+++ b/docs/10-quality/td/TD-REL-SCAN-1-relational-native-scan-storage-inclusive-correctness.adoc
@@ -1,0 +1,125 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-SCAN-1: Relational native (non-Parquet) scan is storage-inclusive & dead-filtered by construction — no merge needed
+
+[cols="1,3"]
+|===
+|Status|**Resolved — investigation only, no code change.** Traced the full pgwire SELECT path
+over a PAX/record-backed (non-Parquet) relational table and confirmed it can neither (a) miss live
+rows nor (b) return dead/tombstoned rows. The `documents()` storage-inclusive-merge concern
+(TD-DOC-PUSHDOWN-1 / invariant #16) does **not** translate to this path because the relational
+storage model is structurally different (single never-evicted authoritative tier, not
+flush-to-PAX-and-clear). A read-after-write + dead-record ratchet test over pgwire
+(`tests/pgwire_relational_native_read_after_write_e2e.rs`) locks the behavior in as a regression
+guard.
+|Priority|LOW (correctness confirmation + regression ratchet; no behavior change)
+|Scope|DOCS + TEST
+|Date|2026-07-11
+|Relates to|**TD-DOC-PUSHDOWN-1** (the document/vector storage-inclusive PAX merge that raised the
+shared concern); CLAUDE.md **Read/Write Correctness Invariants #16** (a: read boundary dead-filter;
+d: same-delta tombstone suppression); **TD-064** (structural per-(tenant, collection) partitioning);
+**ADR-031** (oid cutover, dual-read); ADR-025 (OLAP read-merge — the *Parquet/MATERIALIZE* sibling
+path, covered separately by `pgwire_olap_delta_merge_e2e`).
+|===
+
+== Question investigated
+
+The `documents()` adapter fix (TD-DOC-PUSHDOWN-1) established that a correct PAX read must merge the
+flushed-pruned segment scan with the raw unflushed WAL/memtable delta (including tombstones), dedup
+by `oid`, and apply the canonical `is_record_dead` pass. The open question: does the **general
+relational scan path** — a pgwire `SELECT` over a PAX/record-backed (non-Parquet) table — share the
+same correctness exposure? Specifically, can such a SELECT over a table with both unflushed and
+flushed rows either **(a) miss unflushed rows** or **(b) return dead/tombstoned rows**?
+
+Per the mandate, this was traced *before* assuming a gap. The conclusion is that **no gap exists**
+on this path, for the reasons below.
+
+== Path traced
+
+A pgwire SELECT over a non-Parquet relational table flows:
+
+* `src/network/postgres/relational_pipeline.rs` — `try_run_select` lowers the SELECT and routes via
+  `ComputeScheduler::route_select`.
+* `src/query/compute_scheduler.rs:376` — `route_select_inner`: a relational table that is **not**
+  Parquet-backed takes the **Native (Volcano)** backend (both the OLTP `(false, _)` and the
+  OLAP-on-native `(true, false)` arms; the PAX→DataFusion arm is flag-gated `pax_reader_enabled()`,
+  default OFF). It never silently reaches DataFusion.
+* `src/services/dml/mod.rs:1287` — `scan_table_relational` wraps the caller's row predicate and calls
+  `record_store.scan_records_filtered(filter: None, predicate: Some(..))`.
+* `src/services/record_store.rs:161` — `TableRecordStoreRoute::for_schema`: a relational
+  workload/`GenericRelational` storage specialization routes to `ParquetIcebergStorage`, i.e. the
+  router's `iceberg_store` slot.
+* `src/services/dml/mod.rs:853` — production pgwire wiring (`with_direct_record_storage`, selected in
+  `src/network/shared_services.rs:2123`; `enable_direct_record_writes` defaults to **true**) binds
+  that slot to the shared **`DirectWalTableRecordStore`** (`canonical_store`), NOT an Iceberg/Parquet
+  engine. The route *name* is aspirational; the MVP target is the WAL-backed direct store.
+* `src/services/record_store.rs:2055` — `DirectWalTableRecordStore::scan_records_filtered` reads the
+  per-(tenant, collection) `MemtableRecordStorage` partition(s) via `RecordStorageTableRecordStore`
+  (dual-reading the legacy name-keyed partition only during the ADR-031 O3 oid cutover window, merged
+  `merge_scan_primary_wins`).
+* `src/services/record_memtable.rs:117` — `MemtableRecordStorage::scan_records_filtered` iterates the
+  `DashMap` applying `options.matches_record(record) && predicate`.
+
+== Why (a) "miss unflushed rows" is structurally impossible here
+
+The relational `DirectWalTableRecordStore` holds a **single authoritative in-memory tier**
+(`MemtableRecordStorage`) per (tenant, collection). It is:
+
+* **WAL-durable** — every mutation is appended to the canonical WAL first
+  (`record_store.rs:1925`), and the partition is rebuilt from the WAL on restart
+  (`multi_server.rs:356`, `replay_wal_entries`).
+* **Never flushed to a separate PAX tier and never evicted.** `src/services/record_memtable.rs`
+  header: _"Durability remains in the canonical WAL; this structure is rebuildable from Layer 0
+  entries and must not grow independent persistence."_ A repo-wide search finds **no** flush / evict
+  / clear / compact / checkpoint path that moves relational memtable partitions to PAX and drops them
+  from the read tier.
+
+Therefore there is **no "flushed" relational tier for the reader to miss** — every live row for the
+table's lifetime is resident in the memtable the scan reads. This is precisely where the relational
+path *differs* from `documents()`/vector collections: those read from
+`ObjectStoreVectorRecordStore` (flushed-pruned PAX) **plus** a separate raw unflushed WAL delta, so a
+memtable→PAX flush-and-clear makes a memtable-only read incomplete — hence TD-DOC-PUSHDOWN-1's
+explicit merge. The relational native path has one tier, so the merge is a no-op.
+
+== Why (b) "return dead/tombstoned rows" cannot happen here
+
+Two independent, defense-in-depth reasons:
+
+1. **DELETE physically removes; the memtable never tombstones.**
+   `DirectWalTableRecordStore::write_mutations` maps `Delete` to
+   `partition.delete_record(&key)` (`record_store.rs:1976`), and
+   `MemtableRecordStorage::delete_record` is a `DashMap::remove` (`record_memtable.rs:82`). The
+   inline invariant is explicit: _"memtable deletes don't tombstone"_ (`record_store.rs:1835`). So an
+   insert-then-delete-before-anything leaves no live copy beside a tombstone — invariant **#16d** holds
+   trivially.
+
+2. **Every scan applies the canonical dead-record filter.** Both memtable scan entrypoints
+   (`scan_records_with_options`, `scan_records_filtered`) gate each row on
+   `RecordScanOptions::matches_record` (`crates/foundation/proximadb-records/src/store.rs:125`), which
+   calls `ProximaRecord::is_visible_at(now_ns)` and drops a tombstone (`valid_to_ns == Some(0)`) or a
+   TTL-expired row (`valid_to_ns` in the past) — the canonical predicate, on `valid_to_ns` (ns), never
+   the unit-muddled `expires_at`. So even a tombstone/TTL row reaching the memtable via an upsert is
+   filtered at read — invariant **#16a** holds.
+
+== Decision
+
+No change to the relational scan path. Filing this TD (per the "verify the gap exists, then fix, else
+document why not" mandate) plus a ratchet test:
+
+`tests/pgwire_relational_native_read_after_write_e2e.rs` — over a **non-materialized** (native
+DirectWal) relational table via real pgwire: inserts N rows and asserts read-after-write completeness
+(no live row missed — ratchets (a)); deletes a subset and asserts the deleted ids are invisible while
+survivors remain (delete visibility / dead-filter — ratchets (b) and #16a/#16d); updates a row and
+re-inserts a previously-deleted id to prove no tombstone resurrection. Complements the existing
+`pgwire_olap_delta_merge_e2e` (which covers the *Parquet/MATERIALIZE* OLAP read-merge sibling path).
+
+== Non-goals / adjacent paths (unchanged)
+
+* The **Parquet/MATERIALIZE OLAP** path (ADR-025 delta-merge) is a *different* reader and is already
+  ratcheted by `pgwire_olap_delta_merge_e2e`.
+* The **PAX→DataFusion** analytical reader (`route_select_inner` `(true, false)` +
+  `pax_reader_enabled()`, TD-OLAP-1/ADR-052) is flag-gated default-OFF and is not the subject here.
+* `MemtableRecordStorage::get_record` (point get-by-key) is not `matches_record`-filtered, but the
+  memtable never holds a tombstone (reason 1), so a get cannot return a deleted row; a TTL-expired
+  point-get is a narrow, separate concern outside relational scan and not exercised by pgwire
+  relational INSERT (no TTL surface). Left as-is.

--- a/tests/pgwire_relational_native_read_after_write_e2e.rs
+++ b/tests/pgwire_relational_native_read_after_write_e2e.rs
@@ -1,0 +1,301 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native (non-Parquet) relational scan — read-after-write & dead-record ratchet
+//! (TD-REL-SCAN-1).
+//!
+//! Exercises the production native relational read path end-to-end through the
+//! PostgreSQL wire protocol, never bypassing pgwire or the engine selector. The
+//! table is **never** `MATERIALIZE`d, so it stays PAX/record-backed
+//! (non-Parquet): SELECTs route via `ComputeScheduler::route_select` to the
+//! **Native (Volcano)** backend →
+//! `DmlService::scan_table_relational` →
+//! `DirectWalTableRecordStore` → the per-(tenant, collection)
+//! `MemtableRecordStorage` partition (`enable_direct_record_writes` defaults ON).
+//!
+//! This locks in the TD-REL-SCAN-1 conclusion that the relational native scan is
+//! storage-inclusive and dead-filtered *by construction* (single never-evicted
+//! authoritative tier + `matches_record`/`is_visible_at` dead filter + physical
+//! memtable DELETE), so it can neither (a) miss a live row nor (b) return a
+//! dead/tombstoned row. It is the native sibling of `pgwire_olap_delta_merge_e2e`
+//! (which covers the Parquet/MATERIALIZE OLAP read-merge instead).
+//!
+//! Run with the real server-side cause behind any opaque pgwire `db error`:
+//!   RUST_LOG=proximadb=debug cargo nextest run \
+//!     --test pgwire_relational_native_read_after_write_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::{Client, SimpleQueryMessage};
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Render a tokio_postgres error including the real server-side DbError cause.
+fn explain_err(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("[{}] {}", db.code().code(), db.message())
+    } else {
+        e.to_string()
+    }
+}
+
+async fn exec(client: &Client, sql: &str) {
+    client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("exec `{sql}`: {}", explain_err(&e)));
+}
+
+/// Run a single-cell scalar SELECT and return the one cell as text.
+async fn scalar(client: &Client, sql: &str) -> String {
+    let messages = client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)));
+    for m in &messages {
+        if let SimpleQueryMessage::Row(r) = m {
+            return r
+                .get(0)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "NULL".to_string());
+        }
+    }
+    panic!("query `{sql}` returned no row");
+}
+
+fn num(s: &str) -> i64 {
+    s.parse::<i64>()
+        .unwrap_or_else(|_| panic!("expected integer scalar, got `{s}`"))
+}
+
+/// Collect the first column of every returned row as i64 (simple-query renders
+/// each cell as text). Used to enumerate the surviving `id`s of a scan.
+async fn column_i64(client: &Client, sql: &str) -> Vec<i64> {
+    let messages = client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("query `{sql}`: {}", explain_err(&e)));
+    let mut out = Vec::new();
+    for m in &messages {
+        if let SimpleQueryMessage::Row(r) = m
+            && let Some(cell) = r.get(0)
+        {
+            out.push(
+                cell.parse::<i64>()
+                    .unwrap_or_else(|_| panic!("non-integer id cell `{cell}` from `{sql}`")),
+            );
+        }
+    }
+    out
+}
+
+/// A native (non-materialized) relational table over pgwire must (a) return
+/// EVERY inserted live row — no row "missed" — and (b) never surface a deleted
+/// row, while (c) reflecting updates and (d) allowing a previously-deleted key to
+/// be re-inserted (no tombstone resurrection). All SELECTs are aggregate/ordered
+/// shapes that engage the relational engine → `scan_table_relational` → the
+/// DirectWal memtable scan under test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn native_relational_scan_read_after_write_and_dead_filter() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    // Unique table name so parallel/repeat runs never collide in the catalog.
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let t = format!("rel_raw_{suffix}");
+
+    exec(
+        &client,
+        &format!("CREATE TABLE {t} (id INT PRIMARY KEY, v INT)"),
+    )
+    .await;
+    // NOTE: intentionally NO `ALTER TABLE ... MATERIALIZE` — the table stays
+    // PAX/record-backed (non-Parquet), so reads take the native DirectWal path.
+
+    // --- (a) Read-after-write completeness: insert N rows, expect ALL back. ---
+    // N=64 is comfortably larger than any single-batch boundary, so a "flushed
+    // rows dropped" bug (the documents() failure mode) would surface as a short
+    // COUNT/SUM here. v = id * 10 gives a known closed-form sum.
+    const N: i64 = 64;
+    for id in 1..=N {
+        exec(
+            &client,
+            &format!("INSERT INTO {t} (id, v) VALUES ({id}, {})", id * 10),
+        )
+        .await;
+    }
+    let expected_sum_all: i64 = (1..=N).map(|id| id * 10).sum();
+    assert_eq!(
+        num(&scalar(&client, &format!("SELECT COUNT(*) FROM {t}")).await),
+        N,
+        "read-after-write: every inserted live row must be scanned (none missed)"
+    );
+    assert_eq!(
+        num(&scalar(&client, &format!("SELECT SUM(v) FROM {t}")).await),
+        expected_sum_all,
+        "read-after-write: SUM over all live rows"
+    );
+    let all_ids = column_i64(
+        &client,
+        &format!("SELECT id FROM {t} GROUP BY id ORDER BY id ASC"),
+    )
+    .await;
+    assert_eq!(
+        all_ids,
+        (1..=N).collect::<Vec<_>>(),
+        "read-after-write: ordered enumeration returns exactly the inserted ids"
+    );
+
+    // --- (b) Delete visibility / dead-record filter: drop the upper half. ---
+    // Range predicate (not modulo — the relational frontend doesn't parse `%`).
+    const CUT: i64 = 32;
+    exec(&client, &format!("DELETE FROM {t} WHERE id > {CUT}")).await;
+    let surviving: Vec<i64> = (1..=CUT).collect();
+    let expected_sum_surviving: i64 = surviving.iter().map(|id| id * 10).sum();
+    assert_eq!(
+        num(&scalar(&client, &format!("SELECT COUNT(*) FROM {t}")).await),
+        surviving.len() as i64,
+        "delete: deleted rows must be invisible to the scan (no tombstone leak)"
+    );
+    assert_eq!(
+        num(&scalar(&client, &format!("SELECT SUM(v) FROM {t}")).await),
+        expected_sum_surviving,
+        "delete: SUM must exclude deleted rows"
+    );
+    let after_delete = column_i64(
+        &client,
+        &format!("SELECT id FROM {t} GROUP BY id ORDER BY id ASC"),
+    )
+    .await;
+    assert_eq!(
+        after_delete, surviving,
+        "delete: exactly the surviving ids (1..={CUT}) remain — no deleted id resurfaces, none dropped"
+    );
+
+    // --- (c) Update reflected on the very next read (write invalidates cache). ---
+    // Bump id=1 from v=10 to v=1000; SUM shifts by exactly +990.
+    exec(&client, &format!("UPDATE {t} SET v = 1000 WHERE id = 1")).await;
+    assert_eq!(
+        num(&scalar(&client, &format!("SELECT SUM(v) FROM {t}")).await),
+        expected_sum_surviving + 990,
+        "update: the new value is visible on the next read"
+    );
+
+    // --- (d) No tombstone resurrection: re-insert a previously-deleted key. ---
+    // id=50 was deleted (physical memtable remove); re-inserting must succeed and
+    // reappear with its NEW value — never a stale/tombstoned copy.
+    let reinserted = CUT + 18; // 50 — was in the deleted upper half
+    exec(
+        &client,
+        &format!("INSERT INTO {t} (id, v) VALUES ({reinserted}, 22)"),
+    )
+    .await;
+    let final_ids = column_i64(
+        &client,
+        &format!("SELECT id FROM {t} GROUP BY id ORDER BY id ASC"),
+    )
+    .await;
+    let mut expect_final = surviving.clone();
+    expect_final.push(reinserted);
+    expect_final.sort_unstable();
+    assert_eq!(
+        final_ids, expect_final,
+        "re-insert of a deleted key must reappear exactly once (no tombstone resurrection)"
+    );
+    assert_eq!(
+        num(&scalar(
+            &client,
+            &format!("SELECT v FROM {t} WHERE id = {reinserted}")
+        )
+        .await),
+        22,
+        "re-inserted key carries its new value"
+    );
+}


### PR DESCRIPTION
## Summary

Investigation-first task: does the general **PAX/record-backed (non-Parquet) relational SELECT** path share the flushed+unflushed / dead-record correctness exposure that the `documents()` adapter fixed (TD-DOC-PUSHDOWN-1, invariant #16)?

**Conclusion: no gap — the path is correct by construction.** This PR delivers the investigation record (a TD) plus an end-to-end ratchet test that locks the behavior in. No production behavior change.

## What was traced

pgwire `SELECT` → `ComputeScheduler::route_select` (`compute_scheduler.rs:376`; non-Parquet relational → **Native/Volcano**) → `DmlService::scan_table_relational` (`dml/mod.rs:1287`) → `CatalogRoutingTableRecordStore` → **`DirectWalTableRecordStore`** (`record_store.rs:2055`; the production `canonical_store`, `enable_direct_record_writes` defaults ON) → `MemtableRecordStorage` (`record_memtable.rs:117`).

### Why concern (a) "miss unflushed rows" can't happen
The relational store is a **single, WAL-durable, never-evicted in-memory tier** per (tenant, collection) — rebuilt from the canonical WAL on restart, with **no flush-to-PAX-and-clear** anywhere (repo-wide search: no flush/evict/clear/compact of these partitions). So a memtable-only read is complete. This is exactly where relational differs from `documents()`/vector collections (which read flushed-pruned PAX **+** a separate unflushed WAL delta and therefore need the explicit merge).

### Why concern (b) "return dead/tombstoned rows" can't happen
1. DELETE **physically removes** from the memtable (`record_store.rs:1976` → `DashMap::remove`); the invariant is explicit: *"memtable deletes don't tombstone"* (`record_store.rs:1835`). Invariant #16d holds trivially.
2. Every scan gates rows on `RecordScanOptions::matches_record` → `ProximaRecord::is_visible_at(now_ns)` (`records/store.rs:125`), which drops tombstones (`valid_to_ns==Some(0)`) and TTL-expired rows. Invariant #16a holds.

## Deliverables
- **`TD-REL-SCAN-1`** — documents the trace and why no storage-inclusive merge is needed (Resolved / no code change).
- **`pgwire_relational_native_read_after_write_e2e`** — real server + pgwire over a **non-materialized** native table: read-after-write completeness (64 rows, none missed), delete visibility (deleted ids invisible, survivors intact), update visibility, and no-tombstone-resurrection on re-insert of a deleted key. Complements the existing `pgwire_olap_delta_merge_e2e` (the Parquet/MATERIALIZE sibling path).

## Verification
- `cargo nextest run --test pgwire_relational_native_read_after_write_e2e` → **1 passed**
- `cargo fmt --check` clean; `scripts/check_td_adr_unique.py` → 0 errors