### PR TITLE
fix(release): make artifact validation match the actual release shape — unblock v0.2.2 (3rd blocker)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -692,11 +692,11 @@ jobs:
             if find artifacts -name "$binary" -type f | grep -q .; then
               echo "  [OK] $binary"
               FOUND_ARTIFACTS="$FOUND_ARTIFACTS\n  - $binary"
-              ((BINARY_COUNT++))
+              BINARY_COUNT=$((BINARY_COUNT+1))
             else
               echo "  [MISSING] $binary"
               MISSING_ARTIFACTS="$MISSING_ARTIFACTS\n  - $binary"
-              ((BINARY_MISSING++))
+              BINARY_MISSING=$((BINARY_MISSING+1))
               VALIDATION_PASSED=false
             fi
           done
@@ -712,7 +712,7 @@ jobs:
             CHECKSUM="${binary}.sha256"
             if find artifacts -name "$CHECKSUM" -type f | grep -q .; then
               echo "  [OK] $CHECKSUM"
-              ((CHECKSUM_COUNT++))
+              CHECKSUM_COUNT=$((CHECKSUM_COUNT+1))
             else
               echo "  [MISSING] $CHECKSUM"
               # Checksums are important but not blocking
@@ -736,33 +736,19 @@ jobs:
           # Expected minimums (main wheels, not embedded)
           # Linux x86_64: 5 Python versions (3.8-3.12)
           # Others: 4 Python versions (3.9-3.12)
-          echo "  Linux x86_64 wheels: $LINUX_X64_WHEELS (expected >= 5)"
-          echo "  Linux aarch64 wheels: $LINUX_ARM64_WHEELS (expected >= 4)"
-          echo "  macOS x86_64 wheels: $MACOS_X64_WHEELS (expected >= 4)"
-          echo "  macOS arm64 wheels: $MACOS_ARM64_WHEELS (expected >= 4)"
-          echo "  Windows x64 wheels: $WINDOWS_WHEELS (expected >= 4)"
+          echo "  Linux x86_64 wheels: $LINUX_X64_WHEELS (informational)"
+          echo "  Linux aarch64 wheels: $LINUX_ARM64_WHEELS (informational)"
+          echo "  macOS x86_64 wheels: $MACOS_X64_WHEELS (informational)"
+          echo "  macOS arm64 wheels: $MACOS_ARM64_WHEELS (informational)"
+          echo "  Windows x64 wheels: $WINDOWS_WHEELS (informational)"
           echo ""
 
-          # Check minimum wheel counts (combined main + embedded)
+          # Wheel counts are informational only: this workflow's build-wheels
+          # matrix is disabled (the main package is pure Python and its wheels
+          # publish via release-python.yml), so per-platform compiled-wheel
+          # minimums are unsatisfiable here and must not block the release.
           if [ "$LINUX_X64_WHEELS" -lt 5 ]; then
-            echo "  [WARNING] Fewer than expected Linux x86_64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$LINUX_ARM64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected Linux aarch64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$MACOS_X64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected macOS x86_64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$MACOS_ARM64_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected macOS arm64 wheels"
-            VALIDATION_PASSED=false
-          fi
-          if [ "$WINDOWS_WHEELS" -lt 4 ]; then
-            echo "  [WARNING] Fewer than expected Windows x64 wheels"
-            VALIDATION_PASSED=false
+            echo "  [INFO] No/few Linux x86_64 wheels (expected: wheels ship via release-python.yml)"
           fi
 
           TOTAL_WHEELS=$((LINUX_X64_WHEELS + LINUX_ARM64_WHEELS + MACOS_X64_WHEELS + MACOS_ARM64_WHEELS + WINDOWS_WHEELS))
@@ -1095,6 +1081,7 @@ jobs:
           path: sdist
 
       - name: Consolidate Packages
+        id: consolidate
         run: |
           mkdir -p publish
           cp dist/*.whl publish/ 2>/dev/null || true
@@ -1109,7 +1096,14 @@ jobs:
           echo "Embedded package contents:"
           ls -la publish-embedded/
 
+          # pypa/gh-action-pypi-publish hard-fails on an empty packages-dir;
+          # emit outputs so the publish steps can skip instead (wheel builds
+          # are disabled here and the embedded sdist build is commented out).
+          echo "main_has_files=$([ -n "$(ls -A publish)" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "embedded_has_files=$([ -n "$(ls -A publish-embedded)" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Publish Main Package to PyPI
+        if: steps.consolidate.outputs.main_has_files == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: publish/
@@ -1117,6 +1111,7 @@ jobs:
           verbose: true
 
       - name: Publish Embedded Package to PyPI
+        if: steps.consolidate.outputs.embedded_has_files == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: publish-embedded/


### PR DESCRIPTION
## Why

Release run 29326636907 built **every artifact successfully** (Linux+Windows binaries, sdist, RPM/DEB/MSI — the #970 path fix worked) but died in **Validate Release Artifacts**, killing the run before create-release/publish.

## Three compounding issues fixed

1. **`((VAR++))` under `bash -e`**: returns exit status 1 when VAR is 0, so the job crashed on its very first `[OK]` counter increment. → `VAR=$((VAR+1))` (3 sites).
2. **Unsatisfiable wheel minimums**: the script demands ≥21 per-platform compiled wheels, but this workflow's `build-wheels` matrix is disabled — the main package is pure Python and its wheels publish via `release-python.yml` (which is how 0.2.2 already reached PyPI). → wheel counts demoted to informational.
3. **Empty-dir crash in publish** (latent, would have been blocker #4): `pypa/gh-action-pypi-publish` hard-fails on an empty `packages-dir`, and `publish-embedded/` is always empty here (embedded sdist build commented out). → `has_files` outputs on Consolidate + `if:` guards on both publish steps.

## Verification

Extracted the validate script from the YAML and dry-ran it under `bash -e` against the **exact artifact set run 29326636907 produced** (2 binaries + checksums, sdist, RPM/DEB/MSI, 0 wheels): exits 0, `STATUS: PASSED`, `passed=true`. YAML parse-checked.

Same targeted-hotfix-to-main pattern as #961/#970 (workflows-only; promotion guard advisory).

## After merge

Wait for prerelease-ci on the new HEAD, then **retag v0.2.2 at main HEAD** (the existing tag predates all three fixes and nothing was published from it — its release run died in 16s). The tag push auto-triggers release.yml, whose PREPARE gate passes because the tag sha is the freshly-validated HEAD.