### PR TITLE
docs(td): TD-RDSTRAT-4 — centroid/RaBitQ block clustering + single segment directory + vector zone-map probe-prune

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-4: centroid/RaBitQ block clustering + single segment directory + vector zone-map probe-prune
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (design memo; not yet started). Successor to link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (S1b/S2 landed — the *within-block* binary→SQ8→fp32 striped cascade + cost chooser). This TD attacks the **across-block** term that dominates on object storage: today an unfiltered vector query walks **every** block (only *scalar-predicate* pruning exists — `MetaPrune`/`evaluate_block`), so the coarse binary scan is O(N_blocks) GETs regardless of `k`. Grounded in a cross-system review (Lance, Turbopuffer, Vespa, Milvus, Qdrant, DiskANN/SPANN, pgvector — see *Evidence*). **This TD dominates and subsumes** the marginal in-function stripe-batching follow-up parked in TD-RDSTRAT-3 (batching only nudges the whole-vs-striped crossover; clustering removes the block-count multiplier entirely).
+| Severity | High (cloud cost + latency — `blocks_touched` is the multiplier on both GETs and bytes for every vector query; the single biggest structural gap vs best-in-class object-storage ANN)
+| Component | PAX RaBitQ cascade + segment/flush/compaction: `src/storage/engines/sst/search/mod.rs` (`try_pax_cascade`), `src/storage/engines/sst/segment_format.rs`, `crates/storage/proximadb-block-format` (`ranged`, `vparam`, `rowgroup`, footer/`SegmentIndex`), `src/storage/persistence/filesystem/**/flush_materializer.rs` (write/compaction ordering).
+| Governs / derives from | link:../../12-design/adr/ADR-057-pax-cascade-selective-striped-read-and-chooser.adoc[ADR-057] (the within-block striped cascade this builds on) ; link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (S1b/S2 primitives reused).
+| Relates | link:../../12-design/adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (bytes-scanned / I/O-round-trip cost thesis) ; link:../../12-design/adr/ADR-034-objectstore-access-path-codesign.adoc[ADR-034] (io_trace GET-count measurement mandate) ; link:../../12-design/adr/ADR-036-objectstore-access-tier-codesign.adoc[ADR-036] (per-object access tier — the fp32 tier-3 cost lever) ; link:TD-RDSTRAT-1-read-strategy-chooser.adoc[TD-RDSTRAT-1] / link:TD-RDSTRAT-2-chooser-serves-retired-reader.adoc[TD-RDSTRAT-2] (the chooser lineage).
+|===
+
+== Finding (the one-line critique)
+
+ProximaDB's binary→SQ8→fp32 cascade is **correct and tier-selective _within_ a block** (Stage-1 reads only the
+`EMBED_BASE` RaBitQ codes stripe; Stage-2 reads only the candidate rows of `RERANK_BASE` SQ8; Stage-2b reads only
+top-k of the opt-in `F32_TIER_BASE` fp32 — `segment_format.rs`, `rabitq_search_segment{,_ranged}`). It is **not
+selective _across_ blocks**: for an unfiltered vector query (`filter_expression.is_none()`) the cascade iterates
+**all** blocks and ranks each one's codes. Every best-in-class object-storage system prunes _what the coarse scan
+even looks at_ (IVF `nprobe`, SPANN centroid pruning, graph beam). We do not — because (a) there is **no per-block
+vector centroid / vector zone-map**, only scalar min/max zone-maps, and (b) **flush writes vectors in insertion
+order** (`flush_materializer.rs`), so blocks have no spatial coherence to prune on even if we had the zone-map.
+
+The fix is two composable levers, both **mixed-read-safe, default-OFF, recall-ratcheted**:
+
+* **Lever B — cluster vectors into blocks at flush/compaction + surface a per-block centroid as a _vector_
+  zone-map**, so a query probes centroids and reads only the `nprobe` nearest blocks. Attacks `blocks_touched`.
+* **Lever A — hoist the per-block footers into a _single segment-level directory_** (Lance/Parquet-style single
+  footer), so the centroid probe + block-extent lookup is **one** GET, not O(N_blocks) scattered metadata GETs.
+
+Composed, these turn the query into the **≤3-GET selective cascade** the evidence converges on (Turbopuffer caps
+cold queries at ≤2–3 object-storage round-trips):
+
+[source]
+----
+GET 1  segment directory (single footer): block centroids + zone-maps
+       → probe centroids, select the nprobe nearest blocks          [Lever A + B]
+GET 2  coalesced ranged read of ONLY those blocks' binary code stripes (col EMBED_BASE)
+       → RaBitQ rank; oversample 3–5× target-k                       [fixed-width binary, SIMD popcount]
+       → SQ8 rerank (col RERANK_BASE) on candidates, trim to ~1.5–2× — SIMD int8, NO fp32 fetch
+GET 3  (optional, high-recall) take() fp32 (col F32_TIER_BASE) for the final top-k only, beam/coalesced
+----
+
+== Principle
+
+Same discipline as TD-RDSTRAT-3. Every slice is **atomic** (lands, builds the server binary, independently
+verifiable), **mixed-read-safe** (old + new segments coexist, distinguished by a version/magic byte; readers
+default to the legacy unclustered/whole-footer path when the marker is absent — never a flag-day), and
+**default-OFF** until its gate passes. Clustering **never changes results, only which bytes are read** — recall is
+gated as a **ratchet against the f32 baseline within tolerance** (mandate #8/#10), because coarse pruning that
+drops a true neighbour IS a recall regression (unlike the striped read, which is byte-identical by construction).
+Do **not** build HNSW: the object-storage evidence (Turbopuffer chose SPFresh/SPANN clustering _over_ HNSW to
+minimise round-trips; SPANN is 2× faster than DiskANN at equal recall on cold storage) validates the clustered
+block-scan direction — the co-design cost term is GET round-trips, not graph-walk CPU.
+
+== Slices (atomic, default-OFF, mixed-read-safe, recall-ratcheted)
+
+[cols="1,3,2", options="header"]
+|===
+| Slice | Deliverable | Gate to land
+
+| **S0 — baseline: measure `blocks_touched`** (no product code)
+| Extend the io_trace measurement suite to record, on a representative multi-block RaBitQ segment on a
+  cold-tier-simulated (`s3://`-schemed) path, the current cascade's **blocks scanned**, **GETs**, and **bytes**
+  for a top-k vector query. This is the multiplier S1–S2 must reduce; sets the flip threshold.
+| Test green + a recorded `blocks_touched` / GET / byte baseline for ≥1 representative segment.
+
+| **S1 — flush-time clustering MVP (sort-by-code) + per-block centroid zone-map** (flag
+  `PROXIMADB_PAX_BLOCK_CLUSTER`, default-OFF; new segment version byte)
+| At flush/compaction, order records by their RaBitQ code (Gray/Hamming / space-filling on the sign bits) so
+  contiguous blocks are spatially coherent — **cheap, streaming, no k-means**. Write a per-block **centroid**
+  (mean residual or block-mean vector) + radius into the block metadata (`vparam`/a new vector-zone-map field).
+  Legacy segments (no marker) read unchanged.
+| Round-trip: a clustered segment reads back byte-identical records (parity vs unclustered). Centroid present +
+  decodable. Server binary builds. **No recall change yet** (S1 only reorders + annotates; pruning is S2).
+
+| **S2 — centroid probe-prune at the cascade** (same flag; observe → gated)
+| In `try_pax_cascade`, before the per-block codes scan: rank block centroids vs the (rotated) query, select the
+  `nprobe` nearest blocks (with the `(1+ε)·nearest` closure rule, SPANN-style, so boundary blocks aren't
+  dropped), read **only** those blocks' code stripes. Reuse the TD-RDSTRAT-3 S1b `rabitq_search_segment_ranged`
+  per-block primitive for the selected blocks. `nprobe`/`ε` are tunable knobs, logged via the `rdstrat` target.
+| **SIFT1M recall ratchet ≥ floor** vs the f32 baseline at the chosen `nprobe` (the load-bearing gate) **AND**
+  measured `blocks_touched` / GET reduction ≥ threshold on the S0 trace. Byte-identical results _within_ the
+  selected blocks (the striped read is unchanged).
+
+| **S3 — single segment-level directory** (flag `PROXIMADB_PAX_SEGMENT_FOOTER`, default-OFF; new segment version)
+| Hoist per-block footers → one segment-tail directory (Lance CMO-style: block extents + per-block centroid +
+  zone-maps) so the S2 probe + block-extent lookup is **one** ranged GET instead of O(N_blocks). Legacy
+  per-block-footer segments still read via the existing tail-`SegmentIndex` walk (mixed-read-safe).
+| Probe reads the directory in 1 GET; end-to-end GET count on the S0 trace drops to the ≤3-GET target for a
+  representative `nprobe`. Parity + recall ratchet green.
+
+| **S4 — full IVF/k-means clustering** (upgrade path from S1's sort; same flag family)
+| Replace/augment sort-by-code with a coarse quantizer (k-means centroids at compaction; assign each vector to
+  its nearest centroid; lay out one block-run per centroid — Lance/Milvus/SPANN model). Store the codebook once
+  in the segment directory. Sharper pruning than sort-by-code; opt-in per collection.
+| Recall ratchet ≥ S2 floor at **lower** `nprobe` (i.e. fewer blocks touched for the same recall). Compaction
+  cost measured + bounded.
+
+| **S5 — shared cross-engine primitive + adaptive tier chooser** (cleanup)
+| Promote the clustered binary→SQ8→fp32 cascade to a **shared primitive** so HELIX/NOVA/VIPER inherit it rather
+  than re-diverge (audit-confirmed: only SST implements it today). Extend the TD-RDSTRAT-3 S2 cost chooser to
+  also pick **SQ8-vs-fp32 rerank** per recall target / tier cost.
+| The shared primitive has one parity + recall test; ≥1 second engine consumes it. Chooser observe-logs the
+  tier decision with no behaviour change when OFF.
+|===
+
+== Recall / eval gate (the non-negotiable)
+
+Unlike the striped read (byte-identical to whole-read ⇒ recall preserved by construction), **clustering changes
+which candidates the coarse stage sees** — so recall is the gate, not an afterthought. Per mandates #10/#13:
+
+* Gate every clustering/pruning slice against the **f32 recall baseline within tolerance** on SIFT1M (recall@k),
+  as a **ratchet** (a regression fails CI). `nprobe`/`ε`/oversampling are **calibrated eval thresholds**, versioned
+  in the PR that changes them.
+* The evidence sets expectations: binary-alone recall is only ~92% (dataset-dependent); the **SQ8 middle tier is
+  load-bearing** — Qdrant recovers 0.98+ from 32× binary via **3–4× oversampling + rescore**; Milvus SCANN jumps
+  0.71→0.94 by adding a raw reorder tier. So the cascade must **oversample generously at binary (3–5×), trim at
+  SQ8 (SIMD int8, no object-store round-trip), and touch fp32 only for the final top-k.** A binary-only path that
+  skips SQ8 silently regresses recall — forbidden.
+
+== Evidence (cross-system review, 2026-07-12)
+
+Four converging invariants, observed in Lance, Turbopuffer, Vespa, Milvus, Qdrant, DiskANN/SPANN, pgvector:
+
+[cols="1,4", options="header"]
+|===
+| Invariant | How the field implements it (⇒ what ProximaDB must add)
+
+| **Tiers in separate, independently-addressable storage; fp32 read only by row-id, never scanned**
+| Lance `take()` by row-id for the `refine_factor` shortlist; Qdrant `BinaryRam` codes vs mmap fp32 originals
+  (candidate-ID reads); Vespa binary in-RAM vs fp32 `paged`; DiskANN PQ-in-RAM vs fp32-on-SSD (visited set only);
+  pgvector bit/halfvec index vs fp32 heap. ⇒ **ProximaDB already does this within a block** (cols 20/1000/2000) —
+  keep it.
+
+| **Partition/cluster FIRST so the coarse scan touches bounded data**
+| Lance IVF `nprobes` + per-partition offsets/lengths (range-read only selected partitions); Turbopuffer
+  SPFresh/SPANN clusters; Milvus IVF `nprobe`; SPANN query-aware centroid pruning (read list _j_ only if within
+  `(1+ε)` of the nearest centroid). ⇒ **ProximaDB's gap — this whole TD** (Lever B, S1/S2/S4).
+
+| **Single unified footer / directory ⇒ ≤1–2 IOP random access**
+| Lance v2: one 32-byte footer + CMO/GBO offset tables → any column/page in ≤1 IOP, no row-group scan (~2000×
+  faster random access than Parquet). ⇒ **ProximaDB's per-block footers are the anti-pattern** (Lever A, S3).
+
+| **Recall lives in the oversampling factor, not code precision; budget the query in GET round-trips**
+| Qdrant `oversampling` 3–4× + rescore → 0.98; Vespa `rerank-count` (100/node); Turbopuffer ≤2–3 GETs cold; S3
+  first-byte ~20–100 ms (P90 ~250 ms) ⇒ latency, not CPU, is the objective. ⇒ **ProximaDB: calibrated
+  oversampling knobs + a ≤3-GET budget** (recall gate + S2/S3).
+|===
+
+Do **not** adopt HNSW: Turbopuffer explicitly chose clustering over HNSW to minimise object-storage round-trips;
+SPANN is 2× faster than DiskANN at equal recall on cold storage. ProximaDB's clustered block-scan is the correct
+object-storage direction.
+
+*Caveat:* HELIX/NOVA/VIPER cascade divergence (S5) is from module-summary reads, not a deep source dive — confirm
+before acting on S5. Turbopuffer's exact segment encoding is inferred (closed source); its ≤2–3-GET budget and
+SPFresh clustering are stated by the vendor.


### PR DESCRIPTION
## Summary

Files **TD-RDSTRAT-4** — a design memo + atomic slice plan for the next foundational step in the PAX vector-read arc, successor to TD-RDSTRAT-3 (which landed the *within-block* binary→SQ8→fp32 striped cascade + cost chooser).

**The gap it attacks:** ProximaDB's cascade is tier-selective *within* a block but not *across* blocks — an unfiltered vector query walks **every** block (only scalar-predicate pruning exists), so the coarse binary scan is O(N_blocks) GETs regardless of `k`. Every best-in-class object-storage system prunes what the coarse scan even looks at (IVF `nprobe`, SPANN centroid pruning); we don't.

**Two composable levers** (mixed-read-safe, default-OFF, recall-ratcheted):
- **B** — cluster vectors into blocks at flush/compaction + surface a per-block centroid as a *vector* zone-map → probe-prune to the `nprobe` nearest blocks.
- **A** — hoist per-block footers into one Lance-style segment directory → the centroid probe is **1 GET, not O(N_blocks)**.

Composed → the **≤3-GET selective cascade** the evidence converges on (Turbopuffer caps cold queries at ≤2–3 round-trips).

**Slices** S0–S5: measure `blocks_touched` → sort-by-code MVP → centroid probe-prune → single segment directory → full IVF/k-means → shared cross-engine primitive. Each recall-gated vs the f32 baseline (SIFT1M ratchet).

**Grounded in a cross-system source review** (internal audit + local source-dive of Lance/Qdrant + web research on Turbopuffer/Vespa/Milvus/DiskANN/SPANN/pgvector). Explicitly rejects HNSW (clustering wins on object-storage round-trips). Subsumes the marginal in-function stripe-batching follow-up parked in TD-RDSTRAT-3.

## Checks
- `check_td_adr_unique.py`: 0 errors (TD-RDSTRAT-4 unique across 193 TD ids)
- No-agent-attribution guard: clean
- Docs-only (AsciiDoc); no code paths touched