### PR TITLE
refactor(storage-ports): hoist 2 typed path helpers from root path_resolver (root-crate decomp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8085,6 +8085,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "proximadb-kernel",
  "proximadb-proto",
  "proximadb-quantization-model",
  "proximadb-storage-common",

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -19,6 +19,10 @@ async-trait.workspace = true
 serde.workspace = true
 proximadb-proto.workspace = true
 proximadb-storage-common.workspace = true
+# Foundation-tier: CollectionIdentity (typed path helpers) +
+# the StorageQuantizationEnginePort data types below, all foundation types
+# so the ports are facade-FREE (no DTO/adaptor layer).
+proximadb-kernel.workspace = true
 # Foundation-tier: the StorageQuantizationEnginePort returns these data types
 # (Vec<StorageQuantizedData>, &QuantizedVector, UnifiedQuantizationLevel) — moved to
 # foundation by #842, so the port is facade-FREE (no DTO/adaptor layer).

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -18,7 +18,10 @@ use proximadb_storage_common::StorageEngineType;
 pub mod capabilities;
 pub use capabilities::*;
 pub mod path_resolver;
-pub use path_resolver::{CollectionPathResolver, StorageAssignment};
+pub use path_resolver::{
+    CollectionPathResolver, StorageAssignment, collection_data_path_typed,
+    typed_identity_from_storage_assignment,
+};
 
 /// Read access to collection metadata that storage needs at flush/compaction
 /// time (fetch the proto `Collection` for a name or UUID).

--- a/crates/storage/proximadb-storage-ports/src/path_resolver.rs
+++ b/crates/storage/proximadb-storage-ports/src/path_resolver.rs
@@ -16,6 +16,9 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use proximadb_kernel::stable_id::CollectionIdentity;
+use proximadb_proto::proximadb_v1::StorageAssignment as ProtoStorageAssignment;
+use proximadb_storage_common::StoragePath;
 
 /// Storage location assignment for a collection.
 #[derive(Debug, Clone)]
@@ -101,6 +104,84 @@ pub trait CollectionPathResolver: Send + Sync {
 
     /// Check if a collection exists.
     async fn collection_exists(&self, collection_id: &str) -> Result<bool>;
+}
+
+// ---------------------------------------------------------------------------
+// ADR-031 Phase 4c/4d typed-path helpers (hoisted from the root crate).
+// ---------------------------------------------------------------------------
+//
+// `CollectionIdentity` is a foundation type (`proximadb_kernel::stable_id`);
+// `StoragePath` lives in `proximadb_storage_common`, which CAN now name
+// `CollectionIdentity` (both foundation-tier). So the typed variants live HERE
+// — a port-layer helper that wraps the legacy `StoragePath` calls for the
+// `None` (legacy) branch and composes the account-rooted zero-padded base62
+// path for the `Some(identity)` branch.
+//
+// Both branches share the SAME trailing subpath suffix as the legacy
+// `StoragePath::collection_*_path` (`/data`, … — NO trailing slash), so the
+// `None` branch is byte-identical to the pre-4c path and the `Some` branch
+// differs only in the prefix (mixed-read-safe per-collection).
+
+/// ADR-031 Phase 4d: recover a [`CollectionIdentity`] from a proto
+/// [`ProtoStorageAssignment`]'s typed triple, for the **catalog-free engine
+/// read paths**.
+///
+/// Engines resolve data/wal/index paths deep in the search/flush stack with no
+/// catalog/schema access — the typed identity cannot be re-minted at read time,
+/// so it is carried on the proto collection (set at create by the manager when
+/// `PROXIMADB_TYPED_PATHS=1`) and reconstituted here. All three fields are `Some`
+/// together (the manager sets them atomically) or all `None` (env OFF / legacy
+/// collection created before 4d) → `None` → the typed path helpers fall back to
+/// the byte-identical legacy path (mixed-read-safe per-collection).
+///
+/// `namespace_id` is a `u16` in the typed identity but stored as `uint32` in
+/// proto (proto has no `uint16`); it is narrowed here. Values > `u16::MAX` are
+/// impossible by construction (the catalog mints `NamespaceId = u16`), so the
+/// narrowing is infallible in practice — `None` is returned defensively if a
+/// future caller somehow stored an out-of-range value.
+pub fn typed_identity_from_storage_assignment(
+    storage_assignment: Option<&ProtoStorageAssignment>,
+) -> Option<CollectionIdentity> {
+    let sa = storage_assignment?;
+    let account_id = sa.typed_account_id?;
+    let namespace_id = sa.typed_namespace_id?;
+    let collection_id = sa.typed_collection_id?;
+    // Proto has no uint16; narrow back to the typed NamespaceId (u16).
+    let namespace_id = if namespace_id <= u32::from(u16::MAX) {
+        namespace_id as u16
+    } else {
+        // Defensive: out-of-range means the triple wasn't minted by the catalog
+        // — treat as legacy rather than truncate silently.
+        return None;
+    };
+    Some(CollectionIdentity {
+        account_id,
+        namespace_id,
+        collection_id,
+    })
+}
+
+/// ADR-031 Phase 4c: typed collection **data** directory path.
+///
+/// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/data`
+///   (zero-padded base62, no tenant slot — Phase 4 hierarchy collapse).
+/// * `None`           → byte-identical legacy
+///   [`StoragePath::collection_data_path`] (`{base}/{collection_id}/data`).
+///
+/// The trailing suffix (`/data`, no slash) matches the legacy contract exactly
+/// so reads/writes against a legacy collection (`None`) resolve unchanged.
+pub fn collection_data_path_typed(
+    base: &str,
+    collection_id: &str,
+    identity: Option<CollectionIdentity>,
+) -> String {
+    match identity {
+        Some(id) => {
+            let (acct, ns, coll) = id.path_segments();
+            format!("{base}/accounts/{acct}/{ns}/{coll}/data")
+        }
+        None => StoragePath::collection_data_path(base, collection_id),
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -56,7 +56,16 @@ use std::sync::Arc;
 // signatures only). The root-catalog-coupled concrete impls below stay here
 // and `impl` the crate trait. Re-exported so existing callers
 // (`crate::storage::trait_components::path_resolver::*`) keep compiling.
-pub use proximadb_storage_ports::{CollectionPathResolver, StorageAssignment};
+//
+// `collection_data_path_typed` + `typed_identity_from_storage_assignment` were
+// also hoisted (their only deps are foundation types `CollectionIdentity`
+// [kernel] + `StoragePath` [storage-common] + proto `StorageAssignment`), so
+// they are re-exported here too — the wal/index typed helpers stay root because
+// nothing outside the root calls them yet (no benefit to the move).
+pub use proximadb_storage_ports::{
+    CollectionPathResolver, StorageAssignment, collection_data_path_typed,
+    typed_identity_from_storage_assignment,
+};
 
 // ============================================================================
 // Standard Implementations
@@ -456,83 +465,6 @@ pub fn typed_paths_enabled() -> bool {
         Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),
         Err(_) => false,
     })
-}
-
-/// ADR-031 Phase 4d: recover a [`CollectionIdentity`] from a proto
-/// [`StorageAssignment`](crate::proto::proximadb_v1::StorageAssignment)'s typed
-/// triple, for the **catalog-free engine read paths**.
-///
-/// Engines resolve data/wal/index paths deep in the search/flush stack with no
-/// catalog/schema access — the typed identity cannot be re-minted at read time,
-/// so it is carried on the proto collection (set at create by the manager when
-/// `PROXIMADB_TYPED_PATHS=1`) and reconstituted here. All three fields are `Some`
-/// together (the manager sets them atomically) or all `None` (env OFF / legacy
-/// collection created before 4d) → `None` → the typed path helpers fall back to
-/// the byte-identical legacy path (mixed-read-safe per-collection).
-///
-/// `namespace_id` is a `u16` in the typed identity but stored as `uint32` in
-/// proto (proto has no `uint16`); it is narrowed here. Values > `u16::MAX` are
-/// impossible by construction (the catalog mints `NamespaceId = u16`), so the
-/// narrowing is infallible in practice — `None` is returned defensively if a
-/// future caller somehow stored an out-of-range value.
-pub fn typed_identity_from_storage_assignment(
-    storage_assignment: Option<&crate::proto::proximadb_v1::StorageAssignment>,
-) -> Option<CollectionIdentity> {
-    let sa = storage_assignment?;
-    let account_id = sa.typed_account_id?;
-    let namespace_id = sa.typed_namespace_id?;
-    let collection_id = sa.typed_collection_id?;
-    // Proto has no uint16; narrow back to the typed NamespaceId (u16).
-    let namespace_id = if namespace_id <= u32::from(u16::MAX) {
-        namespace_id as u16
-    } else {
-        // Defensive: out-of-range means the triple wasn't minted by the catalog
-        // — treat as legacy rather than truncate silently.
-        return None;
-    };
-    Some(CollectionIdentity {
-        account_id,
-        namespace_id,
-        collection_id,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// ADR-031 Phase 4c: typed collection DATA subpaths.
-// ---------------------------------------------------------------------------
-//
-// `CollectionIdentity` is a ROOT type (`crate::core::stable_id`); `StoragePath`
-// lives in `proximadb-storage-common`, which CANNOT import root types (workspace
-// boundary). So the typed variants live HERE — a root helper that wraps the
-// legacy `StoragePath` calls for the `None` (legacy) branch and composes the
-// account-rooted zero-padded base62 path for the `Some(identity)` branch.
-//
-// Both branches share the SAME trailing subpath suffix as the legacy
-// `StoragePath::collection_*_path` (`/data`, `/wal`, `/indexes` — NO trailing
-// slash), so the `None` branch is **byte-identical** to the pre-4c path and the
-// `Some` branch differs only in the prefix (mixed-read-safe per-collection).
-
-/// ADR-031 Phase 4c: typed collection **data** directory path.
-///
-/// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/data`
-///   (zero-padded base62, no tenant slot — Phase 4 hierarchy collapse).
-/// * `None`           → byte-identical legacy
-///   [`StoragePath::collection_data_path`] (`{base}/{collection_id}/data`).
-///
-/// The trailing suffix (`/data`, no slash) matches the legacy contract exactly
-/// so reads/writes against a legacy collection (`None`) resolve unchanged.
-pub fn collection_data_path_typed(
-    base: &str,
-    collection_id: &str,
-    identity: Option<CollectionIdentity>,
-) -> String {
-    match identity {
-        Some(id) => {
-            let (acct, ns, coll) = id.path_segments();
-            format!("{base}/accounts/{acct}/{ns}/{coll}/data")
-        }
-        None => StoragePath::collection_data_path(base, collection_id),
-    }
 }
 
 /// ADR-031 Phase 4c: typed collection **WAL** directory path.


### PR DESCRIPTION
## Summary

Small, clean hoist — the LAST root-internal dep of `src/storage/traits` before it can move to its own crate.

Moves 2 functions from `src/storage/trait_components/path_resolver.rs` → `crates/storage/proximadb-storage-ports/src/path_resolver.rs` (where #902 already put the `CollectionPathResolver` trait + `StorageAssignment`). Re-export shims left at the old path so all callers (`crate::storage::trait_components::path_resolver::*`) keep compiling — zero diff to call sites.

## The 2 functions (both facade-free — deps are foundation types only)

1. `collection_data_path_typed(base, collection_id, identity)` — typed `{base}/accounts/{acct}/{ns}/{coll}/data` path; `None` branch is byte-identical legacy `StoragePath::collection_data_path`.
2. `typed_identity_from_storage_assignment(&Option<&ProtoStorageAssignment>)` — recovers a `CollectionIdentity` triple from the proto `StorageAssignment` for catalog-free engine read paths.

**Deps (all foundation-tier, accessible from storage-ports):**
- `CollectionIdentity` — `proximadb-kernel` (dep ADDED to storage-ports)
- `StoragePath` — `proximadb-storage-common` (already a dep)
- proto `StorageAssignment` — `proximadb-proto` (already a dep)

Verified: no `crate::` references in either function body before the move.

## What stays root

The wal/index typed helpers (`collection_wal_path_typed`, `collection_index_path_typed`) stay root — no external caller yet, so no benefit to the move. `DrPathBuilder`, `CachedResolver`, `ConfigFallbackResolver`, `CompositeResolver` stay root (root-catalog-coupled).

## Verification
- `cargo check --lib --bins` — clean
- `cargo check --tests -p proximadb` + `-p proximadb-storage-ports` — clean (only pre-existing dead-code warnings)
- `cargo clippy --lib --bins` — exit 0
- `cargo fmt --all && cargo fmt --check` — clean
- `scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` — clean

Net +21 LOC (moved code + shim).