### PR TITLE
docs(evidence): routed-DuckDb ledger verdict (stay opt-in) + post-#953 native taxonomy; file TD-REL-LOWER-2/3 + TD-EXEC-CANCEL-1

### DIFF
--- a/docs/10-quality/td/TD-EXEC-CANCEL-1-volcano-ignores-query-cancel.adoc
+++ b/docs/10-quality/td/TD-EXEC-CANCEL-1-volcano-ignores-query-cancel.adoc
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-EXEC-CANCEL-1: Volcano ignores pgwire query-cancel mid-execution — a wedged query queues every subsequent query on the session
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14, root-caused live during the post-#953 ledger native sweep.
+| Priority | P1 for operability — one pathological query makes a pgwire session (and anything serialized behind it) unresponsive to both cancel and follow-on queries; the grind burns CPU unboundedly.
+| Component | `src/query/execution` (Volcano executor operator loops), pgwire cancel handling → `ExecutionControls::cancellation_flag`.
+| Evidence | Ledger native sweep 2026-07-14: with a 60 s harness budget + `tokio_postgres` `cancel_query` on timeout, sweep throughput degraded to ~11 min/record (6 records in 65 min) — each cancelled cross-join grind (TD-REL-LOWER-2) kept running server-side, and the session's next `simple_query` queued behind it, compounding. The harness's own comment anticipates exactly this ("the cancel matters — dropping the query future alone leaves the connection busy"); the cancel is *sent* but has no effect on a running Volcano plan.
+|===
+
+== The finding
+
+`ExecutionControls` carries a `cancellation_flag: Option<Arc<AtomicBool>>` with
+`check_cancelled()` "checked by engines at stable boundaries" — but the Volcano execution loops
+for the expensive operators (cross-join/nested-loop pair enumeration at minimum; likely
+scan/aggregate loops too) never call it, and/or the pgwire cancel-request path never sets the
+flag for the in-flight query. Net: a PostgreSQL wire *CancelRequest* — standard client behavior
+(`Ctrl-C` in psql, driver timeouts) — is accepted and ignored. Combined with TD-REL-LOWER-2's
+un-normalized cross products, one bad comma-join renders the session unusable and the CPU pegged
+for minutes to hours.
+
+== Direction
+
+1. **Wire the flag:** the pgwire backend's cancel-request handler must set the active query's
+   `cancellation_flag` (keyed by backend PID/secret per the PG protocol — the plumbing the
+   `cancel_token` client half already speaks).
+2. **Check it where it matters:** cross-join / nested-loop inner loops, scan row loops, and
+   aggregate build loops call `controls.check_cancelled()` on a coarse stride (e.g. every 4–16 k
+   rows — cheap relaxed atomic load, no measurable per-row cost), surfacing
+   `ExecutionError::Cancelled` → pgwire `57014 query_canceled`.
+3. **Gate:** an integration test that starts a deliberately-long native query, sends
+   `cancel_query`, and asserts (a) the client gets `57014` within a bounded window, (b) a
+   follow-on query on the same session answers promptly. The perf-ledger harness then keeps its
+   budget discipline for free.
+
+== Non-goals
+
+Cooperative cancellation for DataFusion/DuckDB arms (DataFusion streams already yield; DuckDB
+in-process cancellation is its own follow-up); fixing the cross-product plan itself
+(TD-REL-LOWER-2).

--- a/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
@@ -74,8 +74,17 @@ Bisected and fixed the dominant decline class plus the two hardening directions:
 
 Remaining (why this stays Open): full TPC-H native-route coverage — residual per-query lowering
 declines (e.g. CASE/EXTRACT/INTERVAL frontend gaps) now fail loudly with the 0A000 message; fix
-incrementally per the pgwire mandate and re-run the ledger native sweep to re-measure the ERR
-taxonomy.
+incrementally per the pgwire mandate.
+
+**Re-measured taxonomy (2026-07-14 native sweep, SF 0.01, post-#953):** the mangled-error class
+collapsed from 72 ledger ERRs to 3 single-table queries (TPC-H Q1/Q4/Q6 — declines the
+multi-table 0A000 guard cannot see; date/interval frontend gaps). TPC-H: **14/22 now lower and
+execute** (Q9–Q22 — then grind the un-normalized cross product, filed as TD-REL-LOWER-2), 3
+comma-join + 2 derived-table clean 0A000 declines (Q2/Q3/Q5, Q7/Q8). TPC-DS: **24 native passes**,
+15 clean 0A000 declines, 8 cross-product grinders, 2 `rebind_columns` internal planner errors on
+alias-named sort keys (q3/q52 — pre-existing pushdown bug newly reachable, filed as
+TD-REL-LOWER-3). Follow-up guard candidate: extend the specific-error treatment to single-table
+relational declines so Q1/Q4/Q6 stop mangling.
 
 == Non-goals
 

--- a/docs/10-quality/td/TD-REL-LOWER-2-comma-join-cross-product-grind.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-2-comma-join-cross-product-grind.adoc
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-2: Comma-joins lower as cross-join + filter — no equi-join rewrite, so Volcano grinds the raw cross product
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14 from the post-#953 ledger native sweep (SF 0.01 release).
+| Priority | P2 — perf, not correctness (results would be right if they ever finished); blocks native-route TPC coverage for join queries and starves `olap/native` join cost cells (the same coverage TD-REL-LOWER-1 unblocked at the *lowering* layer).
+| Component | `crates/query/proximadb-relational-frontend` (comma-FROM → `JoinKind::Cross` + WHERE), `proximadb-relational-planner` (no cross+filter → equi-join rewrite).
+| Evidence | Post-#953 native sweep 2026-07-14 (`TPC_PERF_SCALE=0.01`, 60 s budget): TPC-H Q9–Q22 (14/22) and TPC-DS q65/q67/q69/q70/q76/q79/q82/q87 (8) now LOWER AND EXECUTE — then time out. An earlier 300 s-budget run bounds Q9/Q10 at ≥300 s each. Pre-#953 these all failed fast at lowering, so this grind class was invisible.
+|===
+
+== The finding
+
+TD-REL-LOWER-1 (#953) fixed the qualified-ORDER-BY decline, so comma-join TPC queries now lower
+on the native route. The frontend lowers `FROM a, b, c WHERE a.x = b.x AND …` per ANSI as
+`CrossJoin` nodes with the equality predicates left in the WHERE `Filter` above. The planner never
+rewrites `Filter(equality) over CrossJoin` into the *equi-join* Volcano already has executors for
+(hash + nested-loop — verified in the TD-ROUTE-1 review: the join executors exist), so execution
+enumerates the raw cross product: `lineitem × orders` at SF 0.01 is ~9×10^8 pairs — ≥300 s
+measured, unboundedly worse at scale.
+
+The failure mode *changed shape* rather than appearing: pre-#953 these queries errored fast and
+misleadingly; now they run forever. Both are coverage-blockers, but the grind also wedges shared
+harness/session infrastructure (see TD-EXEC-CANCEL-1 — the grind is not cancellable).
+
+== Direction
+
+1. **Planner rewrite (the fix):** during physical planning, split the post-cross-join filter into
+   conjuncts; each `left.col = right.col` equality conjunct whose sides bind to the two inputs
+   becomes the join condition of an *Inner* join (hash strategy where a hash executor exists),
+   with residual conjuncts kept as a Filter. This is the textbook implicit-join normalization —
+   it reuses the existing join executors, no new operator.
+2. **Chained comma-joins:** apply pairwise left-deep (the frontend already emits left-deep
+   `CrossJoin` chains), pulling each cross-level's applicable equality conjunct down.
+3. **Gate:** the 22 evidence queries produce native `ok` samples within the harness budget (or
+   decline for a *named* residual reason) — ratchet on the ledger, per mandate #10.
+
+== Non-goals
+
+Join *reordering* / CBO (that is TD-OLAP-2 / DataFusion territory); the native route only needs
+the cross→equi normalization, not an optimal order. Not the ClickBench case-folding wall
+(TD-OLAP-18).

--- a/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-3: Projection-pushdown rebind fails on alias-named ORDER BY keys (`rebind_columns: column not in narrowed schema`)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14 from the post-#953 ledger native sweep (SF 0.01 release).
+| Priority | P2 — hard error on valid ANSI SQL (`[XX000] plan: internal planner error`), scope currently 2 TPC-DS queries; pre-existing planner bug newly *reachable* (pre-#953 these queries declined earlier, at lowering).
+| Component | `crates/query/proximadb-relational-planner` — `push_projections_inner` / `rebind_columns` (name-keyed ordinal rebind).
+| Evidence | TPC-DS q3 and q52 on the native route, both: `plan: internal planner error: rebind_columns: column `brand_id` not in narrowed schema`. Shape: comma-join + `GROUP BY` + projection alias used as an ORDER BY key (`select … item.i_brand_id brand_id … order by d_year, sum_agg desc, brand_id`).
+|===
+
+== The finding
+
+`push_projections` narrows Scans to upstream-referenced columns, then rebinds every
+`Expr::Column` ordinal *by name* against the (narrowed) input schema on the walk back up. For the
+q3/q52 shape, a Sort key named by a **projection alias** (`brand_id`, aliasing
+`item.i_brand_id`) fails the name lookup during that rebind — the schema it is rebound against
+carries the *pre-alias* column names, so the pushdown errors out and the query fails with an
+internal-planner error rather than executing.
+
+Lowering is not at fault: the frontend resolves the alias correctly against the Project's output
+schema (this is the ordinary alias path, not the #953 qualified-key fallback). The inconsistency
+is inside the pushdown pass: somewhere between the Sort arm (rebinds keys against
+`new_input.output_schema()`) and the narrowing decisions below it, the schema the Sort keys are
+rebound against does not expose the Project's alias names. The doc comment on
+`push_projections_inner` already concedes the pass "skips join subtrees" because `ColumnRef`
+carries no disambiguation — this is the adjacent gap on the alias axis.
+
+== Direction
+
+1. **Failing unit test first** (planner crate): hand-build (or lower, if the frontend dev-dep is
+   acceptable) the minimal plan — `Sort(keys=[alias]) over Project([col AS alias]) over
+   Aggregate over CrossJoin/Scan` — assert `push_projections` succeeds and the sort key's rebound
+   ordinal points at the alias output slot.
+2. Fix candidates, in preference order: (a) make the Sort/Limit/Distinct arms rebind against the
+   *actual* child output schema **after** its own rewrite (alias names intact at the Project
+   boundary); (b) teach `rebind_columns` to fall back to ordinal-preserving identity when the
+   name is absent but the ordinal is in range *and* the schema width is unchanged; (c) skip
+   narrowing across Project-over-Aggregate boundaries the way join subtrees are skipped
+   (conservative, loses narrowing).
+3. **Gate:** q3 + q52 flip from `internal planner error` to `ok` native samples in the ledger
+   sweep; no pushdown-narrowing regression on the existing planner tests.
+
+== Non-goals
+
+The cross-product perf of the same queries (TD-REL-LOWER-2); join-subtree rebind disambiguation
+(the documented Phase-3 restriction stands).

--- a/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
+++ b/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
@@ -79,3 +79,30 @@ Per the co-design mandate (name the dominant dimensional cost term):
 4. *(Converges)* native-modes for load-bearing shapes (ADR-054) — DuckDB remains for the shapes native doesn't own.
 
 Each step default-safe + ledger-gated, mixed-read-safe, behind the ADR-054 progressive-cutover discipline.
+
+== 7. Routed evidence + promotion verdict (2026-07-14 ledger runs)
+
+Measured through the REAL pgwire route (step-2 wiring), SF 0.01 full-suite + SF 0.1 scoped
+(Q3/Q5/Q8/Q9/Q10), release, `PROXIMADB_DUCKDB_ROUTE=1` vs stock:
+
+* **The wiring is sound.** 142/170 pgwire-sweep records served by `DuckDbCompat` with **zero
+  row-count mismatches** vs the stock DataFusion baseline (SF 0.01) and exact parity on all five
+  SF 0.1 queries. Eligibility behaved (scalar/metadata shapes kept DataFusion); the delta-clean
+  probe added no visible overhead (routed-DuckDB ≤ DuckDB-direct walls); cost cells warmed under
+  the correct backend label via the io_trace re-stamp.
+* **The motivating gap is GONE on the probed shapes.** TD-OLAP-15's 100–700× DataFusion join-plan
+  collapse (Q8 17 233 ms at SF 0.1) no longer reproduces: stock DataFusion now answers Q5/Q8/Q9
+  in ~24 ms at SF 0.1 — the D5 "fallback-path investment" (TD-OLAP-2 NDV via #886 + stats-fed
+  planning #660) landed and fixed the CBO's join plans. DuckDB-direct is comparable (~20–36 ms)
+  with a cold-start outlier (Q3 first-run ~1.3 s: fresh in-memory DB + view registration per
+  query — the stateless-engine cost).
+* **Promotion verdict: stay opt-in default-OFF.** On current evidence DataFusion ≥ DuckDB across
+  both scales probed, so there is no measured win to promote — and that is the routing framework
+  working, not a failure: the cost model, warmed through this route, correctly learns DataFusion
+  as the cheaper arm at these scales. Re-evaluate on shapes/scales where DuckDB's optimizer
+  advantage re-emerges (larger SF, wider joins, window/ROLLUP surfaces DataFusion lacks) — the
+  route, eligibility gates, and per-class staged enable (#946) are ready when it does.
+* Residual observation: a set of CTE-shaped TPC-DS queries (q1, q9, q14a, q23a, q24a, q33, …)
+  execute correctly but carry NO route stamp — they are served by a pre-router path, so the cost
+  model never sees them. Worth a follow-up when CTE lowering lands on the shared route.
+


### PR DESCRIPTION
## What

The ledger evidence run behind #946/#953/#957 — measurement first, per mandate #6. Docs-only: one ADR evidence section, one TD taxonomy update, three new TD filings. Runs: SF 0.01 full-suite (stock + `PROXIMADB_DUCKDB_ROUTE=1`), SF 0.1 scoped Q3/Q5/Q8/Q9/Q10 (stock + routed), release, `--features duckdb`.

### ADR-059 §7 — routed evidence + promotion verdict

- **The #957 wiring is sound**: 142/170 pgwire-sweep records served by DuckDB through the router with **zero row-count mismatches** vs the stock DataFusion baseline; exact parity on all SF 0.1 queries; eligibility correct (scalar/metadata shapes kept DataFusion); no measurable router/delta-probe overhead; cost cells attributed to the serving engine via the re-stamp.
- **The motivating gap no longer reproduces**: TD-OLAP-15's 100–700× DataFusion join collapse (Q8 = 17,233 ms at SF 0.1) is gone — stock DataFusion now answers Q5/Q8/Q9 in ~24 ms at SF 0.1, because the ADR-059 D5 "fallback investment" (TD-OLAP-2 NDV #886 + stats-fed planning #660) fixed the CBO's join plans.
- **Verdict: DuckDb route stays opt-in default-OFF.** No measured win to promote on the probed shapes — and that is the routing framework working: cells warmed through the route correctly learn DataFusion as the cheaper arm at these scales. The route + #946 per-class staged enable are ready if/where DuckDB's advantage re-emerges.
- Residual: CTE-shaped DS queries execute via a pre-router path with no route stamp (invisible to the cost model) — noted for the CTE-lowering follow-up.

### TD-REL-LOWER-1 — re-measured taxonomy (the update it asked for)

Mangled-error class collapsed **72 → 3** (single-table Q1/Q4/Q6 — the multi-table 0A000 guard can't see those declines). TPC-H: **14/22 now lower and execute** on the native route (then grind — see below); TPC-DS: **24 native passes**, 15 clean 0A000 declines.

### Three new filings, each root-caused from the sweep

- **TD-REL-LOWER-2**: comma-joins lower as cross-join + WHERE filter and the planner never rewrites to the equi-join Volcano already has executors for → raw cross-product enumeration, ≥300 s measured on Q9/Q10, 22 queries affected. Fix direction: conjunct-split → Inner-join normalization (textbook, reuses existing executors).
- **TD-REL-LOWER-3**: `rebind_columns: column 'brand_id' not in narrowed schema` — projection-pushdown rebind fails on alias-named ORDER BY keys (DS q3/q52). Pre-existing planner bug, newly reachable post-#953. Fix direction + failing-test-first plan in the TD.
- **TD-EXEC-CANCEL-1** (P1 operability): Volcano ignores pgwire CancelRequest mid-execution — the flag exists (`ExecutionControls::cancellation_flag`) but the expensive loops never check it and the cancel path doesn't set it; a wedged query queues the whole session (measured: sweep throughput degraded to ~11 min/record behind un-cancelled grinds).

`check_td_adr_unique.py` clean (203 TD ids, 0 errors); `work-commit-check` green.

Refs: ADR-059, TD-OLAP-15, TD-OLAP-2, #886, #660, #946, #953, #957.