### PR TITLE
feat(exec): TD-EXEC-2 Slice 1 — stack-probe calibration + geometry io-trace wiring

### DIFF
--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -207,6 +207,25 @@ pub struct IoTrace {
     /// discovery and reuses cached schema/splits/file-sizes.
     table_open_hits: AtomicU64,
     table_open_misses: AtomicU64,
+    /// Plan-geometry vector (TD-EXEC-2 Slice 1, observe-only): the pre-execution
+    /// geometric summary of the served physical plan — depth, node/leaf counts,
+    /// fan-out, blocking-operator count — recorded at the plan→execute seam as
+    /// neutral scalars (io_trace never depends on a query-layer type). One
+    /// measured vector feeds three resource laws: stack sizing, engine routing,
+    /// parallelism. Max semantics so a multi-statement scope keeps its deepest plan.
+    plan_depth: AtomicU64,
+    plan_nodes: AtomicU64,
+    plan_leaves: AtomicU64,
+    plan_fanout: AtomicU64,
+    plan_blocking: AtomicU64,
+    /// Per-operator-kind counts of the served plan (TD-EXEC-2) — the histogram
+    /// half of the geometry vector, keyed by neutral op-kind labels.
+    plan_ops: Mutex<BTreeMap<String, u64>>,
+    /// Measured stack high-water mark (bytes) of the plan-tree recursions
+    /// (planner lowering + executor build), sampled via the planner's
+    /// `stack_probe` (TD-EXEC-2 Slice 1). Max across recordings — the binding
+    /// per-query figure that calibrates `frame_bytes[op_kind]`.
+    stack_hwm_bytes: AtomicU64,
     /// The route this query was served on, as `(shape_class, backend_label)`
     /// strings (co-design C4). Stamped by the `ComputeScheduler` so the flush can
     /// feed the trace-driven cost model the cost of *this kind of query on that
@@ -345,6 +364,37 @@ impl IoTrace {
         self.plan_ms.fetch_add(ms, Ordering::Relaxed);
     }
 
+    /// Record the served plan's geometry vector (TD-EXEC-2 Slice 1, observe-only):
+    /// neutral scalars measured from the physical plan at the plan→execute seam,
+    /// plus the per-op-kind histogram as `(label, count)` pairs. Scalars keep the
+    /// max so a multi-statement scope reflects its deepest plan; histogram counts
+    /// accumulate.
+    pub fn record_plan_geometry(
+        &self,
+        depth: u64,
+        nodes: u64,
+        leaves: u64,
+        fanout: u64,
+        blocking: u64,
+        ops: &[(&str, u64)],
+    ) {
+        self.plan_depth.fetch_max(depth, Ordering::Relaxed);
+        self.plan_nodes.fetch_max(nodes, Ordering::Relaxed);
+        self.plan_leaves.fetch_max(leaves, Ordering::Relaxed);
+        self.plan_fanout.fetch_max(fanout, Ordering::Relaxed);
+        self.plan_blocking.fetch_max(blocking, Ordering::Relaxed);
+        let mut g = self.plan_ops.lock().unwrap_or_else(|p| p.into_inner());
+        for (kind, count) in ops {
+            *g.entry((*kind).to_string()).or_insert(0) += count;
+        }
+    }
+
+    /// Record a measured stack high-water mark (bytes) for one of the plan-tree
+    /// recursions (TD-EXEC-2 Slice 1). Max semantics — the binding figure wins.
+    pub fn record_stack_hwm(&self, bytes: u64) {
+        self.stack_hwm_bytes.fetch_max(bytes, Ordering::Relaxed);
+    }
+
     /// Record a table-OPEN cache outcome: `true` = hit (discovery reused, no
     /// LIST/HEAD/footer I/O), `false` = miss (cold open).
     pub fn record_table_open(&self, hit: bool) {
@@ -417,6 +467,17 @@ impl IoTrace {
             plan_ms: self.plan_ms.load(Ordering::Relaxed),
             table_open_hits: self.table_open_hits.load(Ordering::Relaxed),
             table_open_misses: self.table_open_misses.load(Ordering::Relaxed),
+            plan_depth: self.plan_depth.load(Ordering::Relaxed),
+            plan_nodes: self.plan_nodes.load(Ordering::Relaxed),
+            plan_leaves: self.plan_leaves.load(Ordering::Relaxed),
+            plan_fanout: self.plan_fanout.load(Ordering::Relaxed),
+            plan_blocking: self.plan_blocking.load(Ordering::Relaxed),
+            plan_ops: self
+                .plan_ops
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .clone(),
+            stack_hwm_bytes: self.stack_hwm_bytes.load(Ordering::Relaxed),
             route: self.route(),
         }
     }
@@ -497,6 +558,30 @@ pub struct IoTraceSnapshot {
     /// Table-OPEN cache misses (cold open).
     #[serde(default)]
     pub table_open_misses: u64,
+    /// Served plan's longest root→leaf path (TD-EXEC-2 geometry; 0 = not recorded).
+    #[serde(default)]
+    pub plan_depth: u64,
+    /// Served plan's total operator count (TD-EXEC-2 geometry).
+    #[serde(default)]
+    pub plan_nodes: u64,
+    /// Served plan's leaf (scan/values) count — source fan-in (TD-EXEC-2 geometry).
+    #[serde(default)]
+    pub plan_leaves: u64,
+    /// Served plan's widest sibling set — parallelism signal (TD-EXEC-2 geometry).
+    #[serde(default)]
+    pub plan_fanout: u64,
+    /// Served plan's pipeline-breaker count (joins+sorts+aggregates) —
+    /// memory/spill signal (TD-EXEC-2 geometry).
+    #[serde(default)]
+    pub plan_blocking: u64,
+    /// Served plan's per-operator-kind histogram (TD-EXEC-2 geometry).
+    #[serde(default)]
+    pub plan_ops: BTreeMap<String, u64>,
+    /// Measured stack high-water mark (bytes) of the plan-tree recursions,
+    /// via the planner's `stack_probe` (TD-EXEC-2 Slice 1). The calibration
+    /// figure that resolves `frame_bytes[op_kind]`; 0 = not measured.
+    #[serde(default)]
+    pub stack_hwm_bytes: u64,
 }
 
 impl IoTraceSnapshot {
@@ -695,6 +780,28 @@ pub fn record_open_ms(ms: u64) {
 /// Add pgwire relational-pipeline setup wall ms to the active query trace.
 pub fn record_setup_ms(ms: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_setup_ms(ms));
+}
+
+/// Record the served plan's geometry vector for the active query (TD-EXEC-2
+/// Slice 1, observe-only). Core counter (always-on, like `record_plan_ms`):
+/// the route cost model's geometry tier and the stack calibration fit both
+/// consume it from the ledger. Silently no-ops outside an active scope.
+pub fn record_plan_geometry(
+    depth: u64,
+    nodes: u64,
+    leaves: u64,
+    fanout: u64,
+    blocking: u64,
+    ops: &[(&str, u64)],
+) {
+    let _ =
+        IO_TRACE.try_with(|t| t.record_plan_geometry(depth, nodes, leaves, fanout, blocking, ops));
+}
+
+/// Record a measured plan-recursion stack high-water mark (bytes) for the
+/// active query (TD-EXEC-2 Slice 1). Silently no-ops outside an active scope.
+pub fn record_stack_hwm(bytes: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_stack_hwm(bytes));
 }
 
 /// Add pgwire result-emit wall ms (row encode + socket write) to the active trace.

--- a/crates/query/proximadb-relational-executor/src/lib.rs
+++ b/crates/query/proximadb-relational-executor/src/lib.rs
@@ -254,6 +254,10 @@ pub fn build_executor<F: ReaderFactory>(
     ctx: &ExecutionContext,
 ) -> Result<Box<dyn ExecNode>, ExecError> {
     stacker::maybe_grow(BUILD_RED_ZONE, BUILD_STACK_GROW, || {
+        // TD-EXEC-2 Slice 1: sample the recursion's stack low-water mark when a
+        // probe is armed (a TLS read + branch otherwise — same order as the
+        // maybe_grow check above).
+        proximadb_relational_planner::stack_probe::note();
         build_executor_inner(plan, factory, ctx)
     })
 }
@@ -2628,6 +2632,66 @@ mod tests {
         exec.open().await.unwrap();
         let rows = collect(&mut *exec).await.unwrap();
         assert_eq!(rows.len(), 3);
+    }
+
+    /// Executor-build stack high-water for a `depth`-level filter chain, measured
+    /// on a dedicated large-stack thread so `maybe_grow` never switches segments
+    /// and the probe reading is exact (see the planner's `stack_probe` docs).
+    fn build_stack_hwm(depth: usize) -> u64 {
+        use proximadb_relational_planner::stack_probe;
+        std::thread::Builder::new()
+            // Large enough that even TD-EXEC-1's 200 KB/frame upper guess for
+            // ~1.1k frames fits without segment growth.
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || {
+                let mut plan = scan_users();
+                for _ in 0..depth {
+                    plan = PhysicalPlan::Filter {
+                        input: Box::new(plan),
+                        predicate: Expr::literal(ProximaValue::Boolean(true)),
+                    };
+                }
+                let f = factory_with_users();
+                let ctx = ExecutionContext::default();
+                let (exec, hwm) = stack_probe::probe(|| build_executor(plan, &f, &ctx));
+                // Avoid a deep recursive Drop of the executor tree; only the
+                // measurement matters here.
+                std::mem::forget(exec.expect("deep build must succeed"));
+                hwm
+            })
+            .expect("spawn large-stack calibration thread")
+            .join()
+            .expect("calibration build must not fail")
+    }
+
+    /// TD-EXEC-2 Slice 1 calibration: measure the real per-frame stack cost of
+    /// the executor-build recursion — the second of the three depth-proportional
+    /// recursions (planner lowering, executor build, native walk) — resolving
+    /// the ~100× `frame_bytes` unknown for this crate. The delta between two
+    /// chain depths divides out fixed overhead; the upper bound is a regression
+    /// ratchet against frame bloat.
+    #[test]
+    fn calibrate_build_frame_cost() {
+        let shallow = build_stack_hwm(100);
+        let deep = build_stack_hwm(1100);
+        if shallow == 0 && deep == 0 {
+            // Platform cannot report remaining stack; nothing to calibrate.
+            return;
+        }
+        assert!(
+            deep > shallow,
+            "1100-deep build must consume more stack than 100-deep: \
+             shallow={shallow} deep={deep}"
+        );
+        let per_frame = (deep - shallow) / 1000;
+        eprintln!(
+            "TD-EXEC-2 Slice-1 calibration: executor-build frame cost ≈ {per_frame} B/frame \
+             (hwm {shallow} B @ depth 100 → {deep} B @ depth 1100)"
+        );
+        assert!(
+            per_frame <= 32 * 1024,
+            "executor-build frame cost regressed past 32 KiB/frame: measured {per_frame} B/frame"
+        );
     }
 
     #[tokio::test]

--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -54,6 +54,7 @@ use thiserror::Error;
 /// Plan geometry — a cheap, pre-execution geometric summary of a [`PhysicalPlan`]
 /// (TD-EXEC-2 Slice 1). Observe-only: it makes no decision and changes no behavior.
 pub mod plan_geometry;
+pub mod stack_probe;
 pub use plan_geometry::{OpKind, PlanGeometry, measure_geometry};
 
 // =========================================================================
@@ -756,6 +757,10 @@ const LOWER_STACK_GROW: usize = 4 * 1024 * 1024;
 /// own headroom.
 pub fn lower_to_physical(node: LogicalNode) -> PhysicalPlan {
     stacker::maybe_grow(LOWER_RED_ZONE, LOWER_STACK_GROW, || {
+        // TD-EXEC-2 Slice 1: sample the recursion's stack low-water mark when a
+        // probe is armed (a TLS read + branch otherwise — same order as the
+        // maybe_grow check above).
+        stack_probe::note();
         lower_to_physical_inner(node)
     })
 }
@@ -2418,6 +2423,63 @@ mod tests {
         handle
             .join()
             .expect("deep lowering must not overflow the 512 KiB stack (maybe_grow)");
+    }
+
+    /// Lowering stack high-water for a `depth`-level filter chain, measured on a
+    /// dedicated large-stack thread so `maybe_grow` never switches segments and
+    /// the probe reading is exact (see `stack_probe` module docs).
+    fn lowering_stack_hwm(depth: usize) -> u64 {
+        std::thread::Builder::new()
+            // Large enough that even TD-EXEC-1's 200 KB/frame upper guess for
+            // ~1.1k frames fits without segment growth.
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || {
+                let mut node = users_scan();
+                for _ in 0..depth {
+                    node = LogicalNode::Filter {
+                        input: Box::new(node),
+                        predicate: Expr::literal(ProximaValue::Int64(1)),
+                    };
+                }
+                let (physical, hwm) = stack_probe::probe(|| lower_to_physical(node));
+                // Avoid a deep recursive Drop; only the measurement matters.
+                std::mem::forget(physical);
+                hwm
+            })
+            .expect("spawn large-stack calibration thread")
+            .join()
+            .expect("calibration lowering must not fail")
+    }
+
+    /// TD-EXEC-2 Slice 1 calibration: measure the real per-frame stack cost of
+    /// the lowering recursion, resolving the ~100× `frame_bytes` unknown
+    /// (TD-EXEC-1 estimated 100–200 KB/frame; a code probe suggested ~1 KB).
+    /// The delta between two chain depths divides out the fixed arm-to-entry
+    /// overhead, leaving bytes-per-frame. The upper bound is a regression
+    /// ratchet: a change that bloats lowering frames past 32 KiB fails here
+    /// long before it re-approaches the TD-EXEC-1 guess.
+    #[test]
+    fn calibrate_lowering_frame_cost() {
+        let shallow = lowering_stack_hwm(100);
+        let deep = lowering_stack_hwm(1100);
+        if shallow == 0 && deep == 0 {
+            // Platform cannot report remaining stack; nothing to calibrate.
+            return;
+        }
+        assert!(
+            deep > shallow,
+            "1100-deep lowering must consume more stack than 100-deep: \
+             shallow={shallow} deep={deep}"
+        );
+        let per_frame = (deep - shallow) / 1000;
+        eprintln!(
+            "TD-EXEC-2 Slice-1 calibration: lowering frame cost ≈ {per_frame} B/frame \
+             (hwm {shallow} B @ depth 100 → {deep} B @ depth 1100)"
+        );
+        assert!(
+            per_frame <= 32 * 1024,
+            "lowering frame cost regressed past 32 KiB/frame: measured {per_frame} B/frame"
+        );
     }
 
     // --- Constant folding ---------------------------------------------

--- a/crates/query/proximadb-relational-planner/src/stack_probe.rs
+++ b/crates/query/proximadb-relational-planner/src/stack_probe.rs
@@ -1,0 +1,157 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stack high-water probe — measure the real stack consumed by the plan-tree
+//! recursions (TD-EXEC-2 Slice 1, observe-only).
+//!
+//! TD-EXEC-2 §1.b needs `frame_bytes[op_kind]` to turn the geometry vector into
+//! a stack estimate, but the per-frame cost is a ~100× unknown (TD-EXEC-1 says
+//! 100–200 KB/frame; a code probe suggested ~1 KB). This module measures it:
+//! [`probe`] arms a thread-local low-water mark around a closure, and [`note`]
+//! — called at the entry of each guarded recursion level (the planner's
+//! `lower_to_physical`, the executor's `build_executor`, the native `walk`) —
+//! samples [`stacker::remaining_stack`] into it. The difference between the
+//! remaining stack at arm time and the observed minimum is the recursion's
+//! stack high-water mark in bytes.
+//!
+//! Cost: when no probe is armed, [`note`] is a TLS read + branch (~ns) — the
+//! same order as the `stacker::maybe_grow` check it sits next to. This is a
+//! measurement primitive only; it makes no decision and changes no behavior.
+//!
+//! ## Accuracy under `maybe_grow`
+//!
+//! [`stacker::maybe_grow`] switches deep descents onto freshly-allocated
+//! segments, and [`stacker::remaining_stack`] then reports headroom *within the
+//! current segment*. Samples taken on a grown segment are not comparable to the
+//! arm-time baseline, so past the first growth the reported high-water mark is
+//! a **lower bound**, not an exact figure. In practice this is fine: the
+//! observe-only trace flags such plans by their geometry (`max_depth`), and the
+//! calibration tests run on a dedicated large-stack thread where no growth
+//! occurs and the measurement is exact.
+
+use std::cell::Cell;
+
+thread_local! {
+    /// Remaining-stack low-water mark of the armed probe on this thread;
+    /// `None` when no probe is armed.
+    static LOW_WATER: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// Sample the remaining stack into the armed probe's low-water mark.
+///
+/// Call at the entry of a guarded recursion level. No-op (a TLS read and a
+/// branch) when no [`probe`] is armed on this thread or when the platform
+/// cannot report the remaining stack.
+#[inline]
+pub fn note() {
+    LOW_WATER.with(|lw| {
+        if let Some(current_low) = lw.get()
+            && let Some(remaining) = stacker::remaining_stack()
+            && remaining < current_low
+        {
+            lw.set(Some(remaining));
+        }
+    });
+}
+
+/// Restores the previously-armed probe state on drop, so a panicking closure
+/// cannot leave a stale probe armed on the thread.
+struct Rearm(Option<usize>);
+
+impl Drop for Rearm {
+    fn drop(&mut self) {
+        LOW_WATER.with(|lw| lw.set(self.0.take()));
+    }
+}
+
+/// Run `f` with a stack probe armed and return `(f(), high_water_bytes)`.
+///
+/// `high_water_bytes` is the maximum stack depth [`note`] observed below the
+/// arm point, i.e. the stack the guarded recursions inside `f` actually
+/// consumed. `0` when the platform cannot report the remaining stack or when
+/// nothing called [`note`].
+///
+/// Probes nest safely (the inner probe shadows, then restores, the outer), but
+/// the outer probe does not see samples taken while an inner probe is armed.
+pub fn probe<T>(f: impl FnOnce() -> T) -> (T, u64) {
+    let start = stacker::remaining_stack();
+    let rearm = Rearm(LOW_WATER.with(|lw| lw.replace(start)));
+    let out = f();
+    let low = LOW_WATER.with(|lw| lw.get());
+    drop(rearm);
+    let high_water = match (start, low) {
+        (Some(start), Some(low)) => start.saturating_sub(low) as u64,
+        _ => 0,
+    };
+    (out, high_water)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_without_note_reports_zero() {
+        let (value, hwm) = probe(|| 42);
+        assert_eq!(value, 42);
+        assert_eq!(hwm, 0);
+    }
+
+    #[test]
+    fn note_outside_probe_is_a_noop() {
+        note(); // must not panic or arm anything
+        let (_, hwm) = probe(|| ());
+        assert_eq!(hwm, 0);
+    }
+
+    #[test]
+    fn probe_measures_recursion_depth() {
+        // A recursion that notes at each level and pins a real frame via a
+        // volatile-ish buffer the optimizer cannot elide.
+        fn descend(depth: usize) -> usize {
+            note();
+            let buf = [0u8; 1024];
+            std::hint::black_box(&buf);
+            if depth == 0 {
+                buf.len()
+            } else {
+                std::hint::black_box(descend(depth - 1))
+            }
+        }
+        let (_, shallow) = probe(|| descend(4));
+        let (_, deep) = probe(|| descend(128));
+        // Each frame holds a 1 KiB buffer, so 124 extra frames must consume
+        // at least 124 KiB more stack (when the platform reports it at all).
+        if shallow > 0 || deep > 0 {
+            assert!(
+                deep >= shallow + 124 * 1024,
+                "deep recursion must show a higher stack high-water mark: \
+                 shallow={shallow} deep={deep}"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_probe_restores_the_outer() {
+        fn descend(depth: usize) -> usize {
+            note();
+            let buf = [0u8; 1024];
+            std::hint::black_box(&buf);
+            if depth == 0 {
+                buf.len()
+            } else {
+                std::hint::black_box(descend(depth - 1))
+            }
+        }
+        let ((_, inner_hwm), outer_hwm) = probe(|| {
+            let inner = probe(|| descend(32));
+            descend(64); // sampled by the OUTER probe after the inner restored
+            inner
+        });
+        if inner_hwm > 0 {
+            // The outer probe armed higher up the stack, so its high-water on
+            // the same-depth descent is at least the inner's.
+            assert!(outer_hwm >= inner_hwm);
+        }
+    }
+}

--- a/docs/10-quality/td/TD-EXEC-2-plan-geometry-resource-model.adoc
+++ b/docs/10-quality/td/TD-EXEC-2-plan-geometry-resource-model.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open — design filed 2026-07-10.** First-principles generalization of TD-EXEC-1 (which named the flat 8 MB stack a "blunt band-aid" and asked for measured, shape-sized allocation). Extends the ADR-050/#840 route cost model, not a new engine.
+| Status | **Open — design filed 2026-07-10.** First-principles generalization of TD-EXEC-1 (which named the flat 8 MB stack a "blunt band-aid" and asked for measured, shape-sized allocation). Extends the ADR-050/#840 route cost model, not a new engine. **Progress:** Slice 0 (stack safety, `maybe_grow`) landed via #851; Slice 1 core (`PlanGeometry` + iterative `measure_geometry`) via #854; **Slice 1 calibration + seam wiring landed 2026-07-11** — the ~100× `frame_bytes` unknown is *resolved by measurement* (see §1.b): lowering ≈ **1.46 KB/frame**, executor build ≈ **2.35 KB/frame** (release; 8.7 / 16.3 KB debug), and geometry + `plan_ms` + `stack_hwm_bytes` now record into the io-trace/ledger at the pgwire plan→execute seam.
 | Priority | **P1** — the router and the stack allocator both decide resources today by *rule-of-thumb* (a 2-bit `match` for engine, a flat 8 MB for stack). Both are the same missing capability: predict a query's resource footprint from its plan *geometry*, calibrated by measurement. Closes TD-EXEC-1 Phase 1 and makes the ADR-050 cost model live.
 | Severity | **High for the stack half** (revised) — the band-aid is *test-only*: #843/#846 raised the 8 MB stack in the three TPC test harnesses, but the **production server runs on the tokio default 2 MB** (`apps/proximadb-server/src/main.rs:121` = bare `#[tokio::main]`; the only 8 MB is `EmbeddedProximaDB::new`, `src/embedded/mod.rs:828`, the PyO3 path). The dominant consumer is the **planner recursion, which runs *before any engine*** — so the native `MAX_WALK_DEPTH=32` guard does not protect it. A deep OLAP query (Q2/Q7 already at SF ≥ 0.01) SIGABRTs the production pgwire *process* → this is a **P1 availability bug**, not a sizing inefficiency. Medium for the routing half (leaves the measured cost model dark, `PROXIMADB_ROUTE_COST_OVERRIDE` OFF). *This severity split is why the stack **safety** primitive (§1) is decoupled from — and lands ahead of — the estimate/calibration/routing.*
 | Component | *new* `PlanGeometry` + `measure_geometry` in `crates/query/proximadb-relational-planner/src/lib.rs`; *new* stack estimator (`crates/query/proximadb-relational-planner` or a leaf crate); extends `IoTrace`/`IoTraceSnapshot` (`src/observability/io_trace.rs`), the ledger `LedgerRecord` (`tests/tpc_perf_ledger_e2e.rs`), `QueryShape`/`shape_class` (`src/query/compute_scheduler.rs`, `src/query/route_cost_model.rs`), and the pgwire worker spawn (`src/network/postgres/mod.rs:249`).
@@ -65,6 +65,29 @@ stack_bytes(plan) ≈ C_planner · max_depth
 ....
 
 `C_planner` and `frame_bytes[op_kind]` are **measured** (calibrated from per-query `stacker::remaining_stack()` high-water marks, recorded to the ledger), O(1) to evaluate from `max_depth` + deepest-path op-kinds. The estimate is used to (i) pre-size the worker/segment so the *common* deep plan avoids the mid-descent growth allocation, and optionally (ii) route to a tiered pool — OLTP (≤512 KB shallow) vs OLAP (deep join+subquery). Because these are optimizations, a *wrong* estimate costs a growth allocation or a suboptimal pool — never a crash.
+
+**Measured (Slice 1 calibration, 2026-07-11 — the ~100× unknown resolved).** The `stack_probe`
+module (planner crate) arms a thread-local low-water probe around the guarded recursions; the
+`calibrate_lowering_frame_cost` / `calibrate_build_frame_cost` tests measure a 100-deep vs
+1100-deep filter chain on a dedicated large-stack thread (no `maybe_grow` growth, exact reading)
+and divide out the fixed overhead:
+
+[cols="2,1,1", options="header"]
+|===
+| Recursion | Release | Debug
+| planner `lower_to_physical` | **≈ 1 456 B/frame** | ≈ 8 656 B/frame
+| executor `build_executor` | **≈ 2 352 B/frame** | ≈ 16 336 B/frame
+|===
+
+TD-EXEC-1's 100–200 KB/frame estimate was ~100× high; the ~1 KB code-probe guess was right for
+release builds. The recursions run sequentially and the stack unwinds between them, so the
+binding figure is the **max** per level (executor build), not the sum. Consequences: (a) a
+default 2 MB tokio worker holds ~850 build frames in release but only ~125 in debug — consistent
+with the Q2/Q7 overflows having surfaced in (debug-built) test harnesses at modest plan depths;
+(b) the Slice-0 `red_zone = 256 KiB` buys ~110 release build-frames of headroom per check —
+comfortably safe; (c) a Slice-2 estimate can seed `frame_bytes ≈ 2.4 KB (release) / 16 KB
+(debug)` per plan level, refined per-op-kind by the ledger fit. The tests double as regression
+ratchets (fail past 32 KiB/frame — frame-bloat detection ~14× above measured release cost).
 
 * TD-EXEC-1 Phase 2 (iterative planner, heap work-list) **zeroes the `C_planner · max_depth` term** at the source; the estimator then reflects only the executor's residual recursion. `maybe_grow` makes the iterative planner a *performance* optimization (fewer segment allocations, better cache locality), no longer a correctness prerequisite — the estimator measures its win.
 

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -40,6 +40,7 @@ use proximadb_relational_executor::{ExecError, NodeMetric, ReaderFactory};
 use proximadb_relational_frontend::{CatalogLookup, lower_sql};
 use proximadb_relational_planner::{
     CapabilityResolver, PhysicalPlan, Planner, StaticCapabilities, explain_physical,
+    measure_geometry, stack_probe,
 };
 use proximadb_relational_reader::{ReaderCapabilities, ReaderError, RelationalReader, ScanContext};
 use proximadb_relational_types::{ColumnInfo, Expr, ExprError, RelationalRow, RelationalSchema};
@@ -679,8 +680,42 @@ async fn run_plan<F: ReaderFactory, R: CapabilityResolver>(
     controls: ExecutionControls,
 ) -> Result<ExecutionPipelineResult, String> {
     let planner = Planner::new(resolver);
-    let physical = planner.plan(logical).map_err(|e| format!("plan: {e}"))?;
+    let physical = plan_instrumented(&planner, logical)?;
     execute_physical(physical, factory, controls).await
+}
+
+/// Plan `logical` and record the TD-EXEC-2 Slice-1 observe-only trace fields into
+/// the active io_trace scope: planning wall ms, the planner recursion's measured
+/// stack high-water mark (via `stack_probe`), and the served plan's geometry
+/// vector (`measure_geometry`, iterative — safe on any depth). This is the
+/// plan→execute seam the calibration ledger reads; it makes no decision and
+/// changes no behavior, and every record call no-ops outside an io_trace scope.
+fn plan_instrumented<R: CapabilityResolver>(
+    planner: &Planner<R>,
+    logical: proximadb_relational_algebra::LogicalNode,
+) -> Result<PhysicalPlan, String> {
+    let plan_start = std::time::Instant::now();
+    let (planned, stack_hwm) = stack_probe::probe(|| planner.plan(logical));
+    let physical = planned.map_err(|e| format!("plan: {e}"))?;
+    crate::observability::io_trace::record_plan_ms(plan_start.elapsed().as_millis() as u64);
+    if stack_hwm > 0 {
+        crate::observability::io_trace::record_stack_hwm(stack_hwm);
+    }
+    let g = measure_geometry(&physical);
+    let ops: Vec<(&str, u64)> = g
+        .op_histogram
+        .iter()
+        .map(|(kind, count)| (kind.as_str(), u64::from(*count)))
+        .collect();
+    crate::observability::io_trace::record_plan_geometry(
+        g.max_depth as u64,
+        g.node_count as u64,
+        g.leaf_count as u64,
+        g.max_fanout as u64,
+        u64::from(g.blocking_count),
+        &ops,
+    );
+    Ok(physical)
 }
 
 /// Build + open + drain an executor for an already-planned `physical` plan.
@@ -756,7 +791,7 @@ fn plan_over_snapshot(
         secondary_by_table,
     };
     let planner = Planner::new(resolver);
-    Some(planner.plan(logical).map_err(|e| format!("plan: {e}")))
+    Some(plan_instrumented(&planner, logical))
 }
 
 // =========================================================================

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -343,8 +343,16 @@ impl NativeVolcanoEngine {
             }
             return finalize_row_limit(result, &controls);
         }
-        let mut exec = build_executor(physical, factory, &VolcanoExecutionContext::default())
-            .map_err(|e| ExecutionError::Execution(format!("build_executor: {e}")))?;
+        // TD-EXEC-2 Slice 1 (observe-only): measure the build recursion's stack
+        // high-water mark alongside the plan-lowering probe at the plan seam.
+        let (built, build_hwm) = proximadb_relational_planner::stack_probe::probe(|| {
+            build_executor(physical, factory, &VolcanoExecutionContext::default())
+        });
+        if build_hwm > 0 {
+            crate::observability::io_trace::record_stack_hwm(build_hwm);
+        }
+        let mut exec =
+            built.map_err(|e| ExecutionError::Execution(format!("build_executor: {e}")))?;
         controls.check_cancelled()?;
         exec.open()
             .await
@@ -377,8 +385,16 @@ impl NativeVolcanoEngine {
     ) -> Result<ExecutionStreamResult, ExecutionError> {
         controls.check_cancelled()?;
         let physical = cap_plan(physical, &controls);
-        let mut exec = build_executor(physical, factory, &VolcanoExecutionContext::default())
-            .map_err(|e| ExecutionError::Execution(format!("build_executor: {e}")))?;
+        // TD-EXEC-2 Slice 1 (observe-only): measure the build recursion's stack
+        // high-water mark alongside the plan-lowering probe at the plan seam.
+        let (built, build_hwm) = proximadb_relational_planner::stack_probe::probe(|| {
+            build_executor(physical, factory, &VolcanoExecutionContext::default())
+        });
+        if build_hwm > 0 {
+            crate::observability::io_trace::record_stack_hwm(build_hwm);
+        }
+        let mut exec =
+            built.map_err(|e| ExecutionError::Execution(format!("build_executor: {e}")))?;
         controls.check_cancelled()?;
         exec.open()
             .await

--- a/src/query/execution/native_ops.rs
+++ b/src/query/execution/native_ops.rs
@@ -1321,6 +1321,9 @@ const WALK_STACK_GROW: usize = 4 * 1024 * 1024;
 /// back through this entry, so every level checks its own headroom.
 fn walk(plan: &PhysicalPlan, scan_ctx: Option<&ScanCtx>) -> Result<Walked, ExecutionError> {
     stacker::maybe_grow(WALK_RED_ZONE, WALK_STACK_GROW, || {
+        // TD-EXEC-2 Slice 1: sample the recursion's stack low-water mark when a
+        // probe is armed (a TLS read + branch otherwise).
+        proximadb_relational_planner::stack_probe::note();
         walk_inner(plan, scan_ctx)
     })
 }


### PR DESCRIPTION
## Summary

TD-EXEC-2 **Slice 1** (observe-only): resolve the ~100× `frame_bytes` unknown by measurement, and wire the plan-geometry vector + measured stack high-water mark + `plan_ms` into the per-query io-trace/ledger at the pgwire plan→execute seam. Follows #851 (Slice 0 `maybe_grow` safety) and #854 (`PlanGeometry` + iterative `measure_geometry`).

## The calibration result (the headline)

| Recursion | Release | Debug |
|---|---|---|
| planner `lower_to_physical` | **≈ 1 456 B/frame** | ≈ 8 656 B/frame |
| executor `build_executor` | **≈ 2 352 B/frame** | ≈ 16 336 B/frame |

TD-EXEC-1's 100–200 KB/frame estimate was ~100× high; the ~1 KB code-probe guess was right for release. The recursions unwind between phases, so the binding per-level figure is the **max** (executor build): a default 2 MB tokio worker holds ~850 build frames in release but only ~125 in debug — consistent with the Q2/Q7 overflows having surfaced in debug-built test harnesses. The Slice-0 `red_zone = 256 KiB` buys ~110 release build-frames of headroom per check. Measured values + consequences recorded in the TD doc.

## What changed

- **`stack_probe` (new, planner crate):** thread-local low-water probe over `stacker::remaining_stack()`; `note()` sampled at the three guarded recursion entries (`lower_to_physical`, `build_executor`, native `walk`) — a TLS read + branch when unarmed (same order as the adjacent `maybe_grow` check), panic-safe rearm, exact until the first segment growth (documented lower-bound semantics past it).
- **Calibration ratchet tests** (`calibrate_lowering_frame_cost`, `calibrate_build_frame_cost`): measure 100- vs 1100-deep chains on a dedicated 256 MiB-stack thread (no segment growth → exact), print the measured per-frame cost, and fail past 32 KiB/frame — frame-bloat regression detection ~14× above measured release cost.
- **io-trace (additive, serde-default):** `plan_depth` / `plan_nodes` / `plan_leaves` / `plan_fanout` / `plan_blocking` / `plan_ops` (op-kind histogram) + `stack_hwm_bytes` on `IoTrace`/`IoTraceSnapshot`, recorded as neutral scalars (io_trace keeps zero query-layer deps, same pattern as `route`). Flows into the TPC perf `LedgerRecord` automatically via the existing `#[serde(flatten)]`.
- **pgwire seam:** `plan_instrumented()` shared by `plan_over_snapshot` + `run_plan` records `plan_ms` (previously DataFusion-route-only) + planner stack HWM + the `measure_geometry()` vector on the native relational route; the Volcano engine's build sites record the executor-build HWM.

## Non-goals / phasing

Observe-only per the TD's Slice-1 phasing: no behavior change, no routing decision consumes the vector (Slice 3), no estimate-driven pre-sizing (Slice 2). The shadow reference build is deliberately unprobed to keep the signal clean.

## Verification

- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings` (server binary included) — clean
- `cargo check --all-targets` — clean
- `cargo nextest`: planner + executor + observability-engine libs 403/403; root-crate scoped run (relational_pipeline / io_trace / route_cost / compute_scheduler / native_ops) 91/91
- `make work-commit-check` (fmt, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy, hygiene) — passed
- Rebased on `develop` @ dc18d516d; `git merge-tree` clean

Refs: TD-EXEC-2, TD-EXEC-1, ADR-052 §5 (measured, not asserted); follows #851/#854, complements #886 (cardinality substrate) toward Slice 3.
