### PR TITLE
fix(portability): cherry-pick Windows cfg-gates to main — unblock v0.2.2 release pipeline

### DIFF
--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -1,0 +1,60 @@
+# Windows (MSVC) compile-only ratchet — TD-EMBED-1.
+#
+# proximadb_embedded currently ships Linux + macOS wheels; Windows is blocked
+# only by the Rust engine not yet compiling for x86_64-pc-windows-msvc. This is
+# a COMPILE-ONLY ratchet (no wheel, no C-deps yet): each rung is a crate that
+# now compiles on Windows and MUST stay green. As blockers are fixed the gating
+# scope expands one rung at a time (ratchet only goes up). A separate,
+# non-gating "measure tail" step surfaces the NEXT blocker so the effort is
+# evidence-driven, not speculative.
+#
+# Path-gated + dispatch-only so it costs a Windows runner only when
+# Windows-relevant code changes.
+name: Windows Compile Ratchet
+
+on:
+  pull_request:
+    paths:
+      - 'crates/storage/**'
+      - 'src/storage/**'
+      - 'src/embedded/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/windows-compile-ratchet.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  ratchet:
+    name: cargo check (x86_64-pc-windows-msvc)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+
+      # ---- GATING RUNGS (must stay green; expand as blockers are fixed) --------
+      # Rung 1: proximadb-storage-common compiles on Windows (the memmap2::Advice
+      # madvise gating landed in this PR). Add the next crate here once it's green.
+      - name: Rung 1 — proximadb-storage-common
+        run: cargo check -p proximadb-storage-common
+
+      # ---- MEASURE THE TAIL (non-gating; reveals the next blocker) -------------
+      # The root `proximadb` lib (default features, no `python`) is the engine the
+      # embedded wheel builds minus the PyO3/C-deps. Checking it here surfaces the
+      # next batch of Windows errors without blocking the ratchet. When this goes
+      # green, promote it to a gating rung above; the C-dep (aws-lc-sys/OpenSSL)
+      # story for the actual wheel is a later phase.
+      - name: Measure tail — root proximadb lib (informational)
+        continue-on-error: true
+        run: cargo check -p proximadb --lib

--- a/.github/workflows/windows-compile-ratchet.yml
+++ b/.github/workflows/windows-compile-ratchet.yml
@@ -14,10 +14,15 @@ name: Windows Compile Ratchet
 
 on:
   pull_request:
+    # Scoped to the areas on the remaining Windows-compile path (grown one rung at
+    # a time as blockers are fixed), so this Windows runner only fires on relevant
+    # PRs — not every src change across concurrent sessions.
     paths:
       - 'crates/storage/**'
+      - 'crates/platform/proximadb-runtime/**'
       - 'src/storage/**'
       - 'src/embedded/**'
+      - 'src/network/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/windows-compile-ratchet.yml'

--- a/crates/storage/proximadb-storage-common/src/mmap_file.rs
+++ b/crates/storage/proximadb-storage-common/src/mmap_file.rs
@@ -79,9 +79,20 @@ impl MmapFile {
         })
     }
 
-    /// Advise the kernel about access pattern
+    /// Advise the kernel about access pattern.
+    ///
+    /// `memmap2::Mmap::advise` wraps POSIX `madvise`, which exists only on unix;
+    /// `memmap2::Advice` is not defined on Windows. Advice is a non-binding
+    /// performance hint, so on non-unix this is a correct no-op.
     pub fn advise(&self, advice: Advice) -> Result<()> {
-        self.mmap.advise(advice.into())?;
+        #[cfg(unix)]
+        {
+            self.mmap.advise(advice.into())?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = advice;
+        }
         Ok(())
     }
 }
@@ -212,6 +223,10 @@ pub enum Advice {
     DontNeed,
 }
 
+// `memmap2::Advice` (POSIX `madvise` wrapper) is unix-only, so this conversion
+// is gated to unix; on non-unix the advice is dropped (see `MmapFile::advise`).
+// The public `Advice` enum above stays cross-platform.
+#[cfg(unix)]
 impl From<Advice> for memmap2::Advice {
     fn from(advice: Advice) -> Self {
         match advice {
@@ -443,6 +458,7 @@ mod tests {
             Advice::WillNeed,
             Advice::DontNeed,
         ] {
+            #[cfg(unix)]
             let _: memmap2::Advice = advice.into();
             mmap.advise(advice)?;
         }

--- a/src/network/arrow_ipc/server.rs
+++ b/src/network/arrow_ipc/server.rs
@@ -129,6 +129,7 @@ impl ArrowFlightServer {
                     .serve(addr)
                     .await?;
             }
+            #[cfg(unix)]
             BindTarget::Uds(path) => {
                 let listener = crate::network::uds::bind_unix_listener(&path).map_err(|e| {
                     anyhow::anyhow!("Arrow Flight UDS bind failed at {}: {}", path.display(), e)
@@ -138,6 +139,13 @@ impl ArrowFlightServer {
                     .add_service(flight_server)
                     .serve_with_incoming(incoming)
                     .await?;
+            }
+            #[cfg(not(unix))]
+            BindTarget::Uds(path) => {
+                anyhow::bail!(
+                    "Arrow Flight UDS (unix:{}) is not supported on this platform; use TCP",
+                    path.display()
+                );
             }
         }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -206,6 +206,9 @@ pub mod storage_write_fence;
 // (root-crate decomposition).
 pub use proximadb_tls as tls;
 /// Unix-domain socket binding helpers for portless ("embedded") transport mode.
+/// UDS (tokio's `UnixListener`) is unix-only; on non-unix (Windows) the module is
+/// absent and the transport bind sites fall back to a "use TCP" error.
+#[cfg(unix)]
 pub mod uds;
 
 pub use metrics_service::*;

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -722,6 +722,7 @@ impl MultiServer {
             let grpc_handle = tokio::spawn(async move {
                 let result = match grpc_bind_target {
                     BindTarget::Tcp(addr) => server.serve(addr).await,
+                    #[cfg(unix)]
                     BindTarget::Uds(path) => match crate::network::uds::bind_unix_listener(&path) {
                         Ok(listener) => {
                             let incoming =
@@ -733,6 +734,14 @@ impl MultiServer {
                             return;
                         }
                     },
+                    #[cfg(not(unix))]
+                    BindTarget::Uds(path) => {
+                        tracing::error!(
+                            "gRPC UDS (unix:{}) is not supported on this platform; use TCP",
+                            path.display()
+                        );
+                        return;
+                    }
                 };
                 if let Err(e) = result {
                     tracing::error!("gRPC server error: {}", e);

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -1002,19 +1002,29 @@ impl RestServer {
 
     /// Start the REST server without TLS (plaintext)
     async fn start_plaintext(self) -> anyhow::Result<()> {
-        // Portless ("embedded") mode: serve over a Unix-domain socket.
+        // Portless ("embedded") mode: serve over a Unix-domain socket (unix-only).
         if let Some(uds_path) = self.uds_path.clone() {
-            tracing::info!(
-                "Starting REST server (plaintext) on unix:{}",
-                uds_path.display()
-            );
-            Self::log_endpoints(&self.bind_addr, false);
-            // axum 0.8 serves any `Listener`; tokio's UnixListener qualifies.
-            let listener = crate::network::uds::bind_unix_listener(&uds_path).map_err(|e| {
-                anyhow::anyhow!("REST UDS bind failed at {}: {}", uds_path.display(), e)
-            })?;
-            axum::serve(listener, self.router.into_make_service()).await?;
-            return Ok(());
+            #[cfg(unix)]
+            {
+                tracing::info!(
+                    "Starting REST server (plaintext) on unix:{}",
+                    uds_path.display()
+                );
+                Self::log_endpoints(&self.bind_addr, false);
+                // axum 0.8 serves any `Listener`; tokio's UnixListener qualifies.
+                let listener = crate::network::uds::bind_unix_listener(&uds_path).map_err(|e| {
+                    anyhow::anyhow!("REST UDS bind failed at {}: {}", uds_path.display(), e)
+                })?;
+                axum::serve(listener, self.router.into_make_service()).await?;
+                return Ok(());
+            }
+            #[cfg(not(unix))]
+            {
+                anyhow::bail!(
+                    "REST UDS (unix:{}) is not supported on this platform; use TCP",
+                    uds_path.display()
+                );
+            }
         }
 
         tracing::info!("Starting REST server (plaintext) on {}", self.bind_addr);


### PR DESCRIPTION
## Why

prerelease-ci on main fails only at **Build x86_64-pc-windows-msvc** (run 28826371288): 7× E0425/E0433/E0599 from un-gated \`memmap2::Advice\` / \`Mmap::advise()\` (POSIX \`madvise\` wrappers, unix-only in memmap2). This blocks the release.yml PREPARE gate for v0.2.2, since it requires a passing prerelease-ci on the exact commit.

Both fixes already landed on develop and are proven green there by the Windows Compile Ratchet (rungs 1–3 gating, all recent runs green). This PR cherry-picks them to main as a targeted hotfix — a full develop→qa→main promotion would pull 136 unrelated commits into the release.

## What

Cherry-picks (clean apart from dropping a TD doc that doesn't exist on main's docs tree):

- #800 \`cff977c9d\` — gate \`From<Advice> for memmap2::Advice\` + \`MmapFile::advise()\` behind \`cfg(unix)\` (no-op advice on non-unix); adds the path-gated windows-compile-ratchet workflow.
- #808 \`95f77f60d\` — gate Unix-domain-socket transport consumption (\`UnixListener\` bind) behind \`cfg(unix)\`; \`BindTarget::Uds\` stays cross-platform.

Without #808, the Windows build would just fail at the next blocker after storage-common compiles.

## Verification

- \`cargo check -p proximadb-storage-common -p proximadb-server\` green on Linux (5m06s, unix path unchanged).
- Windows path: same hunks as develop, where ratchet rungs 1–3 (\`cargo check -p proximadb --lib --features python\` on windows-2022) are gating and green.

## After merge

prerelease-ci auto-triggers on main; once green, dispatch \`release.yml\` for v0.2.2.