### PR TITLE
fix(helix): route object-store IO by collection URL

### DIFF
--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -151,7 +151,7 @@ impl ServerProcess {
     }
 }
 
-async fn create_and_insert(base: &str, collection: &str) -> anyhow::Result<()> {
+async fn create_and_insert(base: &str, collection: &str, engine: &str) -> anyhow::Result<()> {
     let http = Client::builder()
         .no_proxy()
         .timeout(Duration::from_secs(30))
@@ -161,7 +161,7 @@ async fn create_and_insert(base: &str, collection: &str) -> anyhow::Result<()> {
         .json(&json!({
             "name": collection,
             "dimension": 8,
-            "engine": "sst",
+            "engine": engine,
             "distance_metric": "cosine",
             "canonical_embedding_precision": "fp32",
             "enable_proxima_record": false
@@ -249,7 +249,8 @@ async fn catalog_wal_and_sst_survive_fresh_local_disks() -> anyhow::Result<()> {
         uuid::Uuid::new_v4().simple()
     );
     let tmp = tempfile::tempdir()?;
-    let collection = format!("td_objstore_{}", uuid::Uuid::new_v4().simple());
+    let sst_collection = format!("td_objstore_sst_{}", uuid::Uuid::new_v4().simple());
+    let helix_collection = format!("td_objstore_helix_{}", uuid::Uuid::new_v4().simple());
 
     let vm1 = tmp.path().join("vm1");
     let vm2 = tmp.path().join("vm2");
@@ -259,15 +260,18 @@ async fn catalog_wal_and_sst_survive_fresh_local_disks() -> anyhow::Result<()> {
     }
 
     let first = ServerProcess::start(&root, &vm1, &tmp.path().join("vm1.toml")).await?;
-    create_and_insert(&first.base_url, &collection).await?;
+    create_and_insert(&first.base_url, &sst_collection, "sst").await?;
+    create_and_insert(&first.base_url, &helix_collection, "helix").await?;
     first.crash()?;
 
     let wal_replay = ServerProcess::start(&root, &vm2, &tmp.path().join("vm2.toml")).await?;
-    assert_recovered(&wal_replay.base_url, &collection, "WAL replay").await?;
+    assert_recovered(&wal_replay.base_url, &sst_collection, "SST WAL replay").await?;
+    assert_recovered(&wal_replay.base_url, &helix_collection, "HELIX WAL replay").await?;
     wal_replay.graceful()?; // materializes SST and reclaims flushed WAL
 
     let cold_sst = ServerProcess::start(&root, &vm3, &tmp.path().join("vm3.toml")).await?;
-    assert_recovered(&cold_sst.base_url, &collection, "cold SST").await?;
+    assert_recovered(&cold_sst.base_url, &sst_collection, "cold SST").await?;
+    assert_recovered(&cold_sst.base_url, &helix_collection, "cold HELIX").await?;
     cold_sst.crash()?;
     Ok(())
 }

--- a/docs/10-quality/td/TD-OBJSTORE-2.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-2.adoc
@@ -83,6 +83,23 @@ SST and VIPER flush/read paths use the recovered
 `Collection.storage_assignment.base_location` and the unified filesystem. They do
 not need a local staging `data_directory` to recover a collection.
 
+=== HELIX filesystem routing
+
+The second live ADLS attempt exposed a local-filesystem escape in HELIX. Although
+HELIX owns a `FilesystemFactory`, its shared caching wrapper was constructed over
+`file://` and reused for collection flush, PCA model persistence, search, point reads,
+and recovery. A recovered object-store assignment was therefore handed to the local
+backend and failed with `Permission denied`.
+
+HELIX now resolves a caching filesystem from each collection's assigned data URL and
+threads that backend through flush, PCA model load/save, metadata discovery, search,
+point reads, full-record reads, compaction, strategy readers, and vector extraction.
+The extractor checks existence through `FileSystem`; it no longer applies
+`std::path::Path::exists` to object URLs and silently drops them. Auto-selection
+remains unchanged: HELIX is a supported production engine on object storage, not
+silently downgraded. The resolved engine is also persisted in `StorageAssignment`
+and used for compression defaults.
+
 === Local-filesystem escape audit
 
 * Graph collection metadata now resolves to
@@ -119,12 +136,14 @@ second instance recovers the table solely from object storage. This fails with t
 === Real process / real backend integration
 
 `apps/proximadb-server/tests/object_store_restart_recovery.rs` launches the production
-server binary three times against one unique `s3://` or `adls://` prefix:
+server binary three times against one unique `s3://` or `adls://` prefix and creates
+both SST and HELIX collections:
 
-. VM 1: create SST collection + insert records; SIGKILL.
-. VM 2 with empty local disk: recover catalog, replay WAL, and find the record; SIGINT
-  to materialize SST and reclaim flushed WAL.
-. VM 3 with another empty local disk: recover catalog and find the record from cold SST.
+. VM 1: create both collections + insert records; SIGKILL.
+. VM 2 with empty local disk: recover catalog, replay WAL, and find both records; SIGINT
+  to materialize SST/HELIX files and reclaim flushed WAL.
+. VM 3 with another empty local disk: recover catalog and find both records from cold
+  object-store files.
 
 Run:
 
@@ -155,3 +174,7 @@ Before marking this TD closed, attach:
 * 2026-07-14 — first live ADLS run recovered the catalog but exposed WAL replay before
   storage-engine registration; fixed startup ordering, duplicate replay, and
   fail-open recovery errors. A passing rerun remains the closure gate.
+* 2026-07-14 — live rerun fail-closed on auto-selected HELIX collections because its
+  caching filesystem remained bound to `file://`; routed HELIX operations through the
+  collection-assigned backend and corrected the persisted resolved engine. A passing
+  rerun remains the closure gate.

--- a/scripts/prove_object_store_durability.sh
+++ b/scripts/prove_object_store_durability.sh
@@ -22,7 +22,8 @@ esac
 echo "TD-OBJSTORE-2 durability proof"
 echo "  object root: ${PROXIMADB_OBJECT_STORE_URL}"
 echo "  backend feature: ${feature}"
-echo "  phases: crash/WAL replay -> graceful SST flush -> fresh-disk cold SST read"
+echo "  engines: SST + HELIX"
+echo "  phases: crash/WAL replay -> graceful flush -> fresh-disk cold read"
 
 cargo test \
   -p proximadb-server \
@@ -31,4 +32,4 @@ cargo test \
   catalog_wal_and_sst_survive_fresh_local_disks \
   -- --ignored --nocapture --test-threads=1
 
-echo "PASS: catalog recovered from metadata_url, WAL replay reattached the collection, and SST served a second fresh-disk restart"
+echo "PASS: catalog recovered from metadata_url, WAL replay reattached SST + HELIX collections, and both engines served a second fresh-disk restart"

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -790,7 +790,9 @@ impl CollectionService {
         if let Some(ref mut storage_cfg) = enriched_config.storage_config {
             let resolved_compression = self.resolve_compression_config(
                 None, // No existing compression config to resolve from
-                config.storage_engine.unwrap_or(StorageEngine::Sst as i32),
+                enriched_config
+                    .storage_engine
+                    .unwrap_or(StorageEngine::Sst as i32),
             );
             if let Some(compression_config) = resolved_compression {
                 storage_cfg.compression = Some(compression_config.algorithm);
@@ -1140,7 +1142,9 @@ impl CollectionService {
             storage_assignment: Some(crate::proto::proximadb_v1::StorageAssignment {
                 primary_path: tenant_base_location.clone(),
                 backup_paths: vec![],
-                engine: config.storage_engine.unwrap_or(StorageEngine::Sst as i32),
+                engine: enriched_config
+                    .storage_engine
+                    .unwrap_or(StorageEngine::Sst as i32),
                 engine_config: std::collections::HashMap::new(),
                 base_location: tenant_base_location.clone(), // Tenant-prefixed path
                 assigned_at: chrono::Utc::now().timestamp_micros(),

--- a/src/storage/engines/helix/extraction.rs
+++ b/src/storage/engines/helix/extraction.rs
@@ -113,21 +113,24 @@ impl VectorExtractor for HelixExtractor {
         }
 
         // Filter out non-existent files to handle race conditions gracefully
-        // (e.g., temp directories cleaned up before AXIS consumer processes events)
+        // (e.g., temp directories cleaned up before AXIS consumer processes events).
+        // Use the configured filesystem: std::path::Path::exists would classify every
+        // object-store URL as missing and silently skip extraction.
         let mut existing_files = Vec::with_capacity(request.file_paths.len());
         let mut missing_count = 0;
         for path in &request.file_paths {
-            // Strip file:// prefix if present
-            let local_path = if path.starts_with("file://") {
-                path.strip_prefix("file://").unwrap_or(path)
-            } else {
-                path.as_str()
-            };
-            if std::path::Path::new(local_path).exists() {
-                existing_files.push(path.clone());
-            } else {
-                missing_count += 1;
-                debug!("[HELIX Extractor] File not found (skipping): {}", path);
+            match self.filesystem.exists(path).await {
+                Ok(true) => existing_files.push(path.clone()),
+                Ok(false) => {
+                    missing_count += 1;
+                    debug!("[HELIX Extractor] File not found (skipping): {}", path);
+                }
+                Err(error) => {
+                    return Err(ExtractionError::IoError(format!(
+                        "Failed to check HELIX file {}: {}",
+                        path, error
+                    )));
+                }
             }
         }
 

--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -97,7 +97,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, warn};
 
 // Core modules
 pub mod clustering;
@@ -280,20 +280,6 @@ pub struct HelixEngine {
     /// Tuned for spatial locality optimization
     config: HelixConfig,
 
-    /// **Unified Caching Filesystem**
-    ///
-    /// Production-grade filesystem with integrated caching:
-    /// - Handles local, S3, Azure, GCS backends
-    /// - Metadata caching for file stats
-    /// - Disk caching for frequently accessed data
-    /// - Prefetch optimization for sequential reads
-    /// - Engine-aware serialization
-    /// - Zero-copy I/O integration
-    ///
-    /// Shared across all file operations (flush, compact, search)
-    filesystem:
-        Arc<crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem>,
-
     /// **Filesystem Factory**
     ///
     /// Creates filesystem instances for backends:
@@ -375,17 +361,6 @@ pub struct HelixEngine {
     ///
     /// RwLock allows concurrent reads, exclusive writes
     levels: Arc<RwLock<HashMap<usize, Vec<SStableMetadata>>>>,
-
-    /// **Leveled Compactor**
-    ///
-    /// Background compaction with Hilbert awareness:
-    /// - Merges overlapping Hilbert ranges across levels
-    /// - Maintains sorted order within each level
-    /// - Splits SSTables at Hilbert boundaries
-    /// - Recomputes zone maps during merge
-    ///
-    /// Runs asynchronously, triggered by level thresholds
-    compactor: Arc<LeveledCompactor>,
 
     /// **Query Optimizer**
     ///
@@ -663,8 +638,11 @@ impl HelixEngine {
 
         // Create UnifiedCachingFilesystem with engine-aware serialization (like SST/VIPER/RAPTOR)
         // This provides metadata caching, disk caching, and prefetch optimization
+        let data_dir_url = data_dir
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("HELIX: Invalid data directory path"))?;
         let base_filesystem = filesystem_factory
-            .get_filesystem("file://")
+            .get_filesystem(data_dir_url)
             .map_err(|e| anyhow::anyhow!("Failed to get base filesystem: {}", e))?;
 
         let filesystem = Arc::new(
@@ -677,11 +655,7 @@ impl HelixEngine {
 
         // Create data directory if it doesn't exist
         // Note: data_dir should come from collection config storage assignment
-        if let Some(dir_str) = data_dir.to_str() {
-            filesystem.create_dir_all(dir_str).await?;
-        } else {
-            return Err(anyhow::anyhow!("HELIX: Invalid data directory path"));
-        }
+        filesystem.create_dir_all(data_dir_url).await?;
 
         // Initialize unified components (similar to SST)
         let distance_compute = if let Some(compute) = distance_compute_override {
@@ -740,13 +714,6 @@ impl HelixEngine {
         // Initialize levels from existing files
         let levels = Self::load_levels(&filesystem, &data_dir).await?;
 
-        // Create compactor
-        let compactor = Arc::new(LeveledCompactor::new(
-            config.clone(),
-            filesystem.clone(),
-            data_dir.clone(),
-        ));
-
         // Create query optimizer
         let query_optimizer = Arc::new(QueryOptimizer::new(
             1000, // Max query history
@@ -765,7 +732,6 @@ impl HelixEngine {
         // Create engine instance (stateless - no collection-specific state)
         let engine = Self {
             config,
-            filesystem,
             filesystem_factory,
             distance_compute,
             storage_quantization_engine,
@@ -773,7 +739,6 @@ impl HelixEngine {
             cache_orchestrator,
             pca_model: Arc::new(RwLock::new(None)),
             levels: Arc::new(RwLock::new(levels)),
-            compactor,
             query_optimizer,
             event_log,
             axis_manager: None, // AXIS manager will be set externally if available
@@ -1003,11 +968,37 @@ impl HelixEngine {
         format!("{}/__model/pca_model.bin", collection_data_dir)
     }
 
+    /// Resolve the caching filesystem from the collection-assigned URL.
+    /// HELIX engines are shared across collections, so a wrapper captured at
+    /// construction time cannot safely represent every local/cloud backend.
+    fn filesystem_for_url(
+        &self,
+        url: &str,
+        collection_id: &str,
+    ) -> Result<
+        Arc<crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem>,
+    > {
+        let underlying = self.filesystem_factory.get_filesystem(url)?;
+        Ok(Arc::new(
+            crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem::new(
+                underlying,
+                collection_id.to_string(),
+                "helix".to_string(),
+            ),
+        ))
+    }
+
     /// Load PCA model from filesystem for a collection
-    async fn load_pca_model(&self, collection_data_dir: &str) -> Result<Option<PCAModel>> {
+    async fn load_pca_model(
+        &self,
+        filesystem: &Arc<
+            crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem,
+        >,
+        collection_data_dir: &str,
+    ) -> Result<Option<PCAModel>> {
         let model_path = self.get_pca_model_path(collection_data_dir);
 
-        match PCAModel::load_from_file(&self.filesystem, &model_path).await {
+        match PCAModel::load_from_file(filesystem, &model_path).await {
             Ok(model) => {
                 tracing::info!(
                     "[HELIX] Loaded persisted PCA model for collection (version: {})",
@@ -1028,17 +1019,24 @@ impl HelixEngine {
     }
 
     /// Save PCA model to filesystem for a collection
-    async fn save_pca_model(&self, collection_data_dir: &str, model: &PCAModel) -> Result<()> {
+    async fn save_pca_model(
+        &self,
+        filesystem: &Arc<
+            crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem,
+        >,
+        collection_data_dir: &str,
+        model: &PCAModel,
+    ) -> Result<()> {
         let model_path = self.get_pca_model_path(collection_data_dir);
 
         // Ensure __model directory exists
         let model_dir = format!("{}/__model", collection_data_dir);
-        self.filesystem
+        filesystem
             .create_dir_all(&model_dir)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to create __model directory: {}", e))?;
 
-        model.save_to_file(&self.filesystem, &model_path).await?;
+        model.save_to_file(filesystem, &model_path).await?;
         tracing::info!(
             "[HELIX] Persisted PCA model for collection at {}",
             model_path
@@ -1087,7 +1085,7 @@ impl HelixEngine {
             data_dir
         );
 
-        let filesystem = self.filesystem_factory.get_filesystem(data_dir)?;
+        let filesystem = self.filesystem_for_url(data_dir, "helix-discovery")?;
         tracing::debug!("[HELIX] Got filesystem for data_dir: {}", data_dir);
 
         // List all .helix files in the directory
@@ -1138,28 +1136,25 @@ impl HelixEngine {
             // Get file size from metadata
             let size_bytes = entry.metadata.size;
 
-            // CRITICAL: Read Hilbert range from file footer for pruning
-            // This enables spatial pruning based on Hilbert curve locality
-            let hilbert_range = self.read_hilbert_range_from_file(file_path).await.ok();
-
-            // CRITICAL: Read num_vectors from header for accurate search performance
-            let num_vectors = self
-                .read_num_vectors_from_file(file_path)
-                .await
-                .unwrap_or_else(|e| {
-                    warn!(
-                        "Failed to read num_vectors from {}: {}, using 0",
-                        file_path, e
-                    );
-                    0
-                });
+            // Read both pruning range and vector count through the backend
+            // selected from this collection URL.
+            let (hilbert_range, num_vectors) =
+                Self::read_file_metadata_from_header(&filesystem, file_path)
+                    .await
+                    .unwrap_or_else(|e| {
+                        warn!(
+                            "Failed to read HELIX metadata from {}: {}, using empty metadata",
+                            file_path, e
+                        );
+                        (None, 0)
+                    });
 
             // Create metadata with Hilbert range for pruning
             let metadata = SStableMetadata {
                 path: std::path::PathBuf::from(file_path),
                 level,
                 hilbert_range, // Now populated from file footer
-                num_vectors,   // Now populated from file header!
+                num_vectors: num_vectors as usize,
                 size_bytes,
                 created_at: chrono::Utc::now(),
                 blocks: Vec::new(),
@@ -1175,39 +1170,6 @@ impl HelixEngine {
             data_dir
         );
         Ok(sstables)
-    }
-
-    /// Read Hilbert range from HELIX unified header
-    /// This is critical for spatial pruning to work effectively
-    async fn read_hilbert_range_from_file(&self, file_path: &str) -> Result<(u64, u64)> {
-        // Use the unified header reader for correct format
-        let (hilbert_range, _) =
-            Self::read_file_metadata_from_header(&self.filesystem, file_path).await?;
-
-        if let Some((min_key, max_key)) = hilbert_range {
-            debug!(
-                "Read Hilbert range from {}: [{}, {}]",
-                file_path, min_key, max_key
-            );
-            Ok((min_key, max_key))
-        } else {
-            Err(anyhow::anyhow!("No Hilbert range found in file"))
-        }
-    }
-
-    /// Read number of vectors from HELIX unified header
-    /// This provides accurate vector count for search optimization
-    async fn read_num_vectors_from_file(&self, file_path: &str) -> Result<usize> {
-        // Use the unified header reader for accurate count
-        let (_, num_vectors) =
-            Self::read_file_metadata_from_header(&self.filesystem, file_path).await?;
-
-        trace!(
-            "Read num_vectors from {}: {} vectors",
-            file_path, num_vectors
-        );
-
-        Ok(num_vectors as usize)
     }
 }
 
@@ -1273,6 +1235,7 @@ impl UnifiedStorageFormat for HelixEngine {
 
         // Get data directory early for both flush and model persistence
         let data_dir = self.get_data_dir_from_flush_params(params)?;
+        let filesystem = self.filesystem_for_url(&data_dir, &collection_id)?;
 
         // SORTED FLUSH OPTIMIZATION: Sort by Hilbert key during L0 flush
         // This enables immediate query pruning even before compaction
@@ -1289,7 +1252,9 @@ impl UnifiedStorageFormat for HelixEngine {
                 } else {
                     drop(model_guard);
                     // Try loading from disk
-                    if let Ok(Some(loaded_model)) = self.load_pca_model(&data_dir).await {
+                    if let Ok(Some(loaded_model)) =
+                        self.load_pca_model(&filesystem, &data_dir).await
+                    {
                         info!(
                             "[HELIX] ✅ Loaded existing PCA model from disk: version={}",
                             loaded_model.version
@@ -1324,7 +1289,7 @@ impl UnifiedStorageFormat for HelixEngine {
                 let trained_model = self.pca_model.read().await.clone();
                 if let Some(ref model) = trained_model {
                     let model_path = self.get_pca_model_path(&data_dir);
-                    match self.save_pca_model(&data_dir, model).await {
+                    match self.save_pca_model(&filesystem, &data_dir, model).await {
                         Ok(_) => info!(
                             "[HELIX] ✅ PCA model persisted: version={}, path={}",
                             model.version, model_path
@@ -1399,13 +1364,13 @@ impl UnifiedStorageFormat for HelixEngine {
         let filename = self.generate_sstable_filename(0);
 
         // Create directory if it doesn't exist
-        self.filesystem.create_dir_all(&data_dir).await?;
+        filesystem.create_dir_all(&data_dir).await?;
 
         let file_path = std::path::Path::new(&data_dir).join(&filename);
 
         // Write unified SIMD-optimized Proxima blocks
         let bytes_written = proxima::write_helix_sstable(
-            &self.filesystem,
+            &filesystem,
             &file_path,
             &sorted_records,
             self.config.proxima_block_size,
@@ -1462,7 +1427,11 @@ impl UnifiedStorageFormat for HelixEngine {
 
         // Trigger compaction if needed
         if self.should_compact().await {
-            let compactor = self.compactor.clone();
+            let compactor = Arc::new(LeveledCompactor::new(
+                self.config.clone(),
+                filesystem.clone(),
+                PathBuf::from(&data_dir),
+            ));
             let levels = self.levels.clone();
             tokio::spawn(async move {
                 if let Err(e) = compactor.compact_l0_to_l1(levels).await {
@@ -1490,6 +1459,10 @@ impl UnifiedStorageFormat for HelixEngine {
     async fn do_compact(&self, params: &CompactionParameters) -> Result<CompactionResult> {
         let collection_id = self.get_collection_id_from_compaction_params(params)?;
         info!("HELIX compaction started for collection {}", collection_id);
+        let data_dir = self.get_data_dir_from_compaction_params(params)?;
+        let filesystem = self.filesystem_for_url(&data_dir, &collection_id)?;
+        let compactor =
+            LeveledCompactor::new(self.config.clone(), filesystem, PathBuf::from(&data_dir));
 
         let start = std::time::Instant::now();
 
@@ -1513,10 +1486,10 @@ impl UnifiedStorageFormat for HelixEngine {
         // Perform compaction based on level
         let (files_compacted, bytes_written) = if level_to_compact == 0 {
             // L0 to L1: Initial clustering with PCA + Hilbert
-            self.compactor.compact_l0_to_l1(self.levels.clone()).await?
+            compactor.compact_l0_to_l1(self.levels.clone()).await?
         } else {
             // Li to Li+1: Progressive refinement with liquid clustering
-            self.compactor
+            compactor
                 .compact_level_to_next(
                     self.levels.clone(),
                     level_to_compact,
@@ -1692,6 +1665,7 @@ impl UnifiedStorageFormat for HelixEngine {
         // HYBRID APPROACH: Use per-collection cache with filesystem discovery
         // Get collection's data directory
         let collection_data_dir = self.get_data_dir_from_collection_config(&ctx.collection)?;
+        let filesystem = self.filesystem_for_url(&collection_data_dir, collection_id)?;
 
         // Get PCA model (load from disk if not in memory)
         let pca_model = {
@@ -1707,7 +1681,10 @@ impl UnifiedStorageFormat for HelixEngine {
                 drop(model_guard); // Release read lock before attempting load
 
                 // Try to load persisted model for this collection
-                if let Some(loaded_model) = self.load_pca_model(&collection_data_dir).await? {
+                if let Some(loaded_model) = self
+                    .load_pca_model(&filesystem, &collection_data_dir)
+                    .await?
+                {
                     debug!(
                         "[HELIX] PCA model loaded from disk: version={}, n_components={}, collection={}",
                         loaded_model.version, loaded_model.n_components, collection_id
@@ -1954,7 +1931,7 @@ impl UnifiedStorageFormat for HelixEngine {
                     &sstables_to_search,
                     k,
                     distance_metric,
-                    &self.filesystem,
+                    &filesystem,
                 )
                 .await?;
 
@@ -2005,7 +1982,7 @@ impl UnifiedStorageFormat for HelixEngine {
 
             // Use parallel search with Hilbert key for block-level pruning
             let results = readers::parallel_search(
-                self.filesystem.clone(),
+                filesystem.clone(),
                 sstables_vec,
                 query_vector.to_vec(),
                 query_hilbert, // CRITICAL: Pass Hilbert key for 80-90% block pruning!
@@ -2034,7 +2011,7 @@ impl UnifiedStorageFormat for HelixEngine {
                 accessed_files.push(sstable.path.to_string_lossy().to_string());
 
                 let sstable_results = readers::search_sstable(
-                    &self.filesystem,
+                    &filesystem,
                     &sstable,
                     query_vector,
                     query_hilbert, // CRITICAL: Pass Hilbert key for 80-90% block pruning!
@@ -2117,8 +2094,8 @@ impl UnifiedStorageFormat for HelixEngine {
         // Construct data directory from base_path and collection_id
         let data_dir = StoragePath::collection_data_path(base_path, collection_id);
 
-        // Use the engine's unified caching filesystem
-        let fs = &self.filesystem;
+        // Resolve the backend from this collection's assigned base path.
+        let fs = self.filesystem_for_url(&data_dir, collection_id)?;
 
         // List all SSTable files in the data directory
         let entries = fs.list(&data_dir).await?;
@@ -2140,7 +2117,7 @@ impl UnifiedStorageFormat for HelixEngine {
                     bloom_filter: None,
                 };
 
-                if let Some(vector) = readers::find_vector_by_id(fs, &metadata, vector_id).await? {
+                if let Some(vector) = readers::find_vector_by_id(&fs, &metadata, vector_id).await? {
                     // Update global cache with found vector
                     if let Some(orchestrator) =
                         crate::storage::cache::orchestrator::CrossCacheOrchestrator::global()
@@ -2238,7 +2215,7 @@ impl UnifiedStorageFormat for HelixEngine {
         let Some(storage_url) = storage_url else {
             return Ok(Vec::new());
         };
-        let fs = self.filesystem_factory.get_filesystem(storage_url)?;
+        let fs = self.filesystem_for_url(storage_url, collection_id)?;
         let mut files = Vec::new();
         if let Ok(entries) = fs.list(storage_url).await {
             for entry in &entries {
@@ -2256,7 +2233,7 @@ impl UnifiedStorageFormat for HelixEngine {
         }
         let reader =
             crate::storage::engines::core::formats::proximablocks::block_reader::HelixBlockReader::new(
-                self.filesystem.clone(),
+                fs,
                 collection_id.to_string(),
             );
         let mut all = Vec::new();

--- a/src/storage/engines/helix/proximablocks_strategy_reader.rs
+++ b/src/storage/engines/helix/proximablocks_strategy_reader.rs
@@ -25,9 +25,6 @@ pub struct UnifiedHELIXReader {
     /// Filesystem factory for direct reads
     filesystem_factory: Arc<FilesystemFactory>,
 
-    /// Cached filesystem for selective reads
-    cached_filesystem: Option<Arc<UnifiedCachingFilesystem>>,
-
     /// Current read strategy
     strategy: ReadAccessStrategy,
 
@@ -58,24 +55,11 @@ impl UnifiedHELIXReader {
         collection_id: String,
         strategy: ReadAccessStrategy,
     ) -> Result<Self> {
-        // Create cached filesystem if needed by strategy
-        let cached_filesystem = if strategy.should_use_cache() {
-            let base_fs = filesystem_factory.get_filesystem("file://")?;
-            Some(Arc::new(UnifiedCachingFilesystem::new(
-                base_fs,
-                collection_id.clone(),
-                "helix".to_string(),
-            )))
-        } else {
-            None
-        };
-
         // Convert unified strategy to HELIX search strategy
         let search_strategy = Self::to_helix_search_strategy(&strategy);
 
         Ok(Self {
             filesystem_factory,
-            cached_filesystem,
             strategy,
             collection_id,
             search_strategy,
@@ -152,7 +136,7 @@ impl UnifiedHELIXReader {
     /// Direct streaming read (for full scans and compaction)
     async fn read_direct_streaming(&self, file_path: &str) -> Result<Vec<VectorRecord>> {
         // Use filesystem factory directly for streaming reads
-        let fs = self.filesystem_factory.get_filesystem("file://")?;
+        let fs = self.filesystem_factory.get_filesystem(file_path)?;
         let _data = fs.read(file_path).await?;
 
         // Deferred: Parse HELIX Proxima format directly without caching
@@ -166,10 +150,9 @@ impl UnifiedHELIXReader {
         file_path: &str,
         _query_hilbert: Option<HilbertKey>,
     ) -> Result<Vec<VectorRecord>> {
-        let cached_fs = self
-            .cached_filesystem
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Cached filesystem not initialized"))?;
+        let base_fs = self.filesystem_factory.get_filesystem(file_path)?;
+        let cached_fs =
+            UnifiedCachingFilesystem::new(base_fs, self.collection_id.clone(), "helix".to_string());
 
         let _data = cached_fs.read(file_path).await?;
 
@@ -195,7 +178,7 @@ impl UnifiedHELIXReader {
 
     /// Check if reader is using cache
     pub fn is_using_cache(&self) -> bool {
-        self.cached_filesystem.is_some()
+        self.strategy.should_use_cache()
     }
 }
 
@@ -207,18 +190,6 @@ impl StrategyAwareReader for UnifiedHELIXReader {
     fn set_strategy(&mut self, strategy: ReadAccessStrategy) {
         self.strategy = strategy;
         self.search_strategy = Self::to_helix_search_strategy(&self.strategy);
-
-        // Update cached filesystem if needed
-        if self.strategy.should_use_cache()
-            && self.cached_filesystem.is_none()
-            && let Ok(base_fs) = self.filesystem_factory.get_filesystem("file://")
-        {
-            self.cached_filesystem = Some(Arc::new(UnifiedCachingFilesystem::new(
-                base_fs,
-                self.collection_id.clone(),
-                "helix".to_string(),
-            )));
-        }
     }
 }
 
@@ -244,7 +215,7 @@ impl DirectHELIXReader {
 
     /// Stream Proxima blocks directly for compaction
     pub async fn stream_proximablocks(&self, file_path: &str) -> Result<Vec<VectorRecord>> {
-        let fs = self.filesystem_factory.get_filesystem("file://")?;
+        let fs = self.filesystem_factory.get_filesystem(file_path)?;
         let _data = fs.read(file_path).await?;
 
         // Deferred: Use Proxima block streaming for direct access
@@ -256,11 +227,12 @@ impl DirectHELIXReader {
         &self,
         sstables: &[SStableMetadata],
     ) -> Result<Vec<VectorRecord>> {
-        let _fs = self.filesystem_factory.get_filesystem("file://")?;
         let mut all_records = Vec::new();
 
         for sstable in sstables {
-            let _data = _fs.read(&sstable.path.to_string_lossy()).await?;
+            let path = sstable.path.to_string_lossy();
+            let fs = self.filesystem_factory.get_filesystem(&path)?;
+            let _data = fs.read(&path).await?;
             // Deferred: Read Proxima blocks and extract records
             // For now, return empty vec - actual implementation would parse Proxima format
         }
@@ -283,8 +255,8 @@ impl DirectHELIXReader {
 /// - Search operations with PCA-based pruning
 /// - Liquid clustering adaptive patterns
 pub struct CachedHELIXReader {
-    cached_filesystem: Arc<UnifiedCachingFilesystem>,
-    _collection_id: String,
+    filesystem_factory: Arc<FilesystemFactory>,
+    collection_id: String,
     search_strategy: HelixSearchStrategy,
 }
 
@@ -294,16 +266,9 @@ impl CachedHELIXReader {
         collection_id: String,
         search_strategy: HelixSearchStrategy,
     ) -> Result<Self> {
-        let base_fs = filesystem_factory.get_filesystem("file://")?;
-        let cached_filesystem = Arc::new(UnifiedCachingFilesystem::new(
-            base_fs,
-            collection_id.clone(),
-            "helix".to_string(),
-        ));
-
         Ok(Self {
-            cached_filesystem,
-            _collection_id: collection_id,
+            filesystem_factory,
+            collection_id,
             search_strategy,
         })
     }
@@ -315,7 +280,10 @@ impl CachedHELIXReader {
         _query_hilbert: Option<HilbertKey>,
         _range_filter: Option<(f64, f64)>, // (min_value, max_value) for any dimension
     ) -> Result<Vec<VectorRecord>> {
-        let _data = self.cached_filesystem.read(file_path).await?;
+        let base_fs = self.filesystem_factory.get_filesystem(file_path)?;
+        let cached_filesystem =
+            UnifiedCachingFilesystem::new(base_fs, self.collection_id.clone(), "helix".to_string());
+        let _data = cached_filesystem.read(file_path).await?;
 
         // Deferred: Apply spatial locality optimized pruning
         match self.search_strategy {
@@ -344,7 +312,10 @@ impl CachedHELIXReader {
         file_path: &str,
         _access_pattern: &str, // Query pattern for adaptation
     ) -> Result<Vec<VectorRecord>> {
-        let _data = self.cached_filesystem.read(file_path).await?;
+        let base_fs = self.filesystem_factory.get_filesystem(file_path)?;
+        let cached_filesystem =
+            UnifiedCachingFilesystem::new(base_fs, self.collection_id.clone(), "helix".to_string());
+        let _data = cached_filesystem.read(file_path).await?;
 
         // Deferred: Apply liquid clustering based on access pattern
         // Cache frequently accessed patterns for better performance


### PR DESCRIPTION
Follow-up to #979 / TD-OBJSTORE-2.\n\nThe live ADLS rerun proved catalog recovery and storage-engine registration, then failed HELIX WAL replay with Permission denied because HELIX captured a file:// caching filesystem at construction. This change resolves the filesystem from each recovered collection URL for flush, PCA model persistence, discovery/search, point/full reads, and compaction. It also persists the resolved engine in StorageAssignment and expands the three-process S3/ADLS proof to SST + HELIX.\n\nVerification:\n- cargo check -p proximadb --lib\n- cargo check -p proximadb-server --features azure --test object_store_restart_recovery\n- cargo fmt --all -- --check\n- git diff --check\n\nClosure gate remains the live ADLS proof after publishing runtime-full.