### PR TITLE
refactor(storage-traits): remove modality layering inversion in quant config parsing (decomp gap 3)

### DIFF
--- a/src/storage/traits/query.rs
+++ b/src/storage/traits/query.rs
@@ -190,29 +190,25 @@ pub struct QuantizationLevel {
 
 impl StorageQueryContext {
     /// Parse quantization config into ready-to-use format for progressive search.
+    ///
+    /// Note: this storage-traits layer only *parses* the supplied config. Smart
+    /// default generation (which depends on the vector modality crate) is owned
+    /// by the higher layer that constructs the collection config — see
+    /// `services/collection/manager.rs`, which populates `custom_levels` at
+    /// collection-create time via the smart-defaults generator. When a config
+    /// reaches here with no `custom_levels`, there are simply no progressive
+    /// levels configured (the consumer never second-guesses the producer).
     fn parse_quantization_config(
         quant_config: &crate::proto::proximadb_v1::QuantizationConfig,
-        dimension: usize,
+        _dimension: usize,
     ) -> Option<ParsedQuantizationConfig> {
         if !quant_config.enabled.unwrap_or(false) {
             return None;
         }
 
-        // Parse or generate progressive levels
-        let progressive_levels = if quant_config.custom_levels.is_empty() {
-            // Use smart defaults if no custom levels provided
-            if let Ok(smart_config) =
-                crate::compute::quantization::QuantizationSmartDefaults::generate_for_dimension(
-                    dimension,
-                )
-            {
-                Self::parse_proto_levels(&smart_config.custom_levels)
-            } else {
-                Vec::new()
-            }
-        } else {
-            Self::parse_proto_levels(&quant_config.custom_levels)
-        };
+        // Parse the progressive levels supplied by the config producer.
+        // Empty custom_levels ⇒ no progressive levels (no modality fallback here).
+        let progressive_levels = Self::parse_proto_levels(&quant_config.custom_levels);
 
         Some(ParsedQuantizationConfig {
             strategy: quant_config.strategy(),


### PR DESCRIPTION
## What

Removes the layering inversion in `StorageQueryContext::parse_quantization_config` (`src/storage/traits/query.rs`), which called `QuantizationSmartDefaults::generate_for_dimension` — a type defined in the **proximadb-vector modality crate** — to backfill progressive levels when a `QuantizationConfig` arrived with empty `custom_levels`.

The storage-traits layer sits *below* modality, so this is a layering inversion that blocks the traits→crate extraction (decomposition gap 3): once `traits` becomes a crate it cannot depend on a modality crate.

## Why dependency inversion (not parameter passing)

The task suggested passing the computed progressive levels as a parameter to the enclosing method. The enclosing public seam is `StorageQueryContext::new`, which has **30+ callers** — including `src/storage/document/storage/cold_tier.rs` and the SST search path, which live **inside the storage layer and therefore also cannot depend on modality**. A required parameter would force storage-internal callers to compute a modality-only value they have no way to reach. So a required-param refactor is the wrong shape here; the honest fix is to stop the consumer from second-guessing the producer.

## The change

```text
src/storage/traits/query.rs | 28 ++++++++++++----------------
1 file changed, 12 insertions(+), 16 deletions(-)
```

`parse_quantization_config` now **only parses** the config it is given. Smart-default generation stays where the producer owns it: `services/collection/manager.rs` already populates `custom_levels` at collection-create time via `QuantizationSmartDefaults`. When a config reaches the parser with no `custom_levels`, it yields no progressive levels — exactly the conservative behaviour the previous `Err` branch already produced.

### Refactored method

```rust
// Before: called into the modality crate
fn parse_quantization_config(quant_config, dimension) -> Option<ParsedQuantizationConfig>
    // ... if custom_levels.is_empty() { QuantizationSmartDefaults::generate_for_dimension(dimension) } ...

// After: parses only; no modality dependency
fn parse_quantization_config(quant_config, _dimension) -> Option<ParsedQuantizationConfig>
    // progressive_levels = parse_proto_levels(&quant_config.custom_levels);
```

Signature unchanged (callers untouched). The `_dimension` param is retained for signature stability; the only behavioural delta is the removed defensive re-derivation.

## Behavioural impact

None on the canonical path: `services/collection/manager.rs` always sets `quantization = Some(config)` with populated `custom_levels` at create time, so configs reaching query-time already carry levels. The only edge case lost: if smart-defaults generation **failed** at create-time (manager falls back to an empty-levels config) and then **succeeded** at query-time, the old code would re-derive levels; the new code yields none. This is a transient-failure recovery path that was already best-effort (the `Err` branch returned empty), and progressive search simply degrades gracefully to non-progressive.

## Verification

- `cargo check --lib --bins` green
- `cargo check --tests -p proximadb` green (only pre-existing warnings)
- `cargo nextest run -p proximadb --lib quant` → **119 passed**, 0 failed
- `cargo clippy --lib --bins` → exit 0
- `cargo fmt --all && cargo fmt --check` clean
- `python3 scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` clean
- `grep -rn QuantizationSmartDefaults src/storage/traits/` → **zero hits** (inversion removed)

## Callers updated

None required — the dependency inversion is internal to `parse_quantization_config`; its sole caller (`StorageQueryContext::new`) is unchanged, and the public `new` signature is unchanged, so all 30+ call sites (incl. tests and storage-internal callers) compile unmodified.
