### PR TITLE
docs(td): TD-RAPTOR-GPU-1 — track dormant GPU RAPTOR P² path after matrix_builder extraction

### DIFF
--- a/docs/10-quality/td/TD-RAPTOR-GPU-1-raptor-p2-gpu-dormant-after-extraction.adoc
+++ b/docs/10-quality/td/TD-RAPTOR-GPU-1-raptor-p2-gpu-dormant-after-extraction.adoc
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RAPTOR-GPU-1: GPU-accelerated RAPTOR P² matrix building dormant after crate extraction
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — accepted regression from the `matrix_builder` extraction (#985, develop 2026-07-14). No compile impact; the `gpu` feature is not in the CI feature matrix.
+| Severity | Low — experimental, opt-in (`gpu` feature), not exercised by any CI suite or default config. Affects only root builds with `-F gpu` doing RAPTOR writes.
+| Component | `crates/storage/proximadb-raptor-engine/src/matrix_builder.rs` (was `src/storage/engines/raptor/matrix_builder.rs`); root-coupled type `crate::compute::gpu::distance::GpuDistanceCompute`.
+| Tracked-by | link:../../12-design/ROOT_CRATE_DECOMPOSITION_ENGINES_EXTRACTION_2026_07_12.adoc[Engines Extraction] (#985); the 4-slice writer extraction (#977 DI + #985 move).
+| Pillar | PERF (GPU acceleration), DECOMP (extraction correctness)
+|===
+
+toc::[]
+
+== Context
+
+The RAPTOR `matrix_builder` builds the Matrix-Trinity P² matrix (intra-rowgroup
+pairwise distances). On macOS-with-Metal it could accelerate the N×N distance
+dispatch via Metal Performance Shaders (`GpuDistanceCompute`). This path was
+gated behind `#[cfg(feature = "gpu")]` and used the **root-local**
+`crate::compute::gpu::distance::GpuDistanceCompute`.
+
+When `matrix_builder` was hoisted out of the root crate into the
+`proximadb-raptor-engine` crate (#985, slice 4 of the writer extraction), the
+GPU path could not move with it: `crate::compute::gpu` is root-local and the
+`proximadb-raptor-engine` crate has no GPU-compute dependency. The cfg-gated
+blocks are retained in the crate but are **always-false** there — the crate
+declares no `gpu` feature and silences `unexpected_cfgs` crate-wide (with a note
+in `Cargo.toml` `[features]` and `lib.rs`). Root's `gpu` feature does not unify
+`proximadb-raptor-engine/gpu`, so the blocks never compile.
+
+== Symptom / impact
+
+A root build with `-F gpu` (e.g. on Apple Silicon for GPU P² acceleration) uses
+the crate's `matrix_builder`, which now runs only the CPU-SIMD P² path.
+GPU-accelerated RAPTOR P² matrix building — previously available — is **no
+longer reachable**. There is **no compile error** (the crate compiles with or
+without root `gpu`) and **no CI breakage** — the `gpu` feature is absent from
+the feature matrix, and the unit job passed at 27m with no OOM.
+
+== Root cause
+
+`GpuDistanceCompute` is defined in the root crate (`src/compute/gpu/`) and is
+not behind a portable port trait or a foundation/horizontal crate. Engine
+leaves extracted to crates cannot name it. The decomposition moved
+`matrix_builder` (and `writer`) out of the root for the build-OOM /
+`CARGO_BUILD_JOBS=2` goal; preserving the experimental GPU path was judged out
+of scope for that slice (it is unmeasured and not in CI).
+
+== Proposed approach (restoration)
+
+Pick one, roughly in order of cost:
+
+1. **GPU-compute port (preferred, smallest blast-radius).** Define a narrow
+   `GpuDistanceComputePort` in `proximadb-storage-ports` covering only the P²
+   dispatch surface `matrix_builder` uses. Root's `GpuDistanceCompute` impls it;
+   the composition root injects it (mirroring the axis / filesystem / quant
+   port-inversion done in #977). The crate holds
+   `Option<Arc<dyn GpuDistanceComputePort>>` and `gpu` becomes a real crate
+   feature gated on the port.
+2. **Hoist `crate::compute::gpu` to a `proximadb-gpu-compute` crate.** Heavier
+   (moves the whole GPU module + its `metal`/backend deps) but removes the
+   root-coupling at the source and lets the `gpu` feature unify naturally
+   (`gpu = [..., "proximadb-raptor-engine/gpu"]`).
+3. **Accept as permanent** (close this TD) if GPU RAPTOR P² is judged not worth
+   restoring — it is experimental, unmeasured, and the CPU-SIMD path remains
+   correct.
+
+Either (1) or (2) should ship **default-OFF** and round-trip / recall-gate the
+path (per the storage-format / storage-feature migration mandate) before
+flipping on.
+
+== Dependencies
+
+- Related: link:TD-OLAP-7-selective-gpu-olap-vector-fusion-wedge.adoc[TD-OLAP-7]
+  (the broader GPU / libcudf-FFI + fused ANN+filter+agg wedge) — a shared
+  gpu-compute port/crate would serve both.
+- Blocks nothing on the critical path; the writer extraction is complete and
+  green without it.
+
+== Verification notes
+
+Confirmed dormant in #985: the crate's `cargo check` (full-clean, authoritative)
+is green with and without root `-F gpu`; `matrix_builder`'s `gpu` cfg blocks are
+syntactically present but never compiled. See the crate `Cargo.toml`
+`[features]` note and `src/lib.rs` `#![allow(unexpected_cfgs)]`.


### PR DESCRIPTION
Files the follow-up TD flagged in #985: when `matrix_builder` moved to the `proximadb-raptor-engine` crate, its experimental Metal-MPS P² GPU path (`crate::compute::gpu`) could not move with it and is now dormant (always-false cfg; `gpu` not in the CI feature matrix; no compile/CI impact). The TD records the regression and three restoration options — (1) a `GpuDistanceComputePort` injection mirroring the #977 port-inversion, (2) hoisting `crate::compute::gpu` to a crate, or (3) accepting it as permanent.

Status: **Open / Low** (experimental, opt-in, unmeasured). Unique id (`td-adr-unique` guard: 0 errors). Doc-only; `work-commit-check` green.