### PR TITLE
docs(td): TD-OLAP-16 — catalog location model (first-principles + 3 bugs)

### DIFF
--- a/docs/10-quality/td/TD-OLAP-16-catalog-location-model-first-principles.adoc
+++ b/docs/10-quality/td/TD-OLAP-16-catalog-location-model-first-principles.adoc
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-16: Catalog location model — first-principles (Hive/Unity/Polaris) + the dual-registration + stale-metadata bugs
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Open — fixes landed in PR #872; follow-ons (default-location, partitions, HLL NDV) pending.** The catalog `location` API was reviewed + fixed from first principles (Hive Metastore / Unity Catalog / Polaris / Horizon model) during the ADR-059 DuckDB engine work. Three bugs were found + fixed: (1) `primary_layout` returned the stale original layout (not the materialized Parquet layout), (2) `cataloged_tables` dedup preferred the stale `public.` catalog (not the updated `proximadb.` catalog), (3) `metadata_url` defaulted to a fixed relative path (`file://./metadata`) that persisted stale tables across test runs.
+| Priority | **P1** — the catalog `location` is the system of record for table storage; a wrong location breaks BOTH correctness (wrong data read) + perf (wrong scan path). The bugs caused the in-process DuckDB TPC route to fail (ok 0/22) until fixed.
+| Component | `src/services/catalog_introspection.rs` (primary_layout, cataloged_tables dedup, table_routing location column), `src/services/dml/mod.rs` (materialize location), `src/datafusion/engine_adapters/object_store_parquet_reader.rs` (DF reader scan path), `src/core/config.rs` (metadata_url default).
+| Governs | ADR-059 (the DuckDB engine reads the SAME parquet via the catalog location), ADR-052 (the scan path is the bytes-scanned cost term), the co-design mandate §3 (the boundary is the contract — `TenantContext` + `DrPathBuilder`; the location is the reader's contract).
+| Relates to | link:../../10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2] (the NDV fix — A1 proxy reverted, A2 HLL pending), link:../../10-quality/td/TD-OLAP-15-native-engine-measured-posture-sf001.adoc[TD-OLAP-15] (the measured posture), link:../../12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc[ADR-059].
+|===
+
+== The first-principles model (Hive/Unity/Polaris)
+
+The catalog `storage_layout.location` should be the **table's base directory** where parquet files are **immediate children** (Hive Metastore / Unity Catalog / Polaris / Horizon model):
+- The reader scans **immediate** parquet files (`.parquet` extension filter skips commit files `_SUCCESS`/`.crc`/`__`).
+- If blank → consult the database/catalog default location (follow-on — not yet implemented).
+- If partitioned → `colname=value/` subdirectories (follow-on — `CatalogPartitionSpec` exists, impl stubbed).
+
+== Bug 1: `primary_layout` returned the stale original layout
+
+**File:** `src/services/catalog_introspection.rs:1249`
+
+`primary_layout` returned the layout named `"primary"` or the first layout — NOT the materialized Parquet layout (named `"parquet-snapshot"`). The materialize (`dml/mod.rs:1527`) calls `set_storage_layouts(vec![layout])` which REPLACES the layouts, but the introspection's `primary_layout` didn't prefer the Parquet layout.
+
+**Fix:** `primary_layout` now prefers `physical_format == Parquet` (the materialized layout) as the primary sort key, with `"primary"` name as a tiebreaker.
+
+== Bug 2: `cataloged_tables` dedup preferred the stale `public.` catalog
+
+**File:** `src/services/catalog_introspection.rs:1198`
+
+Tables are dual-registered: `proximadb.<ns>.<table>` (internal) + `public.<table>` (SQL-standard). `set_storage_layouts` (materialize) updates ONLY the internal `proximadb.` catalog (via `resolve_table_scoped`). The dedup sorted `proximadb.` last + kept the first (`public.`) — which had the STALE layout (original location, not the materialized data dir).
+
+**Fix:** the dedup now sorts by `(!has_parquet, is_proximadb)` — Parquet layouts (materialized) first, then non-proximadb (SQL-standard) as a tiebreaker. The catalog with the materialized Parquet layout (the CURRENT storage state) wins.
+
+== Bug 3: `metadata_url` defaulted to a fixed relative path
+
+**File:** `src/core/config.rs:549`
+
+The default `metadata_url = "file://./metadata"` is a FIXED relative path. The native catalog persists to this path across test runs — stale tables (with old tempdir locations) survive. The test's `PgServer::start()` used `Config::default()` → the catalog was NOT fresh per test run.
+
+**Fix:** the test sets `config.storage.metadata_url = format!("file://{}/metadata", tmp.path().display())` — the catalog is per-tempdir (fresh per test run). The default `file://./metadata` should be changed to derive from `data_dir` (follow-on — affects production).
+
+== The materialize location (first-principles)
+
+**File:** `src/services/dml/mod.rs:1513`
+
+The materialize sets `location = {warehouse_root}/{prefix}/data` — the directory where parquet files are **immediate children** (not the table base dir with a `data/` subpath). The parquet is written to `{prefix}/data/part-0.parquet` (line 1503), so the location = the data dir. The reader scans `{location}` immediate (DuckDB: `read_parquet('{location}')`; DF: `list_objects("")` + fallback to `list_objects("data")` for old tables).
+
+== The NDV status (A1 reverted, A2 pending)
+
+The `num_rows`-as-NDV proxy (A1) was tried + reverted — it overestimates NDV for low-cardinality columns (e.g., `l_returnflag` NDV=2 → proxy=60K) → DataFusion's optimizer chooses a bad join plan (exploding intermediate → stuck at SF=0.01). The proper fix is **A2 (HLL during materialize)** — compute per-column HLL sketches from the materialized records → store in the ADR-037 registry → `statistics_from_splits` overlays real NDV. See link:../../10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2].
+
+== Follow-ons (not blocking)
+
+1. **Default-location resolution** — blank `location` → `{warehouse_root}/{database}/{table}/` (like Hive's `hive.metastore.warehouse.dir`).
+2. **`metadata_url` default fix** — change the default from `file://./metadata` to `{data_dir}/metadata` (affects production, not just tests).
+3. **Partitioned layouts** — `colname=value/` subdirs (`CatalogPartitionSpec` exists, impl stubbed).
+4. **Explicit commit-file skipping** — the `.parquet` extension filter works, but explicit `_`/`.` skip is more robust.
+5. **ClickBench harness `metadata_url`** — same stale `./metadata` issue (the ClickBench test also uses `Config::default()`).


### PR DESCRIPTION
Doc-only. Records the catalog location model review (Hive/Unity/Polaris) + 3 bugs found + fixed in PR #872: (1) primary_layout returned stale layout, (2) cataloged_tables dedup preferred stale public. catalog, (3) metadata_url defaulted to fixed ./metadata (stale across test runs). Plus the NDV status (A1 proxy reverted, A2 HLL pending).