### PR TITLE
fix: close promotion correctness holds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9753,6 +9753,7 @@ checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
  "recursive",
+ "sqlparser_derive 0.3.0",
 ]
 
 [[package]]
@@ -9762,7 +9763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
- "sqlparser_derive",
+ "sqlparser_derive 0.5.0",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ anyhow = "1.0"
 # `sqlparser = { workspace = true }` without first declaring the
 # dep at the workspace level. Same pin as the root `[dependencies]`
 # entry.
-sqlparser = "0.59"
+sqlparser = { version = "0.59", features = ["visitor"] }
 arrow = { version = "58", features = ["prettyprint"] }
 arrow-array = { version = "58", default-features = false }
 bincode = "1.3"
@@ -390,7 +390,7 @@ proximadb-uql = { path = "crates/query/proximadb-uql" }
 proximadb-vector-query = { path = "crates/query/proximadb-vector-query" }
 
 # SQL Parsing
-sqlparser = "0.59"
+sqlparser = { version = "0.59", features = ["visitor"] }
 
 # Async recursion support
 async-recursion = "1.0"

--- a/crates/query/proximadb-relational-executor/src/lib.rs
+++ b/crates/query/proximadb-relational-executor/src/lib.rs
@@ -36,6 +36,7 @@ use proximadb_relational_planner::{
 use proximadb_relational_reader::{ReadSnapshot, ReaderError, RelationalReader, ScanContext};
 use proximadb_relational_types::{BinaryOp, Expr, ExprError, RelationalRow, RelationalSchema};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use thiserror::Error;
@@ -67,6 +68,9 @@ pub enum ExecError {
     #[error("scalar subquery returned more than one row")]
     ScalarSubqueryCardinality,
 
+    #[error("query execution was cancelled")]
+    Cancelled,
+
     #[error("internal executor error: {0}")]
     Internal(String),
 }
@@ -85,6 +89,9 @@ pub struct ExecutionContext {
     /// [`MeteredExec`] that records actual rows + inclusive time. `None` on the
     /// normal execution path → no wrapping, zero overhead.
     pub metrics: Option<Arc<ExecMetrics>>,
+    /// Cooperative request cancellation, checked by executor wrappers at a
+    /// bounded stride inside operator pull loops.
+    pub cancellation_flag: Option<Arc<AtomicBool>>,
 }
 
 impl ExecutionContext {
@@ -92,6 +99,7 @@ impl ExecutionContext {
         Self {
             snapshot,
             metrics: None,
+            cancellation_flag: None,
         }
     }
 
@@ -100,7 +108,13 @@ impl ExecutionContext {
         Self {
             snapshot: ReadSnapshot::latest(),
             metrics: Some(metrics),
+            cancellation_flag: None,
         }
+    }
+
+    pub fn with_cancellation_flag(mut self, flag: Option<Arc<AtomicBool>>) -> Self {
+        self.cancellation_flag = flag;
+        self
     }
 }
 
@@ -377,10 +391,67 @@ fn build_executor_inner<F: ReaderFactory>(
         }
     };
     let _ = (DistinctStrategy::Hash, SortStrategy::InMemory); // silence "imported but only matched in path"
-    Ok(match metric {
+    let node: Box<dyn ExecNode> = match metric {
         Some((metrics, idx)) => Box::new(MeteredExec::new(node, idx, metrics)),
         None => node,
+    };
+    Ok(match &ctx.cancellation_flag {
+        Some(flag) => Box::new(CancellationExec::new(node, flag.clone())),
+        None => node,
     })
+}
+
+/// Cooperative cancellation wrapper installed around every operator. The
+/// stride bounds atomic overhead while ensuring loops inside a parent operator
+/// re-enter a wrapped child and observe cancellation promptly.
+struct CancellationExec {
+    child: Box<dyn ExecNode>,
+    flag: Arc<AtomicBool>,
+    pulls: u32,
+}
+
+impl CancellationExec {
+    const CHECK_MASK: u32 = 4095;
+
+    fn new(child: Box<dyn ExecNode>, flag: Arc<AtomicBool>) -> Self {
+        Self {
+            child,
+            flag,
+            pulls: 0,
+        }
+    }
+
+    fn check(&mut self) -> Result<(), ExecError> {
+        let should_check = self.pulls & Self::CHECK_MASK == 0;
+        self.pulls = self.pulls.wrapping_add(1);
+        if should_check && self.flag.load(Ordering::Relaxed) {
+            Err(ExecError::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[async_trait]
+impl ExecNode for CancellationExec {
+    fn schema(&self) -> &RelationalSchema {
+        self.child.schema()
+    }
+
+    async fn open(&mut self) -> Result<(), ExecError> {
+        self.pulls = 0;
+        self.check()?;
+        self.child.open().await
+    }
+
+    async fn next_row(&mut self) -> Result<Option<RelationalRow>, ExecError> {
+        self.check()?;
+        self.child.next_row().await
+    }
+
+    async fn close(&mut self) -> Result<(), ExecError> {
+        self.child.close().await
+    }
 }
 
 /// Operator keyword for a physical-plan node — matches the planner's
@@ -3794,6 +3865,41 @@ mod tests {
         exec.open().await.unwrap();
         let rows = collect(&mut *exec).await.unwrap();
         assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn executor_wrapper_observes_mid_scan_cancellation() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let schema = RelationalSchema::new(vec![ColumnInfo::new("x", ProximaType::Int64, false)]);
+        let rows = (0..5000)
+            .map(|value| vec![Expr::literal(ProximaValue::Int64(value))])
+            .collect();
+        let plan = PhysicalPlan::Values {
+            rows,
+            output_schema: schema,
+        };
+        let f = factory_with_users();
+        let ctx = ExecutionContext::default().with_cancellation_flag(Some(flag.clone()));
+        let mut exec = build_executor(plan, &f, &ctx).unwrap();
+        exec.open().await.unwrap();
+        assert!(exec.next_row().await.unwrap().is_some());
+
+        flag.store(true, Ordering::Relaxed);
+        let mut cancelled = false;
+        for _ in 0..5000 {
+            match exec.next_row().await {
+                Err(ExecError::Cancelled) => {
+                    cancelled = true;
+                    break;
+                }
+                Ok(Some(_)) => {}
+                other => panic!("expected cancellation before exhaustion, got {other:?}"),
+            }
+        }
+        assert!(
+            cancelled,
+            "cancellation must be observed within the pull stride"
+        );
     }
 
     // ----- Aggregate accumulators (direct unit) -----------------------

--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -1072,8 +1072,13 @@ pub fn push_predicates<R: CapabilityResolver>(plan: PhysicalPlan, resolver: &R) 
                     let left_width = left.output_schema().columns.len();
                     let mut left_bucket: Vec<Expr> = Vec::new();
                     let mut right_bucket: Vec<Expr> = Vec::new();
+                    let mut implicit_join_bucket: Vec<Expr> = Vec::new();
                     let mut residual: Vec<Expr> = Vec::new();
                     for conj in flatten_and(&predicate).into_iter().cloned() {
+                        if kind == JoinKind::Cross && is_cross_side_equality(&conj, left_width) {
+                            implicit_join_bucket.push(conj);
+                            continue;
+                        }
                         let mut ords = Vec::new();
                         collect_column_ordinals(&conj, &mut ords);
                         if ords.is_empty() {
@@ -1107,6 +1112,17 @@ pub fn push_predicates<R: CapabilityResolver>(plan: PhysicalPlan, resolver: &R) 
                         )),
                         None => right,
                     };
+                    let (kind, on, strategy) =
+                        if kind == JoinKind::Cross && !implicit_join_bucket.is_empty() {
+                            let on = combine_all(implicit_join_bucket);
+                            (
+                                JoinKind::Inner,
+                                on.clone(),
+                                pick_join_strategy(JoinKind::Inner, on.as_ref()),
+                            )
+                        } else {
+                            (kind, on, strategy)
+                        };
                     let joined = PhysicalPlan::Join {
                         left: new_left,
                         right: new_right,
@@ -1491,6 +1507,24 @@ fn flatten_and_into<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
         }
         other => out.push(other),
     }
+}
+
+/// Whether `expr` is a column equality spanning the two inputs of a
+/// left++right combined schema. These are the safe join keys that normalize
+/// ANSI comma joins from `Cross + Filter` to an inner equi-join.
+fn is_cross_side_equality(expr: &Expr, left_width: usize) -> bool {
+    let Expr::BinaryOp {
+        op: BinaryOp::Eq,
+        left,
+        right,
+    } = expr
+    else {
+        return false;
+    };
+    let (Expr::Column(left), Expr::Column(right)) = (left.as_ref(), right.as_ref()) else {
+        return false;
+    };
+    (left.ordinal < left_width) != (right.ordinal < left_width)
 }
 
 fn expression_references_columns(expr: &Expr) -> bool {
@@ -3299,6 +3333,82 @@ mod tests {
             matches!(result, PhysicalPlan::Filter { .. }),
             "cross-side conjunct cannot be pushed to one child"
         );
+    }
+
+    #[test]
+    fn comma_join_filter_normalizes_to_hash_join_with_residual() {
+        let join_key = Expr::bin(
+            BinaryOp::Eq,
+            col_at(0, "id", ProximaType::Int64),
+            col_at(4, "user_id", ProximaType::Int64),
+        );
+        let residual = Expr::bin(
+            BinaryOp::Gt,
+            col_at(5, "total", ProximaType::Float64),
+            Expr::literal(ProximaValue::Float64(10.0)),
+        );
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Join {
+                left: Box::new(lower_to_physical(users_scan())),
+                right: Box::new(lower_to_physical(orders_scan())),
+                kind: JoinKind::Cross,
+                on: None,
+                strategy: JoinStrategy::NestedLoop,
+            }),
+            predicate: Expr::bin(BinaryOp::And, join_key, residual),
+        };
+
+        let result = push_predicates(physical, &cap_full(Vec::new()));
+        let PhysicalPlan::Join {
+            kind,
+            on,
+            strategy,
+            right,
+            ..
+        } = result
+        else {
+            panic!("expected normalized join with right residual pushed");
+        };
+        assert_eq!(kind, JoinKind::Inner);
+        assert!(on.is_some(), "cross-side equality becomes the ON key");
+        assert!(matches!(strategy, JoinStrategy::Hash { .. }));
+        assert!(matches!(
+            *right,
+            PhysicalPlan::Scan {
+                predicate: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cross_join_without_equality_is_not_misrewritten() {
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Join {
+                left: Box::new(lower_to_physical(users_scan())),
+                right: Box::new(lower_to_physical(orders_scan())),
+                kind: JoinKind::Cross,
+                on: None,
+                strategy: JoinStrategy::NestedLoop,
+            }),
+            predicate: Expr::bin(
+                BinaryOp::Gt,
+                col_at(0, "id", ProximaType::Int64),
+                col_at(4, "user_id", ProximaType::Int64),
+            ),
+        };
+
+        let result = push_predicates(physical, &cap_full(Vec::new()));
+        let PhysicalPlan::Filter { input, .. } = result else {
+            panic!("non-equi predicate must remain residual");
+        };
+        assert!(matches!(
+            *input,
+            PhysicalPlan::Join {
+                kind: JoinKind::Cross,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
+++ b/docs/10-quality/td/TD-183-document-json-projection-zero-rows.adoc
@@ -106,20 +106,16 @@ predicate function resolves (new `Expr::collect_func_names`), returning a loud
   `json_extract_text` → anchored single-engine (DataFusion correct). Accurate. Ratchet
   8 → 9. Also fixes the latent "no function works in a pushed-down native WHERE" bug.
 
-**PR5 — remaining two (open):**
+**PR5 — final two (resolved):**
 
-* **d06** (`(doc->>'price')::int > 8`) — the cast-wrapped predicate takes a path that
-  bypasses `DmlTableReader::open`'s pre-validation, so it still silently returns 0 rows
-  on native (DataFusion correct). Route that path through the same validate/evaluate
-  fix (or evaluate it through `builtins()` so the cast-of-json predicate errors loud).
-* **d11** (`(doc->>'in_stock')::boolean = true`) — DataFusion drops the `::boolean`
-  cast in frontend lowering, so the analyzer sees `Utf8 = Boolean` and fails coercion
-  (`src/datafusion/logical_lowering.rs:429` is correct; the gap is upstream in
-  `proximadb-relational-frontend` not emitting the `Expr::Cast { ty: Boolean }`).
+* **d06** (`(doc->>'price')::int > 8`) — unified cast evaluation removed the
+  cast-wrapped predicate bypass.
+* **d11** (`(doc->>'in_stock')::boolean = true`) — frontend lowering now preserves
+  the Boolean cast and both engines evaluate the typed comparison consistently.
 
-Each fix removes its ids from `KNOWN_BAD_TD183` and raises `DOC_ACCURACY_RATCHET`
-toward 11; the known-bad guards fail the moment a query becomes correct, forcing the
-bump.
+`KNOWN_BAD_TD183` is empty and `DOC_ACCURACY_RATCHET = 11`. There are no open
+TD-183 query ids; any future regression reopens the ratchet rather than this resolved
+implementation plan.
 
 The secondary native d09 `rebind_columns` planner error
 (`proximadb-relational-planner/src/lib.rs:1735`) is independent and out of scope.

--- a/docs/10-quality/td/TD-FILT-1-metadata-filter-evaluation-fail-loud.adoc
+++ b/docs/10-quality/td/TD-FILT-1-metadata-filter-evaluation-fail-loud.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | In Progress — slice 1 (typed `FilterEvalError` + `evaluate_filter_resolved_strict` / `evaluate_filter_proxima_strict` on the canonical v2 seam) landed 2026-07-07. Slice 2a now wires the strict evaluator into the live hybrid metadata-gating path behind `PROXIMADB_FILTER_FAIL_LOUD` (default-off), so unresolved v2 metadata fields can fail the query instead of silently narrowing results. Re-scoped from a v1 `MetadataValue` target the same day (see below).
+| Status | In Progress — slice 1 (typed `FilterEvalError` + `evaluate_filter_resolved_strict` / `evaluate_filter_proxima_strict` on the canonical v2 seam) landed 2026-07-07. The live hybrid and progressive-search v2 gates now default to the strict evaluator; explicit false-valued compatibility flags temporarily restore the legacy behavior. Lower-level bool-only storage predicates remain to be migrated. Re-scoped from a v1 `MetadataValue` target the same day (see below).
 | Severity | High (silent correctness loss in results — records whose filter field is absent, or a non-scalar leaf, are silently dropped from every non-null comparison with no error)
 | Component | Canonical v2 filter seam: `crates/foundation/proximadb-search-types/src/sql_value_filter.rs` — `evaluate_filter_resolved` (the shared spine, line ~315), `evaluate_filter_proxima` (ProximaTree/ProximaValue adapter, line ~350), `evaluate_filter` (SqlValue adapter).
 | Governs | link:../../12-design/adr/ADR-024-single-canonical-data-type-and-schema.adoc[ADR-024] (single canonical `ProximaValue`/`ProximaRecord` type) + link:../../12-design/adr/ADR-043-unified-relational-expression-evaluation.adoc[ADR-043] (fail-loud predicate evaluation). v2-canonical: only the `ProximaValue`/`ProximaTree` path is extended; the v1 `MetadataValue`/`VectorRecord` path is *not* (see "Re-scope note").
@@ -62,23 +62,23 @@ there is no per-comparison "type mismatch" to surface here. The silent drop on t
   `evaluate_filter_resolved_strict<F>(expr, resolve) -> Result<bool, FilterEvalError>` plus the
   `evaluate_filter_proxima_strict` / `evaluate_filter_strict` adapters. A value comparison against
   an unresolved field returns `Err(MissingField)` instead of silently `false`; `IsNull`/`IsNotNull`
-  keep SQL absence semantics (`Ok`, not an error). The legacy `evaluate_filter*` are **untouched**
-  (zero behavior change) — strict is opt-in.
-* **Slice 2a (landed):** `src/services/operations/vectors/legacy.rs` routes hybrid metadata
-  candidate gating through `evaluate_filter_proxima_strict` when
-  `PROXIMADB_FILTER_FAIL_LOUD` is set. Default-off keeps existing behavior; flag-on propagates
-  `MissingField` as a query error.
+  keep SQL absence semantics (`Ok`, not an error). The legacy `evaluate_filter*` are **untouched**;
+  callers choose strict or legacy evaluation. The canonical v2 callers in Slice 2a now choose
+  strict by default.
+* **Slice 2a (landed):** `src/services/operations/vectors/legacy.rs` and the progressive-search
+  pipeline route v2 metadata gating through `evaluate_filter_proxima_strict` by default.
+  `PROXIMADB_FILTER_FAIL_LOUD=false` and `PROXIMADB_FILTER_STRICT=false` are temporary
+  compatibility escapes; `MissingField` otherwise propagates as a query error.
 * **Slice 2b (remaining):** migrate lower-level vector/storage predicates once their interfaces
   can return `Result` instead of bare `bool`. Do not fake fail-loud semantics by logging and
   returning `false`.
 * **Slice 3 (cleanup):** delete the dead v1 `TypeSafeFilterEvaluator` under v1 sunset (TD-123).
 
-== Why default-off / behavior-preserving
+== Default posture
 
-Making the live `evaluate_filter*` fail-loud by default would change query *results* (rows silently
-dropped today would instead error the query). Correct end-state, but must be gated
-(ADR-052 observe→ingest→act) so it is an explicit opt-in. Slice 1 only added a fail-loud path;
-slice 2a enables it on one live service seam only when `PROXIMADB_FILTER_FAIL_LOUD` is set.
+The supported v2 surface fails loudly because returning a plausible partial result violates
+ADR-043. The explicit false-valued environment settings are rollback controls, not the shipping
+posture; lower-level predicates remain tracked until their interfaces can propagate `Result`.
 
 == How to apply / verify
 

--- a/src/core/search/progressive_search_pipeline.rs
+++ b/src/core/search/progressive_search_pipeline.rs
@@ -841,17 +841,19 @@ impl Default for PipelineConfig {
     }
 }
 
-/// TD-FILT-1 slice 2: when set (`1`/`true`/`on`/`yes`), metadata filtering on the progressive-search
-/// path runs fail-loud — an unresolved filter field errors the query instead of silently dropping
-/// the record. Default off (today's silent behavior). Mirrors the `PROXIMADB_*` env convention.
+/// TD-FILT-1: metadata filtering is fail-loud by default. Operators can temporarily
+/// restore legacy silent-drop behavior with an explicit false value while migrating
+/// affected queries.
 fn filter_strict_enabled() -> bool {
-    match std::env::var("PROXIMADB_FILTER_STRICT") {
-        Ok(v) => matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "on" | "yes"
-        ),
-        Err(_) => false,
-    }
+    let value = std::env::var("PROXIMADB_FILTER_STRICT").ok();
+    filter_strict_for_value(value.as_deref())
+}
+
+fn filter_strict_for_value(value: Option<&str>) -> bool {
+    !matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("0" | "false" | "off" | "no")
+    )
 }
 
 /// Filter `records` by `filter` against each record's `props` (`ProximaTree`). `strict` selects
@@ -989,6 +991,15 @@ mod tests {
             ),
             "strict mode surfaces the unresolved field instead of silently dropping"
         );
+    }
+
+    #[test]
+    fn progressive_filter_is_strict_by_default() {
+        assert!(filter_strict_for_value(None));
+        assert!(filter_strict_for_value(Some("true")));
+        for value in ["0", "false", "OFF", " no "] {
+            assert!(!filter_strict_for_value(Some(value)), "value={value}");
+        }
     }
 
     #[test]

--- a/src/datafusion/document_pax_provider.rs
+++ b/src/datafusion/document_pax_provider.rs
@@ -598,6 +598,74 @@ mod tests {
         }
     }
 
+    /// Test adapter whose unflushed half is the production memtable raw-read
+    /// contract, rather than a fixed vector returned by `FakeRoute`.
+    struct WalMemtableRoute {
+        base: String,
+        memtable: Arc<crate::storage::memtable::implementations::global_partitioned::GlobalPartitionedMemtable>,
+    }
+
+    #[async_trait]
+    impl RecordRoutePort for WalMemtableRoute {
+        async fn insert_records(
+            &self,
+            _c: &str,
+            _r: Vec<ProximaRecord>,
+            _t: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            unreachable!("read-only test route")
+        }
+        async fn get_record(
+            &self,
+            _c: &str,
+            _r: &str,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Option<ProximaRecord>> {
+            unreachable!("read-only test route")
+        }
+        async fn scan_records(
+            &self,
+            _c: &str,
+            _l: usize,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Vec<ProximaRecord>> {
+            unreachable!("read-only test route")
+        }
+        async fn delete_records(
+            &self,
+            _c: &str,
+            _r: Vec<String>,
+            _t: Option<&str>,
+        ) -> anyhow::Result<usize> {
+            unreachable!("read-only test route")
+        }
+        async fn collection_exists(&self, _c: &str, _t: Option<&str>) -> bool {
+            true
+        }
+        async fn ensure_collection(
+            &self,
+            _c: &str,
+            _d: u32,
+            _t: Option<&str>,
+            _p: &[String],
+        ) -> anyhow::Result<()> {
+            unreachable!("read-only test route")
+        }
+        async fn pax_scan_inputs(&self, _c: &str, _t: Option<&str>) -> Option<PaxScanInputs> {
+            Some(PaxScanInputs {
+                base_path: self.base.clone(),
+                columns: Vec::new(),
+            })
+        }
+        async fn unflushed_records(
+            &self,
+            collection: &str,
+            _t: Option<&str>,
+        ) -> anyhow::Result<Vec<ProximaRecord>> {
+            Ok(self.memtable.get_collection_vectors_raw(collection).await?)
+        }
+    }
+
     /// Build a document `ProximaRecord` the way the converged write path does: labeled `document`,
     /// `oid = local_id = id`, props carrying the reserved collection key + the user fields.
     fn doc(
@@ -737,6 +805,79 @@ mod tests {
         assert_eq!(
             ids(p, "SELECT id FROM documents ORDER BY id").await,
             vec!["live"]
+        );
+    }
+
+    /// Invariant 16d production-delta ratchet: a live PAX row followed by an
+    /// unflushed WAL tombstone must not resurrect through `documents()`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn flushed_live_plus_raw_memtable_delete_returns_zero_rows() {
+        use proximadb_block_format::{BlockCompression, BlockMode};
+        use proximadb_storage_common::pax_block::PaxSegmentWriter;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let segments = dir.path().join("segments");
+        std::fs::create_dir_all(&segments).expect("segments dir");
+        let mut writer = PaxSegmentWriter::new(
+            segments.join("data.pax"),
+            BlockMode::Pax,
+            BlockCompression::None,
+            "docs",
+            0,
+            1,
+            None,
+        );
+        writer
+            .add_record(&doc(
+                "d1",
+                "docs",
+                &[("region", ProximaValue::String("US".into()))],
+                10,
+                None,
+            ))
+            .expect("write flushed document");
+        writer.finish().expect("finish PAX segment");
+
+        let memtable = Arc::new(
+            crate::storage::memtable::implementations::global_partitioned::GlobalPartitionedMemtable::new(),
+        );
+        memtable
+            .add_wal_batch(
+                "docs",
+                crate::storage::memtable::specialized::wal_behavior::WALVectorBatch {
+                    batch_id: crate::storage::persistence::write_ahead_log::BatchId::new(),
+                    vector_records: Arc::new(vec![tombstone("d1", 20)]),
+                    timestamp: std::time::SystemTime::now(),
+                    total_size_bytes: 0,
+                    is_flushed: false,
+                    metadata_bloom_filter: None,
+                },
+            )
+            .await
+            .expect("append tombstone to memtable");
+
+        let base = format!("file://{}/", dir.path().display());
+        let route: Arc<dyn RecordRoutePort> = Arc::new(WalMemtableRoute {
+            base: base.clone(),
+            memtable,
+        });
+        let ff = crate::storage::persistence::filesystem::FilesystemFactory::create_default_arc()
+            .await
+            .expect("filesystem factory");
+        let provider = DocumentPaxPushdownProvider::new(
+            route,
+            ff,
+            None,
+            "docs",
+            PaxScanInputs {
+                base_path: base,
+                columns: Vec::new(),
+            },
+        );
+
+        assert!(
+            ids(provider, "SELECT id FROM documents").await.is_empty(),
+            "an unflushed tombstone must suppress the flushed live copy"
         );
     }
 

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -136,6 +136,8 @@ pub enum TenantIdSource {
     JwtClaim,
     /// Derived from API key mapping
     ApiKey,
+    /// Selected by an authenticated system/gateway principal.
+    GatewayDelegation,
     /// Default tenant (single-tenant mode or fallback)
     Default,
     /// System/internal request
@@ -160,6 +162,7 @@ impl std::fmt::Display for TenantIdSource {
             Self::Header => write!(f, "header"),
             Self::JwtClaim => write!(f, "jwt"),
             Self::ApiKey => write!(f, "api_key"),
+            Self::GatewayDelegation => write!(f, "gateway_delegation"),
             Self::Default => write!(f, "default"),
             Self::System => write!(f, "system"),
         }
@@ -351,16 +354,18 @@ impl TenantExtractor {
             self.config.header_trust,
         )? {
             ResolvedTenantAssertion::Asserted(tenant_id) => {
-                if let Some((binding, _)) = &authenticated {
+                let source = if let Some((binding, _)) = &authenticated {
                     debug!(
                         gateway = %binding.tenant_id,
                         acting_tenant = %tenant_id,
                         "gateway principal delegated tenant via X-Tenant-ID"
                     );
+                    TenantIdSource::GatewayDelegation
                 } else {
                     debug!("Extracted tenant_id from header: {}", tenant_id);
-                }
-                Ok(Some((tenant_id, TenantIdSource::Header)))
+                    TenantIdSource::Header
+                };
+                Ok(Some((tenant_id, source)))
             }
             ResolvedTenantAssertion::Credential(tenant_id) => {
                 debug!("Extracted tenant_id from authenticated context: {tenant_id}");
@@ -429,7 +434,7 @@ impl TenantExtractor {
     }
 
     /// Validate tenant exists and is active
-    fn validate_tenant(&self, tenant_id: &str) -> bool {
+    fn validate_tenant(&self, tenant_id: &str, source: TenantIdSource) -> bool {
         // System tenants bypass validation
         if self.config.system_tenants.contains(&tenant_id.to_string()) {
             return true;
@@ -456,9 +461,21 @@ impl TenantExtractor {
                     false
                 }
             }
-        } else {
-            // No manager configured, allow all
+        } else if matches!(
+            source,
+            TenantIdSource::JwtClaim | TenantIdSource::ApiKey | TenantIdSource::GatewayDelegation
+        ) {
+            // Without a local tenant catalog, only a credential-bound tenant
+            // identity remains authoritative. A bare header/default must not
+            // become trusted merely because validation infrastructure is absent.
             true
+        } else {
+            warn!(
+                tenant_id,
+                source = %source,
+                "Tenant validation requested but no TenantManager is configured"
+            );
+            false
         }
     }
 }
@@ -490,7 +507,7 @@ pub async fn tenant_middleware(
             }
 
             // Validate tenant if configured
-            if !extractor.validate_tenant(&tenant_id) {
+            if !extractor.validate_tenant(&tenant_id, source) {
                 return (
                     StatusCode::FORBIDDEN,
                     format!("Tenant '{}' is not valid or not active", tenant_id),
@@ -699,6 +716,11 @@ mod tests {
         assert!(config.default_tenant.is_none());
         assert!(config.require_tenant);
         assert!(config.validate_tenant);
+        assert_eq!(
+            config.header_trust,
+            HeaderTrustPolicy::AuthenticatedOnly,
+            "multi-tenant deployments must reject unbound tenant headers"
+        );
     }
 
     #[test]
@@ -723,6 +745,10 @@ mod tests {
         assert_eq!(TenantIdSource::Header.to_string(), "header");
         assert_eq!(TenantIdSource::JwtClaim.to_string(), "jwt");
         assert_eq!(TenantIdSource::ApiKey.to_string(), "api_key");
+        assert_eq!(
+            TenantIdSource::GatewayDelegation.to_string(),
+            "gateway_delegation"
+        );
         assert_eq!(TenantIdSource::Default.to_string(), "default");
         assert_eq!(TenantIdSource::System.to_string(), "system");
     }
@@ -760,6 +786,17 @@ mod tests {
             .extract_tenant_id(&trust_request(Some("demo1"), None))
             .expect("open mode accepts bare header");
         assert_eq!(result, Some(("demo1".to_string(), TenantIdSource::Header)));
+    }
+
+    #[test]
+    fn strict_validation_without_manager_accepts_only_credential_bound_identity() {
+        let extractor = TenantExtractor::with_config(TenantExtractorConfig::multi_tenant());
+
+        assert!(extractor.validate_tenant("acme", TenantIdSource::JwtClaim));
+        assert!(extractor.validate_tenant("acme", TenantIdSource::ApiKey));
+        assert!(extractor.validate_tenant("acme", TenantIdSource::GatewayDelegation));
+        assert!(!extractor.validate_tenant("acme", TenantIdSource::Header));
+        assert!(!extractor.validate_tenant("acme", TenantIdSource::Default));
     }
 
     #[test]
@@ -841,7 +878,10 @@ mod tests {
         let result = extractor(HeaderTrustPolicy::GatewayOnly)
             .extract_tenant_id(&trust_request(Some("demo1"), Some("system")))
             .expect("gateway delegation must be allowed");
-        assert_eq!(result, Some(("demo1".to_string(), TenantIdSource::Header)));
+        assert_eq!(
+            result,
+            Some(("demo1".to_string(), TenantIdSource::GatewayDelegation))
+        );
     }
 
     /// TD-TENANT-1 follow-up: the first-class principal marker. A credential
@@ -860,7 +900,10 @@ mod tests {
         let result = extractor(HeaderTrustPolicy::GatewayOnly)
             .extract_tenant_id(&req)
             .expect("gateway-role principal must be allowed to delegate");
-        assert_eq!(result, Some(("demo1".to_string(), TenantIdSource::Header)));
+        assert_eq!(
+            result,
+            Some(("demo1".to_string(), TenantIdSource::GatewayDelegation))
+        );
 
         // Same principal WITHOUT the marker → mismatch.
         let mut req = trust_request(Some("demo1"), None);

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -1044,6 +1044,9 @@ impl MultiServer {
                 Some(services.rank_profile_store.clone()),
                 Some(services.discovery_service.clone()),
                 Some(services.external_collection_service.clone()),
+                crate::network::middleware::tenant::TenantExtractorConfig::from_deployment_mode(
+                    self.tenant_deployment_mode.clone(),
+                ),
                 self.config.admin_ui_enabled,
             );
 

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -343,7 +343,8 @@ impl PostgresServer {
             document_service,
             graph_service,
             observability_service,
-        );
+        )
+        .with_session_manager(session_manager.clone());
         let mut protocol = if let Some(direct_write_services) = direct_write_services {
             protocol
                 .with_direct_catalog_manager(catalog_manager, direct_write_services.canonical_store)

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use anyhow::{Context, Result, anyhow};
 use bytes::{Buf, BufMut, BytesMut};
@@ -19,7 +20,7 @@ use tokio::net::TcpStream;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use super::session::Session;
+use super::session::{Session, SessionManager};
 use super::translator::QueryTranslator;
 use super::types::{FieldDescription, PgType};
 use crate::catalog::CatalogManager;
@@ -47,6 +48,9 @@ pub struct PostgresProtocol {
     stream: TcpStream,
     /// Session state
     session: Arc<RwLock<Session>>,
+    /// Shared registry used to resolve PostgreSQL CancelRequest backend keys.
+    session_manager: Option<Arc<SessionManager>>,
+    cancel_request_processed: bool,
     /// Collection service
     collection_port: Arc<dyn proximadb_runtime::CollectionPort>,
     /// Vector operations service for search
@@ -398,6 +402,8 @@ impl PostgresProtocol {
         Self {
             stream,
             session: Arc::new(RwLock::new(session)),
+            session_manager: None,
+            cancel_request_processed: false,
             collection_port,
             vector_ops,
             translator: QueryTranslator::new(),
@@ -418,6 +424,11 @@ impl PostgresProtocol {
             result_bytes_pending: 0,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
         }
+    }
+
+    pub fn with_session_manager(mut self, manager: Arc<SessionManager>) -> Self {
+        self.session_manager = Some(manager);
+        self
     }
 
     /// Attach a shared per-IP rate limiter (and this connection's peer IP) so the
@@ -447,6 +458,8 @@ impl PostgresProtocol {
         Self {
             stream,
             session: Arc::new(RwLock::new(session)),
+            session_manager: None,
+            cancel_request_processed: false,
             collection_port,
             vector_ops,
             translator: QueryTranslator::new(),
@@ -493,6 +506,8 @@ impl PostgresProtocol {
         Self {
             stream,
             session: Arc::new(RwLock::new(session)),
+            session_manager: None,
+            cancel_request_processed: false,
             collection_port,
             vector_ops,
             translator: QueryTranslator::new(),
@@ -677,6 +692,9 @@ impl PostgresProtocol {
     pub async fn run(&mut self) -> Result<()> {
         // Handle startup
         self.handle_startup().await?;
+        if self.cancel_request_processed {
+            return Ok(());
+        }
 
         // Main loop
         loop {
@@ -744,8 +762,18 @@ impl PostgresProtocol {
 
         // Check for cancel request
         if version == 80877102 {
-            // Cancel request - not implemented
-            return Err(anyhow!("Cancel request not supported"));
+            if length != 16 {
+                return Err(anyhow!("Invalid cancel request length"));
+            }
+            let process_id = self.read_i32().await? as u32;
+            let secret_key = self.read_i32().await? as u32;
+            let cancelled = match &self.session_manager {
+                Some(manager) => manager.cancel_query(process_id, secret_key).await,
+                None => false,
+            };
+            debug!(process_id, cancelled, "Processed PostgreSQL CancelRequest");
+            self.cancel_request_processed = true;
+            return Ok(());
         }
 
         // Read startup parameters
@@ -1081,8 +1109,11 @@ impl PostgresProtocol {
     async fn execute_query_with_controls(
         &mut self,
         query: &str,
-        controls: ExecutionControls,
+        mut controls: ExecutionControls,
     ) -> Result<()> {
+        let cancellation_flag = self.session.read().await.cancellation_flag.clone();
+        cancellation_flag.store(false, Ordering::Relaxed);
+        controls.cancellation_flag = Some(cancellation_flag);
         // E0 rate-limiting: reject over-quota queries up front with a pgwire
         // error, using the SAME converged RateLimitState check REST uses (no
         // duplicate limiter). No-op when unset/disabled.
@@ -1296,7 +1327,7 @@ impl PostgresProtocol {
             {
                 return match result {
                     Ok(pr) => self.emit_pipeline_result(pr).await,
-                    Err(msg) => self.send_error("ERROR", "XX000", &msg).await,
+                    Err(msg) => self.send_relational_error(&msg).await,
                 };
             }
             if let Some((column, value)) = Self::extract_simple_constant_select(query) {
@@ -4907,13 +4938,22 @@ impl PostgresProtocol {
             // same scope in the next slice (kept out here to avoid restructuring
             // the borrow in this `&&` let-chain).
             if query.trim_start().to_uppercase().starts_with("SELECT")
-                && let Some(result) = self
-                    .try_run_relational_select_pipeline(query, ExecutionControls::default())
+                && let Some(result) = {
+                    let cancellation_flag = self.session.read().await.cancellation_flag.clone();
+                    cancellation_flag.store(false, Ordering::Relaxed);
+                    self.try_run_relational_select_pipeline(
+                        query,
+                        ExecutionControls {
+                            cancellation_flag: Some(cancellation_flag),
+                            ..Default::default()
+                        },
+                    )
                     .await
+                }
             {
                 let result = match result {
                     Ok(result) => result,
-                    Err(msg) => return self.send_error("ERROR", "XX000", &msg).await,
+                    Err(msg) => return self.send_relational_error(&msg).await,
                 };
                 if let Some(portal) = self.portals.get_mut(portal_name) {
                     portal.execution_state = Some(PortalExecutionState {
@@ -4996,6 +5036,17 @@ impl PostgresProtocol {
             max_rows: Some(max_rows as usize),
             row_limit_mode: RowLimitMode::Truncate,
             ..Default::default()
+        }
+    }
+
+    async fn send_relational_error(&mut self, message: &str) -> Result<()> {
+        if message.contains("query execution was cancelled") {
+            self.send_error("ERROR", "57014", "canceling statement due to user request")
+                .await
+        } else if let Some(message) = message.strip_prefix("0A000: ") {
+            self.send_error("ERROR", "0A000", message).await
+        } else {
+            self.send_error("ERROR", "XX000", message).await
         }
     }
 

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -25,9 +25,10 @@
 //!   the new path end-to-end via psql.
 
 use crate::query::execution::{
-    ExecutionControls, ExecutionPipelineResult, NativeVolcanoEngine, QueryExecutionContext,
-    execute_sql_with_backend, normalize_table_key,
+    ExecutionControls, ExecutionPipelineResult, NativeVolcanoEngine, normalize_table_key,
 };
+#[cfg(feature = "datafusion-integration")]
+use crate::query::execution::{QueryExecutionContext, execute_sql_with_backend};
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use proximadb_data_model::{ProximaType, ProximaValue, StatsTrust};
@@ -852,6 +853,12 @@ async fn execute_physical<F: ReaderFactory>(
     factory: &F,
     controls: ExecutionControls,
 ) -> Result<ExecutionPipelineResult, String> {
+    if plan_has_raw_cross_join(&physical) {
+        return Err(
+            "0A000: native execution declined an unnormalized cross join; use an explicit equi-join or a vectorized backend"
+                .to_string(),
+        );
+    }
     // ADR-030 / TD-158: feed the per-query I/O trace the native engine's compute
     // time so the always-on billing observer can emit KRU(tenant, "native") at
     // scope close. `record_compute_ms` no-ops outside an `io_trace` scope.
@@ -874,9 +881,42 @@ async fn execute_physical_metered<F: ReaderFactory>(
     physical: PhysicalPlan,
     factory: &F,
 ) -> Result<(ExecutionPipelineResult, Vec<NodeMetric>), String> {
+    if plan_has_raw_cross_join(&physical) {
+        return Err(
+            "0A000: native execution declined an unnormalized cross join; use an explicit equi-join or a vectorized backend"
+                .to_string(),
+        );
+    }
     NativeVolcanoEngine::execute_physical_metered(physical, factory, ExecutionControls::default())
         .await
         .map_err(|e| e.to_string())
+}
+
+/// Availability boundary for TD-REL-LOWER-2: after planner normalization,
+/// Volcano must never enumerate a raw cross product. Equi predicates should
+/// already have become inner/hash joins; remaining CROSS nodes fail loudly.
+fn plan_has_raw_cross_join(plan: &PhysicalPlan) -> bool {
+    match plan {
+        PhysicalPlan::Join {
+            left, right, kind, ..
+        } => {
+            *kind == proximadb_relational_algebra::JoinKind::Cross
+                || plan_has_raw_cross_join(left)
+                || plan_has_raw_cross_join(right)
+        }
+        PhysicalPlan::Filter { input, .. }
+        | PhysicalPlan::Project { input, .. }
+        | PhysicalPlan::Aggregate { input, .. }
+        | PhysicalPlan::Sort { input, .. }
+        | PhysicalPlan::Limit { input, .. }
+        | PhysicalPlan::Distinct { input, .. }
+        | PhysicalPlan::AssertMaxOneRow { input } => plan_has_raw_cross_join(input),
+        PhysicalPlan::Union { inputs, .. } => inputs.iter().any(plan_has_raw_cross_join),
+        PhysicalPlan::SetOp { left, right, .. } => {
+            plan_has_raw_cross_join(left) || plan_has_raw_cross_join(right)
+        }
+        PhysicalPlan::Scan { .. } | PhysicalPlan::Values { .. } => false,
+    }
 }
 
 /// Lower + plan a SELECT over an already-prepared `SnapshotCatalog` to a Volcano
@@ -2462,6 +2502,31 @@ mod route_explain_tests {
     use super::*;
 
     #[test]
+    fn native_containment_rejects_any_remaining_cross_join() {
+        let values = || PhysicalPlan::Values {
+            rows: Vec::new(),
+            output_schema: RelationalSchema::new(Vec::new()),
+        };
+        let raw_cross = PhysicalPlan::Join {
+            left: Box::new(values()),
+            right: Box::new(values()),
+            kind: proximadb_relational_algebra::JoinKind::Cross,
+            on: None,
+            strategy: proximadb_relational_algebra::JoinStrategy::NestedLoop,
+        };
+        assert!(plan_has_raw_cross_join(&raw_cross));
+
+        let inner = PhysicalPlan::Join {
+            left: Box::new(values()),
+            right: Box::new(values()),
+            kind: proximadb_relational_algebra::JoinKind::Inner,
+            on: None,
+            strategy: proximadb_relational_algebra::JoinStrategy::NestedLoop,
+        };
+        assert!(!plan_has_raw_cross_join(&inner));
+    }
+
+    #[test]
     fn olap_select_explains_as_olap() {
         let expl = explain_select_route("SELECT service, count(*) FROM events GROUP BY service")
             .expect("routable");
@@ -2609,6 +2674,12 @@ fn query_operation_class(query: &SqlQuery) -> crate::query::compute_scheduler::O
 /// never inspected there) — hence a dedicated shape bit. Fail-closed: set-op /
 /// non-`SELECT` bodies count as join-bearing.
 fn query_join_bearing(query: &SqlQuery) -> bool {
+    // Generic expression traversal covers scalar/IN/EXISTS subqueries in
+    // projection, WHERE, HAVING, GROUP BY, ORDER BY, and other query clauses.
+    // Each such subquery is hoisted or lowered to a join-shaped plan.
+    if ast_has_subquery(query) {
+        return true;
+    }
     // A CTE can carry the join the outer body then scans.
     if let Some(with) = &query.with
         && with
@@ -2619,6 +2690,24 @@ fn query_join_bearing(query: &SqlQuery) -> bool {
         return true;
     }
     set_expr_join_bearing(query.body.as_ref())
+}
+
+fn ast_has_subquery<V: sqlparser::ast::Visit>(node: &V) -> bool {
+    use std::ops::ControlFlow;
+
+    matches!(
+        sqlparser::ast::visit_expressions(node, |expr| {
+            if matches!(
+                expr,
+                SqlExpr::InSubquery { .. } | SqlExpr::Exists { .. } | SqlExpr::Subquery(_)
+            ) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        }),
+        ControlFlow::Break(())
+    )
 }
 
 fn set_expr_join_bearing(body: &SetExpr) -> bool {
@@ -3653,12 +3742,22 @@ mod tests {
         ));
         // Projection scalar subquery hoists into a LEFT JOIN.
         assert!(jb("SELECT id, (SELECT max(x) FROM b) FROM a"));
+        // Subqueries outside SELECT/WHERE are still hoisted into join-shaped
+        // plans and must not remain eligible for Native cost overrides.
+        assert!(jb(
+            "SELECT a.id FROM a GROUP BY a.id, (SELECT max(id) FROM b)"
+        ));
+        assert!(jb("SELECT count(*) FROM a HAVING EXISTS (SELECT 1 FROM b)"));
+        assert!(jb("SELECT id FROM a ORDER BY (SELECT max(id) FROM b)"));
         // Set-op body: fail closed.
         assert!(jb("SELECT id FROM a UNION ALL SELECT id FROM b"));
 
         // Join-free shapes stay eligible for a Native flip.
         assert!(!jb("SELECT * FROM a WHERE id = 1"));
         assert!(!jb("SELECT status, count(*) FROM a GROUP BY status"));
+        assert!(!jb(
+            "SELECT status, count(*) FROM a GROUP BY status HAVING count(*) > 1 ORDER BY status"
+        ));
         assert!(!jb(
             "SELECT count(*) FROM (SELECT id FROM a WHERE id > 5) t"
         ));

--- a/src/network/postgres/session.rs
+++ b/src/network/postgres/session.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 use anyhow::Result;
 use tokio::sync::RwLock;
@@ -43,6 +43,7 @@ impl SessionManager {
             id: format!("pg-{}-{}", process_id, session_num),
             process_id,
             secret_key: rand::random(),
+            cancellation_flag: Arc::new(AtomicBool::new(false)),
             user: String::new(),
             database: String::new(),
             client_addr: addr,
@@ -80,6 +81,20 @@ impl SessionManager {
     /// Get active session count
     pub async fn session_count(&self) -> usize {
         self.sessions.read().await.len()
+    }
+
+    /// Set the cooperative cancellation flag for the backend identified by a
+    /// PostgreSQL CancelRequest `(process_id, secret_key)` pair.
+    pub async fn cancel_query(&self, process_id: u32, secret_key: u32) -> bool {
+        let sessions = self.sessions.read().await;
+        for session in sessions.values() {
+            let session = session.read().await;
+            if session.process_id == process_id && session.secret_key == secret_key {
+                session.cancellation_flag.store(true, Ordering::Relaxed);
+                return true;
+            }
+        }
+        false
     }
 
     /// Cleanup idle sessions
@@ -123,6 +138,9 @@ pub struct Session {
     pub process_id: u32,
     /// Secret key for cancellation
     pub secret_key: u32,
+    /// Request-scoped cooperative cancellation signal shared with the protocol
+    /// handler and the manager's CancelRequest lookup.
+    pub cancellation_flag: Arc<AtomicBool>,
     /// Connected user
     pub user: String,
     /// Connected database
@@ -267,6 +285,7 @@ mod tests {
             id: "test".to_string(),
             process_id: 1,
             secret_key: 123,
+            cancellation_flag: Arc::new(AtomicBool::new(false)),
             user: String::new(),
             database: String::new(),
             client_addr: "127.0.0.1:5432".parse().unwrap(),
@@ -296,6 +315,7 @@ mod tests {
             id: "test".to_string(),
             process_id: 1,
             secret_key: 123,
+            cancellation_flag: Arc::new(AtomicBool::new(false)),
             user: String::new(),
             database: String::new(),
             client_addr: "127.0.0.1:5432".parse().unwrap(),
@@ -305,6 +325,28 @@ mod tests {
             created_at: std::time::Instant::now(),
             last_activity: std::time::Instant::now(),
         }
+    }
+
+    #[tokio::test]
+    async fn cancel_query_requires_matching_backend_secret() {
+        let manager = SessionManager::new();
+        let session = manager
+            .create_session("127.0.0.1:12345".parse().unwrap())
+            .await
+            .unwrap();
+
+        assert!(
+            !manager
+                .cancel_query(session.process_id, session.secret_key ^ 1)
+                .await
+        );
+        assert!(!session.cancellation_flag.load(Ordering::Relaxed));
+        assert!(
+            manager
+                .cancel_query(session.process_id, session.secret_key)
+                .await
+        );
+        assert!(session.cancellation_flag.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -727,6 +727,7 @@ impl RestServer {
         external_collection_service: Option<
             Arc<crate::services::external_collection::ExternalCollectionService>,
         >,
+        tenant_config: TenantExtractorConfig,
         // Mount the read-only `/admin` dashboard (from `[server.admin_ui] enabled`).
         admin_ui_enabled: bool,
     ) -> Router {
@@ -861,10 +862,9 @@ impl RestServer {
         // `/api/v2` request 500s with "missing request extension". The
         // multi-port path applies the same layer in `create_router`; the
         // unified path must apply it too (it is NOT wrapped by the caller).
-        // Default config resolves to the single "default" tenant in dev.
-        // PROXIMADB_TENANT_HEADER_TRUST overrides the bare-header trust policy.
-        let tenant_extractor =
-            TenantExtractor::with_config(TenantExtractorConfig::default().apply_env_overrides());
+        // The caller supplies the same deployment-derived policy used by the
+        // multi-port path. Environment overrides are applied once here.
+        let tenant_extractor = TenantExtractor::with_config(tenant_config.apply_env_overrides());
         let tenant_layer = middleware::from_fn_with_state(tenant_extractor, tenant_middleware);
 
         // Auth layer — convergent with the multi-port `start_with_security`

--- a/src/query/execution/datafusion_engine.rs
+++ b/src/query/execution/datafusion_engine.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "datafusion-integration")]
+use crate::query::execution::engine::RowLimitMode;
+#[cfg(feature = "datafusion-integration")]
 use crate::query::execution::engine::normalize_table_key;
 use crate::query::execution::engine::{
     ExecutionEngine, ExecutionError, ExecutionPipelineResult, ExecutionStreamResult,
-    QueryExecutionContext, RowLimitMode,
+    QueryExecutionContext,
 };
 use async_trait::async_trait;
 #[cfg(feature = "datafusion-integration")]
@@ -644,6 +646,7 @@ mod tests {
 /// vocabulary; the DataFusion *physical* plan would inflate depth/fan-out with
 /// repartition/coalesce nodes the AST estimator never models) — and emit the
 /// same neutral io_trace scalars the native seam emits.
+#[cfg(feature = "datafusion-integration")]
 fn record_logical_plan_geometry(plan: &datafusion::logical_expr::LogicalPlan) {
     let (depth, nodes, leaves, fanout, blocking, ops) = measure_logical_geometry(plan);
     let ops_ref: Vec<(&str, u64)> = ops.iter().map(|(k, v)| (*k, *v)).collect();
@@ -660,6 +663,7 @@ fn record_logical_plan_geometry(plan: &datafusion::logical_expr::LogicalPlan) {
 /// geometry bands stay comparable — `window` is labeled but deliberately not
 /// counted as blocking (the native vocabulary has no window op).
 #[allow(clippy::type_complexity)]
+#[cfg(feature = "datafusion-integration")]
 fn measure_logical_geometry(
     plan: &datafusion::logical_expr::LogicalPlan,
 ) -> (u64, u64, u64, u64, u64, Vec<(&'static str, u64)>) {
@@ -675,6 +679,7 @@ fn measure_logical_geometry(
 }
 
 #[allow(clippy::type_complexity)]
+#[cfg(feature = "datafusion-integration")]
 fn measure_logical_geometry_inner(
     plan: &datafusion::logical_expr::LogicalPlan,
 ) -> (

--- a/src/query/execution/engine.rs
+++ b/src/query/execution/engine.rs
@@ -320,7 +320,8 @@ impl NativeVolcanoEngine {
                 let mut ref_exec = build_executor(
                     physical.clone(),
                     factory,
-                    &VolcanoExecutionContext::default(),
+                    &VolcanoExecutionContext::default()
+                        .with_cancellation_flag(controls.cancellation_flag.clone()),
                 )
                 .map_err(|e| ExecutionError::Execution(format!("shadow build_executor: {e}")))?;
                 ref_exec
@@ -345,8 +346,10 @@ impl NativeVolcanoEngine {
         }
         // TD-EXEC-2 Slice 1 (observe-only): measure the build recursion's stack
         // high-water mark alongside the plan-lowering probe at the plan seam.
+        let volcano_context = VolcanoExecutionContext::default()
+            .with_cancellation_flag(controls.cancellation_flag.clone());
         let (built, build_hwm) = proximadb_relational_planner::stack_probe::probe(|| {
-            build_executor(physical, factory, &VolcanoExecutionContext::default())
+            build_executor(physical, factory, &volcano_context)
         });
         if build_hwm > 0 {
             crate::observability::io_trace::record_stack_hwm(build_hwm);
@@ -387,8 +390,10 @@ impl NativeVolcanoEngine {
         let physical = cap_plan(physical, &controls);
         // TD-EXEC-2 Slice 1 (observe-only): measure the build recursion's stack
         // high-water mark alongside the plan-lowering probe at the plan seam.
+        let volcano_context = VolcanoExecutionContext::default()
+            .with_cancellation_flag(controls.cancellation_flag.clone());
         let (built, build_hwm) = proximadb_relational_planner::stack_probe::probe(|| {
-            build_executor(physical, factory, &VolcanoExecutionContext::default())
+            build_executor(physical, factory, &volcano_context)
         });
         if build_hwm > 0 {
             crate::observability::io_trace::record_stack_hwm(build_hwm);
@@ -453,7 +458,8 @@ impl NativeVolcanoEngine {
             let mut exec = build_executor(
                 physical,
                 factory,
-                &VolcanoExecutionContext::with_metrics(metrics.clone()),
+                &VolcanoExecutionContext::with_metrics(metrics.clone())
+                    .with_cancellation_flag(controls.cancellation_flag.clone()),
             )
             .map_err(|e| ExecutionError::Execution(format!("build_executor: {e}")))?;
             controls.check_cancelled()?;

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -87,7 +87,15 @@ use crate::storage::engines::sst::SstEngine;
 const FILTER_FAIL_LOUD_ENV: &str = "PROXIMADB_FILTER_FAIL_LOUD";
 
 fn filter_fail_loud_enabled() -> bool {
-    std::env::var_os(FILTER_FAIL_LOUD_ENV).is_some()
+    let value = std::env::var(FILTER_FAIL_LOUD_ENV).ok();
+    filter_fail_loud_for_value(value.as_deref())
+}
+
+fn filter_fail_loud_for_value(value: Option<&str>) -> bool {
+    !matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("0" | "false" | "off" | "no")
+    )
 }
 
 fn evaluate_v2_filter_for_record(
@@ -767,7 +775,7 @@ impl VectorOperationsService {
 
         let mut records = self
             .wal_manager
-            .get_collection_vectors(collection_id)
+            .get_collection_vectors_raw(collection_id)
             .await?;
         if let Some(tenant_context) = tenant_context {
             records.retain(|record| {
@@ -4428,7 +4436,7 @@ mod tenant_tests {
     }
 
     #[test]
-    fn filter_fail_loud_gate_preserves_default_and_errors_when_enabled() {
+    fn filter_fail_loud_mode_errors_on_unresolved_fields() {
         use crate::core::search::{ComparisonOperator, FilterExpression};
 
         let filter = FilterExpression::Comparison {
@@ -4453,6 +4461,16 @@ mod tenant_tests {
                 .contains("metadata filter evaluation failed")
         );
         assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn v2_filter_fail_loud_is_default_with_explicit_rollback_values() {
+        assert!(filter_fail_loud_for_value(None));
+        assert!(filter_fail_loud_for_value(Some("true")));
+        assert!(filter_fail_loud_for_value(Some("unexpected")));
+        for value in ["0", "false", "OFF", " no "] {
+            assert!(!filter_fail_loud_for_value(Some(value)), "value={value}");
+        }
     }
 
     #[test]

--- a/src/storage/memtable/implementations/global_partitioned.rs
+++ b/src/storage/memtable/implementations/global_partitioned.rs
@@ -473,6 +473,19 @@ impl CollectionPartition {
         vectors
     }
 
+    /// Return every physical record still held by this unflushed partition.
+    ///
+    /// Unlike [`Self::get_all_vectors`], this intentionally performs no MVCC
+    /// winner selection and no tombstone/TTL filtering. Cross-source readers
+    /// need the complete delta so a delete in WAL can suppress an older live
+    /// copy that has already been flushed.
+    fn get_all_vectors_raw(&self) -> Vec<ProximaRecord> {
+        self.wal_batches
+            .values()
+            .flat_map(|batch| batch.vector_records.iter().cloned())
+            .collect()
+    }
+
     /// Rebuild the deduped, time-ordered [`ScanIndex`] from `wal_batches`.
     ///
     /// Winner selection per oid uses the SAME MVCC rule as
@@ -1039,6 +1052,22 @@ impl GlobalPartitionedMemtable {
         } else {
             Ok(Vec::new())
         }
+    }
+
+    /// Return the raw physical WAL/memtable delta for a collection.
+    ///
+    /// This is deliberately narrower than `get_collection_vectors`: callers
+    /// must perform their own cross-source winner selection and dead filtering.
+    pub async fn get_collection_vectors_raw(
+        &self,
+        collection_id: &str,
+    ) -> Result<Vec<ProximaRecord>> {
+        let collections = self.collections.read().await;
+
+        Ok(collections
+            .get(collection_id)
+            .map(CollectionPartition::get_all_vectors_raw)
+            .unwrap_or_default())
     }
 
     /// Paginated, deduped, time-ordered scan of a collection's unflushed records.
@@ -1972,6 +2001,36 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(oids(&page), vec!["live".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn raw_collection_scan_retains_tombstones_expiry_and_versions() {
+        let m = GlobalPartitionedMemtable::new();
+        let c = "raw-delta";
+        let now_ns = test_now_ns();
+
+        m.add_wal_batch(c, batch_of(vec![rec_at("d1", 10, 1, None)]))
+            .await
+            .unwrap();
+        m.add_wal_batch(c, batch_of(vec![rec_at("d1", 20, 2, Some(0))]))
+            .await
+            .unwrap();
+        m.add_wal_batch(
+            c,
+            batch_of(vec![rec_at("expired", 30, 1, Some(now_ns - 1))]),
+        )
+        .await
+        .unwrap();
+
+        let live = m.get_collection_vectors(c).await.unwrap();
+        assert!(live.is_empty(), "normal scans remain dead-filtered");
+
+        let mut raw = m.get_collection_vectors_raw(c).await.unwrap();
+        raw.sort_by_key(|record| record.updated_at_ns);
+        assert_eq!(raw.len(), 3);
+        assert_eq!(raw[0].record_version, 1);
+        assert_eq!(raw[1].valid_to_ns, Some(0));
+        assert_eq!(raw[2].oid, "expired");
     }
 
     #[tokio::test]

--- a/src/storage/memtable/specialized/wal_behavior.rs
+++ b/src/storage/memtable/specialized/wal_behavior.rs
@@ -837,6 +837,15 @@ impl WALBehaviorWrapper {
         Ok(vectors)
     }
 
+    /// Return every physical unflushed record, including tombstones, expired
+    /// rows, and superseded versions. Intended for cross-source reconciliation.
+    pub async fn get_collection_vectors_raw(
+        &self,
+        collection_id: &str,
+    ) -> Result<Vec<ProximaRecord>> {
+        self.inner.get_collection_vectors_raw(collection_id).await
+    }
+
     /// Paginated, deduped, time-ordered scan of a collection's unflushed records
     /// (TD-099(3d) push-down). Returns up to `limit` records with canonical key
     /// `(updated_at_ns, oid)` strictly greater than `after`, in ascending order,

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -2788,6 +2788,17 @@ impl WriteAheadLogManager {
         }
     }
 
+    /// Return the raw physical unflushed delta for cross-source reconciliation.
+    /// Tombstones, TTL-expired rows, and superseded versions are retained.
+    pub async fn get_collection_vectors_raw(
+        &self,
+        collection_id: &str,
+    ) -> Result<Vec<proximadb_records::ProximaRecord>> {
+        let memtable_config = crate::storage::memtable::core::MemtableConfig::default();
+        let wal_behavior = self.shared_wal_behavior.get_or_init(&memtable_config);
+        wal_behavior.get_collection_vectors_raw(collection_id).await
+    }
+
     /// Paginated, deduped, time-ordered scan of a collection's unflushed records
     /// (TD-099(3d) push-down). See
     /// [`WALBehaviorWrapper::stream_unflushed_records`]. `after` is the raw


### PR DESCRIPTION
## Summary

Closes the highest-risk promotion correctness holds identified in the independent 2026-07-14 review:

- retain raw unflushed tombstones/expired/superseded records for PAX document reconciliation
- make v2 metadata-filter failures loud by default
- thread the deployment tenant policy into unified REST and fail closed when tenant validation lacks a manager
- normalize equi predicates out of cross joins, reject residual raw cross products in Native execution, and cover subqueries in HAVING/GROUP BY/ORDER BY
- implement PostgreSQL CancelRequest with secret validation and cooperative executor cancellation

This is stack 1 of 3 and targets `develop` directly.

## Risk addressed

- A2-F1, A2-F2: silent resurrection and silent filter wrong results
- A3-F1/F2: unified-port cross-tenant header trust
- A1-F1/F2: uncancellable cross products and incomplete join-bearing classification

## Validation

- isolated `cargo check --lib`
- focused tombstone, raw-WAL, tenant, filter, planner, cross-join, cancellation, and executor tests
- `cargo fmt --all -- --check`
- `git diff --check`

## Merge order

1. this PR
2. durability/fencing stack PR
3. evidence/gates stack PR

