### PR TITLE
ci: skip the release build on feat→develop (dev build + clippy + tests suffice)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
       #     The heaviest, pre-promotion gate.
       # `test_tier` is true for base develop, qa, or main (and pushes to qa/main);
       # `extensive` is true only for base main (and pushes to main).
+      # `medium_tier` is true for base qa or main (and pushes to qa/main) — i.e.
+      # develop->qa and qa->main, but NOT feat->develop.
       test_tier: ${{ github.base_ref == 'develop' || github.base_ref == 'qa' || github.base_ref == 'main' || github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/main' }}
+      medium_tier: ${{ github.base_ref == 'qa' || github.base_ref == 'main' || github.ref == 'refs/heads/qa' || github.ref == 'refs/heads/main' }}
       extensive: ${{ github.base_ref == 'main' || github.ref == 'refs/heads/main' }}
       rust: ${{ steps.filter.outputs.rust }}
       # Comprehensive code-path superset gating the always-required rust-compile
@@ -1234,6 +1237,11 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
 
       - name: Build All Binaries
+        # feat->develop (medium_tier=false): skip the release leg's ~30m compile —
+        # the dev build + clippy + test-compile already cover correctness, and the
+        # release binary artifact is only consumed at qa->main (integration-test,
+        # extensive). dev always runs; release runs at develop->qa+ (medium_tier).
+        if: matrix.profile == 'dev' || needs.changes.outputs.medium_tier == 'true'
         # TD-079 retired the root-crate lint debt 2026-05-28 — no
         # `-A warnings` override needed. Cargo build doesn't fail on
         # warnings by default; the rust-clippy job is the authoritative
@@ -1245,7 +1253,7 @@ jobs:
             -p proximadb-migrate
 
       - name: Upload Server Binary
-        if: matrix.profile == 'release'
+        if: matrix.profile == 'release' && needs.changes.outputs.medium_tier == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: proximadb-server-linux-x64


### PR DESCRIPTION
## What

The `rust-build` matrix runs **dev + release** legs on every Rust PR. On `feat→develop` the release leg is redundant:
- **Compile correctness** is already covered by the dev build + `Rust Clippy` + `Rust Compile (test)`.
- The release binary **artifact** is only consumed by `integration-test`, which is gated on `extensive` (**qa→main only**) — nothing on `feat→develop` downloads it.

So the release leg's ~30m compile + a runner is spent for nothing on every `feat→develop` PR.

## Change

Add a `medium_tier` output (base `qa`/`main` — i.e. `develop→qa` and `qa→main`, **not** `feat→develop`) and gate the release leg's build + upload steps on it:
- `feat→develop` (`medium_tier=false`): **dev-only** — release leg skips its build+upload.
- `develop→qa` / `qa→main` (`medium_tier=true`): **unchanged** — both legs build, release uploads the artifact (consumed at `qa→main`).

## Why a new flag, not `test_tier`/`extensive`

`test_tier` is `true` on `feat→develop` too (`base_ref=='develop'`), so it can't gate this. `extensive` (qa→main only) would *also* skip the release build on `develop→qa` — more aggressive than needed. `medium_tier` (qa/main) trims **only** `feat→develop` and leaves `develop→qa` untouched (no behavior change there). This is the most targeted fix for the redundancy.

## Safety

- The release matrix **leg still exists** — it just skips its build step on `feat→develop`, so all 6 `needs: [rust-build]` consumers + `ci-success` resolve exactly as before.
- No `feat→develop` job downloads the artifact (`integration-test` is `extensive`-only), so skipping the upload there breaks nothing.
- Verified: YAML valid, actionlint clean on the changed lines. **This PR's own CI run is the proof** — `Rust Build (release)` should skip (not ~30m) on this `feat→develop` PR.