### PR TITLE
test(datafusion): direct A/B parity gate for documents() PAX pushdown; resolve TD-DOC-PUSHDOWN-1

### DIFF
--- a/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
+++ b/docs/10-quality/td/TD-DOC-PUSHDOWN-1-document-predicate-pushdown-over-pax.adoc
@@ -4,8 +4,8 @@
 
 [cols="1,3"]
 |===
-|Status|In progress — **Reader ranged read (Layer 1 + Layer 2) LANDED; documents adapter now IMPLEMENTED**
-(the correct storage-inclusive merge — `DocumentPaxPushdownProvider`, see "Design (implemented)" below).
+|Status|Done — adapter landed in #868 (a9410ed83); all gates (read-after-write, dead/tombstone,
+dedup-freshest, shredded-typed, measured byte gate) pass.
 Owning
 the reader (rather than waiting on the OLAP workstream) is done. **Layer 1** — `PaxSplitReader`
 fetches a segment via ranged reads: locate the index from a tail suffix → **Stage A** prunes whole

--- a/src/datafusion/document_pax_provider.rs
+++ b/src/datafusion/document_pax_provider.rs
@@ -816,6 +816,143 @@ mod tests {
         );
     }
 
+    /// A `DocumentScanPort` serving a fixed record set through the EXACT transform the production
+    /// `DocumentServiceScan` applies after `query_documents` (dead-filter, canonical document
+    /// rebuild, `proxima_tree_to_json_map` → JSON string) — the MemTable-path A/B twin of
+    /// `FakeRoute::unflushed_records` over the same `Vec<ProximaRecord>`.
+    struct RecordSetScan {
+        records: Vec<ProximaRecord>,
+    }
+
+    #[async_trait]
+    impl crate::datafusion::cross_modal::DocumentScanPort for RecordSetScan {
+        async fn scan(
+            &self,
+            _tenant: &str,
+            _collection: &str,
+        ) -> anyhow::Result<Vec<(String, String)>> {
+            let now_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+            Ok(self
+                .records
+                .iter()
+                .filter(|r| !is_record_dead(r.valid_to_ns, now_ns))
+                .filter_map(
+                    crate::storage::document::canonical_adapter::proxima_record_to_legacy_document,
+                )
+                .map(|doc| {
+                    let json = serde_json::Value::Object(
+                        crate::core::search::sql_value_filter::proxima_tree_to_json_map(&doc.props)
+                            .into_iter()
+                            .collect(),
+                    );
+                    (doc.id, serde_json::to_string(&json).unwrap_or_default())
+                })
+                .collect())
+        }
+    }
+
+    /// Collect the full `(id, props)` projection of a provider, in id order.
+    async fn id_props(provider: Arc<dyn TableProvider>) -> Vec<(String, String)> {
+        let ctx = SessionContext::new();
+        ctx.register_table("documents", provider).unwrap();
+        let batches = ctx
+            .sql("SELECT id, props FROM documents ORDER BY id")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        for b in &batches {
+            let ids = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("id column");
+            let props = b
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("props column");
+            for i in 0..b.num_rows() {
+                out.push((ids.value(i).to_string(), props.value(i).to_string()));
+            }
+        }
+        out
+    }
+
+    /// A/B parity gate — the pushdown provider's `(id, props)` output is byte-identical to the
+    /// existing MemTable path (`DocumentTableProvider` over a `DocumentScanPort`, ADR-055
+    /// P-DFSource) on the SAME record set, running the same
+    /// `SELECT id, props FROM documents ORDER BY id` through BOTH providers end-to-end. This is
+    /// the literal side-by-side proof of the "results identical to the MemTable path" claim, not
+    /// shared-transform inference — including agreement on what is EXCLUDED (TTL-expired,
+    /// tombstoned).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pushdown_output_is_byte_identical_to_memtable_path() {
+        let records = vec![
+            doc(
+                "d1",
+                "docs",
+                &[
+                    ("region", ProximaValue::String("US".into())),
+                    ("amount", ProximaValue::Int64(100)),
+                    ("active", ProximaValue::Boolean(true)),
+                ],
+                10,
+                None,
+            ),
+            doc(
+                "d2",
+                "docs",
+                &[
+                    ("region", ProximaValue::String("EU".into())),
+                    ("score", ProximaValue::Float64(2.5)),
+                ],
+                20,
+                None,
+            ),
+            doc(
+                "d3",
+                "docs",
+                &[("note", ProximaValue::String("unicode ✓ \"quoted\"".into()))],
+                30,
+                None,
+            ),
+            // Both paths must also agree on exclusions: TTL-expired + tombstone.
+            doc(
+                "expired",
+                "docs",
+                &[("region", ProximaValue::String("US".into()))],
+                10,
+                Some(1),
+            ),
+            tombstone("gone", 40),
+        ];
+
+        let pushdown = provider_with(records.clone()).await;
+        let memtable = crate::datafusion::cross_modal::DocumentTableProvider::new(
+            Arc::new(RecordSetScan { records }),
+            proximadb_tenant::DEFAULT_TENANT,
+            "docs",
+        );
+
+        let a = id_props(Arc::new(pushdown)).await;
+        let b = id_props(Arc::new(memtable)).await;
+        assert_eq!(
+            a.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>(),
+            vec!["d1", "d2", "d3"],
+            "live rows only, in id order"
+        );
+        assert_eq!(
+            a, b,
+            "pushdown (id, props) must be byte-identical to the MemTable path"
+        );
+    }
+
     /// Gate 4 — the measured pushdown byte gate (ADR-052 invariant 4). A real multi-block PAX
     /// segment with a shredded `amount` column is scanned through the provider under
     /// `PROXIMADB_DF_PAX_RANGED`; a selective `amount >= N` predicate must (a) issue ranged GETs


### PR DESCRIPTION
## Summary

Follow-up to #868 (TD-DOC-PUSHDOWN-1 adapter), bundled per the PR-sizing mandate:

1. **Direct A/B parity test** (`src/datafusion/document_pax_provider.rs`): the same fixed record set (live docs with string/int/float/bool fields + a TTL-expired doc + a tombstone) is run through BOTH providers with the same `SELECT id, props FROM documents ORDER BY id`:
   - `DocumentPaxPushdownProvider` via the `FakeRoute` unflushed path (no flushed segments needed), and
   - the existing `(id, props)` MemTable path (`DocumentTableProvider` over a `DocumentScanPort` applying the exact production `DocumentServiceScan` transform — dead-filter, canonical document rebuild, `proxima_tree_to_json_map` → JSON string).

   The test asserts the id+props columns are **byte-identical**, including agreement on exclusions (expired + tombstoned absent on both sides). This hardens the "results identical to the MemTable path" gate with a literal side-by-side test rather than shared-transform inference.

2. **TD-DOC-PUSHDOWN-1 → Done**: status flipped to "Done — adapter landed in #868 (a9410ed83); all gates (read-after-write, dead/tombstone, dedup-freshest, shredded-typed, measured byte gate) pass." Resolution section kept as-is.

## Verification

- `cargo nextest run --lib document_pax_provider`: 6/6 pass (incl. the new parity test), re-verified after rebasing onto develop head `322c74d23` (#880/#851 — no file overlap).
- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings`: clean.
- `make work-commit-check`: all deterministic guards pass.
- `scripts/check_td_adr_unique.py`: 0 errors (15 pre-existing README-index warnings).
- `scripts/check_no_agent_attribution.py --range origin/develop..HEAD`: clean.