### PR TITLE
ci(qa-gate): add sccache to compile jobs (fix #980 emulator timeout)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -78,6 +78,8 @@ jobs:
       # 8MB worker stack: correlated subqueries + recall ratchets produce
       # deep-but-finite async call chains that overflow the default ~2MB.
       RUST_MIN_STACK: "8388608"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -88,6 +90,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-qa-integration"
+      # sccache complements rust-cache: content-addressed per-rustc-invocation, so
+      # it hits even when the target/ artifact cache misses (Cargo.lock churn).
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: sccache-${{ runner.os }}-
       - name: Build all integration test binaries (once)
         env:
           CARGO_BUILD_JOBS: "4"
@@ -199,9 +209,15 @@ jobs:
     # The --all scope compiles the full main crate under CARGO_BUILD_JOBS=2 (see
     # scripts/run_cloud_emulator_tests.sh) — a middle ground that stays off the 16GB
     # runner's OOM cliff while halving the old jobs=1 ~35-40m serialized compile that
-    # grew past this budget and got cancelled mid-build (#882). 60m (1h) leaves ample
-    # headroom for the ~20m parallel compile + emulator round-trips.
-    timeout-minutes: 60
+    # grew past this budget and got cancelled mid-build (#882). sccache (below)
+    # covers the COLD compile that rust-cache misses when Cargo.lock churns (e.g. a
+    # promotion merge) — that cold ~35-40m compile + emulator round-trips pushed this
+    # job past the old 60m cap on #980. 90m leaves headroom for the first (cold) run
+    # while sccache warms; subsequent runs compile far less.
+    timeout-minutes: 90
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -212,6 +228,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-qa-cloud-emulator"
+      # sccache complements rust-cache: content-addressed per-rustc-invocation, so
+      # it hits even when the target/ artifact cache misses (Cargo.lock churn).
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: sccache-${{ runner.os }}-
       - name: Validate Cool tier against Azure/S3/GCS emulators
         # docker + aws/az CLIs are preinstalled on ubuntu-latest runners.
         run: bash scripts/run_cloud_emulator_tests.sh


### PR DESCRIPTION
## Problem
The `Cloud object-store emulators (Azurite/MinIO/fake-gcs)` qa-gate job timed out at the 60-min cap on the #980 develop→qa promotion.

## Root cause
The qa-gate compile jobs used `Swatinem/rust-cache` but **no `sccache`**. `rust-cache` keys on `Cargo.lock`, so the promotion's large lockfile churn **missed the cache → full cold main-crate compile (~35–40m)** + emulator round-trips **> 60m → timeout**. The ci.yml `rust-compile` job already uses `sccache` for exactly this reason — it's content-addressed *per rustc invocation*, so it hits even when the whole-`target/` artifact cache misses.

## Fix
Mirror ci.yml's proven sccache wiring (`mozilla-actions/sccache-action@v0.0.10` + `RUSTC_WRAPPER=sccache` + an `actions/cache` for `SCCACHE_DIR`) onto the two **always-on** qa-gate compile jobs that build the full monolith:
- `cloud-emulator-object-store` (the failure) — also `timeout-minutes: 60 → 90` for headroom while sccache warms on the first run.
- `pgwire-recall-tests` (same cold-compile risk; compiles many test binaries on every qa PR).

## Evaluation of the alternatives
- **Increase timeout only** — band-aid; burns ~40m of runner time on every cold compile.
- **Decompose** — doesn't help: the bottleneck is the *compile*, and every shard recompiles the monolith.
- **sccache** ✅ — the real fix. Note: requires `CARGO_INCREMENTAL=0` (already the repo default) — incremental is redundant on clean CI checkouts and *reduces* sccache hit rates.

## Scope left as-is (noted for follow-up)
- `sift-pax-recall` — `workflow_dispatch`-only (rare; 120m budget).
- `rust-coverage-ratchet` — `continue-on-error` (non-blocking); sccache+llvm-cov interaction deferred.

YAML validated; CI-only change (no Rust). Once this lands on develop it flows to qa on the next promotion, after which the emulator job should stay well under budget even on cold compiles.