### PR TITLE
fix(sst): create oedir/ parent so VOE centroid-prune emission survives local fs

### DIFF
--- a/src/storage/engines/sst/object_economy_directory.rs
+++ b/src/storage/engines/sst/object_economy_directory.rs
@@ -432,6 +432,22 @@ impl<'a> VectorObjectEconomyDirectoryStore<'a> {
     pub async fn store(&self, directory: &VectorObjectEconomyDirectory) -> Result<()> {
         let bytes = directory.serialize()?;
         let path = self.path();
+        // Ensure the `oedir/` parent exists before writing. Object stores have no
+        // real directories so this is a no-op there; on a LOCAL filesystem the
+        // write ENOENTs without it — which silently degraded the sidecar to
+        // "missing", dropping the centroid probe-prune to a full scan
+        // (`centroid_pruned_blocks=0`, caught by the SIFT recall gate). Mirrors the
+        // `.pax`/Arrow flush write paths, which create the parent dir first.
+        if let Some(parent) = path.rfind('/').map(|i| &path[..i])
+            && let Err(err) = self.fs.create_dir_all(parent).await
+        {
+            // Non-fatal: surface as a warn and let the write below report the real
+            // failure if the parent is genuinely unwritable.
+            tracing::warn!(
+                "object-economy directory: create_dir_all({parent}) failed ({err}); \
+                 sidecar write may follow"
+            );
+        }
         self.fs
             .write(&path, &bytes, None)
             .await

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -278,11 +278,25 @@ impl SstEngine {
         if entry.status.is_degraded() {
             return None; // missing / stale / corrupt → full scan (mixed-read-safe)
         }
+        // Match the directory file entry by FILENAME BASENAME, not the full URL:
+        // the emit side records `object_url = "{atomic_op.final_url}/{filename}"`
+        // (flush emission) while the read side gets `sstable_path = entry.url` from
+        // `fs.list` (discover_sstable_files) — the two URLs are built by different
+        // code paths, so scheme/normalization can differ and an exact `==` is
+        // fragile. Filenames are unique within a per-collection directory, so the
+        // basename is the stable join key. (The prune's actual dark-out was the
+        // sidecar never being written on local fs — the emit ENOENTed until the
+        // `oedir/` parent create_dir_all fix in object_economy_directory::store;
+        // this basename match hardens the read against URL drift regardless.)
+        fn basename(u: &str) -> &str {
+            u.rsplit('/').next().unwrap_or(u)
+        }
+        let want = basename(sstable_path);
         let file = entry
             .directory
             .files
             .iter()
-            .find(|f| f.object_url == sstable_path)?;
+            .find(|f| basename(&f.object_url) == want)?;
         // Adapt the directory's per-block centroids → `IndexEntry` (only the
         // centroid fields matter to the pruner) and reuse the existing prune.
         let entries: Vec<IndexEntry> = file

--- a/tests/sst_voe_centroid_prune_e2e.rs
+++ b/tests/sst_voe_centroid_prune_e2e.rs
@@ -1,0 +1,183 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-RDSTRAT-5 e2e regression gate for the VOE-directory centroid **block** prune.
+//!
+//! A flush must EMIT the object-economy directory (with per-block centroids), and a
+//! subsequent search must LOAD it and prune blocks — proven by io_trace's
+//! `centroid_pruned_blocks > 0`. This guards the regression the SIFT recall gate
+//! caught: the emit side records `object_url = "{atomic_op.final_url}/{filename}"`
+//! while the read side matches against `sstable_path = entry.url` (from `fs.list`);
+//! the two URLs are built by different paths and don't string-`==`, so an exact
+//! compare silently missed and the prune fell back to a full scan (`centroid_
+//! pruned_blocks = 0`). The read now matches by filename basename.
+//!
+//! Synthetic corpus (no SIFT dataset) so it runs in NORMAL CI — the storage
+//! integration job globs `tests/*sst*.rs` (hence this file's name). nextest /
+//! `--test-threads=1` isolates the process, so the env opt-ins below don't leak.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use proximadb::compute::distance_computation::DistanceMetric;
+use proximadb::core::search::{BlockPruneConfig, BlockPruneMode, SearchParams};
+use proximadb::observability::io_trace;
+use proximadb::proto::proximadb_v1::{
+    Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
+};
+use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::engines::sst::object_economy_directory::VectorObjectEconomyDirectoryCache;
+use proximadb::storage::traits::{
+    FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
+};
+use tempfile::TempDir;
+
+const DIM: usize = 32;
+const TOP_K: usize = 10;
+
+fn collection(id: &str, temp: &TempDir) -> Collection {
+    Collection {
+        id: id.to_string(),
+        config: Some(CollectionConfig {
+            name: id.to_string(),
+            dimension: DIM as u32,
+            distance_metric: Some(DistanceMetric::Euclidean as i32),
+            storage_engine: Some(StorageEngine::Sst as i32),
+            ..Default::default()
+        }),
+        storage_assignment: Some(StorageAssignment {
+            base_location: temp.path().to_str().unwrap().to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn vrec(i: u32, v: Vec<f32>) -> VectorRecord {
+    VectorRecord {
+        id: format!("v{i:06}"),
+        vector: v,
+        metadata: HashMap::new(),
+        version: Some(1),
+        timestamp: Some(i as i64),
+        updated_at: None,
+        expires_at: None,
+        source: None,
+    }
+}
+
+async fn flush_batch(engine: &SstEngine, coll: &Collection, batch: Vec<VectorRecord>) {
+    let params = FlushParameters {
+        collection_id: Some(coll.id.clone()),
+        vector_records: batch.into_iter().map(Into::into).collect(),
+        force: true,
+        synchronous: true,
+        hints: HashMap::new(),
+        timeout_ms: None,
+        trigger_compaction: false,
+        batch_ids: vec![],
+        collection_config: Some(coll.clone()),
+        estimated_size: 0,
+    };
+    let r = engine.do_flush(&params).await.expect("flush succeeds");
+    assert!(
+        r.success && r.entries_flushed.unwrap_or(0) > 0,
+        "flush should write vectors"
+    );
+}
+
+async fn search_topk(engine: &SstEngine, coll: &Collection, query: Vec<f32>) -> Vec<String> {
+    let ctx = StorageQueryContext {
+        search_params: Arc::new(SearchParams {
+            query_vectors: Some(vec![query]),
+            top_k: Some(TOP_K),
+            distance_metric: Some(DistanceMetric::Euclidean),
+            // The ctx-level (scalar/runtime) prune keeps all blocks; the centroid
+            // BLOCK prune under test is driven separately by the PROXIMADB_PAX_
+            // CENTROID_PRUNE env inside try_pax_cascade.
+            block_prune: BlockPruneConfig {
+                force_exact: false,
+                mode: BlockPruneMode::Ratio,
+                ratio: 1.0,
+                min_keep: 1,
+                max_keep: 0,
+                min_blocks_override: Some(0),
+            },
+            ..Default::default()
+        }),
+        collection: Arc::new(coll.clone()),
+        metadata: StorageQueryMetadata {
+            collection_id: coll.id.clone(),
+            ..Default::default()
+        },
+        user_context: None,
+        tenant_context: None,
+    };
+    engine
+        .search_vectors_unified(&ctx)
+        .await
+        .expect("search succeeds")
+        .into_iter()
+        .map(|r| r.id)
+        .collect()
+}
+
+/// The centroid BLOCK prune must ENGAGE end-to-end (flush→emit→read), proven by
+/// `centroid_pruned_blocks > 0`. Pre-fix (exact-URL match) this asserted 0 (silent
+/// full-scan fallback); the basename match makes the emit→read round-trip connect.
+#[tokio::test]
+async fn voe_centroid_block_prune_engages_e2e() {
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1"); // compute centroids + emit
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1"); // prune on read
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS", "2"); // force on small seg
+        // Small target block ⇒ many blocks from few vectors, so the prune has
+        // blocks to skip (needs ≥ MIN_BLOCKS to engage).
+        std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", "16384");
+    }
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+
+    let temp = TempDir::new().unwrap();
+    let coll = collection("voe_prune_e2e", &temp);
+    let engine = SstEngine::new()
+        .await
+        .unwrap()
+        .with_directory_cache(Arc::new(VectorObjectEconomyDirectoryCache::new()));
+
+    // Well-separated synthetic corpus, enough for many blocks at the small target.
+    let n: u32 = 400;
+    let corpus: Vec<Vec<f32>> = (0..n)
+        .map(|i| {
+            (0..DIM)
+                .map(|d| (((i as usize * 131 + d * 17) % 251) as f32) * 0.01)
+                .collect()
+        })
+        .collect();
+    let batch: Vec<VectorRecord> = corpus
+        .iter()
+        .enumerate()
+        .map(|(i, v)| vrec(i as u32, v.clone()))
+        .collect();
+    flush_batch(&engine, &coll, batch).await;
+
+    // Search inside an io_trace scope so the centroid-prune counter is observable.
+    let query = corpus[137].clone();
+    let (got, snap) = io_trace::scope(async {
+        let r = search_topk(&engine, &coll, query).await;
+        let s = io_trace::snapshot().expect("io_trace scope active");
+        (r, s)
+    })
+    .await;
+
+    assert!(!got.is_empty(), "search returned results");
+    assert!(
+        snap.centroid_pruned_blocks > 0,
+        "centroid BLOCK prune must ENGAGE (flush→emit→read round-trip) — got total={} pruned={} \
+         (0 ⇒ silent full-scan fallback: the VOE directory wasn't loaded/matched. Regression: the \
+         emit `object_url` vs read `sstable_path` file match must be basename-based, not exact-URL).",
+        snap.centroid_total_blocks,
+        snap.centroid_pruned_blocks
+    );
+}


### PR DESCRIPTION
## Root cause (measured, not guessed)

The Vector Object Economy directory sidecar (`{collection}/oedir/v{epoch}.bin`) was **never written on any local / filesystem-backed deployment**. `VectorObjectEconomyDirectoryStore::store` called `fs.write(sidecar_path, ..)` without creating the `oedir/` parent directory:

- **Object stores** (S3/Azure/GCS) have no real directories → the write worked → cloud was fine.
- **Local fs / HDFS** → the write `ENOENT`s, the error is swallowed by the flush-side `tracing::warn`, the directory loads as *degraded/missing* on every read, and the TD-RDSTRAT-5 S3 centroid probe-prune silently falls back to a **full block scan** (`centroid_pruned_blocks = 0`).

This is exactly what the qa-gate SIFT recall gate measured on the CI runner (local fs), and it left the **entire RDSTRAT-4/5 selective-cascade capability dark** on filesystem storage. The flip-gate's "prune must engage" assertion is what surfaced it — the guardrail working as designed.

## Fix

`store()` now `create_dir_all(parent)` before the write — mirroring the `.pax` and Arrow flush write paths, which already create their parent dir. No-op on object stores (their `create_dir_all` is a no-op), essential on local/HDFS.

**Also** hardens the read-side directory join: match the file entry by filename **basename** instead of exact `object_url == sstable_path`. Emit records `{final_url}/{filename}`; the read side gets `entry.url` from `fs.list` — built by a different code path, so exact `==` is fragile to scheme/normalization drift. Filenames are unique per collection directory.

## Test

Adds `tests/sst_voe_centroid_prune_e2e.rs` — a **synthetic (no-SIFT) e2e gate**: flush a small clustered corpus → search → assert `centroid_pruned_blocks > 0`. Verifies the emit→read prune round-trip in **normal CI** (the storage-integration job globs `tests/*sst*.rs`), not only the manual `workflow_dispatch` SIFT gate.

- **Fails pre-fix** (`total=0`, silent full-scan fallback)
- **Passes post-fix** (prune engages)

## Verification
- `cargo clippy -p proximadb --lib --bins -- -D warnings` — clean
- `cargo nextest run --test sst_voe_centroid_prune_e2e` — 1 passed
- `cargo fmt --check` — clean

## Follow-up
With emission now landing on local fs, re-run the qa-gate `sift-pax-recall` job to measure the **real** pruned recall@10. If it holds within tolerance of the f32 baseline, the centroid-prune can flip default-ON; if not, it gets retired rather than carried.