### PR TITLE
ci(build): lean CI compile profiles — debug=0 for test + dev (RSS cut)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
+  # Lean CI compile profiles — cut DWARF line-tables (~1.5–3 GiB off the
+  # root-crate test-compile RSS). CI doesn't need backtraces (panics still
+  # print file:line via the panic message); local dev keeps line-tables-only
+  # via the Cargo.toml [profile.test] default. CARGO_INCREMENTAL=0 above
+  # already disables incr-comp, so only debug needs cutting here.
+  CARGO_PROFILE_TEST_DEBUG: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
 
 # ============================================================================
 # This consolidated CI workflow combines:


### PR DESCRIPTION
Adds `CARGO_PROFILE_TEST_DEBUG=0` + `CARGO_PROFILE_DEV_DEBUG=0` to ci.yml's top-level `env:` block. Cuts DWARF line-tables (~1.5–3 GiB off the root-crate test-compile RSS) — the biggest reducible arena chunk after `CARGO_INCREMENTAL=0` (already set).

**CI-only** — local dev keeps `[profile.test].debug = "line-tables-only"` (the Cargo.toml default). The env vars are read by the CI runner, not by local cargo.

**Expected:** the Rust Tests (unit) compile phase drops by ~10–25% (fewer DWARF sections), reducing wall-clock + peak RSS. NOT a jobs=2 enabler (needs root extraction), but a safe, immediate CI speedup.

Refs: build-peak-RSS-methodology (12.8 GiB measurement).