### PR TITLE
refactor(storage-ports): add CacheAccessPatternPort — DI port for CrossCacheOrchestrator (engines-extraction enabler)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -198,3 +198,32 @@ pub trait FilesystemPort: Send + Sync {
     /// Delete the file/dir at `url`.
     async fn delete(&self, url: &str) -> FsResult<()>;
 }
+
+/// Cache-kind for access-pattern tracking — the engine-facing subset of the root
+/// `CacheType` (the 5 variants engines actually track, measured across
+/// `src/storage/engines/`: VectorData, Metadata, DistanceTable, FilterBitmap,
+/// IndexStructure). Foundation-neutral so engine leaves can name it without
+/// depending on the root-local `CacheType`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheKind {
+    VectorData,
+    Metadata,
+    DistanceTable,
+    FilterBitmap,
+    IndexStructure,
+}
+
+/// Cache access-pattern tracking port — inverts the storage→root
+/// `CrossCacheOrchestrator` dependency for access tracking.
+///
+/// Engine leaves hold `Arc<dyn CacheAccessPatternPort>` instead of the root-local
+/// `CrossCacheOrchestrator` (a heavily-coupled global singleton), so engine modules
+/// can move to crates. The surface is exactly the one method engines use —
+/// `pattern_tracker().track_access_async(key, cache_type)` — measured across 12
+/// engine files. The concrete `CrossCacheOrchestrator` impls this in the root crate
+/// (downward edge); the composition root injects it. Non-blocking (the underlying
+/// tracker queues events for background processing).
+pub trait CacheAccessPatternPort: Send + Sync {
+    /// Record a cache access for pattern learning / predictive prefetching.
+    fn track_access(&self, key: String, cache_kind: CacheKind);
+}

--- a/src/storage/cache/orchestrator.rs
+++ b/src/storage/cache/orchestrator.rs
@@ -271,7 +271,27 @@ impl CrossCacheOrchestrator {
     pub fn global() -> Option<Arc<CrossCacheOrchestrator>> {
         GLOBAL_ORCHESTRATOR.get().cloned()
     }
+}
 
+// CacheAccessPatternPort impl — Slice D port-inversion. Exposes the root-local
+// CrossCacheOrchestrator behind the CacheAccessPatternPort trait (defined in
+// proximadb-storage-ports) so engine leaves can depend on Arc<dyn CacheAccessPatternPort>
+// instead of this concrete global-singleton type. Pure delegation to the pattern
+// tracker; CacheKind maps 1:1 to the root CacheType (engine-facing subset).
+impl proximadb_storage_ports::CacheAccessPatternPort for CrossCacheOrchestrator {
+    fn track_access(&self, key: String, cache_kind: proximadb_storage_ports::CacheKind) {
+        let cache_type = match cache_kind {
+            proximadb_storage_ports::CacheKind::VectorData => CacheType::VectorData,
+            proximadb_storage_ports::CacheKind::Metadata => CacheType::Metadata,
+            proximadb_storage_ports::CacheKind::DistanceTable => CacheType::DistanceTable,
+            proximadb_storage_ports::CacheKind::FilterBitmap => CacheType::FilterBitmap,
+            proximadb_storage_ports::CacheKind::IndexStructure => CacheType::IndexStructure,
+        };
+        self.pattern_tracker().track_access_async(key, cache_type);
+    }
+}
+
+impl CrossCacheOrchestrator {
     /// Install the trace-driven cache observer (T2.2).
     ///
     /// This wires the io_trace substrate into the cache sizing loop: every completed

--- a/src/storage/engines/raptor/consolidated_reader.rs
+++ b/src/storage/engines/raptor/consolidated_reader.rs
@@ -20,10 +20,10 @@ use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
 use proximadb_distance_kernel::engine::{DistanceMetric, SimilarityResult, UnifiedDistanceCompute};
 
-use crate::storage::cache::orchestrator::{CacheType, CrossCacheOrchestrator};
 use crate::storage::engines::core::ops::proximacodec::{ProximaCodec, types::ProximaScheme};
 use crate::storage::persistence::filesystem::FileSystem;
 use crate::storage::transaction_coordinator::TransactionCoordinator;
+use proximadb_storage_ports::{CacheAccessPatternPort, CacheKind};
 
 use super::common::{
     ColumnType, // For selective column reading
@@ -272,7 +272,7 @@ pub struct RaptorReader {
     _config: RaptorConfig,
 
     /// Unified cache orchestrator (replaces rowgroup_cache.rs)
-    cache: Arc<CrossCacheOrchestrator>,
+    cache: Arc<dyn CacheAccessPatternPort>,
 
     /// Unified distance computation (replaces simd_encoder.rs distance logic)
     distance_compute: Arc<UnifiedDistanceCompute>,
@@ -343,7 +343,7 @@ impl RaptorReader {
         base_path: String,
         collection_id: String,
         config: RaptorConfig,
-        cache: Arc<CrossCacheOrchestrator>,
+        cache: Arc<dyn CacheAccessPatternPort>,
         filesystem: Arc<dyn FileSystem>,
         transaction_coordinator: Arc<TransactionCoordinator>,
     ) -> Self {
@@ -379,8 +379,7 @@ impl RaptorReader {
                 // Use zero-copy filesystem with integrated caching
                 let cache_key = format!("{}:{}:raptor", file_path, rg_idx);
                 self.cache
-                    .pattern_tracker()
-                    .track_access_async(cache_key.clone(), CacheType::VectorData);
+                    .track_access(cache_key.clone(), CacheKind::VectorData);
 
                 // Try zero-copy cached read first
                 if let Ok(_cached_data) = self.filesystem.read(file_path).await {
@@ -475,8 +474,7 @@ impl RaptorReader {
 
             // DIRECT access to unified cache - no wrapper method
             self.cache
-                .pattern_tracker()
-                .track_access_async(_cache_key.clone(), CacheType::VectorData);
+                .track_access(_cache_key.clone(), CacheKind::VectorData);
 
             // Deferred: Implement proper caching with updated APIs
 
@@ -1130,8 +1128,7 @@ impl RaptorReader {
 
         // Track access pattern for predictive prefetching
         self.cache
-            .pattern_tracker()
-            .track_access_async(cache_key.clone(), CacheType::Metadata);
+            .track_access(cache_key.clone(), CacheKind::Metadata);
 
         // Stat the file first so we can validate the cache.
         let file_metadata = self.filesystem.metadata(file_path).await?;


### PR DESCRIPTION
## Summary

Adds a `CacheAccessPatternPort` trait (storage-ports) + `impl CacheAccessPatternPort for CrossCacheOrchestrator` (root) — port-inverting the storage→root `CrossCacheOrchestrator` access-tracking dependency. Sibling to the FilesystemPort (#943): a Slice-D enabler that removes a root-local global-singleton type from engine leaves' dependency surface, unblocking the eventual per-engine extraction.

## What

- `CacheAccessPatternPort` trait (storage-ports) — surface is the single method engines use: `track_access(key, cache_kind)`.
- `CacheKind` enum (5 variants: VectorData, Metadata, DistanceTable, FilterBitmap, IndexStructure) — the engine-facing subset of the root `CacheType` (measured across `src/storage/engines/`); the impl maps it 1:1.
- `impl CacheAccessPatternPort for CrossCacheOrchestrator` (root) — delegates to `pattern_tracker().track_access_async(..)`.

## First consumer

`raptor/consolidated_reader.rs` swaps its `cache: Arc<CrossCacheOrchestrator>` field + constructor param for `Arc<dyn CacheAccessPatternPort>`, and its 3 call sites for `self.cache.track_access(..)`. The 5 `RaptorReader::new` callers need **zero changes** — `Arc<CrossCacheOrchestrator>` auto-coerces to `Arc<dyn CacheAccessPatternPort>` at the call site.

## Why

`CrossCacheOrchestrator` is a heavily-coupled **global singleton** (registered globally, accessed via `::global()` in 15+ files) — un-hoist-able. Port-injection lets engine leaves depend on the narrow port downward instead, so they can eventually move to crates. 12 engine files use the identical `pattern_tracker().track_access_async()` pattern, so this port is a **broad enabler**, not just for consolidated_reader.

## Note on scope

This is the **dep-clearing enabler**, not the consolidated_reader *extraction*. Recon showed consolidated_reader is tangled with `raptor/common` (the Ca=126 cycle hub — uses `Predicate` + 5 other types from it), so the full move needs the raptor-engine/cycle-hub inversion (the doc's "Engines Slice 2"). This port clears the cache axis (and the dead `_transaction_coordinator` param is noted for a follow-up).

## Verification

- root `--lib` + clippy `--lib --bins` (CI gate): clean
- `cargo fmt --check`: clean
- workspace layering + boundaries: pass
- storage up-edge ratchet: **186** (unchanged — `cache::orchestrator` was intra-storage, not an up-edge)
- `make work-commit-check`: green