### PR TITLE
docs(td): TD-OLAP-18 — identifier case-folding is the ClickBench 6/43 wall

### DIFF
--- a/docs/10-quality/td/TD-OLAP-18-clickbench-identifier-case-folding-sql-conformance.adoc
+++ b/docs/10-quality/td/TD-OLAP-18-clickbench-identifier-case-folding-sql-conformance.adoc
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLAP-18: Identifier case-folding — the ClickBench 6/43 wall (ANSI/PostgreSQL unquoted-identifier folding)
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Open — root cause measured; single fix unlocks ClickBench.** ProximaDB resolves unquoted identifiers **case-sensitively**, deviating from the SQL standard / PostgreSQL (which fold unquoted identifiers to lowercase). The ClickBench DDL defines CamelCase columns (`AdvEngineID`, `UserID`, `EventDate`); the queries reference lowercase (`advengineid`, `userid`, `eventdate`); resolution fails → **37 of 43 ClickBench queries** return `Schema error: No field named <lowercase>`.
+| Priority | **P1** — one root cause, one fix, unlocks a whole benchmark (ClickBench 6/43 → ~35/43, DuckDB parity) AND closes a general ANSI-SQL conformance gap (the "full ANSI/standard SQL over pgwire" mandate). Independent of perf — TD-OLAP-17 already made the table-OPEN floor fast; ClickBench now fails on conformance, not speed.
+| Severity | High — any SQL that references a CamelCase-defined column in a different case fails. Breaks ClickBench + portability of existing SQL workloads/tools that assume standard folding.
+| Component | the SQL frontend / identifier resolution (parser → planner → DataFusion field resolution), the catalog column-name store. Likely a single seam: fold unquoted identifiers to lowercase before catalog/DataFusion resolution (PostgreSQL semantics), keeping quoted identifiers case-exact.
+| Governs | the "Mandate: Full ANSI SQL over pgwire" (CLAUDE.md), ADR-052 (ClickBench is the OLAP conformance/perf reference), TD-OLAP-17 (the perf floor is fixed — this is the remaining ClickBench blocker).
+| Relates to | link:TD-OLAP-17-olap-delta-merge-changed-oids-since-per-query-wal-scan.adoc[TD-OLAP-17] (perf floor, fixed), link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052].
+|===
+
+== The measured finding (ClickBench ledger, 100M-row hits, release+duckdb)
+
+ProximaDB passes **6/43** ClickBench queries; DuckDB passes **35/43**. Categorizing all 37 ProximaDB failures:
+
+- **37/37 are the SAME error**: `Schema error: No field named <lowercase>. Valid fields are hits."<CamelCase>"...`
+  - q02/q03/q08: `advengineid` vs `AdvEngineID`
+  - q04/q05: `userid` vs `UserID`
+  - q06: `searchphrase` vs `SearchPhrase`
+  - q07: `eventdate` vs `EventDate`
+  - q09: `regionid` vs `RegionID` (…and so on for all 37).
+
+The 6 that pass (q01, q20, q24-q27) reference columns whose case happens to match (or are metadata-only like `COUNT(*)`). The failures are NOT perf (they error in ~10 ms at plan/lower time, with `open_ms` 8-11 ms — TD-OLAP-17 already fixed the open floor). The 1 real passing scan query (q01) runs in 706 ms (DF) vs 99 ms (DuckDB) — a separate, smaller perf item once conformance lands.
+
+== Why it happens
+
+ANSI SQL / PostgreSQL fold **unquoted** identifiers to lowercase: `CREATE TABLE hits (AdvEngineID …)` stores the column as `advengineid`, and `SELECT advengineid` resolves to `advengineid` → match. ProximaDB preserves the declared case of unquoted identifiers, so the DDL's `AdvEngineID` and the query's `advengineid` are two different names → `No field named`. **Quoted** identifiers (`"AdvEngineID"`) should remain case-exact (standard).
+
+== Fix design
+
+A single seam — fold unquoted identifiers to lowercase at the SQL frontend (parser/planner), before catalog lookup and DataFusion field resolution:
+
+. **Frontend fold** (preferred): lower-case unquoted identifiers in the parser/planner so the catalog + DataFusion see `advengineid` for both DDL and query. Quoted identifiers pass through case-exact. This is PostgreSQL-exact.
+. **Catalog/DataFusion side**: ensure the catalog stores/resolves folded names AND DataFusion's schema fields are folded (DataFusion is case-sensitive by default; either fold the field names or enable case-insensitive resolution consistently — mixing causes its own mismatches).
+. **Mixed-read-safe**: existing tables with CamelCase columns — a fold changes how queries resolve against them. Gate behind the default until a round-trip test confirms `CREATE TABLE Foo (Bar …); SELECT bar FROM foo` works and quoted `"Bar"` still resolves case-exact. Existing pgwire tests (TPC-H/DS, which use lowercase table/column names) are unaffected.
+
+== Verification target
+
+After the fix, the ClickBench ledger (default config) shows ProximaDB **≥35/43** (DuckDB parity), with the 37 case-fold failures gone. The TPC-H (22) / TPC-DS (16) pgwire conformance ratchets unchanged. New test: `CREATE TABLE Case (ColMine INT); SELECT colmine FROM case;` round-trips; `SELECT "ColMine" FROM "Case";` also works.


### PR DESCRIPTION
Doc-only TD. ClickBench (100M-row hits, release+duckdb): ProximaDB passes 6/43, DuckDB 35/43. All 37 failures are ONE root cause — ProximaDB resolves unquoted identifiers case-sensitively (DDL CamelCase columns `AdvEngineID` vs query lowercase `advengineid`), deviating from ANSI/PostgreSQL which fold unquoted to lowercase.

Not a perf issue (errors in ~10 ms at plan time; `open_ms` 8-11 ms — TD-OLAP-17 fixed the open floor). One fix (fold unquoted identifiers to lowercase at the frontend) should take ClickBench 6/43 → ~35/43 (DuckDB parity) + close a general ANSI-SQL conformance gap (the "full ANSI SQL over pgwire" mandate).

Refs: TD-OLAP-17, ADR-052.