### PR TITLE
feat(storage): per-collection compaction override via tag cascade (ADR-061 D5, TD-WLP-2)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/compaction_override.rs
+++ b/crates/storage/proximadb-storage-common/src/compaction_override.rs
@@ -1,0 +1,187 @@
+//! Per-collection compaction override (ADR-061 D5, TD-WLP-2).
+//!
+//! Compaction re-clusters (it re-runs `write_pax_segment_full`), but the
+//! trigger has been global and default-OFF (`PROXIMADB_L0_COMPACTION_ENABLED`),
+//! so no collection ever re-clusters. This module lets a collection **arm**
+//! compaction per-collection through the same tag cascade as
+//! [`crate::storage_profile::resolve_storage_profile`], while the global env
+//! stays the master kill-switch:
+//!
+//! * env explicitly falsy (`0`/`false`/`off`/`no`) → **hard disable**: no
+//!   per-collection opt-in can arm (the master kill-switch).
+//! * `compaction:on|off` tag (last matching wins) → explicit per-collection
+//!   operator intent decides.
+//! * no tag → the global env governs: truthy → armed (today's opt-in
+//!   behaviour), unset/unrecognized → OFF (today's default).
+//!
+//! Default path unchanged (mixed-read-safe): an untagged collection behaves
+//! byte-for-byte as before for every env state.
+
+/// Tag prefix for the per-collection compaction arm/disarm override on
+/// `CollectionConfig.tags`. Values: `on`/`true`/`1`/`yes`, `off`/`false`/`0`/`no`.
+pub const COMPACTION_TAG_PREFIX: &str = "compaction:";
+
+/// Tag prefix for the per-collection L0 segment-count compaction threshold.
+/// Value: a positive integer (`l0_threshold:2`). Invalid values keep the prior
+/// resolution (parity with the other tag parsers).
+pub const COMPACTION_L0_THRESHOLD_TAG_PREFIX: &str = "l0_threshold:";
+
+/// Global compaction gate env (TD-114). Truthy arms every collection; an
+/// explicitly falsy value is the master kill-switch (TD-WLP-2); unset defers
+/// to the per-collection tag (default OFF).
+pub const L0_COMPACTION_ENABLED_ENV: &str = "PROXIMADB_L0_COMPACTION_ENABLED";
+
+/// Tri-state reading of [`L0_COMPACTION_ENABLED_ENV`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalCompactionGate {
+    /// Env truthy: compaction armed for every collection (legacy opt-in).
+    Armed,
+    /// Env unset or unrecognized: per-collection tags may arm (default OFF).
+    Default,
+    /// Env explicitly falsy: master kill-switch — nothing may arm.
+    HardDisabled,
+}
+
+/// Read the tri-state global compaction gate from the env.
+pub fn global_compaction_gate() -> GlobalCompactionGate {
+    match std::env::var(L0_COMPACTION_ENABLED_ENV)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "1" | "true" | "on" | "yes" => GlobalCompactionGate::Armed,
+        "0" | "false" | "off" | "no" => GlobalCompactionGate::HardDisabled,
+        _ => GlobalCompactionGate::Default,
+    }
+}
+
+/// Resolve whether compaction is armed for a collection with `tags`.
+///
+/// Precedence: global hard-disable > `compaction:on|off` tag (last matching
+/// wins) > global env truthy > default OFF.
+pub fn resolve_compaction_armed(tags: &[String]) -> bool {
+    match global_compaction_gate() {
+        GlobalCompactionGate::HardDisabled => false,
+        gate => compaction_tag(tags).unwrap_or(gate == GlobalCompactionGate::Armed),
+    }
+}
+
+/// Read the per-collection `compaction:on|off` tag (last matching wins; an
+/// unrecognized value keeps the prior resolution). Absent → `None` (defer to
+/// the global gate). Mirrors `pax_vector_format_tag`.
+fn compaction_tag(tags: &[String]) -> Option<bool> {
+    let mut latest: Option<bool> = None;
+    for tag in tags {
+        if let Some(rest) = tag.strip_prefix(COMPACTION_TAG_PREFIX) {
+            latest = match rest.trim().to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" | "yes" => Some(true),
+                "off" | "false" | "0" | "no" => Some(false),
+                _ => latest, // unrecognized value: keep prior resolution
+            };
+        }
+    }
+    latest
+}
+
+/// Resolve the effective L0 compaction threshold for a collection with `tags`:
+/// the last valid positive `l0_threshold:N` tag wins; absent/invalid →
+/// `default_threshold`.
+pub fn resolve_l0_threshold(tags: &[String], default_threshold: usize) -> usize {
+    let mut latest = default_threshold;
+    for tag in tags {
+        if let Some(rest) = tag.strip_prefix(COMPACTION_L0_THRESHOLD_TAG_PREFIX) {
+            match rest.trim().parse::<usize>() {
+                Ok(n) if n >= 1 => latest = n,
+                // invalid / non-positive value: keep prior resolution
+                _ => {}
+            }
+        }
+    }
+    latest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// TD-WLP-2 cascade: hard-disable > tag (last wins) > global env > OFF.
+    #[test]
+    fn test_resolve_compaction_armed_tag_env_default_cascade() {
+        unsafe {
+            std::env::remove_var(L0_COMPACTION_ENABLED_ENV);
+        }
+        // default OFF (today's behaviour)
+        assert!(!resolve_compaction_armed(&[]));
+        assert_eq!(global_compaction_gate(), GlobalCompactionGate::Default);
+        // per-collection opt-in arms while the global gate is unset
+        assert!(resolve_compaction_armed(&tags(&["compaction:on"])));
+        // explicit opt-out stays off
+        assert!(!resolve_compaction_armed(&tags(&["compaction:off"])));
+        // last matching tag wins
+        assert!(resolve_compaction_armed(&tags(&[
+            "compaction:off",
+            "compaction:on"
+        ])));
+        // unrecognized value keeps the prior resolution
+        assert!(resolve_compaction_armed(&tags(&[
+            "compaction:on",
+            "compaction:sideways"
+        ])));
+        // unrelated tags are ignored
+        assert!(!resolve_compaction_armed(&tags(&[
+            "workload_profile:append"
+        ])));
+        // global truthy arms untagged collections (legacy behaviour)...
+        unsafe {
+            std::env::set_var(L0_COMPACTION_ENABLED_ENV, "1");
+        }
+        assert_eq!(global_compaction_gate(), GlobalCompactionGate::Armed);
+        assert!(resolve_compaction_armed(&[]));
+        // ...but an explicit per-collection opt-out still wins
+        assert!(!resolve_compaction_armed(&tags(&["compaction:off"])));
+        // global hard-disable is the master kill-switch: opt-in cannot arm
+        unsafe {
+            std::env::set_var(L0_COMPACTION_ENABLED_ENV, "0");
+        }
+        assert_eq!(global_compaction_gate(), GlobalCompactionGate::HardDisabled);
+        assert!(!resolve_compaction_armed(&tags(&["compaction:on"])));
+        assert!(!resolve_compaction_armed(&[]));
+        unsafe {
+            std::env::set_var(L0_COMPACTION_ENABLED_ENV, "false");
+        }
+        assert!(!resolve_compaction_armed(&tags(&["compaction:on"])));
+        unsafe {
+            std::env::remove_var(L0_COMPACTION_ENABLED_ENV);
+        }
+    }
+
+    /// TD-WLP-2: per-collection L0 threshold tag (last valid wins; invalid or
+    /// non-positive values keep the prior resolution).
+    #[test]
+    fn test_resolve_l0_threshold_tag_overrides_default() {
+        assert_eq!(resolve_l0_threshold(&[], 5), 5);
+        assert_eq!(resolve_l0_threshold(&tags(&["l0_threshold:2"]), 5), 2);
+        // last valid wins
+        assert_eq!(
+            resolve_l0_threshold(&tags(&["l0_threshold:2", "l0_threshold:7"]), 5),
+            7
+        );
+        // invalid / non-positive keep the prior resolution
+        assert_eq!(
+            resolve_l0_threshold(&tags(&["l0_threshold:2", "l0_threshold:zero"]), 5),
+            2
+        );
+        assert_eq!(resolve_l0_threshold(&tags(&["l0_threshold:0"]), 5), 5);
+        assert_eq!(resolve_l0_threshold(&tags(&["l0_threshold:-3"]), 5), 5);
+        // unrelated tags are ignored
+        assert_eq!(
+            resolve_l0_threshold(&tags(&["workload_profile:append"]), 5),
+            5
+        );
+    }
+}

--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cache_config;
 pub mod collection_path;
 pub mod column_projector;
 pub mod columnar_constants;
+pub mod compaction_override;
 pub mod deletion_vector;
 pub mod delta_simd;
 pub mod engine_constants;
@@ -82,6 +83,11 @@ pub use columnar_constants::{
     FIELD_SOURCE, FIELD_TIMESTAMP, FIELD_UPDATED_AT, FIELD_VECTOR_FP32, FIELD_VERSION,
     PARQUET_EXTENSION, QUANTIZATION_COLUMNS, QUANTIZATION_PARAMETER_COLUMNS,
     QUANTIZED_VECTOR_COLUMNS, REQUIRED_COLUMNS, TEMPORAL_COLUMNS, VIPER_FILE_EXTENSION,
+};
+pub use compaction_override::{
+    COMPACTION_L0_THRESHOLD_TAG_PREFIX, COMPACTION_TAG_PREFIX, GlobalCompactionGate,
+    L0_COMPACTION_ENABLED_ENV, global_compaction_gate, resolve_compaction_armed,
+    resolve_l0_threshold,
 };
 pub use delta_simd::{delta_decode_f32, delta_decode_i32_prefix_sum, delta_decode_i64_prefix_sum};
 pub use engine_constants::{

--- a/docs/10-quality/td/TD-WLP-2-per-collection-compaction-override.adoc
+++ b/docs/10-quality/td/TD-WLP-2-per-collection-compaction-override.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — spec filed 2026-07-14 (ADR-061). Not started. Depends on TD-WLP-1.
+| Status | Implemented 2026-07-14 — cascade in `crates/storage/proximadb-storage-common/src/compaction_override.rs` (tri-state global gate: truthy=armed-for-all, explicitly-falsy=master hard-disable, unset=per-collection `compaction:on\|off` tag decides, default OFF); wired into `should_trigger_compaction` (SST flush) with per-collection `l0_threshold:N`, plus `OrchestratorCompactionConfig::effective_for_collection_tags`. TDD gates green: `tests/storage_wlp_compaction_gate.rs` (`test_append_collection_arms_compaction_while_global_off`, `test_global_hard_disable_wins_over_collection_opt_in`) + unit cascade tests. Untagged path byte-for-byte unchanged.
 | Priority | P1 — arms the (dark) compaction re-cluster path per-collection; prerequisite for TD-WLP-4.
 | Severity | Medium — touches the compaction trigger; must preserve the global kill-switch.
 | Component | `src/storage/engines/sst/flush/mod.rs` (`should_trigger_compaction`, `l0_compaction_enabled`, ~595–617); `src/storage/common/compaction_orchestrator.rs` (`OrchestratorCompactionConfig`, ~135–170)

--- a/src/storage/common/compaction_orchestrator.rs
+++ b/src/storage/common/compaction_orchestrator.rs
@@ -153,6 +153,23 @@ pub struct OrchestratorCompactionConfig {
     pub urgency_threshold: f64,
 }
 
+impl OrchestratorCompactionConfig {
+    /// Per-collection resolution (TD-WLP-2 / ADR-061 D5): apply the
+    /// collection's `l0_threshold:N` tag override on top of this config,
+    /// mirroring how `WALConfig::effective_config_for_collection` makes flush
+    /// thresholds per-collection. Absent/invalid tags leave the config
+    /// unchanged.
+    pub fn effective_for_collection_tags(&self, tags: &[String]) -> Self {
+        Self {
+            level0_threshold: proximadb_storage_common::resolve_l0_threshold(
+                tags,
+                self.level0_threshold,
+            ),
+            ..self.clone()
+        }
+    }
+}
+
 impl Default for OrchestratorCompactionConfig {
     fn default() -> Self {
         Self {

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -543,8 +543,17 @@ impl SstEngine {
 
         let final_file_path = format!("{}/{}", atomic_op.final_url, filename);
 
-        // Check if compaction should be triggered
-        let should_trigger_compaction = self.should_trigger_compaction(storage_url).await?;
+        // Check if compaction should be triggered (per-collection tag cascade,
+        // TD-WLP-2 — the global env stays the master kill-switch).
+        let collection_tags: &[String] = params
+            .collection_config
+            .as_ref()
+            .and_then(|c| c.config.as_ref())
+            .map(|cfg| cfg.tags.as_slice())
+            .unwrap_or(&[]);
+        let should_trigger_compaction = self
+            .should_trigger_compaction(storage_url, collection_tags)
+            .await?;
 
         // TD-112: index the just-flushed vectors into AXIS so post-flush search is
         // served by the ANN index rather than a brute-force segment scan.
@@ -595,36 +604,35 @@ impl SstEngine {
         })
     }
 
-    /// Whether L0→base compaction should be triggered after this flush (TD-114).
+    /// Whether L0→base compaction should be triggered after this flush (TD-114,
+    /// per-collection override TD-WLP-2 / ADR-061 D5).
     ///
-    /// Default-OFF: the trigger only arms when `PROXIMADB_L0_COMPACTION_ENABLED`
-    /// is set, so the live flush path is byte-for-byte unchanged unless an
-    /// operator opts in. When armed, it reuses the existing segment discovery to
-    /// count L0 segments and arms once the orchestrator threshold is reached.
-    /// Discovery errors are treated as "not yet" (best-effort, never fails flush).
-    async fn should_trigger_compaction(&self, storage_url: &str) -> Result<bool> {
-        if !l0_compaction_enabled() {
+    /// Default-OFF: absent a per-collection `compaction:on` tag the trigger only
+    /// arms when `PROXIMADB_L0_COMPACTION_ENABLED` is truthy, so the untagged
+    /// flush path is byte-for-byte unchanged. A tagged collection may arm (at
+    /// its own `l0_threshold:N`) while the global gate is unset; an explicitly
+    /// falsy global env is the master kill-switch nothing can override. When
+    /// armed, it reuses the existing segment discovery to count L0 segments and
+    /// arms once the effective threshold is reached. Discovery errors are
+    /// treated as "not yet" (best-effort, never fails flush).
+    async fn should_trigger_compaction(&self, storage_url: &str, tags: &[String]) -> Result<bool> {
+        if !proximadb_storage_common::resolve_compaction_armed(tags) {
             return Ok(false);
         }
+        let threshold =
+            proximadb_storage_common::resolve_l0_threshold(tags, L0_COMPACTION_THRESHOLD);
         let l0_count = self
             .discover_sstable_files(storage_url)
             .await
             .map(|files| files.len())
             .unwrap_or(0);
-        Ok(l0_count >= L0_COMPACTION_THRESHOLD)
+        Ok(l0_count >= threshold)
     }
 }
 
 /// L0 segment count at which compaction arms. Mirrors
 /// `OrchestratorCompactionConfig::level0_threshold` (default 5).
 const L0_COMPACTION_THRESHOLD: usize = 5;
-
-/// Reads the `PROXIMADB_L0_COMPACTION_ENABLED` opt-in flag (default OFF).
-fn l0_compaction_enabled() -> bool {
-    std::env::var("PROXIMADB_L0_COMPACTION_ENABLED")
-        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "on" | "yes"))
-        .unwrap_or(false)
-}
 
 /// Statistics from vector sorting operation
 // Using SortingStats from utils.rs instead of local SortStats

--- a/tests/storage_wlp_compaction_gate.rs
+++ b/tests/storage_wlp_compaction_gate.rs
@@ -1,0 +1,154 @@
+//! TD-WLP-2 (ADR-061 D5) integration gate: per-collection compaction override.
+//!
+//! Compaction arming must resolve per-collection through the tag cascade while
+//! the global env (`PROXIMADB_L0_COMPACTION_ENABLED`) stays the master
+//! kill-switch:
+//!
+//! * an `AppendBulk` collection with an explicit `compaction:on` opt-in arms
+//!   compaction (at its per-collection `l0_threshold:N`) while the global gate
+//!   is OFF;
+//! * an untagged collection under the same global-off never arms (today's
+//!   default, byte-for-byte);
+//! * an explicitly falsy global env hard-disables even opted-in collections.
+//!
+//! Env-sensitive tests rely on nextest's process-per-test isolation.
+
+use anyhow::Result;
+use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::traits::{FlushParameters, FlushResult, UnifiedStorageEngine};
+use proximadb_proto::v1::{Collection, CollectionConfig, StorageAssignment};
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
+
+const GLOBAL_GATE_ENV: &str = "PROXIMADB_L0_COMPACTION_ENABLED";
+
+fn record(id: &str) -> ProximaRecord {
+    ProximaRecord {
+        oid: id.to_string(),
+        created_at_ns: 12_345_000_000,
+        updated_at_ns: 12_345_000_000,
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "test".to_string(),
+            modality: "dense_vector".to_string(),
+            dim: 4,
+            values: EmbeddingValues::Fp32(vec![1.0, 0.0, 0.0, 0.0]),
+            ..Default::default()
+        }],
+        ..ProximaRecord::default()
+    }
+}
+
+fn collection(id: &str, base_location: &str, tags: &[&str]) -> Collection {
+    Collection {
+        id: id.to_string(),
+        config: Some(CollectionConfig {
+            name: id.to_string(),
+            dimension: 4,
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }),
+        storage_assignment: Some(StorageAssignment {
+            base_location: base_location.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+async fn flush_once(engine: &SstEngine, coll: &Collection, ids: &[&str]) -> Result<FlushResult> {
+    let params = FlushParameters {
+        collection_id: Some(coll.id.clone()),
+        vector_records: ids.iter().map(|id| record(id)).collect(),
+        force: true,
+        synchronous: true,
+        collection_config: Some(coll.clone()),
+        ..Default::default()
+    };
+    engine.do_flush(&params).await
+}
+
+/// TD-WLP-2 TDD gate: with the global env unset, a collection tagged
+/// `workload_profile:append` + `compaction:on` reaching L0 >= its
+/// per-collection threshold fires compaction; an untagged collection under the
+/// same global-off does NOT — even past the legacy threshold of 5.
+#[tokio::test]
+async fn test_append_collection_arms_compaction_while_global_off() -> Result<()> {
+    unsafe {
+        std::env::remove_var(GLOBAL_GATE_ENV);
+        std::env::remove_var("PROXIMADB_STORAGE_PROFILE");
+    }
+    let engine = SstEngine::new().await?;
+
+    // Opted-in AppendBulk collection: arms once L0 reaches its own threshold.
+    let opted_dir = tempfile::tempdir()?;
+    let opted = collection(
+        "wlp2_append_opted",
+        opted_dir.path().to_str().expect("utf8 tempdir"),
+        &["workload_profile:append", "compaction:on", "l0_threshold:2"],
+    );
+    let first = flush_once(&engine, &opted, &["a0", "a1"]).await?;
+    assert!(first.success, "first flush must succeed");
+    assert!(
+        !first.compaction_triggered,
+        "1 L0 segment < l0_threshold:2 — compaction must not fire yet"
+    );
+    let second = flush_once(&engine, &opted, &["a2", "a3"]).await?;
+    assert!(second.success, "second flush must succeed");
+    assert!(
+        second.compaction_triggered,
+        "opted-in collection at L0 >= per-collection threshold must arm \
+         compaction while the global gate is OFF (TD-WLP-2)"
+    );
+
+    // Untagged collection: the global gate governs and it is OFF — never arms,
+    // even once past the legacy L0_COMPACTION_THRESHOLD of 5.
+    let untagged_dir = tempfile::tempdir()?;
+    let untagged = collection(
+        "wlp2_untagged",
+        untagged_dir.path().to_str().expect("utf8 tempdir"),
+        &[],
+    );
+    for i in 0..6 {
+        let ids = [format!("u{i}")];
+        let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+        let result = flush_once(&engine, &untagged, &id_refs).await?;
+        assert!(result.success, "untagged flush {i} must succeed");
+        assert!(
+            !result.compaction_triggered,
+            "untagged collection must keep today's default-OFF behaviour \
+             (flush {i})"
+        );
+    }
+    Ok(())
+}
+
+/// The global env explicitly falsy is the master kill-switch: a per-collection
+/// `compaction:on` opt-in cannot arm compaction under it (ADR-061 D5).
+#[tokio::test]
+async fn test_global_hard_disable_wins_over_collection_opt_in() -> Result<()> {
+    unsafe {
+        std::env::set_var(GLOBAL_GATE_ENV, "0");
+    }
+    let engine = SstEngine::new().await?;
+    let dir = tempfile::tempdir()?;
+    let opted = collection(
+        "wlp2_hard_disable",
+        dir.path().to_str().expect("utf8 tempdir"),
+        &["workload_profile:append", "compaction:on", "l0_threshold:1"],
+    );
+    for i in 0..2 {
+        let ids = [format!("h{i}")];
+        let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+        let result = flush_once(&engine, &opted, &id_refs).await?;
+        assert!(result.success, "flush {i} must succeed");
+        assert!(
+            !result.compaction_triggered,
+            "global hard-disable must win over the per-collection opt-in \
+             (flush {i})"
+        );
+    }
+    unsafe {
+        std::env::remove_var(GLOBAL_GATE_ENV);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Second ADR-061 slice (follows #963 / TD-WLP-1). Arms L0 compaction **per-collection** so `AppendBulk` collections can reach the dark compaction re-cluster path, while the global default stays OFF and the global env remains the master kill-switch.

- `compaction_override` module in `proximadb-storage-common`: tri-state global gate on `PROXIMADB_L0_COMPACTION_ENABLED` — truthy = armed for all (legacy behaviour), **explicitly falsy = hard disable nothing can override**, unset = per-collection tag decides (default OFF). Tags: `compaction:on|off` (last matching wins, unrecognized keeps prior — parity with the quant-resolver cascade) and `l0_threshold:N` (last valid positive wins).
- `should_trigger_compaction` (SST flush) now resolves through the cascade using the collection tags already in `FlushParameters`; **the untagged path is byte-for-byte unchanged for every env state** (mixed-read-safe, ADR-061 default-OFF mandate).
- `OrchestratorCompactionConfig::effective_for_collection_tags` mirrors `WALConfig::effective_config_for_collection` — the seam TD-WLP-4 (compaction re-clustering) consumes next.
- TD-WLP-2 Status → Implemented.

## Test plan (TDD)
- Unit cascade tests (red→green) in `compaction_override.rs`: full precedence matrix incl. hard-disable > tag > env-truthy > default, last-tag-wins, opt-out-under-armed, threshold tag parsing.
- Integration gate `tests/storage_wlp_compaction_gate.rs` (named `*storage*` for the storage-integration CI job), both passing:
  - `test_append_collection_arms_compaction_while_global_off` — opted-in collection does NOT fire at 1 segment, fires at its `l0_threshold:2`; an untagged collection never fires through 6 flushes (past the legacy threshold 5).
  - `test_global_hard_disable_wins_over_collection_opt_in`.
- `cargo fmt --check` ✓; `cargo clippy --lib --bins -- -D warnings` exit 0 ✓; `make work-commit-check` ✓; storage-common suite 413/413 ✓. All re-verified after rebase onto develop (post-#963/#962).

Refs ADR-061 (D5), TD-WLP-2.