### PR TITLE
chore(clippy): apply mechanical test-only clippy --fix findings

### DIFF
--- a/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
+++ b/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
@@ -957,7 +957,7 @@ mod tests {
             operator: ComparisonOperator::Equals,
             value: json!(2),
         };
-        assert_eq!(evaluate_filter_proxima(&filter, &props), true);
+        assert!(evaluate_filter_proxima(&filter, &props));
         assert!(evaluate_filter_proxima_strict(&filter, &props).unwrap());
     }
 

--- a/crates/horizontal/proximadb-recall-bench/tests/fp16_e2e.rs
+++ b/crates/horizontal/proximadb-recall-bench/tests/fp16_e2e.rs
@@ -234,7 +234,7 @@ fn fp16_recall_at_10_meets_lld_q13_cosine_gate() {
 
     let q13_gate = RecallSlo::lld_defaults().cosine.at_10;
     assert!(
-        row.mean_recall >= q13_gate as f32,
+        row.mean_recall >= q13_gate,
         "fp16 mean recall@{TOP_K} = {} fell below LLD §Q13 cosine gate {} \
          (this is the LLD's go/no-go threshold for shipping fp16)",
         row.mean_recall,

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -53,7 +53,7 @@ fn cluster_key_resolution_and_sort_order() {
         }
         r
     };
-    let mut records = vec![rec(Some(30)), rec(None), rec(Some(10)), rec(Some(20))];
+    let mut records = [rec(Some(30)), rec(None), rec(Some(10)), rec(Some(20))];
     records.sort_by_cached_key(|r| cluster_sort_key(r, "created"));
     let keys: Vec<Option<i32>> = records
         .iter()

--- a/tests/documents_convergence_bake.rs
+++ b/tests/documents_convergence_bake.rs
@@ -378,10 +378,10 @@ fn bytes_matching(dir: &Path, needle: &str) -> u64 {
                 Ok(ft) if ft.is_dir() => walk(&path, needle, acc),
                 Ok(ft) if ft.is_file() => {
                     let hay = path.to_string_lossy();
-                    if needle.is_empty() || hay.contains(needle) {
-                        if let Ok(md) = entry.metadata() {
-                            *acc += md.len();
-                        }
+                    if (needle.is_empty() || hay.contains(needle))
+                        && let Ok(md) = entry.metadata()
+                    {
+                        *acc += md.len();
                     }
                 }
                 _ => {}
@@ -406,12 +406,11 @@ fn document_wal_files(dir: &Path) -> Vec<PathBuf> {
             match entry.file_type() {
                 Ok(ft) if ft.is_dir() => walk(&path, out),
                 Ok(ft) if ft.is_file() => {
-                    if path.to_string_lossy().contains("document_wal") {
-                        if let Ok(md) = entry.metadata() {
-                            if md.len() > 0 {
-                                out.push(path);
-                            }
-                        }
+                    if path.to_string_lossy().contains("document_wal")
+                        && let Ok(md) = entry.metadata()
+                        && md.len() > 0
+                    {
+                        out.push(path);
                     }
                 }
                 _ => {}

--- a/tests/external_table_pgwire_e2e.rs
+++ b/tests/external_table_pgwire_e2e.rs
@@ -208,8 +208,7 @@ async fn external_location_outside_allowlist_is_rejected() {
              WITH (format='parquet', external_location='file:///etc/', authority='external')",
         )
         .await
-        .err()
-        .expect("CREATE must be rejected when the location is outside the allowlist");
+        .expect_err("CREATE must be rejected when the location is outside the allowlist");
     // tokio-postgres' Display is the terse "db error"; the real message is on
     // the DbError cause.
     let msg = err

--- a/tests/helix_performance_comparison_test.rs
+++ b/tests/helix_performance_comparison_test.rs
@@ -655,7 +655,7 @@ mod performance_comparison_tests {
         for chunk in vectors.chunks(1000) {
             let flush_params = FlushParameters {
                 collection_id: Some("test_collection".to_string()),
-                vector_records: chunk.iter().cloned().collect(),
+                vector_records: chunk.to_vec(),
                 force: true,
                 synchronous: true,
                 hints: HashMap::new(),

--- a/tests/tpc_perf_ledger_e2e.rs
+++ b/tests/tpc_perf_ledger_e2e.rs
@@ -779,8 +779,7 @@ fn gen_tpcds(scale: f64) -> Vec<String> {
         "t_time_sk, t_time, t_hour, t_minute, t_meal_time",
         (0..86_400u64)
             .step_by(60)
-            .enumerate()
-            .map(|(_, secs)| {
+            .map(|secs| {
                 let hour = secs / 3600;
                 let minute = (secs % 3600) / 60;
                 let meal = if (8..10).contains(&hour) {
@@ -849,7 +848,7 @@ fn gen_tpcds(scale: f64) -> Vec<String> {
             let qty = 1 + rng.below(100);
             let price = 1 + rng.below(100);
             let wcost = rng.money(80);
-            let list_price = (price + 10) as u64; // list > sales
+            let list_price = price + 10; // list > sales
             let ext_sales = qty * price;
             let ext_wcost = qty * (wcost.parse::<f64>().unwrap_or(0.0) as u64 + 1);
             let ext_list = qty * list_price;
@@ -1481,15 +1480,15 @@ fn run_duckdb_baseline(
         .arg(&db_path)
         .stdin(Stdio::from(loader_file))
         .output();
-    if let Ok(o) = &load_output {
-        if !o.status.success() {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            eprintln!(
-                "[{benchmark}] · DuckDB load FAILED: {}",
-                stderr.lines().next().unwrap_or("?")
-            );
-            return; // don't run queries against a failed load
-        }
+    if let Ok(o) = &load_output
+        && !o.status.success()
+    {
+        let stderr = String::from_utf8_lossy(&o.stderr);
+        eprintln!(
+            "[{benchmark}] · DuckDB load FAILED: {}",
+            stderr.lines().next().unwrap_or("?")
+        );
+        return; // don't run queries against a failed load
     }
 
     // Verify: confirm data actually loaded (COUNT on the first table).


### PR DESCRIPTION
Mechanical, test-only `cargo clippy --fix --tests --workspace` findings (needless vec!/clone, needless_update, etc. inside `tests/` files and inline `#[cfg(test)] mod tests`). 7 files, net −5 LOC, **zero production logic touched**.

Intrusive findings intentionally excluded: the `items_after_test_module` impl-block relocations in production files (graph/service.rs, quantization_engine.rs, storage_engine.rs) were reverted; the two dominant test lints — `field_reassign_with_default` (107) and `assertions_on_constants` (86) — are not safely machine-applicable and remain as deferred debt.

CI's clippy gate is `--lib --bins` (production), unaffected; this only cleans `clippy --tests` output.