### PR TITLE
docs(taxo): TD-TAXO-1 — canonical storage-engine matrix + enum comment alignment

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/capabilities.rs
+++ b/crates/storage/proximadb-storage-ports/src/capabilities.rs
@@ -40,22 +40,22 @@ pub enum StorageEngineStrategy {
     /// NOVA engine - next-gen columnar with integrated quantization
     Nova,
 
-    /// SWIFT engine - hierarchical superblock architecture
+    /// SWIFT engine - hierarchical superblock architecture (`experimental-engines` gate; incomplete)
     Swift,
 
-    /// RAPTOR engine - experimental parallel tiered storage
+    /// RAPTOR engine - experimental parallel tiered storage (`experimental-engines` gate)
     Raptor,
 
-    /// Hybrid engine - combines row and column optimized paths
+    /// Hybrid - reserved, not implemented (the factory falls back to SST)
     Hybrid,
 
     /// TST engine - time-series optimized storage
     TimeSeries,
 
-    /// CEDAR engine - unified multimodal storage
+    /// CEDAR engine - document-oriented compatibility projection (Columnar Extensible Document Archive)
     Cedar,
 
-    /// CHRONO engine - temporal data storage
+    /// CHRONO engine - removed; retained for wire compatibility (the factory returns an error)
     Chrono,
 }
 

--- a/docs/10-quality/td/TD-TAXO-1-engine-taxonomy-reconciliation.adoc
+++ b/docs/10-quality/td/TD-TAXO-1-engine-taxonomy-reconciliation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open
+| Status | Mostly done (2026-07-13) — canonical matrix landed in `SUPPORTED_SURFACE.adoc` §"Storage Engine Matrix" (all 12 `src/storage/engines/` dirs + ORION + the `Hybrid` reserved variant, each with a tier: Supported/Beta/Experimental/Internal/Removed/Planned); enum doc comments aligned to engine headers (SWIFT/RAPTOR gates, `Hybrid` fallback, CEDAR compat-projection, CHRONO removed); SYSTEM_MAP authority note points at the matrix instead of re-enumerating. **Remaining:** relocate the legacy `titan` dir next to ORION under `src/graph/engines/`; decide proto-value retirement for `Chrono`/`Titan` at a wire-compat window; publish per-engine conformance ratchets before any VIPER/HELIX/NOVA promotion above Beta.
 | Severity | Medium (architecture-communication + routing correctness risk — "one engine taxonomy across read and write" is a stated invariant of the `ComputeScheduler` module, but the taxonomy's surfaces disagree)
 | Component | `crates/storage/proximadb-storage-ports/src/capabilities.rs` (`StorageEngineStrategy`), `src/storage/engines/` (engine module tree), `docs/SUPPORTED_SURFACE.adoc` (support tiers), design-doc engine inventories (SYSTEM_MAP, ADRs)
 | Relates | TD-DOCS-2 (status-of-record drift — this is the engine-inventory instance of the same class), root-crate decomposition Slice D (#906 consolidated 4 duplicate `StorageEngineType` defs; #910 hoisted capability descriptors — the enum is now canonical, its *content* is not yet reconciled)

--- a/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
+++ b/docs/12-design/SYSTEM_MAP_2026_05_30.adoc
@@ -154,7 +154,10 @@ shaping, not executor construction.
 boundary that bypasses tenant context or raw-builds paths is architectural debt. ADR-032/TD-CAT-2
 make catalog metadata the remaining high-risk tenant-prefix gap.
 * Support level comes from link:../SUPPORTED_SURFACE.adoc[docs/SUPPORTED_SURFACE.adoc], not from the
-existence of modules, feature flags, or demos.
+existence of modules, feature flags, or demos. The storage-engine names in the diagrams below are
+illustrative; the canonical per-engine inventory + tiers (including gated, internal, removed, and
+fallback engines) is SUPPORTED_SURFACE §"Storage Engine Matrix" (TD-TAXO-1) — do not re-enumerate
+engines in design docs.
 
 === ASCII architecture snapshot
 

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -265,6 +265,96 @@ for evidence/provenance, and event/history records for temporal state. The v1
 | Product packaging, API parity, and production validation at scale still in progress.
 |===
 
+== Storage Engine Matrix (canonical inventory)
+
+// section verified against HEAD 2026-07-13 (TD-TAXO-1)
+Canonical inventory of every engine under `src/storage/engines/` (TD-TAXO-1). Design docs and
+diagrams link here instead of re-enumerating; an engine module header's self-claim
+("production-ready" etc.) does **not** confer a tier — this table does (per the Authority
+Hierarchy above). The tier caps what may be claimed when naming the engine; the capability rows
+in the Current Matrix stay authoritative for API-level claims. `StorageEngineStrategy` lives in
+`crates/storage/proximadb-storage-ports/src/capabilities.rs`; construction is
+`src/storage/engines/factory.rs`.
+
+|===
+| Engine | Tier | Purpose & wiring | Constraints / notes
+
+| SST
+| Supported
+| Default engine (`StorageEngineStrategy::Sst`, factory `create_sst`). Hybrid columnar OLTP/LSM over PAX blocks; serves the Supported vector surface.
+| The safe default for adoption and examples.
+
+| VIPER
+| Beta
+| `Viper` variant, factory-reachable, ungated. Columnar Parquet with advanced quantization; analytics-leaning.
+| Selectable per collection; no per-engine conformance ratchet published yet — do not market above Beta by name.
+
+| HELIX
+| Beta
+| `Helix` variant, factory-reachable, ungated. Spatial-locality vector storage (Hilbert-curve clustering, zone maps).
+| Same Beta cap as VIPER; see also TD-HELIX-1.
+
+| NOVA
+| Beta
+| `Nova` variant, factory-reachable, ungated. Columnar analytics engine with hierarchical statistics and integrated quantization.
+| Same Beta cap as VIPER/HELIX.
+
+| TST (TimeSeries)
+| Beta
+| `TimeSeries` variant, factory `create_tst`. Time-partitioned columnar: ASOF joins, downsampling, OHLC (TD-009).
+| Tier follows the "Time-series and event foundations" row above.
+
+| CEDAR
+| Beta
+| `Cedar` variant, factory-reachable. Document-oriented **compatibility projection** (Columnar Extensible Document Archive) over canonical `ProximaRecord` durable truth.
+| Not a separate durable authority; tier follows the Document row above.
+
+| SWIFT
+| Experimental
+| `Swift` variant; factory gated behind the `experimental-engines` feature. Hierarchical superblock architecture.
+| Marked incomplete in its own header (30+ deferred items); slated for removal in v1.0 unless completed. Do not market.
+
+| RAPTOR
+| Experimental
+| `Raptor` variant; factory gated behind `experimental-engines`. Row-aligned tiered tensor storage research.
+| Same removal caveat as SWIFT. Do not market.
+
+| EVENTLOG
+| Beta (infrastructure)
+| No enum variant; not factory-creatable. Append-only event-sourcing log (TD-010) behind the event foundations row.
+| Infrastructure, not a selectable collection engine.
+
+| SEQUOIA
+| Internal
+| No enum variant; direct instantiation only (not factory-reachable). Relational row-store storing typed rows against catalog schema (Phase 1).
+| In development; becomes selectable only when it earns a variant + factory route + tier row.
+
+| UNIVERSAL
+| — (not an engine)
+| No variant. Shared distance-compute subsystem (PQ/INT8 kernels, progressive refinement) used by the engines.
+| Listed to keep the inventory exhaustive; never present as an engine.
+
+| CHRONO
+| Removed
+| `Chrono` variant and proto value retained for wire compatibility only; the factory returns an error ("use SST, VIPER, HELIX, or NOVA").
+| Do not reference in new code or docs except as removed.
+
+| TITAN
+| — (graph modality)
+| Graph engine (see ORION row above for the graph tier); the legacy dir under `src/storage/engines/` is not a vector storage strategy — the storage factory falls back to SST with a warning.
+| Candidate for relocation next to ORION; tracked in TD-TAXO-1.
+
+| Hybrid (variant)
+| Planned
+| `Hybrid` enum variant reserved; not implemented — factory falls back to SST with a warning.
+| Do not market as implemented.
+
+| ORION
+| Beta
+| Graph modality engine (`src/graph/engines/orion`), default and recommended for graph workloads; rebuildable CSR projection over canonical records.
+| Tier and scope per the "ORION graph operations" row above; not part of `StorageEngineStrategy`.
+|===
+
 == Not Supported in v0.2
 
 The v0.2 release ships **single-node**, **CRUD-only** writes, and **per-request** freshness/route


### PR DESCRIPTION
## Why (TD-TAXO-1, follow-up to #912)

The engine taxonomy was told four different ways — `StorageEngineStrategy` (10 variants), `src/storage/engines/` (12 dirs, three with no variant), SUPPORTED_SURFACE (no per-engine tiers), and design-doc inventories (partial lists that an external architecture analysis reproduced verbatim, unaware of cedar/chrono/sequoia/titan/tst/universal). `ComputeScheduler` states "one engine taxonomy across read and write" as an invariant; every consumer was resolving the disagreement by guessing.

## What

- **SUPPORTED_SURFACE** — new **"Storage Engine Matrix (canonical inventory)"** section: every dir under `src/storage/engines/` + ORION + the reserved `Hybrid` variant, each with tier, wiring (enum variant / factory route / feature gate), and constraints. Module-header self-claims ("production-ready") do **not** confer tier, per the doc's authority hierarchy. Deliberate decisions now on record instead of tribal knowledge:
  - SST = Supported (default engine); VIPER/HELIX/NOVA = **Beta by name** (no per-engine conformance ratchet yet)
  - SWIFT/RAPTOR = Experimental (`experimental-engines` gate, header-marked incomplete, v1.0 removal caveat)
  - SEQUOIA = Internal (no variant, not factory-reachable); UNIVERSAL = not an engine (shared distance subsystem)
  - CHRONO = **Removed** (factory errors; variant kept for wire compat); TITAN = graph modality (storage factory falls back to SST); Hybrid = Planned (falls back to SST)
- **`capabilities.rs`** — variant doc comments aligned with reality (SWIFT/RAPTOR gates, Hybrid fallback, CEDAR = document compatibility projection not "unified multimodal", CHRONO = removed). Comment-only.
- **SYSTEM_MAP** — authority note points at the matrix; diagram enumerations declared illustrative (design docs must not re-enumerate engines).
- **TD-TAXO-1** — status → mostly done; remaining: `titan` dir relocation, Chrono/Titan proto-value retirement window, per-engine conformance ratchets before promoting VIPER/HELIX/NOVA above Beta.

## Verification

- `make work-commit-check` guards green (incl. `status-asof-check` — SUPPORTED_SURFACE keeps its honest 2026-06-17 doc tag; only the new section is dated 2026-07-13)
- `check_td_adr_unique.py` 0 errors
- `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean (enum change is comment-only)