### PR TITLE
refactor(storage-ports): add FilesystemPort — DI port for FilesystemFactory (engines-extraction enabler)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8118,6 +8118,7 @@ dependencies = [
  "proximadb-quantization-model",
  "proximadb-records",
  "proximadb-storage-common",
+ "proximadb-storage-filesystem-types",
  "serde",
 ]
 

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -32,6 +32,9 @@ proximadb-kernel.workspace = true
 # (Vec<StorageQuantizedData>, &QuantizedVector, UnifiedQuantizationLevel) — moved to
 # foundation by #842, so the port is facade-FREE (no DTO/adaptor layer).
 proximadb-quantization-model.workspace = true
+# Storage-tier: the FilesystemPort names FileSystem / FileOptions / FsResult from
+# this crate (the existing filesystem abstraction). Same-tier dep (storage→storage).
+proximadb-storage-filesystem-types.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -14,6 +14,7 @@
 use anyhow::Result;
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
+use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
 
 pub mod capabilities;
 pub use capabilities::*;
@@ -169,4 +170,31 @@ pub trait StorageQuantizationEnginePort: Send + Sync {
 
     /// Dequantize a vector back to approximate float values.
     async fn dequantize(&self, quantized: &QuantizedVector) -> Result<Vec<f32>>;
+}
+
+/// Filesystem access port — inverts the storage→root `FilesystemFactory` dependency.
+///
+/// Engine leaves hold `Arc<dyn FilesystemPort>` instead of the root-local
+/// `FilesystemFactory` concrete type, so engine modules (`viper/pipeline`,
+/// `raptor/*`, …) can move to crates. The surface is the routing + staging methods
+/// engines actually use — measured across `EngineFilesystemAccess`'s default
+/// methods, `trait_components::writer`, and the engine tests. The concrete
+/// `FilesystemFactory` impls this in the root crate (a downward edge —
+/// root→storage-ports is layering-allowed); the composition root injects it.
+///
+/// This unblocks the engine-leaf extraction (see
+/// `docs/12-design/ROOT_CRATE_DECOMPOSITION_ENGINES_EXTRACTION_2026_07_12.adoc`):
+/// leaves swap their `Arc<FilesystemFactory>` fields for `Arc<dyn FilesystemPort>`.
+#[async_trait::async_trait]
+pub trait FilesystemPort: Send + Sync {
+    /// Resolve the `FileSystem` for a URL's scheme (cached; routed by scheme).
+    fn get_filesystem(&self, url: &str) -> FsResult<std::sync::Arc<dyn FileSystem>>;
+    /// Recursively create the directory at `url`.
+    async fn create_dir_all(&self, url: &str) -> FsResult<()>;
+    /// Write `data` to `url`.
+    async fn write(&self, url: &str, data: &[u8], options: Option<FileOptions>) -> FsResult<()>;
+    /// Atomically move `from_url` → `to_url`.
+    async fn move_atomic(&self, from_url: &str, to_url: &str) -> FsResult<()>;
+    /// Delete the file/dir at `url`.
+    async fn delete(&self, url: &str) -> FsResult<()>;
 }

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -1518,3 +1518,36 @@ mod inline_tests {
 
 #[cfg(test)]
 mod comprehensive_tests;
+
+// ============================================================================
+// FilesystemPort impl — Slice D port-inversion (gap 5/6 enabler)
+// ============================================================================
+// Exposes the root-local `FilesystemFactory` behind the `FilesystemPort` trait
+// (defined in `proximadb-storage-ports`) so engine leaves can depend on
+// `Arc<dyn FilesystemPort>` instead of this concrete type, enabling their
+// extraction to crates. Pure delegation to the inherent methods above; the
+// composition root injects `FilesystemFactory` (as `Arc<dyn FilesystemPort>`)
+// into engines. See `EngineFilesystemAccess` in `src/storage/traits/mod.rs` and
+// `ROOT_CRATE_DECOMPOSITION_ENGINES_EXTRACTION_2026_07_12.adoc`.
+#[async_trait::async_trait]
+impl proximadb_storage_ports::FilesystemPort for FilesystemFactory {
+    fn get_filesystem(&self, url: &str) -> FsResult<std::sync::Arc<dyn FileSystem>> {
+        FilesystemFactory::get_filesystem(self, url)
+    }
+
+    async fn create_dir_all(&self, url: &str) -> FsResult<()> {
+        FilesystemFactory::create_dir_all(self, url).await
+    }
+
+    async fn write(&self, url: &str, data: &[u8], options: Option<FileOptions>) -> FsResult<()> {
+        FilesystemFactory::write(self, url, data, options).await
+    }
+
+    async fn move_atomic(&self, from_url: &str, to_url: &str) -> FsResult<()> {
+        FilesystemFactory::move_atomic(self, from_url, to_url).await
+    }
+
+    async fn delete(&self, url: &str) -> FsResult<()> {
+        FilesystemFactory::delete(self, url).await
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `FilesystemPort` trait to `proximadb-storage-ports` and `impl FilesystemPort for FilesystemFactory` in root — port-inverting the storage→root-`FilesystemFactory` dependency. This is the **unclaimed enabler that #937 (link-7) deferred**: #937 moved `UnifiedStorageFormat` to the `proximadb-storage-traits` crate via "trait split," keeping the `FilesystemFactory`-coupled `EngineFilesystemAccess` methods in root because the type wasn't port-inverted.

## What

- `FilesystemPort` trait (storage-ports): `get_filesystem`, `create_dir_all`, `write`, `move_atomic`, `delete` — the routing + staging surface engines actually use (measured across `EngineFilesystemAccess` defaults, `trait_components::writer`, engine tests). Reuses the **existing** `FileSystem`/`FileOptions`/`FsResult` from `proximadb-storage-filesystem-types` (the catalog `CatalogFilesystemResolver` is the precedent).
- `impl FilesystemPort for FilesystemFactory` (root): pure delegation; no behavior change.

## Why it unblocks

With `Arc<dyn FilesystemPort>` now crate-accessible, engine leaves (`viper/pipeline`, `raptor/*`, …) can swap their `Arc<FilesystemFactory>` fields and move to crates — and #937's deferred `EngineFilesystemAccess` methods can finally follow `UnifiedStorageFormat` into the traits crate. This is the prep the engines-extraction track (the OOM/`CARGO_BUILD_JOBS=2` goal) was waiting on; see `ROOT_CRATE_DECOMPOSITION_ENGINES_EXTRACTION_2026_07_12.adoc` (efferent-corrected recon).

## Risk

**Additive + low-risk:** no existing call-site changes — engines keep storing `FilesystemFactory` (which now also impls `FilesystemPort`). The first consumer is the planned `viper/pipeline` extraction (separate PR).

## Verification

- root `--lib` + clippy `--lib --bins` (CI gate): clean
- `cargo fmt --check`: clean
- workspace layering + boundaries: pass
- storage up-edge ratchet: **197 → 196** (improved)
- `make work-commit-check`: green