### PR TITLE
refactor(decomp): move AXIS flush notification out of storage traits (gap 4)

### DIFF
--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -1389,7 +1389,44 @@ impl UnifiedStorageFormat for NovaEngine {
     // CORE OPERATIONS
     async fn do_flush(&self, params: &FlushParameters) -> Result<FlushResult> {
         // Delegate to modularized flush operations
-        self.flush_ops.flush(params).await
+        let result = self.flush_ops.flush(params).await?;
+
+        // Notify EventLog so the AXIS consumer can build indexes asynchronously.
+        // This lives in each engine's `do_flush` (not the trait default) so the
+        // traits layer stays a pure consumer with no root-service dependency
+        // (root-crate decomposition gap 4). Best-effort: an error is logged, never
+        // propagated — the flush itself already succeeded.
+        if result.success
+            && let Some(collection_id) = params.collection_id.as_ref()
+            && let Some(event_log) = crate::services::events::log::event_log_service()
+        {
+            let vector_count = result.entries_flushed.unwrap_or(0) as usize;
+            if let Err(e) = event_log
+                .notify_flush(
+                    collection_id,
+                    result.file_paths.clone(),
+                    vector_count,
+                    false, // has_quantized
+                    true,  // has_fp32
+                    crate::core::types::StorageEngineType::NOVA,
+                )
+                .await
+            {
+                tracing::warn!(
+                    "⚠️ NOVA: Failed to notify EventLog about flush for '{}': {}",
+                    collection_id,
+                    e
+                );
+            } else {
+                tracing::info!(
+                    "📢 NOVA: Notified EventLog for AXIS indexing: '{}' ({} vectors)",
+                    collection_id,
+                    vector_count
+                );
+            }
+        }
+
+        Ok(result)
     }
 
     /// NOVA's LSM bulk-load override (Phase 2F-b).

--- a/src/storage/traits/mod.rs
+++ b/src/storage/traits/mod.rs
@@ -1276,47 +1276,13 @@ pub trait UnifiedStorageFormat: Send + Sync {
             }
         }
 
-        // 🚀 INDEX UPDATES: Notify EventLog for AXIS indexing service
-        if result.success
-            && let Some(collection_id) = &params.collection_id
-        {
-            // Notify EventLog so AXIS consumer can build indexes asynchronously
-            if let Some(event_log) = crate::services::events::log::event_log_service() {
-                // Use engine_type() method (OCP-compliant - no string matching)
-                let storage_engine_type = self.engine_type();
-
-                let vector_count = result.entries_flushed.unwrap_or(0) as usize;
-                // Use file_paths from FlushResult for AXIS index building
-                if let Err(e) = event_log
-                    .notify_flush(
-                        collection_id,
-                        result.file_paths.clone(),
-                        vector_count,
-                        false, // has_quantized - DEFERRED: pass from params
-                        true,  // has_fp32
-                        storage_engine_type,
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        "⚠️ Failed to notify EventLog about flush for '{}': {}",
-                        collection_id,
-                        e
-                    );
-                } else {
-                    tracing::info!(
-                        "📢 Notified EventLog for AXIS indexing: '{}' ({} vectors)",
-                        collection_id,
-                        vector_count
-                    );
-                }
-            } else {
-                tracing::debug!(
-                    "🔄 Flush successful for collection: {} - EventLog not initialized",
-                    collection_id
-                );
-            }
-        }
+        // NOTE: AXIS/EventLog flush notification is intentionally NOT done here.
+        // The traits layer is a pure consumer (no root-service dependency) — each
+        // engine that needs to trigger async AXIS index building on flush notifies
+        // the EventLog from its own `do_flush` (see VIPER, HELIX, SWIFT, NOVA), and
+        // SST performs direct AXIS indexing via TD-112 `index_flushed_into_axis`.
+        // Centralizing it here created a reach-in into the root event-log service
+        // that blocks moving this module to a crate (root-crate decomposition gap 4).
 
         Ok(result)
     }


### PR DESCRIPTION
## Summary

Closes **gap 4** of the traits→crate decomposition: removes the
`crate::services::events::log::event_log_service()` call from
`src/storage/traits/mod.rs` so the traits module is a **pure consumer**
(no root-service dependency) — same shape as gap 3 (#930,
QuantizationSmartDefaults removal).

## The problem

The `UnifiedStorageFormat::flush()` default implementation at
`src/storage/traits/mod.rs` reached into the root
`crate::services::events::log::event_log_service()` to notify the AXIS
index consumer of flush events. That root-service dependency blocks
moving `src/storage/traits/` into its own crate.

## The fix — engine-owned notification (option a)

The AXIS/EventLog flush notification is pushed down to each engine's own
`do_flush`, matching the pattern **VIPER, HELIX, and SWIFT already
follow** (they were already self-notifying inside `do_flush`, so the
trait default was redundant for them):

- **VIPER / HELIX / SWIFT** — already self-notify inside `do_flush`; the
  trait default was redundant (and is now removed, eliminating the
  double-notify).
- **NOVA** — relied solely on the trait default; the best-effort
  `notify_flush` call is added into `NovaEngine::do_flush` so its AXIS
  trigger is preserved.
- **SST** — unaffected; it does direct AXIS indexing on flush via TD-112
  `index_flushed_into_axis` (`sst/flush/mod.rs`), independent of the
  EventLog path.
- **RAPTOR** (experimental) / **SEQUOIA** (relational, no-op flush): N/A.

Behavior preserved for all GA engines; the notification stays best-effort
(errors logged, never fail the flush).

## Verify
- `cargo check --lib --bins` ✅
- `cargo check --tests -p proximadb` ✅ (test callers unaffected)
- `grep -rn "event_log_service\|services::events::log" src/storage/traits/` → **zero matches** ✅
- `cargo clippy --lib --bins` ✅ (exit 0)
- `cargo fmt --all && cargo fmt --check` ✅
- `python3 scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` ✅