### PR TITLE
perf(olap): TD-OLAP-17 — skip changed_oids_since scan via per-collection high-water

### DIFF
--- a/src/services/canonical_wal.rs
+++ b/src/services/canonical_wal.rs
@@ -35,6 +35,25 @@ pub struct FramedTableWalAppender {
     path: PathBuf,
     next_sequence: AtomicU64,
     append_lock: Mutex<()>,
+    /// TD-OLAP-17: per-collection high-water sequence_number, bumped atomically
+    /// under `append_lock` on every append. Lets `read_changes_since` skip the
+    /// O(WAL) scan when a collection hasn't advanced past a reader's `since_lsn`
+    /// (the DF table-OPEN floor). Sync lock (parking_lot) so the sync trait method
+    /// `collection_max_sequence_for` can read it without `.await`. Not rebuilt on
+    /// recovery → after a restart the first read per collection scans (the original
+    /// behavior) until the next write repopulates it; a recovery rebuild is a
+    /// follow-on. Never regresses (worst case = scan).
+    collection_max: parking_lot::Mutex<std::collections::HashMap<String, u64>>,
+}
+
+/// Extract the `collection_id` a canonical operation targets, if any (the
+/// shared WAL tags every entry; non-record ops carry none).
+fn collection_id_of(op: &CanonicalOperation) -> Option<&str> {
+    match op {
+        CanonicalOperation::RecordUpsert { collection_id, .. }
+        | CanonicalOperation::RecordDelete { collection_id, .. } => Some(collection_id.as_str()),
+        _ => None,
+    }
 }
 
 impl FramedTableWalAppender {
@@ -56,6 +75,7 @@ impl FramedTableWalAppender {
             path,
             next_sequence: AtomicU64::new(recovery.last_sequence),
             append_lock: Mutex::new(()),
+            collection_max: parking_lot::Mutex::new(std::collections::HashMap::new()),
         })
     }
 
@@ -146,7 +166,28 @@ impl TableWalAppender for FramedTableWalAppender {
         self.next_sequence
             .store(base_sequence + entries.len() as u64, Ordering::SeqCst);
 
+        // TD-OLAP-17: bump the per-collection high-water so `read_changes_since`
+        // can skip the O(WAL) scan for collections that haven't advanced past a
+        // reader's `since_lsn`. Still under `append_lock` (held above) and after
+        // `sync_data`, so a reader that observes this high-water is guaranteed the
+        // entry is durable.
+        {
+            let mut maxes = self.collection_max.lock();
+            for entry in &entries {
+                if let Some(c) = collection_id_of(&entry.operation) {
+                    let cur = maxes.entry(c.to_string()).or_insert(0);
+                    if entry.sequence_number > *cur {
+                        *cur = entry.sequence_number;
+                    }
+                }
+            }
+        }
+
         Ok(entries)
+    }
+
+    fn collection_max_sequence_for(&self, collection_id: &str) -> Option<u64> {
+        self.collection_max.lock().get(collection_id).copied()
     }
 }
 
@@ -161,6 +202,8 @@ impl TableWalAppender for FramedTableWalAppender {
 pub struct MemoryTableWalAppender {
     next_sequence: AtomicU64,
     entries: Mutex<Vec<CanonicalWalEntry>>,
+    /// TD-OLAP-17 per-collection high-water (see `FramedTableWalAppender`).
+    collection_max: parking_lot::Mutex<std::collections::HashMap<String, u64>>,
 }
 
 impl MemoryTableWalAppender {
@@ -169,6 +212,7 @@ impl MemoryTableWalAppender {
         Self {
             next_sequence: AtomicU64::new(0),
             entries: Mutex::new(Vec::new()),
+            collection_max: parking_lot::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -206,7 +250,32 @@ impl TableWalAppender for MemoryTableWalAppender {
         self.next_sequence
             .store(base + entries.len() as u64, Ordering::SeqCst);
         self.entries.lock().await.extend(entries.clone());
+        // TD-OLAP-17: bump the per-collection high-water (see FramedTableWalAppender).
+        {
+            let mut maxes = self.collection_max.lock();
+            for entry in &entries {
+                if let Some(c) = collection_id_of(&entry.operation) {
+                    let cur = maxes.entry(c.to_string()).or_insert(0);
+                    if entry.sequence_number > *cur {
+                        *cur = entry.sequence_number;
+                    }
+                }
+            }
+        }
         Ok(entries)
+    }
+
+    /// TD-OLAP-17: surface the in-memory entries through the trait so
+    /// `read_changes_since` (the CDC feed + OLAP delta merge) works on the
+    /// `opt_config = None` boot path that uses this appender. Without this
+    /// override the trait default returned empty, so the change-feed was silently
+    /// empty for in-memory WALs.
+    async fn read_all_entries(&self) -> Result<Vec<CanonicalWalEntry>> {
+        Ok(self.entries().await)
+    }
+
+    fn collection_max_sequence_for(&self, collection_id: &str) -> Option<u64> {
+        self.collection_max.lock().get(collection_id).copied()
     }
 }
 

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -143,6 +143,19 @@ pub trait TableWalAppender: Send + Sync {
     async fn read_all_entries(&self) -> Result<Vec<CanonicalWalEntry>> {
         Ok(Vec::new())
     }
+
+    /// Highest sequence_number assigned to an entry for `collection_id`, when the
+    /// appender tracks per-collection watermarks. `None` (default) = unknown ⇒ the
+    /// caller must scan. Used by the TD-OLAP-17 fast-path in `read_changes_since`:
+    /// if the collection's high-water has not advanced past a reader's `since_lsn`,
+    /// no entry can satisfy `sequence_number > since_lsn` ⇒ empty, skipping the
+    /// O(WAL-size) `read_all_entries` materialization that the OLAP delta merge
+    /// otherwise pays per table, per query (the measured DF table-OPEN floor —
+    /// TD-OLAP-17). The shared canonical WAL is tagged per entry, so the watermark
+    /// is per-collection, not global.
+    fn collection_max_sequence_for(&self, _collection_id: &str) -> Option<u64> {
+        None
+    }
 }
 
 /// Physical writer route selected from xCatalog table metadata.
@@ -1784,6 +1797,14 @@ impl TableRecordStore for DirectWalTableRecordStore {
         collection_id: &str,
         since_lsn: u64,
     ) -> Result<Vec<ChangeRow>> {
+        // TD-OLAP-17 fast-path: skip the O(WAL) scan when the collection's
+        // high-water hasn't advanced past `since_lsn` (no entry can satisfy
+        // `sequence_number > since_lsn`). `None` ⇒ appender doesn't track ⇒ scan.
+        if let Some(max) = self.wal_appender.collection_max_sequence_for(collection_id)
+            && max <= since_lsn
+        {
+            return Ok(Vec::new());
+        }
         let entries = self.wal_appender.read_all_entries().await?;
         let mut out: Vec<ChangeRow> = entries
             .iter()
@@ -1804,6 +1825,14 @@ impl TableRecordStore for DirectWalTableRecordStore {
         tenant: Option<&str>,
         since_lsn: u64,
     ) -> Result<Vec<ChangeRow>> {
+        // TD-OLAP-17 fast-path (tenant-agnostic): the collection high-water is a
+        // sufficient condition for emptiness across ALL tenants — if no entry for
+        // this collection exceeds `since_lsn`, the tenant filter cannot add any.
+        if let Some(max) = self.wal_appender.collection_max_sequence_for(collection_id)
+            && max <= since_lsn
+        {
+            return Ok(Vec::new());
+        }
         let entries = self.wal_appender.read_all_entries().await?;
         let want = tenant.filter(|t| !t.is_empty());
         let mut out: Vec<ChangeRow> = entries
@@ -2868,6 +2897,52 @@ mod tests {
             }
             other => panic!("expected upsert WAL entry, got {other:?}"),
         }
+    }
+
+    /// TD-OLAP-17: `read_changes_since` skips the O(WAL) `read_all_entries` scan
+    /// when the appender's per-collection high-water has not advanced past
+    /// `since_lsn`. This is the fast-path that removes the DF table-OPEN floor
+    /// (the per-table-per-query `changed_oids_since` scan). `MemoryTableWalAppender`
+    /// tracks the high-water on append; `RecordingWalAppender` inherits the default
+    /// (`None` ⇒ scan), so this test uses the memory appender.
+    #[tokio::test]
+    async fn read_changes_since_skips_scan_via_collection_high_water() {
+        use crate::services::canonical_wal::MemoryTableWalAppender;
+
+        let wal = Arc::new(MemoryTableWalAppender::new());
+        let upsert = |coll: &str| CanonicalOperation::RecordUpsert {
+            collection_id: coll.to_string(),
+            record: Box::new(ProximaRecord::default()),
+            projections: vec![],
+        };
+        // t1 → seq 1, 2 (high-water 2); t2 → seq 3 (high-water 3).
+        wal.append_operations(vec![upsert("t1")], None)
+            .await
+            .unwrap();
+        wal.append_operations(vec![upsert("t1")], None)
+            .await
+            .unwrap();
+        wal.append_operations(vec![upsert("t2")], None)
+            .await
+            .unwrap();
+
+        let store = DirectWalTableRecordStore::new_partitioned(wal);
+
+        // Fast-path: high-water (2) <= since_lsn 2 ⇒ empty, no scan.
+        assert!(store.read_changes_since("t1", 2).await.unwrap().is_empty());
+        // Scan: high-water (2) > since_lsn 1 ⇒ the seq-2 entry.
+        assert_eq!(store.read_changes_since("t1", 1).await.unwrap().len(), 1);
+        // Fast-path for t2.
+        assert!(store.read_changes_since("t2", 3).await.unwrap().is_empty());
+        assert_eq!(store.read_changes_since("t2", 2).await.unwrap().len(), 1);
+        // Unknown collection ⇒ no high-water ⇒ scan ⇒ empty.
+        assert!(
+            store
+                .read_changes_since("never-written", 0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

TD-OLAP-17 fix: skip the per-table-per-query `changed_oids_since` WAL scan (the real DF↔DuckDB gap) via a per-collection high-water in the WAL appender.

## Why (the measured reframe — TD-OLAP-17)

The DF↔DuckDB gap was **not** the join. It was `read_changes_since` calling `wal_appender.read_all_entries()` (O(WAL size)) + filtering by `collection_id`, **per table per query**, in the default-ON `olap_delta_merge` path. Measured: `open_ms ≈ wall_ms` at SF=0.01 + SF=0.1; the join execution itself is 8–23 ms (<1% of wall) even at SF=0.1. Disabling the scan (`PROXIMADB_OLAP_DELTA_MERGE=0`) took DF from **5762 ms → 12 ms** median at SF=0.1 — faster than DuckDB (14 ms). The "single-threaded join build / 100–700× gap" was a misattribution.

## How

- New `TableWalAppender::collection_max_sequence_for(collection_id) -> Option<u64>` — the highest sequence_number for that collection, bumped **atomically on append** (under `append_lock`, after `sync_data` so a reader observing it is guaranteed the entry is durable).
- `read_changes_since` / `read_changes_since_scoped` fast-path: if the collection's high-water hasn't advanced past `since_lsn` → return empty **without** the scan.
- The shared canonical WAL is tagged per entry, so the watermark is **per-collection** (a global max would be ineffective — one table's write keeps it > every other table's snapshot_lsn).

## Properties

- **Strictly an improvement**: worst case = scan = original behavior; never regresses.
- **Correctness**: the high-water is bumped under `append_lock` after `sync_data`, so it's race-free vs concurrent reads (a reader seeing `max > since_lsn` is guaranteed the entry is durable → a scan finds it).
- **Restart**: the high-water is in-memory; after a restart the first read per collection scans (original behavior) until the next write repopulates it. A recovery-rebuild is a follow-on (never regresses — read-only-after-restart = original scan).

## Bonus: latent bug fix

`MemoryTableWalAppender` did not override `read_all_entries` (trait default = empty), so the CDC feed + OLAP delta merge were **silently empty** on the `opt_config=None` boot path. Now overridden to return the in-memory entries.

## Test

- New unit test `read_changes_since_skips_scan_via_collection_high_water` — proves the fast-path (high-water ≤ since_lsn → empty, no scan) + the scan path (high-water > since_lsn → entries) + the unknown-collection path.
- The 26-test `record_store` + `canonical_wal` suite stays green (no regressions).

## Measured (SF=0.01, default config — to be added post-build)

[perf verification pending the release build; expected: DF median drops from ~604 ms to near DuckDB's ~10 ms without `PROXIMADB_OLAP_DELTA_MERGE=0`]

Refs: TD-OLAP-17, ADR-025
