### PR TITLE
feat(catalog): wire PartitionLeaseManager into DdlService (full DDL lease acquire/renew)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -2143,16 +2143,20 @@ impl SharedServices {
         // adapter.execute_sql) and the RecordOpsService (REST write path), so DDL
         // writes over either surface address the same catalog state and execute
         // tenant-scoped.
-        // Wire the primary-pod registry + this pod's id so collection/table-scoped
-        // DDL fast-fails misrouted writes (ADR-032). The lease manager (full lease
-        // acquire/renew) is attached separately once constructed later in this fn.
-        let ddl_service = std::sync::Arc::new(
-            crate::services::DdlService::new(catalog_manager.clone())
-                .with_primary_pod_registry(primary_pod_registry.clone())
-                .with_self_pod_id(crate::cluster::primary_pod_registry::resolve_self_pod_id(
-                    None,
-                )),
-        );
+        // Wire the write-lease authority into DDL so collection/table-scoped DDL
+        // fast-fails misrouted writes (ADR-032): the primary-pod registry + pod id
+        // for in-memory routing, and — when the lease system is on — the SAME
+        // PartitionLeaseManager the DML write-gate uses (`lease_manager_for_writes`),
+        // so DDL and DML share one ownership view.
+        let mut ddl = crate::services::DdlService::new(catalog_manager.clone())
+            .with_primary_pod_registry(primary_pod_registry.clone())
+            .with_self_pod_id(crate::cluster::primary_pod_registry::resolve_self_pod_id(
+                None,
+            ));
+        if let Some(manager) = &lease_manager_for_writes {
+            ddl = ddl.with_partition_lease_manager(manager.clone());
+        }
+        let ddl_service = std::sync::Arc::new(ddl);
         // Wire QueryFacadeAdapter onto the runtime handler for unified SQL routing.
         // This enables SQL queries to flow through the facade when the
         // unified-facade-routing feature is enabled. The adapter carries the

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -2337,6 +2337,36 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn check_lease_for_write_with_manager_acquires_and_allows() {
+        // With a PartitionLeaseManager attached (the production wiring when the
+        // lease system is on), check_lease_for_write acquires the lease and
+        // allows the write when there is no contention — the manager-attached
+        // path the registry-only tests above do not cover.
+        use crate::cluster::partition_lease::{PartitionLeaseManager, PartitionLeaseStore};
+        use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
+        use object_store::memory::InMemory;
+        use proximadb_object_store::ProximaObjectStore;
+
+        let backing: std::sync::Arc<dyn object_store::ObjectStore> =
+            std::sync::Arc::new(InMemory::new());
+        let store = PartitionLeaseStore::new(ProximaObjectStore::new(backing), "_operator/leases");
+        let registry = std::sync::Arc::new(PrimaryPodRegistry::new());
+        let manager = std::sync::Arc::new(PartitionLeaseManager::new(
+            std::sync::Arc::new(store),
+            registry.clone(),
+            "pod-self",
+            10_000,
+        ));
+        let ddl = lease_ddl()
+            .with_primary_pod_registry(registry)
+            .with_self_pod_id("pod-self".to_string())
+            .with_partition_lease_manager(manager);
+        ddl.check_lease_for_write(Some("tenant-a"), "coll-1")
+            .await
+            .expect("manager acquires the lease (no contention) => Allow");
+    }
+
     // External-location allowlist (Path Isolation, fail-closed). Serialized by
     // the shared env var; nextest's process-per-test isolation keeps these from
     // racing other tests.


### PR DESCRIPTION
## What

Follow-up to #922. DDL now consults the **same `PartitionLeaseManager` the DML write-gate uses** (`lease_manager_for_writes`), not just the in-memory primary-pod registry. With the lease system on (`PROXIMADB_PARTITION_LEASE_ON` + object store), `CREATE/DROP/ALTER TABLE` acquire/renew the partition lease before executing. The registry remains the fallback for lease-less deployments; the object-store generation fence in `SystemCatalog` remains the correctness authority (ADR-032).

## Why this is small

The manager was **already in scope** at the DDL-service construction site in `SharedServices::new` — it's built earlier for the DML lock service (`lease_manager_for_writes`, the binding `record_ops.set_lease_manager` consumes). So #922 left it unattached only because of an ordering assumption that turned out not to apply. This PR attaches it (4-line wiring); DDL and DML now share one write-authority view. No reordering, no new construction.

## Verification (local)

- `cargo check --lib` — clean
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo fmt --check` — clean
- `make work-commit-check` — passed (boundaries, tenant-path, panic-policy, hygiene)
- nextest: 4/4 `check_lease_for_write` tests pass, incl. the new
  `check_lease_for_write_with_manager_acquires_and_allows` (exercises the
  manager-attached acquire⇒Allow path through the seam — the gap in #922's
  registry-only tests)

Refs: #922, ADR-032.
