### PR TITLE
fix(objstore): object-store durability path-construction bug class + fold #932 (TD-OBJSTORE-1, #960)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -893,14 +893,17 @@ path = "tests/rust/mod.rs"
 # in src/lib.rs; these tests reference proximadb::cdc::*).
 [[test]]
 name = "cdc_e2e_test"
+path = "tests/cdc_e2e_test.rs"
 required-features = ["cdc-kafka"]
 
 [[test]]
 name = "cdc_integration_test"
+path = "tests/cdc_integration_test.rs"
 required-features = ["cdc-kafka"]
 
 [[test]]
 name = "cdc_rest_changefeed_e2e"
+path = "tests/cdc_rest_changefeed_e2e.rs"
 required-features = ["cdc-kafka"]
 
 # Benchmark profile - optimized but allows faster iteration than full release

--- a/crates/control/proximadb-catalog/src/delta.rs
+++ b/crates/control/proximadb-catalog/src/delta.rs
@@ -258,13 +258,22 @@ impl DeltaCatalog {
     fn parse_storage_url(url: &str) -> Result<PathBuf> {
         if let Some(path) = url.strip_prefix("file://") {
             Ok(PathBuf::from(path))
-        } else if url.starts_with("s3://")
-            || url.starts_with("gs://")
-            || url.starts_with("az://")
-            || url.starts_with("abfs://")
-        {
-            // For cloud storage, use local cache directory
+        } else if url.contains("://") {
+            // ANY non-file scheme (s3://, gs://, gcs://, az://, azure://,
+            // adls://, abfs://, …) — never enumerate schemes here: an
+            // unlisted alias used to fall through to "local path" and
+            // create a literal `adls:` directory (TD-OBJSTORE-1, #960).
+            //
+            // The delta catalog does not yet write its metadata to the
+            // object store: it stages into a LOCAL cache directory, which
+            // is NOT durable across VM loss (TD-OBJSTORE-1 deferred item).
             let cache_dir = std::env::temp_dir().join("proximadb_delta_cache");
+            tracing::warn!(
+                "DeltaCatalog storage_url '{}' is an object store; catalog metadata is staged \
+                 in LOCAL, NON-DURABLE {} (TD-OBJSTORE-1)",
+                url,
+                cache_dir.display()
+            );
             Ok(cache_dir)
         } else {
             // Assume local path

--- a/crates/horizontal/proximadb-runtime-common/src/disk_cache.rs
+++ b/crates/horizontal/proximadb-runtime-common/src/disk_cache.rs
@@ -38,7 +38,22 @@ struct CacheStats {
 
 impl DiskCacheManager {
     pub fn new(cache_dir: PathBuf, max_size_gb: usize) -> Self {
-        let _ = std::fs::create_dir_all(&cache_dir);
+        // The disk cache is local by design. A URL-shaped cache_dir
+        // (s3://, adls://, …) would silently create a literal `s3:`
+        // directory — surface it loudly instead (TD-OBJSTORE-1, #960).
+        if cache_dir.to_string_lossy().contains("://") {
+            tracing::error!(
+                "DiskCacheManager cache_dir must be a local directory, got URL-shaped '{}'; \
+                 disk cache will be non-functional",
+                cache_dir.display()
+            );
+        } else if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+            tracing::error!(
+                "DiskCacheManager failed to create cache_dir '{}': {e}; \
+                 disk cache will be non-functional",
+                cache_dir.display()
+            );
+        }
         Self {
             cache_dir,
             max_size_bytes: max_size_gb * 1024 * 1024 * 1024,

--- a/crates/modalities/proximadb-observability-engine/src/alerting/persistence.rs
+++ b/crates/modalities/proximadb-observability-engine/src/alerting/persistence.rs
@@ -190,11 +190,20 @@ impl FileAlertPersistence {
     /// Create a new file-based alert persistence layer.
     ///
     /// # Arguments
-    /// * `base_path` - Directory where alert data will be persisted
-    pub fn new(base_path: impl AsRef<Path>) -> Self {
-        Self {
-            base_path: base_path.as_ref().to_path_buf(),
+    /// * `base_path` - LOCAL directory where alert data will be persisted.
+    ///   Object-store URLs (`s3://…`, `adls://…`) are rejected fail-fast:
+    ///   this backend uses direct `tokio::fs` I/O and cannot address an
+    ///   object store; an object-store-backed `AlertPersistence` port
+    ///   implementation is the TD-OBJSTORE-1 deferred path (#960).
+    pub fn new(base_path: impl AsRef<Path>) -> Result<Self> {
+        let base_path = base_path.as_ref().to_path_buf();
+        if base_path.to_string_lossy().contains("://") {
+            return Err(anyhow!(
+                "FileAlertPersistence requires a local directory; got URL-shaped path '{}'",
+                base_path.display()
+            ));
         }
+        Ok(Self { base_path })
     }
 
     fn rules_path(&self) -> PathBuf {
@@ -377,7 +386,7 @@ mod tests {
     #[tokio::test]
     async fn test_rule_persistence_roundtrip() {
         let tmp = TempDir::new().unwrap();
-        let persistence = FileAlertPersistence::new(tmp.path());
+        let persistence = FileAlertPersistence::new(tmp.path()).expect("local path");
 
         let rule = AlertRule {
             name: "HighCPU".to_string(),
@@ -402,7 +411,7 @@ mod tests {
     #[tokio::test]
     async fn test_alert_state_persistence() {
         let tmp = TempDir::new().unwrap();
-        let persistence = FileAlertPersistence::new(tmp.path());
+        let persistence = FileAlertPersistence::new(tmp.path()).expect("local path");
 
         let active = ActiveAlert {
             alert: Alert {
@@ -437,7 +446,7 @@ mod tests {
     #[tokio::test]
     async fn test_history_append_and_query() {
         let tmp = TempDir::new().unwrap();
-        let persistence = FileAlertPersistence::new(tmp.path());
+        let persistence = FileAlertPersistence::new(tmp.path()).expect("local path");
 
         let entry1 = AlertHistoryEntry {
             alert_name: "HighCPU".to_string(),
@@ -498,7 +507,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_rule() {
         let tmp = TempDir::new().unwrap();
-        let persistence = FileAlertPersistence::new(tmp.path());
+        let persistence = FileAlertPersistence::new(tmp.path()).expect("local path");
 
         let rule = AlertRule {
             name: "Test".to_string(),

--- a/crates/modalities/proximadb-observability-engine/src/query/tantivy_log_index.rs
+++ b/crates/modalities/proximadb-observability-engine/src/query/tantivy_log_index.rs
@@ -208,6 +208,17 @@ impl TantivyLogIndex {
 
         let schema = schema_builder.build();
 
+        // The tantivy index is deliberately LOCAL (fast mmap'd search over
+        // logs whose durable copy lives in the log storage) — reject
+        // object-store URLs fail-fast instead of creating a literal
+        // `s3:`/`adls:` directory (TD-OBJSTORE-1, #960).
+        if path.contains("://") {
+            anyhow::bail!(
+                "tantivy log index path must be a local directory, got URL-shaped '{path}' — \
+                 the index stays local; only the log STORAGE is object-store-durable"
+            );
+        }
+
         // Ensure directory exists
         std::fs::create_dir_all(path).context("Failed to create index directory")?;
 

--- a/crates/storage/proximadb-storage-common/src/unified_cache_config.rs
+++ b/crates/storage/proximadb-storage-common/src/unified_cache_config.rs
@@ -424,6 +424,20 @@ impl UnifiedCacheConfig {
             return Err(ConfigError::InvalidMemoryDistribution(total));
         }
 
+        // The disk cache is local by design (its whole point is to sit in
+        // front of remote storage). Reject URL-shaped paths fail-fast
+        // instead of creating a literal `s3:`/`adls:` directory
+        // (TD-OBJSTORE-1, #960).
+        if self.disk.enabled && self.disk.path.to_string_lossy().contains("://") {
+            return Err(ConfigError::InvalidPath(
+                self.disk.path.clone(),
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "disk cache path must be a local directory, not an object-store URL",
+                ),
+            ));
+        }
+
         if self.disk.enabled && !self.disk.path.exists() {
             std::fs::create_dir_all(&self.disk.path)
                 .map_err(|e| ConfigError::InvalidPath(self.disk.path.clone(), e))?;

--- a/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OBJSTORE-1: Object-store durability end-to-end — path-construction bug class + local-fs escapes
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **In progress** — batch 1 (this PR) fixes the full path-construction class + the WAL/eventlog/audit local-fs escapes; deferred items enumerated below. Updated each deploy/test cycle with anvaiops until all modalities are proven on a live object store.
+| Severity | Critical — with `storage.metadata_url = adls://…` (or `s3://`, `gcs://`) the server constructs invalid `file://adls://…` URLs and/or drives `std::fs`/`tokio::fs` at object-store URLs; metrics, document WAL, audit/event-log, and timeseries subsystems fail at startup or silently write to wrong local paths. Blocks the ADR-0028 anvaiops object-store deployment (issue #960).
+| Component | `src/network/shared_services.rs` (subsystem path wiring), `src/storage/persistence/write_ahead_log/wal_operations.rs` (unified WAL), `src/storage/engines/eventlog/*` (audit event log), `src/audit/*` (security audit storage), `crates/control/proximadb-catalog/src/delta.rs`, defensive: disk caches + tantivy log index.
+| Tracked-by | https://github.com/vjsingh1984/proximaDB/issues/960[#960]; deploy consumer: anvaiops ADR-0028.
+| Pillar | REL, COST (durability on VM loss; object-store at-rest tiering per ADR-036)
+|===
+
+toc::[]
+
+== Context
+
+anvaiops deploys ProximaDB on a single VM with `storage.metadata_url` pointed at an
+object store (`adls://…` via the VM's system-assigned managed identity — secret-less,
+IMDS, azure_blob precedence option 5). The Azure `FileSystem` registers and routes
+correctly (`adls`/`abfs`/`az`/`azure` all alias the flat **Blob** endpoint, HNS-off,
+per ADR-036); what broke at runtime is *path construction between the config and the
+filesystem layer*, plus a set of subsystems that bypass the filesystem abstraction
+entirely.
+
+The bug class has two shapes:
+
+1. **Strip-and-re-prepend**: `metadata_url.replace("file://", "")` followed by
+   `format!("file://{}…")` or `PathBuf::from(...)` — yields invalid
+   `file://adls://…` URLs or literal local `adls:` directories.
+2. **Local-fs on config-derived durable paths**: `std::fs`/`tokio::fs` on values that
+   may carry an object-store scheme (`create_dir_all`, `write`, `read`, `remove_file`).
+
+== Failure inventory — batch 1 (this PR)
+
+[cols="3,3,2,1", options="header"]
+|===
+| Failure | Root cause | Fix | Status
+
+| `shared_services.rs` metrics path (was :1668) — `file://adls://…/metrics`
+| strip-and-re-prepend on `metadata_url`
+| scheme-preserving `join_storage_url()` helper, used at ALL metadata_url join sites
+| ✅ Fixed
+
+| `shared_services.rs` document WAL base (was :1707)
+| `replace("file://","")` strips scheme context; WAL then re-prepends `file://`
+| `join_storage_url` + WAL writer normalization (below)
+| ✅ Fixed
+
+| `shared_services.rs` observability WAL base (was :1733) — NOT in the original audit
+| same
+| same
+| ✅ Fixed
+
+| `shared_services.rs` audit/event-log base (was :1756) — `PathBuf::from(url + "/auditlog")`
+| strip + `PathBuf` on a URL
+| `join_storage_url`; `EventLogConfig::base_dir` is now `String`
+| ✅ Fixed
+
+| `shared_services.rs` timeseries base (was :1784)
+| strip + `PathBuf` on a URL
+| explicit local fallback + loud `warn!` (TST engine is local-native; see Deferred)
+| ⚠️ Fixed (fail-safe local; durability deferred)
+
+| `shared_services.rs` multimodel observability store base (was :1924) — NOT in the original audit
+| strip
+| `join_storage_url` (config value is label-only; underlying I/O is the WAL above)
+| ✅ Fixed
+
+| `UnifiedWALWriter`/`UnifiedWALReader` hardcode `file://` on every segment path
+  (`wal_operations.rs` :588/:605-610/:702/:743-744) — NOT in the original audit; would have
+  broken document/observability WALs even with correct bases
+| segment paths joined from raw base then unconditionally prefixed `file://`
+| base normalized to a scheme-qualified URL once in `new()`; all prefixes removed
+| ✅ Fixed
+
+| Object-store backends reject `FileSystem::append` (azure/s3/gcs: "block blobs do not
+  support append") — WAL flush would fail at first write even with correct URLs
+| WAL flush used `append` + `sync_file`
+| non-`file://` bases buffer the whole segment (bounded by `max_segment_size`) and
+  overwrite the segment object per flush; identical byte layout, recovery unchanged
+| ✅ Fixed
+
+| Eventlog engine `std::fs::create_dir_all` on `base_dir` (mod.rs, index.rs, snapshot.rs)
+| local-fs on config-derived path
+| guarded to local-only bases; object-store bases are flat keyspaces (no mkdir)
+| ✅ Fixed
+
+| Eventlog `SnapshotManager` all I/O via `tokio::fs` (write/read/remove_file)
+| bypassed the injected filesystem
+| routes through injected `Arc<dyn FileSystem>`; `base_dir`/paths are `String`
+| ✅ Fixed
+
+| Eventlog snapshot cleanup never deleted files (truncate-before-slice) — latent bug found during fix
+| `entity_snapshots.truncate(keep)` then slicing `[keep..]` of the truncated vec (empty)
+| `split_off(keep)` first, then delete via filesystem
+| ✅ Fixed
+
+| `FileAuditStorage` (src/audit/storage.rs) all-`tokio::fs`; also **overwrote** its log
+  file on every event (`tokio::fs::write`), losing prior audit events — latent bug
+| local-fs impl + wrong write mode
+| append via `OpenOptions`; scheme guard rejects object-store URLs fail-fast; new
+  `ObjectStoreAuditStorage` (one JSONL object per event via `FilesystemFactory`);
+  `AuditLogger` dispatches by scheme; `S3` backend variant wired to it
+| ✅ Fixed
+
+| Delta catalog `parse_storage_url` scheme allowlist missed `adls://`/`azure://`/`gcs://`
+  → literal local `adls:` directory
+| scheme enumeration instead of generic `contains("://")`
+| generic non-file scheme check + loud warn on local-cache staging
+| ✅ Fixed
+
+| Disk caches (`unified_cache_config.rs` validate, runtime-common `DiskCacheManager`)
+  and tantivy log index would `create_dir_all` a URL-shaped path
+| legitimately-local components lacked scheme validation
+| fail-fast validation (config error / loud tracing::error / bail)
+| ✅ Fixed (defensive)
+
+| `FileAlertPersistence` (observability-engine alerting) `tokio::fs` on caller path
+| local-fs impl (currently unwired — no production constructor)
+| constructor now rejects URL-shaped paths fail-fast
+| ✅ Guarded (object-store port impl deferred)
+|===
+
+== Deferred (documented limitations — next cycles)
+
+[cols="3,3", options="header"]
+|===
+| Item | Notes
+
+| **Timeseries (TST engine) on object store**
+| Engine is local-`PathBuf`-native (per-tenant WAL/partitions/segments). On an
+  object-store `metadata_url` the service now falls back to a LOCAL, NON-DURABLE dir
+  with a loud warn instead of mangling the URL. Durable path: route TST segment I/O
+  through the filesystem abstraction, or flush-to-object-store tiering.
+
+| **Delta catalog metadata on object store**
+| `DeltaCatalog` stages metadata in `$TMPDIR/proximadb_delta_cache` for cloud URLs
+  (now loudly warned). Durable path: write `_delta_catalog.json` + delta logs through
+  `FilesystemFactory`. Note the default catalog path in production is not delta-backed.
+
+| **RAPTOR/SWIFT writers use `FileSystem::append`**
+| Experimental engines (feature-gated `experimental-engines`, default-OFF) append to
+  segment files; object-store backends reject append. Same full-buffer-overwrite or
+  multipart strategy as the WAL fix when these engines graduate.
+
+| **`queue_fs_adapter.rs` uses `append`**
+| Audit whether its queue paths can be object-store-configured; guard or convert.
+
+| **Alerting persistence object-store port**
+| `AlertPersistence` is a port; add an object-store-backed impl (layering: the
+  modality crate cannot see root `FilesystemFactory`; inject from the composition
+  root) when alerting persistence is wired into the server.
+
+| **Per-event audit objects vs. batching**
+| `ObjectStoreAuditStorage` writes one small object per event (correct, simple).
+  If audit volume grows, batch by time window to cut PUT counts (KRU/KOU cost).
+|===
+
+== Verification
+
+* Unit: eventlog index/snapshot creation with `adls://`/`s3://` bases never touches
+  `std::fs` (asserts no literal `s3:`/`adls:` dirs); snapshot path joins preserve
+  scheme; WAL segment URL construction has no double scheme.
+* Integration (`tests/objstore_url_construction_test.rs`): WAL writer+reader round-trip
+  over a `file://` scheme-qualified base (the normalized-URL path all object-store
+  bases share); `join_storage_url` matrix over bare/file/s3/adls/abfs/gcs bases
+  asserting **no `file://<scheme>://` and no `<scheme>://<scheme>://` ever**; audit
+  logger scheme dispatch.
+* Guard: `tests/objstore_url_construction_test.rs::no_strip_and_reprepend_pattern_in_src`
+  greps `src/` for `.replace("file://"` outside an allowlist — the pattern that caused
+  this class is now build-enforced dead.
+* Live: anvaiops redeploys the pinned `-full` image digest with `adls://` config and
+  runs vector/document/graph/hybrid/observability modality tests; failures feed back
+  into this TD.
+
+== History
+
+* 2026-07-14 — batch 1 filed + fixed (this PR); folds in #932 (cdc `[[test]]` explicit
+  paths) to unblock the develop image publish. Refs #960.

--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -1048,7 +1048,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_audit_logger_creation_s3_not_implemented() {
+    async fn test_audit_logger_creation_s3_routes_to_object_store() {
+        // S3 audit now routes through ObjectStoreAuditStorage
+        // (TD-OBJSTORE-1, #960) — it is no longer a hardcoded
+        // "not yet implemented" stub. Behavior is feature-dependent:
+        // a build with the aws feature routes the scheme successfully
+        // (Ok); a build without it fails fast at construction with a
+        // routing error (get_filesystem rejects the unsupported scheme).
+        // Either outcome is correct; what must NOT recur is the old
+        // placeholder error.
         let config = AuditConfig {
             enable_audit_logging: true,
             storage_backend: AuditStorageBackend::S3 {
@@ -1063,14 +1071,21 @@ mod tests {
             compliance_frameworks: vec![],
         };
 
-        let result = AuditLogger::new(config).await;
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("not yet implemented")
-        );
+        match AuditLogger::new(config).await {
+            Ok(_) => {} // aws feature present: scheme routed successfully
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("not yet implemented"),
+                    "S3 audit is implemented via ObjectStoreAuditStorage now; \
+                     unexpected placeholder error: {msg}"
+                );
+                assert!(
+                    msg.contains("not routable"),
+                    "expected a fail-fast routing error without the aws feature, got: {msg}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -1048,15 +1048,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_audit_logger_creation_s3_routes_to_object_store() {
-        // S3 audit now routes through ObjectStoreAuditStorage
-        // (TD-OBJSTORE-1, #960) — it is no longer a hardcoded
-        // "not yet implemented" stub. Behavior is feature-dependent:
-        // a build with the aws feature routes the scheme successfully
-        // (Ok); a build without it fails fast at construction with a
-        // routing error (get_filesystem rejects the unsupported scheme).
-        // Either outcome is correct; what must NOT recur is the old
-        // placeholder error.
+    async fn test_audit_logger_creation_s3_backend() {
+        // TD-OBJSTORE-1 (#960): the S3 backend now routes through
+        // ObjectStoreAuditStorage. With the `aws` feature the s3:// scheme
+        // registers and creation succeeds (credentials are resolved lazily
+        // on first I/O); without it, creation fail-fasts on the
+        // unroutable scheme instead of the old "not yet implemented".
         let config = AuditConfig {
             enable_audit_logging: true,
             storage_backend: AuditStorageBackend::S3 {
@@ -1071,21 +1068,21 @@ mod tests {
             compliance_frameworks: vec![],
         };
 
-        match AuditLogger::new(config).await {
-            Ok(_) => {} // aws feature present: scheme routed successfully
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(
-                    !msg.contains("not yet implemented"),
-                    "S3 audit is implemented via ObjectStoreAuditStorage now; \
-                     unexpected placeholder error: {msg}"
-                );
-                assert!(
-                    msg.contains("not routable"),
-                    "expected a fail-fast routing error without the aws feature, got: {msg}"
-                );
-            }
-        }
+        let result = AuditLogger::new(config).await;
+        #[cfg(feature = "aws")]
+        assert!(
+            result.is_ok(),
+            "S3 audit backend must initialize lazily with the aws feature: {:?}",
+            result.err().map(|e| e.to_string())
+        );
+        #[cfg(not(feature = "aws"))]
+        assert!(
+            result
+                .err()
+                .map(|e| e.to_string())
+                .is_some_and(|msg| msg.contains("not routable")),
+            "S3 audit backend must fail-fast on the unroutable scheme without the aws feature"
+        );
     }
 
     #[tokio::test]

--- a/src/audit/logger.rs
+++ b/src/audit/logger.rs
@@ -215,20 +215,31 @@ impl AuditLogger {
     ) -> Result<Arc<dyn AuditStorage + Send + Sync>> {
         match &config.storage_backend {
             AuditStorageBackend::File { directory } => {
-                let storage = super::storage::FileAuditStorage::new(directory.clone()).await?;
-                Ok(Arc::new(storage))
+                // Dispatch by scheme: object-store URLs (s3://, adls://,
+                // abfs://, gcs://, …) route through the FilesystemFactory;
+                // bare paths and file:// stay on the local backend
+                // (TD-OBJSTORE-1, #960).
+                if directory.contains("://") && !directory.starts_with("file://") {
+                    let storage =
+                        super::storage::ObjectStoreAuditStorage::new(directory.clone()).await?;
+                    Ok(Arc::new(storage))
+                } else {
+                    let storage = super::storage::FileAuditStorage::new(directory.clone()).await?;
+                    Ok(Arc::new(storage))
+                }
             }
             AuditStorageBackend::Database { connection_string } => {
                 let storage =
                     super::storage::DatabaseAuditStorage::new(connection_string.clone()).await?;
                 Ok(Arc::new(storage))
             }
-            AuditStorageBackend::S3 {
-                bucket: _,
-                region: _,
-            } => {
-                // Placeholder for S3 storage implementation
-                Err(anyhow!("S3 audit storage not yet implemented"))
+            AuditStorageBackend::S3 { bucket, region: _ } => {
+                // Route through the same object-store implementation as
+                // scheme-qualified File directories (TD-OBJSTORE-1, #960).
+                let storage =
+                    super::storage::ObjectStoreAuditStorage::new(format!("s3://{bucket}/audit"))
+                        .await?;
+                Ok(Arc::new(storage))
             }
             AuditStorageBackend::Combined {
                 primary: _,

--- a/src/audit/storage.rs
+++ b/src/audit/storage.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use proximadb_security::{AuditEvent, AuditEventType, AuditResult};
 pub use proximadb_security::{AuditStatistics, AuditStorage};
 use std::path::Path;
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 /// File-based audit storage implementation
@@ -24,7 +25,23 @@ pub struct FileAuditStorage {
 impl FileAuditStorage {
     /// Create a new `FileAuditStorage` that writes JSONL audit logs to the given directory.
     /// The directory is created automatically if it does not already exist.
+    ///
+    /// Accepts a bare local path or a `file://` URL. Object-store URLs are
+    /// rejected fail-fast — use [`ObjectStoreAuditStorage`] for those
+    /// (TD-OBJSTORE-1, #960).
     pub async fn new(directory: String) -> Result<Self> {
+        let directory = match directory.strip_prefix("file://") {
+            Some(stripped) => stripped.to_string(),
+            None if directory.contains("://") => {
+                return Err(anyhow!(
+                    "FileAuditStorage requires a local directory; got object-store URL '{}' — \
+                     use ObjectStoreAuditStorage instead",
+                    directory
+                ));
+            }
+            None => directory,
+        };
+
         // Ensure directory exists
         tokio::fs::create_dir_all(&directory)
             .await
@@ -75,8 +92,16 @@ impl AuditStorage for FileAuditStorage {
         let event_json = serde_json::to_string(event)?;
         let log_line = format!("{}\n", event_json);
 
-        // Append to audit log file
-        tokio::fs::write(&file_path, &log_line)
+        // Append to the audit log file (`tokio::fs::write` would truncate,
+        // silently dropping every previously stored event in the file).
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file_path)
+            .await
+            .map_err(|e| anyhow!("Failed to open audit log {}: {}", file_path, e))?;
+        file.write_all(log_line.as_bytes())
             .await
             .map_err(|e| anyhow!("Failed to write audit event to {}: {}", file_path, e))?;
 
@@ -133,45 +158,7 @@ impl AuditStorage for FileAuditStorage {
         let events = self
             .query_events(None, None, Some(since), None, None)
             .await?;
-
-        let mut events_by_type = std::collections::HashMap::new();
-        let mut unique_users = std::collections::HashSet::new();
-        let mut unique_tenants = std::collections::HashSet::new();
-        let mut success_count = 0;
-
-        for event in &events {
-            // Count by event type
-            *events_by_type.entry(event.event_type.clone()).or_insert(0) += 1;
-
-            // Track unique users and tenants
-            if let Some(ref user_id) = event.user_id {
-                unique_users.insert(user_id.clone());
-            }
-            if let Some(ref tenant_id) = event.tenant_id {
-                unique_tenants.insert(tenant_id.clone());
-            }
-
-            // Count successes
-            if matches!(event.result, AuditResult::Success) {
-                success_count += 1;
-            }
-        }
-
-        let success_rate = if !events.is_empty() {
-            (success_count as f64) / (events.len() as f64) * 100.0
-        } else {
-            0.0
-        };
-
-        Ok(AuditStatistics {
-            total_events: events.len() as u64,
-            events_by_type,
-            unique_users: unique_users.len() as u64,
-            unique_tenants: unique_tenants.len() as u64,
-            success_rate,
-            period_start: since,
-            period_end: Utc::now(),
-        })
+        Ok(statistics_from_events(&events, since))
     }
 
     async fn cleanup_old_logs(&self, retention_days: u32) -> Result<usize> {
@@ -234,32 +221,9 @@ impl FileAuditStorage {
 
             match serde_json::from_str::<AuditEvent>(line) {
                 Ok(event) => {
-                    // Apply filters
-                    if let Some(ref filter_type) = event_type
-                        && &event.event_type != filter_type
-                    {
-                        continue;
+                    if event_matches_filters(&event, &event_type, &user_id, since, until) {
+                        events.push(event);
                     }
-
-                    if let Some(ref filter_user) = user_id
-                        && event.user_id.as_ref() != Some(filter_user)
-                    {
-                        continue;
-                    }
-
-                    if let Some(since_time) = since
-                        && event.timestamp < since_time
-                    {
-                        continue;
-                    }
-
-                    if let Some(until_time) = until
-                        && event.timestamp > until_time
-                    {
-                        continue;
-                    }
-
-                    events.push(event);
                 }
                 Err(e) => {
                     warn!(
@@ -272,6 +236,264 @@ impl FileAuditStorage {
         }
 
         Ok(events)
+    }
+}
+
+/// Does `event` pass the optional query filters? Shared by the file- and
+/// object-store-backed implementations.
+fn event_matches_filters(
+    event: &AuditEvent,
+    event_type: &Option<AuditEventType>,
+    user_id: &Option<String>,
+    since: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+) -> bool {
+    if let Some(filter_type) = event_type
+        && &event.event_type != filter_type
+    {
+        return false;
+    }
+    if let Some(filter_user) = user_id
+        && event.user_id.as_ref() != Some(filter_user)
+    {
+        return false;
+    }
+    if let Some(since_time) = since
+        && event.timestamp < since_time
+    {
+        return false;
+    }
+    if let Some(until_time) = until
+        && event.timestamp > until_time
+    {
+        return false;
+    }
+    true
+}
+
+/// Object-store-backed audit storage (TD-OBJSTORE-1, #960).
+///
+/// Persists one JSONL object per audit event under
+/// `{base_url}/audit_{timestamp}_{event_id}.jsonl`, routed through the
+/// scheme-dispatching [`FilesystemFactory`] so the base may be `s3://…`,
+/// `adls://…`/`abfs://…`, `gcs://…`, or `file://…`. Object stores reject
+/// append on immutable/block blobs, so per-event objects replace the local
+/// backend's append-and-rotate layout; the flat keyspace makes the extra
+/// objects cheap and listing is only paid on (rare, admin-facing) queries.
+pub struct ObjectStoreAuditStorage {
+    /// Scheme-qualified base URL for audit objects
+    base_url: String,
+    /// Scheme-dispatching filesystem factory
+    filesystem: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
+}
+
+impl ObjectStoreAuditStorage {
+    /// Create an object-store audit storage rooted at `base_url`
+    /// (scheme-qualified, e.g. `adls://container/data/audit`).
+    pub async fn new(base_url: String) -> Result<Self> {
+        if !base_url.contains("://") {
+            return Err(anyhow!(
+                "ObjectStoreAuditStorage requires a scheme-qualified URL; got '{}' — \
+                 use FileAuditStorage for local directories",
+                base_url
+            ));
+        }
+        let filesystem = Arc::new(
+            crate::storage::persistence::filesystem::FilesystemFactory::create(
+                crate::storage::persistence::filesystem::FilesystemConfig::default(),
+            )
+            .await
+            .map_err(|e| anyhow!("Failed to create filesystem factory: {}", e))?,
+        );
+        // Fail fast on unsupported/misconfigured schemes (e.g. s3:// without
+        // the aws feature) instead of at the first audit write.
+        filesystem
+            .get_filesystem(&base_url)
+            .map_err(|e| anyhow!("Audit storage URL '{}' not routable: {}", base_url, e))?;
+
+        info!("✅ Object-store audit storage initialized: {}", base_url);
+
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            filesystem,
+        })
+    }
+
+    fn object_url(&self, event: &AuditEvent) -> String {
+        format!(
+            "{}/audit_{}_{}.jsonl",
+            self.base_url,
+            event.timestamp.format("%Y%m%d_%H%M%S%.3f"),
+            event.event_id
+        )
+    }
+}
+
+#[async_trait]
+impl AuditStorage for ObjectStoreAuditStorage {
+    async fn store_audit_event(&self, event: &AuditEvent) -> Result<()> {
+        let url = self.object_url(event);
+        let event_json = serde_json::to_string(event)?;
+        let fs = self
+            .filesystem
+            .get_filesystem(&url)
+            .map_err(|e| anyhow!("Audit storage URL '{}' not routable: {}", url, e))?;
+        let options = crate::storage::persistence::filesystem::FileOptions {
+            create_dirs: true,
+            overwrite: true,
+            ..Default::default()
+        };
+        fs.write(&url, event_json.as_bytes(), Some(options))
+            .await
+            .map_err(|e| anyhow!("Failed to write audit event to {}: {}", url, e))?;
+        debug!("📝 Stored audit event {} to {}", event.event_id, url);
+        Ok(())
+    }
+
+    async fn query_events(
+        &self,
+        event_type: Option<AuditEventType>,
+        user_id: Option<String>,
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+        limit: Option<usize>,
+    ) -> Result<Vec<AuditEvent>> {
+        let fs = self
+            .filesystem
+            .get_filesystem(&self.base_url)
+            .map_err(|e| anyhow!("Audit storage URL not routable: {}", e))?;
+        let entries = fs.list(&self.base_url).await.map_err(|e| {
+            anyhow!(
+                "Failed to list audit objects under {}: {}",
+                self.base_url,
+                e
+            )
+        })?;
+
+        let mut events = Vec::new();
+        for entry in entries {
+            if !entry.name.ends_with(".jsonl") {
+                continue;
+            }
+            let data = match fs.read(&entry.url).await {
+                Ok(data) => data,
+                Err(e) => {
+                    warn!("Failed to read audit object {}: {}", entry.url, e);
+                    continue;
+                }
+            };
+            let content = String::from_utf8_lossy(&data);
+            for line in content.lines() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<AuditEvent>(line) {
+                    Ok(event) => {
+                        if event_matches_filters(&event, &event_type, &user_id, since, until) {
+                            events.push(event);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse audit event from {}: {}", entry.url, e);
+                    }
+                }
+            }
+            if let Some(limit) = limit
+                && events.len() >= limit
+            {
+                events.truncate(limit);
+                break;
+            }
+        }
+
+        // Sort by timestamp (newest first)
+        events.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
+        debug!("🔍 Queried {} audit events matching criteria", events.len());
+        Ok(events)
+    }
+
+    async fn get_audit_statistics(&self, since: DateTime<Utc>) -> Result<AuditStatistics> {
+        let events = self
+            .query_events(None, None, Some(since), None, None)
+            .await?;
+        Ok(statistics_from_events(&events, since))
+    }
+
+    async fn cleanup_old_logs(&self, retention_days: u32) -> Result<usize> {
+        let cutoff_date = Utc::now() - chrono::Duration::days(retention_days as i64);
+        let fs = self
+            .filesystem
+            .get_filesystem(&self.base_url)
+            .map_err(|e| anyhow!("Audit storage URL not routable: {}", e))?;
+        let entries = fs.list(&self.base_url).await.map_err(|e| {
+            anyhow!(
+                "Failed to list audit objects under {}: {}",
+                self.base_url,
+                e
+            )
+        })?;
+
+        let mut deleted_files = 0usize;
+        for entry in entries {
+            if !entry.name.ends_with(".jsonl") {
+                continue;
+            }
+            let Some(modified) = entry.metadata.modified else {
+                continue;
+            };
+            if modified < cutoff_date {
+                if let Err(e) = fs.delete(&entry.url).await {
+                    warn!("Failed to delete old audit object {}: {}", entry.url, e);
+                } else {
+                    deleted_files += 1;
+                    info!("🗑️ Deleted old audit object: {}", entry.url);
+                }
+            }
+        }
+
+        info!(
+            "🧹 Cleanup complete: deleted {} old audit objects",
+            deleted_files
+        );
+        Ok(deleted_files)
+    }
+}
+
+/// Aggregate statistics over a set of audit events. Shared by every
+/// [`AuditStorage`] backend.
+fn statistics_from_events(events: &[AuditEvent], since: DateTime<Utc>) -> AuditStatistics {
+    let mut events_by_type = std::collections::HashMap::new();
+    let mut unique_users = std::collections::HashSet::new();
+    let mut unique_tenants = std::collections::HashSet::new();
+    let mut success_count = 0;
+
+    for event in events {
+        *events_by_type.entry(event.event_type.clone()).or_insert(0) += 1;
+        if let Some(ref user_id) = event.user_id {
+            unique_users.insert(user_id.clone());
+        }
+        if let Some(ref tenant_id) = event.tenant_id {
+            unique_tenants.insert(tenant_id.clone());
+        }
+        if matches!(event.result, AuditResult::Success) {
+            success_count += 1;
+        }
+    }
+
+    let success_rate = if !events.is_empty() {
+        (success_count as f64) / (events.len() as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    AuditStatistics {
+        total_events: events.len() as u64,
+        events_by_type,
+        unique_users: unique_users.len() as u64,
+        unique_tenants: unique_tenants.len() as u64,
+        success_rate,
+        period_start: since,
+        period_end: Utc::now(),
     }
 }
 

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -73,6 +73,40 @@ fn lease_manifest_prune_interval_secs() -> u64 {
         .unwrap_or(300)
 }
 
+/// Join a subsystem subpath onto the configured durable storage base
+/// (TD-OBJSTORE-1, #960).
+///
+/// `base` is `storage.metadata_url`: a bare local path (`/data`), a `file://`
+/// URL, or an object-store URL (`s3://…`, `adls://…`, `abfs://…`, `gcs://…`).
+/// The scheme is preserved verbatim; a bare path stays bare (every downstream
+/// consumer normalizes with a `contains("://")` guard). Never strip a scheme
+/// and re-prepend one around this join — stripping `file://` off metadata_url
+/// and then formatting `file://{…}` back on is exactly what produced the
+/// invalid `file://adls://…` URLs on object-store deployments.
+pub(crate) fn join_storage_url(base: &str, sub: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if sub.is_empty() {
+        trimmed.to_string()
+    } else {
+        format!("{}/{}", trimmed, sub.trim_start_matches('/'))
+    }
+}
+
+/// The local-filesystem view of a storage base, for subsystems that cannot yet
+/// run over an object store (TD-OBJSTORE-1 deferred set — e.g. the TST
+/// time-series engine). Returns `None` when the base carries a non-`file`
+/// scheme, so callers can fail over loudly instead of handing an
+/// `adls://…`-shaped string to `std::fs`.
+fn local_storage_path(base: &str) -> Option<std::path::PathBuf> {
+    if let Some(path) = base.strip_prefix("file://") {
+        Some(std::path::PathBuf::from(path))
+    } else if base.contains("://") {
+        None
+    } else {
+        Some(std::path::PathBuf::from(base))
+    }
+}
+
 /// Which consumer is constructing the shared service core.
 ///
 /// The core (catalog, collection, vector/doc/graph compute, storage/WAL,
@@ -1663,10 +1697,7 @@ impl SharedServices {
         let metrics_config = MetricsConfig {
             enabled: true,
             collection_partitions: 16,
-            storage_path: format!(
-                "file://{}/metrics",
-                storage_config.metadata_url.replace("file://", "")
-            ),
+            storage_path: join_storage_url(&storage_config.metadata_url, "metrics"),
             flush_interval_seconds: 60,
             retention_days: 7,
             parallel_scan_threshold: 1000,
@@ -1704,7 +1735,7 @@ impl SharedServices {
 
         // Create DocumentService (moved up for UnifiedHandlers)
         debug!("🔧 SharedServices::new - Creating DocumentService for document queries...");
-        let document_base_path = storage_config.metadata_url.replace("file://", "");
+        let document_base_path = join_storage_url(&storage_config.metadata_url, "");
         // TD-DOC-RETIRE-1 P2 rewires this to the canonical constructor
         // (with_canonical_record_store_and_wal); the deprecated call is intentional until then.
         #[allow(deprecated)]
@@ -1730,7 +1761,7 @@ impl SharedServices {
         debug!(
             "🔧 SharedServices::new - Creating ObservabilityQueryEngine for observability queries..."
         );
-        let observability_base_path = storage_config.metadata_url.replace("file://", "");
+        let observability_base_path = join_storage_url(&storage_config.metadata_url, "");
         let observability_storage = match ObservabilityStorage::new_with_wal(
             &observability_base_path,
         )
@@ -1753,9 +1784,9 @@ impl SharedServices {
 
         // Create EventLogEngine for persistent audit trails (TD-050 Phase 5)
         debug!("🔧 SharedServices::new - Creating EventLogEngine for audit trails...");
-        let event_log_base_path = storage_config.metadata_url.replace("file://", "") + "/auditlog";
+        let event_log_base_path = join_storage_url(&storage_config.metadata_url, "auditlog");
         let event_log_config = crate::storage::engines::eventlog::EventLogConfig {
-            base_dir: std::path::PathBuf::from(event_log_base_path),
+            base_dir: event_log_base_path,
             ..Default::default()
         };
         let event_log_filesystem = Arc::new(
@@ -1780,9 +1811,25 @@ impl SharedServices {
         // TST engine, rooted under the data dir. Non-fatal on failure (surface stays
         // unavailable rather than blocking bootstrap).
         {
-            let ts_base_path = std::path::PathBuf::from(
-                storage_config.metadata_url.replace("file://", "") + "/timeseries",
-            );
+            // The TST engine is local-filesystem-native (PathBuf WAL/segments);
+            // it cannot yet run over an object store. On an object-store
+            // metadata_url the time-series surface stays on local disk
+            // (non-durable across VM loss — TD-OBJSTORE-1 deferred item)
+            // instead of mangling the URL into a local path.
+            let ts_base_path = match local_storage_path(&storage_config.metadata_url) {
+                Some(local) => local.join("timeseries"),
+                None => {
+                    let fallback = std::env::temp_dir().join("proximadb").join("timeseries");
+                    warn!(
+                        "TimeSeriesService does not support object-store storage yet \
+                         (metadata_url={}); falling back to LOCAL, NON-DURABLE {} \
+                         (TD-OBJSTORE-1)",
+                        storage_config.metadata_url,
+                        fallback.display()
+                    );
+                    fallback
+                }
+            };
             if let Err(e) =
                 crate::services::timeseries_service::init_timeseries_service(ts_base_path)
             {
@@ -1921,7 +1968,7 @@ impl SharedServices {
             crate::storage::multimodel::DocumentStore::new(Default::default())
                 .with_service(document_service.clone()),
         );
-        let obs_base_path = storage_config.metadata_url.replace("file://", "");
+        let obs_base_path = join_storage_url(&storage_config.metadata_url, "");
         let observability_store = Arc::new(
             crate::storage::multimodel::ObservabilityStore::new(
                 crate::storage::multimodel::stores::observability_store::ObservabilityStoreConfig {
@@ -3246,5 +3293,69 @@ mod function_store_wiring_tests {
     async fn build_function_store_without_wal_is_empty() {
         let store = build_function_store(None).await;
         assert_eq!(store.list_all().await.unwrap().len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod join_storage_url_tests {
+    use super::{join_storage_url, local_storage_path};
+
+    /// TD-OBJSTORE-1 (#960): every (base, sub) pair must join scheme-preserving
+    /// with no double scheme — the `file://adls://…` class must be impossible.
+    #[test]
+    fn joins_preserve_scheme_for_every_base_shape() {
+        let cases = [
+            ("/data", "metrics", "/data/metrics"),
+            ("/data/", "metrics", "/data/metrics"),
+            ("file:///data", "metrics", "file:///data/metrics"),
+            ("s3://bucket/data", "auditlog", "s3://bucket/data/auditlog"),
+            (
+                "adls://container/data/",
+                "timeseries",
+                "adls://container/data/timeseries",
+            ),
+            (
+                "abfs://container/data",
+                "metrics",
+                "abfs://container/data/metrics",
+            ),
+            (
+                "gcs://bucket/data",
+                "auditlog",
+                "gcs://bucket/data/auditlog",
+            ),
+            ("azure://container/data", "", "azure://container/data"),
+            ("s3://bucket/data", "", "s3://bucket/data"),
+            ("/data", "", "/data"),
+        ];
+        for (base, sub, expected) in cases {
+            let joined = join_storage_url(base, sub);
+            assert_eq!(joined, expected, "join_storage_url({base:?}, {sub:?})");
+            // No double scheme, ever.
+            assert_eq!(
+                joined.matches("://").count(),
+                expected.matches("://").count(),
+                "double scheme in {joined:?}"
+            );
+            assert!(
+                !joined.starts_with("file://s3://") && !joined.starts_with("file://adls://"),
+                "invalid double-scheme URL {joined:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_storage_path_rejects_object_store_bases() {
+        assert_eq!(
+            local_storage_path("/data").as_deref(),
+            Some(std::path::Path::new("/data"))
+        );
+        assert_eq!(
+            local_storage_path("file:///data").as_deref(),
+            Some(std::path::Path::new("/data"))
+        );
+        assert!(local_storage_path("adls://container/data").is_none());
+        assert!(local_storage_path("s3://bucket/data").is_none());
+        assert!(local_storage_path("abfs://container/data").is_none());
     }
 }

--- a/src/services/agent_memory.rs
+++ b/src/services/agent_memory.rs
@@ -1289,7 +1289,7 @@ mod tests {
     }
 
     async fn temp_event_log(name: &str) -> Arc<EventLogEngine> {
-        let base_dir = std::path::PathBuf::from(format!("/tmp/test_memaudit_{name}"));
+        let base_dir = format!("/tmp/test_memaudit_{name}");
         let _ = std::fs::remove_dir_all(&base_dir);
         std::fs::create_dir_all(&base_dir).expect("create dir");
         let cfg = crate::storage::engines::eventlog::EventLogConfig {

--- a/src/storage/engines/eventlog/index.rs
+++ b/src/storage/engines/eventlog/index.rs
@@ -23,7 +23,6 @@ use crate::storage::engines::eventlog::{EntityId, Event, EventSequence, EventTyp
 use chrono::{DateTime, Utc};
 use proximadb_kernel::error::ProximaDBError;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::debug;
@@ -33,8 +32,9 @@ type Result<T> = std::result::Result<T, ProximaDBError>;
 /// Event index for fast lookups
 #[allow(dead_code)]
 pub struct EventIndex {
-    /// Base directory for index storage
-    base_dir: PathBuf,
+    /// Base location for index storage (local path or object-store URL).
+    /// The index itself is purely in-memory; this is retained for diagnostics.
+    base_dir: String,
 
     /// Entity index: entity_id -> Vec<sequence>
     entity_index: Arc<RwLock<HashMap<EntityId, Vec<EventSequence>>>>,
@@ -51,12 +51,17 @@ pub struct EventIndex {
 
 impl EventIndex {
     /// Create a new event index
-    pub fn new(base_dir: PathBuf) -> Result<Self> {
-        debug!("Creating event index at {:?}", base_dir);
+    pub fn new(base_dir: String) -> Result<Self> {
+        debug!("Creating event index at {}", base_dir);
 
-        // Create index directory
-        std::fs::create_dir_all(&base_dir)
-            .map_err(|e| ProximaDBError::Internal(format!("Failed to create index dir: {}", e)))?;
+        // The index is in-memory; only create a directory for local bases.
+        // Object-store URLs (s3://, adls://, …) need no directory and must
+        // never reach std::fs (TD-OBJSTORE-1, #960).
+        if !base_dir.contains("://") {
+            std::fs::create_dir_all(&base_dir).map_err(|e| {
+                ProximaDBError::Internal(format!("Failed to create index dir: {}", e))
+            })?;
+        }
 
         Ok(Self {
             base_dir,
@@ -291,14 +296,23 @@ mod tests {
 
     #[test]
     fn test_index_creation() {
-        let base_dir = PathBuf::from("/tmp/test_event_index");
+        let base_dir = "/tmp/test_event_index".to_string();
         let index = EventIndex::new(base_dir.clone()).unwrap();
         assert_eq!(index.base_dir, base_dir);
     }
 
+    #[test]
+    fn test_index_creation_object_store_url_skips_local_mkdir() {
+        // An object-store base must never hit std::fs — creation succeeds
+        // without touching the local filesystem (TD-OBJSTORE-1, #960).
+        let index = EventIndex::new("adls://container/data/auditlog".to_string()).unwrap();
+        assert_eq!(index.base_dir, "adls://container/data/auditlog");
+        assert!(!std::path::Path::new("adls:").exists());
+    }
+
     #[tokio::test]
     async fn test_index_event() {
-        let base_dir = PathBuf::from("/tmp/test_index_event");
+        let base_dir = "/tmp/test_index_event".to_string();
         let index = EventIndex::new(base_dir.clone()).unwrap();
 
         let event = Event {
@@ -327,7 +341,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_entity_events() {
-        let base_dir = PathBuf::from("/tmp/test_get_entity");
+        let base_dir = "/tmp/test_get_entity".to_string();
         let index = EventIndex::new(base_dir.clone()).unwrap();
 
         // Index multiple events
@@ -365,7 +379,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_stats() {
-        let base_dir = PathBuf::from("/tmp/test_index_stats");
+        let base_dir = "/tmp/test_index_stats".to_string();
         let index = EventIndex::new(base_dir.clone()).unwrap();
 
         let event = Event {

--- a/src/storage/engines/eventlog/mod.rs
+++ b/src/storage/engines/eventlog/mod.rs
@@ -59,7 +59,6 @@ use chrono::{DateTime, Utc};
 use proximadb_kernel::error::ProximaDBError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
@@ -111,8 +110,12 @@ pub struct Event {
 /// Event log configuration
 #[derive(Debug, Clone)]
 pub struct EventLogConfig {
-    /// Base directory for event storage
-    pub base_dir: PathBuf,
+    /// Base location for event storage: a local directory (`/data/auditlog`)
+    /// or a scheme-qualified object-store URL (`s3://…`, `adls://…`) —
+    /// a `String`, not a `PathBuf`, so object-store URLs survive joins
+    /// verbatim (TD-OBJSTORE-1, #960). All I/O routes through the injected
+    /// `FileSystem`.
+    pub base_dir: String,
 
     /// Snapshot interval (number of events after which to snapshot)
     pub snapshot_interval: EventSequence,
@@ -130,7 +133,7 @@ pub struct EventLogConfig {
 impl Default for EventLogConfig {
     fn default() -> Self {
         Self {
-            base_dir: PathBuf::from("/tmp/proximadb/eventlog"),
+            base_dir: "/tmp/proximadb/eventlog".to_string(),
             snapshot_interval: 1000,
             enable_compression: true,
             retention_days: 365 * 7, // 7 years for financial data
@@ -188,19 +191,26 @@ pub struct EventLogEngine {
 impl EventLogEngine {
     /// Create a new event log engine
     pub fn new(config: EventLogConfig, filesystem: Arc<UnifiedCachingFilesystem>) -> Result<Self> {
-        info!("Creating event log engine at {:?}", config.base_dir);
+        info!("Creating event log engine at {}", config.base_dir);
 
-        // Create base directory
-        std::fs::create_dir_all(&config.base_dir).map_err(|e| {
-            ProximaDBError::Internal(format!("Failed to create eventlog dir: {}", e))
-        })?;
+        // Create the base directory only for local bases; an object-store
+        // base (s3://, adls://, …) has no directories — objects materialize
+        // under flat keys on first write (TD-OBJSTORE-1, #960).
+        if !config.base_dir.contains("://") {
+            std::fs::create_dir_all(&config.base_dir).map_err(|e| {
+                ProximaDBError::Internal(format!("Failed to create eventlog dir: {}", e))
+            })?;
+        }
 
         // Initialize sequence counter
         let sequence_counter = Arc::new(RwLock::new(0));
 
         // Initialize components
         let event_index = Arc::new(EventIndex::new(config.base_dir.clone())?);
-        let snapshot_manager = Arc::new(SnapshotManager::new(config.base_dir.clone())?);
+        let snapshot_manager = Arc::new(SnapshotManager::new(
+            config.base_dir.clone(),
+            filesystem.clone() as Arc<dyn FileSystem>,
+        )?);
         let temporal_engine = Arc::new(TemporalQueryEngine::new(
             event_index.clone(),
             snapshot_manager.clone(),
@@ -249,19 +259,10 @@ impl EventLogEngine {
         let serialized = serde_json::to_vec(&event)
             .map_err(|e| ProximaDBError::Internal(format!("Event serialization failed: {}", e)))?;
 
-        // Persist to storage (append-only)
+        // Persist to storage (append-only). Parent directories come from the
+        // `create_dirs` option — never from a direct `tokio::fs` call, which
+        // would break object-store bases (TD-OBJSTORE-1, #960).
         let event_path = self.get_event_path(sequence);
-
-        // Create partition directory if it doesn't exist
-        if let Some(partition_dir) = event_path.parent() {
-            tokio::fs::create_dir_all(partition_dir)
-                .await
-                .map_err(|e| {
-                    ProximaDBError::Internal(format!("Failed to create partition dir: {}", e))
-                })?;
-        }
-
-        // Write with create_dirs option to ensure parent directories exist
         let options = crate::storage::persistence::filesystem::FileOptions {
             create_dirs: true,
             overwrite: true,
@@ -269,7 +270,7 @@ impl EventLogEngine {
         };
         FileSystem::write(
             self.filesystem.as_ref(),
-            &event_path.to_string_lossy(),
+            &event_path,
             &serialized,
             Some(options),
         )
@@ -341,8 +342,7 @@ impl EventLogEngine {
         let mut events = Vec::new();
         for sequence in sequences {
             let event_path = self.get_event_path(sequence);
-            let data =
-                FileSystem::read(self.filesystem.as_ref(), &event_path.to_string_lossy()).await?;
+            let data = FileSystem::read(self.filesystem.as_ref(), &event_path).await?;
 
             let event: Event = serde_json::from_slice(&data).map_err(|e| {
                 ProximaDBError::Internal(format!("Event deserialization failed: {}", e))
@@ -377,8 +377,7 @@ impl EventLogEngine {
         let mut events = Vec::new();
         for sequence in sequences {
             let event_path = self.get_event_path(sequence);
-            let data =
-                FileSystem::read(self.filesystem.as_ref(), &event_path.to_string_lossy()).await?;
+            let data = FileSystem::read(self.filesystem.as_ref(), &event_path).await?;
             let event: Event = serde_json::from_slice(&data).map_err(|e| {
                 ProximaDBError::Internal(format!("Event deserialization failed: {}", e))
             })?;
@@ -506,14 +505,17 @@ impl EventLogEngine {
         Ok(())
     }
 
-    /// Get storage path for an event
-    fn get_event_path(&self, sequence: EventSequence) -> PathBuf {
+    /// Get storage path for an event. String-joined (never `PathBuf::join`)
+    /// so an object-store base URL survives verbatim on every platform.
+    fn get_event_path(&self, sequence: EventSequence) -> String {
         // Partition events by sequence (1000 events per partition)
         let partition = sequence / 1000;
-        self.config
-            .base_dir
-            .join(format!("partition_{:05}", partition))
-            .join(format!("event_{:010}.bin", sequence))
+        format!(
+            "{}/partition_{:05}/event_{:010}.bin",
+            self.config.base_dir.trim_end_matches('/'),
+            partition,
+            sequence
+        )
     }
 }
 
@@ -524,7 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_log_creation() {
-        let base_dir = PathBuf::from("/tmp/test_eventlog_creation");
+        let base_dir = String::from("/tmp/test_eventlog_creation");
         // Create base directory first
         std::fs::create_dir_all(&base_dir).expect("Failed to create test eventlog directory");
 
@@ -554,7 +556,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_event() {
-        let base_dir = PathBuf::from("/tmp/test_eventlog_append");
+        let base_dir = String::from("/tmp/test_eventlog_append");
         // Create base directory first
         std::fs::create_dir_all(&base_dir)
             .expect("Failed to create test eventlog append directory");
@@ -601,7 +603,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_events_by_entity_prefix() {
-        let base_dir = PathBuf::from("/tmp/test_eventlog_prefix");
+        let base_dir = String::from("/tmp/test_eventlog_prefix");
         std::fs::create_dir_all(&base_dir).expect("create dir");
         let config = EventLogConfig {
             base_dir,
@@ -684,7 +686,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_regulatory_compliance() {
-        let base_dir = PathBuf::from("/tmp/test_eventlog_reg");
+        let base_dir = String::from("/tmp/test_eventlog_reg");
         // Create base directory first
         std::fs::create_dir_all(&base_dir)
             .expect("Failed to create test eventlog regulatory directory");
@@ -729,7 +731,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_immutable_audit_trail() {
-        let base_dir = PathBuf::from("/tmp/test_eventlog_immutable");
+        let base_dir = String::from("/tmp/test_eventlog_immutable");
         // Create base directory first
         std::fs::create_dir_all(&base_dir)
             .expect("Failed to create test eventlog immutable directory");

--- a/src/storage/engines/eventlog/snapshot.rs
+++ b/src/storage/engines/eventlog/snapshot.rs
@@ -20,10 +20,10 @@
 //! avoiding full event replay for entities with many events.
 
 use crate::storage::engines::eventlog::{EntityId, EventSequence};
+use crate::storage::persistence::filesystem::{FileOptions, FileSystem};
 use chrono::{DateTime, Utc};
 use proximadb_kernel::error::ProximaDBError;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
@@ -42,8 +42,8 @@ pub struct SnapshotMetadata {
     /// Snapshot creation timestamp
     pub created_at: DateTime<Utc>,
 
-    /// Snapshot file path
-    pub file_path: PathBuf,
+    /// Snapshot file path (local path or object-store URL)
+    pub file_path: String,
 
     /// Snapshot size in bytes
     pub size_bytes: usize,
@@ -51,8 +51,13 @@ pub struct SnapshotMetadata {
 
 /// Snapshot manager for efficient state reconstruction
 pub struct SnapshotManager {
-    /// Base directory for snapshot storage
-    base_dir: PathBuf,
+    /// Base location for snapshot storage (local path or object-store URL)
+    base_dir: String,
+
+    /// Filesystem all snapshot I/O routes through — never direct
+    /// `std::fs`/`tokio::fs`, which cannot address object-store bases
+    /// (TD-OBJSTORE-1, #960).
+    filesystem: Arc<dyn FileSystem>,
 
     /// Snapshot metadata index
     snapshots: Arc<RwLock<HashMap<EntityId, Vec<SnapshotMetadata>>>>,
@@ -79,16 +84,20 @@ pub struct SnapshotStats {
 
 impl SnapshotManager {
     /// Create a new snapshot manager
-    pub fn new(base_dir: PathBuf) -> Result<Self> {
-        debug!("Creating snapshot manager at {:?}", base_dir);
+    pub fn new(base_dir: String, filesystem: Arc<dyn FileSystem>) -> Result<Self> {
+        debug!("Creating snapshot manager at {}", base_dir);
 
-        // Create snapshot directory
-        std::fs::create_dir_all(&base_dir).map_err(|e| {
-            ProximaDBError::Internal(format!("Failed to create snapshot dir: {}", e))
-        })?;
+        // Only local bases get a directory; object-store bases (s3://,
+        // adls://, …) are flat keyspaces and must never reach std::fs.
+        if !base_dir.contains("://") {
+            std::fs::create_dir_all(&base_dir).map_err(|e| {
+                ProximaDBError::Internal(format!("Failed to create snapshot dir: {}", e))
+            })?;
+        }
 
         Ok(Self {
             base_dir,
+            filesystem,
             snapshots: Arc::new(RwLock::new(HashMap::new())),
             stats: Arc::new(RwLock::new(SnapshotStats::default())),
         })
@@ -137,15 +146,16 @@ impl SnapshotManager {
 
         let size_bytes = serialized.len();
 
-        // Create entity directory if it doesn't exist
-        if let Some(entity_dir) = snapshot_path.parent() {
-            tokio::fs::create_dir_all(entity_dir).await.map_err(|e| {
-                ProximaDBError::Internal(format!("Failed to create entity dir: {}", e))
-            })?;
-        }
-
-        // Write snapshot file
-        tokio::fs::write(&snapshot_path, serialized)
+        // Write through the injected filesystem; `create_dirs` covers the
+        // entity subdirectory on local bases and is a no-op on flat
+        // object-store keyspaces.
+        let options = FileOptions {
+            create_dirs: true,
+            overwrite: true,
+            ..Default::default()
+        };
+        self.filesystem
+            .write(&snapshot_path, &serialized, Some(options))
             .await
             .map_err(|e| ProximaDBError::Internal(format!("Failed to write snapshot: {}", e)))?;
 
@@ -216,8 +226,10 @@ impl SnapshotManager {
                 })?
         };
 
-        // Read snapshot file
-        let data = tokio::fs::read(&snapshot_path)
+        // Read snapshot file through the injected filesystem
+        let data = self
+            .filesystem
+            .read(&snapshot_path)
             .await
             .map_err(|e| ProximaDBError::Internal(format!("Failed to read snapshot: {}", e)))?;
 
@@ -306,14 +318,15 @@ impl SnapshotManager {
             let original_count = entity_snapshots.len();
 
             if entity_snapshots.len() > keep_latest {
-                // Sort by sequence descending and keep latest N
+                // Sort by sequence descending, split off the stale tail
+                // BEFORE truncating (truncating first left the tail slice
+                // empty, so the stale files were never actually deleted).
                 entity_snapshots.sort_by_key(|s| std::cmp::Reverse(s.sequence));
-                entity_snapshots.truncate(keep_latest);
+                let to_delete = entity_snapshots.split_off(keep_latest);
 
-                // Delete files for removed snapshots
-                let to_delete = &entity_snapshots[keep_latest..];
-                for snapshot in to_delete {
-                    let _ = tokio::fs::remove_file(&snapshot.file_path).await;
+                // Delete files for removed snapshots via the filesystem
+                for snapshot in &to_delete {
+                    let _ = self.filesystem.delete(&snapshot.file_path).await;
                 }
 
                 let deleted = original_count - keep_latest;
@@ -330,13 +343,17 @@ impl SnapshotManager {
         self.stats.read().await.clone()
     }
 
-    /// Get storage path for a snapshot
-    fn get_snapshot_path(&self, entity_id: &EntityId, sequence: EventSequence) -> PathBuf {
+    /// Get storage path for a snapshot. String-joined (never
+    /// `PathBuf::join`) so an object-store base URL survives verbatim.
+    fn get_snapshot_path(&self, entity_id: &EntityId, sequence: EventSequence) -> String {
         // Sanitize entity_id for filesystem
         let safe_id = entity_id.replace(':', "_");
-        self.base_dir
-            .join(format!("entity_{}", safe_id))
-            .join(format!("snapshot_{:010}.json", sequence))
+        format!(
+            "{}/entity_{}/snapshot_{:010}.json",
+            self.base_dir.trim_end_matches('/'),
+            safe_id,
+            sequence
+        )
     }
 }
 
@@ -344,18 +361,40 @@ impl SnapshotManager {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_snapshot_manager_creation() {
-        let base_dir = PathBuf::from("/tmp/test_snapshot_manager");
-        let manager = SnapshotManager::new(base_dir.clone())
+    async fn local_fs() -> Arc<dyn FileSystem> {
+        let fs = crate::storage::persistence::filesystem::local::LocalFileSystem::new(
+            crate::storage::persistence::filesystem::local::LocalConfig::default(),
+        )
+        .await
+        .expect("local fs");
+        Arc::new(fs)
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_manager_creation() {
+        let base_dir = "/tmp/test_snapshot_manager".to_string();
+        let manager = SnapshotManager::new(base_dir.clone(), local_fs().await)
             .expect("Failed to create snapshot manager for test");
         assert_eq!(manager.base_dir, base_dir);
     }
 
     #[tokio::test]
+    async fn test_snapshot_manager_object_store_url_skips_local_mkdir() {
+        // Object-store bases must never reach std::fs (TD-OBJSTORE-1, #960).
+        let manager =
+            SnapshotManager::new("s3://bucket/data/auditlog".to_string(), local_fs().await)
+                .expect("Failed to create snapshot manager for object-store base");
+        assert_eq!(
+            manager.get_snapshot_path(&"entity:x".to_string(), 7),
+            "s3://bucket/data/auditlog/entity_entity_x/snapshot_0000000007.json"
+        );
+        assert!(!std::path::Path::new("s3:").exists());
+    }
+
+    #[tokio::test]
     async fn test_create_snapshot() {
-        let base_dir = PathBuf::from("/tmp/test_create_snapshot");
-        let manager = SnapshotManager::new(base_dir.clone())
+        let base_dir = "/tmp/test_create_snapshot".to_string();
+        let manager = SnapshotManager::new(base_dir.clone(), local_fs().await)
             .expect("Failed to create snapshot manager for test");
 
         let metadata = manager
@@ -365,7 +404,7 @@ mod tests {
 
         assert_eq!(metadata.entity_id, "entity:test");
         assert_eq!(metadata.sequence, 100);
-        assert!(metadata.file_path.exists());
+        assert!(std::path::Path::new(&metadata.file_path).exists());
 
         // Cleanup
         let _ = std::fs::remove_dir_all(base_dir);
@@ -373,8 +412,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_snapshot() {
-        let base_dir = PathBuf::from("/tmp/test_load_snapshot");
-        let manager = SnapshotManager::new(base_dir.clone())
+        let base_dir = "/tmp/test_load_snapshot".to_string();
+        let manager = SnapshotManager::new(base_dir.clone(), local_fs().await)
             .expect("Failed to create snapshot manager for test");
 
         // Create snapshot
@@ -397,8 +436,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_old_snapshots() {
-        let base_dir = PathBuf::from("/tmp/test_cleanup_snapshots");
-        let manager = SnapshotManager::new(base_dir.clone())
+        let base_dir = "/tmp/test_cleanup_snapshots".to_string();
+        let manager = SnapshotManager::new(base_dir.clone(), local_fs().await)
             .expect("Failed to create snapshot manager for test");
 
         // Create multiple snapshots

--- a/src/storage/engines/eventlog/temporal.rs
+++ b/src/storage/engines/eventlog/temporal.rs
@@ -282,17 +282,26 @@ impl TemporalQueryEngine {
 mod tests {
     use super::*;
     use crate::storage::engines::eventlog::{Event, EventLogConfig};
+    use crate::storage::persistence::filesystem::FileSystem;
     use std::collections::HashMap;
-    use std::path::PathBuf;
+
+    async fn local_fs() -> Arc<dyn FileSystem> {
+        let fs = crate::storage::persistence::filesystem::local::LocalFileSystem::new(
+            crate::storage::persistence::filesystem::local::LocalConfig::default(),
+        )
+        .await
+        .expect("local fs");
+        Arc::new(fs)
+    }
 
     #[tokio::test]
     async fn test_temporal_engine_creation() {
-        let base_dir = PathBuf::from("/tmp/test_temporal_engine");
+        let base_dir = String::from("/tmp/test_temporal_engine");
         let event_index = Arc::new(
             EventIndex::new(base_dir.clone()).expect("Failed to create event index for test"),
         );
         let snapshot_manager = Arc::new(
-            SnapshotManager::new(base_dir.clone())
+            SnapshotManager::new(base_dir.clone(), local_fs().await)
                 .expect("Failed to create snapshot manager for test"),
         );
         let config = EventLogConfig::default();
@@ -304,12 +313,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_entity_exists_at() {
-        let base_dir = PathBuf::from("/tmp/test_entity_exists");
+        let base_dir = String::from("/tmp/test_entity_exists");
         let event_index = Arc::new(
             EventIndex::new(base_dir.clone()).expect("Failed to create event index for test"),
         );
         let snapshot_manager = Arc::new(
-            SnapshotManager::new(base_dir.clone())
+            SnapshotManager::new(base_dir.clone(), local_fs().await)
                 .expect("Failed to create snapshot manager for test"),
         );
         let config = EventLogConfig::default();

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -505,7 +505,11 @@ impl UnifiedWALWriter {
         }
 
         Ok(Self {
-            base_path,
+            // Store the SCHEME-QUALIFIED url, never the bare path: every
+            // segment path is joined from this, and no site below may
+            // re-prepend `file://` — on an object-store base that yields
+            // invalid `file://s3://…` URLs (TD-OBJSTORE-1, #960).
+            base_path: base_url,
             sequence_number: std::sync::atomic::AtomicU64::new(max_seq),
             filesystem,
             current_segment_path: None,
@@ -585,17 +589,39 @@ impl UnifiedWALWriter {
         if let Some(ref path) = self.current_segment_path
             && !self.current_segment_data.is_empty()
         {
-            let url = format!("file://{}", path);
+            // `path` is already scheme-qualified (joined from the normalized
+            // base_path by `open_new_segment`).
+            let url = path.clone();
             let fs = self.filesystem.get_filesystem(&url)?;
 
-            // WAL segments are append-only. Avoid read-modify-write here:
-            // cached reads can lag behind recent writes, and rewriting the
-            // segment risks dropping entries that were already durable.
-            fs.append(&url, &self.current_segment_data).await?;
-            fs.sync_file(&url).await?;
+            if self.base_path.starts_with("file://") {
+                // Local: WAL segments are append-only. Avoid
+                // read-modify-write here: cached reads can lag behind recent
+                // writes, and rewriting the segment risks dropping entries
+                // that were already durable.
+                fs.append(&url, &self.current_segment_data).await?;
+                fs.sync_file(&url).await?;
 
-            // Clear buffer after successful write
-            self.current_segment_data.clear();
+                // Clear buffer after successful write
+                self.current_segment_data.clear();
+            } else {
+                // Object store (s3://, adls://, …): block/immutable blobs
+                // reject append, so the buffer holds the WHOLE segment
+                // (bounded by max_segment_size and cleared on rotation) and
+                // each flush overwrites the segment object with the full
+                // contents. The byte layout is identical to the appended
+                // local segment, so recovery reads both the same way
+                // (TD-OBJSTORE-1, #960).
+                let options = crate::storage::persistence::filesystem::FileOptions {
+                    create_dirs: true,
+                    overwrite: true,
+                    ..Default::default()
+                };
+                fs.write(&url, &self.current_segment_data, Some(options))
+                    .await?;
+                // Buffer intentionally NOT cleared: it is the durable
+                // segment image until rotation.
+            }
         }
         Ok(())
     }
@@ -606,8 +632,9 @@ impl UnifiedWALWriter {
         self.current_segment_path = Some(filename.clone());
         self.current_segment_data.clear();
 
-        // Ensure the file exists
-        let url = format!("file://{}", filename);
+        // Ensure the file exists. `filename` is already scheme-qualified
+        // (base_path is normalized in `new`).
+        let url = filename;
         let fs = self.filesystem.get_filesystem(&url)?;
         if !fs.exists(&url).await? {
             // Create empty file
@@ -699,7 +726,7 @@ impl UnifiedWALWriter {
         // first. The marker's segment and everything above it are kept.
         let mut reclaimed = 0u64;
         for seg in indices.into_iter().filter(|&s| s < marker_segment) {
-            let url = format!("file://{}/wal_{:08}.log", self.base_path, seg);
+            let url = format!("{}/wal_{:08}.log", base_url, seg);
             fs.delete(&url).await?;
             reclaimed += 1;
             tracing::debug!(segment = seg, lsn, "TD-066 (d): reclaimed WAL segment");
@@ -732,16 +759,25 @@ impl UnifiedWALReader {
                 .map_err(|e| anyhow::anyhow!("Failed to create filesystem: {}", e))?,
         );
 
+        // Normalize to a scheme-qualified url once, mirroring the writer:
+        // object-store bases (s3://, adls://, …) pass through untouched
+        // (TD-OBJSTORE-1, #960).
+        let base_url = if base_path.contains("://") {
+            base_path
+        } else {
+            format!("file://{}", base_path)
+        };
+
         Ok(Self {
-            base_path,
+            base_path: base_url,
             filesystem,
         })
     }
 
     /// Read all WAL entries from a segment
     pub async fn read_segment(&self, segment_number: u32) -> anyhow::Result<Vec<UnifiedWALEntry>> {
-        let filename = format!("{}/wal_{:08}.log", self.base_path, segment_number);
-        let url = format!("file://{}", filename);
+        // base_path is scheme-qualified (normalized in `new`).
+        let url = format!("{}/wal_{:08}.log", self.base_path, segment_number);
         let fs = self.filesystem.get_filesystem(&url)?;
 
         if !fs.exists(&url).await? {

--- a/tests/eventlog_integration_test.rs
+++ b/tests/eventlog_integration_test.rs
@@ -25,13 +25,12 @@ use proximadb::storage::persistence::filesystem::{
     UnifiedCachingFilesystem, local::LocalFileSystem,
 };
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Test basic event append and read
 #[tokio::test]
 async fn test_eventlog_append_and_read() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_append_read");
+    let base_dir = String::from("/tmp/test_eventlog_append_read");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -102,7 +101,7 @@ async fn test_eventlog_append_and_read() {
 /// Test immutable audit trail
 #[tokio::test]
 async fn test_eventlog_immutable_audit_trail() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_immutable");
+    let base_dir = String::from("/tmp/test_eventlog_immutable");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -179,7 +178,7 @@ async fn test_eventlog_immutable_audit_trail() {
 /// Test MiFID II regulatory compliance
 #[tokio::test]
 async fn test_eventlog_mifid2_compliance() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_mifid2");
+    let base_dir = String::from("/tmp/test_eventlog_mifid2");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -250,7 +249,7 @@ async fn test_eventlog_mifid2_compliance() {
 /// Test temporal queries - point-in-time reconstruction
 #[tokio::test]
 async fn test_eventlog_temporal_queries() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_temporal");
+    let base_dir = String::from("/tmp/test_eventlog_temporal");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -355,7 +354,7 @@ async fn test_eventlog_temporal_queries() {
 /// Test snapshot creation and loading
 #[tokio::test]
 async fn test_eventlog_snapshots() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_snapshots");
+    let base_dir = String::from("/tmp/test_eventlog_snapshots");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -407,7 +406,7 @@ async fn test_eventlog_snapshots() {
 /// Test event replay
 #[tokio::test]
 async fn test_eventlog_replay() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_replay");
+    let base_dir = String::from("/tmp/test_eventlog_replay");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {
@@ -483,7 +482,7 @@ async fn test_eventlog_replay() {
 /// Test high-volume event ingestion (simulating ibkrtrading 119MB/day)
 #[tokio::test]
 async fn test_eventlog_high_volume_ingestion() {
-    let base_dir = PathBuf::from("/tmp/test_eventlog_volume");
+    let base_dir = String::from("/tmp/test_eventlog_volume");
     std::fs::create_dir_all(&base_dir).expect("Failed to create test directory");
 
     let config = EventLogConfig {

--- a/tests/objstore_url_construction_test.rs
+++ b/tests/objstore_url_construction_test.rs
@@ -1,0 +1,208 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-OBJSTORE-1 (#960): object-store durability — URL construction guards.
+//!
+//! The bug class: `metadata_url.replace("file://", "")` followed by
+//! re-prepending a scheme (`format!("file://{}…")` / `PathBuf::from`)
+//! produced invalid `file://adls://…` URLs, and several subsystems drove
+//! `std::fs`/`tokio::fs` at object-store URLs. These tests pin the fixed
+//! behavior:
+//!
+//! 1. The unified WAL writer/reader normalize their base to ONE
+//!    scheme-qualified URL and never double-prefix — proven by a full
+//!    write→flush→recover round-trip over a scheme-qualified base (the
+//!    exact code path an `adls://`/`s3://` base takes, minus the network).
+//! 2. The eventlog engine accepts a scheme-qualified base without touching
+//!    the local filesystem for directory creation.
+//! 3. Audit storage dispatches by scheme and fail-fasts on mismatches.
+//! 4. A source-level guard: the `.replace("file://"` strip-and-re-prepend
+//!    pattern must never reappear in `src/`.
+
+use proximadb::storage::persistence::write_ahead_log::wal_operations::{
+    ObservabilityOperation, UnifiedWALOperation, UnifiedWALReader, UnifiedWALWriter,
+};
+
+fn obs_op(name: &str) -> UnifiedWALOperation {
+    UnifiedWALOperation::ObservabilityOp(ObservabilityOperation::CreateNamespace {
+        namespace: name.to_string(),
+        config_json: "{}".to_string(),
+    })
+}
+
+/// A scheme-qualified WAL base must round-trip write→flush→recover without
+/// constructing any `file://file://…` (double-scheme) segment URL. This is
+/// the same normalized-URL code path an object-store base exercises.
+#[tokio::test]
+async fn wal_round_trips_over_scheme_qualified_base() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let base = format!("file://{}", dir.path().display());
+
+    let mut writer = UnifiedWALWriter::new(base.clone()).await.expect("writer");
+    writer.append(obs_op("ns-a")).await.expect("append a");
+    writer.append(obs_op("ns-b")).await.expect("append b");
+    writer.flush().await.expect("flush");
+
+    // Segments must land under the LOCAL directory (no literal `file:` dir
+    // beside it — the signature of a double-prefixed URL).
+    let seg = dir.path().join("wal_00000000.log");
+    assert!(
+        seg.exists(),
+        "expected WAL segment at {} — segment URL was mis-joined",
+        seg.display()
+    );
+    assert!(
+        !dir.path().join("file:").exists(),
+        "double-scheme URL constructed: found literal `file:` directory"
+    );
+
+    let reader = UnifiedWALReader::new(base).await.expect("reader");
+    let entries = reader.read_all().await.expect("read_all");
+    assert_eq!(entries.len(), 2, "both WAL entries must recover");
+}
+
+/// A BARE local path base must keep working exactly as before (the writer
+/// normalizes it to `file://…` internally).
+#[tokio::test]
+async fn wal_round_trips_over_bare_local_base() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let base = dir.path().display().to_string();
+
+    let mut writer = UnifiedWALWriter::new(base.clone()).await.expect("writer");
+    writer.append(obs_op("ns-bare")).await.expect("append");
+    writer.flush().await.expect("flush");
+
+    let reader = UnifiedWALReader::new(base).await.expect("reader");
+    let entries = reader.read_all().await.expect("read_all");
+    assert_eq!(entries.len(), 1);
+}
+
+/// The eventlog engine (audit trail) must accept a scheme-qualified base and
+/// route persistence through its injected filesystem — full append→read over
+/// a `file://` URL base, with no stray literal scheme directories.
+#[tokio::test]
+async fn eventlog_engine_over_scheme_qualified_base() {
+    use proximadb::storage::engines::eventlog::{Event, EventLogConfig, EventLogEngine};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let base = format!("file://{}", dir.path().display());
+
+    let local = proximadb::storage::persistence::filesystem::local::LocalFileSystem::new(
+        proximadb::storage::persistence::filesystem::local::LocalConfig::default(),
+    )
+    .await
+    .expect("local fs");
+    let fs = Arc::new(
+        proximadb::storage::persistence::filesystem::UnifiedCachingFilesystem::new(
+            Arc::new(local),
+            "objstore_url_test".to_string(),
+            "eventlog".to_string(),
+        ),
+    );
+
+    let config = EventLogConfig {
+        base_dir: base,
+        ..Default::default()
+    };
+    let engine = EventLogEngine::new(config, fs).expect("engine over URL base");
+
+    let event = Event {
+        sequence: 0,
+        entity_id: "tenant:acme".to_string(),
+        event_type: "CollectionCreated".to_string(),
+        data: serde_json::json!({"name": "docs"}),
+        timestamp: chrono::Utc::now(),
+        causation_id: None,
+        metadata: std::collections::HashMap::new(),
+    };
+    let appended = engine.append_event(event).await.expect("append");
+
+    let events = engine
+        .read_events(&"tenant:acme".to_string(), 0, 10)
+        .await
+        .expect("read");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].sequence, appended.sequence);
+    assert!(
+        !dir.path().join("file:").exists(),
+        "eventlog constructed a double-scheme path"
+    );
+}
+
+/// Audit storage dispatch: the local backend rejects object-store URLs
+/// fail-fast; the object-store backend rejects bare paths fail-fast; and the
+/// object-store backend round-trips over a factory-routed `file://` URL.
+#[tokio::test]
+async fn audit_storage_scheme_dispatch() {
+    use proximadb::audit::storage::{FileAuditStorage, ObjectStoreAuditStorage};
+
+    let err = FileAuditStorage::new("adls://container/data/audit".to_string())
+        .await
+        .err()
+        .expect("FileAuditStorage must reject object-store URLs");
+    assert!(err.to_string().contains("ObjectStoreAuditStorage"));
+
+    let err = ObjectStoreAuditStorage::new("/tmp/not-a-url".to_string())
+        .await
+        .err()
+        .expect("ObjectStoreAuditStorage must reject bare paths");
+    assert!(err.to_string().contains("scheme-qualified"));
+
+    // Factory-routed round-trip (file:// exercises the same
+    // get_filesystem → write/list/read path as adls:///s3://).
+    use proximadb_security::AuditStorage as _;
+    use proximadb_security::{AuditEvent, AuditEventType, AuditResource, AuditResult};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = ObjectStoreAuditStorage::new(format!("file://{}", dir.path().display()))
+        .await
+        .expect("object-store audit storage over file:// URL");
+
+    let event = AuditEvent::new(
+        AuditEventType::Authentication,
+        AuditResource::new("collection".to_string(), "docs".to_string()),
+        "login".to_string(),
+        AuditResult::Success,
+    );
+    store.store_audit_event(&event).await.expect("store");
+
+    let events = store
+        .query_events(None, None, None, None, None)
+        .await
+        .expect("query");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_id, event.event_id);
+}
+
+/// Source guard: the strip-and-re-prepend pattern (`.replace("file://"`)
+/// that produced `file://adls://…` URLs must not reappear anywhere in `src/`.
+#[test]
+fn no_strip_and_reprepend_pattern_in_src() {
+    fn scan(dir: &std::path::Path, offenders: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                scan(&path, offenders);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs")
+                && let Ok(content) = std::fs::read_to_string(&path)
+                && content.contains(".replace(\"file://\"")
+            {
+                offenders.push(path.display().to_string());
+            }
+        }
+    }
+
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    scan(&src, &mut offenders);
+    assert!(
+        offenders.is_empty(),
+        "`.replace(\"file://\"` (strip-and-re-prepend, TD-OBJSTORE-1 #960) found in: {:?} — \
+         use a scheme-preserving join (see shared_services::join_storage_url) instead",
+        offenders
+    );
+}


### PR DESCRIPTION
## Summary

anvaiops' ADR-0028 object-store deployment (`storage.metadata_url = adls://…`, VM managed identity) failed at runtime; a full code audit found the complete bug class. This PR fixes it all in one batch so a single CI cycle + image publish carries every fix. Tracking doc: `docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc` (full failure inventory with root causes + status). Refs #960.

**Also folds #932** (explicit `path` on the three cdc `[[test]]` targets) — the develop `publish-image.yml` is blocked on it (Docker context copies no `tests/`, rust:1.95 cargo hard-errors at manifest parse). Folding avoids a second full CI runner cycle for a 3-line change; #932 can be closed as superseded when this merges.

## The bug class

1. **Strip-and-re-prepend**: `metadata_url.replace("file://", "")` then `format!("file://{}…")` / `PathBuf::from(url)` → invalid `file://adls://…` URLs or literal local `adls:` directories. **Six** sites in `shared_services.rs` (the audit found 4; observability WAL base and the multimodel observability store were the same pattern).
2. **Local-fs escapes on config-derived durable paths**: eventlog engine + SnapshotManager, audit storage, delta catalog.
3. **Found while fixing (would have broken adls even with correct URLs):**
   - `UnifiedWALWriter/Reader` hardcoded `file://` on every segment path (4 sites) — now normalizes the base to one scheme-qualified URL in `new()`.
   - Object-store backends **reject `FileSystem::append`** — WAL flush now full-segment-overwrites on non-`file://` bases (identical byte layout; recovery unchanged; buffer bounded by `max_segment_size`).
   - `FileAuditStorage` **truncated its log on every event** (`tokio::fs::write`) — latent audit data loss, now appends.
   - Eventlog snapshot cleanup never deleted files (truncate-before-slice).
   - Delta catalog scheme allowlist missed `adls://`/`azure://`/`gcs://` → literal `adls:` dir.

## What's deferred (documented in the TD, loud warns at runtime)

- **Timeseries (TST)** is local-`PathBuf`-native → local non-durable fallback + `warn!` on object-store bases.
- **Delta catalog metadata** stages in a local temp cache for cloud URLs (pre-existing; now warned).
- RAPTOR/SWIFT (experimental, default-OFF) and `queue_fs_adapter` still use `append`.
- Alerting persistence object-store port impl (currently unwired; constructor now fail-fasts on URLs).

## Verification

- `cargo check --all-targets`, `cargo clippy --lib --bins -- -D warnings`, `cargo fmt --check`, `make work-commit-check`, `check_td_adr_unique.py` all green locally.
- 107 affected tests pass (nextest), including new:
  - WAL write→flush→recover round-trip over a scheme-qualified base + bare-path back-compat,
  - eventlog append→read over a URL base (no literal scheme dirs),
  - audit scheme dispatch + factory-routed round-trip,
  - `join_storage_url` matrix (bare/file/s3/adls/abfs/gcs × sub — **no double scheme, ever**),
  - source guard failing the build if `.replace("file://"` reappears in `src/`.
- `abfs://` is confirmed registered as a first-class alias (with `adls`/`az`/`azure`) to the same flat Blob backend per ADR-036.

## After merge

develop image publish (`publish-image.yml`, runtime-full) → anvaiops pins the `sha-…-full` digest and runs modality tests over adls; failures feed the next TD-OBJSTORE-1 cycle.