### PR TITLE
feat(tenant): TD-TENANT-1 phase 2 — shared trust primitive across REST/gRPC/Flight/pgwire, [security.tenant] config, stable-id port, gateway marker

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -283,6 +283,14 @@ collection_affinity = true
 enabled = false  # Enable for production
 mode = "development"  # development | production | enterprise
 
+# [security.tenant]  # TD-TENANT-1: tenant-identity trust
+# Bare tenant-assertion trust policy applied to EVERY network surface
+# (REST X-Tenant-ID, gRPC/Arrow Flight x-tenant-id metadata, pgwire startup
+# database / tenant session vars). Unset => deployment-mode preset
+# ("open"; "authenticated-only" under multi-tenant strict mode). The
+# PROXIMADB_TENANT_HEADER_TRUST env var overrides both.
+# header_trust = "open"  # open | authenticated-only | gateway-only
+
 [security.authentication]
 enabled = false
 methods = ["api_key"]

--- a/crates/foundation/proximadb-tenant/src/identity_trust.rs
+++ b/crates/foundation/proximadb-tenant/src/identity_trust.rs
@@ -1,0 +1,381 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Tenant-assertion trust — the ONE shared primitive every network surface
+//! uses to reconcile an *asserted* tenant (REST `X-Tenant-ID` header, gRPC /
+//! Arrow Flight `x-tenant-id` metadata, pgwire startup `database` parameter /
+//! session variable) against an *authenticated* tenant binding (JWT claim /
+//! API-key mapping), under a deployment [`HeaderTrustPolicy`] (TD-TENANT-1).
+//!
+//! Before this module each surface reconciled independently and drifted:
+//! REST rejected mismatches with 403, Arrow Flight hand-rolled the same
+//! check, gRPC silently *ignored* a mismatched assertion, and pgwire
+//! accepted any assertion. All four now call
+//! [`resolve_tenant_assertion`]; the surface maps the result onto its own
+//! error vocabulary (HTTP 403 / gRPC `PERMISSION_DENIED` / SQLSTATE 28000).
+
+use serde::{Deserialize, Serialize};
+
+/// Trust policy for a **bare** tenant assertion — a request that asserts a
+/// tenant while carrying NO authenticated tenant binding. When a binding
+/// exists, assertion≠binding is rejected in every mode; `GatewayOnly`
+/// additionally lets an authenticated gateway principal delegate — select an
+/// acting tenant via the assertion (the trusted-gateway topology: the gateway
+/// authenticates with a service credential and stamps the end user's tenant
+/// per request).
+///
+/// Configured via `[security.tenant] header_trust` in `config.toml`, or the
+/// `PROXIMADB_TENANT_HEADER_TRUST` env override applied at server
+/// construction. Unset ⇒ `Open` (default-safe).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HeaderTrustPolicy {
+    /// Accept the bare assertion verbatim. Correct for dev, single-tenant,
+    /// and network-isolated trusted-gateway topologies. The default.
+    #[default]
+    Open,
+    /// Reject any request that asserts a tenant without an authenticated
+    /// binding. Credential-derived tenants (JWT/API-key) are unaffected.
+    AuthenticatedOnly,
+    /// Like `AuthenticatedOnly`, but an authenticated **gateway principal**
+    /// (see [`AuthenticatedTenantBinding::is_gateway_principal`]) may assert
+    /// a different tenant to act on its behalf (delegation).
+    GatewayOnly,
+}
+
+impl std::fmt::Display for HeaderTrustPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Open => write!(f, "open"),
+            Self::AuthenticatedOnly => write!(f, "authenticated-only"),
+            Self::GatewayOnly => write!(f, "gateway-only"),
+        }
+    }
+}
+
+impl std::str::FromStr for HeaderTrustPolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "open" => Ok(Self::Open),
+            "authenticated-only" | "authenticated-match" => Ok(Self::AuthenticatedOnly),
+            "gateway-only" => Ok(Self::GatewayOnly),
+            other => Err(format!(
+                "invalid tenant header-trust policy '{other}' \
+                 (expected open | authenticated-only | gateway-only)"
+            )),
+        }
+    }
+}
+
+impl HeaderTrustPolicy {
+    /// The env override key, applied at server construction (never in
+    /// constructors, so tests and embedded uses stay hermetic).
+    pub const ENV_KEY: &'static str = "PROXIMADB_TENANT_HEADER_TRUST";
+
+    /// Resolve the deployment-effective policy: env override > `configured`
+    /// (config.toml `[security.tenant] header_trust`) > `preset` (deployment-
+    /// mode default). Returns the policy plus an optional warning to log —
+    /// an unparseable env value TIGHTENS to `AuthenticatedOnly` (fail-closed)
+    /// instead of silently running whatever the fallback was.
+    pub fn effective(preset: Self, configured: Option<Self>) -> (Self, Option<String>) {
+        let fallback = configured.unwrap_or(preset);
+        match std::env::var(Self::ENV_KEY) {
+            Ok(raw) => match raw.parse::<Self>() {
+                Ok(policy) => (policy, None),
+                Err(e) => (
+                    Self::AuthenticatedOnly,
+                    Some(format!(
+                        "invalid {}: {e}; tightening to authenticated-only",
+                        Self::ENV_KEY
+                    )),
+                ),
+            },
+            Err(_) => (fallback, None),
+        }
+    }
+}
+
+/// The authenticated tenant binding a surface derived from a verified
+/// credential (JWT `tenant_id` claim, API-key→tenant mapping).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedTenantBinding {
+    /// The tenant the credential is bound to.
+    pub tenant_id: String,
+    /// Whether the principal is a gateway/operator (first-class
+    /// [`GATEWAY_ROLE`]/[`OPERATOR_ROLE`] role marker, or — compat — its
+    /// bound tenant is in the deployment's system-tenant list). Only
+    /// consulted by [`HeaderTrustPolicy::GatewayOnly`] delegation.
+    pub is_gateway_principal: bool,
+}
+
+/// How the tenant identity was resolved. The surface maps this onto its own
+/// source vocabulary (e.g. REST `TenantIdSource::Header` vs `JwtClaim`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedTenantAssertion {
+    /// The bare assertion was accepted (`Open`), or a gateway principal
+    /// delegated to the asserted tenant (`GatewayOnly`).
+    Asserted(String),
+    /// The credential's tenant binding won (assertion absent or equal).
+    Credential(String),
+    /// Nothing asserted and nothing bound — the caller applies its
+    /// deployment default (or rejects, if it requires a tenant).
+    NoTenant,
+}
+
+/// Rejection reasons. Every variant is an isolation event worth an audit log
+/// at the surface (`target: "proximadb::tenant_audit"`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TenantAssertionError {
+    /// A credentialed principal asserted a DIFFERENT tenant — the masquerade
+    /// signature (and not a permitted gateway delegation).
+    Mismatch {
+        asserted: String,
+        authenticated: String,
+    },
+    /// A bare assertion was rejected by a non-`Open` policy.
+    UnauthenticatedAssertionRejected { asserted: String },
+}
+
+impl std::fmt::Display for TenantAssertionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mismatch {
+                asserted,
+                authenticated,
+            } => write!(
+                f,
+                "tenant '{asserted}' does not match authenticated tenant '{authenticated}'"
+            ),
+            Self::UnauthenticatedAssertionRejected { asserted } => write!(
+                f,
+                "tenant '{asserted}' asserted without authenticated credentials; this \
+                 deployment requires a tenant-bound credential"
+            ),
+        }
+    }
+}
+
+/// Reconcile an asserted tenant against an authenticated binding under the
+/// deployment policy. Pure — no I/O, no logging; surfaces own the mapping to
+/// wire errors and the audit trail.
+///
+/// Truth table (A = asserted, B = binding):
+///
+/// | A | B | policy | result |
+/// |---|---|--------|--------|
+/// | – | – | any    | `NoTenant` |
+/// | – | ✓ | any    | `Credential(B)` |
+/// | ✓ | – | `Open` | `Asserted(A)` |
+/// | ✓ | – | strict | `UnauthenticatedAssertionRejected` |
+/// | ✓ | ✓, A==B | any | `Credential(B)` |
+/// | ✓ | ✓, A≠B, gateway + `GatewayOnly` | | `Asserted(A)` (delegation) |
+/// | ✓ | ✓, A≠B otherwise | any | `Mismatch` |
+pub fn resolve_tenant_assertion(
+    asserted: Option<&str>,
+    binding: Option<&AuthenticatedTenantBinding>,
+    policy: HeaderTrustPolicy,
+) -> Result<ResolvedTenantAssertion, TenantAssertionError> {
+    let asserted = asserted
+        .map(str::trim)
+        .filter(|tenant_id| !tenant_id.is_empty());
+
+    match (asserted, binding) {
+        (None, None) => Ok(ResolvedTenantAssertion::NoTenant),
+        (None, Some(binding)) => Ok(ResolvedTenantAssertion::Credential(
+            binding.tenant_id.clone(),
+        )),
+        (Some(asserted), None) => match policy {
+            HeaderTrustPolicy::Open => Ok(ResolvedTenantAssertion::Asserted(asserted.to_string())),
+            HeaderTrustPolicy::AuthenticatedOnly | HeaderTrustPolicy::GatewayOnly => {
+                Err(TenantAssertionError::UnauthenticatedAssertionRejected {
+                    asserted: asserted.to_string(),
+                })
+            }
+        },
+        (Some(asserted), Some(binding)) => {
+            if asserted == binding.tenant_id {
+                return Ok(ResolvedTenantAssertion::Credential(
+                    binding.tenant_id.clone(),
+                ));
+            }
+            if policy == HeaderTrustPolicy::GatewayOnly && binding.is_gateway_principal {
+                return Ok(ResolvedTenantAssertion::Asserted(asserted.to_string()));
+            }
+            Err(TenantAssertionError::Mismatch {
+                asserted: asserted.to_string(),
+                authenticated: binding.tenant_id.clone(),
+            })
+        }
+    }
+}
+
+/// Role marking a gateway/service principal permitted to delegate tenants
+/// under [`HeaderTrustPolicy::GatewayOnly`]. Stamped from credential data
+/// (e.g. a `gateway: true` JWT claim) at `UnifiedUserContext` construction.
+pub const GATEWAY_ROLE: &str = "gateway";
+/// Operator/control-plane role — also a gateway-capable principal.
+pub const OPERATOR_ROLE: &str = "operator";
+
+/// Port for resolving a tenant's ADR-031 stable `u64` id at the identity
+/// boundary. Implemented by the catalog once tenant stable-id minting lands;
+/// surfaces carry the resolved id on their tenant context so catalog/storage
+/// keying can move off raw strings without re-resolving per operation.
+/// `None` = no stable id minted for this tenant (yet) — callers must treat
+/// the id as an optimization, never a second source of truth.
+pub trait TenantStableIdResolver: Send + Sync {
+    fn stable_id_of(&self, tenant_id: &str) -> Option<u64>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(tenant: &str, gateway: bool) -> AuthenticatedTenantBinding {
+        AuthenticatedTenantBinding {
+            tenant_id: tenant.to_string(),
+            is_gateway_principal: gateway,
+        }
+    }
+
+    #[test]
+    fn nothing_asserted_nothing_bound_is_no_tenant() {
+        for policy in [
+            HeaderTrustPolicy::Open,
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert_eq!(
+                resolve_tenant_assertion(None, None, policy),
+                Ok(ResolvedTenantAssertion::NoTenant)
+            );
+        }
+    }
+
+    #[test]
+    fn credential_binding_wins_when_nothing_asserted() {
+        for policy in [
+            HeaderTrustPolicy::Open,
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert_eq!(
+                resolve_tenant_assertion(None, Some(&binding("acme", false)), policy),
+                Ok(ResolvedTenantAssertion::Credential("acme".to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn bare_assertion_accepted_only_under_open() {
+        assert_eq!(
+            resolve_tenant_assertion(Some("demo1"), None, HeaderTrustPolicy::Open),
+            Ok(ResolvedTenantAssertion::Asserted("demo1".to_string()))
+        );
+        for policy in [
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert_eq!(
+                resolve_tenant_assertion(Some("demo1"), None, policy),
+                Err(TenantAssertionError::UnauthenticatedAssertionRejected {
+                    asserted: "demo1".to_string()
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn matching_assertion_resolves_to_credential() {
+        assert_eq!(
+            resolve_tenant_assertion(
+                Some("acme"),
+                Some(&binding("acme", false)),
+                HeaderTrustPolicy::AuthenticatedOnly
+            ),
+            Ok(ResolvedTenantAssertion::Credential("acme".to_string()))
+        );
+    }
+
+    #[test]
+    fn mismatch_rejected_for_non_gateway_in_every_mode() {
+        for policy in [
+            HeaderTrustPolicy::Open,
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert_eq!(
+                resolve_tenant_assertion(Some("victim"), Some(&binding("acme", false)), policy),
+                Err(TenantAssertionError::Mismatch {
+                    asserted: "victim".to_string(),
+                    authenticated: "acme".to_string(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_delegation_only_under_gateway_only() {
+        assert_eq!(
+            resolve_tenant_assertion(
+                Some("demo1"),
+                Some(&binding("system", true)),
+                HeaderTrustPolicy::GatewayOnly
+            ),
+            Ok(ResolvedTenantAssertion::Asserted("demo1".to_string()))
+        );
+        for policy in [
+            HeaderTrustPolicy::Open,
+            HeaderTrustPolicy::AuthenticatedOnly,
+        ] {
+            assert!(matches!(
+                resolve_tenant_assertion(Some("demo1"), Some(&binding("system", true)), policy),
+                Err(TenantAssertionError::Mismatch { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn whitespace_and_empty_assertions_are_treated_as_absent() {
+        assert_eq!(
+            resolve_tenant_assertion(Some("   "), None, HeaderTrustPolicy::AuthenticatedOnly),
+            Ok(ResolvedTenantAssertion::NoTenant)
+        );
+        assert_eq!(
+            resolve_tenant_assertion(Some(""), None, HeaderTrustPolicy::AuthenticatedOnly),
+            Ok(ResolvedTenantAssertion::NoTenant)
+        );
+    }
+
+    #[test]
+    fn policy_parses_and_displays() {
+        use std::str::FromStr;
+        assert_eq!(
+            HeaderTrustPolicy::from_str("open").unwrap(),
+            HeaderTrustPolicy::Open
+        );
+        assert_eq!(
+            HeaderTrustPolicy::from_str("AUTHENTICATED_MATCH").unwrap(),
+            HeaderTrustPolicy::AuthenticatedOnly
+        );
+        assert_eq!(
+            HeaderTrustPolicy::from_str("gateway-only").unwrap(),
+            HeaderTrustPolicy::GatewayOnly
+        );
+        assert!(HeaderTrustPolicy::from_str("everything-goes").is_err());
+        assert_eq!(HeaderTrustPolicy::default(), HeaderTrustPolicy::Open);
+        assert_eq!(HeaderTrustPolicy::GatewayOnly.to_string(), "gateway-only");
+    }
+
+    #[test]
+    fn policy_serde_round_trips_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&HeaderTrustPolicy::AuthenticatedOnly).unwrap(),
+            "\"authenticated-only\""
+        );
+        assert_eq!(
+            serde_json::from_str::<HeaderTrustPolicy>("\"gateway-only\"").unwrap(),
+            HeaderTrustPolicy::GatewayOnly
+        );
+    }
+}

--- a/crates/foundation/proximadb-tenant/src/lib.rs
+++ b/crates/foundation/proximadb-tenant/src/lib.rs
@@ -419,3 +419,16 @@ pub mod rbac_context;
 pub use rbac_context::{
     RbacTenantContext, UnifiedAuthMethod, UnifiedPermission, UnifiedUserContext,
 };
+
+// ============================================================================
+// Tenant-assertion trust (TD-TENANT-1): the ONE shared primitive every
+// network surface (REST, gRPC, Arrow Flight, pgwire) uses to reconcile an
+// asserted tenant against an authenticated binding under the deployment
+// HeaderTrustPolicy, plus the ADR-031 stable-id resolver port.
+// ============================================================================
+pub mod identity_trust;
+pub use identity_trust::{
+    AuthenticatedTenantBinding, GATEWAY_ROLE, HeaderTrustPolicy, OPERATOR_ROLE,
+    ResolvedTenantAssertion, TenantAssertionError, TenantStableIdResolver,
+    resolve_tenant_assertion,
+};

--- a/crates/foundation/proximadb-tenant/src/rbac_context.rs
+++ b/crates/foundation/proximadb-tenant/src/rbac_context.rs
@@ -151,6 +151,23 @@ impl UnifiedUserContext {
         self.user_id != "anonymous"
     }
 
+    /// First-class gateway/operator principal marker (TD-TENANT-1). A gateway
+    /// principal may delegate — assert a different acting tenant — under
+    /// [`crate::identity_trust::HeaderTrustPolicy::GatewayOnly`]. Stamped
+    /// from credential data at construction: a `gateway`/`operator` role
+    /// (e.g. from a `gateway: true` JWT claim) or a `gateway: "true"`
+    /// metadata entry. Prefer this over tenant-name membership in a
+    /// system-tenant list (the compat fallback surfaces still honor).
+    pub fn is_gateway_principal(&self) -> bool {
+        self.roles.iter().any(|role| {
+            role == crate::identity_trust::GATEWAY_ROLE
+                || role == crate::identity_trust::OPERATOR_ROLE
+        }) || self
+            .metadata
+            .get("gateway")
+            .is_some_and(|value| value == "true")
+    }
+
     /// Check if the user session has expired. A session with no expiry is never
     /// considered expired.
     pub fn is_session_expired(&self) -> bool {

--- a/docs/10-quality/td/TD-TENANT-1-header-trust-policy.adoc
+++ b/docs/10-quality/td/TD-TENANT-1-header-trust-policy.adoc
@@ -49,25 +49,53 @@ hermetic): `PROXIMADB_TENANT_HEADER_TRUST=open|authenticated-only|gateway-only`.
 An unparseable value tightens to `authenticated-only` (fail-closed) rather than
 silently running `open`. Unset ⇒ config value; default-safe, no flag-day.
 
-== Follow-ups (open)
+== Phase 2 (shipped) — the follow-ups
 
-1. **Non-REST surfaces.** The policy currently gates the REST tenant
-   middleware only. pgwire, gRPC, and Arrow Flight extract tenant identity
-   through their own paths and must honor the same policy (one shared
-   resolution primitive in `proximadb-tenant`, not three re-implementations).
-2. **config.toml surface.** Expose `header_trust` under `[security.tenant]`
-   (today: preset + env override). Belongs with the TD-CAT-3
-   `TenantDeploymentMode` plumbing.
-3. **Stable-id resolution at the boundary (ADR-031).** The middleware resolves
-   a tenant *string*; catalog/storage keying should map it to the tenant's
-   stable `u64` id (per-type `IdAllocator`,
-   `crates/control/proximadb-catalog/src/id_allocator.rs`) so logical names
-   stay per-tenant aliases — `(tenant stable-id, namespace stable-id, logical
-   name) → table stable-id`, never a global name lookup. PR #956 already
-   routes /documents auto-create through `create_table → mint_stable_identity`;
-   audit remaining DDL paths for bare catalog writes.
-4. **Gateway principal marker.** `gateway-only` keys on
-   `system_tenants` membership of the *bound tenant*. A first-class operator/
-   service-principal marker on `UnifiedUserContext` (role-based) would be
-   cleaner than tenant-name membership once the two-tier operator/account
-   model (Phase 5) lands.
+1. **[DONE] One shared primitive, every surface.** The policy logic moved to
+   the foundation crate: `proximadb_tenant::identity_trust::resolve_tenant_assertion`
+   (pure; truth-table tested). All four surfaces call it:
+   * REST middleware (`src/network/middleware/tenant.rs`) — delegates and maps
+     onto `TenantIdSource` + 403.
+   * gRPC auth layer (`src/network/grpc/auth.rs`) — resolves once per request,
+     stores the verdict in `GrpcAuthContext::resolved_tenant`, rejects with
+     `PERMISSION_DENIED`. This CLOSED a pre-existing gap: a non-capability
+     credential's mismatched `x-tenant-id` used to be silently ignored.
+   * Arrow Flight (`src/network/arrow_ipc/service.rs`) — replaces the
+     hand-rolled mismatch match; also applies the policy when no
+     SecurityCoordinator is wired (bare-by-definition assertions).
+   * pgwire (`src/network/postgres/{mod,protocol}.rs`) — trust auth means
+     every assertion is bare; enforced at the TWO assertion entry points:
+     startup `database` (FATAL 28000 at handshake) and
+     `SET proximadb.write.tenant_id` (ERROR 28000). The ~15 downstream
+     resolve call sites are untouched — assertions are gated at entry.
+2. **[DONE] config.toml surface.** `[security.tenant] header_trust` on
+   `SecurityConfig` (serde kebab-case enum). Effective policy resolved ONCE in
+   `database.rs` via `HeaderTrustPolicy::effective` (env > config > mode
+   preset; unparseable env tightens to `authenticated-only`) and threaded
+   through `MultiServer::with_tenant_header_trust` into every surface.
+3. **[PARTIAL] Stable-id resolution at the boundary (ADR-031).** The port
+   (`proximadb_tenant::TenantStableIdResolver`) + carry
+   (`MiddlewareTenantContext::tenant_stable_id`, stamped when a resolver is
+   wired via `TenantExtractor::with_stable_id_resolver`) shipped. REMAINING:
+   catalog-side tenant stable-id minting (a tenant-type `IdAllocator` space +
+   durable id on the tenant entity) — no tenant→u64 mapping exists in the
+   catalog yet, so no production resolver is wired. The string `tenant_id`
+   stays authoritative; the stable id is an optimization, never a second
+   source of truth. PR #956 already routes /documents auto-create through
+   `create_table → mint_stable_identity`; audit remaining DDL paths for bare
+   catalog writes when minting lands.
+4. **[DONE] Gateway principal marker.** First-class
+   `UnifiedUserContext::is_gateway_principal()` (a `gateway`/`operator` role
+   or `gateway: "true"` metadata, stamped from credential data). The REST
+   middleware keeps `system_tenants` membership as a compat fallback; the
+   gRPC/Flight surfaces use the marker only (the desired end state).
+
+== Follow-ups (still open)
+
+* Catalog-side tenant stable-id minting + a production
+  `TenantStableIdResolver` (see item 3 above).
+* Credential-side stamping of the gateway role beyond JWTs (API-key config
+  schema carries no roles today; SSO/mTLS untouched).
+* pgwire authenticated bindings: the surface still runs trust auth, so
+  strict policies disable tenant selection over pgwire entirely; password/
+  SCRAM auth with tenant-bound credentials would restore it.

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -241,8 +241,8 @@ for evidence/provenance, and event/history records for temporal state. The v1
 
 | Security runtime
 | Beta
-| JWT, API key, SSO hooks, mTLS identity, and CRL-backed revocation reload/freshness checks are present. REST tenant identity is credential-bound by policy (TD-TENANT-1): a header that contradicts an authenticated tenant binding is always 403; the bare `X-Tenant-ID` header is governed by `HeaderTrustPolicy` (`open` default / `authenticated-only` in the multi-tenant strict preset / `gateway-only` for trusted-gateway delegation), overridable via `PROXIMADB_TENANT_HEADER_TRUST`. Rejections emit `proximadb::tenant_audit` warns.
-| Security admin/status APIs and stronger online revocation policy are incomplete. The header-trust policy gates the REST boundary only — pgwire/gRPC/Arrow Flight tenant extraction honoring the same policy is an open follow-up (TD-TENANT-1).
+| JWT, API key, SSO hooks, mTLS identity, and CRL-backed revocation reload/freshness checks are present. Tenant identity is credential-bound by policy on EVERY network surface (TD-TENANT-1, one shared primitive in `proximadb-tenant`): an assertion that contradicts an authenticated tenant binding is always rejected (HTTP 403 / gRPC PERMISSION_DENIED / SQLSTATE 28000); the bare assertion (REST `X-Tenant-ID`, gRPC/Arrow Flight `x-tenant-id` metadata, pgwire startup `database` + tenant session vars) is governed by `HeaderTrustPolicy` (`open` default / `authenticated-only` in the multi-tenant strict preset / `gateway-only` for trusted-gateway delegation via a first-class gateway-principal role marker), configurable via `[security.tenant] header_trust` and overridable via `PROXIMADB_TENANT_HEADER_TRUST`. Rejections emit `proximadb::tenant_audit` warns.
+| Security admin/status APIs and stronger online revocation policy are incomplete. pgwire runs trust auth (no credential binding), so strict policies disable pgwire tenant selection rather than authenticate it; ADR-031 tenant stable-id minting behind the `TenantStableIdResolver` port is pending (TD-TENANT-1).
 
 | Hybrid retrieval
 | Beta

--- a/src/database.rs
+++ b/src/database.rs
@@ -608,6 +608,28 @@ impl ProximaDB {
             );
         }
 
+        // TD-TENANT-1: resolve the deployment-effective bare tenant-assertion
+        // trust policy ONCE (env > [security.tenant] header_trust > deployment-
+        // mode preset) and thread it into every network surface via MultiServer.
+        let (tenant_header_trust, trust_warning) = proximadb_tenant::HeaderTrustPolicy::effective(
+            match &tenant_deployment_mode {
+                proximadb_tenant::TenantDeploymentMode::MultiTenant => {
+                    proximadb_tenant::HeaderTrustPolicy::AuthenticatedOnly
+                }
+                proximadb_tenant::TenantDeploymentMode::SingleTenant { .. } => {
+                    proximadb_tenant::HeaderTrustPolicy::Open
+                }
+            },
+            config
+                .security
+                .as_ref()
+                .and_then(|security| security.tenant.header_trust),
+        );
+        if let Some(warning) = trust_warning {
+            tracing::warn!("{warning}");
+        }
+        tracing::info!(policy = %tenant_header_trust, "🔐 tenant header-trust policy (TD-TENANT-1)");
+
         let multi_server = network::MultiServer::new_with_queue_client(
             multi_config,
             shared_services,
@@ -616,7 +638,8 @@ impl ProximaDB {
             tenant_deployment_mode,
             llm_engine,
             queue_client.clone(),
-        );
+        )
+        .with_tenant_header_trust(tenant_header_trust);
         tracing::debug!("✅ ProximaDB::new - MultiServer created");
 
         // Phase 2H wiring (drainer half): spawn the drainer only when

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -137,6 +137,10 @@ pub struct ProximaFlightService {
     vector_operations_service: Arc<crate::services::VectorOperationsService>,
     collection_service: Arc<crate::services::CollectionService>,
     security_coordinator: Option<Arc<SecurityCoordinator>>,
+    /// TD-TENANT-1: the deployment's bare `x-tenant-id` trust policy,
+    /// enforced through the ONE shared primitive in
+    /// `authenticated_flight_context`. Default `Open` (legacy behavior).
+    tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
     catalog_manager: Option<Arc<CatalogManager>>,
     /// R-7c.4b: when present, the `rank_features_export` Flight action
     /// drives the multi-phase ranking pipeline through this singleton.
@@ -238,6 +242,7 @@ impl ProximaFlightService {
             vector_operations_service,
             collection_service,
             security_coordinator: None,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
             catalog_manager: None,
             rank_services: None,
             primary_pod_gate: None,
@@ -321,6 +326,14 @@ impl ProximaFlightService {
         security_coordinator: Option<Arc<SecurityCoordinator>>,
     ) -> Self {
         self.security_coordinator = security_coordinator;
+        self
+    }
+
+    /// Set the deployment's bare `x-tenant-id` trust policy (TD-TENANT-1) —
+    /// the same policy the REST middleware, gRPC auth layer, and pgwire
+    /// resolve seams enforce through the shared primitive.
+    pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
+        self.tenant_header_trust = policy;
         self
     }
 
@@ -534,10 +547,36 @@ impl ProximaFlightService {
         metadata: &tonic::metadata::MetadataMap,
         peer_certs: Option<Arc<Vec<tonic::transport::CertificateDer<'static>>>>,
     ) -> std::result::Result<AuthenticatedFlightContext, TonicStatus> {
+        use proximadb_tenant::identity_trust::{
+            AuthenticatedTenantBinding, ResolvedTenantAssertion, resolve_tenant_assertion,
+        };
+
         let requested_tenant_id = Self::tenant_id_from_metadata(metadata);
         let Some(security_coordinator) = &self.security_coordinator else {
+            // No auth wired: the assertion is bare by definition — the
+            // deployment policy decides (TD-TENANT-1). `Open` preserves the
+            // legacy behavior; strict policies reject the assertion.
+            let tenant_id = match resolve_tenant_assertion(
+                requested_tenant_id.as_deref(),
+                None,
+                self.tenant_header_trust,
+            ) {
+                Ok(ResolvedTenantAssertion::Asserted(tenant)) => Some(tenant),
+                Ok(ResolvedTenantAssertion::Credential(_)) => unreachable!("no binding provided"),
+                Ok(ResolvedTenantAssertion::NoTenant) => None,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "proximadb::tenant_audit",
+                        surface = "arrow_flight",
+                        policy = %self.tenant_header_trust,
+                        %error,
+                        "rejected bare x-tenant-id without authenticated tenant binding"
+                    );
+                    return Err(TonicStatus::permission_denied(error.to_string()));
+                }
+            };
             return Ok(AuthenticatedFlightContext {
-                tenant_id: requested_tenant_id,
+                tenant_id,
                 capability: None,
             });
         };
@@ -551,15 +590,35 @@ impl ProximaFlightService {
             .map_err(|e| TonicStatus::unauthenticated(format!("Authentication failed: {}", e)))?;
 
         let capability = DataPlaneCapability::from_user_context(&user_context);
-        let tenant_id = match (requested_tenant_id, user_context.tenant_id) {
-            (Some(requested), Some(authenticated)) if requested != authenticated => {
-                return Err(TonicStatus::permission_denied(format!(
-                    "Tenant '{}' does not match authenticated tenant '{}'",
-                    requested, authenticated
-                )));
+        // TD-TENANT-1: the ONE shared reconciliation primitive (same call
+        // REST / gRPC / pgwire make) replaces the hand-rolled mismatch match.
+        let binding = user_context
+            .tenant_id
+            .as_ref()
+            .map(|tenant_id| AuthenticatedTenantBinding {
+                tenant_id: tenant_id.clone(),
+                is_gateway_principal: user_context.is_gateway_principal(),
+            });
+        let tenant_id = match resolve_tenant_assertion(
+            requested_tenant_id.as_deref(),
+            binding.as_ref(),
+            self.tenant_header_trust,
+        ) {
+            Ok(
+                ResolvedTenantAssertion::Asserted(tenant)
+                | ResolvedTenantAssertion::Credential(tenant),
+            ) => Some(tenant),
+            Ok(ResolvedTenantAssertion::NoTenant) => None,
+            Err(error) => {
+                tracing::warn!(
+                    target: "proximadb::tenant_audit",
+                    surface = "arrow_flight",
+                    policy = %self.tenant_header_trust,
+                    %error,
+                    "rejected x-tenant-id under tenant trust policy"
+                );
+                return Err(TonicStatus::permission_denied(error.to_string()));
             }
-            (Some(requested), _) => Some(requested),
-            (None, authenticated) => authenticated,
         };
         Ok(AuthenticatedFlightContext {
             tenant_id,

--- a/src/network/auth/middleware.rs
+++ b/src/network/auth/middleware.rs
@@ -1128,6 +1128,7 @@ mod tests {
             },
             encryption: crate::security::EncryptionConfig::default(),
             key_store: crate::security::KeyStoreConfig::default(),
+            tenant: Default::default(),
         }
     }
 
@@ -1176,6 +1177,7 @@ mod tests {
             },
             encryption: crate::security::EncryptionConfig::default(),
             key_store: crate::security::KeyStoreConfig::default(),
+            tenant: Default::default(),
         }
     }
 

--- a/src/network/grpc/auth.rs
+++ b/src/network/grpc/auth.rs
@@ -16,6 +16,11 @@ use tonic::codegen::http::{self, HeaderMap, Request as HttpRequest, Response as 
 use tonic::{Code, Request, Status};
 use tower::{Layer, Service};
 
+use proximadb_tenant::identity_trust::{
+    AuthenticatedTenantBinding, HeaderTrustPolicy, ResolvedTenantAssertion, TenantAssertionError,
+    resolve_tenant_assertion,
+};
+
 use crate::network::auth::middleware::DataPlaneCapability;
 use crate::security::{AuthenticationData, SecurityCoordinator, UnifiedUserContext};
 
@@ -23,18 +28,31 @@ use crate::security::{AuthenticationData, SecurityCoordinator, UnifiedUserContex
 pub struct GrpcAuthContext {
     pub user_context: UnifiedUserContext,
     pub capability: Option<DataPlaneCapability>,
+    /// The request tenant as resolved by the ONE shared trust primitive
+    /// (`proximadb_tenant::resolve_tenant_assertion`, TD-TENANT-1): the
+    /// credential binding, an accepted `x-tenant-id` assertion, or a
+    /// permitted gateway delegation. `None` = no tenant asserted or bound.
+    pub resolved_tenant: Option<String>,
 }
 
 #[derive(Clone)]
 pub struct GrpcAuthLayer {
     security_coordinator: Arc<SecurityCoordinator>,
+    header_trust: HeaderTrustPolicy,
 }
 
 impl GrpcAuthLayer {
     pub fn new(security_coordinator: Arc<SecurityCoordinator>) -> Self {
         Self {
             security_coordinator,
+            header_trust: HeaderTrustPolicy::default(),
         }
+    }
+
+    /// Set the deployment's bare `x-tenant-id` trust policy (TD-TENANT-1).
+    pub fn with_header_trust(mut self, header_trust: HeaderTrustPolicy) -> Self {
+        self.header_trust = header_trust;
+        self
     }
 }
 
@@ -42,6 +60,7 @@ impl GrpcAuthLayer {
 pub struct GrpcAuthService<S> {
     inner: S,
     security_coordinator: Arc<SecurityCoordinator>,
+    header_trust: HeaderTrustPolicy,
 }
 
 impl<S> Layer<S> for GrpcAuthLayer {
@@ -51,6 +70,7 @@ impl<S> Layer<S> for GrpcAuthLayer {
         GrpcAuthService {
             inner,
             security_coordinator: self.security_coordinator.clone(),
+            header_trust: self.header_trust,
         }
     }
 }
@@ -77,8 +97,11 @@ where
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
+        let header_trust = self.header_trust;
+
         Box::pin(async move {
-            match authenticate_http_request(&security_coordinator, &mut request).await {
+            match authenticate_http_request(&security_coordinator, &mut request, header_trust).await
+            {
                 Ok(()) => inner.call(request).await,
                 Err(status) => Ok(status_to_http_response(status)),
             }
@@ -89,6 +112,7 @@ where
 pub async fn authenticate_http_request<B>(
     security_coordinator: &SecurityCoordinator,
     request: &mut HttpRequest<B>,
+    header_trust: HeaderTrustPolicy,
 ) -> Result<(), Status> {
     let path = request.uri().path();
     if is_arrow_flight_path(path) {
@@ -107,6 +131,48 @@ pub async fn authenticate_http_request<B>(
         validate_tenant_metadata(&user_context, request.headers())?;
     }
 
+    // TD-TENANT-1: reconcile the asserted `x-tenant-id` against the
+    // credential's tenant binding through the ONE shared primitive (same call
+    // REST / Arrow Flight / pgwire make). This also closes the pre-existing
+    // gRPC gap where a NON-capability credential's metadata mismatch was
+    // silently ignored instead of rejected.
+    let asserted = request
+        .headers()
+        .get("x-tenant-id")
+        .and_then(|value| value.to_str().ok());
+    let binding = user_context
+        .tenant_id
+        .as_ref()
+        .map(|tenant_id| AuthenticatedTenantBinding {
+            tenant_id: tenant_id.clone(),
+            is_gateway_principal: user_context.is_gateway_principal(),
+        });
+    let resolved_tenant = match resolve_tenant_assertion(asserted, binding.as_ref(), header_trust) {
+        Ok(
+            ResolvedTenantAssertion::Asserted(tenant) | ResolvedTenantAssertion::Credential(tenant),
+        ) => Some(tenant),
+        Ok(ResolvedTenantAssertion::NoTenant) => None,
+        Err(error @ TenantAssertionError::Mismatch { .. }) => {
+            tracing::warn!(
+                target: "proximadb::tenant_audit",
+                surface = "grpc",
+                %error,
+                "rejected x-tenant-id: does not match authenticated tenant binding"
+            );
+            return Err(Status::permission_denied(error.to_string()));
+        }
+        Err(error @ TenantAssertionError::UnauthenticatedAssertionRejected { .. }) => {
+            tracing::warn!(
+                target: "proximadb::tenant_audit",
+                surface = "grpc",
+                policy = %header_trust,
+                %error,
+                "rejected bare x-tenant-id without authenticated tenant binding"
+            );
+            return Err(Status::permission_denied(error.to_string()));
+        }
+    };
+
     // Open-core cache tier hook: record the tenant's tier from `x-tenant-tier`
     // metadata (control-plane supplied, opaque id) for the cache policy, before
     // `user_context` is moved into the auth context.
@@ -121,6 +187,7 @@ pub async fn authenticate_http_request<B>(
     request.extensions_mut().insert(GrpcAuthContext {
         user_context,
         capability,
+        resolved_tenant,
     });
 
     if let (Some(tenant), Some(tier)) = (tenant_for_tier, tier_claim) {
@@ -137,11 +204,17 @@ pub fn data_plane_capability<T>(request: &Request<T>) -> Option<DataPlaneCapabil
 }
 
 pub fn tenant_id<T>(request: &Request<T>) -> Option<String> {
-    request
-        .extensions()
-        .get::<GrpcAuthContext>()
-        .and_then(|context| context.user_context.tenant_id.clone())
-        .or_else(|| tenant_id_from_metadata(request.metadata()))
+    if let Some(context) = request.extensions().get::<GrpcAuthContext>() {
+        // The auth layer already reconciled assertion vs binding under the
+        // deployment policy (TD-TENANT-1); its verdict is authoritative.
+        return context
+            .resolved_tenant
+            .clone()
+            .or_else(|| context.user_context.tenant_id.clone());
+    }
+    // No auth layer on this mount (dev / embedded): bare metadata is the only
+    // signal — the legacy Open behavior. Strict policies require the layer.
+    tenant_id_from_metadata(request.metadata())
 }
 
 /// The RESOLVED request tenant for gRPC + Arrow Flight — the authenticated /
@@ -449,6 +522,7 @@ mod tests {
             },
             encryption: crate::security::EncryptionConfig::default(),
             key_store: crate::security::KeyStoreConfig::default(),
+            tenant: Default::default(),
         }
     }
 
@@ -504,7 +578,7 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        authenticate_http_request(&coordinator().await, &mut request)
+        authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
             .await
             .expect("valid gRPC capability should authenticate");
 
@@ -532,9 +606,10 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        let status = authenticate_http_request(&coordinator().await, &mut request)
-            .await
-            .expect_err("REST capability must not authorize generic gRPC");
+        let status =
+            authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
+                .await
+                .expect_err("REST capability must not authorize generic gRPC");
         assert_eq!(status.code(), Code::PermissionDenied);
     }
 
@@ -548,9 +623,10 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        let status = authenticate_http_request(&coordinator().await, &mut request)
-            .await
-            .expect_err("capability must not authorize catalog methods");
+        let status =
+            authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
+                .await
+                .expect_err("capability must not authorize catalog methods");
         assert_eq!(status.code(), Code::PermissionDenied);
     }
 
@@ -616,7 +692,7 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        authenticate_http_request(&coordinator().await, &mut request)
+        authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
             .await
             .expect("Flight service performs its own auth");
         assert!(request.extensions().get::<GrpcAuthContext>().is_none());
@@ -632,9 +708,10 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        let status = authenticate_http_request(&coordinator().await, &mut request)
-            .await
-            .expect_err("tenant header mismatch must fail");
+        let status =
+            authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
+                .await
+                .expect_err("tenant header mismatch must fail");
         assert_eq!(status.code(), Code::PermissionDenied);
     }
 
@@ -664,7 +741,7 @@ mod tests {
             .body(())
             .expect("request should build");
 
-        authenticate_http_request(&coordinator().await, &mut request)
+        authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
             .await
             .expect("normal JWT should authenticate");
         assert!(
@@ -674,5 +751,89 @@ mod tests {
                 .and_then(|context| context.capability.as_ref())
                 .is_none()
         );
+    }
+
+    async fn normal_jwt(tenant: Option<&str>) -> String {
+        let jwt_service = JwtService::new(crate::network::auth::config::JwtConfig {
+            secret: Some("dev-jwt-secret".to_string()),
+            expiration_secs: 900,
+            refresh_expiration_secs: 86400,
+            issuer: "operator-control-plane".to_string(),
+            audience: "proximadb-data-plane".to_string(),
+            algorithm: JwtAlgorithm::HS256,
+        })
+        .expect("jwt service should initialize");
+        jwt_service
+            .generate_token_pair(
+                "admin-user",
+                tenant.map(str::to_string),
+                vec!["admin".to_string()],
+            )
+            .await
+            .expect("jwt should generate")
+            .access_token
+    }
+
+    /// TD-TENANT-1 gap closure: a NON-capability credential asserting a
+    /// different tenant via `x-tenant-id` was previously silently ignored
+    /// (the authenticated tenant just won). It is now a PERMISSION_DENIED
+    /// in every policy mode — the same masquerade rejection REST applies.
+    #[tokio::test]
+    async fn grpc_auth_rejects_normal_jwt_tenant_metadata_mismatch() {
+        let token = normal_jwt(Some("tenant-a")).await;
+        let mut request = HttpRequest::builder()
+            .uri("/proximadb.v1.CollectionService/ListCollections")
+            .header("authorization", format!("Bearer {token}"))
+            .header("x-tenant-id", "tenant-b")
+            .body(())
+            .expect("request should build");
+
+        let status =
+            authenticate_http_request(&coordinator().await, &mut request, HeaderTrustPolicy::Open)
+                .await
+                .expect_err("normal-JWT tenant metadata mismatch must fail");
+        assert_eq!(status.code(), Code::PermissionDenied);
+    }
+
+    /// A credential with NO tenant binding asserting a tenant via metadata:
+    /// accepted under `open` (resolved tenant = the assertion), rejected
+    /// under `authenticated-only`.
+    #[tokio::test]
+    async fn grpc_auth_applies_policy_to_unbound_credential_assertions() {
+        let token = normal_jwt(None).await;
+        let build = |token: &str| {
+            HttpRequest::builder()
+                .uri("/proximadb.v1.CollectionService/ListCollections")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-tenant-id", "demo1")
+                .body(())
+                .expect("request should build")
+        };
+
+        let mut open_request = build(&token);
+        authenticate_http_request(
+            &coordinator().await,
+            &mut open_request,
+            HeaderTrustPolicy::Open,
+        )
+        .await
+        .expect("open policy accepts the assertion");
+        assert_eq!(
+            open_request
+                .extensions()
+                .get::<GrpcAuthContext>()
+                .and_then(|context| context.resolved_tenant.as_deref()),
+            Some("demo1")
+        );
+
+        let mut strict_request = build(&token);
+        let status = authenticate_http_request(
+            &coordinator().await,
+            &mut strict_request,
+            HeaderTrustPolicy::AuthenticatedOnly,
+        )
+        .await
+        .expect_err("strict policy rejects the unbound assertion");
+        assert_eq!(status.code(), Code::PermissionDenied);
     }
 }

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -76,6 +76,12 @@ pub struct MiddlewareTenantContext {
     /// Whether this is a system/admin tenant with elevated privileges. Doubles
     /// as the operator (control-plane) marker.
     pub is_system_tenant: bool,
+    /// ADR-031 stable `u64` id of the tenant, resolved at the identity
+    /// boundary when a [`proximadb_tenant::TenantStableIdResolver`] is wired
+    /// on the extractor. `None` = not resolved / not yet minted — always an
+    /// optimization for catalog/storage keying, never a second source of
+    /// truth (the string `tenant_id` remains authoritative).
+    pub tenant_stable_id: Option<u64>,
 }
 
 impl MiddlewareTenantContext {
@@ -88,6 +94,7 @@ impl MiddlewareTenantContext {
             account_id: None,
             source,
             is_system_tenant,
+            tenant_stable_id: None,
         }
     }
 
@@ -135,72 +142,17 @@ pub enum TenantIdSource {
     System,
 }
 
-/// Trust policy for the **bare** `X-Tenant-ID` header — i.e. a request that
-/// asserts a tenant via header while carrying NO authenticated tenant binding
-/// (no JWT claim / API-key mapping). When a binding exists, the header must
-/// match it (403 otherwise) in every mode; `GatewayOnly` additionally lets an
-/// authenticated system/gateway principal delegate — select an acting tenant
-/// via the header (the trusted-gateway topology: the gateway authenticates
-/// with a service credential and stamps the end user's tenant per request).
-///
-/// Env override at server construction: `PROXIMADB_TENANT_HEADER_TRUST` =
-/// `open` | `authenticated-only` | `gateway-only` (see
-/// [`TenantExtractorConfig::apply_env_overrides`]). Unset ⇒ the config value
-/// (default-safe: `Open` preserves existing deployments).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum HeaderTrustPolicy {
-    /// Accept the bare header verbatim. Correct for dev, single-tenant, and
-    /// network-isolated trusted-gateway topologies. The default.
-    #[default]
-    Open,
-    /// Reject (403 + audit log) any request that asserts a tenant via header
-    /// without an authenticated binding. Credential-derived tenants
-    /// (JWT/API-key) are unaffected. Default for
-    /// [`TenantExtractorConfig::multi_tenant`] strict mode.
-    AuthenticatedOnly,
-    /// Like `AuthenticatedOnly`, but an authenticated **system/gateway
-    /// principal** (its bound tenant is in
-    /// [`TenantExtractorConfig::system_tenants`]) may set `X-Tenant-ID` to act
-    /// on behalf of that tenant (delegation is audit-logged).
-    GatewayOnly,
-}
+/// The bare-header trust policy — MOVED to the foundation crate
+/// (`proximadb_tenant::identity_trust`, TD-TENANT-1 follow-up) so pgwire,
+/// gRPC, and Arrow Flight share the exact same reconciliation primitive.
+/// Re-exported here so `crate::network::middleware::tenant::HeaderTrustPolicy`
+/// stays a stable path.
+pub use proximadb_tenant::identity_trust::HeaderTrustPolicy;
 
-impl std::fmt::Display for HeaderTrustPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Open => write!(f, "open"),
-            Self::AuthenticatedOnly => write!(f, "authenticated-only"),
-            Self::GatewayOnly => write!(f, "gateway-only"),
-        }
-    }
-}
-
-impl std::str::FromStr for HeaderTrustPolicy {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim().to_ascii_lowercase().replace('_', "-").as_str() {
-            "open" => Ok(Self::Open),
-            "authenticated-only" | "authenticated-match" => Ok(Self::AuthenticatedOnly),
-            "gateway-only" => Ok(Self::GatewayOnly),
-            other => Err(format!(
-                "invalid tenant header-trust policy '{other}' \
-                 (expected open | authenticated-only | gateway-only)"
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum TenantExtractionError {
-    HeaderAuthenticatedMismatch {
-        requested: String,
-        authenticated: String,
-    },
-    /// The bare header was rejected by a non-`Open` [`HeaderTrustPolicy`]:
-    /// the request asserted a tenant without any authenticated binding.
-    UnauthenticatedHeaderRejected { requested: String },
-}
+use proximadb_tenant::identity_trust::{
+    AuthenticatedTenantBinding, ResolvedTenantAssertion, TenantAssertionError,
+    resolve_tenant_assertion,
+};
 
 impl std::fmt::Display for TenantIdSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -306,32 +258,21 @@ impl TenantExtractorConfig {
     }
 
     /// Apply deployment env overrides. Called at server construction (NOT in
-    /// constructors, so tests and embedded uses stay hermetic). Currently:
-    /// `PROXIMADB_TENANT_HEADER_TRUST` = `open` | `authenticated-only` |
-    /// `gateway-only` overrides `header_trust`; an unparseable value is
-    /// rejected loudly rather than silently weakening the policy.
+    /// constructors, so tests and embedded uses stay hermetic). Delegates to
+    /// the ONE shared resolution (`HeaderTrustPolicy::effective`): env
+    /// `PROXIMADB_TENANT_HEADER_TRUST` wins; an unparseable value tightens
+    /// to `authenticated-only` (fail-closed) rather than silently weakening.
     pub fn apply_env_overrides(mut self) -> Self {
-        if let Ok(raw) = std::env::var("PROXIMADB_TENANT_HEADER_TRUST") {
-            match raw.parse::<HeaderTrustPolicy>() {
-                Ok(policy) => {
-                    tracing::info!(
-                        %policy,
-                        "tenant header-trust policy set from PROXIMADB_TENANT_HEADER_TRUST"
-                    );
-                    self.header_trust = policy;
-                }
-                Err(e) => {
-                    // Fail-closed: an operator explicitly set a policy we can't
-                    // parse — tighten to AuthenticatedOnly instead of silently
-                    // running Open.
-                    warn!(
-                        error = %e,
-                        "invalid PROXIMADB_TENANT_HEADER_TRUST; tightening to authenticated-only"
-                    );
-                    self.header_trust = HeaderTrustPolicy::AuthenticatedOnly;
-                }
-            }
+        let (policy, warning) = HeaderTrustPolicy::effective(self.header_trust, None);
+        if let Some(warning) = warning {
+            warn!("{warning}");
+        } else if policy != self.header_trust {
+            tracing::info!(
+                %policy,
+                "tenant header-trust policy set from PROXIMADB_TENANT_HEADER_TRUST"
+            );
         }
+        self.header_trust = policy;
         self
     }
 }
@@ -342,6 +283,9 @@ pub struct TenantExtractor {
     config: TenantExtractorConfig,
     /// Optional TenantManager for validation
     tenant_manager: Option<Arc<crate::storage::tenant::TenantManager>>,
+    /// Optional ADR-031 stable-id resolver: when wired, the middleware stamps
+    /// `MiddlewareTenantContext::tenant_stable_id` at the identity boundary.
+    stable_id_resolver: Option<Arc<dyn proximadb_tenant::TenantStableIdResolver>>,
 }
 
 impl TenantExtractor {
@@ -350,6 +294,7 @@ impl TenantExtractor {
         Self {
             config: TenantExtractorConfig::default(),
             tenant_manager: None,
+            stable_id_resolver: None,
         }
     }
 
@@ -358,6 +303,7 @@ impl TenantExtractor {
         Self {
             config,
             tenant_manager: None,
+            stable_id_resolver: None,
         }
     }
 
@@ -370,76 +316,78 @@ impl TenantExtractor {
         self
     }
 
-    /// Extract tenant ID from request
+    /// Wire the ADR-031 tenant stable-id resolver (catalog-backed once tenant
+    /// stable-id minting lands; see TD-TENANT-1 follow-ups).
+    pub fn with_stable_id_resolver(
+        mut self,
+        resolver: Arc<dyn proximadb_tenant::TenantStableIdResolver>,
+    ) -> Self {
+        self.stable_id_resolver = Some(resolver);
+        self
+    }
+
+    /// Extract tenant ID from request. Delegates the assertion-vs-binding
+    /// reconciliation to the ONE shared primitive
+    /// (`proximadb_tenant::resolve_tenant_assertion`, TD-TENANT-1) — the same
+    /// call pgwire, gRPC, and Arrow Flight make — and maps the result onto
+    /// the REST source vocabulary + default-tenant fallback.
     fn extract_tenant_id(
         &self,
         req: &Request,
-    ) -> Result<Option<(String, TenantIdSource)>, TenantExtractionError> {
+    ) -> Result<Option<(String, TenantIdSource)>, TenantAssertionError> {
         let requested_tenant = req
             .headers()
             .get(X_TENANT_ID)
-            .and_then(|header_value| header_value.to_str().ok())
-            .map(str::trim)
-            .filter(|tenant_id| !tenant_id.is_empty())
-            .map(ToOwned::to_owned);
+            .and_then(|header_value| header_value.to_str().ok());
 
-        if let Some((authenticated_tenant, source)) = Self::authenticated_tenant_id(req) {
-            if let Some(requested) = requested_tenant
-                && requested != authenticated_tenant
-            {
-                // GatewayOnly delegation: an authenticated system/gateway
-                // principal may act on behalf of the header tenant (the
-                // trusted-gateway topology — the gateway authenticates with a
-                // service credential and stamps the end user's tenant).
-                if self.config.header_trust == HeaderTrustPolicy::GatewayOnly
-                    && self.config.system_tenants.contains(&authenticated_tenant)
-                {
+        let authenticated = self.authenticated_tenant_binding(req);
+        let binding = authenticated
+            .as_ref()
+            .map(|(binding, _source)| binding.clone());
+
+        match resolve_tenant_assertion(
+            requested_tenant,
+            binding.as_ref(),
+            self.config.header_trust,
+        )? {
+            ResolvedTenantAssertion::Asserted(tenant_id) => {
+                if let Some((binding, _)) = &authenticated {
                     debug!(
-                        gateway = %authenticated_tenant,
-                        acting_tenant = %requested,
+                        gateway = %binding.tenant_id,
+                        acting_tenant = %tenant_id,
                         "gateway principal delegated tenant via X-Tenant-ID"
                     );
-                    return Ok(Some((requested, TenantIdSource::Header)));
-                }
-                return Err(TenantExtractionError::HeaderAuthenticatedMismatch {
-                    requested,
-                    authenticated: authenticated_tenant,
-                });
-            }
-            debug!(
-                "Extracted tenant_id from authenticated context: {}",
-                authenticated_tenant
-            );
-            return Ok(Some((authenticated_tenant, source)));
-        }
-
-        // Bare header — no authenticated tenant binding to compare against.
-        // Whether it is an identity or a masquerade vector is the deployment's
-        // header-trust policy call (see `HeaderTrustPolicy`).
-        if let Some(tenant_id) = requested_tenant {
-            return match self.config.header_trust {
-                HeaderTrustPolicy::Open => {
+                } else {
                     debug!("Extracted tenant_id from header: {}", tenant_id);
-                    Ok(Some((tenant_id, TenantIdSource::Header)))
                 }
-                HeaderTrustPolicy::AuthenticatedOnly | HeaderTrustPolicy::GatewayOnly => {
-                    Err(TenantExtractionError::UnauthenticatedHeaderRejected {
-                        requested: tenant_id,
-                    })
+                Ok(Some((tenant_id, TenantIdSource::Header)))
+            }
+            ResolvedTenantAssertion::Credential(tenant_id) => {
+                debug!("Extracted tenant_id from authenticated context: {tenant_id}");
+                let source = authenticated
+                    .map(|(_, source)| source)
+                    .unwrap_or(TenantIdSource::JwtClaim);
+                Ok(Some((tenant_id, source)))
+            }
+            ResolvedTenantAssertion::NoTenant => {
+                if let Some(ref default_tenant) = self.config.default_tenant {
+                    debug!("Using default tenant: {}", default_tenant);
+                    return Ok(Some((default_tenant.clone(), TenantIdSource::Default)));
                 }
-            };
+                Ok(None)
+            }
         }
-
-        // Priority 3: Default tenant (if configured)
-        if let Some(ref default_tenant) = self.config.default_tenant {
-            debug!("Using default tenant: {}", default_tenant);
-            return Ok(Some((default_tenant.clone(), TenantIdSource::Default)));
-        }
-
-        Ok(None)
     }
 
-    fn authenticated_tenant_id(req: &Request) -> Option<(String, TenantIdSource)> {
+    /// The authenticated tenant binding for this request, if any, with the
+    /// gateway-capability flag the `GatewayOnly` delegation consults: the
+    /// first-class principal marker (`UnifiedUserContext::is_gateway_principal`,
+    /// stamped from credential data) OR — compat — the bound tenant being in
+    /// the deployment's `system_tenants` list.
+    fn authenticated_tenant_binding(
+        &self,
+        req: &Request,
+    ) -> Option<(AuthenticatedTenantBinding, TenantIdSource)> {
         if let Some(user_context) = req
             .extensions()
             .get::<crate::security::UnifiedUserContext>()
@@ -453,13 +401,28 @@ impl TenantExtractor {
             } else {
                 TenantIdSource::JwtClaim
             };
-            return Some((tenant_id.clone(), source));
+            let is_gateway_principal = user_context.is_gateway_principal()
+                || self.config.system_tenants.contains(tenant_id);
+            return Some((
+                AuthenticatedTenantBinding {
+                    tenant_id: tenant_id.clone(),
+                    is_gateway_principal,
+                },
+                source,
+            ));
         }
 
         if let Some(user_info) = req.extensions().get::<super::auth::UserInfo>()
             && let Some(ref tenant_id) = user_info.tenant_id
         {
-            return Some((tenant_id.clone(), TenantIdSource::ApiKey));
+            let is_gateway_principal = self.config.system_tenants.contains(tenant_id);
+            return Some((
+                AuthenticatedTenantBinding {
+                    tenant_id: tenant_id.clone(),
+                    is_gateway_principal,
+                },
+                TenantIdSource::ApiKey,
+            ));
         }
 
         None
@@ -547,7 +510,13 @@ pub async fn tenant_middleware(
                 .map(|s| s.to_string());
 
             // Inject tenant context into request extensions
-            let context = MiddlewareTenantContext::new(tenant_id, source);
+            let mut context = MiddlewareTenantContext::new(tenant_id, source);
+            // ADR-031: stamp the tenant's stable u64 id at the boundary when a
+            // resolver is wired, so downstream catalog/storage keying can use
+            // it without re-resolving per operation.
+            if let Some(resolver) = &extractor.stable_id_resolver {
+                context.tenant_stable_id = resolver.stable_id_of(&context.tenant_id);
+            }
             if let Some(tier) = tier_claim {
                 crate::services::record_store::set_tenant_tier(&context.tenant_id, tier);
             }
@@ -578,15 +547,15 @@ pub async fn tenant_middleware(
                 next.run(req).await
             }
         }
-        Err(TenantExtractionError::HeaderAuthenticatedMismatch {
-            requested,
+        Err(TenantAssertionError::Mismatch {
+            asserted,
             authenticated,
         }) => {
             // Audit trail: a credentialed principal asserted a DIFFERENT
             // tenant via header — the masquerade signature.
             warn!(
                 target: "proximadb::tenant_audit",
-                requested = %requested,
+                requested = %asserted,
                 authenticated = %authenticated,
                 source = %TenantIdSource::Header,
                 "rejected X-Tenant-ID: does not match authenticated tenant binding"
@@ -595,15 +564,15 @@ pub async fn tenant_middleware(
                 StatusCode::FORBIDDEN,
                 format!(
                     "Tenant '{}' does not match authenticated tenant '{}'",
-                    requested, authenticated
+                    asserted, authenticated
                 ),
             )
                 .into_response()
         }
-        Err(TenantExtractionError::UnauthenticatedHeaderRejected { requested }) => {
+        Err(TenantAssertionError::UnauthenticatedAssertionRejected { asserted }) => {
             warn!(
                 target: "proximadb::tenant_audit",
-                requested = %requested,
+                requested = %asserted,
                 source = %TenantIdSource::Header,
                 policy = %extractor.config.header_trust,
                 "rejected bare X-Tenant-ID without authenticated tenant binding"
@@ -613,7 +582,7 @@ pub async fn tenant_middleware(
                 format!(
                     "Tenant '{}' asserted via X-Tenant-ID without authenticated credentials; \
                      this deployment requires a tenant-bound credential (JWT or API key)",
-                    requested
+                    asserted
                 ),
             )
                 .into_response()
@@ -800,8 +769,8 @@ mod tests {
             .expect_err("bare header must be rejected without a credential binding");
         assert_eq!(
             err,
-            TenantExtractionError::UnauthenticatedHeaderRejected {
-                requested: "demo1".to_string()
+            TenantAssertionError::UnauthenticatedAssertionRejected {
+                asserted: "demo1".to_string()
             }
         );
     }
@@ -813,7 +782,7 @@ mod tests {
             .expect_err("bare header must be rejected without a credential binding");
         assert!(matches!(
             err,
-            TenantExtractionError::UnauthenticatedHeaderRejected { .. }
+            TenantAssertionError::UnauthenticatedAssertionRejected { .. }
         ));
     }
 
@@ -855,8 +824,8 @@ mod tests {
                 .expect_err("header != binding is the masquerade signature");
             assert_eq!(
                 err,
-                TenantExtractionError::HeaderAuthenticatedMismatch {
-                    requested: "victim".to_string(),
+                TenantAssertionError::Mismatch {
+                    asserted: "victim".to_string(),
                     authenticated: "acme".to_string(),
                 },
                 "policy {policy}"
@@ -875,6 +844,36 @@ mod tests {
         assert_eq!(result, Some(("demo1".to_string(), TenantIdSource::Header)));
     }
 
+    /// TD-TENANT-1 follow-up: the first-class principal marker. A credential
+    /// carrying the `gateway` role may delegate under `GatewayOnly` even when
+    /// its bound tenant is NOT in `system_tenants` — the marker, not the
+    /// tenant name, is the capability.
+    #[test]
+    fn gateway_role_marker_delegates_without_system_tenant_membership() {
+        let mut req = trust_request(Some("demo1"), None);
+        let mut ctx = crate::security::UnifiedUserContext::anonymous();
+        ctx.tenant_id = Some("svc-gw".to_string());
+        ctx.auth_method = crate::security::UnifiedAuthMethod::JWT;
+        ctx.roles.push(proximadb_tenant::GATEWAY_ROLE.to_string());
+        req.extensions_mut().insert(ctx);
+
+        let result = extractor(HeaderTrustPolicy::GatewayOnly)
+            .extract_tenant_id(&req)
+            .expect("gateway-role principal must be allowed to delegate");
+        assert_eq!(result, Some(("demo1".to_string(), TenantIdSource::Header)));
+
+        // Same principal WITHOUT the marker → mismatch.
+        let mut req = trust_request(Some("demo1"), None);
+        let mut ctx = crate::security::UnifiedUserContext::anonymous();
+        ctx.tenant_id = Some("svc-gw".to_string());
+        ctx.auth_method = crate::security::UnifiedAuthMethod::JWT;
+        req.extensions_mut().insert(ctx);
+        let err = extractor(HeaderTrustPolicy::GatewayOnly)
+            .extract_tenant_id(&req)
+            .expect_err("non-gateway principal must not delegate");
+        assert!(matches!(err, TenantAssertionError::Mismatch { .. }));
+    }
+
     #[test]
     fn non_gateway_modes_do_not_allow_system_delegation() {
         // Delegation is a GatewayOnly capability — Open/AuthenticatedOnly keep
@@ -887,10 +886,7 @@ mod tests {
                 .extract_tenant_id(&trust_request(Some("demo1"), Some("system")))
                 .expect_err("delegation requires gateway-only mode");
             assert!(
-                matches!(
-                    err,
-                    TenantExtractionError::HeaderAuthenticatedMismatch { .. }
-                ),
+                matches!(err, TenantAssertionError::Mismatch { .. }),
                 "policy {policy}"
             );
         }

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -121,6 +121,12 @@ pub struct MultiServer {
     /// producer instead of falling back to inline embed. None when
     /// `PROXIMADB_QUEUE_ROOT` is unset.
     queue_client: Option<Arc<proximadb_queue::QueueClient>>,
+    /// TD-TENANT-1: the deployment-effective bare tenant-assertion trust
+    /// policy (env > `[security.tenant] header_trust` > deployment-mode
+    /// preset, resolved once in `database.rs`), threaded into EVERY network
+    /// surface: REST tenant middleware, gRPC auth layer, Arrow Flight
+    /// service, and pgwire protocol.
+    tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
 }
 
 impl MultiServer {
@@ -261,7 +267,17 @@ impl MultiServer {
             server_handles: Arc::new(Mutex::new(Vec::new())),
             llm_engine,
             queue_client,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
         }
+    }
+
+    /// TD-TENANT-1: set the deployment-effective bare tenant-assertion trust
+    /// policy (resolve once via `HeaderTrustPolicy::effective` from the
+    /// deployment-mode preset + `[security.tenant] header_trust` + env, then
+    /// pass here). Threaded into every network surface at start.
+    pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
+        self.tenant_header_trust = policy;
+        self
     }
 
     async fn build_direct_pgwire_write_services(
@@ -501,9 +517,10 @@ impl MultiServer {
             };
             let mut server_builder =
                 server_builder.layer(tower::util::option_layer(if self.rest_auth_enabled {
-                    self.security_coordinator
-                        .clone()
-                        .map(crate::network::grpc::auth::GrpcAuthLayer::new)
+                    self.security_coordinator.clone().map(|sc| {
+                        crate::network::grpc::auth::GrpcAuthLayer::new(sc)
+                            .with_header_trust(self.tenant_header_trust)
+                    })
                 } else {
                     None
                 }));
@@ -679,6 +696,7 @@ impl MultiServer {
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
             let api_handlers = services.api_handlers.clone();
+            let tenant_header_trust = self.tenant_header_trust;
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
@@ -689,7 +707,8 @@ impl MultiServer {
                     arrow_vector_ops,
                     arrow_collection,
                     arrow_graph,
-                );
+                )
+                .with_tenant_header_trust(tenant_header_trust);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
@@ -735,6 +754,7 @@ impl MultiServer {
             let security_coordinator = self.security_coordinator.clone();
             let rest_auth_enabled = self.rest_auth_enabled;
             let tenant_deployment_mode = self.tenant_deployment_mode.clone();
+            let tenant_header_trust = self.tenant_header_trust;
             let data_dir = self.config.data_dir.clone();
             let query_adapter = Some(services.query_adapter());
             let graph_execution_service = services.graph_execution_service.clone();
@@ -773,6 +793,10 @@ impl MultiServer {
                     crate::network::middleware::tenant::TenantExtractorConfig::from_deployment_mode(
                         tenant_deployment_mode,
                     );
+                // TD-TENANT-1: the deployment-effective policy (config/env
+                // resolved once in database.rs) overrides the mode preset;
+                // server.rs re-applies the env override idempotently.
+                rest_security.tenant.header_trust = tenant_header_trust;
                 rest_security.auth.enabled = auth_enabled;
 
                 // Pass port objects so document/graph/observability routes use
@@ -856,6 +880,7 @@ impl MultiServer {
                     )
                 });
 
+            let tenant_header_trust = self.tenant_header_trust;
             let postgres_handle = tokio::spawn(async move {
                 use crate::network::postgres::PostgresServer;
                 let mut server = PostgresServer::new(
@@ -874,6 +899,7 @@ impl MultiServer {
                     server.with_rank_pipeline(rank_services, rank_profile_store, function_store);
                 server = server.with_primary_pod_gate(primary_pod_registry, self_pod_id);
                 server = server.with_warehouse_materialization(warehouse_root_url);
+                server = server.with_tenant_header_trust(tenant_header_trust);
                 if let Some(limiter) = pgwire_rate_limiter {
                     server = server.with_rate_limiter(limiter);
                 }
@@ -1058,6 +1084,7 @@ impl MultiServer {
                 } else {
                     None
                 })
+                .with_tenant_header_trust(self.tenant_header_trust)
                 .with_catalog_manager(Some(services.catalog_manager.clone()));
             let flight_server =
                 arrow_flight::flight_service_server::FlightServiceServer::new(flight_service)
@@ -1066,9 +1093,10 @@ impl MultiServer {
 
             let mut server_builder = tonic::transport::Server::builder().layer(
                 tower::util::option_layer(if self.rest_auth_enabled {
-                    self.security_coordinator
-                        .clone()
-                        .map(crate::network::grpc::auth::GrpcAuthLayer::new)
+                    self.security_coordinator.clone().map(|sc| {
+                        crate::network::grpc::auth::GrpcAuthLayer::new(sc)
+                            .with_header_trust(self.tenant_header_trust)
+                    })
                 } else {
                     None
                 }),
@@ -1154,6 +1182,7 @@ impl MultiServer {
             let services = self.shared_services.clone();
             let direct_write_services = self.build_direct_pgwire_write_services().await?;
             let warehouse_root_url = format!("file://{}/warehouse", self.config.data_dir.display());
+            let tenant_header_trust = self.tenant_header_trust;
             let postgres_handle = tokio::spawn(async move {
                 use crate::network::postgres::PostgresServer;
 
@@ -1183,6 +1212,7 @@ impl MultiServer {
                     services.self_pod_id.clone(),
                 );
                 server = server.with_warehouse_materialization(warehouse_root_url);
+                server = server.with_tenant_header_trust(tenant_header_trust);
 
                 if let Err(e) = server.start().await {
                     tracing::error!("❌ PostgreSQL Server error: {}", e);
@@ -1400,9 +1430,10 @@ impl MultiServer {
             };
             let mut server_builder =
                 server_builder.layer(tower::util::option_layer(if self.rest_auth_enabled {
-                    self.security_coordinator
-                        .clone()
-                        .map(crate::network::grpc::auth::GrpcAuthLayer::new)
+                    self.security_coordinator.clone().map(|sc| {
+                        crate::network::grpc::auth::GrpcAuthLayer::new(sc)
+                            .with_header_trust(self.tenant_header_trust)
+                    })
                 } else {
                     None
                 }));
@@ -1515,6 +1546,7 @@ impl MultiServer {
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
             let api_handlers = services.api_handlers.clone();
+            let tenant_header_trust = self.tenant_header_trust;
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
@@ -1525,7 +1557,8 @@ impl MultiServer {
                     arrow_vector_ops,
                     arrow_collection,
                     arrow_graph,
-                );
+                )
+                .with_tenant_header_trust(tenant_header_trust);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
@@ -1560,6 +1593,7 @@ impl MultiServer {
             let security_coordinator = self.security_coordinator.clone();
             let rest_auth_enabled = self.rest_auth_enabled;
             let tenant_deployment_mode = self.tenant_deployment_mode.clone();
+            let tenant_header_trust = self.tenant_header_trust;
             let data_dir = self.config.data_dir.clone();
             let query_adapter = Some(services.query_adapter());
             let graph_execution_service = services.graph_execution_service.clone();
@@ -1593,6 +1627,10 @@ impl MultiServer {
                     crate::network::middleware::tenant::TenantExtractorConfig::from_deployment_mode(
                         tenant_deployment_mode,
                     );
+                // TD-TENANT-1: the deployment-effective policy (config/env
+                // resolved once in database.rs) overrides the mode preset;
+                // server.rs re-applies the env override idempotently.
+                rest_security.tenant.header_trust = tenant_header_trust;
                 rest_security.auth.enabled = auth_enabled;
 
                 let rest_ports = RestServerPorts {

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -102,6 +102,9 @@ pub struct PostgresServer {
     /// E0: shared per-IP rate limiter applied to the pgwire query path,
     /// consistent with REST. `None` (default) = no pgwire rate-limiting.
     rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
+    /// TD-TENANT-1: the deployment's bare tenant-assertion trust policy,
+    /// threaded into every per-connection `PostgresProtocol`. Default `Open`.
+    tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
     /// Whether the server is running
     running: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -143,8 +146,16 @@ impl PostgresServer {
             self_pod_id: None,
             warehouse_root_url: None,
             rate_limiter: None,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
             running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    /// TD-TENANT-1: set the deployment's bare tenant-assertion trust policy —
+    /// the same `HeaderTrustPolicy` the REST/gRPC/Arrow Flight surfaces hold.
+    pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
+        self.tenant_header_trust = policy;
+        self
     }
 
     /// E0: attach a shared per-IP rate limiter so each per-connection
@@ -257,6 +268,7 @@ impl PostgresServer {
                     let self_pod_id = self.self_pod_id.clone();
                     let warehouse_root_url = self.warehouse_root_url.clone();
                     let rate_limiter = self.rate_limiter.clone();
+                    let tenant_header_trust = self.tenant_header_trust;
 
                     tokio::spawn(async move {
                         if let Err(e) = Self::handle_connection(
@@ -275,6 +287,7 @@ impl PostgresServer {
                             self_pod_id,
                             warehouse_root_url,
                             rate_limiter,
+                            tenant_header_trust,
                         )
                         .await
                         {
@@ -315,6 +328,7 @@ impl PostgresServer {
         self_pod_id: Option<String>,
         warehouse_root_url: Option<String>,
         rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
+        tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
     ) -> Result<()> {
         // Create session
         let session = session_manager.create_session(addr).await?;
@@ -359,6 +373,9 @@ impl PostgresServer {
         if let Some(limiter) = rate_limiter {
             protocol = protocol.with_rate_limiter(limiter, addr.ip());
         }
+        // TD-TENANT-1: same bare-assertion trust policy as REST/gRPC/Flight,
+        // enforced at the startup handshake and the tenant session vars.
+        protocol = protocol.with_tenant_header_trust(tenant_header_trust);
 
         // Run protocol loop
         match protocol.run().await {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -99,6 +99,13 @@ pub struct PostgresProtocol {
     /// result set, flushed to the meter (direction=result) at CommandComplete /
     /// PortalSuspended. Zero on the free path / non-row commands.
     result_bytes_pending: u64,
+    /// TD-TENANT-1: the deployment's bare tenant-assertion trust policy. On
+    /// pgwire there is NO authenticated binding (trust auth), so a startup
+    /// `database` (== tenant/catalog, TD-064) or `SET proximadb.write.tenant_id`
+    /// naming a non-default tenant is a bare assertion by definition — strict
+    /// policies reject it at the assertion point (SQLSTATE 28000) through the
+    /// same shared primitive REST/gRPC/Arrow Flight use. Default `Open`.
+    tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
 }
 
 /// Slice 6.3 gate-input bundle. Distinct type per surface for module
@@ -409,6 +416,7 @@ impl PostgresProtocol {
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
         }
     }
 
@@ -457,6 +465,7 @@ impl PostgresProtocol {
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
         }
     }
 
@@ -502,6 +511,7 @@ impl PostgresProtocol {
             rate_limiter: None,
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
+            tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
         }
     }
 
@@ -521,6 +531,40 @@ impl PostgresProtocol {
             self_pod_id,
         });
         self
+    }
+
+    /// TD-TENANT-1: set the deployment's bare tenant-assertion trust policy —
+    /// the same `HeaderTrustPolicy` REST/gRPC/Arrow Flight enforce.
+    pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
+        self.tenant_header_trust = policy;
+        self
+    }
+
+    /// TD-TENANT-1: gate a pgwire tenant assertion (startup `database` or the
+    /// tenant session var) through the shared trust primitive. pgwire has no
+    /// authenticated binding (trust auth), so the binding is always `None`;
+    /// the ONE canonical default tenant does not count as an assertion.
+    /// Returns the audit-logged error message to send when rejected.
+    fn check_pgwire_tenant_assertion(&self, asserted: &str) -> std::result::Result<(), String> {
+        use proximadb_tenant::identity_trust::resolve_tenant_assertion;
+
+        let asserted = asserted.trim();
+        if asserted.is_empty() || asserted == proximadb_tenant::DEFAULT_TENANT {
+            return Ok(());
+        }
+        match resolve_tenant_assertion(Some(asserted), None, self.tenant_header_trust) {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                warn!(
+                    target: "proximadb::tenant_audit",
+                    surface = "pgwire",
+                    policy = %self.tenant_header_trust,
+                    %error,
+                    "rejected bare pgwire tenant assertion"
+                );
+                Err(error.to_string())
+            }
+        }
     }
 
     /// Attach catalog-backed DDL/DML services to an existing protocol handler.
@@ -708,6 +752,17 @@ impl PostgresProtocol {
         let param_len = length - 8;
         let params = self.read_bytes(param_len).await?;
         let params = self.parse_startup_params(&params)?;
+
+        // TD-TENANT-1: the startup `database` doubles as the tenant/catalog
+        // (TD-064) and pgwire runs trust auth — the assertion is bare by
+        // definition. Under a strict policy, reject the connection at the
+        // handshake (SQLSTATE 28000) instead of granting the asserted tenant.
+        if let Some(database) = params.get("database")
+            && let Err(message) = self.check_pgwire_tenant_assertion(database)
+        {
+            self.send_error("FATAL", "28000", &message).await?;
+            return Err(anyhow!("pgwire tenant assertion rejected: {message}"));
+        }
 
         // Store parameters in session
         {
@@ -944,6 +999,19 @@ impl PostgresProtocol {
 
     async fn execute_set_parameter(&mut self, query: &str) -> Result<()> {
         let (name, value) = Self::parse_set_parameter(query)?;
+        // TD-TENANT-1: the tenant session vars are the second pgwire
+        // assertion entry point (after the startup `database`). Gate them
+        // through the same policy — an ERROR, not a silent no-op, so the
+        // client knows the assertion did not take effect.
+        let normalized_name = name.trim().to_ascii_lowercase();
+        if matches!(
+            normalized_name.as_str(),
+            "proximadb.write.tenant_id" | "proximadb.write_tenant_id"
+        ) && let Err(message) = self.check_pgwire_tenant_assertion(&value)
+        {
+            self.send_error("ERROR", "28000", &message).await?;
+            return Ok(());
+        }
         {
             let mut session = self.session.write().await;
             session.set_parameter(&name, &value);

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -1247,6 +1247,7 @@ mod tests {
             },
             encryption: crate::security::EncryptionConfig::default(),
             key_store: crate::security::KeyStoreConfig::default(),
+            tenant: Default::default(),
         }
     }
 

--- a/src/security/security_coordinator.rs
+++ b/src/security/security_coordinator.rs
@@ -38,6 +38,22 @@ pub struct SecurityConfig {
     /// Key store configuration
     #[serde(default)]
     pub key_store: KeyStoreConfig,
+    /// Tenant-identity trust configuration (`[security.tenant]`, TD-TENANT-1).
+    #[serde(default)]
+    pub tenant: TenantTrustConfig,
+}
+
+/// `[security.tenant]` — tenant-identity trust knobs (TD-TENANT-1).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TenantTrustConfig {
+    /// Bare tenant-assertion trust policy for every network surface (REST
+    /// `X-Tenant-ID`, gRPC / Arrow Flight `x-tenant-id` metadata, pgwire
+    /// startup `database` / tenant session vars): `"open"` |
+    /// `"authenticated-only"` | `"gateway-only"`. Unset ⇒ the deployment-mode
+    /// preset (`open`; `authenticated-only` under multi-tenant strict mode).
+    /// The `PROXIMADB_TENANT_HEADER_TRUST` env override wins over both.
+    #[serde(default)]
+    pub header_trust: Option<proximadb_tenant::HeaderTrustPolicy>,
 }
 
 /// Security mode for different deployment scenarios
@@ -626,6 +642,7 @@ mod tests {
             },
             encryption: EncryptionConfig::default(),
             key_store: KeyStoreConfig::default(),
+            tenant: Default::default(),
         }
     }
 

--- a/tests/recall_tune_auth_e2e.rs
+++ b/tests/recall_tune_auth_e2e.rs
@@ -125,6 +125,7 @@ fn auth_config_with_dev_key() -> SecurityConfig {
         },
         encryption: EncryptionConfig::default(),
         key_store: KeyStoreConfig::default(),
+        tenant: Default::default(),
     }
 }
 


### PR DESCRIPTION
TD-TENANT-1 Phase 2 — the four follow-ups from PR #965, as one coherent slice: one shared tenant-trust primitive across every network surface, the `[security.tenant]` config key, the ADR-031 stable-id boundary port, and the first-class gateway-principal marker.

## 1. One shared primitive — REST, gRPC, Arrow Flight, pgwire

The reconciliation logic moved to the foundation crate: `proximadb_tenant::identity_trust::resolve_tenant_assertion(asserted, binding, policy)` — pure, truth-table documented and tested. Each surface maps the verdict onto its own error vocabulary and emits `proximadb::tenant_audit` warns on rejection:

| Surface | Assertion source | Rejection | Notes |
|---|---|---|---|
| REST | `X-Tenant-ID` header | HTTP 403 | middleware now delegates to the primitive (behavior preserved; existing tests unchanged) |
| gRPC | `x-tenant-id` metadata | `PERMISSION_DENIED` | **closes a real gap**: a NON-capability credential asserting a different tenant was previously silently ignored (authenticated tenant just won); it is now rejected in every mode. Verdict stored in `GrpcAuthContext::resolved_tenant`; `grpc_auth::tenant_id()` prefers it |
| Arrow Flight | `x-tenant-id` (+ variants) metadata | `PERMISSION_DENIED` | replaces the hand-rolled mismatch match; policy now also applies when no SecurityCoordinator is wired (assertions are bare by definition there) |
| pgwire | startup `database` (== tenant/catalog, TD-064) and `SET proximadb.write.tenant_id` | SQLSTATE 28000 (FATAL at handshake / ERROR on SET) | pgwire runs trust auth, so every assertion is bare; enforced at the two assertion entry points — the ~15 downstream resolve call sites are untouched. Under strict policies pgwire tenant selection is disabled rather than silently mis-scoped |

Default remains `Open` everywhere — no existing deployment changes behavior; the strict presets/knobs opt in.

## 2. `[security.tenant]` config key

- `SecurityConfig.tenant.header_trust: Option<HeaderTrustPolicy>` (`#[serde(default)]`, kebab-case enum) + commented sample in `config/config.toml`.
- Effective policy resolved ONCE in `database.rs` via the new `HeaderTrustPolicy::effective(preset, configured)`: env `PROXIMADB_TENANT_HEADER_TRUST` > config > deployment-mode preset (`open`; `authenticated-only` for multi-tenant). Unparseable env tightens to `authenticated-only` (fail-closed).
- Threaded via `MultiServer::with_tenant_header_trust` into all surfaces: both REST spawns, all three `GrpcAuthLayer` sites, all three Flight-service constructions, both `PostgresServer` spawns. The REST middleware's `apply_env_overrides` now delegates to the same helper (idempotent re-application).

## 3. ADR-031 stable-id resolution at the boundary (port + carry)

- `proximadb_tenant::TenantStableIdResolver` port (foundation) and `MiddlewareTenantContext::tenant_stable_id: Option<u64>`, stamped at the identity boundary when a resolver is wired (`TenantExtractor::with_stable_id_resolver`).
- Deliberately partial: **no tenant→u64 mapping exists in the catalog yet** (verified — the per-type `IdAllocator` spaces cover namespaces/collections, tenants are string-keyed in `TenantManager`), so no production resolver is wired. The string `tenant_id` stays authoritative; the id is an optimization for catalog/storage keying, never a second source of truth. Catalog-side minting is the recorded follow-up in TD-TENANT-1.

## 4. First-class gateway-principal marker

- `UnifiedUserContext::is_gateway_principal()`: a `gateway`/`operator` role or `gateway: "true"` metadata entry, stamped from credential data. `GATEWAY_ROLE`/`OPERATOR_ROLE` constants live in the foundation crate.
- `GatewayOnly` delegation now keys on the marker on all surfaces; the REST middleware keeps `system_tenants` membership as a compat fallback. A credential carrying the `gateway` role can delegate even when its bound tenant is not a system tenant (tested).

## Tests

- Foundation: 8 truth-table tests on `resolve_tenant_assertion` (+ parse/serde) — every (asserted × binding × policy) cell.
- REST middleware: full suite updated to the shared error vocabulary; new test proving gateway-ROLE delegation without system-tenant membership.
- gRPC: new tests for the closed mismatch gap (normal JWT + mismatched metadata → PERMISSION_DENIED) and policy application to unbound-credential assertions (open accepts + records `resolved_tenant`; strict rejects).

## Docs

- TD-TENANT-1 updated: Phase 2 shipped, remaining follow-ups re-scoped (catalog tenant stable-id minting; API-key/SSO/mTLS gateway-role stamping; pgwire authenticated bindings).
- SUPPORTED_SURFACE security row: policy now covers every surface; pgwire trust-auth caveat and stable-id pending status stated.

## Verification

- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings`
- `cargo test -p proximadb-tenant --lib`; `cargo nextest run --lib -E 'test(/middleware::tenant|grpc::auth/)'`
- `cargo build -p proximadb-server`
- `make work-commit-check`, `scripts/check_td_adr_unique.py`
