### PR TITLE
feat(observability): measured plan geometry on the DataFusion route — calibration audit fires on the dominant OLAP path

### DIFF
--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -242,6 +242,7 @@ impl DataFusionLocalEngine {
             }
         };
         crate::observability::io_trace::record_plan_ms(plan_start.elapsed().as_millis() as u64);
+        record_logical_plan_geometry(df.logical_plan());
         let df = match context.controls.max_rows {
             Some(max_rows) => {
                 let fetch = match context.controls.row_limit_mode {
@@ -633,6 +634,83 @@ mod tests {
 /// suppress-set is a rebuildable projection of the canonical WAL (ADR-020), so no
 /// new durable state is introduced. MemTable-backed (whole base in memory) —
 /// acceptable for the opt-in foundation; a streaming provider is future work.
+/// TD-EXEC-2 Slice-3 follow-up: measured plan geometry for the DataFusion
+/// route. `plan_instrumented` (the native-planner seam) never runs here, which
+/// left the estimate-vs-measured calibration audit dark on the dominant OLAP
+/// route — the geometry ledger fields were always zero for DataFusion-served
+/// queries (measured: 0/170 rows with `plan_depth > 0` on the 2026-07-13
+/// DataFusion sweep). Measure the served LOGICAL plan — the apples-to-apples
+/// equivalent of the native Volcano physical plan (same semantic operator
+/// vocabulary; the DataFusion *physical* plan would inflate depth/fan-out with
+/// repartition/coalesce nodes the AST estimator never models) — and emit the
+/// same neutral io_trace scalars the native seam emits.
+fn record_logical_plan_geometry(plan: &datafusion::logical_expr::LogicalPlan) {
+    let (depth, nodes, leaves, fanout, blocking, ops) = measure_logical_geometry(plan);
+    let ops_ref: Vec<(&str, u64)> = ops.iter().map(|(k, v)| (*k, *v)).collect();
+    crate::observability::io_trace::record_plan_geometry(
+        depth, nodes, leaves, fanout, blocking, &ops_ref,
+    );
+}
+
+/// Iterative geometry walk over a DataFusion `LogicalPlan` — never recursion,
+/// per TD-EXEC-2 (a recursive walk would overflow on the deep plan it is
+/// measuring). Op labels use the native `plan_geometry::OpKind` vocabulary so
+/// per-op ledger analysis reads across engines, and *blocking* counts exactly
+/// the ops `OpKind::is_blocking` counts (join + sort + aggregate) so the
+/// geometry bands stay comparable — `window` is labeled but deliberately not
+/// counted as blocking (the native vocabulary has no window op).
+#[allow(clippy::type_complexity)]
+fn measure_logical_geometry(
+    plan: &datafusion::logical_expr::LogicalPlan,
+) -> (u64, u64, u64, u64, u64, Vec<(&'static str, u64)>) {
+    use datafusion::logical_expr::LogicalPlan as Lp;
+    let mut max_depth = 0u64;
+    let mut nodes = 0u64;
+    let mut leaves = 0u64;
+    let mut max_fanout = 0u64;
+    let mut blocking = 0u64;
+    let mut ops: std::collections::BTreeMap<&'static str, u64> = std::collections::BTreeMap::new();
+    let mut work: Vec<(&Lp, u64)> = vec![(plan, 1)];
+    while let Some((node, depth)) = work.pop() {
+        nodes += 1;
+        max_depth = max_depth.max(depth);
+        let (label, is_blocking) = match node {
+            Lp::TableScan(_) => ("scan", false),
+            Lp::Filter(_) => ("filter", false),
+            Lp::Projection(_) => ("project", false),
+            Lp::Aggregate(_) => ("aggregate", true),
+            Lp::Sort(_) => ("sort", true),
+            Lp::Join(_) => ("join", true),
+            Lp::Limit(_) => ("limit", false),
+            Lp::Distinct(_) => ("distinct", false),
+            Lp::Union(_) => ("union", false),
+            Lp::Values(_) | Lp::EmptyRelation(_) => ("values", false),
+            Lp::Window(_) => ("window", false),
+            _ => ("other", false),
+        };
+        *ops.entry(label).or_insert(0) += 1;
+        if is_blocking {
+            blocking += 1;
+        }
+        let inputs = node.inputs();
+        max_fanout = max_fanout.max(inputs.len() as u64);
+        if inputs.is_empty() {
+            leaves += 1;
+        }
+        for child in inputs {
+            work.push((child, depth + 1));
+        }
+    }
+    (
+        max_depth,
+        nodes,
+        leaves,
+        max_fanout,
+        blocking,
+        ops.into_iter().collect(),
+    )
+}
+
 #[cfg(feature = "datafusion-integration")]
 async fn register_merged_olap_table(
     ctx: &datafusion::prelude::SessionContext,
@@ -903,4 +981,52 @@ fn arrow_cell_to_proxima(
             Err(_) => ProximaValue::Null,
         }
     })
+}
+
+#[cfg(test)]
+mod geometry_tests {
+    use super::measure_logical_geometry;
+    use datafusion::logical_expr::{LogicalPlanBuilder, col, lit};
+
+    #[test]
+    fn logical_geometry_measures_chain_depth_and_blocking() {
+        // values → filter → sort → limit: depth 4, one leaf, one breaker (sort).
+        let plan = LogicalPlanBuilder::values(vec![vec![lit(1i64)]])
+            .expect("values")
+            .filter(lit(true))
+            .expect("filter")
+            .sort(vec![col("column1").sort(true, false)])
+            .expect("sort")
+            .limit(0, Some(10))
+            .expect("limit")
+            .build()
+            .expect("build");
+        let (depth, nodes, leaves, fanout, blocking, ops) = measure_logical_geometry(&plan);
+        assert_eq!(depth, 4);
+        assert_eq!(nodes, 4);
+        assert_eq!(leaves, 1);
+        assert_eq!(fanout, 1);
+        assert_eq!(blocking, 1, "sort is the only breaker in the chain");
+        let get = |k: &str| ops.iter().find(|(l, _)| *l == k).map(|(_, n)| *n);
+        assert_eq!(get("values"), Some(1));
+        assert_eq!(get("filter"), Some(1));
+        assert_eq!(get("sort"), Some(1));
+        assert_eq!(get("limit"), Some(1));
+    }
+
+    #[test]
+    fn logical_geometry_counts_union_fanout() {
+        let side = || LogicalPlanBuilder::values(vec![vec![lit(1i64)]]).expect("values");
+        let plan = side()
+            .union(side().build().expect("build"))
+            .expect("union")
+            .build()
+            .expect("build");
+        let (depth, nodes, leaves, fanout, blocking, _) = measure_logical_geometry(&plan);
+        assert_eq!(depth, 2);
+        assert_eq!(nodes, 3);
+        assert_eq!(leaves, 2);
+        assert_eq!(fanout, 2);
+        assert_eq!(blocking, 0, "union streams; not a breaker in OpKind terms");
+    }
 }

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -872,8 +872,9 @@ impl RouteCostModel {
         // MEASURED plan geometry the trace carries (Slice 1). This makes the
         // estimator's accuracy a live, falsifiable series — divergence rate =
         // fraction of folds where the labels differ — not just an offline
-        // ledger analysis. Skipped when the trace has no measured geometry
-        // (e.g. the DataFusion route plans outside the native planner).
+        // ledger analysis. Both planner seams emit measured geometry (the
+        // native `plan_instrumented` and the DataFusion adapter's logical-plan
+        // walk); skipped only when the trace carries none (legacy paths).
         if snap.plan_depth > 0
             && let Some(estimated) = shape_class.split('/').find(|s| s.starts_with("geom="))
             && let Some(measured) = crate::query::compute_scheduler::GeometryClass::from_estimate(


### PR DESCRIPTION
## Problem

`plan_instrumented` (TD-EXEC-2 Slice 1) lives in the **native planner**, so DataFusion-served queries recorded zero plan geometry — **measured: 0/170 ledger rows with `plan_depth > 0`** on the 2026-07-13 DataFusion sweep. The estimate-vs-measured band audit (Slice 3's live calibration loop) was dark on the dominant OLAP route.

## Fix

The DataFusion adapter measures the served **logical** plan — the apples-to-apples equivalent of the native Volcano physical plan (same semantic operator vocabulary; the DF *physical* plan would inflate depth/fan-out with repartition/coalesce nodes the AST estimator never models):

- Iterative worklist walk (never recursion, per TD-EXEC-2 — a recursive walk would overflow on the deep plan it measures).
- Ops mapped to the native `plan_geometry::OpKind` vocabulary so per-op ledger analysis reads across engines; **blocking counts exactly what `OpKind::is_blocking` counts** (join+sort+aggregate — `window` labeled but deliberately not a breaker) so geometry bands stay comparable.
- Emits through the same `record_plan_geometry` io_trace path (neutral scalars; ADR-039 adapter allow-list respected — all `datafusion::` usage stays in `datafusion_engine.rs`).

## Verified end-to-end (release, SF 0.001 TPC sweep)

- **146/170 ok rows now carry measured geometry (was 0/170)**.
- The calibration audit fires on the DF route: **12.3% divergence (18/146), strictly under-estimating** — consistent with the native route's one-directional pattern (23.5%), with three new named estimator gaps for a future band refit: DF window lowering adds levels (`win_rank`/`win_running` sxhi→mxhi), set-ops lower to join/aggregate trees (`except`/`intersect` sxlo→mxhi), deep TPC-DS group-bys (`q38/q61/q65/q67` mxhi→dxhi).

## Tests / gates

2 new unit tests on `LogicalPlanBuilder` fixtures (chain depth/blocking; union fan-out) · `cargo fmt --check` · `clippy --lib --bins -- -D warnings` · `make work-commit-check` · attribution guard · geometry test filter 8/8.

Companion: #916 (harness + Slice-3 evidence; the TD-EXEC-2 'calibration gap' bullet filed there is closed by this PR — will cross-reference after both land).

Ref TD-EXEC-2, TD-OLAP-4, ADR-039, ADR-058.