### PR TITLE
refactor(storage): consolidate 4 duplicate StorageEngineType defs onto canonical crate type (Slice-D)

### DIFF
--- a/src/infrastructure/tier_data_movement.rs
+++ b/src/infrastructure/tier_data_movement.rs
@@ -55,14 +55,10 @@ pub struct TierDataMovement {
     storage_engine: StorageEngineType,
 }
 
-/// The storage engine implementation that determines the on-disk data format
-#[derive(Debug, Clone)]
-pub enum StorageEngineType {
-    /// Sorted String Table engine (ProximaBlocks hybrid columnar format)
-    SST,
-    /// VIPER columnar Parquet-based engine
-    VIPER,
-}
+/// Canonical storage engine type (re-exported from `proximadb-storage-common` via
+/// `core::types`). The previous local 2-variant copy (a subset: SST, VIPER) was
+/// consolidated into the single source of truth.
+pub use crate::core::types::StorageEngineType;
 
 impl TierDataMovement {
     /// Create a new coordinator for the given collection and storage engine type
@@ -86,6 +82,10 @@ impl TierDataMovement {
             | InfrastructureTier::CloudDeepArchive { .. } => match self.storage_engine {
                 StorageEngineType::SST => TierDataFormat::SST,
                 StorageEngineType::VIPER => TierDataFormat::VIPER,
+                // Non-columnar engines (TST/NOVA/etc.) default to the SST
+                // (ProximaBlocks) tier format — consistent with the strategy→type
+                // mapping in `storage/traits` (Cedar/Chrono→SST).
+                _ => TierDataFormat::SST,
             },
         }
     }

--- a/src/metrics/collectors/filesystem.rs
+++ b/src/metrics/collectors/filesystem.rs
@@ -8,16 +8,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-/// Storage engine types for metrics tracking
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum StorageEngineType {
-    SST,
-    VIPER,
-    NOVA,
-    RAPTOR,
-    SWIFT,
-    HELIX,
-}
+/// Canonical storage engine type (re-exported from `proximadb-storage-common` via
+/// `core::types`). The previous local 6-variant copy (a subset missing TST) was
+/// consolidated into the single source of truth.
+pub use crate::core::types::StorageEngineType;
 
 /// File operation types
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -264,6 +258,9 @@ impl FilesystemMetricsCollector {
                     .helix_bytes_written
                     .fetch_add(bytes, Ordering::Relaxed);
             }
+            // TST (and any future engine) has no dedicated per-engine counter yet;
+            // only the general counters below are updated.
+            _ => {}
         }
 
         // Also update general counters
@@ -385,6 +382,13 @@ impl FilesystemMetricsCollector {
                     .general_metrics
                     .helix_bytes_written
                     .load(Ordering::Relaxed),
+            },
+            // TST (and any future engine) has no dedicated per-engine counters yet.
+            _ => EngineFileStats {
+                files_read: 0,
+                files_written: 0,
+                bytes_read: 0,
+                bytes_written: 0,
             },
         }
     }

--- a/src/query/rl_planner/integration.rs
+++ b/src/query/rl_planner/integration.rs
@@ -99,6 +99,9 @@ impl RLPlannerIntegration {
             StorageEngineType::SWIFT => StorageEngine::Swift,
             StorageEngineType::NOVA => StorageEngine::Nova,
             StorageEngineType::RAPTOR => StorageEngine::Raptor,
+            // TST (and any unmapped engine) maps to SST capabilities as the
+            // safest baseline, consistent with the planner's SST default.
+            _ => StorageEngine::Sst,
         }
     }
 
@@ -434,6 +437,9 @@ impl RLPlannerIntegration {
             StorageEngineType::SWIFT => ProgressiveEngineType::SWIFT,
             StorageEngineType::NOVA => ProgressiveEngineType::NOVA,
             StorageEngineType::RAPTOR => ProgressiveEngineType::RAPTOR,
+            // TST (and any engine without a progressive-quantization path)
+            // falls back to SST, the planner's default.
+            _ => ProgressiveEngineType::SST,
         }
     }
 }

--- a/src/query/rl_planner/paths/mod.rs
+++ b/src/query/rl_planner/paths/mod.rs
@@ -22,6 +22,9 @@ pub fn get_paths(engine: StorageEngineType) -> Vec<OptimizationPath> {
         StorageEngineType::SWIFT => swift_paths::paths(),
         StorageEngineType::NOVA => nova_paths::paths(),
         StorageEngineType::RAPTOR => raptor_paths::paths(),
+        // TST (and any engine without a dedicated path set) reuses the SST
+        // optimization paths as the safest baseline.
+        _ => sst_paths::paths(),
     }
 }
 

--- a/src/query/rl_planner/state.rs
+++ b/src/query/rl_planner/state.rs
@@ -5,30 +5,11 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Storage engine types for state encoding
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-pub enum StorageEngineType {
-    #[default]
-    SST,
-    HELIX,
-    VIPER,
-    SWIFT,
-    NOVA,
-    RAPTOR,
-}
-
-impl std::fmt::Display for StorageEngineType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SST => write!(f, "SST"),
-            Self::HELIX => write!(f, "HELIX"),
-            Self::VIPER => write!(f, "VIPER"),
-            Self::SWIFT => write!(f, "SWIFT"),
-            Self::NOVA => write!(f, "NOVA"),
-            Self::RAPTOR => write!(f, "RAPTOR"),
-        }
-    }
-}
+/// Canonical storage engine type (re-exported from `proximadb-storage-common` via
+/// `core::types`). The previous local 6-variant copy (a subset missing TST) was
+/// consolidated into the single source of truth; the canonical type carries its
+/// own `Display`/`as_str`/`from_name`/`FromStr`.
+pub use crate::core::types::StorageEngineType;
 
 /// Available index types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/storage/common/compaction_utils.rs
+++ b/src/storage/common/compaction_utils.rs
@@ -18,73 +18,13 @@ use crate::core::config::CompactionConfig;
 use crate::storage::common::compaction_orchestrator::{GenericFileMetadata, TieredFileRegistry};
 use crate::storage::persistence::filesystem::FilesystemFactory;
 
-/// Storage engine type for EventLog filtering
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum StorageEngineType {
-    SST,
-    VIPER,
-    NOVA,
-    SWIFT,
-    HELIX,
-    RAPTOR,
-    TST,
-}
-
-impl std::fmt::Display for StorageEngineType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StorageEngineType::SST => write!(f, "SST"),
-            StorageEngineType::VIPER => write!(f, "VIPER"),
-            StorageEngineType::NOVA => write!(f, "NOVA"),
-            StorageEngineType::SWIFT => write!(f, "SWIFT"),
-            StorageEngineType::HELIX => write!(f, "HELIX"),
-            StorageEngineType::RAPTOR => write!(f, "RAPTOR"),
-            StorageEngineType::TST => write!(f, "TST"),
-        }
-    }
-}
-
-impl StorageEngineType {
-    /// Convert from proto StorageEngine enum
-    pub fn from_proto(engine: i32) -> Self {
-        use crate::proto::proximadb_v1::StorageEngine;
-        match StorageEngine::try_from(engine) {
-            Ok(StorageEngine::Sst) => StorageEngineType::SST,
-            Ok(StorageEngine::Viper) => StorageEngineType::VIPER,
-            Ok(StorageEngine::Nova) => StorageEngineType::NOVA,
-            Ok(StorageEngine::Swift) => StorageEngineType::SWIFT,
-            Ok(StorageEngine::Tst) => StorageEngineType::TST,
-            _ => StorageEngineType::VIPER, // Default to VIPER
-        }
-    }
-
-    /// Convert from string representation
-    pub fn from_str_uppercase(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            "SST" => StorageEngineType::SST,
-            "VIPER" => StorageEngineType::VIPER,
-            "NOVA" => StorageEngineType::NOVA,
-            "SWIFT" => StorageEngineType::SWIFT,
-            "HELIX" => StorageEngineType::HELIX,
-            "RAPTOR" => StorageEngineType::RAPTOR,
-            "TST" => StorageEngineType::TST,
-            _ => StorageEngineType::VIPER, // Default to VIPER
-        }
-    }
-
-    /// Get file extension for this engine type
-    pub fn file_extension(&self) -> &str {
-        match self {
-            StorageEngineType::SST => ".sst",
-            StorageEngineType::VIPER => ".parquet",
-            StorageEngineType::NOVA => ".nova",
-            StorageEngineType::SWIFT => ".swift",
-            StorageEngineType::HELIX => ".helix",
-            StorageEngineType::RAPTOR => ".raptor",
-            StorageEngineType::TST => ".tst",
-        }
-    }
-}
+/// Canonical storage engine type (re-exported from `proximadb-storage-common` via
+/// `core::types`). The previous local 7-variant copy was consolidated into the
+/// single source of truth — variant sets were identical (SST/VIPER/NOVA/SWIFT/
+/// HELIX/RAPTOR/TST). The dead `from_proto`/`from_str_uppercase`/`file_extension`
+/// helpers had no external callers and were dropped (proto bridging lives on the
+/// canonical type and the proto-bridge impls in `background_flush_context`).
+pub use crate::core::types::StorageEngineType;
 
 /// Result of file discovery with EventLog filtering
 #[derive(Debug, Clone)]
@@ -475,21 +415,6 @@ pub struct CompactionTaskInfo {
     pub extension: String,
     pub pending_files_count: usize,
     pub total_files_count: usize,
-}
-
-impl StorageEngineType {
-    /// Get string representation
-    pub fn as_str(&self) -> &str {
-        match self {
-            StorageEngineType::SST => "SST",
-            StorageEngineType::VIPER => "VIPER",
-            StorageEngineType::NOVA => "NOVA",
-            StorageEngineType::SWIFT => "SWIFT",
-            StorageEngineType::HELIX => "HELIX",
-            StorageEngineType::RAPTOR => "RAPTOR",
-            StorageEngineType::TST => "TST",
-        }
-    }
 }
 
 /// Self-healing behavior for compaction


### PR DESCRIPTION
## Summary

Slice-D root-crate-decomposition link. Dedup the 4 SCREAMING_CASE `StorageEngineType` copies onto the **canonical definition already living in `crates/storage/proximadb-storage-common/src/engine_type.rs`** (re-exported via `core::types::StorageEngineType`). `src/storage/traits` already depends on this canonical type — these were the remaining stale local copies that shadowed it.

A canonical type already existed (the task premise that `src/storage/traits` depends on a root-internal type is already resolved for that path); this PR is the **dedup** pass to retire the duplicate `enum` defs that shadowed it.

## Consolidated (4 defs -> re-export shims)

Variant sets were clean subsets of (or identical to) the canonical 7-variant `SST/VIPER/NOVA/RAPTOR/SWIFT/HELIX/TST`:

| File | Was | Now |
|---|---|---|
| `src/storage/common/compaction_utils.rs` | 7-variant enum (identical) + dead `from_proto`/`from_str_uppercase`/`file_extension` + redundant `as_str` impl | `pub use crate::core::types::StorageEngineType` |
| `src/metrics/collectors/filesystem.rs` | 6-variant subset (missing TST) | re-export + `_ =>` fallthrough arms |
| `src/infrastructure/tier_data_movement.rs` | 2-variant subset (SST/VIPER) | re-export + `_ => TierDataFormat::SST` |
| `src/query/rl_planner/state.rs` | 6-variant subset (missing TST) + `Default` | re-export; dropped `Default` derive; `_ =>` fallthroughs in integration.rs/paths/mod.rs |

Net **-81 lines**.

## Deliberately NOT consolidated (semantic divergence)

- `src/core/search/filter_contract.rs` — 10-variant enum **mixes index types** (HNSW/IVF/BruteForce/DiskANN/Annoy/LSH) **with storage engines** (SST/VIPER/HELIX/NOVA). Semantically a filter-pushdown type, not a storage-engine type. Merging would be wrong.
- `src/storage/background_flush_context.rs` — 3-variant **PascalCase** (`Viper`/`Sst`/`Tst`) proto-bridge with different casing convention. Merging risks silent breakage.

## Reroute / impl-move details

- The 4 local `enum` defs were replaced with `pub use crate::core::types::StorageEngineType;` (the canonical crate type re-exported via `core::types::storage`).
- A **second inherent `impl StorageEngineType { fn as_str }`** block was found in `compaction_utils.rs` at a different file section than the def (#901 gotcha: inherent impls can live in a different file). It was redundant (canonical already provides `as_str`) and an orphan-rule violation post-consolidation — deleted.
- Proto-bridge impls (`TryFrom<i32>`, `from_proto`) on the divergent `background_flush_context` PascalCase type were left in place (that type was not consolidated).
- Matches that were exhaustive over the local subset (omitting TST) gained `_ =>` fallthrough arms (SST default, consistent with the planner's SST default and the strategy→type mapping in `storage/traits`).

## Gates verified

- `cargo check --lib --bins` ✓
- `cargo check --tests -p proximadb` ✓ (only pre-existing dead-code warnings)
- `cargo check --tests -p proximadb-storage-common` ✓
- `cargo nextest run -p proximadb-storage-common` ✓ 407/407 pass (incl. canonical round-trip tests)
- `cargo nextest run -p proximadb --lib rl_planner` ✓ 100/100
- `cargo nextest run -p proximadb --lib compaction` ✓ 75/75
- `cargo nextest run -p proximadb --lib filesystem_metrics` ✓ 1/1 (the metrics integration test using the consolidated type)
- `cargo clippy --lib --bins` ✓ 0 warnings
- `cargo fmt --all` + `cargo fmt --check` ✓
- `python3 scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` ✓ exit 0
