### PR TITLE
ci(sccache): pin sccache-action to v0.0.10 (@v0 does not exist) — unblocks all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,7 +1201,7 @@ jobs:
 
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache
@@ -1298,7 +1298,7 @@ jobs:
 
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache
@@ -1573,7 +1573,7 @@ jobs:
           prefix-key: "v1-rust-nightly-coverage"
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache


### PR DESCRIPTION
## 🔴 Critical — unblocks all PRs (develop-wide CI regression)

#920 wired `mozilla-actions/sccache-action` into the 3 heavy Rust-compile jobs (`rust-compile` lib/test + `rust-build`), but referenced it as `@v0`. That action **publishes no `v0` moving tag** (branches: `main`; tags: `v0.0.1`…`v0.0.10`), so every compile/build job fails immediately at setup:

```
Unable to resolve action `mozilla-actions/sccache-action@v0`, unable to find version `v0`
```

Since `rust-compile` and `rust-build` are required gates, **every open PR is currently red** through no fault of its own (e.g. #921 fails `Rust Compile (lib)`/`(test)` in 2s).

## Fix

Pin to the latest tag **`v0.0.10`** (3 occurrences in `.github/workflows/ci.yml`). The surrounding config (action installs sccache + sets `RUSTC_WRAPPER`/`SCCACHE_DIR`; a separate `actions/cache@v4` persists the cache dir) is unchanged and correct.

## Verification

- `gh api repos/mozilla-actions/sccache-action/tags` → `v0.0.1`…`v0.0.10` (no `v0`); `.../branches` → no `v0`.
- This PR's own CI runs the fixed workflow, so its compile/build jobs are expected to pass.