### PR TITLE
fix(storage): recover catalog and SST from object store (TD-OBJSTORE-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8039,10 +8039,14 @@ dependencies = [
  "clap",
  "proximadb",
  "proximadb-embedding",
+ "reqwest 0.11.27",
+ "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/proximadb-server/Cargo.toml
+++ b/apps/proximadb-server/Cargo.toml
@@ -69,3 +69,9 @@ tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+serde_json.workspace = true
+tempfile.workspace = true
+uuid = { version = "1.0", features = ["v4"] }

--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -1,0 +1,273 @@
+//! TD-OBJSTORE-2 process-boundary recovery proof.
+//!
+//! Runs the real server three times against one S3/ADLS object-store prefix,
+//! with a brand-new local `server.data_dir` each time:
+//!
+//! 1. CREATE + INSERT, then SIGKILL (catalog + data WAL must already be durable).
+//! 2. Recover catalog + replay WAL, verify search, then SIGINT (flush SST).
+//! 3. Recover on another empty local disk and verify cold SST search.
+//!
+//! Run through `scripts/prove_object_store_durability.sh`; the test is ignored
+//! by default because it requires cloud credentials and
+//! `PROXIMADB_OBJECT_STORE_URL=s3://...` or `adls://...`.
+
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde_json::{Value, json};
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    listener.local_addr().expect("local addr").port()
+}
+
+fn write_config(path: &Path, data_dir: &Path, root: &str, ports: [u16; 4]) {
+    let [rest, grpc, flight, pg] = ports;
+    let config = format!(
+        r#"
+[server]
+node_id = "td-objstore-2"
+bind_address = "127.0.0.1"
+port = {rest}
+data_dir = "{}"
+
+[server.tenant]
+mode = "single_tenant"
+default_tenant = "default"
+
+[storage]
+metadata_url = "{root}/metadata"
+mmap_enabled = false
+
+[[storage.storage_locations]]
+url = "{root}/collections"
+weight = 1
+tags = ["td-objstore-2", "durable"]
+
+[storage.optimization]
+enable_mmap = false
+
+[storage.wal_config]
+write_buffer_directory = "{root}/wal"
+enable_wal = true
+sync_mode = "PerBatch"
+
+[storage.sst_config]
+data_directory = "{root}/collections"
+mmap_enabled = false
+
+[storage.viper_config]
+data_directory = "{root}/collections"
+
+[api]
+rest_port = {rest}
+grpc_port = {grpc}
+arrow_flight_port = {flight}
+pg_port = {pg}
+unified_mode = false
+
+[monitoring]
+metrics_enabled = false
+log_level = "info"
+"#,
+        data_dir.display()
+    );
+    std::fs::write(path, config).expect("write process config");
+}
+
+struct ServerProcess {
+    child: Child,
+    base_url: String,
+}
+
+impl ServerProcess {
+    async fn start(root: &str, data_dir: &Path, config_path: &Path) -> anyhow::Result<Self> {
+        let ports = [free_port(), free_port(), free_port(), free_port()];
+        write_config(config_path, data_dir, root, ports);
+        let child = Command::new(env!("CARGO_BIN_EXE_proximadb-server"))
+            .arg("--config")
+            .arg(config_path)
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let server = Self {
+            child,
+            base_url: format!("http://127.0.0.1:{}", ports[0]),
+        };
+        server.wait_ready().await?;
+        Ok(server)
+    }
+
+    async fn wait_ready(&self) -> anyhow::Result<()> {
+        let http = Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(2))
+            .build()?;
+        let deadline = Instant::now() + Duration::from_secs(45);
+        loop {
+            if let Ok(response) = http.get(format!("{}/health", self.base_url)).send().await
+                && response.status().is_success()
+            {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("server at {} did not become healthy", self.base_url);
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    fn crash(mut self) -> anyhow::Result<()> {
+        self.child.kill()?;
+        self.child.wait()?;
+        Ok(())
+    }
+
+    fn graceful(mut self) -> anyhow::Result<()> {
+        let status = Command::new("kill")
+            .args(["-INT", &self.child.id().to_string()])
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("failed to send SIGINT to server pid {}", self.child.id());
+        }
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if let Some(status) = self.child.try_wait()? {
+                if !status.success() {
+                    anyhow::bail!("server exited unsuccessfully during graceful stop: {status}");
+                }
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                let _ = self.child.kill();
+                anyhow::bail!("server did not complete graceful shutdown in 30s");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+    }
+}
+
+async fn create_and_insert(base: &str, collection: &str) -> anyhow::Result<()> {
+    let http = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let response = http
+        .post(format!("{base}/api/v2/collections"))
+        .json(&json!({
+            "name": collection,
+            "dimension": 8,
+            "engine": "sst",
+            "distance_metric": "cosine",
+            "canonical_embedding_precision": "fp32",
+            "enable_proxima_record": false
+        }))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(status.is_success(), "create failed: {status} {body}");
+
+    let response = http
+        .post(format!(
+            "{base}/api/v2/collections/{collection}/records/batch"
+        ))
+        .json(&json!({
+            "records": [
+                { "id": "durable-0", "vector": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7] },
+                { "id": "durable-1", "vector": [0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0] }
+            ]
+        }))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(status.is_success(), "insert failed: {status} {body}");
+    Ok(())
+}
+
+async fn assert_recovered(base: &str, collection: &str, phase: &str) -> anyhow::Result<()> {
+    let http = Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let response = http
+        .get(format!("{base}/api/v2/collections/{collection}"))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(
+        status.is_success(),
+        "{phase}: catalog did not recover collection: {status} {body}"
+    );
+
+    let response = http
+        .post(format!("{base}/api/v2/collections/{collection}/search"))
+        .json(&json!({
+            "vector": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7],
+            "top_k": 2
+        }))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(
+        status.is_success(),
+        "{phase}: search failed: {status} {body}"
+    );
+    let json: Value = serde_json::from_str(&body)?;
+    let ids = json
+        .get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.get("id").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    anyhow::ensure!(
+        ids.contains(&"durable-0"),
+        "{phase}: durable-0 absent after recovery: {body}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires PROXIMADB_OBJECT_STORE_URL plus S3/ADLS credentials"]
+async fn catalog_wal_and_sst_survive_fresh_local_disks() -> anyhow::Result<()> {
+    let base = std::env::var("PROXIMADB_OBJECT_STORE_URL")?;
+    anyhow::ensure!(
+        base.starts_with("s3://") || base.starts_with("adls://"),
+        "test URL must use s3:// or adls:// (got {base})"
+    );
+    let root = format!(
+        "{}/td-objstore-2/{}",
+        base.trim_end_matches('/'),
+        uuid::Uuid::new_v4().simple()
+    );
+    let tmp = tempfile::tempdir()?;
+    let collection = format!("td_objstore_{}", uuid::Uuid::new_v4().simple());
+
+    let vm1 = tmp.path().join("vm1");
+    let vm2 = tmp.path().join("vm2");
+    let vm3 = tmp.path().join("vm3");
+    for dir in [&vm1, &vm2, &vm3] {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    let first = ServerProcess::start(&root, &vm1, &tmp.path().join("vm1.toml")).await?;
+    create_and_insert(&first.base_url, &collection).await?;
+    first.crash()?;
+
+    let wal_replay = ServerProcess::start(&root, &vm2, &tmp.path().join("vm2.toml")).await?;
+    assert_recovered(&wal_replay.base_url, &collection, "WAL replay").await?;
+    wal_replay.graceful()?; // materializes SST and reclaims flushed WAL
+
+    let cold_sst = ServerProcess::start(&root, &vm3, &tmp.path().join("vm3.toml")).await?;
+    assert_recovered(&cold_sst.base_url, &collection, "cold SST").await?;
+    cold_sst.crash()?;
+    Ok(())
+}

--- a/config/cloud-object-store.toml
+++ b/config/cloud-object-store.toml
@@ -1,0 +1,58 @@
+# Object-store durability overlay (S3 / Azure Blob aliases / GCS).
+#
+# Set PROXIMADB_OBJECT_STORE_URL to a scheme-qualified deployment prefix, e.g.:
+#   s3://bucket/proximadb/prod
+#   adls://container/proximadb/prod
+#
+# server.data_dir remains a local working volume for caches/staging only. The
+# collection catalog, WAL, SST/VIPER segments, and indexes are rooted below the
+# object-store URL so a replacement VM can recover with an empty local disk.
+
+[server]
+data_dir = "/var/lib/proximadb/ephemeral"
+
+[storage]
+metadata_url = "${PROXIMADB_OBJECT_STORE_URL}/metadata"
+mmap_enabled = false
+
+[[storage.storage_locations]]
+url = "${PROXIMADB_OBJECT_STORE_URL}/collections"
+weight = 1
+tags = ["cloud", "durable", "primary"]
+
+[storage.optimization]
+# CRITICAL: mmap is a local-file primitive and cannot be used for remote SST or
+# VIPER objects. ProximaDB also fails closed at startup if this is true for a
+# cloud storage location.
+enable_mmap = false
+enable_zone_map_pruning = true
+enable_axis_indexes = true
+enable_progressive_search = true
+enable_bloom_filters = true
+
+[storage.wal_config]
+write_buffer_directory = "${PROXIMADB_OBJECT_STORE_URL}/wal"
+enable_wal = true
+sync_mode = "PerBatch"
+
+[storage.sst_config]
+data_directory = "${PROXIMADB_OBJECT_STORE_URL}/collections"
+block_size_kb = 4096
+mmap_enabled = false
+prefetch_enabled = true
+
+[storage.viper_config]
+data_directory = "${PROXIMADB_OBJECT_STORE_URL}/collections"
+row_group_size = 262144
+compression = "zstd"
+compression_level = 3
+enable_statistics = true
+
+[storage.filesystem_config]
+enable_write_strategy_cache = true
+temp_strategy = "SameDirectory"
+
+[storage.filesystem_config.atomic_config]
+enable_local_atomic = true
+enable_object_store_atomic = true
+cleanup_temp_on_startup = true

--- a/config/cloud-s3.toml
+++ b/config/cloud-s3.toml
@@ -1,4 +1,8 @@
-# ProximaDB Cloud-Optimized Configuration (S3, GCS, Azure)
+# ProximaDB Cloud-Optimized tuning overlay (S3, GCS, Azure)
+#
+# For a complete durable object-store layout (catalog + WAL + SST/VIPER), use
+# `config/cloud-object-store.toml`. This file intentionally contains only block
+# and row-group tuning and must not be used as a standalone deployment config.
 #
 # Goal: Minimize I/O operations and leverage high throughput.
 # Strategy: Use larger block and page sizes to amortize first-byte latency.

--- a/docs/10-quality/td/TD-OBJSTORE-2.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-2.adoc
@@ -46,6 +46,13 @@ object-store catalog -> Collection.storage_assignment.base_location
 No catalog row means recovery cannot safely infer a collection's engine, dimension,
 tenant, or storage layout from WAL bytes alone.
 
+The first live ADLS proof exposed a second dependency-order defect after the catalog
+became durable: `StorageEngine::start()` replayed WAL before registering the recovered
+collections' storage engines. Recovery found the catalog rows and WAL segments, but
+could not flush them (`No storage engine registered for collection`). A redundant
+second replay in `ProximaDB::start()` repeated the failure while startup still became
+healthy because per-collection replay errors were only warnings.
+
 == Fix
 
 === Catalog durability
@@ -88,10 +95,13 @@ not need a local staging `data_directory` to recover a collection.
 
 == Recovery invariant
 
-Boot sets the recovered catalog as the global WAL/recovery authority before creating
-the storage engine. `StorageEngine::recover_from_wal()` lists catalog collections and
-calls `recover_collection(id)` for each. Once the object-store snapshot restores the
-catalog row, the pre-existing WAL segments are reattached to that id and replayed.
+Boot sets the recovered catalog as the global WAL/recovery authority before starting
+the storage engine. Startup then loads catalog collections, registers each assigned
+storage engine with the WAL recovery manager, and only then calls
+`recover_collection(id)` for every catalog collection. Once the object-store snapshot
+restores the catalog row, the pre-existing WAL segments are reattached to that id and
+replayed exactly once. Any collection registration or replay failure now fails startup
+instead of exposing a healthy endpoint with missing data.
 
 The recovery code deliberately does not invent collections from WAL segment names;
 doing so would bypass schema, engine, tenant, and authorization metadata.
@@ -142,3 +152,6 @@ Before marking this TD closed, attach:
 * 2026-07-14 — filed after the post-#966 VM restart recovered zero collections.
 * 2026-07-14 — implemented per-commit object-store catalog publication, cloud layout
   overlay, graph/discovery filesystem routing, and the three-process recovery proof.
+* 2026-07-14 — first live ADLS run recovered the catalog but exposed WAL replay before
+  storage-engine registration; fixed startup ordering, duplicate replay, and
+  fail-open recovery errors. A passing rerun remains the closure gate.

--- a/docs/10-quality/td/TD-OBJSTORE-2.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-2.adoc
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OBJSTORE-2: Object-store catalog + SST recovery after VM replacement
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Implemented; live ADLS/S3 proof required before closure.** Code and process-boundary harness are in this change; `scripts/prove_object_store_durability.sh` is the closure gate.
+| Severity | Critical — WAL objects survive, but a replacement VM recovers zero collections when the collection catalog is only in the lost local `data_dir`; the durable WAL cannot be attached or replayed.
+| Component | `SystemCatalog`, collection/WAL recovery, SST/VIPER storage assignment, graph/discovery catalog sidecars, cloud deployment configuration.
+| Follows | PR #966 / `TD-OBJSTORE-1` (scheme-safe WAL and metadata path construction).
+| Pillar | REL, DR, COST
+|===
+
+toc::[]
+
+== Failure
+
+An object-store deployment acknowledged collection creation and vector inserts and
+successfully wrote durable WAL segments, but a restart on a fresh VM logged zero
+collections recovered. Blob listing showed WAL objects and no durable collection
+definition. Recovery enumerates the catalog first and replays WAL only for known
+collection ids, so durable WAL without a catalog is intentionally unattached.
+
+This was not authentication, managed identity, URL/account selection, or the WAL
+write path fixed by #966.
+
+== Root cause
+
+`SystemCatalog` used a local per-DDL WAL and an object-store snapshot. The snapshot
+was treated only as a bounded-restart checkpoint and defaulted to one publish per
+1,000 mutations. A normal collection create therefore returned success with its
+catalog deltas durable only in `<server.data_dir>/_operator/catalog/...wal`. VM
+replacement discarded that WAL before the threshold was reached.
+
+The data-plane path is catalog-driven:
+
+----
+object-store catalog -> Collection.storage_assignment.base_location
+                     -> register/recover known collection ids
+                     -> replay object-store WAL into the matching memtable
+                     -> flush/read SST or VIPER below the same base_location
+----
+
+No catalog row means recovery cannot safely infer a collection's engine, dimension,
+tenant, or storage layout from WAL bytes alone.
+
+== Fix
+
+=== Catalog durability
+
+`CatalogSnapshotStore::requires_snapshot_on_commit()` distinguishes an object-store
+snapshot that is the only artifact surviving local-volume loss from a local snapshot
+whose adjacent WAL is already durable. `ObjectStoreSnapshotStore` returns true.
+
+After durable local append and in-memory apply, every object-store catalog commit now
+publishes its generation-fenced snapshot before returning success. Local catalogs
+retain the 1,000-mutation checkpoint cadence. A failed remote publish fails the DDL
+acknowledgement.
+
+=== SST/VIPER layout
+
+`config/cloud-object-store.toml` is the canonical deployment overlay. One
+`PROXIMADB_OBJECT_STORE_URL` roots:
+
+* `metadata_url` (collection/system catalog and catalog sidecars);
+* `storage_locations` (per-collection WAL, SST/VIPER data, and indexes);
+* the explicit WAL and SST/VIPER data-directory settings.
+
+Both `[storage].mmap_enabled`/SST mmap and
+`[storage.optimization].enable_mmap` are false. Startup already rejects a cloud
+storage location when the optimization mmap switch is true.
+
+SST and VIPER flush/read paths use the recovered
+`Collection.storage_assignment.base_location` and the unified filesystem. They do
+not need a local staging `data_directory` to recover a collection.
+
+=== Local-filesystem escape audit
+
+* Graph collection metadata now resolves to
+  `<metadata_url>/graph_collections.json`; object URLs use `FileSystem` read/write.
+* Discovery jobs now resolve to
+  `<metadata_url>/discovery_jobs/registry.json`; remote full-snapshot PUTs are
+  serialized through one ordered writer so an older mutation cannot land last.
+* Local constructors retain temp-file + rename behavior and receive only stripped
+  `file://` paths. Scheme-qualified paths never reach `std::fs`/`tokio::fs`.
+
+== Recovery invariant
+
+Boot sets the recovered catalog as the global WAL/recovery authority before creating
+the storage engine. `StorageEngine::recover_from_wal()` lists catalog collections and
+calls `recover_collection(id)` for each. Once the object-store snapshot restores the
+catalog row, the pre-existing WAL segments are reattached to that id and replayed.
+
+The recovery code deliberately does not invent collections from WAL segment names;
+doing so would bypass schema, engine, tenant, and authorization metadata.
+
+== Verification
+
+=== Deterministic catalog regression
+
+`object_store_commit_survives_fresh_local_wal_without_checkpoint` uses one in-memory
+object store and two unrelated temporary local WAL directories. It creates one
+namespace/table, performs no explicit checkpoint or graceful shutdown, and proves the
+second instance recovers the table solely from object storage. This fails with the old
+1,000-mutation threshold.
+
+=== Real process / real backend integration
+
+`apps/proximadb-server/tests/object_store_restart_recovery.rs` launches the production
+server binary three times against one unique `s3://` or `adls://` prefix:
+
+. VM 1: create SST collection + insert records; SIGKILL.
+. VM 2 with empty local disk: recover catalog, replay WAL, and find the record; SIGINT
+  to materialize SST and reclaim flushed WAL.
+. VM 3 with another empty local disk: recover catalog and find the record from cold SST.
+
+Run:
+
+----
+PROXIMADB_OBJECT_STORE_URL=adls://container/proximadb-proof \
+  scripts/prove_object_store_durability.sh
+----
+
+The harness requires the server's `azure` or `aws` feature and ambient managed
+identity/IAM credentials. It is ignored in credential-free CI and is the anvaiops
+deployment proof.
+
+== Closure evidence
+
+Before marking this TD closed, attach:
+
+* the complete proof-script output showing WAL-replay and cold-SST phases pass;
+* an object listing containing `_operator/catalog/_manifests`, collection WAL, and
+  collection data objects;
+* the published `runtime-full` immutable image digest deployed by anvaiops;
+* restart logs showing a non-zero catalog collection count and successful WAL replay.
+
+== History
+
+* 2026-07-14 — filed after the post-#966 VM restart recovered zero collections.
+* 2026-07-14 — implemented per-commit object-store catalog publication, cloud layout
+  overlay, graph/discovery filesystem routing, and the three-process recovery proof.

--- a/docs/10-quality/td/TD-OBJSTORE-3.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-3.adoc
@@ -1,0 +1,123 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OBJSTORE-3: Consolidate cloud bootstrap environment-variable resolution
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** Discovered during the live ADLS closure proof for `TD-OBJSTORE-2`.
+| Severity | High — two Azure clients in one process require different names for the same account, allowing a deployment to pass data-plane initialization but fail catalog initialization (or the reverse).
+| Component | Cloud bootstrap configuration, `proximadb-object-store`, unified `FileSystem`, deployment documentation and validation.
+| Follows | `TD-OBJSTORE-2` / PR #979.
+| Pillar | REL, DR, SEC, OPS
+|===
+
+toc::[]
+
+== Problem
+
+ProximaDB currently exposes implementation details of two Azure clients as an
+operator-facing configuration contract:
+
+* the unified Azure `FileSystem` reads `AZURE_STORAGE_ACCOUNT`;
+* the upstream `object_store` catalog path reads
+  `AZURE_STORAGE_ACCOUNT_NAME` (`azure_storage_account_name` after option
+  normalization).
+
+Both values describe the same Azure storage account. During the
+`TD-OBJSTORE-2` live proof the VM supplied `AZURE_STORAGE_ACCOUNT`, so the
+unified filesystem could be configured, while object-store catalog startup
+failed with `Account must be specified`. Requiring operators to set both names
+permanently makes correctness depend on Docker/Terraform duplication and lets
+the two values silently diverge.
+
+The same class must be audited for access keys, endpoints, identity selectors,
+and for the AWS/GCS adapters: ProximaDB and upstream SDK spellings must not
+become independent sources of truth.
+
+== Recommendation
+
+Consolidate aliases *within each provider* at the ProximaDB boundary. Do not
+collapse Azure, AWS, and GCS into one generic account variable: their identity,
+endpoint, and resource models are materially different.
+
+For Azure, introduce one canonical operator-facing variable:
+
+----
+PROXIMADB_AZURE_STORAGE_ACCOUNT
+----
+
+Resolve it once into an internal `AzureBootstrapConfig`, then pass the resolved
+account programmatically to both the unified filesystem builder and
+`object_store::parse_url_opts`. Do not mutate the process environment to adapt
+one client to the other.
+
+Keep existing provider-native variables as compatibility aliases during
+migration. Recommended precedence:
+
+. `PROXIMADB_AZURE_STORAGE_ACCOUNT` (canonical ProximaDB contract);
+. `AZURE_STORAGE_ACCOUNT_NAME` (upstream `object_store` spelling);
+. `AZURE_STORAGE_ACCOUNT` (existing ProximaDB/deployment spelling).
+
+If two populated aliases have different values, fail startup with a redacted,
+actionable conflict error. If legacy aliases agree, accept them and emit a
+once-per-process deprecation warning. Absence remains valid only for explicitly
+configured emulator/default-development modes.
+
+Apply the same pattern to the remaining Azure options and audit AWS/GCS:
+
+* access key / account key;
+* endpoint and emulator selection;
+* managed/workload-identity client, tenant, and token-file inputs;
+* AWS region, endpoint, path-style, and web-identity inputs;
+* GCS project, endpoint, service-account, and anonymous-emulator inputs.
+
+Provider-standard variables should continue to work. Consolidation means one
+resolver and one resolved value inside ProximaDB, not removal of standard cloud
+credential-chain compatibility.
+
+== URL contract
+
+Environment consolidation must be paired with one documented Azure URL shape.
+For the flat Blob backend used by ProximaDB, the URL host is the container and
+the account comes from the resolved bootstrap configuration:
+
+----
+adls://proximadb/metadata
+az://proximadb/metadata
+----
+
+Do not encode an alternative account/container interpretation in one client.
+All Azure aliases must normalize to the same parsed `(account, container,
+object-prefix)` tuple before either catalog or data-plane initialization.
+
+== Acceptance criteria
+
+* A process configured with only `PROXIMADB_AZURE_STORAGE_ACCOUNT` initializes
+  both object-store catalog and unified filesystem clients under managed
+  identity.
+* Each legacy account alias works independently during the migration window.
+* Conflicting aliases fail before any catalog or data write.
+* Table-driven tests cover precedence, conflicts, empty values, emulator mode,
+  and URL normalization for `az://`, `azure://`, `adls://`, and `abfs://`.
+* A process-boundary ADLS test creates catalog + WAL + SST state, restarts with
+  a fresh local data directory, and recovers using only the canonical variable.
+* Deployment templates set one account variable; they do not duplicate values
+  merely to satisfy different internal libraries.
+* Operator documentation lists canonical names, supported aliases, precedence,
+  and deprecation timing.
+
+== Relationship to remote configuration bootstrap
+
+This TD is compatible with loading the main TOML from `file://`, `s3://`,
+`gs://`, or Azure object storage. The remote config loader still needs a small
+bootstrap envelope (config URL plus ambient identity/provider account). The
+resolver defined here should be the single source used by that bootstrap loader
+and by normal storage initialization.
+
+== History
+
+* 2026-07-14 — filed after the live `TD-OBJSTORE-2` ADLS proof showed
+  `AZURE_STORAGE_ACCOUNT` reached the container while catalog initialization
+  still required `AZURE_STORAGE_ACCOUNT_NAME`.

--- a/scripts/prove_object_store_durability.sh
+++ b/scripts/prove_object_store_durability.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# TD-OBJSTORE-2: destructive, process-boundary durability proof over a unique
+# prefix below PROXIMADB_OBJECT_STORE_URL. The Rust harness creates its own UUID
+# sub-prefix and three fresh local VM directories; it never deletes user data.
+
+set -euo pipefail
+
+if [[ -z "${PROXIMADB_OBJECT_STORE_URL:-}" ]]; then
+  echo "PROXIMADB_OBJECT_STORE_URL is required (s3://bucket/prefix or adls://container/prefix)" >&2
+  exit 2
+fi
+
+case "${PROXIMADB_OBJECT_STORE_URL}" in
+  s3://*) feature=aws ;;
+  adls://*) feature=azure ;;
+  *)
+    echo "unsupported proof URL: ${PROXIMADB_OBJECT_STORE_URL} (expected s3:// or adls://)" >&2
+    exit 2
+    ;;
+esac
+
+echo "TD-OBJSTORE-2 durability proof"
+echo "  object root: ${PROXIMADB_OBJECT_STORE_URL}"
+echo "  backend feature: ${feature}"
+echo "  phases: crash/WAL replay -> graceful SST flush -> fresh-disk cold SST read"
+
+cargo test \
+  -p proximadb-server \
+  --features "${feature}" \
+  --test object_store_restart_recovery \
+  catalog_wal_and_sst_survive_fresh_local_disks \
+  -- --ignored --nocapture --test-threads=1
+
+echo "PASS: catalog recovered from metadata_url, WAL replay reattached the collection, and SST served a second fresh-disk restart"

--- a/src/database.rs
+++ b/src/database.rs
@@ -722,9 +722,10 @@ impl ProximaDB {
     pub async fn start(&mut self) -> anyhow::Result<()> {
         tracing::info!("🚀 ProximaDB::start - Starting database services...");
 
-        // Step 1: Start storage engine (recovers collections from metadata)
+        // Step 1: Start the storage engine. It restores the catalog, registers
+        // collection storage engines, and replays WAL in that dependency order.
         tracing::info!(
-            "📦 ProximaDB::start - Step 1: Starting storage engine for collection recovery..."
+            "📦 ProximaDB::start - Step 1: Starting storage engine and durable recovery..."
         );
         {
             let mut storage = self.storage.write().await;
@@ -733,32 +734,11 @@ impl ProximaDB {
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to start storage engine: {}", e))?;
         }
-        tracing::info!(
-            "✅ ProximaDB::start - Storage engine started, collections recovered from metadata_info"
-        );
+        tracing::info!("✅ ProximaDB::start - Storage engine started, catalog and WAL recovered");
 
-        // Step 2: Recover vectors from WAL (persisted data)
+        // Step 2: Recover graphs from snapshots + WAL
         tracing::info!(
-            "📦 ProximaDB::start - Step 2: Recovering vectors from WAL (persisted data)..."
-        );
-        {
-            let storage = self.storage.read().await;
-            match storage.recover_from_wal().await {
-                Ok(()) => {
-                    tracing::info!("✅ ProximaDB::start - Vectors recovered from WAL successfully");
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "⚠️  ProximaDB::start - WAL recovery failed (continuing anyway): {}",
-                        e
-                    );
-                }
-            }
-        }
-
-        // Step 3: Recover graphs from snapshots + WAL
-        tracing::info!(
-            "🌳 ProximaDB::start - Step 3: Recovering graphs from persistent storage..."
+            "🌳 ProximaDB::start - Step 2: Recovering graphs from persistent storage..."
         );
         if let Some(ref multi_server) = self.multi_server {
             match multi_server
@@ -779,16 +759,16 @@ impl ProximaDB {
             }
         }
 
-        // Step 4: Recover assignments from collection metadata
+        // Step 3: Recover assignments from collection metadata
         tracing::info!(
-            "🗺️ ProximaDB::start - Step 4: Recovering assignments from collection metadata..."
+            "🗺️ ProximaDB::start - Step 3: Recovering assignments from collection metadata..."
         );
         tracing::info!(
             "✅ ProximaDB::start - Assignment recovery completed (or skipped if no service)"
         );
 
-        // Step 5: Recover vectors from write buffer (in-memory data)
-        tracing::info!("🔄 ProximaDB::start - Step 5: Recovering vectors from write buffer...");
+        // Step 4: Recover vectors from write buffer (in-memory data)
+        tracing::info!("🔄 ProximaDB::start - Step 4: Recovering vectors from write buffer...");
         if let Some(ref multi_server) = self.multi_server {
             multi_server
                 .shared_services
@@ -799,13 +779,13 @@ impl ProximaDB {
                 })?;
         }
 
-        // Step 6: Initialize RL Query Planner (if enabled)
-        tracing::info!("🎯 ProximaDB::start - Step 6: Initializing RL Query Planner...");
+        // Step 5: Initialize RL Query Planner (if enabled)
+        tracing::info!("🎯 ProximaDB::start - Step 5: Initializing RL Query Planner...");
         self.init_rl_planner().await?;
 
-        // Step 7: Start multi-server (HTTP and gRPC on separate ports)
+        // Step 6: Start multi-server (HTTP and gRPC on separate ports)
         tracing::info!(
-            "🌐 ProximaDB::start - Step 7: Starting multi-server (gRPC:5679 + REST:5678)..."
+            "🌐 ProximaDB::start - Step 6: Starting multi-server (gRPC:5679 + REST:5678)..."
         );
         if let Some(ref mut multi_server) = self.multi_server {
             multi_server

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1497,17 +1497,29 @@ impl SharedServices {
         debug!(
             "🔧 SharedServices::new - Creating SHARED GraphCollectionService instance with auto-recovery..."
         );
-        let graph_collection_service =
-            match crate::services::GraphCollectionService::new_with_recovery().await {
-                Ok(svc) => Arc::new(svc),
-                Err(e) => {
-                    warn!(
-                        "Failed to create GraphCollectionService with recovery: {}. Using non-persistent service.",
-                        e
-                    );
-                    Arc::new(crate::services::GraphCollectionService::new())
-                }
-            };
+        let graph_metadata_url =
+            join_storage_url(&storage_config.metadata_url, "graph_collections.json");
+        let graph_collection_service = match if graph_metadata_url.starts_with("file://") {
+            crate::services::GraphCollectionService::new_with_recovery_at(std::path::PathBuf::from(
+                graph_metadata_url.trim_start_matches("file://"),
+            ))
+            .await
+        } else {
+            crate::services::GraphCollectionService::new_with_recovery_at_url(
+                graph_metadata_url.clone(),
+                filesystem_factory.clone(),
+            )
+            .await
+        } {
+            Ok(svc) => Arc::new(svc),
+            Err(e) => {
+                warn!(
+                    "Failed to create GraphCollectionService with recovery at {}: {}. Using non-persistent service.",
+                    graph_metadata_url, e
+                );
+                Arc::new(crate::services::GraphCollectionService::new())
+            }
+        };
         debug!(
             "✅ SharedServices::new - Shared GraphCollectionService created (with auto-recovery)"
         );
@@ -2257,27 +2269,39 @@ impl SharedServices {
         // sender is intentionally leaked (matching the always-on
         // start_axis_consumer maintenance pattern): dropping it would make the
         // executor's `shutdown.changed()` return Err and exit immediately.
-        // Registry is in-memory for this first (experimental) wiring; durable
-        // persistence under the data dir is a follow-up.
+        // Registry is durable below metadata_url when a full config is present;
+        // embedded/test wiring without one remains in-memory.
         let snapshot_coordinator = Arc::new(
             crate::services::snapshot::SnapshotPublishCoordinator::new(catalog_manager.clone()),
         );
         // Phase 8 (F1): per-collection discovery-job registry. Durable when a
-        // full config is present (jobs + states survive restart), mirroring the
-        // primary-pod registry persistence pattern; in-memory otherwise
-        // (embedded/test harnesses without a data dir).
+        // full config is present (jobs + states survive restart). Object-store
+        // deployments route the sidecar through FileSystem below metadata_url;
+        // embedded/test harnesses without a config remain in-memory.
         let discovery_registry = match opt_config {
-            Some(cfg) => {
-                let path = cfg
-                    .server
-                    .data_dir
-                    .join("discovery_jobs")
-                    .join("registry.json");
+            Some(_cfg) => {
+                let url =
+                    join_storage_url(&storage_config.metadata_url, "discovery_jobs/registry.json");
                 info!(
                     "🔍 SharedServices: discovery-job registry persistence at {}",
-                    path.display()
+                    url
                 );
-                Arc::new(crate::services::discovery::DiscoveryRegistry::load_or_create_at(path))
+                if url.starts_with("file://") {
+                    Arc::new(
+                        crate::services::discovery::DiscoveryRegistry::load_or_create_at(
+                            std::path::PathBuf::from(url.trim_start_matches("file://")),
+                        ),
+                    )
+                } else {
+                    Arc::new(
+                        crate::services::discovery::DiscoveryRegistry::load_or_create_at_url(
+                            url,
+                            filesystem_factory.clone(),
+                        )
+                        .await
+                        .context("opening object-store discovery registry")?,
+                    )
+                }
             }
             None => Arc::new(crate::services::discovery::DiscoveryRegistry::new()),
         };

--- a/src/services/catalog_snapshot_store.rs
+++ b/src/services/catalog_snapshot_store.rs
@@ -66,6 +66,17 @@ pub enum SnapshotWrite {
 /// rejected instead of clobbering the newer pod's snapshot.
 #[async_trait]
 pub trait CatalogSnapshotStore: Send + Sync {
+    /// Whether this snapshot is the only durable copy that survives loss of the
+    /// catalog WAL's local volume. Object-store deployments keep a local WAL as
+    /// a write-ahead staging log, but that WAL is not durable across VM/pod
+    /// replacement. They therefore must publish a snapshot for every committed
+    /// DDL before acknowledging it. Local stores return `false`: their WAL is
+    /// already on the durable filesystem and snapshots remain a bounded-restart
+    /// optimization.
+    fn requires_snapshot_on_commit(&self) -> bool {
+        false
+    }
+
     /// Read the current snapshot blob with its pointer version + fencing
     /// generation, or `None` if none has been written yet.
     async fn read(&self) -> Result<Option<SnapshotRead>>;
@@ -223,6 +234,10 @@ impl ObjectStoreSnapshotStore {
 
 #[async_trait]
 impl CatalogSnapshotStore for ObjectStoreSnapshotStore {
+    fn requires_snapshot_on_commit(&self) -> bool {
+        true
+    }
+
     async fn read(&self) -> Result<Option<SnapshotRead>> {
         match self
             .committer

--- a/src/services/discovery/registry.rs
+++ b/src/services/discovery/registry.rs
@@ -1,12 +1,12 @@
 //! `DiscoveryRegistry` — durable in-memory registry of discovery jobs.
 //!
-//! Mirrors the persistence pattern of
-//! `crate::cluster::primary_pod_registry::PrimaryPodRegistry`: a `DashMap` is
-//! authoritative in memory; when constructed with a path, every mutation
-//! atomically rewrites a JSON sidecar (temp file + rename). Write failures are
-//! logged, never propagated — the in-memory state stays authoritative.
+//! A `DashMap` is authoritative in memory. Local persistence atomically rewrites
+//! a JSON sidecar (temp file + rename); object-store persistence sends ordered
+//! full-snapshot PUTs through the unified filesystem. Write failures are logged,
+//! never propagated — the in-memory state stays authoritative.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
@@ -22,10 +22,26 @@ struct PersistedRegistry {
 }
 
 /// Durable registry of discovery jobs keyed by `job_id`.
-#[derive(Default)]
 pub struct DiscoveryRegistry {
     jobs: DashMap<String, DiscoveryJob>,
-    persistence_path: Option<PathBuf>,
+    persistence: Option<RegistryPersistence>,
+}
+
+enum RegistryPersistence {
+    Local(PathBuf),
+    ObjectStore {
+        url: String,
+        writer: tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
+    },
+}
+
+impl Default for DiscoveryRegistry {
+    fn default() -> Self {
+        Self {
+            jobs: DashMap::new(),
+            persistence: None,
+        }
+    }
 }
 
 impl DiscoveryRegistry {
@@ -40,7 +56,7 @@ impl DiscoveryRegistry {
     pub fn load_or_create_at(path: PathBuf) -> Self {
         let registry = Self {
             jobs: DashMap::new(),
-            persistence_path: Some(path.clone()),
+            persistence: Some(RegistryPersistence::Local(path.clone())),
         };
 
         match std::fs::read(&path) {
@@ -73,6 +89,70 @@ impl DiscoveryRegistry {
         }
 
         registry
+    }
+
+    /// Registry persisted through the unified filesystem at a scheme-qualified
+    /// URL. This is the production constructor for object-store metadata; URL-
+    /// shaped paths never reach `std::fs`.
+    pub async fn load_or_create_at_url(
+        url: String,
+        filesystem_factory: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
+    ) -> anyhow::Result<Self> {
+        let filesystem = filesystem_factory.get_filesystem(&url)?;
+        let (writer, mut writes) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+        let writer_url = url.clone();
+        let writer_filesystem = filesystem.clone();
+        // One worker serializes full-snapshot PUTs in mutation order. Spawning
+        // one task per mutation could let an older snapshot land after a newer
+        // one and roll the registry backward.
+        tokio::spawn(async move {
+            while let Some(serialized) = writes.recv().await {
+                if let Err(err) = writer_filesystem
+                    .write_atomic(&writer_url, &serialized, None)
+                    .await
+                {
+                    tracing::warn!(
+                        "DiscoveryRegistry: failed to persist to {} ({}); in-memory state remains authoritative",
+                        writer_url,
+                        err
+                    );
+                }
+            }
+        });
+        let registry = Self {
+            jobs: DashMap::new(),
+            persistence: Some(RegistryPersistence::ObjectStore {
+                url: url.clone(),
+                writer,
+            }),
+        };
+        if filesystem.exists(&url).await? {
+            match filesystem.read(&url).await {
+                Ok(bytes) => match serde_json::from_slice::<PersistedRegistry>(&bytes) {
+                    Ok(persisted) => {
+                        tracing::info!(
+                            "DiscoveryRegistry: loaded {} jobs from {}",
+                            persisted.jobs.len(),
+                            url
+                        );
+                        for job in persisted.jobs {
+                            registry.jobs.insert(job.job_id.clone(), job);
+                        }
+                    }
+                    Err(err) => tracing::warn!(
+                        "DiscoveryRegistry: object at {} is corrupt ({}); starting empty",
+                        url,
+                        err
+                    ),
+                },
+                Err(err) => tracing::warn!(
+                    "DiscoveryRegistry: cannot read {} ({}); starting empty",
+                    url,
+                    err
+                ),
+            }
+        }
+        Ok(registry)
     }
 
     /// Record a newly created (`Scheduled`) job.
@@ -147,19 +227,41 @@ impl DiscoveryRegistry {
     }
 
     fn persist_if_configured(&self) {
-        let Some(path) = self.persistence_path.as_ref() else {
+        let Some(persistence) = self.persistence.as_ref() else {
             return;
         };
         let persisted = PersistedRegistry {
             schema_version: REGISTRY_SCHEMA_VERSION,
             jobs: self.jobs.iter().map(|e| e.value().clone()).collect(),
         };
-        if let Err(err) = atomic_write_json(path, &persisted) {
-            tracing::warn!(
-                "DiscoveryRegistry: failed to persist to {} ({}); in-memory state remains authoritative",
-                path.display(),
-                err
-            );
+        match persistence {
+            RegistryPersistence::Local(path) => {
+                if let Err(err) = atomic_write_json(path, &persisted) {
+                    tracing::warn!(
+                        "DiscoveryRegistry: failed to persist to {} ({}); in-memory state remains authoritative",
+                        path.display(),
+                        err
+                    );
+                }
+            }
+            RegistryPersistence::ObjectStore { url, writer } => {
+                let serialized = match serde_json::to_vec_pretty(&persisted) {
+                    Ok(serialized) => serialized,
+                    Err(err) => {
+                        tracing::warn!("DiscoveryRegistry: serialization failed: {err}");
+                        return;
+                    }
+                };
+                // Mutations are synchronous control-plane calls today. Enqueue
+                // the full snapshot to the single ordered remote writer rather
+                // than blocking the caller's worker thread on object-store I/O.
+                if writer.send(serialized).is_err() {
+                    tracing::warn!(
+                        "DiscoveryRegistry: persistence worker for {} stopped; in-memory state remains authoritative",
+                        url
+                    );
+                }
+            }
         }
     }
 }

--- a/src/services/graph_collection.rs
+++ b/src/services/graph_collection.rs
@@ -130,6 +130,13 @@ pub struct GraphCollectionService {
     /// Path to persistence file
     persistence_path: PathBuf,
 
+    /// Object-store filesystem for URL-backed metadata. `None` preserves the
+    /// local temp-file + rename implementation used by embedded/local mode.
+    persistence_filesystem: Option<Arc<dyn crate::storage::persistence::filesystem::FileSystem>>,
+
+    /// Scheme-qualified object path when `persistence_filesystem` is set.
+    persistence_url: Option<String>,
+
     /// Lock for persistence operations
     persistence_lock: Arc<RwLock<()>>,
 
@@ -154,6 +161,8 @@ impl GraphCollectionService {
         Self {
             collections: Arc::new(DashMap::new()),
             persistence_path,
+            persistence_filesystem: None,
+            persistence_url: None,
             persistence_lock: Arc::new(RwLock::new(())),
             max_graphs: 1000,
             metadata_cache_size: 100,
@@ -204,9 +213,52 @@ impl GraphCollectionService {
         Ok(service)
     }
 
+    /// Create a graph collection service whose sidecar lives under an object-
+    /// store metadata URL. All reads/writes go through the unified filesystem;
+    /// no URL-shaped path reaches `std::fs`/`tokio::fs`.
+    pub async fn new_with_recovery_at_url(
+        persistence_url: String,
+        filesystem_factory: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
+    ) -> Result<Self> {
+        let filesystem = filesystem_factory
+            .get_filesystem(&persistence_url)
+            .map_err(|e| {
+                ProximaDBError::Internal(format!(
+                    "Failed to open graph metadata filesystem at {persistence_url}: {e}"
+                ))
+            })?;
+        let service = Self {
+            collections: Arc::new(DashMap::new()),
+            // Never used by the URL-backed branch; retained to keep the local
+            // constructor and its tests byte-identical.
+            persistence_path: PathBuf::new(),
+            persistence_filesystem: Some(filesystem),
+            persistence_url: Some(persistence_url),
+            persistence_lock: Arc::new(RwLock::new(())),
+            max_graphs: 1000,
+            metadata_cache_size: 100,
+        };
+        service.load_from_disk().await?;
+        Ok(service)
+    }
+
     /// Load graph collections from persistent storage
     pub async fn load_from_disk(&self) -> Result<usize> {
         let _lock = self.persistence_lock.read().await;
+
+        if let (Some(filesystem), Some(url)) = (&self.persistence_filesystem, &self.persistence_url)
+        {
+            if !filesystem.exists(url).await.map_err(|e| {
+                ProximaDBError::Internal(format!("Failed to probe graph metadata at {url}: {e}"))
+            })? {
+                debug!("Graph metadata object does not exist yet: {}", url);
+                return Ok(0);
+            }
+            let contents = filesystem.read(url).await.map_err(|e| {
+                ProximaDBError::Internal(format!("Failed to read graph metadata object {url}: {e}"))
+            })?;
+            return self.load_serialized_store(&contents);
+        }
 
         if !self.persistence_path.exists() {
             debug!(
@@ -222,10 +274,13 @@ impl GraphCollectionService {
                 ProximaDBError::Internal(format!("Failed to read graph metadata file: {}", e))
             })?;
 
-        let store: GraphMetadataStore = serde_json::from_str(&contents).map_err(|e| {
+        self.load_serialized_store(contents.as_bytes())
+    }
+
+    fn load_serialized_store(&self, contents: &[u8]) -> Result<usize> {
+        let store: GraphMetadataStore = serde_json::from_slice(contents).map_err(|e| {
             ProximaDBError::Internal(format!("Failed to parse graph metadata: {}", e))
         })?;
-
         let count = store.collections.len();
         for (graph_id, metadata) in store.collections {
             let collection = Arc::new(metadata.to_collection());
@@ -267,6 +322,24 @@ impl GraphCollectionService {
         let contents = serde_json::to_string_pretty(&store).map_err(|e| {
             ProximaDBError::Internal(format!("Failed to serialize graph metadata: {}", e))
         })?;
+
+        if let (Some(filesystem), Some(url)) = (&self.persistence_filesystem, &self.persistence_url)
+        {
+            filesystem
+                .write_atomic(url, contents.as_bytes(), None)
+                .await
+                .map_err(|e| {
+                    ProximaDBError::Internal(format!(
+                        "Failed to persist graph metadata object {url}: {e}"
+                    ))
+                })?;
+            debug!(
+                "Saved {} graph collections to object storage at {}",
+                store.collections.len(),
+                url
+            );
+            return Ok(());
+        }
 
         fs::write(&temp_path, &contents).await.map_err(|e| {
             ProximaDBError::Internal(format!("Failed to write graph metadata: {}", e))

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -331,7 +331,12 @@ impl SystemCatalog {
                 .commits_since_snapshot
                 .fetch_add(applied, Ordering::SeqCst)
                 + applied;
-            if n >= cfg.threshold {
+            // For an object-store catalog the local WAL is only a staging log:
+            // a VM/pod replacement starts with a fresh local data_dir, so the
+            // snapshot is the ONLY catalog artifact that survives. Publish it
+            // before acknowledging every DDL. Local catalogs retain the normal
+            // threshold because their WAL itself is durable.
+            if cfg.store.requires_snapshot_on_commit() || n >= cfg.threshold {
                 self.checkpoint_locked(cfg).await?;
                 self.commits_since_snapshot.store(0, Ordering::SeqCst);
             }
@@ -1257,6 +1262,67 @@ mod tests {
                 "table {t} must survive object-store snapshot + WAL tail + reopen"
             );
         }
+        Ok(())
+    }
+
+    /// TD-OBJSTORE-2 regression: one collection-sized DDL batch must survive a
+    /// restart onto a fresh local volume without an explicit checkpoint. Before
+    /// this fix the default threshold (1,000 mutations) left these mutations
+    /// only in the local catalog WAL, so a VM replacement recovered an empty
+    /// catalog even though the data WAL was durable in object storage.
+    #[tokio::test]
+    async fn object_store_commit_survives_fresh_local_wal_without_checkpoint() -> Result<()> {
+        use crate::services::catalog_snapshot_store::ObjectStoreSnapshotStore;
+        use proximadb_object_store::ProximaObjectStore;
+
+        let first_vm = tempfile::tempdir()?;
+        let replacement_vm = tempfile::tempdir()?;
+        let backing: Arc<dyn object_store::ObjectStore> =
+            Arc::new(object_store::memory::InMemory::new());
+        let key = "_operator/catalog/_manifests/";
+
+        {
+            let store = Arc::new(ObjectStoreSnapshotStore::new(
+                ProximaObjectStore::new(backing.clone()),
+                "memory:///",
+                key,
+            ));
+            let cat = SystemCatalog::open_with_snapshot_store(
+                "default",
+                first_vm.path().join("catalog.wal"),
+                store,
+            )
+            .await?;
+            cat.create_namespace(&nslevels(&["default"]), HashMap::new())
+                .await?;
+            cat.create_table(
+                &TableIdentifier::new(nslevels(&["default"]), "durable_collection"),
+                vec_schema("durable_collection"),
+            )
+            .await?;
+            // No checkpoint and no graceful shutdown: model abrupt VM loss.
+        }
+
+        let store = Arc::new(ObjectStoreSnapshotStore::new(
+            ProximaObjectStore::new(backing),
+            "memory:///",
+            key,
+        ));
+        let reopened = SystemCatalog::open_with_snapshot_store(
+            "default",
+            replacement_vm.path().join("catalog.wal"),
+            store,
+        )
+        .await?;
+        assert!(
+            reopened
+                .table_exists(&TableIdentifier::new(
+                    nslevels(&["default"]),
+                    "durable_collection"
+                ))
+                .await?,
+            "catalog DDL must be present when the replacement VM has no local WAL"
+        );
         Ok(())
     }
 

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -1237,13 +1237,17 @@ mod tests {
             cat.checkpoint().await?;
             assert_eq!(wal_entry_count(dir.path()).await, 0);
 
-            // A post-snapshot DDL lands only on the local WAL tail.
+            // A post-snapshot DDL on an object-store catalog is acknowledged only
+            // after it publishes its own snapshot (TD-OBJSTORE-2: the local WAL is
+            // a staging log that does not survive VM/pod replacement, so the
+            // snapshot must carry every committed DDL). That publish compacts the
+            // local WAL tail back to empty — the DDL now lives in the snapshot.
             cat.create_table(
                 &TableIdentifier::new(nslevels(&["s"]), "t3"),
                 vec_schema("t3"),
             )
             .await?;
-            assert_eq!(wal_entry_count(dir.path()).await, 1);
+            assert_eq!(wal_entry_count(dir.path()).await, 0);
         }
 
         // Reopen with a new store handle over the SAME backing object store and
@@ -1565,10 +1569,18 @@ mod tests {
         Ok(())
     }
 
-    /// A **superseded** owner steps down: when a newer-generation pod has taken
-    /// the catalog over, a sinval poll on the old owner reloads the newer
-    /// snapshot, **discards** its own now-doomed unpublished writes, and flips to
-    /// read-only (no lost update — the fence + step-down converge to one writer).
+    /// A **superseded** owner steps down on its next sinval poll: when a
+    /// newer-generation pod has taken the catalog over, an old owner that has
+    /// not written since the takeover learns of it lazily, reloads the newer
+    /// snapshot, and flips to read-only (no lost update — the fence + step-down
+    /// converge to one writer).
+    ///
+    /// With object-store snapshot-on-commit (TD-OBJSTORE-2) every DDL publishes,
+    /// so a superseded owner fences on its *next write* rather than via a later
+    /// poll — there is no "unpublished local write" window to exercise here.
+    /// The poll path is therefore driven by an owner that has been silent since
+    /// the takeover. (The write-time fence + discard of a doomed write is
+    /// covered by `fenced_checkpoint_steps_down_and_reloads`.)
     #[tokio::test]
     async fn superseded_owner_steps_down_via_poll() -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -1590,10 +1602,9 @@ mod tests {
         pod_b.create_table(&tid("t2"), vec_schema("t2")).await?;
         pod_b.checkpoint().await?;
 
-        // Pod A writes t3 locally — unaware it has been superseded; it is visible
-        // on A until the next poll.
-        pod_a.create_table(&tid("t3"), vec_schema("t3")).await?;
-        assert!(pod_a.table_exists(&tid("t3")).await?);
+        // Pod A has not written since the takeover, so no checkpoint-time fence
+        // has fired yet — it still believes it owns the catalog.
+        assert!(!pod_a.is_read_only());
 
         // Sinval poll on A: a higher generation owns the catalog → step down.
         match pod_a.reload_if_stale().await? {
@@ -1611,13 +1622,9 @@ mod tests {
             pod_a.is_read_only(),
             "superseded owner must step down to read-only"
         );
-        // A converges to B's snapshot: sees t1 + t2, and its doomed t3 is gone.
+        // A converges to B's snapshot: sees t1 + t2.
         assert!(pod_a.table_exists(&tid("t1")).await?);
         assert!(pod_a.table_exists(&tid("t2")).await?);
-        assert!(
-            !pod_a.table_exists(&tid("t3")).await?,
-            "the superseded pod's unpublished write must be discarded (no lost update)"
-        );
         // A can no longer write.
         assert!(
             pod_a

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -185,15 +185,21 @@ impl StorageEngine {
     pub async fn start(&mut self) -> crate::storage::Result<()> {
         tracing::info!("🚀 STORAGE_ENGINE: Starting storage engine");
 
-        // Replay WAL to recover state
-        tracing::info!("📊 STORAGE_ENGINE: About to call recover_from_wal()");
-        self.recover_from_wal().await?;
-        tracing::info!("✅ STORAGE_ENGINE: WAL recovery completed, moving to load_collections()");
-
-        // Initialize existing collections
+        // Load the durable catalog before WAL replay. Recovery flushes each WAL
+        // batch through the collection's assigned storage engine, so those
+        // engines must be registered first (especially after a cold restart,
+        // when the catalog itself has just been restored from object storage).
         tracing::info!("📊 STORAGE_ENGINE: About to call load_collections()");
         self.load_collections().await?;
-        tracing::info!("✅ STORAGE_ENGINE: Collections loaded, starting compaction workers");
+        tracing::info!("✅ STORAGE_ENGINE: Collections loaded");
+
+        tracing::info!("📊 STORAGE_ENGINE: About to call register_collections_for_recovery()");
+        self.register_collections_for_recovery().await?;
+        tracing::info!("✅ STORAGE_ENGINE: Recovery engines registered");
+
+        tracing::info!("📊 STORAGE_ENGINE: About to call recover_from_wal()");
+        self.recover_from_wal().await?;
+        tracing::info!("✅ STORAGE_ENGINE: WAL recovery completed, starting compaction workers");
 
         // Start compaction workers
         // We need to replace the compaction manager to start workers
@@ -442,6 +448,7 @@ impl StorageEngine {
 
         // Recover each collection
         let mut total_vectors_recovered = 0u64;
+        let mut recovery_failures = Vec::new();
         for collection in collections {
             tracing::debug!("Recovering collection: {}", collection.id);
 
@@ -458,9 +465,17 @@ impl StorageEngine {
                         "⚠️  STORAGE_ENGINE: Failed to recover collection {}: {}",
                         collection.id, e
                     );
-                    // Continue with other collections even if one fails
+                    recovery_failures.push(format!("{}: {}", collection.id, e));
                 }
             }
+        }
+
+        if !recovery_failures.is_empty() {
+            return Err(crate::storage::StorageError::WalError(format!(
+                "WAL recovery failed for {} collection(s): {}",
+                recovery_failures.len(),
+                recovery_failures.join("; ")
+            )));
         }
 
         info!(
@@ -490,16 +505,20 @@ impl StorageEngine {
         info!("📋 Found {} collections to register", collections.len());
 
         // Get recovery manager from WAL
-        let recovery_manager = match self.write_ahead_log_manager.get_recovery_manager().await {
-            Ok(rm) => rm,
-            Err(e) => {
-                warn!("⚠️ Failed to get recovery manager: {}", e);
-                return Ok(()); // Continue even if we can't get recovery manager
-            }
-        };
+        let recovery_manager = self
+            .write_ahead_log_manager
+            .get_recovery_manager()
+            .await
+            .map_err(|e| {
+                crate::storage::StorageError::WalError(format!(
+                    "Failed to get recovery manager before registration: {}",
+                    e
+                ))
+            })?;
 
         // Store collection count before iterating
         let collection_count = collections.len();
+        let mut registration_failures = Vec::new();
 
         // Register each collection's storage engine
         for collection in &collections {
@@ -535,6 +554,7 @@ impl StorageEngine {
                             "⚠️ Failed to register engine for collection {}: {}",
                             collection.id, e
                         );
+                        registration_failures.push(format!("{}: {}", collection.id, e));
                     } else {
                         info!(
                             "✅ Registered {} engine for collection {} (from {})",
@@ -553,8 +573,17 @@ impl StorageEngine {
                         "⚠️ Failed to create engine for collection {}: {}",
                         collection.id, e
                     );
+                    registration_failures.push(format!("{}: {}", collection.id, e));
                 }
             }
+        }
+
+        if !registration_failures.is_empty() {
+            return Err(crate::storage::StorageError::WalError(format!(
+                "Storage-engine registration failed for {} collection(s): {}",
+                registration_failures.len(),
+                registration_failures.join("; ")
+            )));
         }
 
         info!(

--- a/tests/objstore_url_construction_test.rs
+++ b/tests/objstore_url_construction_test.rs
@@ -175,6 +175,89 @@ async fn audit_storage_scheme_dispatch() {
     assert_eq!(events[0].event_id, event.event_id);
 }
 
+/// Graph collection metadata follows `metadata_url` through FileSystem rather
+/// than falling back to the hard-coded `/tmp/proximadb/metadata` sidecar.
+#[tokio::test]
+async fn graph_catalog_round_trips_through_scheme_qualified_metadata_url() {
+    use proximadb::proto::proximadb_v1::CreateGraphRequest;
+    use proximadb::services::GraphCollectionService;
+    use proximadb::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let url = format!("file://{}/graph_collections.json", dir.path().display());
+    let factory = Arc::new(
+        FilesystemFactory::create(FilesystemConfig::default())
+            .await
+            .expect("filesystem factory"),
+    );
+    {
+        let service =
+            GraphCollectionService::new_with_recovery_at_url(url.clone(), factory.clone())
+                .await
+                .expect("graph service");
+        service
+            .create_graph(CreateGraphRequest {
+                graph_id: "durable-graph".to_string(),
+                name: Some("durable-graph".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("create graph");
+    }
+    let reopened = GraphCollectionService::new_with_recovery_at_url(url, factory)
+        .await
+        .expect("reopen graph service");
+    assert!(
+        reopened
+            .get_graph("durable-graph")
+            .await
+            .expect("get graph")
+            .is_some()
+    );
+}
+
+/// Discovery registry object-store mode uses one ordered filesystem writer and
+/// can restore its job snapshot through a scheme-qualified URL.
+#[tokio::test]
+async fn discovery_registry_round_trips_through_scheme_qualified_metadata_url() {
+    use proximadb::services::discovery::{DiscoveryJob, DiscoveryJobKind, DiscoveryRegistry};
+    use proximadb::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("discovery")).expect("discovery dir");
+    let url = format!("file://{}/discovery/registry.json", dir.path().display());
+    let factory = Arc::new(
+        FilesystemFactory::create(FilesystemConfig::default())
+            .await
+            .expect("filesystem factory"),
+    );
+    let job_id = {
+        let registry = DiscoveryRegistry::load_or_create_at_url(url.clone(), factory.clone())
+            .await
+            .expect("discovery registry");
+        let job = registry.schedule(DiscoveryJob::new(
+            "durable-collection",
+            DiscoveryJobKind::Recluster,
+        ));
+        let fs = factory.get_filesystem(&url).expect("filesystem");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while !fs.exists(&url).await.expect("exists") {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "ordered discovery writer did not persist in time"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        job.job_id
+    };
+    let reopened = DiscoveryRegistry::load_or_create_at_url(url, factory)
+        .await
+        .expect("reopen discovery registry");
+    assert!(reopened.get(&job_id).is_some());
+}
+
 /// Source guard: the strip-and-re-prepend pattern (`.replace("file://"`)
 /// that produced `file://adls://…` URLs must not reappear anywhere in `src/`.
 #[test]


### PR DESCRIPTION
## Summary

- publish the object-store catalog snapshot before acknowledging every DDL commit, so fresh-VM recovery has collection definitions before WAL replay
- route graph collection and discovery registry sidecars through metadata_url and the unified filesystem
- add a complete mmap-disabled cloud object-store layout for catalog, WAL, SST, and VIPER
- add a three-process S3/ADLS restart proof and TD-OBJSTORE-2 closure document

## Verification

- cargo check -p proximadb --lib
- catalog fresh-local-WAL regression: 1 passed
- objstore_url_construction_test: 7 passed
- proximadb-server object_store_restart_recovery harness: compiled successfully
- cargo fmt --all -- --check
- bash -n scripts/prove_object_store_durability.sh
- python3 scripts/check_td_adr_unique.py: 0 errors
- git diff --check

Live S3/ADLS proof remains the deployment closure gate because this runner has no PROXIMADB_OBJECT_STORE_URL or cloud credentials.