### PR TITLE
feat(pgwire): TD-XMODAL-4 S1 — vector_search UDTF resolves over pgwire returning id+score+payload

### DIFF
--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -31,7 +31,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow_array::{Float32Array, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow_array::{Float64Array, Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableFunctionImpl};
@@ -53,27 +53,51 @@ use crate::services::timeseries_service::{TimeSeriesService, TsPoint};
 /// (each is O(V+E)) regardless of a user-supplied `max_depth`.
 const MAX_GRAPH_TRAVERSE_DEPTH: i64 = 64;
 
-/// The lean Arrow schema a vector-search source exposes for joins: `(id, score)`.
-/// `id` joins against a relational key; `score` is the similarity the SQL can rank
-/// or filter on.
+/// The Arrow schema a vector-search source exposes: `(id, score, metadata)`
+/// (TD-XMODAL-4 S1). `id` joins against a relational key; `score` is the similarity
+/// the SQL can rank/filter on (Float64 to match the pgwire `<->` operator path's
+/// Float8); `metadata` is the record's stored payload as a JSON string, so a single
+/// `SELECT * FROM vector_search(...)` is useful without a self-join.
 pub fn vector_matches_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
-        Field::new("score", DataType::Float32, false),
+        Field::new("score", DataType::Float64, false),
+        Field::new("metadata", DataType::Utf8, false),
     ]))
 }
 
-/// Convert vector-search results into an `(id, score)` [`RecordBatch`] that DataFusion
-/// can register as a table and JOIN against relational data on `id`. This is the
-/// bridge from the vector modality into the shared (DataFusion) query plane.
+/// Convert vector-search results into an `(id, score, metadata)` [`RecordBatch`]
+/// DataFusion can register as a table and JOIN against relational data on `id`.
+/// The bridge from the vector modality into the shared (DataFusion) query plane.
+///
+/// `metadata` is rendered as JSON. The result is the legacy v1 [`SearchVectorRecord`]
+/// (whose `metadata` is `SqlValue`-typed); TD-XMODAL-4 S1 converts each value to the
+/// **v2 canonical [`ProximaValue`]** (`sql_value_to_proxima`, serde-native) before
+/// serializing, so the payload is v2-typed (ADR-024) even though the underlying
+/// `search()` kernel is still v1 — the single-kernel unification onto
+/// `unified_search_native` is S2.
 pub fn vector_matches_to_batch(results: &[SearchVectorRecord]) -> Result<RecordBatch, ArrowError> {
+    use proximadb_records::conversions::sql_value_to_proxima;
     let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
-    let scores: Vec<f32> = results.iter().map(|r| r.score as f32).collect();
+    let scores: Vec<f64> = results.iter().map(|r| r.score).collect();
+    let metadata: Vec<String> = results
+        .iter()
+        .map(|r| {
+            // v1 SqlValue → v2 ProximaValue (inferred type) → JSON.
+            let v2: std::collections::HashMap<String, _> = r
+                .metadata
+                .iter()
+                .map(|(k, val)| (k.clone(), sql_value_to_proxima(val)))
+                .collect();
+            serde_json::to_string(&v2).unwrap_or_else(|_| "{}".to_string())
+        })
+        .collect();
     RecordBatch::try_new(
         vector_matches_schema(),
         vec![
             Arc::new(StringArray::from(ids)),
-            Arc::new(Float32Array::from(scores)),
+            Arc::new(Float64Array::from(scores)),
+            Arc::new(StringArray::from(metadata)),
         ],
     )
 }
@@ -1036,11 +1060,26 @@ mod tests {
     }
 
     #[test]
-    fn vector_matches_batch_has_id_score_schema() {
+    fn vector_matches_batch_has_id_score_metadata_schema() {
         let batch = vector_matches_to_batch(&[sv("a", 0.9), sv("b", 0.5)]).unwrap();
         assert_eq!(batch.num_rows(), 2);
+        // TD-XMODAL-4 S1: (id, score, metadata) — payload rides with id+score so a
+        // standalone `SELECT * FROM vector_search(...)` needs no self-join.
         assert_eq!(batch.schema().field(0).name(), "id");
         assert_eq!(batch.schema().field(1).name(), "score");
+        assert_eq!(
+            batch.schema().field(1).data_type(),
+            &DataType::Float64,
+            "score is Float64 to match the pgwire <-> operator path"
+        );
+        assert_eq!(batch.schema().field(2).name(), "metadata");
+        // Empty metadata (the sv helper) serializes to an empty JSON object.
+        let meta = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(meta.value(0), "{}");
     }
 
     /// The moat proof: vector-search results JOIN a relational table in ONE

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -2714,6 +2714,17 @@ fn set_expr_engages(body: &SetExpr) -> bool {
             // Aggregated forms (e.g. d09 GROUP BY) already engage via `has_group_by`.
             let has_json_extract = select.projection.iter().any(select_item_has_json_extract)
                 || select.selection.as_ref().is_some_and(expr_has_json_extract);
+            // TD-XMODAL-4 S1: a table-valued function in FROM (a `TableFactor::Table`
+            // carrying `args`, e.g. `vector_search('c','[..]',k)` / `timeseries_range`
+            // / `graph_traverse`) is a DataFusion UDTF — the legacy single-table path
+            // can't serve it, so engage the relational/OLAP route to reach DataFusion
+            // where the UDTFs are registered. This is what makes a STANDALONE
+            // `SELECT * FROM vector_search(...)` resolve over pgwire (before, only a
+            // JOIN engaged). Default-safe: a plain table has `args: None`.
+            let has_table_function = select
+                .from
+                .iter()
+                .any(|twj| matches!(&twj.relation, TableFactor::Table { args: Some(_), .. }));
             has_join
                 || has_group_by
                 || select.having.is_some()
@@ -2722,6 +2733,7 @@ fn set_expr_engages(body: &SetExpr) -> bool {
                 || has_projection_subquery
                 || has_derived
                 || has_json_extract
+                || has_table_function
         }
         _ => false,
     }
@@ -2927,6 +2939,30 @@ mod tests {
             [Statement::Query(query)] => query_engages_relational_engine(query),
             _ => panic!("expected a single SELECT statement"),
         }
+    }
+
+    /// TD-XMODAL-4 S1: a STANDALONE table-valued function in FROM (a DataFusion
+    /// UDTF like `vector_search`/`timeseries_range`/`graph_traverse`) must engage the
+    /// relational route so it reaches DataFusion where the UDTF is registered — this
+    /// is what makes `SELECT * FROM vector_search(...)` resolve over pgwire (before,
+    /// only a JOIN engaged; a lone UDTF FROM fell through to the legacy path).
+    #[test]
+    fn standalone_table_function_from_engages() {
+        assert!(
+            gate("SELECT * FROM vector_search('c', '[0.1,0.2,0.3]', 5)"),
+            "lone vector_search UDTF must engage the relational route"
+        );
+        assert!(
+            gate("SELECT id, score FROM vector_search('c', '[0.1]', 10) WHERE score > 0.5"),
+            "UDTF FROM engages even without a join"
+        );
+        assert!(
+            gate("SELECT * FROM timeseries_range('c', 0, 100)"),
+            "other UDTFs engage the same way"
+        );
+        // Default-safe: a plain single-table SELECT does NOT engage via this signal
+        // (it has `args: None`) — it stays on the hardened legacy OLTP path.
+        assert!(!gate("SELECT id, name FROM users WHERE id = 1"));
     }
 
     /// ADR-058 D5 / §9.A: the stats-trust derivation is the load-bearing security


### PR DESCRIPTION
## Summary

First slice of **TD-XMODAL-4** (unified vector-SQL routing): make the `vector_search(...)` UDTF a first-class pgwire surface returning id+score+**payload**.

The UDTF (`VectorSearchTableFunction`) was already registered on the pgwire DataFusion path — but only reachable via a JOIN, and it returned only `(id, score)`. S1 fixes both:

- **S1a — engagement**: `relational_pipeline.rs::set_expr_engages` gains a `has_table_function` signal (a `TableFactor::Table { args: Some(_), .. }` in FROM). A **standalone** `SELECT * FROM vector_search('c','[..]',k)` now engages the relational route → reaches DataFusion where the UDTF is registered (before, only a JOIN engaged; a lone UDTF FROM fell through to the legacy single-table path). **Default-safe**: a plain table has `args: None`. Also covers `timeseries_range`/`graph_traverse`.
- **S1b — payload (v2-typed)**: the UDTF schema widens from `(id, score)` to `(id, score Float64, metadata)` — `score` Float64 to match the pgwire `<->` operator path, `metadata` as JSON. The record is the legacy v1 `SearchVectorRecord` (`SqlValue` metadata, no serde), so each value is converted to the **v2 canonical `ProximaValue`** (`sql_value_to_proxima`, serde-native) before serializing — payload is v2-typed (**ADR-024**) even though the underlying `search()` kernel is still v1.

**Deferred to S2** (with the router integration, where it belongs): the true single-kernel unification — promoting `unified_search_native` onto `VectorOpsPort` so the UDTF *and* the `<->` operator share one v2 kernel (needs a `proximadb-runtime → proximadb-search-types` dep + config-type threading).

## Tests
- `standalone_table_function_from_engages` — a lone UDTF FROM engages; a plain single-table SELECT does not (default-safe).
- `vector_matches_batch_has_id_score_metadata_schema` — the `(id, score Float64, metadata)` schema + empty-metadata → `{}`.
- `vector_matches_join_relational_in_one_sql_plan` — the JOIN-in-one-plan moat still holds.
- Clippy `--lib --bins -D warnings` clean; `cargo fmt` clean.

Refs TD-XMODAL-4 (S1). Next: S2 (router QueryShape vector signal + single v2 kernel + `<->`→canonical-node rewrite).