### PR TITLE
refactor(storage-ports): AxisClusteringPort + writer axis DI adoption (writer-extraction enabler, slice 1/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8167,6 +8167,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "proximadb-distance-kernel",
  "proximadb-filter-expression",
  "proximadb-kernel",
  "proximadb-proto",

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -35,6 +35,9 @@ proximadb-quantization-model.workspace = true
 # Storage-tier: the FilesystemPort names FileSystem / FileOptions / FsResult from
 # this crate (the existing filesystem abstraction). Same-tier dep (storage→storage).
 proximadb-storage-filesystem-types.workspace = true
+# Foundation-tier: the AxisClusteringPort names DistanceMetric (the clustering
+# methods take it as a param). Foundation dep (storage→foundation).
+proximadb-distance-kernel.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -12,6 +12,7 @@
 //! foundation proto types the contracts unavoidably name.
 
 use anyhow::Result;
+use proximadb_distance_kernel::DistanceMetric;
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
@@ -226,4 +227,40 @@ pub enum CacheKind {
 pub trait CacheAccessPatternPort: Send + Sync {
     /// Record a cache access for pattern learning / predictive prefetching.
     fn track_access(&self, key: String, cache_kind: CacheKind);
+}
+
+/// AXIS clustering port — inverts the raptor→root `AxisClusteringEngine`
+/// dependency for the clustering surface RAPTOR's writer needs (k-means
+/// clustering, centroid-distance matrix, component-boosted assignment). The
+/// surface is exactly `ReusableClusteringEngine`'s 3 methods (sync,
+/// primitive-typed + `DistanceMetric`). Engine leaves hold `Arc<dyn
+/// AxisClusteringPort>` instead of the root-local `AxisClusteringEngine`; the
+/// concrete engine impls this in the root (downward edge). Enables the raptor
+/// `writer` extraction.
+pub trait AxisClusteringPort: Send + Sync {
+    /// k-means clustering (k-means++ init) → (centroids, cluster assignments).
+    fn cluster_vectors_simple(
+        &self,
+        vectors: &[Vec<f32>],
+        k: usize,
+        distance_metric: DistanceMetric,
+        max_iterations: usize,
+    ) -> Result<(Vec<Vec<f32>>, Vec<usize>)>;
+
+    /// Centroid-to-centroid distance matrix (k×k).
+    fn calculate_centroid_distance_matrix(
+        &self,
+        centroids: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+    ) -> Result<Vec<Vec<f32>>>;
+
+    /// Assign vectors to clusters with component boosting → (cluster_id, boosted_distance).
+    fn assign_vectors_with_component_boosting(
+        &self,
+        vectors: &[Vec<f32>],
+        centroids: &[Vec<f32>],
+        centroid_distances: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+        boosting_weights: &[f32],
+    ) -> Result<Vec<(usize, f32)>>;
 }

--- a/src/index/axis/clustering.rs
+++ b/src/index/axis/clustering.rs
@@ -954,6 +954,60 @@ impl ReusableClusteringEngine for AxisClusteringEngine {
     }
 }
 
+// AxisClusteringPort impl — Slice D port-inversion. Exposes the root-local
+// AxisClusteringEngine behind the AxisClusteringPort trait (defined in
+// proximadb-storage-ports) so raptor engine leaves (writer / IvfClusteringBuilder)
+// can depend on `Arc<dyn AxisClusteringPort>` instead of this concrete type,
+// enabling their extraction to crates. Pure delegation to the
+// ReusableClusteringEngine methods above; the composition root injects the engine.
+impl proximadb_storage_ports::AxisClusteringPort for AxisClusteringEngine {
+    fn cluster_vectors_simple(
+        &self,
+        vectors: &[Vec<f32>],
+        k: usize,
+        distance_metric: DistanceMetric,
+        max_iterations: usize,
+    ) -> Result<(Vec<Vec<f32>>, Vec<usize>)> {
+        ReusableClusteringEngine::cluster_vectors_simple(
+            self,
+            vectors,
+            k,
+            distance_metric,
+            max_iterations,
+        )
+    }
+
+    fn calculate_centroid_distance_matrix(
+        &self,
+        centroids: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+    ) -> Result<Vec<Vec<f32>>> {
+        ReusableClusteringEngine::calculate_centroid_distance_matrix(
+            self,
+            centroids,
+            distance_metric,
+        )
+    }
+
+    fn assign_vectors_with_component_boosting(
+        &self,
+        vectors: &[Vec<f32>],
+        centroids: &[Vec<f32>],
+        centroid_distances: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+        boosting_weights: &[f32],
+    ) -> Result<Vec<(usize, f32)>> {
+        ReusableClusteringEngine::assign_vectors_with_component_boosting(
+            self,
+            vectors,
+            centroids,
+            centroid_distances,
+            distance_metric,
+            boosting_weights,
+        )
+    }
+}
+
 /// Helper methods for simplified clustering
 impl AxisClusteringEngine {
     /// Simplified K-Means++ initialization without full AXIS overhead

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -32,9 +32,34 @@ use super::smart_rowgroup_sizing::SmartRowGroupSizer;
 
 // Deep integration with AXIS clustering
 use crate::index::axis::clustering::{
-    ClusterManager, ClusteringAlgorithm, ClusteringConfig, KMeansConfig,
+    AxisClusteringEngine, ClusterManager, ClusteringAlgorithm, ClusteringConfig, KMeansConfig,
+    KMeansInit,
 };
 use proximadb_index_types::ClusterAssignment;
+
+/// Build the AXIS clustering engine for RAPTOR with the standard config, returning
+/// it behind the AxisClusteringPort DI port. Injected into RaptorWriter (which no
+/// longer constructs it internally — Slice D port-inversion).
+fn make_raptor_axis_clustering(
+    config: &super::config::RaptorConfig,
+) -> std::sync::Arc<dyn proximadb_storage_ports::AxisClusteringPort> {
+    let axis_clustering_config = ClusteringConfig {
+        algorithm: ClusteringAlgorithm::KMeans(KMeansConfig {
+            k: super::constants::clustering::DEFAULT_CLUSTER_COUNT,
+            max_iterations: super::constants::clustering::KMEANS_MAX_ITERATIONS,
+            tolerance: super::constants::clustering::KMEANS_TOLERANCE as f32,
+            n_init: super::constants::clustering::KMEANS_INIT_ATTEMPTS,
+            init_method: KMeansInit::KMeansPlusPlus,
+        }),
+        min_vectors_for_clustering: config.rowgroup_size,
+        max_clusters: super::constants::clustering::MAX_CLUSTER_COUNT,
+        distance_metric: proximadb_distance_kernel::DistanceMetric::Euclidean,
+        adaptive_cluster_count: true,
+        recompute_threshold: 10000,
+        enable_incremental: false,
+    };
+    std::sync::Arc::new(AxisClusteringEngine::new(axis_clustering_config))
+}
 
 // Deep integration with filesystem API for cloud-aware I/O
 use crate::storage::persistence::filesystem::TierConfig;
@@ -517,6 +542,7 @@ impl RaptorEngine {
                 config.clone(),
                 "placeholder".to_string(),
                 config.dimension, // dimension from config
+                make_raptor_axis_clustering(&config),
             )
             .await?,
         ));
@@ -2227,6 +2253,7 @@ impl UnifiedStorageFormat for RaptorEngine {
             self.config.clone(),
             collection_id.to_string(),
             collection_dimension as usize,
+            make_raptor_axis_clustering(&self.config),
         )
         .await?;
 

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -78,11 +78,8 @@ use crate::storage::engines::core::ops::proximacodec::{
 };
 use crate::storage::persistence::filesystem::FileSystem;
 
-// Import AXIS clustering for reuse
-use crate::index::axis::clustering::{
-    AxisClusteringEngine, ClusteringAlgorithm, ClusteringConfig as AxisClusteringConfig,
-    KMeansConfig, KMeansInit, ReusableClusteringEngine,
-};
+// AXIS clustering is injected via the AxisClusteringPort DI port (Slice D)
+use proximadb_storage_ports::AxisClusteringPort;
 
 use super::config::CompressionCodec as RaptorCompressionCodec;
 use super::constants;
@@ -287,7 +284,7 @@ struct IvfClusteringBuilder {
     #[allow(dead_code)]
     hardware: Arc<HardwareCapabilities>,
     /// AXIS clustering engine for reusable k-means implementation
-    axis_clustering: Arc<AxisClusteringEngine>,
+    axis_clustering: Arc<dyn AxisClusteringPort>,
     /// Pre-computed centroids for k clusters
     centroids: Vec<Centroid>,
     /// Boosting parameters
@@ -360,26 +357,11 @@ struct Centroid {
 // This avoids duplication and keeps related data together
 
 impl IvfClusteringBuilder {
-    fn new(target_rowgroup_size: usize, hardware: Arc<HardwareCapabilities>) -> Self {
-        // Create AXIS clustering configuration for RAPTOR
-        let axis_clustering_config = AxisClusteringConfig {
-            algorithm: ClusteringAlgorithm::KMeans(KMeansConfig {
-                k: constants::clustering::DEFAULT_CLUSTER_COUNT,
-                max_iterations: constants::clustering::KMEANS_MAX_ITERATIONS,
-                tolerance: constants::clustering::KMEANS_TOLERANCE as f32,
-                n_init: constants::clustering::KMEANS_INIT_ATTEMPTS,
-                init_method: KMeansInit::KMeansPlusPlus,
-            }),
-            min_vectors_for_clustering: target_rowgroup_size,
-            max_clusters: constants::clustering::MAX_CLUSTER_COUNT,
-            distance_metric: DistanceMetric::Euclidean,
-            adaptive_cluster_count: true,
-            recompute_threshold: 10000,
-            enable_incremental: false, // Disable for RAPTOR use case
-        };
-
-        let axis_clustering = Arc::new(AxisClusteringEngine::new(axis_clustering_config));
-
+    fn new(
+        target_rowgroup_size: usize,
+        hardware: Arc<HardwareCapabilities>,
+        axis_clustering: Arc<dyn AxisClusteringPort>,
+    ) -> Self {
         Self {
             nodes: Vec::new(),
             id_to_node: HashMap::new(),
@@ -2574,6 +2556,7 @@ impl RaptorWriter {
         config: RaptorConfig,
         collection_id: String,
         dimension: usize,
+        axis_clustering: Arc<dyn AxisClusteringPort>,
     ) -> Result<Self> {
         // Initialize filesystem using local filesystem
         use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
@@ -2711,7 +2694,11 @@ impl RaptorWriter {
                 id_hashes: Vec::new(),
                 row_offsets: Vec::new(),
             },
-            ivf_builder: IvfClusteringBuilder::new(rowgroup_size, get_hardware_capabilities()),
+            ivf_builder: IvfClusteringBuilder::new(
+                rowgroup_size,
+                get_hardware_capabilities(),
+                axis_clustering,
+            ),
             column_projections: ColumnProjectionsBuilder {
                 metadata_columns: HashMap::new(),
                 filter_bitmaps: HashMap::new(),


### PR DESCRIPTION
## Summary

Adds `AxisClusteringPort` trait (storage-ports) + `impl AxisClusteringPort for AxisClusteringEngine` (root) — port-inverting the raptor→root `AxisClusteringEngine` dependency for the clustering surface RAPTOR's writer needs. Sibling enabler to FilesystemPort (#943) + CacheAccessPatternPort (#948).

## What

- `AxisClusteringPort` trait (storage-ports) — surface is exactly `ReusableClusteringEngine`'s 3 methods (sync, primitive-typed + `DistanceMetric`): `cluster_vectors_simple`, `calculate_centroid_distance_matrix`, `assign_vectors_with_component_boosting`.
- `impl AxisClusteringPort for AxisClusteringEngine` (root, `clustering.rs`) — pure delegation to the `ReusableClusteringEngine` methods.

## Why

Engine leaves (the raptor `writer`, ~5,800 LOC) will hold `Arc<dyn AxisClusteringPort>` instead of the root-local `AxisClusteringEngine`, enabling the writer extraction to a crate. The adoption (writer/IvfClusteringBuilder swap to the port + axis-engine construction moving to the composition root) happens in the writer-move PR.

## Risk

**Additive + low-risk** — no existing call-site changes (writer keeps constructing `AxisClusteringEngine` for now; the port is the future seam, like FilesystemPort #943 was).

## Verification
- storage-ports crate + root `--lib` + clippy `--lib --bins` (CI gate): clean
- fmt clean · layering + boundaries pass · up-edges 181 (held) · work-commit-check green