### PR TITLE
refactor(raptor): inject axis/filesystem/quant ports into writer (DI slices 1-3; supersedes #968)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8167,6 +8167,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "proximadb-distance-kernel",
  "proximadb-filter-expression",
  "proximadb-kernel",
  "proximadb-proto",

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -28,6 +28,9 @@ proximadb-records.workspace = true
 # the StorageQuantizationEnginePort data types below, all foundation types
 # so the ports are facade-FREE (no DTO/adaptor layer).
 proximadb-kernel.workspace = true
+# Foundation-tier: the AxisClusteringPort names DistanceMetric (k-means +
+# centroid-distance methods) — pure-data leaf type.
+proximadb-distance-kernel.workspace = true
 # Foundation-tier: the StorageQuantizationEnginePort returns these data types
 # (Vec<StorageQuantizedData>, &QuantizedVector, UnifiedQuantizationLevel) — moved to
 # foundation by #842, so the port is facade-FREE (no DTO/adaptor layer).

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -12,6 +12,7 @@
 //! foundation proto types the contracts unavoidably name.
 
 use anyhow::Result;
+use proximadb_distance_kernel::DistanceMetric;
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
@@ -226,4 +227,40 @@ pub enum CacheKind {
 pub trait CacheAccessPatternPort: Send + Sync {
     /// Record a cache access for pattern learning / predictive prefetching.
     fn track_access(&self, key: String, cache_kind: CacheKind);
+}
+
+/// AXIS clustering port — inverts the raptor→root `AxisClusteringEngine`
+/// dependency for the clustering surface RAPTOR's writer needs (k-means
+/// clustering, centroid-distance matrix, component-boosted assignment). The
+/// surface is exactly `ReusableClusteringEngine`'s 3 methods (sync,
+/// primitive-typed + `DistanceMetric`). Engine leaves hold `Arc<dyn
+/// AxisClusteringPort>` instead of the root-local `AxisClusteringEngine`; the
+/// concrete engine impls this in the root (downward edge). Enables the raptor
+/// `writer` extraction.
+pub trait AxisClusteringPort: Send + Sync {
+    /// k-means clustering (k-means++ init) -> (centroids, cluster assignments).
+    fn cluster_vectors_simple(
+        &self,
+        vectors: &[Vec<f32>],
+        k: usize,
+        distance_metric: DistanceMetric,
+        max_iterations: usize,
+    ) -> Result<(Vec<Vec<f32>>, Vec<usize>)>;
+
+    /// Centroid-to-centroid distance matrix (k*k).
+    fn calculate_centroid_distance_matrix(
+        &self,
+        centroids: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+    ) -> Result<Vec<Vec<f32>>>;
+
+    /// Assign vectors to clusters with component boosting -> (cluster_id, boosted_distance).
+    fn assign_vectors_with_component_boosting(
+        &self,
+        vectors: &[Vec<f32>],
+        centroids: &[Vec<f32>],
+        centroid_distances: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+        boosting_weights: &[f32],
+    ) -> Result<Vec<(usize, f32)>>;
 }

--- a/src/index/axis/clustering.rs
+++ b/src/index/axis/clustering.rs
@@ -954,6 +954,60 @@ impl ReusableClusteringEngine for AxisClusteringEngine {
     }
 }
 
+// AxisClusteringPort impl — Slice D port-inversion. Exposes the root-local
+// AxisClusteringEngine behind the AxisClusteringPort trait (defined in
+// proximadb-storage-ports) so raptor engine leaves (writer / IvfClusteringBuilder)
+// can depend on `Arc<dyn AxisClusteringPort>` instead of this concrete type,
+// enabling their extraction to crates. Pure delegation to the
+// ReusableClusteringEngine methods above; the composition root injects the engine.
+impl proximadb_storage_ports::AxisClusteringPort for AxisClusteringEngine {
+    fn cluster_vectors_simple(
+        &self,
+        vectors: &[Vec<f32>],
+        k: usize,
+        distance_metric: DistanceMetric,
+        max_iterations: usize,
+    ) -> Result<(Vec<Vec<f32>>, Vec<usize>)> {
+        ReusableClusteringEngine::cluster_vectors_simple(
+            self,
+            vectors,
+            k,
+            distance_metric,
+            max_iterations,
+        )
+    }
+
+    fn calculate_centroid_distance_matrix(
+        &self,
+        centroids: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+    ) -> Result<Vec<Vec<f32>>> {
+        ReusableClusteringEngine::calculate_centroid_distance_matrix(
+            self,
+            centroids,
+            distance_metric,
+        )
+    }
+
+    fn assign_vectors_with_component_boosting(
+        &self,
+        vectors: &[Vec<f32>],
+        centroids: &[Vec<f32>],
+        centroid_distances: &[Vec<f32>],
+        distance_metric: DistanceMetric,
+        boosting_weights: &[f32],
+    ) -> Result<Vec<(usize, f32)>> {
+        ReusableClusteringEngine::assign_vectors_with_component_boosting(
+            self,
+            vectors,
+            centroids,
+            centroid_distances,
+            distance_metric,
+            boosting_weights,
+        )
+    }
+}
+
 /// Helper methods for simplified clustering
 impl AxisClusteringEngine {
     /// Simplified K-Means++ initialization without full AXIS overhead

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -32,9 +32,79 @@ use super::smart_rowgroup_sizing::SmartRowGroupSizer;
 
 // Deep integration with AXIS clustering
 use crate::index::axis::clustering::{
-    ClusterManager, ClusteringAlgorithm, ClusteringConfig, KMeansConfig,
+    AxisClusteringEngine, ClusterManager, ClusteringAlgorithm, ClusteringConfig, KMeansConfig,
+    KMeansInit,
 };
 use proximadb_index_types::ClusterAssignment;
+
+/// Build the AXIS clustering engine for RAPTOR with the standard config,
+/// returned behind the `AxisClusteringPort` DI port. Injected into RaptorWriter
+/// (which no longer constructs it internally — Slice D port-inversion).
+fn make_raptor_axis_clustering(
+    config: &super::config::RaptorConfig,
+) -> std::sync::Arc<dyn proximadb_storage_ports::AxisClusteringPort> {
+    let axis_clustering_config = ClusteringConfig {
+        algorithm: ClusteringAlgorithm::KMeans(KMeansConfig {
+            k: super::constants::clustering::DEFAULT_CLUSTER_COUNT,
+            max_iterations: super::constants::clustering::KMEANS_MAX_ITERATIONS,
+            tolerance: super::constants::clustering::KMEANS_TOLERANCE as f32,
+            n_init: super::constants::clustering::KMEANS_INIT_ATTEMPTS,
+            init_method: KMeansInit::KMeansPlusPlus,
+        }),
+        min_vectors_for_clustering: config.rowgroup_size,
+        max_clusters: super::constants::clustering::MAX_CLUSTER_COUNT,
+        distance_metric: proximadb_distance_kernel::DistanceMetric::Euclidean,
+        adaptive_cluster_count: true,
+        recompute_threshold: 10000,
+        enable_incremental: false,
+    };
+    std::sync::Arc::new(AxisClusteringEngine::new(axis_clustering_config))
+}
+
+/// Build the local filesystem for RAPTOR behind the `FileSystem` trait. Injected
+/// into RaptorWriter (which no longer constructs `LocalFileSystem` internally).
+async fn make_raptor_filesystem()
+-> anyhow::Result<std::sync::Arc<dyn crate::storage::persistence::filesystem::FileSystem>> {
+    use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+    Ok(std::sync::Arc::new(
+        LocalFileSystem::new(LocalConfig::default()).await?,
+    ))
+}
+
+/// Build the storage-quantization chain for RAPTOR (codebook store -> unified
+/// quant -> storage quant) behind the `StorageQuantizationEnginePort` DI port.
+/// Injected into RaptorWriter (which no longer constructs it internally).
+async fn make_raptor_quantization_engine(
+    config: &super::config::RaptorConfig,
+) -> anyhow::Result<std::sync::Arc<dyn proximadb_storage_ports::StorageQuantizationEnginePort>> {
+    use crate::compute::quantization::quantization_engine::{
+        CodebookStore, InMemoryCodebookStore, UnifiedQuantizationEngine,
+    };
+    use crate::compute::quantization::storage_engine::{
+        StorageQuantizationConfig, StorageQuantizationEngine,
+    };
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+
+    let distance_compute = std::sync::Arc::new(UnifiedDistanceCompute::new(
+        proximadb_distance_kernel::DistanceMetric::Cosine,
+    ));
+    let codebook_store: std::sync::Arc<dyn CodebookStore> =
+        std::sync::Arc::new(InMemoryCodebookStore::new());
+    let unified_quantization = std::sync::Arc::new(UnifiedQuantizationEngine::new(
+        distance_compute.clone(),
+        codebook_store,
+    ));
+    let quant_config = StorageQuantizationConfig {
+        enable_hardware_acceleration: config.enable_simd,
+        distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
+        ..Default::default()
+    };
+    Ok(std::sync::Arc::new(StorageQuantizationEngine::new(
+        unified_quantization,
+        distance_compute,
+        quant_config,
+    )))
+}
 
 // Deep integration with filesystem API for cloud-aware I/O
 use crate::storage::persistence::filesystem::TierConfig;
@@ -517,6 +587,9 @@ impl RaptorEngine {
                 config.clone(),
                 "placeholder".to_string(),
                 config.dimension, // dimension from config
+                make_raptor_filesystem().await?,
+                make_raptor_quantization_engine(&config).await?,
+                make_raptor_axis_clustering(&config),
             )
             .await?,
         ));
@@ -2227,6 +2300,9 @@ impl UnifiedStorageFormat for RaptorEngine {
             self.config.clone(),
             collection_id.to_string(),
             collection_dimension as usize,
+            make_raptor_filesystem().await?,
+            make_raptor_quantization_engine(&self.config).await?,
+            make_raptor_axis_clustering(&self.config),
         )
         .await?;
 

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -66,7 +66,6 @@ use super::common::{
     RowGroupBloomFilter, RowGroupNeighbor,
 };
 use super::matrix_builder::MatrixBuilder;
-use crate::compute::quantization::storage_engine::StorageQuantizationEngine;
 use crate::proto::proximadb_v1::VectorRecord;
 use proximadb_distance_kernel::DistanceMetric;
 use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
@@ -78,11 +77,9 @@ use crate::storage::engines::core::ops::proximacodec::{
 };
 use crate::storage::persistence::filesystem::FileSystem;
 
-// Import AXIS clustering for reuse
-use crate::index::axis::clustering::{
-    AxisClusteringEngine, ClusteringAlgorithm, ClusteringConfig as AxisClusteringConfig,
-    KMeansConfig, KMeansInit, ReusableClusteringEngine,
-};
+// AXIS clustering + quantization are injected via DI ports (Slice D) — the
+// concrete engines are constructed at the composition root (engine.rs).
+use proximadb_storage_ports::{AxisClusteringPort, StorageQuantizationEnginePort};
 
 use super::config::CompressionCodec as RaptorCompressionCodec;
 use super::constants;
@@ -137,7 +134,7 @@ pub struct RaptorWriter {
     /// Standard compression engine for vector data
     compression: Arc<StandardCompression>,
     /// Quantization engine for reducing memory footprint
-    quantization_engine: Arc<StorageQuantizationEngine>,
+    quantization_engine: Arc<dyn StorageQuantizationEnginePort>,
     /// Memory pool for efficient vector allocation
     #[allow(dead_code)]
     memory_pool: Arc<VectorMemoryPool>,
@@ -287,7 +284,7 @@ struct IvfClusteringBuilder {
     #[allow(dead_code)]
     hardware: Arc<HardwareCapabilities>,
     /// AXIS clustering engine for reusable k-means implementation
-    axis_clustering: Arc<AxisClusteringEngine>,
+    axis_clustering: Arc<dyn AxisClusteringPort>,
     /// Pre-computed centroids for k clusters
     centroids: Vec<Centroid>,
     /// Boosting parameters
@@ -360,26 +357,11 @@ struct Centroid {
 // This avoids duplication and keeps related data together
 
 impl IvfClusteringBuilder {
-    fn new(target_rowgroup_size: usize, hardware: Arc<HardwareCapabilities>) -> Self {
-        // Create AXIS clustering configuration for RAPTOR
-        let axis_clustering_config = AxisClusteringConfig {
-            algorithm: ClusteringAlgorithm::KMeans(KMeansConfig {
-                k: constants::clustering::DEFAULT_CLUSTER_COUNT,
-                max_iterations: constants::clustering::KMEANS_MAX_ITERATIONS,
-                tolerance: constants::clustering::KMEANS_TOLERANCE as f32,
-                n_init: constants::clustering::KMEANS_INIT_ATTEMPTS,
-                init_method: KMeansInit::KMeansPlusPlus,
-            }),
-            min_vectors_for_clustering: target_rowgroup_size,
-            max_clusters: constants::clustering::MAX_CLUSTER_COUNT,
-            distance_metric: DistanceMetric::Euclidean,
-            adaptive_cluster_count: true,
-            recompute_threshold: 10000,
-            enable_incremental: false, // Disable for RAPTOR use case
-        };
-
-        let axis_clustering = Arc::new(AxisClusteringEngine::new(axis_clustering_config));
-
+    fn new(
+        target_rowgroup_size: usize,
+        hardware: Arc<HardwareCapabilities>,
+        axis_clustering: Arc<dyn AxisClusteringPort>,
+    ) -> Self {
         Self {
             nodes: Vec::new(),
             id_to_node: HashMap::new(),
@@ -2384,6 +2366,31 @@ impl MetadataEncoding {
     }
 }
 
+/// Build a minimal `AxisClusteringEngine` behind the `AxisClusteringPort` for the
+/// isolated unit tests below — they construct `IvfClusteringBuilder` directly,
+/// without the composition root (engine.rs) that normally injects the engine.
+#[cfg(test)]
+fn make_test_axis_clustering() -> Arc<dyn AxisClusteringPort> {
+    use crate::index::axis::clustering::{
+        AxisClusteringEngine, ClusteringAlgorithm, ClusteringConfig, KMeansConfig, KMeansInit,
+    };
+    Arc::new(AxisClusteringEngine::new(ClusteringConfig {
+        algorithm: ClusteringAlgorithm::KMeans(KMeansConfig {
+            k: 3,
+            max_iterations: 10,
+            tolerance: 0.01,
+            n_init: 1,
+            init_method: KMeansInit::KMeansPlusPlus,
+        }),
+        min_vectors_for_clustering: 3,
+        max_clusters: 10,
+        distance_metric: DistanceMetric::Euclidean,
+        adaptive_cluster_count: false,
+        recompute_threshold: 100,
+        enable_incremental: false,
+    }))
+}
+
 #[cfg(test)]
 mod minimal_hnsw_tests {
     use super::*;
@@ -2392,7 +2399,7 @@ mod minimal_hnsw_tests {
     fn test_distance_aware_clustering() {
         // Create a minimal HNSW builder
         let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
-        let mut builder = IvfClusteringBuilder::new(3, hw_caps); // Small row groups for testing
+        let mut builder = IvfClusteringBuilder::new(3, hw_caps, make_test_axis_clustering()); // Small row groups for testing
 
         // Add nodes with predefined edges and distances
         // Node 0 connects to 1 (distance 0.1) and 2 (distance 0.8)
@@ -2507,7 +2514,7 @@ mod minimal_hnsw_tests {
 #[test]
 fn test_uniqueness_guarantee() {
     let hw_caps = proximadb_hardware_caps::get_hardware_capabilities();
-    let mut builder = IvfClusteringBuilder::new(5, hw_caps);
+    let mut builder = IvfClusteringBuilder::new(5, hw_caps, make_test_axis_clustering());
 
     // Add 10 nodes
     for i in 0..10 {
@@ -2574,14 +2581,14 @@ impl RaptorWriter {
         config: RaptorConfig,
         collection_id: String,
         dimension: usize,
+        // Injected collaborators (Slice D port-inversion): the composition root
+        // (engine.rs) constructs the concrete engines + filesystem and injects
+        // them, so this module depends only on the port traits — enabling its
+        // extraction to a crate.
+        filesystem: Arc<dyn FileSystem>,
+        quantization_engine: Arc<dyn StorageQuantizationEnginePort>,
+        axis_clustering: Arc<dyn AxisClusteringPort>,
     ) -> Result<Self> {
-        // Initialize filesystem using local filesystem
-        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
-        let local_config = LocalConfig::default();
-        let local_fs = LocalFileSystem::new(local_config).await?;
-        let filesystem: Arc<dyn crate::storage::persistence::filesystem::FileSystem> =
-            Arc::new(local_fs);
-
         // Initialize hardware capabilities
         let hardware = get_hardware_capabilities();
 
@@ -2600,39 +2607,10 @@ impl RaptorWriter {
             proximadb_distance_kernel::DistanceMetric::Cosine,
         ));
 
-        // Initialize codebook store for quantization
-        let codebook_store: Arc<
-            dyn crate::compute::quantization::quantization_engine::CodebookStore,
-        > = Arc::new(
-            crate::compute::quantization::quantization_engine::InMemoryCodebookStore::new(),
-        );
-
-        // Initialize unified quantization engine
-        let unified_quantization = Arc::new(
-            crate::compute::quantization::quantization_engine::UnifiedQuantizationEngine::new(
-                distance_compute.clone(),
-                codebook_store,
-            ),
-        );
-
-        // Initialize storage quantization engine config
-        // Uses default INT8 quantization (fast, no training required)
-        // PQ can be explicitly enabled in collection config when needed
-        let quant_config =
-            crate::compute::quantization::storage_engine::StorageQuantizationConfig {
-                enable_hardware_acceleration: config.enable_simd,
-                distance_metric: proximadb_distance_kernel::DistanceMetric::Cosine,
-                ..Default::default() // INT8 by default, PQ requires explicit config
-            };
-
-        // Initialize quantization engine
-        let quantization_engine = Arc::new(StorageQuantizationEngine::new(
-            unified_quantization,
-            distance_compute.clone(),
-            quant_config,
-        ));
-
-        // Distance compute already initialized above
+        // Quantization engine is injected (see fn params above) — the concrete
+        // codebook store / unified quant / storage quant chain is assembled at
+        // the composition root (engine.rs). The distance_compute initialized
+        // above is this writer's own field.
 
         // Initialize memory pool with default configuration
         let memory_pool = Arc::new(VectorMemoryPool::new());
@@ -2711,7 +2689,11 @@ impl RaptorWriter {
                 id_hashes: Vec::new(),
                 row_offsets: Vec::new(),
             },
-            ivf_builder: IvfClusteringBuilder::new(rowgroup_size, get_hardware_capabilities()),
+            ivf_builder: IvfClusteringBuilder::new(
+                rowgroup_size,
+                get_hardware_capabilities(),
+                axis_clustering,
+            ),
             column_projections: ColumnProjectionsBuilder {
                 metadata_columns: HashMap::new(),
                 filter_bitmaps: HashMap::new(),


### PR DESCRIPTION
## Summary

RaptorWriter and IvfClusteringBuilder now receive their collaborators via **dependency injection** instead of constructing concrete root-crate types internally. This is the writer-extraction enabler (slices 1-3 of the 4-slice plan) — it severs `writer.rs`'s efferent coupling to root-crate types, preparing its move to the `proximadb-raptor-engine` crate (the biggest raptor leaf, ~5,800 LOC).

| dep | before (constructed in writer) | after (injected) |
|---|---|---|
| clustering | `Arc<AxisClusteringEngine>` | `Arc<dyn AxisClusteringPort>` |
| filesystem | `LocalFileSystem::new(LocalConfig::default())` | `Arc<dyn FileSystem>` (field was already this type) |
| quantization | codebook → unified-quant → storage-quant chain | `Arc<dyn StorageQuantizationEnginePort>` |

The composition root (`engine.rs`) constructs and injects all three via helpers (`make_raptor_axis_clustering`, `make_raptor_filesystem`, `make_raptor_quantization_engine`), built with the **same configs the writer previously constructed inline** — so behavior is unchanged. The move itself (slice 4) follows as a separate stacked PR.

## Supersedes #968

#968 (axis-only slice 1) was **open, red, and 9 commits behind develop**. Its only failure was the test-caller signature ripple (`IvfClusteringBuilder::new` gained a 3rd arg but two `#[cfg(test)]` callers weren't updated — `error[E0061]: takes 3 arguments but 2 supplied`), which cascaded through `cargo check --tests` and the whole integration-test compile. This PR folds slice 1 in cleanly (port + impl + adoption) and fixes the ripple, then adds slices 2 (FS) and 3 (quant) on top — consolidating the cohesive DI work into one PR per the batch-PR-sizing mandate. **#968 can be closed.**

## Changes
- `storage-ports`: add `AxisClusteringPort` (3 methods mirroring `ReusableClusteringEngine`) + `proximadb-distance-kernel` dep.
- `index/axis/clustering`: `impl AxisClusteringPort for AxisClusteringEngine` (pure delegation).
- `raptor/writer`: fields retyped to the port trait objects; `new()` takes the 3 injected deps; internal construction removed; the two `IvfClusteringBuilder` unit-test callers get a test port via a `#[cfg(test)]` helper.
- `raptor/engine`: 3 construct-and-inject helpers; both `RaptorWriter::new` callers updated.

## Verification
- `cargo check --lib` ✅
- `cargo check --tests` ✅ (the #968 failure mode — resolved)
- `cargo clippy --lib --bins -- -D warnings` ✅
- `cargo fmt --check` ✅
- layering (`check-layering.sh`) + storage up-edges (≤180, `check_workspace_boundaries.py`) ✅
- `make work-commit-check` ✅ (panic-policy delta −2)
- 78/78 raptor lib unit tests pass, incl. the two axis-DI test callers and `writer::test_memory_reduction` (full `RaptorWriter` construction with injected deps)

Storage up-edges unchanged (the new `impl` lives in `src/index`, an index→storage-ports edge, not a storage up-edge).
