### PR TITLE
docs(td): TD-V1SUNSET-3 — SqlValue (v1) → ProximaValue (v2) migration scoping

### DIFF
--- a/docs/10-quality/td/TD-V1SUNSET-3-sqlvalue-to-proximavalue.adoc
+++ b/docs/10-quality/td/TD-V1SUNSET-3-sqlvalue-to-proximavalue.adoc
@@ -1,0 +1,93 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-V1SUNSET-3: SqlValue (v1) → ProximaValue (v2) — predicate/metadata value migration
+:toc: macro
+:icons: font
+:last-updated: 2026-07-14
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+
+| Status | **Scoped (plan; implementation not started).** This TD scopes the migration of the v1 proto
+`SqlValue` to the v2 canonical `ProximaValue`. It migrates nothing yet; execution is a dedicated
+slice (or series of slices), independent of the OOM/decomposition track.
+| Severity | Medium — `SqlValue` is a v1 proto *wire/in-memory* type used for predicate pushdown and
+metadata stats (not a durable format), so this is an in-memory type swap (lower risk than the
+VectorRecord durable migration in link:TD-V1SUNSET-2-vectorrecord-to-proximatecord-first-slice.adoc[TD-V1SUNSET-2]).
+Internal-only; recovery is a revert.
+| Component | The raptor crates first (`proximadb-raptor-common` — `Predicate`/`PredicateOp` + the
+`min_value`/`max_value`/`default_value` stats, where `MetadataValue = SqlValue`; `proximadb-raptor-engine`
+— ~79 `SqlValue`/`sql_value::Value` refs in predicate evaluation), then the broader codebase (~77 files
+reference `proximadb_v1::SqlValue`/`sql_value`).
+| Tracked-by | link:../../12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024] (the
+canonical-type decision); link:../../12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc[V1_RETIREMENT_ROADMAP]
+(the v1 sunset, of which TD-V1SUNSET-1 REST/gRPC + TD-V1SUNSET-2 VectorRecord are sibling slices); the
+v1-proto ratchet (`scripts/check_v1_proto_usage.py`).
+| Depends-on | `ProximaValue` (already exists in `proximadb-data-model`, 27+ variants — verified). A
+`SqlValue → ProximaValue` bridge (does **not** exist yet — this TD adds it). The raptor crates
+landed by the decomposition track (`proximadb-raptor-common` #955/#958, `proximadb-raptor-engine`
+#962) — the migration lands cleanly in those crates post-extraction.
+|===
+
+== Context — why v1 `SqlValue` is still in the raptor path
+
+The raptor engine is legacy code that predates v2/`ProximaValue`. It uses the v1 proto
+`SqlValue` (+ `sql_value::Value` variants: `StringValue`/`NumberValue`/`BoolValue`/…) for
+**predicate pushdown** — matching metadata values during scans. The raptor-common `Predicate`
+struct holds `value: MetadataValue` where `MetadataValue` is a re-export alias for
+`proximadb_proto::proximadb_v1::SqlValue` (`raptor-common/src/lib.rs:498`). The decomposition
+track relocated this code as-is (the moves preserve v1 by design — a relocation is not a
+migration), which surfaced the question this TD answers.
+
+`ProximaValue` (`proximadb_data_model::ProximaValue`, the link:../../12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024]
+canonical seam) is the v2 target — and the codebase already flags the migration:
+`sql_value_filter.rs:44` comments *"v2-canonical: this lives on the `ProximaValue`/`ProximaTree`
+seam (ADR-024)"*.
+
+== The v2 target — `ProximaValue` (rich, typed)
+
+`ProximaValue` is a 27+-variant typed enum (`proximadb-data-model/src/lib.rs:629`) — far richer
+than v1 `SqlValue`:
+
+```
+Boolean | Int8..Int64 | UInt8..UInt64 | Float16 | Float32 | Float64 | Decimal |
+String | Symbol | Binary | Date | Time | Timestamp | TimestampTz | Uuid | ULID |
+Json | Jsonb | Array<Vec<ProximaValue>> | Map | Struct | DenseVector(Vec<f32>) | …
+```
+
+== Surface (measured)
+
+* **raptor crates** (the first slice): ~79 `SqlValue`/`sql_value::Value` refs — `raptor-common`
+  (`Predicate.value`, `PredicateOp`, the column-stats `min_value`/`max_value`/`default_value`) +
+  `raptor-engine` (predicate evaluation match arms).
+* **Codebase-wide** (the later slice): ~77 files reference `proximadb_v1::SqlValue`/`sql_value`.
+* **No `SqlValue ↔ ProximaValue` bridge exists** today (verified — `proximadb-data-model` has
+  neither direction). This TD adds it.
+
+== Approach — phased, bridge-first
+
+. **Build the bridge** (`proximadb-data-model` or `proximadb-records`): `SqlValue → ProximaValue`
+  (variant mapping: `StringValue→String`, `NumberValue→Float64`/`Int64`, `BoolValue→Boolean`, …)
+  + the inverse for any read-back boundary.
+. **Slice 1 — raptor crates**: swap `MetadataValue` (= `SqlValue`) for `ProximaValue` inside the
+  raptor crates, converting at the input boundary (predicates arrive as `SqlValue` from the rest
+  of the codebase; the bridge converts once on entry). This aligns the raptor crates to v2
+  *without* a codebase-wide flag-day.
+. **Slice 2 — codebase-wide**: retire `SqlValue` entirely as the rest of the v1 sunset completes
+  (the ~77 files), removing the bridge once no v1 caller remains.
+
+== Risks / non-goals
+
+* **Not a durable-format migration** (unlike VectorRecord/PAX). `SqlValue` is an in-memory/wire
+  predicate type — no on-disk format, no mixed-read concern, no recall gate. Lower risk.
+* **Variant-mapping lossiness**: `SqlValue::NumberValue` (f64?) → `ProximaValue::Float64` vs
+  `Int64` — the bridge must preserve precision (choose by value where possible, else Float64).
+* **Non-goal**: this TD does not migrate `VectorRecord` (TD-V1SUNSET-2) or the REST/gRPC v1
+  surface (TD-V1SUNSET-1) — those are sibling slices.
+
+== Refs
+link:TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc[TD-V1SUNSET-1],
+link:TD-V1SUNSET-2-vectorrecord-to-proximatecord-first-slice.adoc[TD-V1SUNSET-2],
+link:../../12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024],
+link:../../12-design/V1_RETIREMENT_ROADMAP_2026_07_08.adoc[V1_RETIREMENT_ROADMAP].


### PR DESCRIPTION
Docs-only. Files TD-V1SUNSET-3 scoping the migration of the v1 proto `SqlValue` to the v2 canonical `ProximaValue` (ADR-024). Triggered by the raptor extraction surfacing that the relocated code still uses v1 `SqlValue` for predicate pushdown (the moves preserve v1 — a relocation is not a migration).

Scopes: the surface (raptor crates ~79 refs first; codebase-wide ~77 files later), the v2 target (`ProximaValue` 27+ variants, in `proximadb-data-model`), the missing `SqlValue↔ProximaValue` bridge (build it), a phased approach (bridge → raptor-first with boundary conversion → codebase-wide retirement). Lower risk than VectorRecord (in-memory type, no durable format). Sibling to TD-V1SUNSET-1 (REST/gRPC) + TD-V1SUNSET-2 (VectorRecord).

Migration execution is a separate slice (after #962); this TD only scopes/tracks it. 0 TD-id collisions (check_td_adr_unique).