### PR TITLE
feat(route): geometry estimator v2 + subquery-aware measurement — divergence 12.3% → 8.2%

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -46,7 +46,7 @@ use proximadb_relational_reader::{ReaderCapabilities, ReaderError, RelationalRea
 use proximadb_relational_types::{ColumnInfo, Expr, ExprError, RelationalRow, RelationalSchema};
 use sqlparser::ast::{
     BinaryOperator, Expr as SqlExpr, GroupByExpr, Query as SqlQuery, SelectItem, SetExpr,
-    Statement, TableFactor, TableWithJoins,
+    SetOperator, Statement, TableFactor, TableWithJoins,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
@@ -2659,6 +2659,36 @@ fn geometry_of_body(body: &SetExpr) -> (u32, u32) {
             if select.having.is_some() {
                 depth += 1; // post-aggregate Filter
             }
+            // v2 (measured 2026-07-13): predicate/projection subqueries lower
+            // to HOISTED join branches (semi/anti/left) — the deepest path may
+            // run through the branch, and each hoist is a breaker. v1 ignored
+            // them; TPC-H Q22 measured mxhi against an sxlo estimate.
+            let mut subqueries: Vec<&SqlQuery> = Vec::new();
+            if let Some(sel) = &select.selection {
+                geometry_subqueries_of_expr(sel, &mut subqueries);
+            }
+            if let Some(having) = &select.having {
+                geometry_subqueries_of_expr(having, &mut subqueries);
+            }
+            for item in &select.projection {
+                if let SelectItem::UnnamedExpr(e) | SelectItem::ExprWithAlias { expr: e, .. } = item
+                {
+                    geometry_subqueries_of_expr(e, &mut subqueries);
+                }
+            }
+            for sub in subqueries {
+                let (sd, sb) = geometry_of_query(sub);
+                depth = depth.max(sd) + 1; // hoisted Join above the deeper side
+                blocking += sb + 1; // branch breakers + the join itself
+            }
+            // v2: a window function lowers to a Window node plus the sort it
+            // implies — two extra levels (measured: win_rank/win_running
+            // banded mxhi against an sxhi estimate; depth-only divergence, so
+            // no breaker is added — mirrors `measure_logical_geometry`, which
+            // labels window without counting it as blocking).
+            if select.projection.iter().any(select_item_has_window) {
+                depth += 2;
+            }
             depth += 1; // Project
             if select.distinct.is_some() {
                 depth += 1; // Distinct
@@ -2666,10 +2696,21 @@ fn geometry_of_body(body: &SetExpr) -> (u32, u32) {
             (depth, blocking)
         }
         SetExpr::Query(q) => geometry_of_query(q),
-        SetExpr::SetOperation { left, right, .. } => {
+        SetExpr::SetOperation {
+            op, left, right, ..
+        } => {
             let (dl, bl) = geometry_of_body(left);
             let (dr, br) = geometry_of_body(right);
-            (dl.max(dr) + 1, bl + br)
+            match op {
+                // UNION streams through a concat node.
+                SetOperator::Union => (dl.max(dr) + 1, bl + br),
+                // v2: EXCEPT/INTERSECT lower to distinct-aggregates on BOTH
+                // sides under an anti/semi join plus alias/projection wrappers
+                // — not a single set node (measured: both banded mxhi against
+                // an sxlo estimate; the DF lowering adds ~5 levels and 3
+                // breakers: two side aggregates + the join).
+                _ => (dl.max(dr) + 5, bl + br + 3),
+            }
         }
         _ => (1, 0),
     }
@@ -2694,6 +2735,45 @@ fn geometry_of_table_factor(tf: &TableFactor) -> (u32, u32) {
             table_with_joins, ..
         } => geometry_of_table_with_joins(table_with_joins),
         _ => (1, 0), // named table → Scan leaf
+    }
+}
+
+/// Collect the subqueries in an expression tree (scalar `(SELECT …)`,
+/// `EXISTS`, `IN (SELECT …)`) — the shapes lowering hoists into join
+/// branches. Traversal mirrors [`where_has_subquery`].
+fn geometry_subqueries_of_expr<'a>(expr: &'a SqlExpr, out: &mut Vec<&'a SqlQuery>) {
+    match expr {
+        SqlExpr::Subquery(q) => out.push(q),
+        SqlExpr::Exists { subquery, .. } => out.push(subquery),
+        SqlExpr::InSubquery { subquery, .. } => out.push(subquery),
+        SqlExpr::BinaryOp { left, right, .. } => {
+            geometry_subqueries_of_expr(left, out);
+            geometry_subqueries_of_expr(right, out);
+        }
+        SqlExpr::UnaryOp { expr, .. } | SqlExpr::Nested(expr) | SqlExpr::Cast { expr, .. } => {
+            geometry_subqueries_of_expr(expr, out)
+        }
+        _ => {}
+    }
+}
+
+/// True if a projection item applies a window function (`… OVER (…)`).
+fn select_item_has_window(item: &SelectItem) -> bool {
+    let expr = match item {
+        SelectItem::UnnamedExpr(e) | SelectItem::ExprWithAlias { expr: e, .. } => e,
+        _ => return false,
+    };
+    expr_has_window(expr)
+}
+
+fn expr_has_window(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Function(f) => f.over.is_some(),
+        SqlExpr::BinaryOp { left, right, .. } => expr_has_window(left) || expr_has_window(right),
+        SqlExpr::UnaryOp { expr, .. } | SqlExpr::Nested(expr) | SqlExpr::Cast { expr, .. } => {
+            expr_has_window(expr)
+        }
+        _ => false,
     }
 }
 
@@ -3152,6 +3232,61 @@ mod tests {
                 }
             ),
             "nested join+agg+two sorts must band mid/deep × high: {nested:?}"
+        );
+    }
+
+    #[test]
+    fn geometry_estimator_v2_covers_the_measured_gaps() {
+        use crate::query::compute_scheduler::{BlockingBand, DepthBand, GeometryClass};
+        let raw = |sql: &str| {
+            let s = Parser::parse_sql(&GenericDialect {}, sql).expect("parse");
+            match s.as_slice() {
+                [Statement::Query(q)] => geometry_of_query(q),
+                _ => panic!("one SELECT"),
+            }
+        };
+        let geom = |sql: &str| {
+            let (d, b) = raw(sql);
+            GeometryClass::from_estimate(d, b)
+        };
+        // Gap 1 — predicate subqueries (TPC-H Q22 shape: v1 banded sxlo,
+        // measured mxhi). Each subquery is a hoisted join branch.
+        let q22ish = geom(
+            "SELECT cntrycode, COUNT(*) FROM customer              WHERE c_acctbal > (SELECT AVG(c_acctbal) FROM customer WHERE c_acctbal > 0)              AND NOT EXISTS (SELECT * FROM orders WHERE o_custkey = c_custkey)              GROUP BY cntrycode ORDER BY cntrycode",
+        );
+        assert_eq!(
+            q22ish,
+            GeometryClass::Known {
+                depth: DepthBand::Mid,
+                blocking: BlockingBand::High,
+            },
+            "Q22 shape must band mxhi (measured 10x5)"
+        );
+        // Gap 2 — window functions add Window + implied-sort levels
+        // (depth-only; window is not a breaker in the OpKind vocabulary).
+        let (d_plain, b_plain) = raw("SELECT x FROM t");
+        let (d_win, b_win) = raw("SELECT rank() OVER (ORDER BY x) FROM t");
+        assert_eq!(d_win, d_plain + 2, "window adds two levels");
+        assert_eq!(b_win, b_plain, "window adds no breaker");
+        // Gap 3 — EXCEPT/INTERSECT lower to side-aggregates + join, unlike
+        // UNION's streaming concat (measured: simple set-ops banded mxhi).
+        let except = geom("SELECT a FROM t EXCEPT SELECT a FROM u");
+        assert_eq!(
+            except,
+            GeometryClass::Known {
+                depth: DepthBand::Mid,
+                blocking: BlockingBand::High,
+            },
+            "EXCEPT must band mid x high"
+        );
+        let union = geom("SELECT a FROM t UNION ALL SELECT a FROM u");
+        assert_eq!(
+            union,
+            GeometryClass::Known {
+                depth: DepthBand::Shallow,
+                blocking: BlockingBand::Zero,
+            },
+            "UNION ALL stays a streaming concat"
         );
     }
 

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -663,13 +663,42 @@ fn record_logical_plan_geometry(plan: &datafusion::logical_expr::LogicalPlan) {
 fn measure_logical_geometry(
     plan: &datafusion::logical_expr::LogicalPlan,
 ) -> (u64, u64, u64, u64, u64, Vec<(&'static str, u64)>) {
-    use datafusion::logical_expr::LogicalPlan as Lp;
+    let (depth, nodes, leaves, fanout, blocking, ops) = measure_logical_geometry_inner(plan);
+    (
+        depth,
+        nodes,
+        leaves,
+        fanout,
+        blocking,
+        ops.into_iter().collect(),
+    )
+}
+
+#[allow(clippy::type_complexity)]
+fn measure_logical_geometry_inner(
+    plan: &datafusion::logical_expr::LogicalPlan,
+) -> (
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+    std::collections::BTreeMap<&'static str, u64>,
+) {
+    use datafusion::logical_expr::{Expr as DfExpr, LogicalPlan as Lp};
+    use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
     let mut max_depth = 0u64;
     let mut nodes = 0u64;
     let mut leaves = 0u64;
     let mut max_fanout = 0u64;
     let mut blocking = 0u64;
     let mut ops: std::collections::BTreeMap<&'static str, u64> = std::collections::BTreeMap::new();
+    // Expression-embedded subquery plans (scalar / EXISTS / IN) with the depth
+    // of the node that carries them. They are NOT tree inputs — `inputs()`
+    // never yields them — so a plain child walk under-measures exactly the
+    // shapes the estimator counts as hoisted branches (observed: Q4/Q17/Q20/
+    // Q22/q32 audited as estimator over-estimates until this walk landed).
+    let mut sub_plans: Vec<(std::sync::Arc<Lp>, u64)> = Vec::new();
     let mut work: Vec<(&Lp, u64)> = vec![(plan, 1)];
     while let Some((node, depth)) = work.pop() {
         nodes += 1;
@@ -692,6 +721,23 @@ fn measure_logical_geometry(
         if is_blocking {
             blocking += 1;
         }
+        for expr in node.expressions() {
+            let _ = expr.apply(|e| {
+                match e {
+                    DfExpr::ScalarSubquery(sq) => {
+                        sub_plans.push((std::sync::Arc::clone(&sq.subquery), depth));
+                    }
+                    DfExpr::Exists(ex) => {
+                        sub_plans.push((std::sync::Arc::clone(&ex.subquery.subquery), depth));
+                    }
+                    DfExpr::InSubquery(is) => {
+                        sub_plans.push((std::sync::Arc::clone(&is.subquery.subquery), depth));
+                    }
+                    _ => {}
+                }
+                Ok(TreeNodeRecursion::Continue)
+            });
+        }
         let inputs = node.inputs();
         max_fanout = max_fanout.max(inputs.len() as u64);
         if inputs.is_empty() {
@@ -701,14 +747,24 @@ fn measure_logical_geometry(
             work.push((child, depth + 1));
         }
     }
-    (
-        max_depth,
-        nodes,
-        leaves,
-        max_fanout,
-        blocking,
-        ops.into_iter().collect(),
-    )
+    // Fold each subquery branch: its ops are real work, its deepest path may
+    // exceed the outer chain, and decorrelation lowers the branch to a join —
+    // count that breaker so the measurement matches what executes (and the
+    // estimator's hoisted-branch semantics). Function-level recursion here is
+    // bounded by SQL subquery NESTING, which sqlparser's recursion limit caps
+    // at parse time — unlike chain depth, it cannot be adversarially deep.
+    for (sub, parent_depth) in sub_plans {
+        let (sd, sn, sl, sf, sb, sops) = measure_logical_geometry_inner(&sub);
+        max_depth = max_depth.max(parent_depth + 1 + sd);
+        nodes += sn;
+        leaves += sl;
+        max_fanout = max_fanout.max(sf);
+        blocking += sb + 1; // the decorrelated join
+        for (k, v) in sops {
+            *ops.entry(k).or_insert(0) += v;
+        }
+    }
+    (max_depth, nodes, leaves, max_fanout, blocking, ops)
 }
 
 #[cfg(feature = "datafusion-integration")]
@@ -1012,6 +1068,37 @@ mod geometry_tests {
         assert_eq!(get("filter"), Some(1));
         assert_eq!(get("sort"), Some(1));
         assert_eq!(get("limit"), Some(1));
+    }
+
+    #[test]
+    fn logical_geometry_measures_expression_subquery_branches() {
+        use datafusion::logical_expr::exists;
+        use std::sync::Arc;
+        // Subquery branch: values → filter (depth 2, 2 nodes, 0 breakers).
+        let sub = LogicalPlanBuilder::values(vec![vec![lit(1i64)]])
+            .expect("values")
+            .filter(lit(true))
+            .expect("filter")
+            .build()
+            .expect("build");
+        // Outer: filter(EXISTS(sub)) is the root (depth 1), values below it
+        // (depth 2); the branch hangs off the filter node.
+        let plan = LogicalPlanBuilder::values(vec![vec![lit(2i64)]])
+            .expect("values")
+            .filter(exists(Arc::new(sub)))
+            .expect("filter")
+            .build()
+            .expect("build");
+        let (depth, nodes, leaves, _fanout, blocking, ops) = measure_logical_geometry(&plan);
+        // Outer tree: filter(1) + values(2). Branch folds beneath the filter:
+        // parent_depth(1) + 1 + sub_depth(2) = 4.
+        assert_eq!(depth, 4, "deepest path runs through the subquery branch");
+        assert_eq!(nodes, 4, "outer 2 + branch 2");
+        assert_eq!(leaves, 2, "one leaf per side");
+        assert_eq!(blocking, 1, "the decorrelated join is a breaker");
+        let get = |k: &str| ops.iter().find(|(l, _)| *l == k).map(|(_, n)| *n);
+        assert_eq!(get("filter"), Some(2), "both filters counted");
+        assert_eq!(get("values"), Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the estimator gaps the Slice-3 calibration audit named, and fixes the measurement artifact the first verification sweep exposed. Follow-on to #909 (geometry tier) and #931 (DataFusion-route measurement).

### Estimator v2 (`query_geometry_class`, AST walk)

The audit measured three one-directional under-estimation gaps (native 23.5%, DataFusion 12.3%):

- **Predicate/projection subqueries** lower to hoisted join branches (TPC-H Q22: est `sxlo` vs meas `mxhi`) → count each branch's geometry plus the join above it.
- **Window functions** add Window + implied-sort levels (`win_rank`/`win_running`: depth-only divergence) → +2 depth, no breaker (mirrors the measurement vocabulary).
- **EXCEPT/INTERSECT** lower to side-aggregates under an anti/semi join (est `sxlo` vs meas `mxhi`) → +5 depth/+3 breakers; `UNION ALL` stays a streaming concat.

### Subquery-aware measurement (`measure_logical_geometry`)

The v2-alone sweep read 13.7% divergence with the direction *flipped* — an artifact: the logical-plan walk followed only `node.inputs()`, so subquery plans held **inside expressions** (`ScalarSubquery`/`EXISTS`/`IN`) were invisible to the audit — exactly the shapes v2 counts. The walk now collects them per node (`TreeNode::apply` per expression) and folds each branch, counting the decorrelated join as the breaker that actually executes. Recursion is bounded by SQL subquery *nesting* (sqlparser parse-time cap), unlike chain depth.

## Measured (release, SF 0.001 DataFusion sweep, 146 audited folds)

| Estimator | Measurement | Divergence |
|---|---|---|
| v1 | inputs-only | 12.3% (all under) |
| v2 | inputs-only | 13.7% (direction flipped — artifact) |
| **v2** | **subquery-aware** | **8.2%** (under, one mild over) |

Remaining named (future refit): deep group-by wrapper depth (q61/q65/q67 `mxhi→dxhi`), Q4/Q17 one band shy, q87 chained-EXCEPT mild over-estimate.

Re-keying is deterministic per query and degrades gracefully through the hierarchical consult (#909): warmed ancestor cells keep serving while re-banded classes warm.

## Tests / gates

New: Q22 shape bands `mxhi` (measured 10×5); window delta +2/+0; EXCEPT vs UNION ALL separation; EXISTS branch folds into the measured geometry with the join counted. `fmt --check` · `clippy --lib --bins -- -D warnings` · `make work-commit-check` · attribution guard · geometry filter 10/10 locally.

Ref TD-EXEC-2 (Slice 3 calibration loop), TD-OLAP-4, ADR-058.