### PR TITLE
fix(build): explicit path on cdc [[test]] targets — unbreaks the Docker image build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -895,14 +895,17 @@ path = "tests/rust/mod.rs"
 # in src/lib.rs; these tests reference proximadb::cdc::*).
 [[test]]
 name = "cdc_e2e_test"
+path = "tests/cdc_e2e_test.rs"
 required-features = ["cdc-kafka"]
 
 [[test]]
 name = "cdc_integration_test"
+path = "tests/cdc_integration_test.rs"
 required-features = ["cdc-kafka"]
 
 [[test]]
 name = "cdc_rest_changefeed_e2e"
+path = "tests/cdc_rest_changefeed_e2e.rs"
 required-features = ["cdc-kafka"]
 
 # Benchmark profile - optimized but allows faster iteration than full release


### PR DESCRIPTION
**Symptom**: `publish-image.yml` dispatched on develop (run 29231029148) fails on both arches at the builder step:
```
error: failed to parse manifest at /build/Cargo.toml
Caused by: can't find cdc_e2e_test test at tests/cdc_e2e_test.rs or tests/cdc_e2e_test/main.rs
```

**Cause**: the Dockerfile's context copies `src/ proto/ config/ apps/ clients/ crates/` but not `tests/`. The three cdc `[[test]]` entries added with the cdc-kafka feature-gating (#859) carry no explicit `path`, and rust:1.95's cargo hard-errors at manifest parse when a declared target's default file is absent. Explicit-path targets are tolerated — the pre-existing `[[test]] integration → tests/rust/mod.rs` sits in the same context and the qa image (2026-07-09, same Dockerfile + toolchain) built fine with it.

**Fix**: add `path = "tests/<name>.rs"` to the three cdc test targets — the same convention every other declared target in this manifest already follows. Zero behavior change for normal checkouts (explicit paths equal the defaults).

**Motivation**: anvaiops wants the commercial overlay rebuilt on a develop-HEAD engine image; the publish from develop is blocked on this.