### PR TITLE
docs(td): TD-OLAP-17 — olap delta-merge changed_oids_since is the DF table-OPEN floor

### DIFF
--- a/docs/10-quality/td/TD-OLAP-17-olap-delta-merge-changed-oids-since-per-query-wal-scan.adoc
+++ b/docs/10-quality/td/TD-OLAP-17-olap-delta-merge-changed-oids-since-per-query-wal-scan.adoc
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-17: OLAP delta-merge `changed_oids_since` per-query WAL scan is the DataFusion table-OPEN floor (the real DF↔DuckDB gap)
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Open — root cause identified + measured; fix design below.** The long-assumed "single-threaded join build" gap is a *misattribution*: DataFusion's scan+join execution is at parity with (faster than) DuckDB once the per-table-per-query `changed_oids_since` WAL scan is removed.
+| Priority | **P0** — this is THE lever that closes the measured 60× (SF=0.01) / 400× (SF=0.1) DF↔DuckDB gap. Disabling the scan takes DF from 5762 ms → 12 ms median at SF=0.1 (faster than DuckDB's 14 ms). Every other OLAP perf lever (A2 NDV, TD-OLAP-3 runtime filters, TD-OLAP-6 clustering, morsel scheduling) is masked behind this floor until it moves.
+| Severity | Critical — the perceived 100-700× "join gap" (ADR-052, TD-OLAP-15) misdirected months of optimization toward the join, when the join is 8-23 ms (<1% of wall) even at SF=0.1.
+| Component | `src/services/dml/mod.rs::DmlService::changed_oids_since` (line ~830, the `OlapDeltaSource` impl), `src/query/execution/datafusion_engine.rs::register_merged_olap_table` (line ~637), `src/network/postgres/relational_pipeline.rs::olap_delta_merge_enabled` (default ON, line ~1303).
+| Governs | ADR-025 (the OLAP read-merge), ADR-052 (the analytics-competitiveness thesis — the dominant cost was per-query setup, NOT execution), the co-design mandate §2 (trace before you tune — this is the measured per-query trace that re-roots the cost term).
+| Relates to | link:TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2] (A2 NDV — correct but addresses the 8-23 ms join, a non-bottleneck), link:TD-OLAP-4-parquet-footer-stats-cbo.adoc[TD-OLAP-4] (table_open_cache — does not help, different path), link:TD-OLAP-15-native-engine-measured-posture-sf001.adoc[TD-OLAP-15] (the measured posture — re-interpreted), link:../../12-design/adr/ADR-025-relational-cold-path-wal-read-merge.adoc[ADR-025].
+|===
+
+== The measured finding (TPC perf ledger, local-tempdir, release+duckdb)
+
+Per-query, `open_ms ≈ wall_ms` and `join_ms = compute_ms − open_ms` is **8-23 ms** at *both* scales — the table-OPEN is ~99% of every DF query:
+
+[cols=">1,>1,>1,>1,>1",options="header"]
+|===
+| scale | route | DF median | DuckDB median | ratio
+| SF=0.01  | delta-merge ON (default)  | 604-682 ms | 10-13 ms | ~60×
+| SF=0.01  | delta-merge OFF (`PROXIMADB_OLAP_DELTA_MERGE=0`) | **6-7 ms** | 9-12 ms | **DF faster**
+| SF=0.1   | delta-merge ON (default)  | 5762-5772 ms | 14-15 ms | ~400×
+| SF=0.1   | delta-merge OFF           | **10-12 ms** | 14-15 ms | **DF faster**
+|===
+
+`PROXIMADB_OLAP_DELTA_MERGE=0` bypasses `register_merged_olap_table` entirely (bare Parquet register), so `changed_oids_since` never runs. The gap collapses to parity at both scales — **DF is faster than DuckDB once the per-query WAL scan is removed.**
+
+== Root cause
+
+`olap_delta_merge` is **default ON** (`olap_delta_merge_on(None) => true`). Every materialized table (`ProjectionPublication` authority + single-column PK) is opted in. So every DF query, for every table it touches, takes `register_merged_olap_table`, which calls `changed_oids_since(table, snapshot_lsn, tenant)`:
+
+- `read_changes_since_scoped(table, tenant, snapshot_lsn)` — a canonical-WAL change-feed scan since the snapshot LSN.
+- `resolve_select_table(table, tenant)` — a catalog resolve.
+- If the table has an `object_id` ≠ name (ADR-031 dual-key), a **second** `read_changes_since_scoped(oid_key, …)`.
+
+For a read-mostly benchmark (materialize once, no post-snapshot writes) the result is **empty** — but the scan still runs, per table, per query, and **scales with WAL size** (the bulk-INSERT WAL is large). At SF=0.1 the scan is ~5.7 s across the 8 tpch tables (~700 ms/table); at SF=0.1 tpcds (22 tables) ~5.8 s.
+
+== Why the table_open_cache (TD-OLAP-4) does NOT help
+
+`PROXIMADB_OLAP_TABLE_CACHE` caches the **Parquet footer discovery** (LIST+HEAD+footer) on the *bare-register* path (`register_object_store_parquet_location`). But the merged path runs `changed_oids_since` **before** it falls through to the bare register (line ~664), and `changed_oids_since` is unaffected by the footer cache. Enabling the cache drops `bytes_read` (46→31 MB — fewer footer fetches) but `open_ms` is unchanged (~1780 ms at SF=0.01) because `changed_oids_since` dominates.
+
+== A2 (TD-OLAP-2) status — correct, not the lever
+
+A2 (PR #886, MERGED) populates the ADR-037 registry with per-column HLL NDV so `distinct_count` is no longer `Absent`. This is a real **completeness** fix — TD-DFR-1's read-side overlay was reading an empty registry — and it unblocks future CBO (join ordering, broadcast vs repartition). But the join execution is **8-23 ms even at SF=0.1**, so making it multi-core (the A2 thesis) cannot move the median while `changed_oids_since` is ~99% of wall. A2 stays; it is not reverted. It pays off once this TD's fix removes the open floor.
+
+== Fix design (the lever)
+
+The delta is **empty for read-mostly tables** (the common OLAP case the merge fast-path already assumes at line ~664). The scan is pure overhead there. Options, in order of ambition:
+
+. **High-water-LSN skip (preferred):** track per-`(tenant, table)` the max WAL LSN observed; if it has not advanced past `snapshot_lsn`, return the cached empty result without scanning. Invalidate on any write to that table (the write path already knows the LSN it produced — wire it to bump the high-water). This is the read-side analogue of `table_open_cache`, keyed on the WAL cursor instead of the footer. O(1) per query for read-mostly; correct (a write advances the cursor → re-scan).
+
+. **Snapshot-LSN ≤ flushed-LSN fast path:** if the table's durable-flushed WAL LSN ≤ `snapshot_lsn`, the cold Parquet base is definitionally current → skip the scan with no per-table state (the merge's own empty-delta fast path, hoisted ahead of the scan).
+
+. **Session/query-scoped memo:** within one `QueryExecutionContext`, a table's `changed_oids_since` result is invariant → compute once, memo across the query's table registrations (today each query re-registers all tables).
+
+. **Default-OFF until baked (near-term unblock):** flip `olap_delta_merge` default to OFF (env-gated) for read-only/warehouse workloads where the live-merge is not needed; the cold Parquet base is read directly. This immediately recovers parity (measured) at the cost of eventual freshness (post-snapshot writes are invisible until re-MATERIALIZE) — acceptable for the ratchet/benchmark/warehouse shape, gated for correctness-sensitive shapes.
+
+== Verification target
+
+After the fix, the TPC perf ledger (default config, no env overrides) shows DF median within 2-3× of DuckDB at SF=0.1 (today: 400×), with `open_ms` ≪ `compute_ms`. Conformance ratchets (TPC-H 22 / TPC-DS 16 over pgwire) unchanged. The live-merge correctness (read-after-write across the snapshot LSN) preserved by an integration test that writes post-MATERIALIZE + reads.


### PR DESCRIPTION
Doc-only TD. Measured (TPC perf ledger, release+duckdb): the DF↔DuckDB gap is the per-table-per-query `changed_oids_since` WAL scan (default-ON `olap_delta_merge`), NOT the join. `open_ms ≈ wall_ms` at both scales; join execution is 8-23 ms (<1% of wall) even at SF=0.1.

Disabling the scan (`PROXIMADB_OLAP_DELTA_MERGE=0`) takes DF from **5762 ms → 12 ms median at SF=0.1 — faster than DuckDB (14 ms)**. The long-assumed "single-threaded join build" 100-700× gap (ADR-052, TD-OLAP-15) is a misattribution; DataFusion scan+join is at parity with DuckDB.

Explains why TD-OLAP-4 (table_open_cache) doesn't help (caches the footer, not the WAL delta — different path) and clarifies A2 (#886, TD-OLAP-2): a correct completeness fix (registry population) but addresses a non-bottleneck; pays off once this floor moves.

Fix design in the TD: high-water-LSN skip / snapshot-LSN fast path / query-scoped memo / default-OFF (near-term). **P0** — every other OLAP perf lever (A2 NDV, runtime filters, clustering, morsel) is masked behind this floor until it moves.

Refs: ADR-025, ADR-052, TD-OLAP-2/4/15.