### PR TITLE
feat(sst): TD-RDSTRAT-5 flip-gate — real SIFT centroid-prune recall ratchet (prune-engaged, no false positive)

### DIFF
--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -142,6 +142,13 @@ pub struct IoTrace {
     /// promotion gate consumes.
     splits_total: AtomicU64,
     splits_pruned: AtomicU64,
+    /// PAX cascade centroid block-prune outcome (TD-RDSTRAT-5 S3): `centroid_pruned_blocks`
+    /// of `centroid_total_blocks` skipped by the VOE-directory centroid probe before
+    /// scanning. Distinct from `splits_*` (row-group runtime filter) so the ratios
+    /// don't cross-contaminate; the recall gate asserts this engaged
+    /// (`centroid_pruned_blocks > 0`) rather than silently falling back to a full scan.
+    centroid_total_blocks: AtomicU64,
+    centroid_pruned_blocks: AtomicU64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): how often the probe scan's
     /// `wait_complete()` rendezvous resolved with the filter arrived (pruning
     /// enabled) vs timed out (filterless, conservative), plus the wall ms spent
@@ -288,6 +295,15 @@ impl IoTrace {
     pub fn record_splits(&self, total: u64, pruned: u64) {
         self.splits_total.fetch_add(total, Ordering::Relaxed);
         self.splits_pruned.fetch_add(pruned, Ordering::Relaxed);
+    }
+
+    /// Record a PAX cascade centroid block-prune outcome (TD-RDSTRAT-5 S3): of
+    /// `total` blocks in the segment, `pruned` were skipped by the centroid probe.
+    pub fn record_centroid_prune(&self, total: u64, pruned: u64) {
+        self.centroid_total_blocks
+            .fetch_add(total, Ordering::Relaxed);
+        self.centroid_pruned_blocks
+            .fetch_add(pruned, Ordering::Relaxed);
     }
 
     /// Record a runtime-filter wait outcome (ADR-056 AQE-S11): `arrived` = the
@@ -445,6 +461,8 @@ impl IoTrace {
             logical_striped_gets: self.logical_striped_gets.load(Ordering::Relaxed),
             splits_total: self.splits_total.load(Ordering::Relaxed),
             splits_pruned: self.splits_pruned.load(Ordering::Relaxed),
+            centroid_total_blocks: self.centroid_total_blocks.load(Ordering::Relaxed),
+            centroid_pruned_blocks: self.centroid_pruned_blocks.load(Ordering::Relaxed),
             runtime_filter_arrived: self.runtime_filter_arrived.load(Ordering::Relaxed),
             runtime_filter_timed_out: self.runtime_filter_timed_out.load(Ordering::Relaxed),
             runtime_filter_wait_ms: self.runtime_filter_wait_ms.load(Ordering::Relaxed),
@@ -510,6 +528,13 @@ pub struct IoTraceSnapshot {
     /// Splits skipped before fetch — with `splits_total`, the skip ratio.
     #[serde(default)]
     pub splits_pruned: u64,
+    /// PAX cascade centroid block-prune (TD-RDSTRAT-5 S3): total blocks in the
+    /// segment and how many the centroid probe skipped. `centroid_pruned_blocks > 0`
+    /// proves the prune engaged (vs a silent full-scan fallback).
+    #[serde(default)]
+    pub centroid_total_blocks: u64,
+    #[serde(default)]
+    pub centroid_pruned_blocks: u64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): arrived vs timed-out +
     /// the wall ms spent waiting. `arrived / (arrived + timed_out)` is the
     /// per-workload signal the route cost model learns to tune the wait budget.
@@ -729,6 +754,13 @@ pub fn record_range_gets(gets: u64) {
 /// snapshot. Silently no-ops outside an active scope.
 pub fn record_splits(total: u64, pruned: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_splits(total, pruned));
+}
+
+/// Record a PAX cascade centroid block-prune outcome for the active query
+/// (TD-RDSTRAT-5 S3): of `total` blocks, `pruned` were skipped by the centroid
+/// probe. Silently no-ops outside an active scope.
+pub fn record_centroid_prune(total: u64, pruned: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_centroid_prune(total, pruned));
 }
 
 /// Record a runtime-filter wait outcome for the active query (ADR-056 AQE-S11).

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -42,6 +42,33 @@ fn env_flag_on(var: &str) -> bool {
     }
 }
 
+/// TD-RDSTRAT-5 S3: the centroid probe-prune config, tunable via env so operators
+/// (and the recall gate) can set the `nprobe` aggressiveness and force pruning on
+/// small segments. Defaults to [`BlockPruneConfig::default`] (Sqrt mode, the
+/// production `MIN_BLOCKS_FOR_PRUNING`=100 threshold). Env overrides:
+///   * `PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS` — bypass the 100-block threshold
+///     (e.g. `2` to prune small segments; the recall gate uses this).
+///   * `PROXIMADB_PAX_CENTROID_PRUNE_RATIO` — switch to Ratio mode keeping this
+///     fraction of blocks (0.0–1.0) instead of Sqrt.
+pub fn centroid_prune_config() -> crate::core::search::BlockPruneConfig {
+    use crate::core::search::{BlockPruneConfig, BlockPruneMode};
+    let mut cfg = BlockPruneConfig::default();
+    if let Some(mb) = std::env::var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+    {
+        cfg.min_blocks_override = Some(mb);
+    }
+    if let Some(r) = std::env::var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO")
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+    {
+        cfg.mode = BlockPruneMode::Ratio;
+        cfg.ratio = r.clamp(0.0, 1.0);
+    }
+    cfg
+}
+
 /// The f32 vector of `record`'s embedding `idx`, if present and Fp32-typed (the
 /// canonical write-time embedding representation — quantization happens inside the
 /// block writer). Non-Fp32 variants return `None` (they don't contribute a key).

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -301,8 +301,17 @@ impl SstEngine {
         {
             return None;
         }
-        let prune = crate::core::search::BlockPruneConfig::default();
-        Some(select_blocks_by_centroid(query, &entries, metric, &prune))
+        let prune = crate::storage::engines::sst::block_cluster::centroid_prune_config();
+        let total = entries.len();
+        let selected = select_blocks_by_centroid(query, &entries, metric, &prune);
+        // Record the prune outcome so the recall gate can assert the probe engaged
+        // (centroid_pruned_blocks > 0) rather than silently falling back to a full
+        // scan. `total - selected` is how many blocks the centroid probe skipped.
+        crate::observability::io_trace::record_centroid_prune(
+            total as u64,
+            total.saturating_sub(selected.len()) as u64,
+        );
+        Some(selected)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -359,6 +359,148 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     );
 }
 
+/// TD-RDSTRAT-5 flip gate: the VOE-directory centroid prune must (a) ACTUALLY
+/// engage on SIFT (not silently fall back to a full scan) and (b) hold recall@10
+/// within tolerance. The engine is wired WITH a directory cache and clustering +
+/// prune are enabled, so a flush emits the directory and the read prunes;
+/// io_trace's `centroid_pruned_blocks > 0` proves engagement (a full-scan fallback
+/// would leave it 0 and fail — no false positive). Gates the default-ON flip.
+#[tokio::test]
+async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1");
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+        // Force pruning on multi-block segments (bypass the 100-block prod threshold)
+        // and keep a generous block fraction so recall stays sane on the coarse S1
+        // sign-bit clustering; CI ratchets the floor UP as clustering improves.
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS", "2");
+        if std::env::var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO").is_err() {
+            std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO", "0.5");
+        }
+    }
+
+    let base_path = match dataset_path("sift_base.fvecs") {
+        Some(p) if p.exists() => p,
+        _ => {
+            eprintln!(
+                "skip: PROXIMADB_SIFT_DATASET_DIR unset/missing — centroid-prune ratchet needs SIFT1M"
+            );
+            return;
+        }
+    };
+
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+    let subset_n: Option<usize> = std::env::var("PROXIMADB_SIFT_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0);
+    let max_queries: usize = std::env::var("PROXIMADB_SIFT_QUERIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_QUERIES);
+    // Pruned recall floor: separate + conservative (pruning + coarse clustering
+    // trims recall vs the unpruned 0.90 baseline). CI measures and ratchets it UP.
+    let floor: f64 = std::env::var("PROXIMADB_SIFT_CENTROID_RECALL_FLOOR")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|f| (0.0..=1.0).contains(f))
+        .unwrap_or(0.70);
+
+    let temp_dir = TempDir::new().unwrap();
+    let collection = collection("sift_voe_centroid_prune", &temp_dir);
+    // Wire the directory cache — WITHOUT it, S2 emission is skipped and the read
+    // silently falls back to a full scan (the prune would never engage).
+    let engine = SstEngine::new().await.unwrap().with_directory_cache(Arc::new(
+        proximadb::storage::engines::sst::object_economy_directory::VectorObjectEconomyDirectoryCache::new(),
+    ));
+
+    let base = read_vec_records_f32(&base_path, subset_n).expect("read sift_base.fvecs");
+    let n = base.len();
+    assert!(n >= TOP_K, "need at least {TOP_K} base vectors, got {n}");
+
+    let mut batch: Vec<VectorRecord> = Vec::with_capacity(BATCH_SIZE);
+    for (i, v) in base.iter().enumerate() {
+        batch.push(vector_record(i as u32, v.clone()));
+        if batch.len() == BATCH_SIZE {
+            let b = std::mem::take(&mut batch);
+            flush_batch(&engine, &collection, b).await;
+        }
+    }
+    if !batch.is_empty() {
+        flush_batch(&engine, &collection, batch).await;
+    }
+
+    let query_path = dataset_path("sift_query.fvecs");
+    let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
+        Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
+        None => base.iter().take(max_queries.min(n)).cloned().collect(),
+    };
+    let qcount = queries.len();
+    let gt_path = dataset_path("sift_groundtruth.ivecs");
+    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
+    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
+        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
+        gt.into_iter()
+            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
+            .collect()
+    } else {
+        queries
+            .iter()
+            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
+            .collect()
+    };
+    drop(base);
+
+    // Run the whole search loop inside ONE io_trace scope so the centroid-prune
+    // counter accumulates across queries; the snapshot proves the prune engaged.
+    let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
+        let mut recall_sum = 0.0f64;
+        let mut measured = 0usize;
+        for (qi, query) in queries.iter().enumerate() {
+            let got = search_topk(&engine, &collection, query.clone()).await;
+            if got.is_empty() {
+                continue;
+            }
+            let got_ids: std::collections::HashSet<String> = got.into_iter().take(TOP_K).collect();
+            let overlap = got_ids.intersection(&ground_truth[qi]).count();
+            recall_sum += overlap as f64 / TOP_K as f64;
+            measured += 1;
+        }
+        let recall = if measured > 0 {
+            recall_sum / measured as f64
+        } else {
+            0.0
+        };
+        let snap = proximadb::observability::io_trace::snapshot().expect("io_trace scope active");
+        (recall, measured, snap)
+    })
+    .await;
+
+    assert!(measured > 0, "no queries succeeded — cannot report recall");
+    eprintln!(
+        "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, \
+         floor={floor}); centroid blocks total={} pruned={}",
+        snap.centroid_total_blocks, snap.centroid_pruned_blocks
+    );
+    // (a) The prune MUST have engaged — a silent full-scan fallback leaves this 0.
+    assert!(
+        snap.centroid_pruned_blocks > 0,
+        "centroid prune did NOT engage (centroid_pruned_blocks=0) — a full-scan fallback would \
+         make this recall test a false positive. Check with_directory_cache + \
+         PROXIMADB_PAX_BLOCK_CLUSTER emission + PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS."
+    );
+    // (b) Recall must clear the (conservative, CI-ratcheted) floor.
+    assert!(
+        recall >= floor,
+        "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} < {floor} floor (N={n}) — \
+         default-ON flip BLOCKED until the clustering/nprobe is tuned \
+         (PROXIMADB_PAX_CENTROID_PRUNE_RATIO / S4 IVF clustering)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Loader unit tests — synthetic .fvecs/.ivecs round-trip (no dataset needed).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The gate the RDSTRAT-5 default-ON flip needs — one that **actually exercises** the VOE-directory centroid prune (S3, #914) instead of silently falling back to a full scan.

- **io_trace `centroid_{total,pruned}_blocks` counter** (distinct from `splits_*`) + `record_centroid_prune`, recorded in `voe_centroid_selected_blocks` so the prune outcome is observable.
- **`block_cluster::centroid_prune_config()`** — env-tunable `BlockPruneConfig` (`PROXIMADB_PAX_CENTROID_PRUNE_{MIN_BLOCKS,RATIO}`) so operators tune nprobe and the gate can force pruning on small segments; default = `BlockPruneConfig::default()`. `try_pax_cascade` uses it (was `::default()`).
- **`tests/sift_pax_recall_ratchet_test.rs`: `sift_voe_centroid_prune_recall_at_10_ratchet`** — wires the engine **with a directory cache** + enables cluster+prune, runs search inside an `io_trace` scope, and **asserts `centroid_pruned_blocks > 0` (prune engaged) BEFORE the recall floor** — so a full-scan fallback fails instead of passing a false positive. Conservative pruned-recall floor (`PROXIMADB_SIFT_CENTROID_RECALL_FLOOR`, default 0.70), ratcheted up in CI as clustering improves.

Local: clippy `--lib --bins -D warnings` clean; tests pass (SIFT skips without dataset). Unblocks the RDSTRAT-5 default-ON flip once CI measures the pruned recall. Refs TD-RDSTRAT-5.