### PR TITLE
feat(storage): StorageProfile + resolve_storage_profile tag-cascade resolver (ADR-061 D1, TD-WLP-1)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -48,6 +48,7 @@ pub mod smart_io_metrics;
 pub mod spatial_encoding;
 pub mod storage_error;
 pub mod storage_path;
+pub mod storage_profile;
 pub mod swift_id_index;
 pub mod tenant_performance;
 pub mod tiering_policy;
@@ -146,6 +147,9 @@ pub use smart_io_metrics::{FileIoMetrics, IoMetrics, IoMetricsSnapshot};
 pub use spatial_encoding::{CodeType, SpatialCode, U512};
 pub use storage_error::{ErrorContext, StorageError, StorageErrorKind};
 pub use storage_path::StoragePath;
+pub use storage_profile::{
+    STORAGE_PROFILE_ENV, STORAGE_PROFILE_TAG_PREFIX, StorageProfile, resolve_storage_profile,
+};
 pub use swift_id_index::{
     BPlusNode, BlockLocation, IdIndex, IndexStats as SwiftIndexStats, RecordLocation,
     TwoLevelIdIndex,

--- a/crates/storage/proximadb-storage-common/src/storage_profile.rs
+++ b/crates/storage/proximadb-storage-common/src/storage_profile.rs
@@ -1,0 +1,159 @@
+//! Per-collection workload storage profile (ADR-061 D1, TD-WLP-1).
+//!
+//! `StorageProfile` selects the **read-acceleration projection strategy** for a
+//! collection — it is deliberately distinct from `CatalogWorkloadProfile`
+//! (query-shape → engine routing) per ADR-061 D6, and it never changes the
+//! durability contract: canonical `ProximaRecord` + WAL stay the sole durable
+//! authority for every profile (ADR-061 D2).
+//!
+//! Resolution mirrors the `resolve_pax_vector_quant` cascade
+//! (`src/storage/engines/sst/flush/mod.rs`): per-collection
+//! `workload_profile:append|bulk|churn` tag > env `PROXIMADB_STORAGE_PROFILE` >
+//! default `append`. The resolver takes the collection's tag list (`&[String]`)
+//! rather than the v1 proto `CollectionConfig` so it adds no v1-proto reference
+//! (TD-123 ratchet) — tag extraction happens at the call site, matching
+//! `pax_rerank_quant_tag`.
+
+/// Tag prefix encoding the per-collection storage profile on
+/// `CollectionConfig.tags` — mirrors the `pax_vector_format:` /
+/// `pax_rerank_quant:` tag conventions. Values: `append`, `bulk`, `churn`.
+pub const STORAGE_PROFILE_TAG_PREFIX: &str = "workload_profile:";
+
+/// Deployment-wide storage-profile default env. Outranked by the
+/// per-collection tag; unset / unrecognized → `AppendBulk`.
+pub const STORAGE_PROFILE_ENV: &str = "PROXIMADB_STORAGE_PROFILE";
+
+/// Per-collection storage-projection strategy (ADR-061).
+///
+/// `AppendBulk` (tag values `append` / `bulk`): durable clustered PAX-LSM
+/// segments + VOE directory — today's behaviour, and the default absent any
+/// tag/env. `Churn` (tag value `churn`): in-memory mutable ANN index + ORION
+/// graph + `oid` fusion for bounded, hot, update-heavy working sets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StorageProfile {
+    /// Append-heavy / bulk-load: clustered PAX-LSM projection (default).
+    #[default]
+    AppendBulk,
+    /// Update-heavy code-RAG: in-memory mutable projection (ADR-061 D4).
+    Churn,
+}
+
+/// Resolve the storage profile for a collection from its tag list.
+///
+/// Precedence: `workload_profile:` tag (last matching wins; an unrecognized
+/// value keeps the prior resolution, parity with `resolve_pax_vector_quant`) >
+/// env `PROXIMADB_STORAGE_PROFILE` > default `AppendBulk`.
+pub fn resolve_storage_profile(tags: &[String]) -> StorageProfile {
+    if let Some(profile) = storage_profile_tag(tags) {
+        return profile;
+    }
+    match std::env::var(STORAGE_PROFILE_ENV)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "churn" => StorageProfile::Churn,
+        // `append` / `bulk` / unset / unrecognized → AppendBulk default.
+        _ => StorageProfile::AppendBulk,
+    }
+}
+
+/// Read the per-collection `workload_profile:append|bulk|churn` tag from a tag
+/// list. Last matching tag wins; an unrecognized value keeps the prior
+/// resolution (parity with `pax_vector_format_tag`). Absent → `None` (defer to
+/// env/default).
+fn storage_profile_tag(tags: &[String]) -> Option<StorageProfile> {
+    let mut latest: Option<StorageProfile> = None;
+    for tag in tags {
+        if let Some(rest) = tag.strip_prefix(STORAGE_PROFILE_TAG_PREFIX) {
+            latest = match rest.trim().to_ascii_lowercase().as_str() {
+                "append" | "bulk" => Some(StorageProfile::AppendBulk),
+                "churn" => Some(StorageProfile::Churn),
+                _ => latest, // unrecognized value: keep prior resolution
+            };
+        }
+    }
+    latest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// TD-WLP-1 TDD gate: the tag > env > default cascade, mirroring
+    /// `resolve_pax_vector_quant_default_and_precedence`.
+    #[test]
+    fn test_resolve_storage_profile_tag_env_default_cascade() {
+        unsafe {
+            std::env::remove_var(STORAGE_PROFILE_ENV);
+        }
+        // absent → AppendBulk default
+        assert_eq!(resolve_storage_profile(&[]), StorageProfile::AppendBulk);
+        // `append` and `bulk` tags → AppendBulk
+        assert_eq!(
+            resolve_storage_profile(&tags(&["workload_profile:append"])),
+            StorageProfile::AppendBulk
+        );
+        assert_eq!(
+            resolve_storage_profile(&tags(&["workload_profile:bulk"])),
+            StorageProfile::AppendBulk
+        );
+        // `churn` tag → Churn
+        assert_eq!(
+            resolve_storage_profile(&tags(&["workload_profile:churn"])),
+            StorageProfile::Churn
+        );
+        // unknown tag value → AppendBulk default (defer to env/default)
+        assert_eq!(
+            resolve_storage_profile(&tags(&["workload_profile:nonsense"])),
+            StorageProfile::AppendBulk
+        );
+        // unrelated tags are ignored
+        assert_eq!(
+            resolve_storage_profile(&tags(&["recall_target:0.95"])),
+            StorageProfile::AppendBulk
+        );
+        // last matching tag wins (parity with resolve_pax_vector_quant)
+        assert_eq!(
+            resolve_storage_profile(&tags(&[
+                "workload_profile:append",
+                "workload_profile:churn"
+            ])),
+            StorageProfile::Churn
+        );
+        // an unrecognized LAST value keeps the prior resolution, not the default
+        assert_eq!(
+            resolve_storage_profile(&tags(&[
+                "workload_profile:churn",
+                "workload_profile:nonsense"
+            ])),
+            StorageProfile::Churn
+        );
+        // env fallback: no tag + env churn → Churn
+        unsafe {
+            std::env::set_var(STORAGE_PROFILE_ENV, "churn");
+        }
+        assert_eq!(resolve_storage_profile(&[]), StorageProfile::Churn);
+        // tag beats env: append tag + env churn → AppendBulk
+        assert_eq!(
+            resolve_storage_profile(&tags(&["workload_profile:append"])),
+            StorageProfile::AppendBulk
+        );
+        // env `append` / `bulk` → AppendBulk; unrecognized env → default
+        unsafe {
+            std::env::set_var(STORAGE_PROFILE_ENV, "bulk");
+        }
+        assert_eq!(resolve_storage_profile(&[]), StorageProfile::AppendBulk);
+        unsafe {
+            std::env::set_var(STORAGE_PROFILE_ENV, "nonsense");
+        }
+        assert_eq!(resolve_storage_profile(&[]), StorageProfile::AppendBulk);
+        unsafe {
+            std::env::remove_var(STORAGE_PROFILE_ENV);
+        }
+    }
+}

--- a/docs/10-quality/td/TD-WLP-1-storage-profile-tag-cascade-resolver.adoc
+++ b/docs/10-quality/td/TD-WLP-1-storage-profile-tag-cascade-resolver.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — spec filed 2026-07-14 (ADR-061). Not started.
+| Status | Implemented 2026-07-14 — `StorageProfile` + `resolve_storage_profile` in `crates/storage/proximadb-storage-common/src/storage_profile.rs` (TDD gate `test_resolve_storage_profile_tag_env_default_cascade` green). One spec deviation: the resolver takes the collection's tag list (`&[String]`), not `&CollectionConfig`, so it adds no v1-proto reference (TD-123 ratchet) — parity with `pax_rerank_quant_tag`; tag extraction happens at the call site. Inert as specced: nothing consumes it yet.
 | Priority | P1 — the foundation every other WLP slice consumes; ships first, inert.
 | Severity | Low — pure definition; nothing consumes the resolver yet, so no behaviour change.
 | Component | `src/storage/engines/sst/flush/mod.rs` (the `resolve_*` cascade, ~770–895); a small enum module (co-located, or `crates/storage/proximadb-storage-common/src`)


### PR DESCRIPTION
## Summary

First implementation slice of ADR-061 (per-collection workload profiles). Defines the `StorageProfile` attribute and its resolution — and nothing else — so it is trivially safe to land and unblocks WLP-2..6.

- `enum StorageProfile { AppendBulk, Churn }` (default `AppendBulk`) in `crates/storage/proximadb-storage-common/src/storage_profile.rs` — a stable crate path every later WLP consumer (compaction, SST flush, read paths) can reach without root-crate internal module paths.
- `resolve_storage_profile(tags: &[String])` mirrors the `resolve_pax_vector_quant` cascade exactly: tag `workload_profile:append|bulk|churn` > env `PROXIMADB_STORAGE_PROFILE` > default `append`; `append`/`bulk` → `AppendBulk`; unknown/absent → `AppendBulk`; last-matching tag wins, unrecognized value keeps the prior resolution.
- **Inert by construction (default-OFF):** no read/write path consumes the resolver in this slice, so behaviour is byte-for-byte unchanged. Not wired into `CatalogWorkloadProfile` (ADR-061 D6 — storage projection ≠ query route).
- TD-WLP-1 Status updated to Implemented.

### Spec deviation (documented in the TD)
TD-WLP-1 specced `resolve_storage_profile(config: &CollectionConfig)`; the landed resolver takes the collection tag list (`&[String]`) instead so it adds **no v1-proto reference** (TD-123 ratchet), matching the newer `pax_rerank_quant_tag` convention — tag extraction happens at the call site.

## Test plan (TDD)
- `test_resolve_storage_profile_tag_env_default_cascade` written first, watched fail red (stub returned `AppendBulk` for the churn case), then implementation turned it green. Covers: churn tag → Churn; env fallback; tag-beats-env; append/bulk → AppendBulk; unknown/absent → default; last-matching-tag-wins + unrecognized-last-keeps-prior parity with `resolve_pax_vector_quant`.
- `cargo fmt --check` ✓; `cargo clippy --lib --bins -- -D warnings` exit 0 ✓
- `cargo nextest run -p proximadb-storage-common`: 411/411 ✓
- `make work-commit-check` ✓; `scripts/check_td_adr_unique.py` 0 errors ✓

Refs ADR-061, TD-WLP-1 (filed in #959).