### PR TITLE
fix(worktree): skip detached-HEAD worktrees in clean (avoid deleting unmerged work)

### DIFF
--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -164,7 +164,15 @@ cmd_clean() {
   while read -r dir; do
     [ "$dir" = "$(repo_main)" ] && continue
     local br; br="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo)"
-    [ -n "$br" ] || continue
+    # A detached worktree reports the literal string "HEAD", which
+    # branch_in_develop resolves against the MAIN checkout (= the develop
+    # branch) — so it always looks "merged" and the worktree gets deleted even
+    # when its commit is not in develop. Skip detached worktrees (mirroring
+    # cmd_doctor); reattach to a branch or remove explicitly via `worktree.sh rm`.
+    if [ -z "$br" ] || [ "$br" = "HEAD" ]; then
+      [ "$br" = "HEAD" ] && printf 'skip (detached HEAD — reattach or `worktree.sh rm`): %s\n' "$dir" >&2
+      continue
+    fi
     branch_in_develop "$br" || continue
     if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]; then
       printf 'skip (dirty): %s (%s)\n' "$dir" "$br" >&2; continue


### PR DESCRIPTION
## Problem

`worktree.sh clean` could **delete a worktree whose work is not in `develop`** — silent data loss.

`cmd_clean` gets the branch with `git rev-parse --abbrev-ref HEAD`. For a **detached-HEAD** worktree that returns the literal string `"HEAD"`. `branch_in_develop("HEAD")` then runs:

```
git -C <main> merge-base --is-ancestor HEAD origin/develop
```

`HEAD` is resolved against the **main checkout** (which sits on `develop`), so it's always an ancestor of `origin/develop` → always `"merged"` → `git worktree remove` deletes the worktree **regardless of what commit it's actually on**.

Worse, the dirty check (`status --porcelain`) doesn't see gitignored files, so a detached worktree holding uncommitted/ignored work gets wiped with no warning.

## Fix

Mirror the guard `cmd_doctor` already has (`worktree.sh:330`): skip worktrees whose `abbrev-ref` is empty or `"HEAD"`, and point the user at reattach or `worktree.sh rm`.

```diff
-    [ -n "$br" ] || continue
+    if [ -z "$br" ] || [ "$br" = "HEAD" ]; then
+      [ "$br" = "HEAD" ] && printf 'skip (detached HEAD — reattach or `worktree.sh rm`): %s\n' "$dir" >&2
+      continue
+    fi
     branch_in_develop "$br" || continue
```

`branch_in_develop` itself is unchanged, so the named-branch path (the normal case) behaves exactly as before — no regression.

## Verification

Repro: `git worktree add --detach /tmp/scratch origin/develop` (a worktree on a develop commit, but detached), then `worktree.sh clean --dry-run`:
- **Before:** `would clean` (HEAD aliases develop) → would delete it.
- **After:** `skip (detached HEAD — reattach or worktree.sh rm)` → protected; worktree + content survive.

`bash -n` clean. (shellcheck SC2016 on the new line is a false positive — the backticks are literal output text, matching the existing style on lines 343/360.)
