### PR TITLE
fix(ci): pin sccache-action to v0.0.10 — @v0 does not resolve, failing every Rust job at setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,7 +1201,7 @@ jobs:
 
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache
@@ -1298,7 +1298,7 @@ jobs:
 
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache
@@ -1573,7 +1573,7 @@ jobs:
           prefix-key: "v1-rust-nightly-coverage"
       # sccache complements rust-cache: caches individual rustc invocations
       # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:
           path: /home/runner/.cache/sccache


### PR DESCRIPTION
## Problem

**Every Rust-touching PR is red at develop right now.** `mozilla-actions/sccache-action@v0` (added by #920) does not resolve — the action has only `v0.0.x` tags, no `v0` major alias — so **Set up job fails in ~2s** on `rust-compile`, `rust-test`, and `rust-coverage`. Observed on #916 and #923 (identical 4-job setup failures; a `--failed` rerun reproduced it exactly — deterministic, not a runner flake).

#920's own CI was green because it only touched `ci.yml`: the `changes` gate skipped every Rust job, so the broken ref never executed until the first Rust-touching PRs arrived.

## Fix

Pin all 3 references to the latest real tag `v0.0.10` (verified via the action repo's tag list; matches this workflow's version-tag pinning convention, e.g. `actions/cache@v4`).

## Verification

`grep -n 'sccache-action@' .github/workflows/ci.yml` → 3× `@v0.0.10`; attribution guard passed. CI on this PR is itself the end-to-end proof: the Rust jobs must get past Set up job.