### PR TITLE
ci(tests): drop sccache from the Rust Tests job — unit arm OOM-kills the runner (3/3 since #920)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,9 +1280,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, rust-build]
     if: needs.changes.outputs.rust == 'true' && needs.changes.outputs.test_tier == 'true' && !inputs.skip_tests
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIR: /home/runner/.cache/sccache
+    # NO sccache here (reverted from #920): with RUSTC_WRAPPER=sccache this job's
+    # root-crate test-binary compile OOM-killed the 16GB runner 3/3 times on
+    # 2026-07-13 (exit 143 after ~10min of silence mid-compile — the documented
+    # "runner received a shutdown signal" signature CARGO_BUILD_JOBS=1 exists to
+    # prevent). The three heavy COMPILE jobs keep sccache (proven green ~20min);
+    # this job stays on rust-cache alone, its last-known-good profile.
     strategy:
       fail-fast: false
       matrix:
@@ -1302,15 +1305,6 @@ jobs:
         with:
           prefix-key: "v1-rust-nightly-dev"
           shared-key: "build"
-
-      # sccache complements rust-cache: caches individual rustc invocations
-      # (content-addressed), so it hits even when the target/ artifact cache misses.
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - uses: actions/cache@v4
-        with:
-          path: /home/runner/.cache/sccache
-          key: sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: sccache-${{ runner.os }}-
 
       - name: Install Dependencies
         run: |
@@ -1338,9 +1332,6 @@ jobs:
           else
             cargo test ${{ matrix.args }} -- --test-threads=${{ matrix.threads }}
           fi
-
-      - name: sccache stats
-        run: sccache --show-stats || true
 
   # TD-168 develop early-detection: run the CHEAP object-store Cool-tier tests
   # (scripts/run_cloud_emulator_tests.sh --fast — compiles only the small


### PR DESCRIPTION
## Why

Since #920 wired `RUSTC_WRAPPER=sccache` into the **Rust Tests** matrix job, the **unit** arm has been killed 3/3 times (2026-07-13) with the documented OOM signature: exit 143 after ~10 minutes of log silence mid-compile of the root crate's 8400-test binary — *'runner received a shutdown signal'*, the exact failure `CARGO_BUILD_JOBS=1` exists to prevent (see the job's own comment). The job passed at ~04:00 the same day on #915, **before** #920 merged; every run after has died:

- run 29225971881: exit 143 at 07:50 (killed mid-compile)
- run 29229210147 attempt 2: *hosted runner lost communication* (OOM/CPU starvation per GitHub's own diagnostic)
- run 29229210147 attempt 3 (job 86770770032): last compile output 10:23:39 → shutdown signal 10:33:06, exit 143

This is currently **blocking every PR** (CI Success requires the unit job) — e.g. #923 is green on all 34 other checks across three attempts.

## What

Surgical revert to last-known-good: remove sccache (env + action + cache + stats steps) from the **Rust Tests matrix job only**. The three heavy **compile** jobs keep sccache — they are proven green with it (~20 min). The test job stays on `Swatinem/rust-cache` alone, exactly its pre-#920 profile. Evidence and reasoning are recorded in a comment on the job so the next optimization attempt starts from the failure data.

## Verification

- YAML validated (`yaml.safe_load`)
- The proof is this PR's own **Rust Tests (unit)** check completing — it runs with the fixed workflow via the merge ref.