### PR TITLE
fix: fence DDL/append paths + fail-closed promotion evidence (#982+#983 consolidated)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,26 @@
 - [ ] Refactoring (no functional changes)
 - [ ] CI/CD improvement
 
+### Move / Decomposition Inventory
+
+<!-- Required when files or modules move. A move PR should contain only path/import
+changes. If behavior also changes, list every behavior change explicitly here or
+split it into a separate PR. -->
+
+- [ ] No files/modules moved
+- [ ] Pure move only (path/import changes; `git diff --find-renames` reviewed)
+- [ ] Move plus behavior change; complete behavioral inventory below
+
+Behavioral inventory (routing, defaults, cfg gates, service wiring, errors, persistence):
+
+- None
+
+Feature configurations exercised for a move:
+
+- [ ] Default
+- [ ] `--no-default-features`
+- [ ] `experimental-engines`
+
 ### Changes
 
 <!-- List the key changes made in this PR -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,11 +722,16 @@ jobs:
       matrix:
         include:
           # The two combos the published images actually ship (PR #78):
-          - { label: "cloud-full",          pkg: proximadb-server, feats: "cloud-full" }
-          - { label: "cloud-full,onnx",     pkg: proximadb-server, feats: "cloud-full,onnx" }
+          - { label: "cloud-full",          pkg: proximadb-server, args: "--features cloud-full" }
+          - { label: "cloud-full,onnx",     pkg: proximadb-server, args: "--features cloud-full,onnx" }
           # Other gated surfaces invisible to default CI:
-          - { label: "cluster",             pkg: proximadb,        feats: "cluster" }
-          - { label: "enterprise-catalogs", pkg: proximadb,        feats: "enterprise-catalogs" }
+          - { label: "cluster",             pkg: proximadb,        args: "--features cluster" }
+          - { label: "enterprise-catalogs", pkg: proximadb,        args: "--features enterprise-catalogs" }
+          # Refactor/move coverage: these configurations catch cfg drift hidden
+          # by the default build. Keep them in the same mandatory matrix rather
+          # than relying on a PR being correctly labelled as mechanical.
+          - { label: "no-default-features",  pkg: proximadb,        args: "--no-default-features" }
+          - { label: "experimental-engines", pkg: proximadb,        args: "--features experimental-engines" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -739,10 +744,10 @@ jobs:
         with:
           prefix-key: "v1-feature-matrix"
           shared-key: ${{ matrix.label }}
-      - name: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+      - name: cargo check -p ${{ matrix.pkg }} ${{ matrix.args }}
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+        run: cargo check -p ${{ matrix.pkg }} ${{ matrix.args }}
 
   rust-security:
     name: Security Audit
@@ -1118,6 +1123,8 @@ jobs:
       # merge. Convention: docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc.
       - name: Check TD/ADR id uniqueness
         run: python3 scripts/check_td_adr_unique.py
+      - name: Check resolved TD status/body consistency
+        run: python3 scripts/check_td_status_consistency.py
       - name: Check documentation links
         run: |
           echo "Checking for broken links in documentation..."

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -141,18 +141,17 @@ jobs:
       - name: Run TD-112 post-flush recall ratchet (TD-182 P0b)
         run: cargo test --test td112_postflush_recall_e2e recall -- --nocapture
 
-  # WS8: real-dataset PAX RaBitQ→SQ8 recall artifact. MANUAL ONLY
-  # (workflow_dispatch) — it downloads the SIFT1M corpus (~160 MB) and runs a
-  # heavy recall bench, so it is deliberately NOT in the always-on
-  # `pgwire-recall-tests` job (avoids 160 MB-download flakiness on every qa PR).
+  # WS8: real-dataset PAX RaBitQ→SQ8 recall artifact. Runs on promotion PRs and
+  # workflow_dispatch. It downloads the SIFT1M corpus (~525 MB) and runs a heavy
+  # release-mode recall gate, so it remains separate from normal PR CI.
   # Produces the dated recall@10 ≥ 0.90 artifact that GATES the PAX default-on
   # flip (Phase F): the existing `pax-recall-ratchet` is a synthetic DIM=64 CI
   # floor only (representativeness caveat in BENCHMARK_EVIDENCE.toml WS8). The
-  # ratchet self-skips when the corpus is absent, so a non-manual trigger would
-  # just skip — the `if:` keeps it from scheduling at all.
+  # Local runs may skip when the corpus is absent. This QA job sets
+  # PROXIMADB_RECALL_DATASET_REQUIRED=1, so a missing/corrupt corpus fails loud.
   sift-pax-recall:
     name: SIFT1M PAX RaBitQ recall ratchet (WS8)
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -186,13 +185,15 @@ jobs:
       - name: Build ratchet binary
         env:
           CARGO_BUILD_JOBS: "4"
-        run: cargo test --test sift_pax_recall_ratchet_test --no-run
+        run: cargo test --release --test sift_pax_recall_ratchet_test --no-run
       - name: Run SIFT PAX recall ratchet (N=${{ inputs.sift_n || '100000' }})
         env:
           PROXIMADB_SIFT_DATASET_DIR: /home/runner/sift1m
           PROXIMADB_SIFT_N: ${{ inputs.sift_n || '100000' }}
           PROXIMADB_SIFT_QUERIES: "1000"
-        run: cargo test --test sift_pax_recall_ratchet_test -- --nocapture
+          PROXIMADB_RECALL_DATASET_REQUIRED: "1"
+          PROXIMADB_SIFT_CENTROID_MAX_RECALL_DROP: "0"
+        run: cargo test --release --test sift_pax_recall_ratchet_test -- --nocapture
 
   # Validate the object-store access-tier cost lever (TD-168/TD-173) against REAL
   # cloud APIs via emulators — Azurite (Azure), MinIO (S3), fake-gcs (GCP) — the

--- a/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
+++ b/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
@@ -4,7 +4,7 @@
 
 [cols="1,3"]
 |===
-|Status|Core resolved (v2 gRPC scoped + auto-provision); REST-v2 store-split follow-on open
+|Status|In progress — v2 gRPC core resolved; pgwire/REST-v1 and entity follow-ons open
 |Priority|LOW
 |Scope|FEAT
 |Date|2026-07-05

--- a/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
+++ b/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
@@ -4,7 +4,7 @@
 
 [cols="1,3"]
 |===
-|Status|Core resolved (lazy auto-provision); follow-ons open
+|Status|In progress — lazy auto-provision core resolved; create/list scoping follow-ons open
 |Priority|MED
 |Scope|FEAT
 |Date|2026-07-05

--- a/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
+++ b/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
@@ -5,24 +5,24 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | **Proposed** (filed 2026-07-10). Grounded in the SF=0.1 measurement (TD-OLAP-15 §DuckDB gap) + the TD-OLAP-2 diagnosis (missing NDV → DataFusion CBO-blind → 100–700× join gap at scale). Decider sign-off pending.
+| Status | **Proposed / evidence-only** (filed 2026-07-10; causal account corrected 2026-07-14). The original NDV/CBO diagnosis was superseded by TD-OLAP-17: the dominant measured floor was a per-table, per-query WAL change scan during table open. Decider sign-off pending.
 | Decider | Vijaykumar Singh (2026-07-10)
 | Date | 2026-07-10
 | Relates to | link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (bytes-scanned is the dominant cloud-OLAP cost term; the seam is swappable), link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (the backend leakage boundary / seam), link:ADR-058-engine-routing-eligibility-selection-stats-trust.adoc[ADR-058] (eligibility-vs-selection routing; D2 keeps `ComputeBackend` an enum), link:ADR-054-native-execution-engine-progressive-cutover.adoc[ADR-054] (the native engine — orthogonal PAX wedge), link:../../10-quality/td/TD-OLAP-15-native-engine-measured-posture-sf001.adoc[TD-OLAP-15] (the measured gap), link:../../10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2] (the DF-CBO fix this partly defers), link:../../10-quality/td/TD-EXEC-2-plan-geometry-resource-model.adoc[TD-EXEC-2] (plan-geometry → engine routing).
-| Refines | ADR-052's "DataFusion is the OLAP engine" → **"the OLAP engine is router-selected per query geometry; DuckDB-Local is a plugin OLAP engine for join-heavy parquet, DataFusion the fallback, native the PAX-wedge."** Reaffirms ADR-058 D2 (enum for routing) + clarifies the `ExecutionEngine` trait is the open execution seam.
-| Tracked under | Wiring TD (to be filed on sign-off): `impl ExecutionEngine for DuckDbLocalEngine`; register ProximaDB parquet via DuckDB's object-store reader; ADR-058 router selects `DuckDbCompat` for join-heavy parquet OLAP.
+| Refines | ADR-052's "DataFusion is the OLAP engine" only after comparable evidence: **DuckDB-Local is currently an explicit, evidence-only plugin route; DataFusion remains the OLAP floor and native remains the PAX wedge.** Reaffirms ADR-058 D2 (enum for routing) + clarifies the `ExecutionEngine` trait is the open execution seam.
+| Tracked under | Evidence wiring: `impl ExecutionEngine for DuckDbLocalEngine`; register ProximaDB parquet via DuckDB's object-store reader; keep `DuckDbCompat` out of live cost ranking until value parity and comparable I/O accounting land.
 |===
 
 == 1. Context + the question
 
-The SF=0.1 measurement (TD-OLAP-15) showed the DuckDB gap **widens with scale**: 25–70× at SF=0.01 → **100–700× at SF=0.1** (Q5 552×, Q8 556×, q61 697×). DataFusion scales ~super-linearly on joins (Q8: 310ms→17233ms for 10× data — a bad plan), while DuckDB stays flat at ~25–35ms (multi-core + CBO reorder + broadcast). The TD-OLAP-2 diagnosis confirmed the root cause: **missing NDV (`distinct_count`) → DataFusion's CBO can't estimate join cardinality → no reorder, no `BroadcastJoin`** → catastrophic join plans. `splits_pruned` *does* fire at SF=0.1 (zone-map pruning works), so the gap is **compute (join plan), not bytes-scanned** — and it worsens super-linearly without stats.
+The SF=0.1 measurement (TD-OLAP-15) appeared to show a DuckDB gap widening with scale: 25–70× at SF=0.01 → 100–700× at SF=0.1. The initial diagnosis attributed that wall time to missing NDV and CBO-blind join plans. TD-OLAP-17 subsequently isolated the dominant term: `changed_oids_since` scanned the bulk-ingest WAL once per table per query even when the post-snapshot delta was empty. Its high-water fast path reduced the default DataFusion median from **5762 ms to 12 ms at SF=0.1** (and 604 ms to 7 ms at SF=0.01), faster than the measured DuckDB 14–15 ms. Table-open time collapsed from about 1780 ms to 0–1 ms. NDV remains a valid completeness and plan-quality improvement, but it did not cause the measured gap close.
 
-TD-OLAP-2 (populate NDV → DF CBO) is the proper fix but is substantial (statistics-collection infrastructure) and uncertain (would DF+NDV match DuckDB's mature optimizer?). The question: **wire DuckDB-Local embedded as a plugin OLAP engine now** to close the 100–700× gap immediately, while native builds its wedge and TD-OLAP-2 lands?
+The remaining question is narrower: should DuckDB-Local remain available as an embedded evidence engine for shapes where its optimizer or SQL surface may show a measured advantage, without treating the now-closed WAL table-open gap as justification for promotion?
 
 == 2. The decision
 
 === D1 — DuckDB-Local embedded as a plugin OLAP engine for parquet/materialized tables
-DuckDB (in-process, like DataFusion) serves the **join-heavy parquet OLAP path** (today's DataFusion path). It reads the **same materialized parquet** via its object-store reader — no data migration. It closes the gap because it owns the **compute term** (CBO + broadcast + vectorized joins) that is the confirmed root cause; the bytes-scanned term is unchanged. The `ComputeBackend::DuckDbCompat` enum variant already exists (`table_write_plan.rs:113`) — wiring = implementing the engine, not adding the variant.
+DuckDB (in-process, like DataFusion) can probe the **join-heavy parquet OLAP path** over the same materialized parquet, with no data migration. It is not credited with closing the historical gap: TD-OLAP-17's WAL high-water fast path did that. The `ComputeBackend::DuckDbCompat` enum variant already exists (`table_write_plan.rs:113`), so the evidence route exercises the existing engine seam.
 
 === D2 — Hybrid dispatch: `ExecutionEngine` trait (execution, open) + `ComputeBackend` enum (routing, closed)
 Best practice for a multi-engine DB is **open execution, closed routing**:
@@ -32,40 +32,40 @@ Best practice for a multi-engine DB is **open execution, closed routing**:
 **Not a full trait-ify of `ComputeBackend`.** The engine set *converges* (see D4 — eventually native-modes for load-bearing), it does not grow unboundedly, so an open plugin *registry* is over-engineering. Adding DuckDB = `impl ExecutionEngine for DuckDbLocalEngine` + wire the existing `DuckDbCompat` arm in `execute_sql_with_backend`.
 
 === D3 — Geometry-shape routing (ADR-058 + TD-EXEC-2): each shape → the engine that owns its dominant cost term
-The router (ADR-058 eligibility-then-selection) picks the engine per **query geometry** (shape) by co-design cost-term:
-- **Join-heavy parquet OLAP** → DuckDB (compute-term advantage: CBO/broadcast).
+The router (ADR-058 eligibility-then-selection) may eventually pick the engine per **query geometry** (shape) when the relevant cost terms are comparable:
+- **Join-heavy parquet OLAP** → DataFusion by default; DuckDB only through the explicit evidence route until a compute advantage survives value-level and I/O-comparable measurement.
 - **PAX / native vector store** → native scan wedge (bytes-scanned advantage: PAX-native scan + footer-elision, ADR-052/TD-OLAP-1).
 - **Simple / point / OLTP** → native Volcano or DataFusion (the floor).
 
 This is the TD-EXEC-2 plan-geometry → resource/cost model: geometry decides which engine's dominant-cost-term advantage applies.
 
-=== D4 — Final state: native (modes) load-bearing; for now shapes route to whichever engine wins
-The end-state is **native in various modes for load-bearing shapes** (the ADR-054 progressive cutover — native vectorized + morsel + spill for the shapes it can serve soundly). **For now**, geometry routes to DuckDB/DataFusion/native per perf + co-design cost — DuckDB is the perf bridge for join-OLAP until native's join/spill/CBO (TD-OLAP-11 + TD-OLAP-2) closes the gap on the shapes native owns. DuckDB is **not** "until native replaces it on parquet-OLAP" — native's wedge is the PAX scan + multimodal join, not parquet-OLAP-join-perf; DuckDB may remain the parquet-OLAP engine permanently.
+=== D4 — Final state: native (modes) load-bearing; DuckDB remains evidence-only pending promotion evidence
+The end-state is **native in various modes for load-bearing shapes** (the ADR-054 progressive cutover — native vectorized + morsel + spill for the shapes it can serve soundly). DataFusion remains the parquet OLAP floor. DuckDB may be reconsidered for shapes where an advantage is demonstrated after the TD-OLAP-17 correction, with exact value parity and comparable I/O quantities; the current record does not justify a live routing role.
 
 === D5 — DataFusion stays the floor/fallback; TD-OLAP-2 continues
-DF remains the swappable floor (the ADR-039 seam's default). TD-OLAP-2 (DF + NDV/CBO) continues as the **fallback-path investment** — if DuckDB is ever unavailable (dep/operational), DF+CBO is the backup. Do not delete that work.
+DF remains the swappable floor (the ADR-039 seam's default). TD-OLAP-2 (DF + NDV/CBO) continues as a plan-quality investment, but it is not credited with the measured 5762→12 ms gap close; TD-OLAP-17's WAL high-water fast path is.
 
 === D6 — Native is NOT defunded
-DuckDB serves parquet-OLAP; native's wedge (PAX scan + footer-elision + multimodal join, ADR-052/TD-OLAP-1/ADR-054) is **orthogonal**. The two-engine (now three: DuckDB + DF + native) strategy: each engine owns its dominant-cost-term advantage. DuckDB's perf does not reduce urgency for native's wedge — that's the differentiator, not parquet-join-perf.
+DuckDB's evidence harness does not replace native's wedge (PAX scan + footer-elision + multimodal join, ADR-052/TD-OLAP-1/ADR-054). No DuckDB performance advantage should reduce urgency for native work unless it is reproduced with the corrected table-open path and comparable cost dimensions.
 
 == 3. Co-design / first-principles reasoning
 
 Per the co-design mandate (name the dominant dimensional cost term):
-- **DuckDB** moves the **compute** term (join plan: CBO reorder + broadcast + vectorized) — the confirmed root cause of the 100–700× gap. It reads the same bytes (no bytes-scanned regression); it fixes the compute.
+- **DuckDB** may move the compute term (join reorder + vectorized execution) on particular shapes, but that advantage must be measured after the TD-OLAP-17 table-open floor and with comparable I/O accounting; it was not the cause of the observed 5762→12 ms correction.
 - **Native** moves the **bytes-scanned** term (PAX-native scan + footer-elision) — its wedge. Orthogonal to DuckDB's compute advantage.
-- **Routing** is the dimensional delegation (ADR-058): geometry → the engine that owns the cost term the query is bound by. A join-bound query → compute engine (DuckDB); a scan-bound query → scan engine (native).
+- **Routing** is the dimensional delegation (ADR-058): geometry may select an engine only when the compared cost cells describe the same dimensions. DuckDB's compute-only cells do not yet satisfy that condition.
 - First-principles check vs the ecosystem: Postgres (table access methods + FDWs = open execution via traits, closed routing), Spark (catalyst + pluggable execution), Trino (connector trait). The hybrid (open execution trait + closed routing enum) is the established pattern; a single closed enum or a fully-open registry are the two extremes this steers between.
 
 == 4. Alternatives rejected
 
 - **Full trait-ify of `ComputeBackend` (open plugin registry).** Rejected (ADR-058 D2's reasoning, reaffirmed): the engine set converges to native-modes (D4), not unbounded growth; the enum is already open via `ExternalDelegated(String)`; `dyn`-dispatch once-per-query is fine but a registry is YAGNI. The `ExecutionEngine` trait already gives the open-execution property.
-- **Just fix DF (TD-OLAP-2) instead of adding DuckDB.** Rejected as the *sole* path: TD-OLAP-2 is substantial + uncertain (DF+NDV may not match DuckDB's mature optimizer). DuckDB closes the gap decisively now; TD-OLAP-2 continues as the fallback-path investment (D5). Both, not either/or.
+- **Remove the DuckDB evidence route because the historical gap closed.** Rejected for now: the route can still provide useful differential evidence on unsupported or wider shapes, but it is not a production cost-model candidate without the D3 gates.
 - **DuckDB as a CLI subprocess (like the benchmark baseline).** Rejected: per-query process spawn + no shared state. Embedded (in-process) is the right posture (shared, like DF).
 - **Let DuckDB replace native.** Rejected (D6): native's wedge (PAX/multimodal) is orthogonal; DuckDB doesn't read PAX or host multimodal join semantics.
 
 == 5. Consequences
 
-*Positive:* closes a 100–700× join gap immediately; exercises the plugin architecture (ADR-039/058) the system was built for; DuckDB handles *more* SQL than DF/Volcano (window/ROLLUP/CUBE — fewer feature gaps, recall the TPC-DS native failures); each engine owns its cost-term advantage (clean separation).
+*Positive:* exercises the plugin architecture (ADR-039/058) and provides a differential harness for SQL shapes such as window/ROLLUP/CUBE without changing the production default.
 
 *Negative / trade-offs:* **`libduckdb` is a heavy C++ native dependency** in a Rust project (build complexity, binary size, supply-chain) — DataFusion is pure-Rust, DuckDB is not; this is the main cost. **Operational**: another in-process engine (memory, threads, version pinning). **SQL dialect**: DuckDB ≈ Postgres-ish but differs; net positive (more complete). **Risk of defunding native**: mitigated by D6 (orthogonal wedge) — must be policed at the ADR/roadmap level.
 
@@ -74,7 +74,7 @@ Per the co-design mandate (name the dominant dimensional cost term):
 == 6. Rollout (announced here; implemented in follow-up PRs)
 
 1. **Wire `DuckDbLocalEngine`** — `impl ExecutionEngine`; register ProximaDB parquet via DuckDB's object-store reader; wire the `DuckDbCompat` arm in `execute_sql_with_backend`. Default-OFF (env gate) + ledger-gated promotion (ADR-054 progressive-cutover discipline). *(LANDED 2026-07-11, #872 — engine + `execute_sql_with_backend` arm behind `--features duckdb`.)*
-2. **Geometry routing** — ADR-058 router selects `DuckDbCompat` for join-heavy parquet OLAP (eligibility: parquet-backed + join/agg shape; DF the fallback). The cost model (ADR-058 D3/D4) learns per-shape-per-engine. *(LANDED 2026-07-14: `PROXIMADB_DUCKDB_ROUTE` (default OFF) gates a DuckDB PRIMARY attempt for join-bearing/grouped parquet shapes with DataFusion the correctness floor; eligibility additionally requires every referenced table's ADR-025 post-snapshot delta be EMPTY (TD-OLAP-17 high-water probe, fail-closed) since DuckDB reads bare parquet; `DuckDbCompat` joins the `olap/parquet` freshness-safe cost-model candidate set when compiled + route-enabled, so cells warm through the router and the #946 per-class override can flip to it; the io_trace route is re-stamped to the engine that actually served, so cost cells never mis-attribute floor-served queries. Enable gate: `tests/duckdb_route_pgwire_e2e.rs` — result parity + attribution.)*
+2. **Geometry evidence route** — `PROXIMADB_DUCKDB_ROUTE` (default OFF) gates a DuckDB PRIMARY attempt for join-bearing/grouped parquet shapes with DataFusion the correctness floor; eligibility additionally requires every referenced table's ADR-025 post-snapshot delta be EMPTY (TD-OLAP-17 high-water probe, fail-closed) since DuckDB reads bare parquet. The io_trace route is re-stamped to the engine that actually served. DuckDB cells are deliberately excluded from live cost-model ranking/exploration while its reader reports compute time but not comparable physical GET/byte quantities; the explicit route is an evidence harness, not an override candidate. Promotion requires value-level differential coverage (including NULL and decimal semantics) and comparable I/O accounting. Enable gate: `tests/duckdb_route_pgwire_e2e.rs`.*
 3. **Trust gate (ADR-058 D5/§9.A)** — DuckDB reads the same parquet; the `StatsTrust` gate applies (external parquet → DuckDB scans, doesn't trust footer for elision — though DuckDB's own elision is its internal concern; the gate is at ProximaDB's parquet-registration boundary).
 4. *(Converges)* native-modes for load-bearing shapes (ADR-054) — DuckDB remains for the shapes native doesn't own.
 
@@ -85,24 +85,25 @@ Each step default-safe + ledger-gated, mixed-read-safe, behind the ADR-054 progr
 Measured through the REAL pgwire route (step-2 wiring), SF 0.01 full-suite + SF 0.1 scoped
 (Q3/Q5/Q8/Q9/Q10), release, `PROXIMADB_DUCKDB_ROUTE=1` vs stock:
 
-* **The wiring is sound.** 142/170 pgwire-sweep records served by `DuckDbCompat` with **zero
-  row-count mismatches** vs the stock DataFusion baseline (SF 0.01) and exact parity on all five
-  SF 0.1 queries. Eligibility behaved (scalar/metadata shapes kept DataFusion); the delta-clean
+* **The wiring is promising but the broad sweep was row-count-only.** 142/170 pgwire-sweep records
+  served by `DuckDbCompat` with zero row-count mismatches vs the stock DataFusion baseline
+  (SF 0.01), while five SF 0.1 queries had exact value parity. Eligibility behaved
+  (scalar/metadata shapes kept DataFusion); the delta-clean
   probe added no visible overhead (routed-DuckDB ≤ DuckDB-direct walls); cost cells warmed under
   the correct backend label via the io_trace re-stamp.
-* **The motivating gap is GONE on the probed shapes.** TD-OLAP-15's 100–700× DataFusion join-plan
+* **The motivating gap is GONE on the probed shapes.** TD-OLAP-15's 100–700× DataFusion wall-time
   collapse (Q8 17 233 ms at SF 0.1) no longer reproduces: stock DataFusion now answers Q5/Q8/Q9
-  in ~24 ms at SF 0.1 — the D5 "fallback-path investment" (TD-OLAP-2 NDV via #886 + stats-fed
-  planning #660) landed and fixed the CBO's join plans. DuckDB-direct is comparable (~20–36 ms)
+  in ~24 ms at SF 0.1. TD-OLAP-17 attributes the dominant correction to the WAL high-water
+  fast path (5762→12 ms in its controlled run), not NDV/CBO. DuckDB-direct is comparable (~20–36 ms)
   with a cold-start outlier (Q3 first-run ~1.3 s: fresh in-memory DB + view registration per
   query — the stateless-engine cost).
-* **Promotion verdict: stay opt-in default-OFF.** On current evidence DataFusion ≥ DuckDB across
+* **Promotion verdict: evidence-only, opt-in, default-OFF.** On current evidence DataFusion ≥ DuckDB across
   both scales probed, so there is no measured win to promote — and that is the routing framework
   working, not a failure: the cost model, warmed through this route, correctly learns DataFusion
-  as the cheaper arm at these scales. Re-evaluate on shapes/scales where DuckDB's optimizer
-  advantage re-emerges (larger SF, wider joins, window/ROLLUP surfaces DataFusion lacks) — the
-  route, eligibility gates, and per-class staged enable (#946) are ready when it does.
+  as the cheaper arm at these scales. DuckDB is excluded from live override ranking until physical
+  I/O quantities and broader value-level differential coverage are available. Re-evaluate on
+  shapes/scales where DuckDB's optimizer advantage re-emerges (larger SF, wider joins,
+  window/ROLLUP surfaces DataFusion lacks).
 * Residual observation: a set of CTE-shaped TPC-DS queries (q1, q9, q14a, q23a, q24a, q33, …)
   execute correctly but carry NO route stamp — they are served by a pre-router path, so the cost
   model never sees them. Worth a follow-up when CTE lowering lands on the shared route.
-

--- a/scripts/check_td_status_consistency.py
+++ b/scripts/check_td_status_consistency.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Reject resolved TDs whose body still declares open work."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TD_DIR = ROOT / "docs" / "10-quality" / "td"
+RESOLVED = re.compile(
+    r"(?:\|\s*Status\s*\||\*\*Status:\*\*)\s*(?:\*\*)?Resolved\b", re.I
+)
+OPEN_HEADING = re.compile(r"^==+\s+.*\b(?:open|remaining|pending)\b", re.I)
+OPEN_MILESTONE = re.compile(
+    r"^\*\*[^\n]*(?:\bopen\b|\bremaining\b|\bpending\b)[^\n]*\*\*:?\s*$", re.I
+)
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in sorted(TD_DIR.glob("TD-*.adoc")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if not any(RESOLVED.search(line) for line in lines[:30]):
+            continue
+        for line_no, line in enumerate(lines, 1):
+            if OPEN_HEADING.search(line) or OPEN_MILESTONE.search(line):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line_no}: resolved TD declares open work: {line.strip()}"
+                )
+
+    if violations:
+        print("TD status consistency check failed:", file=sys.stderr)
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+    print("TD status consistency check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -798,28 +798,13 @@ fn parse_backend_label(label: &str) -> Option<ComputeBackend> {
 /// DataFusion floor serves otherwise and the route is re-stamped).
 fn freshness_safe_backends_from_class(shape_class: &str) -> Vec<ComputeBackend> {
     if shape_class.starts_with("olap/parquet") {
-        let mut safe = vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal];
-        if duckdb_route_candidate() {
-            safe.push(ComputeBackend::DuckDbCompat);
-        }
-        safe
+        // DuckDB remains an explicit-route evidence harness until its reader
+        // reports comparable GET/byte quantities. Ranking compute-only cells
+        // beside fully metered engines would make live overrides prefer an
+        // artificially cheap candidate.
+        vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal]
     } else {
         vec![ComputeBackend::Native]
-    }
-}
-
-/// Whether `DuckDbCompat` participates as a cost-model candidate: compiled in
-/// (`--features duckdb`) AND route-enabled (`PROXIMADB_DUCKDB_ROUTE`, default
-/// OFF per ADR-059 §6 / ADR-054 progressive-cutover). Without both, the
-/// frozen table never ranks or explores DuckDB, so no flip can target it.
-fn duckdb_route_candidate() -> bool {
-    #[cfg(feature = "duckdb")]
-    {
-        crate::query::execution::duckdb_engine::duckdb_route_enabled()
-    }
-    #[cfg(not(feature = "duckdb"))]
-    {
-        false
     }
 }
 
@@ -2194,13 +2179,12 @@ mod tests {
         );
     }
 
-    /// ADR-059: with the `duckdb` feature compiled AND `PROXIMADB_DUCKDB_ROUTE`
-    /// set, DuckDbCompat joins the olap/parquet freshness-safe set — its cells
-    /// rank and it can be explored/flipped to. (nextest process-per-test
-    /// isolation makes the env-before-first-call OnceLock read deterministic.)
+    /// DuckDB traces remain evidence-only until its I/O quantities are
+    /// comparable to the other engines. Even an explicitly enabled route may
+    /// collect cells, but the live model must not rank or explore them.
     #[cfg(feature = "duckdb")]
     #[test]
-    fn duckdb_joins_the_olap_parquet_safe_set_when_route_enabled() {
+    fn duckdb_cells_are_evidence_only_when_route_enabled() {
         unsafe { std::env::set_var("PROXIMADB_DUCKDB_ROUTE", "1") };
         let m = RouteCostModel::new().with_min_samples(1);
         m.observe_by_label("olap/parquet", "DuckDbCompat", &snap(2, 1 << 20, 1));
@@ -2208,14 +2192,12 @@ mod tests {
         m.recompute();
         let consult = m.consult("olap/parquet").expect("baked");
         assert!(
-            consult
+            !consult
                 .ranked()
                 .iter()
                 .any(|c| backend_label(&c.backend) == "DuckDbCompat"),
-            "DuckDbCompat must rank as a freshness-safe candidate"
+            "compute-only DuckDB cells must not feed live overrides"
         );
-        // Cheapest-first: DuckDB (2 GETs) beats DataFusion (200 GETs) here.
-        assert_eq!(backend_label(&consult.ranked()[0].backend), "DuckDbCompat");
         // OLTP classes never gain DuckDB regardless of the gate.
         m.observe_by_label("oltp/native", "DuckDbCompat", &snap(2, 1 << 20, 1));
         m.recompute();

--- a/tests/duckdb_route_pgwire_e2e.rs
+++ b/tests/duckdb_route_pgwire_e2e.rs
@@ -141,7 +141,15 @@ fn eligible_cases() -> Vec<(&'static str, Vec<&'static str>)> {
         ),
         (
             "SELECT o_orderstatus, count(*) FROM orders GROUP BY o_orderstatus ORDER BY o_orderstatus",
-            vec!["F|2", "O|2", "P|1"],
+            vec!["F|2", "O|3", "P|1"],
+        ),
+        (
+            "SELECT o.o_orderstatus, CAST(sum(l.l_extendedprice) AS DECIMAL(12,2)) FROM orders o JOIN lineitem l ON o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus",
+            vec!["F|90.00", "O|80.00", "P|80.00"],
+        ),
+        (
+            "SELECT o.o_orderkey, l.l_extendedprice FROM orders o LEFT JOIN lineitem l ON o.o_orderkey = l.l_orderkey WHERE o.o_orderkey = 6",
+            vec!["6|"],
         ),
     ]
 }
@@ -182,7 +190,7 @@ async fn eval_body() {
         "DROP TABLE IF EXISTS orders",
         "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_totalprice DOUBLE PRECISION, o_orderstatus VARCHAR)",
         "CREATE TABLE lineitem (l_orderkey INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION)",
-        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F')",
+        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F'),(6,40,NULL,'O')",
         "INSERT INTO lineitem VALUES (1,5.0,50.0),(1,2.0,20.0),(2,3.0,60.0),(3,1.0,10.0),(4,4.0,80.0),(5,2.0,30.0)",
     ] {
         client
@@ -214,7 +222,7 @@ async fn eval_body() {
     let rows = query_rows(&client, "SELECT count(*) FROM orders")
         .await
         .expect("scalar count");
-    assert_eq!(rows, vec!["5".to_string()]);
+    assert_eq!(rows, vec!["6".to_string()]);
 
     // 2. Attribution: DuckDbCompat cells learned for eligible classes only.
     let cells = proximadb::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL.learned_cell_keys();

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -30,6 +30,7 @@
 //!                                CI floor); unset → full 1M + provided GT
 //!   PROXIMADB_SIFT_QUERIES       cap the query count (default 1000)
 //!   PROXIMADB_SIFT_RECALL_FLOOR  ratchet threshold (default 0.90)
+//!   PROXIMADB_RECALL_DATASET_REQUIRED fail instead of skip when corpus is absent
 //!
 //! nextest isolates each test in its own process, so the PAX env vars set here
 //! don't leak. `set_var` is `unsafe` (edition 2024).
@@ -43,9 +44,11 @@ use proximadb::storage::engines::sst::SstEngine;
 use proximadb::storage::traits::{
     FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
 };
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::TempDir;
 
 const DIMENSION: usize = 128;
@@ -119,6 +122,12 @@ fn dataset_path(filename: &str) -> Option<PathBuf> {
     })
 }
 
+fn dataset_required() -> bool {
+    std::env::var("PROXIMADB_RECALL_DATASET_REQUIRED")
+        .ok()
+        .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on"))
+}
+
 /// Squared L2 distance (order-preserving — fine for ranking).
 fn l2_sq(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
@@ -131,8 +140,47 @@ fn brute_force_topk(base: &[Vec<f32>], query: &[f32], k: usize) -> Vec<String> {
         .enumerate()
         .map(|(i, v)| (i, l2_sq(query, v)))
         .collect();
-    sims.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    sims.iter().take(k).map(|(i, _)| format!("v{i}")).collect()
+    if sims.len() > k {
+        sims.select_nth_unstable_by(k, |a, b| a.1.total_cmp(&b.1));
+        sims.truncate(k);
+    }
+    sims.into_iter().map(|(i, _)| format!("v{i}")).collect()
+}
+
+/// Build exact top-k sets for a prefix subset without doing a full sort per
+/// query. SIFT's provided top-100 row is still exact after filtering to ids in
+/// the subset whenever it contains at least `TOP_K` such ids. The remaining
+/// rows fall back to a parallel brute-force linear selection.
+fn exact_ground_truth(
+    base: &[Vec<f32>],
+    queries: &[Vec<f32>],
+    gt_path: Option<&Path>,
+) -> (Vec<std::collections::HashSet<String>>, usize) {
+    let provided = gt_path
+        .filter(|path| path.exists())
+        .map(|path| read_vec_records_u32(path, Some(queries.len())).expect("read gt"))
+        .unwrap_or_default();
+    let fallback_count = AtomicUsize::new(0);
+    let result = queries
+        .par_iter()
+        .enumerate()
+        .map(|(qi, query)| {
+            if let Some(row) = provided.get(qi) {
+                let filtered: Vec<u32> = row
+                    .iter()
+                    .copied()
+                    .filter(|id| (*id as usize) < base.len())
+                    .take(TOP_K)
+                    .collect();
+                if filtered.len() == TOP_K {
+                    return filtered.into_iter().map(vid).collect();
+                }
+            }
+            fallback_count.fetch_add(1, Ordering::Relaxed);
+            brute_force_topk(base, query, TOP_K).into_iter().collect()
+        })
+        .collect();
+    (result, fallback_count.load(Ordering::Relaxed))
 }
 
 fn vid(i: u32) -> String {
@@ -240,6 +288,10 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     let base_path = match dataset_path("sift_base.fvecs") {
         Some(p) => p,
         None => {
+            assert!(
+                !dataset_required(),
+                "PROXIMADB_SIFT_DATASET_DIR is required by this recall gate"
+            );
             eprintln!(
                 "skip: PROXIMADB_SIFT_DATASET_DIR unset — SIFT1M ratchet needs the TEXMEX corpus"
             );
@@ -247,6 +299,10 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
         }
     };
     if !base_path.exists() {
+        assert!(
+            !dataset_required(),
+            "required SIFT dataset is missing: {base_path:?}"
+        );
         eprintln!("skip: {base_path:?} not found — download SIFT1M (.fvecs) to enable");
         return;
     }
@@ -297,6 +353,12 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
 
     // --- Load queries -----------------------------------------------------------------
     let query_path = dataset_path("sift_query.fvecs");
+    if dataset_required() {
+        assert!(
+            query_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT query corpus is missing: {query_path:?}"
+        );
+    }
     let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
         Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
         None => {
@@ -307,22 +369,19 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     };
     let qcount = queries.len();
 
-    // --- Ground truth: provided (.ivecs) for full 1M, brute-force for subsets ---------
+    // --- Ground truth: filtered provided top-100 plus exact subset fallback ------------
     let gt_path = dataset_path("sift_groundtruth.ivecs");
-    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
-    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
-        eprintln!("using provided sift_groundtruth.ivecs (full 1M)");
-        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
-        gt.into_iter()
-            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
-            .collect()
-    } else {
-        eprintln!("computing brute-force L2 ground truth over the {n}-vector subset");
-        queries
-            .iter()
-            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
-            .collect()
-    };
+    if dataset_required() {
+        assert!(
+            gt_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT ground-truth corpus is missing: {gt_path:?}"
+        );
+    }
+    let (ground_truth, brute_force_rows) = exact_ground_truth(&base, &queries, gt_path.as_deref());
+    eprintln!(
+        "ground truth rows={qcount}: provided/filterable={}, brute-force={brute_force_rows}",
+        qcount - brute_force_rows
+    );
     // base no longer needed for GT in the provided-GT path; drop to free memory
     // before the query loop on the 1M run.
     drop(base);
@@ -345,12 +404,8 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     assert!(measured > 0, "no queries succeeded — cannot report recall");
     let recall = recall_sum / measured as f64;
     eprintln!(
-        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, floor={floor}); {}",
-        if use_provided_gt {
-            "provided-GT"
-        } else {
-            "brute-force-GT"
-        }
+        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} over {measured} queries \
+         (N={n}, floor={floor}, brute-force-GT rows={brute_force_rows})",
     );
     assert!(
         recall >= floor,
@@ -385,6 +440,10 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
     let base_path = match dataset_path("sift_base.fvecs") {
         Some(p) if p.exists() => p,
         _ => {
+            assert!(
+                !dataset_required(),
+                "SIFT1M corpus is required by the VOE promotion gate"
+            );
             eprintln!(
                 "skip: PROXIMADB_SIFT_DATASET_DIR unset/missing — centroid-prune ratchet needs SIFT1M"
             );
@@ -402,13 +461,19 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
         .unwrap_or(DEFAULT_QUERIES);
-    // Pruned recall floor: separate + conservative (pruning + coarse clustering
-    // trims recall vs the unpruned 0.90 baseline). CI measures and ratchets it UP.
+    // Keep an absolute floor as a secondary sanity check. The promotion decision
+    // is the same-run differential below; an absolute 0.70 floor allowed severe
+    // regressions whenever the unpruned path happened to be much better.
     let floor: f64 = std::env::var("PROXIMADB_SIFT_CENTROID_RECALL_FLOOR")
         .ok()
         .and_then(|v| v.parse::<f64>().ok())
         .filter(|f| (0.0..=1.0).contains(f))
-        .unwrap_or(0.70);
+        .unwrap_or(0.90);
+    let max_recall_drop: f64 = std::env::var("PROXIMADB_SIFT_CENTROID_MAX_RECALL_DROP")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|f| (0.0..=1.0).contains(f))
+        .unwrap_or(0.0);
 
     let temp_dir = TempDir::new().unwrap();
     let collection = collection("sift_voe_centroid_prune", &temp_dir);
@@ -435,27 +500,58 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
     }
 
     let query_path = dataset_path("sift_query.fvecs");
+    if dataset_required() {
+        assert!(
+            query_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT query corpus is missing: {query_path:?}"
+        );
+    }
     let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
         Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
         None => base.iter().take(max_queries.min(n)).cloned().collect(),
     };
     let qcount = queries.len();
     let gt_path = dataset_path("sift_groundtruth.ivecs");
-    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
-    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
-        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
-        gt.into_iter()
-            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
-            .collect()
-    } else {
-        queries
-            .iter()
-            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
-            .collect()
-    };
+    if dataset_required() {
+        assert!(
+            gt_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT ground-truth corpus is missing: {gt_path:?}"
+        );
+    }
+    let (ground_truth, brute_force_rows) = exact_ground_truth(&base, &queries, gt_path.as_deref());
+    eprintln!(
+        "VOE ground truth rows={qcount}: provided/filterable={}, brute-force={brute_force_rows}",
+        qcount - brute_force_rows
+    );
     drop(base);
 
-    // Run the whole search loop inside ONE io_trace scope so the centroid-prune
+    // Measure the unpruned production path on the exact same flushed segments,
+    // query set, and ground truth. This makes the gate a differential rather
+    // than an absolute floor that can pass despite a large recall loss.
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_CENTROID_PRUNE");
+    }
+    let mut baseline_sum = 0.0f64;
+    let mut baseline_measured = 0usize;
+    for (qi, query) in queries.iter().enumerate() {
+        let got = search_topk(&engine, &collection, query.clone()).await;
+        if got.is_empty() {
+            continue;
+        }
+        let got_ids: std::collections::HashSet<String> = got.into_iter().take(TOP_K).collect();
+        baseline_sum += got_ids.intersection(&ground_truth[qi]).count() as f64 / TOP_K as f64;
+        baseline_measured += 1;
+    }
+    assert!(
+        baseline_measured > 0,
+        "unpruned baseline returned no results"
+    );
+    let baseline_recall = baseline_sum / baseline_measured as f64;
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+    }
+
+    // Run the pruned search loop inside ONE io_trace scope so the centroid-prune
     // counter accumulates across queries; the snapshot proves the prune engaged.
     let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
         let mut recall_sum = 0.0f64;
@@ -482,8 +578,9 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
 
     assert!(measured > 0, "no queries succeeded — cannot report recall");
     eprintln!(
-        "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, \
-         floor={floor}); centroid blocks total={} pruned={}",
+        "SIFT VOE recall@{TOP_K}: unpruned={baseline_recall:.4}, pruned={recall:.4} over \
+         {measured} queries (N={n}, floor={floor}, max_drop={max_recall_drop}); centroid \
+         blocks total={} pruned={}",
         snap.centroid_total_blocks, snap.centroid_pruned_blocks
     );
     // (a) The prune MUST have engaged — a silent full-scan fallback leaves this 0.
@@ -499,6 +596,12 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
         "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} < {floor} floor (N={n}) — \
          default-ON flip BLOCKED until the clustering/nprobe is tuned \
          (PROXIMADB_PAX_CENTROID_PRUNE_RATIO / S4 IVF clustering)"
+    );
+    assert!(
+        recall + max_recall_drop >= baseline_recall,
+        "SIFT VOE centroid-prune recall regressed from same-run unpruned \
+         {baseline_recall:.4} to {recall:.4} (allowed drop {max_recall_drop:.4}, N={n}) — \
+         default-ON flip remains blocked"
     );
 }
 

--- a/tests/sst_voe_centroid_prune_e2e.rs
+++ b/tests/sst_voe_centroid_prune_e2e.rs
@@ -12,9 +12,9 @@
 //! compare silently missed and the prune fell back to a full scan (`centroid_
 //! pruned_blocks = 0`). The read now matches by filename basename.
 //!
-//! Synthetic corpus (no SIFT dataset) so it runs in NORMAL CI — the storage
-//! integration job globs `tests/*sst*.rs` (hence this file's name). nextest /
-//! `--test-threads=1` isolates the process, so the env opt-ins below don't leak.
+//! A 768-dimensional, multi-flush corpus runs in normal CI. It is not a substitute
+//! for the required real-dataset gate, but it catches dimensional and segment-churn
+//! regressions between those heavier runs.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -32,7 +32,7 @@ use proximadb::storage::traits::{
 };
 use tempfile::TempDir;
 
-const DIM: usize = 32;
+const DIM: usize = 768;
 const TOP_K: usize = 10;
 
 fn collection(id: &str, temp: &TempDir) -> Collection {
@@ -136,7 +136,7 @@ async fn voe_centroid_block_prune_engages_e2e() {
         std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS", "2"); // force on small seg
         // Small target block ⇒ many blocks from few vectors, so the prune has
         // blocks to skip (needs ≥ MIN_BLOCKS to engage).
-        std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", "16384");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", "4096");
     }
     let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
 
@@ -147,8 +147,10 @@ async fn voe_centroid_block_prune_engages_e2e() {
         .unwrap()
         .with_directory_cache(Arc::new(VectorObjectEconomyDirectoryCache::new()));
 
-    // Well-separated synthetic corpus, enough for many blocks at the small target.
-    let n: u32 = 400;
+    // Production-dimensional structured corpus, enough for many blocks at the
+    // small target. Four flush generations exercise directory accumulation and
+    // the multi-segment read shape that exposed the measured churn regression.
+    let n: u32 = 80;
     let corpus: Vec<Vec<f32>> = (0..n)
         .map(|i| {
             (0..DIM)
@@ -156,23 +158,42 @@ async fn voe_centroid_block_prune_engages_e2e() {
                 .collect()
         })
         .collect();
-    let batch: Vec<VectorRecord> = corpus
-        .iter()
-        .enumerate()
-        .map(|(i, v)| vrec(i as u32, v.clone()))
-        .collect();
-    flush_batch(&engine, &coll, batch).await;
+    for (generation, chunk) in corpus.chunks(20).enumerate() {
+        let batch: Vec<VectorRecord> = chunk
+            .iter()
+            .enumerate()
+            .map(|(i, v)| vrec((generation * 20 + i) as u32, v.clone()))
+            .collect();
+        flush_batch(&engine, &coll, batch).await;
+    }
 
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_CENTROID_PRUNE");
+    }
+    let query_indices = [7usize, 23, 49, 79];
+    let mut baseline = Vec::new();
+    for &i in &query_indices {
+        baseline.push(search_topk(&engine, &coll, corpus[i].clone()).await);
+    }
+
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+    }
     // Search inside an io_trace scope so the centroid-prune counter is observable.
-    let query = corpus[137].clone();
-    let (got, snap) = io_trace::scope(async {
-        let r = search_topk(&engine, &coll, query).await;
+    let (pruned, snap) = io_trace::scope(async {
+        let mut results = Vec::new();
+        for &i in &query_indices {
+            results.push(search_topk(&engine, &coll, corpus[i].clone()).await);
+        }
         let s = io_trace::snapshot().expect("io_trace scope active");
-        (r, s)
+        (results, s)
     })
     .await;
 
-    assert!(!got.is_empty(), "search returned results");
+    assert!(
+        pruned.iter().all(|got| !got.is_empty()),
+        "search returned results"
+    );
     assert!(
         snap.centroid_pruned_blocks > 0,
         "centroid BLOCK prune must ENGAGE (flush→emit→read round-trip) — got total={} pruned={} \
@@ -180,5 +201,9 @@ async fn voe_centroid_block_prune_engages_e2e() {
          emit `object_url` vs read `sstable_path` file match must be basename-based, not exact-URL).",
         snap.centroid_total_blocks,
         snap.centroid_pruned_blocks
+    );
+    assert_eq!(
+        pruned, baseline,
+        "768D multi-flush VOE results must not regress against the same-run unpruned path"
     );
 }


### PR DESCRIPTION
## Summary

Makes promotion evidence fail closed and corrects the evidence record identified in the independent 2026-07-14 review:

- require real SIFT data in the QA promotion gate and compare pruned recall against a same-run unpruned baseline
- keep VOE centroid pruning dark while the real SIFT result regresses
- add a production-dimensional churn ratchet and feature-matrix CI for move PRs
- exclude DuckDB from live cost overrides until I/O quantities are comparable and strengthen value-level parity
- correct ADR-059 attribution for the WAL table-open scan removal
- add TD header/body consistency checking and normalize stale TD statuses
- add move-PR behavioral inventory requirements

This is stack 3 of 3 and is based on the durability/fencing branch.

## Measured evidence

Real SIFT1M subset, N=100000 and 1000 queries:

- ordinary PAX cascade recall@10: 0.9892
- VOE unpruned recall@10: 0.9891
- VOE pruned recall@10: 0.8087

The QA promotion ratchet intentionally fails on the current pruning algorithm, blocking a default-ON flip until recall is non-regressive.

## Validation

- stacked `cargo check --lib`
- `cargo check --lib --features experimental-engines`
- `cargo check -p proximadb --no-default-features --lib`
- DuckDB pgwire value-parity test
- real SIFT dataset-required release ratchet
- VOE production-dimension multi-flush test
- TD consistency checker, formatting, and diff hygiene

## Dependency and merge order

#981 is merged. This PR now depends on replacement durability PR #988; merge #988 first, then retarget this PR to `develop` if GitHub does not do so automatically.
