### PR TITLE
ci(qa-gate): bump cloud-emulator build to CARGO_BUILD_JOBS=2 to fit the 60m budget

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -196,9 +196,11 @@ jobs:
   cloud-emulator-object-store:
     name: Cloud object-store emulators (Azurite/MinIO/fake-gcs)
     runs-on: ubuntu-latest
-    # The --all scope compiles the full main crate under CARGO_BUILD_JOBS=1 (the OOM
-    # mitigation — see scripts/run_cloud_emulator_tests.sh); serialized compile is
-    # ~35-40m, so 60m leaves headroom over the old 45m budget that the OOM-kill hit.
+    # The --all scope compiles the full main crate under CARGO_BUILD_JOBS=2 (see
+    # scripts/run_cloud_emulator_tests.sh) — a middle ground that stays off the 16GB
+    # runner's OOM cliff while halving the old jobs=1 ~35-40m serialized compile that
+    # grew past this budget and got cancelled mid-build (#882). 60m (1h) leaves ample
+    # headroom for the ~20m parallel compile + emulator round-trips.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/scripts/run_cloud_emulator_tests.sh
+++ b/scripts/run_cloud_emulator_tests.sh
@@ -13,7 +13,7 @@
 #            Used by the develop early-detection job so a tier regression is caught
 #            on the introducing feat→develop PR.
 #   --all  : (default) also run cold_graph_record_store_round_trips_on_real_azure,
-#            which compiles the full main crate and runs under CARGO_BUILD_JOBS=1.
+#            which compiles the full main crate and runs under CARGO_BUILD_JOBS=2.
 #
 # Requires: docker, cargo, aws CLI (MinIO bucket), az CLI (Azurite container),
 # curl (fake-gcs bucket). On GitHub ubuntu-latest all are preinstalled.
@@ -93,11 +93,13 @@ cargo test -p proximadb-object-store --features aws,azure,gcp -- --ignored --noc
   put_with_tier_against_fake_gcs
 
 if [ "$SCOPE" = "all" ]; then
-  # Compiles the full main `proximadb` crate (~8400-test binary). CARGO_BUILD_JOBS=1
-  # serializes crate compilation so the 16GB hosted runner is NOT OOM-killed mid-link
-  # — the exact failure that made the qa-gate job red ("runner received a shutdown
-  # signal"). Same mitigation as ci.yml's rust-test unit job (see its comment).
-  CARGO_BUILD_JOBS=1 cargo test -p proximadb --features azure -- --ignored --nocapture \
+  # Compiles the full main `proximadb` crate (~8400-test binary). CARGO_BUILD_JOBS=2
+  # caps compile parallelism low enough to keep the 16GB hosted runner off the OOM
+  # cliff (the "runner received a shutdown signal" failure that jobs=1 was added to
+  # dodge), while halving the serialized ~35-40m compile that grew past the 60m job
+  # budget and got cancelled mid-build. 2 (not the .cargo/config.toml default of 3)
+  # is the deliberate middle ground: faster than 1, safer than 3 on a 16GB runner.
+  CARGO_BUILD_JOBS=2 cargo test -p proximadb --features azure -- --ignored --nocapture \
     cold_graph_record_store_round_trips_on_real_azure
 fi
 


### PR DESCRIPTION
## Problem

The qa-gate **Cloud object-store emulators (Azurite/MinIO/fake-gcs)** job was cancelled after exceeding its 60m cap during the develop→qa promotion (#882). The job log shows it died **mid-compile** — the terminated orphans were `cargo`/`rustc`, cargo was still emitting build warnings for test crates, and there is **zero** test-execution or emulator-connection output. It never reached the actual validation. Not a code regression and correctly non-gating (the `CI Success` aggregator passed), but it will keep timing out.

## Root cause

The `--all` scope compiles the full main `proximadb` crate (~8400-test binary) under **`CARGO_BUILD_JOBS=1`** (set in `scripts/run_cloud_emulator_tests.sh` as the original OOM mitigation). That serialized ~35–40m build has grown past the 60m budget as the crate expanded.

## Fix

- **`CARGO_BUILD_JOBS` 1 → 2** in `scripts/run_cloud_emulator_tests.sh` — roughly halves the compile (~20m), comfortably under budget, while staying **below** the `.cargo/config.toml` default of 3. A deliberate middle ground: faster than 1, safer than 3 on the 16GB hosted runner (keeps it off the OOM cliff jobs=1 was added to dodge).
- **`timeout-minutes` stays 60 (1h).** Rationale comments in both the script and `qa-gate.yml` updated to match.

No behavior change to the tests themselves — pure CI build-parallelism/budget tuning.