### PR TITLE
feat(sst): TD-RDSTRAT-5 S3 — VOE-directory centroid probe-prune at the PAX cascade (default-OFF)

### DIFF
--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -20,11 +20,23 @@ use proximadb_records::{EmbeddingValues, ProximaRecord};
 /// reorder records by their sign-code at flush/compaction so blocks are
 /// spatially coherent (and centroids are computed for the VOE directory).
 pub fn block_cluster_enabled() -> bool {
-    match std::env::var("PROXIMADB_PAX_BLOCK_CLUSTER")
-        .ok()
-        .as_deref()
-        .map(str::trim)
-    {
+    env_flag_on("PROXIMADB_PAX_BLOCK_CLUSTER")
+}
+
+/// TD-RDSTRAT-5 S3 (read side): opt-in for the VOE-directory centroid probe-prune
+/// at the PAX cascade. Default OFF — the cascade scans every block; set
+/// `PROXIMADB_PAX_CENTROID_PRUNE=1` to load the Vector Object Economy directory
+/// (cache-first) and scan only the blocks whose centroid survives the prune.
+/// Recall-affecting, so it stays default-OFF behind this flag until the SIFT1M
+/// recall ratchet (CI gate) clears the flip. Falls back to the unfiltered scan
+/// whenever the directory is absent/stale or the segment wasn't clustered.
+pub fn centroid_prune_enabled() -> bool {
+    env_flag_on("PROXIMADB_PAX_CENTROID_PRUNE")
+}
+
+/// Shared truthy-env parser for the block-clustering flags.
+fn env_flag_on(var: &str) -> bool {
+    match std::env::var(var).ok().as_deref().map(str::trim) {
         Some(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
         None => false,
     }

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -239,6 +239,73 @@ impl SstEngine {
     /// **Metric gate.** Serves only Euclidean collections — the cascade's rerank is
     /// L2-validated (recall 0.932 @ N=100k). Other metrics stay on the generic scan
     /// until the cascade is metric-generalized + re-validated (follow-up).
+    /// TD-RDSTRAT-5 S3: the block indices to scan for `sstable_path`, from the
+    /// Vector Object Economy directory's per-block centroids (loaded cache-first).
+    /// Returns `None` — "scan every block" (unchanged) — whenever the prune can't
+    /// apply: no directory cache, the directory is missing/stale/corrupt, this file
+    /// isn't in the directory, or it carries no centroids (unclustered). So the
+    /// caller degrades safely to the full scan. `Some(indices)` are the survivors of
+    /// [`select_blocks_by_centroid`] over the file's block centroids.
+    async fn voe_centroid_selected_blocks(
+        &self,
+        collection_id: &str,
+        collection_root: &str,
+        sstable_path: &str,
+        query: &[f32],
+        metric: DistanceMetric,
+    ) -> Option<Vec<usize>> {
+        use crate::storage::engines::sst::IndexEntry;
+        use crate::storage::engines::sst::object_economy_directory::load_directory_for;
+        use crate::storage::engines::sst::readers::block_pruning::select_blocks_by_centroid;
+        use proximadb_catalog::CatalogAuthorityMode;
+
+        let cache = self.directory_cache_ref()?;
+        let fs = self.filesystem().get_filesystem(sstable_path).ok()?;
+        let handle = cache.handle_for(collection_id);
+        let (cid, root) = (collection_id.to_string(), collection_root.to_string());
+        let entry = handle
+            .get_or_load(move || async move {
+                load_directory_for(
+                    fs.as_ref(),
+                    &cid,
+                    &root,
+                    0,
+                    CatalogAuthorityMode::RebuildableProjection,
+                )
+                .await
+            })
+            .await;
+        if entry.status.is_degraded() {
+            return None; // missing / stale / corrupt → full scan (mixed-read-safe)
+        }
+        let file = entry
+            .directory
+            .files
+            .iter()
+            .find(|f| f.object_url == sstable_path)?;
+        // Adapt the directory's per-block centroids → `IndexEntry` (only the
+        // centroid fields matter to the pruner) and reuse the existing prune.
+        let entries: Vec<IndexEntry> = file
+            .blocks
+            .iter()
+            .map(|b| IndexEntry {
+                block_centroid: b.centroid_fp32.clone().unwrap_or_default(),
+                block_centroid_fp16: b.centroid_fp16.clone(),
+                ..Default::default()
+            })
+            .collect();
+        // No usable centroids (unclustered segment) ⇒ don't prune.
+        if entries
+            .iter()
+            .all(|e| e.block_centroid.is_empty() && e.block_centroid_fp16.is_none())
+        {
+            return None;
+        }
+        let prune = crate::core::search::BlockPruneConfig::default();
+        Some(select_blocks_by_centroid(query, &entries, metric, &prune))
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn try_pax_cascade(
         &self,
         sstable_path: &str,
@@ -246,6 +313,8 @@ impl SstEngine {
         filter_expression: Option<&FilterExpression>,
         k: usize,
         distance_metric: DistanceMetric,
+        collection_id: &str,
+        collection_root: &str,
     ) -> anyhow::Result<Option<Vec<OptimizedSearchRecord>>> {
         use crate::storage::engines::core::coalesce_strategy::{
             choose_whole_vs_striped, is_cloud_path, read_strategy_chooser_enabled,
@@ -316,7 +385,40 @@ impl SstEngine {
                 striped_read_enabled()
             };
 
+        // TD-RDSTRAT-5 S3 (default-OFF): centroid probe-prune. When enabled and the
+        // VOE directory yields a block selection for this file, scan ONLY those
+        // blocks via the ranged reader (forces the ranged path). `None` ⇒ no prune
+        // ⇒ the existing whole/striped logic below (mixed-read-safe fallback).
+        let selected_blocks: Option<Vec<usize>> = if filter_expression.is_none()
+            && crate::storage::engines::sst::block_cluster::centroid_prune_enabled()
+        {
+            self.voe_centroid_selected_blocks(
+                collection_id,
+                collection_root,
+                sstable_path,
+                query_vector,
+                distance_metric,
+            )
+            .await
+        } else {
+            None
+        };
+
         let hits = 'hits: {
+            if let Some(sel) = selected_blocks.as_deref()
+                && let Some(hits) = rabitq_search_segment_ranged(
+                    fs.as_ref(),
+                    sstable_path,
+                    query_vector,
+                    k,
+                    pool,
+                    rank_metric,
+                    Some(sel),
+                )
+                .await?
+            {
+                break 'hits hits;
+            }
             if use_striped
                 && let Some(hits) = rabitq_search_segment_ranged(
                     fs.as_ref(),
@@ -325,6 +427,7 @@ impl SstEngine {
                     k,
                     pool,
                     rank_metric,
+                    None,
                 )
                 .await?
             {
@@ -1075,6 +1178,8 @@ impl SstEngine {
                         filter_expression,
                         k,
                         distance_metric,
+                        collection_id,
+                        storage_url,
                     )
                     .await
                 {

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -542,6 +542,10 @@ pub async fn rabitq_search_segment_ranged(
     k: usize,
     pool: usize,
     metric: RankMetric,
+    // TD-RDSTRAT-5 S3: when `Some`, scan ONLY these block indices (the centroid
+    // probe-prune survivors). `None` scans every block (unchanged behaviour). An
+    // index out of range is simply never matched (no panic).
+    selected: Option<&[usize]>,
 ) -> Result<Option<Vec<CascadeHit>>> {
     use proximadb_block_format::BlockFooter;
     use proximadb_block_format::ranged::{BlockLayout, footer_tail_range, metadata_ranges};
@@ -578,7 +582,13 @@ pub async fn rabitq_search_segment_ranged(
     let pool = pool.max(k);
     let mut any_rabitq = false;
     let mut hits: Vec<CascadeHit> = Vec::new();
-    for entry in &index.blocks {
+    for (block_idx, entry) in index.blocks.iter().enumerate() {
+        // S3 centroid prune: skip blocks the probe-prune didn't select.
+        if let Some(sel) = selected
+            && !sel.contains(&block_idx)
+        {
+            continue;
+        }
         let (off, bsz) = (entry.offset, entry.size as u64);
         if off + bsz > size {
             anyhow::bail!("striped read: block [{off}..+{bsz}] past segment {size}");
@@ -1568,7 +1578,7 @@ mod tests {
             let whole = rabitq_search_segment(&bytes, &query, 10, 100, metric, None)
                 .unwrap()
                 .expect("whole cascade hits");
-            let ranged = rabitq_search_segment_ranged(&fs, path_str, &query, 10, 100, metric)
+            let ranged = rabitq_search_segment_ranged(&fs, path_str, &query, 10, 100, metric, None)
                 .await
                 .unwrap()
                 .expect("ranged cascade hits");
@@ -1580,6 +1590,109 @@ mod tests {
                 "striped read must byte-identically match the whole segment ({metric:?})"
             );
         }
+    }
+
+    /// TD-RDSTRAT-5 S3: the block filter on the ranged reader. Selecting ALL block
+    /// indices is byte-identical to `None` (parity); a strict subset scans only
+    /// those blocks (fewer/equal hits); the empty set scans nothing (`None`).
+    #[tokio::test]
+    async fn ranged_block_filter_selects_only_chosen_blocks() {
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        let (dim, n) = (64usize, 400usize);
+        let corpus: Vec<Vec<f32>> = (0..n)
+            .map(|i| {
+                (0..dim)
+                    .map(|d| (((i * 131 + d * 17) % 251) as f32) * 0.01)
+                    .collect()
+            })
+            .collect();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| rec(&format!("r{i}"), 1000 + i as i64, v.clone()))
+            .collect();
+        write_pax_segment_full(
+            &path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        let path_str = path.to_str().unwrap();
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let query = corpus[137].clone();
+        let (n_blocks, _, _) = segment_index_summary(&fs, path_str)
+            .await
+            .unwrap()
+            .expect("summary");
+        assert!(
+            n_blocks >= 2,
+            "need a multi-block segment to exercise the filter"
+        );
+        let key = |h: &[CascadeHit]| {
+            h.iter()
+                .map(|x| (x.oid.clone(), x.distance))
+                .collect::<Vec<_>>()
+        };
+
+        let none =
+            rabitq_search_segment_ranged(&fs, path_str, &query, 10, 100, RankMetric::L2, None)
+                .await
+                .unwrap()
+                .expect("hits");
+        let all_sel: Vec<usize> = (0..n_blocks as usize).collect();
+        let all = rabitq_search_segment_ranged(
+            &fs,
+            path_str,
+            &query,
+            10,
+            100,
+            RankMetric::L2,
+            Some(&all_sel),
+        )
+        .await
+        .unwrap()
+        .expect("hits");
+        assert_eq!(
+            key(&none),
+            key(&all),
+            "selecting all blocks == None (parity)"
+        );
+
+        let b0 = rabitq_search_segment_ranged(
+            &fs,
+            path_str,
+            &query,
+            10,
+            100,
+            RankMetric::L2,
+            Some(&[0]),
+        )
+        .await
+        .unwrap()
+        .expect("block 0 hits");
+        assert!(!b0.is_empty(), "block 0 carries RaBitQ candidates");
+        assert!(
+            b0.len() <= none.len(),
+            "a strict subset scans fewer-or-equal blocks"
+        );
+
+        let empty =
+            rabitq_search_segment_ranged(&fs, path_str, &query, 10, 100, RankMetric::L2, Some(&[]))
+                .await
+                .unwrap();
+        assert!(
+            empty.is_none_or(|h| h.is_empty()),
+            "empty selection scans no blocks ⇒ no hits"
+        );
     }
 
     /// TD-RDSTRAT-3 S2: `segment_index_summary` reads the cost inputs from the tail


### PR DESCRIPTION
## Summary

The **read-path** payoff of the RDSTRAT-4/5 arc: `try_pax_cascade` can now prune blocks by centroid before scanning, using the Vector Object Economy directory S1/S2 populate — so a vector query touches only the `nprobe` nearest blocks instead of every block.

Behind **`PROXIMADB_PAX_CENTROID_PRUNE=1` (default-OFF)**:
1. Load the VOE directory **cache-first** (`handle_for` + `get_or_load` → `load_directory_for`).
2. Find this segment's file entry (`object_url == sstable_path`), adapt its per-block centroids → `IndexEntry`, and **reuse the existing `select_blocks_by_centroid`** (no new prune logic).
3. Scan only the survivors via a new optional **block filter** on `rabitq_search_segment_ranged`.

**Mixed-read-safe fallback** to the full whole/striped scan whenever the prune can't apply: flag off, no directory cache, directory missing/stale/corrupt (`DirectoryLoadStatus::is_degraded`), file not in the directory, or unclustered (no centroids). Filtered queries stay on the whole path.

## Recall gate — deliberately deferred (not a false-positive)
S3 is **default-OFF because it's recall-affecting**; the default-ON flip is gated on a SIFT1M recall ratchet. I did **not** add that test here: the current SIFT harness doesn't wire the directory cache, so a centroid-prune recall test would silently **fall back to full scan** and pass *without exercising the prune* — a false-positive gate, and unverifiable locally (dataset absent). The flip slice must first wire the test engine `with_directory_cache` **and** add a *prune-engaged* assertion (a blocks-pruned counter in the cascade io_trace).

## Tests (validated locally)
- `ranged_block_filter_selects_only_chosen_blocks`: selecting **all** blocks == `None` (**byte-identical parity**), a strict subset scans fewer-or-equal, the empty set scans nothing.
- Existing ranged/whole parity test still holds.
- Clippy `--lib --bins -D warnings` clean (`CLIPPY_EXIT=0`, 0 warnings); 7/7 tests pass; `cargo fmt` clean; verified on the develop-rebased base (no dep drift).

Refs TD-RDSTRAT-5 (S3). Prereq for the default-ON flip: SIFT recall ratchet + blocks-pruned counter.