### PR TITLE
refactor(decomp): hoist RBAC context types to proximadb-tenant (Slice D link)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8141,11 +8141,13 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "proximadb-proto",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/foundation/proximadb-tenant/Cargo.toml
+++ b/crates/foundation/proximadb-tenant/Cargo.toml
@@ -16,8 +16,10 @@ path = "src/lib.rs"
 [dependencies]
 proximadb-proto.workspace = true
 serde.workspace = true
-anyhow.workspace = true
 serde_json.workspace = true
+chrono.workspace = true
+uuid = { version = "1.0", features = ["v4"] }
+anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/foundation/proximadb-tenant/src/lib.rs
+++ b/crates/foundation/proximadb-tenant/src/lib.rs
@@ -406,3 +406,16 @@ pub use tenant_tier_types::{
     FeatureFlags, ObjectEconomyQuantizationCeiling, TenantTierRecord, Tier,
     TierObjectEconomyConfig, tier_config,
 };
+
+// ============================================================================
+// RBAC authorization-context data types (moved from
+// `src/security/rbac_service.rs` — Slice D root-crate shrinkage).
+// Leaf data types (permission enum, auth method, user/tenant context) with no
+// root-internal dependencies — pure String / chrono / serde / std collections.
+// The originating `rbac_service.rs` keeps a `pub use` re-export of every type
+// below, so existing `crate::security::rbac_service::<Type>` paths are unchanged.
+// ============================================================================
+pub mod rbac_context;
+pub use rbac_context::{
+    RbacTenantContext, UnifiedAuthMethod, UnifiedPermission, UnifiedUserContext,
+};

--- a/crates/foundation/proximadb-tenant/src/rbac_context.rs
+++ b/crates/foundation/proximadb-tenant/src/rbac_context.rs
@@ -1,0 +1,304 @@
+//! RBAC authorization-context data types (moved from `src/security/rbac_service.rs` — Slice D).
+//!
+//! These are the **leaf data** types that flow through the RBAC / authorization
+//! surface: the permission enum, the auth-method discriminator, the
+//! authenticated user context, and the resolved tenant context. They are pure
+//! data (no behavior, no root-internal dependencies — only `String` / `chrono`
+//! / `serde` / std collections), so they belong at the foundation tier where
+//! every higher layer can depend *down* on them without reaching into the
+//! services/security layer.
+//!
+//! The originating `src/security/rbac_service.rs` keeps a `pub use` re-export of
+//! every type below, so all existing `crate::security::rbac_service::<Type>`
+//! call sites continue to resolve unchanged (the move is source-compatible).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Unified permission model consolidating all permission types (tenant / domain /
+/// collection / vector / entity / graph / query / system / business-context /
+/// field-level).
+///
+/// Self-contained leaf enum: every payload is a `String` (or pair of `String`s),
+/// so this type has no dependencies beyond std + serde. It is the field type of
+/// [`UnifiedUserContext::effective_permissions`] and is consulted throughout the
+/// RBAC manager for wildcard / hierarchy resolution.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UnifiedPermission {
+    // === TENANT LEVEL PERMISSIONS ===
+    TenantAdmin,
+    TenantRead,
+    TenantWrite,
+
+    // === DOMAIN LEVEL PERMISSIONS ===
+    DomainCreate,
+    DomainRead(String),
+    DomainWrite(String),
+    DomainAdmin(String),
+
+    // === COLLECTION LEVEL PERMISSIONS ===
+    // Collection management
+    CollectionCreate,
+    CollectionRead(String),
+    CollectionWrite(String),
+    CollectionDelete(String),
+    CollectionAdmin(String),
+
+    // Collection metadata
+    ReadCollectionMetadata(String),
+    UpdateCollectionMetadata(String),
+    ListCollections,
+
+    // === VECTOR LEVEL PERMISSIONS ===
+    VectorInsert(String), // Collection-specific vector operations
+    VectorDelete(String),
+    VectorSearch(String),
+    VectorUpdate(String),
+    VectorRead(String),
+
+    // === ENTITY LEVEL PERMISSIONS ===
+    EntityRead(String),
+    EntityWrite(String),
+    EntityDelete(String),
+
+    // === GRAPH LEVEL PERMISSIONS ===
+    GraphCreateRelations(String), // Collection-specific graph operations
+    GraphDeleteRelations(String),
+    GraphTraverse(String),
+    GraphReadRelations(String),
+
+    // === QUERY LEVEL PERMISSIONS ===
+    ExecuteSqlQueries(String),   // Collection-specific SQL queries
+    ExecuteSksFunctions(String), // SKS function execution
+
+    // === SYSTEM LEVEL PERMISSIONS ===
+    ViewSystemMetrics,
+    ViewSystemHealth,
+    ConfigureSystem,
+    AuditRead,
+    SystemAdmin,
+
+    // === BUSINESS CONTEXT PERMISSIONS ===
+    // (From Enhanced RBAC for business intelligence)
+    RiskDataAccess,
+    FinancialDataAccess,
+    ComplianceDataAccess,
+    CustomerDataAccess,
+
+    // === SPECIAL PERMISSIONS ===
+    FieldLevelRead(String, String), // (collection, field)
+    FieldLevelWrite(String, String),
+}
+
+/// Authentication method enum for the unified security surface.
+///
+/// This lives in the security/rbac boundary and intentionally differs from the
+/// inbound transport/auth-provider `AuthMethod` modeled at the network edge: it
+/// discriminates *how an authenticated principal authenticated*, not which wire
+/// provider carried the credential.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum UnifiedAuthMethod {
+    SSO { provider: String },
+    JWT,
+    ApiKey,
+    ClientCertificate,
+    Internal,
+}
+
+/// Unified user context for all authentication methods.
+///
+/// Carries the resolved identity of an authenticated principal: who they are
+/// (`user_id`), which tenant they act under (`tenant_id`), their granted roles
+/// and effective permission set, the method by which they authenticated, and
+/// session bookkeeping. Leaf data type — fields are primitives, `chrono`
+/// timestamps, std collections, and the two leaf enums above.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnifiedUserContext {
+    pub user_id: String,
+    pub tenant_id: Option<String>,
+    pub roles: Vec<String>,
+    pub effective_permissions: HashSet<UnifiedPermission>,
+    pub auth_method: UnifiedAuthMethod,
+    pub session_id: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl UnifiedUserContext {
+    /// Create an anonymous user context.
+    ///
+    /// Used by auth surfaces when no principal could be resolved (e.g. auth
+    /// disabled). Moved alongside the type from `src/security/auth_service.rs`
+    /// (Slice D) — inherent methods must live in the defining crate.
+    pub fn anonymous() -> Self {
+        Self {
+            user_id: "anonymous".to_string(),
+            tenant_id: None,
+            roles: vec!["anonymous".to_string()],
+            effective_permissions: HashSet::new(),
+            auth_method: UnifiedAuthMethod::Internal,
+            session_id: format!("anon_{}", uuid::Uuid::new_v4()),
+            expires_at: None,
+            created_at: Utc::now(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Check if user is authenticated (i.e. not the anonymous principal).
+    pub fn is_authenticated(&self) -> bool {
+        self.user_id != "anonymous"
+    }
+
+    /// Check if the user session has expired. A session with no expiry is never
+    /// considered expired.
+    pub fn is_session_expired(&self) -> bool {
+        match self.expires_at {
+            Some(expires_at) => Utc::now() > expires_at,
+            None => false,
+        }
+    }
+
+    /// Get the user display name — falls back to the `user_id` when no
+    /// `display_name` metadata entry is present.
+    pub fn display_name(&self) -> String {
+        self.metadata
+            .get("display_name")
+            .unwrap_or(&self.user_id)
+            .clone()
+    }
+}
+
+/// Tenant context for authorized operations.
+///
+/// The resolved tenant against which an authorized request executes — used by
+/// the RBAC manager to scope `AuthorizationResult::tenant_context`. The
+/// back-compat alias `TenantContext` (re-exported by the originating
+/// `rbac_service.rs`) points here.
+#[derive(Debug, Clone)]
+pub struct RbacTenantContext {
+    pub tenant_id: String,
+    pub tenant_name: String,
+    pub security_policy: String,
+    pub compliance_frameworks: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that every `UnifiedPermission` variant can be constructed and that
+    /// each produces a distinct `Debug` representation. Moved alongside the type
+    /// from `src/security/rbac_service.rs` — this is a data-type test (no manager
+    /// behavior), so it travels with the type.
+    #[test]
+    fn unified_permission_variants_are_distinct() {
+        let permissions: Vec<UnifiedPermission> = vec![
+            UnifiedPermission::TenantAdmin,
+            UnifiedPermission::TenantRead,
+            UnifiedPermission::TenantWrite,
+            UnifiedPermission::DomainCreate,
+            UnifiedPermission::DomainRead("d1".into()),
+            UnifiedPermission::DomainWrite("d1".into()),
+            UnifiedPermission::DomainAdmin("d1".into()),
+            UnifiedPermission::CollectionCreate,
+            UnifiedPermission::CollectionRead("c1".into()),
+            UnifiedPermission::CollectionWrite("c1".into()),
+            UnifiedPermission::CollectionDelete("c1".into()),
+            UnifiedPermission::CollectionAdmin("c1".into()),
+            UnifiedPermission::ReadCollectionMetadata("c1".into()),
+            UnifiedPermission::UpdateCollectionMetadata("c1".into()),
+            UnifiedPermission::ListCollections,
+            UnifiedPermission::VectorInsert("c1".into()),
+            UnifiedPermission::VectorDelete("c1".into()),
+            UnifiedPermission::VectorSearch("c1".into()),
+            UnifiedPermission::VectorUpdate("c1".into()),
+            UnifiedPermission::VectorRead("c1".into()),
+            UnifiedPermission::EntityRead("e1".into()),
+            UnifiedPermission::EntityWrite("e1".into()),
+            UnifiedPermission::EntityDelete("e1".into()),
+            UnifiedPermission::GraphCreateRelations("g1".into()),
+            UnifiedPermission::GraphDeleteRelations("g1".into()),
+            UnifiedPermission::GraphTraverse("g1".into()),
+            UnifiedPermission::GraphReadRelations("g1".into()),
+            UnifiedPermission::ExecuteSqlQueries("c1".into()),
+            UnifiedPermission::ExecuteSksFunctions("c1".into()),
+            UnifiedPermission::ViewSystemMetrics,
+            UnifiedPermission::ViewSystemHealth,
+            UnifiedPermission::ConfigureSystem,
+            UnifiedPermission::AuditRead,
+            UnifiedPermission::SystemAdmin,
+            UnifiedPermission::RiskDataAccess,
+            UnifiedPermission::FinancialDataAccess,
+            UnifiedPermission::ComplianceDataAccess,
+            UnifiedPermission::CustomerDataAccess,
+            UnifiedPermission::FieldLevelRead("c1".into(), "field_a".into()),
+            UnifiedPermission::FieldLevelWrite("c1".into(), "field_b".into()),
+        ];
+
+        // Each variant should produce a distinct Debug string.
+        let debug_strings: HashSet<String> = permissions.iter().map(|p| format!("{p:?}")).collect();
+        assert_eq!(
+            debug_strings.len(),
+            permissions.len(),
+            "all permission variants should produce unique Debug representations"
+        );
+    }
+
+    #[test]
+    fn unified_auth_method_round_trips_serde() {
+        let methods = vec![
+            UnifiedAuthMethod::SSO {
+                provider: "okta".into(),
+            },
+            UnifiedAuthMethod::JWT,
+            UnifiedAuthMethod::ApiKey,
+            UnifiedAuthMethod::ClientCertificate,
+            UnifiedAuthMethod::Internal,
+        ];
+        for method in methods {
+            let json = serde_json::to_string(&method).expect("serialize");
+            let back: UnifiedAuthMethod = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(method, back);
+        }
+    }
+
+    #[test]
+    fn unified_user_context_round_trips_serde() {
+        let ctx = UnifiedUserContext {
+            user_id: "u1".into(),
+            tenant_id: Some("t1".into()),
+            roles: vec!["admin".into()],
+            effective_permissions: [
+                UnifiedPermission::TenantRead,
+                UnifiedPermission::VectorSearch("c1".into()),
+            ]
+            .into_iter()
+            .collect(),
+            auth_method: UnifiedAuthMethod::JWT,
+            session_id: "s1".into(),
+            expires_at: None,
+            created_at: Utc::now(),
+            metadata: HashMap::from([("k".into(), "v".into())]),
+        };
+        let json = serde_json::to_string(&ctx).expect("serialize");
+        let back: UnifiedUserContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.user_id, "u1");
+        assert_eq!(back.tenant_id.as_deref(), Some("t1"));
+        assert_eq!(back.auth_method, UnifiedAuthMethod::JWT);
+        assert_eq!(back.effective_permissions.len(), 2);
+    }
+
+    #[test]
+    fn rbac_tenant_context_constructs() {
+        let ctx = RbacTenantContext {
+            tenant_id: "tenant_1".into(),
+            tenant_name: "Acme Corp".into(),
+            security_policy: "strict".into(),
+            compliance_frameworks: vec!["SOC2".into(), "GDPR".into()],
+        };
+        assert_eq!(ctx.tenant_id, "tenant_1");
+        assert_eq!(ctx.compliance_frameworks.len(), 2);
+    }
+}

--- a/src/security/auth_service.rs
+++ b/src/security/auth_service.rs
@@ -905,43 +905,12 @@ pub struct ClientCertificateData {
     pub raw_cert_der: Option<Vec<u8>>,
 }
 
-impl UnifiedUserContext {
-    /// Create anonymous user context
-    pub fn anonymous() -> Self {
-        Self {
-            user_id: "anonymous".to_string(),
-            tenant_id: None,
-            roles: vec!["anonymous".to_string()],
-            effective_permissions: HashSet::new(),
-            auth_method: UnifiedAuthMethod::Internal,
-            session_id: format!("anon_{}", uuid::Uuid::new_v4()),
-            expires_at: None,
-            created_at: Utc::now(),
-            metadata: HashMap::new(),
-        }
-    }
-
-    /// Check if user is authenticated
-    pub fn is_authenticated(&self) -> bool {
-        self.user_id != "anonymous"
-    }
-
-    /// Check if user session is expired
-    pub fn is_session_expired(&self) -> bool {
-        match self.expires_at {
-            Some(expires_at) => Utc::now() > expires_at,
-            None => false,
-        }
-    }
-
-    /// Get user display name
-    pub fn display_name(&self) -> String {
-        self.metadata
-            .get("display_name")
-            .unwrap_or(&self.user_id)
-            .clone()
-    }
-}
+// NOTE: the inherent `impl UnifiedUserContext { anonymous / is_authenticated /
+// is_session_expired / display_name }` block previously defined here was moved
+// to `proximadb_tenant::rbac_context` (Slice D hoist) — inherent impls must live
+// in the defining crate, and the type now lives in the foundation `proximadb-
+// tenant` crate. All methods remain accessible in scope via the
+// `crate::security::rbac_service` re-export.
 
 /// Create audit event for authentication attempt
 fn create_auth_audit_event(

--- a/src/security/rbac_service.rs
+++ b/src/security/rbac_service.rs
@@ -32,73 +32,12 @@ struct PermissionCacheEntry {
     cached_at: DateTime<Utc>,
 }
 
-/// Unified permission model consolidating all permission types
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub enum UnifiedPermission {
-    // === TENANT LEVEL PERMISSIONS ===
-    TenantAdmin,
-    TenantRead,
-    TenantWrite,
-
-    // === DOMAIN LEVEL PERMISSIONS ===
-    DomainCreate,
-    DomainRead(String),
-    DomainWrite(String),
-    DomainAdmin(String),
-
-    // === COLLECTION LEVEL PERMISSIONS ===
-    // Collection management
-    CollectionCreate,
-    CollectionRead(String),
-    CollectionWrite(String),
-    CollectionDelete(String),
-    CollectionAdmin(String),
-
-    // Collection metadata
-    ReadCollectionMetadata(String),
-    UpdateCollectionMetadata(String),
-    ListCollections,
-
-    // === VECTOR LEVEL PERMISSIONS ===
-    VectorInsert(String), // Collection-specific vector operations
-    VectorDelete(String),
-    VectorSearch(String),
-    VectorUpdate(String),
-    VectorRead(String),
-
-    // === ENTITY LEVEL PERMISSIONS ===
-    EntityRead(String),
-    EntityWrite(String),
-    EntityDelete(String),
-
-    // === GRAPH LEVEL PERMISSIONS ===
-    GraphCreateRelations(String), // Collection-specific graph operations
-    GraphDeleteRelations(String),
-    GraphTraverse(String),
-    GraphReadRelations(String),
-
-    // === QUERY LEVEL PERMISSIONS ===
-    ExecuteSqlQueries(String),   // Collection-specific SQL queries
-    ExecuteSksFunctions(String), // SKS function execution
-
-    // === SYSTEM LEVEL PERMISSIONS ===
-    ViewSystemMetrics,
-    ViewSystemHealth,
-    ConfigureSystem,
-    AuditRead,
-    SystemAdmin,
-
-    // === BUSINESS CONTEXT PERMISSIONS ===
-    // (From Enhanced RBAC for business intelligence)
-    RiskDataAccess,
-    FinancialDataAccess,
-    ComplianceDataAccess,
-    CustomerDataAccess,
-
-    // === SPECIAL PERMISSIONS ===
-    FieldLevelRead(String, String), // (collection, field)
-    FieldLevelWrite(String, String),
-}
+/// Unified permission model consolidating all permission types.
+///
+/// Hoisted to the `proximadb-tenant` foundation crate (Slice D root-crate
+/// shrinkage) — re-exported here so all existing `crate::security::rbac_service`
+/// call sites resolve unchanged. See [`proximadb_tenant::UnifiedPermission`].
+pub use proximadb_tenant::UnifiedPermission;
 
 /// Unified role definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,32 +52,21 @@ pub struct UnifiedRole {
     pub is_system_role: bool,
 }
 
-/// Unified user context for all authentication methods
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnifiedUserContext {
-    pub user_id: String,
-    pub tenant_id: Option<String>,
-    pub roles: Vec<String>,
-    pub effective_permissions: HashSet<UnifiedPermission>,
-    pub auth_method: UnifiedAuthMethod,
-    pub session_id: String,
-    pub expires_at: Option<DateTime<Utc>>,
-    pub created_at: DateTime<Utc>,
-    pub metadata: HashMap<String, String>,
-}
+/// Unified user context for all authentication methods.
+///
+/// Hoisted to the `proximadb-tenant` foundation crate (Slice D root-crate
+/// shrinkage) — re-exported here so all existing `crate::security::rbac_service`
+/// call sites resolve unchanged. See [`proximadb_tenant::UnifiedUserContext`].
+pub use proximadb_tenant::UnifiedUserContext;
 
 /// Authentication method enum for the unified security surface.
 /// This lives in the security/rbac boundary and intentionally differs from
 /// `crate::network::auth::AuthMethod`, which models inbound transport/auth-provider
 /// style handling at the network edge.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum UnifiedAuthMethod {
-    SSO { provider: String },
-    JWT,
-    ApiKey,
-    ClientCertificate,
-    Internal,
-}
+///
+/// Hoisted to the `proximadb-tenant` foundation crate (Slice D) — re-exported
+/// here. See [`proximadb_tenant::UnifiedAuthMethod`].
+pub use proximadb_tenant::UnifiedAuthMethod;
 
 /// Compatibility alias preserved for existing call sites in the security crate.
 pub type AuthMethod = UnifiedAuthMethod;
@@ -916,17 +844,15 @@ pub struct AuthorizationResult {
     pub reason: Option<String>,
 }
 
+/// Tenant context for authorized operations.
+///
+/// Hoisted to the `proximadb-tenant` foundation crate (Slice D root-crate
+/// shrinkage) — re-exported here so all existing `crate::security::rbac_service`
+/// call sites resolve unchanged. See [`proximadb_tenant::RbacTenantContext`].
+pub use proximadb_tenant::RbacTenantContext;
+
 /// Backwards-compat alias for [`RbacTenantContext`].
 pub type TenantContext = RbacTenantContext;
-
-/// Tenant context for authorized operations
-#[derive(Debug, Clone)]
-pub struct RbacTenantContext {
-    pub tenant_id: String,
-    pub tenant_name: String,
-    pub security_policy: String,
-    pub compliance_frameworks: Vec<String>,
-}
 
 #[cfg(test)]
 mod tests {
@@ -1016,62 +942,9 @@ mod tests {
     // New infrastructure tests
     // =========================================================================
 
-    #[test]
-    fn test_unified_permission_variants() {
-        // Verify that all UnifiedPermission variants can be constructed
-        // and are distinct via Debug output (compile-time + runtime check).
-        let permissions: Vec<UnifiedPermission> = vec![
-            UnifiedPermission::TenantAdmin,
-            UnifiedPermission::TenantRead,
-            UnifiedPermission::TenantWrite,
-            UnifiedPermission::DomainCreate,
-            UnifiedPermission::DomainRead("d1".into()),
-            UnifiedPermission::DomainWrite("d1".into()),
-            UnifiedPermission::DomainAdmin("d1".into()),
-            UnifiedPermission::CollectionCreate,
-            UnifiedPermission::CollectionRead("c1".into()),
-            UnifiedPermission::CollectionWrite("c1".into()),
-            UnifiedPermission::CollectionDelete("c1".into()),
-            UnifiedPermission::CollectionAdmin("c1".into()),
-            UnifiedPermission::ReadCollectionMetadata("c1".into()),
-            UnifiedPermission::UpdateCollectionMetadata("c1".into()),
-            UnifiedPermission::ListCollections,
-            UnifiedPermission::VectorInsert("c1".into()),
-            UnifiedPermission::VectorDelete("c1".into()),
-            UnifiedPermission::VectorSearch("c1".into()),
-            UnifiedPermission::VectorUpdate("c1".into()),
-            UnifiedPermission::VectorRead("c1".into()),
-            UnifiedPermission::EntityRead("e1".into()),
-            UnifiedPermission::EntityWrite("e1".into()),
-            UnifiedPermission::EntityDelete("e1".into()),
-            UnifiedPermission::GraphCreateRelations("g1".into()),
-            UnifiedPermission::GraphDeleteRelations("g1".into()),
-            UnifiedPermission::GraphTraverse("g1".into()),
-            UnifiedPermission::GraphReadRelations("g1".into()),
-            UnifiedPermission::ExecuteSqlQueries("c1".into()),
-            UnifiedPermission::ExecuteSksFunctions("c1".into()),
-            UnifiedPermission::ViewSystemMetrics,
-            UnifiedPermission::ViewSystemHealth,
-            UnifiedPermission::ConfigureSystem,
-            UnifiedPermission::AuditRead,
-            UnifiedPermission::SystemAdmin,
-            UnifiedPermission::RiskDataAccess,
-            UnifiedPermission::FinancialDataAccess,
-            UnifiedPermission::ComplianceDataAccess,
-            UnifiedPermission::CustomerDataAccess,
-            UnifiedPermission::FieldLevelRead("c1".into(), "field_a".into()),
-            UnifiedPermission::FieldLevelWrite("c1".into(), "field_b".into()),
-        ];
-
-        // Each variant should produce a distinct Debug string
-        let debug_strings: HashSet<String> =
-            permissions.iter().map(|p| format!("{:?}", p)).collect();
-        assert_eq!(
-            debug_strings.len(),
-            permissions.len(),
-            "all permission variants should produce unique Debug representations"
-        );
-    }
+    // NOTE: `test_unified_permission_variants` moved to the `proximadb-tenant`
+    // crate alongside the `UnifiedPermission` type (Slice D hoist — it is a pure
+    // data-type test with no manager behavior).
 
     #[test]
     fn test_data_model_alias() {


### PR DESCRIPTION
## What

Hoist the four leaf RBAC authorization-context data types out of the root `src/security/rbac_service.rs` into the foundation `proximadb-tenant` crate. This is a Slice-D root-crate-shrinkage link that unblocks the engine-port-traits module move: the types that `src/storage/traits/query.rs` imports from `rbac_service` (`TenantContext`, `UnifiedUserContext`) are now crate-accessible.

## Types moved

All four are leaf data types with no root-internal dependencies (only `String` / `chrono` / `serde` / `uuid` / std collections):

| Type | Kind | Notes |
|---|---|---|
| `UnifiedPermission` | enum (~40 variants) | field type of `UnifiedUserContext::effective_permissions` |
| `UnifiedAuthMethod` | enum | field type of `UnifiedUserContext::auth_method` |
| `UnifiedUserContext` | struct | + 4 inherent methods moved from `auth_service.rs` (`anonymous` / `is_authenticated` / `is_session_expired` / `display_name`) — inherent impls must live in the defining crate |
| `RbacTenantContext` | struct | the struct behind the `TenantContext` alias |

Destination: `crates/foundation/proximadb-tenant/src/rbac_context.rs` (new submodule), re-exported from the crate root.

## Source compatibility

`rbac_service.rs` keeps a `pub use proximadb_tenant::<Type>` re-export shim for every moved type, plus the existing `TenantContext` (= `RbacTenantContext`) and `AuthMethod` (= `UnifiedAuthMethod`) aliases. **No call site is rerouted** — all `crate::security::rbac_service::<Type>` paths (~477 refs across the four types) resolve unchanged. The move is a net root-crate shrinkage of ~191 lines.

The data-type unit test `test_unified_permission_variants` moved with `UnifiedPermission` to the tenant crate (it is a pure data-type test). The manager-behavior tests stay in `rbac_service.rs` and continue to construct the moved types in place through the re-export.

This matches the existing Slice-D pattern in the tenant crate (`TenantStorageUsage`, `tenant_tier_types` were both hoisted the same way).

## Why not defer

Investigation confirmed the cluster is hoistable as a unit: the field types `UnifiedPermission` and `UnifiedAuthMethod` are self-contained leaf types (no `Permission`/`Role`/`UnifiedGroupContext` root-internal deps), so moving `UnifiedUserContext` does not trigger the cascade the brief warned about.

## Verification (all local)

- `cargo check --lib --bins` — clean
- `cargo check --tests -p proximadb` and `-p proximadb-tenant` — clean
- `cargo nextest run -p proximadb-tenant` — 17/17 (incl. 4 new data-type tests)
- `cargo nextest run -p proximadb --lib rbac` — 33/33 (in-place manager tests pass via the re-export shim)
- `cargo clippy --lib --bins` — exit 0
- `cargo fmt --all && cargo fmt --check` — clean
- `scripts/check_workspace_boundaries.py` — no boundary findings
- `scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` — clean