### PR TITLE
fix: fence DDL and unsafe append paths

### DIFF
--- a/crates/storage/proximadb-storage-encryption/src/filesystem.rs
+++ b/crates/storage/proximadb-storage-encryption/src/filesystem.rs
@@ -214,6 +214,10 @@ impl FileSystem for EncryptedFilesystem {
         self.write(path, &existing, None).await
     }
 
+    fn supports_append(&self) -> bool {
+        self.underlying.supports_append()
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let actual_path = self.actual_path(path);
         let mut deleted = false;

--- a/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
@@ -198,6 +198,9 @@ impl FileSystem for CountingFileSystem {
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
         self.inner.append(path, data).await
     }
+    fn supports_append(&self) -> bool {
+        self.inner.supports_append()
+    }
     async fn delete(&self, path: &str) -> FsResult<()> {
         self.inner.delete(path).await
     }

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -543,6 +543,15 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
     /// Append to file
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()>;
 
+    /// Whether this backend provides a native, durable append operation.
+    ///
+    /// Object stores intentionally leave this false. Callers whose on-disk
+    /// format requires append must reject the backend during construction,
+    /// before accepting data, rather than discovering the mismatch on flush.
+    fn supports_append(&self) -> bool {
+        false
+    }
+
     /// Delete file or directory
     async fn delete(&self, path: &str) -> FsResult<()>;
 

--- a/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
@@ -160,13 +160,23 @@ The bug class has two shapes:
   remaining refinements are tracked in TD-CAT-4. The catalog pointer is
   last-writer-wins (single-writer warehouse model) until CAS lands.
 
-| **RAPTOR/SWIFT writers use `FileSystem::append`**
-| Experimental engines (feature-gated `experimental-engines`, default-OFF) append to
-  segment files; object-store backends reject append. Same full-buffer-overwrite or
-  multipart strategy as the WAL fix when these engines graduate.
+| **RAPTOR writer format still requires append**
+| Contained: `FileSystem::supports_append` makes the backend capability explicit and
+  `RaptorWriter` rejects incompatible injected backends during construction. RAPTOR
+  remains feature-gated/default-OFF. A full-buffer-overwrite or multipart format is
+  still required before RAPTOR can support object stores.
 
-| **`queue_fs_adapter.rs` uses `append`**
-| Audit whether its queue paths can be object-store-configured; guard or convert.
+| **Queue root format still requires append**
+| Contained: `FactoryQueueFs::new` now rejects a root whose resolved backend does not
+  advertise durable append. Object-store archive targets remain independent, but an
+  object-store queue root is unsupported until the queue segment format becomes
+  immutable/replace-based.
+
+| **Filesystem trait retains the `append` method**
+| `supports_append` prevents capability-blind constructors, but the method remains on
+  the shared trait for local/HDFS compatibility. New append-dependent formats must
+  check the capability at construction; removing/splitting the method is a later
+  workspace-wide API migration.
 
 | **Alerting persistence object-store port**
 | `AlertPersistence` is a port; add an object-store-backed impl (layering: the
@@ -188,6 +198,11 @@ The bug class has two shapes:
   bases share); `join_storage_url` matrix over bare/file/s3/adls/abfs/gcs bases
   asserting **no `file://<scheme>://` and no `<scheme>://<scheme>://` ever**; audit
   logger scheme dispatch.
+* Construction ratchets: queue roots and RAPTOR writers reject a backend without
+  `supports_append`; object-store backends retain the default `false`, while local and
+  HDFS advertise `true`.
+* WAL reopen ratchet: current-format `wal_NNNNNNNN.log` frames are scanned on writer
+  construction and the next `sequence_number` resumes at `max + 1`.
 * Guard: `tests/objstore_url_construction_test.rs::no_strip_and_reprepend_pattern_in_src`
   greps `src/` for `.replace("file://"` outside an allowlist — the pattern that caused
   this class is now build-enforced dead.

--- a/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
+++ b/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
@@ -55,6 +55,15 @@ The **operator catalog stays in AnvaiOps** (per `OSS_ENTERPRISE_BOUNDARY`); this
 * Provide a one-shot repath/migration that re-emits existing flat catalog assets under their tenant-prefixed paths and stamps the marker.
 * Gate promotion on round-trip + cross-read tests (legacy flat and new prefixed coexist), not just compile.
 
+=== Fence-scope clarification
+
+The `SystemCatalog` generation fence protects publication of the catalog snapshot pointer. It does
+not fence data-plane or external DDL side effects such as writing a MATERIALIZE Parquet object or
+building an index. Table-scoped DDL therefore uses the renewable per-resource partition lease as
+its operation authority and revalidates that lease before reporting success. The process must wire
+one shared `PartitionLeaseManager` (and one renewal loop) into DML, REST, and per-connection pgwire
+DDL; constructing a second manager creates a divergent TTL/ownership timeline and is not valid.
+
 == Consequences
 
 *Positive.* The catalog becomes durable and shared, so stateless pods can serve any tenant after a cold start (the serverless unlock). Isolation is structural and fail-closed, so it holds for every workload class — agent (many tiny bursty tenants), data-engineering (Iceberg/Parquet, TD-119 tenant-scoped REST), OLTP/pgwire, graph, docs — with no per-modality isolation code. Per-tenant lifecycle, CRR, and billing become prefix operations. The misconfiguration footgun (intended multi-tenant silently permissive) is closed.

--- a/src/cluster/primary_pod_registry.rs
+++ b/src/cluster/primary_pod_registry.rs
@@ -551,10 +551,10 @@ pub fn consult_for_write(
 ///
 /// ## Split-brain safety
 ///
-/// Even if a pod bypasses this check (e.g., local single-pod deployment),
-/// the object-store fence in `SystemCatalog` still enforces generation fencing
-/// on every DDL commit. The lease is a latency optimization; the fence is
-/// the correctness authority.
+/// `SystemCatalog` generation-fences its snapshot pointer, not arbitrary DDL
+/// side effects. Callers performing external writes (for example MATERIALIZE)
+/// must therefore keep this renewable lease wired and revalidate ownership
+/// before publishing success.
 ///
 /// ## Usage
 ///

--- a/src/database.rs
+++ b/src/database.rs
@@ -1307,7 +1307,8 @@ async fn open_queue_client_from_resolved(
             .await
             .map_err(|e| anyhow::anyhow!("FilesystemFactory init: {}", e))?,
     );
-    let fs_adapter = crate::services::queue_fs_adapter::FactoryQueueFs::new(factory, &rq.root);
+    let fs_adapter = crate::services::queue_fs_adapter::FactoryQueueFs::new(factory, &rq.root)
+        .map_err(|e| anyhow::anyhow!("queue filesystem capability check: {}", e))?;
 
     let queue = proximadb_queue::QueueClient::open_with_fs(queue_cfg, Some(fs_adapter))
         .await

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -859,6 +859,7 @@ impl MultiServer {
             // pair the REST / gRPC v2 / Arrow Flight surfaces hold.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
+            let partition_lease_manager = services.partition_lease_manager.clone();
             // Warehouse object-store root for `ALTER TABLE … MATERIALIZE`, derived from
             // the server data dir the same way document/observability roots are.
             let warehouse_root_url = format!("file://{}/warehouse", self.config.data_dir.display());
@@ -898,6 +899,7 @@ impl MultiServer {
                 server =
                     server.with_rank_pipeline(rank_services, rank_profile_store, function_store);
                 server = server.with_primary_pod_gate(primary_pod_registry, self_pod_id);
+                server = server.with_partition_lease_manager(partition_lease_manager);
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
                 if let Some(limiter) = pgwire_rate_limiter {
@@ -1214,6 +1216,8 @@ impl MultiServer {
                     services.primary_pod_registry.clone(),
                     services.self_pod_id.clone(),
                 );
+                server =
+                    server.with_partition_lease_manager(services.partition_lease_manager.clone());
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
 

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -93,6 +93,7 @@ pub struct PostgresServer {
     /// can decide once whether to wire the gate.
     primary_pod_registry: Option<Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>>,
     self_pod_id: Option<String>,
+    partition_lease_manager: Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
     /// Object-store root URL the warehouse materializer publishes Parquet snapshots
     /// under (the same URL the OLAP reader reopens the store from). When `Some`,
     /// every per-connection `DdlService` is wired with a `DmlTableMaterializer` so
@@ -144,6 +145,7 @@ impl PostgresServer {
             rank_pipeline: None,
             primary_pod_registry: None,
             self_pod_id: None,
+            partition_lease_manager: None,
             warehouse_root_url: None,
             rate_limiter: None,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
@@ -180,6 +182,16 @@ impl PostgresServer {
     ) -> Self {
         self.primary_pod_registry = Some(registry);
         self.self_pod_id = Some(self_pod_id);
+        self
+    }
+
+    /// Attach the same durable lease manager used by the REST/DML write gates
+    /// so per-connection pgwire DDL does not degrade to registry-only checks.
+    pub fn with_partition_lease_manager(
+        mut self,
+        manager: Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
+    ) -> Self {
+        self.partition_lease_manager = manager;
         self
     }
 
@@ -266,6 +278,7 @@ impl PostgresServer {
                     // routing decisions.
                     let primary_pod_registry = self.primary_pod_registry.clone();
                     let self_pod_id = self.self_pod_id.clone();
+                    let partition_lease_manager = self.partition_lease_manager.clone();
                     let warehouse_root_url = self.warehouse_root_url.clone();
                     let rate_limiter = self.rate_limiter.clone();
                     let tenant_header_trust = self.tenant_header_trust;
@@ -285,6 +298,7 @@ impl PostgresServer {
                             rank_pipeline,
                             primary_pod_registry,
                             self_pod_id,
+                            partition_lease_manager,
                             warehouse_root_url,
                             rate_limiter,
                             tenant_header_trust,
@@ -326,6 +340,9 @@ impl PostgresServer {
         rank_pipeline: Option<PgwireRankPipeline>,
         primary_pod_registry: Option<Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>>,
         self_pod_id: Option<String>,
+        partition_lease_manager: Option<
+            Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        >,
         warehouse_root_url: Option<String>,
         rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
         tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
@@ -367,7 +384,10 @@ impl PostgresServer {
         // sides are present so a partial wiring fails closed (no
         // gate, legacy behavior) rather than silently misconfigured.
         if let (Some(registry), Some(pod_id)) = (primary_pod_registry, self_pod_id) {
-            protocol = protocol.with_primary_pod_gate(registry, pod_id);
+            protocol = protocol.with_primary_pod_gate(registry.clone(), pod_id.clone());
+            if let Some(manager) = partition_lease_manager {
+                protocol = protocol.with_ddl_lease_manager(manager, registry, pod_id);
+            }
         }
         // E0: apply the shared per-IP rate limiter (subject = this peer's IP) so
         // the pgwire query path is rate-limited consistently with REST.

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -582,6 +582,24 @@ impl PostgresProtocol {
         }
     }
 
+    /// Attach the durable partition-lease authority to this connection's DDL
+    /// service after rank/materializer decoration has finished.
+    pub fn with_ddl_lease_manager(
+        mut self,
+        manager: Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        registry: Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>,
+        self_pod_id: String,
+    ) -> Self {
+        if let Some(ddl) = self.ddl_service.as_mut().and_then(Arc::get_mut) {
+            ddl.set_write_lease_authority(manager, registry, self_pod_id);
+        } else {
+            tracing::error!(
+                "pgwire DDL lease authority could not be attached to the per-connection service"
+            );
+        }
+        self
+    }
+
     /// Attach catalog-backed DDL/DML services to an existing protocol handler.
     pub fn with_catalog_manager(mut self, catalog_manager: Arc<CatalogManager>) -> Self {
         self.ddl_service = Some(Arc::new(DdlService::new(catalog_manager.clone())));

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -327,15 +327,12 @@ pub struct SharedServices {
 
     /// Partition lease manager for per-collection write authority (Phase 7c).
     ///
-    /// When enabled via `PROXIMADB_PARTITION_LEASE_ON` and object-store
-    /// deployment, this manager acquires/renews generation-fenced leases
-    /// over `(tenant, collection)` partitions. Protocol handlers consult
-    /// `consult_for_write_leased` before DDL writes to ensure split-brain-free
-    /// local writes. Single-pod deployments leave this `None` (pure in-memory
-    /// `primary_pod_registry` lookup).
-    ///
-    /// The lease is a latency optimization; the object-store fence in
-    /// `SystemCatalog` is the correctness authority.
+    /// This is the same manager used by RecordOps/DML and the storage-write
+    /// fence, including its process-lifetime renewal loop. Protocol handlers
+    /// consult it before DDL writes so no per-surface manager or lease timeline
+    /// can diverge. `None` only when the configured lease store cannot open.
+    /// `SystemCatalog` separately fences catalog snapshot publication; it does
+    /// not fence MATERIALIZE/index side effects.
     pub partition_lease_manager:
         Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
 
@@ -2230,8 +2227,8 @@ impl SharedServices {
         // vector-record write path acquires/confirms the collection lease and the
         // shared registry the network gates consult reflects ground truth after
         // restart/partition (Scenario-1 routing truth). Absent → fail-open.
-        if let Some(lease_manager) = lease_manager_for_writes {
-            record_ops.set_lease_manager(lease_manager);
+        if let Some(lease_manager) = &lease_manager_for_writes {
+            record_ops.set_lease_manager(lease_manager.clone());
             debug!(
                 "✅ SharedServices::new - PartitionLeaseManager wired to RecordOpsService (lease-on-write)"
             );
@@ -2431,60 +2428,10 @@ impl SharedServices {
         // Phase 7c: resolve self_pod_id for partition lease manager initialization
         let self_pod_id_resolved = crate::cluster::primary_pod_registry::resolve_self_pod_id(None);
 
-        // Phase 7c: partition lease manager for per-collection write authority
-        let partition_lease_manager: Option<
-            std::sync::Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
-        > = {
-            // Only initialize for object-store deployments when explicitly enabled
-            let is_objstore = storage_config.metadata_url.starts_with("s3://")
-                || storage_config.metadata_url.starts_with("gs://")
-                || storage_config.metadata_url.starts_with("az://")
-                || storage_config.metadata_url.starts_with("memory://");
-            let lease_enabled = std::env::var("PROXIMADB_PARTITION_LEASE_ON")
-                .ok()
-                .and_then(|v| v.parse::<bool>().ok())
-                .unwrap_or(false);
-
-            if is_objstore && lease_enabled {
-                use crate::storage::trait_components::path_resolver::DrPathBuilder;
-                // Use DrPathBuilder for the lease prefix (under _catalog/leases)
-                let lease_prefix = DrPathBuilder::partition_lease_prefix();
-                // Lease TTL: 60 seconds by default (configurable via env)
-                let lease_ms = std::env::var("PROXIMADB_PARTITION_LEASE_SECS")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60) as i64
-                    * 1000;
-
-                match crate::cluster::partition_lease::PartitionLeaseStore::from_url(
-                    &storage_config.metadata_url,
-                    lease_prefix,
-                ) {
-                    Ok(lease_store) => {
-                        let lease_mgr = crate::cluster::partition_lease::PartitionLeaseManager::new(
-                            std::sync::Arc::new(lease_store),
-                            primary_pod_registry.clone(),
-                            &self_pod_id_resolved,
-                            lease_ms,
-                        );
-                        info!(
-                            "✅ SharedServices: partition lease manager enabled (TTL={}ms)",
-                            lease_ms
-                        );
-                        Some(std::sync::Arc::new(lease_mgr))
-                    }
-                    Err(err) => {
-                        warn!(
-                            "⚠️ SharedServices: failed to create partition lease store, disabling: {}",
-                            err
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        };
+        // Expose the exact manager already wired to DML and its renewal loop.
+        // The previous second constructor created an independent lease timeline
+        // (different TTL, no renew loop) for protocol DDL.
+        let partition_lease_manager = lease_manager_for_writes.clone();
 
         info!(
             "✅ SharedServices: Business logic hub ready for ALL protocols (gRPC, REST, WebSocket, etc.)"

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -549,6 +549,20 @@ impl DdlService {
         self
     }
 
+    /// Wire the complete write-lease authority onto an already-assembled DDL
+    /// service. Pgwire builds rank/materializer decorators per connection, so a
+    /// mutating setter avoids rebuilding the service and dropping those handles.
+    pub fn set_write_lease_authority(
+        &mut self,
+        manager: Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        registry: Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>,
+        self_pod_id: String,
+    ) {
+        self.partition_lease_manager = Some(manager);
+        self.primary_pod_registry = Some(registry);
+        self.self_pod_id = Some(self_pod_id);
+    }
+
     /// Attach the primary-pod registry used for write-routing decisions.
     pub fn with_primary_pod_registry(
         mut self,
@@ -571,8 +585,11 @@ impl DdlService {
     /// present ⇒ lease acquire/renew; absent ⇒ in-memory registry lookup only.
     /// Returns `Err` naming the target pod when another pod holds authority.
     ///
-    /// This is a latency / fast-fail optimization; the object-store generation
-    /// fence in `SystemCatalog` remains the correctness authority (ADR-032).
+    /// `SystemCatalog` generation-fences catalog snapshot publication, but it
+    /// does not fence external side effects such as a Parquet MATERIALIZE write.
+    /// The renewable partition lease is therefore the authority for these
+    /// table-scoped operations; the post-operation check detects displacement
+    /// before success/catalog-cache publication.
     async fn check_lease_for_write(&self, tenant: Option<&str>, collection_id: &str) -> Result<()> {
         use crate::cluster::primary_pod_registry::{
             WriteRoutingDecision, consult_for_write_leased,
@@ -661,6 +678,7 @@ impl DdlService {
                 self.alter_table(&table_name, changes, tenant).await
             }
             DdlStatement::MaterializeTable { name } => {
+                self.check_lease_for_write(tenant, &name).await?;
                 let materializer = self.materializer.as_ref().ok_or_else(|| {
                     anyhow!(
                         "ALTER TABLE … MATERIALIZE requires a configured warehouse object \
@@ -668,9 +686,13 @@ impl DdlService {
                     )
                 })?;
                 let location = materializer.materialize(&name, tenant).await?;
+                // MATERIALIZE can outlive a lease TTL. Revalidate before
+                // publishing success so a displaced pod cannot bless stale work.
+                self.check_lease_for_write(tenant, &name).await?;
                 // TD-OLAP-4: a re-MATERIALIZE republishes the base at this
                 // location, so any cached table-OPEN discovery (schema/splits/
                 // sizes) for it is now stale — drop it so reads re-discover.
+                #[cfg(feature = "datafusion-integration")]
                 crate::datafusion::engine_adapters::table_open_cache::invalidate_location(
                     &location,
                 );
@@ -685,23 +707,31 @@ impl DdlService {
                 index_type,
                 if_not_exists,
             } => {
-                self.create_index(
-                    &index_name,
-                    &table_name,
-                    columns,
-                    index_type,
-                    if_not_exists,
-                    tenant,
-                )
-                .await
+                self.check_lease_for_write(tenant, &table_name).await?;
+                let result = self
+                    .create_index(
+                        &index_name,
+                        &table_name,
+                        columns,
+                        index_type,
+                        if_not_exists,
+                        tenant,
+                    )
+                    .await?;
+                self.check_lease_for_write(tenant, &table_name).await?;
+                Ok(result)
             }
             DdlStatement::DropIndex {
                 index_name,
                 table_name,
                 if_exists,
             } => {
-                self.drop_index(&index_name, &table_name, if_exists, tenant)
-                    .await
+                self.check_lease_for_write(tenant, &table_name).await?;
+                let result = self
+                    .drop_index(&index_name, &table_name, if_exists, tenant)
+                    .await?;
+                self.check_lease_for_write(tenant, &table_name).await?;
+                Ok(result)
             }
             DdlStatement::CreateNamespace {
                 namespace,
@@ -2335,6 +2365,103 @@ mod tests {
             msg.contains("pod-other"),
             "error should name the target pod: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn materialize_and_index_arms_all_apply_the_lease_gate() {
+        use crate::cluster::primary_pod_registry::{AssignmentReason, PrimaryPodRegistry};
+        let registry = std::sync::Arc::new(PrimaryPodRegistry::new());
+        registry.assign("tenant-a", "coll-1", "pod-other", AssignmentReason::Create);
+        let ddl = lease_ddl()
+            .with_primary_pod_registry(registry)
+            .with_self_pod_id("pod-self".to_string());
+
+        let statements = [
+            DdlStatement::MaterializeTable {
+                name: "coll-1".to_string(),
+            },
+            DdlStatement::CreateIndex {
+                index_name: "idx".to_string(),
+                table_name: "coll-1".to_string(),
+                columns: vec!["id".to_string()],
+                index_type: IndexType::BTree,
+                if_not_exists: false,
+            },
+            DdlStatement::DropIndex {
+                index_name: "idx".to_string(),
+                table_name: "coll-1".to_string(),
+                if_exists: false,
+            },
+        ];
+
+        for statement in statements {
+            let err = ddl
+                .execute_scoped(statement, Some("tenant-a"))
+                .await
+                .expect_err("every table-scoped arm must reject a foreign lease");
+            assert!(err.to_string().contains("pod-other"), "{err}");
+        }
+    }
+
+    struct LeaseTakeoverMaterializer {
+        contender: std::sync::Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+    }
+
+    #[async_trait::async_trait]
+    impl TableMaterializer for LeaseTakeoverMaterializer {
+        async fn materialize(&self, table_name: &str, tenant: Option<&str>) -> Result<String> {
+            let future_ms = chrono::Utc::now().timestamp_millis() + 100;
+            assert!(
+                self.contender
+                    .acquire(tenant.unwrap_or("default"), table_name, future_ms)
+                    .await?,
+                "the second pod should acquire after the first lease expires"
+            );
+            Ok("file:///tmp/materialized".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn materialize_revalidates_after_lease_expiry_and_takeover() {
+        use crate::cluster::partition_lease::{PartitionLeaseManager, PartitionLeaseStore};
+        use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
+        use object_store::memory::InMemory;
+        use proximadb_object_store::ProximaObjectStore;
+
+        let backing: std::sync::Arc<dyn object_store::ObjectStore> =
+            std::sync::Arc::new(InMemory::new());
+        let store = std::sync::Arc::new(PartitionLeaseStore::new(
+            ProximaObjectStore::new(backing),
+            "_operator/leases",
+        ));
+        let registry_a = std::sync::Arc::new(PrimaryPodRegistry::new());
+        let registry_b = std::sync::Arc::new(PrimaryPodRegistry::new());
+        let manager_a = std::sync::Arc::new(PartitionLeaseManager::new(
+            store.clone(),
+            registry_a.clone(),
+            "pod-a",
+            10,
+        ));
+        let manager_b =
+            std::sync::Arc::new(PartitionLeaseManager::new(store, registry_b, "pod-b", 10));
+        let ddl = lease_ddl()
+            .with_primary_pod_registry(registry_a)
+            .with_self_pod_id("pod-a".to_string())
+            .with_partition_lease_manager(manager_a)
+            .with_materializer(std::sync::Arc::new(LeaseTakeoverMaterializer {
+                contender: manager_b,
+            }));
+
+        let err = ddl
+            .execute_scoped(
+                DdlStatement::MaterializeTable {
+                    name: "coll-1".to_string(),
+                },
+                Some("tenant-a"),
+            )
+            .await
+            .expect_err("post-operation lease validation must detect takeover");
+        assert!(err.to_string().contains("pod-b"), "{err}");
     }
 
     #[tokio::test]

--- a/src/services/queue_fs_adapter.rs
+++ b/src/services/queue_fs_adapter.rs
@@ -51,16 +51,34 @@ pub struct FactoryQueueFs {
 }
 
 impl FactoryQueueFs {
+    fn require_append_capability(
+        root_url: &str,
+        filesystem_type: &str,
+        supports_append: bool,
+    ) -> QueueResult<()> {
+        if !supports_append {
+            return Err(QueueError::Persistence(format!(
+                "queue root {root_url} uses backend {filesystem_type} without durable append support"
+            )));
+        }
+        Ok(())
+    }
+
     // Returns `Arc<dyn QueueFs>` directly because every caller stores the
     // adapter behind a trait object; exposing the concrete type would force
     // every call site to add a redundant `.as_queue_fs()` cast.
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(factory: Arc<FilesystemFactory>, root_url: impl Into<String>) -> Arc<dyn QueueFs> {
+    pub fn new(
+        factory: Arc<FilesystemFactory>,
+        root_url: impl Into<String>,
+    ) -> QueueResult<Arc<dyn QueueFs>> {
         let mut root_url: String = root_url.into();
         while root_url.ends_with('/') {
             root_url.pop();
         }
-        Arc::new(Self { factory, root_url })
+        let fs = factory.get_filesystem(&root_url).map_err(Self::map_err)?;
+        Self::require_append_capability(&root_url, fs.filesystem_type(), fs.supports_append())?;
+        Ok(Arc::new(Self { factory, root_url }))
     }
 
     /// Translate a queue-supplied `&Path` to a URL the factory accepts.
@@ -203,5 +221,13 @@ mod tests {
             normalize("s3://bucket/queue///".to_string()),
             "s3://bucket/queue"
         );
+    }
+
+    #[test]
+    fn constructor_capability_check_rejects_non_append_backend() {
+        let err = FactoryQueueFs::require_append_capability("s3://bucket/queue", "s3", false)
+            .expect_err("object-store queue roots must fail before accepting data");
+        assert!(err.to_string().contains("without durable append support"));
+        FactoryQueueFs::require_append_capability("file:///queue", "local", true).unwrap();
     }
 }

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -2300,7 +2300,7 @@ impl UnifiedStorageFormat for RaptorEngine {
             self.config.clone(),
             collection_id.to_string(),
             collection_dimension as usize,
-            make_raptor_filesystem().await?,
+            self.filesystem.clone(),
             make_raptor_quantization_engine(&self.config).await?,
             make_raptor_axis_clustering(&self.config),
         )

--- a/src/storage/engines/raptor/writer.rs
+++ b/src/storage/engines/raptor/writer.rs
@@ -2589,6 +2589,14 @@ impl RaptorWriter {
         quantization_engine: Arc<dyn StorageQuantizationEnginePort>,
         axis_clustering: Arc<dyn AxisClusteringPort>,
     ) -> Result<Self> {
+        if !filesystem.supports_append() {
+            anyhow::bail!(
+                "RAPTOR requires durable append, but backend {} for {} does not support it",
+                filesystem.filesystem_type(),
+                file_path
+            );
+        }
+
         // Initialize hardware capabilities
         let hardware = get_hardware_capabilities();
 

--- a/src/storage/persistence/filesystem/caching_filesystem.rs
+++ b/src/storage/persistence/filesystem/caching_filesystem.rs
@@ -351,6 +351,10 @@ impl FileSystem for UnifiedCachingFilesystem {
         self.underlying_fs.append(path, data).await
     }
 
+    fn supports_append(&self) -> bool {
+        self.underlying_fs.supports_append()
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let cache_key = self.cache_key(path);
 

--- a/src/storage/persistence/filesystem/hdfs.rs
+++ b/src/storage/persistence/filesystem/hdfs.rs
@@ -526,6 +526,10 @@ impl FileSystem for HdfsFileSystem {
         self.client.append_file(&normalized_path, data).await
     }
 
+    fn supports_append(&self) -> bool {
+        true
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         tracing::debug!("🗑️ HDFS delete: {}", path);
         let normalized_path = self.normalize_path(path);

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -578,6 +578,10 @@ impl FileSystem for LocalFileSystem {
         Ok(())
     }
 
+    fn supports_append(&self) -> bool {
+        true
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let path_str = self.resolve_path(path)?;
         let resolved_path = PathBuf::from(path_str);

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -459,7 +459,7 @@ impl UnifiedWALWriter {
 
         // Discover existing WAL files to resume from max sequence number and
         // the highest existing segment index.
-        let mut max_seq: u64 = 0;
+        let mut next_seq: u64 = 0;
         let mut segment_count: u64 = 0;
         // TD-066 (d): track the HIGHEST existing segment index, not just the
         // count. After an LSN-bounded prefix truncation the surviving segments
@@ -484,9 +484,25 @@ impl UnifiedWALWriter {
                     if parts.len() >= 4
                         && let Ok(seq) = parts[3].parse::<u64>()
                     {
-                        max_seq = max_seq.max(seq);
+                        next_seq = next_seq.max(seq.saturating_add(1));
                     }
                 }
+            }
+        }
+
+        // The current `wal_{segment}.log` filename carries no sequence range.
+        // Recover the allocator from frame contents; otherwise every reopen
+        // restarts at zero and duplicates sequence numbers within one WAL.
+        if max_segment_index.is_some() {
+            let reader = UnifiedWALReader::new(base_url.clone()).await?;
+            if let Some(last_seq) = reader
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|entry| entry.sequence_number)
+                .max()
+            {
+                next_seq = next_seq.max(last_seq.saturating_add(1));
             }
         }
 
@@ -498,7 +514,7 @@ impl UnifiedWALWriter {
                 "WAL recovery: found {} segments (next index {}), resuming from sequence {}",
                 segment_count,
                 segment_counter,
-                max_seq
+                next_seq
             );
         } else {
             tracing::debug!("WAL writer initialized fresh for path: {}", base_path);
@@ -510,7 +526,7 @@ impl UnifiedWALWriter {
             // re-prepend `file://` — on an object-store base that yields
             // invalid `file://s3://…` URLs (TD-OBJSTORE-1, #960).
             base_path: base_url,
-            sequence_number: std::sync::atomic::AtomicU64::new(max_seq),
+            sequence_number: std::sync::atomic::AtomicU64::new(next_seq),
             filesystem,
             current_segment_path: None,
             current_segment_data: Vec::new(),
@@ -1234,6 +1250,34 @@ mod tests {
             1,
             "new append must open a fresh segment past the max"
         );
+    }
+
+    #[tokio::test]
+    async fn writer_reopen_resumes_sequence_after_current_format_segments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().to_str().unwrap().to_string();
+
+        let mut writer = UnifiedWALWriter::new(path.clone()).await.unwrap();
+        assert_eq!(writer.append(node_op("g", "a")).await.unwrap(), 0);
+        assert_eq!(writer.append(node_op("g", "b")).await.unwrap(), 1);
+        writer.flush().await.unwrap();
+        drop(writer);
+
+        let mut reopened = UnifiedWALWriter::new(path.clone()).await.unwrap();
+        assert_eq!(
+            reopened.append(node_op("g", "c")).await.unwrap(),
+            2,
+            "the current wal_NNNNNNNN.log format must restore the next sequence"
+        );
+        reopened.flush().await.unwrap();
+
+        let entries = UnifiedWALReader::new(path)
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap();
+        assert_eq!(seqs(&entries), vec![0, 1, 2]);
     }
 
     /// A stale/missing checkpoint marker must never delete live frames: truncate


### PR DESCRIPTION
## Summary

Adds durability and fencing containment for the object-store and DDL findings from the independent 2026-07-14 review:

- wire pgwire DDL to the same renewable partition lease manager used by DML
- lease-check MaterializeTable/CreateIndex/DropIndex and revalidate ownership before success
- document the SystemCatalog fence boundary for external side effects
- add filesystem append capability reporting and reject unsupported queue/RAPTOR object-store paths
- recover the unified WAL sequence allocator from current-format segments after reopen
- expand TD-OBJSTORE-1 deferred-surface disclosure

This is stack 2 of 3 and is based on the promotion-correctness branch.

## Risk addressed

- A9-F1: unfenced/duplicate long-running DDL work
- A4-F1/F2: append-class reintroduction and incomplete object-store disclosure
- A4-F3: WAL sequence reuse after reopen

## Validation

- isolated stacked `cargo check --lib`
- focused DDL lease/expiry, queue capability, RAPTOR capability, and WAL reopen tests
- `cargo fmt --all -- --check`
- `git diff --check`

## Dependency and merge order

Depends on the promotion-correctness PR. Merge that PR first, then retarget this PR to `develop` if GitHub does not do so automatically.

