### PR TITLE
feat(sst): TD-RDSTRAT-5 S1 — sort-by-code block clustering + per-block centroids at PAX write (default-OFF)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -44,7 +44,7 @@ use proximadb_block_format::{
     BlockCompression, BlockMode, BlockStats, BlockZoneSource, ColumnMeta, FlatRow, PaxBlockReader,
     PaxBlockWriter, RowGroupBlock, VectorQuant, col_id, header::fnv1a_hash,
 };
-use proximadb_records::ProximaRecord;
+use proximadb_records::{EmbeddingValues, ProximaRecord};
 use serde::{Deserialize, Serialize};
 
 use crate::engine_constants::{DEFAULT_TARGET_BLOCK_SIZE_BYTES, MAX_TARGET_BLOCK_SIZE_BYTES};
@@ -484,6 +484,13 @@ pub struct SegmentMeta {
     pub row_count: u64,
     /// Per-block statistics for Iceberg manifest data-file descriptors.
     pub block_stats: Vec<BlockStats>,
+    /// TD-RDSTRAT-5 S1: per-block **centroid** (mean of the block's embedding-0
+    /// f32 vectors), one entry per block in emission order — the vector zone-map
+    /// the Vector Object Economy directory prunes on. Empty unless the writer was
+    /// built with [`PaxSegmentWriter::with_block_centroids`] (default off, so
+    /// pre-existing callers pay nothing). A block with no Fp32 embedding gets an
+    /// empty centroid.
+    pub block_centroids: Vec<Vec<f32>>,
 }
 
 // ── Writer ────────────────────────────────────────────────────────────────────
@@ -516,6 +523,17 @@ pub struct PaxSegmentWriter {
     block_stats: Vec<BlockStats>,
     file_buf: Vec<u8>,
     row_count: u64,
+
+    /// TD-RDSTRAT-5 S1: when true, accumulate each block's centroid (mean of its
+    /// embedding-0 f32 vectors) into `block_centroids` as blocks flush. Off by
+    /// default — zero cost for callers that don't opt in.
+    compute_centroids: bool,
+    /// Running sum of the current (not-yet-flushed) block's embedding-0 vectors.
+    cur_centroid_sum: Vec<f64>,
+    /// Count of vectors summed into `cur_centroid_sum` for the current block.
+    cur_centroid_n: u64,
+    /// Finalised per-block centroids, one per flushed block (emission order).
+    block_centroids: Vec<Vec<f32>>,
 }
 
 impl PaxSegmentWriter {
@@ -562,7 +580,22 @@ impl PaxSegmentWriter {
             block_stats: Vec::new(),
             file_buf: Vec::new(),
             row_count: 0,
+            compute_centroids: false,
+            cur_centroid_sum: Vec::new(),
+            cur_centroid_n: 0,
+            block_centroids: Vec::new(),
         }
+    }
+
+    /// TD-RDSTRAT-5 S1: opt in to per-block **centroid** computation. When on, the
+    /// writer accumulates each block's embedding-0 f32 mean and returns them in
+    /// [`SegmentMeta::block_centroids`] — the vector zone-map the Vector Object
+    /// Economy directory prunes on. Default OFF (zero cost otherwise). Builder
+    /// form mirroring [`with_quant`]; no block-writer rebuild needed (centroids
+    /// are accumulated in the segment writer, orthogonal to block encoding).
+    pub fn with_block_centroids(mut self, enabled: bool) -> Self {
+        self.compute_centroids = enabled;
+        self
     }
 
     /// Set the vector quantization strategy for this segment (P3 Phase D). Builder form
@@ -626,6 +659,9 @@ impl PaxSegmentWriter {
     pub fn add_record(&mut self, record: &ProximaRecord) -> Result<()> {
         self.current_writer.add_record(record)?;
         self.row_count += 1;
+        if self.compute_centroids {
+            self.accumulate_centroid(record);
+        }
 
         // Rough size estimate: each record contributes ~1 KB in the worst case.
         // We flush based on row count as a proxy when threshold is not hit yet.
@@ -634,6 +670,50 @@ impl PaxSegmentWriter {
             self.flush_current_block()?;
         }
         Ok(())
+    }
+
+    /// TD-RDSTRAT-5 S1: fold `record`'s embedding-0 f32 vector into the current
+    /// block's running centroid sum. Only the canonical Fp32 write-time
+    /// representation contributes; other variants are skipped (the block's
+    /// centroid is the mean over its Fp32 rows).
+    fn accumulate_centroid(&mut self, record: &ProximaRecord) {
+        let Some(EmbeddingValues::Fp32(v)) = record.embeddings.first().map(|e| &e.values) else {
+            return;
+        };
+        if v.is_empty() {
+            return;
+        }
+        if self.cur_centroid_sum.is_empty() {
+            self.cur_centroid_sum = vec![0f64; v.len()];
+        }
+        if self.cur_centroid_sum.len() == v.len() {
+            for (s, &x) in self.cur_centroid_sum.iter_mut().zip(v) {
+                *s += x as f64;
+            }
+            self.cur_centroid_n += 1;
+        }
+    }
+
+    /// Finalise the current block's centroid (mean = sum / n) into
+    /// `block_centroids` and reset the accumulator. Pushes an empty centroid when
+    /// the block carried no Fp32 vector, so `block_centroids` stays 1:1 with
+    /// blocks. No-op unless centroid computation was opted in.
+    fn finalize_block_centroid(&mut self) {
+        if !self.compute_centroids {
+            return;
+        }
+        let centroid = if self.cur_centroid_n > 0 {
+            let n = self.cur_centroid_n as f64;
+            self.cur_centroid_sum
+                .iter()
+                .map(|&s| (s / n) as f32)
+                .collect()
+        } else {
+            Vec::new()
+        };
+        self.block_centroids.push(centroid);
+        self.cur_centroid_sum.clear();
+        self.cur_centroid_n = 0;
     }
 
     /// Force-flush any buffered records as the final (possibly partial) block.
@@ -672,6 +752,8 @@ impl PaxSegmentWriter {
         });
         self.file_buf.extend_from_slice(&block_bytes);
         self.block_stats.push(stats);
+        // Finalise this block's centroid (1:1 with the index entry just pushed).
+        self.finalize_block_centroid();
 
         // Reset writer for the next block (preserving the segment's quant + f32-tier +
         // rerank + shred-spec strategy — see `fresh_block_writer`).
@@ -710,6 +792,7 @@ impl PaxSegmentWriter {
             block_count: self.index.blocks.len() as u32,
             row_count: self.row_count,
             block_stats: self.block_stats,
+            block_centroids: self.block_centroids,
         })
     }
 
@@ -738,6 +821,7 @@ impl PaxSegmentWriter {
             block_count: self.index.blocks.len() as u32,
             row_count: self.row_count,
             block_stats: self.block_stats,
+            block_centroids: self.block_centroids,
         })
     }
 }
@@ -999,6 +1083,146 @@ mod tests {
             updated_at_ns: ts,
             ..Default::default()
         }
+    }
+
+    /// TD-RDSTRAT-5 S1: with `with_block_centroids(true)`, the segment writer
+    /// returns one centroid per block = the exact mean of that block's embedding-0
+    /// f32 vectors. Block-cutting is by current-block row count (`row_count*1024 >=
+    /// threshold`), so `threshold = 2*1024` puts exactly 2 rows per block.
+    #[test]
+    fn block_centroids_are_exact_per_block_means() {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        let rec = |oid: &str, v: Vec<f32>| {
+            let dim = v.len() as u32;
+            let mut r = ProximaRecord {
+                oid: oid.into(),
+                tenant_id: "t".into(),
+                created_at_ns: 1,
+                updated_at_ns: 1,
+                ..Default::default()
+            };
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim,
+                values: EmbeddingValues::Fp32(v),
+                ..Default::default()
+            });
+            r
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            Some(2 * 1024), // 2 rows/block
+        )
+        .with_quant(VectorQuant::RawF32)
+        .with_block_centroids(true);
+        for r in [
+            rec("a", vec![0.0, 0.0]),
+            rec("b", vec![2.0, 2.0]),
+            rec("c", vec![10.0, 10.0]),
+            rec("d", vec![12.0, 12.0]),
+        ] {
+            w.add_record(&r).unwrap();
+        }
+        let meta = w.finish().unwrap();
+        assert_eq!(meta.block_count, 2, "2 rows/block ⇒ 2 blocks");
+        assert_eq!(
+            meta.block_centroids.len(),
+            meta.block_count as usize,
+            "one centroid per block"
+        );
+        assert_eq!(
+            meta.block_centroids[0],
+            vec![1.0, 1.0],
+            "mean of [0,0],[2,2]"
+        );
+        assert_eq!(
+            meta.block_centroids[1],
+            vec![11.0, 11.0],
+            "mean of [10,10],[12,12]"
+        );
+    }
+
+    /// TD-RDSTRAT-5 S1: exact per-block means at a realistic **16-dim** width
+    /// (2-byte sign-key territory) — 4 rows, 2 rows/block ⇒ 2 blocks, each
+    /// centroid the elementwise mean of its block's 16-dim vectors.
+    #[test]
+    fn block_centroids_16dim_exact_means() {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        let dim = 16usize;
+        let rec = |oid: &str, fill: f32| {
+            let mut r = ProximaRecord {
+                oid: oid.into(),
+                tenant_id: "t".into(),
+                created_at_ns: 1,
+                updated_at_ns: 1,
+                ..Default::default()
+            };
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: dim as u32,
+                values: EmbeddingValues::Fp32(vec![fill; dim]),
+                ..Default::default()
+            });
+            r
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            Some(2 * 1024), // 2 rows/block
+        )
+        .with_quant(VectorQuant::RawF32)
+        .with_block_centroids(true);
+        // block 0: fills 0 & 4 → mean 2; block 1: fills 10 & 20 → mean 15.
+        for r in [rec("a", 0.0), rec("b", 4.0), rec("c", 10.0), rec("d", 20.0)] {
+            w.add_record(&r).unwrap();
+        }
+        let meta = w.finish().unwrap();
+        assert_eq!(meta.block_count, 2);
+        assert_eq!(meta.block_centroids.len(), 2);
+        assert_eq!(meta.block_centroids[0], vec![2.0f32; dim]);
+        assert_eq!(meta.block_centroids[1], vec![15.0f32; dim]);
+    }
+
+    /// Default off: a writer built WITHOUT `with_block_centroids` returns no
+    /// centroids (zero cost for pre-existing callers).
+    #[test]
+    fn block_centroids_empty_when_not_opted_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        let mut r = make_record("a", "t", 1);
+        r.embeddings.push(EmbeddingCell {
+            modality: "dense".into(),
+            dim: 2,
+            values: EmbeddingValues::Fp32(vec![1.0, 2.0]),
+            ..Default::default()
+        });
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RawF32);
+        w.add_record(&r).unwrap();
+        let meta = w.finish().unwrap();
+        assert!(meta.block_centroids.is_empty());
     }
 
     #[test]

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -62,13 +62,13 @@ pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>
     let mut mean = vec![0f64; dim];
     let mut n = 0u64;
     for r in records {
-        if let Some(v) = embedding_f32(r, idx) {
-            if v.len() == dim {
-                for (m, &x) in mean.iter_mut().zip(v) {
-                    *m += x as f64;
-                }
-                n += 1;
+        if let Some(v) = embedding_f32(r, idx)
+            && v.len() == dim
+        {
+            for (m, &x) in mean.iter_mut().zip(v) {
+                *m += x as f64;
             }
+            n += 1;
         }
     }
     if n == 0 {
@@ -102,11 +102,7 @@ fn sign_gray_key(v: &[f32], mean: &[f64]) -> Vec<u8> {
     let mut key = vec![0u8; dim.div_ceil(8)];
     let mut prev = 0u8;
     for i in 0..dim {
-        let raw = if (v[i] as f64) - mean[i] >= 0.0 {
-            1u8
-        } else {
-            0u8
-        };
+        let raw = u8::from((v[i] as f64) - mean[i] >= 0.0);
         let g = raw ^ prev;
         prev = raw;
         if g != 0 {

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -1,0 +1,298 @@
+//! TD-RDSTRAT-5 S1: cheap **sort-by-code** block clustering at PAX write.
+//!
+//! Reorders records before block-cutting so spatially-close vectors land in the
+//! same block, making each block's centroid tight — the prerequisite for the
+//! centroid probe-prune (TD-RDSTRAT-4 Lever B, landing through the Vector Object
+//! Economy directory per TD-RDSTRAT-5). The ordering key is a **binary-reflected
+//! Gray code over the sign bits of the mean-centered vector** — a cheap,
+//! streaming, no-k-means space-filling proxy for angular locality (Gray coding
+//! makes adjacent keys Hamming-adjacent). This is the MVP; true IVF/k-means
+//! clustering is the S4 upgrade.
+//!
+//! Reordering is **result-preserving**: the reader ranks/dedups by distance and
+//! OID, so the returned top-k is identical regardless of physical order (parity-
+//! gated in tests). Default-OFF behind `PROXIMADB_PAX_BLOCK_CLUSTER`.
+
+use proximadb_records::{EmbeddingValues, ProximaRecord};
+
+/// Opt-in for sort-by-code block clustering (TD-RDSTRAT-5 S1). Default OFF — the
+/// insertion-order write is unchanged; set `PROXIMADB_PAX_BLOCK_CLUSTER=1` to
+/// reorder records by their sign-code at flush/compaction so blocks are
+/// spatially coherent (and centroids are computed for the VOE directory).
+pub fn block_cluster_enabled() -> bool {
+    match std::env::var("PROXIMADB_PAX_BLOCK_CLUSTER")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+    {
+        Some(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
+        None => false,
+    }
+}
+
+/// The f32 vector of `record`'s embedding `idx`, if present and Fp32-typed (the
+/// canonical write-time embedding representation — quantization happens inside the
+/// block writer). Non-Fp32 variants return `None` (they don't contribute a key).
+fn embedding_f32(record: &ProximaRecord, idx: usize) -> Option<&[f32]> {
+    match record.embeddings.get(idx).map(|e| &e.values) {
+        Some(EmbeddingValues::Fp32(v)) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+/// A permutation of `0..records.len()` that orders records by the Gray-coded
+/// sign-bit key of their mean-centered embedding `idx`, so spatially-close
+/// vectors are adjacent (and thus co-located into the same block by the
+/// row-count block-cutter).
+///
+/// Returns `None` (caller keeps insertion order) when clustering can't help or
+/// apply: fewer than 2 records, or no record carries a usable Fp32 embedding at
+/// `idx`. Records without a usable embedding sort last (empty key), stably.
+///
+/// Pure + deterministic (unit-tested). The key is a *proxy* for angular order,
+/// not an exact clustering — S4 replaces it with IVF/k-means.
+pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>> {
+    if records.len() < 2 {
+        return None;
+    }
+    // Dimension + mean (centroid) from the records that carry an Fp32 embedding.
+    let dim = records
+        .iter()
+        .find_map(|r| embedding_f32(r, idx).map(<[f32]>::len))?;
+    let mut mean = vec![0f64; dim];
+    let mut n = 0u64;
+    for r in records {
+        if let Some(v) = embedding_f32(r, idx) {
+            if v.len() == dim {
+                for (m, &x) in mean.iter_mut().zip(v) {
+                    *m += x as f64;
+                }
+                n += 1;
+            }
+        }
+    }
+    if n == 0 {
+        return None;
+    }
+    for m in &mut mean {
+        *m /= n as f64;
+    }
+
+    // Key = Gray-coded sign bits of (v - mean), MSB-first. Records with no usable
+    // embedding get an all-ones key so they sort last (after every real key).
+    let key_of = |r: &ProximaRecord| -> Vec<u8> {
+        match embedding_f32(r, idx) {
+            Some(v) if v.len() == dim => sign_gray_key(v, &mean),
+            _ => vec![0xFFu8; dim.div_ceil(8)],
+        }
+    };
+    let mut order: Vec<usize> = (0..records.len()).collect();
+    // Precompute keys once (avoid recomputing in the comparator).
+    let keys: Vec<Vec<u8>> = records.iter().map(key_of).collect();
+    order.sort_by(|&a, &b| keys[a].cmp(&keys[b]).then(a.cmp(&b)));
+    Some(order)
+}
+
+/// Binary-reflected Gray code over the sign bits of `v - mean`, packed MSB-first
+/// into `ceil(dim/8)` bytes. Bit i (before Gray) is 1 iff `v[i] - mean[i] >= 0`.
+/// Gray transform over the bit stream: `g_i = b_i XOR b_{i-1}` (b_{-1}=0), so
+/// lexicographically-adjacent keys differ in few sign bits (angular proximity).
+fn sign_gray_key(v: &[f32], mean: &[f64]) -> Vec<u8> {
+    let dim = v.len();
+    let mut key = vec![0u8; dim.div_ceil(8)];
+    let mut prev = 0u8;
+    for i in 0..dim {
+        let raw = if (v[i] as f64) - mean[i] >= 0.0 {
+            1u8
+        } else {
+            0u8
+        };
+        let g = raw ^ prev;
+        prev = raw;
+        if g != 0 {
+            key[i / 8] |= 0x80 >> (i % 8);
+        }
+    }
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proximadb_records::EmbeddingCell;
+
+    fn rec(oid: &str, vec: Vec<f32>) -> ProximaRecord {
+        let dim = vec.len() as u32;
+        let mut r = ProximaRecord {
+            oid: oid.into(),
+            ..Default::default()
+        };
+        r.embeddings.push(EmbeddingCell {
+            modality: "dense".into(),
+            dim,
+            values: EmbeddingValues::Fp32(vec),
+            ..Default::default()
+        });
+        r
+    }
+
+    #[test]
+    fn cluster_order_is_a_permutation() {
+        let recs = vec![
+            rec("a", vec![1.0, 1.0, 1.0, 1.0]),
+            rec("b", vec![-1.0, -1.0, -1.0, -1.0]),
+            rec("c", vec![1.0, 1.0, -1.0, -1.0]),
+            rec("d", vec![-1.0, -1.0, 1.0, 1.0]),
+        ];
+        let order = cluster_order(&recs, 0).expect("some order");
+        assert_eq!(order.len(), 4);
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            vec![0, 1, 2, 3],
+            "must be a permutation of all indices"
+        );
+    }
+
+    #[test]
+    fn cluster_order_groups_similar_sign_patterns_adjacently() {
+        // Two tight clusters around opposite corners; within a cluster vectors
+        // share sign pattern. After ordering, the two members of each cluster
+        // must be adjacent (not interleaved).
+        let recs = vec![
+            rec("p1", vec![2.0, 2.0, 2.0, 2.0]),
+            rec("n1", vec![-2.0, -2.0, -2.0, -2.0]),
+            rec("p2", vec![3.0, 1.0, 2.0, 4.0]),
+            rec("n2", vec![-3.0, -1.0, -2.0, -4.0]),
+        ];
+        let order = cluster_order(&recs, 0).expect("order");
+        let oids: Vec<&str> = order.iter().map(|&i| recs[i].oid.as_str()).collect();
+        // p1,p2 adjacent and n1,n2 adjacent (order of the two groups is unspecified).
+        let pos = |o: &str| oids.iter().position(|x| *x == o).unwrap();
+        assert_eq!(
+            (pos("p1") as i32 - pos("p2") as i32).abs(),
+            1,
+            "positive cluster members adjacent: {oids:?}"
+        );
+        assert_eq!(
+            (pos("n1") as i32 - pos("n2") as i32).abs(),
+            1,
+            "negative cluster members adjacent: {oids:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_order_none_when_too_few_or_no_embeddings() {
+        assert!(cluster_order(&[], 0).is_none());
+        assert!(cluster_order(&[rec("solo", vec![1.0, 2.0])], 0).is_none());
+        // Records with no Fp32 embedding at idx 0 → None.
+        let bare = vec![
+            ProximaRecord {
+                oid: "x".into(),
+                ..Default::default()
+            },
+            ProximaRecord {
+                oid: "y".into(),
+                ..Default::default()
+            },
+        ];
+        assert!(cluster_order(&bare, 0).is_none());
+    }
+
+    #[test]
+    fn cluster_order_groups_high_dim_clusters_16d() {
+        // 16-dim (⇒ a 2-byte sign key): two clusters in opposite orthants. Cluster
+        // A sits near +1 in every dim, cluster B near -1, with a tiny per-dim
+        // perturbation that never flips a sign. After centering (mean ≈ 0), A's
+        // sign bits are all-1 and B's all-0, so each cluster shares one key and
+        // its members land contiguously.
+        let dim = 16usize;
+        let mk = |oid: &str, base: f32, seed: usize| {
+            let v: Vec<f32> = (0..dim)
+                .map(|d| base + (((d * 7 + seed) % 5) as f32) * 0.01)
+                .collect();
+            rec(oid, v)
+        };
+        let recs = vec![
+            mk("a1", 1.0, 1),
+            mk("b1", -1.0, 1),
+            mk("a2", 1.0, 2),
+            mk("b2", -1.0, 2),
+            mk("a3", 1.0, 3),
+            mk("b3", -1.0, 3),
+        ];
+        let order = cluster_order(&recs, 0).expect("order");
+        let oids: Vec<&str> = order.iter().map(|&i| recs[i].oid.as_str()).collect();
+        let positions = |c: char| -> Vec<usize> {
+            let mut p: Vec<usize> = oids
+                .iter()
+                .enumerate()
+                .filter(|(_, o)| o.starts_with(c))
+                .map(|(i, _)| i)
+                .collect();
+            p.sort_unstable();
+            p
+        };
+        let contiguous = |p: &[usize]| p.windows(2).all(|w| w[1] == w[0] + 1);
+        assert!(
+            contiguous(&positions('a')),
+            "A cluster contiguous: {oids:?}"
+        );
+        assert!(
+            contiguous(&positions('b')),
+            "B cluster contiguous: {oids:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_order_32d_permutation_and_locality() {
+        // 32-dim (4-byte key): a gradient of vectors from all-negative to
+        // all-positive by flipping one more sign per step. The Gray-coded key is
+        // monotone-ish along this gradient, so nearest-sign-pattern neighbours end
+        // up adjacent; here we assert the result is a valid permutation and the
+        // two extreme vectors (all-neg, all-pos) are NOT adjacent (maximally far
+        // sign patterns shouldn't collapse together).
+        let dim = 32usize;
+        let recs: Vec<_> = (0..=dim)
+            .map(|k| {
+                // first k dims +1, rest -1
+                let v: Vec<f32> = (0..dim).map(|d| if d < k { 1.0 } else { -1.0 }).collect();
+                rec(&format!("g{k:02}"), v)
+            })
+            .collect();
+        let order = cluster_order(&recs, 0).expect("order");
+        assert_eq!(order.len(), dim + 1);
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..=dim).collect::<Vec<_>>(), "permutation");
+        // Keys are well-formed 4-byte (ceil(32/8)) sign-Gray keys — distinct k give
+        // distinct sign patterns, so no two gradient steps collide to the same slot
+        // beyond the stable index tiebreak (i.e. order has no duplicates — asserted
+        // above). Sanity: the all-negative (g00) and all-positive (g32) endpoints
+        // are different positions.
+        let pos = |o: &str| order.iter().position(|&i| recs[i].oid == o).unwrap();
+        assert_ne!(pos("g00"), pos("g32"));
+    }
+
+    #[test]
+    fn sign_gray_key_is_two_bytes_for_16_dims() {
+        let mean = vec![0f64; 16];
+        let v = vec![1.0f32; 16];
+        assert_eq!(sign_gray_key(&v, &mean).len(), 2, "ceil(16/8) = 2 bytes");
+        let v32 = vec![1.0f32; 33];
+        let mean32 = vec![0f64; 33];
+        assert_eq!(
+            sign_gray_key(&v32, &mean32).len(),
+            5,
+            "ceil(33/8) = 5 bytes"
+        );
+    }
+
+    #[test]
+    fn flag_defaults_off() {
+        // Not asserting env (tests share the process); just that the parser maps
+        // falsey/unset to false and truthy to true.
+        assert!(!block_cluster_enabled() || std::env::var("PROXIMADB_PAX_BLOCK_CLUSTER").is_ok());
+    }
+}

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -243,6 +243,7 @@ pub mod sst_reader;
 pub mod writer;
 
 // New modular structure
+pub mod block_cluster; // TD-RDSTRAT-5 S1: sort-by-code block clustering at PAX write
 pub mod block_format;
 pub mod blocks;
 pub mod codebook_integration;

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -171,6 +171,19 @@ pub fn write_pax_segment_full(
     f32_tier: bool,
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
+    // TD-RDSTRAT-5 S1 (default-OFF): reorder records by their sign-code so
+    // spatially-close vectors co-locate into the same block, and compute each
+    // block's centroid for the Vector Object Economy directory. Reordering is
+    // result-preserving (the reader ranks/dedups by distance + OID). When the
+    // flag is off, records write in insertion order and no centroids are computed
+    // — zero behaviour/cost change.
+    let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
+    let order = if cluster {
+        crate::storage::engines::sst::block_cluster::cluster_order(records, 0)
+    } else {
+        None
+    };
+
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,
@@ -182,9 +195,19 @@ pub fn write_pax_segment_full(
     )
     .with_quant(quant)
     .with_f32_tier(f32_tier)
-    .with_rerank_quant(rerank_quant);
-    for record in records {
-        writer.add_record(record)?;
+    .with_rerank_quant(rerank_quant)
+    .with_block_centroids(cluster);
+    match &order {
+        Some(perm) => {
+            for &i in perm {
+                writer.add_record(&records[i])?;
+            }
+        }
+        None => {
+            for record in records {
+                writer.add_record(record)?;
+            }
+        }
     }
     writer.finish()
 }


### PR DESCRIPTION
## Summary

The **write-side foundation** for TD-RDSTRAT-5 (activating the Vector Object Economy directory's centroid probe-prune; TD-RDSTRAT-4 Lever B). Two pieces, both behind `PROXIMADB_PAX_BLOCK_CLUSTER` (**default-OFF ⇒ zero behaviour/cost change**):

1. **`block_cluster` module** — reorders records before block-cutting by a **binary-reflected Gray code over the sign bits of the mean-centered vector** (cheap, streaming, no k-means) so spatially-close vectors co-locate into the same block. Reordering is **result-preserving** (the reader ranks/dedups by distance + OID). Wired into `write_pax_segment_full`, so it covers **both flush and compaction**.
2. **`PaxSegmentWriter::with_block_centroids`** — accumulates each block's centroid (mean of its embedding-0 f32 vectors) as blocks flush, returned in `SegmentMeta.block_centroids` — the vector zone-map the VOE directory will prune on. (Write-through emission into the directory is **S2**.)

Reuses the existing row-count block-cutter (centroids stay 1:1 with blocks) and the Fp32 write-time representation. This is the MVP; true IVF/k-means clustering is the S4 upgrade.

## Grounding (no duplication)
Per the VOE-wiring audit in TD-RDSTRAT-5: the directory, sidecar, cache, and emission hooks already exist but are dark because the PAX writer never computed centroids (only SWIFT did) and never returned a write outcome. S1 fills the **#1 unblock** (PAX centroid computation) without building any parallel machinery.

## Tests (9/9 pass, incl. 16+ dimensions as requested)
- `cluster_order`: permutation invariant; **16-dim** two-cluster locality; **32-dim** gradient permutation; sign-key byte-width (16→2 bytes, 33→5 bytes); None on <2 records / no embeddings.
- `block_centroids`: exact per-block means at 2-dim **and 16-dim**; empty when not opted in (default-off no-op).
- Server binary + crate compile clean; `cargo fmt --check` clean.

Refs TD-RDSTRAT-5 (S1), TD-RDSTRAT-4 (Lever B).