### PR TITLE
fix(release): update packaging asset paths after directory consolidation — unblock v0.2.2 platform packages

### DIFF
--- a/.github/workflows/_platform-packages.yml
+++ b/.github/workflows/_platform-packages.yml
@@ -90,7 +90,7 @@ jobs:
             tar -xzf binary-cache/proximadb-*.tar.gz -C rpm_build/usr/bin --strip-components=1
           fi
           cp -r config/* rpm_build/etc/proximadb/
-          cp packaging/systemd/proximadb.service rpm_build/usr/lib/systemd/system/
+          cp deploy/packaging/systemd/proximadb.service rpm_build/usr/lib/systemd/system/
 
           fpm -s dir -t rpm \
             -n proximadb \
@@ -101,8 +101,8 @@ jobs:
             --license "Apache-2.0" \
             --vendor "ProximaDB" \
             --rpm-dist "el8" \
-            --after-install packaging/scripts/postinstall.sh \
-            --before-remove packaging/scripts/preremove.sh \
+            --after-install deploy/packaging/scripts/postinstall.sh \
+            --before-remove deploy/packaging/scripts/preremove.sh \
             rpm_build/=/
 
           echo "success=true" >> $GITHUB_OUTPUT
@@ -179,8 +179,8 @@ jobs:
             --vendor "ProximaDB" \
             --deb-priority "optional" \
             --deb-systemd \
-            --after-install packaging/scripts/postinstall.sh \
-            --before-remove packaging/scripts/preremove.sh \
+            --after-install deploy/packaging/scripts/postinstall.sh \
+            --before-remove deploy/packaging/scripts/preremove.sh \
             deb_build/=/
 
           echo "success=true" >> $GITHUB_OUTPUT
@@ -338,7 +338,7 @@ jobs:
         id: build
         run: |
           $VERSION = "${{ inputs.version }}"
-          wix build -o "proximadb-$VERSION.msi" packaging\wix\proximadb.wxs
+          wix build -o "proximadb-$VERSION.msi" deploy\packaging\wix\proximadb.wxs
           echo "success=true" >> $GITHUB_OUTPUT
 
       - name: Upload MSI Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,9 +512,9 @@ jobs:
 
           tar -xzf binary/proximadb-*.tar.gz -C rpm_build/usr/bin --strip-components=1
           cp config/config.toml rpm_build/etc/proximadb/
-          cp packaging/systemd/proximadb.service rpm_build/usr/lib/systemd/system/
-          cp packaging/scripts/postinstall.sh rpm_build/tmp/postinstall.sh
-          cp packaging/scripts/preremove.sh rpm_build/tmp/preremove.sh
+          cp deploy/packaging/systemd/proximadb.service rpm_build/usr/lib/systemd/system/
+          cp deploy/packaging/scripts/postinstall.sh rpm_build/tmp/postinstall.sh
+          cp deploy/packaging/scripts/preremove.sh rpm_build/tmp/preremove.sh
 
           fpm -s dir -t rpm \
             -n proximadb \
@@ -568,9 +568,9 @@ jobs:
 
           tar -xzf binary/proximadb-*.tar.gz -C deb_build/usr/bin --strip-components=1
           cp config/config.toml deb_build/etc/proximadb/
-          cp packaging/systemd/proximadb.service deb_build/lib/systemd/system/
-          cp packaging/scripts/postinstall.sh deb_build/tmp/postinstall.sh
-          cp packaging/scripts/preremove.sh deb_build/tmp/preremove.sh
+          cp deploy/packaging/systemd/proximadb.service deb_build/lib/systemd/system/
+          cp deploy/packaging/scripts/postinstall.sh deb_build/tmp/postinstall.sh
+          cp deploy/packaging/scripts/preremove.sh deb_build/tmp/preremove.sh
 
           # Build DEB with systemd support
           # Note: --deb-systemd flag removed - using manual scripts instead
@@ -632,7 +632,7 @@ jobs:
       - name: Build MSI
         run: |
           $VERSION = "${{ needs.prepare.outputs.version }}"
-          wix build -d "Version=$VERSION" -o "proximadb-$VERSION-x64.msi" packaging\wix\proximadb.wxs
+          wix build -d "Version=$VERSION" -o "proximadb-$VERSION-x64.msi" deploy\packaging\wix\proximadb.wxs
 
       - name: Upload MSI Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

Release run 29318286226 (v0.2.2) cleared the prerelease-ci gate and built all core artifacts (Linux + Windows binaries, sdist), but died in **Build RPM / DEB / MSI**:

```
cp: cannot stat 'packaging/systemd/proximadb.service': No such file or directory
wix.exe : error WIX0103: Cannot find the input file 'packaging\wix\proximadb.wxs'.
```

`ffa4c7054` ("Consolidate release asset directories", 2026-05-19) moved `packaging/` → `deploy/packaging/`, but `release.yml` and `_platform-packages.yml` kept the old paths. Invisible until now: platform packages only build during real releases, and the last one (v0.2.0) predates the move. develop carries the same stale paths — ported there separately so the drift doesn't recur.

## What

All 13 stale references across the two workflows rewritten `packaging/...` → `deploy/packaging/...` (including the Windows-backslash WiX path). No other changes. All four referenced files exist at the new location on main.

Same targeted-hotfix-to-main pattern as #961 (release-pipeline fix; promotion guard is advisory).

## After merge

Re-dispatch `release.yml` (version=0.2.2, dry_run=false). PyPI steps remain `skip-existing` (0.2.2 Python packages already published); this run delivers the GitHub Release binaries + platform packages, crates.io, Homebrew.