### PR TITLE
fix(develop): back-merge bench fixes + --benches CI gate from qa (#980)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,14 @@ concurrency:
   # Dedup push+PR of the same branch into one group; cancel superseded runs
   # on feature/PR branches, but let protected-branch validation finish.
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}
+  # Exempt promotion surfaces (push to qa; PRs targeting qa or main) in addition
+  # to main/develop pushes. A develop->qa promotion PR with head=develop lands in
+  # the SAME group as develop pushes, so with cancel-in-progress:true every
+  # feat->develop synchronize killed the in-flight promotion run before its
+  # checks could finish — the promotion never completed during develop churn.
+  # qa-gate.yml already sets cancel-in-progress:false for this reason; mirror it
+  # here. Feature PRs (base=develop) still cancel superseded runs as before.
+  cancel-in-progress: ${{ !(github.event_name == 'pull_request' && contains(fromJson('["qa", "main"]'), github.base_ref)) && !contains(fromJson('["main", "develop", "qa"]'), github.ref_name) }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1149,9 +1149,11 @@ jobs:
   # Both matrix legs are in `ci-success.needs`.
   #
   # The `test` shape is `--lib --bins --tests` (unit + integration tests) — the
-  # correctness-bearing targets. Benches/examples are excluded for now (they
-  # carry separate pre-existing rot); widen to `--all-targets` once those are
-  # repaired.
+  # correctness-bearing targets. The `benches` shape compiles the criterion
+  # micro-benchmarks so internal-API refactors can no longer rot them silently
+  # (TD-BENCH-1: bench_14 was fixed, the 2 unrepairable-against-current-APIs
+  # benches are disabled in Cargo.toml; the rest compile). Examples are still
+  # excluded (separate rot).
   rust-compile:
     name: Rust Compile (${{ matrix.shape }})
     runs-on: ubuntu-latest
@@ -1173,6 +1175,8 @@ jobs:
             args: "--workspace --lib --bins"
           - shape: test
             args: "--workspace --lib --bins --tests"
+          - shape: benches
+            args: "--workspace --benches"
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1093,10 +1093,13 @@ name = "bench_22_multimodal_queries"
 harness = false
 path = "benches/bench_22_multimodal_queries.rs"
 
-[[bench]]
-name = "bench_cross_modal_fusion_e2e"
-harness = false
-path = "benches/bench_cross_modal_fusion_e2e.rs"
+# Disabled — rotted against refactored internal APIs (VectorOperationsService,
+# GraphOperationsService::{create_graph,add_node,add_edge}, FilesystemFactory::new,
+# GraphFusionParams); see TD-BENCH-1. Resurrect once those surfaces stabilize.
+# [[bench]]
+# name = "bench_cross_modal_fusion_e2e"
+# harness = false
+# path = "benches/bench_cross_modal_fusion_e2e.rs"
 
 [[bench]]
 name = "bench_23_codec_vector_base_xor"
@@ -1123,10 +1126,12 @@ name = "bench_vector_object_economy_e2e"
 harness = false
 path = "benches/bench_vector_object_economy_e2e.rs"
 
-[[bench]]
-name = "bench_warm_path_profile"
-harness = false
-path = "benches/bench_warm_path_profile.rs"
+# Disabled — rotted: IndexEngine no longer exposes insert_record (downcast to
+# AxisManager required); see TD-BENCH-1. Resurrect once that path stabilizes.
+# [[bench]]
+# name = "bench_warm_path_profile"
+# harness = false
+# path = "benches/bench_warm_path_profile.rs"
 
 # Recall@k computation bench (criterion). NOTE: measures the recall-computation
 # utility over synthetic vectors + simulated approximate results — it does NOT

--- a/benches/bench_14_graph_operations.rs
+++ b/benches/bench_14_graph_operations.rs
@@ -21,11 +21,15 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use proximadb::{
-    graph::{Edge, Node, PropertyValue, property_value::Value, service::GraphOperationsService},
-    proto::proximadb_v1::{
-        CreateGraphRequest, NodeQuery, PropertyFilter, PropertyFilterOperator, TraversalAlgorithm,
-        TraversalRequest,
+    graph::{
+        Edge, Node, NodeQuery, PropertyFilter, PropertyFilterOperator, PropertyValue,
+        TraversalAlgorithm, TraversalRequest, property_value::Value,
+        service::GraphOperationsService,
     },
+    // CreateGraphRequest is still served from the v1 proto surface (graph creation
+    // has not been migrated to the neutral domain model yet); the query/traversal
+    // request types above were moved to `graph::*` by TD-123 Step 1 (#177).
+    proto::proximadb_v1::CreateGraphRequest,
     services::graph_collection::GraphCollectionService,
 };
 use std::collections::HashMap;

--- a/docs/10-quality/td/TD-BENCH-1-rotted-criterion-benches-no-compile-gate.adoc
+++ b/docs/10-quality/td/TD-BENCH-1-rotted-criterion-benches-no-compile-gate.adoc
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-BENCH-1: Criterion benches rotted against refactored internal APIs (no `--benches` CI gate)
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — 2 rotted benches disabled (`bench_cross_modal_fusion_e2e`, `bench_warm_path_profile`); `bench_14_graph_operations` fixed; `cargo check --benches` CI gate added to prevent recurrence.
+| Severity | Low (dev/maintainability) — the criterion benches are NOT the release benchmark surface (that is the `proximadb-bench` binary, built by `release.yml` and covered by the `--lib --bins` clippy gate). Only `bench_21_query_cache` is exercised in CI.
+| Component | `benches/*` (criterion micro-benchmarks); CI compile scope (`ci.yml`).
+| Tracked-by | develop->qa promotion 2026-07-14.
+| Pillar | QUALITY (test/CI hygiene), DX
+|===
+
+toc::[]
+
+== Symptom
+
+`cargo check --benches` (and therefore `cargo check-fast` / `--all-targets`) failed on `develop` and `qa`. Surfaced during the 2026-07-14 develop->qa promotion:
+
+* `bench_14_graph_operations` — 6 `E0308` mismatched-type errors (constructing v1 proto request types while the graph service API takes `proximadb::graph::*` domain types).
+* `bench_cross_modal_fusion_e2e` — 28 errors across many refactored APIs (`VectorOperationsService::{create_collection,insert_record,flush_collection}`, `GraphOperationsService::{create_graph,add_node,add_edge}`, `FilesystemFactory::new`, `GraphFusionParams` fields, `graph::GraphConfig`, `graph::executor`).
+* `bench_warm_path_profile` — `IndexEngine::insert_record` no longer exists (the trait now exposes only `as_any`; insertion requires a downcast to `AxisManager`).
+
+All other ~27 active `[[bench]]` targets compiled.
+
+== Root cause
+
+Two compounding factors:
+
+1. **API migrations were not propagated to the benches.** The graph engine was decoupled from v1 proto by TD-123 Step 1 (#177, "decouple graph engine from v1 proto via neutral domain model"), which moved `NodeQuery` / `PropertyFilter` / `TraversalRequest` / `TraversalAlgorithm` from `proto::proximadb_v1` to the neutral `proximadb::graph::*` domain model. Independently, `IndexEngine` was refactored (record insertion removed from the trait) and the `VectorOperationsService` / `GraphOperationsService` / `FilesystemFactory` surfaces changed. The criterion benches were never updated to match.
+2. **No CI gate compiles benches.** The clippy gate is `cargo clippy --lib --bins` (`ci.yml`); tests run via `nextest --lib` plus per-file `cargo test --test <name>`. `benches/**` appears in CI only as a change-detection path-filter, never as a compile target. With nothing compiling `--benches`, every internal API change rotted the benches *silently* — exactly the drift class noted in earlier engineering records.
+
+== Action taken (this entry)
+
+* **`bench_14_graph_operations`: fixed** — pure import change: pull the query/traversal request types from `graph::*` instead of `proto::proximadb_v1`. The domain types are structurally identical to the former proto ones (same fields, same enum discriminants), so no construction edits were needed; this also resolved the `PropertyValue`-inside-`PropertyFilter` mismatch.
+* **`bench_cross_modal_fusion_e2e` and `bench_warm_path_profile`: disabled** — their `[[bench]]` entries in `Cargo.toml` are commented out (matching the `bench_01/02/03` "Migrated to proximadb-bench binary" precedent), so the bench suite is compile-clean.
+* **`cargo check --benches` CI gate added** to `ci.yml` so any future API change that breaks a bench fails the introducing PR instead of rotting silently.
+
+== Plan (to resurrect the 2 disabled benches)
+
+`bench_cross_modal_fusion_e2e` and `bench_warm_path_profile` should be re-enabled once their target surfaces stabilize, by rewriting them against the current APIs:
+
+* `bench_warm_path_profile`: downcast the AXIS manager via `IndexEngine::as_any().downcast_ref::<AxisManager>()` and use the current insert path.
+* `bench_cross_modal_fusion_e2e`: reconstruct collection/ingest via the current `VectorOperationsService` surface, graph mutation via `GraphOperationsService::{create_node,create_edge}` (+ `GraphCollectionService::create_graph`), and the current `FilesystemFactory` constructor; align `GraphFusionParams` with its present fields.
+
+Re-enable by uncommenting the two `[[bench]]` blocks in `Cargo.toml`.


### PR DESCRIPTION
The bench hygiene from the #980 develop→qa promotion landed on **qa but not develop**, leaving a loophole: the new `--benches` compile gate only fired at *promotion time* (late), but bench drift is *introduced* on feat→develop PRs (where API migrations happen). develop's `cargo check --benches` was still red (bench_14 + 2 rotted benches unfixed there) and develop's CI didn't notice because the gate wasn't there.

This cherry-picks the three #980 commits onto develop so the drift-catching gate sits where drift originates:

1. **`bench_14_graph_operations`** — use `graph::*` domain types (TD-123 Step 1 migration).
2. **Disable the 2 rotted benches** (`bench_cross_modal_fusion_e2e`, `bench_warm_path_profile`) + file **TD-BENCH-1**.
3. **`benches` leg in the `rust-compile` CI gate** (`cargo check --workspace --benches`) + the ci.yml promotion-surface `cancel-in-progress` exemption (consistency with qa).

Verified: `cargo check --benches --keep-going` now **passes on develop** (was red), lockfile consistent, fmt clean, deterministic guards green. CI-only + bench-source change; no production code touched.