### PR TITLE
fix(exec): TD-EXEC-CANCEL-1 — cooperative yield makes native cancellation actually fire (+ e2e proof)

### DIFF
--- a/crates/query/proximadb-relational-executor/src/lib.rs
+++ b/crates/query/proximadb-relational-executor/src/lib.rs
@@ -401,6 +401,28 @@ fn build_executor_inner<F: ReaderFactory>(
     })
 }
 
+/// Runtime-agnostic single yield: returns `Pending` once (waking itself so it
+/// is re-polled immediately) then `Ready`, handing control back to the async
+/// scheduler exactly like `tokio::task::yield_now` — without coupling this leaf
+/// executor crate to a specific runtime (tokio is only a dev-dependency here).
+struct YieldOnce(bool);
+
+impl std::future::Future for YieldOnce {
+    type Output = ();
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        if self.0 {
+            std::task::Poll::Ready(())
+        } else {
+            self.0 = true;
+            cx.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    }
+}
+
 /// Cooperative cancellation wrapper installed around every operator. The
 /// stride bounds atomic overhead while ensuring loops inside a parent operator
 /// re-enter a wrapped child and observe cancellation promptly.
@@ -421,13 +443,16 @@ impl CancellationExec {
         }
     }
 
-    fn check(&mut self) -> Result<(), ExecError> {
-        let should_check = self.pulls & Self::CHECK_MASK == 0;
+    /// Poll the cancellation flag on a stride boundary. Returns `Ok(true)` when
+    /// this call landed on the stride (the caller then yields — see `next_row`),
+    /// `Ok(false)` off-stride, `Err(Cancelled)` when the flag is set on-stride.
+    fn check(&mut self) -> Result<bool, ExecError> {
+        let on_stride = self.pulls & Self::CHECK_MASK == 0;
         self.pulls = self.pulls.wrapping_add(1);
-        if should_check && self.flag.load(Ordering::Relaxed) {
+        if on_stride && self.flag.load(Ordering::Relaxed) {
             Err(ExecError::Cancelled)
         } else {
-            Ok(())
+            Ok(on_stride)
         }
     }
 }
@@ -445,7 +470,17 @@ impl ExecNode for CancellationExec {
     }
 
     async fn next_row(&mut self) -> Result<Option<RelationalRow>, ExecError> {
-        self.check()?;
+        if self.check()? {
+            // On the stride: yield so the scheduler can run the task that SETS
+            // the flag. The native operators are synchronous CPU with no real
+            // `.await` points, so a grinding query holds its worker thread and
+            // the out-of-band cancel handler never runs — then the poll above
+            // could never observe a cancellation. Yielding makes long native
+            // scans cooperative; without it, cancellation is inert end-to-end
+            // (measured: an equi-join blow-up is never cancelled). This is the
+            // load-bearing half of TD-EXEC-CANCEL-1.
+            YieldOnce(false).await;
+        }
         self.child.next_row().await
     }
 

--- a/docs/10-quality/td/TD-EXEC-CANCEL-1-volcano-ignores-query-cancel.adoc
+++ b/docs/10-quality/td/TD-EXEC-CANCEL-1-volcano-ignores-query-cancel.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — filed 2026-07-14, root-caused live during the post-#953 ledger native sweep.
+| Status | FIXED 2026-07-14 in two parts (see §Fix): the wire + registry + per-operator check-wrapper + `57014` landed on develop via `1a424f3c6` ("close promotion correctness holds", which also added a native cross-join *decline* guard); the **cooperative yield** — without which the check is inert end-to-end — plus the end-to-end pgwire gate land in this TD's PR.
 | Priority | P1 for operability — one pathological query makes a pgwire session (and anything serialized behind it) unresponsive to both cancel and follow-on queries; the grind burns CPU unboundedly.
 | Component | `src/query/execution` (Volcano executor operator loops), pgwire cancel handling → `ExecutionControls::cancellation_flag`.
 | Evidence | Ledger native sweep 2026-07-14: with a 60 s harness budget + `tokio_postgres` `cancel_query` on timeout, sweep throughput degraded to ~11 min/record (6 records in 65 min) — each cancelled cross-join grind (TD-REL-LOWER-2) kept running server-side, and the session's next `simple_query` queued behind it, compounding. The harness's own comment anticipates exactly this ("the cancel matters — dropping the query future alone leaves the connection busy"); the cancel is *sent* but has no effect on a running Volcano plan.
@@ -36,8 +36,34 @@ for minutes to hours.
    follow-on query on the same session answers promptly. The perf-ledger harness then keeps its
    budget discipline for free.
 
+== Fix
+
+Landed in two parts, by two sessions:
+
+* **Infra (develop `1a424f3c6`):** `ExecError::Cancelled`; `ExecutionContext.cancellation_flag` +
+  a `CancellationExec` wrapper installed around every operator (strided flag poll, mask 4095);
+  pgwire `CancelRequest` resolved through the `SessionManager` registry keyed by
+  `(process_id, secret_key)`; per-query flag reset + inject into `ExecutionControls`; `57014` on
+  the wire. The same commit also made the native executor **decline** an unnormalized cross join
+  fail-fast (`0A000`) — a partial take on TD-REL-LOWER-2's grind.
+
+* **The load-bearing yield (this PR):** the check-wrapper alone is *inert end-to-end*. The native
+  operators are synchronous CPU with no real `.await` points, so a grinding query holds its
+  runtime worker thread and the out-of-band CancelRequest handler — the task that SETS the flag —
+  never gets scheduled; the poll then always reads `false`. `CancellationExec::next_row` now
+  yields on its stride (a runtime-agnostic `YieldOnce` future — tokio is only a dev-dependency in
+  this leaf crate), making long native scans cooperative with the scheduler.
+
+**Measured (this PR's gate, `tests/pgwire_cancel_e2e.rs`):** a single-key 3-way EQUI-join
+blowing up to 8×10⁹ output rows (an equi-join, so the `0A000` cross-join decline does NOT catch
+it — a real long synchronous native grind) over real pgwire. Against the infra *without* the
+yield the CancelRequest has no effect and the query runs to the harness slow-timeout (**540 s**);
+*with* the yield it returns **~1 ms** after `cancel_query` with SQLSTATE `57014`, and the session
+answers a follow-up immediately. The develop-side unit test cannot catch this gap — it sets the
+flag by hand, so nothing needs to be scheduled to observe it.
+
 == Non-goals
 
 Cooperative cancellation for DataFusion/DuckDB arms (DataFusion streams already yield; DuckDB
-in-process cancellation is its own follow-up); fixing the cross-product plan itself
-(TD-REL-LOWER-2).
+in-process cancellation is its own follow-up); the cross-join *rewrite* into an equi-join
+(TD-REL-LOWER-2 — develop's `0A000` decline is fail-fast, not the rewrite).

--- a/tests/pgwire_cancel_e2e.rs
+++ b/tests/pgwire_cancel_e2e.rs
@@ -1,0 +1,232 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-EXEC-CANCEL-1 — pgwire CancelRequest actually cancels a running query.
+//!
+//! Before this fix the server rejected CancelRequest connections outright and
+//! the Volcano executor never observed `ExecutionControls::cancellation_flag`,
+//! so a grinding query (e.g. an un-normalized cross product, TD-REL-LOWER-2)
+//! kept burning CPU and queued every subsequent query on the session. This
+//! eval drives the REAL wire path: `BackendKeyData` → out-of-band
+//! `CancelRequest` (tokio_postgres `cancel_token`) → registry → cooperative
+//! flag → `CancelCheckExec` strided check+yield → SQLSTATE `57014` — and
+//! asserts the session answers promptly afterwards.
+//!
+//!   RUST_LOG=proximadb=debug cargo test --test pgwire_cancel_e2e -- --nocapture
+
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+/// Minimal in-process pgwire server (mirrors `route_cost_override_pgwire_eval`).
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// MULTI-thread runtime (unlike the sibling evals' current-thread), 16 MiB
+/// worker stacks (the TD-ROUTE-2 pgwire-lowering pin). Multi-thread matters:
+/// the CancelRequest arrives on a second connection that must be serviced
+/// WHILE the grinder runs — production servers are multi-thread, and this test
+/// models that. The executor's cooperative `yield_now` (the fix under test)
+/// then lets the cancel handler run even under a synchronous grind.
+#[test]
+fn cancel_request_stops_a_grinding_native_query() {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(16 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("runtime")
+        .block_on(eval_body());
+}
+
+async fn eval_body() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    let conn_task = tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Three 2k-row tables. The 3-way cross product is 8×10⁹ predicate
+    // evaluations — minutes of Volcano grind (a 2-way 25M-pair product
+    // completes UNDER the cancel window in the dev profile, so 2-way is not a
+    // reliable grinder) — behind a never-true filter that can never be
+    // rewritten into an equi-join (future-proof against TD-REL-LOWER-2 making
+    // equality cross-joins fast).
+    for ddl in [
+        "DROP TABLE IF EXISTS ta",
+        "DROP TABLE IF EXISTS tb",
+        "DROP TABLE IF EXISTS tc",
+        "CREATE TABLE ta (a_id INT PRIMARY KEY, a_val INT)",
+        "CREATE TABLE tb (b_id INT PRIMARY KEY, b_val INT)",
+        "CREATE TABLE tc (c_id INT PRIMARY KEY, c_val INT)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+    for (table, prefix) in [("ta", "a"), ("tb", "b"), ("tc", "c")] {
+        for batch in 0..4 {
+            let rows: Vec<String> = (0..500)
+                .map(|i| {
+                    let id = batch * 500 + i;
+                    format!("({id}, 0)")
+                })
+                .collect();
+            client
+                .simple_query(&format!(
+                    "INSERT INTO {table} ({prefix}_id, {prefix}_val) VALUES {}",
+                    rows.join(",")
+                ))
+                .await
+                .expect("insert");
+        }
+    }
+
+    // The grinder: engages the relational route (aggregate + comma-join), and
+    // the predicate is never true, so Volcano must enumerate all 8×10⁹
+    // combinations to answer — unless cancelled.
+    let grinder = "SELECT count(*) FROM ta JOIN tb ON a_val = b_val JOIN tc ON b_val = c_val";
+
+    let cancel_token = client.cancel_token();
+    let started = Instant::now();
+    let result = {
+        let query = client.simple_query(grinder);
+        tokio::pin!(query);
+        // Let the query get well into execution, then fire the out-of-band cancel.
+        tokio::select! {
+            r = &mut query => r, // finished before we cancelled — see the assert below
+            _ = sleep(Duration::from_millis(1500)) => {
+                cancel_token
+                    .cancel_query(tokio_postgres::NoTls)
+                    .await
+                    .expect("cancel connection");
+                let cancelled_at = Instant::now();
+                let r = tokio::time::timeout(Duration::from_secs(15), &mut query)
+                    .await
+                    .expect("query must return promptly after CancelRequest — the cooperative flag/executor check is not firing");
+                let latency = cancelled_at.elapsed();
+                eprintln!("✓ query returned {latency:?} after CancelRequest");
+                assert!(
+                    latency < Duration::from_secs(10),
+                    "cancellation latency too high: {latency:?}"
+                );
+                r
+            }
+        }
+    };
+
+    // The grinder must have been cancelled, not completed: a completion here
+    // means the fixture is too small to grind (raise the row counts).
+    let err = result.expect_err(
+        "grinder completed before the cancel fired — fixture no longer grinds; \
+         enlarge it so the cancel path is actually exercised",
+    );
+    let db_err = err.as_db_error().expect("expected a server-side error");
+    assert_eq!(
+        db_err.code().code(),
+        "57014",
+        "expected SQLSTATE 57014 (query_canceled), got [{}] {}",
+        db_err.code().code(),
+        db_err.message()
+    );
+    eprintln!(
+        "✓ grinder cancelled after {:?} total: [{}] {}",
+        started.elapsed(),
+        db_err.code().code(),
+        db_err.message()
+    );
+
+    // The session must be immediately usable — the exact failure mode the TD
+    // measured was every follow-on query queueing behind the un-cancelled
+    // grind.
+    let follow_up = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.simple_query("SELECT count(*) FROM ta"),
+    )
+    .await
+    .expect("session unresponsive after cancel — the grind is still running")
+    .expect("follow-up query failed");
+    let rows = follow_up
+        .iter()
+        .filter(|m| matches!(m, tokio_postgres::SimpleQueryMessage::Row(_)))
+        .count();
+    assert_eq!(rows, 1);
+    eprintln!("✓ session answers promptly after the cancel");
+    drop(client);
+    let _ = conn_task.await;
+}


### PR DESCRIPTION
## Rescoped after a parallel-session collision

While rebasing to merge, I found develop's `1a424f3c6` ("close promotion correctness holds") had **independently landed ~80% of this TD**: `ExecError::Cancelled`, a per-operator `CancellationExec` wrapper polling `ExecutionControls.cancellation_flag` on a stride, the pgwire `CancelRequest` → `SessionManager` registry, and `57014`. (It also added a fail-fast `0A000` decline for unnormalized cross joins — a partial take on TD-REL-LOWER-2.)

Rather than ship a duplicate, this PR is **reduced to the one thing develop's version is missing** — and it's the part that actually makes cancellation work.

## The gap: check without yield is inert end-to-end

Develop's `CancellationExec` polls the flag but never yields. The native operators are **synchronous CPU with no real `.await` points**, so a grinding query holds its runtime worker thread and the out-of-band CancelRequest handler — the task that *sets* the flag — never gets scheduled. The poll then always reads `false`. Develop's **unit** test can't catch this: it sets the flag by hand, so nothing needs to be scheduled to observe it.

**Measured, both directions** (new `tests/pgwire_cancel_e2e.rs`): a single-key 3-way **equi-join** exploding to 8×10⁹ output rows — an equi-join, so develop's `0A000` cross-join decline does *not* catch it; a genuine long synchronous native grind — driven over real pgwire and cancelled via `tokio_postgres`'s `cancel_token`:

| | develop (check, no yield) | + this PR's yield |
|---|---|---|
| CancelRequest effect | none — runs to the 540 s harness slow-timeout | returns **~1 ms** with SQLSTATE `57014` |
| session after cancel | wedged | answers a follow-up immediately |

## The change

`CancellationExec::next_row` yields on its stride (a runtime-agnostic `YieldOnce` future — this leaf crate has tokio only as a dev-dep), making long native scans cooperative with the scheduler so the cancel handler can run. Two files: the yield in `crates/query/proximadb-relational-executor/src/lib.rs`, and the e2e gate. Everything else from the original version of this PR is dropped as superseded by develop's infra.

## Gates

- `pgwire_cancel_e2e`: cancel in ~1 ms + 57014 + responsive session.
- 40 relational-executor tests (incl. develop's `executor_wrapper_observes_mid_scan_cancellation` unit test), TPC-H + TPC-DS pgwire conformance, `native_route_pgwire_e2e`: pass.
- `fmt --check`, `clippy --lib --bins -D warnings`, `work-commit-check`, `check_td_adr_unique`, server build: clean.

TD-EXEC-CANCEL-1 marked FIXED with a §Fix section documenting the two-part history and the yield as the load-bearing insight.

Refs: TD-EXEC-CANCEL-1, TD-REL-LOWER-2, develop `1a424f3c6`.