### PR TITLE
fix: fence DDL and unsafe append paths

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,26 @@
 - [ ] Refactoring (no functional changes)
 - [ ] CI/CD improvement
 
+### Move / Decomposition Inventory
+
+<!-- Required when files or modules move. A move PR should contain only path/import
+changes. If behavior also changes, list every behavior change explicitly here or
+split it into a separate PR. -->
+
+- [ ] No files/modules moved
+- [ ] Pure move only (path/import changes; `git diff --find-renames` reviewed)
+- [ ] Move plus behavior change; complete behavioral inventory below
+
+Behavioral inventory (routing, defaults, cfg gates, service wiring, errors, persistence):
+
+- None
+
+Feature configurations exercised for a move:
+
+- [ ] Default
+- [ ] `--no-default-features`
+- [ ] `experimental-engines`
+
 ### Changes
 
 <!-- List the key changes made in this PR -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,11 +722,16 @@ jobs:
       matrix:
         include:
           # The two combos the published images actually ship (PR #78):
-          - { label: "cloud-full",          pkg: proximadb-server, feats: "cloud-full" }
-          - { label: "cloud-full,onnx",     pkg: proximadb-server, feats: "cloud-full,onnx" }
+          - { label: "cloud-full",          pkg: proximadb-server, args: "--features cloud-full" }
+          - { label: "cloud-full,onnx",     pkg: proximadb-server, args: "--features cloud-full,onnx" }
           # Other gated surfaces invisible to default CI:
-          - { label: "cluster",             pkg: proximadb,        feats: "cluster" }
-          - { label: "enterprise-catalogs", pkg: proximadb,        feats: "enterprise-catalogs" }
+          - { label: "cluster",             pkg: proximadb,        args: "--features cluster" }
+          - { label: "enterprise-catalogs", pkg: proximadb,        args: "--features enterprise-catalogs" }
+          # Refactor/move coverage: these configurations catch cfg drift hidden
+          # by the default build. Keep them in the same mandatory matrix rather
+          # than relying on a PR being correctly labelled as mechanical.
+          - { label: "no-default-features",  pkg: proximadb,        args: "--no-default-features" }
+          - { label: "experimental-engines", pkg: proximadb,        args: "--features experimental-engines" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -739,10 +744,10 @@ jobs:
         with:
           prefix-key: "v1-feature-matrix"
           shared-key: ${{ matrix.label }}
-      - name: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+      - name: cargo check -p ${{ matrix.pkg }} ${{ matrix.args }}
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-        run: cargo check -p ${{ matrix.pkg }} --features ${{ matrix.feats }}
+        run: cargo check -p ${{ matrix.pkg }} ${{ matrix.args }}
 
   rust-security:
     name: Security Audit
@@ -1118,6 +1123,8 @@ jobs:
       # merge. Convention: docs/12-design/HOW_TO_FILE_TD_AND_ADR.adoc.
       - name: Check TD/ADR id uniqueness
         run: python3 scripts/check_td_adr_unique.py
+      - name: Check resolved TD status/body consistency
+        run: python3 scripts/check_td_status_consistency.py
       - name: Check documentation links
         run: |
           echo "Checking for broken links in documentation..."

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -141,18 +141,17 @@ jobs:
       - name: Run TD-112 post-flush recall ratchet (TD-182 P0b)
         run: cargo test --test td112_postflush_recall_e2e recall -- --nocapture
 
-  # WS8: real-dataset PAX RaBitQ→SQ8 recall artifact. MANUAL ONLY
-  # (workflow_dispatch) — it downloads the SIFT1M corpus (~160 MB) and runs a
-  # heavy recall bench, so it is deliberately NOT in the always-on
-  # `pgwire-recall-tests` job (avoids 160 MB-download flakiness on every qa PR).
+  # WS8: real-dataset PAX RaBitQ→SQ8 recall artifact. Runs on promotion PRs and
+  # workflow_dispatch. It downloads the SIFT1M corpus (~525 MB) and runs a heavy
+  # release-mode recall gate, so it remains separate from normal PR CI.
   # Produces the dated recall@10 ≥ 0.90 artifact that GATES the PAX default-on
   # flip (Phase F): the existing `pax-recall-ratchet` is a synthetic DIM=64 CI
   # floor only (representativeness caveat in BENCHMARK_EVIDENCE.toml WS8). The
-  # ratchet self-skips when the corpus is absent, so a non-manual trigger would
-  # just skip — the `if:` keeps it from scheduling at all.
+  # Local runs may skip when the corpus is absent. This QA job sets
+  # PROXIMADB_RECALL_DATASET_REQUIRED=1, so a missing/corrupt corpus fails loud.
   sift-pax-recall:
     name: SIFT1M PAX RaBitQ recall ratchet (WS8)
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -186,13 +185,15 @@ jobs:
       - name: Build ratchet binary
         env:
           CARGO_BUILD_JOBS: "4"
-        run: cargo test --test sift_pax_recall_ratchet_test --no-run
+        run: cargo test --release --test sift_pax_recall_ratchet_test --no-run
       - name: Run SIFT PAX recall ratchet (N=${{ inputs.sift_n || '100000' }})
         env:
           PROXIMADB_SIFT_DATASET_DIR: /home/runner/sift1m
           PROXIMADB_SIFT_N: ${{ inputs.sift_n || '100000' }}
           PROXIMADB_SIFT_QUERIES: "1000"
-        run: cargo test --test sift_pax_recall_ratchet_test -- --nocapture
+          PROXIMADB_RECALL_DATASET_REQUIRED: "1"
+          PROXIMADB_SIFT_CENTROID_MAX_RECALL_DROP: "0"
+        run: cargo test --release --test sift_pax_recall_ratchet_test -- --nocapture
 
   # Validate the object-store access-tier cost lever (TD-168/TD-173) against REAL
   # cloud APIs via emulators — Azurite (Azure), MinIO (S3), fake-gcs (GCP) — the

--- a/crates/storage/proximadb-raptor-engine/src/writer.rs
+++ b/crates/storage/proximadb-raptor-engine/src/writer.rs
@@ -2608,6 +2608,14 @@ impl RaptorWriter {
         quantization_engine: Arc<dyn StorageQuantizationEnginePort>,
         axis_clustering: Arc<dyn AxisClusteringPort>,
     ) -> Result<Self> {
+        if !filesystem.supports_append() {
+            anyhow::bail!(
+                "RAPTOR requires durable append, but backend {} for {} does not support it",
+                filesystem.filesystem_type(),
+                file_path
+            );
+        }
+
         // Initialize hardware capabilities
         let hardware = get_hardware_capabilities();
 

--- a/crates/storage/proximadb-storage-encryption/src/filesystem.rs
+++ b/crates/storage/proximadb-storage-encryption/src/filesystem.rs
@@ -214,6 +214,10 @@ impl FileSystem for EncryptedFilesystem {
         self.write(path, &existing, None).await
     }
 
+    fn supports_append(&self) -> bool {
+        self.underlying.supports_append()
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let actual_path = self.actual_path(path);
         let mut deleted = false;

--- a/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
@@ -198,6 +198,9 @@ impl FileSystem for CountingFileSystem {
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
         self.inner.append(path, data).await
     }
+    fn supports_append(&self) -> bool {
+        self.inner.supports_append()
+    }
     async fn delete(&self, path: &str) -> FsResult<()> {
         self.inner.delete(path).await
     }

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -543,6 +543,15 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
     /// Append to file
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()>;
 
+    /// Whether this backend provides a native, durable append operation.
+    ///
+    /// Object stores intentionally leave this false. Callers whose on-disk
+    /// format requires append must reject the backend during construction,
+    /// before accepting data, rather than discovering the mismatch on flush.
+    fn supports_append(&self) -> bool {
+        false
+    }
+
     /// Delete file or directory
     async fn delete(&self, path: &str) -> FsResult<()>;
 

--- a/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
+++ b/docs/10-quality/td/TD-DOC-TENANT-1-document-structural-tenant-isolation.adoc
@@ -4,7 +4,7 @@
 
 [cols="1,3"]
 |===
-|Status|Core resolved (v2 gRPC scoped + auto-provision); REST-v2 store-split follow-on open
+|Status|In progress — v2 gRPC core resolved; pgwire/REST-v1 and entity follow-ons open
 |Priority|LOW
 |Scope|FEAT
 |Date|2026-07-05

--- a/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
+++ b/docs/10-quality/td/TD-GRAPH-TENANT-1-graph-collection-creation-scoping.adoc
@@ -4,7 +4,7 @@
 
 [cols="1,3"]
 |===
-|Status|Core resolved (lazy auto-provision); follow-ons open
+|Status|In progress — lazy auto-provision core resolved; create/list scoping follow-ons open
 |Priority|MED
 |Scope|FEAT
 |Date|2026-07-05

--- a/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
@@ -160,13 +160,23 @@ The bug class has two shapes:
   remaining refinements are tracked in TD-CAT-4. The catalog pointer is
   last-writer-wins (single-writer warehouse model) until CAS lands.
 
-| **RAPTOR/SWIFT writers use `FileSystem::append`**
-| Experimental engines (feature-gated `experimental-engines`, default-OFF) append to
-  segment files; object-store backends reject append. Same full-buffer-overwrite or
-  multipart strategy as the WAL fix when these engines graduate.
+| **RAPTOR writer format still requires append**
+| Contained: `FileSystem::supports_append` makes the backend capability explicit and
+  `RaptorWriter` rejects incompatible injected backends during construction. RAPTOR
+  remains feature-gated/default-OFF. A full-buffer-overwrite or multipart format is
+  still required before RAPTOR can support object stores.
 
-| **`queue_fs_adapter.rs` uses `append`**
-| Audit whether its queue paths can be object-store-configured; guard or convert.
+| **Queue root format still requires append**
+| Contained: `FactoryQueueFs::new` now rejects a root whose resolved backend does not
+  advertise durable append. Object-store archive targets remain independent, but an
+  object-store queue root is unsupported until the queue segment format becomes
+  immutable/replace-based.
+
+| **Filesystem trait retains the `append` method**
+| `supports_append` prevents capability-blind constructors, but the method remains on
+  the shared trait for local/HDFS compatibility. New append-dependent formats must
+  check the capability at construction; removing/splitting the method is a later
+  workspace-wide API migration.
 
 | **Alerting persistence object-store port**
 | `AlertPersistence` is a port; add an object-store-backed impl (layering: the
@@ -188,6 +198,11 @@ The bug class has two shapes:
   bases share); `join_storage_url` matrix over bare/file/s3/adls/abfs/gcs bases
   asserting **no `file://<scheme>://` and no `<scheme>://<scheme>://` ever**; audit
   logger scheme dispatch.
+* Construction ratchets: queue roots and RAPTOR writers reject a backend without
+  `supports_append`; object-store backends retain the default `false`, while local and
+  HDFS advertise `true`.
+* WAL reopen ratchet: current-format `wal_NNNNNNNN.log` frames are scanned on writer
+  construction and the next `sequence_number` resumes at `max + 1`.
 * Guard: `tests/objstore_url_construction_test.rs::no_strip_and_reprepend_pattern_in_src`
   greps `src/` for `.replace("file://"` outside an allowlist — the pattern that caused
   this class is now build-enforced dead.

--- a/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
+++ b/docs/12-design/adr/ADR-032-durable-tenant-prefixed-object-store-catalog.adoc
@@ -55,6 +55,15 @@ The **operator catalog stays in AnvaiOps** (per `OSS_ENTERPRISE_BOUNDARY`); this
 * Provide a one-shot repath/migration that re-emits existing flat catalog assets under their tenant-prefixed paths and stamps the marker.
 * Gate promotion on round-trip + cross-read tests (legacy flat and new prefixed coexist), not just compile.
 
+=== Fence-scope clarification
+
+The `SystemCatalog` generation fence protects publication of the catalog snapshot pointer. It does
+not fence data-plane or external DDL side effects such as writing a MATERIALIZE Parquet object or
+building an index. Table-scoped DDL therefore uses the renewable per-resource partition lease as
+its operation authority and revalidates that lease before reporting success. The process must wire
+one shared `PartitionLeaseManager` (and one renewal loop) into DML, REST, and per-connection pgwire
+DDL; constructing a second manager creates a divergent TTL/ownership timeline and is not valid.
+
 == Consequences
 
 *Positive.* The catalog becomes durable and shared, so stateless pods can serve any tenant after a cold start (the serverless unlock). Isolation is structural and fail-closed, so it holds for every workload class — agent (many tiny bursty tenants), data-engineering (Iceberg/Parquet, TD-119 tenant-scoped REST), OLTP/pgwire, graph, docs — with no per-modality isolation code. Per-tenant lifecycle, CRR, and billing become prefix operations. The misconfiguration footgun (intended multi-tenant silently permissive) is closed.

--- a/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
+++ b/docs/12-design/adr/ADR-059-duckdb-local-plugin-olap-engine-geometry-routed.adoc
@@ -5,24 +5,24 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | **Proposed** (filed 2026-07-10). Grounded in the SF=0.1 measurement (TD-OLAP-15 §DuckDB gap) + the TD-OLAP-2 diagnosis (missing NDV → DataFusion CBO-blind → 100–700× join gap at scale). Decider sign-off pending.
+| Status | **Proposed / evidence-only** (filed 2026-07-10; causal account corrected 2026-07-14). The original NDV/CBO diagnosis was superseded by TD-OLAP-17: the dominant measured floor was a per-table, per-query WAL change scan during table open. Decider sign-off pending.
 | Decider | Vijaykumar Singh (2026-07-10)
 | Date | 2026-07-10
 | Relates to | link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (bytes-scanned is the dominant cloud-OLAP cost term; the seam is swappable), link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (the backend leakage boundary / seam), link:ADR-058-engine-routing-eligibility-selection-stats-trust.adoc[ADR-058] (eligibility-vs-selection routing; D2 keeps `ComputeBackend` an enum), link:ADR-054-native-execution-engine-progressive-cutover.adoc[ADR-054] (the native engine — orthogonal PAX wedge), link:../../10-quality/td/TD-OLAP-15-native-engine-measured-posture-sf001.adoc[TD-OLAP-15] (the measured gap), link:../../10-quality/td/TD-OLAP-2-statistics-fed-cbo-cardinality.adoc[TD-OLAP-2] (the DF-CBO fix this partly defers), link:../../10-quality/td/TD-EXEC-2-plan-geometry-resource-model.adoc[TD-EXEC-2] (plan-geometry → engine routing).
-| Refines | ADR-052's "DataFusion is the OLAP engine" → **"the OLAP engine is router-selected per query geometry; DuckDB-Local is a plugin OLAP engine for join-heavy parquet, DataFusion the fallback, native the PAX-wedge."** Reaffirms ADR-058 D2 (enum for routing) + clarifies the `ExecutionEngine` trait is the open execution seam.
-| Tracked under | Wiring TD (to be filed on sign-off): `impl ExecutionEngine for DuckDbLocalEngine`; register ProximaDB parquet via DuckDB's object-store reader; ADR-058 router selects `DuckDbCompat` for join-heavy parquet OLAP.
+| Refines | ADR-052's "DataFusion is the OLAP engine" only after comparable evidence: **DuckDB-Local is currently an explicit, evidence-only plugin route; DataFusion remains the OLAP floor and native remains the PAX wedge.** Reaffirms ADR-058 D2 (enum for routing) + clarifies the `ExecutionEngine` trait is the open execution seam.
+| Tracked under | Evidence wiring: `impl ExecutionEngine for DuckDbLocalEngine`; register ProximaDB parquet via DuckDB's object-store reader; keep `DuckDbCompat` out of live cost ranking until value parity and comparable I/O accounting land.
 |===
 
 == 1. Context + the question
 
-The SF=0.1 measurement (TD-OLAP-15) showed the DuckDB gap **widens with scale**: 25–70× at SF=0.01 → **100–700× at SF=0.1** (Q5 552×, Q8 556×, q61 697×). DataFusion scales ~super-linearly on joins (Q8: 310ms→17233ms for 10× data — a bad plan), while DuckDB stays flat at ~25–35ms (multi-core + CBO reorder + broadcast). The TD-OLAP-2 diagnosis confirmed the root cause: **missing NDV (`distinct_count`) → DataFusion's CBO can't estimate join cardinality → no reorder, no `BroadcastJoin`** → catastrophic join plans. `splits_pruned` *does* fire at SF=0.1 (zone-map pruning works), so the gap is **compute (join plan), not bytes-scanned** — and it worsens super-linearly without stats.
+The SF=0.1 measurement (TD-OLAP-15) appeared to show a DuckDB gap widening with scale: 25–70× at SF=0.01 → 100–700× at SF=0.1. The initial diagnosis attributed that wall time to missing NDV and CBO-blind join plans. TD-OLAP-17 subsequently isolated the dominant term: `changed_oids_since` scanned the bulk-ingest WAL once per table per query even when the post-snapshot delta was empty. Its high-water fast path reduced the default DataFusion median from **5762 ms to 12 ms at SF=0.1** (and 604 ms to 7 ms at SF=0.01), faster than the measured DuckDB 14–15 ms. Table-open time collapsed from about 1780 ms to 0–1 ms. NDV remains a valid completeness and plan-quality improvement, but it did not cause the measured gap close.
 
-TD-OLAP-2 (populate NDV → DF CBO) is the proper fix but is substantial (statistics-collection infrastructure) and uncertain (would DF+NDV match DuckDB's mature optimizer?). The question: **wire DuckDB-Local embedded as a plugin OLAP engine now** to close the 100–700× gap immediately, while native builds its wedge and TD-OLAP-2 lands?
+The remaining question is narrower: should DuckDB-Local remain available as an embedded evidence engine for shapes where its optimizer or SQL surface may show a measured advantage, without treating the now-closed WAL table-open gap as justification for promotion?
 
 == 2. The decision
 
 === D1 — DuckDB-Local embedded as a plugin OLAP engine for parquet/materialized tables
-DuckDB (in-process, like DataFusion) serves the **join-heavy parquet OLAP path** (today's DataFusion path). It reads the **same materialized parquet** via its object-store reader — no data migration. It closes the gap because it owns the **compute term** (CBO + broadcast + vectorized joins) that is the confirmed root cause; the bytes-scanned term is unchanged. The `ComputeBackend::DuckDbCompat` enum variant already exists (`table_write_plan.rs:113`) — wiring = implementing the engine, not adding the variant.
+DuckDB (in-process, like DataFusion) can probe the **join-heavy parquet OLAP path** over the same materialized parquet, with no data migration. It is not credited with closing the historical gap: TD-OLAP-17's WAL high-water fast path did that. The `ComputeBackend::DuckDbCompat` enum variant already exists (`table_write_plan.rs:113`), so the evidence route exercises the existing engine seam.
 
 === D2 — Hybrid dispatch: `ExecutionEngine` trait (execution, open) + `ComputeBackend` enum (routing, closed)
 Best practice for a multi-engine DB is **open execution, closed routing**:
@@ -32,40 +32,40 @@ Best practice for a multi-engine DB is **open execution, closed routing**:
 **Not a full trait-ify of `ComputeBackend`.** The engine set *converges* (see D4 — eventually native-modes for load-bearing), it does not grow unboundedly, so an open plugin *registry* is over-engineering. Adding DuckDB = `impl ExecutionEngine for DuckDbLocalEngine` + wire the existing `DuckDbCompat` arm in `execute_sql_with_backend`.
 
 === D3 — Geometry-shape routing (ADR-058 + TD-EXEC-2): each shape → the engine that owns its dominant cost term
-The router (ADR-058 eligibility-then-selection) picks the engine per **query geometry** (shape) by co-design cost-term:
-- **Join-heavy parquet OLAP** → DuckDB (compute-term advantage: CBO/broadcast).
+The router (ADR-058 eligibility-then-selection) may eventually pick the engine per **query geometry** (shape) when the relevant cost terms are comparable:
+- **Join-heavy parquet OLAP** → DataFusion by default; DuckDB only through the explicit evidence route until a compute advantage survives value-level and I/O-comparable measurement.
 - **PAX / native vector store** → native scan wedge (bytes-scanned advantage: PAX-native scan + footer-elision, ADR-052/TD-OLAP-1).
 - **Simple / point / OLTP** → native Volcano or DataFusion (the floor).
 
 This is the TD-EXEC-2 plan-geometry → resource/cost model: geometry decides which engine's dominant-cost-term advantage applies.
 
-=== D4 — Final state: native (modes) load-bearing; for now shapes route to whichever engine wins
-The end-state is **native in various modes for load-bearing shapes** (the ADR-054 progressive cutover — native vectorized + morsel + spill for the shapes it can serve soundly). **For now**, geometry routes to DuckDB/DataFusion/native per perf + co-design cost — DuckDB is the perf bridge for join-OLAP until native's join/spill/CBO (TD-OLAP-11 + TD-OLAP-2) closes the gap on the shapes native owns. DuckDB is **not** "until native replaces it on parquet-OLAP" — native's wedge is the PAX scan + multimodal join, not parquet-OLAP-join-perf; DuckDB may remain the parquet-OLAP engine permanently.
+=== D4 — Final state: native (modes) load-bearing; DuckDB remains evidence-only pending promotion evidence
+The end-state is **native in various modes for load-bearing shapes** (the ADR-054 progressive cutover — native vectorized + morsel + spill for the shapes it can serve soundly). DataFusion remains the parquet OLAP floor. DuckDB may be reconsidered for shapes where an advantage is demonstrated after the TD-OLAP-17 correction, with exact value parity and comparable I/O quantities; the current record does not justify a live routing role.
 
 === D5 — DataFusion stays the floor/fallback; TD-OLAP-2 continues
-DF remains the swappable floor (the ADR-039 seam's default). TD-OLAP-2 (DF + NDV/CBO) continues as the **fallback-path investment** — if DuckDB is ever unavailable (dep/operational), DF+CBO is the backup. Do not delete that work.
+DF remains the swappable floor (the ADR-039 seam's default). TD-OLAP-2 (DF + NDV/CBO) continues as a plan-quality investment, but it is not credited with the measured 5762→12 ms gap close; TD-OLAP-17's WAL high-water fast path is.
 
 === D6 — Native is NOT defunded
-DuckDB serves parquet-OLAP; native's wedge (PAX scan + footer-elision + multimodal join, ADR-052/TD-OLAP-1/ADR-054) is **orthogonal**. The two-engine (now three: DuckDB + DF + native) strategy: each engine owns its dominant-cost-term advantage. DuckDB's perf does not reduce urgency for native's wedge — that's the differentiator, not parquet-join-perf.
+DuckDB's evidence harness does not replace native's wedge (PAX scan + footer-elision + multimodal join, ADR-052/TD-OLAP-1/ADR-054). No DuckDB performance advantage should reduce urgency for native work unless it is reproduced with the corrected table-open path and comparable cost dimensions.
 
 == 3. Co-design / first-principles reasoning
 
 Per the co-design mandate (name the dominant dimensional cost term):
-- **DuckDB** moves the **compute** term (join plan: CBO reorder + broadcast + vectorized) — the confirmed root cause of the 100–700× gap. It reads the same bytes (no bytes-scanned regression); it fixes the compute.
+- **DuckDB** may move the compute term (join reorder + vectorized execution) on particular shapes, but that advantage must be measured after the TD-OLAP-17 table-open floor and with comparable I/O accounting; it was not the cause of the observed 5762→12 ms correction.
 - **Native** moves the **bytes-scanned** term (PAX-native scan + footer-elision) — its wedge. Orthogonal to DuckDB's compute advantage.
-- **Routing** is the dimensional delegation (ADR-058): geometry → the engine that owns the cost term the query is bound by. A join-bound query → compute engine (DuckDB); a scan-bound query → scan engine (native).
+- **Routing** is the dimensional delegation (ADR-058): geometry may select an engine only when the compared cost cells describe the same dimensions. DuckDB's compute-only cells do not yet satisfy that condition.
 - First-principles check vs the ecosystem: Postgres (table access methods + FDWs = open execution via traits, closed routing), Spark (catalyst + pluggable execution), Trino (connector trait). The hybrid (open execution trait + closed routing enum) is the established pattern; a single closed enum or a fully-open registry are the two extremes this steers between.
 
 == 4. Alternatives rejected
 
 - **Full trait-ify of `ComputeBackend` (open plugin registry).** Rejected (ADR-058 D2's reasoning, reaffirmed): the engine set converges to native-modes (D4), not unbounded growth; the enum is already open via `ExternalDelegated(String)`; `dyn`-dispatch once-per-query is fine but a registry is YAGNI. The `ExecutionEngine` trait already gives the open-execution property.
-- **Just fix DF (TD-OLAP-2) instead of adding DuckDB.** Rejected as the *sole* path: TD-OLAP-2 is substantial + uncertain (DF+NDV may not match DuckDB's mature optimizer). DuckDB closes the gap decisively now; TD-OLAP-2 continues as the fallback-path investment (D5). Both, not either/or.
+- **Remove the DuckDB evidence route because the historical gap closed.** Rejected for now: the route can still provide useful differential evidence on unsupported or wider shapes, but it is not a production cost-model candidate without the D3 gates.
 - **DuckDB as a CLI subprocess (like the benchmark baseline).** Rejected: per-query process spawn + no shared state. Embedded (in-process) is the right posture (shared, like DF).
 - **Let DuckDB replace native.** Rejected (D6): native's wedge (PAX/multimodal) is orthogonal; DuckDB doesn't read PAX or host multimodal join semantics.
 
 == 5. Consequences
 
-*Positive:* closes a 100–700× join gap immediately; exercises the plugin architecture (ADR-039/058) the system was built for; DuckDB handles *more* SQL than DF/Volcano (window/ROLLUP/CUBE — fewer feature gaps, recall the TPC-DS native failures); each engine owns its cost-term advantage (clean separation).
+*Positive:* exercises the plugin architecture (ADR-039/058) and provides a differential harness for SQL shapes such as window/ROLLUP/CUBE without changing the production default.
 
 *Negative / trade-offs:* **`libduckdb` is a heavy C++ native dependency** in a Rust project (build complexity, binary size, supply-chain) — DataFusion is pure-Rust, DuckDB is not; this is the main cost. **Operational**: another in-process engine (memory, threads, version pinning). **SQL dialect**: DuckDB ≈ Postgres-ish but differs; net positive (more complete). **Risk of defunding native**: mitigated by D6 (orthogonal wedge) — must be policed at the ADR/roadmap level.
 
@@ -74,7 +74,7 @@ Per the co-design mandate (name the dominant dimensional cost term):
 == 6. Rollout (announced here; implemented in follow-up PRs)
 
 1. **Wire `DuckDbLocalEngine`** — `impl ExecutionEngine`; register ProximaDB parquet via DuckDB's object-store reader; wire the `DuckDbCompat` arm in `execute_sql_with_backend`. Default-OFF (env gate) + ledger-gated promotion (ADR-054 progressive-cutover discipline). *(LANDED 2026-07-11, #872 — engine + `execute_sql_with_backend` arm behind `--features duckdb`.)*
-2. **Geometry routing** — ADR-058 router selects `DuckDbCompat` for join-heavy parquet OLAP (eligibility: parquet-backed + join/agg shape; DF the fallback). The cost model (ADR-058 D3/D4) learns per-shape-per-engine. *(LANDED 2026-07-14: `PROXIMADB_DUCKDB_ROUTE` (default OFF) gates a DuckDB PRIMARY attempt for join-bearing/grouped parquet shapes with DataFusion the correctness floor; eligibility additionally requires every referenced table's ADR-025 post-snapshot delta be EMPTY (TD-OLAP-17 high-water probe, fail-closed) since DuckDB reads bare parquet; `DuckDbCompat` joins the `olap/parquet` freshness-safe cost-model candidate set when compiled + route-enabled, so cells warm through the router and the #946 per-class override can flip to it; the io_trace route is re-stamped to the engine that actually served, so cost cells never mis-attribute floor-served queries. Enable gate: `tests/duckdb_route_pgwire_e2e.rs` — result parity + attribution.)*
+2. **Geometry evidence route** — `PROXIMADB_DUCKDB_ROUTE` (default OFF) gates a DuckDB PRIMARY attempt for join-bearing/grouped parquet shapes with DataFusion the correctness floor; eligibility additionally requires every referenced table's ADR-025 post-snapshot delta be EMPTY (TD-OLAP-17 high-water probe, fail-closed) since DuckDB reads bare parquet. The io_trace route is re-stamped to the engine that actually served. DuckDB cells are deliberately excluded from live cost-model ranking/exploration while its reader reports compute time but not comparable physical GET/byte quantities; the explicit route is an evidence harness, not an override candidate. Promotion requires value-level differential coverage (including NULL and decimal semantics) and comparable I/O accounting. Enable gate: `tests/duckdb_route_pgwire_e2e.rs`.*
 3. **Trust gate (ADR-058 D5/§9.A)** — DuckDB reads the same parquet; the `StatsTrust` gate applies (external parquet → DuckDB scans, doesn't trust footer for elision — though DuckDB's own elision is its internal concern; the gate is at ProximaDB's parquet-registration boundary).
 4. *(Converges)* native-modes for load-bearing shapes (ADR-054) — DuckDB remains for the shapes native doesn't own.
 
@@ -85,24 +85,25 @@ Each step default-safe + ledger-gated, mixed-read-safe, behind the ADR-054 progr
 Measured through the REAL pgwire route (step-2 wiring), SF 0.01 full-suite + SF 0.1 scoped
 (Q3/Q5/Q8/Q9/Q10), release, `PROXIMADB_DUCKDB_ROUTE=1` vs stock:
 
-* **The wiring is sound.** 142/170 pgwire-sweep records served by `DuckDbCompat` with **zero
-  row-count mismatches** vs the stock DataFusion baseline (SF 0.01) and exact parity on all five
-  SF 0.1 queries. Eligibility behaved (scalar/metadata shapes kept DataFusion); the delta-clean
+* **The wiring is promising but the broad sweep was row-count-only.** 142/170 pgwire-sweep records
+  served by `DuckDbCompat` with zero row-count mismatches vs the stock DataFusion baseline
+  (SF 0.01), while five SF 0.1 queries had exact value parity. Eligibility behaved
+  (scalar/metadata shapes kept DataFusion); the delta-clean
   probe added no visible overhead (routed-DuckDB ≤ DuckDB-direct walls); cost cells warmed under
   the correct backend label via the io_trace re-stamp.
-* **The motivating gap is GONE on the probed shapes.** TD-OLAP-15's 100–700× DataFusion join-plan
+* **The motivating gap is GONE on the probed shapes.** TD-OLAP-15's 100–700× DataFusion wall-time
   collapse (Q8 17 233 ms at SF 0.1) no longer reproduces: stock DataFusion now answers Q5/Q8/Q9
-  in ~24 ms at SF 0.1 — the D5 "fallback-path investment" (TD-OLAP-2 NDV via #886 + stats-fed
-  planning #660) landed and fixed the CBO's join plans. DuckDB-direct is comparable (~20–36 ms)
+  in ~24 ms at SF 0.1. TD-OLAP-17 attributes the dominant correction to the WAL high-water
+  fast path (5762→12 ms in its controlled run), not NDV/CBO. DuckDB-direct is comparable (~20–36 ms)
   with a cold-start outlier (Q3 first-run ~1.3 s: fresh in-memory DB + view registration per
   query — the stateless-engine cost).
-* **Promotion verdict: stay opt-in default-OFF.** On current evidence DataFusion ≥ DuckDB across
+* **Promotion verdict: evidence-only, opt-in, default-OFF.** On current evidence DataFusion ≥ DuckDB across
   both scales probed, so there is no measured win to promote — and that is the routing framework
   working, not a failure: the cost model, warmed through this route, correctly learns DataFusion
-  as the cheaper arm at these scales. Re-evaluate on shapes/scales where DuckDB's optimizer
-  advantage re-emerges (larger SF, wider joins, window/ROLLUP surfaces DataFusion lacks) — the
-  route, eligibility gates, and per-class staged enable (#946) are ready when it does.
+  as the cheaper arm at these scales. DuckDB is excluded from live override ranking until physical
+  I/O quantities and broader value-level differential coverage are available. Re-evaluate on
+  shapes/scales where DuckDB's optimizer advantage re-emerges (larger SF, wider joins,
+  window/ROLLUP surfaces DataFusion lacks).
 * Residual observation: a set of CTE-shaped TPC-DS queries (q1, q9, q14a, q23a, q24a, q33, …)
   execute correctly but carry NO route stamp — they are served by a pre-router path, so the cost
   model never sees them. Worth a follow-up when CTE lowering lands on the shared route.
-

--- a/scripts/check_td_status_consistency.py
+++ b/scripts/check_td_status_consistency.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Reject resolved TDs whose body still declares open work."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TD_DIR = ROOT / "docs" / "10-quality" / "td"
+RESOLVED = re.compile(
+    r"(?:\|\s*Status\s*\||\*\*Status:\*\*)\s*(?:\*\*)?Resolved\b", re.I
+)
+OPEN_HEADING = re.compile(r"^==+\s+.*\b(?:open|remaining|pending)\b", re.I)
+OPEN_MILESTONE = re.compile(
+    r"^\*\*[^\n]*(?:\bopen\b|\bremaining\b|\bpending\b)[^\n]*\*\*:?\s*$", re.I
+)
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in sorted(TD_DIR.glob("TD-*.adoc")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if not any(RESOLVED.search(line) for line in lines[:30]):
+            continue
+        for line_no, line in enumerate(lines, 1):
+            if OPEN_HEADING.search(line) or OPEN_MILESTONE.search(line):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line_no}: resolved TD declares open work: {line.strip()}"
+                )
+
+    if violations:
+        print("TD status consistency check failed:", file=sys.stderr)
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+    print("TD status consistency check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cluster/primary_pod_registry.rs
+++ b/src/cluster/primary_pod_registry.rs
@@ -551,10 +551,10 @@ pub fn consult_for_write(
 ///
 /// ## Split-brain safety
 ///
-/// Even if a pod bypasses this check (e.g., local single-pod deployment),
-/// the object-store fence in `SystemCatalog` still enforces generation fencing
-/// on every DDL commit. The lease is a latency optimization; the fence is
-/// the correctness authority.
+/// `SystemCatalog` generation-fences its snapshot pointer, not arbitrary DDL
+/// side effects. Callers performing external writes (for example MATERIALIZE)
+/// must therefore keep this renewable lease wired and revalidate ownership
+/// before publishing success.
 ///
 /// ## Usage
 ///

--- a/src/database.rs
+++ b/src/database.rs
@@ -1307,7 +1307,8 @@ async fn open_queue_client_from_resolved(
             .await
             .map_err(|e| anyhow::anyhow!("FilesystemFactory init: {}", e))?,
     );
-    let fs_adapter = crate::services::queue_fs_adapter::FactoryQueueFs::new(factory, &rq.root);
+    let fs_adapter = crate::services::queue_fs_adapter::FactoryQueueFs::new(factory, &rq.root)
+        .map_err(|e| anyhow::anyhow!("queue filesystem capability check: {}", e))?;
 
     let queue = proximadb_queue::QueueClient::open_with_fs(queue_cfg, Some(fs_adapter))
         .await

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -859,6 +859,7 @@ impl MultiServer {
             // pair the REST / gRPC v2 / Arrow Flight surfaces hold.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
+            let partition_lease_manager = services.partition_lease_manager.clone();
             // Warehouse object-store root for `ALTER TABLE … MATERIALIZE`, derived from
             // the server data dir the same way document/observability roots are.
             let warehouse_root_url = format!("file://{}/warehouse", self.config.data_dir.display());
@@ -898,6 +899,7 @@ impl MultiServer {
                 server =
                     server.with_rank_pipeline(rank_services, rank_profile_store, function_store);
                 server = server.with_primary_pod_gate(primary_pod_registry, self_pod_id);
+                server = server.with_partition_lease_manager(partition_lease_manager);
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
                 if let Some(limiter) = pgwire_rate_limiter {
@@ -1214,6 +1216,8 @@ impl MultiServer {
                     services.primary_pod_registry.clone(),
                     services.self_pod_id.clone(),
                 );
+                server =
+                    server.with_partition_lease_manager(services.partition_lease_manager.clone());
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
 

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -93,6 +93,7 @@ pub struct PostgresServer {
     /// can decide once whether to wire the gate.
     primary_pod_registry: Option<Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>>,
     self_pod_id: Option<String>,
+    partition_lease_manager: Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
     /// Object-store root URL the warehouse materializer publishes Parquet snapshots
     /// under (the same URL the OLAP reader reopens the store from). When `Some`,
     /// every per-connection `DdlService` is wired with a `DmlTableMaterializer` so
@@ -144,6 +145,7 @@ impl PostgresServer {
             rank_pipeline: None,
             primary_pod_registry: None,
             self_pod_id: None,
+            partition_lease_manager: None,
             warehouse_root_url: None,
             rate_limiter: None,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
@@ -180,6 +182,16 @@ impl PostgresServer {
     ) -> Self {
         self.primary_pod_registry = Some(registry);
         self.self_pod_id = Some(self_pod_id);
+        self
+    }
+
+    /// Attach the same durable lease manager used by the REST/DML write gates
+    /// so per-connection pgwire DDL does not degrade to registry-only checks.
+    pub fn with_partition_lease_manager(
+        mut self,
+        manager: Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
+    ) -> Self {
+        self.partition_lease_manager = manager;
         self
     }
 
@@ -266,6 +278,7 @@ impl PostgresServer {
                     // routing decisions.
                     let primary_pod_registry = self.primary_pod_registry.clone();
                     let self_pod_id = self.self_pod_id.clone();
+                    let partition_lease_manager = self.partition_lease_manager.clone();
                     let warehouse_root_url = self.warehouse_root_url.clone();
                     let rate_limiter = self.rate_limiter.clone();
                     let tenant_header_trust = self.tenant_header_trust;
@@ -285,6 +298,7 @@ impl PostgresServer {
                             rank_pipeline,
                             primary_pod_registry,
                             self_pod_id,
+                            partition_lease_manager,
                             warehouse_root_url,
                             rate_limiter,
                             tenant_header_trust,
@@ -326,6 +340,9 @@ impl PostgresServer {
         rank_pipeline: Option<PgwireRankPipeline>,
         primary_pod_registry: Option<Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>>,
         self_pod_id: Option<String>,
+        partition_lease_manager: Option<
+            Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        >,
         warehouse_root_url: Option<String>,
         rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
         tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
@@ -367,7 +384,10 @@ impl PostgresServer {
         // sides are present so a partial wiring fails closed (no
         // gate, legacy behavior) rather than silently misconfigured.
         if let (Some(registry), Some(pod_id)) = (primary_pod_registry, self_pod_id) {
-            protocol = protocol.with_primary_pod_gate(registry, pod_id);
+            protocol = protocol.with_primary_pod_gate(registry.clone(), pod_id.clone());
+            if let Some(manager) = partition_lease_manager {
+                protocol = protocol.with_ddl_lease_manager(manager, registry, pod_id);
+            }
         }
         // E0: apply the shared per-IP rate limiter (subject = this peer's IP) so
         // the pgwire query path is rate-limited consistently with REST.

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -582,6 +582,24 @@ impl PostgresProtocol {
         }
     }
 
+    /// Attach the durable partition-lease authority to this connection's DDL
+    /// service after rank/materializer decoration has finished.
+    pub fn with_ddl_lease_manager(
+        mut self,
+        manager: Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        registry: Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>,
+        self_pod_id: String,
+    ) -> Self {
+        if let Some(ddl) = self.ddl_service.as_mut().and_then(Arc::get_mut) {
+            ddl.set_write_lease_authority(manager, registry, self_pod_id);
+        } else {
+            tracing::error!(
+                "pgwire DDL lease authority could not be attached to the per-connection service"
+            );
+        }
+        self
+    }
+
     /// Attach catalog-backed DDL/DML services to an existing protocol handler.
     pub fn with_catalog_manager(mut self, catalog_manager: Arc<CatalogManager>) -> Self {
         self.ddl_service = Some(Arc::new(DdlService::new(catalog_manager.clone())));

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -327,15 +327,12 @@ pub struct SharedServices {
 
     /// Partition lease manager for per-collection write authority (Phase 7c).
     ///
-    /// When enabled via `PROXIMADB_PARTITION_LEASE_ON` and object-store
-    /// deployment, this manager acquires/renews generation-fenced leases
-    /// over `(tenant, collection)` partitions. Protocol handlers consult
-    /// `consult_for_write_leased` before DDL writes to ensure split-brain-free
-    /// local writes. Single-pod deployments leave this `None` (pure in-memory
-    /// `primary_pod_registry` lookup).
-    ///
-    /// The lease is a latency optimization; the object-store fence in
-    /// `SystemCatalog` is the correctness authority.
+    /// This is the same manager used by RecordOps/DML and the storage-write
+    /// fence, including its process-lifetime renewal loop. Protocol handlers
+    /// consult it before DDL writes so no per-surface manager or lease timeline
+    /// can diverge. `None` only when the configured lease store cannot open.
+    /// `SystemCatalog` separately fences catalog snapshot publication; it does
+    /// not fence MATERIALIZE/index side effects.
     pub partition_lease_manager:
         Option<Arc<crate::cluster::partition_lease::PartitionLeaseManager>>,
 
@@ -2230,8 +2227,8 @@ impl SharedServices {
         // vector-record write path acquires/confirms the collection lease and the
         // shared registry the network gates consult reflects ground truth after
         // restart/partition (Scenario-1 routing truth). Absent → fail-open.
-        if let Some(lease_manager) = lease_manager_for_writes {
-            record_ops.set_lease_manager(lease_manager);
+        if let Some(lease_manager) = &lease_manager_for_writes {
+            record_ops.set_lease_manager(lease_manager.clone());
             debug!(
                 "✅ SharedServices::new - PartitionLeaseManager wired to RecordOpsService (lease-on-write)"
             );
@@ -2431,60 +2428,10 @@ impl SharedServices {
         // Phase 7c: resolve self_pod_id for partition lease manager initialization
         let self_pod_id_resolved = crate::cluster::primary_pod_registry::resolve_self_pod_id(None);
 
-        // Phase 7c: partition lease manager for per-collection write authority
-        let partition_lease_manager: Option<
-            std::sync::Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
-        > = {
-            // Only initialize for object-store deployments when explicitly enabled
-            let is_objstore = storage_config.metadata_url.starts_with("s3://")
-                || storage_config.metadata_url.starts_with("gs://")
-                || storage_config.metadata_url.starts_with("az://")
-                || storage_config.metadata_url.starts_with("memory://");
-            let lease_enabled = std::env::var("PROXIMADB_PARTITION_LEASE_ON")
-                .ok()
-                .and_then(|v| v.parse::<bool>().ok())
-                .unwrap_or(false);
-
-            if is_objstore && lease_enabled {
-                use crate::storage::trait_components::path_resolver::DrPathBuilder;
-                // Use DrPathBuilder for the lease prefix (under _catalog/leases)
-                let lease_prefix = DrPathBuilder::partition_lease_prefix();
-                // Lease TTL: 60 seconds by default (configurable via env)
-                let lease_ms = std::env::var("PROXIMADB_PARTITION_LEASE_SECS")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .unwrap_or(60) as i64
-                    * 1000;
-
-                match crate::cluster::partition_lease::PartitionLeaseStore::from_url(
-                    &storage_config.metadata_url,
-                    lease_prefix,
-                ) {
-                    Ok(lease_store) => {
-                        let lease_mgr = crate::cluster::partition_lease::PartitionLeaseManager::new(
-                            std::sync::Arc::new(lease_store),
-                            primary_pod_registry.clone(),
-                            &self_pod_id_resolved,
-                            lease_ms,
-                        );
-                        info!(
-                            "✅ SharedServices: partition lease manager enabled (TTL={}ms)",
-                            lease_ms
-                        );
-                        Some(std::sync::Arc::new(lease_mgr))
-                    }
-                    Err(err) => {
-                        warn!(
-                            "⚠️ SharedServices: failed to create partition lease store, disabling: {}",
-                            err
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        };
+        // Expose the exact manager already wired to DML and its renewal loop.
+        // The previous second constructor created an independent lease timeline
+        // (different TTL, no renew loop) for protocol DDL.
+        let partition_lease_manager = lease_manager_for_writes.clone();
 
         info!(
             "✅ SharedServices: Business logic hub ready for ALL protocols (gRPC, REST, WebSocket, etc.)"

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -798,28 +798,13 @@ fn parse_backend_label(label: &str) -> Option<ComputeBackend> {
 /// DataFusion floor serves otherwise and the route is re-stamped).
 fn freshness_safe_backends_from_class(shape_class: &str) -> Vec<ComputeBackend> {
     if shape_class.starts_with("olap/parquet") {
-        let mut safe = vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal];
-        if duckdb_route_candidate() {
-            safe.push(ComputeBackend::DuckDbCompat);
-        }
-        safe
+        // DuckDB remains an explicit-route evidence harness until its reader
+        // reports comparable GET/byte quantities. Ranking compute-only cells
+        // beside fully metered engines would make live overrides prefer an
+        // artificially cheap candidate.
+        vec![ComputeBackend::Native, ComputeBackend::DataFusionLocal]
     } else {
         vec![ComputeBackend::Native]
-    }
-}
-
-/// Whether `DuckDbCompat` participates as a cost-model candidate: compiled in
-/// (`--features duckdb`) AND route-enabled (`PROXIMADB_DUCKDB_ROUTE`, default
-/// OFF per ADR-059 §6 / ADR-054 progressive-cutover). Without both, the
-/// frozen table never ranks or explores DuckDB, so no flip can target it.
-fn duckdb_route_candidate() -> bool {
-    #[cfg(feature = "duckdb")]
-    {
-        crate::query::execution::duckdb_engine::duckdb_route_enabled()
-    }
-    #[cfg(not(feature = "duckdb"))]
-    {
-        false
     }
 }
 
@@ -2194,13 +2179,12 @@ mod tests {
         );
     }
 
-    /// ADR-059: with the `duckdb` feature compiled AND `PROXIMADB_DUCKDB_ROUTE`
-    /// set, DuckDbCompat joins the olap/parquet freshness-safe set — its cells
-    /// rank and it can be explored/flipped to. (nextest process-per-test
-    /// isolation makes the env-before-first-call OnceLock read deterministic.)
+    /// DuckDB traces remain evidence-only until its I/O quantities are
+    /// comparable to the other engines. Even an explicitly enabled route may
+    /// collect cells, but the live model must not rank or explore them.
     #[cfg(feature = "duckdb")]
     #[test]
-    fn duckdb_joins_the_olap_parquet_safe_set_when_route_enabled() {
+    fn duckdb_cells_are_evidence_only_when_route_enabled() {
         unsafe { std::env::set_var("PROXIMADB_DUCKDB_ROUTE", "1") };
         let m = RouteCostModel::new().with_min_samples(1);
         m.observe_by_label("olap/parquet", "DuckDbCompat", &snap(2, 1 << 20, 1));
@@ -2208,14 +2192,12 @@ mod tests {
         m.recompute();
         let consult = m.consult("olap/parquet").expect("baked");
         assert!(
-            consult
+            !consult
                 .ranked()
                 .iter()
                 .any(|c| backend_label(&c.backend) == "DuckDbCompat"),
-            "DuckDbCompat must rank as a freshness-safe candidate"
+            "compute-only DuckDB cells must not feed live overrides"
         );
-        // Cheapest-first: DuckDB (2 GETs) beats DataFusion (200 GETs) here.
-        assert_eq!(backend_label(&consult.ranked()[0].backend), "DuckDbCompat");
         // OLTP classes never gain DuckDB regardless of the gate.
         m.observe_by_label("oltp/native", "DuckDbCompat", &snap(2, 1 << 20, 1));
         m.recompute();

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -549,6 +549,20 @@ impl DdlService {
         self
     }
 
+    /// Wire the complete write-lease authority onto an already-assembled DDL
+    /// service. Pgwire builds rank/materializer decorators per connection, so a
+    /// mutating setter avoids rebuilding the service and dropping those handles.
+    pub fn set_write_lease_authority(
+        &mut self,
+        manager: Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+        registry: Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>,
+        self_pod_id: String,
+    ) {
+        self.partition_lease_manager = Some(manager);
+        self.primary_pod_registry = Some(registry);
+        self.self_pod_id = Some(self_pod_id);
+    }
+
     /// Attach the primary-pod registry used for write-routing decisions.
     pub fn with_primary_pod_registry(
         mut self,
@@ -571,8 +585,11 @@ impl DdlService {
     /// present ⇒ lease acquire/renew; absent ⇒ in-memory registry lookup only.
     /// Returns `Err` naming the target pod when another pod holds authority.
     ///
-    /// This is a latency / fast-fail optimization; the object-store generation
-    /// fence in `SystemCatalog` remains the correctness authority (ADR-032).
+    /// `SystemCatalog` generation-fences catalog snapshot publication, but it
+    /// does not fence external side effects such as a Parquet MATERIALIZE write.
+    /// The renewable partition lease is therefore the authority for these
+    /// table-scoped operations; the post-operation check detects displacement
+    /// before success/catalog-cache publication.
     async fn check_lease_for_write(&self, tenant: Option<&str>, collection_id: &str) -> Result<()> {
         use crate::cluster::primary_pod_registry::{
             WriteRoutingDecision, consult_for_write_leased,
@@ -661,6 +678,7 @@ impl DdlService {
                 self.alter_table(&table_name, changes, tenant).await
             }
             DdlStatement::MaterializeTable { name } => {
+                self.check_lease_for_write(tenant, &name).await?;
                 let materializer = self.materializer.as_ref().ok_or_else(|| {
                     anyhow!(
                         "ALTER TABLE … MATERIALIZE requires a configured warehouse object \
@@ -668,9 +686,13 @@ impl DdlService {
                     )
                 })?;
                 let location = materializer.materialize(&name, tenant).await?;
+                // MATERIALIZE can outlive a lease TTL. Revalidate before
+                // publishing success so a displaced pod cannot bless stale work.
+                self.check_lease_for_write(tenant, &name).await?;
                 // TD-OLAP-4: a re-MATERIALIZE republishes the base at this
                 // location, so any cached table-OPEN discovery (schema/splits/
                 // sizes) for it is now stale — drop it so reads re-discover.
+                #[cfg(feature = "datafusion-integration")]
                 crate::datafusion::engine_adapters::table_open_cache::invalidate_location(
                     &location,
                 );
@@ -685,23 +707,31 @@ impl DdlService {
                 index_type,
                 if_not_exists,
             } => {
-                self.create_index(
-                    &index_name,
-                    &table_name,
-                    columns,
-                    index_type,
-                    if_not_exists,
-                    tenant,
-                )
-                .await
+                self.check_lease_for_write(tenant, &table_name).await?;
+                let result = self
+                    .create_index(
+                        &index_name,
+                        &table_name,
+                        columns,
+                        index_type,
+                        if_not_exists,
+                        tenant,
+                    )
+                    .await?;
+                self.check_lease_for_write(tenant, &table_name).await?;
+                Ok(result)
             }
             DdlStatement::DropIndex {
                 index_name,
                 table_name,
                 if_exists,
             } => {
-                self.drop_index(&index_name, &table_name, if_exists, tenant)
-                    .await
+                self.check_lease_for_write(tenant, &table_name).await?;
+                let result = self
+                    .drop_index(&index_name, &table_name, if_exists, tenant)
+                    .await?;
+                self.check_lease_for_write(tenant, &table_name).await?;
+                Ok(result)
             }
             DdlStatement::CreateNamespace {
                 namespace,
@@ -2335,6 +2365,103 @@ mod tests {
             msg.contains("pod-other"),
             "error should name the target pod: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn materialize_and_index_arms_all_apply_the_lease_gate() {
+        use crate::cluster::primary_pod_registry::{AssignmentReason, PrimaryPodRegistry};
+        let registry = std::sync::Arc::new(PrimaryPodRegistry::new());
+        registry.assign("tenant-a", "coll-1", "pod-other", AssignmentReason::Create);
+        let ddl = lease_ddl()
+            .with_primary_pod_registry(registry)
+            .with_self_pod_id("pod-self".to_string());
+
+        let statements = [
+            DdlStatement::MaterializeTable {
+                name: "coll-1".to_string(),
+            },
+            DdlStatement::CreateIndex {
+                index_name: "idx".to_string(),
+                table_name: "coll-1".to_string(),
+                columns: vec!["id".to_string()],
+                index_type: IndexType::BTree,
+                if_not_exists: false,
+            },
+            DdlStatement::DropIndex {
+                index_name: "idx".to_string(),
+                table_name: "coll-1".to_string(),
+                if_exists: false,
+            },
+        ];
+
+        for statement in statements {
+            let err = ddl
+                .execute_scoped(statement, Some("tenant-a"))
+                .await
+                .expect_err("every table-scoped arm must reject a foreign lease");
+            assert!(err.to_string().contains("pod-other"), "{err}");
+        }
+    }
+
+    struct LeaseTakeoverMaterializer {
+        contender: std::sync::Arc<crate::cluster::partition_lease::PartitionLeaseManager>,
+    }
+
+    #[async_trait::async_trait]
+    impl TableMaterializer for LeaseTakeoverMaterializer {
+        async fn materialize(&self, table_name: &str, tenant: Option<&str>) -> Result<String> {
+            let future_ms = chrono::Utc::now().timestamp_millis() + 100;
+            assert!(
+                self.contender
+                    .acquire(tenant.unwrap_or("default"), table_name, future_ms)
+                    .await?,
+                "the second pod should acquire after the first lease expires"
+            );
+            Ok("file:///tmp/materialized".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn materialize_revalidates_after_lease_expiry_and_takeover() {
+        use crate::cluster::partition_lease::{PartitionLeaseManager, PartitionLeaseStore};
+        use crate::cluster::primary_pod_registry::PrimaryPodRegistry;
+        use object_store::memory::InMemory;
+        use proximadb_object_store::ProximaObjectStore;
+
+        let backing: std::sync::Arc<dyn object_store::ObjectStore> =
+            std::sync::Arc::new(InMemory::new());
+        let store = std::sync::Arc::new(PartitionLeaseStore::new(
+            ProximaObjectStore::new(backing),
+            "_operator/leases",
+        ));
+        let registry_a = std::sync::Arc::new(PrimaryPodRegistry::new());
+        let registry_b = std::sync::Arc::new(PrimaryPodRegistry::new());
+        let manager_a = std::sync::Arc::new(PartitionLeaseManager::new(
+            store.clone(),
+            registry_a.clone(),
+            "pod-a",
+            10,
+        ));
+        let manager_b =
+            std::sync::Arc::new(PartitionLeaseManager::new(store, registry_b, "pod-b", 10));
+        let ddl = lease_ddl()
+            .with_primary_pod_registry(registry_a)
+            .with_self_pod_id("pod-a".to_string())
+            .with_partition_lease_manager(manager_a)
+            .with_materializer(std::sync::Arc::new(LeaseTakeoverMaterializer {
+                contender: manager_b,
+            }));
+
+        let err = ddl
+            .execute_scoped(
+                DdlStatement::MaterializeTable {
+                    name: "coll-1".to_string(),
+                },
+                Some("tenant-a"),
+            )
+            .await
+            .expect_err("post-operation lease validation must detect takeover");
+        assert!(err.to_string().contains("pod-b"), "{err}");
     }
 
     #[tokio::test]

--- a/src/services/queue_fs_adapter.rs
+++ b/src/services/queue_fs_adapter.rs
@@ -51,16 +51,34 @@ pub struct FactoryQueueFs {
 }
 
 impl FactoryQueueFs {
+    fn require_append_capability(
+        root_url: &str,
+        filesystem_type: &str,
+        supports_append: bool,
+    ) -> QueueResult<()> {
+        if !supports_append {
+            return Err(QueueError::Persistence(format!(
+                "queue root {root_url} uses backend {filesystem_type} without durable append support"
+            )));
+        }
+        Ok(())
+    }
+
     // Returns `Arc<dyn QueueFs>` directly because every caller stores the
     // adapter behind a trait object; exposing the concrete type would force
     // every call site to add a redundant `.as_queue_fs()` cast.
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(factory: Arc<FilesystemFactory>, root_url: impl Into<String>) -> Arc<dyn QueueFs> {
+    pub fn new(
+        factory: Arc<FilesystemFactory>,
+        root_url: impl Into<String>,
+    ) -> QueueResult<Arc<dyn QueueFs>> {
         let mut root_url: String = root_url.into();
         while root_url.ends_with('/') {
             root_url.pop();
         }
-        Arc::new(Self { factory, root_url })
+        let fs = factory.get_filesystem(&root_url).map_err(Self::map_err)?;
+        Self::require_append_capability(&root_url, fs.filesystem_type(), fs.supports_append())?;
+        Ok(Arc::new(Self { factory, root_url }))
     }
 
     /// Translate a queue-supplied `&Path` to a URL the factory accepts.
@@ -203,5 +221,13 @@ mod tests {
             normalize("s3://bucket/queue///".to_string()),
             "s3://bucket/queue"
         );
+    }
+
+    #[test]
+    fn constructor_capability_check_rejects_non_append_backend() {
+        let err = FactoryQueueFs::require_append_capability("s3://bucket/queue", "s3", false)
+            .expect_err("object-store queue roots must fail before accepting data");
+        assert!(err.to_string().contains("without durable append support"));
+        FactoryQueueFs::require_append_capability("file:///queue", "local", true).unwrap();
     }
 }

--- a/src/storage/engines/raptor/engine.rs
+++ b/src/storage/engines/raptor/engine.rs
@@ -2300,7 +2300,7 @@ impl UnifiedStorageFormat for RaptorEngine {
             self.config.clone(),
             collection_id.to_string(),
             collection_dimension as usize,
-            make_raptor_filesystem().await?,
+            self.filesystem.clone(),
             make_raptor_quantization_engine(&self.config).await?,
             make_raptor_axis_clustering(&self.config),
         )

--- a/src/storage/persistence/filesystem/caching_filesystem.rs
+++ b/src/storage/persistence/filesystem/caching_filesystem.rs
@@ -351,6 +351,10 @@ impl FileSystem for UnifiedCachingFilesystem {
         self.underlying_fs.append(path, data).await
     }
 
+    fn supports_append(&self) -> bool {
+        self.underlying_fs.supports_append()
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let cache_key = self.cache_key(path);
 

--- a/src/storage/persistence/filesystem/hdfs.rs
+++ b/src/storage/persistence/filesystem/hdfs.rs
@@ -526,6 +526,10 @@ impl FileSystem for HdfsFileSystem {
         self.client.append_file(&normalized_path, data).await
     }
 
+    fn supports_append(&self) -> bool {
+        true
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         tracing::debug!("🗑️ HDFS delete: {}", path);
         let normalized_path = self.normalize_path(path);

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -578,6 +578,10 @@ impl FileSystem for LocalFileSystem {
         Ok(())
     }
 
+    fn supports_append(&self) -> bool {
+        true
+    }
+
     async fn delete(&self, path: &str) -> FsResult<()> {
         let path_str = self.resolve_path(path)?;
         let resolved_path = PathBuf::from(path_str);

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -459,7 +459,7 @@ impl UnifiedWALWriter {
 
         // Discover existing WAL files to resume from max sequence number and
         // the highest existing segment index.
-        let mut max_seq: u64 = 0;
+        let mut next_seq: u64 = 0;
         let mut segment_count: u64 = 0;
         // TD-066 (d): track the HIGHEST existing segment index, not just the
         // count. After an LSN-bounded prefix truncation the surviving segments
@@ -484,9 +484,25 @@ impl UnifiedWALWriter {
                     if parts.len() >= 4
                         && let Ok(seq) = parts[3].parse::<u64>()
                     {
-                        max_seq = max_seq.max(seq);
+                        next_seq = next_seq.max(seq.saturating_add(1));
                     }
                 }
+            }
+        }
+
+        // The current `wal_{segment}.log` filename carries no sequence range.
+        // Recover the allocator from frame contents; otherwise every reopen
+        // restarts at zero and duplicates sequence numbers within one WAL.
+        if max_segment_index.is_some() {
+            let reader = UnifiedWALReader::new(base_url.clone()).await?;
+            if let Some(last_seq) = reader
+                .read_all()
+                .await?
+                .into_iter()
+                .map(|entry| entry.sequence_number)
+                .max()
+            {
+                next_seq = next_seq.max(last_seq.saturating_add(1));
             }
         }
 
@@ -498,7 +514,7 @@ impl UnifiedWALWriter {
                 "WAL recovery: found {} segments (next index {}), resuming from sequence {}",
                 segment_count,
                 segment_counter,
-                max_seq
+                next_seq
             );
         } else {
             tracing::debug!("WAL writer initialized fresh for path: {}", base_path);
@@ -510,7 +526,7 @@ impl UnifiedWALWriter {
             // re-prepend `file://` — on an object-store base that yields
             // invalid `file://s3://…` URLs (TD-OBJSTORE-1, #960).
             base_path: base_url,
-            sequence_number: std::sync::atomic::AtomicU64::new(max_seq),
+            sequence_number: std::sync::atomic::AtomicU64::new(next_seq),
             filesystem,
             current_segment_path: None,
             current_segment_data: Vec::new(),
@@ -1234,6 +1250,34 @@ mod tests {
             1,
             "new append must open a fresh segment past the max"
         );
+    }
+
+    #[tokio::test]
+    async fn writer_reopen_resumes_sequence_after_current_format_segments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().to_str().unwrap().to_string();
+
+        let mut writer = UnifiedWALWriter::new(path.clone()).await.unwrap();
+        assert_eq!(writer.append(node_op("g", "a")).await.unwrap(), 0);
+        assert_eq!(writer.append(node_op("g", "b")).await.unwrap(), 1);
+        writer.flush().await.unwrap();
+        drop(writer);
+
+        let mut reopened = UnifiedWALWriter::new(path.clone()).await.unwrap();
+        assert_eq!(
+            reopened.append(node_op("g", "c")).await.unwrap(),
+            2,
+            "the current wal_NNNNNNNN.log format must restore the next sequence"
+        );
+        reopened.flush().await.unwrap();
+
+        let entries = UnifiedWALReader::new(path)
+            .await
+            .unwrap()
+            .read_all()
+            .await
+            .unwrap();
+        assert_eq!(seqs(&entries), vec![0, 1, 2]);
     }
 
     /// A stale/missing checkpoint marker must never delete live frames: truncate

--- a/tests/duckdb_route_pgwire_e2e.rs
+++ b/tests/duckdb_route_pgwire_e2e.rs
@@ -141,7 +141,15 @@ fn eligible_cases() -> Vec<(&'static str, Vec<&'static str>)> {
         ),
         (
             "SELECT o_orderstatus, count(*) FROM orders GROUP BY o_orderstatus ORDER BY o_orderstatus",
-            vec!["F|2", "O|2", "P|1"],
+            vec!["F|2", "O|3", "P|1"],
+        ),
+        (
+            "SELECT o.o_orderstatus, CAST(sum(l.l_extendedprice) AS DECIMAL(12,2)) FROM orders o JOIN lineitem l ON o.o_orderkey = l.l_orderkey GROUP BY o.o_orderstatus ORDER BY o.o_orderstatus",
+            vec!["F|90.00", "O|80.00", "P|80.00"],
+        ),
+        (
+            "SELECT o.o_orderkey, l.l_extendedprice FROM orders o LEFT JOIN lineitem l ON o.o_orderkey = l.l_orderkey WHERE o.o_orderkey = 6",
+            vec!["6|"],
         ),
     ]
 }
@@ -182,7 +190,7 @@ async fn eval_body() {
         "DROP TABLE IF EXISTS orders",
         "CREATE TABLE orders (o_orderkey INT PRIMARY KEY, o_custkey INT, o_totalprice DOUBLE PRECISION, o_orderstatus VARCHAR)",
         "CREATE TABLE lineitem (l_orderkey INT, l_quantity DOUBLE PRECISION, l_extendedprice DOUBLE PRECISION)",
-        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F')",
+        "INSERT INTO orders VALUES (1,10,100.0,'O'),(2,20,200.0,'F'),(3,10,50.0,'O'),(4,30,300.0,'P'),(5,20,150.0,'F'),(6,40,NULL,'O')",
         "INSERT INTO lineitem VALUES (1,5.0,50.0),(1,2.0,20.0),(2,3.0,60.0),(3,1.0,10.0),(4,4.0,80.0),(5,2.0,30.0)",
     ] {
         client
@@ -214,7 +222,7 @@ async fn eval_body() {
     let rows = query_rows(&client, "SELECT count(*) FROM orders")
         .await
         .expect("scalar count");
-    assert_eq!(rows, vec!["5".to_string()]);
+    assert_eq!(rows, vec!["6".to_string()]);
 
     // 2. Attribution: DuckDbCompat cells learned for eligible classes only.
     let cells = proximadb::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL.learned_cell_keys();

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -30,6 +30,7 @@
 //!                                CI floor); unset → full 1M + provided GT
 //!   PROXIMADB_SIFT_QUERIES       cap the query count (default 1000)
 //!   PROXIMADB_SIFT_RECALL_FLOOR  ratchet threshold (default 0.90)
+//!   PROXIMADB_RECALL_DATASET_REQUIRED fail instead of skip when corpus is absent
 //!
 //! nextest isolates each test in its own process, so the PAX env vars set here
 //! don't leak. `set_var` is `unsafe` (edition 2024).
@@ -43,9 +44,11 @@ use proximadb::storage::engines::sst::SstEngine;
 use proximadb::storage::traits::{
     FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
 };
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::TempDir;
 
 const DIMENSION: usize = 128;
@@ -119,6 +122,12 @@ fn dataset_path(filename: &str) -> Option<PathBuf> {
     })
 }
 
+fn dataset_required() -> bool {
+    std::env::var("PROXIMADB_RECALL_DATASET_REQUIRED")
+        .ok()
+        .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on"))
+}
+
 /// Squared L2 distance (order-preserving — fine for ranking).
 fn l2_sq(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
@@ -131,8 +140,47 @@ fn brute_force_topk(base: &[Vec<f32>], query: &[f32], k: usize) -> Vec<String> {
         .enumerate()
         .map(|(i, v)| (i, l2_sq(query, v)))
         .collect();
-    sims.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    sims.iter().take(k).map(|(i, _)| format!("v{i}")).collect()
+    if sims.len() > k {
+        sims.select_nth_unstable_by(k, |a, b| a.1.total_cmp(&b.1));
+        sims.truncate(k);
+    }
+    sims.into_iter().map(|(i, _)| format!("v{i}")).collect()
+}
+
+/// Build exact top-k sets for a prefix subset without doing a full sort per
+/// query. SIFT's provided top-100 row is still exact after filtering to ids in
+/// the subset whenever it contains at least `TOP_K` such ids. The remaining
+/// rows fall back to a parallel brute-force linear selection.
+fn exact_ground_truth(
+    base: &[Vec<f32>],
+    queries: &[Vec<f32>],
+    gt_path: Option<&Path>,
+) -> (Vec<std::collections::HashSet<String>>, usize) {
+    let provided = gt_path
+        .filter(|path| path.exists())
+        .map(|path| read_vec_records_u32(path, Some(queries.len())).expect("read gt"))
+        .unwrap_or_default();
+    let fallback_count = AtomicUsize::new(0);
+    let result = queries
+        .par_iter()
+        .enumerate()
+        .map(|(qi, query)| {
+            if let Some(row) = provided.get(qi) {
+                let filtered: Vec<u32> = row
+                    .iter()
+                    .copied()
+                    .filter(|id| (*id as usize) < base.len())
+                    .take(TOP_K)
+                    .collect();
+                if filtered.len() == TOP_K {
+                    return filtered.into_iter().map(vid).collect();
+                }
+            }
+            fallback_count.fetch_add(1, Ordering::Relaxed);
+            brute_force_topk(base, query, TOP_K).into_iter().collect()
+        })
+        .collect();
+    (result, fallback_count.load(Ordering::Relaxed))
 }
 
 fn vid(i: u32) -> String {
@@ -240,6 +288,10 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     let base_path = match dataset_path("sift_base.fvecs") {
         Some(p) => p,
         None => {
+            assert!(
+                !dataset_required(),
+                "PROXIMADB_SIFT_DATASET_DIR is required by this recall gate"
+            );
             eprintln!(
                 "skip: PROXIMADB_SIFT_DATASET_DIR unset — SIFT1M ratchet needs the TEXMEX corpus"
             );
@@ -247,6 +299,10 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
         }
     };
     if !base_path.exists() {
+        assert!(
+            !dataset_required(),
+            "required SIFT dataset is missing: {base_path:?}"
+        );
         eprintln!("skip: {base_path:?} not found — download SIFT1M (.fvecs) to enable");
         return;
     }
@@ -297,6 +353,12 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
 
     // --- Load queries -----------------------------------------------------------------
     let query_path = dataset_path("sift_query.fvecs");
+    if dataset_required() {
+        assert!(
+            query_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT query corpus is missing: {query_path:?}"
+        );
+    }
     let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
         Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
         None => {
@@ -307,22 +369,19 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     };
     let qcount = queries.len();
 
-    // --- Ground truth: provided (.ivecs) for full 1M, brute-force for subsets ---------
+    // --- Ground truth: filtered provided top-100 plus exact subset fallback ------------
     let gt_path = dataset_path("sift_groundtruth.ivecs");
-    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
-    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
-        eprintln!("using provided sift_groundtruth.ivecs (full 1M)");
-        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
-        gt.into_iter()
-            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
-            .collect()
-    } else {
-        eprintln!("computing brute-force L2 ground truth over the {n}-vector subset");
-        queries
-            .iter()
-            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
-            .collect()
-    };
+    if dataset_required() {
+        assert!(
+            gt_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT ground-truth corpus is missing: {gt_path:?}"
+        );
+    }
+    let (ground_truth, brute_force_rows) = exact_ground_truth(&base, &queries, gt_path.as_deref());
+    eprintln!(
+        "ground truth rows={qcount}: provided/filterable={}, brute-force={brute_force_rows}",
+        qcount - brute_force_rows
+    );
     // base no longer needed for GT in the provided-GT path; drop to free memory
     // before the query loop on the 1M run.
     drop(base);
@@ -345,12 +404,8 @@ async fn sift_pax_cascade_recall_at_10_ratchet() {
     assert!(measured > 0, "no queries succeeded — cannot report recall");
     let recall = recall_sum / measured as f64;
     eprintln!(
-        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, floor={floor}); {}",
-        if use_provided_gt {
-            "provided-GT"
-        } else {
-            "brute-force-GT"
-        }
+        "SIFT PAX cascade recall@{TOP_K} = {recall:.4} over {measured} queries \
+         (N={n}, floor={floor}, brute-force-GT rows={brute_force_rows})",
     );
     assert!(
         recall >= floor,
@@ -385,6 +440,10 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
     let base_path = match dataset_path("sift_base.fvecs") {
         Some(p) if p.exists() => p,
         _ => {
+            assert!(
+                !dataset_required(),
+                "SIFT1M corpus is required by the VOE promotion gate"
+            );
             eprintln!(
                 "skip: PROXIMADB_SIFT_DATASET_DIR unset/missing — centroid-prune ratchet needs SIFT1M"
             );
@@ -402,13 +461,19 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
         .unwrap_or(DEFAULT_QUERIES);
-    // Pruned recall floor: separate + conservative (pruning + coarse clustering
-    // trims recall vs the unpruned 0.90 baseline). CI measures and ratchets it UP.
+    // Keep an absolute floor as a secondary sanity check. The promotion decision
+    // is the same-run differential below; an absolute 0.70 floor allowed severe
+    // regressions whenever the unpruned path happened to be much better.
     let floor: f64 = std::env::var("PROXIMADB_SIFT_CENTROID_RECALL_FLOOR")
         .ok()
         .and_then(|v| v.parse::<f64>().ok())
         .filter(|f| (0.0..=1.0).contains(f))
-        .unwrap_or(0.70);
+        .unwrap_or(0.90);
+    let max_recall_drop: f64 = std::env::var("PROXIMADB_SIFT_CENTROID_MAX_RECALL_DROP")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|f| (0.0..=1.0).contains(f))
+        .unwrap_or(0.0);
 
     let temp_dir = TempDir::new().unwrap();
     let collection = collection("sift_voe_centroid_prune", &temp_dir);
@@ -435,27 +500,58 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
     }
 
     let query_path = dataset_path("sift_query.fvecs");
+    if dataset_required() {
+        assert!(
+            query_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT query corpus is missing: {query_path:?}"
+        );
+    }
     let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
         Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
         None => base.iter().take(max_queries.min(n)).cloned().collect(),
     };
     let qcount = queries.len();
     let gt_path = dataset_path("sift_groundtruth.ivecs");
-    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
-    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
-        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
-        gt.into_iter()
-            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
-            .collect()
-    } else {
-        queries
-            .iter()
-            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
-            .collect()
-    };
+    if dataset_required() {
+        assert!(
+            gt_path.as_ref().is_some_and(|path| path.exists()),
+            "required SIFT ground-truth corpus is missing: {gt_path:?}"
+        );
+    }
+    let (ground_truth, brute_force_rows) = exact_ground_truth(&base, &queries, gt_path.as_deref());
+    eprintln!(
+        "VOE ground truth rows={qcount}: provided/filterable={}, brute-force={brute_force_rows}",
+        qcount - brute_force_rows
+    );
     drop(base);
 
-    // Run the whole search loop inside ONE io_trace scope so the centroid-prune
+    // Measure the unpruned production path on the exact same flushed segments,
+    // query set, and ground truth. This makes the gate a differential rather
+    // than an absolute floor that can pass despite a large recall loss.
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_CENTROID_PRUNE");
+    }
+    let mut baseline_sum = 0.0f64;
+    let mut baseline_measured = 0usize;
+    for (qi, query) in queries.iter().enumerate() {
+        let got = search_topk(&engine, &collection, query.clone()).await;
+        if got.is_empty() {
+            continue;
+        }
+        let got_ids: std::collections::HashSet<String> = got.into_iter().take(TOP_K).collect();
+        baseline_sum += got_ids.intersection(&ground_truth[qi]).count() as f64 / TOP_K as f64;
+        baseline_measured += 1;
+    }
+    assert!(
+        baseline_measured > 0,
+        "unpruned baseline returned no results"
+    );
+    let baseline_recall = baseline_sum / baseline_measured as f64;
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+    }
+
+    // Run the pruned search loop inside ONE io_trace scope so the centroid-prune
     // counter accumulates across queries; the snapshot proves the prune engaged.
     let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
         let mut recall_sum = 0.0f64;
@@ -482,8 +578,9 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
 
     assert!(measured > 0, "no queries succeeded — cannot report recall");
     eprintln!(
-        "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} over {measured} queries (N={n}, \
-         floor={floor}); centroid blocks total={} pruned={}",
+        "SIFT VOE recall@{TOP_K}: unpruned={baseline_recall:.4}, pruned={recall:.4} over \
+         {measured} queries (N={n}, floor={floor}, max_drop={max_recall_drop}); centroid \
+         blocks total={} pruned={}",
         snap.centroid_total_blocks, snap.centroid_pruned_blocks
     );
     // (a) The prune MUST have engaged — a silent full-scan fallback leaves this 0.
@@ -499,6 +596,12 @@ async fn sift_voe_centroid_prune_recall_at_10_ratchet() {
         "SIFT VOE centroid-prune recall@{TOP_K} = {recall:.4} < {floor} floor (N={n}) — \
          default-ON flip BLOCKED until the clustering/nprobe is tuned \
          (PROXIMADB_PAX_CENTROID_PRUNE_RATIO / S4 IVF clustering)"
+    );
+    assert!(
+        recall + max_recall_drop >= baseline_recall,
+        "SIFT VOE centroid-prune recall regressed from same-run unpruned \
+         {baseline_recall:.4} to {recall:.4} (allowed drop {max_recall_drop:.4}, N={n}) — \
+         default-ON flip remains blocked"
     );
 }
 

--- a/tests/sst_voe_centroid_prune_e2e.rs
+++ b/tests/sst_voe_centroid_prune_e2e.rs
@@ -12,9 +12,9 @@
 //! compare silently missed and the prune fell back to a full scan (`centroid_
 //! pruned_blocks = 0`). The read now matches by filename basename.
 //!
-//! Synthetic corpus (no SIFT dataset) so it runs in NORMAL CI — the storage
-//! integration job globs `tests/*sst*.rs` (hence this file's name). nextest /
-//! `--test-threads=1` isolates the process, so the env opt-ins below don't leak.
+//! A 768-dimensional, multi-flush corpus runs in normal CI. It is not a substitute
+//! for the required real-dataset gate, but it catches dimensional and segment-churn
+//! regressions between those heavier runs.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -32,7 +32,7 @@ use proximadb::storage::traits::{
 };
 use tempfile::TempDir;
 
-const DIM: usize = 32;
+const DIM: usize = 768;
 const TOP_K: usize = 10;
 
 fn collection(id: &str, temp: &TempDir) -> Collection {
@@ -136,7 +136,7 @@ async fn voe_centroid_block_prune_engages_e2e() {
         std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS", "2"); // force on small seg
         // Small target block ⇒ many blocks from few vectors, so the prune has
         // blocks to skip (needs ≥ MIN_BLOCKS to engage).
-        std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", "16384");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", "4096");
     }
     let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
 
@@ -147,8 +147,10 @@ async fn voe_centroid_block_prune_engages_e2e() {
         .unwrap()
         .with_directory_cache(Arc::new(VectorObjectEconomyDirectoryCache::new()));
 
-    // Well-separated synthetic corpus, enough for many blocks at the small target.
-    let n: u32 = 400;
+    // Production-dimensional structured corpus, enough for many blocks at the
+    // small target. Four flush generations exercise directory accumulation and
+    // the multi-segment read shape that exposed the measured churn regression.
+    let n: u32 = 80;
     let corpus: Vec<Vec<f32>> = (0..n)
         .map(|i| {
             (0..DIM)
@@ -156,23 +158,42 @@ async fn voe_centroid_block_prune_engages_e2e() {
                 .collect()
         })
         .collect();
-    let batch: Vec<VectorRecord> = corpus
-        .iter()
-        .enumerate()
-        .map(|(i, v)| vrec(i as u32, v.clone()))
-        .collect();
-    flush_batch(&engine, &coll, batch).await;
+    for (generation, chunk) in corpus.chunks(20).enumerate() {
+        let batch: Vec<VectorRecord> = chunk
+            .iter()
+            .enumerate()
+            .map(|(i, v)| vrec((generation * 20 + i) as u32, v.clone()))
+            .collect();
+        flush_batch(&engine, &coll, batch).await;
+    }
 
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_CENTROID_PRUNE");
+    }
+    let query_indices = [7usize, 23, 49, 79];
+    let mut baseline = Vec::new();
+    for &i in &query_indices {
+        baseline.push(search_topk(&engine, &coll, corpus[i].clone()).await);
+    }
+
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+    }
     // Search inside an io_trace scope so the centroid-prune counter is observable.
-    let query = corpus[137].clone();
-    let (got, snap) = io_trace::scope(async {
-        let r = search_topk(&engine, &coll, query).await;
+    let (pruned, snap) = io_trace::scope(async {
+        let mut results = Vec::new();
+        for &i in &query_indices {
+            results.push(search_topk(&engine, &coll, corpus[i].clone()).await);
+        }
         let s = io_trace::snapshot().expect("io_trace scope active");
-        (r, s)
+        (results, s)
     })
     .await;
 
-    assert!(!got.is_empty(), "search returned results");
+    assert!(
+        pruned.iter().all(|got| !got.is_empty()),
+        "search returned results"
+    );
     assert!(
         snap.centroid_pruned_blocks > 0,
         "centroid BLOCK prune must ENGAGE (flush→emit→read round-trip) — got total={} pruned={} \
@@ -180,5 +201,9 @@ async fn voe_centroid_block_prune_engages_e2e() {
          emit `object_url` vs read `sstable_path` file match must be basename-based, not exact-URL).",
         snap.centroid_total_blocks,
         snap.centroid_pruned_blocks
+    );
+    assert_eq!(
+        pruned, baseline,
+        "768D multi-flush VOE results must not regress against the same-run unpruned path"
     );
 }


### PR DESCRIPTION
## Summary

Adds durability and fencing containment for the object-store and DDL findings from the independent 2026-07-14 review:

- wire pgwire DDL to the same renewable partition lease manager used by DML
- lease-check MaterializeTable/CreateIndex/DropIndex and revalidate ownership before success
- document the SystemCatalog fence boundary for external side effects
- add filesystem append capability reporting and reject unsupported queue/RAPTOR object-store paths
- recover the unified WAL sequence allocator from current-format segments after reopen
- expand TD-OBJSTORE-1 deferred-surface disclosure

This is stack 2 of 3. It replaces #982, which GitHub automatically closed when the already-merged #981 base branch was deleted.

## Risk addressed

- A9-F1: unfenced/duplicate long-running DDL work
- A4-F1/F2: append-class reintroduction and incomplete object-store disclosure
- A4-F3: WAL sequence reuse after reopen

## Validation

- isolated stacked `cargo check --lib`
- focused DDL lease/expiry, queue capability, RAPTOR capability, and WAL reopen tests
- `cargo fmt --all -- --check`
- `git diff --check`

## Dependency and merge order

#981 is merged. This replacement targets `develop` directly; merge it before #983.
