### PR TITLE
fix(rel): TD-REL-LOWER-1 — qualified ORDER BY keys unlock native-route joins; legacy multi-table guard; Q19 mixed-numeric arithmetic

### DIFF
--- a/crates/foundation/proximadb-relational-types/src/lib.rs
+++ b/crates/foundation/proximadb-relational-types/src/lib.rs
@@ -464,14 +464,15 @@ impl Expr {
                         ProximaType::Boolean
                     }
                 } else if op.is_arithmetic() {
-                    // For now: same-type arithmetic. Implicit
-                    // promotion is a Phase 3 add-on.
                     if lt == rt {
                         lt
+                    } else if numeric_type(&lt) && numeric_type(&rt) {
+                        // Mixed numeric arithmetic widens both sides to f64 at
+                        // evaluation (`eval_arithmetic`, TPC-H Q19) — the plan
+                        // schema must agree.
+                        ProximaType::Float64
                     } else {
-                        // Best-effort: prefer the "wider" of the two
-                        // for display; the type checker rejects this
-                        // at planning time.
+                        // Best-effort for display; evaluation errors loudly.
                         lt
                     }
                 } else {
@@ -1033,11 +1034,22 @@ fn eval_arithmetic(
             }
             _ => unreachable!(),
         })),
-        _ => Err(ExprError::OperatorNotDefined {
-            op: op.as_str().into(),
-            left: proxima_value_type(l).unwrap_or(ProximaType::Boolean),
-            right: proxima_value_type(r).unwrap_or(ProximaType::Boolean),
-        }),
+        _ => {
+            // Mixed numeric operands (TPC-H Q19: `1 - l_discount`, Int64 vs
+            // Float64): widen both sides to f64 and retry — the same SQL
+            // promotion `values_equal`/`compare_ord` already apply, with the
+            // same documented precision caveat for very large i64. Terminates:
+            // the retry hits the (Float64, Float64) arm above. Non-numeric
+            // operands still error loudly.
+            if let (Some(lf), Some(rf)) = (try_to_f64(l), try_to_f64(r)) {
+                return eval_arithmetic(op, &Float64(lf), &Float64(rf));
+            }
+            Err(ExprError::OperatorNotDefined {
+                op: op.as_str().into(),
+                left: proxima_value_type(l).unwrap_or(ProximaType::Boolean),
+                right: proxima_value_type(r).unwrap_or(ProximaType::Boolean),
+            })
+        }
     }
 }
 
@@ -1141,6 +1153,25 @@ fn compare_ord(l: &ProximaValue, r: &ProximaValue) -> Result<std::cmp::Ordering,
 /// to support SQL's implicit cross-type numeric comparisons
 /// (e.g. `int_col > 25` where `25` parses as Int64 and the column
 /// is Int32). Returns `None` for non-numeric values.
+/// True for the numeric `ProximaType`s that widen to f64 in mixed-type
+/// arithmetic/comparison (the `try_to_f64` value-level counterpart).
+fn numeric_type(t: &ProximaType) -> bool {
+    matches!(
+        t,
+        ProximaType::Int8
+            | ProximaType::Int16
+            | ProximaType::Int32
+            | ProximaType::Int64
+            | ProximaType::UInt8
+            | ProximaType::UInt16
+            | ProximaType::UInt32
+            | ProximaType::UInt64
+            | ProximaType::Float16
+            | ProximaType::Float32
+            | ProximaType::Float64
+    )
+}
+
 fn try_to_f64(v: &ProximaValue) -> Option<f64> {
     use ProximaValue as V;
     match v {
@@ -1976,6 +2007,59 @@ mod tests {
         assert_eq!(
             Expr::unary(UnaryOp::Not, Expr::literal(ProximaValue::Boolean(true))).result_type(),
             ProximaType::Boolean
+        );
+    }
+
+    /// TD-REL-LOWER-1 / TPC-H Q19: mixed numeric arithmetic (`1 - l_discount`,
+    /// Int64 vs Float64) widens both sides to f64 — the same promotion
+    /// comparisons already apply — instead of `OperatorNotDefined`.
+    #[test]
+    fn mixed_numeric_arithmetic_widens_to_f64() {
+        let cases = [
+            (
+                BinaryOp::Minus,
+                ProximaValue::Int64(1),
+                ProximaValue::Float64(0.06),
+                0.94,
+            ),
+            (
+                BinaryOp::Mul,
+                ProximaValue::Float64(2.5),
+                ProximaValue::Int32(4),
+                10.0,
+            ),
+            (
+                BinaryOp::Plus,
+                ProximaValue::Int64(3),
+                ProximaValue::Float32(0.5),
+                3.5,
+            ),
+        ];
+        for (op, l, r, want) in cases {
+            let got = eval_binary(op, &l, &r).expect("mixed numeric arithmetic must evaluate");
+            let ProximaValue::Float64(v) = got else {
+                panic!("expected Float64, got {got:?}");
+            };
+            assert!((v - want).abs() < 1e-9, "{op:?}: got {v}, want {want}");
+        }
+        // Non-numeric mixes still error loudly.
+        assert!(
+            eval_binary(
+                BinaryOp::Minus,
+                &ProximaValue::String("a".into()),
+                &ProximaValue::Int64(1)
+            )
+            .is_err()
+        );
+        // And the static result type agrees with the widened evaluation.
+        assert_eq!(
+            Expr::bin(
+                BinaryOp::Minus,
+                Expr::literal(ProximaValue::Int64(1)),
+                Expr::literal(ProximaValue::Float64(0.06))
+            )
+            .result_type(),
+            ProximaType::Float64
         );
     }
 

--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -1877,7 +1877,21 @@ fn apply_order_by(
     let scope = Scope::from_schema(&plan.output_schema());
     let mut keys = Vec::with_capacity(exprs.len());
     for o in exprs {
-        let expr = lower_expr_sealed(&o.expr, &scope)?;
+        // ORDER BY resolves against the post-projection scope, which carries no
+        // table qualifiers (`Scope::from_schema` — the Project erased them). A
+        // qualified sort key (`ORDER BY t.col` / `alias.col`) that names a
+        // projected output column therefore resolves by its bare column name
+        // (ANSI: sort keys designate output columns). Without this fallback the
+        // whole query declines to the legacy single-table path (TD-REL-LOWER-1).
+        let expr = match (lower_expr_sealed(&o.expr, &scope), &o.expr) {
+            (Ok(e), _) => e,
+            (Err(FrontendError::ColumnNotFound(_)), SqlExpr::CompoundIdentifier(parts))
+                if !parts.is_empty() =>
+            {
+                Expr::column(scope.resolve_unqualified(&parts[parts.len() - 1].value)?)
+            }
+            (Err(e), _) => return Err(e),
+        };
         let descending = matches!(o.options.asc, Some(false));
         let nulls_first = match o.options.nulls_first {
             Some(b) => b,
@@ -3311,5 +3325,65 @@ mod tests {
             }
             other => panic!("expected strpos FuncCall, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod td_rel_lower_order_by {
+    use super::*;
+    fn catalog() -> InMemoryCatalog {
+        let mut c = InMemoryCatalog::new();
+        c.register(
+            "users",
+            RelationalSchema::new(vec![
+                ColumnInfo::new("id", ProximaType::Int64, false),
+                ColumnInfo::new("name", ProximaType::String, true),
+            ]),
+        );
+        c.register(
+            "orders",
+            RelationalSchema::new(vec![
+                ColumnInfo::new("oid", ProximaType::Int64, false),
+                ColumnInfo::new("uid", ProximaType::Int64, false),
+                ColumnInfo::new("total", ProximaType::Float64, false),
+            ]),
+        );
+        c
+    }
+
+    /// TD-REL-LOWER-1 root cause: a qualified ORDER BY key over an aliased
+    /// join declined (`ColumnNotFound("u.name")`) because the post-projection
+    /// scope carries no table qualifiers — sending the whole query down the
+    /// legacy single-table fallthrough. It must lower.
+    #[test]
+    fn order_by_qualified_key_over_aliased_join_lowers() {
+        for sql in [
+            "SELECT u.name, sum(o.total) FROM users u JOIN orders o ON u.id = o.uid GROUP BY u.name ORDER BY u.name",
+            "SELECT u.name, sum(o.total) FROM users u, orders o WHERE u.id = o.uid GROUP BY u.name ORDER BY u.name",
+            "SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.uid ORDER BY u.name",
+            "SELECT users.name FROM users ORDER BY users.name",
+        ] {
+            let plan = lower_sql(sql, &catalog())
+                .unwrap_or_else(|e| panic!("must lower, declined: {e:?}\n  {sql}"));
+            assert!(
+                matches!(plan, LogicalNode::Sort { .. }),
+                "outermost Sort for {sql}"
+            );
+        }
+    }
+
+    /// The fallback resolves by the BARE column name — a qualified key whose
+    /// column does not exist in the output still errors (never silently binds).
+    #[test]
+    fn order_by_qualified_key_missing_column_still_errors() {
+        let err = lower_sql(
+            "SELECT u.name FROM users u ORDER BY u.no_such_column",
+            &catalog(),
+        )
+        .expect_err("unknown sort column must decline");
+        assert!(
+            matches!(err, FrontendError::ColumnNotFound(_)),
+            "got {err:?}"
+        );
     }
 }

--- a/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — filed 2026-07-13 from measured ledger evidence (TPC perf-ledger native sweep, SF 0.01 release).
+| Status | Open (core classes FIXED 2026-07-13, see §Progress) — filed 2026-07-13 from measured ledger evidence (TPC perf-ledger native sweep, SF 0.01 release).
 | Priority | P2 — correctness of the *error*, not of results (queries fail loudly, never return wrong rows); blocks native-route TPC-H coverage and starves `olap/native` cost-model cells for join shapes.
 | Component | `src/network/postgres/relational_pipeline.rs` (lowering decline → legacy fallthrough), legacy single-table FROM parser.
 | Evidence | TPC perf-ledger native sweep 2026-07-13: 72 ERR / 172 records. Taxonomy: `Table 'customer,' does not exist` ×8, `Table 'supplier,'`/`'lineitem,'`/`'store_sales,'`/… (every comma-list FROM), `Table '(select' does not exist` ×4 (derived tables), `operator - is not defined for Int64 and Float64` (TPC-H Q19) ×4.
@@ -49,6 +49,33 @@ evaluator, likely TD-186 territory.
 4. Q19 coercion: int→float promotion for arithmetic over Float64 columns in the
    native expression evaluator (or route such filters to DataFusion by
    eligibility until fixed).
+
+== Progress (2026-07-13)
+
+Bisected and fixed the dominant decline class plus the two hardening directions:
+
+* **Root cause of the join/comma-join fallthrough was neither the join nor the comma** — the
+  frontend already lowers comma-joins as cross joins and handles derived tables. The decliner was
+  a **qualified ORDER BY key** (`ORDER BY t.col` / `alias.col`): `apply_order_by` resolves against
+  the post-projection scope, which carries no table qualifiers (`Scope::from_schema`), so the key
+  hit `ColumnNotFound` and the whole query fell to the legacy tokenizer. Fixed: a qualified sort
+  key that names a projected output column now resolves by its bare column name (ANSI: sort keys
+  designate output columns); an unknown column still errors. Aliased explicit-JOIN, aliased
+  comma-join, unaliased comma-join, and derived-table SELECTs now execute correctly on the native
+  route (`tests/rel_lower_native_join_e2e.rs`), and the geometry-calibration ratchet battery runs
+  its join shapes on BOTH seams.
+* **Direction 3 (clear error):** the legacy pgwire SELECT path now rejects a multi-table /
+  derived-table FROM with a specific `0A000` error (`legacy_unsupported_from_shape`) instead of
+  misparsing `customer,` / `(select` as table names — any residual decline reads as "unsupported
+  on this route", never a phantom missing table/column.
+* **Direction 4 (Q19 coercion):** mixed numeric arithmetic (`1 - l_discount`, Int64 vs Float64)
+  now widens both sides to f64 in `eval_arithmetic` — the same promotion `values_equal`/
+  `compare_ord` already applied — and `Expr::result_type` agrees (`Float64`).
+
+Remaining (why this stays Open): full TPC-H native-route coverage — residual per-query lowering
+declines (e.g. CASE/EXTRACT/INTERVAL frontend gaps) now fail loudly with the 0A000 message; fix
+incrementally per the pgwire mandate and re-run the ledger native sweep to re-measure the ERR
+taxonomy.
 
 == Non-goals
 

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -1240,6 +1240,27 @@ impl PostgresProtocol {
                 return self.execute_vector_search(query).await;
             }
 
+            // TD-REL-LOWER-1: the legacy path below is SINGLE-TABLE only — its
+            // `FROM <token>` extraction misparses a multi-table FROM
+            // (`customer,` / `(select` become "table names") and then fails
+            // with a misleading "Table/Column does not exist". If the
+            // relational pipeline declined a multi-table query, say so
+            // specifically instead of dispatching it here.
+            if let Some(shape) = Self::legacy_unsupported_from_shape(&upper) {
+                return self
+                    .send_error(
+                        "ERROR",
+                        "0A000",
+                        &format!(
+                            "SELECT with {shape} in FROM is not supported on the legacy \
+                             single-table path; the relational engine declined to lower this \
+                             query (TD-REL-LOWER-1). Run the server with \
+                             RUST_LOG=proximadb=debug to see the decline reason."
+                        ),
+                    )
+                    .await;
+            }
+
             // Check if this is a simple table query
             if let Some(table_name) = self.extract_table_name(&upper) {
                 // Detect store type from table name or query content
@@ -1954,6 +1975,32 @@ impl PostgresProtocol {
     }
 
     /// Extract table name from query
+    /// TD-REL-LOWER-1: detect a multi-table / derived-table FROM in an
+    /// (uppercased) SELECT the relational pipeline has already declined, so the
+    /// legacy single-table path can reject it with a specific error instead of
+    /// misparsing `customer,` or `(select` as a table name. Inspects only the
+    /// FROM clause segment (up to the next clause keyword), so commas in the
+    /// projection, WHERE `IN (…)` lists, or ORDER BY never false-positive.
+    fn legacy_unsupported_from_shape(upper: &str) -> Option<&'static str> {
+        let from_pos = upper.find("FROM ")?;
+        let after = &upper[from_pos + 5..];
+        let clause_end = [" WHERE ", " GROUP ", " ORDER ", " HAVING ", " LIMIT ", ";"]
+            .iter()
+            .filter_map(|kw| after.find(kw))
+            .min()
+            .unwrap_or(after.len());
+        let from_clause = after[..clause_end].trim();
+        if from_clause.starts_with('(') {
+            Some("a derived table (subquery)")
+        } else if from_clause.contains(',') {
+            Some("a comma-separated table list")
+        } else if from_clause.contains(" JOIN ") {
+            Some("a JOIN")
+        } else {
+            None
+        }
+    }
+
     fn extract_table_name(&self, query: &str) -> Option<String> {
         // Simple extraction: look for FROM <table>
         let from_pos = query.find("FROM ")?;

--- a/src/network/postgres/protocol_tests.rs
+++ b/src/network/postgres/protocol_tests.rs
@@ -1277,3 +1277,44 @@ fn pgwire_gate_scopes_per_tenant_collection_pair() {
         PgwireGateOutcome::Misrouted { .. }
     ));
 }
+
+/// TD-REL-LOWER-1: the legacy single-table SELECT path must recognize a
+/// multi-table / derived-table FROM (which the relational pipeline declined)
+/// and reject it specifically — never misparse `customer,` / `(select` as a
+/// table name.
+#[test]
+fn legacy_from_shape_guard_flags_multi_table_selects() {
+    let flagged = [
+        // Comma-joins (TPC-H form) — with and without WHERE.
+        "SELECT * FROM CUSTOMER, ORDERS WHERE C_CUSTKEY = O_CUSTKEY",
+        "SELECT COUNT(*) FROM ORDERS, LINEITEM",
+        // Explicit JOINs.
+        "SELECT * FROM ORDERS O JOIN LINEITEM L ON O.O_ORDERKEY = L.L_ORDERKEY WHERE 1=1",
+        "SELECT * FROM A LEFT JOIN B ON A.X = B.X",
+        // Derived table.
+        "SELECT AVG(S) FROM (SELECT SUM(T) AS S FROM ORDERS GROUP BY K) D",
+    ];
+    for q in flagged {
+        assert!(
+            PostgresProtocol::legacy_unsupported_from_shape(q).is_some(),
+            "must flag: {q}"
+        );
+    }
+    let clean = [
+        // Single-table shapes — including commas in the projection, an IN list
+        // in WHERE, and a multi-key ORDER BY (commas OUTSIDE the FROM clause).
+        "SELECT A, B, C FROM ORDERS WHERE K IN (1, 2, 3)",
+        "SELECT A FROM ORDERS ORDER BY A, B",
+        "SELECT COUNT(*) FROM ORDERS GROUP BY K, J",
+        "SELECT A FROM ORDERS O WHERE O.K = 1",
+        // No FROM at all.
+        "SELECT 1",
+    ];
+    for q in clean {
+        assert_eq!(
+            PostgresProtocol::legacy_unsupported_from_shape(q),
+            None,
+            "must not flag: {q}"
+        );
+    }
+}

--- a/tests/rel_lower_native_join_e2e.rs
+++ b/tests/rel_lower_native_join_e2e.rs
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-LOWER-1 — comma-join / derived-table / explicit-JOIN SELECTs on the
+//! NATIVE (pre-MATERIALIZE) route.
+//!
+//! The measured failure (perf-ledger native sweep, 2026-07-13): the relational
+//! lowering declines these shapes, the query falls through to the legacy
+//! single-table path, and its naive FROM tokenizer produces misleading errors
+//! (`Table 'customer,' does not exist`, `Column 'l_extendedprice)' does not
+//! exist in table 'orders'`). Per the full-ANSI-over-pgwire mandate, the
+//! relational route must serve these shapes on native storage — this suite is
+//! the regression gate.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test rel_lower_native_join_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+/// Minimal in-process pgwire server (mirrors `route_cost_override_pgwire_eval`).
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+fn db_error_detail(e: &tokio_postgres::Error) -> String {
+    e.as_db_error()
+        .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+        .unwrap_or_else(|| e.to_string())
+}
+
+/// Run a query and return its rows as sorted `col|col|…` strings.
+async fn query_rows(client: &tokio_postgres::Client, sql: &str) -> Result<Vec<String>, String> {
+    let msgs = client
+        .simple_query(sql)
+        .await
+        .map_err(|e| db_error_detail(&e))?;
+    let mut rows = Vec::new();
+    for m in msgs {
+        if let tokio_postgres::SimpleQueryMessage::Row(r) = m {
+            let cols: Vec<String> = (0..r.len())
+                .map(|i| r.get(i).unwrap_or("").to_string())
+                .collect();
+            rows.push(cols.join("|"));
+        }
+    }
+    rows.sort();
+    Ok(rows)
+}
+
+/// `(sql, expected sorted rows)` — deterministic over the fixture data below.
+/// Every shape here previously fell through to the legacy single-table parser
+/// on the native route and errored.
+fn join_cases() -> Vec<(&'static str, Vec<&'static str>)> {
+    vec![
+        // Explicit JOIN + GROUP BY (the calibration-battery carve-out).
+        (
+            "SELECT o.o_orderstatus, sum(l.l_extendedprice) FROM orders o JOIN lineitem l ON o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus",
+            vec!["F|90", "O|80", "P|80"],
+        ),
+        // Comma-join (implicit cross join + filter) — the TPC-H form, 8 of 22.
+        (
+            "SELECT o.o_orderstatus, sum(l.l_extendedprice) FROM orders o, lineitem l WHERE o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus",
+            vec!["F|90", "O|80", "P|80"],
+        ),
+        // Unaliased comma-join with qualified names.
+        (
+            "SELECT count(*) FROM orders, lineitem WHERE orders.o_orderkey = lineitem.l_orderkey",
+            vec!["6"],
+        ),
+        // Derived table (subquery in FROM).
+        (
+            "SELECT avg(t.s) FROM (SELECT o_custkey, sum(o_totalprice) AS s FROM orders GROUP BY o_custkey) t",
+            vec!["266.6666666666667"],
+        ),
+    ]
+}
+
+/// TD-ROUTE-2 harness pin: run on a dedicated 16 MiB thread (dev-profile pgwire
+/// lowering overflows the default test stack) — same as the sibling evals.
+#[test]
+fn native_route_serves_comma_join_and_derived_table_selects() {
+    std::thread::Builder::new()
+        .name("rel-lower-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime")
+                .block_on(eval_body())
+        })
+        .expect("spawn eval thread")
+        .join()
+        .expect("eval thread panicked");
+}
+
+async fn eval_body() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for ddl in [
+        "DROP TABLE IF EXISTS lineitem",
+        "DROP TABLE IF EXISTS orders",
+        "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_totalprice DOUBLE PRECISION, o_orderstatus VARCHAR)",
+        "CREATE TABLE lineitem (l_orderkey INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION)",
+        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F')",
+        "INSERT INTO lineitem VALUES (1,5.0,50.0),(1,2.0,20.0),(2,3.0,60.0),(3,1.0,10.0),(4,4.0,80.0),(5,2.0,30.0)",
+    ] {
+        client
+            .simple_query(ddl)
+            .await
+            .unwrap_or_else(|e| panic!("{ddl}: {}", db_error_detail(&e)));
+    }
+
+    // NATIVE route: tables are NOT materialized — this is the seam where these
+    // shapes used to fall through to the legacy single-table parser.
+    let mut failures = Vec::new();
+    for (sql, expected) in join_cases() {
+        match query_rows(&client, sql).await {
+            Ok(rows) => {
+                let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+                if rows != expected {
+                    failures.push(format!(
+                        "WRONG ROWS on native route:\n  {sql}\n  expected {expected:?}\n  got      {rows:?}"
+                    ));
+                }
+            }
+            Err(e) => failures.push(format!("ERROR on native route:\n  {sql}\n  {e}")),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "TD-REL-LOWER-1 native-route failures ({}):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/tests/route_geometry_calibration_e2e.rs
+++ b/tests/route_geometry_calibration_e2e.rs
@@ -183,9 +183,8 @@ const CORE_BATTERY: &[&str] = &[
 ];
 
 /// Join / predicate-subquery shapes (deeper geometry, the v2 hoisted-branch
-/// terms). DataFusion-seam only: on the native route these fall through to the
-/// legacy single-table parser (TD-REL-LOWER-1) and error — extend to both seams
-/// when that lands.
+/// terms). Run on BOTH seams since the TD-REL-LOWER-1 fix (qualified ORDER BY
+/// keys over aliased joins no longer decline to the legacy single-table path).
 const JOIN_BATTERY: &[&str] = &[
     "SELECT o.o_orderstatus, sum(l.l_extendedprice) FROM orders o JOIN lineitem l ON o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus",
     "SELECT count(*) FROM orders WHERE o_orderkey IN (SELECT l_orderkey FROM lineitem WHERE l_quantity > 2.0)",
@@ -258,6 +257,7 @@ async fn calibration_body() {
     // the native planner's `plan_instrumented`.
     let before_native = total_samples(&geometry_samples());
     run_battery("native", CORE_BATTERY).await;
+    run_battery("native", JOIN_BATTERY).await;
     // The fold runs on the io_trace flush at query completion — already done by
     // the time the pgwire response returns, but yield once to be safe.
     sleep(Duration::from_millis(200)).await;


### PR DESCRIPTION
## What

Fixes the TD-REL-LOWER-1 native-route fallthrough (filed in #916 from the perf-ledger native sweep: 72 ERR / 172 records with mangled `Table 'customer,' does not exist` / `Column 'l_extendedprice)'` errors), plus the two hardening directions the TD calls for.

### 1. Root cause: qualified ORDER BY keys (relational frontend)

Bisected with a lowering probe: the fallthrough was **neither the comma-join nor the derived table** — the frontend already lowers `FROM a, b` as cross joins and handles `FROM (SELECT …) t`. The decliner was `ORDER BY t.col` / `ORDER BY alias.col`: `apply_order_by` resolves sort keys against the **post-projection scope**, which carries no table qualifiers (`Scope::from_schema`), so any qualified key hit `ColumnNotFound("u.name")` and the whole query fell through to the legacy single-table tokenizer — which then misparsed and emitted the misleading errors. Fix: a qualified sort key that names a projected output column resolves by its bare column name (ANSI: sort keys designate output columns); an unknown column still errors loudly.

Result: aliased explicit-JOIN, aliased comma-join, unaliased comma-join, and derived-table SELECTs now **execute with correct rows on the native (pre-MATERIALIZE) route** — verified end-to-end by the new `tests/rel_lower_native_join_e2e.rs` (row-level asserts against fixture data).

### 2. Legacy path: specific rejection instead of mangled errors (TD direction 3)

The legacy pgwire SELECT path is single-table only; its `FROM <token>` extraction misparses multi-table FROM. New `legacy_unsupported_from_shape` guard inspects only the FROM clause segment (commas in projections, `IN (…)` lists, and ORDER BY never false-positive — unit-tested) and rejects comma-lists / JOINs / derived tables with a specific `0A000` error naming TD-REL-LOWER-1 and how to get the decline reason. Any residual relational decline now fails loudly and actionably, never as a phantom missing table/column.

### 3. TPC-H Q19: mixed-numeric arithmetic (TD direction 4)

`1 - l_discount` (Int64 vs Float64) errored with `operator - is not defined`. `eval_arithmetic` now widens mixed numeric operands to f64 — exactly the promotion `values_equal`/`compare_ord` already apply, same documented precision caveat — and `Expr::result_type` agrees (`Float64`) so plan schemas match evaluation.

### Compounding #946

The geometry-calibration ratchet battery's join/subquery/derived shapes now run on **both** measured seams (previously DataFusion-only with a TD-REL-LOWER-1 carve-out): 18/18 calibration samples per seam, divergence 0%.

## Evidence (local, this branch)

- New `rel_lower_native_join_e2e`: 4/4 shapes correct on the native route (previously 2 errored with mangled messages).
- `route_geometry_calibration_e2e`: both seams live, 36 samples, 0% divergence.
- TPC-H + TPC-DS pgwire conformance suites: pass (no ratchet regression from the ORDER BY change).
- `route_cost_override_pgwire_eval`, `native_route_pgwire_e2e`, `route_cost_offline_eval`: pass.
- All 4 relational crates' suites (191 tests) + new frontend/types/protocol unit tests: pass.
- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings`, `make work-commit-check`, server binary build: clean.

## Docs

TD-REL-LOWER-1 gains a §Progress section: core classes fixed, TD stays Open for full TPC-H native coverage (residual CASE/EXTRACT/INTERVAL frontend gaps now fail loudly with the 0A000 message; re-measure the ledger ERR taxonomy next sweep).

Refs: TD-REL-LOWER-1, #916, #946.